### PR TITLE
[codex] Split A1 M48-M55 activities by tab

### DIFF
--- a/curriculum/l2-uk-en/a1/a1-finale/activities.yaml
+++ b/curriculum/l2-uk-en/a1/a1-finale/activities.yaml
@@ -1,227 +1,224 @@
-- id: act-1
-  type: fill-in
-  title: Complete the A1 line
-  instruction: Choose the word or phrase that fits the time and situation.
-  items:
-    - sentence: "Учора я ___ у кафе."
-      answer: "снідав"
-      options:
-        - "снідав"
-        - "снідаю"
-        - "буду снідати"
-      explanation: "Учора points to the past."
-    - sentence: "Зараз я ___ на метро."
-      answer: "їду"
-      options:
-        - "їду"
-        - "їхав"
-        - "буду їхати"
-      explanation: "Зараз points to the present."
-    - sentence: "Завтра я ___ гуляти в парку."
-      answer: "буду"
-      options:
-        - "буду"
-        - "був"
-        - "є"
-      explanation: "Буду + infinitive is the A1 future."
-    - sentence: "___, будь ласка."
-      answer: "Повторіть"
-      options:
-        - "Повторіть"
-        - "Сувенір"
-        - "Квиток"
-      explanation: "Повторіть, будь ласка is the repair phrase."
-- id: act-2
-  type: order
-  title: Put the final day in order
-  instruction: Arrange the events from morning to night.
-  items:
-    - "Я прокинувся в готелі."
-    - "Я снідав у кафе."
-    - "Я їхав на метро в центр."
-    - "Я купив сувенір."
-    - "Я обідав з Оленою."
-    - "Ми ходили в кіно."
-    - "Я повернувся в готель."
-  correct_order: [0, 1, 2, 3, 4, 5, 6]
-- id: act-3
-  type: match-up
-  title: Situation and phrase
-  instruction: Match each everyday situation with the A1 phrase.
-  pairs:
-    - left: "introducing yourself"
-      right: "Мене звати..."
-    - left: "asking for directions"
-      right: "Як дістатися до метро?"
-    - left: "ordering coffee"
-      right: "Каву з молоком, будь ласка."
-    - left: "asking the price"
-      right: "Скільки коштує?"
-    - left: "repairing understanding"
-      right: "Повторіть, будь ласка."
-    - left: "asking for help"
-      right: "Мені потрібна допомога."
-- id: act-4
-  type: group-sort
-  title: Sort your A1 toolkit
-  instruction: Put each phrase into the right communication group.
-  groups:
-    - name: "people"
-      items:
-        - "Мене звати"
-        - "Я з Канади"
-        - "Це моя подруга"
-    - name: "city"
-      items:
-        - "Де метро?"
-        - "Я на вулиці"
-        - "Як дістатися до центру?"
-    - name: "food and shopping"
-      items:
-        - "Каву, будь ласка"
-        - "Скільки коштує?"
-        - "Я беру це"
-    - name: "time"
-      items:
-        - "Учора я був"
-        - "Зараз я йду"
-        - "Завтра я буду читати"
-- id: act-5
-  type: quiz
-  title: Choose the A1 response
-  instruction: Pick the response that fits the situation.
-  items:
-    - prompt: "A cashier says: Сто гривень."
-      options:
-        - text: "Карткою можна?"
-          correct: true
-        - text: "Я з Канади."
-          correct: false
-        - text: "Мені холодно."
-          correct: false
-      explanation: "Карткою можна? fits payment."
-    - prompt: "A friend asks: Що ти робив сьогодні?"
-      options:
-        - text: "Зранку я снідав у кафе."
-          correct: true
-        - text: "Завтра я снідав у кафе."
-          correct: false
-        - text: "Я метро коштує."
-          correct: false
-      explanation: "The question asks about earlier today, so a past line fits."
-    - prompt: "You did not understand the direction."
-      options:
-        - text: "Повторіть, будь ласка."
-          correct: true
-        - text: "Я беру це."
-          correct: false
-        - text: "Він мій тато."
-          correct: false
-      explanation: "Use a repair phrase."
-    - prompt: "You want to talk about tomorrow."
-      options:
-        - text: "Завтра я буду гуляти."
-          correct: true
-        - text: "Завтра я гуляв."
-          correct: false
-        - text: "Учора я буду гуляти."
-          correct: false
-      explanation: "Завтра pairs with буду + infinitive."
-- id: act-6
-  type: true-false
-  title: A1 finale check
-  instruction: Decide whether the line is clear A1 Ukrainian.
-  items:
-    - statement: "Мене звати Сара. Я з Канади."
-      answer: true
-      explanation: "This is clear A1 identity language."
-    - statement: "Вчора я снідаю у кафе."
-      answer: false
-      explanation: "Use past after Вчора: я снідав / снідала."
-    - statement: "Зараз я їду на метро."
-      answer: true
-      explanation: "Зараз plus present їду is clear."
-    - statement: "Завтра я буду читати українську."
-      answer: true
-      explanation: "Буду + infinitive is the A1 future."
-    - statement: "Моє ім'я є Адам."
-      answer: false
-      explanation: "Use Мене звати Адам."
-- id: act-7
-  type: unjumble
-  title: Build final A1 lines
-  instruction: Put the words in a natural order.
-  items:
-    - words: "Учора/я/снідав/у/кафе."
-      answer: "Учора я снідав у кафе."
-    - words: "Зараз/я/їду/на/метро."
-      answer: "Зараз я їду на метро."
-    - words: "Завтра/я/буду/гуляти/в/парку."
-      answer: "Завтра я буду гуляти в парку."
-    - words: "Повторіть,/будь/ласка."
-      answer: "Повторіть, будь ласка."
-- id: act-8
-  type: fill-in
-  title: Final story frame
-  instruction: Choose the phrase that completes the ten-sentence story frame.
-  items:
-    - sentence: "Мене ___."
-      answer: "звати"
-      options:
-        - "звати"
-        - "коштує"
-        - "болить"
-      explanation: "Мене звати introduces your name."
-    - sentence: "Зранку я ___ у кафе."
-      answer: "снідав"
-      options:
-        - "снідав"
-        - "кафе"
-        - "буду"
-      explanation: "This is a past line in the story."
-    - sentence: "Ввечері ми ___ в кіно."
-      answer: "ходили"
-      options:
-        - "ходили"
-        - "кіно"
-        - "сім"
-      explanation: "Ходили is the past plural form already practiced."
-    - sentence: "Завтра я ___ повторювати українську."
-      answer: "буду"
-      options:
-        - "буду"
-        - "був"
-        - "є"
-      explanation: "Use буду + infinitive for a future plan."
-- id: act-9
-  type: translate
-  title: Finish A1
-  instruction: Choose the Ukrainian phrase that matches the English prompt.
-  items:
-    - source: "My name is Adam. I am from Canada."
-      options:
-        - text: "Мене звати Адам. Я з Канади."
-          correct: true
-        - text: "Моє ім'я є Адам. Я маю Канада."
-          correct: false
-        - text: "Адам коштує Канада."
-          correct: false
-      explanation: "Use Мене звати... and Я з..."
-    - source: "Yesterday I bought a souvenir."
-      options:
-        - text: "Учора я купив сувенір."
-          correct: true
-        - text: "Завтра я купив сувенір."
-          correct: false
-        - text: "Сувенір мене звати."
-          correct: false
-      explanation: "Учора points to the past."
-    - source: "Tomorrow I will read Ukrainian."
-      options:
-        - text: "Завтра я буду читати українську."
-          correct: true
-        - text: "Учора я буду читати українську."
-          correct: false
-        - text: "Завтра я читав українську."
-          correct: false
-      explanation: "Use завтра + буду читати."
+inline:
+  - id: act-1
+    type: fill-in
+    title: Complete the A1 line
+    instruction: Choose the word or phrase that fits the time and situation.
+    items:
+      - sentence: 'Учора я ___ у кафе.'
+        answer: 'снідав'
+        options:
+          - 'снідав'
+          - 'снідаю'
+          - 'буду снідати'
+        explanation: 'Учора points to the past.'
+      - sentence: 'Зараз я ___ на метро.'
+        answer: 'їду'
+        options:
+          - 'їду'
+          - 'їхав'
+          - 'буду їхати'
+        explanation: 'Зараз points to the present.'
+      - sentence: 'Завтра я ___ гуляти в парку.'
+        answer: 'буду'
+        options:
+          - 'буду'
+          - 'був'
+          - 'є'
+        explanation: 'Буду + infinitive is the A1 future.'
+      - sentence: '___, будь ласка.'
+        answer: 'Повторіть'
+        options:
+          - 'Повторіть'
+          - 'Сувенір'
+          - 'Квиток'
+        explanation: 'Повторіть, будь ласка is the repair phrase.'
+  - id: act-2
+    type: order
+    title: Put the final day in order
+    instruction: Arrange the events from morning to night.
+    items:
+      - 'Я прокинувся в готелі.'
+      - 'Я снідав у кафе.'
+      - 'Я їхав на метро в центр.'
+      - 'Я купив сувенір.'
+      - 'Я обідав з Оленою.'
+      - 'Ми ходили в кіно.'
+      - 'Я повернувся в готель.'
+    correct_order: [0, 1, 2, 3, 4, 5, 6]
+  - id: act-3
+    type: match-up
+    title: Situation and phrase
+    instruction: Match each everyday situation with the A1 phrase.
+    pairs:
+      - left: 'introducing yourself'
+        right: 'Мене звати...'
+      - left: 'asking for directions'
+        right: 'Як дістатися до метро?'
+      - left: 'ordering coffee'
+        right: 'Каву з молоком, будь ласка.'
+      - left: 'asking the price'
+        right: 'Скільки коштує?'
+      - left: 'repairing understanding'
+        right: 'Повторіть, будь ласка.'
+      - left: 'asking for help'
+        right: 'Мені потрібна допомога.'
+  - id: act-4
+    type: group-sort
+    title: Sort your A1 toolkit
+    instruction: Put each phrase into the right communication group.
+    groups:
+      - name: 'people'
+        items:
+          - 'Мене звати'
+          - 'Я з Канади'
+          - 'Це моя подруга'
+      - name: 'city'
+        items:
+          - 'Де метро?'
+          - 'Я на вулиці'
+          - 'Як дістатися до центру?'
+      - name: 'food and shopping'
+        items:
+          - 'Каву, будь ласка'
+          - 'Скільки коштує?'
+          - 'Я беру це'
+      - name: 'time'
+        items:
+          - 'Учора я був'
+          - 'Зараз я йду'
+          - 'Завтра я буду читати'
+workbook:
+  - type: quiz
+    title: Choose the A1 response
+    instruction: Pick the response that fits the situation.
+    items:
+      - prompt: 'A cashier says: Сто гривень.'
+        options:
+          - text: 'Карткою можна?'
+            correct: true
+          - text: 'Я з Канади.'
+            correct: false
+          - text: 'Мені холодно.'
+            correct: false
+        explanation: 'Карткою можна? fits payment.'
+      - prompt: 'A friend asks: Що ти робив сьогодні?'
+        options:
+          - text: 'Зранку я снідав у кафе.'
+            correct: true
+          - text: 'Завтра я снідав у кафе.'
+            correct: false
+          - text: 'Я метро коштує.'
+            correct: false
+        explanation: 'The question asks about earlier today, so a past line fits.'
+      - prompt: 'You did not understand the direction.'
+        options:
+          - text: 'Повторіть, будь ласка.'
+            correct: true
+          - text: 'Я беру це.'
+            correct: false
+          - text: 'Він мій тато.'
+            correct: false
+        explanation: 'Use a repair phrase.'
+      - prompt: 'You want to talk about tomorrow.'
+        options:
+          - text: 'Завтра я буду гуляти.'
+            correct: true
+          - text: 'Завтра я гуляв.'
+            correct: false
+          - text: 'Учора я буду гуляти.'
+            correct: false
+        explanation: 'Завтра pairs with буду + infinitive.'
+  - type: true-false
+    title: A1 finale check
+    instruction: Decide whether the line is clear A1 Ukrainian.
+    items:
+      - statement: 'Мене звати Сара. Я з Канади.'
+        answer: true
+        explanation: 'This is clear A1 identity language.'
+      - statement: 'Вчора я снідаю у кафе.'
+        answer: false
+        explanation: 'Use past after Вчора: я снідав / снідала.'
+      - statement: 'Зараз я їду на метро.'
+        answer: true
+        explanation: 'Зараз plus present їду is clear.'
+      - statement: 'Завтра я буду читати українську.'
+        answer: true
+        explanation: 'Буду + infinitive is the A1 future.'
+      - statement: "Моє ім'я є Адам."
+        answer: false
+        explanation: 'Use Мене звати Адам.'
+  - type: unjumble
+    title: Build final A1 lines
+    instruction: Put the words in a natural order.
+    items:
+      - words: 'Учора/я/снідав/у/кафе.'
+        answer: 'Учора я снідав у кафе.'
+      - words: 'Зараз/я/їду/на/метро.'
+        answer: 'Зараз я їду на метро.'
+      - words: 'Завтра/я/буду/гуляти/в/парку.'
+        answer: 'Завтра я буду гуляти в парку.'
+      - words: 'Повторіть,/будь/ласка.'
+        answer: 'Повторіть, будь ласка.'
+  - type: fill-in
+    title: Final story frame
+    instruction: Choose the phrase that completes the ten-sentence story frame.
+    items:
+      - sentence: 'Мене ___.'
+        answer: 'звати'
+        options:
+          - 'звати'
+          - 'коштує'
+          - 'болить'
+        explanation: 'Мене звати introduces your name.'
+      - sentence: 'Зранку я ___ у кафе.'
+        answer: 'снідав'
+        options:
+          - 'снідав'
+          - 'кафе'
+          - 'буду'
+        explanation: 'This is a past line in the story.'
+      - sentence: 'Ввечері ми ___ в кіно.'
+        answer: 'ходили'
+        options:
+          - 'ходили'
+          - 'кіно'
+          - 'сім'
+        explanation: 'Ходили is the past plural form already practiced.'
+      - sentence: 'Завтра я ___ повторювати українську.'
+        answer: 'буду'
+        options:
+          - 'буду'
+          - 'був'
+          - 'є'
+        explanation: 'Use буду + infinitive for a future plan.'
+  - type: translate
+    title: Finish A1
+    instruction: Choose the Ukrainian phrase that matches the English prompt.
+    items:
+      - source: 'My name is Adam. I am from Canada.'
+        options:
+          - text: 'Мене звати Адам. Я з Канади.'
+            correct: true
+          - text: "Моє ім'я є Адам. Я маю Канада."
+            correct: false
+          - text: 'Адам коштує Канада.'
+            correct: false
+        explanation: 'Use Мене звати... and Я з...'
+      - source: 'Yesterday I bought a souvenir.'
+        options:
+          - text: 'Учора я купив сувенір.'
+            correct: true
+          - text: 'Завтра я купив сувенір.'
+            correct: false
+          - text: 'Сувенір мене звати.'
+            correct: false
+        explanation: 'Учора points to the past.'
+      - source: 'Tomorrow I will read Ukrainian.'
+        options:
+          - text: 'Завтра я буду читати українську.'
+            correct: true
+          - text: 'Учора я буду читати українську.'
+            correct: false
+          - text: 'Завтра я читав українську.'
+            correct: false
+        explanation: 'Use завтра + буду читати.'

--- a/curriculum/l2-uk-en/a1/a1-finale/module.md
+++ b/curriculum/l2-uk-en/a1/a1-finale/module.md
@@ -120,11 +120,8 @@ Notice the three time zones:
 This is enough for an A1 final story. It has a place, actions, people, food,
 transport, money, and plans.
 
-<!-- INJECT_ACTIVITY: act-5 -->
 
-<!-- INJECT_ACTIVITY: act-6 -->
 
-<!-- INJECT_ACTIVITY: act-7 -->
 
 ## Чекліст А1
 
@@ -156,7 +153,6 @@ You can now handle short everyday exchanges.
 <DialogueBox uk="Студент 1: Я буду говорити щодня. Я буду читати короткі тексти. Я буду слухати українську." en="Student 1: I will speak every day. I will read short texts. I will listen to Ukrainian." />
 <DialogueBox uk="Студент 2: Чудовий план. До зустрічі!" en="Student 2: Great plan. See you!" />
 
-<!-- INJECT_ACTIVITY: act-8 -->
 
 ## Підсумок
 
@@ -179,5 +175,3 @@ Short signpost: A2 will help you speak and read longer connected texts. For
 today, the win is A1: clear short speech in real situations.
 
 Вітаю. Це початок, і це вже багато.
-
-<!-- INJECT_ACTIVITY: act-9 -->

--- a/curriculum/l2-uk-en/a1/emergencies/activities.yaml
+++ b/curriculum/l2-uk-en/a1/emergencies/activities.yaml
@@ -1,234 +1,231 @@
-- id: act-1
-  type: fill-in
-  title: Complete the emergency line
-  instruction: Choose the word or number that completes the phrase.
-  items:
-    - sentence: "___! Тут аварія."
-      answer: "Допоможіть"
-      options:
-        - "Допоможіть"
-        - "Дякую"
-        - "Вітаю"
-      explanation: "Допоможіть is the help call."
-    - sentence: "Подзвоніть за номером ___."
-      answer: "112"
-      options:
-        - "112"
-        - "55"
-        - "800"
-      explanation: "112 is the single emergency number."
-    - sentence: "Мене ___ Анна."
-      answer: "звати"
-      options:
-        - "звати"
-        - "болить"
-        - "адреса"
-      explanation: "Мене звати gives your name."
-    - sentence: "Я ___ вулиці Шевченка."
-      answer: "на"
-      options:
-        - "на"
-        - "о"
-        - "до"
-      explanation: "Use на вулиці for on a street."
-- id: act-2
-  type: match-up
-  title: Numbers and services
-  instruction: Match each number with the service word.
-  pairs:
-    - left: "112"
-      right: "екстрена допомога"
-    - left: "101"
-      right: "служба порятунку"
-    - left: "102"
-      right: "поліція"
-    - left: "103"
-      right: "швидка"
-    - left: "104"
-      right: "газова служба"
-- id: act-3
-  type: group-sort
-  title: Sort emergency words
-  instruction: Put each phrase into the right group.
-  groups:
-    - name: "numbers"
-      items:
-        - "112"
-        - "101"
-        - "102"
-        - "103"
-        - "104"
-    - name: "problems"
-      items:
-        - "Тут аварія"
-        - "Тут пожежа"
-        - "Мені погано"
-        - "Я загубив паспорт"
-    - name: "place and identity"
-      items:
-        - "Я на вулиці"
-        - "Я біля метро"
-        - "Мене звати"
-        - "Мій номер телефону"
-- id: act-4
-  type: quiz
-  title: Choose the emergency phrase
-  instruction: Pick the clearest A1 phrase.
-  items:
-    - prompt: "You need to say: There is a fire here."
-      options:
-        - text: "Тут пожежа."
-          correct: true
-        - text: "Тут паспорт."
-          correct: false
-        - text: "Мене пожежа."
-          correct: false
-      explanation: "Тут пожежа is the short problem sentence."
-    - prompt: "You need police."
-      options:
-        - text: "Потрібна поліція."
-          correct: true
-        - text: "Потрібна аптека."
-          correct: false
-        - text: "Поліція болить."
-          correct: false
-      explanation: "Потрібна поліція asks for police help."
-    - prompt: "You want someone to call 103."
-      options:
-        - text: "Подзвоніть за номером 103, будь ласка."
-          correct: true
-        - text: "Я номер сто три."
-          correct: false
-        - text: "Сто три звати."
-          correct: false
-      explanation: "Use Подзвоніть за номером..."
-- id: act-5
-  type: true-false
-  title: Emergency language check
-  instruction: Decide whether the phrase is clear emergency language.
-  items:
-    - statement: "Допоможіть! Тут аварія."
-      answer: true
-      explanation: "This gives a help call and a problem."
-    - statement: "Я на вулиці Франка."
-      answer: true
-      explanation: "This gives a location."
-    - statement: "Мене номер Анна."
-      answer: false
-      explanation: "Use Мене звати Анна."
-    - statement: "Потрібна швидка."
-      answer: true
-      explanation: "This asks for an ambulance."
-    - statement: "Подзвоніть за номером голова."
-      answer: false
-      explanation: "A phone phrase needs a number."
-- id: act-6
-  type: unjumble
-  title: Build emergency lines
-  instruction: Put the words in a natural order.
-  items:
-    - words: "Допоможіть!/Тут/аварія."
-      answer: "Допоможіть! Тут аварія."
-    - words: "Я/на/вулиці/Шевченка."
-      answer: "Я на вулиці Шевченка."
-    - words: "Мене/звати/Анна."
-      answer: "Мене звати Анна."
-    - words: "Подзвоніть/за/номером/112."
-      answer: "Подзвоніть за номером 112."
-- id: act-7
-  type: fill-in
-  title: Location details
-  instruction: Choose the location word that fits.
-  items:
-    - sentence: "Я ___ метро."
-      answer: "біля"
-      options:
-        - "біля"
-        - "звати"
-        - "номер"
-      explanation: "Біля means near."
-    - sentence: "Будинок ___."
-      answer: "п'ять"
-      options:
-        - "п'ять"
-        - "поліція"
-        - "швидка"
-      explanation: "Будинок п'ять gives a building number."
-    - sentence: "Я ___ готелі."
-      answer: "в"
-      options:
-        - "в"
-        - "о"
-        - "за"
-      explanation: "Use в готелі for in a hotel."
-    - sentence: "Я ___ аптеки."
-      answer: "навпроти"
-      options:
-        - "навпроти"
-        - "повторіть"
-        - "аварія"
-      explanation: "Навпроти means opposite."
-- id: act-8
-  type: quiz
-  title: Personal information
-  instruction: Choose the answer that matches the question.
-  items:
-    - prompt: "Як вас звати?"
-      options:
-        - text: "Мене звати Сара."
-          correct: true
-        - text: "Я на вулиці Сара."
-          correct: false
-        - text: "Потрібна Сара."
-          correct: false
-      explanation: "Мене звати... answers the name question."
-    - prompt: "Ваш номер телефону?"
-      options:
-        - text: "Мій номер телефону: нуль дев'яносто сім..."
-          correct: true
-        - text: "Мене звати телефон."
-          correct: false
-        - text: "Тут телефон пожежа."
-          correct: false
-      explanation: "Мій номер телефону... gives the number."
-    - prompt: "Ви розумієте?"
-      options:
-        - text: "Я трохи розумію. Повторіть, будь ласка."
-          correct: true
-        - text: "Я вулиці розумію."
-          correct: false
-        - text: "Паспорт повторіть номер."
-          correct: false
-      explanation: "Use a repair phrase when understanding is limited."
-- id: act-9
-  type: translate
-  title: Emergency message
-  instruction: Choose the Ukrainian phrase that matches the English prompt.
-  items:
-    - source: "Help! There is an accident here."
-      options:
-        - text: "Допоможіть! Тут аварія."
-          correct: true
-        - text: "Дякую! Тут аптека."
-          correct: false
-        - text: "Мене звати аварія."
-          correct: false
-      explanation: "Use Допоможіть and Тут аварія."
-    - source: "I am on Shevchenka Street."
-      options:
-        - text: "Я на вулиці Шевченка."
-          correct: true
-        - text: "Я о вулиці Шевченка."
-          correct: false
-        - text: "Я номер Шевченка."
-          correct: false
-      explanation: "Use на вулиці for on a street."
-    - source: "Please call 102."
-      options:
-        - text: "Подзвоніть за номером 102, будь ласка."
-          correct: true
-        - text: "Повторіть номер 102 звати."
-          correct: false
-        - text: "Сто два на вулиці."
-          correct: false
-      explanation: "Use Подзвоніть за номером..."
+inline:
+  - id: act-1
+    type: fill-in
+    title: Complete the emergency line
+    instruction: Choose the word or number that completes the phrase.
+    items:
+      - sentence: '___! Тут аварія.'
+        answer: 'Допоможіть'
+        options:
+          - 'Допоможіть'
+          - 'Дякую'
+          - 'Вітаю'
+        explanation: 'Допоможіть is the help call.'
+      - sentence: 'Подзвоніть за номером ___.'
+        answer: '112'
+        options:
+          - '112'
+          - '55'
+          - '800'
+        explanation: '112 is the single emergency number.'
+      - sentence: 'Мене ___ Анна.'
+        answer: 'звати'
+        options:
+          - 'звати'
+          - 'болить'
+          - 'адреса'
+        explanation: 'Мене звати gives your name.'
+      - sentence: 'Я ___ вулиці Шевченка.'
+        answer: 'на'
+        options:
+          - 'на'
+          - 'о'
+          - 'до'
+        explanation: 'Use на вулиці for on a street.'
+  - id: act-2
+    type: match-up
+    title: Numbers and services
+    instruction: Match each number with the service word.
+    pairs:
+      - left: '112'
+        right: 'екстрена допомога'
+      - left: '101'
+        right: 'служба порятунку'
+      - left: '102'
+        right: 'поліція'
+      - left: '103'
+        right: 'швидка'
+      - left: '104'
+        right: 'газова служба'
+  - id: act-3
+    type: group-sort
+    title: Sort emergency words
+    instruction: Put each phrase into the right group.
+    groups:
+      - name: 'numbers'
+        items:
+          - '112'
+          - '101'
+          - '102'
+          - '103'
+          - '104'
+      - name: 'problems'
+        items:
+          - 'Тут аварія'
+          - 'Тут пожежа'
+          - 'Мені погано'
+          - 'Я загубив паспорт'
+      - name: 'place and identity'
+        items:
+          - 'Я на вулиці'
+          - 'Я біля метро'
+          - 'Мене звати'
+          - 'Мій номер телефону'
+  - id: act-4
+    type: quiz
+    title: Choose the emergency phrase
+    instruction: Pick the clearest A1 phrase.
+    items:
+      - prompt: 'You need to say: There is a fire here.'
+        options:
+          - text: 'Тут пожежа.'
+            correct: true
+          - text: 'Тут паспорт.'
+            correct: false
+          - text: 'Мене пожежа.'
+            correct: false
+        explanation: 'Тут пожежа is the short problem sentence.'
+      - prompt: 'You need police.'
+        options:
+          - text: 'Потрібна поліція.'
+            correct: true
+          - text: 'Потрібна аптека.'
+            correct: false
+          - text: 'Поліція болить.'
+            correct: false
+        explanation: 'Потрібна поліція asks for police help.'
+      - prompt: 'You want someone to call 103.'
+        options:
+          - text: 'Подзвоніть за номером 103, будь ласка.'
+            correct: true
+          - text: 'Я номер сто три.'
+            correct: false
+          - text: 'Сто три звати.'
+            correct: false
+        explanation: 'Use Подзвоніть за номером...'
+workbook:
+  - type: true-false
+    title: Emergency language check
+    instruction: Decide whether the phrase is clear emergency language.
+    items:
+      - statement: 'Допоможіть! Тут аварія.'
+        answer: true
+        explanation: 'This gives a help call and a problem.'
+      - statement: 'Я на вулиці Франка.'
+        answer: true
+        explanation: 'This gives a location.'
+      - statement: 'Мене номер Анна.'
+        answer: false
+        explanation: 'Use Мене звати Анна.'
+      - statement: 'Потрібна швидка.'
+        answer: true
+        explanation: 'This asks for an ambulance.'
+      - statement: 'Подзвоніть за номером голова.'
+        answer: false
+        explanation: 'A phone phrase needs a number.'
+  - type: unjumble
+    title: Build emergency lines
+    instruction: Put the words in a natural order.
+    items:
+      - words: 'Допоможіть!/Тут/аварія.'
+        answer: 'Допоможіть! Тут аварія.'
+      - words: 'Я/на/вулиці/Шевченка.'
+        answer: 'Я на вулиці Шевченка.'
+      - words: 'Мене/звати/Анна.'
+        answer: 'Мене звати Анна.'
+      - words: 'Подзвоніть/за/номером/112.'
+        answer: 'Подзвоніть за номером 112.'
+  - type: fill-in
+    title: Location details
+    instruction: Choose the location word that fits.
+    items:
+      - sentence: 'Я ___ метро.'
+        answer: 'біля'
+        options:
+          - 'біля'
+          - 'звати'
+          - 'номер'
+        explanation: 'Біля means near.'
+      - sentence: 'Будинок ___.'
+        answer: "п'ять"
+        options:
+          - "п'ять"
+          - 'поліція'
+          - 'швидка'
+        explanation: "Будинок п'ять gives a building number."
+      - sentence: 'Я ___ готелі.'
+        answer: 'в'
+        options:
+          - 'в'
+          - 'о'
+          - 'за'
+        explanation: 'Use в готелі for in a hotel.'
+      - sentence: 'Я ___ аптеки.'
+        answer: 'навпроти'
+        options:
+          - 'навпроти'
+          - 'повторіть'
+          - 'аварія'
+        explanation: 'Навпроти means opposite.'
+  - type: quiz
+    title: Personal information
+    instruction: Choose the answer that matches the question.
+    items:
+      - prompt: 'Як вас звати?'
+        options:
+          - text: 'Мене звати Сара.'
+            correct: true
+          - text: 'Я на вулиці Сара.'
+            correct: false
+          - text: 'Потрібна Сара.'
+            correct: false
+        explanation: 'Мене звати... answers the name question.'
+      - prompt: 'Ваш номер телефону?'
+        options:
+          - text: "Мій номер телефону: нуль дев'яносто сім..."
+            correct: true
+          - text: 'Мене звати телефон.'
+            correct: false
+          - text: 'Тут телефон пожежа.'
+            correct: false
+        explanation: 'Мій номер телефону... gives the number.'
+      - prompt: 'Ви розумієте?'
+        options:
+          - text: 'Я трохи розумію. Повторіть, будь ласка.'
+            correct: true
+          - text: 'Я вулиці розумію.'
+            correct: false
+          - text: 'Паспорт повторіть номер.'
+            correct: false
+        explanation: 'Use a repair phrase when understanding is limited.'
+  - type: translate
+    title: Emergency message
+    instruction: Choose the Ukrainian phrase that matches the English prompt.
+    items:
+      - source: 'Help! There is an accident here.'
+        options:
+          - text: 'Допоможіть! Тут аварія.'
+            correct: true
+          - text: 'Дякую! Тут аптека.'
+            correct: false
+          - text: 'Мене звати аварія.'
+            correct: false
+        explanation: 'Use Допоможіть and Тут аварія.'
+      - source: 'I am on Shevchenka Street.'
+        options:
+          - text: 'Я на вулиці Шевченка.'
+            correct: true
+          - text: 'Я о вулиці Шевченка.'
+            correct: false
+          - text: 'Я номер Шевченка.'
+            correct: false
+        explanation: 'Use на вулиці for on a street.'
+      - source: 'Please call 102.'
+        options:
+          - text: 'Подзвоніть за номером 102, будь ласка.'
+            correct: true
+          - text: 'Повторіть номер 102 звати.'
+            correct: false
+          - text: 'Сто два на вулиці.'
+            correct: false
+        explanation: 'Use Подзвоніть за номером...'

--- a/curriculum/l2-uk-en/a1/emergencies/module.md
+++ b/curriculum/l2-uk-en/a1/emergencies/module.md
@@ -133,9 +133,7 @@ a woman or girl.
 For an A1 call, one problem sentence is enough. Add location next. Keep each
 line separate: help, problem, place, identity, repair.
 
-<!-- INJECT_ACTIVITY: act-5 -->
 
-<!-- INJECT_ACTIVITY: act-6 -->
 
 ## Де ви?
 
@@ -162,7 +160,6 @@ Say numbers slowly. If you need time to repeat, use:
 
 **Повільніше, будь ласка. Я повторюю адресу.**
 
-<!-- INJECT_ACTIVITY: act-7 -->
 
 ### Особиста інформація
 
@@ -184,7 +181,6 @@ Keep the answer slow and separate:
 
 This is not a story. It is a clear information block.
 
-<!-- INJECT_ACTIVITY: act-8 -->
 
 ## Підсумок
 
@@ -208,5 +204,3 @@ One complete A1 call can be very short:
 <DialogueBox uk="Допоможіть! Тут пожежа. Я в Києві, на вулиці Франка, будинок десять. Мене звати Сара Браун. Мій номер телефону: нуль дев'яносто сім, триста десять, двадцять два, сорок один. Повторіть, будь ласка." en="Help! There is a fire here. I am in Kyiv, on Franka Street, building ten. My name is Sarah Brown. My phone number is zero ninety-seven, three hundred ten, twenty-two, forty-one. Please repeat." />
 
 That is the goal: a clear problem, a clear place, and clear identity words.
-
-<!-- INJECT_ACTIVITY: act-9 -->

--- a/curriculum/l2-uk-en/a1/health/activities.yaml
+++ b/curriculum/l2-uk-en/a1/health/activities.yaml
@@ -1,239 +1,236 @@
-- id: act-1
-  type: fill-in
-  title: Complete the health phrase
-  instruction: Choose the word that completes the A1 phrase.
-  items:
-    - sentence: "У мене болить ___."
-      answer: "голова"
-      options:
-        - "голова"
-        - "лікар"
-        - "аптека"
-      explanation: "Голова is a body part, so it fits after болить."
-    - sentence: "Мені потрібен ___."
-      answer: "лікар"
-      options:
-        - "лікар"
-        - "голова"
-        - "кашель"
-      explanation: "Лікар means doctor."
-    - sentence: "У мене ___."
-      answer: "температура"
-      options:
-        - "температура"
-        - "праворуч"
-        - "квиток"
-      explanation: "У мене температура is a fixed symptom phrase."
-    - sentence: "___, будь ласка."
-      answer: "Повторіть"
-      options:
-        - "Повторіть"
-        - "Болить"
-        - "Нежить"
-      explanation: "Повторіть, будь ласка asks someone to repeat."
-- id: act-2
-  type: match-up
-  title: Body words
-  instruction: Match each Ukrainian body word with English.
-  pairs:
-    - left: "голова"
-      right: "head"
-    - left: "горло"
-      right: "throat"
-    - left: "живіт"
-      right: "stomach"
-    - left: "спина"
-      right: "back"
-    - left: "рука"
-      right: "hand / arm"
-    - left: "нога"
-      right: "leg / foot"
-    - left: "зуб"
-      right: "tooth"
-    - left: "вухо"
-      right: "ear"
-- id: act-3
-  type: group-sort
-  title: Sort health words
-  instruction: Put each phrase into the right group.
-  groups:
-    - name: "body parts"
-      items:
-        - "голова"
-        - "горло"
-        - "живіт"
-        - "спина"
-        - "зуб"
-    - name: "symptom phrases"
-      items:
-        - "У мене температура"
-        - "У мене кашель"
-        - "У мене нежить"
-        - "Мені погано"
-    - name: "help phrases"
-      items:
-        - "Мені потрібен лікар"
-        - "Де тут аптека?"
-        - "Повторіть, будь ласка"
-- id: act-4
-  type: quiz
-  title: Choose the clear A1 phrase
-  instruction: Choose the phrase that communicates the problem clearly.
-  items:
-    - prompt: "You want to say: My stomach hurts."
-      options:
-        - text: "У мене болить живіт."
-          correct: true
-        - text: "Я живіт болить."
-          correct: false
-        - text: "Мій живіт є болить."
-          correct: false
-      explanation: "Use У мене болить + body part."
-    - prompt: "You need a doctor."
-      options:
-        - text: "Мені потрібен лікар."
-          correct: true
-        - text: "Я потрібно лікар."
-          correct: false
-        - text: "Лікар болить."
-          correct: false
-      explanation: "Мені потрібен лікар is the fixed help phrase."
-    - prompt: "You do not understand."
-      options:
-        - text: "Я не розумію."
-          correct: true
-        - text: "Я не аптека."
-          correct: false
-        - text: "У мене розумію."
-          correct: false
-      explanation: "Я не розумію is the repair phrase."
-- id: act-5
-  type: true-false
-  title: Phrase-level health check
-  instruction: Decide whether the sentence is a clear A1 health phrase.
-  items:
-    - statement: "У мене болить горло."
-      answer: true
-      explanation: "This follows У мене болить + body part."
-    - statement: "Моя голова болить."
-      answer: false
-      explanation: "Use the more natural A1 phrase: У мене болить голова."
-    - statement: "У мене кашель."
-      answer: true
-      explanation: "This is a fixed symptom phrase."
-    - statement: "Я є хворий."
-      answer: false
-      explanation: "Drop є: Я хворий."
-    - statement: "Мені потрібен лікар."
-      answer: true
-      explanation: "This is the help phrase."
-- id: act-6
-  type: unjumble
-  title: Build health lines
-  instruction: Put the words in a natural order.
-  items:
-    - words: "У/мене/болить/голова"
-      answer: "У мене болить голова."
-    - words: "Мені/потрібен/лікар"
-      answer: "Мені потрібен лікар."
-    - words: "Я/не/розумію"
-      answer: "Я не розумію."
-    - words: "Повторіть/будь/ласка"
-      answer: "Повторіть, будь ласка."
-- id: act-7
-  type: fill-in
-  title: Doctor or pharmacy phrases
-  instruction: Choose the phrase that fits the short situation.
-  items:
-    - sentence: "Добрий день. У мене болить ___."
-      answer: "спина"
-      options:
-        - "спина"
-        - "лікар"
-        - "аптека"
-      explanation: "Спина is a body part."
-    - sentence: "Вибачте. Де тут ___?"
-      answer: "аптека"
-      options:
-        - "аптека"
-        - "болить"
-        - "нога"
-      explanation: "Де тут аптека? asks for the pharmacy."
-    - sentence: "Мені ___."
-      answer: "погано"
-      options:
-        - "погано"
-        - "голова"
-        - "кашель"
-      explanation: "Мені погано means I feel bad."
-    - sentence: "___, будь ласка. Я не розумію."
-      answer: "Повільніше"
-      options:
-        - "Повільніше"
-        - "Голова"
-        - "Температура"
-      explanation: "Повільніше asks someone to speak more slowly."
-- id: act-8
-  type: quiz
-  title: Repair health phrases
-  instruction: Choose the natural Ukrainian repair.
-  items:
-    - prompt: "Repair: Моя рука болить."
-      options:
-        - text: "У мене болить рука."
-          correct: true
-        - text: "У мене рука лікар."
-          correct: false
-        - text: "Рука потрібен мене."
-          correct: false
-      explanation: "Use У мене болить + body part."
-    - prompt: "Repair: Я потрібно лікар."
-      options:
-        - text: "Мені потрібен лікар."
-          correct: true
-        - text: "Я потрібен лікар."
-          correct: false
-        - text: "Лікар потрібно я."
-          correct: false
-      explanation: "Use the fixed phrase Мені потрібен лікар."
-    - prompt: "Repair: У мене є нежить."
-      options:
-        - text: "У мене нежить."
-          correct: true
-        - text: "Я нежить болить."
-          correct: false
-        - text: "Нежить потрібен."
-          correct: false
-      explanation: "Use the simple phrase У мене нежить."
-- id: act-9
-  type: translate
-  title: Say what hurts
-  instruction: Choose the Ukrainian phrase that matches the English prompt.
-  items:
-    - source: "My throat hurts."
-      options:
-        - text: "У мене болить горло."
-          correct: true
-        - text: "Мені потрібен лікар."
-          correct: false
-        - text: "У мене нежить."
-          correct: false
-      explanation: "Use У мене болить + горло."
-    - source: "I need a doctor."
-      options:
-        - text: "Мені потрібен лікар."
-          correct: true
-        - text: "У мене болить зуб."
-          correct: false
-        - text: "Де тут аптека?"
-          correct: false
-      explanation: "Мені потрібен лікар is the help phrase."
-    - source: "Please repeat."
-      options:
-        - text: "Повторіть, будь ласка."
-          correct: true
-        - text: "Мені погано."
-          correct: false
-        - text: "У мене кашель."
-          correct: false
-      explanation: "Use Повторіть, будь ласка."
+inline:
+  - id: act-1
+    type: fill-in
+    title: Complete the health phrase
+    instruction: Choose the word that completes the A1 phrase.
+    items:
+      - sentence: 'У мене болить ___.'
+        answer: 'голова'
+        options:
+          - 'голова'
+          - 'лікар'
+          - 'аптека'
+        explanation: 'Голова is a body part, so it fits after болить.'
+      - sentence: 'Мені потрібен ___.'
+        answer: 'лікар'
+        options:
+          - 'лікар'
+          - 'голова'
+          - 'кашель'
+        explanation: 'Лікар means doctor.'
+      - sentence: 'У мене ___.'
+        answer: 'температура'
+        options:
+          - 'температура'
+          - 'праворуч'
+          - 'квиток'
+        explanation: 'У мене температура is a fixed symptom phrase.'
+      - sentence: '___, будь ласка.'
+        answer: 'Повторіть'
+        options:
+          - 'Повторіть'
+          - 'Болить'
+          - 'Нежить'
+        explanation: 'Повторіть, будь ласка asks someone to repeat.'
+  - id: act-2
+    type: match-up
+    title: Body words
+    instruction: Match each Ukrainian body word with English.
+    pairs:
+      - left: 'голова'
+        right: 'head'
+      - left: 'горло'
+        right: 'throat'
+      - left: 'живіт'
+        right: 'stomach'
+      - left: 'спина'
+        right: 'back'
+      - left: 'рука'
+        right: 'hand / arm'
+      - left: 'нога'
+        right: 'leg / foot'
+      - left: 'зуб'
+        right: 'tooth'
+      - left: 'вухо'
+        right: 'ear'
+  - id: act-3
+    type: group-sort
+    title: Sort health words
+    instruction: Put each phrase into the right group.
+    groups:
+      - name: 'body parts'
+        items:
+          - 'голова'
+          - 'горло'
+          - 'живіт'
+          - 'спина'
+          - 'зуб'
+      - name: 'symptom phrases'
+        items:
+          - 'У мене температура'
+          - 'У мене кашель'
+          - 'У мене нежить'
+          - 'Мені погано'
+      - name: 'help phrases'
+        items:
+          - 'Мені потрібен лікар'
+          - 'Де тут аптека?'
+          - 'Повторіть, будь ласка'
+  - id: act-4
+    type: quiz
+    title: Choose the clear A1 phrase
+    instruction: Choose the phrase that communicates the problem clearly.
+    items:
+      - prompt: 'You want to say: My stomach hurts.'
+        options:
+          - text: 'У мене болить живіт.'
+            correct: true
+          - text: 'Я живіт болить.'
+            correct: false
+          - text: 'Мій живіт є болить.'
+            correct: false
+        explanation: 'Use У мене болить + body part.'
+      - prompt: 'You need a doctor.'
+        options:
+          - text: 'Мені потрібен лікар.'
+            correct: true
+          - text: 'Я потрібно лікар.'
+            correct: false
+          - text: 'Лікар болить.'
+            correct: false
+        explanation: 'Мені потрібен лікар is the fixed help phrase.'
+      - prompt: 'You do not understand.'
+        options:
+          - text: 'Я не розумію.'
+            correct: true
+          - text: 'Я не аптека.'
+            correct: false
+          - text: 'У мене розумію.'
+            correct: false
+        explanation: 'Я не розумію is the repair phrase.'
+workbook:
+  - type: true-false
+    title: Phrase-level health check
+    instruction: Decide whether the sentence is a clear A1 health phrase.
+    items:
+      - statement: 'У мене болить горло.'
+        answer: true
+        explanation: 'This follows У мене болить + body part.'
+      - statement: 'Моя голова болить.'
+        answer: false
+        explanation: 'Use the more natural A1 phrase: У мене болить голова.'
+      - statement: 'У мене кашель.'
+        answer: true
+        explanation: 'This is a fixed symptom phrase.'
+      - statement: 'Я є хворий.'
+        answer: false
+        explanation: 'Drop є: Я хворий.'
+      - statement: 'Мені потрібен лікар.'
+        answer: true
+        explanation: 'This is the help phrase.'
+  - type: unjumble
+    title: Build health lines
+    instruction: Put the words in a natural order.
+    items:
+      - words: 'У/мене/болить/голова'
+        answer: 'У мене болить голова.'
+      - words: 'Мені/потрібен/лікар'
+        answer: 'Мені потрібен лікар.'
+      - words: 'Я/не/розумію'
+        answer: 'Я не розумію.'
+      - words: 'Повторіть/будь/ласка'
+        answer: 'Повторіть, будь ласка.'
+  - type: fill-in
+    title: Doctor or pharmacy phrases
+    instruction: Choose the phrase that fits the short situation.
+    items:
+      - sentence: 'Добрий день. У мене болить ___.'
+        answer: 'спина'
+        options:
+          - 'спина'
+          - 'лікар'
+          - 'аптека'
+        explanation: 'Спина is a body part.'
+      - sentence: 'Вибачте. Де тут ___?'
+        answer: 'аптека'
+        options:
+          - 'аптека'
+          - 'болить'
+          - 'нога'
+        explanation: 'Де тут аптека? asks for the pharmacy.'
+      - sentence: 'Мені ___.'
+        answer: 'погано'
+        options:
+          - 'погано'
+          - 'голова'
+          - 'кашель'
+        explanation: 'Мені погано means I feel bad.'
+      - sentence: '___, будь ласка. Я не розумію.'
+        answer: 'Повільніше'
+        options:
+          - 'Повільніше'
+          - 'Голова'
+          - 'Температура'
+        explanation: 'Повільніше asks someone to speak more slowly.'
+  - type: quiz
+    title: Repair health phrases
+    instruction: Choose the natural Ukrainian repair.
+    items:
+      - prompt: 'Repair: Моя рука болить.'
+        options:
+          - text: 'У мене болить рука.'
+            correct: true
+          - text: 'У мене рука лікар.'
+            correct: false
+          - text: 'Рука потрібен мене.'
+            correct: false
+        explanation: 'Use У мене болить + body part.'
+      - prompt: 'Repair: Я потрібно лікар.'
+        options:
+          - text: 'Мені потрібен лікар.'
+            correct: true
+          - text: 'Я потрібен лікар.'
+            correct: false
+          - text: 'Лікар потрібно я.'
+            correct: false
+        explanation: 'Use the fixed phrase Мені потрібен лікар.'
+      - prompt: 'Repair: У мене є нежить.'
+        options:
+          - text: 'У мене нежить.'
+            correct: true
+          - text: 'Я нежить болить.'
+            correct: false
+          - text: 'Нежить потрібен.'
+            correct: false
+        explanation: 'Use the simple phrase У мене нежить.'
+  - type: translate
+    title: Say what hurts
+    instruction: Choose the Ukrainian phrase that matches the English prompt.
+    items:
+      - source: 'My throat hurts.'
+        options:
+          - text: 'У мене болить горло.'
+            correct: true
+          - text: 'Мені потрібен лікар.'
+            correct: false
+          - text: 'У мене нежить.'
+            correct: false
+        explanation: 'Use У мене болить + горло.'
+      - source: 'I need a doctor.'
+        options:
+          - text: 'Мені потрібен лікар.'
+            correct: true
+          - text: 'У мене болить зуб.'
+            correct: false
+          - text: 'Де тут аптека?'
+            correct: false
+        explanation: 'Мені потрібен лікар is the help phrase.'
+      - source: 'Please repeat.'
+        options:
+          - text: 'Повторіть, будь ласка.'
+            correct: true
+          - text: 'Мені погано.'
+            correct: false
+          - text: 'У мене кашель.'
+            correct: false
+        explanation: 'Use Повторіть, будь ласка.'

--- a/curriculum/l2-uk-en/a1/health/module.md
+++ b/curriculum/l2-uk-en/a1/health/module.md
@@ -148,9 +148,7 @@ Other useful fixed phrases:
 Use **хворий** if you speak as a man or boy. Use **хвора** if you speak as a
 woman or girl.
 
-<!-- INJECT_ACTIVITY: act-5 -->
 
-<!-- INJECT_ACTIVITY: act-6 -->
 
 ## Просити про допомогу
 
@@ -198,7 +196,6 @@ Use these scripts as ready-made cards. Replace only the body word or place word.
 These scripts repeat the same safe pattern: greet, name the symptom, ask for a
 doctor, and use a repair phrase. You can say them slowly and still be clear.
 
-<!-- INJECT_ACTIVITY: act-7 -->
 
 ### Repair traps
 
@@ -215,7 +212,6 @@ Keep the Ukrainian phrase shape.
 These repairs are about natural Ukrainian phrases. You do not need to name the
 grammar. Memorize the safe chunks and use them.
 
-<!-- INJECT_ACTIVITY: act-8 -->
 
 ## Підсумок
 
@@ -236,5 +232,3 @@ One complete A1 message can be this short:
 
 That is enough for this module: say the symptom, ask for help, and use repair
 phrases when you need them.
-
-<!-- INJECT_ACTIVITY: act-9 -->

--- a/curriculum/l2-uk-en/a1/my-plans/activities.yaml
+++ b/curriculum/l2-uk-en/a1/my-plans/activities.yaml
@@ -1,284 +1,280 @@
-- id: act-1
-  type: fill-in
-  title: Build a dated plan
-  instruction: Choose the word that completes the plan.
-  items:
-    - sentence: "У ___ я буду працювати."
-      answer: "понеділок"
-      options:
-        - "понеділок"
-        - "третій"
-        - "шостій"
-      explanation: "У понеділок names the day."
-    - sentence: "У суботу ___ я буду прибирати квартиру."
-      answer: "зранку"
-      options:
-        - "зранку"
-        - "о"
-        - "план"
-      explanation: "Зранку names the part of the day."
-    - sentence: "___ шостій ми будемо дивитися кіно."
-      answer: "О"
-      options:
-        - "О"
-        - "У"
-        - "На"
-      explanation: "Use о with clock time."
-    - sentence: "У неділю він буде ___."
-      answer: "відпочивати"
-      options:
-        - "відпочивати"
-        - "відпочиває"
-        - "відпочивав"
-      explanation: "After буде, use the infinitive."
-    - sentence: "У п'ятницю ввечері буде ___."
-      answer: "вечірка"
-      options:
-        - "вечірка"
-        - "квартира"
-        - "тиждень"
-      explanation: "Вечірка means party."
-- id: act-2
-  type: match-up
-  title: Invitations and answers
-  instruction: Match each invitation with a natural answer.
-  pairs:
-    - left: "Ходімо в кіно!"
-      right: "З задоволенням!"
-    - left: "Давай зустрінемося о п'ятій!"
-      right: "Чудово! До зустрічі!"
-    - left: "Ти будеш вільний у суботу?"
-      right: "На жаль, не можу."
-    - left: "Ходімо в кафе о шостій!"
-      right: "Добре! О шостій."
-    - left: "Ти будеш на вечірці?"
-      right: "Звичайно буду!"
-- id: act-3
-  type: quiz
-  title: Planning pattern
-  instruction: Choose the sentence that stays in the A1 planning pattern.
-  items:
-    - prompt: "Which line gives a day, time, and compound future?"
-      options:
-        - text: "У суботу о третій я буду готувати."
-          correct: true
-        - text: "У суботу о третій я готую вчора."
-          correct: false
-        - text: "У суботу о третій я готував."
-          correct: false
-      explanation: "The plan uses day + time + буду + infinitive."
-    - prompt: "Which invitation reuses the M43 chunk?"
-      options:
-        - text: "Ходімо в кіно!"
-          correct: true
-        - text: "Я буду кіно."
-          correct: false
-        - text: "Кіно буде прибирати."
-          correct: false
-      explanation: "Ходімо is a familiar invitation chunk."
-    - prompt: "Which answer politely refuses?"
-      options:
-        - text: "На жаль, не можу."
-          correct: true
-        - text: "З задоволенням!"
-          correct: false
-        - text: "Звичайно буду!"
-          correct: false
-      explanation: "На жаль, не можу is a polite refusal."
-    - prompt: "Which phrase asks about availability?"
-      options:
-        - text: "Ти будеш вільна у суботу?"
-          correct: true
-        - text: "Ти була вільна учора?"
-          correct: false
-        - text: "Ти вільна о вчора?"
-          correct: false
-      explanation: "Будеш вільна asks about future availability."
-- id: act-4
-  type: group-sort
-  title: Sort planning phrases
-  instruction: Put each phrase into the right planning group.
-  groups:
-    - name: "days"
-      items:
-        - "у понеділок"
-        - "у середу"
-        - "у суботу"
-        - "в неділю"
-    - name: "times"
-      items:
-        - "о третій"
-        - "о п'ятій"
-        - "о шостій"
-        - "ввечері"
-    - name: "invitations"
-      items:
-        - "Ходімо в кіно!"
-        - "Давай зустрінемося!"
-    - name: "answers"
-      items:
-        - "З задоволенням!"
-        - "На жаль, не можу."
-        - "Звичайно буду!"
-- id: act-5
-  type: true-false
-  title: Check the weekly plan
-  instruction: Decide whether each line is a clear A1 plan.
-  items:
-    - statement: "У суботу я буду прибирати квартиру."
-      answer: true
-      explanation: "Буду + прибирати is correct."
-    - statement: "У неділю ми будемо відпочивати."
-      answer: true
-      explanation: "Будемо + відпочивати is correct."
-    - statement: "О шостій ви будете дивитеся кіно."
-      answer: false
-      explanation: "After будете, use дивитися."
-    - statement: "У п'ятницю ввечері буде вечірка."
-      answer: true
-      explanation: "This is a clear scheduled event."
-    - statement: "У середу я буду вчу українську."
-      answer: false
-      explanation: "After буду, use вчити."
-    - statement: "Ти будеш вільний у суботу?"
-      answer: true
-      explanation: "This asks about future availability."
-- id: act-6
-  type: unjumble
-  title: Build planning lines
-  instruction: Put the words in a natural order.
-  items:
-    - words: ["У", "суботу", "я", "буду", "прибирати", "квартиру"]
-      answer: "У суботу я буду прибирати квартиру."
-    - words: ["О", "шостій", "ми", "будемо", "дивитися", "кіно"]
-      answer: "О шостій ми будемо дивитися кіно."
-    - words: ["Ти", "будеш", "вільна", "у", "суботу"]
-      answer: "Ти будеш вільна у суботу?"
-    - words: ["Давай", "зустрінемося", "о", "п'ятій"]
-      answer: "Давай зустрінемося о п'ятій!"
-    - words: ["На", "жаль", "не", "можу"]
-      answer: "На жаль, не можу."
-- id: act-7
-  type: order
-  title: Put the week in order
-  instruction: Arrange the days from Monday to Sunday.
-  items:
-    - "У понеділок я буду працювати."
-    - "У вівторок я буду вчити українську."
-    - "У середу буде зустріч."
-    - "У четвер я буду готувати."
-    - "У п'ятницю буде вечірка."
-    - "У суботу я буду прибирати."
-    - "В неділю я буду відпочивати."
-  correct_order: [0, 1, 2, 3, 4, 5, 6]
-- id: act-8
-  type: fill-in
-  title: Complete the week schedule
-  instruction: Choose the future form or planning phrase.
-  items:
-    - sentence: "У вівторок я ___ українську."
-      answer: "буду вчити"
-      options:
-        - "буду вчити"
-        - "вчив"
-        - "вчу"
-      explanation: "Use буду + infinitive for a future plan."
-    - sentence: "У середу ми ___ вечерю."
-      answer: "будемо готувати"
-      options:
-        - "будемо готувати"
-        - "готували"
-        - "готуємо"
-      explanation: "Use будемо + infinitive."
-    - sentence: "У четвер вона ___ допізна."
-      answer: "буде працювати"
-      options:
-        - "буде працювати"
-        - "працювала"
-        - "працює"
-      explanation: "Use буде + infinitive."
-    - sentence: "___, не можу. У суботу я буду працювати."
-      answer: "На жаль"
-      options:
-        - "На жаль"
-        - "Звичайно"
-        - "З задоволенням"
-      explanation: "На жаль, не можу is a polite refusal."
-- id: act-9
-  type: translate
-  title: Say your plans
-  instruction: Choose the Ukrainian sentence that matches the English prompt.
-  items:
-    - source: "On Saturday I will clean the apartment."
-      options:
-        - text: "У суботу я буду прибирати квартиру."
-          correct: true
-        - text: "У суботу я прибираю вчора."
-          correct: false
-        - text: "У суботу я прибирала учора."
-          correct: false
-      explanation: "Use буду прибирати for a future plan."
-    - source: "At six we will watch a film."
-      options:
-        - text: "О шостій ми будемо дивитися кіно."
-          correct: true
-        - text: "О шостій ми дивилися кіно."
-          correct: false
-        - text: "О шостій ми дивимося учора."
-          correct: false
-      explanation: "Use о шостій + будемо дивитися."
-    - source: "Will you be free on Saturday? (to a female friend)"
-      options:
-        - text: "Ти будеш вільна у суботу?"
-          correct: true
-        - text: "Ти була вільна у суботу?"
-          correct: false
-        - text: "Ти буде вільна у суботу?"
-          correct: false
-      explanation: "Ти takes будеш."
-    - source: "Unfortunately, I cannot."
-      options:
-        - text: "На жаль, не можу."
-          correct: true
-        - text: "З задоволенням!"
-          correct: false
-        - text: "Звичайно буду!"
-          correct: false
-      explanation: "На жаль, не можу is the polite refusal."
-- id: act-10
-  type: error-correction
-  title: Repair plan sentences
-  instruction: Fix the weekly plan by keeping the compound future.
-  items:
-    - sentence: "У суботу я буду прибираю квартиру."
-      error: "прибираю"
-      correction: "прибирати"
-      explanation: "After буду, use the infinitive прибирати."
-    - sentence: "У неділю ми будемо відпочиваємо."
-      error: "відпочиваємо"
-      correction: "відпочивати"
-      explanation: "After будемо, use відпочивати."
-    - sentence: "О шостій ви будете дивитеся кіно."
-      error: "дивитеся"
-      correction: "дивитися"
-      explanation: "After будете, use дивитися."
-    - sentence: "Вони будуть готують на вечірку."
-      error: "готують"
-      correction: "готувати"
-      explanation: "After будуть, use готувати."
-    - sentence: "У середу я буду вчу українську."
-      error: "вчу"
-      correction: "вчити"
-      explanation: "After буду, use вчити."
-    - sentence: "Я буду роблю домашнє завдання."
-      error: "Я буду роблю домашнє завдання."
-      correction: "Я буду робити домашнє завдання."
-      explanation: "After буду, use the infinitive робити."
-    - sentence: "На понеділок я маю урок."
-      error: "На понеділок"
-      correction: "У понеділок"
-      explanation: "Use у with weekdays: у понеділок."
-    - sentence: "На шостій ми будемо дивитися кіно."
-      error: "На шостій"
-      correction: "О шостій"
-      explanation: "Use о with clock time: о шостій."
+inline:
+  - id: act-1
+    type: fill-in
+    title: Build a dated plan
+    instruction: Choose the word that completes the plan.
+    items:
+      - sentence: 'У ___ я буду працювати.'
+        answer: 'понеділок'
+        options:
+          - 'понеділок'
+          - 'третій'
+          - 'шостій'
+        explanation: 'У понеділок names the day.'
+      - sentence: 'У суботу ___ я буду прибирати квартиру.'
+        answer: 'зранку'
+        options:
+          - 'зранку'
+          - 'о'
+          - 'план'
+        explanation: 'Зранку names the part of the day.'
+      - sentence: '___ шостій ми будемо дивитися кіно.'
+        answer: 'О'
+        options:
+          - 'О'
+          - 'У'
+          - 'На'
+        explanation: 'Use о with clock time.'
+      - sentence: 'У неділю він буде ___.'
+        answer: 'відпочивати'
+        options:
+          - 'відпочивати'
+          - 'відпочиває'
+          - 'відпочивав'
+        explanation: 'After буде, use the infinitive.'
+      - sentence: "У п'ятницю ввечері буде ___."
+        answer: 'вечірка'
+        options:
+          - 'вечірка'
+          - 'квартира'
+          - 'тиждень'
+        explanation: 'Вечірка means party.'
+  - id: act-2
+    type: match-up
+    title: Invitations and answers
+    instruction: Match each invitation with a natural answer.
+    pairs:
+      - left: 'Ходімо в кіно!'
+        right: 'З задоволенням!'
+      - left: "Давай зустрінемося о п'ятій!"
+        right: 'Чудово! До зустрічі!'
+      - left: 'Ти будеш вільний у суботу?'
+        right: 'На жаль, не можу.'
+      - left: 'Ходімо в кафе о шостій!'
+        right: 'Добре! О шостій.'
+      - left: 'Ти будеш на вечірці?'
+        right: 'Звичайно буду!'
+  - id: act-3
+    type: quiz
+    title: Planning pattern
+    instruction: Choose the sentence that stays in the A1 planning pattern.
+    items:
+      - prompt: 'Which line gives a day, time, and compound future?'
+        options:
+          - text: 'У суботу о третій я буду готувати.'
+            correct: true
+          - text: 'У суботу о третій я готую вчора.'
+            correct: false
+          - text: 'У суботу о третій я готував.'
+            correct: false
+        explanation: 'The plan uses day + time + буду + infinitive.'
+      - prompt: 'Which invitation reuses the M43 chunk?'
+        options:
+          - text: 'Ходімо в кіно!'
+            correct: true
+          - text: 'Я буду кіно.'
+            correct: false
+          - text: 'Кіно буде прибирати.'
+            correct: false
+        explanation: 'Ходімо is a familiar invitation chunk.'
+      - prompt: 'Which answer politely refuses?'
+        options:
+          - text: 'На жаль, не можу.'
+            correct: true
+          - text: 'З задоволенням!'
+            correct: false
+          - text: 'Звичайно буду!'
+            correct: false
+        explanation: 'На жаль, не можу is a polite refusal.'
+      - prompt: 'Which phrase asks about availability?'
+        options:
+          - text: 'Ти будеш вільна у суботу?'
+            correct: true
+          - text: 'Ти була вільна учора?'
+            correct: false
+          - text: 'Ти вільна о вчора?'
+            correct: false
+        explanation: 'Будеш вільна asks about future availability.'
+  - id: act-4
+    type: group-sort
+    title: Sort planning phrases
+    instruction: Put each phrase into the right planning group.
+    groups:
+      - name: 'days'
+        items:
+          - 'у понеділок'
+          - 'у середу'
+          - 'у суботу'
+          - 'в неділю'
+      - name: 'times'
+        items:
+          - 'о третій'
+          - "о п'ятій"
+          - 'о шостій'
+          - 'ввечері'
+      - name: 'invitations'
+        items:
+          - 'Ходімо в кіно!'
+          - 'Давай зустрінемося!'
+      - name: 'answers'
+        items:
+          - 'З задоволенням!'
+          - 'На жаль, не можу.'
+          - 'Звичайно буду!'
+workbook:
+  - type: true-false
+    title: Check the weekly plan
+    instruction: Decide whether each line is a clear A1 plan.
+    items:
+      - statement: 'У суботу я буду прибирати квартиру.'
+        answer: true
+        explanation: 'Буду + прибирати is correct.'
+      - statement: 'У неділю ми будемо відпочивати.'
+        answer: true
+        explanation: 'Будемо + відпочивати is correct.'
+      - statement: 'О шостій ви будете дивитеся кіно.'
+        answer: false
+        explanation: 'After будете, use дивитися.'
+      - statement: "У п'ятницю ввечері буде вечірка."
+        answer: true
+        explanation: 'This is a clear scheduled event.'
+      - statement: 'У середу я буду вчу українську.'
+        answer: false
+        explanation: 'After буду, use вчити.'
+      - statement: 'Ти будеш вільний у суботу?'
+        answer: true
+        explanation: 'This asks about future availability.'
+  - type: unjumble
+    title: Build planning lines
+    instruction: Put the words in a natural order.
+    items:
+      - words: ['У', 'суботу', 'я', 'буду', 'прибирати', 'квартиру']
+        answer: 'У суботу я буду прибирати квартиру.'
+      - words: ['О', 'шостій', 'ми', 'будемо', 'дивитися', 'кіно']
+        answer: 'О шостій ми будемо дивитися кіно.'
+      - words: ['Ти', 'будеш', 'вільна', 'у', 'суботу']
+        answer: 'Ти будеш вільна у суботу?'
+      - words: ['Давай', 'зустрінемося', 'о', "п'ятій"]
+        answer: "Давай зустрінемося о п'ятій!"
+      - words: ['На', 'жаль', 'не', 'можу']
+        answer: 'На жаль, не можу.'
+  - type: order
+    title: Put the week in order
+    instruction: Arrange the days from Monday to Sunday.
+    items:
+      - 'У понеділок я буду працювати.'
+      - 'У вівторок я буду вчити українську.'
+      - 'У середу буде зустріч.'
+      - 'У четвер я буду готувати.'
+      - "У п'ятницю буде вечірка."
+      - 'У суботу я буду прибирати.'
+      - 'В неділю я буду відпочивати.'
+    correct_order: [0, 1, 2, 3, 4, 5, 6]
+  - type: fill-in
+    title: Complete the week schedule
+    instruction: Choose the future form or planning phrase.
+    items:
+      - sentence: 'У вівторок я ___ українську.'
+        answer: 'буду вчити'
+        options:
+          - 'буду вчити'
+          - 'вчив'
+          - 'вчу'
+        explanation: 'Use буду + infinitive for a future plan.'
+      - sentence: 'У середу ми ___ вечерю.'
+        answer: 'будемо готувати'
+        options:
+          - 'будемо готувати'
+          - 'готували'
+          - 'готуємо'
+        explanation: 'Use будемо + infinitive.'
+      - sentence: 'У четвер вона ___ допізна.'
+        answer: 'буде працювати'
+        options:
+          - 'буде працювати'
+          - 'працювала'
+          - 'працює'
+        explanation: 'Use буде + infinitive.'
+      - sentence: '___, не можу. У суботу я буду працювати.'
+        answer: 'На жаль'
+        options:
+          - 'На жаль'
+          - 'Звичайно'
+          - 'З задоволенням'
+        explanation: 'На жаль, не можу is a polite refusal.'
+  - type: translate
+    title: Say your plans
+    instruction: Choose the Ukrainian sentence that matches the English prompt.
+    items:
+      - source: 'On Saturday I will clean the apartment.'
+        options:
+          - text: 'У суботу я буду прибирати квартиру.'
+            correct: true
+          - text: 'У суботу я прибираю вчора.'
+            correct: false
+          - text: 'У суботу я прибирала учора.'
+            correct: false
+        explanation: 'Use буду прибирати for a future plan.'
+      - source: 'At six we will watch a film.'
+        options:
+          - text: 'О шостій ми будемо дивитися кіно.'
+            correct: true
+          - text: 'О шостій ми дивилися кіно.'
+            correct: false
+          - text: 'О шостій ми дивимося учора.'
+            correct: false
+        explanation: 'Use о шостій + будемо дивитися.'
+      - source: 'Will you be free on Saturday? (to a female friend)'
+        options:
+          - text: 'Ти будеш вільна у суботу?'
+            correct: true
+          - text: 'Ти була вільна у суботу?'
+            correct: false
+          - text: 'Ти буде вільна у суботу?'
+            correct: false
+        explanation: 'Ти takes будеш.'
+      - source: 'Unfortunately, I cannot.'
+        options:
+          - text: 'На жаль, не можу.'
+            correct: true
+          - text: 'З задоволенням!'
+            correct: false
+          - text: 'Звичайно буду!'
+            correct: false
+        explanation: 'На жаль, не можу is the polite refusal.'
+  - type: error-correction
+    title: Repair plan sentences
+    instruction: Fix the weekly plan by keeping the compound future.
+    items:
+      - sentence: 'У суботу я буду прибираю квартиру.'
+        error: 'прибираю'
+        correction: 'прибирати'
+        explanation: 'After буду, use the infinitive прибирати.'
+      - sentence: 'У неділю ми будемо відпочиваємо.'
+        error: 'відпочиваємо'
+        correction: 'відпочивати'
+        explanation: 'After будемо, use відпочивати.'
+      - sentence: 'О шостій ви будете дивитеся кіно.'
+        error: 'дивитеся'
+        correction: 'дивитися'
+        explanation: 'After будете, use дивитися.'
+      - sentence: 'Вони будуть готують на вечірку.'
+        error: 'готують'
+        correction: 'готувати'
+        explanation: 'After будуть, use готувати.'
+      - sentence: 'У середу я буду вчу українську.'
+        error: 'вчу'
+        correction: 'вчити'
+        explanation: 'After буду, use вчити.'
+      - sentence: 'Я буду роблю домашнє завдання.'
+        error: 'Я буду роблю домашнє завдання.'
+        correction: 'Я буду робити домашнє завдання.'
+        explanation: 'After буду, use the infinitive робити.'
+      - sentence: 'На понеділок я маю урок.'
+        error: 'На понеділок'
+        correction: 'У понеділок'
+        explanation: 'Use у with weekdays: у понеділок.'
+      - sentence: 'На шостій ми будемо дивитися кіно.'
+        error: 'На шостій'
+        correction: 'О шостій'
+        explanation: 'Use о with clock time: о шостій.'

--- a/curriculum/l2-uk-en/a1/my-plans/module.md
+++ b/curriculum/l2-uk-en/a1/my-plans/module.md
@@ -163,11 +163,8 @@ For a group chat, make each message short. One friend can write **Я буду
 прибирати зранку.** Another can answer **Я буду вільна о шостій.** Then the
 invitation can be only **Ходімо в кіно!**
 
-<!-- INJECT_ACTIVITY: act-5 -->
 
-<!-- INJECT_ACTIVITY: act-6 -->
 
-<!-- INJECT_ACTIVITY: act-7 -->
 
 ### Repair traps
 
@@ -199,7 +196,6 @@ Use **у / в** with days:
 - **у суботу**;
 - **в неділю**.
 
-<!-- INJECT_ACTIVITY: act-8 -->
 
 ## Підсумок
 
@@ -234,7 +230,3 @@ Self-check:
 
 Stop here after your week plan. The next module moves to a personal story, but
 this module stays with plans, invitations, days, and times.
-
-<!-- INJECT_ACTIVITY: act-9 -->
-
-<!-- INJECT_ACTIVITY: act-10 -->

--- a/curriculum/l2-uk-en/a1/my-story/activities.yaml
+++ b/curriculum/l2-uk-en/a1/my-story/activities.yaml
@@ -1,214 +1,211 @@
-- id: act-1
-  type: fill-in
-  title: Choose the time signal
-  instruction: Pick the word that matches the time of the sentence.
-  items:
-    - sentence: "___ я жив у Торонто."
-      answer: "Раніше"
-      options:
-        - "Раніше"
-        - "Зараз"
-        - "Далі"
-      explanation: "Раніше points to the past."
-    - sentence: "___ я живу в Києві."
-      answer: "Зараз"
-      options:
-        - "Зараз"
-        - "Учора"
-        - "Далі"
-      explanation: "Зараз points to the present."
-    - sentence: "___ я буду вчити українську."
-      answer: "Далі"
-      options:
-        - "Далі"
-        - "У дитинстві"
-        - "Раніше"
-      explanation: "Далі points to a future plan."
-    - sentence: "___ я ходила в школу."
-      answer: "У дитинстві"
-      options:
-        - "У дитинстві"
-        - "Завтра"
-        - "Зараз"
-      explanation: "У дитинстві is a past-life signal."
-- id: act-2
-  type: order
-  title: Put the life story in order
-  instruction: Arrange the lines from past to future.
-  items:
-    - "Я народився в Канаді."
-    - "У дитинстві я жив у Торонто."
-    - "Потім я переїхав у Київ."
-    - "Зараз я живу в Києві."
-    - "Далі я буду вчити українську."
-  correct_order: [0, 1, 2, 3, 4]
-- id: act-3
-  type: match-up
-  title: Match the tense
-  instruction: Match each phrase with its time.
-  pairs:
-    - left: "я народився"
-      right: "past"
-    - left: "я жила"
-      right: "past"
-    - left: "я живу"
-      right: "present"
-    - left: "я працюю"
-      right: "present"
-    - left: "я буду подорожувати"
-      right: "future"
-    - left: "ми будемо вчити"
-      right: "future"
-- id: act-4
-  type: group-sort
-  title: Sort story pieces
-  instruction: Put each phrase into the right story group.
-  groups:
-    - name: "past"
-      items:
-        - "я народився"
-        - "я жила"
-        - "переїхав"
-        - "у дитинстві"
-    - name: "present"
-      items:
-        - "зараз"
-        - "я живу"
-        - "я працюю"
-        - "я вивчаю"
-    - name: "future"
-      items:
-        - "далі"
-        - "я буду жити"
-        - "ми будемо вчити"
-        - "вона буде працювати"
-- id: act-5
-  type: true-false
-  title: A1 story check
-  instruction: Decide whether the sentence stays in the A1 story frame.
-  items:
-    - statement: "Раніше я жив у Варшаві."
-      answer: true
-      explanation: "Раніше plus past жив is a clear past sentence."
-    - statement: "Зараз я буду живу в Києві."
-      answer: false
-      explanation: "Do not put буду before a present form. Use Зараз я живу."
-    - statement: "Далі я буду подорожувати."
-      answer: true
-      explanation: "Буду + infinitive is the A1 future pattern."
-    - statement: "Мене звати Софія."
-      answer: true
-      explanation: "This is the normal A1 name chunk."
-    - statement: "Моє ім'я є Софія."
-      answer: false
-      explanation: "Use Мене звати..., not an English-style my-name-is sentence."
-- id: act-6
-  type: unjumble
-  title: Build story lines
-  instruction: Put the words in a natural order.
-  items:
-    - words: "Раніше/я/жив/у/Торонто"
-      answer: "Раніше я жив у Торонто."
-    - words: "Зараз/я/живу/в/Києві"
-      answer: "Зараз я живу в Києві."
-    - words: "Далі/я/буду/вчити/українську"
-      answer: "Далі я буду вчити українську."
-    - words: "Мене/звати/Софія"
-      answer: "Мене звати Софія."
-- id: act-7
-  type: fill-in
-  title: Complete the mini biography
-  instruction: Choose the form that fits the time word.
-  items:
-    - sentence: "Я ___ у Львові."
-      answer: "народилася"
-      options:
-        - "народилася"
-        - "народжуся"
-        - "народжуюся"
-      explanation: "Use the familiar past chunk народилася."
-    - sentence: "Раніше я ___ в Одесі."
-      answer: "жила"
-      options:
-        - "жила"
-        - "живу"
-        - "буду жити"
-      explanation: "Раніше points to the past."
-    - sentence: "Зараз я ___ в офісі."
-      answer: "працюю"
-      options:
-        - "працюю"
-        - "працювала"
-        - "буду працювати"
-      explanation: "Зараз points to the present."
-    - sentence: "Далі я ___ українську щодня."
-      answer: "буду вчити"
-      options:
-        - "буду вчити"
-        - "вчила"
-        - "вчу"
-      explanation: "Далі points to the future."
-- id: act-8
-  type: quiz
-  title: Repair the story
-  instruction: Choose the better A1 sentence.
-  items:
-    - prompt: "Which sentence matches the time word?"
-      options:
-        - text: "Зараз я живу в Києві."
-          correct: true
-        - text: "Зараз я жив у Києві."
-          correct: false
-        - text: "Зараз я буду живу в Києві."
-          correct: false
-      explanation: "Зараз uses the present form живу."
-    - prompt: "Which sentence uses the A1 future?"
-      options:
-        - text: "Далі я буду працювати."
-          correct: true
-        - text: "Далі я працював."
-          correct: false
-        - text: "Далі я працюю учора."
-          correct: false
-      explanation: "Буду + infinitive is the A1 future."
-    - prompt: "Which is the natural name sentence?"
-      options:
-        - text: "Мене звати Данило."
-          correct: true
-        - text: "Моє ім'я є Данило."
-          correct: false
-        - text: "Я звати Данило."
-          correct: false
-      explanation: "Use the chunk Мене звати..."
-- id: act-9
-  type: translate
-  title: Say your story
-  instruction: Choose the Ukrainian sentence that matches the English prompt.
-  items:
-    - source: "Earlier I lived in Toronto."
-      options:
-        - text: "Раніше я жив у Торонто."
-          correct: true
-        - text: "Зараз я живу в Торонто."
-          correct: false
-        - text: "Далі я буду жити в Торонто."
-          correct: false
-      explanation: "Earlier points to the past."
-    - source: "Now I live in Kyiv."
-      options:
-        - text: "Зараз я живу в Києві."
-          correct: true
-        - text: "Раніше я жив у Києві."
-          correct: false
-        - text: "Далі я буду жити в Києві."
-          correct: false
-      explanation: "Now points to the present."
-    - source: "Next I will study Ukrainian."
-      options:
-        - text: "Далі я буду вчити українську."
-          correct: true
-        - text: "Далі я вчив українську."
-          correct: false
-        - text: "Зараз я вчив українську."
-          correct: false
-      explanation: "Use буду + infinitive for the future."
+inline:
+  - id: act-1
+    type: fill-in
+    title: Choose the time signal
+    instruction: Pick the word that matches the time of the sentence.
+    items:
+      - sentence: '___ я жив у Торонто.'
+        answer: 'Раніше'
+        options:
+          - 'Раніше'
+          - 'Зараз'
+          - 'Далі'
+        explanation: 'Раніше points to the past.'
+      - sentence: '___ я живу в Києві.'
+        answer: 'Зараз'
+        options:
+          - 'Зараз'
+          - 'Учора'
+          - 'Далі'
+        explanation: 'Зараз points to the present.'
+      - sentence: '___ я буду вчити українську.'
+        answer: 'Далі'
+        options:
+          - 'Далі'
+          - 'У дитинстві'
+          - 'Раніше'
+        explanation: 'Далі points to a future plan.'
+      - sentence: '___ я ходила в школу.'
+        answer: 'У дитинстві'
+        options:
+          - 'У дитинстві'
+          - 'Завтра'
+          - 'Зараз'
+        explanation: 'У дитинстві is a past-life signal.'
+  - id: act-2
+    type: order
+    title: Put the life story in order
+    instruction: Arrange the lines from past to future.
+    items:
+      - 'Я народився в Канаді.'
+      - 'У дитинстві я жив у Торонто.'
+      - 'Потім я переїхав у Київ.'
+      - 'Зараз я живу в Києві.'
+      - 'Далі я буду вчити українську.'
+    correct_order: [0, 1, 2, 3, 4]
+  - id: act-3
+    type: match-up
+    title: Match the tense
+    instruction: Match each phrase with its time.
+    pairs:
+      - left: 'я народився'
+        right: 'past'
+      - left: 'я жила'
+        right: 'past'
+      - left: 'я живу'
+        right: 'present'
+      - left: 'я працюю'
+        right: 'present'
+      - left: 'я буду подорожувати'
+        right: 'future'
+      - left: 'ми будемо вчити'
+        right: 'future'
+  - id: act-4
+    type: group-sort
+    title: Sort story pieces
+    instruction: Put each phrase into the right story group.
+    groups:
+      - name: 'past'
+        items:
+          - 'я народився'
+          - 'я жила'
+          - 'переїхав'
+          - 'у дитинстві'
+      - name: 'present'
+        items:
+          - 'зараз'
+          - 'я живу'
+          - 'я працюю'
+          - 'я вивчаю'
+      - name: 'future'
+        items:
+          - 'далі'
+          - 'я буду жити'
+          - 'ми будемо вчити'
+          - 'вона буде працювати'
+workbook:
+  - type: true-false
+    title: A1 story check
+    instruction: Decide whether the sentence stays in the A1 story frame.
+    items:
+      - statement: 'Раніше я жив у Варшаві.'
+        answer: true
+        explanation: 'Раніше plus past жив is a clear past sentence.'
+      - statement: 'Зараз я буду живу в Києві.'
+        answer: false
+        explanation: 'Do not put буду before a present form. Use Зараз я живу.'
+      - statement: 'Далі я буду подорожувати.'
+        answer: true
+        explanation: 'Буду + infinitive is the A1 future pattern.'
+      - statement: 'Мене звати Софія.'
+        answer: true
+        explanation: 'This is the normal A1 name chunk.'
+      - statement: "Моє ім'я є Софія."
+        answer: false
+        explanation: 'Use Мене звати..., not an English-style my-name-is sentence.'
+  - type: unjumble
+    title: Build story lines
+    instruction: Put the words in a natural order.
+    items:
+      - words: 'Раніше/я/жив/у/Торонто'
+        answer: 'Раніше я жив у Торонто.'
+      - words: 'Зараз/я/живу/в/Києві'
+        answer: 'Зараз я живу в Києві.'
+      - words: 'Далі/я/буду/вчити/українську'
+        answer: 'Далі я буду вчити українську.'
+      - words: 'Мене/звати/Софія'
+        answer: 'Мене звати Софія.'
+  - type: fill-in
+    title: Complete the mini biography
+    instruction: Choose the form that fits the time word.
+    items:
+      - sentence: 'Я ___ у Львові.'
+        answer: 'народилася'
+        options:
+          - 'народилася'
+          - 'народжуся'
+          - 'народжуюся'
+        explanation: 'Use the familiar past chunk народилася.'
+      - sentence: 'Раніше я ___ в Одесі.'
+        answer: 'жила'
+        options:
+          - 'жила'
+          - 'живу'
+          - 'буду жити'
+        explanation: 'Раніше points to the past.'
+      - sentence: 'Зараз я ___ в офісі.'
+        answer: 'працюю'
+        options:
+          - 'працюю'
+          - 'працювала'
+          - 'буду працювати'
+        explanation: 'Зараз points to the present.'
+      - sentence: 'Далі я ___ українську щодня.'
+        answer: 'буду вчити'
+        options:
+          - 'буду вчити'
+          - 'вчила'
+          - 'вчу'
+        explanation: 'Далі points to the future.'
+  - type: quiz
+    title: Repair the story
+    instruction: Choose the better A1 sentence.
+    items:
+      - prompt: 'Which sentence matches the time word?'
+        options:
+          - text: 'Зараз я живу в Києві.'
+            correct: true
+          - text: 'Зараз я жив у Києві.'
+            correct: false
+          - text: 'Зараз я буду живу в Києві.'
+            correct: false
+        explanation: 'Зараз uses the present form живу.'
+      - prompt: 'Which sentence uses the A1 future?'
+        options:
+          - text: 'Далі я буду працювати.'
+            correct: true
+          - text: 'Далі я працював.'
+            correct: false
+          - text: 'Далі я працюю учора.'
+            correct: false
+        explanation: 'Буду + infinitive is the A1 future.'
+      - prompt: 'Which is the natural name sentence?'
+        options:
+          - text: 'Мене звати Данило.'
+            correct: true
+          - text: "Моє ім'я є Данило."
+            correct: false
+          - text: 'Я звати Данило.'
+            correct: false
+        explanation: 'Use the chunk Мене звати...'
+  - type: translate
+    title: Say your story
+    instruction: Choose the Ukrainian sentence that matches the English prompt.
+    items:
+      - source: 'Earlier I lived in Toronto.'
+        options:
+          - text: 'Раніше я жив у Торонто.'
+            correct: true
+          - text: 'Зараз я живу в Торонто.'
+            correct: false
+          - text: 'Далі я буду жити в Торонто.'
+            correct: false
+        explanation: 'Earlier points to the past.'
+      - source: 'Now I live in Kyiv.'
+        options:
+          - text: 'Зараз я живу в Києві.'
+            correct: true
+          - text: 'Раніше я жив у Києві.'
+            correct: false
+          - text: 'Далі я буду жити в Києві.'
+            correct: false
+        explanation: 'Now points to the present.'
+      - source: 'Next I will study Ukrainian.'
+        options:
+          - text: 'Далі я буду вчити українську.'
+            correct: true
+          - text: 'Далі я вчив українську.'
+            correct: false
+          - text: 'Зараз я вчив українську.'
+            correct: false
+        explanation: 'Use буду + infinitive for the future.'

--- a/curriculum/l2-uk-en/a1/my-story/module.md
+++ b/curriculum/l2-uk-en/a1/my-story/module.md
@@ -165,11 +165,8 @@ If a line feels hard, shorten it. A strong A1 story can be only six sentences:
 **Мене звати Адам. Я народився в Канаді. Раніше я жив у Торонто. Зараз я живу
 в Києві. Я вивчаю українську. Далі я буду працювати і подорожувати.**
 
-<!-- INJECT_ACTIVITY: act-5 -->
 
-<!-- INJECT_ACTIVITY: act-6 -->
 
-<!-- INJECT_ACTIVITY: act-7 -->
 
 ### Repair traps
 
@@ -187,7 +184,6 @@ Keep the time word and the verb in the same time.
 The last repair is important. Ukrainian does not need the English-style
 sentence **my name is...**. Use the familiar A1 chunk **Мене звати...**.
 
-<!-- INJECT_ACTIVITY: act-8 -->
 
 ## Підсумок
 
@@ -209,5 +205,3 @@ One final model:
 
 Stop here. If you can tell this kind of story, you can connect past, present,
 and future without leaving A1.
-
-<!-- INJECT_ACTIVITY: act-9 -->

--- a/curriculum/l2-uk-en/a1/what-happened/activities.yaml
+++ b/curriculum/l2-uk-en/a1/what-happened/activities.yaml
@@ -1,304 +1,300 @@
-- id: act-1
-  type: match-up
-  title: Past endings map
-  instruction: Match each subject with the regular past-tense ending.
-  pairs:
-    - left: "він"
-      right: "-в"
-    - left: "вона"
-      right: "-ла"
-    - left: "воно"
-      right: "-ло"
-    - left: "вони"
-      right: "-ли"
-    - left: "ми"
-      right: "-ли"
-    - left: "Олена"
-      right: "-ла"
-    - left: "Тарас"
-      right: "-в"
-    - left: "друзі"
-      right: "-ли"
-- id: act-2
-  type: fill-in
-  title: Choose the past form
-  instruction: Pick the form that fits the subject.
-  items:
-    - sentence: "Учора він ___ книжку."
-      answer: "читав"
-      options:
-        - "читав"
-        - "читала"
-        - "читали"
-      explanation: "Він is masculine singular, so use читав."
-    - sentence: "Олена ___ вечерю."
-      answer: "готувала"
-      options:
-        - "готувала"
-        - "готував"
-        - "готували"
-      explanation: "Олена is feminine singular, so use готувала."
-    - sentence: "Ми ___ в парку."
-      answer: "гуляли"
-      options:
-        - "гуляли"
-        - "гуляв"
-        - "гуляла"
-      explanation: "Ми is plural, so use гуляли."
-    - sentence: "Вони ___ разом."
-      answer: "працювали"
-      options:
-        - "працювали"
-        - "працював"
-        - "працювало"
-      explanation: "Вони is plural, so use працювали."
-    - sentence: "Тарас ___ фільм."
-      answer: "дивився"
-      options:
-        - "дивився"
-        - "дивилася"
-        - "дивилися"
-      explanation: "Тарас is masculine singular, so use дивився."
-    - sentence: "Марія ___ телефоном."
-      answer: "говорила"
-      options:
-        - "говорила"
-        - "говорив"
-        - "говорили"
-      explanation: "Марія is feminine singular, so use говорила."
-- id: act-3
-  type: quiz
-  title: Gender, not person
-  instruction: Choose the statement that matches the A1 past-tense rule.
-  items:
-    - prompt: "Why can я читав and ти читав have the same ending?"
-      options:
-        - text: "Because past tense marks masculine singular here."
-          correct: true
-        - text: "Because я and ти always use one ending."
-          correct: false
-        - text: "Because Ukrainian has no person forms."
-          correct: false
-      explanation: "The past ending shows gender in the singular, not person."
-    - prompt: "Which form fits a female speaker saying I read?"
-      options:
-        - text: "Я читала."
-          correct: true
-        - text: "Я читав."
-          correct: false
-        - text: "Я читали."
-          correct: false
-      explanation: "A female speaker uses the feminine form читала."
-    - prompt: "Which form fits a group?"
-      options:
-        - text: "Ми читали."
-          correct: true
-        - text: "Ми читав."
-          correct: false
-        - text: "Ми читала."
-          correct: false
-      explanation: "Plural past uses -ли."
-    - prompt: "Which question fits Ivan?"
-      options:
-        - text: "Що ти робив?"
-          correct: true
-        - text: "Що ти робила?"
-          correct: false
-        - text: "Що ти робило?"
-          correct: false
-      explanation: "Ivan is male, so ask робив."
-- id: act-4
-  type: group-sort
-  title: Sort the forms
-  instruction: Sort each past-tense form by ending.
-  groups:
-    - name: "-в"
-      items:
-        - "читав"
-        - "працював"
-        - "гуляв"
-    - name: "-ла"
-      items:
-        - "читала"
-        - "працювала"
-        - "гуляла"
-    - name: "-ло"
-      items:
-        - "читало"
-        - "працювало"
-        - "гуляло"
-    - name: "-ли"
-      items:
-        - "читали"
-        - "працювали"
-        - "гуляли"
-- id: act-5
-  type: true-false
-  title: Check the past form
-  instruction: Decide whether each sentence uses the expected A1 past ending.
-  items:
-    - statement: "Олена читала книжку."
-      answer: true
-      explanation: "Олена is feminine singular, so читала fits."
-    - statement: "Тарас читала книжку."
-      answer: false
-      explanation: "Use Тарас читав."
-    - statement: "Вони працювали разом."
-      answer: true
-      explanation: "Вони takes the plural form -ли."
-    - statement: "Ми читалимо текст."
-      answer: false
-      explanation: "Do not add present endings. Use Ми читали текст."
-    - statement: "Сонце працювало."
-      answer: true
-      explanation: "Сонце is neuter, so -ло fits."
-    - statement: "Я буду читав завтра."
-      answer: false
-      explanation: "After буду, use the infinitive: буду читати."
-- id: act-6
-  type: unjumble
-  title: Build short past sentences
-  instruction: Put the words in a natural order.
-  items:
-    - words: ["Учора", "Тарас", "читав", "книжку"]
-      answer: "Учора Тарас читав книжку."
-    - words: ["Олена", "готувала", "вечерю"]
-      answer: "Олена готувала вечерю."
-    - words: ["Ми", "гуляли", "в", "парку"]
-      answer: "Ми гуляли в парку."
-    - words: ["Вони", "працювали", "разом"]
-      answer: "Вони працювали разом."
-    - words: ["Що", "ти", "робив", "учора"]
-      answer: "Що ти робив учора?"
-    - words: ["Що", "ти", "робила", "учора"]
-      answer: "Що ти робила учора?"
-- id: act-7
-  type: order
-  title: From one subject to many
-  instruction: Put the transformation path in order.
-  items:
-    - "він читав"
-    - "вона читала"
-    - "воно читало"
-    - "вони читали"
-  correct_order: [0, 1, 2, 3]
-- id: act-8
-  type: error-correction
-  title: Repair the A1 past tense
-  instruction: Fix the sentence by choosing the correct A1 form.
-  items:
-    - sentence: "Чоловік: Я читала. Жінка: Я читав."
-      error: "Чоловік: Я читала. Жінка: Я читав."
-      correction: "Чоловік: Я читав. Жінка: Я читала."
-      explanation: "The male speaker uses читав; the female speaker uses читала."
-    - sentence: "Чоловік: Я читала."
-      error: "читала"
-      correction: "читав"
-      explanation: "A male speaker says Я читав."
-    - sentence: "Жінка: Я читав."
-      error: "читав"
-      correction: "читала"
-      explanation: "A female speaker says Я читала."
-    - sentence: "Ми читалимо текст."
-      error: "читалимо"
-      correction: "читали"
-      explanation: "Past plural is читали; do not add -мо."
-    - sentence: "Вони читалить текст."
-      error: "читалить"
-      correction: "читали"
-      explanation: "Past plural is читали; do not add present endings."
-    - sentence: "Сонце встав."
-      error: "встав"
-      correction: "Сонце встало."
-      explanation: "Сонце is neuter, so use -ло."
-    - sentence: "Я буду читав завтра."
-      error: "читав"
-      correction: "читати"
-      explanation: "After буду, use the infinitive читати."
-    - sentence: "Він принісв книгу. або Він везв сумку."
-      error: "принісв / везв"
-      correction: "Він приніс книгу. / Він віз сумку."
-      explanation: "This is later recognition only; do not build these forms by the A1 regular pattern."
-- id: act-9
-  type: translate
-  title: Say it in Ukrainian
-  instruction: Choose the Ukrainian line that matches the English prompt.
-  items:
-    - source: "Yesterday he read a book."
-      options:
-        - text: "Учора він читав книжку."
-          correct: true
-        - text: "Учора вона читала книжку."
-          correct: false
-        - text: "Учора вони читали книжку."
-          correct: false
-      explanation: "He is masculine singular, so use читав."
-    - source: "Yesterday she cooked dinner."
-      options:
-        - text: "Учора вона готувала вечерю."
-          correct: true
-        - text: "Учора він готував вечерю."
-          correct: false
-        - text: "Учора ми готували вечерю."
-          correct: false
-      explanation: "She is feminine singular, so use готувала."
-    - source: "We walked in the park."
-      options:
-        - text: "Ми гуляли в парку."
-          correct: true
-        - text: "Він гуляв у парку."
-          correct: false
-        - text: "Вона гуляла в парку."
-          correct: false
-      explanation: "We is plural, so use гуляли."
-    - source: "What were you doing yesterday? (to Ivan)"
-      options:
-        - text: "Що ти робив учора?"
-          correct: true
-        - text: "Що ти робила учора?"
-          correct: false
-        - text: "Що ви робили учора?"
-          correct: false
-      explanation: "Ivan is male, so the question uses робив."
-    - source: "What were you doing yesterday? (to Olena)"
-      options:
-        - text: "Що ти робила учора?"
-          correct: true
-        - text: "Що ти робив учора?"
-          correct: false
-        - text: "Що вони робили учора?"
-          correct: false
-      explanation: "Olena is female, so the question uses робила."
-- id: act-10
-  type: odd-one-out
-  title: Find the ending that does not fit
-  instruction: Choose the form that does not belong in each set.
-  items:
-    - prompt: "Forms for feminine singular"
-      words:
-        - "читала"
-        - "працювала"
-        - "гуляли"
-      answer: "гуляли"
-      explanation: "Гуляли is plural, not feminine singular."
-    - prompt: "Forms for plural"
-      words:
-        - "читали"
-        - "говорили"
-        - "говорив"
-      answer: "говорив"
-      explanation: "Говорив is masculine singular."
-    - prompt: "Forms for masculine singular"
-      words:
-        - "читав"
-        - "готував"
-        - "готувала"
-      answer: "готувала"
-      explanation: "Готувала is feminine singular."
-    - prompt: "Forms for neuter singular"
-      words:
-        - "читало"
-        - "працювало"
-        - "працювали"
-      answer: "працювали"
-      explanation: "Працювали is plural."
+inline:
+  - id: act-1
+    type: match-up
+    title: Past endings map
+    instruction: Match each subject with the regular past-tense ending.
+    pairs:
+      - left: 'він'
+        right: '-в'
+      - left: 'вона'
+        right: '-ла'
+      - left: 'воно'
+        right: '-ло'
+      - left: 'вони'
+        right: '-ли'
+      - left: 'ми'
+        right: '-ли'
+      - left: 'Олена'
+        right: '-ла'
+      - left: 'Тарас'
+        right: '-в'
+      - left: 'друзі'
+        right: '-ли'
+  - id: act-2
+    type: fill-in
+    title: Choose the past form
+    instruction: Pick the form that fits the subject.
+    items:
+      - sentence: 'Учора він ___ книжку.'
+        answer: 'читав'
+        options:
+          - 'читав'
+          - 'читала'
+          - 'читали'
+        explanation: 'Він is masculine singular, so use читав.'
+      - sentence: 'Олена ___ вечерю.'
+        answer: 'готувала'
+        options:
+          - 'готувала'
+          - 'готував'
+          - 'готували'
+        explanation: 'Олена is feminine singular, so use готувала.'
+      - sentence: 'Ми ___ в парку.'
+        answer: 'гуляли'
+        options:
+          - 'гуляли'
+          - 'гуляв'
+          - 'гуляла'
+        explanation: 'Ми is plural, so use гуляли.'
+      - sentence: 'Вони ___ разом.'
+        answer: 'працювали'
+        options:
+          - 'працювали'
+          - 'працював'
+          - 'працювало'
+        explanation: 'Вони is plural, so use працювали.'
+      - sentence: 'Тарас ___ фільм.'
+        answer: 'дивився'
+        options:
+          - 'дивився'
+          - 'дивилася'
+          - 'дивилися'
+        explanation: 'Тарас is masculine singular, so use дивився.'
+      - sentence: 'Марія ___ телефоном.'
+        answer: 'говорила'
+        options:
+          - 'говорила'
+          - 'говорив'
+          - 'говорили'
+        explanation: 'Марія is feminine singular, so use говорила.'
+  - id: act-3
+    type: quiz
+    title: Gender, not person
+    instruction: Choose the statement that matches the A1 past-tense rule.
+    items:
+      - prompt: 'Why can я читав and ти читав have the same ending?'
+        options:
+          - text: 'Because past tense marks masculine singular here.'
+            correct: true
+          - text: 'Because я and ти always use one ending.'
+            correct: false
+          - text: 'Because Ukrainian has no person forms.'
+            correct: false
+        explanation: 'The past ending shows gender in the singular, not person.'
+      - prompt: 'Which form fits a female speaker saying I read?'
+        options:
+          - text: 'Я читала.'
+            correct: true
+          - text: 'Я читав.'
+            correct: false
+          - text: 'Я читали.'
+            correct: false
+        explanation: 'A female speaker uses the feminine form читала.'
+      - prompt: 'Which form fits a group?'
+        options:
+          - text: 'Ми читали.'
+            correct: true
+          - text: 'Ми читав.'
+            correct: false
+          - text: 'Ми читала.'
+            correct: false
+        explanation: 'Plural past uses -ли.'
+      - prompt: 'Which question fits Ivan?'
+        options:
+          - text: 'Що ти робив?'
+            correct: true
+          - text: 'Що ти робила?'
+            correct: false
+          - text: 'Що ти робило?'
+            correct: false
+        explanation: 'Ivan is male, so ask робив.'
+  - id: act-4
+    type: group-sort
+    title: Sort the forms
+    instruction: Sort each past-tense form by ending.
+    groups:
+      - name: '-в'
+        items:
+          - 'читав'
+          - 'працював'
+          - 'гуляв'
+      - name: '-ла'
+        items:
+          - 'читала'
+          - 'працювала'
+          - 'гуляла'
+      - name: '-ло'
+        items:
+          - 'читало'
+          - 'працювало'
+          - 'гуляло'
+      - name: '-ли'
+        items:
+          - 'читали'
+          - 'працювали'
+          - 'гуляли'
+workbook:
+  - type: true-false
+    title: Check the past form
+    instruction: Decide whether each sentence uses the expected A1 past ending.
+    items:
+      - statement: 'Олена читала книжку.'
+        answer: true
+        explanation: 'Олена is feminine singular, so читала fits.'
+      - statement: 'Тарас читала книжку.'
+        answer: false
+        explanation: 'Use Тарас читав.'
+      - statement: 'Вони працювали разом.'
+        answer: true
+        explanation: 'Вони takes the plural form -ли.'
+      - statement: 'Ми читалимо текст.'
+        answer: false
+        explanation: 'Do not add present endings. Use Ми читали текст.'
+      - statement: 'Сонце працювало.'
+        answer: true
+        explanation: 'Сонце is neuter, so -ло fits.'
+      - statement: 'Я буду читав завтра.'
+        answer: false
+        explanation: 'After буду, use the infinitive: буду читати.'
+  - type: unjumble
+    title: Build short past sentences
+    instruction: Put the words in a natural order.
+    items:
+      - words: ['Учора', 'Тарас', 'читав', 'книжку']
+        answer: 'Учора Тарас читав книжку.'
+      - words: ['Олена', 'готувала', 'вечерю']
+        answer: 'Олена готувала вечерю.'
+      - words: ['Ми', 'гуляли', 'в', 'парку']
+        answer: 'Ми гуляли в парку.'
+      - words: ['Вони', 'працювали', 'разом']
+        answer: 'Вони працювали разом.'
+      - words: ['Що', 'ти', 'робив', 'учора']
+        answer: 'Що ти робив учора?'
+      - words: ['Що', 'ти', 'робила', 'учора']
+        answer: 'Що ти робила учора?'
+  - type: order
+    title: From one subject to many
+    instruction: Put the transformation path in order.
+    items:
+      - 'він читав'
+      - 'вона читала'
+      - 'воно читало'
+      - 'вони читали'
+    correct_order: [0, 1, 2, 3]
+  - type: error-correction
+    title: Repair the A1 past tense
+    instruction: Fix the sentence by choosing the correct A1 form.
+    items:
+      - sentence: 'Чоловік: Я читала. Жінка: Я читав.'
+        error: 'Чоловік: Я читала. Жінка: Я читав.'
+        correction: 'Чоловік: Я читав. Жінка: Я читала.'
+        explanation: 'The male speaker uses читав; the female speaker uses читала.'
+      - sentence: 'Чоловік: Я читала.'
+        error: 'читала'
+        correction: 'читав'
+        explanation: 'A male speaker says Я читав.'
+      - sentence: 'Жінка: Я читав.'
+        error: 'читав'
+        correction: 'читала'
+        explanation: 'A female speaker says Я читала.'
+      - sentence: 'Ми читалимо текст.'
+        error: 'читалимо'
+        correction: 'читали'
+        explanation: 'Past plural is читали; do not add -мо.'
+      - sentence: 'Вони читалить текст.'
+        error: 'читалить'
+        correction: 'читали'
+        explanation: 'Past plural is читали; do not add present endings.'
+      - sentence: 'Сонце встав.'
+        error: 'встав'
+        correction: 'Сонце встало.'
+        explanation: 'Сонце is neuter, so use -ло.'
+      - sentence: 'Я буду читав завтра.'
+        error: 'читав'
+        correction: 'читати'
+        explanation: 'After буду, use the infinitive читати.'
+      - sentence: 'Він принісв книгу. або Він везв сумку.'
+        error: 'принісв / везв'
+        correction: 'Він приніс книгу. / Він віз сумку.'
+        explanation: 'This is later recognition only; do not build these forms by the A1 regular pattern.'
+  - type: translate
+    title: Say it in Ukrainian
+    instruction: Choose the Ukrainian line that matches the English prompt.
+    items:
+      - source: 'Yesterday he read a book.'
+        options:
+          - text: 'Учора він читав книжку.'
+            correct: true
+          - text: 'Учора вона читала книжку.'
+            correct: false
+          - text: 'Учора вони читали книжку.'
+            correct: false
+        explanation: 'He is masculine singular, so use читав.'
+      - source: 'Yesterday she cooked dinner.'
+        options:
+          - text: 'Учора вона готувала вечерю.'
+            correct: true
+          - text: 'Учора він готував вечерю.'
+            correct: false
+          - text: 'Учора ми готували вечерю.'
+            correct: false
+        explanation: 'She is feminine singular, so use готувала.'
+      - source: 'We walked in the park.'
+        options:
+          - text: 'Ми гуляли в парку.'
+            correct: true
+          - text: 'Він гуляв у парку.'
+            correct: false
+          - text: 'Вона гуляла в парку.'
+            correct: false
+        explanation: 'We is plural, so use гуляли.'
+      - source: 'What were you doing yesterday? (to Ivan)'
+        options:
+          - text: 'Що ти робив учора?'
+            correct: true
+          - text: 'Що ти робила учора?'
+            correct: false
+          - text: 'Що ви робили учора?'
+            correct: false
+        explanation: 'Ivan is male, so the question uses робив.'
+      - source: 'What were you doing yesterday? (to Olena)'
+        options:
+          - text: 'Що ти робила учора?'
+            correct: true
+          - text: 'Що ти робив учора?'
+            correct: false
+          - text: 'Що вони робили учора?'
+            correct: false
+        explanation: 'Olena is female, so the question uses робила.'
+  - type: odd-one-out
+    title: Find the ending that does not fit
+    instruction: Choose the form that does not belong in each set.
+    items:
+      - prompt: 'Forms for feminine singular'
+        words:
+          - 'читала'
+          - 'працювала'
+          - 'гуляли'
+        answer: 'гуляли'
+        explanation: 'Гуляли is plural, not feminine singular.'
+      - prompt: 'Forms for plural'
+        words:
+          - 'читали'
+          - 'говорили'
+          - 'говорив'
+        answer: 'говорив'
+        explanation: 'Говорив is masculine singular.'
+      - prompt: 'Forms for masculine singular'
+        words:
+          - 'читав'
+          - 'готував'
+          - 'готувала'
+        answer: 'готувала'
+        explanation: 'Готувала is feminine singular.'
+      - prompt: 'Forms for neuter singular'
+        words:
+          - 'читало'
+          - 'працювало'
+          - 'працювали'
+        answer: 'працювали'
+        explanation: 'Працювали is plural.'

--- a/curriculum/l2-uk-en/a1/what-happened/module.md
+++ b/curriculum/l2-uk-en/a1/what-happened/module.md
@@ -164,11 +164,8 @@ That is why the past tense is not a person table. **Я**, **ти**, and **він
 can all use **читав** when the subject is masculine singular. **Я**, **ти**,
 and **вона** can all use **читала** when the subject is feminine singular.
 
-<!-- INJECT_ACTIVITY: act-5 -->
 
-<!-- INJECT_ACTIVITY: act-6 -->
 
-<!-- INJECT_ACTIVITY: act-7 -->
 
 ### Repair traps
 
@@ -218,7 +215,6 @@ same speaker. Do not start with **я працював** and then switch to
 **я гуляла** unless the speaker changes. A clean A1 story repeats one pattern
 until your ear notices it.
 
-<!-- INJECT_ACTIVITY: act-8 -->
 
 ## Підсумок
 
@@ -252,9 +248,7 @@ Self-check:
 Stop here when the endings feel visible. The next module uses the same forms
 to tell a simple story about yesterday.
 
-<!-- INJECT_ACTIVITY: act-9 -->
 
-<!-- INJECT_ACTIVITY: act-10 -->
 
 <span id="repair-past-gender-interference"></span>
 

--- a/curriculum/l2-uk-en/a1/what-will-happen/activities.yaml
+++ b/curriculum/l2-uk-en/a1/what-will-happen/activities.yaml
@@ -1,284 +1,280 @@
-- id: act-1
-  type: match-up
-  title: Match the future form
-  instruction: Match each person with the future form of бути.
-  pairs:
-    - left: "я"
-      right: "буду"
-    - left: "ти"
-      right: "будеш"
-    - left: "він / вона"
-      right: "буде"
-    - left: "ми"
-      right: "будемо"
-    - left: "ви"
-      right: "будете"
-    - left: "вони"
-      right: "будуть"
-- id: act-2
-  type: fill-in
-  title: Build the compound future
-  instruction: Choose the correct form of бути.
-  items:
-    - sentence: "Завтра я ___ працювати."
-      answer: "буду"
-      options:
-        - "буду"
-        - "буде"
-        - "будемо"
-      explanation: "Я takes буду."
-    - sentence: "Що ти ___ робити ввечері?"
-      answer: "будеш"
-      options:
-        - "будеш"
-        - "буду"
-        - "будете"
-      explanation: "Ти takes будеш."
-    - sentence: "Вона ___ читати книжку."
-      answer: "буде"
-      options:
-        - "буде"
-        - "будуть"
-        - "будемо"
-      explanation: "Вона takes буде."
-    - sentence: "Ми ___ дивитися футбол."
-      answer: "будемо"
-      options:
-        - "будемо"
-        - "буде"
-        - "буду"
-      explanation: "Ми takes будемо."
-    - sentence: "Ви ___ гуляти в парку?"
-      answer: "будете"
-      options:
-        - "будете"
-        - "будеш"
-        - "будуть"
-      explanation: "Ви takes будете."
-    - sentence: "Вони ___ відпочивати."
-      answer: "будуть"
-      options:
-        - "будуть"
-        - "будемо"
-        - "буде"
-      explanation: "Вони takes будуть."
-- id: act-3
-  type: quiz
-  title: Future pattern check
-  instruction: Choose the answer that keeps the A1 compound future.
-  items:
-    - prompt: "Which sentence means I will read?"
-      options:
-        - text: "Я буду читати."
-          correct: true
-        - text: "Я буду читаю."
-          correct: false
-        - text: "Я читаю завтра."
-          correct: false
-      explanation: "Use буду + infinitive: буду читати."
-    - prompt: "What stays unchanged after будемо?"
-      options:
-        - text: "The infinitive."
-          correct: true
-        - text: "A present-tense ending."
-          correct: false
-        - text: "A past-tense ending."
-          correct: false
-      explanation: "The second verb stays in the infinitive."
-    - prompt: "Which form fits ми?"
-      options:
-        - text: "Ми будемо робити."
-          correct: true
-        - text: "Ми буде робити."
-          correct: false
-        - text: "Ми будеш робити."
-          correct: false
-      explanation: "Ми takes будемо."
-    - prompt: "Which question asks about tomorrow?"
-      options:
-        - text: "Що ти будеш робити завтра?"
-          correct: true
-        - text: "Що ти робиш учора?"
-          correct: false
-        - text: "Що ти робив зараз?"
-          correct: false
-      explanation: "Будеш робити завтра is the future question."
-- id: act-4
-  type: group-sort
-  title: Sort the time frames
-  instruction: Sort each sentence by time.
-  groups:
-    - name: "past"
-      items:
-        - "Учора я читав."
-        - "Учора вона працювала."
-    - name: "present"
-      items:
-        - "Зараз я читаю."
-        - "Зараз ми працюємо."
-    - name: "future"
-      items:
-        - "Завтра я буду читати."
-        - "Наступного тижня ми будемо працювати."
-- id: act-5
-  type: true-false
-  title: Check the compound future
-  instruction: Decide whether each sentence uses буду + infinitive correctly.
-  items:
-    - statement: "Я буду читати завтра."
-      answer: true
-      explanation: "Буду + читати is correct."
-    - statement: "Ти будеш робити ввечері?"
-      answer: true
-      explanation: "Будеш + робити is correct."
-    - statement: "Вона буде читає книжку."
-      answer: false
-      explanation: "After буде, use читати."
-    - statement: "Ми будемо дивитися футбол."
-      answer: true
-      explanation: "Будемо + дивитися is correct."
-    - statement: "Вони будуть працюють."
-      answer: false
-      explanation: "After будуть, use працювати."
-    - statement: "Ви будете гуляти в парку?"
-      answer: true
-      explanation: "Будете + гуляти is correct."
-- id: act-6
-  type: unjumble
-  title: Build future sentences
-  instruction: Put the words in a natural order.
-  items:
-    - words: ["Завтра", "я", "буду", "працювати"]
-      answer: "Завтра я буду працювати."
-    - words: ["Що", "ти", "будеш", "робити", "ввечері"]
-      answer: "Що ти будеш робити ввечері?"
-    - words: ["Вона", "буде", "читати", "книжку"]
-      answer: "Вона буде читати книжку."
-    - words: ["Ми", "будемо", "дивитися", "футбол"]
-      answer: "Ми будемо дивитися футбол."
-    - words: ["Вони", "будуть", "відпочивати"]
-      answer: "Вони будуть відпочивати."
-- id: act-7
-  type: order
-  title: From now to tomorrow
-  instruction: Put the mini-sequence in a natural time order.
-  items:
-    - "Зараз я читаю."
-    - "Ввечері я буду готувати."
-    - "Завтра я буду працювати."
-    - "Наступного тижня я буду відпочивати."
-  correct_order: [0, 1, 2, 3]
-- id: act-8
-  type: fill-in
-  title: Keep the infinitive
-  instruction: Choose the infinitive after the future form of бути.
-  items:
-    - sentence: "Я буду ___ завтра."
-      answer: "читати"
-      options:
-        - "читати"
-        - "читаю"
-        - "читав"
-      explanation: "After буду, use the infinitive читати."
-    - sentence: "Ти будеш ___ ввечері?"
-      answer: "робити"
-      options:
-        - "робити"
-        - "робиш"
-        - "робив"
-      explanation: "After будеш, use робити."
-    - sentence: "Вона буде ___ вечерю."
-      answer: "готувати"
-      options:
-        - "готувати"
-        - "готує"
-        - "готувала"
-      explanation: "After буде, use готувати."
-    - sentence: "Ми будемо ___ футбол."
-      answer: "дивитися"
-      options:
-        - "дивитися"
-        - "дивимося"
-        - "дивилися"
-      explanation: "After будемо, use дивитися."
-    - sentence: "Вони будуть ___."
-      answer: "відпочивати"
-      options:
-        - "відпочивати"
-        - "відпочивають"
-        - "відпочивали"
-      explanation: "After будуть, use відпочивати."
-- id: act-9
-  type: translate
-  title: Say future plans
-  instruction: Choose the Ukrainian sentence that matches the English prompt.
-  items:
-    - source: "Tomorrow I will work."
-      options:
-        - text: "Завтра я буду працювати."
-          correct: true
-        - text: "Учора я працював."
-          correct: false
-        - text: "Зараз я працюю."
-          correct: false
-      explanation: "Tomorrow needs буду працювати."
-    - source: "What will you do in the evening?"
-      options:
-        - text: "Що ти будеш робити ввечері?"
-          correct: true
-        - text: "Що ти робив учора?"
-          correct: false
-        - text: "Що ти робиш зараз?"
-          correct: false
-      explanation: "Use будеш робити for you will do."
-    - source: "We will watch football."
-      options:
-        - text: "Ми будемо дивитися футбол."
-          correct: true
-        - text: "Ми дивимося футбол."
-          correct: false
-        - text: "Ми дивилися футбол."
-          correct: false
-      explanation: "Use будемо дивитися."
-    - source: "They will rest."
-      options:
-        - text: "Вони будуть відпочивати."
-          correct: true
-        - text: "Вони відпочивають."
-          correct: false
-        - text: "Вони відпочивали."
-          correct: false
-      explanation: "Use будуть відпочивати."
-- id: act-10
-  type: error-correction
-  title: Repair future forms
-  instruction: Fix the sentence by using буду + infinitive.
-  items:
-    - sentence: "Я буду читаю завтра."
-      error: "читаю"
-      correction: "читати"
-      explanation: "After буду, use the infinitive читати."
-    - sentence: "Ти будеш робиш ввечері?"
-      error: "робиш"
-      correction: "робити"
-      explanation: "After будеш, use робити."
-    - sentence: "Вона буде читає книжку."
-      error: "читає"
-      correction: "читати"
-      explanation: "After буде, use читати."
-    - sentence: "Ми будемо дивимося футбол."
-      error: "дивимося"
-      correction: "дивитися"
-      explanation: "After будемо, use дивитися."
-    - sentence: "Ми будемо читаємо текст."
-      error: "Ми будемо читаємо текст."
-      correction: "Ми будемо читати текст."
-      explanation: "In the compound future, only будемо changes; the second verb stays читати."
-    - sentence: "Вони будуть працюють."
-      error: "працюють"
-      correction: "працювати"
-      explanation: "After будуть, use працювати."
-    - sentence: "Я буде робити завтра."
-      error: "буде"
-      correction: "буду"
-      explanation: "Я takes буду."
+inline:
+  - id: act-1
+    type: match-up
+    title: Match the future form
+    instruction: Match each person with the future form of бути.
+    pairs:
+      - left: 'я'
+        right: 'буду'
+      - left: 'ти'
+        right: 'будеш'
+      - left: 'він / вона'
+        right: 'буде'
+      - left: 'ми'
+        right: 'будемо'
+      - left: 'ви'
+        right: 'будете'
+      - left: 'вони'
+        right: 'будуть'
+  - id: act-2
+    type: fill-in
+    title: Build the compound future
+    instruction: Choose the correct form of бути.
+    items:
+      - sentence: 'Завтра я ___ працювати.'
+        answer: 'буду'
+        options:
+          - 'буду'
+          - 'буде'
+          - 'будемо'
+        explanation: 'Я takes буду.'
+      - sentence: 'Що ти ___ робити ввечері?'
+        answer: 'будеш'
+        options:
+          - 'будеш'
+          - 'буду'
+          - 'будете'
+        explanation: 'Ти takes будеш.'
+      - sentence: 'Вона ___ читати книжку.'
+        answer: 'буде'
+        options:
+          - 'буде'
+          - 'будуть'
+          - 'будемо'
+        explanation: 'Вона takes буде.'
+      - sentence: 'Ми ___ дивитися футбол.'
+        answer: 'будемо'
+        options:
+          - 'будемо'
+          - 'буде'
+          - 'буду'
+        explanation: 'Ми takes будемо.'
+      - sentence: 'Ви ___ гуляти в парку?'
+        answer: 'будете'
+        options:
+          - 'будете'
+          - 'будеш'
+          - 'будуть'
+        explanation: 'Ви takes будете.'
+      - sentence: 'Вони ___ відпочивати.'
+        answer: 'будуть'
+        options:
+          - 'будуть'
+          - 'будемо'
+          - 'буде'
+        explanation: 'Вони takes будуть.'
+  - id: act-3
+    type: quiz
+    title: Future pattern check
+    instruction: Choose the answer that keeps the A1 compound future.
+    items:
+      - prompt: 'Which sentence means I will read?'
+        options:
+          - text: 'Я буду читати.'
+            correct: true
+          - text: 'Я буду читаю.'
+            correct: false
+          - text: 'Я читаю завтра.'
+            correct: false
+        explanation: 'Use буду + infinitive: буду читати.'
+      - prompt: 'What stays unchanged after будемо?'
+        options:
+          - text: 'The infinitive.'
+            correct: true
+          - text: 'A present-tense ending.'
+            correct: false
+          - text: 'A past-tense ending.'
+            correct: false
+        explanation: 'The second verb stays in the infinitive.'
+      - prompt: 'Which form fits ми?'
+        options:
+          - text: 'Ми будемо робити.'
+            correct: true
+          - text: 'Ми буде робити.'
+            correct: false
+          - text: 'Ми будеш робити.'
+            correct: false
+        explanation: 'Ми takes будемо.'
+      - prompt: 'Which question asks about tomorrow?'
+        options:
+          - text: 'Що ти будеш робити завтра?'
+            correct: true
+          - text: 'Що ти робиш учора?'
+            correct: false
+          - text: 'Що ти робив зараз?'
+            correct: false
+        explanation: 'Будеш робити завтра is the future question.'
+  - id: act-4
+    type: group-sort
+    title: Sort the time frames
+    instruction: Sort each sentence by time.
+    groups:
+      - name: 'past'
+        items:
+          - 'Учора я читав.'
+          - 'Учора вона працювала.'
+      - name: 'present'
+        items:
+          - 'Зараз я читаю.'
+          - 'Зараз ми працюємо.'
+      - name: 'future'
+        items:
+          - 'Завтра я буду читати.'
+          - 'Наступного тижня ми будемо працювати.'
+workbook:
+  - type: true-false
+    title: Check the compound future
+    instruction: Decide whether each sentence uses буду + infinitive correctly.
+    items:
+      - statement: 'Я буду читати завтра.'
+        answer: true
+        explanation: 'Буду + читати is correct.'
+      - statement: 'Ти будеш робити ввечері?'
+        answer: true
+        explanation: 'Будеш + робити is correct.'
+      - statement: 'Вона буде читає книжку.'
+        answer: false
+        explanation: 'After буде, use читати.'
+      - statement: 'Ми будемо дивитися футбол.'
+        answer: true
+        explanation: 'Будемо + дивитися is correct.'
+      - statement: 'Вони будуть працюють.'
+        answer: false
+        explanation: 'After будуть, use працювати.'
+      - statement: 'Ви будете гуляти в парку?'
+        answer: true
+        explanation: 'Будете + гуляти is correct.'
+  - type: unjumble
+    title: Build future sentences
+    instruction: Put the words in a natural order.
+    items:
+      - words: ['Завтра', 'я', 'буду', 'працювати']
+        answer: 'Завтра я буду працювати.'
+      - words: ['Що', 'ти', 'будеш', 'робити', 'ввечері']
+        answer: 'Що ти будеш робити ввечері?'
+      - words: ['Вона', 'буде', 'читати', 'книжку']
+        answer: 'Вона буде читати книжку.'
+      - words: ['Ми', 'будемо', 'дивитися', 'футбол']
+        answer: 'Ми будемо дивитися футбол.'
+      - words: ['Вони', 'будуть', 'відпочивати']
+        answer: 'Вони будуть відпочивати.'
+  - type: order
+    title: From now to tomorrow
+    instruction: Put the mini-sequence in a natural time order.
+    items:
+      - 'Зараз я читаю.'
+      - 'Ввечері я буду готувати.'
+      - 'Завтра я буду працювати.'
+      - 'Наступного тижня я буду відпочивати.'
+    correct_order: [0, 1, 2, 3]
+  - type: fill-in
+    title: Keep the infinitive
+    instruction: Choose the infinitive after the future form of бути.
+    items:
+      - sentence: 'Я буду ___ завтра.'
+        answer: 'читати'
+        options:
+          - 'читати'
+          - 'читаю'
+          - 'читав'
+        explanation: 'After буду, use the infinitive читати.'
+      - sentence: 'Ти будеш ___ ввечері?'
+        answer: 'робити'
+        options:
+          - 'робити'
+          - 'робиш'
+          - 'робив'
+        explanation: 'After будеш, use робити.'
+      - sentence: 'Вона буде ___ вечерю.'
+        answer: 'готувати'
+        options:
+          - 'готувати'
+          - 'готує'
+          - 'готувала'
+        explanation: 'After буде, use готувати.'
+      - sentence: 'Ми будемо ___ футбол.'
+        answer: 'дивитися'
+        options:
+          - 'дивитися'
+          - 'дивимося'
+          - 'дивилися'
+        explanation: 'After будемо, use дивитися.'
+      - sentence: 'Вони будуть ___.'
+        answer: 'відпочивати'
+        options:
+          - 'відпочивати'
+          - 'відпочивають'
+          - 'відпочивали'
+        explanation: 'After будуть, use відпочивати.'
+  - type: translate
+    title: Say future plans
+    instruction: Choose the Ukrainian sentence that matches the English prompt.
+    items:
+      - source: 'Tomorrow I will work.'
+        options:
+          - text: 'Завтра я буду працювати.'
+            correct: true
+          - text: 'Учора я працював.'
+            correct: false
+          - text: 'Зараз я працюю.'
+            correct: false
+        explanation: 'Tomorrow needs буду працювати.'
+      - source: 'What will you do in the evening?'
+        options:
+          - text: 'Що ти будеш робити ввечері?'
+            correct: true
+          - text: 'Що ти робив учора?'
+            correct: false
+          - text: 'Що ти робиш зараз?'
+            correct: false
+        explanation: 'Use будеш робити for you will do.'
+      - source: 'We will watch football.'
+        options:
+          - text: 'Ми будемо дивитися футбол.'
+            correct: true
+          - text: 'Ми дивимося футбол.'
+            correct: false
+          - text: 'Ми дивилися футбол.'
+            correct: false
+        explanation: 'Use будемо дивитися.'
+      - source: 'They will rest.'
+        options:
+          - text: 'Вони будуть відпочивати.'
+            correct: true
+          - text: 'Вони відпочивають.'
+            correct: false
+          - text: 'Вони відпочивали.'
+            correct: false
+        explanation: 'Use будуть відпочивати.'
+  - type: error-correction
+    title: Repair future forms
+    instruction: Fix the sentence by using буду + infinitive.
+    items:
+      - sentence: 'Я буду читаю завтра.'
+        error: 'читаю'
+        correction: 'читати'
+        explanation: 'After буду, use the infinitive читати.'
+      - sentence: 'Ти будеш робиш ввечері?'
+        error: 'робиш'
+        correction: 'робити'
+        explanation: 'After будеш, use робити.'
+      - sentence: 'Вона буде читає книжку.'
+        error: 'читає'
+        correction: 'читати'
+        explanation: 'After буде, use читати.'
+      - sentence: 'Ми будемо дивимося футбол.'
+        error: 'дивимося'
+        correction: 'дивитися'
+        explanation: 'After будемо, use дивитися.'
+      - sentence: 'Ми будемо читаємо текст.'
+        error: 'Ми будемо читаємо текст.'
+        correction: 'Ми будемо читати текст.'
+        explanation: 'In the compound future, only будемо changes; the second verb stays читати.'
+      - sentence: 'Вони будуть працюють.'
+        error: 'працюють'
+        correction: 'працювати'
+        explanation: 'After будуть, use працювати.'
+      - sentence: 'Я буде робити завтра.'
+        error: 'буде'
+        correction: 'буду'
+        explanation: 'Я takes буду.'

--- a/curriculum/l2-uk-en/a1/what-will-happen/module.md
+++ b/curriculum/l2-uk-en/a1/what-will-happen/module.md
@@ -188,11 +188,8 @@ For a quick spoken answer, repeat the pattern twice: **Завтра я буду
 працювати. Ввечері я буду відпочивати.** The repetition is useful because the
 infinitives stay visible.
 
-<!-- INJECT_ACTIVITY: act-5 -->
 
-<!-- INJECT_ACTIVITY: act-6 -->
 
-<!-- INJECT_ACTIVITY: act-7 -->
 
 ### Repair traps
 
@@ -218,7 +215,6 @@ Another trap is choosing the wrong future form of **бути**:
 | <del>**ми буде робити**</del> | **ми будемо робити** |
 | <del>**вони будемо робити**</del> | **вони будуть робити** |
 
-<!-- INJECT_ACTIVITY: act-8 -->
 
 ## Підсумок
 
@@ -249,7 +245,3 @@ Self-check:
 
 Stop with the compound future. The next module uses this same pattern for
 plans and invitations with days and times.
-
-<!-- INJECT_ACTIVITY: act-9 -->
-
-<!-- INJECT_ACTIVITY: act-10 -->

--- a/curriculum/l2-uk-en/a1/yesterday/activities.yaml
+++ b/curriculum/l2-uk-en/a1/yesterday/activities.yaml
@@ -1,284 +1,280 @@
-- id: act-1
-  type: order
-  title: Put the day in order
-  instruction: Arrange Анна's yesterday from morning to night.
-  items:
-    - "Зранку я прокинулася о сьомій."
-    - "Спочатку я поснідала."
-    - "Потім я пішла на роботу."
-    - "Вдень я обідала з колегою."
-    - "Ввечері я повернулася додому."
-    - "Нарешті я лягла спати."
-  correct_order: [0, 1, 2, 3, 4, 5]
-- id: act-2
-  type: fill-in
-  title: Time words for yesterday
-  instruction: Choose the time word that fits each part of the day.
-  items:
-    - sentence: "___ я прокинулася о сьомій."
-      answer: "Зранку"
-      options:
-        - "Зранку"
-        - "Ввечері"
-        - "Нарешті"
-      explanation: "Зранку marks the morning."
-    - sentence: "___ я пішла на роботу."
-      answer: "Потім"
-      options:
-        - "Потім"
-        - "Учора"
-        - "Вночі"
-      explanation: "Потім moves the story to the next action."
-    - sentence: "___ я обідала в кафе."
-      answer: "Вдень"
-      options:
-        - "Вдень"
-        - "Зранку"
-        - "Нарешті"
-      explanation: "Вдень fits lunch or the middle of the day."
-    - sentence: "___ я повернулася додому."
-      answer: "Ввечері"
-      options:
-        - "Ввечері"
-        - "Спочатку"
-        - "Зранку"
-      explanation: "Ввечері marks the evening."
-    - sentence: "___ я лягла спати."
-      answer: "Нарешті"
-      options:
-        - "Нарешті"
-        - "Вдень"
-        - "Після цього"
-      explanation: "Нарешті can mark the last action."
-- id: act-3
-  type: group-sort
-  title: Sort story words
-  instruction: Put each word or phrase into the right story group.
-  groups:
-    - name: "time markers"
-      items:
-        - "учора"
-        - "зранку"
-        - "вдень"
-        - "ввечері"
-        - "потім"
-        - "нарешті"
-    - name: "routine actions"
-      items:
-        - "прокинулася"
-        - "поснідала"
-        - "обідала"
-        - "повернулася"
-        - "лягла спати"
-    - name: "small details"
-      items:
-        - "з колегою"
-        - "біля офісу"
-        - "продукти"
-        - "серіал"
-- id: act-4
-  type: quiz
-  title: Keep the speaker consistent
-  instruction: Choose the line that keeps Анна's story in the same speaker pattern.
-  items:
-    - prompt: "Анна says: Зранку я прокинулася. What should come next?"
-      options:
-        - text: "Потім я поснідала."
-          correct: true
-        - text: "Потім я поснідав."
-          correct: false
-        - text: "Потім я поснідали."
-          correct: false
-      explanation: "Анна keeps the feminine form поснідала."
-    - prompt: "Which pair fits one female speaker?"
-      options:
-        - text: "Я пішла. Я повернулася."
-          correct: true
-        - text: "Я пішла. Я повернувся."
-          correct: false
-        - text: "Я пішов. Я повернулася."
-          correct: false
-      explanation: "Both verbs stay feminine."
-    - prompt: "Which line is a clean end to Анна's day?"
-      options:
-        - text: "Нарешті я лягла спати."
-          correct: true
-        - text: "Нарешті я ліг спати."
-          correct: false
-        - text: "Нарешті я лягли спати."
-          correct: false
-      explanation: "For Анна, use лягла."
-    - prompt: "What does учора do in the story?"
-      options:
-        - text: "It places the story in the past day."
-          correct: true
-        - text: "It means the story happens tomorrow."
-          correct: false
-        - text: "It changes the verb into the present tense."
-          correct: false
-      explanation: "Учора is the time marker for yesterday."
-- id: act-5
-  type: match-up
-  title: Infinitive to story form
-  instruction: Match each infinitive with the feminine past form used by Анна.
-  pairs:
-    - left: "прокинутися"
-      right: "прокинулася"
-    - left: "поснідати"
-      right: "поснідала"
-    - left: "піти"
-      right: "пішла"
-    - left: "обідати"
-      right: "обідала"
-    - left: "повернутися"
-      right: "повернулася"
-    - left: "лягти"
-      right: "лягла"
-- id: act-6
-  type: true-false
-  title: Does the story stay consistent?
-  instruction: Decide whether the sentence fits one female speaker's yesterday story.
-  items:
-    - statement: "Учора я прокинулася о сьомій."
-      answer: true
-      explanation: "This can fit Анна's story."
-    - statement: "Потім я поснідав."
-      answer: false
-      explanation: "For Анна, use поснідала."
-    - statement: "Вдень я обідала з колегою."
-      answer: true
-      explanation: "Обідала matches the female speaker."
-    - statement: "Ввечері я повернувся додому."
-      answer: false
-      explanation: "For Анна, use повернулася."
-    - statement: "Нарешті я лягла спати."
-      answer: true
-      explanation: "Лягла matches the female speaker."
-    - statement: "Учора я працює в офісі."
-      answer: false
-      explanation: "Учора needs a past form: працювала."
-- id: act-7
-  type: unjumble
-  title: Build yesterday sentences
-  instruction: Put the words in a natural order.
-  items:
-    - words: ["Учора", "я", "прокинулася", "о", "сьомій"]
-      answer: "Учора я прокинулася о сьомій."
-    - words: ["Потім", "я", "поснідала"]
-      answer: "Потім я поснідала."
-    - words: ["Вдень", "я", "обідала", "з", "колегою"]
-      answer: "Вдень я обідала з колегою."
-    - words: ["Ввечері", "я", "купила", "продукти"]
-      answer: "Ввечері я купила продукти."
-    - words: ["Нарешті", "я", "лягла", "спати"]
-      answer: "Нарешті я лягла спати."
-- id: act-8
-  type: translate
-  title: Say the day in Ukrainian
-  instruction: Choose the Ukrainian sentence that matches the English prompt.
-  items:
-    - source: "Yesterday I woke up at seven. (female speaker)"
-      options:
-        - text: "Учора я прокинулася о сьомій."
-          correct: true
-        - text: "Учора я прокинувся о сьомій."
-          correct: false
-        - text: "Учора я прокидаюся о сьомій."
-          correct: false
-      explanation: "For a female speaker in the past, use прокинулася."
-    - source: "Then I had breakfast. (female speaker)"
-      options:
-        - text: "Потім я поснідала."
-          correct: true
-        - text: "Потім я поснідав."
-          correct: false
-        - text: "Потім я снідаю."
-          correct: false
-      explanation: "Поснідала fits the female speaker."
-    - source: "In the afternoon I had lunch with a colleague. (female speaker)"
-      options:
-        - text: "Вдень я обідала з колегою."
-          correct: true
-        - text: "Вдень я обідав з колегою."
-          correct: false
-        - text: "Завтра я буду обідати з колегою."
-          correct: false
-      explanation: "The time is yesterday, so use past tense."
-    - source: "In the evening I watched a series. (female speaker)"
-      options:
-        - text: "Ввечері я дивилася серіал."
-          correct: true
-        - text: "Ввечері я дивився серіал."
-          correct: false
-        - text: "Ввечері я дивлюся серіал."
-          correct: false
-      explanation: "Дивилася matches the female speaker."
-- id: act-9
-  type: fill-in
-  title: Complete Анна's story
-  instruction: Choose the form that keeps the whole story in Анна's voice.
-  items:
-    - sentence: "Учора я ___ о пів на сьому."
-      answer: "прокинулася"
-      options:
-        - "прокинулася"
-        - "прокинувся"
-        - "прокинулися"
-      explanation: "Анна says прокинулася."
-    - sentence: "Потім я ___ кашу і пила каву."
-      answer: "їла"
-      options:
-        - "їла"
-        - "їв"
-        - "їли"
-      explanation: "Їла matches the female speaker."
-    - sentence: "Вдень я ___ салат."
-      answer: "замовила"
-      options:
-        - "замовила"
-        - "замовив"
-        - "замовили"
-      explanation: "Замовила matches Анна."
-    - sentence: "Після роботи я ___ продукти."
-      answer: "купила"
-      options:
-        - "купила"
-        - "купив"
-        - "купили"
-      explanation: "Купила keeps the same speaker pattern."
-    - sentence: "Об одинадцятій я ___ спати."
-      answer: "лягла"
-      options:
-        - "лягла"
-        - "ліг"
-        - "лягли"
-      explanation: "Лягла fits a female speaker."
-- id: act-10
-  type: error-correction
-  title: Repair the yesterday narrative
-  instruction: Fix the sentence so it matches one female speaker's day.
-  items:
-    - sentence: "Зранку я прокинувся о сьомій."
-      error: "прокинувся"
-      correction: "прокинулася"
-      explanation: "Анна is the speaker, so use прокинулася."
-    - sentence: "Потім я поснідав."
-      error: "поснідав"
-      correction: "поснідала"
-      explanation: "Keep the feminine form."
-    - sentence: "Вдень я обідав з колегою."
-      error: "обідав"
-      correction: "обідала"
-      explanation: "Обідала matches the female speaker."
-    - sentence: "Ввечері я повернувся додому."
-      error: "повернувся"
-      correction: "повернулася"
-      explanation: "Use повернулася for Анна."
-    - sentence: "Нарешті я ліг спати."
-      error: "ліг"
-      correction: "лягла"
-      explanation: "Use лягла for a female speaker."
-    - sentence: "Учора я працює в офісі."
-      error: "працює"
-      correction: "працювала"
-      explanation: "Учора needs the past form працювала."
+inline:
+  - id: act-1
+    type: order
+    title: Put the day in order
+    instruction: Arrange Анна's yesterday from morning to night.
+    items:
+      - 'Зранку я прокинулася о сьомій.'
+      - 'Спочатку я поснідала.'
+      - 'Потім я пішла на роботу.'
+      - 'Вдень я обідала з колегою.'
+      - 'Ввечері я повернулася додому.'
+      - 'Нарешті я лягла спати.'
+    correct_order: [0, 1, 2, 3, 4, 5]
+  - id: act-2
+    type: fill-in
+    title: Time words for yesterday
+    instruction: Choose the time word that fits each part of the day.
+    items:
+      - sentence: '___ я прокинулася о сьомій.'
+        answer: 'Зранку'
+        options:
+          - 'Зранку'
+          - 'Ввечері'
+          - 'Нарешті'
+        explanation: 'Зранку marks the morning.'
+      - sentence: '___ я пішла на роботу.'
+        answer: 'Потім'
+        options:
+          - 'Потім'
+          - 'Учора'
+          - 'Вночі'
+        explanation: 'Потім moves the story to the next action.'
+      - sentence: '___ я обідала в кафе.'
+        answer: 'Вдень'
+        options:
+          - 'Вдень'
+          - 'Зранку'
+          - 'Нарешті'
+        explanation: 'Вдень fits lunch or the middle of the day.'
+      - sentence: '___ я повернулася додому.'
+        answer: 'Ввечері'
+        options:
+          - 'Ввечері'
+          - 'Спочатку'
+          - 'Зранку'
+        explanation: 'Ввечері marks the evening.'
+      - sentence: '___ я лягла спати.'
+        answer: 'Нарешті'
+        options:
+          - 'Нарешті'
+          - 'Вдень'
+          - 'Після цього'
+        explanation: 'Нарешті can mark the last action.'
+  - id: act-3
+    type: group-sort
+    title: Sort story words
+    instruction: Put each word or phrase into the right story group.
+    groups:
+      - name: 'time markers'
+        items:
+          - 'учора'
+          - 'зранку'
+          - 'вдень'
+          - 'ввечері'
+          - 'потім'
+          - 'нарешті'
+      - name: 'routine actions'
+        items:
+          - 'прокинулася'
+          - 'поснідала'
+          - 'обідала'
+          - 'повернулася'
+          - 'лягла спати'
+      - name: 'small details'
+        items:
+          - 'з колегою'
+          - 'біля офісу'
+          - 'продукти'
+          - 'серіал'
+  - id: act-4
+    type: quiz
+    title: Keep the speaker consistent
+    instruction: Choose the line that keeps Анна's story in the same speaker pattern.
+    items:
+      - prompt: 'Анна says: Зранку я прокинулася. What should come next?'
+        options:
+          - text: 'Потім я поснідала.'
+            correct: true
+          - text: 'Потім я поснідав.'
+            correct: false
+          - text: 'Потім я поснідали.'
+            correct: false
+        explanation: 'Анна keeps the feminine form поснідала.'
+      - prompt: 'Which pair fits one female speaker?'
+        options:
+          - text: 'Я пішла. Я повернулася.'
+            correct: true
+          - text: 'Я пішла. Я повернувся.'
+            correct: false
+          - text: 'Я пішов. Я повернулася.'
+            correct: false
+        explanation: 'Both verbs stay feminine.'
+      - prompt: "Which line is a clean end to Анна's day?"
+        options:
+          - text: 'Нарешті я лягла спати.'
+            correct: true
+          - text: 'Нарешті я ліг спати.'
+            correct: false
+          - text: 'Нарешті я лягли спати.'
+            correct: false
+        explanation: 'For Анна, use лягла.'
+      - prompt: 'What does учора do in the story?'
+        options:
+          - text: 'It places the story in the past day.'
+            correct: true
+          - text: 'It means the story happens tomorrow.'
+            correct: false
+          - text: 'It changes the verb into the present tense.'
+            correct: false
+        explanation: 'Учора is the time marker for yesterday.'
+workbook:
+  - type: match-up
+    title: Infinitive to story form
+    instruction: Match each infinitive with the feminine past form used by Анна.
+    pairs:
+      - left: 'прокинутися'
+        right: 'прокинулася'
+      - left: 'поснідати'
+        right: 'поснідала'
+      - left: 'піти'
+        right: 'пішла'
+      - left: 'обідати'
+        right: 'обідала'
+      - left: 'повернутися'
+        right: 'повернулася'
+      - left: 'лягти'
+        right: 'лягла'
+  - type: true-false
+    title: Does the story stay consistent?
+    instruction: Decide whether the sentence fits one female speaker's yesterday story.
+    items:
+      - statement: 'Учора я прокинулася о сьомій.'
+        answer: true
+        explanation: "This can fit Анна's story."
+      - statement: 'Потім я поснідав.'
+        answer: false
+        explanation: 'For Анна, use поснідала.'
+      - statement: 'Вдень я обідала з колегою.'
+        answer: true
+        explanation: 'Обідала matches the female speaker.'
+      - statement: 'Ввечері я повернувся додому.'
+        answer: false
+        explanation: 'For Анна, use повернулася.'
+      - statement: 'Нарешті я лягла спати.'
+        answer: true
+        explanation: 'Лягла matches the female speaker.'
+      - statement: 'Учора я працює в офісі.'
+        answer: false
+        explanation: 'Учора needs a past form: працювала.'
+  - type: unjumble
+    title: Build yesterday sentences
+    instruction: Put the words in a natural order.
+    items:
+      - words: ['Учора', 'я', 'прокинулася', 'о', 'сьомій']
+        answer: 'Учора я прокинулася о сьомій.'
+      - words: ['Потім', 'я', 'поснідала']
+        answer: 'Потім я поснідала.'
+      - words: ['Вдень', 'я', 'обідала', 'з', 'колегою']
+        answer: 'Вдень я обідала з колегою.'
+      - words: ['Ввечері', 'я', 'купила', 'продукти']
+        answer: 'Ввечері я купила продукти.'
+      - words: ['Нарешті', 'я', 'лягла', 'спати']
+        answer: 'Нарешті я лягла спати.'
+  - type: translate
+    title: Say the day in Ukrainian
+    instruction: Choose the Ukrainian sentence that matches the English prompt.
+    items:
+      - source: 'Yesterday I woke up at seven. (female speaker)'
+        options:
+          - text: 'Учора я прокинулася о сьомій.'
+            correct: true
+          - text: 'Учора я прокинувся о сьомій.'
+            correct: false
+          - text: 'Учора я прокидаюся о сьомій.'
+            correct: false
+        explanation: 'For a female speaker in the past, use прокинулася.'
+      - source: 'Then I had breakfast. (female speaker)'
+        options:
+          - text: 'Потім я поснідала.'
+            correct: true
+          - text: 'Потім я поснідав.'
+            correct: false
+          - text: 'Потім я снідаю.'
+            correct: false
+        explanation: 'Поснідала fits the female speaker.'
+      - source: 'In the afternoon I had lunch with a colleague. (female speaker)'
+        options:
+          - text: 'Вдень я обідала з колегою.'
+            correct: true
+          - text: 'Вдень я обідав з колегою.'
+            correct: false
+          - text: 'Завтра я буду обідати з колегою.'
+            correct: false
+        explanation: 'The time is yesterday, so use past tense.'
+      - source: 'In the evening I watched a series. (female speaker)'
+        options:
+          - text: 'Ввечері я дивилася серіал.'
+            correct: true
+          - text: 'Ввечері я дивився серіал.'
+            correct: false
+          - text: 'Ввечері я дивлюся серіал.'
+            correct: false
+        explanation: 'Дивилася matches the female speaker.'
+  - type: fill-in
+    title: Complete Анна's story
+    instruction: Choose the form that keeps the whole story in Анна's voice.
+    items:
+      - sentence: 'Учора я ___ о пів на сьому.'
+        answer: 'прокинулася'
+        options:
+          - 'прокинулася'
+          - 'прокинувся'
+          - 'прокинулися'
+        explanation: 'Анна says прокинулася.'
+      - sentence: 'Потім я ___ кашу і пила каву.'
+        answer: 'їла'
+        options:
+          - 'їла'
+          - 'їв'
+          - 'їли'
+        explanation: 'Їла matches the female speaker.'
+      - sentence: 'Вдень я ___ салат.'
+        answer: 'замовила'
+        options:
+          - 'замовила'
+          - 'замовив'
+          - 'замовили'
+        explanation: 'Замовила matches Анна.'
+      - sentence: 'Після роботи я ___ продукти.'
+        answer: 'купила'
+        options:
+          - 'купила'
+          - 'купив'
+          - 'купили'
+        explanation: 'Купила keeps the same speaker pattern.'
+      - sentence: 'Об одинадцятій я ___ спати.'
+        answer: 'лягла'
+        options:
+          - 'лягла'
+          - 'ліг'
+          - 'лягли'
+        explanation: 'Лягла fits a female speaker.'
+  - type: error-correction
+    title: Repair the yesterday narrative
+    instruction: Fix the sentence so it matches one female speaker's day.
+    items:
+      - sentence: 'Зранку я прокинувся о сьомій.'
+        error: 'прокинувся'
+        correction: 'прокинулася'
+        explanation: 'Анна is the speaker, so use прокинулася.'
+      - sentence: 'Потім я поснідав.'
+        error: 'поснідав'
+        correction: 'поснідала'
+        explanation: 'Keep the feminine form.'
+      - sentence: 'Вдень я обідав з колегою.'
+        error: 'обідав'
+        correction: 'обідала'
+        explanation: 'Обідала matches the female speaker.'
+      - sentence: 'Ввечері я повернувся додому.'
+        error: 'повернувся'
+        correction: 'повернулася'
+        explanation: 'Use повернулася for Анна.'
+      - sentence: 'Нарешті я ліг спати.'
+        error: 'ліг'
+        correction: 'лягла'
+        explanation: 'Use лягла for a female speaker.'
+      - sentence: 'Учора я працює в офісі.'
+        error: 'працює'
+        correction: 'працювала'
+        explanation: 'Учора needs the past form працювала.'

--- a/curriculum/l2-uk-en/a1/yesterday/module.md
+++ b/curriculum/l2-uk-en/a1/yesterday/module.md
@@ -174,11 +174,8 @@ Do not mix the two templates inside one story. If the story begins **я
 **я лягла**. If the story begins **я прокинувся**, continue with
 **я поснідав**, **я пішов**, **я повернувся**, **я ліг**.
 
-<!-- INJECT_ACTIVITY: act-5 -->
 
-<!-- INJECT_ACTIVITY: act-6 -->
 
-<!-- INJECT_ACTIVITY: act-7 -->
 
 ### Build a short day story
 
@@ -206,7 +203,6 @@ such as **кафе**, a person such as **колега**, or an object such as
 **продукти**. The time line should still be easy to scan from morning to
 evening.
 
-<!-- INJECT_ACTIVITY: act-8 -->
 
 ## Підсумок
 
@@ -248,7 +244,3 @@ Self-check with one six-sentence story:
 | **Нарешті я лягла спати.** | Finally I went to bed. |
 
 If every verb matches the same speaker, the story is doing its job.
-
-<!-- INJECT_ACTIVITY: act-9 -->
-
-<!-- INJECT_ACTIVITY: act-10 -->


### PR DESCRIPTION
## Summary

Refs #2811.

- Converted A1 M48-M55 activity files from flat V1 lists to V2 top-level `inline:` and `workbook:` lists.
- Kept the default split for every scoped module: 4 Lesson-tab inline activities, with the remaining activities in workbook (`4+6` for M48-M51, `4+5` for M52-M55).
- Removed only the `act-5+` injection markers from each `module.md`; retained `act-1` through `act-4` markers in order.
- Preserved all original activity content; workbook entries are idless and inline IDs still match Lesson-tab markers.

## Validation

- Structural/content check: all eight modules preserved original counts and flattened content; inline IDs match retained markers; workbook entries have no `id`.
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/generate_mdx.py l2-uk-en a1 N --validate` for N=48..55: all passed (`VALIDATION PASSED`). Generated Starlight MDX files were restored and are not included.
- `npx prettier --check` on the eight changed `activities.yaml` files: passed.
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest -q tests/test_yaml_activities.py tests/test_generate_mdx.py tests/test_activity_helpers_flatten.py`: 118 passed.
- `git diff --check origin/main..HEAD`: clean.
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`: passed.