### PR TITLE
Split A1 M2-M7 activity files into inline/workbook

### DIFF
--- a/curriculum/l2-uk-en/a1/checkpoint-first-contact/activities.yaml
+++ b/curriculum/l2-uk-en/a1/checkpoint-first-contact/activities.yaml
@@ -1,424 +1,423 @@
-- id: act-1
-  type: quiz
-  title: First-contact readiness
-  instruction: Choose the safe Ukrainian line for the checkpoint situation.
-  items:
-    - prompt: You greet a peer at the start of class.
-      options:
-        - text: Привіт!
-          correct: true
-        - text: До побачення!
-          correct: false
-        - text: Мені теж.
-          correct: false
-      explanation: Привіт is the informal peer greeting.
-    - prompt: You greet a teacher or administrator neutrally.
-      options:
-        - text: Добрий день!
-          correct: true
-        - text: Бувай!
-          correct: false
-        - text: Мене звати!
-          correct: false
-      explanation: Добрий день is the safe neutral formal greeting.
-    - prompt: You introduce your name.
-      options:
-        - text: Мене звати Олена.
-          correct: true
-        - text: Моє ім'я є Олена.
-          correct: false
-        - text: Я звати Олена.
-          correct: false
-      explanation: Мене звати... is the canonical first-name chunk.
-    - prompt: You say that you are a student.
-      options:
-        - text: Я студент.
-          correct: true
-        - text: Я є студент.
-          correct: false
-        - text: Мене студент.
-          correct: false
-      explanation: Ukrainian usually omits the present-tense copula in this identity line.
-    - prompt: You say your age.
-      options:
-        - text: Мені 20 років.
-          correct: true
-        - text: Я маю 20 років.
-          correct: false
-        - text: Я 20 роки.
-          correct: false
-      explanation: Age uses Мені ... років.
-    - prompt: You close the first meeting politely.
-      options:
-        - text: Дуже приємно. До побачення!
-          correct: true
-        - text: Дуже прізвище. Привіт!
-          correct: false
-        - text: Звідки ти? Мені теж!
-          correct: false
-      explanation: Дуже приємно and До побачення close the exchange.
-- id: act-2
-  type: match-up
-  title: Questions and answers
-  instruction: Match each first-contact question with the natural answer.
-  pairs:
-    - left: Як тебе звати?
-      right: Мене звати Богдан.
-    - left: Звідки ти?
-      right: Я з Дніпра.
-    - left: Ти студентка?
-      right: Так, я студентка.
-    - left: У тебе є брат?
-      right: Так, у мене є брат.
-    - left: Як її звати?
-      right: Її звати Ірина.
-    - left: Чий це словник?
-      right: Це мій словник.
-    - left: Скільки тобі років?
-      right: Мені 20 років.
-    - left: Дуже приємно.
-      right: Мені теж.
-- id: act-3
-  type: fill-in
-  title: Complete the review text
-  instruction: Choose the missing word or chunk in the self-introduction.
-  items:
-    - sentence: Привіт! ___ звати Марко.
-      answer: Мене
-      options:
-        - Мене
-        - Моє
-        - Мій
-      explanation: Мене звати... is the safe name chunk.
-    - sentence: Моє ___ Коваленко.
-      answer: прізвище
-      options:
-        - прізвище
-        - фамілія
-        - професія
-      explanation: Прізвище is the standard Ukrainian word for surname.
-    - sentence: Я ___ Києва.
-      answer: з
-      options:
-        - з
-        - у
-        - це
-      explanation: Я з... gives origin.
-    - sentence: Я ___.
-      answer: студент
-      options:
-        - студент
-        - є студент
-        - мене студент
-      explanation: The A1 identity sentence does not need є.
-    - sentence: ___ 20 років.
-      answer: Мені
-      options:
-        - Мені
-        - Я маю
-        - Мене
-      explanation: Age uses Мені ... років.
-    - sentence: У мене ___ сестра.
-      answer: є
-      options:
-        - є
-        - звати
-        - з
-      explanation: У мене є... is the I-have chunk.
-    - sentence: Це ___ мама.
-      answer: моя
-      options:
-        - моя
-        - мій
-        - моє
-      explanation: Мама is feminine, so use моя.
-    - sentence: Дуже ___ познайомитися!
-      answer: приємно
-      options:
-        - приємно
-        - прізвище
-        - звати
-      explanation: Дуже приємно познайомитися closes a first meeting.
-- id: act-4
-  type: quiz
-  title: Fix common A1.1 traps
-  instruction: Choose the normative Ukrainian form.
-  items:
-    - prompt: Name introduction
-      options:
-        - text: Мене звати Джон.
-          correct: true
-        - text: Моє ім'я є Джон.
-          correct: false
-      explanation: Ukrainian introduces a name with Мене звати...
-    - prompt: Identity sentence
-      options:
-        - text: Я студент.
-          correct: true
-        - text: Я є студент.
-          correct: false
-      explanation: Present identity normally omits є.
-    - prompt: Age sentence
-      options:
-        - text: Мені 20 років.
-          correct: true
-        - text: Я маю 20 років.
-          correct: false
-      explanation: Age uses Мені ... років.
-    - prompt: Direct address
-      options:
-        - text: Привіт, Максиме!
-          correct: true
-        - text: Привіт, Максим!
-          correct: false
-      explanation: Direct address uses the vocative form in the safe example.
-    - prompt: Safe greeting
-      options:
-        - text: Добрий день! Мене звати Оксана.
-          correct: true
-        - text: Здрастуйте! Мене звати Оксана.
-          correct: false
-      explanation: Добрий день is the safe standard greeting.
-    - prompt: Surname
-      options:
-        - text: Моє прізвище Сміт.
-          correct: true
-        - text: Моя фамілія Сміт.
-          correct: false
-      explanation: Прізвище is the standard Ukrainian word for surname.
-    - prompt: Farewell
-      options:
-        - text: До побачення!
-          correct: true
-        - text: Пока!
-          correct: false
-      explanation: До побачення is the safe standard farewell.
-    - prompt: Noun gender habit
-      options:
-        - text: Вивчення слова разом із його родом
-          correct: true
-        - text: Ігнорування роду іменника
-          correct: false
-      explanation: Store a Ukrainian noun with its gender cues from the beginning.
-- id: act-5
-  type: fill-in
-  title: Full dialogue blanks
-  instruction: Complete the peer language-course dialogue.
-  items:
-    - sentence: ___! Мене звати Богдан.
-      answer: Привіт
-      options:
-        - Привіт
-        - Прізвище
-        - Років
-      explanation: Привіт opens a peer exchange.
-    - sentence: Привіт, ___! Мене звати Соломія.
-      answer: Богдане
-      options:
-        - Богдане
-        - Богдан
-        - Богдана
-      explanation: Богдане is the vocative direct-address form.
-    - sentence: Дуже приємно, ___.
-      answer: Соломіє
-      options:
-        - Соломіє
-        - Соломія
-        - Соломію
-      explanation: Соломіє is the vocative direct-address form.
-    - sentence: ___ ти? Я з Дніпра.
-      answer: Звідки
-      options:
-        - Звідки
-        - Хто
-        - Чий
-      explanation: Звідки ти? asks where someone is from.
-    - sentence: Моя майбутня ___ — вчителька.
-      answer: професія
-      options:
-        - професія
-        - прізвище
-        - адреса
-      explanation: Професія names a profession or occupation.
-    - sentence: У мене є сестра. ___ звати Ірина.
-      answer: Її
-      options:
-        - Її
-        - Його
-        - Я
-      explanation: Її fits a sister.
-    - sentence: У мене є брат. ___ звати Назар.
-      answer: Його
-      options:
-        - Його
-        - Її
-        - Вона
-      explanation: Його fits a brother.
-    - sentence: Дуже приємно ___!
-      answer: познайомитися
-      options:
-        - познайомитися
-        - походження
-        - допомогти
-      explanation: Дуже приємно познайомитися is a first-meeting closure.
-- id: act-6
-  type: quiz
-  title: Put the meeting in order
-  instruction: Choose the next line in the first-contact exchange.
-  items:
-    - prompt: "Opening line: Привіт! Мене звати Богдан."
-      options:
-        - text: Привіт, Богдане! Мене звати Соломія.
-          correct: true
-        - text: До побачення!
-          correct: false
-        - text: Мені 20 років.
-          correct: false
-      explanation: The other person answers with a greeting and name.
-    - prompt: "Line: Дуже приємно, Соломіє."
-      options:
-        - text: Мені теж. Звідки ти?
-          correct: true
-        - text: Моє прізвище словник.
-          correct: false
-        - text: Це моя гривня.
-          correct: false
-      explanation: Мені теж gives the reciprocal answer and keeps the exchange moving.
-    - prompt: "Line: Я з Дніпра. А ти?"
-      options:
-        - text: Я з Тернополя.
-          correct: true
-        - text: Його звати Назар.
-          correct: false
-        - text: Це мій брат.
-          correct: false
-      explanation: A ти? asks the same origin question back.
-    - prompt: "Line: У мене є брат."
-      options:
-        - text: Дуже приємно. До побачення!
-          correct: true
-        - text: Моє ім'я є брат.
-          correct: false
-        - text: Я маю брат років.
-          correct: false
-      explanation: A polite closing fits after the family line.
-- id: act-7
-  type: quiz
-  title: Checkpoint quick translation
-  instruction: Choose the English meaning of each Ukrainian line.
-  items:
-    - prompt: Мене звати Олена.
-      options:
-        - text: My name is Olena.
-          correct: true
-        - text: I am from Olena.
-          correct: false
-        - text: Olena is my surname.
-          correct: false
-      explanation: Мене звати... gives a name.
-    - prompt: Моє прізвище Мельник.
-      options:
-        - text: My surname is Melnyk.
-          correct: true
-        - text: My profession is Melnyk.
-          correct: false
-        - text: My family is Melnyk.
-          correct: false
-      explanation: Прізвище means surname.
-    - prompt: Я з Канади.
-      options:
-        - text: I am from Canada.
-          correct: true
-        - text: I am in Canada.
-          correct: false
-        - text: I have Canada.
-          correct: false
-      explanation: Я з... gives origin.
-    - prompt: Я студентка.
-      options:
-        - text: I am a female student.
-          correct: true
-        - text: I have a student.
-          correct: false
-        - text: My name is student.
-          correct: false
-      explanation: Identity uses the noun directly here.
-    - prompt: У мене є сестра.
-      options:
-        - text: I have a sister.
-          correct: true
-        - text: You have a sister.
-          correct: false
-        - text: This is my sister.
-          correct: false
-      explanation: У мене є... is the I-have chunk.
-    - prompt: Мені теж.
-      options:
-        - text: Me too.
-          correct: true
-        - text: Nice to meet you.
-          correct: false
-        - text: Goodbye.
-          correct: false
-      explanation: Мені теж gives the reciprocal answer.
-- id: act-8
-  type: match-up
-  title: Review vocabulary map
-  instruction: Match the Ukrainian checkpoint word with its English cue.
-  pairs:
-    - left: ім'я
-      right: first name
-    - left: прізвище
-      right: surname
-    - left: знайомство
-      right: acquaintance or introduction
-    - left: професія
-      right: profession
-    - left: національність
-      right: nationality
-    - left: походження
-      right: origin
-    - left: словник
-      right: dictionary
-    - left: адреса
-      right: address
-- id: act-9
-  type: fill-in
-  title: Digital chat etiquette
-  instruction: Complete the short course-chat exchange.
-  items:
-    - sentence: ___! Мене звати Ліна.
-      answer: Привіт
-      options:
-        - Привіт
-        - Пока
-        - Прізвище
-      explanation: Привіт opens an informal chat.
-    - sentence: Я ___ Одеси.
-      answer: з
-      options:
-        - з
-        - є
-        - моя
-      explanation: Я з... gives origin.
-    - sentence: Привіт, ___!
-      answer: Ліно
-      options:
-        - Ліно
-        - Ліна
-        - Ліну
-      explanation: Ліно is the vocative form in direct address.
-    - sentence: Дуже ___!
-      answer: приємно
-      options:
-        - приємно
-        - професія
-        - адреса
-      explanation: Дуже приємно is a polite first-contact response.
-    - sentence: Мені ___.
-      answer: теж
-      options:
-        - теж
-        - звати
-        - словник
-      explanation: Мені теж means me too.
+inline:
+  - id: act-1
+    type: quiz
+    title: First-contact readiness
+    instruction: Choose the safe Ukrainian line for the checkpoint situation.
+    items:
+      - prompt: You greet a peer at the start of class.
+        options:
+          - text: Привіт!
+            correct: true
+          - text: До побачення!
+            correct: false
+          - text: Мені теж.
+            correct: false
+        explanation: Привіт is the informal peer greeting.
+      - prompt: You greet a teacher or administrator neutrally.
+        options:
+          - text: Добрий день!
+            correct: true
+          - text: Бувай!
+            correct: false
+          - text: Мене звати!
+            correct: false
+        explanation: Добрий день is the safe neutral formal greeting.
+      - prompt: You introduce your name.
+        options:
+          - text: Мене звати Олена.
+            correct: true
+          - text: Моє ім'я є Олена.
+            correct: false
+          - text: Я звати Олена.
+            correct: false
+        explanation: Мене звати... is the canonical first-name chunk.
+      - prompt: You say that you are a student.
+        options:
+          - text: Я студент.
+            correct: true
+          - text: Я є студент.
+            correct: false
+          - text: Мене студент.
+            correct: false
+        explanation: Ukrainian usually omits the present-tense copula in this identity line.
+      - prompt: You say your age.
+        options:
+          - text: Мені 20 років.
+            correct: true
+          - text: Я маю 20 років.
+            correct: false
+          - text: Я 20 роки.
+            correct: false
+        explanation: Age uses Мені ... років.
+      - prompt: You close the first meeting politely.
+        options:
+          - text: Дуже приємно. До побачення!
+            correct: true
+          - text: Дуже прізвище. Привіт!
+            correct: false
+          - text: Звідки ти? Мені теж!
+            correct: false
+        explanation: Дуже приємно and До побачення close the exchange.
+  - id: act-2
+    type: match-up
+    title: Questions and answers
+    instruction: Match each first-contact question with the natural answer.
+    pairs:
+      - left: Як тебе звати?
+        right: Мене звати Богдан.
+      - left: Звідки ти?
+        right: Я з Дніпра.
+      - left: Ти студентка?
+        right: Так, я студентка.
+      - left: У тебе є брат?
+        right: Так, у мене є брат.
+      - left: Як її звати?
+        right: Її звати Ірина.
+      - left: Чий це словник?
+        right: Це мій словник.
+      - left: Скільки тобі років?
+        right: Мені 20 років.
+      - left: Дуже приємно.
+        right: Мені теж.
+  - id: act-3
+    type: fill-in
+    title: Complete the review text
+    instruction: Choose the missing word or chunk in the self-introduction.
+    items:
+      - sentence: Привіт! ___ звати Марко.
+        answer: Мене
+        options:
+          - Мене
+          - Моє
+          - Мій
+        explanation: Мене звати... is the safe name chunk.
+      - sentence: Моє ___ Коваленко.
+        answer: прізвище
+        options:
+          - прізвище
+          - фамілія
+          - професія
+        explanation: Прізвище is the standard Ukrainian word for surname.
+      - sentence: Я ___ Києва.
+        answer: з
+        options:
+          - з
+          - у
+          - це
+        explanation: Я з... gives origin.
+      - sentence: Я ___.
+        answer: студент
+        options:
+          - студент
+          - є студент
+          - мене студент
+        explanation: The A1 identity sentence does not need є.
+      - sentence: ___ 20 років.
+        answer: Мені
+        options:
+          - Мені
+          - Я маю
+          - Мене
+        explanation: Age uses Мені ... років.
+      - sentence: У мене ___ сестра.
+        answer: є
+        options:
+          - є
+          - звати
+          - з
+        explanation: У мене є... is the I-have chunk.
+      - sentence: Це ___ мама.
+        answer: моя
+        options:
+          - моя
+          - мій
+          - моє
+        explanation: Мама is feminine, so use моя.
+      - sentence: Дуже ___ познайомитися!
+        answer: приємно
+        options:
+          - приємно
+          - прізвище
+          - звати
+        explanation: Дуже приємно познайомитися closes a first meeting.
+  - id: act-4
+    type: quiz
+    title: Fix common A1.1 traps
+    instruction: Choose the normative Ukrainian form.
+    items:
+      - prompt: Name introduction
+        options:
+          - text: Мене звати Джон.
+            correct: true
+          - text: Моє ім'я є Джон.
+            correct: false
+        explanation: Ukrainian introduces a name with Мене звати...
+      - prompt: Identity sentence
+        options:
+          - text: Я студент.
+            correct: true
+          - text: Я є студент.
+            correct: false
+        explanation: Present identity normally omits є.
+      - prompt: Age sentence
+        options:
+          - text: Мені 20 років.
+            correct: true
+          - text: Я маю 20 років.
+            correct: false
+        explanation: Age uses Мені ... років.
+      - prompt: Direct address
+        options:
+          - text: Привіт, Максиме!
+            correct: true
+          - text: Привіт, Максим!
+            correct: false
+        explanation: Direct address uses the vocative form in the safe example.
+      - prompt: Safe greeting
+        options:
+          - text: Добрий день! Мене звати Оксана.
+            correct: true
+          - text: Здрастуйте! Мене звати Оксана.
+            correct: false
+        explanation: Добрий день is the safe standard greeting.
+      - prompt: Surname
+        options:
+          - text: Моє прізвище Сміт.
+            correct: true
+          - text: Моя фамілія Сміт.
+            correct: false
+        explanation: Прізвище is the standard Ukrainian word for surname.
+      - prompt: Farewell
+        options:
+          - text: До побачення!
+            correct: true
+          - text: Пока!
+            correct: false
+        explanation: До побачення is the safe standard farewell.
+      - prompt: Noun gender habit
+        options:
+          - text: Вивчення слова разом із його родом
+            correct: true
+          - text: Ігнорування роду іменника
+            correct: false
+        explanation: Store a Ukrainian noun with its gender cues from the beginning.
+  - id: act-5
+    type: fill-in
+    title: Full dialogue blanks
+    instruction: Complete the peer language-course dialogue.
+    items:
+      - sentence: ___! Мене звати Богдан.
+        answer: Привіт
+        options:
+          - Привіт
+          - Прізвище
+          - Років
+        explanation: Привіт opens a peer exchange.
+      - sentence: Привіт, ___! Мене звати Соломія.
+        answer: Богдане
+        options:
+          - Богдане
+          - Богдан
+          - Богдана
+        explanation: Богдане is the vocative direct-address form.
+      - sentence: Дуже приємно, ___.
+        answer: Соломіє
+        options:
+          - Соломіє
+          - Соломія
+          - Соломію
+        explanation: Соломіє is the vocative direct-address form.
+      - sentence: ___ ти? Я з Дніпра.
+        answer: Звідки
+        options:
+          - Звідки
+          - Хто
+          - Чий
+        explanation: Звідки ти? asks where someone is from.
+      - sentence: Моя майбутня ___ — вчителька.
+        answer: професія
+        options:
+          - професія
+          - прізвище
+          - адреса
+        explanation: Професія names a profession or occupation.
+      - sentence: У мене є сестра. ___ звати Ірина.
+        answer: Її
+        options:
+          - Її
+          - Його
+          - Я
+        explanation: Її fits a sister.
+      - sentence: У мене є брат. ___ звати Назар.
+        answer: Його
+        options:
+          - Його
+          - Її
+          - Вона
+        explanation: Його fits a brother.
+      - sentence: Дуже приємно ___!
+        answer: познайомитися
+        options:
+          - познайомитися
+          - походження
+          - допомогти
+        explanation: Дуже приємно познайомитися is a first-meeting closure.
+  - id: act-6
+    type: quiz
+    title: Put the meeting in order
+    instruction: Choose the next line in the first-contact exchange.
+    items:
+      - prompt: 'Opening line: Привіт! Мене звати Богдан.'
+        options:
+          - text: Привіт, Богдане! Мене звати Соломія.
+            correct: true
+          - text: До побачення!
+            correct: false
+          - text: Мені 20 років.
+            correct: false
+        explanation: The other person answers with a greeting and name.
+      - prompt: 'Line: Дуже приємно, Соломіє.'
+        options:
+          - text: Мені теж. Звідки ти?
+            correct: true
+          - text: Моє прізвище словник.
+            correct: false
+          - text: Це моя гривня.
+            correct: false
+        explanation: Мені теж gives the reciprocal answer and keeps the exchange moving.
+      - prompt: 'Line: Я з Дніпра. А ти?'
+        options:
+          - text: Я з Тернополя.
+            correct: true
+          - text: Його звати Назар.
+            correct: false
+          - text: Це мій брат.
+            correct: false
+        explanation: A ти? asks the same origin question back.
+      - prompt: 'Line: У мене є брат.'
+        options:
+          - text: Дуже приємно. До побачення!
+            correct: true
+          - text: Моє ім'я є брат.
+            correct: false
+          - text: Я маю брат років.
+            correct: false
+        explanation: A polite closing fits after the family line.
+workbook:
+  - type: quiz
+    title: Checkpoint quick translation
+    instruction: Choose the English meaning of each Ukrainian line.
+    items:
+      - prompt: Мене звати Олена.
+        options:
+          - text: My name is Olena.
+            correct: true
+          - text: I am from Olena.
+            correct: false
+          - text: Olena is my surname.
+            correct: false
+        explanation: Мене звати... gives a name.
+      - prompt: Моє прізвище Мельник.
+        options:
+          - text: My surname is Melnyk.
+            correct: true
+          - text: My profession is Melnyk.
+            correct: false
+          - text: My family is Melnyk.
+            correct: false
+        explanation: Прізвище means surname.
+      - prompt: Я з Канади.
+        options:
+          - text: I am from Canada.
+            correct: true
+          - text: I am in Canada.
+            correct: false
+          - text: I have Canada.
+            correct: false
+        explanation: Я з... gives origin.
+      - prompt: Я студентка.
+        options:
+          - text: I am a female student.
+            correct: true
+          - text: I have a student.
+            correct: false
+          - text: My name is student.
+            correct: false
+        explanation: Identity uses the noun directly here.
+      - prompt: У мене є сестра.
+        options:
+          - text: I have a sister.
+            correct: true
+          - text: You have a sister.
+            correct: false
+          - text: This is my sister.
+            correct: false
+        explanation: У мене є... is the I-have chunk.
+      - prompt: Мені теж.
+        options:
+          - text: Me too.
+            correct: true
+          - text: Nice to meet you.
+            correct: false
+          - text: Goodbye.
+            correct: false
+        explanation: Мені теж gives the reciprocal answer.
+  - type: match-up
+    title: Review vocabulary map
+    instruction: Match the Ukrainian checkpoint word with its English cue.
+    pairs:
+      - left: ім'я
+        right: first name
+      - left: прізвище
+        right: surname
+      - left: знайомство
+        right: acquaintance or introduction
+      - left: професія
+        right: profession
+      - left: національність
+        right: nationality
+      - left: походження
+        right: origin
+      - left: словник
+        right: dictionary
+      - left: адреса
+        right: address
+  - type: fill-in
+    title: Digital chat etiquette
+    instruction: Complete the short course-chat exchange.
+    items:
+      - sentence: ___! Мене звати Ліна.
+        answer: Привіт
+        options:
+          - Привіт
+          - Пока
+          - Прізвище
+        explanation: Привіт opens an informal chat.
+      - sentence: Я ___ Одеси.
+        answer: з
+        options:
+          - з
+          - є
+          - моя
+        explanation: Я з... gives origin.
+      - sentence: Привіт, ___!
+        answer: Ліно
+        options:
+          - Ліно
+          - Ліна
+          - Ліну
+        explanation: Ліно is the vocative form in direct address.
+      - sentence: Дуже ___!
+        answer: приємно
+        options:
+          - приємно
+          - професія
+          - адреса
+        explanation: Дуже приємно is a polite first-contact response.
+      - sentence: Мені ___.
+        answer: теж
+        options:
+          - теж
+          - звати
+          - словник
+        explanation: Мені теж means me too.

--- a/curriculum/l2-uk-en/a1/my-family/activities.yaml
+++ b/curriculum/l2-uk-en/a1/my-family/activities.yaml
@@ -1,394 +1,392 @@
-- id: act-1
-  type: quiz
-  title: Family photo questions
-  instruction: Choose the Ukrainian line that fits the photo exchange.
-  items:
-    - prompt: You ask one peer whether they have a brother.
-      options:
-        - text: У тебе є брат?
-          correct: true
-        - text: У мене є брат?
-          correct: false
-        - text: Це брат?
-          correct: false
-      explanation: У тебе є...? asks one familiar person whether they have someone.
-    - prompt: You answer yes and say you have one sister.
-      options:
-        - text: Так, у мене є одна сестра.
-          correct: true
-        - text: Так, у тебе є одна сестра.
-          correct: false
-        - text: Так, це одна сестра.
-          correct: false
-      explanation: У мене є... answers for yourself.
-    - prompt: You answer no with the safe A1 answer.
-      options:
-        - text: Ні.
-          correct: true
-        - text: У мене немає брат.
-          correct: false
-        - text: Ні є брат.
-          correct: false
-      explanation: Keep the negative answer simple at A1.
-    - prompt: You ask what his name is.
-      options:
-        - text: Як його звати?
-          correct: true
-        - text: Як її звати?
-          correct: false
-        - text: Що його звати?
-          correct: false
-      explanation: Його fits a brother, dad, son, or grandfather.
-    - prompt: You identify your mom in a photo.
-      options:
-        - text: Це моя мама.
-          correct: true
-        - text: Це мій мама.
-          correct: false
-        - text: Це моє мама.
-          correct: false
-      explanation: Мама is feminine, so use моя.
-    - prompt: You identify your parents.
-      options:
-        - text: Це мої батьки.
-          correct: true
-        - text: Це мій батьки.
-          correct: false
-        - text: Це моя батьки.
-          correct: false
-      explanation: Батьки is plural, so use мої.
-- id: act-2
-  type: match-up
-  title: Family words
-  instruction: Match the English cue with the Ukrainian family word.
-  pairs:
-    - left: mother
-      right: мама
-    - left: father
-      right: тато
-    - left: brother
-      right: брат
-    - left: sister
-      right: сестра
-    - left: grandmother
-      right: бабуся
-    - left: grandfather
-      right: дідусь
-    - left: parents
-      right: батьки
-    - left: relatives
-      right: родичі
-- id: act-3
-  type: fill-in
-  title: Build the I-have chunk
-  instruction: Choose the word or phrase that completes the family sentence.
-  items:
-    - sentence: ___ мене є брат.
-      answer: У
-      options:
-        - У
-        - Це
-        - Хто
-      explanation: У мене є... is the whole I-have chunk.
-    - sentence: У ___ є сестра.
-      answer: мене
-      options:
-        - мене
-        - мій
-        - це
-      explanation: У мене є... answers for yourself.
-    - sentence: У ___ є брат?
-      answer: тебе
-      options:
-        - тебе
-        - мене
-        - він
-      explanation: У тебе є...? asks one familiar person.
-    - sentence: У ___ є діти?
-      answer: вас
-      options:
-        - вас
-        - твій
-        - вона
-      explanation: У вас є...? is formal or plural.
-    - sentence: У мене є ___ брат.
-      answer: один
-      options:
-        - один
-        - одна
-        - дві
-      explanation: Брат is masculine, so use один.
-    - sentence: У мене є ___ сестра.
-      answer: одна
-      options:
-        - одна
-        - один
-        - два
-      explanation: Сестра is feminine, so use одна.
-    - sentence: У мене є ___ брати.
-      answer: два
-      options:
-        - два
-        - дві
-        - одна
-      explanation: Брати uses два.
-    - sentence: У мене є ___ сестри.
-      answer: дві
-      options:
-        - дві
-        - два
-        - один
-      explanation: Сестри uses дві.
-- id: act-4
-  type: fill-in
-  title: My or your?
-  instruction: Choose the possessive form that matches the family word.
-  items:
-    - sentence: Це ___ брат.
-      answer: мій
-      options:
-        - мій
-        - моя
-        - моє
-        - мої
-      explanation: Брат is masculine.
-    - sentence: Це ___ мама.
-      answer: моя
-      options:
-        - моя
-        - мій
-        - моє
-        - мої
-      explanation: Мама is feminine.
-    - sentence: Це ___ місто.
-      answer: моє
-      options:
-        - моє
-        - мій
-        - моя
-        - мої
-      explanation: Місто is neuter.
-    - sentence: Це ___ батьки.
-      answer: мої
-      options:
-        - мої
-        - мій
-        - моя
-        - моє
-      explanation: Батьки is plural.
-    - sentence: Це ___ тато?
-      answer: твій
-      options:
-        - твій
-        - твоя
-        - твоє
-        - твої
-      explanation: Тато is masculine even though it ends in -о.
-    - sentence: Це ___ сестра?
-      answer: твоя
-      options:
-        - твоя
-        - твій
-        - твоє
-        - твої
-      explanation: Сестра is feminine.
-    - sentence: Це ___ прізвище?
-      answer: твоє
-      options:
-        - твоє
-        - твій
-        - твоя
-        - твої
-      explanation: Прізвище is neuter.
-    - sentence: Це ___ родичі?
-      answer: твої
-      options:
-        - твої
-        - твій
-        - твоя
-        - твоє
-      explanation: Родичі is plural.
-- id: act-5
-  type: error-correction
-  title: Choose the Ukrainian family sentence
-  instruction: Choose the safer Ukrainian line.
-  items:
-    - sentence: Моє ім'я є Джон.
-      error: Моє ім'я є Джон.
-      correction: Мене звати Джон.
-      options:
-        - Мене звати Джон.
-        - Моє ім'я є Джон.
-      explanation: Мене звати... is the natural first-introduction model.
-    - sentence: Я маю 20 років.
-      error: Я маю 20 років.
-      correction: Мені 20 років.
-      options:
-        - Мені 20 років.
-        - Я маю 20 років.
-      explanation: Age uses the chunk Мені ... років.
-    - sentence: Це мій мама.
-      error: Це мій мама.
-      correction: Це моя мама.
-      options:
-        - Це моя мама.
-        - Це мій мама.
-      explanation: Мама is feminine, so use моя.
-    - sentence: Я є брат.
-      error: Я є брат.
-      correction: Я брат.
-      options:
-        - Я брат.
-        - Я є брат.
-      explanation: Present-time identity can omit є.
-    - sentence: Батьки (у значенні батька)
-      error: Батьки (у значенні батька)
-      correction: Тато / батько
-      options:
-        - Тато / батько
-        - Батьки
-      explanation: Батьки means parents, not one father.
-    - sentence: Чия це? (про брата)
-      error: Чия це? (про брата)
-      correction: Чий це брат?
-      options:
-        - Чий це брат?
-        - Чия це?
-      explanation: Брат is masculine, so the question word is чий.
-- id: act-6
-  type: fill-in
-  title: Native family words
-  instruction: Fill the sentence with the native Ukrainian family word.
-  items:
-    - sentence: Моя ___ — вчителька.
-      answer: дружина
-      options:
-        - дружина
-        - сестра
-      explanation: Дружина is the Ukrainian word for wife.
-    - sentence: Мій ___ працює в лікарні.
-      answer: чоловік
-      options:
-        - чоловік
-        - тато
-      explanation: Чоловік can mean man or husband by context.
-    - sentence: Це моя ___ Тетяна.
-      answer: бабуся
-      options:
-        - бабуся
-        - мама
-      explanation: Бабуся is the Ukrainian word for grandmother.
-    - sentence: Це мої ___.
-      answer: родичі
-      options:
-        - родичі
-        - батьки
-      explanation: Родичі means relatives.
-    - sentence: Це маленька ___.
-      answer: дитина
-      options:
-        - дитина
-        - сім'я
-      explanation: Дитина is the Ukrainian word for child.
-    - sentence: Це мій ___ брат.
-      answer: молодший
-      options:
-        - молодший
-        - старший
-      explanation: Молодший means younger.
-    - sentence: Мій старший брат уже ___.
-      answer: одружений
-      options:
-        - одружений
-        - студент
-      explanation: Одружений means married.
-- id: act-7
-  type: fill-in
-  title: Complete the photo dialogue
-  instruction: Choose the missing word from the family conversation.
-  items:
-    - sentence: Це ___ сім'я на фотографії.
-      answer: моя
-      options:
-        - моя
-        - мій
-        - моє
-      explanation: Сім'я is feminine.
-    - sentence: ___ це? Це мій тато.
-      answer: Хто
-      options:
-        - Хто
-        - Що
-        - Де
-      explanation: Use хто for a person.
-    - sentence: Це моя сестра. ___ звати Катя.
-      answer: Її
-      options:
-        - Її
-        - Його
-        - Вони
-      explanation: Її fits a sister.
-    - sentence: Це мій брат. ___ звати Коля.
-      answer: Його
-      options:
-        - Його
-        - Її
-        - Вона
-      explanation: Його fits a brother.
-    - sentence: А це ___ бабуся?
-      answer: твоя
-      options:
-        - твоя
-        - твій
-        - твоє
-      explanation: Бабуся is feminine.
-- id: act-8
-  type: translate
-  title: Family vocabulary quick check
-  instruction: Choose the English meaning.
-  items:
-    - source: сім'я
-      options:
-        - text: family, close household
-          correct: true
-        - text: surname
-          correct: false
-        - text: profession
-          correct: false
-      explanation: Сім'я is the close family word.
-    - source: родина
-      options:
-        - text: family or kin
-          correct: true
-        - text: only one parent
-          correct: false
-        - text: first name
-          correct: false
-      explanation: Родина often sounds wider than сім'я.
-    - source: У мене є брат.
-      options:
-        - text: I have a brother.
-          correct: true
-        - text: You have a brother.
-          correct: false
-        - text: This is my brother.
-          correct: false
-      explanation: У мене є... is the I-have chunk.
-    - source: Це моя сестра.
-      options:
-        - text: This is my sister.
-          correct: true
-        - text: This is my brother.
-          correct: false
-        - text: This is her sister.
-          correct: false
-      explanation: Моя matches сестра.
-    - source: Чий це брат?
-      options:
-        - text: Whose brother is this?
-          correct: true
-        - text: Who is this sister?
-          correct: false
-        - text: Do you have a brother?
-          correct: false
-      explanation: Чий asks whose and matches брат.
+inline:
+  - id: act-1
+    type: quiz
+    title: Family photo questions
+    instruction: Choose the Ukrainian line that fits the photo exchange.
+    items:
+      - prompt: You ask one peer whether they have a brother.
+        options:
+          - text: У тебе є брат?
+            correct: true
+          - text: У мене є брат?
+            correct: false
+          - text: Це брат?
+            correct: false
+        explanation: У тебе є...? asks one familiar person whether they have someone.
+      - prompt: You answer yes and say you have one sister.
+        options:
+          - text: Так, у мене є одна сестра.
+            correct: true
+          - text: Так, у тебе є одна сестра.
+            correct: false
+          - text: Так, це одна сестра.
+            correct: false
+        explanation: У мене є... answers for yourself.
+      - prompt: You answer no with the safe A1 answer.
+        options:
+          - text: Ні.
+            correct: true
+          - text: У мене немає брат.
+            correct: false
+          - text: Ні є брат.
+            correct: false
+        explanation: Keep the negative answer simple at A1.
+      - prompt: You ask what his name is.
+        options:
+          - text: Як його звати?
+            correct: true
+          - text: Як її звати?
+            correct: false
+          - text: Що його звати?
+            correct: false
+        explanation: Його fits a brother, dad, son, or grandfather.
+      - prompt: You identify your mom in a photo.
+        options:
+          - text: Це моя мама.
+            correct: true
+          - text: Це мій мама.
+            correct: false
+          - text: Це моє мама.
+            correct: false
+        explanation: Мама is feminine, so use моя.
+      - prompt: You identify your parents.
+        options:
+          - text: Це мої батьки.
+            correct: true
+          - text: Це мій батьки.
+            correct: false
+          - text: Це моя батьки.
+            correct: false
+        explanation: Батьки is plural, so use мої.
+  - id: act-2
+    type: match-up
+    title: Family words
+    instruction: Match the English cue with the Ukrainian family word.
+    pairs:
+      - left: mother
+        right: мама
+      - left: father
+        right: тато
+      - left: brother
+        right: брат
+      - left: sister
+        right: сестра
+      - left: grandmother
+        right: бабуся
+      - left: grandfather
+        right: дідусь
+      - left: parents
+        right: батьки
+      - left: relatives
+        right: родичі
+  - id: act-3
+    type: fill-in
+    title: Build the I-have chunk
+    instruction: Choose the word or phrase that completes the family sentence.
+    items:
+      - sentence: ___ мене є брат.
+        answer: У
+        options:
+          - У
+          - Це
+          - Хто
+        explanation: У мене є... is the whole I-have chunk.
+      - sentence: У ___ є сестра.
+        answer: мене
+        options:
+          - мене
+          - мій
+          - це
+        explanation: У мене є... answers for yourself.
+      - sentence: У ___ є брат?
+        answer: тебе
+        options:
+          - тебе
+          - мене
+          - він
+        explanation: У тебе є...? asks one familiar person.
+      - sentence: У ___ є діти?
+        answer: вас
+        options:
+          - вас
+          - твій
+          - вона
+        explanation: У вас є...? is formal or plural.
+      - sentence: У мене є ___ брат.
+        answer: один
+        options:
+          - один
+          - одна
+          - дві
+        explanation: Брат is masculine, so use один.
+      - sentence: У мене є ___ сестра.
+        answer: одна
+        options:
+          - одна
+          - один
+          - два
+        explanation: Сестра is feminine, so use одна.
+      - sentence: У мене є ___ брати.
+        answer: два
+        options:
+          - два
+          - дві
+          - одна
+        explanation: Брати uses два.
+      - sentence: У мене є ___ сестри.
+        answer: дві
+        options:
+          - дві
+          - два
+          - один
+        explanation: Сестри uses дві.
+  - id: act-4
+    type: fill-in
+    title: My or your?
+    instruction: Choose the possessive form that matches the family word.
+    items:
+      - sentence: Це ___ брат.
+        answer: мій
+        options:
+          - мій
+          - моя
+          - моє
+          - мої
+        explanation: Брат is masculine.
+      - sentence: Це ___ мама.
+        answer: моя
+        options:
+          - моя
+          - мій
+          - моє
+          - мої
+        explanation: Мама is feminine.
+      - sentence: Це ___ місто.
+        answer: моє
+        options:
+          - моє
+          - мій
+          - моя
+          - мої
+        explanation: Місто is neuter.
+      - sentence: Це ___ батьки.
+        answer: мої
+        options:
+          - мої
+          - мій
+          - моя
+          - моє
+        explanation: Батьки is plural.
+      - sentence: Це ___ тато?
+        answer: твій
+        options:
+          - твій
+          - твоя
+          - твоє
+          - твої
+        explanation: Тато is masculine even though it ends in -о.
+      - sentence: Це ___ сестра?
+        answer: твоя
+        options:
+          - твоя
+          - твій
+          - твоє
+          - твої
+        explanation: Сестра is feminine.
+      - sentence: Це ___ прізвище?
+        answer: твоє
+        options:
+          - твоє
+          - твій
+          - твоя
+          - твої
+        explanation: Прізвище is neuter.
+      - sentence: Це ___ родичі?
+        answer: твої
+        options:
+          - твої
+          - твій
+          - твоя
+          - твоє
+        explanation: Родичі is plural.
+workbook:
+  - type: error-correction
+    title: Choose the Ukrainian family sentence
+    instruction: Choose the safer Ukrainian line.
+    items:
+      - sentence: Моє ім'я є Джон.
+        error: Моє ім'я є Джон.
+        correction: Мене звати Джон.
+        options:
+          - Мене звати Джон.
+          - Моє ім'я є Джон.
+        explanation: Мене звати... is the natural first-introduction model.
+      - sentence: Я маю 20 років.
+        error: Я маю 20 років.
+        correction: Мені 20 років.
+        options:
+          - Мені 20 років.
+          - Я маю 20 років.
+        explanation: Age uses the chunk Мені ... років.
+      - sentence: Це мій мама.
+        error: Це мій мама.
+        correction: Це моя мама.
+        options:
+          - Це моя мама.
+          - Це мій мама.
+        explanation: Мама is feminine, so use моя.
+      - sentence: Я є брат.
+        error: Я є брат.
+        correction: Я брат.
+        options:
+          - Я брат.
+          - Я є брат.
+        explanation: Present-time identity can omit є.
+      - sentence: Батьки (у значенні батька)
+        error: Батьки (у значенні батька)
+        correction: Тато / батько
+        options:
+          - Тато / батько
+          - Батьки
+        explanation: Батьки means parents, not one father.
+      - sentence: Чия це? (про брата)
+        error: Чия це? (про брата)
+        correction: Чий це брат?
+        options:
+          - Чий це брат?
+          - Чия це?
+        explanation: Брат is masculine, so the question word is чий.
+  - type: fill-in
+    title: Native family words
+    instruction: Fill the sentence with the native Ukrainian family word.
+    items:
+      - sentence: Моя ___ — вчителька.
+        answer: дружина
+        options:
+          - дружина
+          - сестра
+        explanation: Дружина is the Ukrainian word for wife.
+      - sentence: Мій ___ працює в лікарні.
+        answer: чоловік
+        options:
+          - чоловік
+          - тато
+        explanation: Чоловік can mean man or husband by context.
+      - sentence: Це моя ___ Тетяна.
+        answer: бабуся
+        options:
+          - бабуся
+          - мама
+        explanation: Бабуся is the Ukrainian word for grandmother.
+      - sentence: Це мої ___.
+        answer: родичі
+        options:
+          - родичі
+          - батьки
+        explanation: Родичі means relatives.
+      - sentence: Це маленька ___.
+        answer: дитина
+        options:
+          - дитина
+          - сім'я
+        explanation: Дитина is the Ukrainian word for child.
+      - sentence: Це мій ___ брат.
+        answer: молодший
+        options:
+          - молодший
+          - старший
+        explanation: Молодший means younger.
+      - sentence: Мій старший брат уже ___.
+        answer: одружений
+        options:
+          - одружений
+          - студент
+        explanation: Одружений means married.
+  - type: fill-in
+    title: Complete the photo dialogue
+    instruction: Choose the missing word from the family conversation.
+    items:
+      - sentence: Це ___ сім'я на фотографії.
+        answer: моя
+        options:
+          - моя
+          - мій
+          - моє
+        explanation: Сім'я is feminine.
+      - sentence: ___ це? Це мій тато.
+        answer: Хто
+        options:
+          - Хто
+          - Що
+          - Де
+        explanation: Use хто for a person.
+      - sentence: Це моя сестра. ___ звати Катя.
+        answer: Її
+        options:
+          - Її
+          - Його
+          - Вони
+        explanation: Її fits a sister.
+      - sentence: Це мій брат. ___ звати Коля.
+        answer: Його
+        options:
+          - Його
+          - Її
+          - Вона
+        explanation: Його fits a brother.
+      - sentence: А це ___ бабуся?
+        answer: твоя
+        options:
+          - твоя
+          - твій
+          - твоє
+        explanation: Бабуся is feminine.
+  - type: translate
+    title: Family vocabulary quick check
+    instruction: Choose the English meaning.
+    items:
+      - source: сім'я
+        options:
+          - text: family, close household
+            correct: true
+          - text: surname
+            correct: false
+          - text: profession
+            correct: false
+        explanation: Сім'я is the close family word.
+      - source: родина
+        options:
+          - text: family or kin
+            correct: true
+          - text: only one parent
+            correct: false
+          - text: first name
+            correct: false
+        explanation: Родина often sounds wider than сім'я.
+      - source: У мене є брат.
+        options:
+          - text: I have a brother.
+            correct: true
+          - text: You have a brother.
+            correct: false
+          - text: This is my brother.
+            correct: false
+        explanation: У мене є... is the I-have chunk.
+      - source: Це моя сестра.
+        options:
+          - text: This is my sister.
+            correct: true
+          - text: This is my brother.
+            correct: false
+          - text: This is her sister.
+            correct: false
+        explanation: Моя matches сестра.
+      - source: Чий це брат?
+        options:
+          - text: Whose brother is this?
+            correct: true
+          - text: Who is this sister?
+            correct: false
+          - text: Do you have a brother?
+            correct: false
+        explanation: Чий asks whose and matches брат.

--- a/curriculum/l2-uk-en/a1/reading-ukrainian/activities.yaml
+++ b/curriculum/l2-uk-en/a1/reading-ukrainian/activities.yaml
@@ -1,219 +1,217 @@
-- id: act-1
-  type: count-syllables
-  title: Count vowel sounds
-  instruction: Count the vowel sounds. Each vowel sound makes one склад.
-  max_count: 5
-  items:
-  - word: день
-    correct: 1
-  - word: ма́ма
-    correct: 2
-  - word: молоко́
-    correct: 3
-  - word: ву́лиця
-    correct: 3
-  - word: бібліоте́ка
-    correct: 5
-  - word: Украї́на
-    correct: 4
-- id: act-2
-  type: match-up
-  title: Vowel letter jobs
-  instruction: Match each letter with its beginner reading job.
-  pairs:
-  - left: А
-    right: clean [а]
-  - left: О
-    right: clean [о]
-  - left: И
-    right: clean [и]
-  - left: І
-    right: clean [і]
-  - left: Я at word start
-    right: '[йа]'
-  - left: Ї
-    right: always [йі]
-- id: act-3
-  type: divide-words
-  title: Split into склади́
-  instruction: Divide each word into syllables.
-  items:
-  - word: мама
-    answer: ма ма
-  - word: молоко
-    answer: мо ло ко
-  - word: вулиця
-    answer: ву ли ця
-  - word: столиця
-    answer: сто ли ця
-  - word: людина
-    answer: лю ди на
-  - word: бібліотека
-    answer: бі блі о те ка
-- id: act-4
-  type: error-correction
-  title: Reading traps
-  instruction: Choose the safer Ukrainian reading habit.
-  items:
-  - sentence: Do not read молоко as м[а]локо.
-    error: м[а]локо
-    correction: молоко
-    options:
-    - молоко
-    - blurred о
-    explanation: Ukrainian о stays clean; read молоко with three open beats.
-  - sentence: Do not read дж as two broken sounds.
-    error: two broken sounds
-    correction: one joined sound
-    options:
-    - one joined sound
-    - д plus ж
-    explanation: ДЖ marks one joined reading unit in words such as джерело.
-  - sentence: Do not read Ї as plain І.
-    error: plain І
-    correction: '[йі]'
-    options:
-    - '[йі]'
-    - '[і]'
-    explanation: Ї is always [йі].
-  - sentence: Do not add a vowel after день.
-    error: add a vowel
-    correction: soften н and stop
-    options:
-    - soften н and stop
-    - add і after нь
-    explanation: Ь has no sound of its own; it softens the previous consonant.
-- id: act-5
-  type: quiz
-  title: Textbook check
-  instruction: Choose the correct answer.
-  items:
-  - prompt: What is a склад?
-    options:
-    - text: a syllable
-      correct: true
-    - text: a letter
-      correct: false
-    - text: a greeting
-      correct: false
-    explanation: A склад is a syllable.
-  - prompt: How many syllables are in молоко?
-    options:
-    - text: '3'
-      correct: true
-    - text: '2'
-      correct: false
-    - text: '1'
-      correct: false
-    explanation: молоко has three vowel sounds and three syllables.
-  - prompt: Which letter is always [йі]?
-    options:
-    - text: Ї
-      correct: true
-    - text: І
-      correct: false
-    - text: И
-      correct: false
-    explanation: Ї is always [йі].
-- id: act-6
-  type: group-sort
-  title: One, two, or three syllables?
-  instruction: Sort the words by syllable count.
-  groups:
-  - label: One syllable
+inline:
+  - id: act-1
+    type: count-syllables
+    title: Count vowel sounds
+    instruction: Count the vowel sounds. Each vowel sound makes one склад.
+    max_count: 5
     items:
-    - день
-    - Львів
-  - label: Two syllables
+      - word: день
+        correct: 1
+      - word: ма́ма
+        correct: 2
+      - word: молоко́
+        correct: 3
+      - word: ву́лиця
+        correct: 3
+      - word: бібліоте́ка
+        correct: 5
+      - word: Украї́на
+        correct: 4
+  - id: act-2
+    type: match-up
+    title: Vowel letter jobs
+    instruction: Match each letter with its beginner reading job.
+    pairs:
+      - left: А
+        right: clean [а]
+      - left: О
+        right: clean [о]
+      - left: И
+        right: clean [и]
+      - left: І
+        right: clean [і]
+      - left: Я at word start
+        right: '[йа]'
+      - left: Ї
+        right: always [йі]
+  - id: act-3
+    type: divide-words
+    title: Split into склади́
+    instruction: Divide each word into syllables.
     items:
-    - ма́ма
-    - та́то
-    - Ки́їв
-  - label: Three syllables
+      - word: мама
+        answer: ма ма
+      - word: молоко
+        answer: мо ло ко
+      - word: вулиця
+        answer: ву ли ця
+      - word: столиця
+        answer: сто ли ця
+      - word: людина
+        answer: лю ди на
+      - word: бібліотека
+        answer: бі блі о те ка
+  - id: act-4
+    type: error-correction
+    title: Reading traps
+    instruction: Choose the safer Ukrainian reading habit.
     items:
-    - молоко́
-    - ву́лиця
-    - столи́ця
-- id: act-7
-  type: true-false
-  title: Reading facts
-  instruction: Choose true or false.
-  items:
-  - statement: Every Ukrainian syllable needs a vowel sound.
-    correct: true
-    explanation: The vowel sound is the core of the syllable.
-  - statement: Ї sometimes softens the previous consonant.
-    correct: false
-    explanation: Ї is always [йі].
-  - statement: In молоко, о stays clean.
-    correct: true
-    explanation: Do not reduce о to an unclear English-style vowel.
-  - statement: ДЖ and ДЗ should be read as joined units.
-    correct: true
-    explanation: They are digraph reading units.
-- id: act-8
-  type: translate
-  title: Reading words
-  instruction: Choose the English meaning.
-  items:
-  - source: ма́ма
-    options:
-    - text: mother
-      correct: true
-    - text: street
-      correct: false
-    - text: milk
-      correct: false
-    explanation: Ма́ма means mother.
-  - source: молоко́
-    options:
-    - text: milk
-      correct: true
-    - text: apple
-      correct: false
-    - text: day
-      correct: false
-    explanation: Молоко́ means milk.
-  - source: ву́лиця
-    options:
-    - text: street
-      correct: true
-    - text: person
-      correct: false
-    - text: capital
-      correct: false
-    explanation: Ву́лиця means street.
-  - source: я́блуко
-    options:
-    - text: apple
-      correct: true
-    - text: song
-      correct: false
-    - text: mirror
-      correct: false
-    explanation: Я́блуко means apple.
-- id: act-9
-  type: watch-and-repeat
-  title: Vowel reading pass
-  instruction: Watch the alphabet overview again, then repeat the simple vowels.
-  items:
-  - letter: А
-    sound: '[а]'
-    word: ма́ма
-    video: https://www.youtube.com/watch?v=ksXIXj7CXwc
-  - letter: О
-    sound: '[о]'
-    word: молоко́
-    video: https://www.youtube.com/watch?v=ksXIXj7CXwc
-  - letter: У
-    sound: '[у]'
-    word: ву́лиця
-    video: https://www.youtube.com/watch?v=ksXIXj7CXwc
-  - letter: И
-    sound: '[и]'
-    word: ми
-    video: https://www.youtube.com/watch?v=ksXIXj7CXwc
-  - letter: І
-    sound: '[і]'
-    word: ді́ти
-    video: https://www.youtube.com/watch?v=ksXIXj7CXwc
+      - sentence: Do not read молоко as м[а]локо.
+        error: м[а]локо
+        correction: молоко
+        options:
+          - молоко
+          - blurred о
+        explanation: Ukrainian о stays clean; read молоко with three open beats.
+      - sentence: Do not read дж as two broken sounds.
+        error: two broken sounds
+        correction: one joined sound
+        options:
+          - one joined sound
+          - д plus ж
+        explanation: ДЖ marks one joined reading unit in words such as джерело.
+      - sentence: Do not read Ї as plain І.
+        error: plain І
+        correction: '[йі]'
+        options:
+          - '[йі]'
+          - '[і]'
+        explanation: Ї is always [йі].
+      - sentence: Do not add a vowel after день.
+        error: add a vowel
+        correction: soften н and stop
+        options:
+          - soften н and stop
+          - add і after нь
+        explanation: Ь has no sound of its own; it softens the previous consonant.
+  - id: act-5
+    type: quiz
+    title: Textbook check
+    instruction: Choose the correct answer.
+    items:
+      - prompt: What is a склад?
+        options:
+          - text: a syllable
+            correct: true
+          - text: a letter
+            correct: false
+          - text: a greeting
+            correct: false
+        explanation: A склад is a syllable.
+      - prompt: How many syllables are in молоко?
+        options:
+          - text: '3'
+            correct: true
+          - text: '2'
+            correct: false
+          - text: '1'
+            correct: false
+        explanation: молоко has three vowel sounds and three syllables.
+      - prompt: Which letter is always [йі]?
+        options:
+          - text: Ї
+            correct: true
+          - text: І
+            correct: false
+          - text: И
+            correct: false
+        explanation: Ї is always [йі].
+workbook:
+  - type: group-sort
+    title: One, two, or three syllables?
+    instruction: Sort the words by syllable count.
+    groups:
+      - label: One syllable
+        items:
+          - день
+          - Львів
+      - label: Two syllables
+        items:
+          - ма́ма
+          - та́то
+          - Ки́їв
+      - label: Three syllables
+        items:
+          - молоко́
+          - ву́лиця
+          - столи́ця
+  - type: true-false
+    title: Reading facts
+    instruction: Choose true or false.
+    items:
+      - statement: Every Ukrainian syllable needs a vowel sound.
+        correct: true
+        explanation: The vowel sound is the core of the syllable.
+      - statement: Ї sometimes softens the previous consonant.
+        correct: false
+        explanation: Ї is always [йі].
+      - statement: In молоко, о stays clean.
+        correct: true
+        explanation: Do not reduce о to an unclear English-style vowel.
+      - statement: ДЖ and ДЗ should be read as joined units.
+        correct: true
+        explanation: They are digraph reading units.
+  - type: translate
+    title: Reading words
+    instruction: Choose the English meaning.
+    items:
+      - source: ма́ма
+        options:
+          - text: mother
+            correct: true
+          - text: street
+            correct: false
+          - text: milk
+            correct: false
+        explanation: Ма́ма means mother.
+      - source: молоко́
+        options:
+          - text: milk
+            correct: true
+          - text: apple
+            correct: false
+          - text: day
+            correct: false
+        explanation: Молоко́ means milk.
+      - source: ву́лиця
+        options:
+          - text: street
+            correct: true
+          - text: person
+            correct: false
+          - text: capital
+            correct: false
+        explanation: Ву́лиця means street.
+      - source: я́блуко
+        options:
+          - text: apple
+            correct: true
+          - text: song
+            correct: false
+          - text: mirror
+            correct: false
+        explanation: Я́блуко means apple.
+  - type: watch-and-repeat
+    title: Vowel reading pass
+    instruction: Watch the alphabet overview again, then repeat the simple vowels.
+    items:
+      - letter: А
+        sound: '[а]'
+        word: ма́ма
+        video: https://www.youtube.com/watch?v=ksXIXj7CXwc
+      - letter: О
+        sound: '[о]'
+        word: молоко́
+        video: https://www.youtube.com/watch?v=ksXIXj7CXwc
+      - letter: У
+        sound: '[у]'
+        word: ву́лиця
+        video: https://www.youtube.com/watch?v=ksXIXj7CXwc
+      - letter: И
+        sound: '[и]'
+        word: ми
+        video: https://www.youtube.com/watch?v=ksXIXj7CXwc
+      - letter: І
+        sound: '[і]'
+        word: ді́ти
+        video: https://www.youtube.com/watch?v=ksXIXj7CXwc

--- a/curriculum/l2-uk-en/a1/special-signs/activities.yaml
+++ b/curriculum/l2-uk-en/a1/special-signs/activities.yaml
@@ -1,250 +1,248 @@
-- id: act-1
-  type: quiz
-  title: Soft or separate?
-  instruction: Choose the beginner reading explanation.
-  items:
-  - prompt: In буря́к, what happens before я?
-    options:
-    - text: Р softens before я.
-      correct: true
-    - text: There is an apostrophe.
-      correct: false
-    - text: Ї is always [йі].
-      correct: false
-    explanation: Буря́к has no apostrophe; р softens before я.
-  - prompt: In бур'я́н, what does the apostrophe do?
-    options:
-    - text: It keeps р hard and lets you hear [йа].
-      correct: true
-    - text: It makes р disappear.
-      correct: false
-    - text: It adds the sound [і].
-      correct: false
-    explanation: The apostrophe separates р from я.
-  - prompt: What is always true about Ї?
-    options:
-    - text: It is always [йі].
-      correct: true
-    - text: It is silent.
-      correct: false
-    - text: It is the soft sign.
-      correct: false
-    explanation: Ї always represents [йі].
-- id: act-2
-  type: match-up
-  title: What does ь do?
-  instruction: Match each word with the soft-sign clue.
-  pairs:
-  - left: день
-    right: soft final н
-  - left: кінь
-    right: soft final н
-  - left: сіль
-    right: soft final л
-  - left: вчи́тель
-    right: soft final л
-  - left: м'яки́й знак
-    right: no sound of its own
-- id: act-3
-  type: fill-in
-  title: Add the sign
-  instruction: Choose ь, apostrophe, or no sign.
-  items:
-  - sentence: сім_я
-    answer: ''''
-    options:
-    - ''''
-    - ь
-    - no sign
-  - sentence: ден_
-    answer: ь
-    options:
-    - ь
-    - ''''
-    - no sign
-  - sentence: п_ять
-    answer: ''''
-    options:
-    - ''''
-    - ь
-    - no sign
-  - sentence: свя́то needs ____.
-    answer: no sign
-    options:
-    - no sign
-    - ''''
-    - ь
-  - sentence: бур_ян
-    answer: ''''
-    options:
-    - ''''
-    - ь
-    - no sign
-  - sentence: мале́нький needs ____.
-    answer: ь
-    options:
-    - ь
-    - ''''
-    - no sign
-- id: act-4
-  type: error-correction
-  title: Fix common L2 mistakes
-  instruction: Choose the correct Ukrainian form.
-  items:
-  - sentence: Do not write сімя without the apostrophe.
-    error: сімя
-    correction: сім'я́
-    options:
-    - сім'я́
-    - family word without apostrophe
-    explanation: The apostrophe is required in сім'я́.
-  - sentence: Do not write ден.
-    error: ден
-    correction: день
-    options:
-    - день
-    - ден
-    explanation: День needs the soft sign.
-  - sentence: Do not write св'ято with an apostrophe.
-    error: св'ято
-    correction: свя́то
-    options:
-    - свя́то
-    - св'ято
-    explanation: Свя́то is a prepared no-apostrophe word.
-  - sentence: Do not write льожка with an invented soft sign.
-    error: льожка
-    correction: ло́жка
-    options:
-    - ло́жка
-    - invented soft-sign spelling
-    explanation: Ло́жка does not have a soft sign after л.
-  - sentence: Do not read сім'я́ as сім-пауза-я.
-    error: сім-пауза-я
-    correction: smooth й sound
-    options:
-    - smooth й sound
-    - full stop
-    explanation: The apostrophe separates sounds but does not create a full pause.
-- id: act-5
-  type: divide-words
-  title: Line-break models
-  instruction: Choose the prepared line-break model.
-  items:
-  - word: Мар'я́на
-    answer: Мар'-яна
-  - word: дерев'я́ний
-    answer: дерев'-яний
-  - word: бур'я́н
-    answer: бур'-ян
-  - word: па́льці
-    answer: паль-ці
-- id: act-6
-  type: group-sort
-  title: Sort by sign
-  instruction: Sort each word into the correct group.
-  groups:
-  - label: Has ь
+inline:
+  - id: act-1
+    type: quiz
+    title: Soft or separate?
+    instruction: Choose the beginner reading explanation.
     items:
-    - день
-    - кінь
-    - сіль
-    - вчи́тель
-    - мале́нький
-  - label: Has apostrophe
+      - prompt: In буря́к, what happens before я?
+        options:
+          - text: Р softens before я.
+            correct: true
+          - text: There is an apostrophe.
+            correct: false
+          - text: Ї is always [йі].
+            correct: false
+        explanation: Буря́к has no apostrophe; р softens before я.
+      - prompt: In бур'я́н, what does the apostrophe do?
+        options:
+          - text: It keeps р hard and lets you hear [йа].
+            correct: true
+          - text: It makes р disappear.
+            correct: false
+          - text: It adds the sound [і].
+            correct: false
+        explanation: The apostrophe separates р from я.
+      - prompt: What is always true about Ї?
+        options:
+          - text: It is always [йі].
+            correct: true
+          - text: It is silent.
+            correct: false
+          - text: It is the soft sign.
+            correct: false
+        explanation: Ї always represents [йі].
+  - id: act-2
+    type: match-up
+    title: What does ь do?
+    instruction: Match each word with the soft-sign clue.
+    pairs:
+      - left: день
+        right: soft final н
+      - left: кінь
+        right: soft final н
+      - left: сіль
+        right: soft final л
+      - left: вчи́тель
+        right: soft final л
+      - left: м'яки́й знак
+        right: no sound of its own
+  - id: act-3
+    type: fill-in
+    title: Add the sign
+    instruction: Choose ь, apostrophe, or no sign.
     items:
-    - сім'я́
-    - м'я́со
-    - п'ять
-    - комп'ю́тер
-    - бур'я́н
-  - label: No sign
+      - sentence: сім_я
+        answer: "'"
+        options:
+          - "'"
+          - ь
+          - no sign
+      - sentence: ден_
+        answer: ь
+        options:
+          - ь
+          - "'"
+          - no sign
+      - sentence: п_ять
+        answer: "'"
+        options:
+          - "'"
+          - ь
+          - no sign
+      - sentence: свя́то needs ____.
+        answer: no sign
+        options:
+          - no sign
+          - "'"
+          - ь
+      - sentence: бур_ян
+        answer: "'"
+        options:
+          - "'"
+          - ь
+          - no sign
+      - sentence: мале́нький needs ____.
+        answer: ь
+        options:
+          - ь
+          - "'"
+          - no sign
+  - id: act-4
+    type: error-correction
+    title: Fix common L2 mistakes
+    instruction: Choose the correct Ukrainian form.
     items:
-    - буря́к
-    - свя́то
-    - цвях
-    - ло́жка
-- id: act-7
-  type: true-false
-  title: Sign facts
-  instruction: Choose true or false.
-  items:
-  - statement: Ь has no sound of its own.
-    correct: true
-    explanation: It softens the previous consonant.
-  - statement: Apostrophe keeps the previous consonant hard.
-    correct: true
-    explanation: It separates the consonant from the iotated vowel.
-  - statement: Ї is sometimes silent.
-    correct: false
-    explanation: Ї is always [йі].
-  - statement: Свя́то has an apostrophe.
-    correct: false
-    explanation: Свя́то is a no-apostrophe model word.
-- id: act-8
-  type: translate
-  title: Sign words
-  instruction: Choose the English meaning.
-  items:
-  - source: день
-    options:
-    - text: day
-      correct: true
-    - text: meat
-      correct: false
-    - text: family
-      correct: false
-    explanation: День means day.
-  - source: сім'я́
-    options:
-    - text: family
-      correct: true
-    - text: salt
-      correct: false
-    - text: holiday
-      correct: false
-    explanation: Сім'я́ means family.
-  - source: м'я́со
-    options:
-    - text: meat
-      correct: true
-    - text: teacher
-      correct: false
-    - text: nail
-      correct: false
-    explanation: М'я́со means meat.
-  - source: свя́то
-    options:
-    - text: holiday
-      correct: true
-    - text: weed
-      correct: false
-    - text: horse
-      correct: false
-    explanation: Свя́то means holiday.
-- id: act-9
-  type: quiz
-  title: Correct form
-  instruction: Choose the correctly written word.
-  items:
-  - prompt: Choose the correct form for family.
-    options:
-    - text: сім'я́
-      correct: true
-    - text: family word without apostrophe
-      correct: false
-    explanation: Сім'я́ needs the apostrophe.
-  - prompt: Choose the correct form for day.
-    options:
-    - text: день
-      correct: true
-    - text: ден
-      correct: false
-    explanation: День needs the soft sign.
-  - prompt: Choose the no-apostrophe word.
-    options:
-    - text: свя́то
-      correct: true
-    - text: apostrophe spelling
-      correct: false
-    explanation: Свя́то is the prepared no-apostrophe word.
+      - sentence: Do not write сімя without the apostrophe.
+        error: сімя
+        correction: сім'я́
+        options:
+          - сім'я́
+          - family word without apostrophe
+        explanation: The apostrophe is required in сім'я́.
+      - sentence: Do not write ден.
+        error: ден
+        correction: день
+        options:
+          - день
+          - ден
+        explanation: День needs the soft sign.
+      - sentence: Do not write св'ято with an apostrophe.
+        error: св'ято
+        correction: свя́то
+        options:
+          - свя́то
+          - св'ято
+        explanation: Свя́то is a prepared no-apostrophe word.
+      - sentence: Do not write льожка with an invented soft sign.
+        error: льожка
+        correction: ло́жка
+        options:
+          - ло́жка
+          - invented soft-sign spelling
+        explanation: Ло́жка does not have a soft sign after л.
+      - sentence: Do not read сім'я́ as сім-пауза-я.
+        error: сім-пауза-я
+        correction: smooth й sound
+        options:
+          - smooth й sound
+          - full stop
+        explanation: The apostrophe separates sounds but does not create a full pause.
+  - id: act-5
+    type: divide-words
+    title: Line-break models
+    instruction: Choose the prepared line-break model.
+    items:
+      - word: Мар'я́на
+        answer: Мар'-яна
+      - word: дерев'я́ний
+        answer: дерев'-яний
+      - word: бур'я́н
+        answer: бур'-ян
+      - word: па́льці
+        answer: паль-ці
+workbook:
+  - type: group-sort
+    title: Sort by sign
+    instruction: Sort each word into the correct group.
+    groups:
+      - label: Has ь
+        items:
+          - день
+          - кінь
+          - сіль
+          - вчи́тель
+          - мале́нький
+      - label: Has apostrophe
+        items:
+          - сім'я́
+          - м'я́со
+          - п'ять
+          - комп'ю́тер
+          - бур'я́н
+      - label: No sign
+        items:
+          - буря́к
+          - свя́то
+          - цвях
+          - ло́жка
+  - type: true-false
+    title: Sign facts
+    instruction: Choose true or false.
+    items:
+      - statement: Ь has no sound of its own.
+        correct: true
+        explanation: It softens the previous consonant.
+      - statement: Apostrophe keeps the previous consonant hard.
+        correct: true
+        explanation: It separates the consonant from the iotated vowel.
+      - statement: Ї is sometimes silent.
+        correct: false
+        explanation: Ї is always [йі].
+      - statement: Свя́то has an apostrophe.
+        correct: false
+        explanation: Свя́то is a no-apostrophe model word.
+  - type: translate
+    title: Sign words
+    instruction: Choose the English meaning.
+    items:
+      - source: день
+        options:
+          - text: day
+            correct: true
+          - text: meat
+            correct: false
+          - text: family
+            correct: false
+        explanation: День means day.
+      - source: сім'я́
+        options:
+          - text: family
+            correct: true
+          - text: salt
+            correct: false
+          - text: holiday
+            correct: false
+        explanation: Сім'я́ means family.
+      - source: м'я́со
+        options:
+          - text: meat
+            correct: true
+          - text: teacher
+            correct: false
+          - text: nail
+            correct: false
+        explanation: М'я́со means meat.
+      - source: свя́то
+        options:
+          - text: holiday
+            correct: true
+          - text: weed
+            correct: false
+          - text: horse
+            correct: false
+        explanation: Свя́то means holiday.
+  - type: quiz
+    title: Correct form
+    instruction: Choose the correctly written word.
+    items:
+      - prompt: Choose the correct form for family.
+        options:
+          - text: сім'я́
+            correct: true
+          - text: family word without apostrophe
+            correct: false
+        explanation: Сім'я́ needs the apostrophe.
+      - prompt: Choose the correct form for day.
+        options:
+          - text: день
+            correct: true
+          - text: ден
+            correct: false
+        explanation: День needs the soft sign.
+      - prompt: Choose the no-apostrophe word.
+        options:
+          - text: свя́то
+            correct: true
+          - text: apostrophe spelling
+            correct: false
+        explanation: Свя́то is the prepared no-apostrophe word.

--- a/curriculum/l2-uk-en/a1/stress-and-melody/activities.yaml
+++ b/curriculum/l2-uk-en/a1/stress-and-melody/activities.yaml
@@ -1,252 +1,250 @@
-- id: act-1
-  type: quiz
-  title: Where is the stress?
-  instruction: Choose the stressed syllable shown by the accent mark.
-  items:
-  - prompt: In ка́ва, where is the stress?
-    options:
-    - text: first syllable
-      correct: true
-    - text: final syllable
-      correct: false
-    - text: no stress
-      correct: false
-    explanation: Ка́ва is stressed on ка́.
-  - prompt: In вода́, where is the stress?
-    options:
-    - text: final syllable
-      correct: true
-    - text: first syllable
-      correct: false
-    - text: every syllable equally
-      correct: false
-    explanation: Вода́ is stressed on да́.
-  - prompt: In столи́ця, where is the stress?
-    options:
-    - text: middle syllable
-      correct: true
-    - text: first syllable
-      correct: false
-    - text: final syllable
-      correct: false
-    explanation: Столи́ця is stressed on ли́.
-  - prompt: What should you do with unstressed vowels in молоко́?
-    options:
-    - text: Keep each vowel clear.
-      correct: true
-    - text: Drop the first vowel.
-      correct: false
-    - text: Read every о as а.
-      correct: false
-    explanation: Ukrainian unstressed vowels stay clear.
-- id: act-2
-  type: quiz
-  title: Melody choice
-  instruction: Choose the beginner sentence melody.
-  items:
-  - prompt: Це ка́ва.
-    options:
-    - text: falling ↘
-      correct: true
-    - text: rising ↗
-      correct: false
-    explanation: A statement uses falling melody.
-  - prompt: Це ка́ва?
-    options:
-    - text: rising ↗
-      correct: true
-    - text: falling ↘
-      correct: false
-    explanation: A yes/no question uses rising melody.
-  - prompt: Де метро́?
-    options:
-    - text: falling ↘
-      correct: true
-    - text: rising ↗
-      correct: false
-    explanation: A question with де uses falling melody at A1.
-  - prompt: Як га́рно!
-    options:
-    - text: stronger falling ↘↘
-      correct: true
-    - text: rising ↗
-      correct: false
-    explanation: An exclamation uses a stronger falling contour.
-- id: act-3
-  type: match-up
-  title: Stress changes meaning
-  instruction: Match the stressed word with the English meaning.
-  pairs:
-  - left: за́мок
-    right: castle
-  - left: замо́к
-    right: lock
-  - left: а́тлас
-    right: atlas
-  - left: атла́с
-    right: satin
-  - left: о́рган
-    right: body organ
-  - left: орга́н
-    right: musical instrument
-- id: act-4
-  type: fill-in
-  title: Punctuation and melody
-  instruction: Choose the punctuation mark that matches the sentence.
-  items:
-  - sentence: Це ка́ва_
-    answer: .
-    options:
-    - .
-    - '?'
-    - '!'
-    explanation: The statement takes a full stop and falling melody.
-  - sentence: Це метро́_
-    answer: '?'
-    options:
-    - '?'
-    - .
-    - '!'
-    explanation: The yes/no question takes a question mark and rising melody.
-  - sentence: Де апте́ка_
-    answer: '?'
-    options:
-    - '?'
-    - .
-    - '!'
-    explanation: Де makes it a question, but the melody is falling.
-  - sentence: Як га́рно_
-    answer: '!'
-    options:
-    - '!'
-    - '?'
-    - .
-    explanation: This is an exclamation.
-  - sentence: Так, це вода́_
-    answer: .
-    options:
-    - .
-    - '?'
-    - '!'
-    explanation: This is a statement.
-- id: act-5
-  type: error-correction
-  title: Fix stress-transfer traps
-  instruction: Choose the safer Ukrainian reading habit.
-  items:
-  - sentence: Keep all vowels clear in молоко́.
-    error: blurred first two vowels
-    correction: мо-ло-ко́
-    options:
-    - мо-ло-ко́
-    - blurred vowels
-    explanation: Ukrainian vowels stay clear outside stress.
-  - sentence: Put stress on the -ме́тр part in кіломе́тр.
-    error: кі́лометр
-    correction: кіломе́тр
-    options:
-    - кіломе́тр
-    - кі́лометр
-    explanation: The prepared model is кіломе́тр.
-  - sentence: Notice mobile stress in кни́жка / книжки́.
-    error: кни́жки
-    correction: книжки́
-    options:
-    - книжки́
-    - кни́жки
-    explanation: This plural model moves stress to the ending.
-  - sentence: Stress -на́- in одина́дцять.
-    error: о́динадцять
-    correction: одина́дцять
-    options:
-    - одина́дцять
-    - о́динадцять
-    explanation: The A1 target has stress on -на́-.
-  - sentence: Stress -на́- in чотирна́дцять.
-    error: чоти́рнадцять
-    correction: чотирна́дцять
-    options:
-    - чотирна́дцять
-    - чоти́рнадцять
-    explanation: The A1 target has stress on -на́-.
-- id: act-6
-  type: group-sort
-  title: Sort by stress position
-  instruction: Sort each word by the marked stressed syllable.
-  groups:
-  - label: First syllable
+inline:
+  - id: act-1
+    type: quiz
+    title: Where is the stress?
+    instruction: Choose the stressed syllable shown by the accent mark.
     items:
-    - ма́ма
-    - та́то
-    - ра́нок
-    - ка́ва
-  - label: Middle syllable
+      - prompt: In ка́ва, where is the stress?
+        options:
+          - text: first syllable
+            correct: true
+          - text: final syllable
+            correct: false
+          - text: no stress
+            correct: false
+        explanation: Ка́ва is stressed on ка́.
+      - prompt: In вода́, where is the stress?
+        options:
+          - text: final syllable
+            correct: true
+          - text: first syllable
+            correct: false
+          - text: every syllable equally
+            correct: false
+        explanation: Вода́ is stressed on да́.
+      - prompt: In столи́ця, where is the stress?
+        options:
+          - text: middle syllable
+            correct: true
+          - text: first syllable
+            correct: false
+          - text: final syllable
+            correct: false
+        explanation: Столи́ця is stressed on ли́.
+      - prompt: What should you do with unstressed vowels in молоко́?
+        options:
+          - text: Keep each vowel clear.
+            correct: true
+          - text: Drop the first vowel.
+            correct: false
+          - text: Read every о as а.
+            correct: false
+        explanation: Ukrainian unstressed vowels stay clear.
+  - id: act-2
+    type: quiz
+    title: Melody choice
+    instruction: Choose the beginner sentence melody.
     items:
-    - столи́ця
-    - люди́на
-    - одина́дцять
-    - чотирна́дцять
-  - label: Final syllable
+      - prompt: Це ка́ва.
+        options:
+          - text: falling ↘
+            correct: true
+          - text: rising ↗
+            correct: false
+        explanation: A statement uses falling melody.
+      - prompt: Це ка́ва?
+        options:
+          - text: rising ↗
+            correct: true
+          - text: falling ↘
+            correct: false
+        explanation: A yes/no question uses rising melody.
+      - prompt: Де метро́?
+        options:
+          - text: falling ↘
+            correct: true
+          - text: rising ↗
+            correct: false
+        explanation: A question with де uses falling melody at A1.
+      - prompt: Як га́рно!
+        options:
+          - text: stronger falling ↘↘
+            correct: true
+          - text: rising ↗
+            correct: false
+        explanation: An exclamation uses a stronger falling contour.
+  - id: act-3
+    type: match-up
+    title: Stress changes meaning
+    instruction: Match the stressed word with the English meaning.
+    pairs:
+      - left: за́мок
+        right: castle
+      - left: замо́к
+        right: lock
+      - left: а́тлас
+        right: atlas
+      - left: атла́с
+        right: satin
+      - left: о́рган
+        right: body organ
+      - left: орга́н
+        right: musical instrument
+  - id: act-4
+    type: fill-in
+    title: Punctuation and melody
+    instruction: Choose the punctuation mark that matches the sentence.
     items:
-    - вода́
-    - зима́
-    - рука́
-    - метро́
-- id: act-7
-  type: true-false
-  title: Stress and melody facts
-  instruction: Choose true or false.
-  items:
-  - statement: Ukrainian stress can fall on different syllables.
-    correct: true
-    explanation: Stress is free, so learn it with each word.
-  - statement: Ordinary Ukrainian texts usually mark every stress.
-    correct: false
-    explanation: Stress marks appear in learning materials and dictionaries, not most ordinary texts.
-  - statement: A yes/no question such as Це вода́? rises at A1.
-    correct: true
-    explanation: Yes/no questions use rising melody.
-  - statement: A question with де always needs rising melody at A1.
-    correct: false
-    explanation: A question with a question word such as де uses falling melody.
-- id: act-8
-  type: translate
-  title: New stress words
-  instruction: Choose the English meaning.
-  items:
-  - source: наголос
-    options:
-    - text: stress / accent
-      correct: true
-    - text: lock
-      correct: false
-    - text: water
-      correct: false
-    explanation: Наголос means word stress or accent.
-  - source: ка́ва
-    options:
-    - text: coffee
-      correct: true
-    - text: capital
-      correct: false
-    - text: morning
-      correct: false
-    explanation: Ка́ва means coffee.
-  - source: вода́
-    options:
-    - text: water
-      correct: true
-    - text: photograph
-      correct: false
-    - text: atlas
-      correct: false
-    explanation: Вода́ means water.
-  - source: столи́ця
-    options:
-    - text: capital
-      correct: true
-    - text: metro
-      correct: false
-    - text: family
-      correct: false
-    explanation: Столи́ця means capital.
+      - sentence: Це ка́ва_
+        answer: .
+        options:
+          - .
+          - '?'
+          - '!'
+        explanation: The statement takes a full stop and falling melody.
+      - sentence: Це метро́_
+        answer: '?'
+        options:
+          - '?'
+          - .
+          - '!'
+        explanation: The yes/no question takes a question mark and rising melody.
+      - sentence: Де апте́ка_
+        answer: '?'
+        options:
+          - '?'
+          - .
+          - '!'
+        explanation: Де makes it a question, but the melody is falling.
+      - sentence: Як га́рно_
+        answer: '!'
+        options:
+          - '!'
+          - '?'
+          - .
+        explanation: This is an exclamation.
+      - sentence: Так, це вода́_
+        answer: .
+        options:
+          - .
+          - '?'
+          - '!'
+        explanation: This is a statement.
+workbook:
+  - type: error-correction
+    title: Fix stress-transfer traps
+    instruction: Choose the safer Ukrainian reading habit.
+    items:
+      - sentence: Keep all vowels clear in молоко́.
+        error: blurred first two vowels
+        correction: мо-ло-ко́
+        options:
+          - мо-ло-ко́
+          - blurred vowels
+        explanation: Ukrainian vowels stay clear outside stress.
+      - sentence: Put stress on the -ме́тр part in кіломе́тр.
+        error: кі́лометр
+        correction: кіломе́тр
+        options:
+          - кіломе́тр
+          - кі́лометр
+        explanation: The prepared model is кіломе́тр.
+      - sentence: Notice mobile stress in кни́жка / книжки́.
+        error: кни́жки
+        correction: книжки́
+        options:
+          - книжки́
+          - кни́жки
+        explanation: This plural model moves stress to the ending.
+      - sentence: Stress -на́- in одина́дцять.
+        error: о́динадцять
+        correction: одина́дцять
+        options:
+          - одина́дцять
+          - о́динадцять
+        explanation: The A1 target has stress on -на́-.
+      - sentence: Stress -на́- in чотирна́дцять.
+        error: чоти́рнадцять
+        correction: чотирна́дцять
+        options:
+          - чотирна́дцять
+          - чоти́рнадцять
+        explanation: The A1 target has stress on -на́-.
+  - type: group-sort
+    title: Sort by stress position
+    instruction: Sort each word by the marked stressed syllable.
+    groups:
+      - label: First syllable
+        items:
+          - ма́ма
+          - та́то
+          - ра́нок
+          - ка́ва
+      - label: Middle syllable
+        items:
+          - столи́ця
+          - люди́на
+          - одина́дцять
+          - чотирна́дцять
+      - label: Final syllable
+        items:
+          - вода́
+          - зима́
+          - рука́
+          - метро́
+  - type: true-false
+    title: Stress and melody facts
+    instruction: Choose true or false.
+    items:
+      - statement: Ukrainian stress can fall on different syllables.
+        correct: true
+        explanation: Stress is free, so learn it with each word.
+      - statement: Ordinary Ukrainian texts usually mark every stress.
+        correct: false
+        explanation: Stress marks appear in learning materials and dictionaries, not most ordinary texts.
+      - statement: A yes/no question such as Це вода́? rises at A1.
+        correct: true
+        explanation: Yes/no questions use rising melody.
+      - statement: A question with де always needs rising melody at A1.
+        correct: false
+        explanation: A question with a question word such as де uses falling melody.
+  - type: translate
+    title: New stress words
+    instruction: Choose the English meaning.
+    items:
+      - source: наголос
+        options:
+          - text: stress / accent
+            correct: true
+          - text: lock
+            correct: false
+          - text: water
+            correct: false
+        explanation: Наголос means word stress or accent.
+      - source: ка́ва
+        options:
+          - text: coffee
+            correct: true
+          - text: capital
+            correct: false
+          - text: morning
+            correct: false
+        explanation: Ка́ва means coffee.
+      - source: вода́
+        options:
+          - text: water
+            correct: true
+          - text: photograph
+            correct: false
+          - text: atlas
+            correct: false
+        explanation: Вода́ means water.
+      - source: столи́ця
+        options:
+          - text: capital
+            correct: true
+          - text: metro
+            correct: false
+          - text: family
+            correct: false
+        explanation: Столи́ця means capital.

--- a/curriculum/l2-uk-en/a1/who-am-i/activities.yaml
+++ b/curriculum/l2-uk-en/a1/who-am-i/activities.yaml
@@ -1,345 +1,342 @@
-- id: act-1
-  type: quiz
-  title: Formal or informal?
-  instruction: Choose the phrase that fits the social situation.
-  items:
-    - prompt: You meet a classmate your age.
-      options:
-        - text: Як тебе звати?
-          correct: true
-        - text: Як вас звати?
-          correct: false
-      explanation: Use тебе with one familiar peer.
-    - prompt: You meet an unknown adult at orientation.
-      options:
-        - text: Як вас звати?
-          correct: true
-        - text: Як тебе звати?
-          correct: false
-      explanation: Use вас with one unknown adult or in a formal setting.
-    - prompt: A peer asks your name. You answer and return the question.
-      options:
-        - text: Мене звати Олена. А тебе?
-          correct: true
-        - text: Мене звати Олена. А вас?
-          correct: false
-      explanation: The peer situation stays informal.
-    - prompt: An instructor asks your name. You answer and return the question.
-      options:
-        - text: Мене звати Петро. А вас?
-          correct: true
-        - text: Мене звати Петро. А тебе?
-          correct: false
-      explanation: The instructor situation stays formal.
-- id: act-2
-  type: fill-in
-  title: Build the name chunk
-  instruction: Choose the missing word or phrase.
-  items:
-    - sentence: ___ звати Марко.
-      answer: Мене
-      options:
-        - Мене
-        - Ти
-        - Це
-      explanation: Мене звати... is the whole chunk for my name is.
-    - sentence: Як ___ звати?
-      answer: тебе
-      options:
-        - тебе
-        - я
-        - він
-      explanation: Як тебе звати? is informal.
-    - sentence: Як ___ звати?
-      answer: вас
-      options:
-        - вас
-        - вона
-        - ми
-      explanation: Як вас звати? is formal or plural.
-    - sentence: Дуже ___!
-      answer: приємно
-      options:
-        - приємно
-        - студент
-        - звідки
-      explanation: Дуже приємно closes the introduction after names.
-    - sentence: Мене звати Олена. А ___?
-      answer: тебе
-      options:
-        - тебе
-        - Київ
-        - це
-      explanation: А тебе? returns the name question informally.
-- id: act-3
-  type: match-up
-  title: This is / Who is this?
-  instruction: Match the Ukrainian phrase with the English cue.
-  pairs:
-    - left: Це Андрій.
-      right: This is Andrii.
-    - left: Це Оксана.
-      right: This is Oksana.
-    - left: Хто це?
-      right: Who is this?
-    - left: Що це?
-      right: What is this?
-    - left: Це кава.
-      right: This is coffee.
-- id: act-4
-  type: quiz
-  title: Pronoun choice
-  instruction: Choose the pronoun that fits the English cue.
-  items:
-    - prompt: I
-      options:
-        - text: я
-          correct: true
-        - text: ти
-          correct: false
-        - text: вони
-          correct: false
-      explanation: Я is the speaker.
-    - prompt: you, one friend
-      options:
-        - text: ти
-          correct: true
-        - text: ви
-          correct: false
-        - text: він
-          correct: false
-      explanation: Ти is one informal you.
-    - prompt: you, one unknown adult
-      options:
-        - text: ви
-          correct: true
-        - text: ти
-          correct: false
-        - text: вона
-          correct: false
-      explanation: Ви is formal for one person and also plural.
-    - prompt: she
-      options:
-        - text: вона
-          correct: true
-        - text: він
-          correct: false
-        - text: я
-          correct: false
-      explanation: Вона points to a woman or girl.
-- id: act-7
-  type: error-correction
-  title: Choose the Ukrainian sentence
-  anchor_id: fix-common-l2-traps
-  instruction: Choose the safer Ukrainian identity line.
-  items:
-    - sentence: Я є студент.
-      error: Я є студент.
-      correction: Я студент.
-      options:
-        - Я студент.
-        - Я є студент.
-      explanation: In present-time identity, say Я студент or Я — студент.
-    - sentence: Моє ім'я є Джон.
-      error: Моє ім'я є Джон.
-      correction: Мене звати Джон.
-      options:
-        - Мене звати Джон.
-        - Моє ім'я є Джон.
-      explanation: Мене звати... is the high-frequency introduction model.
-    - sentence: Я маю 20 років.
-      error: Я маю 20 років.
-      correction: Мені 20 років.
-      options:
-        - Мені 20 років.
-        - Я маю 20 років.
-      explanation: Age uses a different chunk and is not the model for this lesson.
-    - sentence: Оксана каже, "Я (жінка) лікар."
-      error: Я (жінка) лікар.
-      correction: Я лікарка.
-      options:
-        - Я лікарка.
-        - Я (жінка) лікар.
-      explanation: Лікарка is the standard feminine form for a woman doctor.
-    - sentence: Воно мій тато.
-      error: Воно
-      correction: Це мій тато.
-      options:
-        - Це мій тато.
-        - Воно мій тато.
-      explanation: Use це for identifying a person, or він after the person is known.
-    - sentence: Привіт, пане професоре!
-      error: Привіт
-      correction: Добрий день, пане професоре!
-      options:
-        - Добрий день, пане професоре!
-        - Привіт, пане професоре!
-      explanation: Use Добрий день with a professor or unknown adult.
-- id: act-5
-  type: match-up
-  title: Profession pairs
-  instruction: Match the masculine and feminine profession forms.
-  pairs:
-    - left: студент
-      right: студентка
-    - left: вчитель
-      right: вчителька
-    - left: лікар
-      right: лікарка
-    - left: програміст
-      right: програмістка
-    - left: інженер
-      right: інженерка
-    - left: українець
-      right: українка
-    - left: канадієць
-      right: канадка
-    - left: американець
-      right: американка
-- id: act-6
-  type: fill-in
-  title: Complete the dialogue
-  instruction: Choose the phrase that completes the first meeting.
-  items:
-    - sentence: Привіт! Як ___ звати?
-      answer: тебе
-      options:
-        - тебе
-        - вас
-        - це
-      explanation: Привіт points to an informal peer situation.
-    - sentence: Мене ___ Олена.
-      answer: звати
-      options:
-        - звати
-        - це
-        - з
-      explanation: Мене звати... is the name chunk.
-    - sentence: Мене звати Марко. ___ тебе?
-      answer: А
-      options:
-        - А
-        - Хто
-        - Що
-      explanation: А тебе? returns the question.
-    - sentence: Добрий день! Як ___ звати?
-      answer: вас
-      options:
-        - вас
-        - тебе
-        - я
-      explanation: Добрий день fits the formal version here.
-    - sentence: Дуже ___!
-      answer: приємно
-      options:
-        - приємно
-        - Київ
-        - студентка
-      explanation: Дуже приємно follows the name exchange.
-    - sentence: ___ ти? Я з Канади.
-      answer: Звідки
-      options:
-        - Звідки
-        - Хто
-        - Що
-      explanation: Звідки asks where someone is from.
-- id: act-8
-  type: fill-in
-  title: Choose the Ukrainian norm
-  instruction: Fill the sentence with the native Ukrainian choice.
-  items:
-    - sentence: Це мій ___.
-      answer: тато
-      options:
-        - тато
-        - Russian-influenced dad word
-      explanation: Тато is the native Ukrainian choice for dad.
-    - sentence: Це моя ___ Марія.
-      answer: дружина
-      options:
-        - дружина
-        - Russian-influenced wife word
-      explanation: Дружина is the native Ukrainian choice for wife.
-    - sentence: ___, як вас звати?
-      answer: Вибачте
-      options:
-        - Вибачте
-        - Russian-influenced excuse-me word
-      explanation: Вибачте and пробачте are safe Ukrainian choices.
-    - sentence: ___, дуже приємно!
-      answer: Дякую
-      options:
-        - Дякую
-        - Russian-style thank-you word
-      explanation: Дякую and спасибі are safe Ukrainian choices.
-    - sentence: Мені ___ приємно.
-      answer: теж
-      options:
-        - теж
-        - Russian-style also word
-      explanation: Теж and також are safe Ukrainian choices.
-    - sentence: Оксана — ___.
-      answer: інженерка
-      options:
-        - інженерка
-        - masculine generic for a woman
-      explanation: Use the feminitive for a woman when the Ukrainian form exists.
-- id: act-9
-  type: translate
-  title: First-contact vocabulary
-  instruction: Choose the English meaning.
-  items:
-    - source: Мене звати...
-      options:
-        - text: My name is...
-          correct: true
-        - text: Where are you from?
-          correct: false
-        - text: This is...
-          correct: false
-      explanation: Мене звати... is the name chunk.
-    - source: Як тебе звати?
-      options:
-        - text: What is your name? informal
-          correct: true
-        - text: Who is this?
-          correct: false
-        - text: I am from Ukraine.
-          correct: false
-      explanation: Тебе marks the informal version.
-    - source: Як вас звати?
-      options:
-        - text: What is your name? formal
-          correct: true
-        - text: And yours? informal
-          correct: false
-        - text: This is Kyiv.
-          correct: false
-      explanation: Вас marks the formal version.
-    - source: Дуже приємно!
-      options:
-        - text: Pleased to meet you!
-          correct: true
-        - text: Goodbye!
-          correct: false
-        - text: Where from?
-          correct: false
-      explanation: Дуже приємно closes the introduction politely.
-    - source: Звідки ти?
-      options:
-        - text: Where are you from? informal
-          correct: true
-        - text: What is this?
-          correct: false
-        - text: I am a student.
-          correct: false
-      explanation: Звідки asks from where.
-    - source: Я — студентка.
-      options:
-        - text: I am a female student.
-          correct: true
-        - text: She is a doctor.
-          correct: false
-        - text: My name is...
-          correct: false
-      explanation: Студентка is the feminine form.
+inline:
+  - id: act-1
+    type: quiz
+    title: Formal or informal?
+    instruction: Choose the phrase that fits the social situation.
+    items:
+      - prompt: You meet a classmate your age.
+        options:
+          - text: Як тебе звати?
+            correct: true
+          - text: Як вас звати?
+            correct: false
+        explanation: Use тебе with one familiar peer.
+      - prompt: You meet an unknown adult at orientation.
+        options:
+          - text: Як вас звати?
+            correct: true
+          - text: Як тебе звати?
+            correct: false
+        explanation: Use вас with one unknown adult or in a formal setting.
+      - prompt: A peer asks your name. You answer and return the question.
+        options:
+          - text: Мене звати Олена. А тебе?
+            correct: true
+          - text: Мене звати Олена. А вас?
+            correct: false
+        explanation: The peer situation stays informal.
+      - prompt: An instructor asks your name. You answer and return the question.
+        options:
+          - text: Мене звати Петро. А вас?
+            correct: true
+          - text: Мене звати Петро. А тебе?
+            correct: false
+        explanation: The instructor situation stays formal.
+  - id: act-2
+    type: fill-in
+    title: Build the name chunk
+    instruction: Choose the missing word or phrase.
+    items:
+      - sentence: ___ звати Марко.
+        answer: Мене
+        options:
+          - Мене
+          - Ти
+          - Це
+        explanation: Мене звати... is the whole chunk for my name is.
+      - sentence: Як ___ звати?
+        answer: тебе
+        options:
+          - тебе
+          - я
+          - він
+        explanation: Як тебе звати? is informal.
+      - sentence: Як ___ звати?
+        answer: вас
+        options:
+          - вас
+          - вона
+          - ми
+        explanation: Як вас звати? is formal or plural.
+      - sentence: Дуже ___!
+        answer: приємно
+        options:
+          - приємно
+          - студент
+          - звідки
+        explanation: Дуже приємно closes the introduction after names.
+      - sentence: Мене звати Олена. А ___?
+        answer: тебе
+        options:
+          - тебе
+          - Київ
+          - це
+        explanation: А тебе? returns the name question informally.
+  - id: act-3
+    type: match-up
+    title: This is / Who is this?
+    instruction: Match the Ukrainian phrase with the English cue.
+    pairs:
+      - left: Це Андрій.
+        right: This is Andrii.
+      - left: Це Оксана.
+        right: This is Oksana.
+      - left: Хто це?
+        right: Who is this?
+      - left: Що це?
+        right: What is this?
+      - left: Це кава.
+        right: This is coffee.
+  - id: act-4
+    type: quiz
+    title: Pronoun choice
+    instruction: Choose the pronoun that fits the English cue.
+    items:
+      - prompt: I
+        options:
+          - text: я
+            correct: true
+          - text: ти
+            correct: false
+          - text: вони
+            correct: false
+        explanation: Я is the speaker.
+      - prompt: you, one friend
+        options:
+          - text: ти
+            correct: true
+          - text: ви
+            correct: false
+          - text: він
+            correct: false
+        explanation: Ти is one informal you.
+      - prompt: you, one unknown adult
+        options:
+          - text: ви
+            correct: true
+          - text: ти
+            correct: false
+          - text: вона
+            correct: false
+        explanation: Ви is formal for one person and also plural.
+      - prompt: she
+        options:
+          - text: вона
+            correct: true
+          - text: він
+            correct: false
+          - text: я
+            correct: false
+        explanation: Вона points to a woman or girl.
+workbook:
+  - type: error-correction
+    title: Choose the Ukrainian sentence
+    anchor_id: fix-common-l2-traps
+    instruction: Choose the safer Ukrainian identity line.
+    items:
+      - sentence: Я є студент.
+        error: Я є студент.
+        correction: Я студент.
+        options:
+          - Я студент.
+          - Я є студент.
+        explanation: In present-time identity, say Я студент or Я — студент.
+      - sentence: Моє ім'я є Джон.
+        error: Моє ім'я є Джон.
+        correction: Мене звати Джон.
+        options:
+          - Мене звати Джон.
+          - Моє ім'я є Джон.
+        explanation: Мене звати... is the high-frequency introduction model.
+      - sentence: Я маю 20 років.
+        error: Я маю 20 років.
+        correction: Мені 20 років.
+        options:
+          - Мені 20 років.
+          - Я маю 20 років.
+        explanation: Age uses a different chunk and is not the model for this lesson.
+      - sentence: Оксана каже, "Я (жінка) лікар."
+        error: Я (жінка) лікар.
+        correction: Я лікарка.
+        options:
+          - Я лікарка.
+          - Я (жінка) лікар.
+        explanation: Лікарка is the standard feminine form for a woman doctor.
+      - sentence: Воно мій тато.
+        error: Воно
+        correction: Це мій тато.
+        options:
+          - Це мій тато.
+          - Воно мій тато.
+        explanation: Use це for identifying a person, or він after the person is known.
+      - sentence: Привіт, пане професоре!
+        error: Привіт
+        correction: Добрий день, пане професоре!
+        options:
+          - Добрий день, пане професоре!
+          - Привіт, пане професоре!
+        explanation: Use Добрий день with a professor or unknown adult.
+  - type: match-up
+    title: Profession pairs
+    instruction: Match the masculine and feminine profession forms.
+    pairs:
+      - left: студент
+        right: студентка
+      - left: вчитель
+        right: вчителька
+      - left: лікар
+        right: лікарка
+      - left: програміст
+        right: програмістка
+      - left: інженер
+        right: інженерка
+      - left: українець
+        right: українка
+      - left: канадієць
+        right: канадка
+      - left: американець
+        right: американка
+  - type: fill-in
+    title: Complete the dialogue
+    instruction: Choose the phrase that completes the first meeting.
+    items:
+      - sentence: Привіт! Як ___ звати?
+        answer: тебе
+        options:
+          - тебе
+          - вас
+          - це
+        explanation: Привіт points to an informal peer situation.
+      - sentence: Мене ___ Олена.
+        answer: звати
+        options:
+          - звати
+          - це
+          - з
+        explanation: Мене звати... is the name chunk.
+      - sentence: Мене звати Марко. ___ тебе?
+        answer: А
+        options:
+          - А
+          - Хто
+          - Що
+        explanation: А тебе? returns the question.
+      - sentence: Добрий день! Як ___ звати?
+        answer: вас
+        options:
+          - вас
+          - тебе
+          - я
+        explanation: Добрий день fits the formal version here.
+      - sentence: Дуже ___!
+        answer: приємно
+        options:
+          - приємно
+          - Київ
+          - студентка
+        explanation: Дуже приємно follows the name exchange.
+      - sentence: ___ ти? Я з Канади.
+        answer: Звідки
+        options:
+          - Звідки
+          - Хто
+          - Що
+        explanation: Звідки asks where someone is from.
+  - type: fill-in
+    title: Choose the Ukrainian norm
+    instruction: Fill the sentence with the native Ukrainian choice.
+    items:
+      - sentence: Це мій ___.
+        answer: тато
+        options:
+          - тато
+          - Russian-influenced dad word
+        explanation: Тато is the native Ukrainian choice for dad.
+      - sentence: Це моя ___ Марія.
+        answer: дружина
+        options:
+          - дружина
+          - Russian-influenced wife word
+        explanation: Дружина is the native Ukrainian choice for wife.
+      - sentence: ___, як вас звати?
+        answer: Вибачте
+        options:
+          - Вибачте
+          - Russian-influenced excuse-me word
+        explanation: Вибачте and пробачте are safe Ukrainian choices.
+      - sentence: ___, дуже приємно!
+        answer: Дякую
+        options:
+          - Дякую
+          - Russian-style thank-you word
+        explanation: Дякую and спасибі are safe Ukrainian choices.
+      - sentence: Мені ___ приємно.
+        answer: теж
+        options:
+          - теж
+          - Russian-style also word
+        explanation: Теж and також are safe Ukrainian choices.
+      - sentence: Оксана — ___.
+        answer: інженерка
+        options:
+          - інженерка
+          - masculine generic for a woman
+        explanation: Use the feminitive for a woman when the Ukrainian form exists.
+  - type: translate
+    title: First-contact vocabulary
+    instruction: Choose the English meaning.
+    items:
+      - source: Мене звати...
+        options:
+          - text: My name is...
+            correct: true
+          - text: Where are you from?
+            correct: false
+          - text: This is...
+            correct: false
+        explanation: Мене звати... is the name chunk.
+      - source: Як тебе звати?
+        options:
+          - text: What is your name? informal
+            correct: true
+          - text: Who is this?
+            correct: false
+          - text: I am from Ukraine.
+            correct: false
+        explanation: Тебе marks the informal version.
+      - source: Як вас звати?
+        options:
+          - text: What is your name? formal
+            correct: true
+          - text: And yours? informal
+            correct: false
+          - text: This is Kyiv.
+            correct: false
+        explanation: Вас marks the formal version.
+      - source: Дуже приємно!
+        options:
+          - text: Pleased to meet you!
+            correct: true
+          - text: Goodbye!
+            correct: false
+          - text: Where from?
+            correct: false
+        explanation: Дуже приємно closes the introduction politely.
+      - source: Звідки ти?
+        options:
+          - text: Where are you from? informal
+            correct: true
+          - text: What is this?
+            correct: false
+          - text: I am a student.
+            correct: false
+        explanation: Звідки asks from where.
+      - source: Я — студентка.
+        options:
+          - text: I am a female student.
+            correct: true
+          - text: She is a doctor.
+            correct: false
+          - text: My name is...
+            correct: false
+        explanation: Студентка is the feminine form.


### PR DESCRIPTION
## Summary
Refactor six A1 activity YAML files to V2 shape (`inline` + `workbook`) for modules 2-7.

## Validation summary
- parser check: PASS
  - reading-ukrainian: inline=5 workbook=4 total=9
  - special-signs: inline=5 workbook=4 total=9
  - stress-and-melody: inline=4 workbook=4 total=8
  - who-am-i: inline=4 workbook=5 total=9
  - my-family: inline=4 workbook=4 total=8
  - checkpoint-first-contact: inline=6 workbook=3 total=9
- `.venv/bin/python scripts/generate_mdx.py l2-uk-en a1 N --validate` for N=2..7: PASS
- `.venv/bin/python -m pytest -q tests/test_yaml_activities.py tests/test_generate_mdx.py tests/test_activity_helpers_flatten.py`: PASS (118 passed)
- `npx prettier --check` on 6 YAML files: PASS
- `git diff --check`: clean
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`: PASS

Refs: #2714
