### PR TITLE
[codex] Split A1 M36-M41 activities by tab

### DIFF
--- a/curriculum/l2-uk-en/a1/at-the-cafe/activities.yaml
+++ b/curriculum/l2-uk-en/a1/at-the-cafe/activities.yaml
@@ -1,355 +1,353 @@
-- id: act-1
-  type: match-up
-  title: Cafe line to function
-  instruction: Match each cafe phrase with what it does.
-  pairs:
-    - left: "Рахунок, будь ласка."
-      right: "ask for the bill"
-    - left: "Що ви рекомендуєте?"
-      right: "ask for a recommendation"
-    - left: "Мені борщ, будь ласка."
-      right: "order food"
-    - left: "Скільки коштує?"
-      right: "ask the price"
-    - left: "Можна карткою?"
-      right: "ask to pay by card"
-    - left: "Дуже смачно!"
-      right: "praise the food"
-    - left: "Тут вільно?"
-      right: "ask about a free seat"
-    - left: "Вам тут чи із собою?"
-      right: "ask about format"
-    - left: "Велику каву, будь ласка."
-      right: "order a size chunk"
-- id: act-2
-  type: fill-in
-  title: Order with мені
-  instruction: Choose the form that completes the cafe order.
-  items:
-    - sentence: "Мені ___, будь ласка."
-      answer: "каву"
-      options:
-        - "каву"
-        - "кава"
-        - "каві"
-      explanation: "Кава becomes каву in an order."
-    - sentence: "Мені ___, будь ласка."
-      answer: "воду"
-      options:
-        - "воду"
-        - "вода"
-        - "водою"
-      explanation: "Вода becomes воду."
-    - sentence: "Мені ___, будь ласка."
-      answer: "борщ"
-      options:
-        - "борщ"
-        - "борщу"
-        - "борщем"
-      explanation: "Борщ is masculine inanimate and stays борщ."
-    - sentence: "Мені ___, будь ласка."
-      answer: "салат"
-      options:
-        - "салат"
-        - "салату"
-        - "салатом"
-      explanation: "Салат stays салат in this A1 pattern."
-    - sentence: "Дайте, будь ласка, ___."
-      answer: "чай"
-      options:
-        - "чай"
-        - "чаю"
-        - "чаєм"
-      explanation: "Чай stays чай."
-    - sentence: "Я буду ___."
-      answer: "піцу"
-      options:
-        - "піцу"
-        - "піца"
-        - "піці"
-      explanation: "Піца becomes піцу."
-    - sentence: "Можна ___?"
-      answer: "хліб"
-      options:
-        - "хліб"
-        - "хліба"
-        - "хлібом"
-      explanation: "Хліб stays хліб."
-    - sentence: "Мені ___ із собою, будь ласка."
-      answer: "маленьку каву"
-      options:
-        - "маленьку каву"
-        - "маленька кава"
-        - "маленької кави"
-      explanation: "Use маленьку каву as one ordering chunk."
-- id: act-3
-  type: quiz
-  title: What do you say?
-  instruction: Choose the line that fits the cafe situation.
-  items:
-    - prompt: "You want to order coffee."
-      options:
-        - text: "Мені каву, будь ласка."
-          correct: true
-        - text: "Рахунок, будь ласка."
-          correct: false
-        - text: "Що ви рекомендуєте?"
-          correct: false
-      explanation: "Мені каву, будь ласка is an order."
-    - prompt: "You want to pay."
-      options:
-        - text: "Рахунок, будь ласка."
-          correct: true
-        - text: "Можна меню?"
-          correct: false
-        - text: "Це гостре?"
-          correct: false
-      explanation: "Ask for the bill with рахунок."
-    - prompt: "You want to know the price."
-      options:
-        - text: "Скільки коштує?"
-          correct: true
-        - text: "Це з м'ясом?"
-          correct: false
-        - text: "Тут вільно?"
-          correct: false
-      explanation: "Скільки коштує? asks how much it costs."
-    - prompt: "You want a recommendation."
-      options:
-        - text: "Що ви рекомендуєте?"
-          correct: true
-        - text: "Є вегетаріанське меню?"
-          correct: false
-        - text: "Все було дуже смачно!"
-          correct: false
-      explanation: "Рекомендуєте asks the server to recommend."
-    - prompt: "You want to praise the food."
-      options:
-        - text: "Все було дуже смачно!"
-          correct: true
-        - text: "Можна карткою?"
-          correct: false
-        - text: "Без цукру."
-          correct: false
-      explanation: "This is the praise line after eating."
-    - prompt: "You want to know whether a seat is free."
-      options:
-        - text: "Тут вільно?"
-          correct: true
-        - text: "Ще одну каву, будь ласка."
-          correct: false
-        - text: "Рахунок, будь ласка."
-          correct: false
-      explanation: "Тут вільно? asks if the place is free."
-    - prompt: "You want to know whether a dish is spicy."
-      options:
-        - text: "Це гостре?"
-          correct: true
-        - text: "Це з м'ясом?"
-          correct: false
-        - text: "Скільки коштує?"
-          correct: false
-      explanation: "Гостре means spicy here."
-    - prompt: "You want to pay by card."
-      options:
-        - text: "Можна карткою?"
-          correct: true
-        - text: "Є вегетаріанське меню?"
-          correct: false
-        - text: "Що ви рекомендуєте?"
-          correct: false
-      explanation: "Карткою is the card-payment chunk."
-- id: act-4
-  type: fill-in
-  title: Complete the cafe dialogue
-  instruction: Choose the word or phrase that fits the dialogue.
-  items:
-    - sentence: "Добрий день! Ось ___."
-      answer: "меню"
-      options:
-        - "меню"
-        - "рахунок"
-        - "картка"
-      explanation: "The server gives the menu first."
-    - sentence: "Дякую. Що ви ___?"
-      answer: "рекомендуєте"
-      options:
-        - "рекомендуєте"
-        - "коштуєте"
-        - "платите"
-      explanation: "Що ви рекомендуєте? asks for advice."
-    - sentence: "Борщ дуже ___."
-      answer: "смачний"
-      options:
-        - "смачний"
-        - "вільний"
-        - "картковий"
-      explanation: "Борщ is described as tasty."
-    - sentence: "Добре, ___ борщ і хліб, будь ласка."
-      answer: "мені"
-      options:
-        - "мені"
-        - "я"
-        - "мене"
-      explanation: "Мені begins the order frame."
-    - sentence: "А що будете ___?"
-      answer: "пити"
-      options:
-        - "пити"
-        - "читати"
-        - "платити"
-      explanation: "The server asks what you will drink."
-    - sentence: "Добре, одну ___."
-      answer: "хвилинку"
-      options:
-        - "хвилинку"
-        - "годину"
-        - "картку"
-      explanation: "Одну хвилинку means one moment."
-- id: act-5
-  type: true-false
-  title: Cafe culture checks
-  instruction: Decide whether each statement fits the module.
-  items:
-    - statement: "Рахунок, будь ласка asks for the bill."
-      answer: true
-      explanation: "Рахунок is the bill."
-    - statement: "Вам тут чи із собою? asks whether the order is for here or to go."
-      answer: true
-      explanation: "Тут and із собою are the format answers."
-    - statement: "Велику каву is taught here as an adjective table."
-      answer: false
-      explanation: "It is taught as one cafe chunk."
-    - statement: "Кава на винос is the course form."
-      answer: false
-      explanation: "Use кава із собою."
-    - statement: "Можна карткою? asks whether card payment is possible."
-      answer: true
-      explanation: "Карткою is the card-payment chunk."
-    - statement: "Дуже смачно було! is a food praise line."
-      answer: true
-      explanation: "Use it after the meal."
-    - statement: "Пірожене is the course word for pastry."
-      answer: false
-      explanation: "Use тістечко."
-    - statement: "Перепрошую is a polite way to get attention."
-      answer: true
-      explanation: "It is a neutral service-scene attention getter."
-- id: act-6
-  type: order
-  title: One cafe visit
-  instruction: Put the cafe visit in order.
-  is_ukrainian: true
-  items:
-    - "Добрий день! Можна меню?"
-    - "Що ви рекомендуєте?"
-    - "Мені борщ і хліб, будь ласка."
-    - "А мені маленьку каву із собою."
-    - "Рахунок, будь ласка."
-    - "Можна карткою?"
-    - "Дякую, все було дуже смачно!"
-    - "До побачення!"
-  correct_order: [0, 1, 2, 3, 4, 5, 6, 7]
-- id: act-7
-  type: group-sort
-  title: Cafe shelves
-  instruction: Sort each phrase by its cafe job.
-  groups:
-    - name: "Greeting or attention"
-      items:
-        - "Добрий день!"
-        - "Доброго ранку!"
-        - "Перепрошую."
-    - name: "Ordering"
-      items:
-        - "Мені каву, будь ласка."
-        - "Дайте, будь ласка, борщ."
-        - "Велику каву із собою."
-    - name: "Questions"
-      items:
-        - "Що ви рекомендуєте?"
-        - "Скільки коштує?"
-        - "Це гостре?"
-    - name: "Payment or closing"
-      items:
-        - "Рахунок, будь ласка."
-        - "Можна карткою?"
-        - "До побачення!"
-- id: act-8
-  type: error-correction
-  title: Repair cafe interference
-  instruction: Choose the clean Ukrainian repair.
-  anchor_id: repair-at-the-cafe-interference
-  items:
-    - sentence: "Доброго дня!"
-      error: "Доброго дня!"
-      answer: "Добрий день!"
-      options:
-        - "Добрий день!"
-        - "Доброго дня!"
-        - "Добрий дня!"
-      explanation: "Use Добрий день as the neutral greeting."
-    - sentence: "Вибачаюсь!"
-      error: "Вибачаюсь!"
-      answer: "Вибачте! / Перепрошую!"
-      options:
-        - "Вибачте! / Перепрошую!"
-        - "Вибачаюсь!"
-        - "Я вибачаю себе!"
-      explanation: "Use Вибачте or Перепрошую."
-    - sentence: "Я хочу кава."
-      error: "Я хочу кава."
-      answer: "Я хочу каву. / Дайте каву."
-      options:
-        - "Я хочу каву. / Дайте каву."
-        - "Я хочу кава."
-        - "Я хочу каві."
-      explanation: "Кава becomes каву in this request."
-    - sentence: "ПрошУ (як прохання)"
-      error: "ПрошУ (як прохання)"
-      answer: "ПрОшу (як \"будь ласка\")"
-      options:
-        - "ПрОшу (як \"будь ласка\")"
-        - "ПрошУ (як прохання)"
-        - "Прошу без наголосу."
-      explanation: "As a polite inserted word meaning please, the stress is ПрОшу."
-    - sentence: "[балєт], [проблєма]"
-      error: "[балєт], [проблєма]"
-      answer: "[балет], [проблема]"
-      options:
-        - "[балет], [проблема]"
-        - "[балєт], [проблєма]"
-        - "[балет], [проблєма]"
-      explanation: "Keep л before е hard in these examples."
-    - sentence: "Здрастуйте! / Пока!"
-      error: "Здрастуйте! / Пока!"
-      answer: "Добрий день! / До побачення!"
-      options:
-        - "Добрий день! / До побачення!"
-        - "Здрастуйте! / Пока!"
-        - "Добрий день! / Пока!"
-      explanation: "Use Ukrainian greeting and goodbye formulas."
-    - sentence: "Можна счет?"
-      error: "счет"
-      answer: "Можна рахунок?"
-      options:
-        - "Можна рахунок?"
-        - "Можна счет?"
-        - "Можна рахунка?"
-      explanation: "Use рахунок."
-    - sentence: "Кава на винос."
-      error: "на винос"
-      answer: "Кава із собою."
-      options:
-        - "Кава із собою."
-        - "Кава на винос."
-        - "Кава з себе."
-      explanation: "The course chunk is із собою."
-    - sentence: "Дайте пірожене."
-      error: "пірожене"
-      answer: "Дайте тістечко."
-      options:
-        - "Дайте тістечко."
-        - "Дайте пірожене."
-        - "Дайте тісто."
-      explanation: "Use тістечко."
+inline:
+  - id: act-1
+    type: match-up
+    title: Cafe line to function
+    instruction: Match each cafe phrase with what it does.
+    pairs:
+      - left: 'Рахунок, будь ласка.'
+        right: 'ask for the bill'
+      - left: 'Що ви рекомендуєте?'
+        right: 'ask for a recommendation'
+      - left: 'Мені борщ, будь ласка.'
+        right: 'order food'
+      - left: 'Скільки коштує?'
+        right: 'ask the price'
+      - left: 'Можна карткою?'
+        right: 'ask to pay by card'
+      - left: 'Дуже смачно!'
+        right: 'praise the food'
+      - left: 'Тут вільно?'
+        right: 'ask about a free seat'
+      - left: 'Вам тут чи із собою?'
+        right: 'ask about format'
+      - left: 'Велику каву, будь ласка.'
+        right: 'order a size chunk'
+  - id: act-2
+    type: fill-in
+    title: Order with мені
+    instruction: Choose the form that completes the cafe order.
+    items:
+      - sentence: 'Мені ___, будь ласка.'
+        answer: 'каву'
+        options:
+          - 'каву'
+          - 'кава'
+          - 'каві'
+        explanation: 'Кава becomes каву in an order.'
+      - sentence: 'Мені ___, будь ласка.'
+        answer: 'воду'
+        options:
+          - 'воду'
+          - 'вода'
+          - 'водою'
+        explanation: 'Вода becomes воду.'
+      - sentence: 'Мені ___, будь ласка.'
+        answer: 'борщ'
+        options:
+          - 'борщ'
+          - 'борщу'
+          - 'борщем'
+        explanation: 'Борщ is masculine inanimate and stays борщ.'
+      - sentence: 'Мені ___, будь ласка.'
+        answer: 'салат'
+        options:
+          - 'салат'
+          - 'салату'
+          - 'салатом'
+        explanation: 'Салат stays салат in this A1 pattern.'
+      - sentence: 'Дайте, будь ласка, ___.'
+        answer: 'чай'
+        options:
+          - 'чай'
+          - 'чаю'
+          - 'чаєм'
+        explanation: 'Чай stays чай.'
+      - sentence: 'Я буду ___.'
+        answer: 'піцу'
+        options:
+          - 'піцу'
+          - 'піца'
+          - 'піці'
+        explanation: 'Піца becomes піцу.'
+      - sentence: 'Можна ___?'
+        answer: 'хліб'
+        options:
+          - 'хліб'
+          - 'хліба'
+          - 'хлібом'
+        explanation: 'Хліб stays хліб.'
+      - sentence: 'Мені ___ із собою, будь ласка.'
+        answer: 'маленьку каву'
+        options:
+          - 'маленьку каву'
+          - 'маленька кава'
+          - 'маленької кави'
+        explanation: 'Use маленьку каву as one ordering chunk.'
+  - id: act-3
+    type: quiz
+    title: What do you say?
+    instruction: Choose the line that fits the cafe situation.
+    items:
+      - prompt: 'You want to order coffee.'
+        options:
+          - text: 'Мені каву, будь ласка.'
+            correct: true
+          - text: 'Рахунок, будь ласка.'
+            correct: false
+          - text: 'Що ви рекомендуєте?'
+            correct: false
+        explanation: 'Мені каву, будь ласка is an order.'
+      - prompt: 'You want to pay.'
+        options:
+          - text: 'Рахунок, будь ласка.'
+            correct: true
+          - text: 'Можна меню?'
+            correct: false
+          - text: 'Це гостре?'
+            correct: false
+        explanation: 'Ask for the bill with рахунок.'
+      - prompt: 'You want to know the price.'
+        options:
+          - text: 'Скільки коштує?'
+            correct: true
+          - text: "Це з м'ясом?"
+            correct: false
+          - text: 'Тут вільно?'
+            correct: false
+        explanation: 'Скільки коштує? asks how much it costs.'
+      - prompt: 'You want a recommendation.'
+        options:
+          - text: 'Що ви рекомендуєте?'
+            correct: true
+          - text: 'Є вегетаріанське меню?'
+            correct: false
+          - text: 'Все було дуже смачно!'
+            correct: false
+        explanation: 'Рекомендуєте asks the server to recommend.'
+      - prompt: 'You want to praise the food.'
+        options:
+          - text: 'Все було дуже смачно!'
+            correct: true
+          - text: 'Можна карткою?'
+            correct: false
+          - text: 'Без цукру.'
+            correct: false
+        explanation: 'This is the praise line after eating.'
+      - prompt: 'You want to know whether a seat is free.'
+        options:
+          - text: 'Тут вільно?'
+            correct: true
+          - text: 'Ще одну каву, будь ласка.'
+            correct: false
+          - text: 'Рахунок, будь ласка.'
+            correct: false
+        explanation: 'Тут вільно? asks if the place is free.'
+      - prompt: 'You want to know whether a dish is spicy.'
+        options:
+          - text: 'Це гостре?'
+            correct: true
+          - text: "Це з м'ясом?"
+            correct: false
+          - text: 'Скільки коштує?'
+            correct: false
+        explanation: 'Гостре means spicy here.'
+      - prompt: 'You want to pay by card.'
+        options:
+          - text: 'Можна карткою?'
+            correct: true
+          - text: 'Є вегетаріанське меню?'
+            correct: false
+          - text: 'Що ви рекомендуєте?'
+            correct: false
+        explanation: 'Карткою is the card-payment chunk.'
+  - id: act-4
+    type: fill-in
+    title: Complete the cafe dialogue
+    instruction: Choose the word or phrase that fits the dialogue.
+    items:
+      - sentence: 'Добрий день! Ось ___.'
+        answer: 'меню'
+        options:
+          - 'меню'
+          - 'рахунок'
+          - 'картка'
+        explanation: 'The server gives the menu first.'
+      - sentence: 'Дякую. Що ви ___?'
+        answer: 'рекомендуєте'
+        options:
+          - 'рекомендуєте'
+          - 'коштуєте'
+          - 'платите'
+        explanation: 'Що ви рекомендуєте? asks for advice.'
+      - sentence: 'Борщ дуже ___.'
+        answer: 'смачний'
+        options:
+          - 'смачний'
+          - 'вільний'
+          - 'картковий'
+        explanation: 'Борщ is described as tasty.'
+      - sentence: 'Добре, ___ борщ і хліб, будь ласка.'
+        answer: 'мені'
+        options:
+          - 'мені'
+          - 'я'
+          - 'мене'
+        explanation: 'Мені begins the order frame.'
+      - sentence: 'А що будете ___?'
+        answer: 'пити'
+        options:
+          - 'пити'
+          - 'читати'
+          - 'платити'
+        explanation: 'The server asks what you will drink.'
+      - sentence: 'Добре, одну ___.'
+        answer: 'хвилинку'
+        options:
+          - 'хвилинку'
+          - 'годину'
+          - 'картку'
+        explanation: 'Одну хвилинку means one moment.'
+workbook:
+  - type: true-false
+    title: Cafe culture checks
+    instruction: Decide whether each statement fits the module.
+    items:
+      - statement: 'Рахунок, будь ласка asks for the bill.'
+        answer: true
+        explanation: 'Рахунок is the bill.'
+      - statement: 'Вам тут чи із собою? asks whether the order is for here or to go.'
+        answer: true
+        explanation: 'Тут and із собою are the format answers.'
+      - statement: 'Велику каву is taught here as an adjective table.'
+        answer: false
+        explanation: 'It is taught as one cafe chunk.'
+      - statement: 'Кава на винос is the course form.'
+        answer: false
+        explanation: 'Use кава із собою.'
+      - statement: 'Можна карткою? asks whether card payment is possible.'
+        answer: true
+        explanation: 'Карткою is the card-payment chunk.'
+      - statement: 'Дуже смачно було! is a food praise line.'
+        answer: true
+        explanation: 'Use it after the meal.'
+      - statement: 'Пірожене is the course word for pastry.'
+        answer: false
+        explanation: 'Use тістечко.'
+      - statement: 'Перепрошую is a polite way to get attention.'
+        answer: true
+        explanation: 'It is a neutral service-scene attention getter.'
+  - type: order
+    title: One cafe visit
+    instruction: Put the cafe visit in order.
+    is_ukrainian: true
+    items:
+      - 'Добрий день! Можна меню?'
+      - 'Що ви рекомендуєте?'
+      - 'Мені борщ і хліб, будь ласка.'
+      - 'А мені маленьку каву із собою.'
+      - 'Рахунок, будь ласка.'
+      - 'Можна карткою?'
+      - 'Дякую, все було дуже смачно!'
+      - 'До побачення!'
+    correct_order: [0, 1, 2, 3, 4, 5, 6, 7]
+  - type: group-sort
+    title: Cafe shelves
+    instruction: Sort each phrase by its cafe job.
+    groups:
+      - name: 'Greeting or attention'
+        items:
+          - 'Добрий день!'
+          - 'Доброго ранку!'
+          - 'Перепрошую.'
+      - name: 'Ordering'
+        items:
+          - 'Мені каву, будь ласка.'
+          - 'Дайте, будь ласка, борщ.'
+          - 'Велику каву із собою.'
+      - name: 'Questions'
+        items:
+          - 'Що ви рекомендуєте?'
+          - 'Скільки коштує?'
+          - 'Це гостре?'
+      - name: 'Payment or closing'
+        items:
+          - 'Рахунок, будь ласка.'
+          - 'Можна карткою?'
+          - 'До побачення!'
+  - type: error-correction
+    title: Repair cafe interference
+    instruction: Choose the clean Ukrainian repair.
+    anchor_id: repair-at-the-cafe-interference
+    items:
+      - sentence: 'Доброго дня!'
+        error: 'Доброго дня!'
+        answer: 'Добрий день!'
+        options:
+          - 'Добрий день!'
+          - 'Доброго дня!'
+          - 'Добрий дня!'
+        explanation: 'Use Добрий день as the neutral greeting.'
+      - sentence: 'Вибачаюсь!'
+        error: 'Вибачаюсь!'
+        answer: 'Вибачте! / Перепрошую!'
+        options:
+          - 'Вибачте! / Перепрошую!'
+          - 'Вибачаюсь!'
+          - 'Я вибачаю себе!'
+        explanation: 'Use Вибачте or Перепрошую.'
+      - sentence: 'Я хочу кава.'
+        error: 'Я хочу кава.'
+        answer: 'Я хочу каву. / Дайте каву.'
+        options:
+          - 'Я хочу каву. / Дайте каву.'
+          - 'Я хочу кава.'
+          - 'Я хочу каві.'
+        explanation: 'Кава becomes каву in this request.'
+      - sentence: 'ПрошУ (як прохання)'
+        error: 'ПрошУ (як прохання)'
+        answer: 'ПрОшу (як "будь ласка")'
+        options:
+          - 'ПрОшу (як "будь ласка")'
+          - 'ПрошУ (як прохання)'
+          - 'Прошу без наголосу.'
+        explanation: 'As a polite inserted word meaning please, the stress is ПрОшу.'
+      - sentence: '[балєт], [проблєма]'
+        error: '[балєт], [проблєма]'
+        answer: '[балет], [проблема]'
+        options:
+          - '[балет], [проблема]'
+          - '[балєт], [проблєма]'
+          - '[балет], [проблєма]'
+        explanation: 'Keep л before е hard in these examples.'
+      - sentence: 'Здрастуйте! / Пока!'
+        error: 'Здрастуйте! / Пока!'
+        answer: 'Добрий день! / До побачення!'
+        options:
+          - 'Добрий день! / До побачення!'
+          - 'Здрастуйте! / Пока!'
+          - 'Добрий день! / Пока!'
+        explanation: 'Use Ukrainian greeting and goodbye formulas.'
+      - sentence: 'Можна счет?'
+        error: 'счет'
+        answer: 'Можна рахунок?'
+        options:
+          - 'Можна рахунок?'
+          - 'Можна счет?'
+          - 'Можна рахунка?'
+        explanation: 'Use рахунок.'
+      - sentence: 'Кава на винос.'
+        error: 'на винос'
+        answer: 'Кава із собою.'
+        options:
+          - 'Кава із собою.'
+          - 'Кава на винос.'
+          - 'Кава з себе.'
+        explanation: 'The course chunk is із собою.'
+      - sentence: 'Дайте пірожене.'
+        error: 'пірожене'
+        answer: 'Дайте тістечко.'
+        options:
+          - 'Дайте тістечко.'
+          - 'Дайте пірожене.'
+          - 'Дайте тісто.'
+        explanation: 'Use тістечко.'

--- a/curriculum/l2-uk-en/a1/at-the-cafe/module.md
+++ b/curriculum/l2-uk-en/a1/at-the-cafe/module.md
@@ -194,7 +194,6 @@ Use Ukrainian cafe words, not Russian or hybrid service language.
 The phrase **кава із собою** is the clean order. You may hear other forms in
 the world, but this course gives you the Ukrainian standard to use.
 
-<!-- INJECT_ACTIVITY: act-5 -->
 
 ## Підсумок
 
@@ -231,9 +230,3 @@ Self-check:
 | **<!-- bad -->ПрошУ<!-- /bad -->** as "please" | **ПрОшу** as a polite inserted word |
 | **<!-- bad -->[балєт], [проблєма]<!-- /bad -->** | **[балет], [проблема]** |
 | **<!-- bad -->Здрастуйте! / Пока!<!-- /bad -->** | **Добрий день! / До побачення!** |
-
-<!-- INJECT_ACTIVITY: act-6 -->
-
-<!-- INJECT_ACTIVITY: act-7 -->
-
-<!-- INJECT_ACTIVITY: act-8 -->

--- a/curriculum/l2-uk-en/a1/checkpoint-food-shopping/activities.yaml
+++ b/curriculum/l2-uk-en/a1/checkpoint-food-shopping/activities.yaml
@@ -1,375 +1,373 @@
-- id: act-1
-  type: group-sort
-  title: Food by gender
-  instruction: Sort the foods by the review groups.
-  groups:
-    - name: "Masculine"
-      items:
-        - "сир"
-        - "борщ"
-        - "хліб"
-        - "чай"
-    - name: "Feminine"
-      items:
-        - "вода"
-        - "кава"
-        - "каша"
-        - "піца"
-    - name: "Neuter"
-      items:
-        - "молоко"
-        - "яблуко"
-        - "меню"
-        - "м'ясо"
-    - name: "Plural"
-      items:
-        - "вареники"
-        - "помідори"
-        - "тарілки"
-        - "склянки"
-- id: act-2
-  type: quiz
-  title: Accusative checkpoint
-  instruction: Choose the correct object form.
-  items:
-    - prompt: "Я їм ___."
-      options:
-        - text: "салат"
-          correct: true
-        - text: "салата"
-          correct: false
-        - text: "салату"
-          correct: false
-      explanation: "Салат is masculine inanimate and stays салат."
-    - prompt: "Я бачу ___."
-      options:
-        - text: "брата"
-          correct: true
-        - text: "брат"
-          correct: false
-        - text: "брату"
-          correct: false
-      explanation: "Брат is a male person, so use брата."
-    - prompt: "Я п'ю ___."
-      options:
-        - text: "воду"
-          correct: true
-        - text: "вода"
-          correct: false
-        - text: "води"
-          correct: false
-      explanation: "Вода becomes воду for the direct object."
-    - prompt: "Я знаю ___."
-      options:
-        - text: "Олену"
-          correct: true
-        - text: "Олена"
-          correct: false
-        - text: "Олени"
-          correct: false
-      explanation: "Use Олену after знаю."
-    - prompt: "Я люблю ___."
-      options:
-        - text: "борщ"
-          correct: true
-        - text: "борщу"
-          correct: false
-        - text: "борщем"
-          correct: false
-      explanation: "Борщ is food and stays борщ."
-    - prompt: "Я чекаю ___."
-      options:
-        - text: "друга"
-          correct: true
-        - text: "друг"
-          correct: false
-        - text: "другу"
-          correct: false
-      explanation: "Use друга for the person you are waiting for."
-    - prompt: "Я купую ___."
-      options:
-        - text: "хліб"
-          correct: true
-        - text: "хліба"
-          correct: false
-        - text: "хлібу"
-          correct: false
-      explanation: "Хліб stays хліб here."
-    - prompt: "Я бачу ___."
-      options:
-        - text: "лікаря"
-          correct: true
-        - text: "лікар"
-          correct: false
-        - text: "лікарю"
-          correct: false
-      explanation: "Use лікаря after бачу."
-    - prompt: "Я їм ___."
-      options:
-        - text: "піцу"
-          correct: true
-        - text: "піца"
-          correct: false
-        - text: "піци"
-          correct: false
-      explanation: "Choose піцу after я їм."
-    - prompt: "Я люблю ___."
-      options:
-        - text: "маму"
-          correct: true
-        - text: "мама"
-          correct: false
-        - text: "мами"
-          correct: false
-      explanation: "Use маму as the direct object."
-- id: act-3
-  type: fill-in
-  title: Market and cafe day
-  instruction: Choose the word or phrase that completes the dialogue.
-  items:
-    - sentence: "— Що ти їси на сніданок? — Я їм ___ і п'ю каву."
-      answer: "кашу"
-      options:
-        - "кашу"
-        - "каша"
-        - "каші"
-      explanation: "After я їм, choose кашу."
-    - sentence: "— Потім іду на ринок. Скільки ___ помідори?"
-      answer: "коштують"
-      options:
-        - "коштують"
-        - "коштує"
-        - "коштувати"
-      explanation: "Use коштують with plural помідори."
-    - sentence: "— Тридцять ___."
-      answer: "гривень"
-      options:
-        - "гривень"
-        - "гривні"
-        - "гривня"
-      explanation: "30 uses гривень."
-    - sentence: "— Дайте ___ яблук, будь ласка."
-      answer: "кілограм"
-      options:
-        - "кілограм"
-        - "літр"
-        - "пляшку"
-      explanation: "Use кілограм яблук."
-    - sentence: "— Потім у кафе: ___ борщ і воду, будь ласка."
-      answer: "Мені"
-      options:
-        - "Мені"
-        - "Я"
-        - "Мною"
-      explanation: "Мені begins the cafe order chunk."
-    - sentence: "— Рахунок, будь ласка. Можна ___?"
-      answer: "карткою"
-      options:
-        - "карткою"
-        - "картка"
-        - "картки"
-      explanation: "Карткою is the payment chunk."
-    - sentence: "— О, я бачу ___! Олено, привіт!"
-      answer: "Олену"
-      options:
-        - "Олену"
-        - "Олена"
-        - "Олени"
-      explanation: "The greeting uses Олено, but the object is Олену."
-    - sentence: "— Ти знаєш мого ___?"
-      answer: "брата"
-      options:
-        - "брата"
-        - "брат"
-        - "братом"
-      explanation: "Use брата for мого брата."
-- id: act-4
-  type: match-up
-  title: Situation to phrase
-  instruction: Match each situation with the phrase you can say.
-  pairs:
-    - left: "In the checkpoint cafe, you ask for coffee with milk."
-      right: "Мені каву з молоком, будь ласка."
-    - left: "You ask for the price."
-      right: "Скільки коштує?"
-    - left: "At the register, you check whether card payment is possible."
-      right: "Можна карткою?"
-    - left: "The server asks where you will eat."
-      right: "Тут чи із собою?"
-    - left: "You ask for one kilogram of apples."
-      right: "Дайте кілограм яблук."
-    - left: "The price feels high."
-      right: "Дорого!"
-    - left: "You ask if a seat is free."
-      right: "Тут вільно?"
-    - left: "After lunch, you thank the server for the meal."
-      right: "Було дуже смачно, дякую!"
-- id: act-5
-  type: true-false
-  title: Food-shopping checks
-  instruction: Decide whether each statement fits A1.6.
-  items:
-    - statement: "Борщ is presented as a Ukrainian cultural food form."
-      answer: true
-      explanation: "The checkpoint keeps борщ in Ukrainian cultural context."
-    - statement: "Вареники з картоплею is treated as a useful food chunk."
-      answer: true
-      explanation: "Use the phrase as a memorized chunk here."
-    - statement: "Adding -а to борщ is not the A1.6 target form."
-      answer: false
-      explanation: "Use Я люблю борщ."
-    - statement: "Мені каву з молоком, будь ласка is a cafe order."
-      answer: true
-      explanation: "It is the ordering frame from M38."
-    - statement: "Скільки коштують помідори? asks a price for plural tomatoes."
-      answer: true
-      explanation: "Plural помідори takes коштують."
-    - statement: "Я знаю брата uses кого? for a person."
-      answer: true
-      explanation: "The person form is брата."
-    - statement: "Смачного! is a natural line when serving guests."
-      answer: true
-      explanation: "Use Смачного! before eating."
-    - statement: "This checkpoint starts A1.7 phone and email content."
-      answer: false
-      explanation: "A1.7 comes next; this checkpoint closes A1.6."
-- id: act-6
-  type: unjumble
-  title: Build food-shopping lines
-  instruction: Put each line in the correct word order.
-  items:
-    - words: ["Анна", "йде", "на", "ринок"]
-      answer: "Анна йде на ринок."
-    - words: ["Вона", "купує", "помідори", "сир", "і", "хліб"]
-      answer: "Вона купує помідори, сир і хліб."
-    - words: ["З", "вас", "сто", "сорок", "гривень"]
-      answer: "З вас сто сорок гривень."
-    - words: ["Анна", "платить", "карткою"]
-      answer: "Анна платить карткою."
-    - words: ["Потім", "Анна", "йде", "в", "кафе"]
-      answer: "Потім Анна йде в кафе."
-    - words: ["Вона", "замовляє", "борщ", "і", "каву", "з", "молоком"]
-      answer: "Вона замовляє борщ і каву з молоком."
-    - words: ["У", "кафе", "Анна", "бачить", "Олену"]
-      answer: "У кафе Анна бачить Олену."
-    - words: ["Анна", "готує", "вареники", "з", "картоплею"]
-      answer: "Анна готує вареники з картоплею."
-    - words: ["Гості", "беруть", "тарілки", "і", "склянки"]
-      answer: "Гості беруть тарілки і склянки."
-    - words: ["Анна", "каже", "Смачного"]
-      answer: "Анна каже: Смачного!"
-- id: act-7
-  type: fill-in
-  title: Serve the table
-  instruction: Complete the dinner scene.
-  items:
-    - sentence: "Анна готує ___ з картоплею."
-      answer: "вареники"
-      options:
-        - "вареники"
-        - "рахунок"
-        - "картку"
-      explanation: "Вареники з картоплею is the food chunk."
-    - sentence: "Вона ставить на стіл ___."
-      answer: "тарілки"
-      options:
-        - "тарілки"
-        - "гривні"
-        - "лікаря"
-      explanation: "Тарілки go on the table."
-    - sentence: "Гості беруть ___."
-      answer: "склянки"
-      options:
-        - "склянки"
-        - "магазин"
-        - "брата"
-      explanation: "Склянки are glasses."
-    - sentence: "Анна каже: ___"
-      answer: "Смачного!"
-      options:
-        - "Смачного!"
-        - "Скільки коштує?"
-        - "Плачу карткою."
-      explanation: "Смачного! is the meal line."
-    - sentence: "Олена бере ___ хліба."
-      answer: "шматок"
-      options:
-        - "шматок"
-        - "літр"
-        - "пляшку"
-      explanation: "Use шматок хліба."
-    - sentence: "Анна наливає ___ води."
-      answer: "склянку"
-      options:
-        - "склянку"
-        - "кілограм"
-        - "буханку"
-      explanation: "Use склянку води."
-- id: act-8
-  type: quiz
-  title: Repair A1.6 interference
-  instruction: Pick the A1.6 sentence you would actually say.
-  items:
-    - prompt: "Repair: Я хочу вода."
-      options:
-        - text: "Я хочу воду. (Або: Я хочу води)."
-          correct: true
-        - text: "Я хочу вода."
-          correct: false
-        - text: "Я хочу водою."
-          correct: false
-      explanation: "Use the direct-object form or the memorized service chunk."
-    - prompt: "Repair: Я люблю борща."
-      options:
-        - text: "Я люблю борщ."
-          correct: true
-        - text: "Я люблю борща."
-          correct: false
-        - text: "Я люблю борщу."
-          correct: false
-      explanation: "Борщ stays борщ as a food object."
-    - prompt: "Repair: Смачний кава."
-      options:
-        - text: "Смачна кава."
-          correct: true
-        - text: "Смачний кава."
-          correct: false
-        - text: "Смачне кава."
-          correct: false
-      explanation: "Кава is feminine: смачна кава."
-    - prompt: "Repair: Я є голодний."
-      options:
-        - text: "Я голодний. (Або: Я хочу їсти)."
-          correct: true
-        - text: "Я є голодний."
-          correct: false
-        - text: "Я маю голодний."
-          correct: false
-      explanation: "Omit є in this present-tense state line."
-    - prompt: "Repair: Моє ім'я є Джон, і я хочу меню."
-      options:
-        - text: "Мене звати Джон, дайте меню."
-          correct: true
-        - text: "Моє ім'я є Джон, і я хочу меню."
-          correct: false
-        - text: "Я є Джон і я маю меню."
-          correct: false
-      explanation: "Use Мене звати for introducing yourself."
-    - prompt: "Repair: Чи не могли б ви дати мені рахунок?"
-      options:
-        - text: "Дайте, будь ласка, рахунок."
-          correct: true
-        - text: "Чи не могли б ви дати мені рахунок?"
-          correct: false
-        - text: "Дайте мені рахунком."
-          correct: false
-      explanation: "The A1 service request is direct and polite."
-    - prompt: "Repair: Я плачу рублями."
-      options:
-        - text: "Я плачу гривнями."
-          correct: true
-        - text: "Я плачу рублями."
-          correct: false
-        - text: "Я плачу гривень."
-          correct: false
-      explanation: "Use гривня for Ukrainian currency."
+inline:
+  - id: act-1
+    type: group-sort
+    title: Food by gender
+    instruction: Sort the foods by the review groups.
+    groups:
+      - name: 'Masculine'
+        items:
+          - 'сир'
+          - 'борщ'
+          - 'хліб'
+          - 'чай'
+      - name: 'Feminine'
+        items:
+          - 'вода'
+          - 'кава'
+          - 'каша'
+          - 'піца'
+      - name: 'Neuter'
+        items:
+          - 'молоко'
+          - 'яблуко'
+          - 'меню'
+          - "м'ясо"
+      - name: 'Plural'
+        items:
+          - 'вареники'
+          - 'помідори'
+          - 'тарілки'
+          - 'склянки'
+  - id: act-2
+    type: quiz
+    title: Accusative checkpoint
+    instruction: Choose the correct object form.
+    items:
+      - prompt: 'Я їм ___.'
+        options:
+          - text: 'салат'
+            correct: true
+          - text: 'салата'
+            correct: false
+          - text: 'салату'
+            correct: false
+        explanation: 'Салат is masculine inanimate and stays салат.'
+      - prompt: 'Я бачу ___.'
+        options:
+          - text: 'брата'
+            correct: true
+          - text: 'брат'
+            correct: false
+          - text: 'брату'
+            correct: false
+        explanation: 'Брат is a male person, so use брата.'
+      - prompt: "Я п'ю ___."
+        options:
+          - text: 'воду'
+            correct: true
+          - text: 'вода'
+            correct: false
+          - text: 'води'
+            correct: false
+        explanation: 'Вода becomes воду for the direct object.'
+      - prompt: 'Я знаю ___.'
+        options:
+          - text: 'Олену'
+            correct: true
+          - text: 'Олена'
+            correct: false
+          - text: 'Олени'
+            correct: false
+        explanation: 'Use Олену after знаю.'
+      - prompt: 'Я люблю ___.'
+        options:
+          - text: 'борщ'
+            correct: true
+          - text: 'борщу'
+            correct: false
+          - text: 'борщем'
+            correct: false
+        explanation: 'Борщ is food and stays борщ.'
+      - prompt: 'Я чекаю ___.'
+        options:
+          - text: 'друга'
+            correct: true
+          - text: 'друг'
+            correct: false
+          - text: 'другу'
+            correct: false
+        explanation: 'Use друга for the person you are waiting for.'
+      - prompt: 'Я купую ___.'
+        options:
+          - text: 'хліб'
+            correct: true
+          - text: 'хліба'
+            correct: false
+          - text: 'хлібу'
+            correct: false
+        explanation: 'Хліб stays хліб here.'
+      - prompt: 'Я бачу ___.'
+        options:
+          - text: 'лікаря'
+            correct: true
+          - text: 'лікар'
+            correct: false
+          - text: 'лікарю'
+            correct: false
+        explanation: 'Use лікаря after бачу.'
+      - prompt: 'Я їм ___.'
+        options:
+          - text: 'піцу'
+            correct: true
+          - text: 'піца'
+            correct: false
+          - text: 'піци'
+            correct: false
+        explanation: 'Choose піцу after я їм.'
+      - prompt: 'Я люблю ___.'
+        options:
+          - text: 'маму'
+            correct: true
+          - text: 'мама'
+            correct: false
+          - text: 'мами'
+            correct: false
+        explanation: 'Use маму as the direct object.'
+  - id: act-3
+    type: fill-in
+    title: Market and cafe day
+    instruction: Choose the word or phrase that completes the dialogue.
+    items:
+      - sentence: "— Що ти їси на сніданок? — Я їм ___ і п'ю каву."
+        answer: 'кашу'
+        options:
+          - 'кашу'
+          - 'каша'
+          - 'каші'
+        explanation: 'After я їм, choose кашу.'
+      - sentence: '— Потім іду на ринок. Скільки ___ помідори?'
+        answer: 'коштують'
+        options:
+          - 'коштують'
+          - 'коштує'
+          - 'коштувати'
+        explanation: 'Use коштують with plural помідори.'
+      - sentence: '— Тридцять ___.'
+        answer: 'гривень'
+        options:
+          - 'гривень'
+          - 'гривні'
+          - 'гривня'
+        explanation: '30 uses гривень.'
+      - sentence: '— Дайте ___ яблук, будь ласка.'
+        answer: 'кілограм'
+        options:
+          - 'кілограм'
+          - 'літр'
+          - 'пляшку'
+        explanation: 'Use кілограм яблук.'
+      - sentence: '— Потім у кафе: ___ борщ і воду, будь ласка.'
+        answer: 'Мені'
+        options:
+          - 'Мені'
+          - 'Я'
+          - 'Мною'
+        explanation: 'Мені begins the cafe order chunk.'
+      - sentence: '— Рахунок, будь ласка. Можна ___?'
+        answer: 'карткою'
+        options:
+          - 'карткою'
+          - 'картка'
+          - 'картки'
+        explanation: 'Карткою is the payment chunk.'
+      - sentence: '— О, я бачу ___! Олено, привіт!'
+        answer: 'Олену'
+        options:
+          - 'Олену'
+          - 'Олена'
+          - 'Олени'
+        explanation: 'The greeting uses Олено, but the object is Олену.'
+      - sentence: '— Ти знаєш мого ___?'
+        answer: 'брата'
+        options:
+          - 'брата'
+          - 'брат'
+          - 'братом'
+        explanation: 'Use брата for мого брата.'
+  - id: act-4
+    type: match-up
+    title: Situation to phrase
+    instruction: Match each situation with the phrase you can say.
+    pairs:
+      - left: 'In the checkpoint cafe, you ask for coffee with milk.'
+        right: 'Мені каву з молоком, будь ласка.'
+      - left: 'You ask for the price.'
+        right: 'Скільки коштує?'
+      - left: 'At the register, you check whether card payment is possible.'
+        right: 'Можна карткою?'
+      - left: 'The server asks where you will eat.'
+        right: 'Тут чи із собою?'
+      - left: 'You ask for one kilogram of apples.'
+        right: 'Дайте кілограм яблук.'
+      - left: 'The price feels high.'
+        right: 'Дорого!'
+      - left: 'You ask if a seat is free.'
+        right: 'Тут вільно?'
+      - left: 'After lunch, you thank the server for the meal.'
+        right: 'Було дуже смачно, дякую!'
+workbook:
+  - type: true-false
+    title: Food-shopping checks
+    instruction: Decide whether each statement fits A1.6.
+    items:
+      - statement: 'Борщ is presented as a Ukrainian cultural food form.'
+        answer: true
+        explanation: 'The checkpoint keeps борщ in Ukrainian cultural context.'
+      - statement: 'Вареники з картоплею is treated as a useful food chunk.'
+        answer: true
+        explanation: 'Use the phrase as a memorized chunk here.'
+      - statement: 'Adding -а to борщ is not the A1.6 target form.'
+        answer: false
+        explanation: 'Use Я люблю борщ.'
+      - statement: 'Мені каву з молоком, будь ласка is a cafe order.'
+        answer: true
+        explanation: 'It is the ordering frame from M38.'
+      - statement: 'Скільки коштують помідори? asks a price for plural tomatoes.'
+        answer: true
+        explanation: 'Plural помідори takes коштують.'
+      - statement: 'Я знаю брата uses кого? for a person.'
+        answer: true
+        explanation: 'The person form is брата.'
+      - statement: 'Смачного! is a natural line when serving guests.'
+        answer: true
+        explanation: 'Use Смачного! before eating.'
+      - statement: 'This checkpoint starts A1.7 phone and email content.'
+        answer: false
+        explanation: 'A1.7 comes next; this checkpoint closes A1.6.'
+  - type: unjumble
+    title: Build food-shopping lines
+    instruction: Put each line in the correct word order.
+    items:
+      - words: ['Анна', 'йде', 'на', 'ринок']
+        answer: 'Анна йде на ринок.'
+      - words: ['Вона', 'купує', 'помідори', 'сир', 'і', 'хліб']
+        answer: 'Вона купує помідори, сир і хліб.'
+      - words: ['З', 'вас', 'сто', 'сорок', 'гривень']
+        answer: 'З вас сто сорок гривень.'
+      - words: ['Анна', 'платить', 'карткою']
+        answer: 'Анна платить карткою.'
+      - words: ['Потім', 'Анна', 'йде', 'в', 'кафе']
+        answer: 'Потім Анна йде в кафе.'
+      - words: ['Вона', 'замовляє', 'борщ', 'і', 'каву', 'з', 'молоком']
+        answer: 'Вона замовляє борщ і каву з молоком.'
+      - words: ['У', 'кафе', 'Анна', 'бачить', 'Олену']
+        answer: 'У кафе Анна бачить Олену.'
+      - words: ['Анна', 'готує', 'вареники', 'з', 'картоплею']
+        answer: 'Анна готує вареники з картоплею.'
+      - words: ['Гості', 'беруть', 'тарілки', 'і', 'склянки']
+        answer: 'Гості беруть тарілки і склянки.'
+      - words: ['Анна', 'каже', 'Смачного']
+        answer: 'Анна каже: Смачного!'
+  - type: fill-in
+    title: Serve the table
+    instruction: Complete the dinner scene.
+    items:
+      - sentence: 'Анна готує ___ з картоплею.'
+        answer: 'вареники'
+        options:
+          - 'вареники'
+          - 'рахунок'
+          - 'картку'
+        explanation: 'Вареники з картоплею is the food chunk.'
+      - sentence: 'Вона ставить на стіл ___.'
+        answer: 'тарілки'
+        options:
+          - 'тарілки'
+          - 'гривні'
+          - 'лікаря'
+        explanation: 'Тарілки go on the table.'
+      - sentence: 'Гості беруть ___.'
+        answer: 'склянки'
+        options:
+          - 'склянки'
+          - 'магазин'
+          - 'брата'
+        explanation: 'Склянки are glasses.'
+      - sentence: 'Анна каже: ___'
+        answer: 'Смачного!'
+        options:
+          - 'Смачного!'
+          - 'Скільки коштує?'
+          - 'Плачу карткою.'
+        explanation: 'Смачного! is the meal line.'
+      - sentence: 'Олена бере ___ хліба.'
+        answer: 'шматок'
+        options:
+          - 'шматок'
+          - 'літр'
+          - 'пляшку'
+        explanation: 'Use шматок хліба.'
+      - sentence: 'Анна наливає ___ води.'
+        answer: 'склянку'
+        options:
+          - 'склянку'
+          - 'кілограм'
+          - 'буханку'
+        explanation: 'Use склянку води.'
+  - type: quiz
+    title: Repair A1.6 interference
+    instruction: Pick the A1.6 sentence you would actually say.
+    items:
+      - prompt: 'Repair: Я хочу вода.'
+        options:
+          - text: 'Я хочу воду. (Або: Я хочу води).'
+            correct: true
+          - text: 'Я хочу вода.'
+            correct: false
+          - text: 'Я хочу водою.'
+            correct: false
+        explanation: 'Use the direct-object form or the memorized service chunk.'
+      - prompt: 'Repair: Я люблю борща.'
+        options:
+          - text: 'Я люблю борщ.'
+            correct: true
+          - text: 'Я люблю борща.'
+            correct: false
+          - text: 'Я люблю борщу.'
+            correct: false
+        explanation: 'Борщ stays борщ as a food object.'
+      - prompt: 'Repair: Смачний кава.'
+        options:
+          - text: 'Смачна кава.'
+            correct: true
+          - text: 'Смачний кава.'
+            correct: false
+          - text: 'Смачне кава.'
+            correct: false
+        explanation: 'Кава is feminine: смачна кава.'
+      - prompt: 'Repair: Я є голодний.'
+        options:
+          - text: 'Я голодний. (Або: Я хочу їсти).'
+            correct: true
+          - text: 'Я є голодний.'
+            correct: false
+          - text: 'Я маю голодний.'
+            correct: false
+        explanation: 'Omit є in this present-tense state line.'
+      - prompt: "Repair: Моє ім'я є Джон, і я хочу меню."
+        options:
+          - text: 'Мене звати Джон, дайте меню.'
+            correct: true
+          - text: "Моє ім'я є Джон, і я хочу меню."
+            correct: false
+          - text: 'Я є Джон і я маю меню.'
+            correct: false
+        explanation: 'Use Мене звати for introducing yourself.'
+      - prompt: 'Repair: Чи не могли б ви дати мені рахунок?'
+        options:
+          - text: 'Дайте, будь ласка, рахунок.'
+            correct: true
+          - text: 'Чи не могли б ви дати мені рахунок?'
+            correct: false
+          - text: 'Дайте мені рахунком.'
+            correct: false
+        explanation: 'The A1 service request is direct and polite.'
+      - prompt: 'Repair: Я плачу рублями.'
+        options:
+          - text: 'Я плачу гривнями.'
+            correct: true
+          - text: 'Я плачу рублями.'
+            correct: false
+          - text: 'Я плачу гривень.'
+            correct: false
+        explanation: 'Use гривня for Ukrainian currency.'

--- a/curriculum/l2-uk-en/a1/checkpoint-food-shopping/module.md
+++ b/curriculum/l2-uk-en/a1/checkpoint-food-shopping/module.md
@@ -185,7 +185,6 @@ The dialogue is a role play. It uses etiquette formulas and a cafe invitation
 idea: **Хочеш, аби твої друзі розділили з тобою свято?** For A1, that becomes
 a simple invitation: **Ходімо в кафе. Я хочу каву і торт.**
 
-<!-- INJECT_ACTIVITY: act-5 -->
 
 ## Підсумок
 
@@ -216,9 +215,3 @@ inside this checkpoint. Finish A1.6 by making the food-shopping story smooth.
 | **Моє ім'я є Джон, і я хочу меню.** | **Мене звати Джон, дайте меню.** |
 | **Чи не могли б ви дати мені рахунок?** | **Дайте, будь ласка, рахунок.** |
 | payment with a non-Ukrainian currency | **Я плачу гривнями.** |
-
-<!-- INJECT_ACTIVITY: act-6 -->
-
-<!-- INJECT_ACTIVITY: act-7 -->
-
-<!-- INJECT_ACTIVITY: act-8 -->

--- a/curriculum/l2-uk-en/a1/food-and-drink/activities.yaml
+++ b/curriculum/l2-uk-en/a1/food-and-drink/activities.yaml
@@ -1,346 +1,344 @@
-- id: act-1
-  type: group-sort
-  title: Food, drink, and meal words
-  instruction: Sort each word by the shelf it belongs on.
-  groups:
-    - name: "Їжа"
-      items:
-        - "хліб"
-        - "риба"
-        - "м'ясо"
-        - "каша"
-        - "сир"
-    - name: "Напої"
-      items:
-        - "кава"
-        - "чай"
-        - "вода"
-        - "сік"
-        - "молоко"
-    - name: "Прийоми їжі"
-      items:
-        - "сніданок"
-        - "обід"
-        - "вечеря"
-    - name: "Українські страви"
-      items:
-        - "борщ"
-        - "вареники"
-        - "сало"
-- id: act-2
-  type: match-up
-  title: Breakfast table pairs
-  instruction: Match each Ukrainian food or drink phrase with its meaning.
-  pairs:
-    - left: "кава з молоком"
-      right: "coffee with milk"
-    - left: "чай без цукру"
-      right: "tea without sugar"
-    - left: "хліб з маслом"
-      right: "bread with butter"
-    - left: "каша"
-      right: "porridge"
-    - left: "яблуко"
-      right: "apple"
-    - left: "Смачного!"
-      right: "Enjoy your meal!"
-    - left: "я снідаю"
-      right: "I have breakfast"
-    - left: "вода з газом"
-      right: "sparkling water"
-- id: act-3
-  type: fill-in
-  title: Cafe chunks, not case tables
-  instruction: Choose the whole chunk that completes the service line.
-  items:
-    - sentence: "Мені каву ___, будь ласка."
-      answer: "з молоком"
-      options:
-        - "з молоком"
-        - "з молоко"
-        - "без молоко"
-      explanation: "Learn каву з молоком as one service chunk."
-    - sentence: "Чай ___, будь ласка."
-      answer: "без цукру"
-      options:
-        - "без цукру"
-        - "без цукор"
-        - "з цукор"
-      explanation: "Без цукру is the ready chunk."
-    - sentence: "Я їм хліб ___."
-      answer: "з маслом"
-      options:
-        - "з маслом"
-        - "без масло"
-        - "з масло"
-      explanation: "Use хліб з маслом as a whole phrase."
-    - sentence: "Дайте, будь ласка, воду ___."
-      answer: "з газом"
-      options:
-        - "з газом"
-        - "з газ"
-        - "без газ"
-      explanation: "Вода з газом is the useful drink phrase."
-    - sentence: "Я люблю каву ___."
-      answer: "без молока"
-      options:
-        - "без молока"
-        - "без молоко"
-        - "з молока"
-      explanation: "Без молока is memorized here as a chunk."
-    - sentence: "Вона п'є чай ___."
-      answer: "з лимоном"
-      options:
-        - "з лимоном"
-        - "з лимон"
-        - "без лимон"
-      explanation: "Чай з лимоном is a ready phrase."
-- id: act-4
-  type: true-false
-  title: Food guardrails
-  instruction: Decide whether each statement fits this module.
-  items:
-    - statement: "Борщ is taught here as a Ukrainian cultural dish."
-      answer: true
-      explanation: "Borscht is framed as Ukrainian, not as generic regional soup."
-    - statement: "At A1, без цукру is taught as a full chunk."
-      answer: true
-      explanation: "The module does not teach a formal genitive lesson."
-    - statement: "Творог is the standard course word for cheese."
-      answer: false
-      explanation: "Use сир, or кисломолочний сир when needed."
-    - statement: "Смажена картопля is the clean Ukrainian form."
-      answer: true
-      explanation: "Do not use жарена картопля as course language."
-    - statement: "Я п'ю борщ is the natural line for soup."
-      answer: false
-      explanation: "Ukrainian says я їм борщ."
-    - statement: "Смачного! is the natural meal formula."
-      answer: true
-      explanation: "Use Смачного! when people begin eating."
-    - statement: "Я снідаю means I have breakfast."
-      answer: true
-      explanation: "Use the compact meal verb."
-    - statement: "Борщ дуже смачно is the best sentence."
-      answer: false
-      explanation: "Say Борщ дуже смачний for the noun борщ."
-- id: act-5
-  type: quiz
-  title: Daily meal choices
-  instruction: Choose the line that answers the prompt naturally.
-  items:
-    - prompt: "Що ти робиш вранці?"
-      options:
-        - text: "Я снідаю."
-          correct: true
-        - text: "Я обідаю."
-          correct: false
-        - text: "Я вечеряю."
-          correct: false
-      explanation: "Breakfast uses снідати."
-    - prompt: "Що ти їси на обід?"
-      options:
-        - text: "Я їм борщ і салат."
-          correct: true
-        - text: "Я п'ю борщ і салат."
-          correct: false
-        - text: "Я їм чай без цукру."
-          correct: false
-      explanation: "Soup is eaten; tea is drunk."
-    - prompt: "Що ти п'єш?"
-      options:
-        - text: "Воду або компот."
-          correct: true
-        - text: "Картоплю або рибу."
-          correct: false
-        - text: "Сало або сир."
-          correct: false
-      explanation: "Вода and компот are drinks."
-    - prompt: "Which line names a Ukrainian cultural food?"
-      options:
-        - text: "Борщ зі сметаною."
-          correct: true
-        - text: "Лимонад з газом."
-          correct: false
-        - text: "Кава з молоком."
-          correct: false
-      explanation: "Borscht is a Ukrainian cultural dish."
-    - prompt: "How do you politely ask for tea without sugar?"
-      options:
-        - text: "Чай без цукру, будь ласка."
-          correct: true
-        - text: "Чай без цукор, будь ласка."
-          correct: false
-        - text: "Чай з цукру, будь ласка."
-          correct: false
-      explanation: "Use the memorized chunk без цукру."
-    - prompt: "What do you say as people start eating?"
-      options:
-        - text: "Смачного!"
-          correct: true
-        - text: "Добрий вечір!"
-          correct: false
-        - text: "До побачення!"
-          correct: false
-      explanation: "Смачного! is the meal formula."
-- id: act-6
-  type: order
-  title: One food day
-  instruction: Put the food day from morning to evening.
-  is_ukrainian: true
-  items:
-    - "Вранці я снідаю вдома."
-    - "Я їм кашу і яблуко."
-    - "Я п'ю каву з молоком."
-    - "Вдень я обідаю на роботі."
-    - "На обід я їм борщ зі сметаною."
-    - "Увечері я вечеряю вдома."
-    - "Я їм рибу з рисом."
-    - "Я п'ю чай без цукру."
-  correct_order: [0, 1, 2, 3, 4, 5, 6, 7]
-- id: act-7
-  type: unjumble
-  title: Build safe food lines
-  instruction: Put the words in a natural A1 order.
-  items:
-    - words:
-        - "Я"
-        - "снідаю"
-        - "вдома"
-      answer: "Я снідаю вдома"
-    - words:
-        - "Мені"
-        - "каву"
-        - "з"
-        - "молоком"
-        - "будь ласка"
-      answer: "Мені каву з молоком, будь ласка"
-    - words:
-        - "Борщ"
-        - "дуже"
-        - "смачний"
-      answer: "Борщ дуже смачний"
-    - words:
-        - "Я"
-        - "їм"
-        - "борщ"
-      answer: "Я їм борщ"
-    - words:
-        - "Чай"
-        - "без"
-        - "цукру"
-        - "будь ласка"
-      answer: "Чай без цукру, будь ласка"
-    - words:
-        - "Смачного"
-      answer: "Смачного"
-- id: act-8
-  type: error-correction
-  title: Repair food and drink interference
-  instruction: Choose the clean Ukrainian repair.
-  anchor_id: repair-food-and-drink-interference
-  items:
-    - sentence: "Я маю голод. / Я є голодний."
-      error: "Я маю голод. / Я є голодний."
-      answer: "Я хочу їсти. / Я голодний."
-      options:
-        - "Я хочу їсти. / Я голодний."
-        - "Я маю голод. / Я є голодний."
-        - "Я є хочу їсти. / Я маю голодний."
-      explanation: "Use Я хочу їсти or Я голодний; do not copy English have/be patterns."
-    - sentence: "Кіт п'є теплий молоко."
-      error: "теплий молоко"
-      answer: "Кіт п'є тепле молоко."
-      options:
-        - "Кіт п'є тепле молоко."
-        - "Кіт п'є теплий молоко."
-        - "Кіт п'є тепла молоко."
-      explanation: "Молоко is neuter, so use тепле молоко."
-    - sentence: "Вареники з творогом."
-      error: "творогом"
-      answer: "Вареники із сиром."
-      options:
-        - "Вареники із сиром."
-        - "Вареники з творогом."
-        - "Вареники із сир."
-      explanation: "Use сир for the course form."
-    - sentence: "Я люблю творог."
-      error: "творог"
-      answer: "Я люблю сир."
-      options:
-        - "Я люблю сир."
-        - "Я люблю творог."
-        - "Я люблю сиром."
-      explanation: "Use сир as the course form."
-    - sentence: "На столі жарена картопля."
-      error: "жарена"
-      answer: "На столі смажена картопля."
-      options:
-        - "На столі смажена картопля."
-        - "На столі жарена картопля."
-        - "На столі смажений картопля."
-      explanation: "Use смажена картопля."
-    - sentence: "Жарена картопля."
-      error: "Жарена"
-      answer: "Смажена картопля."
-      options:
-        - "Смажена картопля."
-        - "Жарена картопля."
-        - "Смажений картопля."
-      explanation: "The clean Ukrainian phrase is смажена картопля."
-    - sentence: "Дайте мені один воду."
-      error: "один воду"
-      answer: "Дайте мені одну воду. (або склянку води)"
-      options:
-        - "Дайте мені одну воду. (або склянку води)"
-        - "Дайте мені один воду."
-        - "Дайте мені одне воду."
-      explanation: "Use одну воду, or ask for a glass of water."
-    - sentence: "Суп з картофель."
-      error: "картофель"
-      answer: "Суп із картоплею. або Картопляний суп."
-      options:
-        - "Суп із картоплею. або Картопляний суп."
-        - "Суп з картофель."
-        - "Суп із картофель."
-      explanation: "Use картопля / картоплею or картопляний."
-    - sentence: "Я їм сніданок о сьомій."
-      error: "їм сніданок"
-      answer: "Я снідаю о сьомій."
-      options:
-        - "Я снідаю о сьомій."
-        - "Я їм сніданок о сьомій."
-        - "Я сніданок о сьомій."
-      explanation: "Use the meal verb снідати."
-    - sentence: "Я п'ю борщ."
-      error: "п'ю"
-      answer: "Я їм борщ."
-      options:
-        - "Я їм борщ."
-        - "Я п'ю борщ."
-        - "Я п'ю суп."
-      explanation: "Soup is eaten in Ukrainian."
-    - sentence: "Клубнічний джем."
-      error: "Клубнічний"
-      answer: "Полуничний джем."
-      options:
-        - "Полуничний джем."
-        - "Клубнічний джем."
-        - "Клубніка джем."
-      explanation: "Use полуниця / полуничний, not the Russian-root form."
-    - sentence: "Дайте чай без цукор."
-      error: "без цукор"
-      answer: "Дайте чай без цукру."
-      options:
-        - "Дайте чай без цукру."
-        - "Дайте чай без цукор."
-        - "Дайте чай з цукру."
-      explanation: "Без цукру is memorized as a whole chunk."
-    - sentence: "Борщ дуже смачно."
-      error: "дуже смачно"
-      answer: "Борщ дуже смачний."
-      options:
-        - "Борщ дуже смачний."
-        - "Борщ дуже смачно."
-        - "Борщ дуже смачна."
-      explanation: "With the noun борщ, use смачний."
+inline:
+  - id: act-1
+    type: group-sort
+    title: Food, drink, and meal words
+    instruction: Sort each word by the shelf it belongs on.
+    groups:
+      - name: 'Їжа'
+        items:
+          - 'хліб'
+          - 'риба'
+          - "м'ясо"
+          - 'каша'
+          - 'сир'
+      - name: 'Напої'
+        items:
+          - 'кава'
+          - 'чай'
+          - 'вода'
+          - 'сік'
+          - 'молоко'
+      - name: 'Прийоми їжі'
+        items:
+          - 'сніданок'
+          - 'обід'
+          - 'вечеря'
+      - name: 'Українські страви'
+        items:
+          - 'борщ'
+          - 'вареники'
+          - 'сало'
+  - id: act-2
+    type: match-up
+    title: Breakfast table pairs
+    instruction: Match each Ukrainian food or drink phrase with its meaning.
+    pairs:
+      - left: 'кава з молоком'
+        right: 'coffee with milk'
+      - left: 'чай без цукру'
+        right: 'tea without sugar'
+      - left: 'хліб з маслом'
+        right: 'bread with butter'
+      - left: 'каша'
+        right: 'porridge'
+      - left: 'яблуко'
+        right: 'apple'
+      - left: 'Смачного!'
+        right: 'Enjoy your meal!'
+      - left: 'я снідаю'
+        right: 'I have breakfast'
+      - left: 'вода з газом'
+        right: 'sparkling water'
+  - id: act-3
+    type: fill-in
+    title: Cafe chunks, not case tables
+    instruction: Choose the whole chunk that completes the service line.
+    items:
+      - sentence: 'Мені каву ___, будь ласка.'
+        answer: 'з молоком'
+        options:
+          - 'з молоком'
+          - 'з молоко'
+          - 'без молоко'
+        explanation: 'Learn каву з молоком as one service chunk.'
+      - sentence: 'Чай ___, будь ласка.'
+        answer: 'без цукру'
+        options:
+          - 'без цукру'
+          - 'без цукор'
+          - 'з цукор'
+        explanation: 'Без цукру is the ready chunk.'
+      - sentence: 'Я їм хліб ___.'
+        answer: 'з маслом'
+        options:
+          - 'з маслом'
+          - 'без масло'
+          - 'з масло'
+        explanation: 'Use хліб з маслом as a whole phrase.'
+      - sentence: 'Дайте, будь ласка, воду ___.'
+        answer: 'з газом'
+        options:
+          - 'з газом'
+          - 'з газ'
+          - 'без газ'
+        explanation: 'Вода з газом is the useful drink phrase.'
+      - sentence: 'Я люблю каву ___.'
+        answer: 'без молока'
+        options:
+          - 'без молока'
+          - 'без молоко'
+          - 'з молока'
+        explanation: 'Без молока is memorized here as a chunk.'
+      - sentence: "Вона п'є чай ___."
+        answer: 'з лимоном'
+        options:
+          - 'з лимоном'
+          - 'з лимон'
+          - 'без лимон'
+        explanation: 'Чай з лимоном is a ready phrase.'
+  - id: act-4
+    type: true-false
+    title: Food guardrails
+    instruction: Decide whether each statement fits this module.
+    items:
+      - statement: 'Борщ is taught here as a Ukrainian cultural dish.'
+        answer: true
+        explanation: 'Borscht is framed as Ukrainian, not as generic regional soup.'
+      - statement: 'At A1, без цукру is taught as a full chunk.'
+        answer: true
+        explanation: 'The module does not teach a formal genitive lesson.'
+      - statement: 'Творог is the standard course word for cheese.'
+        answer: false
+        explanation: 'Use сир, or кисломолочний сир when needed.'
+      - statement: 'Смажена картопля is the clean Ukrainian form.'
+        answer: true
+        explanation: 'Do not use жарена картопля as course language.'
+      - statement: "Я п'ю борщ is the natural line for soup."
+        answer: false
+        explanation: 'Ukrainian says я їм борщ.'
+      - statement: 'Смачного! is the natural meal formula.'
+        answer: true
+        explanation: 'Use Смачного! when people begin eating.'
+      - statement: 'Я снідаю means I have breakfast.'
+        answer: true
+        explanation: 'Use the compact meal verb.'
+      - statement: 'Борщ дуже смачно is the best sentence.'
+        answer: false
+        explanation: 'Say Борщ дуже смачний for the noun борщ.'
+workbook:
+  - type: quiz
+    title: Daily meal choices
+    instruction: Choose the line that answers the prompt naturally.
+    items:
+      - prompt: 'Що ти робиш вранці?'
+        options:
+          - text: 'Я снідаю.'
+            correct: true
+          - text: 'Я обідаю.'
+            correct: false
+          - text: 'Я вечеряю.'
+            correct: false
+        explanation: 'Breakfast uses снідати.'
+      - prompt: 'Що ти їси на обід?'
+        options:
+          - text: 'Я їм борщ і салат.'
+            correct: true
+          - text: "Я п'ю борщ і салат."
+            correct: false
+          - text: 'Я їм чай без цукру.'
+            correct: false
+        explanation: 'Soup is eaten; tea is drunk.'
+      - prompt: "Що ти п'єш?"
+        options:
+          - text: 'Воду або компот.'
+            correct: true
+          - text: 'Картоплю або рибу.'
+            correct: false
+          - text: 'Сало або сир.'
+            correct: false
+        explanation: 'Вода and компот are drinks.'
+      - prompt: 'Which line names a Ukrainian cultural food?'
+        options:
+          - text: 'Борщ зі сметаною.'
+            correct: true
+          - text: 'Лимонад з газом.'
+            correct: false
+          - text: 'Кава з молоком.'
+            correct: false
+        explanation: 'Borscht is a Ukrainian cultural dish.'
+      - prompt: 'How do you politely ask for tea without sugar?'
+        options:
+          - text: 'Чай без цукру, будь ласка.'
+            correct: true
+          - text: 'Чай без цукор, будь ласка.'
+            correct: false
+          - text: 'Чай з цукру, будь ласка.'
+            correct: false
+        explanation: 'Use the memorized chunk без цукру.'
+      - prompt: 'What do you say as people start eating?'
+        options:
+          - text: 'Смачного!'
+            correct: true
+          - text: 'Добрий вечір!'
+            correct: false
+          - text: 'До побачення!'
+            correct: false
+        explanation: 'Смачного! is the meal formula.'
+  - type: order
+    title: One food day
+    instruction: Put the food day from morning to evening.
+    is_ukrainian: true
+    items:
+      - 'Вранці я снідаю вдома.'
+      - 'Я їм кашу і яблуко.'
+      - "Я п'ю каву з молоком."
+      - 'Вдень я обідаю на роботі.'
+      - 'На обід я їм борщ зі сметаною.'
+      - 'Увечері я вечеряю вдома.'
+      - 'Я їм рибу з рисом.'
+      - "Я п'ю чай без цукру."
+    correct_order: [0, 1, 2, 3, 4, 5, 6, 7]
+  - type: unjumble
+    title: Build safe food lines
+    instruction: Put the words in a natural A1 order.
+    items:
+      - words:
+          - 'Я'
+          - 'снідаю'
+          - 'вдома'
+        answer: 'Я снідаю вдома'
+      - words:
+          - 'Мені'
+          - 'каву'
+          - 'з'
+          - 'молоком'
+          - 'будь ласка'
+        answer: 'Мені каву з молоком, будь ласка'
+      - words:
+          - 'Борщ'
+          - 'дуже'
+          - 'смачний'
+        answer: 'Борщ дуже смачний'
+      - words:
+          - 'Я'
+          - 'їм'
+          - 'борщ'
+        answer: 'Я їм борщ'
+      - words:
+          - 'Чай'
+          - 'без'
+          - 'цукру'
+          - 'будь ласка'
+        answer: 'Чай без цукру, будь ласка'
+      - words:
+          - 'Смачного'
+        answer: 'Смачного'
+  - type: error-correction
+    title: Repair food and drink interference
+    instruction: Choose the clean Ukrainian repair.
+    anchor_id: repair-food-and-drink-interference
+    items:
+      - sentence: 'Я маю голод. / Я є голодний.'
+        error: 'Я маю голод. / Я є голодний.'
+        answer: 'Я хочу їсти. / Я голодний.'
+        options:
+          - 'Я хочу їсти. / Я голодний.'
+          - 'Я маю голод. / Я є голодний.'
+          - 'Я є хочу їсти. / Я маю голодний.'
+        explanation: 'Use Я хочу їсти or Я голодний; do not copy English have/be patterns.'
+      - sentence: "Кіт п'є теплий молоко."
+        error: 'теплий молоко'
+        answer: "Кіт п'є тепле молоко."
+        options:
+          - "Кіт п'є тепле молоко."
+          - "Кіт п'є теплий молоко."
+          - "Кіт п'є тепла молоко."
+        explanation: 'Молоко is neuter, so use тепле молоко.'
+      - sentence: 'Вареники з творогом.'
+        error: 'творогом'
+        answer: 'Вареники із сиром.'
+        options:
+          - 'Вареники із сиром.'
+          - 'Вареники з творогом.'
+          - 'Вареники із сир.'
+        explanation: 'Use сир for the course form.'
+      - sentence: 'Я люблю творог.'
+        error: 'творог'
+        answer: 'Я люблю сир.'
+        options:
+          - 'Я люблю сир.'
+          - 'Я люблю творог.'
+          - 'Я люблю сиром.'
+        explanation: 'Use сир as the course form.'
+      - sentence: 'На столі жарена картопля.'
+        error: 'жарена'
+        answer: 'На столі смажена картопля.'
+        options:
+          - 'На столі смажена картопля.'
+          - 'На столі жарена картопля.'
+          - 'На столі смажений картопля.'
+        explanation: 'Use смажена картопля.'
+      - sentence: 'Жарена картопля.'
+        error: 'Жарена'
+        answer: 'Смажена картопля.'
+        options:
+          - 'Смажена картопля.'
+          - 'Жарена картопля.'
+          - 'Смажений картопля.'
+        explanation: 'The clean Ukrainian phrase is смажена картопля.'
+      - sentence: 'Дайте мені один воду.'
+        error: 'один воду'
+        answer: 'Дайте мені одну воду. (або склянку води)'
+        options:
+          - 'Дайте мені одну воду. (або склянку води)'
+          - 'Дайте мені один воду.'
+          - 'Дайте мені одне воду.'
+        explanation: 'Use одну воду, or ask for a glass of water.'
+      - sentence: 'Суп з картофель.'
+        error: 'картофель'
+        answer: 'Суп із картоплею. або Картопляний суп.'
+        options:
+          - 'Суп із картоплею. або Картопляний суп.'
+          - 'Суп з картофель.'
+          - 'Суп із картофель.'
+        explanation: 'Use картопля / картоплею or картопляний.'
+      - sentence: 'Я їм сніданок о сьомій.'
+        error: 'їм сніданок'
+        answer: 'Я снідаю о сьомій.'
+        options:
+          - 'Я снідаю о сьомій.'
+          - 'Я їм сніданок о сьомій.'
+          - 'Я сніданок о сьомій.'
+        explanation: 'Use the meal verb снідати.'
+      - sentence: "Я п'ю борщ."
+        error: "п'ю"
+        answer: 'Я їм борщ.'
+        options:
+          - 'Я їм борщ.'
+          - "Я п'ю борщ."
+          - "Я п'ю суп."
+        explanation: 'Soup is eaten in Ukrainian.'
+      - sentence: 'Клубнічний джем.'
+        error: 'Клубнічний'
+        answer: 'Полуничний джем.'
+        options:
+          - 'Полуничний джем.'
+          - 'Клубнічний джем.'
+          - 'Клубніка джем.'
+        explanation: 'Use полуниця / полуничний, not the Russian-root form.'
+      - sentence: 'Дайте чай без цукор.'
+        error: 'без цукор'
+        answer: 'Дайте чай без цукру.'
+        options:
+          - 'Дайте чай без цукру.'
+          - 'Дайте чай без цукор.'
+          - 'Дайте чай з цукру.'
+        explanation: 'Без цукру is memorized as a whole chunk.'
+      - sentence: 'Борщ дуже смачно.'
+        error: 'дуже смачно'
+        answer: 'Борщ дуже смачний.'
+        options:
+          - 'Борщ дуже смачний.'
+          - 'Борщ дуже смачно.'
+          - 'Борщ дуже смачна.'
+        explanation: 'With the noun борщ, use смачний.'

--- a/curriculum/l2-uk-en/a1/food-and-drink/module.md
+++ b/curriculum/l2-uk-en/a1/food-and-drink/module.md
@@ -206,7 +206,6 @@ You may also recognize simple buying measures: **літр**, **грам**, and
 **сто грамів сиру**, **кілограм картоплі**. The detailed number patterns belong
 to later shopping practice.
 
-<!-- INJECT_ACTIVITY: act-5 -->
 
 ## Щоденний раціон
 
@@ -242,7 +241,6 @@ as **мені подобається борщ** are enough.
 Again, keep the chunks whole. **Без цукру** and **без молока** are service
 phrases, not a case chart. You will meet the grammar later with more room.
 
-<!-- INJECT_ACTIVITY: act-6 -->
 
 <span id="repair-food-and-drink-interference"></span>
 
@@ -264,7 +262,6 @@ The goal is not to shame a learner who has heard mixed forms. The goal is to
 give the learner clean, memorable Ukrainian forms early. Food vocabulary is
 high-frequency, so early repairs matter.
 
-<!-- INJECT_ACTIVITY: act-7 -->
 
 ## Підсумок
 
@@ -291,5 +288,3 @@ Final self-check:
 Now write your own six-line food day. Include one breakfast line, one lunch
 line, one dinner line, one drink with **з**, one drink with **без**, and one
 Ukrainian cultural dish.
-
-<!-- INJECT_ACTIVITY: act-8 -->

--- a/curriculum/l2-uk-en/a1/i-eat-i-drink/activities.yaml
+++ b/curriculum/l2-uk-en/a1/i-eat-i-drink/activities.yaml
@@ -1,318 +1,316 @@
-- id: act-1
-  type: fill-in
-  title: Direct object endings
-  instruction: Choose the correct direct-object form after їсти or пити.
-  items:
-    - sentence: "Я їм ___."
-      answer: "рибу"
-      options:
-        - "рибу"
-        - "риба"
-        - "рибі"
-      explanation: "Риба is feminine, so direct object is рибу."
-    - sentence: "Вона п'є ___."
-      answer: "воду"
-      options:
-        - "воду"
-        - "вода"
-        - "воді"
-      explanation: "Вода becomes воду after п'є."
-    - sentence: "Він їсть ___."
-      answer: "хліб"
-      options:
-        - "хліб"
-        - "хлібу"
-        - "хлібом"
-      explanation: "Хліб is masculine inanimate and stays хліб."
-    - sentence: "Ми п'ємо ___."
-      answer: "молоко"
-      options:
-        - "молоко"
-        - "молоку"
-        - "молоком"
-      explanation: "Молоко is neuter and stays молоко."
-    - sentence: "Вони їдять ___."
-      answer: "кашу"
-      options:
-        - "кашу"
-        - "каша"
-        - "каші"
-      explanation: "Каша becomes кашу."
-    - sentence: "Ти п'єш ___."
-      answer: "каву"
-      options:
-        - "каву"
-        - "кава"
-        - "каві"
-      explanation: "Кава becomes каву."
-    - sentence: "Я їм ___."
-      answer: "суп"
-      options:
-        - "суп"
-        - "супу"
-        - "супом"
-      explanation: "Суп is masculine inanimate and stays суп."
-    - sentence: "Вона їсть ___."
-      answer: "картоплю"
-      options:
-        - "картоплю"
-        - "картопля"
-        - "картоплі"
-      explanation: "Картопля ends in -я, so direct object is картоплю."
-- id: act-2
-  type: quiz
-  title: Choose the food line
-  instruction: Pick the natural A1 line.
-  items:
-    - prompt: "Я п'ю..."
-      options:
-        - text: "каву"
-          correct: true
-        - text: "кава"
-          correct: false
-        - text: "кави"
-          correct: false
-      explanation: "After п'ю, feminine кава becomes каву."
-    - prompt: "Він їсть..."
-      options:
-        - text: "рибу"
-          correct: true
-        - text: "риба"
-          correct: false
-        - text: "рибі"
-          correct: false
-      explanation: "Риба becomes рибу as a direct object."
-    - prompt: "Ми п'ємо..."
-      options:
-        - text: "сік"
-          correct: true
-        - text: "соку"
-          correct: false
-        - text: "соком"
-          correct: false
-      explanation: "Сік is masculine inanimate and stays сік."
-    - prompt: "Вона їсть..."
-      options:
-        - text: "м'ясо"
-          correct: true
-        - text: "м'ясу"
-          correct: false
-        - text: "м'яса"
-          correct: false
-      explanation: "М'ясо is neuter and stays м'ясо."
-    - prompt: "Вони п'ють..."
-      options:
-        - text: "воду"
-          correct: true
-        - text: "вода"
-          correct: false
-        - text: "воді"
-          correct: false
-      explanation: "Вода becomes воду."
-    - prompt: "Ти їси..."
-      options:
-        - text: "кашу"
-          correct: true
-        - text: "каша"
-          correct: false
-        - text: "каші"
-          correct: false
-      explanation: "Каша becomes кашу."
-- id: act-3
-  type: match-up
-  title: Verb person pairs
-  instruction: Match each subject with the correct form.
-  pairs:
-    - left: "я + їсти"
-      right: "я їм"
-    - left: "ти + їсти"
-      right: "ти їси"
-    - left: "він + їсти"
-      right: "він їсть"
-    - left: "ми + їсти"
-      right: "ми їмо"
-    - left: "вони + їсти"
-      right: "вони їдять"
-    - left: "я + пити"
-      right: "я п'ю"
-    - left: "ми + пити"
-      right: "ми п'ємо"
-    - left: "вони + пити"
-      right: "вони п'ють"
-- id: act-4
-  type: fill-in
-  title: Eat and drink forms
-  instruction: Choose the correct form of їсти or пити.
-  items:
-    - sentence: "Я ___ суп."
-      answer: "їм"
-      options:
-        - "їм"
-        - "їси"
-        - "їсть"
-      explanation: "Я uses їм."
-    - sentence: "Ми ___ чай."
-      answer: "п'ємо"
-      options:
-        - "п'ємо"
-        - "п'єте"
-        - "п'ють"
-      explanation: "Ми uses п'ємо."
-    - sentence: "Вона ___ хліб."
-      answer: "їсть"
-      options:
-        - "їсть"
-        - "їст"
-        - "їси"
-      explanation: "Вона uses їсть with the soft sign."
-    - sentence: "Вони ___ воду."
-      answer: "п'ють"
-      options:
-        - "п'ють"
-        - "п'єте"
-        - "п'ю"
-      explanation: "Вони uses п'ють."
-    - sentence: "Ти ___ рибу?"
-      answer: "їси"
-      options:
-        - "їси"
-        - "їсиш"
-        - "їсть"
-      explanation: "Ти uses the short form їси."
-    - sentence: "Ви ___ каву?"
-      answer: "п'єте"
-      options:
-        - "п'єте"
-        - "п'ємо"
-        - "п'єш"
-      explanation: "Ви uses п'єте."
-    - sentence: "Він ___ сік."
-      answer: "п'є"
-      options:
-        - "п'є"
-        - "п'ю"
-        - "п'єш"
-      explanation: "Він uses п'є."
-    - sentence: "Вони ___ кашу."
-      answer: "їдять"
-      options:
-        - "їдять"
-        - "їдете"
-        - "їсте"
-      explanation: "Вони uses їдять."
-- id: act-5
-  type: group-sort
-  title: What changes in the direct object?
-  instruction: Sort each noun by what happens after їм or п'ю.
-  groups:
-    - name: "Changes to -у/-ю"
-      items:
-        - "кава -> каву"
-        - "вода -> воду"
-        - "риба -> рибу"
-        - "каша -> кашу"
-        - "картопля -> картоплю"
-    - name: "No change"
-      items:
-        - "хліб -> хліб"
-        - "сік -> сік"
-        - "молоко -> молоко"
-        - "м'ясо -> м'ясо"
-        - "яблуко -> яблуко"
-- id: act-6
-  type: true-false
-  title: Direct object checks
-  instruction: Decide whether each statement fits the A1 rule.
-  items:
-    - statement: "Я п'ю каву is correct."
-      answer: true
-      explanation: "Кава becomes каву."
-    - statement: "Я п'ю кава is correct."
-      answer: false
-      explanation: "Use каву after п'ю."
-    - statement: "Я їм хліб is correct."
-      answer: true
-      explanation: "Хліб stays хліб."
-    - statement: "Ми п'ємо молоко is correct."
-      answer: true
-      explanation: "Молоко stays молоко."
-    - statement: "Ти їсиш яблуко is correct."
-      answer: false
-      explanation: "The correct verb form is ти їси."
-    - statement: "Він їст суп is correct."
-      answer: false
-      explanation: "Use він їсть with the soft sign."
-    - statement: "Я хочу пити is a safe A1 line."
-      answer: true
-      explanation: "Хотіти can take an infinitive."
-    - statement: "Я хочу воду is also possible."
-      answer: true
-      explanation: "Вода becomes воду as the object of хочу."
-- id: act-7
-  type: order
-  title: Lunch-box conversation
-  instruction: Put the conversation in a natural order.
-  is_ukrainian: true
-  items:
-    - "Що ти їси на обід?"
-    - "Я їм суп і салат."
-    - "А що ти п'єш?"
-    - "Я п'ю воду або сік."
-    - "Олена їсть хліб з маслом."
-    - "Діти п'ють молоко."
-    - "Смачного!"
-  correct_order: [0, 1, 2, 3, 4, 5, 6]
-- id: act-8
-  type: error-correction
-  title: Repair eat and drink interference
-  instruction: Choose the clean Ukrainian repair.
-  anchor_id: repair-i-eat-i-drink-interference
-  items:
-    - sentence: "Я є їм хліб."
-      error: "Я є їм хліб."
-      answer: "Я їм хліб."
-      options:
-        - "Я їм хліб."
-        - "Я є їм хліб."
-        - "Я є їсти хліб."
-      explanation: "Do not use є as an English-style helper."
-    - sentence: "Я хочу вода."
-      error: "Я хочу вода."
-      answer: "Я хочу пити. або Я хочу воду."
-      options:
-        - "Я хочу пити. або Я хочу воду."
-        - "Я хочу вода."
-        - "Я хочу воді."
-      explanation: "Use an infinitive or the direct object воду."
-    - sentence: "Він їст суп."
-      error: "Він їст суп."
-      answer: "Він їсть суп."
-      options:
-        - "Він їсть суп."
-        - "Він їст суп."
-        - "Він їси суп."
-      explanation: "Write їсть with the soft sign."
-    - sentence: "Ти їсиш яблуко."
-      error: "Ти їсиш яблуко."
-      answer: "Ти їси яблуко."
-      options:
-        - "Ти їси яблуко."
-        - "Ти їсиш яблуко."
-        - "Ти їсть яблуко."
-      explanation: "The form is ти їси."
-    - sentence: "Я мию мене."
-      error: "Я мию мене."
-      answer: "Я вмиваюся."
-      options:
-        - "Я вмиваюся."
-        - "Я мию мене."
-        - "Я мию я."
-      explanation: "Use the Ukrainian reflexive verb вмиватися."
-    - sentence: "На перерві: Я п'ю кава."
-      error: "Я п'ю кава."
-      answer: "Я п'ю каву."
-      options:
-        - "Я п'ю кава."
-        - "Я п'ю каві."
-        - "Я п'ю каву."
-      explanation: "Кава becomes каву after п'ю."
+inline:
+  - id: act-1
+    type: fill-in
+    title: Direct object endings
+    instruction: Choose the correct direct-object form after їсти or пити.
+    items:
+      - sentence: 'Я їм ___.'
+        answer: 'рибу'
+        options:
+          - 'рибу'
+          - 'риба'
+          - 'рибі'
+        explanation: 'Риба is feminine, so direct object is рибу.'
+      - sentence: "Вона п'є ___."
+        answer: 'воду'
+        options:
+          - 'воду'
+          - 'вода'
+          - 'воді'
+        explanation: "Вода becomes воду after п'є."
+      - sentence: 'Він їсть ___.'
+        answer: 'хліб'
+        options:
+          - 'хліб'
+          - 'хлібу'
+          - 'хлібом'
+        explanation: 'Хліб is masculine inanimate and stays хліб.'
+      - sentence: "Ми п'ємо ___."
+        answer: 'молоко'
+        options:
+          - 'молоко'
+          - 'молоку'
+          - 'молоком'
+        explanation: 'Молоко is neuter and stays молоко.'
+      - sentence: 'Вони їдять ___.'
+        answer: 'кашу'
+        options:
+          - 'кашу'
+          - 'каша'
+          - 'каші'
+        explanation: 'Каша becomes кашу.'
+      - sentence: "Ти п'єш ___."
+        answer: 'каву'
+        options:
+          - 'каву'
+          - 'кава'
+          - 'каві'
+        explanation: 'Кава becomes каву.'
+      - sentence: 'Я їм ___.'
+        answer: 'суп'
+        options:
+          - 'суп'
+          - 'супу'
+          - 'супом'
+        explanation: 'Суп is masculine inanimate and stays суп.'
+      - sentence: 'Вона їсть ___.'
+        answer: 'картоплю'
+        options:
+          - 'картоплю'
+          - 'картопля'
+          - 'картоплі'
+        explanation: 'Картопля ends in -я, so direct object is картоплю.'
+  - id: act-2
+    type: quiz
+    title: Choose the food line
+    instruction: Pick the natural A1 line.
+    items:
+      - prompt: "Я п'ю..."
+        options:
+          - text: 'каву'
+            correct: true
+          - text: 'кава'
+            correct: false
+          - text: 'кави'
+            correct: false
+        explanation: "After п'ю, feminine кава becomes каву."
+      - prompt: 'Він їсть...'
+        options:
+          - text: 'рибу'
+            correct: true
+          - text: 'риба'
+            correct: false
+          - text: 'рибі'
+            correct: false
+        explanation: 'Риба becomes рибу as a direct object.'
+      - prompt: "Ми п'ємо..."
+        options:
+          - text: 'сік'
+            correct: true
+          - text: 'соку'
+            correct: false
+          - text: 'соком'
+            correct: false
+        explanation: 'Сік is masculine inanimate and stays сік.'
+      - prompt: 'Вона їсть...'
+        options:
+          - text: "м'ясо"
+            correct: true
+          - text: "м'ясу"
+            correct: false
+          - text: "м'яса"
+            correct: false
+        explanation: "М'ясо is neuter and stays м'ясо."
+      - prompt: "Вони п'ють..."
+        options:
+          - text: 'воду'
+            correct: true
+          - text: 'вода'
+            correct: false
+          - text: 'воді'
+            correct: false
+        explanation: 'Вода becomes воду.'
+      - prompt: 'Ти їси...'
+        options:
+          - text: 'кашу'
+            correct: true
+          - text: 'каша'
+            correct: false
+          - text: 'каші'
+            correct: false
+        explanation: 'Каша becomes кашу.'
+  - id: act-3
+    type: match-up
+    title: Verb person pairs
+    instruction: Match each subject with the correct form.
+    pairs:
+      - left: 'я + їсти'
+        right: 'я їм'
+      - left: 'ти + їсти'
+        right: 'ти їси'
+      - left: 'він + їсти'
+        right: 'він їсть'
+      - left: 'ми + їсти'
+        right: 'ми їмо'
+      - left: 'вони + їсти'
+        right: 'вони їдять'
+      - left: 'я + пити'
+        right: "я п'ю"
+      - left: 'ми + пити'
+        right: "ми п'ємо"
+      - left: 'вони + пити'
+        right: "вони п'ють"
+  - id: act-4
+    type: fill-in
+    title: Eat and drink forms
+    instruction: Choose the correct form of їсти or пити.
+    items:
+      - sentence: 'Я ___ суп.'
+        answer: 'їм'
+        options:
+          - 'їм'
+          - 'їси'
+          - 'їсть'
+        explanation: 'Я uses їм.'
+      - sentence: 'Ми ___ чай.'
+        answer: "п'ємо"
+        options:
+          - "п'ємо"
+          - "п'єте"
+          - "п'ють"
+        explanation: "Ми uses п'ємо."
+      - sentence: 'Вона ___ хліб.'
+        answer: 'їсть'
+        options:
+          - 'їсть'
+          - 'їст'
+          - 'їси'
+        explanation: 'Вона uses їсть with the soft sign.'
+      - sentence: 'Вони ___ воду.'
+        answer: "п'ють"
+        options:
+          - "п'ють"
+          - "п'єте"
+          - "п'ю"
+        explanation: "Вони uses п'ють."
+      - sentence: 'Ти ___ рибу?'
+        answer: 'їси'
+        options:
+          - 'їси'
+          - 'їсиш'
+          - 'їсть'
+        explanation: 'Ти uses the short form їси.'
+      - sentence: 'Ви ___ каву?'
+        answer: "п'єте"
+        options:
+          - "п'єте"
+          - "п'ємо"
+          - "п'єш"
+        explanation: "Ви uses п'єте."
+      - sentence: 'Він ___ сік.'
+        answer: "п'є"
+        options:
+          - "п'є"
+          - "п'ю"
+          - "п'єш"
+        explanation: "Він uses п'є."
+      - sentence: 'Вони ___ кашу.'
+        answer: 'їдять'
+        options:
+          - 'їдять'
+          - 'їдете'
+          - 'їсте'
+        explanation: 'Вони uses їдять.'
+workbook:
+  - type: group-sort
+    title: What changes in the direct object?
+    instruction: Sort each noun by what happens after їм or п'ю.
+    groups:
+      - name: 'Changes to -у/-ю'
+        items:
+          - 'кава -> каву'
+          - 'вода -> воду'
+          - 'риба -> рибу'
+          - 'каша -> кашу'
+          - 'картопля -> картоплю'
+      - name: 'No change'
+        items:
+          - 'хліб -> хліб'
+          - 'сік -> сік'
+          - 'молоко -> молоко'
+          - "м'ясо -> м'ясо"
+          - 'яблуко -> яблуко'
+  - type: true-false
+    title: Direct object checks
+    instruction: Decide whether each statement fits the A1 rule.
+    items:
+      - statement: "Я п'ю каву is correct."
+        answer: true
+        explanation: 'Кава becomes каву.'
+      - statement: "Я п'ю кава is correct."
+        answer: false
+        explanation: "Use каву after п'ю."
+      - statement: 'Я їм хліб is correct.'
+        answer: true
+        explanation: 'Хліб stays хліб.'
+      - statement: "Ми п'ємо молоко is correct."
+        answer: true
+        explanation: 'Молоко stays молоко.'
+      - statement: 'Ти їсиш яблуко is correct.'
+        answer: false
+        explanation: 'The correct verb form is ти їси.'
+      - statement: 'Він їст суп is correct.'
+        answer: false
+        explanation: 'Use він їсть with the soft sign.'
+      - statement: 'Я хочу пити is a safe A1 line.'
+        answer: true
+        explanation: 'Хотіти can take an infinitive.'
+      - statement: 'Я хочу воду is also possible.'
+        answer: true
+        explanation: 'Вода becomes воду as the object of хочу.'
+  - type: order
+    title: Lunch-box conversation
+    instruction: Put the conversation in a natural order.
+    is_ukrainian: true
+    items:
+      - 'Що ти їси на обід?'
+      - 'Я їм суп і салат.'
+      - "А що ти п'єш?"
+      - "Я п'ю воду або сік."
+      - 'Олена їсть хліб з маслом.'
+      - "Діти п'ють молоко."
+      - 'Смачного!'
+    correct_order: [0, 1, 2, 3, 4, 5, 6]
+  - type: error-correction
+    title: Repair eat and drink interference
+    instruction: Choose the clean Ukrainian repair.
+    anchor_id: repair-i-eat-i-drink-interference
+    items:
+      - sentence: 'Я є їм хліб.'
+        error: 'Я є їм хліб.'
+        answer: 'Я їм хліб.'
+        options:
+          - 'Я їм хліб.'
+          - 'Я є їм хліб.'
+          - 'Я є їсти хліб.'
+        explanation: 'Do not use є as an English-style helper.'
+      - sentence: 'Я хочу вода.'
+        error: 'Я хочу вода.'
+        answer: 'Я хочу пити. або Я хочу воду.'
+        options:
+          - 'Я хочу пити. або Я хочу воду.'
+          - 'Я хочу вода.'
+          - 'Я хочу воді.'
+        explanation: 'Use an infinitive or the direct object воду.'
+      - sentence: 'Він їст суп.'
+        error: 'Він їст суп.'
+        answer: 'Він їсть суп.'
+        options:
+          - 'Він їсть суп.'
+          - 'Він їст суп.'
+          - 'Він їси суп.'
+        explanation: 'Write їсть with the soft sign.'
+      - sentence: 'Ти їсиш яблуко.'
+        error: 'Ти їсиш яблуко.'
+        answer: 'Ти їси яблуко.'
+        options:
+          - 'Ти їси яблуко.'
+          - 'Ти їсиш яблуко.'
+          - 'Ти їсть яблуко.'
+        explanation: 'The form is ти їси.'
+      - sentence: 'Я мию мене.'
+        error: 'Я мию мене.'
+        answer: 'Я вмиваюся.'
+        options:
+          - 'Я вмиваюся.'
+          - 'Я мию мене.'
+          - 'Я мию я.'
+        explanation: 'Use the Ukrainian reflexive verb вмиватися.'
+      - sentence: "На перерві: Я п'ю кава."
+        error: "Я п'ю кава."
+        answer: "Я п'ю каву."
+        options:
+          - "Я п'ю кава."
+          - "Я п'ю каві."
+          - "Я п'ю каву."
+        explanation: "Кава becomes каву after п'ю."

--- a/curriculum/l2-uk-en/a1/i-eat-i-drink/module.md
+++ b/curriculum/l2-uk-en/a1/i-eat-i-drink/module.md
@@ -185,7 +185,6 @@ The contrast also repairs a common learner line:
 **Я хочу воду**. Both are useful. The first uses an infinitive. The second uses
 the direct object **воду**.
 
-<!-- INJECT_ACTIVITY: act-5 -->
 
 ## Підсумок
 
@@ -226,9 +225,3 @@ being squeezed into English or Russian frames.
 
 For self-check, name three things you eat today and three things you drink.
 Say them aloud with **я їм** and **я п'ю**.
-
-<!-- INJECT_ACTIVITY: act-6 -->
-
-<!-- INJECT_ACTIVITY: act-7 -->
-
-<!-- INJECT_ACTIVITY: act-8 -->

--- a/curriculum/l2-uk-en/a1/people-around-me/activities.yaml
+++ b/curriculum/l2-uk-en/a1/people-around-me/activities.yaml
@@ -1,338 +1,336 @@
-- id: act-1
-  type: quiz
-  title: Хто чи що?
-  instruction: Choose whether the word answers хто? or що?
-  items:
-    - prompt: "учитель"
-      options:
-        - text: "хто?"
-          correct: true
-        - text: "що?"
-          correct: false
-      explanation: "A teacher is a person."
-    - prompt: "директор"
-      options:
-        - text: "хто?"
-          correct: true
-        - text: "що?"
-          correct: false
-      explanation: "A director is a person."
-    - prompt: "тато"
-      options:
-        - text: "хто?"
-          correct: true
-        - text: "що?"
-          correct: false
-      explanation: "Тато is a person."
-    - prompt: "кіт"
-      options:
-        - text: "хто?"
-          correct: true
-        - text: "що?"
-          correct: false
-      explanation: "Animals answer хто? in this grammar contrast."
-    - prompt: "дерево"
-      options:
-        - text: "що?"
-          correct: true
-        - text: "хто?"
-          correct: false
-      explanation: "Plants are граматичні неістоти in Ukrainian."
-    - prompt: "хліб"
-      options:
-        - text: "що?"
-          correct: true
-        - text: "хто?"
-          correct: false
-      explanation: "Хліб is a thing."
-    - prompt: "книга"
-      options:
-        - text: "що?"
-          correct: true
-        - text: "хто?"
-          correct: false
-      explanation: "Книга is a thing."
-    - prompt: "подруга"
-      options:
-        - text: "хто?"
-          correct: true
-        - text: "що?"
-          correct: false
-      explanation: "Подруга is a person."
-- id: act-2
-  type: fill-in
-  title: Я бачу...
-  instruction: Choose the object form that completes the sentence.
-  items:
-    - sentence: "Я бачу ___."
-      answer: "маму"
-      options:
-        - "маму"
-        - "мама"
-        - "мами"
-      explanation: "Мама becomes маму."
-    - sentence: "Я бачу ___."
-      answer: "брата"
-      options:
-        - "брата"
-        - "брат"
-        - "брату"
-      explanation: "A male person changes: брат -> брата."
-    - sentence: "Я знаю ___."
-      answer: "Олену"
-      options:
-        - "Олену"
-        - "Олена"
-        - "Олени"
-      explanation: "Олена becomes Олену."
-    - sentence: "Я знаю ___."
-      answer: "друга"
-      options:
-        - "друга"
-        - "друг"
-        - "другу"
-      explanation: "Друг becomes друга."
-    - sentence: "Я люблю ___."
-      answer: "тата"
-      options:
-        - "тата"
-        - "тато"
-        - "таті"
-      explanation: "Тато becomes тата."
-    - sentence: "Я чекаю ___."
-      answer: "вчителя"
-      options:
-        - "вчителя"
-        - "вчитель"
-        - "вчителю"
-      explanation: "Вчитель becomes вчителя."
-    - sentence: "Я шукаю ___."
-      answer: "подругу"
-      options:
-        - "подругу"
-        - "подруга"
-        - "подруги"
-      explanation: "Подруга becomes подругу."
-    - sentence: "Я бачу ___."
-      answer: "сусіда"
-      options:
-        - "сусіда"
-        - "сусід"
-        - "сусіду"
-      explanation: "Сусід becomes сусіда."
-    - sentence: "Я чекаю ___."
-      answer: "лікаря"
-      options:
-        - "лікаря"
-        - "лікар"
-        - "лікарю"
-      explanation: "Лікар becomes лікаря."
-    - sentence: "Я знаю ___."
-      answer: "сестру"
-      options:
-        - "сестру"
-        - "сестра"
-        - "сестри"
-      explanation: "Сестра becomes сестру."
-- id: act-3
-  type: group-sort
-  title: Кого or що shelves
-  instruction: Sort the object forms by the question they answer.
-  groups:
-    - name: "Істоти: кого?"
-      items:
-        - "брата"
-        - "маму"
-        - "друга"
-        - "лікаря"
-        - "Олену"
-        - "сусіда"
-    - name: "Неістоти: що?"
-      items:
-        - "хліб"
-        - "каву"
-        - "воду"
-        - "чай"
-        - "борщ"
-        - "дерево"
-- id: act-4
-  type: match-up
-  title: Dictionary form to object form
-  instruction: Match the dictionary form with the direct-object form.
-  pairs:
-    - left: "мама"
-      right: "маму"
-    - left: "Олена"
-      right: "Олену"
-    - left: "сестра"
-      right: "сестру"
-    - left: "подруга"
-      right: "подругу"
-    - left: "брат"
-      right: "брата"
-    - left: "друг"
-      right: "друга"
-    - left: "лікар"
-      right: "лікаря"
-    - left: "сусід"
-      right: "сусіда"
-- id: act-5
-  type: fill-in
-  title: People dialogue
-  instruction: Complete the short dialogue about people around you.
-  items:
-    - sentence: "— Кого ти ___?"
-      answer: "бачиш"
-      options:
-        - "бачиш"
-        - "бачити"
-        - "бачить"
-      explanation: "Кого ти бачиш? asks whom you see."
-    - sentence: "— Я бачу ___ і маму."
-      answer: "брата"
-      options:
-        - "брата"
-        - "брат"
-        - "братом"
-      explanation: "Брат becomes брата."
-    - sentence: "— Ти знаєш мого ___ Тараса?"
-      answer: "друга"
-      options:
-        - "друга"
-        - "друг"
-        - "другу"
-      explanation: "Мого друга is the object phrase."
-    - sentence: "— Ні, я не ___ твого друга."
-      answer: "знаю"
-      options:
-        - "знаю"
-        - "знає"
-        - "знати"
-      explanation: "Я знаю / не знаю."
-    - sentence: "— А кого ти ___?"
-      answer: "чекаєш"
-      options:
-        - "чекаєш"
-        - "чекати"
-        - "чекає"
-      explanation: "Кого ти чекаєш? asks whom you are waiting for."
-    - sentence: "— Я чекаю ___."
-      answer: "лікаря"
-      options:
-        - "лікаря"
-        - "лікар"
-        - "лікарем"
-      explanation: "Лікар becomes лікаря."
-- id: act-6
-  type: true-false
-  title: Animate accusative checks
-  instruction: Decide whether each statement fits the lesson.
-  items:
-    - statement: "Кого? is the question for people and animals as direct objects."
-      answer: true
-      explanation: "Use кого? for animate direct objects."
-    - statement: "Я бачу хліб keeps хліб unchanged."
-      answer: true
-      explanation: "Хліб is an inanimate masculine noun in this A1 pattern."
-    - statement: "Я бачу брата changes брат because брат is a male person."
-      answer: true
-      explanation: "Male animate nouns change in this object position."
-    - statement: "Мама becomes маму, like кава becomes каву."
-      answer: true
-      explanation: "The feminine object ending is familiar from M37."
-    - statement: "Дерево answers хто? in Ukrainian grammar."
-      answer: false
-      explanation: "Дерево answers що?"
-    - statement: "Я бачу його is a useful pronoun chunk."
-      answer: true
-      explanation: "Його is an object pronoun chunk."
-    - statement: "Натовп is treated as a person for this contrast."
-      answer: false
-      explanation: "Натовп is a collective noun treated as inanimate."
-    - statement: "Plural instrumental endings are the main A1 goal here."
-      answer: false
-      explanation: "They are only a later bridge note."
-- id: act-7
-  type: order
-  title: Introduce a brother
-  instruction: Put the dialogue in order.
-  is_ukrainian: true
-  items:
-    - "Кого ти бачиш на фото?"
-    - "Я бачу маму і тата."
-    - "А хто це?"
-    - "Це мій брат."
-    - "Ти знаєш мого брата?"
-    - "Ні, я не знаю твого брата."
-    - "Ходімо, я тебе познайомлю!"
-  correct_order: [0, 1, 2, 3, 4, 5, 6]
-- id: act-8
-  type: error-correction
-  title: Repair people-around-me interference
-  instruction: Choose the clean Ukrainian repair.
-  anchor_id: repair-people-around-me-interference
-  items:
-    - sentence: "Я бачу мій брат."
-      error: "Я бачу мій брат."
-      answer: "Я бачу мого брата."
-      options:
-        - "Я бачу мого брата."
-        - "Я бачу мій брат."
-        - "Я бачу моїм братом."
-      explanation: "Use the object phrase мого брата."
-    - sentence: "Дерево — це хто?"
-      error: "Дерево — це хто?"
-      answer: "Дерево — це що?"
-      options:
-        - "Дерево — це що?"
-        - "Дерево — це хто?"
-        - "Дерево — це кого?"
-      explanation: "Plants answer що? in Ukrainian grammar."
-    - sentence: "Я люблю він."
-      error: "Я люблю він."
-      answer: "Я люблю його."
-      options:
-        - "Я люблю його."
-        - "Я люблю він."
-        - "Я люблю йому."
-      explanation: "Use the object pronoun його."
-    - sentence: "Ми бачимо велику натовп."
-      error: "Ми бачимо велику натовп."
-      answer: "Ми бачимо великий натовп."
-      options:
-        - "Ми бачимо великий натовп."
-        - "Ми бачимо велику натовп."
-        - "Ми бачимо великого натовпа."
-      explanation: "Натовп is treated as inanimate here."
-    - sentence: "Я зустрів сусіду."
-      error: "Я зустрів сусіду."
-      answer: "Я зустрів сусіда."
-      options:
-        - "Я зустрів сусіда."
-        - "Я зустрів сусіду."
-        - "Я зустрів сусідом."
-      explanation: "Сусід becomes сусіда."
-    - sentence: "Він має 20 років."
-      error: "Він має 20 років."
-      answer: "Йому 20 років."
-      options:
-        - "Йому 20 років."
-        - "Він має 20 років."
-        - "Його 20 років."
-      explanation: "Age uses йому in this chunk."
-    - sentence: "Я є студент."
-      error: "Я є студент."
-      answer: "Я студент."
-      options:
-        - "Я студент."
-        - "Я є студент."
-        - "Я маю студент."
-      explanation: "In this basic identity line, omit є."
-    - sentence: "Яка твоя фамілія?"
-      error: "Яка твоя фамілія?"
-      answer: "Яке твоє прізвище?"
-      options:
-        - "Яке твоє прізвище?"
-        - "Яка твоя фамілія?"
-        - "Який твій фамілія?"
-      explanation: "Use прізвище for surname."
+inline:
+  - id: act-1
+    type: quiz
+    title: Хто чи що?
+    instruction: Choose whether the word answers хто? or що?
+    items:
+      - prompt: 'учитель'
+        options:
+          - text: 'хто?'
+            correct: true
+          - text: 'що?'
+            correct: false
+        explanation: 'A teacher is a person.'
+      - prompt: 'директор'
+        options:
+          - text: 'хто?'
+            correct: true
+          - text: 'що?'
+            correct: false
+        explanation: 'A director is a person.'
+      - prompt: 'тато'
+        options:
+          - text: 'хто?'
+            correct: true
+          - text: 'що?'
+            correct: false
+        explanation: 'Тато is a person.'
+      - prompt: 'кіт'
+        options:
+          - text: 'хто?'
+            correct: true
+          - text: 'що?'
+            correct: false
+        explanation: 'Animals answer хто? in this grammar contrast.'
+      - prompt: 'дерево'
+        options:
+          - text: 'що?'
+            correct: true
+          - text: 'хто?'
+            correct: false
+        explanation: 'Plants are граматичні неістоти in Ukrainian.'
+      - prompt: 'хліб'
+        options:
+          - text: 'що?'
+            correct: true
+          - text: 'хто?'
+            correct: false
+        explanation: 'Хліб is a thing.'
+      - prompt: 'книга'
+        options:
+          - text: 'що?'
+            correct: true
+          - text: 'хто?'
+            correct: false
+        explanation: 'Книга is a thing.'
+      - prompt: 'подруга'
+        options:
+          - text: 'хто?'
+            correct: true
+          - text: 'що?'
+            correct: false
+        explanation: 'Подруга is a person.'
+  - id: act-2
+    type: fill-in
+    title: Я бачу...
+    instruction: Choose the object form that completes the sentence.
+    items:
+      - sentence: 'Я бачу ___.'
+        answer: 'маму'
+        options:
+          - 'маму'
+          - 'мама'
+          - 'мами'
+        explanation: 'Мама becomes маму.'
+      - sentence: 'Я бачу ___.'
+        answer: 'брата'
+        options:
+          - 'брата'
+          - 'брат'
+          - 'брату'
+        explanation: 'A male person changes: брат -> брата.'
+      - sentence: 'Я знаю ___.'
+        answer: 'Олену'
+        options:
+          - 'Олену'
+          - 'Олена'
+          - 'Олени'
+        explanation: 'Олена becomes Олену.'
+      - sentence: 'Я знаю ___.'
+        answer: 'друга'
+        options:
+          - 'друга'
+          - 'друг'
+          - 'другу'
+        explanation: 'Друг becomes друга.'
+      - sentence: 'Я люблю ___.'
+        answer: 'тата'
+        options:
+          - 'тата'
+          - 'тато'
+          - 'таті'
+        explanation: 'Тато becomes тата.'
+      - sentence: 'Я чекаю ___.'
+        answer: 'вчителя'
+        options:
+          - 'вчителя'
+          - 'вчитель'
+          - 'вчителю'
+        explanation: 'Вчитель becomes вчителя.'
+      - sentence: 'Я шукаю ___.'
+        answer: 'подругу'
+        options:
+          - 'подругу'
+          - 'подруга'
+          - 'подруги'
+        explanation: 'Подруга becomes подругу.'
+      - sentence: 'Я бачу ___.'
+        answer: 'сусіда'
+        options:
+          - 'сусіда'
+          - 'сусід'
+          - 'сусіду'
+        explanation: 'Сусід becomes сусіда.'
+      - sentence: 'Я чекаю ___.'
+        answer: 'лікаря'
+        options:
+          - 'лікаря'
+          - 'лікар'
+          - 'лікарю'
+        explanation: 'Лікар becomes лікаря.'
+      - sentence: 'Я знаю ___.'
+        answer: 'сестру'
+        options:
+          - 'сестру'
+          - 'сестра'
+          - 'сестри'
+        explanation: 'Сестра becomes сестру.'
+  - id: act-3
+    type: group-sort
+    title: Кого or що shelves
+    instruction: Sort the object forms by the question they answer.
+    groups:
+      - name: 'Істоти: кого?'
+        items:
+          - 'брата'
+          - 'маму'
+          - 'друга'
+          - 'лікаря'
+          - 'Олену'
+          - 'сусіда'
+      - name: 'Неістоти: що?'
+        items:
+          - 'хліб'
+          - 'каву'
+          - 'воду'
+          - 'чай'
+          - 'борщ'
+          - 'дерево'
+  - id: act-4
+    type: match-up
+    title: Dictionary form to object form
+    instruction: Match the dictionary form with the direct-object form.
+    pairs:
+      - left: 'мама'
+        right: 'маму'
+      - left: 'Олена'
+        right: 'Олену'
+      - left: 'сестра'
+        right: 'сестру'
+      - left: 'подруга'
+        right: 'подругу'
+      - left: 'брат'
+        right: 'брата'
+      - left: 'друг'
+        right: 'друга'
+      - left: 'лікар'
+        right: 'лікаря'
+      - left: 'сусід'
+        right: 'сусіда'
+workbook:
+  - type: fill-in
+    title: People dialogue
+    instruction: Complete the short dialogue about people around you.
+    items:
+      - sentence: '— Кого ти ___?'
+        answer: 'бачиш'
+        options:
+          - 'бачиш'
+          - 'бачити'
+          - 'бачить'
+        explanation: 'Кого ти бачиш? asks whom you see.'
+      - sentence: '— Я бачу ___ і маму.'
+        answer: 'брата'
+        options:
+          - 'брата'
+          - 'брат'
+          - 'братом'
+        explanation: 'Брат becomes брата.'
+      - sentence: '— Ти знаєш мого ___ Тараса?'
+        answer: 'друга'
+        options:
+          - 'друга'
+          - 'друг'
+          - 'другу'
+        explanation: 'Мого друга is the object phrase.'
+      - sentence: '— Ні, я не ___ твого друга.'
+        answer: 'знаю'
+        options:
+          - 'знаю'
+          - 'знає'
+          - 'знати'
+        explanation: 'Я знаю / не знаю.'
+      - sentence: '— А кого ти ___?'
+        answer: 'чекаєш'
+        options:
+          - 'чекаєш'
+          - 'чекати'
+          - 'чекає'
+        explanation: 'Кого ти чекаєш? asks whom you are waiting for.'
+      - sentence: '— Я чекаю ___.'
+        answer: 'лікаря'
+        options:
+          - 'лікаря'
+          - 'лікар'
+          - 'лікарем'
+        explanation: 'Лікар becomes лікаря.'
+  - type: true-false
+    title: Animate accusative checks
+    instruction: Decide whether each statement fits the lesson.
+    items:
+      - statement: 'Кого? is the question for people and animals as direct objects.'
+        answer: true
+        explanation: 'Use кого? for animate direct objects.'
+      - statement: 'Я бачу хліб keeps хліб unchanged.'
+        answer: true
+        explanation: 'Хліб is an inanimate masculine noun in this A1 pattern.'
+      - statement: 'Я бачу брата changes брат because брат is a male person.'
+        answer: true
+        explanation: 'Male animate nouns change in this object position.'
+      - statement: 'Мама becomes маму, like кава becomes каву.'
+        answer: true
+        explanation: 'The feminine object ending is familiar from M37.'
+      - statement: 'Дерево answers хто? in Ukrainian grammar.'
+        answer: false
+        explanation: 'Дерево answers що?'
+      - statement: 'Я бачу його is a useful pronoun chunk.'
+        answer: true
+        explanation: 'Його is an object pronoun chunk.'
+      - statement: 'Натовп is treated as a person for this contrast.'
+        answer: false
+        explanation: 'Натовп is a collective noun treated as inanimate.'
+      - statement: 'Plural instrumental endings are the main A1 goal here.'
+        answer: false
+        explanation: 'They are only a later bridge note.'
+  - type: order
+    title: Introduce a brother
+    instruction: Put the dialogue in order.
+    is_ukrainian: true
+    items:
+      - 'Кого ти бачиш на фото?'
+      - 'Я бачу маму і тата.'
+      - 'А хто це?'
+      - 'Це мій брат.'
+      - 'Ти знаєш мого брата?'
+      - 'Ні, я не знаю твого брата.'
+      - 'Ходімо, я тебе познайомлю!'
+    correct_order: [0, 1, 2, 3, 4, 5, 6]
+  - type: error-correction
+    title: Repair people-around-me interference
+    instruction: Choose the clean Ukrainian repair.
+    anchor_id: repair-people-around-me-interference
+    items:
+      - sentence: 'Я бачу мій брат.'
+        error: 'Я бачу мій брат.'
+        answer: 'Я бачу мого брата.'
+        options:
+          - 'Я бачу мого брата.'
+          - 'Я бачу мій брат.'
+          - 'Я бачу моїм братом.'
+        explanation: 'Use the object phrase мого брата.'
+      - sentence: 'Дерево — це хто?'
+        error: 'Дерево — це хто?'
+        answer: 'Дерево — це що?'
+        options:
+          - 'Дерево — це що?'
+          - 'Дерево — це хто?'
+          - 'Дерево — це кого?'
+        explanation: 'Plants answer що? in Ukrainian grammar.'
+      - sentence: 'Я люблю він.'
+        error: 'Я люблю він.'
+        answer: 'Я люблю його.'
+        options:
+          - 'Я люблю його.'
+          - 'Я люблю він.'
+          - 'Я люблю йому.'
+        explanation: 'Use the object pronoun його.'
+      - sentence: 'Ми бачимо велику натовп.'
+        error: 'Ми бачимо велику натовп.'
+        answer: 'Ми бачимо великий натовп.'
+        options:
+          - 'Ми бачимо великий натовп.'
+          - 'Ми бачимо велику натовп.'
+          - 'Ми бачимо великого натовпа.'
+        explanation: 'Натовп is treated as inanimate here.'
+      - sentence: 'Я зустрів сусіду.'
+        error: 'Я зустрів сусіду.'
+        answer: 'Я зустрів сусіда.'
+        options:
+          - 'Я зустрів сусіда.'
+          - 'Я зустрів сусіду.'
+          - 'Я зустрів сусідом.'
+        explanation: 'Сусід becomes сусіда.'
+      - sentence: 'Він має 20 років.'
+        error: 'Він має 20 років.'
+        answer: 'Йому 20 років.'
+        options:
+          - 'Йому 20 років.'
+          - 'Він має 20 років.'
+          - 'Його 20 років.'
+        explanation: 'Age uses йому in this chunk.'
+      - sentence: 'Я є студент.'
+        error: 'Я є студент.'
+        answer: 'Я студент.'
+        options:
+          - 'Я студент.'
+          - 'Я є студент.'
+          - 'Я маю студент.'
+        explanation: 'In this basic identity line, omit є.'
+      - sentence: 'Яка твоя фамілія?'
+        error: 'Яка твоя фамілія?'
+        answer: 'Яке твоє прізвище?'
+        options:
+          - 'Яке твоє прізвище?'
+          - 'Яка твоя фамілія?'
+          - 'Який твій фамілія?'
+        explanation: 'Use прізвище for surname.'

--- a/curriculum/l2-uk-en/a1/people-around-me/module.md
+++ b/curriculum/l2-uk-en/a1/people-around-me/module.md
@@ -218,11 +218,3 @@ Repair these common learner forms:
 | age with possession | **Йому 20 років.** |
 | forced present copula | **Я студент.** |
 | family-name term | **Яке твоє прізвище?** |
-
-<!-- INJECT_ACTIVITY: act-5 -->
-
-<!-- INJECT_ACTIVITY: act-6 -->
-
-<!-- INJECT_ACTIVITY: act-7 -->
-
-<!-- INJECT_ACTIVITY: act-8 -->

--- a/curriculum/l2-uk-en/a1/shopping/activities.yaml
+++ b/curriculum/l2-uk-en/a1/shopping/activities.yaml
@@ -1,352 +1,350 @@
-- id: act-1
-  type: fill-in
-  title: Price questions
-  instruction: Choose the word that completes each shopping question.
-  items:
-    - sentence: "Скільки ___ хліб?"
-      answer: "коштує"
-      options:
-        - "коштує"
-        - "коштують"
-        - "коштувати"
-      explanation: "Use коштує with one item."
-    - sentence: "Скільки ___ молоко?"
-      answer: "коштує"
-      options:
-        - "коштує"
-        - "коштують"
-        - "коштувала"
-      explanation: "Молоко is one item here, so use коштує."
-    - sentence: "Скільки ___ цей сир?"
-      answer: "коштує"
-      options:
-        - "коштує"
-        - "коштують"
-        - "коштуєте"
-      explanation: "Цей сир is singular."
-    - sentence: "Скільки ___ яблука?"
-      answer: "коштують"
-      options:
-        - "коштують"
-        - "коштує"
-        - "коштувати"
-      explanation: "Яблука is plural, so use коштують."
-    - sentence: "Скільки ___ помідори?"
-      answer: "коштують"
-      options:
-        - "коштують"
-        - "коштує"
-        - "коштуєш"
-      explanation: "Помідори is plural."
-    - sentence: "Скільки ___ пляшка води?"
-      answer: "коштує"
-      options:
-        - "коштує"
-        - "коштують"
-        - "коштуємо"
-      explanation: "Пляшка is one bottle."
-    - sentence: "Скільки ___ три пляшки води?"
-      answer: "коштують"
-      options:
-        - "коштують"
-        - "коштує"
-        - "коштувала"
-      explanation: "Three bottles are plural in this price question."
-    - sentence: "Скільки ___ ця сукня?"
-      answer: "коштує"
-      options:
-        - "коштує"
-        - "коштують"
-        - "коштуємо"
-      explanation: "Ця сукня is singular."
-- id: act-2
-  type: quiz
-  title: Гривня, гривні, гривень
-  instruction: Choose the currency form that fits the number.
-  items:
-    - prompt: "21 ___"
-      options:
-        - text: "гривня"
-          correct: true
-        - text: "гривні"
-          correct: false
-        - text: "гривень"
-          correct: false
-      explanation: "21 ends like 1: гривня."
-    - prompt: "32 ___"
-      options:
-        - text: "гривні"
-          correct: true
-        - text: "гривня"
-          correct: false
-        - text: "гривень"
-          correct: false
-      explanation: "32 ends like 2: гривні."
-    - prompt: "45 ___"
-      options:
-        - text: "гривень"
-          correct: true
-        - text: "гривня"
-          correct: false
-        - text: "гривні"
-          correct: false
-      explanation: "45 uses гривень."
-    - prompt: "100 ___"
-      options:
-        - text: "гривень"
-          correct: true
-        - text: "гривня"
-          correct: false
-        - text: "гривні"
-          correct: false
-      explanation: "100 uses гривень."
-    - prompt: "1 ___"
-      options:
-        - text: "гривня"
-          correct: true
-        - text: "гривні"
-          correct: false
-        - text: "гривень"
-          correct: false
-      explanation: "1 is гривня."
-    - prompt: "3 ___"
-      options:
-        - text: "гривні"
-          correct: true
-        - text: "гривня"
-          correct: false
-        - text: "гривень"
-          correct: false
-      explanation: "3 is гривні."
-    - prompt: "10 ___"
-      options:
-        - text: "гривень"
-          correct: true
-        - text: "гривня"
-          correct: false
-        - text: "гривні"
-          correct: false
-      explanation: "10 is гривень."
-    - prompt: "54 ___"
-      options:
-        - text: "гривні"
-          correct: true
-        - text: "гривня"
-          correct: false
-        - text: "гривень"
-          correct: false
-      explanation: "54 ends like 4: гривні."
-- id: act-3
-  type: match-up
-  title: Where do you buy it?
-  instruction: Match each item with a likely place or department.
-  pairs:
-    - left: "помідори"
-      right: "ринок"
-    - left: "м'ясо"
-      right: "м'ясний відділ"
-    - left: "сир"
-      right: "молочний відділ"
-    - left: "хліб"
-      right: "крамниця"
-    - left: "молоко"
-      right: "супермаркет"
-    - left: "вода"
-      right: "магазин"
-    - left: "сукня"
-      right: "магазин одягу"
-    - left: "книжка"
-      right: "книгарня"
-- id: act-4
-  type: fill-in
-  title: Quantity chunks
-  instruction: Choose the quantity word or phrase that fits the product.
-  items:
-    - sentence: "Дайте, будь ласка, ___ яблук."
-      answer: "один кілограм"
-      options:
-        - "один кілограм"
-        - "одна пляшка"
-        - "один літр"
-      explanation: "Use один кілограм яблук as a buying chunk."
-    - sentence: "Дайте ___ молока."
-      answer: "літр"
-      options:
-        - "літр"
-        - "пляшку"
-        - "буханку"
-      explanation: "Use літр молока."
-    - sentence: "Дайте ___ води."
-      answer: "пляшку"
-      options:
-        - "пляшку"
-        - "кілограм"
-        - "буханку"
-      explanation: "Use пляшку води."
-    - sentence: "Дайте ___ чаю."
-      answer: "пачку"
-      options:
-        - "пачку"
-        - "літр"
-        - "пляшку"
-      explanation: "Use пачку чаю."
-    - sentence: "Дайте ___ хліба."
-      answer: "буханку"
-      options:
-        - "буханку"
-        - "літр"
-        - "пляшку"
-      explanation: "Use буханку хліба."
-    - sentence: "Дайте, будь ласка, ___ помідорів."
-      answer: "два кілограми"
-      options:
-        - "два кілограми"
-        - "дві пляшки"
-        - "два літри"
-      explanation: "Use два кілограми помідорів."
-    - sentence: "Купіть три ___ води."
-      answer: "пляшки"
-      options:
-        - "пляшки"
-        - "пляшка"
-        - "кілограм"
-      explanation: "Use три пляшки води."
-- id: act-5
-  type: group-sort
-  title: Shopping shelves
-  instruction: Sort each phrase by what it does in a shopping visit.
-  groups:
-    - name: "Start or availability"
-      items:
-        - "Добрий день!"
-        - "У вас є хліб?"
-        - "Чи є у вас яблука?"
-    - name: "Price"
-      items:
-        - "Скільки коштує?"
-        - "Скільки коштують яблука?"
-        - "Дорого!"
-    - name: "Quantity"
-      items:
-        - "один кілограм яблук"
-        - "літр молока"
-        - "пляшка води"
-    - name: "Checkout"
-      items:
-        - "З вас сто сім гривень."
-        - "Можна карткою?"
-        - "Карткою, будь ласка."
-- id: act-6
-  type: order
-  title: One shopping visit
-  instruction: Put the shopping visit in order.
-  is_ukrainian: true
-  items:
-    - "Добрий день! У вас є яблука?"
-    - "Так, є."
-    - "Скільки коштує кілограм яблук?"
-    - "Сорок гривень."
-    - "Дайте, будь ласка, один кілограм яблук."
-    - "З вас сорок гривень."
-    - "Можна карткою?"
-    - "Карткою, будь ласка."
-  correct_order: [0, 1, 2, 3, 4, 5, 6, 7]
-- id: act-7
-  type: true-false
-  title: Shopping decisions
-  instruction: Decide whether each statement fits this module.
-  items:
-    - statement: "Скільки коштує? asks about price."
-      answer: true
-      explanation: "Коштує is the price verb."
-    - statement: "Скільки коштують яблука? is used for plural apples."
-      answer: true
-      explanation: "Use коштують with plural items."
-    - statement: "Кілограм яблук is taught here as a ready shopping chunk."
-      answer: true
-      explanation: "The module avoids a full case lesson."
-    - statement: "Карткою, будь ласка means by card, please."
-      answer: true
-      explanation: "It is the checkout payment chunk."
-    - statement: "З вас сто сім гривень is a greeting."
-      answer: false
-      explanation: "It is a checkout total."
-    - statement: "Приміряти is useful when trying on clothes."
-      answer: true
-      explanation: "Use приміряти for clothing."
-    - statement: "Скільки це є? is the course price question."
-      answer: false
-      explanation: "Use Скільки це коштує?"
-    - statement: "Грн is the common price-label abbreviation for гривня."
-      answer: true
-      explanation: "Грн appears on price labels."
-- id: act-8
-  type: error-correction
-  title: Repair shopping interference
-  instruction: Choose the clean Ukrainian repair.
-  anchor_id: repair-shopping-interference
-  items:
-    - sentence: "How much is it? → Скільки це є?"
-      error: "How much is it? → Скільки це є?"
-      answer: "Скільки це коштує?"
-      options:
-        - "Скільки це коштує?"
-        - "Скільки це є?"
-        - "Скільки це має?"
-      explanation: "Use коштує for price questions."
-    - sentence: "I have 20 hryvnias. → Я маю 20 гривнів."
-      error: "I have 20 hryvnias. → Я маю 20 гривнів."
-      answer: "У мене є 20 гривень."
-      options:
-        - "У мене є 20 гривень."
-        - "Я маю 20 гривнів."
-        - "У мене 20 гривні."
-      explanation: "Use У мене є and гривень."
-    - sentence: "Do you have...? → Ви маєте хліб?"
-      error: "Do you have...? → Ви маєте хліб?"
-      answer: "У вас є хліб?"
-      options:
-        - "У вас є хліб?"
-        - "Ви маєте хліб?"
-        - "Вас є хліб?"
-      explanation: "Use the shop availability chunk У вас є."
-    - sentence: "I will pay with a card. → Я плачу з карткою."
-      error: "I will pay with a card. → Я плачу з карткою."
-      answer: "Карткою, будь ласка."
-      options:
-        - "Карткою, будь ласка."
-        - "Я плачу з карткою."
-        - "З карткою, будь ласка."
-      explanation: "At checkout, use the chunk Карткою, будь ласка."
-    - sentence: "Give me one kilo apples. → Дайте один кілограм яблука."
-      error: "Give me one kilo apples. → Дайте один кілограм яблука."
-      answer: "Дайте, будь ласка, один кілограм яблук."
-      options:
-        - "Дайте, будь ласка, один кілограм яблук."
-        - "Дайте один кілограм яблука."
-        - "Дайте одна кілограм яблук."
-      explanation: "Use the whole chunk один кілограм яблук."
-    - sentence: "It costs 50 grivnas. → Це коштує 50 гривн."
-      error: "It costs 50 grivnas. → Це коштує 50 гривн."
-      answer: "Це коштує 50 гривень."
-      options:
-        - "Це коштує 50 гривень."
-        - "Це коштує 50 гривн."
-        - "Це коштує 50 гривні."
-      explanation: "The money word is гривня; 50 uses гривень."
-    - sentence: "Я хочу поміряти пальто."
-      error: "поміряти"
-      answer: "Я хочу приміряти пальто."
-      options:
-        - "Я хочу приміряти пальто."
-        - "Я хочу поміряти пальто."
-        - "Я хочу міряти пальто."
-      explanation: "Use приміряти for trying on clothes."
-    - sentence: "Два яблука коштує сорок гривень."
-      error: "коштує"
-      answer: "Два яблука коштують сорок гривень."
-      options:
-        - "Два яблука коштують сорок гривень."
-        - "Два яблука коштує сорок гривень."
-        - "Два яблука коштувати сорок гривень."
-      explanation: "Use коштують with plural apples."
+inline:
+  - id: act-1
+    type: fill-in
+    title: Price questions
+    instruction: Choose the word that completes each shopping question.
+    items:
+      - sentence: 'Скільки ___ хліб?'
+        answer: 'коштує'
+        options:
+          - 'коштує'
+          - 'коштують'
+          - 'коштувати'
+        explanation: 'Use коштує with one item.'
+      - sentence: 'Скільки ___ молоко?'
+        answer: 'коштує'
+        options:
+          - 'коштує'
+          - 'коштують'
+          - 'коштувала'
+        explanation: 'Молоко is one item here, so use коштує.'
+      - sentence: 'Скільки ___ цей сир?'
+        answer: 'коштує'
+        options:
+          - 'коштує'
+          - 'коштують'
+          - 'коштуєте'
+        explanation: 'Цей сир is singular.'
+      - sentence: 'Скільки ___ яблука?'
+        answer: 'коштують'
+        options:
+          - 'коштують'
+          - 'коштує'
+          - 'коштувати'
+        explanation: 'Яблука is plural, so use коштують.'
+      - sentence: 'Скільки ___ помідори?'
+        answer: 'коштують'
+        options:
+          - 'коштують'
+          - 'коштує'
+          - 'коштуєш'
+        explanation: 'Помідори is plural.'
+      - sentence: 'Скільки ___ пляшка води?'
+        answer: 'коштує'
+        options:
+          - 'коштує'
+          - 'коштують'
+          - 'коштуємо'
+        explanation: 'Пляшка is one bottle.'
+      - sentence: 'Скільки ___ три пляшки води?'
+        answer: 'коштують'
+        options:
+          - 'коштують'
+          - 'коштує'
+          - 'коштувала'
+        explanation: 'Three bottles are plural in this price question.'
+      - sentence: 'Скільки ___ ця сукня?'
+        answer: 'коштує'
+        options:
+          - 'коштує'
+          - 'коштують'
+          - 'коштуємо'
+        explanation: 'Ця сукня is singular.'
+  - id: act-2
+    type: quiz
+    title: Гривня, гривні, гривень
+    instruction: Choose the currency form that fits the number.
+    items:
+      - prompt: '21 ___'
+        options:
+          - text: 'гривня'
+            correct: true
+          - text: 'гривні'
+            correct: false
+          - text: 'гривень'
+            correct: false
+        explanation: '21 ends like 1: гривня.'
+      - prompt: '32 ___'
+        options:
+          - text: 'гривні'
+            correct: true
+          - text: 'гривня'
+            correct: false
+          - text: 'гривень'
+            correct: false
+        explanation: '32 ends like 2: гривні.'
+      - prompt: '45 ___'
+        options:
+          - text: 'гривень'
+            correct: true
+          - text: 'гривня'
+            correct: false
+          - text: 'гривні'
+            correct: false
+        explanation: '45 uses гривень.'
+      - prompt: '100 ___'
+        options:
+          - text: 'гривень'
+            correct: true
+          - text: 'гривня'
+            correct: false
+          - text: 'гривні'
+            correct: false
+        explanation: '100 uses гривень.'
+      - prompt: '1 ___'
+        options:
+          - text: 'гривня'
+            correct: true
+          - text: 'гривні'
+            correct: false
+          - text: 'гривень'
+            correct: false
+        explanation: '1 is гривня.'
+      - prompt: '3 ___'
+        options:
+          - text: 'гривні'
+            correct: true
+          - text: 'гривня'
+            correct: false
+          - text: 'гривень'
+            correct: false
+        explanation: '3 is гривні.'
+      - prompt: '10 ___'
+        options:
+          - text: 'гривень'
+            correct: true
+          - text: 'гривня'
+            correct: false
+          - text: 'гривні'
+            correct: false
+        explanation: '10 is гривень.'
+      - prompt: '54 ___'
+        options:
+          - text: 'гривні'
+            correct: true
+          - text: 'гривня'
+            correct: false
+          - text: 'гривень'
+            correct: false
+        explanation: '54 ends like 4: гривні.'
+  - id: act-3
+    type: match-up
+    title: Where do you buy it?
+    instruction: Match each item with a likely place or department.
+    pairs:
+      - left: 'помідори'
+        right: 'ринок'
+      - left: "м'ясо"
+        right: "м'ясний відділ"
+      - left: 'сир'
+        right: 'молочний відділ'
+      - left: 'хліб'
+        right: 'крамниця'
+      - left: 'молоко'
+        right: 'супермаркет'
+      - left: 'вода'
+        right: 'магазин'
+      - left: 'сукня'
+        right: 'магазин одягу'
+      - left: 'книжка'
+        right: 'книгарня'
+  - id: act-4
+    type: fill-in
+    title: Quantity chunks
+    instruction: Choose the quantity word or phrase that fits the product.
+    items:
+      - sentence: 'Дайте, будь ласка, ___ яблук.'
+        answer: 'один кілограм'
+        options:
+          - 'один кілограм'
+          - 'одна пляшка'
+          - 'один літр'
+        explanation: 'Use один кілограм яблук as a buying chunk.'
+      - sentence: 'Дайте ___ молока.'
+        answer: 'літр'
+        options:
+          - 'літр'
+          - 'пляшку'
+          - 'буханку'
+        explanation: 'Use літр молока.'
+      - sentence: 'Дайте ___ води.'
+        answer: 'пляшку'
+        options:
+          - 'пляшку'
+          - 'кілограм'
+          - 'буханку'
+        explanation: 'Use пляшку води.'
+      - sentence: 'Дайте ___ чаю.'
+        answer: 'пачку'
+        options:
+          - 'пачку'
+          - 'літр'
+          - 'пляшку'
+        explanation: 'Use пачку чаю.'
+      - sentence: 'Дайте ___ хліба.'
+        answer: 'буханку'
+        options:
+          - 'буханку'
+          - 'літр'
+          - 'пляшку'
+        explanation: 'Use буханку хліба.'
+      - sentence: 'Дайте, будь ласка, ___ помідорів.'
+        answer: 'два кілограми'
+        options:
+          - 'два кілограми'
+          - 'дві пляшки'
+          - 'два літри'
+        explanation: 'Use два кілограми помідорів.'
+      - sentence: 'Купіть три ___ води.'
+        answer: 'пляшки'
+        options:
+          - 'пляшки'
+          - 'пляшка'
+          - 'кілограм'
+        explanation: 'Use три пляшки води.'
+workbook:
+  - type: group-sort
+    title: Shopping shelves
+    instruction: Sort each phrase by what it does in a shopping visit.
+    groups:
+      - name: 'Start or availability'
+        items:
+          - 'Добрий день!'
+          - 'У вас є хліб?'
+          - 'Чи є у вас яблука?'
+      - name: 'Price'
+        items:
+          - 'Скільки коштує?'
+          - 'Скільки коштують яблука?'
+          - 'Дорого!'
+      - name: 'Quantity'
+        items:
+          - 'один кілограм яблук'
+          - 'літр молока'
+          - 'пляшка води'
+      - name: 'Checkout'
+        items:
+          - 'З вас сто сім гривень.'
+          - 'Можна карткою?'
+          - 'Карткою, будь ласка.'
+  - type: order
+    title: One shopping visit
+    instruction: Put the shopping visit in order.
+    is_ukrainian: true
+    items:
+      - 'Добрий день! У вас є яблука?'
+      - 'Так, є.'
+      - 'Скільки коштує кілограм яблук?'
+      - 'Сорок гривень.'
+      - 'Дайте, будь ласка, один кілограм яблук.'
+      - 'З вас сорок гривень.'
+      - 'Можна карткою?'
+      - 'Карткою, будь ласка.'
+    correct_order: [0, 1, 2, 3, 4, 5, 6, 7]
+  - type: true-false
+    title: Shopping decisions
+    instruction: Decide whether each statement fits this module.
+    items:
+      - statement: 'Скільки коштує? asks about price.'
+        answer: true
+        explanation: 'Коштує is the price verb.'
+      - statement: 'Скільки коштують яблука? is used for plural apples.'
+        answer: true
+        explanation: 'Use коштують with plural items.'
+      - statement: 'Кілограм яблук is taught here as a ready shopping chunk.'
+        answer: true
+        explanation: 'The module avoids a full case lesson.'
+      - statement: 'Карткою, будь ласка means by card, please.'
+        answer: true
+        explanation: 'It is the checkout payment chunk.'
+      - statement: 'З вас сто сім гривень is a greeting.'
+        answer: false
+        explanation: 'It is a checkout total.'
+      - statement: 'Приміряти is useful when trying on clothes.'
+        answer: true
+        explanation: 'Use приміряти for clothing.'
+      - statement: 'Скільки це є? is the course price question.'
+        answer: false
+        explanation: 'Use Скільки це коштує?'
+      - statement: 'Грн is the common price-label abbreviation for гривня.'
+        answer: true
+        explanation: 'Грн appears on price labels.'
+  - type: error-correction
+    title: Repair shopping interference
+    instruction: Choose the clean Ukrainian repair.
+    anchor_id: repair-shopping-interference
+    items:
+      - sentence: 'How much is it? → Скільки це є?'
+        error: 'How much is it? → Скільки це є?'
+        answer: 'Скільки це коштує?'
+        options:
+          - 'Скільки це коштує?'
+          - 'Скільки це є?'
+          - 'Скільки це має?'
+        explanation: 'Use коштує for price questions.'
+      - sentence: 'I have 20 hryvnias. → Я маю 20 гривнів.'
+        error: 'I have 20 hryvnias. → Я маю 20 гривнів.'
+        answer: 'У мене є 20 гривень.'
+        options:
+          - 'У мене є 20 гривень.'
+          - 'Я маю 20 гривнів.'
+          - 'У мене 20 гривні.'
+        explanation: 'Use У мене є and гривень.'
+      - sentence: 'Do you have...? → Ви маєте хліб?'
+        error: 'Do you have...? → Ви маєте хліб?'
+        answer: 'У вас є хліб?'
+        options:
+          - 'У вас є хліб?'
+          - 'Ви маєте хліб?'
+          - 'Вас є хліб?'
+        explanation: 'Use the shop availability chunk У вас є.'
+      - sentence: 'I will pay with a card. → Я плачу з карткою.'
+        error: 'I will pay with a card. → Я плачу з карткою.'
+        answer: 'Карткою, будь ласка.'
+        options:
+          - 'Карткою, будь ласка.'
+          - 'Я плачу з карткою.'
+          - 'З карткою, будь ласка.'
+        explanation: 'At checkout, use the chunk Карткою, будь ласка.'
+      - sentence: 'Give me one kilo apples. → Дайте один кілограм яблука.'
+        error: 'Give me one kilo apples. → Дайте один кілограм яблука.'
+        answer: 'Дайте, будь ласка, один кілограм яблук.'
+        options:
+          - 'Дайте, будь ласка, один кілограм яблук.'
+          - 'Дайте один кілограм яблука.'
+          - 'Дайте одна кілограм яблук.'
+        explanation: 'Use the whole chunk один кілограм яблук.'
+      - sentence: 'It costs 50 grivnas. → Це коштує 50 гривн.'
+        error: 'It costs 50 grivnas. → Це коштує 50 гривн.'
+        answer: 'Це коштує 50 гривень.'
+        options:
+          - 'Це коштує 50 гривень.'
+          - 'Це коштує 50 гривн.'
+          - 'Це коштує 50 гривні.'
+        explanation: 'The money word is гривня; 50 uses гривень.'
+      - sentence: 'Я хочу поміряти пальто.'
+        error: 'поміряти'
+        answer: 'Я хочу приміряти пальто.'
+        options:
+          - 'Я хочу приміряти пальто.'
+          - 'Я хочу поміряти пальто.'
+          - 'Я хочу міряти пальто.'
+        explanation: 'Use приміряти for trying on clothes.'
+      - sentence: 'Два яблука коштує сорок гривень.'
+        error: 'коштує'
+        answer: 'Два яблука коштують сорок гривень.'
+        options:
+          - 'Два яблука коштують сорок гривень.'
+          - 'Два яблука коштує сорок гривень.'
+          - 'Два яблука коштувати сорок гривень.'
+        explanation: 'Use коштують with plural apples.'

--- a/curriculum/l2-uk-en/a1/shopping/module.md
+++ b/curriculum/l2-uk-en/a1/shopping/module.md
@@ -206,11 +206,3 @@ Use these repairs in shopping scenes:
 | card payment with **з** | **Карткою, будь ласка.** |
 | weak quantity chunk | **Дайте, будь ласка, один кілограм яблук.** |
 | wrong currency ending | **Це коштує 50 гривень.** |
-
-<!-- INJECT_ACTIVITY: act-5 -->
-
-<!-- INJECT_ACTIVITY: act-6 -->
-
-<!-- INJECT_ACTIVITY: act-7 -->
-
-<!-- INJECT_ACTIVITY: act-8 -->


### PR DESCRIPTION
## Summary

Refs #2807.

- Convert A1 M36-M41 activity YAML from flat V1 lists to V2 `inline` + `workbook` lists.
- Keep act-1..act-4 as Lesson-tab inline checks with matching module injection markers.
- Move act-5..act-8 to idless Workbook-tab practice and remove only those lesson injection markers.
- Use the default 4/4 split for all six scoped modules.

## Validation

- Structural check: all six modules preserve 8 total activities; inline IDs are act-1..act-4 and match retained module markers; workbook entries are idless.
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/generate_mdx.py l2-uk-en a1 N --validate` for N=36..41: all six runs passed with `VALIDATION PASSED`.
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest -q tests/test_yaml_activities.py tests/test_generate_mdx.py tests/test_activity_helpers_flatten.py`: 118 passed.
- `npx prettier --check` on the six changed `activities.yaml` files: passed.
- `git diff --check origin/main..HEAD`: passed.
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`: passed.