### PR TITLE
fix(a1): align M1-M4 with Ohoiko pattern

### DIFF
--- a/curriculum/l2-uk-en/a1/reading-ukrainian/activities.yaml
+++ b/curriculum/l2-uk-en/a1/reading-ukrainian/activities.yaml
@@ -20,7 +20,7 @@ inline:
   - id: act-2
     type: match-up
     title: Робота голосних лі́тер
-    instruction: З'єднай літеру з її beginner reading job.
+    instruction: З'єднай лі́теру з її першою читацькою роботою.
     pairs:
       - left: А
         right: чистий [а]
@@ -37,7 +37,7 @@ inline:
   - id: act-3
     type: divide-words
     title: Поділи на склади́
-    instruction: Divide each printed word into syllables.
+    instruction: Поділи кожне друковане слово на склади́.
     items:
       - word: ма́ма
         answer: ма ма
@@ -54,50 +54,50 @@ inline:
   - id: act-4
     type: error-correction
     title: Пастки читання
-    instruction: Choose the safer Ukrainian reading habit.
+    instruction: Обери безпечнішу українську читацьку звичку.
     items:
       - sentence: Молоко́ — не міняй о на інший звук.
         error: м[а]локо
         correction: молоко
         options:
           - молоко
-          - blurred о
-        explanation: Ukrainian о stays clear; read молоко́ with three open beats.
+          - нечітке о
+        explanation: Українське о залишається чистим; читай молоко́ у три відкриті удари.
       - sentence: Джерело́ — не розривай дж.
-        error: two broken sounds
-        correction: one joined sound
+        error: два розірвані звуки
+        correction: один злитий звук
         options:
-          - one joined sound
-          - д plus ж
-        explanation: ДЖ marks one joined reading unit in words such as джерело́.
+          - один злитий звук
+          - д плюс ж
+        explanation: ДЖ позначає одну злиту читацьку одиницю у словах як джерело́.
       - sentence: Украї́на — не читай ї як plain і.
-        error: plain і
+        error: просте і
         correction: '[йі]'
         options:
           - '[йі]'
           - '[і]'
-        explanation: Ї is always [йі].
+        explanation: Ї завжди читаємо як [йі].
       - sentence: День — не додавай голосний після нь.
-        error: add a vowel
-        correction: soften н and stop
+        error: додати голосний
+        correction: пом'якшити н і зупинитися
         options:
-          - soften н and stop
-          - add і after нь
-        explanation: Ь has no sound of its own; it softens the previous consonant.
+          - пом'якшити н і зупинитися
+          - додати і після нь
+        explanation: Ь не має власного звука; він м'якшить попередній при́голосний.
   - id: act-5
     type: quiz
     title: Переві́рка читання
-    instruction: Choose the correct answer.
+    instruction: Обери правильну відповідь.
     items:
       - prompt: Склад — що це?
         options:
-          - text: syllable
+          - text: склад
             correct: true
-          - text: letter
+          - text: лі́тера
             correct: false
-          - text: greeting
+          - text: вітання
             correct: false
-        explanation: Склад is a syllable.
+        explanation: Склад — це один голосовий удар у слові.
       - prompt: Молоко́ — скільки складів?
         options:
           - text: '3'
@@ -106,7 +106,7 @@ inline:
             correct: false
           - text: '1'
             correct: false
-        explanation: Молоко́ has three vowel sounds and three syllables.
+        explanation: Молоко́ має три голосні звуки й три склади́.
       - prompt: Яка літера завжди [йі]?
         options:
           - text: Ї
@@ -115,11 +115,11 @@ inline:
             correct: false
           - text: И
             correct: false
-        explanation: Ї is always [йі].
+        explanation: Ї завжди читаємо як [йі].
 workbook:
   - type: group-sort
     title: Один, два чи три склади́
-    instruction: Sort the words by syllable count.
+    instruction: Розподіли слова за кількістю складів.
     groups:
       - label: Один склад
         items:
@@ -137,37 +137,37 @@ workbook:
           - столи́ця
   - type: true-false
     title: Факти про читання
-    instruction: Choose true or false.
+    instruction: Обери правда чи неправда.
     items:
       - statement: Кожен український склад має голосни́й звук.
         correct: true
-        explanation: The vowel sound is the core of the syllable.
+        explanation: Голосни́й звук — центр складу.
       - statement: Ї іноді м'якшить попередній при́голосний.
         correct: false
-        explanation: Ї is always [йі].
+        explanation: Ї завжди читаємо як [йі].
       - statement: У молоко́ звук о залишається чистим.
         correct: true
-        explanation: Do not reduce о to an unclear vowel.
+        explanation: Не перетворюй о на нечіткий голосни́й.
       - statement: ДЖ and ДЗ should be read as joined units.
         correct: true
-        explanation: They are digraph reading units.
+        explanation: ДЖ і ДЗ читаємо як злиті одиниці.
   - type: match-up
     title: Друк і зошит
-    instruction: Match the printed word to the notebook recognition cue.
+    instruction: З'єднай друковане слово з підказкою в зо́шиті.
     pairs:
       - left: 'друк: ма́ма'
         right: 'зошит: ма́ма'
       - left: 'друк: молоко́'
         right: 'зошит: молоко́'
       - left: 'друк: день'
-        right: 'зошит: word with final ь'
+        right: 'зошит: слово з кінцевим ь'
       - left: 'друк: Ки́їв'
-        right: 'зошит: word with ї'
+        right: 'зошит: слово з ї'
       - left: 'друк: ву́лиця'
-        right: 'зошит: three-syllable city word'
+        right: 'зошит: трискладове слово про місто'
   - type: watch-and-repeat
     title: Повтор голосних
-    instruction: Watch the alphabet overview again, then repeat the simple vowels.
+    instruction: Подивися огляд абетки ще раз, потім повтори прості голосні.
     items:
       - letter: А
         sound: '[а]'

--- a/curriculum/l2-uk-en/a1/reading-ukrainian/activities.yaml
+++ b/curriculum/l2-uk-en/a1/reading-ukrainian/activities.yaml
@@ -1,9 +1,9 @@
 inline:
   - id: act-1
     type: count-syllables
-    title: Count vowel sounds
-    instruction: Count the vowel sounds. Each vowel sound makes one склад.
-    max_count: 5
+    title: Рахуй склади́
+    instruction: Рахуй голосні звуки. Кожен голосни́й звук дає один склад.
+    maxCount: 5
     items:
       - word: день
         correct: 1
@@ -19,65 +19,65 @@ inline:
         correct: 4
   - id: act-2
     type: match-up
-    title: Vowel letter jobs
-    instruction: Match each letter with its beginner reading job.
+    title: Робота голосних лі́тер
+    instruction: З'єднай літеру з її beginner reading job.
     pairs:
       - left: А
-        right: clean [а]
+        right: чистий [а]
       - left: О
-        right: clean [о]
+        right: чистий [о]
       - left: И
-        right: clean [и]
+        right: чистий [и]
       - left: І
-        right: clean [і]
-      - left: Я at word start
+        right: чистий [і]
+      - left: Я на початку слова
         right: '[йа]'
       - left: Ї
-        right: always [йі]
+        right: завжди [йі]
   - id: act-3
     type: divide-words
-    title: Split into склади́
-    instruction: Divide each word into syllables.
+    title: Поділи на склади́
+    instruction: Divide each printed word into syllables.
     items:
-      - word: мама
+      - word: ма́ма
         answer: ма ма
-      - word: молоко
+      - word: молоко́
         answer: мо ло ко
-      - word: вулиця
+      - word: ву́лиця
         answer: ву ли ця
-      - word: столиця
+      - word: столи́ця
         answer: сто ли ця
-      - word: людина
+      - word: люди́на
         answer: лю ди на
-      - word: бібліотека
+      - word: бібліоте́ка
         answer: бі блі о те ка
   - id: act-4
     type: error-correction
-    title: Reading traps
+    title: Пастки читання
     instruction: Choose the safer Ukrainian reading habit.
     items:
-      - sentence: Do not read молоко as м[а]локо.
+      - sentence: Молоко́ — не міняй о на інший звук.
         error: м[а]локо
         correction: молоко
         options:
           - молоко
           - blurred о
-        explanation: Ukrainian о stays clean; read молоко with three open beats.
-      - sentence: Do not read дж as two broken sounds.
+        explanation: Ukrainian о stays clear; read молоко́ with three open beats.
+      - sentence: Джерело́ — не розривай дж.
         error: two broken sounds
         correction: one joined sound
         options:
           - one joined sound
           - д plus ж
-        explanation: ДЖ marks one joined reading unit in words such as джерело.
-      - sentence: Do not read Ї as plain І.
-        error: plain І
+        explanation: ДЖ marks one joined reading unit in words such as джерело́.
+      - sentence: Украї́на — не читай ї як plain і.
+        error: plain і
         correction: '[йі]'
         options:
           - '[йі]'
           - '[і]'
         explanation: Ї is always [йі].
-      - sentence: Do not add a vowel after день.
+      - sentence: День — не додавай голосний після нь.
         error: add a vowel
         correction: soften н and stop
         options:
@@ -86,19 +86,19 @@ inline:
         explanation: Ь has no sound of its own; it softens the previous consonant.
   - id: act-5
     type: quiz
-    title: Textbook check
+    title: Переві́рка читання
     instruction: Choose the correct answer.
     items:
-      - prompt: What is a склад?
+      - prompt: Склад — що це?
         options:
-          - text: a syllable
+          - text: syllable
             correct: true
-          - text: a letter
+          - text: letter
             correct: false
-          - text: a greeting
+          - text: greeting
             correct: false
-        explanation: A склад is a syllable.
-      - prompt: How many syllables are in молоко?
+        explanation: Склад is a syllable.
+      - prompt: Молоко́ — скільки складів?
         options:
           - text: '3'
             correct: true
@@ -106,8 +106,8 @@ inline:
             correct: false
           - text: '1'
             correct: false
-        explanation: молоко has three vowel sounds and three syllables.
-      - prompt: Which letter is always [йі]?
+        explanation: Молоко́ has three vowel sounds and three syllables.
+      - prompt: Яка літера завжди [йі]?
         options:
           - text: Ї
             correct: true
@@ -118,81 +118,55 @@ inline:
         explanation: Ї is always [йі].
 workbook:
   - type: group-sort
-    title: One, two, or three syllables?
+    title: Один, два чи три склади́
     instruction: Sort the words by syllable count.
     groups:
-      - label: One syllable
+      - label: Один склад
         items:
           - день
           - Львів
-      - label: Two syllables
+      - label: Два склади́
         items:
           - ма́ма
           - та́то
           - Ки́їв
-      - label: Three syllables
+      - label: Три склади́
         items:
           - молоко́
           - ву́лиця
           - столи́ця
   - type: true-false
-    title: Reading facts
+    title: Факти про читання
     instruction: Choose true or false.
     items:
-      - statement: Every Ukrainian syllable needs a vowel sound.
+      - statement: Кожен український склад має голосни́й звук.
         correct: true
         explanation: The vowel sound is the core of the syllable.
-      - statement: Ї sometimes softens the previous consonant.
+      - statement: Ї іноді м'якшить попередній при́голосний.
         correct: false
         explanation: Ї is always [йі].
-      - statement: In молоко, о stays clean.
+      - statement: У молоко́ звук о залишається чистим.
         correct: true
-        explanation: Do not reduce о to an unclear English-style vowel.
+        explanation: Do not reduce о to an unclear vowel.
       - statement: ДЖ and ДЗ should be read as joined units.
         correct: true
         explanation: They are digraph reading units.
-  - type: translate
-    title: Reading words
-    instruction: Choose the English meaning.
-    items:
-      - source: ма́ма
-        options:
-          - text: mother
-            correct: true
-          - text: street
-            correct: false
-          - text: milk
-            correct: false
-        explanation: Ма́ма means mother.
-      - source: молоко́
-        options:
-          - text: milk
-            correct: true
-          - text: apple
-            correct: false
-          - text: day
-            correct: false
-        explanation: Молоко́ means milk.
-      - source: ву́лиця
-        options:
-          - text: street
-            correct: true
-          - text: person
-            correct: false
-          - text: capital
-            correct: false
-        explanation: Ву́лиця means street.
-      - source: я́блуко
-        options:
-          - text: apple
-            correct: true
-          - text: song
-            correct: false
-          - text: mirror
-            correct: false
-        explanation: Я́блуко means apple.
+  - type: match-up
+    title: Друк і зошит
+    instruction: Match the printed word to the notebook recognition cue.
+    pairs:
+      - left: 'друк: ма́ма'
+        right: 'зошит: ма́ма'
+      - left: 'друк: молоко́'
+        right: 'зошит: молоко́'
+      - left: 'друк: день'
+        right: 'зошит: word with final ь'
+      - left: 'друк: Ки́їв'
+        right: 'зошит: word with ї'
+      - left: 'друк: ву́лиця'
+        right: 'зошит: three-syllable city word'
   - type: watch-and-repeat
-    title: Vowel reading pass
+    title: Повтор голосних
     instruction: Watch the alphabet overview again, then repeat the simple vowels.
     items:
       - letter: А

--- a/curriculum/l2-uk-en/a1/reading-ukrainian/module.md
+++ b/curriculum/l2-uk-en/a1/reading-ukrainian/module.md
@@ -1,13 +1,22 @@
-# Reading Ukrainian
+# Читаємо українською
 
-This module turns the alphabet from Module 1 into a reading tool. You still do
-not need long Ukrainian sentences. The goal is smaller and more useful: see a
-word, find its vowel sounds, split it into syllables, and read it without
-guessing from English spelling habits.
+**ма — мо — му — ми. ма́ма. молоко́.** — syllables and first words.
 
-You already practiced counting **склади** in Module 1 with the rule **one vowel
-sound = one склад**. Here we use that same skill more deliberately: not just to
-count syllables, but as the first step for reading any new Ukrainian word.
+Printed Ukrainian comes first. English support comes after the eye has found
+the letters, vowel sounds, and syllables.
+
+Use one lawful listening pass before you read fast. Open the public ULP
+[Ukrainian Alphabet guide](https://www.ukrainianlessons.com/ukrainian-alphabet/)
+only as a listen-and-repeat support. Do not download, transcribe, remix, or
+reuse the audio. Listen for the vowel, point to it on this page, then read the
+printed word.
+
+You already know one rule from Module 1:
+
+**one vowel sound = one склад**
+
+Here you use it as a reading tool: see a word, find its vowel sounds, split it
+into syllables, and read it without guessing from another alphabet.
 
 By the end, you can:
 
@@ -15,23 +24,23 @@ By the end, you can:
 - read simple open syllables such as **ма**, **мо**, **му**, **ми**;
 - keep the six simple vowel sounds clear;
 - explain what **Я, Ю, Є, Ї** do at beginner level;
-- read short practice words such as **ма́ма**, **молоко́**, **день**,
-  **я́блуко**, **люди́на**, and **ву́лиця**;
+- read **ма́ма**, **молоко́**, **день**, **я́блуко**, **люди́на**, and
+  **ву́лиця**;
 - avoid the first reading traps: splitting **дж** and **дз**, ignoring **ь**,
-  blurring **о**, and losing the **й** sound in **ї**.
+  blurring **о**, and losing **й** in **ї**.
 
-## Syllables
+## Склади
 
-Start every reading attempt with one question:
+**склад** — syllable.
 
-**Where are the vowel sounds?**
+Start every reading attempt with one Ukrainian question:
+
+**Де голосні звуки?** — Where are the vowel sounds?
 
 In Ukrainian, every syllable has a vowel sound. A single vowel can be a whole
-syllable, and a consonant by itself cannot make a syllable. This is the school
-rule behind beginner reading: count the vowel sounds, and you have the number
-of **склади́**.
+syllable, and a consonant by itself cannot make a syllable.
 
-| Word | Vowel letters to notice | Syllables |
+| Слово́ | Голосні to notice | Склади́ |
 | --- | --- | --- |
 | **день** | **е** | 1 |
 | **ма́ма** | **а + а** | 2 |
@@ -39,11 +48,10 @@ of **склади́**.
 | **ву́лиця** | **у + и + я** | 3 |
 
 Use a simple body check. Put a hand lightly under your chin and say the word
-slowly. Each open vowel pulse makes the chin move. That movement is not the
-whole science of Ukrainian, but it is a good beginner check before you write or
-choose an answer.
+slowly. Each open vowel pulse makes the chin move. That movement is a
+beginner check before you write or choose an answer.
 
-Now build from syllables instead of naming letters one by one:
+Build from syllables instead of naming letters one by one:
 
 | Letter path | Reading path |
 | --- | --- |
@@ -55,34 +63,29 @@ Now build from syllables instead of naming letters one by one:
 Then join syllables:
 
 **ма + ма = ма́ма**
+
 **мо + ло + ко = молоко́**
 
-This is why Ukrainian early reading feels different from English. Do not ask,
-"What English word does this look like?" Ask, "Where are the vowel sounds, and
-what syllables do they make?"
-
 :::tip
-When a workbook item asks for **склад**, it means "syllable." Find the vowel
-sound first. That is the anchor.
+**склад** — syllable. Find the vowel sound first. That is the anchor.
 :::
 
 <!-- INJECT_ACTIVITY: act-1 -->
 
-## Vowel Letters
+## Голосні лі́тери
 
-Ukrainian has six simple vowel sounds:
+**А О У Е И І** — six simple vowel letters.
+
+The sounds are:
 
 **[а] [о] [у] [е] [и] [і]**
 
-The simple vowel letters are:
+Read them as clean sounds. In **молоко́**, every **о** stays **о**:
 
-**А О У Е И І**
+**мо-ло-ко́**
 
-Read them as clean sounds. Do not reduce **о** into an English-style unclear
-vowel. In **молоко́**, every **о** stays **о**:
-
-**молоко́** has three syllables. Say it slowly as three open beats, but keep
-the written word whole on the page.
+Say it slowly as three open beats, but keep the written word whole on the
+page.
 
 Now add the four special vowel letters:
 
@@ -90,30 +93,32 @@ Now add the four special vowel letters:
 
 At beginner level, use this two-job rule:
 
-| Letter | At the start of a word or after a vowel/apostrophe | After a consonant |
+| Лі́тера | At the start of a word or after a vowel/apostrophe | After a consonant |
 | --- | --- | --- |
 | **Я** | **[йа]** as in **я́блуко** | softens the consonant + **[а]** |
 | **Ю** | **[йу]** | softens the consonant + **[у]** |
 | **Є** | **[йе]** | softens the consonant + **[е]** |
 | **Ї** | always **[йі]** | always **[йі]** |
 
-That last line matters. **Ї** is not a softening letter. It is always two
-sounds: **[йі]**. In **Украї́на**, read **ї** as **[йі]**.
+**Ї** is not a softening letter. It is always two sounds: **[йі]**. In
+**Украї́на**, read **ї** as **[йі]**.
 
 Use three safe examples:
 
-| Word | Meaning | What to read |
+| Слово́ | English support | What to read |
 | --- | --- | --- |
 | **я́блуко** | apple | **я** starts the word: **[йа]** |
 | **люди́на** | person | **ю** follows **л** and marks softness + **[у]** |
 | **пі́сня** | song | **я** follows **н** and marks softness + **[а]** |
 
-You do not need to describe every phonetic detail yet. You need a safe reading
-habit: look at the position of **Я, Ю, Є, Ї**, then read the word slowly.
+You do not need every phonetic detail yet. Look at the position of
+**Я, Ю, Є, Ї**, then read the word slowly.
 
 <!-- INJECT_ACTIVITY: act-2 -->
 
-## Reading Words
+## Читаємо слова́
+
+**ма́ма. та́то. вода́. ка́ша.**
 
 Use this three-step reading routine:
 
@@ -123,7 +128,7 @@ Use this three-step reading routine:
 
 Try the routine with easy words:
 
-| Word | Split | Meaning |
+| Слово́ | Split | English support |
 | --- | --- | --- |
 | **ма́ма** | 2 syllables | mother |
 | **та́то** | 2 syllables | father |
@@ -132,9 +137,9 @@ Try the routine with easy words:
 | **ву́лиця** | 3 syllables | street |
 | **столи́ця** | 3 syllables | capital |
 
-Longer words are not magic. They are the same routine with more vowel sounds:
+Longer words use the same routine with more vowel sounds:
 
-| Word | Split | Beginner note |
+| Слово́ | Split | Beginner note |
 | --- | --- | --- |
 | **університе́т** | 5 syllables | read from left to right |
 | **бібліоте́ка** | 5 syllables | **о** is its own vowel pulse |
@@ -142,7 +147,7 @@ Longer words are not magic. They are the same routine with more vowel sounds:
 
 Names of Ukrainian cities are also good reading practice:
 
-| City | Split | Note |
+| Мі́сто | Split | Note |
 | --- | --- | --- |
 | **Ки́їв** | 2 syllables | **ї** is **[йі]** |
 | **Львів** | 1 syllable | one vowel sound |
@@ -150,8 +155,7 @@ Names of Ukrainian cities are also good reading practice:
 | **Дніпро́** | 2 syllables | consonant cluster, still two vowels |
 | **Полта́ва** | 3 syllables | steady open syllables |
 
-There are three signs or combinations to notice now and study more deeply in
-Module 3:
+Three signs or combinations return in Module 3:
 
 | Form | Beginner reading habit |
 | --- | --- |
@@ -160,55 +164,61 @@ Module 3:
 | **ДЖ / ДЗ** | one joined sound, not two broken sounds |
 
 Read **день** with soft **н**, not with an extra vowel after it. Read
-**сім'я́** with a clear break before **я**. Read **джерело́** with joined
+**сім'я́** with a clear **й** before **я**. Read **джерело́** with joined
 **дж**.
 
 <!-- INJECT_ACTIVITY: act-3 -->
 
-## Reading Traps
+## Пастки читання
 
-English can push you toward the wrong habit. Use these safety checks:
+**молоко́. день. Украї́на. джерело́.**
+
+Use these safety checks:
 
 | Trap | Safer Ukrainian habit |
 | --- | --- |
 | Reading letter by letter | Read by syllables: three beats in **молоко́** |
-| Reducing unstressed **о** | Keep **о** clean every time |
+| Blurring unstressed **о** | Keep **о** clear every time |
 | Reading **дж** as **д + ж** | Join it as one sound |
 | Ignoring **ь** | Make the previous consonant soft |
 | Reading **ї** as plain **і** | Read **ї** as **[йі]** |
 | Treating apostrophe as decoration | Keep the following **й** sound |
 
-Keep the Ukrainian system independent. Do not explain **И**, **І**, **Г**, or
-**О** through another language's alphabet. Build the category from Ukrainian
-examples: **ми**, **ді́ти**, **гора́**, **молоко́**.
+Build the categories from Ukrainian examples: **ми**, **ді́ти**, **гора́**,
+**молоко́**. Do not use another language's alphabet as the shortcut.
 
 <!-- INJECT_ACTIVITY: act-4 -->
 
-## Textbook Check
+## Друк, зошит, перевірка
+
+**Друк:** **ма́ма**, **молоко́**, **день**, **Ки́їв**.
+
+**Зошит:** the same known words written by you, a teacher, or a tutor.
+
+Recognition comes before long handwriting production. Ask a native Ukrainian
+teacher or tutor to write one known word in their own hand. Your job is only to
+match it to the printed word and read it aloud. Do not copy or trace a
+third-party handwriting sample.
+
+| Друк | Notebook recognition prompt |
+| --- | --- |
+| **ма́ма** | Which printed word matches the handwritten **ма́ма**? |
+| **молоко́** | Which printed word matches the handwritten **молоко́**? |
+| **день** | Which printed word has the final soft sign? |
+| **Ки́їв** | Which printed word has **ї**? |
 
 Use a short partner routine when possible. Student A points to the word.
 Student B says only the number of vowel sounds. Then both students read the
-word aloud. If you are alone, cover the English meaning first, count the vowel
-sounds, and read before you check the translation. This keeps the page from
-becoming a memorized list of English meanings. The reading skill is the target.
+word aloud. If you are alone, cover the English support first, count the vowel
+sounds, and read before you check meaning.
 
-When a word feels long, do not panic. Long Ukrainian words are usually long
-because they have more syllables, not because the spelling has become
-unpredictable. **Університе́т** has five vowel sounds. **Бібліоте́ка** also has
-five vowel sounds. The same routine works for both: find the vowels, count the
-beats, then read smoothly. You are not expected to use these words in free
-conversation yet. They are training weights for your eyes and mouth.
-
-You can also mark your confidence after each word:
+When a word feels long, slow down:
 
 | Mark | Meaning |
 | --- | --- |
 | **1** | I can find the vowel sounds. |
 | **2** | I can count the syllables. |
 | **3** | I can read the word aloud smoothly. |
-
-The workbook repeats easy words and a few longer words on purpose. Repetition
-is how the alphabet becomes automatic.
 
 Before you leave the lesson tab, check that you can do these things:
 
@@ -217,11 +227,11 @@ Before you leave the lesson tab, check that you can do these things:
 - count three vowel sounds in **ву́лиця**;
 - say why **Ї** is always **[йі]**;
 - read **я́блуко**, **люди́на**, **пі́сня**, and **день** slowly;
-- keep **о** clean in **молоко́** and **столи́ця**;
+- keep **о** clear in **молоко́** and **столи́ця**;
 - say that **дж** and **дз** are joined reading units;
-- avoid Russian or English shortcuts when you describe Ukrainian sounds.
+- match a known printed word to a notebook version before copying it.
 
-The workbook now gives you short recognition and reading checks. Use the same
-routine every time: vowel sounds first, syllables second, smooth reading third.
+The workbook repeats easy words and a few longer words on purpose. Repetition
+is how the alphabet becomes automatic.
 
 <!-- INJECT_ACTIVITY: act-5 -->

--- a/curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml
+++ b/curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml
@@ -1,53 +1,53 @@
-version: "1.0"
-module: "sounds-letters-and-hello"
-level: "a1"
+version: '1.0'
+module: 'sounds-letters-and-hello'
+level: 'a1'
 
 inline:
   - id: act-1
     type: quiz
-    title: Sound or letter
+    title: Звук чи лі́тера
     instruction: Choose the correct anchor.
     items:
-      - question: What do we hear and pronounce?
+      - question: Звук — що ми робимо?
         options:
-          - лі́тера
-          - Звук
-          - Слово
+          - бачимо на сторі́нці
+          - чуємо й вимовля́ємо
+          - ставимо апо́строф
         correct: 1
         explanation: Звук is what we hear and pronounce.
-      - question: What do we see in writing?
+      - question: Лі́тера — що ми робимо?
         options:
-          - Звук
-          - лі́тера
-          - Вимова
-        correct: 1
+          - бачимо й пишемо
+          - чуємо без сторі́нки
+          - рахуємо як склад
+        correct: 0
         explanation: Лі́тера is the written sign.
-      - question: How many letters are in the Ukrainian alphabet?
+      - question: Українська абе́тка — скільки лі́тер?
         options:
-          - "38"
-          - "33"
-          - "6"
+          - '38'
+          - '33'
+          - '6'
         correct: 1
         explanation: The standard Ukrainian alphabet has 33 letters.
-      - question: Why can 33 letters point to more sounds?
+      - question: Я, Ю, Є, Ї — чому вони особливі?
         options:
-          - Some letters have more than one job
-          - English spelling changes Ukrainian sounds
-          - Every letter is silent
+          - мають більше ніж одну роботу
+          - завжди мовчать
+          - завжди є при́голосними
         correct: 0
         explanation: Some Ukrainian letters can point to more than one sound or modify a nearby sound.
-      - question: Which sign has no sound of its own?
+      - question: Ь — що правильно?
         options:
-          - А
-          - Ь
-          - О
+          - має власний голосни́й звук
+          - не має власного звука
+          - це літера О
         correct: 1
         explanation: Ь has no sound of its own.
-      - question: Which word has three vowel sounds?
+      - question: Молоко́ — скільки голосних звуків?
         options:
-          - Приві́т
-          - молоко́
-          - Мов
+          - два
+          - три
+          - один
         correct: 1
         explanation: Молоко́ has three vowel sounds, о + о + о.
 
@@ -76,29 +76,29 @@ inline:
     instruction: З'єднай літеру з її звуком або функцією.
     pairs:
       - left: І
-        right: "[і]"
+        right: '[і]'
       - left: В
-        right: "[в]"
+        right: '[в]'
       - left: А
-        right: "[а]"
+        right: '[а]'
       - left: О
-        right: "[о]"
+        right: '[о]'
       - left: У
-        right: "[у]"
+        right: '[у]'
       - left: Н
-        right: "[н]"
+        right: '[н]'
       - left: Ч
-        right: "[ч]"
+        right: '[ч]'
       - left: Ь
-        right: softens the previous consonant
+        right: м'якшить попередній при́голосний
       - left: Я
-        right: "[йа] or softens the previous consonant"
+        right: "[йа] або м'якшить попередній при́голосний"
       - left: Ї
-        right: "[йі]"
+        right: '[йі]'
       - left: Щ
-        right: "[шч]"
+        right: '[шч]'
       - left: Д
-        right: "[д]"
+        right: '[д]'
 
   - id: act-4
     type: watch-and-repeat
@@ -207,8 +207,8 @@ inline:
 
   - id: act-5
     type: fill-in
-    title: Short dialogue
-    instruction: Choose the phrase that completes the first dialogue.
+    title: Короткий діало́г
+    instruction: Choose the phrase that completes the Ukrainian line.
     items:
       - sentence: Приві́т! ___ спра́ви?
         answer: Як
@@ -228,13 +228,13 @@ inline:
           - А тебе́
           - А у тебе́
           - А тобі́
-      - sentence: "___ тебе́ бачити! (woman speaker)"
+      - sentence: '___ тебе́ ба́чити! (говорить жінка)'
         answer: Рада
         options:
           - Рада
           - Радий
           - Раді
-      - sentence: "___ тебе́ бачити! (man speaker)"
+      - sentence: '___ тебе́ ба́чити! (говорить чоловік)'
         answer: Радий
         options:
           - Радий
@@ -242,30 +242,28 @@ inline:
           - Раді
 
 workbook:
-  - id: wb-1
-    type: true-false
-    title: Quick sound checks
-    instruction: Decide whether each review statement is true or false.
+  - type: true-false
+    title: Швидка переві́рка звуків
+    instruction: Choose true or false.
     items:
-      - statement: Звук is what you hear and pronounce.
+      - statement: Звук — це те, що ми чуємо й вимовля́ємо.
         correct: true
-        explanation: The learner hears and pronounces a sound.
-      - statement: Ь has its own vowel sound.
+        explanation: Звук is what the learner hears and pronounces.
+      - statement: Ь має власний голосни́й звук.
         correct: false
         explanation: Ь has no sound of its own; it softens the previous consonant.
-      - statement: Молоко́ has three vowel sounds.
+      - statement: Молоко́ має три голосні звуки.
         correct: true
         explanation: The vowels are о + о + о.
-      - statement: До́брий день is a greeting phrase.
+      - statement: До́брий день — це вітальна фра́за.
         correct: true
         explanation: It is one of the first ready-made greetings in the lesson.
-      - statement: In this module, Щ is taught as [ш].
+      - statement: У цьому модулі Щ = [ш].
         correct: false
-        explanation: This module teaches Щ as [шч].
+        explanation: Here, Щ = [шч].
 
-  - id: wb-2
-    type: order
-    title: Build the greeting exchange
+  - type: order
+    title: Склади діало́г
     instruction: Put the mini-dialogue in a natural order.
     items:
       - А у тебе́?
@@ -278,32 +276,15 @@ workbook:
       - 2
       - 0
 
-  - id: wb-3
-    type: fill-in
-    title: Pick the right phrase
-    instruction: Choose the greeting or closing phrase that fits each moment.
-    items:
-      - sentence: "Morning arrival at school: ___!"
-        answer: До́брого ра́нку
-        options:
-          - До́брого ра́нку
-          - До поба́чення
-          - На все до́бре
-      - sentence: "Casual hello to one friend: ___!"
-        answer: Приві́т
-        options:
-          - Приві́т
-          - До́брий ве́чір
-          - До поба́чення
-      - sentence: "Midday greeting to a teacher: ___!"
-        answer: До́брий день
-        options:
-          - До́брий день
-          - Приві́т
-          - На все до́бре
-      - sentence: "Leaving the room: ___!"
-        answer: До поба́чення
-        options:
-          - До поба́чення
-          - Як спра́ви
-          - Мене́ зва́ти
+  - type: match-up
+    title: Друк і зошит
+    instruction: Match the printed card to the notebook recognition cue.
+    pairs:
+      - left: 'друк: П п'
+        right: 'зошит: teacher writes п'
+      - left: 'друк: М м'
+        right: 'зошит: teacher writes м'
+      - left: 'друк: Приві́т'
+        right: 'зошит: приві́т'
+      - left: 'друк: ма́ма'
+        right: 'зошит: ма́ма'

--- a/curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml
+++ b/curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml
@@ -6,7 +6,7 @@ inline:
   - id: act-1
     type: quiz
     title: Звук чи лі́тера
-    instruction: Choose the correct anchor.
+    instruction: Обери правильну опору.
     items:
       - question: Звук — що ми робимо?
         options:
@@ -14,42 +14,42 @@ inline:
           - чуємо й вимовля́ємо
           - ставимо апо́строф
         correct: 1
-        explanation: Звук is what we hear and pronounce.
+        explanation: Звук — це те, що ми чуємо й вимовля́ємо.
       - question: Лі́тера — що ми робимо?
         options:
           - бачимо й пишемо
           - чуємо без сторі́нки
           - рахуємо як склад
         correct: 0
-        explanation: Лі́тера is the written sign.
+        explanation: Лі́тера — це письмовий знак.
       - question: Українська абе́тка — скільки лі́тер?
         options:
           - '38'
           - '33'
           - '6'
         correct: 1
-        explanation: The standard Ukrainian alphabet has 33 letters.
+        explanation: Стандартна українська абе́тка має 33 лі́тери.
       - question: Я, Ю, Є, Ї — чому вони особливі?
         options:
           - мають більше ніж одну роботу
           - завжди мовчать
           - завжди є при́голосними
         correct: 0
-        explanation: Some Ukrainian letters can point to more than one sound or modify a nearby sound.
+        explanation: Деякі українські лі́тери мають більше ніж одну роботу.
       - question: Ь — що правильно?
         options:
           - має власний голосни́й звук
           - не має власного звука
           - це літера О
         correct: 1
-        explanation: Ь has no sound of its own.
+        explanation: Ь не має власного звука.
       - question: Молоко́ — скільки голосних звуків?
         options:
           - два
           - три
           - один
         correct: 1
-        explanation: Молоко́ has three vowel sounds, о + о + о.
+        explanation: 'Молоко́ має три голосні звуки: о + о + о.'
 
   - id: act-2
     type: count-syllables
@@ -208,7 +208,7 @@ inline:
   - id: act-5
     type: fill-in
     title: Короткий діало́г
-    instruction: Choose the phrase that completes the Ukrainian line.
+    instruction: Обери фра́зу, яка доповнює український рядок.
     items:
       - sentence: Приві́т! ___ спра́ви?
         answer: Як
@@ -244,23 +244,23 @@ inline:
 workbook:
   - type: true-false
     title: Швидка переві́рка звуків
-    instruction: Choose true or false.
+    instruction: Обери правда чи неправда.
     items:
       - statement: Звук — це те, що ми чуємо й вимовля́ємо.
         correct: true
-        explanation: Звук is what the learner hears and pronounces.
+        explanation: Звук — це те, що ми чуємо й вимовля́ємо.
       - statement: Ь має власний голосни́й звук.
         correct: false
-        explanation: Ь has no sound of its own; it softens the previous consonant.
+        explanation: Ь не має власного звука; він м'якшить попередній при́голосний.
       - statement: Молоко́ має три голосні звуки.
         correct: true
-        explanation: The vowels are о + о + о.
+        explanation: 'Голосні звуки: о + о + о.'
       - statement: До́брий день — це вітальна фра́за.
         correct: true
-        explanation: It is one of the first ready-made greetings in the lesson.
+        explanation: Це одна з перших готових фраз вітання в уро́ці.
       - statement: У цьому модулі Щ = [ш].
         correct: false
-        explanation: Here, Щ = [шч].
+        explanation: У цьому модулі Щ = [шч].
 
   - type: order
     title: Склади діало́г
@@ -278,12 +278,12 @@ workbook:
 
   - type: match-up
     title: Друк і зошит
-    instruction: Match the printed card to the notebook recognition cue.
+    instruction: З'єднай друковану картку з підказкою в зо́шиті.
     pairs:
       - left: 'друк: П п'
-        right: 'зошит: teacher writes п'
+        right: 'зошит: учитель пише п'
       - left: 'друк: М м'
-        right: 'зошит: teacher writes м'
+        right: 'зошит: учитель пише м'
       - left: 'друк: Приві́т'
         right: 'зошит: приві́т'
       - left: 'друк: ма́ма'

--- a/curriculum/l2-uk-en/a1/sounds-letters-and-hello/module.md
+++ b/curriculum/l2-uk-en/a1/sounds-letters-and-hello/module.md
@@ -1,40 +1,47 @@
 # Звуки, літери та привіт
 
-**Звук — sound. Лі́тера — letter.** This first module starts with what you
-hear, then connects it to what you see on the page.
+**Приві́т! Звук. Лі́тера.** — Hi! Sound. Letter.
 
-Work in this order:
+Спо́чатку слуха́ємо: **звук**. Поті́м ба́чимо на сторі́нці:
+**лі́тера**. English support: hear, see, repeat, then greet.
 
-1. hear a sound;
-2. see the letter;
-3. repeat a short word;
-4. use one greeting phrase.
-
-You do not need long Ukrainian sentences yet. You need a few stable anchors:
-**звук**, **лі́тера**, **ма́ма**, **молоко́**, **Приві́т**, and
-**До́брий день**.
-
-## Звук і лі́тера
-
-**Звук — sound.** You hear it and pronounce it.
-
-**Лі́тера — letter.** You see it and write it.
-
-Keep the two ideas separate:
-
-| Ukrainian anchor | English support |
+| Українська опора | English support |
 | --- | --- |
 | **звук** | what your mouth says and your ear hears |
 | **лі́тера** | the written sign on the page |
 | **абе́тка** | the alphabet |
 
-Ukrainian has **33 letters** in the alphabet. In speech, Ukrainian uses more
-sounds because some letters can point to more than one sound or modify a nearby
-sound.
+Work in this small order:
+
+1. **слу́хай** — hear a sound;
+2. **диви́сь** — see the letter;
+3. **повтори́** — repeat one short word;
+4. **скажи́** — use one greeting phrase.
+
+You need only a few stable anchors today: **звук**, **лі́тера**,
+**ма́ма**, **молоко́**, **Приві́т**, and **До́брий день**.
+
+## Звук і лі́тера
+
+**звук** — what you hear and pronounce.
+
+**лі́тера** — what you see and write.
+
+Keep the two ideas separate:
+
+| Я ба́чу | Я чу́ю |
+| --- | --- |
+| **лі́тера А** | **[а]** |
+| **лі́тера М** | **[м]** |
+| **лі́тера О** | **[о]** |
+
+Українська абе́тка має **33 лі́тери**. In speech, Ukrainian has more
+sounds because some letters can point to more than one sound or modify a
+nearby sound.
 
 Three beginner clues:
 
-- **Я, Ю, Є, Ї** can point to a **й + vowel** sound in some positions.
+- **Я, Ю, Є, Ї** can point to **й + vowel** in some positions.
 - **Ь** has no sound of its own; it softens the previous consonant.
 - **Щ** is taught here as **[шч]**.
 
@@ -42,11 +49,9 @@ Three beginner clues:
 
 ## Голосні звуки
 
-**Голосни́й звук — vowel sound.** A vowel is open and easy to sing.
+**[а] [о] [у] [е] [и] [і]** — six simple vowel sounds.
 
-Start with six simple vowel sounds:
-
-**[а] [о] [у] [е] [и] [і]**
+**Голосни́й звук** — vowel sound. A vowel is open and easy to sing.
 
 The simple vowel letters are:
 
@@ -56,26 +61,28 @@ Use the beginner rule:
 
 **one vowel sound = one склад**
 
-| Word | Vowel sounds | Syllables |
+| Слово́ | Голосні звуки | Склади́ |
 | --- | --- | --- |
 | **ма́ма** | **а + а** | 2 |
 | **молоко́** | **о + о + о** | 3 |
 | **Приві́т** | **и + і** | 2 |
 | **о́ко** | **о + о** | 2 |
 
-Important habit: keep **о** clean. In **молоко́**, every **о** is still **о**.
-Do not blur it into an English-style reduced vowel.
+Important habit: keep **о** clear. In **молоко́**, every **о** is still
+**о**. Do not blur it into a reduced vowel.
 
 <!-- INJECT_ACTIVITY: act-2 -->
 
 ## При́голосні звуки
 
-**При́голосний звук — consonant sound.** A consonant uses a small block or
-contact in the mouth: lips, teeth, tongue, or throat.
+**[м] [п] [т] [н]** — four easy consonant sounds.
 
-Try four easy consonants:
+**При́голосний звук** — consonant sound. A consonant uses a small block
+or contact in the mouth: lips, teeth, tongue, or throat.
 
-| Sound | Body cue |
+Try the body cue first:
+
+| Звук | Body cue |
 | --- | --- |
 | **[м]** | close your lips and hum |
 | **[п]** | close your lips and release |
@@ -84,7 +91,7 @@ Try four easy consonants:
 
 Now take **Приві́т** apart:
 
-| Letter | Sound type |
+| Лі́тера | Type |
 | --- | --- |
 | **П** | consonant |
 | **Р** | consonant |
@@ -93,14 +100,17 @@ Now take **Приві́т** apart:
 | **І** | vowel |
 | **Т** | consonant |
 
-So **Приві́т** has **2 vowel sounds** and **4 consonant sounds**.
+**Приві́т** has **2 vowel sounds** and **4 consonant sounds**.
 
 <!-- INJECT_ACTIVITY: act-3 -->
 
 ## Абетка: first video pass
 
-Use this table as a first full pass through the Ukrainian alphabet. Do not try
-to master all 33 letters in one sitting. Repeat a small group, then add more.
+**А, Б, В... Я** — the full Ukrainian alphabet.
+
+Use this as a first pass. Do not try to master all 33 letters in one
+sitting. Repeat a small group, then add more. The linked public videos
+are for listening and repeating; do not download or reuse the audio.
 
 | Лі́тера | Sound | Small word | Video |
 | --- | --- | --- | --- |
@@ -138,13 +148,28 @@ to master all 33 letters in one sitting. Repeat a small group, then add more.
 | Ю | [йу] | ю́шка | https://www.youtube.com/watch?v=9JdIBYCTWGw |
 | Я | [йа] | я́блуко | https://www.youtube.com/watch?v=yhSAf41LX8I |
 
+**Друк / зошит** — print / notebook recognition.
+
+Recognition comes before handwriting production. Use original text on this
+page, your own notebook, or a teacher/tutor's live handwriting. Do not copy a
+third-party handwriting sample.
+
+| Друк | Зошит: recognition cue | What to do |
+| --- | --- | --- |
+| **П п** | teacher writes **п** by hand | point to **П** |
+| **М м** | teacher writes **м** by hand | point to **М** |
+| **Приві́т** | notebook label **приві́т** | match the word |
+| **ма́ма** | notebook label **ма́ма** | match the word |
+
 <!-- INJECT_ACTIVITY: act-4 -->
 
 ## Приві́т: first greeting phrases
 
+**Приві́т!** — Hi!
+
 Use these as whole phrases first. Grammar can wait.
 
-| Ukrainian | English support |
+| Українська | English support |
 | --- | --- |
 | **Приві́т!** | Hi! |
 | **До́брий день!** | Hello / good day |
@@ -153,26 +178,49 @@ Use these as whole phrases first. Grammar can wait.
 | **До поба́чення!** | Goodbye |
 | **На все до́бре!** | All the best |
 
-Now add one short exchange:
+Read the Ukrainian first:
 
-<DialogueBox uk="Приві́т!" en="Hi!" />
-<DialogueBox uk="Як спра́ви?" en="How are you?" />
-<DialogueBox uk="До́бре." en="Fine." />
-<DialogueBox uk="А у тебе́?" en="And you?" />
+```text
+О́ля: Приві́т!
+Тара́с: Приві́т!
+О́ля: Як спра́ви?
+Тара́с: До́бре.
+О́ля: А у тебе́?
+Тара́с: Чудо́во!
+```
+
+Support after the dialogue:
+
+| Українська | English support |
+| --- | --- |
+| **Як спра́ви?** | How are you? |
+| **До́бре.** | Fine / good. |
+| **А у тебе́?** | And you? |
+| **Чудо́во!** | Great! |
 
 Use **А у тебе́?** after **Як спра́ви?**. For a name exchange, use
 **А тебе́?**
 
-<DialogueBox uk="Як тебе́ зва́ти?" en="What is your name?" />
-<DialogueBox uk="Мене́ зва́ти Анна." en="My name is Anna." />
-<DialogueBox uk="А тебе́?" en="And you?" />
+```text
+Марко́: Як тебе́ зва́ти?
+Софі́я: Мене́ зва́ти Софі́я. А тебе́?
+Марко́: Мене́ зва́ти Марко́.
+```
+
+Support after the dialogue:
+
+| Українська | English support |
+| --- | --- |
+| **Як тебе́ зва́ти?** | What is your name? |
+| **Мене́ зва́ти...** | My name is... |
+| **А тебе́?** | And you? |
 
 Two ready phrases also show speaker gender:
 
 | Speaker | Phrase |
 | --- | --- |
-| man | **Радий тебе́ бачити.** |
-| woman | **Рада тебе́ бачити.** |
+| man | **Радий тебе́ ба́чити.** |
+| woman | **Рада тебе́ ба́чити.** |
 
 <!-- INJECT_ACTIVITY: act-5 -->
 
@@ -183,7 +231,9 @@ Keep this module small and clean:
 1. Keep **о** clear in **молоко́**.
 2. Hear the difference between **и** and **і** in **Приві́т**.
 3. Remember that **Ь** has no sound of its own.
-4. Use **Приві́т**, **До́брий день**, and **Мене́ зва́ти...** as whole phrases.
+4. Match print to notebook handwriting before you try to write fast.
+5. Ask a native Ukrainian teacher or tutor to listen to **Приві́т**,
+   **До́брий день**, and **Мене́ зва́ти...**
 
 End with one reliable line:
 

--- a/curriculum/l2-uk-en/a1/special-signs/activities.yaml
+++ b/curriculum/l2-uk-en/a1/special-signs/activities.yaml
@@ -2,7 +2,7 @@ inline:
   - id: act-1
     type: quiz
     title: М'яко чи розді́льно
-    instruction: Choose the beginner reading explanation.
+    instruction: Обери перше читацьке пояснення.
     items:
       - prompt: Буря́к — що стається перед я?
         options:
@@ -12,7 +12,7 @@ inline:
             correct: false
           - text: Ї завжди [йі].
             correct: false
-        explanation: Буря́к has no apostrophe; р softens before я.
+        explanation: У слові буря́к немає апо́строфа; р м'якшиться перед я.
       - prompt: Бур'я́н — що робить апо́строф?
         options:
           - text: Р лишається твердим, потім чути [йа].
@@ -21,7 +21,7 @@ inline:
             correct: false
           - text: Додає звук [і].
             correct: false
-        explanation: The apostrophe separates р from я.
+        explanation: Апо́строф відділяє р від я.
       - prompt: Ї — що завжди правильно?
         options:
           - text: Завжди [йі].
@@ -30,11 +30,11 @@ inline:
             correct: false
           - text: Це м'яки́й знак.
             correct: false
-        explanation: Ї always represents [йі].
+        explanation: Ї завжди позначає [йі].
   - id: act-2
     type: match-up
     title: Що робить ь
-    instruction: Match each word with the soft-sign clue.
+    instruction: З'єднай кожне слово з підказкою про м'яки́й знак.
     pairs:
       - left: день
         right: м'який фінальний н
@@ -49,30 +49,30 @@ inline:
   - id: act-3
     type: fill-in
     title: Додай знак
-    instruction: Choose ь, apostrophe, or no sign.
+    instruction: Обери ь, апо́строф або без знака.
     items:
       - sentence: сім_я
         answer: "'"
         options:
           - "'"
           - ь
-          - no sign
+          - без знака
       - sentence: ден_
         answer: ь
         options:
           - ь
           - "'"
-          - no sign
+          - без знака
       - sentence: п_ять
         answer: "'"
         options:
           - "'"
           - ь
-          - no sign
-      - sentence: свя́то needs ____.
-        answer: no sign
+          - без знака
+      - sentence: свя́то потребує ____.
+        answer: без знака
         options:
-          - no sign
+          - без знака
           - "'"
           - ь
       - sentence: бур_ян
@@ -80,24 +80,24 @@ inline:
         options:
           - "'"
           - ь
-          - no sign
+          - без знака
       - sentence: мале́нький needs ____.
         answer: ь
         options:
           - ь
           - "'"
-          - no sign
+          - без знака
   - id: act-4
     type: error-correction
     title: Виправ пастки
-    instruction: Choose the correct Ukrainian form.
+    instruction: Обери правильну українську форму.
     items:
       - sentence: Сім'я́ — не губи апо́строф.
         error: сімя
         correction: сім'я́
         options:
           - сім'я́
-          - family word without apostrophe
+          - сімя без апо́строфа
         explanation: The apostrophe is required in сім'я́.
       - sentence: День — не пиши ден.
         error: ден
@@ -105,32 +105,32 @@ inline:
         options:
           - день
           - ден
-        explanation: День needs the soft sign.
+        explanation: День потребує м'якого знака.
       - sentence: Свя́то — не додавай апо́строф.
         error: св'ято
         correction: свя́то
         options:
           - свя́то
           - св'ято
-        explanation: Свя́то is a prepared no-apostrophe word.
+        explanation: Свя́то — підготовлене слово без апо́строфа.
       - sentence: Ло́жка — не вигадуй м'яки́й знак.
         error: льожка
         correction: ло́жка
         options:
           - ло́жка
-          - invented soft-sign spelling
-        explanation: Ло́жка does not have a soft sign after л.
+          - вигадане написання з ь
+        explanation: Ло́жка не має м'якого знака після л.
       - sentence: Сім'я́ — не роби повну паузу.
         error: сім-пауза-я
-        correction: smooth й sound
+        correction: плавний звук й
         options:
-          - smooth й sound
+          - плавний звук й
           - full stop
-        explanation: The apostrophe separates sounds but does not create a full pause.
+        explanation: Апо́строф розділяє звуки, але не створює повної паузи.
   - id: act-5
     type: divide-words
     title: Перенос слів
-    instruction: Choose the prepared line-break model.
+    instruction: Обери підготовлену модель переносу.
     items:
       - word: Мар'я́на
         answer: Мар'-яна
@@ -143,7 +143,7 @@ inline:
 workbook:
   - type: group-sort
     title: Сортуй за знаком
-    instruction: Sort each word into the correct group.
+    instruction: Розподіли кожне слово в правильну групу.
     groups:
       - label: Є ь
         items:
@@ -167,56 +167,56 @@ workbook:
           - ло́жка
   - type: true-false
     title: Факти про знаки
-    instruction: Choose true or false.
+    instruction: Обери правда чи неправда.
     items:
       - statement: Ь не має власного звука.
         correct: true
-        explanation: It softens the previous consonant.
+        explanation: Він м'якшить попередній при́голосний.
       - statement: Апо́строф тримає попередній при́голосний твердим.
         correct: true
-        explanation: It separates the consonant from the iotated vowel.
+        explanation: Він відділяє при́голосний від йотованої голосної.
       - statement: Ї іноді мовчить.
         correct: false
-        explanation: Ї is always [йі].
+        explanation: Ї завжди читаємо як [йі].
       - statement: Свя́то має апо́строф.
         correct: false
-        explanation: Свя́то is a no-apostrophe model word.
+        explanation: Свя́то — модельне слово без апо́строфа.
   - type: match-up
     title: Друк і зошит
-    instruction: Match the printed word to the notebook recognition cue.
+    instruction: З'єднай друковане слово з підказкою в зо́шиті.
     pairs:
       - left: 'друк: день'
-        right: 'зошит: word with final ь'
+        right: 'зошит: слово з кінцевим ь'
       - left: "друк: сім'я́"
         right: 'зошит: apostrophe before я'
       - left: "друк: п'ять"
-        right: 'зошит: apostrophe plus final ь'
+        right: 'зошит: апо́строф і кінцевий ь'
       - left: 'друк: свя́то'
         right: 'зошит: no apostrophe'
       - left: "друк: бур'я́н"
         right: 'зошит: apostrophe after р'
   - type: quiz
     title: Правильна форма
-    instruction: Choose the correctly written word.
+    instruction: Обери правильно написане слово.
     items:
       - prompt: Сім'я́ — яка форма правильна?
         options:
           - text: сім'я́
             correct: true
-          - text: family word without apostrophe
+          - text: сімя без апо́строфа
             correct: false
-        explanation: Сім'я́ needs the apostrophe.
+        explanation: Сім'я́ потребує апо́строфа.
       - prompt: День — яка форма правильна?
         options:
           - text: день
             correct: true
           - text: ден
             correct: false
-        explanation: День needs the soft sign.
+        explanation: День потребує м'якого знака.
       - prompt: Слово без апо́строфа?
         options:
           - text: свя́то
             correct: true
           - text: apostrophe spelling
             correct: false
-        explanation: Свя́то is the prepared no-apostrophe word.
+        explanation: Свя́то — підготовлене слово без апо́строфа.

--- a/curriculum/l2-uk-en/a1/special-signs/activities.yaml
+++ b/curriculum/l2-uk-en/a1/special-signs/activities.yaml
@@ -1,54 +1,54 @@
 inline:
   - id: act-1
     type: quiz
-    title: Soft or separate?
+    title: М'яко чи розді́льно
     instruction: Choose the beginner reading explanation.
     items:
-      - prompt: In буря́к, what happens before я?
+      - prompt: Буря́к — що стається перед я?
         options:
-          - text: Р softens before я.
+          - text: Р м'якшиться перед я.
             correct: true
-          - text: There is an apostrophe.
+          - text: Є апо́строф.
             correct: false
-          - text: Ї is always [йі].
+          - text: Ї завжди [йі].
             correct: false
         explanation: Буря́к has no apostrophe; р softens before я.
-      - prompt: In бур'я́н, what does the apostrophe do?
+      - prompt: Бур'я́н — що робить апо́строф?
         options:
-          - text: It keeps р hard and lets you hear [йа].
+          - text: Р лишається твердим, потім чути [йа].
             correct: true
-          - text: It makes р disappear.
+          - text: Р зникає.
             correct: false
-          - text: It adds the sound [і].
+          - text: Додає звук [і].
             correct: false
         explanation: The apostrophe separates р from я.
-      - prompt: What is always true about Ї?
+      - prompt: Ї — що завжди правильно?
         options:
-          - text: It is always [йі].
+          - text: Завжди [йі].
             correct: true
-          - text: It is silent.
+          - text: Мовчить.
             correct: false
-          - text: It is the soft sign.
+          - text: Це м'яки́й знак.
             correct: false
         explanation: Ї always represents [йі].
   - id: act-2
     type: match-up
-    title: What does ь do?
+    title: Що робить ь
     instruction: Match each word with the soft-sign clue.
     pairs:
       - left: день
-        right: soft final н
+        right: м'який фінальний н
       - left: кінь
-        right: soft final н
+        right: м'який фінальний н
       - left: сіль
-        right: soft final л
+        right: м'який фінальний л
       - left: вчи́тель
-        right: soft final л
+        right: м'який фінальний л
       - left: м'яки́й знак
-        right: no sound of its own
+        right: не має власного звука
   - id: act-3
     type: fill-in
-    title: Add the sign
+    title: Додай знак
     instruction: Choose ь, apostrophe, or no sign.
     items:
       - sentence: сім_я
@@ -89,38 +89,38 @@ inline:
           - no sign
   - id: act-4
     type: error-correction
-    title: Fix common L2 mistakes
+    title: Виправ пастки
     instruction: Choose the correct Ukrainian form.
     items:
-      - sentence: Do not write сімя without the apostrophe.
+      - sentence: Сім'я́ — не губи апо́строф.
         error: сімя
         correction: сім'я́
         options:
           - сім'я́
           - family word without apostrophe
         explanation: The apostrophe is required in сім'я́.
-      - sentence: Do not write ден.
+      - sentence: День — не пиши ден.
         error: ден
         correction: день
         options:
           - день
           - ден
         explanation: День needs the soft sign.
-      - sentence: Do not write св'ято with an apostrophe.
+      - sentence: Свя́то — не додавай апо́строф.
         error: св'ято
         correction: свя́то
         options:
           - свя́то
           - св'ято
         explanation: Свя́то is a prepared no-apostrophe word.
-      - sentence: Do not write льожка with an invented soft sign.
+      - sentence: Ло́жка — не вигадуй м'яки́й знак.
         error: льожка
         correction: ло́жка
         options:
           - ло́жка
           - invented soft-sign spelling
         explanation: Ло́жка does not have a soft sign after л.
-      - sentence: Do not read сім'я́ as сім-пауза-я.
+      - sentence: Сім'я́ — не роби повну паузу.
         error: сім-пауза-я
         correction: smooth й sound
         options:
@@ -129,7 +129,7 @@ inline:
         explanation: The apostrophe separates sounds but does not create a full pause.
   - id: act-5
     type: divide-words
-    title: Line-break models
+    title: Перенос слів
     instruction: Choose the prepared line-break model.
     items:
       - word: Мар'я́на
@@ -142,104 +142,78 @@ inline:
         answer: паль-ці
 workbook:
   - type: group-sort
-    title: Sort by sign
+    title: Сортуй за знаком
     instruction: Sort each word into the correct group.
     groups:
-      - label: Has ь
+      - label: Є ь
         items:
           - день
           - кінь
           - сіль
           - вчи́тель
           - мале́нький
-      - label: Has apostrophe
+      - label: Є апо́строф
         items:
           - сім'я́
           - м'я́со
           - п'ять
           - комп'ю́тер
           - бур'я́н
-      - label: No sign
+      - label: Немає знака
         items:
           - буря́к
           - свя́то
           - цвях
           - ло́жка
   - type: true-false
-    title: Sign facts
+    title: Факти про знаки
     instruction: Choose true or false.
     items:
-      - statement: Ь has no sound of its own.
+      - statement: Ь не має власного звука.
         correct: true
         explanation: It softens the previous consonant.
-      - statement: Apostrophe keeps the previous consonant hard.
+      - statement: Апо́строф тримає попередній при́голосний твердим.
         correct: true
         explanation: It separates the consonant from the iotated vowel.
-      - statement: Ї is sometimes silent.
+      - statement: Ї іноді мовчить.
         correct: false
         explanation: Ї is always [йі].
-      - statement: Свя́то has an apostrophe.
+      - statement: Свя́то має апо́строф.
         correct: false
         explanation: Свя́то is a no-apostrophe model word.
-  - type: translate
-    title: Sign words
-    instruction: Choose the English meaning.
-    items:
-      - source: день
-        options:
-          - text: day
-            correct: true
-          - text: meat
-            correct: false
-          - text: family
-            correct: false
-        explanation: День means day.
-      - source: сім'я́
-        options:
-          - text: family
-            correct: true
-          - text: salt
-            correct: false
-          - text: holiday
-            correct: false
-        explanation: Сім'я́ means family.
-      - source: м'я́со
-        options:
-          - text: meat
-            correct: true
-          - text: teacher
-            correct: false
-          - text: nail
-            correct: false
-        explanation: М'я́со means meat.
-      - source: свя́то
-        options:
-          - text: holiday
-            correct: true
-          - text: weed
-            correct: false
-          - text: horse
-            correct: false
-        explanation: Свя́то means holiday.
+  - type: match-up
+    title: Друк і зошит
+    instruction: Match the printed word to the notebook recognition cue.
+    pairs:
+      - left: 'друк: день'
+        right: 'зошит: word with final ь'
+      - left: "друк: сім'я́"
+        right: 'зошит: apostrophe before я'
+      - left: "друк: п'ять"
+        right: 'зошит: apostrophe plus final ь'
+      - left: 'друк: свя́то'
+        right: 'зошит: no apostrophe'
+      - left: "друк: бур'я́н"
+        right: 'зошит: apostrophe after р'
   - type: quiz
-    title: Correct form
+    title: Правильна форма
     instruction: Choose the correctly written word.
     items:
-      - prompt: Choose the correct form for family.
+      - prompt: Сім'я́ — яка форма правильна?
         options:
           - text: сім'я́
             correct: true
           - text: family word without apostrophe
             correct: false
         explanation: Сім'я́ needs the apostrophe.
-      - prompt: Choose the correct form for day.
+      - prompt: День — яка форма правильна?
         options:
           - text: день
             correct: true
           - text: ден
             correct: false
         explanation: День needs the soft sign.
-      - prompt: Choose the no-apostrophe word.
+      - prompt: Слово без апо́строфа?
         options:
           - text: свя́то
             correct: true

--- a/curriculum/l2-uk-en/a1/special-signs/module.md
+++ b/curriculum/l2-uk-en/a1/special-signs/module.md
@@ -1,17 +1,24 @@
-# Special Signs
+# Особливі знаки
 
-This module teaches two Ukrainian signs that change how nearby letters are
-read: **ь** and **'**. They are small on the page, but they are not decorative.
-They tell your mouth what to do.
+**день. сім'я́. буря́к. бур'я́н.** — four words, two signs, three
+beginner contrasts.
+
+The signs are small on the page, but they are not decorative. They tell your
+mouth how to read the nearby letters.
+
+Use a live or original listening pass. A native Ukrainian teacher or tutor can
+say **день**, **сім'я́**, **буря́к**, **бур'я́н**, and **свя́то** once; you
+point to the sign you hear on the page. If you record anything, record only
+your own voice or a teacher who has given permission. Do not download or copy
+third-party audio.
 
 Keep the goal simple. You are not learning every spelling rule today. You are
-learning three beginner contrasts:
+learning these beginner contrasts:
 
-- **день**: the soft sign **ь** has no sound, but it softens the consonant
-  before it;
-- **сім'я́**: the apostrophe keeps the previous consonant hard and lets you hear
+- **день** — **ь** has no sound, but it softens the consonant before it;
+- **сім'я́** — apostrophe keeps the previous consonant hard and lets you hear
   **[й]** before **я**;
-- **буря́к / бур'я́н / свя́то / цвях**: sometimes **я** softens, sometimes the
+- **буря́к / бур'я́н / свя́то / цвях** — sometimes **я** softens, sometimes
   apostrophe separates, and sometimes there is no apostrophe after a consonant
   cluster.
 
@@ -20,16 +27,14 @@ By the end, you can:
 - recognize **ь** and apostrophe in common A1 words;
 - read **день**, **кінь**, **сіль**, and **вчи́тель** without adding an extra
   vowel;
-- read **сім'я́**, **м'я́со**, **п'ять**, and **комп'ю́тер** with a clear **й**
-  after the apostrophe;
-- sort words into "soft sign," "apostrophe," and "no sign";
-- choose the safer form when an English habit creates a mistake.
+- read **сім'я́**, **м'я́со**, **п'ять**, and **комп'ю́тер** with **й** after
+  the apostrophe;
+- sort words into **м'яки́й знак**, **апо́строф**, and **без зна́ка**;
+- choose the safer form when a visual habit creates a mistake.
 
-## Iotated Vowels First
+## Йотовані голосні first
 
-Before the two signs make sense, review the four special vowel letters:
-
-**Я Ю Є Ї**
+**Я Ю Є Ї** — the four special vowel letters.
 
 At beginner level, use this rule:
 
@@ -41,33 +46,28 @@ At beginner level, use this rule:
 
 Compare two words:
 
-| Word | What happens |
+| Слово́ | What happens |
 | --- | --- |
 | **буря́к** | no apostrophe; **р** softens before **я** |
 | **бур'я́н** | apostrophe; **р** stays hard, then you hear **[йа]** |
 
-The apostrophe is not an English punctuation mark here. In Ukrainian reading,
-it is a sound instruction: do not soften the previous consonant; keep the next
-**й** sound.
+The apostrophe is a Ukrainian reading instruction: do not soften the previous
+consonant; keep the next **й** sound.
 
-Use a listening habit before a spelling habit. Say or hear the word slowly.
-Ask: "Do I hear a separate **й** before **я, ю, є, ї**?" If yes, the apostrophe
-may be part of the spelling. If no, the vowel letter may simply be softening
-the previous consonant. You are still working with prepared words, not guessing
-new spellings alone.
+Use a hearing habit before a spelling habit. Say or hear the word slowly. Ask:
+**Чую окремий й?** — Do I hear a separate **й** before **я, ю, є, ї**? If yes,
+apostrophe may be part of the prepared spelling. If no, the vowel letter may
+simply be softening the previous consonant.
 
 <!-- INJECT_ACTIVITY: act-1 -->
 
-## The Soft Sign
+## М'яки́й знак
 
-The soft sign is:
+**Ь ь** — **м'яки́й знак**.
 
-**Ь ь**
+It has no sound of its own. It changes the consonant before it.
 
-Its Ukrainian name is **м'яки́й знак**. It has no sound of its own. It changes
-the consonant before it.
-
-| Word | Meaning | What to notice |
+| Слово́ | English support | What to notice |
 | --- | --- | --- |
 | **день** | day | final **нь** is soft |
 | **кінь** | horse | final **нь** is soft |
@@ -83,28 +83,23 @@ Short contrast pairs show the job:
 | --- | --- | --- |
 | **стан** | **стань** | hard ending vs soft ending |
 | **лан** | **лань** | hard ending vs soft ending |
-| **рис** | **рись** | hard final **с** vs a soft final consonant |
+| **рис** | **рись** | hard final **с** vs soft final consonant |
 
 These pairs are reading tools. You do not need to use all of them in
-conversation today. You need to see that **ь** can change the word even though
-it has no sound of its own.
+conversation today.
 
 :::tip
-Think of **ь** as a silent instruction for your tongue. It points backward to
-the consonant before it.
+**ь** points backward. It is a silent instruction for the consonant before it.
 :::
 
 <!-- INJECT_ACTIVITY: act-2 -->
 
-## The Apostrophe
+## Апостроф
 
-The apostrophe is:
+**'** — **апо́строф**.
 
-**'**
-
-In this course, read it as a separation sign. It does not make a pause like a
-full stop. It keeps the previous consonant hard and lets the next **я, ю, є, ї**
-start with **[й]**.
+Read it as a separation sign. It does not make a big pause. It keeps the
+previous consonant hard and lets the next **я, ю, є, ї** start with **[й]**.
 
 The first A1 model is:
 
@@ -112,7 +107,7 @@ The first A1 model is:
 
 Start with these words:
 
-| Word | Meaning | What to hear |
+| Слово́ | English support | What to hear |
 | --- | --- | --- |
 | **сім'я́** | family | **м** stays hard, then **[йа]** |
 | **м'я́со** | meat | **м** stays hard, then **[йа]** |
@@ -121,19 +116,18 @@ Start with these words:
 | **ім'я́** | name | **м** stays hard, then **[йа]** |
 | **комп'ю́тер** | computer | **п** stays hard, then **[йу]** |
 
-Do not turn the apostrophe into a big break. Read **п'ять** smoothly, with a
-clear **й** sound. The airflow continues; the spelling tells you to separate
-the consonant from the iotated vowel.
+Read **п'ять** smoothly, with a clear **й** sound. The airflow continues; the
+spelling tells you to separate the consonant from the iotated vowel.
 
 For now, do not build a large system from loanwords. **Комп'ю́тер** is useful
 because learners know the object, but the lesson target is the apostrophe
-itself, not every exception in international words.
+itself.
 
 <!-- INJECT_ACTIVITY: act-3 -->
 
-## Contrast and L2 Reading Traps
+## Контраст і пастки
 
-The central contrast is:
+**буря́к / бур'я́н / свя́то / цвях** — the central contrast.
 
 | Scenario | Example | Beginner explanation |
 | --- | --- | --- |
@@ -141,8 +135,8 @@ The central contrast is:
 | apostrophe | **бур'я́н** | **р** stays hard, then **[йа]** |
 | consonant cluster with no apostrophe | **свя́то**, **цвях** | no apostrophe in these prepared words |
 
-This is why mechanical spelling fails. You cannot simply put apostrophe before
-every **я**. You also cannot ignore apostrophe when it is written.
+Mechanical spelling fails here. You cannot put apostrophe before every **я**.
+You also cannot ignore apostrophe when it is written.
 
 Use these safe decisions:
 
@@ -164,13 +158,13 @@ Common learner traps:
 | inventing a soft-sign version of **ло́жка** | do not invent a soft sign or soft **л** |
 | treating apostrophe as a hard stop | keep airflow and pronounce **й** |
 
-Keep this module fully Ukrainian-centered. Do not explain the apostrophe
-through another language's alphabet or a "hard sign." Ukrainian has its own
-apostrophe and its own soft sign. Learn them from Ukrainian words.
+Keep this module Ukrainian-centered. Do not explain the apostrophe through
+another alphabet or another sign. Ukrainian has its own apostrophe and its own
+soft sign.
 
 <!-- INJECT_ACTIVITY: act-4 -->
 
-## Line Breaks and Textbook Check
+## Перенос, друк, зошит
 
 You will sometimes see words split across a line in printed Ukrainian. At this
 level, use only prepared models:
@@ -183,30 +177,38 @@ level, use only prepared models:
 | **па́льці** | `паль-ці` |
 
 The simple idea: **ь** and apostrophe stay with the letter before them. Also,
-do not leave one single letter alone on a line. You do not need to create new
-line breaks by yourself yet; you only need to recognize the model.
+do not leave one single letter alone on a line.
+
+**Друк / зошит** — recognition before writing.
+
+Use original text on this page, your own notebook, or live handwriting from a
+teacher/tutor. Do not copy a third-party handwriting sample.
+
+| Друк | Notebook recognition prompt |
+| --- | --- |
+| **день** | find the soft sign at the end |
+| **сім'я́** | find the apostrophe before **я** |
+| **п'ять** | find both apostrophe and soft sign |
+| **свя́то** | confirm there is no apostrophe |
+
+Ask a native Ukrainian teacher or tutor to listen to a short read-aloud:
+**день, сім'я́, буря́к, бур'я́н, свя́то**. The feedback target is small:
+soft ending, clear **й**, no invented pause.
 
 Before you leave the lesson tab, check that you can do these things:
 
 - say that **ь** has no sound of its own;
 - read **день**, **кінь**, **сіль**, and **вчи́тель** without adding **і**;
 - say that apostrophe keeps the previous consonant hard;
-- read **сім'я́**, **м'я́со**, **п'ять**, and **комп'ю́тер** with **й** after the
-  apostrophe;
-- explain the difference between **буря́к** and **бур'я́н** in English;
+- read **сім'я́**, **м'я́со**, **п'ять**, and **комп'ю́тер** with **й** after
+  the apostrophe;
+- explain **буря́к** and **бур'я́н** with the support table;
 - remember that **свя́то** and **цвях** have no apostrophe;
 - choose the correct sign in short prepared words;
-- identify missing-apostrophe, missing-soft-sign, and invented-soft-sign errors.
+- identify missing-apostrophe, missing-soft-sign, and invented-soft-sign
+  errors.
 
 Use the signs as reading instructions, not decorations. A useful final routine
-is: find the sign, say what it does in English, then read the word once. For
-**день**, say "soft sign, no sound, soft final consonant." For **сім'я́**, say
-"apostrophe, hard consonant, then **йа**." For **буря́к**, say "no apostrophe,
-soft **р**." For **свя́то**, say "prepared no-apostrophe word." This routine is
-slow on purpose. It prevents guessing and gives your mouth a stable Ukrainian
-habit before the next module adds stress and melody.
-
-The workbook adds extra practice with the same contrasts: sorting, quick
-facts, word recognition, and choosing the correct written form.
+is: find the sign, say what it does, then read the word once.
 
 <!-- INJECT_ACTIVITY: act-5 -->

--- a/curriculum/l2-uk-en/a1/stress-and-melody/activities.yaml
+++ b/curriculum/l2-uk-en/a1/stress-and-melody/activities.yaml
@@ -2,7 +2,7 @@ inline:
   - id: act-1
     type: quiz
     title: Де на́голос
-    instruction: Listen first, then choose the stressed syllable shown by the accent mark.
+    instruction: Спочатку слухай, потім обери склад із позначеним на́голосом.
     items:
       - prompt: 'Слухай, потім читай: ка́ва. Де на́голос?'
         options:
@@ -12,7 +12,7 @@ inline:
             correct: false
           - text: немає наголосу
             correct: false
-        explanation: Ка́ва is stressed on ка́.
+        explanation: У слові ка́ва на́голос на ка́.
       - prompt: 'Слухай, потім читай: вода́. Де на́голос?'
         options:
           - text: останній склад
@@ -21,7 +21,7 @@ inline:
             correct: false
           - text: усі склади однакові
             correct: false
-        explanation: Вода́ is stressed on да́.
+        explanation: У слові вода́ на́голос на да́.
       - prompt: 'Слухай, потім читай: столи́ця. Де на́голос?'
         options:
           - text: середній склад
@@ -30,7 +30,7 @@ inline:
             correct: false
           - text: останній склад
             correct: false
-        explanation: Столи́ця is stressed on ли́.
+        explanation: У слові столи́ця на́голос на ли́.
       - prompt: 'Молоко́: що робимо з ненаголошеними голосними?'
         options:
           - text: тримаємо кожен голосни́й чистим
@@ -39,11 +39,11 @@ inline:
             correct: false
           - text: читаємо кожне о як а
             correct: false
-        explanation: Ukrainian unstressed vowels stay clear.
+        explanation: Українські ненаголошені голосні залишаються чистими.
   - id: act-2
     type: quiz
     title: Вибір мелодики
-    instruction: Choose the beginner sentence melody.
+    instruction: Обери першу модель мелодики речення.
     items:
       - prompt: Це ка́ва.
         options:
@@ -51,32 +51,32 @@ inline:
             correct: true
           - text: висхідна ↗
             correct: false
-        explanation: A statement uses falling melody.
+        explanation: Твердження має спадну мелодику.
       - prompt: Це ка́ва?
         options:
           - text: висхідна ↗
             correct: true
           - text: спадна ↘
             correct: false
-        explanation: A yes/no question uses rising melody.
+        explanation: Так/ні питання має висхідну мелодику.
       - prompt: Де метро́?
         options:
           - text: спадна ↘
             correct: true
           - text: висхідна ↗
             correct: false
-        explanation: A question with де uses falling melody at A1.
+        explanation: Питання з де на A1 має спадну мелодику.
       - prompt: Як га́рно!
         options:
           - text: сильніша спадна ↘↘
             correct: true
           - text: висхідна ↗
             correct: false
-        explanation: An exclamation uses a stronger falling contour.
+        explanation: Оклик має сильнішу спадну мелодику.
   - id: act-3
     type: match-up
     title: На́голос змінює значення
-    instruction: Match the stressed word with the English meaning.
+    instruction: З'єднай наголошене слово з короткою англійською підказкою.
     pairs:
       - left: за́мок
         right: castle
@@ -93,7 +93,7 @@ inline:
   - id: act-4
     type: fill-in
     title: Пунктуація і мелодика
-    instruction: Choose the punctuation mark that matches the sentence.
+    instruction: Обери розділовий знак, який відповідає реченню.
     items:
       - sentence: Це ка́ва_
         answer: .
@@ -101,78 +101,78 @@ inline:
           - .
           - '?'
           - '!'
-        explanation: The statement takes a full stop and falling melody.
+        explanation: Твердження має крапку й спадну мелодику.
       - sentence: Це метро́_
         answer: '?'
         options:
           - '?'
           - .
           - '!'
-        explanation: The yes/no question takes a question mark and rising melody.
+        explanation: Так/ні питання має знак питання й висхідну мелодику.
       - sentence: Де апте́ка_
         answer: '?'
         options:
           - '?'
           - .
           - '!'
-        explanation: Де makes it a question, but the melody is falling.
+        explanation: Де робить це питанням, але мелодика спадна.
       - sentence: Як га́рно_
         answer: '!'
         options:
           - '!'
           - '?'
           - .
-        explanation: This is an exclamation.
+        explanation: Це оклик.
       - sentence: Так, це вода́_
         answer: .
         options:
           - .
           - '?'
           - '!'
-        explanation: This is a statement.
+        explanation: Це твердження.
 workbook:
   - type: error-correction
     title: Виправ пастки наголосу
-    instruction: Choose the safer Ukrainian reading habit.
+    instruction: Обери безпечнішу українську читацьку звичку.
     items:
       - sentence: Молоко́ — тримай усі голосні чистими.
-        error: blurred first two vowels
+        error: нечіткі перші два голосні
         correction: мо-ло-ко́
         options:
           - мо-ло-ко́
-          - blurred vowels
-        explanation: Ukrainian vowels stay clear outside stress.
+          - нечіткі голосні
+        explanation: Українські голосні залишаються чистими поза на́голосом.
       - sentence: Кіломе́тр — став на́голос на -ме́тр.
         error: кі́лометр
         correction: кіломе́тр
         options:
           - кіломе́тр
           - кі́лометр
-        explanation: The prepared model is кіломе́тр.
+        explanation: Підготовлена модель — кіломе́тр.
       - sentence: Кни́жка / книжки́ — помічай рухомий на́голос.
         error: кни́жки
         correction: книжки́
         options:
           - книжки́
           - кни́жки
-        explanation: This plural model moves stress to the ending.
+        explanation: У цій множинній моделі на́голос переходить на закінчення.
       - sentence: Одина́дцять — наголос на -на́-.
         error: о́динадцять
         correction: одина́дцять
         options:
           - одина́дцять
           - о́динадцять
-        explanation: The A1 target has stress on -на́-.
+        explanation: Ціль A1 має на́голос на -на́-.
       - sentence: Чотирна́дцять — наголос на -на́-.
         error: чоти́рнадцять
         correction: чотирна́дцять
         options:
           - чотирна́дцять
           - чоти́рнадцять
-        explanation: The A1 target has stress on -на́-.
+        explanation: Ціль A1 має на́голос на -на́-.
   - type: group-sort
     title: Сортуй за наголосом
-    instruction: Sort each word by the marked stressed syllable.
+    instruction: Розподіли кожне слово за позначеним наголошеним складом.
     groups:
       - label: Перший склад
         items:
@@ -194,35 +194,35 @@ workbook:
           - метро́
   - type: match-up
     title: Друк і зошит
-    instruction: Match the printed word to the notebook recognition cue.
+    instruction: З'єднай друковане слово з підказкою в зо́шиті.
     pairs:
       - left: 'друк: ка́ва'
-        right: 'зошит: stress on first syllable'
+        right: 'зошит: на́голос на першому складі'
       - left: 'друк: вода́'
-        right: 'зошит: stress on final syllable'
+        right: 'зошит: на́голос на останньому складі'
       - left: 'друк: молоко́'
-        right: 'зошит: three clear о sounds'
+        right: 'зошит: три чисті звуки о'
       - left: 'друк: метро́'
-        right: 'зошит: final stressed vowel'
+        right: 'зошит: останній наголошений голосни́й'
   - type: true-false
     title: Факти про наголос і мелодику
-    instruction: Choose true or false.
+    instruction: Обери правда чи неправда.
     items:
       - statement: Український на́голос може бути на різних складах.
         correct: true
-        explanation: Stress is free, so learn it with each word.
+        explanation: На́голос вільний, тому вчи його разом із кожним словом.
       - statement: Звичайні українські тексти завжди мають позначки наголосу.
         correct: false
-        explanation: Stress marks appear in learning materials and dictionaries, not most ordinary texts.
+        explanation: Позначки наголосу є в навчальних матеріалах і словниках, а не в більшості звичайних текстів.
       - statement: Так/ні питання Це вода́? має висхідну мелодику на A1.
         correct: true
-        explanation: Yes/no questions use rising melody.
+        explanation: Так/ні питання має висхідну мелодику.
       - statement: Питання з де завжди потребує висхідної мелодики на A1.
         correct: false
-        explanation: A question with a question word such as де uses falling melody.
+        explanation: Питання з питальним словом як де має спадну мелодику.
   - type: translate
     title: Слова з наголосом
-    instruction: Choose the English support meaning after reading the Ukrainian first.
+    instruction: Спочатку прочитай українське слово, потім обери англійську підказку.
     items:
       - source: на́голос
         options:
@@ -232,7 +232,7 @@ workbook:
             correct: false
           - text: water
             correct: false
-        explanation: На́голос means word stress or accent.
+        explanation: На́голос — stress / accent.
       - source: ка́ва
         options:
           - text: coffee
@@ -241,7 +241,7 @@ workbook:
             correct: false
           - text: morning
             correct: false
-        explanation: Ка́ва means coffee.
+        explanation: Ка́ва — coffee.
       - source: вода́
         options:
           - text: water
@@ -250,7 +250,7 @@ workbook:
             correct: false
           - text: atlas
             correct: false
-        explanation: Вода́ means water.
+        explanation: Вода́ — water.
       - source: столи́ця
         options:
           - text: capital
@@ -259,4 +259,4 @@ workbook:
             correct: false
           - text: family
             correct: false
-        explanation: Столи́ця means capital.
+        explanation: Столи́ця — capital.

--- a/curriculum/l2-uk-en/a1/stress-and-melody/activities.yaml
+++ b/curriculum/l2-uk-en/a1/stress-and-melody/activities.yaml
@@ -1,81 +1,81 @@
 inline:
   - id: act-1
     type: quiz
-    title: Where is the stress?
-    instruction: Choose the stressed syllable shown by the accent mark.
+    title: Де на́голос
+    instruction: Listen first, then choose the stressed syllable shown by the accent mark.
     items:
-      - prompt: In ка́ва, where is the stress?
+      - prompt: 'Слухай, потім читай: ка́ва. Де на́голос?'
         options:
-          - text: first syllable
+          - text: перший склад
             correct: true
-          - text: final syllable
+          - text: останній склад
             correct: false
-          - text: no stress
+          - text: немає наголосу
             correct: false
         explanation: Ка́ва is stressed on ка́.
-      - prompt: In вода́, where is the stress?
+      - prompt: 'Слухай, потім читай: вода́. Де на́голос?'
         options:
-          - text: final syllable
+          - text: останній склад
             correct: true
-          - text: first syllable
+          - text: перший склад
             correct: false
-          - text: every syllable equally
+          - text: усі склади однакові
             correct: false
         explanation: Вода́ is stressed on да́.
-      - prompt: In столи́ця, where is the stress?
+      - prompt: 'Слухай, потім читай: столи́ця. Де на́голос?'
         options:
-          - text: middle syllable
+          - text: середній склад
             correct: true
-          - text: first syllable
+          - text: перший склад
             correct: false
-          - text: final syllable
+          - text: останній склад
             correct: false
         explanation: Столи́ця is stressed on ли́.
-      - prompt: What should you do with unstressed vowels in молоко́?
+      - prompt: 'Молоко́: що робимо з ненаголошеними голосними?'
         options:
-          - text: Keep each vowel clear.
+          - text: тримаємо кожен голосни́й чистим
             correct: true
-          - text: Drop the first vowel.
+          - text: пропускаємо перший голосни́й
             correct: false
-          - text: Read every о as а.
+          - text: читаємо кожне о як а
             correct: false
         explanation: Ukrainian unstressed vowels stay clear.
   - id: act-2
     type: quiz
-    title: Melody choice
+    title: Вибір мелодики
     instruction: Choose the beginner sentence melody.
     items:
       - prompt: Це ка́ва.
         options:
-          - text: falling ↘
+          - text: спадна ↘
             correct: true
-          - text: rising ↗
+          - text: висхідна ↗
             correct: false
         explanation: A statement uses falling melody.
       - prompt: Це ка́ва?
         options:
-          - text: rising ↗
+          - text: висхідна ↗
             correct: true
-          - text: falling ↘
+          - text: спадна ↘
             correct: false
         explanation: A yes/no question uses rising melody.
       - prompt: Де метро́?
         options:
-          - text: falling ↘
+          - text: спадна ↘
             correct: true
-          - text: rising ↗
+          - text: висхідна ↗
             correct: false
         explanation: A question with де uses falling melody at A1.
       - prompt: Як га́рно!
         options:
-          - text: stronger falling ↘↘
+          - text: сильніша спадна ↘↘
             correct: true
-          - text: rising ↗
+          - text: висхідна ↗
             correct: false
         explanation: An exclamation uses a stronger falling contour.
   - id: act-3
     type: match-up
-    title: Stress changes meaning
+    title: На́голос змінює значення
     instruction: Match the stressed word with the English meaning.
     pairs:
       - left: за́мок
@@ -92,7 +92,7 @@ inline:
         right: musical instrument
   - id: act-4
     type: fill-in
-    title: Punctuation and melody
+    title: Пунктуація і мелодика
     instruction: Choose the punctuation mark that matches the sentence.
     items:
       - sentence: Це ка́ва_
@@ -132,38 +132,38 @@ inline:
         explanation: This is a statement.
 workbook:
   - type: error-correction
-    title: Fix stress-transfer traps
+    title: Виправ пастки наголосу
     instruction: Choose the safer Ukrainian reading habit.
     items:
-      - sentence: Keep all vowels clear in молоко́.
+      - sentence: Молоко́ — тримай усі голосні чистими.
         error: blurred first two vowels
         correction: мо-ло-ко́
         options:
           - мо-ло-ко́
           - blurred vowels
         explanation: Ukrainian vowels stay clear outside stress.
-      - sentence: Put stress on the -ме́тр part in кіломе́тр.
+      - sentence: Кіломе́тр — став на́голос на -ме́тр.
         error: кі́лометр
         correction: кіломе́тр
         options:
           - кіломе́тр
           - кі́лометр
         explanation: The prepared model is кіломе́тр.
-      - sentence: Notice mobile stress in кни́жка / книжки́.
+      - sentence: Кни́жка / книжки́ — помічай рухомий на́голос.
         error: кни́жки
         correction: книжки́
         options:
           - книжки́
           - кни́жки
         explanation: This plural model moves stress to the ending.
-      - sentence: Stress -на́- in одина́дцять.
+      - sentence: Одина́дцять — наголос на -на́-.
         error: о́динадцять
         correction: одина́дцять
         options:
           - одина́дцять
           - о́динадцять
         explanation: The A1 target has stress on -на́-.
-      - sentence: Stress -на́- in чотирна́дцять.
+      - sentence: Чотирна́дцять — наголос на -на́-.
         error: чоти́рнадцять
         correction: чотирна́дцять
         options:
@@ -171,48 +171,60 @@ workbook:
           - чоти́рнадцять
         explanation: The A1 target has stress on -на́-.
   - type: group-sort
-    title: Sort by stress position
+    title: Сортуй за наголосом
     instruction: Sort each word by the marked stressed syllable.
     groups:
-      - label: First syllable
+      - label: Перший склад
         items:
           - ма́ма
           - та́то
           - ра́нок
           - ка́ва
-      - label: Middle syllable
+      - label: Середній склад
         items:
           - столи́ця
           - люди́на
           - одина́дцять
           - чотирна́дцять
-      - label: Final syllable
+      - label: Останній склад
         items:
           - вода́
           - зима́
           - рука́
           - метро́
+  - type: match-up
+    title: Друк і зошит
+    instruction: Match the printed word to the notebook recognition cue.
+    pairs:
+      - left: 'друк: ка́ва'
+        right: 'зошит: stress on first syllable'
+      - left: 'друк: вода́'
+        right: 'зошит: stress on final syllable'
+      - left: 'друк: молоко́'
+        right: 'зошит: three clear о sounds'
+      - left: 'друк: метро́'
+        right: 'зошит: final stressed vowel'
   - type: true-false
-    title: Stress and melody facts
+    title: Факти про наголос і мелодику
     instruction: Choose true or false.
     items:
-      - statement: Ukrainian stress can fall on different syllables.
+      - statement: Український на́голос може бути на різних складах.
         correct: true
         explanation: Stress is free, so learn it with each word.
-      - statement: Ordinary Ukrainian texts usually mark every stress.
+      - statement: Звичайні українські тексти завжди мають позначки наголосу.
         correct: false
         explanation: Stress marks appear in learning materials and dictionaries, not most ordinary texts.
-      - statement: A yes/no question such as Це вода́? rises at A1.
+      - statement: Так/ні питання Це вода́? має висхідну мелодику на A1.
         correct: true
         explanation: Yes/no questions use rising melody.
-      - statement: A question with де always needs rising melody at A1.
+      - statement: Питання з де завжди потребує висхідної мелодики на A1.
         correct: false
         explanation: A question with a question word such as де uses falling melody.
   - type: translate
-    title: New stress words
-    instruction: Choose the English meaning.
+    title: Слова з наголосом
+    instruction: Choose the English support meaning after reading the Ukrainian first.
     items:
-      - source: наголос
+      - source: на́голос
         options:
           - text: stress / accent
             correct: true
@@ -220,7 +232,7 @@ workbook:
             correct: false
           - text: water
             correct: false
-        explanation: Наголос means word stress or accent.
+        explanation: На́голос means word stress or accent.
       - source: ка́ва
         options:
           - text: coffee

--- a/curriculum/l2-uk-en/a1/stress-and-melody/module.md
+++ b/curriculum/l2-uk-en/a1/stress-and-melody/module.md
@@ -1,60 +1,73 @@
-# Stress and Melody
+# Наголос і мелодика
 
-This module teaches two things you cannot see in ordinary Ukrainian spelling:
-word stress and sentence melody. A printed word usually does not show stress.
-A printed sentence shows only a small clue: **.**, **?**, or **!**. Your job
-today is to build a slow, reliable reading habit.
+**ка́ва. вода́. Це ка́ва? Де метро́?** — stress and sentence melody.
 
-Keep the target modest. You are not memorizing every stress pattern in
-Ukrainian. You are learning why stress matters, how to read prepared words with
-stress marks, and how to use three beginner sentence melodies.
+First listen, then read. Use the lawful public resource already listed for
+this module: [ULP Season 1, Episode 5 — Pronunciation
+Trainer](https://www.ukrainianlessons.com/episode5/). Open the page, listen
+for the stress practice, and repeat short model words. Do not download,
+transcribe, remix, or reuse the audio; this lesson only links to it for
+listening support.
+
+Today you are not memorizing every stress pattern in Ukrainian. You are
+learning why stress matters, how to read prepared words with stress marks, and
+how to use three beginner sentence melodies.
 
 By the end, you can:
 
-- explain that **наголос** means word stress;
-- read prepared A1 words such as **ка́ва**, **вода́**, **ра́нок**, and
-  **метро́** with the marked syllable stronger and a little longer;
-- avoid reducing clear Ukrainian vowels in unstressed syllables;
+- explain **на́голос** — word stress;
+- read **ка́ва**, **вода́**, **ра́нок**, and **метро́** with the marked syllable
+  stronger and a little longer;
+- keep Ukrainian vowels clear outside stress;
 - recognize pairs where stress changes meaning, such as **за́мок** and
   **замо́к**;
 - use falling melody for statements, rising melody for yes/no questions, and
   falling melody for questions with **хто**, **що**, **де**, **коли**, or
   **як**;
-- read a short greeting dialogue with a Ukrainian-centered rhythm.
+- read a short greeting dialogue with Ukrainian rhythm.
 
-## Stress
+## Наголос
 
-**Наголос** is the syllable you say with more force and a little more length.
+**ка́ва. вода́. молоко́.** Listen first, then read the marks.
+
+**На́голос** is the syllable you say with more force and a little more length.
 In learning materials, this course marks it with an accent: **ка́ва**,
-**вода́**, **молоко́**. In normal Ukrainian texts, the mark is usually absent,
-so you learn stress as part of each new word.
+**вода́**, **молоко́**. In ordinary Ukrainian texts, the mark is usually
+absent, so you learn stress as part of each new word.
 
-Ukrainian stress is free. That means it can fall near the beginning, middle, or
-end of a word. Compare these prepared words:
+Use this listening pass before the table:
+
+1. Open the linked ULP Episode 5 page.
+2. Listen for one short stress model.
+3. Without reading the English support, point to the stronger syllable in the
+   marked word.
+4. Repeat the word once.
+
+Ukrainian stress is free. It can fall near the beginning, middle, or end of a
+word.
 
 | Model | Read it slowly |
 | --- | --- |
 | first syllable | **ма́ма**, **та́то**, **ра́нок**, **ка́ва**, **кни́га** |
 | final syllable | **вода́**, **зима́**, **рука́**, **метро́**, **кафе́** |
-| middle syllable | **столи́ця**, **люди́на**, **оди́надцять** |
+| middle syllable | **столи́ця**, **люди́на**, **одина́дцять** |
 
 There is no useful shortcut for A1 learners. Treat stress as part of the word,
 just like spelling. When you add a word to your notebook, add its stress too:
 **ка́ва**, not just кава.
 
 A second habit matters just as much: do not blur unstressed vowels. In
-**молоко́**, the first two **о** sounds stay Ukrainian **о**. They are lighter
-than the stressed final **о**, but they do not become a neutral sound. Read
-slowly first: **мо-ло-ко́**. Keep every vowel clear, then speed up.
+**молоко́**, the first two **о** sounds stay **о**. They are lighter than the
+stressed final **о**, but they stay clear. Read slowly first:
+**мо-ло-ко́**. Keep every vowel clear, then speed up.
 
 Some Ukrainian words move stress when the form changes. For now, only notice
-the idea. A word like **кни́жка** can become **книжки́** in plural. That is a
-future grammar habit, but you can already hear that Ukrainian stress can move.
+the idea. **кни́жка** can become **книжки́** in plural. That is a future
+grammar habit, but you can already hear that Ukrainian stress can move.
 
-Stress can also change meaning. These pairs look the same until you hear the
-stress:
+Stress can also change meaning:
 
-| Pair | Meaning |
+| Pair | English support |
 | --- | --- |
 | **за́мок** | castle |
 | **замо́к** | lock |
@@ -68,7 +81,9 @@ and check a dictionary such as goroh.pp.ua when you are unsure.
 
 <!-- INJECT_ACTIVITY: act-1 -->
 
-## Intonation
+## Мелодика
+
+**Це ка́ва. Це ка́ва? Як га́рно!** — same words can carry different melody.
 
 **Мелодика** is the movement of the voice across a whole sentence. For A1, use
 three safe models:
@@ -79,9 +94,8 @@ three safe models:
 | yes/no question | **Це ка́ва?** | rising **↗** |
 | exclamation | **Як га́рно!** | stronger falling **↘↘** |
 
-The same words can change intent when the melody changes. **Це ка́ва.** tells
-someone what it is. **Це ка́ва?** asks for confirmation. The punctuation helps
-you choose the melody, but your voice must still do the work.
+The punctuation helps you choose the melody, but your voice must still do the
+work.
 
 Now add the most important beginner exception. A question with a question word
 usually falls, not rises:
@@ -104,17 +118,16 @@ But a yes/no question rises:
 Logical stress is the important word inside the sentence. In **Це ка́ва?**,
 you can make **ка́ва** the important word if you are checking the object. In
 **А у те́бе?**, the important part is **те́бе** because you are turning the
-question back to the other person. At A1, do not overthink it. Mark the
-important word, then let the question melody rise or fall according to the
-sentence type.
+question back to the other person.
 
-Keep the explanation Ukrainian-centered. Do not compare Ukrainian rhythm to
-another language as the main teaching tool. Listen to the Ukrainian words,
-notice the stress, and copy the contour.
+Keep the explanation Ukrainian-centered. Listen to the Ukrainian words, notice
+the stress, and copy the contour.
 
 <!-- INJECT_ACTIVITY: act-2 -->
 
-## Reading Aloud
+## Читаємо вголос
+
+**украї́нська. фотогра́фія. відпочи́нок.**
 
 Use this three-step routine for longer words:
 
@@ -132,11 +145,9 @@ Practice:
 | **одина́дцять** | the **на́** part is strongest |
 | **чотирна́дцять** | the **на́** part is strongest |
 
-For the full number words below, put stress on **на́**:
-**одина́дцять**, **чотирна́дцять**. This protects you from the common habit of
-pulling stress to the first syllable. When you write these in your notebook,
+For the number words below, put stress on **на́**:
+**одина́дцять**, **чотирна́дцять**. When you write these in your notebook,
 write the full word with the stress mark, then underline only the strong part.
-That keeps the spelling intact while still making the sound pattern visible.
 
 :::tip
 For this module, a stress mark is a training wheel. It is not usually printed
@@ -144,30 +155,53 @@ in ordinary Ukrainian texts, but it helps your eyes remember the sound until
 the word becomes familiar.
 :::
 
-Read the small dialogue from Module 1 with melody:
+Read the Ukrainian dialogue first:
 
-<DialogueBox uk="О́ля: Приві́т! ↘" en="Olia: Hi!" />
-<DialogueBox uk="Тара́с: Приві́т! Як спра́ви? ↘" en="Taras: Hi! How are things?" />
-<DialogueBox uk="О́ля: До́бре! А у те́бе? ↗" en="Olia: Good! And you?" />
-<DialogueBox uk="Тара́с: До́бре! ↘" en="Taras: Good!" />
+```text
+О́ля: Приві́т! ↘
+Тара́с: Приві́т! Як спра́ви? ↘
+О́ля: До́бре! А у те́бе? ↗
+Тара́с: До́бре! ↘
+```
+
+Support after the dialogue:
+
+| Українська | English support |
+| --- | --- |
+| **Приві́т!** | Hi! |
+| **Як спра́ви?** | How are things? |
+| **До́бре!** | Good! |
+| **А у те́бе?** | And you? |
 
 Notice two details. **Як спра́ви?** has the question word **як**, so the
 beginner model is falling. **А у те́бе?** is a yes/no-style return question, so
-it rises. Keep every vowel clear in **Приві́т**, **До́бре**, and **те́бе**.
+it rises.
 
-Now read a second tiny exchange. It uses the same words, but the punctuation
-changes your melody:
+Now read a second tiny exchange:
 
-<DialogueBox uk="О́ля: Це ка́ва. ↘" en="Olia: This is coffee." />
-<DialogueBox uk="Тара́с: Це ка́ва? ↗" en="Taras: Is this coffee?" />
-<DialogueBox uk="О́ля: Так, це ка́ва. ↘" en="Olia: Yes, this is coffee." />
-<DialogueBox uk="Тара́с: Де вода́? ↘" en="Taras: Where is the water?" />
-<DialogueBox uk="О́ля: Ось вода́. ↘" en="Olia: Here is water." />
-<DialogueBox uk="Тара́с: Як га́рно! ↘↘" en="Taras: How nice!" />
+```text
+О́ля: Це ка́ва. ↘
+Тара́с: Це ка́ва? ↗
+О́ля: Так, це ка́ва. ↘
+Тара́с: Де вода́? ↘
+О́ля: Ось вода́. ↘
+Тара́с: Як га́рно! ↘↘
+```
+
+Support after the dialogue:
+
+| Українська | English support |
+| --- | --- |
+| **Це ка́ва.** | This is coffee. |
+| **Це ка́ва?** | Is this coffee? |
+| **Так, це ка́ва.** | Yes, this is coffee. |
+| **Де вода́?** | Where is the water? |
+| **Ось вода́.** | Here is water. |
+| **Як га́рно!** | How nice! |
 
 <!-- INJECT_ACTIVITY: act-3 -->
 
-Common L2 traps now become workbook habits:
+Common traps now become workbook habits:
 
 | Trap | Safer Ukrainian habit |
 | --- | --- |
@@ -181,22 +215,45 @@ Common L2 traps now become workbook habits:
 You do not need to produce all of these words fluently today. You need to
 recognize the safer habit and avoid building the wrong one.
 
-## Textbook Check
+## Друк, зошит, голос
+
+**Друк:** **ка́ва**, **вода́**, **молоко́**, **метро́**.
+
+**Зошит:** the same known words written by you, a teacher, or a tutor with the
+stress mark preserved.
+
+Recognition comes before fast writing. Match the notebook word to the printed
+word, then read it aloud with the stress and melody.
+
+| Друк | Notebook recognition prompt |
+| --- | --- |
+| **ка́ва** | Which notebook word has stress on the first syllable? |
+| **вода́** | Which notebook word has stress on the final syllable? |
+| **молоко́** | Which notebook word keeps all three **о** sounds clear? |
+| **метро́** | Which notebook word ends with the stressed vowel? |
+
+## Перевірка
 
 Before you leave the lesson tab, check four things aloud:
 
-- What is **наголос**?
+- What is **на́голос**?
 - Can stress change meaning? Say **за́мок** and **замо́к**.
 - Which melody do you use for **Це апте́ка?**
 - Which melody do you use for **Де метро́?**
 
 Final reading:
 
-<DialogueBox uk="Це апте́ка? ↗" en="Is this a pharmacy?" />
-<DialogueBox uk="Так, це апте́ка. ↘" en="Yes, this is a pharmacy." />
-<DialogueBox uk="Як га́рно! ↘↘" en="How nice!" />
+```text
+О́ля: Це апте́ка? ↗
+Тара́с: Так, це апте́ка. ↘
+О́ля: Як га́рно! ↘↘
+```
 
-The workbook adds extra practice with the same skills: clear-vowel error
-correction, stress sorting, quick facts, and word recognition.
+Ask a native Ukrainian teacher or tutor to listen to one read-aloud from this
+module. The feedback target is narrow: stress, clear vowels, and the direction
+of the sentence melody.
+
+The workbook adds extra practice with the same skills: clear-vowel repair,
+stress sorting, quick facts, and word recognition.
 
 <!-- INJECT_ACTIVITY: act-4 -->


### PR DESCRIPTION
## Summary
- retrofit A1 M1-M4 lesson tabs toward the Anna Ohoiko / ULP S1 Ukrainian-first pattern
- replace interleaved DialogueBox glossing with Ukrainian-only dialogues followed by support tables
- add lawful listening paths plus print/notebook recognition support across the literacy/pronunciation slice
- keep activity YAML in V2 inline/workbook shape with inline marker parity

Refs #2714

## Validation
- .venv/bin/python scripts/generate_mdx.py l2-uk-en a1 N --validate for N=1,2,3,4
- .venv/bin/python -m pytest -q tests/test_yaml_activities.py tests/test_generate_mdx.py tests/test_activity_helpers_flatten.py tests/test_yaml_activities_v7_types.py
- /Users/krisztiankoos/projects/learn-ukrainian/node_modules/.bin/prettier --check four changed activities.yaml files
- /Users/krisztiankoos/projects/learn-ukrainian/node_modules/.bin/markdownlint-cli2 --no-globs four changed module.md files
- git diff --check
- .venv/bin/python scripts/audit/lint_agent_trailer.py

## Gate Notes
- no generated status/audit/review/MDX artifacts included
- no .python-version, .yamllint, or .markdownlint.json changes
- activity files remain root-level inline/workbook, no activities wrapper
- workbook-only translation retained where used