### PR TITLE
fix(a1): align M5-M7 with Ohoiko pattern

### DIFF
--- a/curriculum/l2-uk-en/a1/checkpoint-first-contact/activities.yaml
+++ b/curriculum/l2-uk-en/a1/checkpoint-first-contact/activities.yaml
@@ -1,10 +1,10 @@
 inline:
   - id: act-1
     type: quiz
-    title: First-contact readiness
-    instruction: Choose the safe Ukrainian line for the checkpoint situation.
+    title: Готовність до знайомства
+    instruction: Обери безпечний український рядок для ситуації.
     items:
-      - prompt: You greet a peer at the start of class.
+      - prompt: Ти вітаєш ровесника на початку заняття.
         options:
           - text: Привіт!
             correct: true
@@ -12,8 +12,8 @@ inline:
             correct: false
           - text: Мені теж.
             correct: false
-        explanation: Привіт is the informal peer greeting.
-      - prompt: You greet a teacher or administrator neutrally.
+        explanation: Привіт — неформальне привітання для ровесника.
+      - prompt: Ти нейтрально вітаєш викладача або адміністратора.
         options:
           - text: Добрий день!
             correct: true
@@ -21,8 +21,8 @@ inline:
             correct: false
           - text: Мене звати!
             correct: false
-        explanation: Добрий день is the safe neutral formal greeting.
-      - prompt: You introduce your name.
+        explanation: Добрий день — безпечне нейтральне формальне привітання.
+      - prompt: Ти називаєш своє ім'я.
         options:
           - text: Мене звати Олена.
             correct: true
@@ -30,8 +30,8 @@ inline:
             correct: false
           - text: Я звати Олена.
             correct: false
-        explanation: Мене звати... is the canonical first-name chunk.
-      - prompt: You say that you are a student.
+        explanation: Мене звати... — головний блок для імені.
+      - prompt: Ти кажеш, що ти студент.
         options:
           - text: Я студент.
             correct: true
@@ -39,8 +39,8 @@ inline:
             correct: false
           - text: Мене студент.
             correct: false
-        explanation: Ukrainian usually omits the present-tense copula in this identity line.
-      - prompt: You say your age.
+        explanation: У такому реченні українська зазвичай не додає є.
+      - prompt: Ти кажеш свій вік.
         options:
           - text: Мені 20 років.
             correct: true
@@ -48,8 +48,8 @@ inline:
             correct: false
           - text: Я 20 роки.
             correct: false
-        explanation: Age uses Мені ... років.
-      - prompt: You close the first meeting politely.
+        explanation: Вік подаємо блоком Мені ... років.
+      - prompt: Ти ввічливо завершуєш перше знайомство.
         options:
           - text: Дуже приємно. До побачення!
             correct: true
@@ -57,11 +57,11 @@ inline:
             correct: false
           - text: Звідки ти? Мені теж!
             correct: false
-        explanation: Дуже приємно and До побачення close the exchange.
+        explanation: Дуже приємно і До побачення завершують розмову.
   - id: act-2
     type: match-up
-    title: Questions and answers
-    instruction: Match each first-contact question with the natural answer.
+    title: Питання і відповіді
+    instruction: З'єднай питання з природною відповіддю.
     pairs:
       - left: Як тебе звати?
         right: Мене звати Богдан.
@@ -81,8 +81,8 @@ inline:
         right: Мені теж.
   - id: act-3
     type: fill-in
-    title: Complete the review text
-    instruction: Choose the missing word or chunk in the self-introduction.
+    title: Доповни текст
+    instruction: Обери пропущене слово або блок у самопрезентації.
     items:
       - sentence: Привіт! ___ звати Марко.
         answer: Мене
@@ -90,121 +90,121 @@ inline:
           - Мене
           - Моє
           - Мій
-        explanation: Мене звати... is the safe name chunk.
+        explanation: Мене звати... — безпечний блок для імені.
       - sentence: Моє ___ Коваленко.
         answer: прізвище
         options:
           - прізвище
           - фамілія
           - професія
-        explanation: Прізвище is the standard Ukrainian word for surname.
+        explanation: Прізвище — стандартне українське слово для surname.
       - sentence: Я ___ Києва.
         answer: з
         options:
           - з
           - у
           - це
-        explanation: Я з... gives origin.
+        explanation: Я з... дає походження.
       - sentence: Я ___.
         answer: студент
         options:
           - студент
           - є студент
           - мене студент
-        explanation: The A1 identity sentence does not need є.
+        explanation: A1-речення ідентичності не потребує є.
       - sentence: ___ 20 років.
         answer: Мені
         options:
           - Мені
           - Я маю
           - Мене
-        explanation: Age uses Мені ... років.
+        explanation: Вік подаємо блоком Мені ... років.
       - sentence: У мене ___ сестра.
         answer: є
         options:
           - є
           - звати
           - з
-        explanation: У мене є... is the I-have chunk.
+        explanation: У мене є... — блок для "I have".
       - sentence: Це ___ мама.
         answer: моя
         options:
           - моя
           - мій
           - моє
-        explanation: Мама is feminine, so use моя.
+        explanation: Мама — жіночого роду, тому моя.
       - sentence: Дуже ___ познайомитися!
         answer: приємно
         options:
           - приємно
           - прізвище
           - звати
-        explanation: Дуже приємно познайомитися closes a first meeting.
+        explanation: Дуже приємно познайомитися завершує знайомство.
   - id: act-4
     type: quiz
-    title: Fix common A1.1 traps
-    instruction: Choose the normative Ukrainian form.
+    title: Виправ A1.1 пастки
+    instruction: Обери нормативну українську форму.
     items:
-      - prompt: Name introduction
+      - prompt: Представлення імені
         options:
           - text: Мене звати Джон.
             correct: true
           - text: Моє ім'я є Джон.
             correct: false
-        explanation: Ukrainian introduces a name with Мене звати...
-      - prompt: Identity sentence
+        explanation: Українська представляє ім'я через Мене звати...
+      - prompt: Речення ідентичності
         options:
           - text: Я студент.
             correct: true
           - text: Я є студент.
             correct: false
-        explanation: Present identity normally omits є.
-      - prompt: Age sentence
+        explanation: Теперішня ідентичність зазвичай не додає є.
+      - prompt: Речення про вік
         options:
           - text: Мені 20 років.
             correct: true
           - text: Я маю 20 років.
             correct: false
-        explanation: Age uses Мені ... років.
-      - prompt: Direct address
+        explanation: Вік подаємо блоком Мені ... років.
+      - prompt: Пряме звертання
         options:
           - text: Привіт, Максиме!
             correct: true
           - text: Привіт, Максим!
             correct: false
-        explanation: Direct address uses the vocative form in the safe example.
-      - prompt: Safe greeting
+        explanation: Пряме звертання має кличну форму в безпечному прикладі.
+      - prompt: Безпечне привітання
         options:
           - text: Добрий день! Мене звати Оксана.
             correct: true
           - text: Здрастуйте! Мене звати Оксана.
             correct: false
-        explanation: Добрий день is the safe standard greeting.
-      - prompt: Surname
+        explanation: Добрий день — безпечне стандартне привітання.
+      - prompt: Прізвище
         options:
           - text: Моє прізвище Сміт.
             correct: true
           - text: Моя фамілія Сміт.
             correct: false
-        explanation: Прізвище is the standard Ukrainian word for surname.
-      - prompt: Farewell
+        explanation: Прізвище — стандартне українське слово.
+      - prompt: Прощання
         options:
           - text: До побачення!
             correct: true
           - text: Пока!
             correct: false
-        explanation: До побачення is the safe standard farewell.
-      - prompt: Noun gender habit
+        explanation: До побачення — безпечне стандартне прощання.
+      - prompt: Звичка до роду іменника
         options:
           - text: Вивчення слова разом із його родом
             correct: true
           - text: Ігнорування роду іменника
             correct: false
-        explanation: Store a Ukrainian noun with its gender cues from the beginning.
+        explanation: Запам'ятовуй український іменник разом із підказками роду.
   - id: act-5
     type: fill-in
-    title: Full dialogue blanks
-    instruction: Complete the peer language-course dialogue.
+    title: Пропуски в діалозі
+    instruction: Доповни діалог на мовних курсах.
     items:
       - sentence: ___! Мене звати Богдан.
         answer: Привіт
@@ -212,62 +212,62 @@ inline:
           - Привіт
           - Прізвище
           - Років
-        explanation: Привіт opens a peer exchange.
+        explanation: Привіт відкриває розмову ровесників.
       - sentence: Привіт, ___! Мене звати Соломія.
         answer: Богдане
         options:
           - Богдане
           - Богдан
           - Богдана
-        explanation: Богдане is the vocative direct-address form.
+        explanation: Богдане — клична форма прямого звертання.
       - sentence: Дуже приємно, ___.
         answer: Соломіє
         options:
           - Соломіє
           - Соломія
           - Соломію
-        explanation: Соломіє is the vocative direct-address form.
+        explanation: Соломіє — клична форма прямого звертання.
       - sentence: ___ ти? Я з Дніпра.
         answer: Звідки
         options:
           - Звідки
           - Хто
           - Чий
-        explanation: Звідки ти? asks where someone is from.
+        explanation: Звідки ти? питає, звідки людина.
       - sentence: Моя майбутня ___ — вчителька.
         answer: професія
         options:
           - професія
           - прізвище
           - адреса
-        explanation: Професія names a profession or occupation.
+        explanation: Професія називає фах або заняття.
       - sentence: У мене є сестра. ___ звати Ірина.
         answer: Її
         options:
           - Її
           - Його
           - Я
-        explanation: Її fits a sister.
+        explanation: Її підходить до сестри.
       - sentence: У мене є брат. ___ звати Назар.
         answer: Його
         options:
           - Його
           - Її
           - Вона
-        explanation: Його fits a brother.
+        explanation: Його підходить до брата.
       - sentence: Дуже приємно ___!
         answer: познайомитися
         options:
           - познайомитися
           - походження
           - допомогти
-        explanation: Дуже приємно познайомитися is a first-meeting closure.
+        explanation: Дуже приємно познайомитися завершує першу зустріч.
   - id: act-6
     type: quiz
-    title: Put the meeting in order
-    instruction: Choose the next line in the first-contact exchange.
+    title: Порядок знайомства
+    instruction: Обери наступний рядок у розмові.
     items:
-      - prompt: 'Opening line: Привіт! Мене звати Богдан.'
+      - prompt: 'Перший рядок: Привіт! Мене звати Богдан.'
         options:
           - text: Привіт, Богдане! Мене звати Соломія.
             correct: true
@@ -275,8 +275,8 @@ inline:
             correct: false
           - text: Мені 20 років.
             correct: false
-        explanation: The other person answers with a greeting and name.
-      - prompt: 'Line: Дуже приємно, Соломіє.'
+        explanation: Інша людина відповідає привітанням та іменем.
+      - prompt: 'Рядок: Дуже приємно, Соломіє.'
         options:
           - text: Мені теж. Звідки ти?
             correct: true
@@ -284,8 +284,8 @@ inline:
             correct: false
           - text: Це моя гривня.
             correct: false
-        explanation: Мені теж gives the reciprocal answer and keeps the exchange moving.
-      - prompt: 'Line: Я з Дніпра. А ти?'
+        explanation: Мені теж дає взаємну відповідь і рухає розмову далі.
+      - prompt: 'Рядок: Я з Дніпра. А ти?'
         options:
           - text: Я з Тернополя.
             correct: true
@@ -293,8 +293,8 @@ inline:
             correct: false
           - text: Це мій брат.
             correct: false
-        explanation: A ти? asks the same origin question back.
-      - prompt: 'Line: У мене є брат.'
+        explanation: А ти? повертає питання про походження.
+      - prompt: 'Рядок: У мене є брат.'
         options:
           - text: Дуже приємно. До побачення!
             correct: true
@@ -302,11 +302,11 @@ inline:
             correct: false
           - text: Я маю брат років.
             correct: false
-        explanation: A polite closing fits after the family line.
+        explanation: Після родинного рядка пасує ввічливе завершення.
 workbook:
   - type: quiz
-    title: Checkpoint quick translation
-    instruction: Choose the English meaning of each Ukrainian line.
+    title: Швидкий переклад
+    instruction: Обери англійське значення кожного українського рядка.
     items:
       - prompt: Мене звати Олена.
         options:
@@ -363,8 +363,8 @@ workbook:
             correct: false
         explanation: Мені теж gives the reciprocal answer.
   - type: match-up
-    title: Review vocabulary map
-    instruction: Match the Ukrainian checkpoint word with its English cue.
+    title: Карта лексики
+    instruction: З'єднай українське контрольне слово з англійською підказкою.
     pairs:
       - left: ім'я
         right: first name
@@ -383,8 +383,8 @@ workbook:
       - left: адреса
         right: address
   - type: fill-in
-    title: Digital chat etiquette
-    instruction: Complete the short course-chat exchange.
+    title: Етикет у чаті
+    instruction: Доповни коротку розмову в чаті курсу.
     items:
       - sentence: ___! Мене звати Ліна.
         answer: Привіт

--- a/curriculum/l2-uk-en/a1/checkpoint-first-contact/activities.yaml
+++ b/curriculum/l2-uk-en/a1/checkpoint-first-contact/activities.yaml
@@ -97,7 +97,7 @@ inline:
           - прізвище
           - фамілія
           - професія
-        explanation: Прізвище — стандартне українське слово для surname.
+        explanation: Прізвище — стандартне українське слово для родового імені.
       - sentence: Я ___ Києва.
         answer: з
         options:
@@ -111,7 +111,7 @@ inline:
           - студент
           - є студент
           - мене студент
-        explanation: A1-речення ідентичності не потребує є.
+        explanation: Речення A1 про ідентичність не потребує є.
       - sentence: ___ 20 років.
         answer: Мені
         options:
@@ -125,7 +125,7 @@ inline:
           - є
           - звати
           - з
-        explanation: У мене є... — блок для "I have".
+        explanation: У мене є... — блок, щоб сказати, що хтось або щось є в мене.
       - sentence: Це ___ мама.
         answer: моя
         options:
@@ -316,7 +316,7 @@ workbook:
             correct: false
           - text: Olena is my surname.
             correct: false
-        explanation: Мене звати... gives a name.
+        explanation: Мене звати... називає ім'я.
       - prompt: Моє прізвище Мельник.
         options:
           - text: My surname is Melnyk.
@@ -325,7 +325,7 @@ workbook:
             correct: false
           - text: My family is Melnyk.
             correct: false
-        explanation: Прізвище means surname.
+        explanation: Прізвище означає родове ім'я.
       - prompt: Я з Канади.
         options:
           - text: I am from Canada.
@@ -334,7 +334,7 @@ workbook:
             correct: false
           - text: I have Canada.
             correct: false
-        explanation: Я з... gives origin.
+        explanation: Я з... подає походження.
       - prompt: Я студентка.
         options:
           - text: I am a female student.
@@ -343,7 +343,7 @@ workbook:
             correct: false
           - text: My name is student.
             correct: false
-        explanation: Identity uses the noun directly here.
+        explanation: У цьому реченні ідентичність виражена іменником без є.
       - prompt: У мене є сестра.
         options:
           - text: I have a sister.
@@ -352,7 +352,7 @@ workbook:
             correct: false
           - text: This is my sister.
             correct: false
-        explanation: У мене є... is the I-have chunk.
+        explanation: У мене є... — блок для наявності.
       - prompt: Мені теж.
         options:
           - text: Me too.
@@ -361,7 +361,7 @@ workbook:
             correct: false
           - text: Goodbye.
             correct: false
-        explanation: Мені теж gives the reciprocal answer.
+        explanation: Мені теж дає взаємну відповідь.
   - type: match-up
     title: Карта лексики
     instruction: З'єднай українське контрольне слово з англійською підказкою.
@@ -392,32 +392,32 @@ workbook:
           - Привіт
           - Пока
           - Прізвище
-        explanation: Привіт opens an informal chat.
+        explanation: Привіт відкриває неформальний чат.
       - sentence: Я ___ Одеси.
         answer: з
         options:
           - з
           - є
           - моя
-        explanation: Я з... gives origin.
+        explanation: Я з... подає походження.
       - sentence: Привіт, ___!
         answer: Ліно
         options:
           - Ліно
           - Ліна
           - Ліну
-        explanation: Ліно is the vocative form in direct address.
+        explanation: Ліно — клична форма прямого звертання.
       - sentence: Дуже ___!
         answer: приємно
         options:
           - приємно
           - професія
           - адреса
-        explanation: Дуже приємно is a polite first-contact response.
+        explanation: Дуже приємно — ввічлива відповідь під час першого знайомства.
       - sentence: Мені ___.
         answer: теж
         options:
           - теж
           - звати
           - словник
-        explanation: Мені теж means me too.
+        explanation: Мені теж означає взаємну відповідь.

--- a/curriculum/l2-uk-en/a1/checkpoint-first-contact/module.md
+++ b/curriculum/l2-uk-en/a1/checkpoint-first-contact/module.md
@@ -1,4 +1,7 @@
-# Checkpoint: First Contact
+# Підсумок: перший контакт
+
+**Приві́т! Мене́ зва́ти Богдан. Я з Дніпра́.** — Hi! My name is Bohdan.
+I am from Dnipro.
 
 This checkpoint is a working rehearsal for the first six modules. Nothing here
 needs a new grammar rule. You are checking whether the first-contact pieces can
@@ -21,22 +24,13 @@ By the end, you can:
 
 The checkpoint keeps a Ukrainian-first frame. Ukrainian letters, stress, and
 soft signs are explained as Ukrainian habits. The page never asks you to compare
-them to Russian letters or Russian pronunciation. Russian-influenced greetings
-and calques appear only as wrong choices inside correction practice.
+them to Russian letters or Russian pronunciation. Non-target greetings and
+calques appear only as wrong choices inside correction practice.
 
 The roadmap behind this checkpoint has six learner steps: sound and alphabet
 control, greeting chunks, self-introduction, noun gender habits, vocative
 address, and modern chat etiquette. Use that order as a checklist, not as new
 grammar to memorize.
-
-<!--
-Крок 1: Базова фонетика та українська абетка.
-Крок 2: Етикетні формули вітання та прощання як монолітні блоки; чунки; Доброго ранку; завершувати етикетними фразами на кшталт «Радий/а знайомству».
-Крок 3: Алгоритм знайомства та базова самопрезентація; якщо представляєтеся самі, чітко назвіть своє повне ім’я та прізвище; Як ся маєш?; Як ваші справи?
-Крок 4: Категорія роду українських іменників.
-Крок 5: Запровадження кличного відмінка як вияву глибокої поваги; А1; самобутньою ознакою української мови; особливість кличного відмінка; у яких життєвих ситуаціях ми використовуємо іменники в кличному відмінку.
-Крок 6: Адаптація до сучасних цифрових засобів комунікації та іншомовної лексики; спілкуватися будь з ким на великій відстані; розширення політичних, економічних і культурних зв’язків України з іноземними (передовсім з англомовними) країнами.
--->
 
 <!-- INJECT_ACTIVITY: act-1 -->
 
@@ -44,14 +38,14 @@ grammar to memorize.
 
 You now have six small toolkits.
 
-| Toolkit | You can do this now |
+| Опора | Що ти вже робиш |
 | --- | --- |
-| Sounds and letters | recognize Ukrainian letters, vowels, **ґ**, **ї**, **є**, **и**, **і**, **ь**, and the apostrophe |
-| Reading | read short words and syllables slowly but confidently |
-| Special signs | hear that **сім'я**, **бур'ян**, and **день** are not spelled decoration; the sign changes the sound |
-| Stress and melody | mark the stressed syllable and use a rising yes/no question melody |
-| Who am I? | say your name, origin, nationality, profession, and age |
-| My family | name close family members and use **У мене є...** |
+| **Звуки́ й лі́тери** | recognize Ukrainian letters, vowels, **ґ**, **ї**, **є**, **и**, **і**, **ь**, and the apostrophe |
+| **Чита́ння** | read short words and syllables slowly but confidently |
+| **Спеціа́льні зна́ки** | hear that **сім'я́**, **бур'я́н**, and **день** are not spelled decoration |
+| **На́голос і мело́дія** | mark the stressed syllable and use a rising yes/no question melody |
+| **Хто я?** | say your name, origin, nationality, profession, and age |
+| **Моя́ сім'я́** | name close family members and use **У ме́не є...** |
 
 A checkpoint is not a memory trick. It is a task: can you meet one new person
 and keep the exchange moving? Use short sentences. Use the chunks exactly. If
@@ -59,17 +53,17 @@ you hesitate, return to the sentence frame instead of translating from English.
 
 Keep these blocks as whole blocks:
 
-| English need | Ukrainian block |
+| Український блок | English support |
 | --- | --- |
-| What is your name? | **Як тебе звати?** |
-| My name is... | **Мене звати...** |
-| Nice to meet you. | **Дуже приємно.** |
-| Me too. | **Мені теж.** |
-| Where are you from? | **Звідки ти?** |
-| I am from... | **Я з...** |
-| I am a student. | **Я студент / студентка.** |
-| I am 20 years old. | **Мені 20 років.** |
-| I have... | **У мене є...** |
+| **Як тебе́ зва́ти?** | What is your name? |
+| **Мене́ зва́ти...** | My name is... |
+| **Ду́же приє́мно.** | Nice to meet you. |
+| **Мені́ теж.** | Me too. |
+| **Зві́дки ти?** | Where are you from? |
+| **Я з...** | I am from... |
+| **Я студе́нт / студе́нтка.** | I am a student. |
+| **Мені́ 20 ро́ків.** | I am 20 years old. |
+| **У ме́не є...** | I have... |
 
 Formal address still exists, but this checkpoint uses a peer language-course
 setting, so the main dialogue stays in **ти**. Do not mix **ти** and **Ви** in
@@ -89,15 +83,27 @@ Read this text aloud. Use the letter and stress habits from the script modules.
 The content is only the A1.1 world: name, place, role, family, and a simple
 closing.
 
-<DialogueBox uk="Привіт! Мене звати Марко." en="Hi! My name is Marko." />
-<DialogueBox uk="Моє прізвище Коваленко." en="My surname is Kovalenko." />
-<DialogueBox uk="Я з Києва, але зараз я студент у Львові." en="I am from Kyiv, but now I am a student in Lviv." />
-<DialogueBox uk="Мені 20 років." en="I am 20 years old." />
-<DialogueBox uk="Моя професія зараз — студент." en="My profession or role now is student." />
-<DialogueBox uk="У мене є мама, тато і сестра." en="I have a mom, a dad, and a sister." />
-<DialogueBox uk="Моя мама — вчителька, а мій тато — інженер." en="My mom is a teacher, and my dad is an engineer." />
-<DialogueBox uk="Мою сестру звати Оля." en="My sister's name is Olia." />
-<DialogueBox uk="Дуже приємно познайомитися!" en="Very nice to meet you!" />
+```text
+Приві́т! Мене́ зва́ти Марко́.
+Моє́ прі́звище Ковале́нко.
+Я з Ки́єва, але́ за́раз я студе́нт у Льво́ві.
+Мені́ 20 ро́ків.
+Моя́ профе́сія за́раз — студе́нт.
+У ме́не є ма́ма, та́то і сестра́.
+Моя́ ма́ма — вчи́телька, а мій та́то — інжене́р.
+Мою́ сестру́ зва́ти О́ля.
+Ду́же приє́мно познайо́митися!
+```
+
+Support after the text:
+
+| Українська | English support |
+| --- | --- |
+| **Моє́ прі́звище Ковале́нко.** | My surname is Kovalenko. |
+| **Я з Ки́єва.** | I am from Kyiv. |
+| **Мені́ 20 ро́ків.** | I am 20 years old. |
+| **У ме́не є ма́ма, та́то і сестра́.** | I have a mom, dad, and sister. |
+| **Ду́же приє́мно познайо́митися!** | Very nice to meet you! |
 
 Now check the reading decisions.
 
@@ -124,14 +130,14 @@ letters. That habit matters more than speed.
 The grammar checkpoint has six safe patterns. They are small, but they cover a
 real first meeting.
 
-| Pattern | Safe line | Watch out |
+| Опора | Безпечний рядок | Не треба зараз |
 | --- | --- | --- |
-| **Це + noun** | **Це Богдан. Це моя сестра.** | Do not overbuild the sentence. |
-| Identity without **є** | **Я студент. Вона лікарка.** | Do not say **Я є студент** in this A1 sentence. |
-| Name | **Мене звати Соломія.** | Do not build **Моє ім'я є...** from English. |
-| Origin | **Я з Канади. Я зі Львова.** | Use **з / зі** as the learned chunk. |
-| Age | **Мені 20 років.** | Do not use the English "have years" shape. |
-| Possession | **У мене є брат.** | Learn the whole chunk, not a verb for "have." |
+| **Це + noun** | **Це Богдан. Це моя́ сестра́.** | Do not overbuild the sentence. |
+| Identity without **є** | **Я студе́нт. Вона́ лі́карка.** | Do not say **Я є студент** in this A1 sentence. |
+| Name | **Мене́ зва́ти Соломі́я.** | Do not build **Моє́ ім'я́ є...** from English. |
+| Origin | **Я з Кана́ди. Я зі Льво́ва.** | Use **з / зі** as the learned chunk. |
+| Age | **Мені́ 20 ро́ків.** | Do not use the English "have years" shape. |
+| Possession | **У ме́не є брат.** | Learn the whole chunk, not a verb for "have." |
 
 For family and identity, the owned word chooses the possessive form:
 
@@ -148,9 +154,9 @@ with its gender when that helps you later: **словник** is masculine,
 system today, but you do need the habit of learning a noun with its form cues.
 
 The safe social vocabulary also stays native Ukrainian. Use **прізвище** for
-surname, not the colloquial or Russian-influenced **фамілія**. Use **тато** or
-**батько** for father in this course context, not the Russian-influenced
-**папа**. Use **Добрий день** or **Вітаю** when you need a neutral hello, and
+surname in official-style lines, not colloquial **фамілія**. Use **тато** or
+**батько** for father in this course context; keep **папа** as recognition, not
+the active A1 default. Use **Добрий день** or **Вітаю** when you need a neutral hello, and
 **До побачення** for goodbye.
 
 <!-- INJECT_ACTIVITY: act-4 -->
@@ -161,30 +167,44 @@ This is the full first-contact task. Read it once for meaning, then read it
 again aloud. The setting is a break on the first day of Ukrainian courses, so
 both people use **ти**.
 
-<DialogueBox uk="Богдан: Привіт! Мене звати Богдан." en="Bohdan: Hi! My name is Bohdan." />
-<DialogueBox uk="Соломія: Привіт, Богдане! Мене звати Соломія." en="Solomiia: Hi, Bohdane! My name is Solomiia." />
-<DialogueBox uk="Богдан: Дуже приємно, Соломіє." en="Bohdan: Very nice to meet you, Solomiie." />
-<DialogueBox uk="Соломія: Мені теж. Звідки ти?" en="Solomiia: Me too. Where are you from?" />
-<DialogueBox uk="Богдан: Я з Дніпра. А ти?" en="Bohdan: I am from Dnipro. And you?" />
-<DialogueBox uk="Соломія: Я з Тернополя." en="Solomiia: I am from Ternopil." />
-<DialogueBox uk="Богдан: Ти студентка?" en="Bohdan: Are you a student?" />
-<DialogueBox uk="Соломія: Так, я студентка. Моя майбутня професія — вчителька." en="Solomiia: Yes, I am a student. My future profession is teacher." />
-<DialogueBox uk="Богдан: Класно. Я студент, майбутній інженер." en="Bohdan: Nice. I am a student, a future engineer." />
-<DialogueBox uk="Соломія: У тебе є брати чи сестри?" en="Solomiia: Do you have brothers or sisters?" />
-<DialogueBox uk="Богдан: Так, у мене є сестра. Її звати Ірина." en="Bohdan: Yes, I have a sister. Her name is Iryna." />
-<DialogueBox uk="Соломія: У мене є брат. Його звати Назар." en="Solomiia: I have a brother. His name is Nazar." />
-<DialogueBox uk="Богдан: Дуже приємно познайомитися." en="Bohdan: Very nice to meet you." />
-<DialogueBox uk="Соломія: Мені теж. До побачення!" en="Solomiia: Me too. Goodbye!" />
+```text
+Богда́н: Приві́т! Мене́ зва́ти Богда́н.
+Соломі́я: Приві́т, Богда́не! Мене́ зва́ти Соломі́я.
+Богда́н: Ду́же приє́мно, Соломі́є.
+Соломі́я: Мені́ теж. Зві́дки ти?
+Богда́н: Я з Дніпра́. А ти?
+Соломі́я: Я з Терно́поля.
+Богда́н: Ти студе́нтка?
+Соломі́я: Так, я студе́нтка. Моя́ майбу́тня профе́сія — вчи́телька.
+Богда́н: Кла́сно. Я студе́нт, майбу́тній інжене́р.
+Соломі́я: У те́бе є брати́ чи се́стри?
+Богда́н: Так, у ме́не є сестра́. Її́ зва́ти Іри́на.
+Соломі́я: У ме́не є брат. Його́ зва́ти Наза́р.
+Богда́н: Ду́же приє́мно познайо́митися.
+Соломі́я: Мені́ теж. До поба́чення!
+```
+
+Support after the dialogue:
+
+| Українська | English support |
+| --- | --- |
+| **Приві́т, Богда́не!** | Hi, Bohdan! |
+| **Ду́же приє́мно, Соломі́є.** | Very nice to meet you, Solomiia. |
+| **Я з Дніпра́.** | I am from Dnipro. |
+| **У те́бе є брати́ чи се́стри?** | Do you have brothers or sisters? |
+| **До поба́чення!** | Goodbye! |
 
 Use this as your graduation speech for A1.1:
 
-<DialogueBox uk="Привіт! Мене звати Олена." en="Hi! My name is Olena." />
-<DialogueBox uk="Моє прізвище Мельник." en="My surname is Melnyk." />
-<DialogueBox uk="Я з Канади. Я канадка." en="I am from Canada. I am Canadian." />
-<DialogueBox uk="Я студентка. Моя майбутня професія — лікарка." en="I am a student. My future profession is doctor." />
-<DialogueBox uk="Моя мама — вчителька, а мій тато — інженер." en="My mom is a teacher, and my dad is an engineer." />
-<DialogueBox uk="У мене є одна сестра." en="I have one sister." />
-<DialogueBox uk="Дуже приємно познайомитися!" en="Very nice to meet you!" />
+```text
+Приві́т! Мене́ зва́ти Оле́на.
+Моє́ прі́звище Ме́льник.
+Я з Кана́ди. Я кана́дка.
+Я студе́нтка. Моя́ майбу́тня профе́сія — лі́карка.
+Моя́ ма́ма — вчи́телька, а мій та́то — інжене́р.
+У ме́не є одна́ сестра́.
+Ду́же приє́мно познайо́митися!
+```
 
 If you want a shorter answer, keep five sentences: name, origin, role, one
 family line, and closing. That is enough for the checkpoint.
@@ -198,10 +218,20 @@ start with a greeting, name yourself, ask one clear question, and close
 politely. Do not hide behind emoji-only messages when the task is language
 practice.
 
-<DialogueBox uk="Привіт! Мене звати Ліна. Я з Одеси. А тебе?" en="Hi! My name is Lina. I am from Odesa. And you?" />
-<DialogueBox uk="Привіт, Ліно! Мене звати Том. Я з Канади." en="Hi, Lino! My name is Tom. I am from Canada." />
-<DialogueBox uk="Дуже приємно!" en="Very nice to meet you!" />
-<DialogueBox uk="Мені теж." en="Me too." />
+```text
+Лі́на: Приві́т! Мене́ зва́ти Лі́на. Я з Оде́си. А тебе́?
+Том: Приві́т, Лі́но! Мене́ зва́ти Том. Я з Кана́ди.
+Лі́на: Ду́же приє́мно!
+Том: Мені́ теж.
+```
+
+Support after the chat:
+
+| Українська | English support |
+| --- | --- |
+| **А тебе́?** | And you? |
+| **Приві́т, Лі́но!** | Hi, Lina! |
+| **Мені́ теж.** | Me too. |
 
 This chat task also reviews the borrowed-word habit from the wiki brief:
 modern Ukrainian can use international words, but your core first-contact
@@ -209,6 +239,17 @@ grammar should stay Ukrainian. Say **чат** if the setting is a chat, but stil
 say **Мене звати...**, **Я з...**, and **До побачення**.
 
 <!-- INJECT_ACTIVITY: act-6 -->
+
+## Слу́хай, зошит, підсумок
+
+For lawful listening, use Ukrainian Lessons Podcast Episode 10 as listen-only
+review support. Listen for short chunks you already know, repeat them, and
+return to this page. Do not copy or transcribe paid material.
+
+For handwriting recognition, ask a teacher, tutor, or classmate to write an
+original five-line card with **ім'я́**, **прі́звище**, **Кана́да**,
+**сестра́**, and **До поба́чення**. First compare the notebook card with the
+printed model; then write your own final card.
 
 ## Підсумок
 
@@ -228,11 +269,13 @@ Use this final self-check before you move on.
 
 Your final model can be simple:
 
-<DialogueBox uk="Добрий день! Мене звати Алекс." en="Good afternoon! My name is Alex." />
-<DialogueBox uk="Я з Канади. Я студент." en="I am from Canada. I am a student." />
-<DialogueBox uk="Мені 20 років." en="I am 20 years old." />
-<DialogueBox uk="У мене є брат." en="I have a brother." />
-<DialogueBox uk="Дуже приємно познайомитися!" en="Very nice to meet you!" />
+```text
+До́брий день! Мене́ зва́ти Алекс.
+Я з Кана́ди. Я студе́нт.
+Мені́ 20 ро́ків.
+У ме́не є брат.
+Ду́же приє́мно познайо́митися!
+```
 
 Use the workbook for extra practice: quick translation, vocabulary mapping,
 and digital chat etiquette. Passing the workbook means the A1.1 first-contact

--- a/curriculum/l2-uk-en/a1/my-family/activities.yaml
+++ b/curriculum/l2-uk-en/a1/my-family/activities.yaml
@@ -90,7 +90,7 @@ inline:
           - У
           - Це
           - Хто
-        explanation: У мене є... — цілий блок для "I have".
+        explanation: У мене є... — цілий блок, щоб сказати, що хтось або щось є в мене.
       - sentence: У ___ є сестра.
         answer: мене
         options:
@@ -220,44 +220,44 @@ workbook:
         options:
           - Мене звати Джон.
           - Моє ім'я є Джон.
-        explanation: Мене звати... is the natural first-introduction model.
+        explanation: Мене звати... — природна модель першого представлення.
       - sentence: Я маю 20 років.
         error: Я маю 20 років.
         correction: Мені 20 років.
         options:
           - Мені 20 років.
           - Я маю 20 років.
-        explanation: Age uses the chunk Мені ... років.
+        explanation: Вік подаємо блоком Мені ... років.
       - sentence: Це мій мама.
         error: Це мій мама.
         correction: Це моя мама.
         options:
           - Це моя мама.
           - Це мій мама.
-        explanation: Мама is feminine, so use моя.
+        explanation: Мама — жіночого роду, тому вживай моя.
       - sentence: Я є брат.
         error: Я є брат.
         correction: Я брат.
         options:
           - Я брат.
           - Я є брат.
-        explanation: Present-time identity can omit є.
+        explanation: Теперішня ідентичність може не мати є.
       - sentence: Батьки (у значенні батька)
         error: Батьки (у значенні батька)
         correction: Тато / батько
         options:
           - Тато / батько
           - Батьки
-        explanation: Батьки means parents, not one father.
+        explanation: Батьки означає маму й тата або кількох батьків, а не одного тата.
       - sentence: Чия це? (про брата)
         error: Чия це? (про брата)
         correction: Чий це брат?
         options:
           - Чий це брат?
           - Чия це?
-        explanation: Брат is masculine, so the question word is чий.
+        explanation: Брат — чоловічого роду, тому питальне слово чий.
   - type: fill-in
-    title: Native family words
+    title: Українські родинні слова
     instruction: Заповни речення українським родинним словом.
     items:
       - sentence: Моя ___ — вчителька.
@@ -265,45 +265,45 @@ workbook:
         options:
           - дружина
           - сестра
-        explanation: Дружина is the Ukrainian word for wife.
+        explanation: Дружина — українське слово для жінки в шлюбі.
       - sentence: Мій ___ працює в лікарні.
         answer: чоловік
         options:
           - чоловік
           - тато
-        explanation: Чоловік can mean man or husband by context.
+        explanation: Чоловік може означати людину чоловічої статі або партнера в шлюбі за контекстом.
       - sentence: Це моя ___ Тетяна.
         answer: бабуся
         options:
           - бабуся
           - мама
-        explanation: Бабуся is the Ukrainian word for grandmother.
+        explanation: Бабуся називає маму мами або тата.
       - sentence: Це мої ___.
         answer: родичі
         options:
           - родичі
           - батьки
-        explanation: Родичі means relatives.
+        explanation: Родичі — це люди з родини.
       - sentence: Це маленька ___.
         answer: дитина
         options:
           - дитина
           - сім'я
-        explanation: Дитина is the Ukrainian word for child.
+        explanation: Дитина — українське слово для малюка або сина чи доньки.
       - sentence: Це мій ___ брат.
         answer: молодший
         options:
           - молодший
           - старший
-        explanation: Молодший means younger.
+        explanation: Молодший означає менший за віком.
       - sentence: Мій старший брат уже ___.
         answer: одружений
         options:
           - одружений
           - студент
-        explanation: Одружений means married.
+        explanation: Одружений означає, що людина має дружину або чоловіка.
   - type: fill-in
-    title: Complete the photo dialogue
+    title: Доповни фотодіалог
     instruction: Обери пропущене слово з родинної розмови.
     items:
       - sentence: Це ___ сім'я на фотографії.
@@ -312,7 +312,7 @@ workbook:
           - моя
           - мій
           - моє
-        explanation: Сім'я is feminine.
+        explanation: Сім'я — жіночого роду.
       - sentence: ___ це? Це мій тато.
         answer: Хто
         options:
@@ -326,23 +326,23 @@ workbook:
           - Її
           - Його
           - Вони
-        explanation: Її fits a sister.
+        explanation: Її підходить до сестри.
       - sentence: Це мій брат. ___ звати Коля.
         answer: Його
         options:
           - Його
           - Її
           - Вона
-        explanation: Його fits a brother.
+        explanation: Його підходить до брата.
       - sentence: А це ___ бабуся?
         answer: твоя
         options:
           - твоя
           - твій
           - твоє
-        explanation: Бабуся is feminine.
+        explanation: Бабуся — жіночого роду.
   - type: translate
-    title: Family vocabulary quick check
+    title: Швидка перевірка родинної лексики
     instruction: Обери англійське значення.
     items:
       - source: сім'я
@@ -353,7 +353,7 @@ workbook:
             correct: false
           - text: profession
             correct: false
-        explanation: Сім'я is the close family word.
+        explanation: Сім'я — слово для близької родини.
       - source: родина
         options:
           - text: family or kin
@@ -362,7 +362,7 @@ workbook:
             correct: false
           - text: first name
             correct: false
-        explanation: Родина often sounds wider than сім'я.
+        explanation: Родина часто звучить ширше, ніж сім'я.
       - source: У мене є брат.
         options:
           - text: I have a brother.
@@ -371,7 +371,7 @@ workbook:
             correct: false
           - text: This is my brother.
             correct: false
-        explanation: У мене є... is the I-have chunk.
+        explanation: У мене є... — блок, щоб сказати, що щось або хтось є в мене.
       - source: Це моя сестра.
         options:
           - text: This is my sister.
@@ -380,7 +380,7 @@ workbook:
             correct: false
           - text: This is her sister.
             correct: false
-        explanation: Моя matches сестра.
+        explanation: Моя узгоджується зі словом сестра.
       - source: Чий це брат?
         options:
           - text: Whose brother is this?
@@ -389,4 +389,4 @@ workbook:
             correct: false
           - text: Do you have a brother?
             correct: false
-        explanation: Чий asks whose and matches брат.
+        explanation: Чий питає про належність і узгоджується зі словом брат.

--- a/curriculum/l2-uk-en/a1/my-family/activities.yaml
+++ b/curriculum/l2-uk-en/a1/my-family/activities.yaml
@@ -1,10 +1,10 @@
 inline:
   - id: act-1
     type: quiz
-    title: Family photo questions
-    instruction: Choose the Ukrainian line that fits the photo exchange.
+    title: Питання до фото
+    instruction: Обери український рядок для фото-розмови.
     items:
-      - prompt: You ask one peer whether they have a brother.
+      - prompt: Ти питаєш одного ровесника про брата.
         options:
           - text: У тебе є брат?
             correct: true
@@ -12,8 +12,8 @@ inline:
             correct: false
           - text: Це брат?
             correct: false
-        explanation: У тебе є...? asks one familiar person whether they have someone.
-      - prompt: You answer yes and say you have one sister.
+        explanation: У тебе є...? питає одну знайому людину.
+      - prompt: Ти відповідаєш так і кажеш, що маєш одну сестру.
         options:
           - text: Так, у мене є одна сестра.
             correct: true
@@ -21,8 +21,8 @@ inline:
             correct: false
           - text: Так, це одна сестра.
             correct: false
-        explanation: У мене є... answers for yourself.
-      - prompt: You answer no with the safe A1 answer.
+        explanation: У мене є... відповідає за себе.
+      - prompt: Ти відповідаєш ні короткою A1-фразою.
         options:
           - text: Ні.
             correct: true
@@ -30,8 +30,8 @@ inline:
             correct: false
           - text: Ні є брат.
             correct: false
-        explanation: Keep the negative answer simple at A1.
-      - prompt: You ask what his name is.
+        explanation: На A1 тримай заперечну відповідь простою.
+      - prompt: Ти питаєш, як його звати.
         options:
           - text: Як його звати?
             correct: true
@@ -39,8 +39,8 @@ inline:
             correct: false
           - text: Що його звати?
             correct: false
-        explanation: Його fits a brother, dad, son, or grandfather.
-      - prompt: You identify your mom in a photo.
+        explanation: Його підходить до брата, тата, сина або дідуся.
+      - prompt: Ти показуєш маму на фото.
         options:
           - text: Це моя мама.
             correct: true
@@ -48,8 +48,8 @@ inline:
             correct: false
           - text: Це моє мама.
             correct: false
-        explanation: Мама is feminine, so use моя.
-      - prompt: You identify your parents.
+        explanation: Мама — жіночого роду, тому моя.
+      - prompt: Ти показуєш батьків.
         options:
           - text: Це мої батьки.
             correct: true
@@ -57,32 +57,32 @@ inline:
             correct: false
           - text: Це моя батьки.
             correct: false
-        explanation: Батьки is plural, so use мої.
+        explanation: Батьки — множина, тому мої.
   - id: act-2
     type: match-up
-    title: Family words
-    instruction: Match the English cue with the Ukrainian family word.
+    title: Слова родини
+    instruction: З'єднай українське слово з українською підказкою.
     pairs:
-      - left: mother
-        right: мама
-      - left: father
-        right: тато
-      - left: brother
-        right: брат
-      - left: sister
-        right: сестра
-      - left: grandmother
-        right: бабуся
-      - left: grandfather
-        right: дідусь
-      - left: parents
-        right: батьки
-      - left: relatives
-        right: родичі
+      - left: мама
+        right: мати
+      - left: тато
+        right: батько
+      - left: брат
+        right: син для моїх батьків
+      - left: сестра
+        right: дочка для моїх батьків
+      - left: бабуся
+        right: мама мами або тата
+      - left: дідусь
+        right: тато мами або тата
+      - left: батьки
+        right: мама і тато
+      - left: родичі
+        right: люди з родини
   - id: act-3
     type: fill-in
-    title: Build the I-have chunk
-    instruction: Choose the word or phrase that completes the family sentence.
+    title: Склади У мене є
+    instruction: Обери слово або фразу для родинного речення.
     items:
       - sentence: ___ мене є брат.
         answer: У
@@ -90,60 +90,60 @@ inline:
           - У
           - Це
           - Хто
-        explanation: У мене є... is the whole I-have chunk.
+        explanation: У мене є... — цілий блок для "I have".
       - sentence: У ___ є сестра.
         answer: мене
         options:
           - мене
           - мій
           - це
-        explanation: У мене є... answers for yourself.
+        explanation: У мене є... відповідає за себе.
       - sentence: У ___ є брат?
         answer: тебе
         options:
           - тебе
           - мене
           - він
-        explanation: У тебе є...? asks one familiar person.
+        explanation: У тебе є...? питає одну знайому людину.
       - sentence: У ___ є діти?
         answer: вас
         options:
           - вас
           - твій
           - вона
-        explanation: У вас є...? is formal or plural.
+        explanation: У вас є...? — формально або множина.
       - sentence: У мене є ___ брат.
         answer: один
         options:
           - один
           - одна
           - дві
-        explanation: Брат is masculine, so use один.
+        explanation: Брат — чоловічого роду, тому один.
       - sentence: У мене є ___ сестра.
         answer: одна
         options:
           - одна
           - один
           - два
-        explanation: Сестра is feminine, so use одна.
+        explanation: Сестра — жіночого роду, тому одна.
       - sentence: У мене є ___ брати.
         answer: два
         options:
           - два
           - дві
           - одна
-        explanation: Брати uses два.
+        explanation: Брати вживаємо з два.
       - sentence: У мене є ___ сестри.
         answer: дві
         options:
           - дві
           - два
           - один
-        explanation: Сестри uses дві.
+        explanation: Сестри вживаємо з дві.
   - id: act-4
     type: fill-in
-    title: My or your?
-    instruction: Choose the possessive form that matches the family word.
+    title: Мій чи моя?
+    instruction: Обери присвійний займенник до родинного слова.
     items:
       - sentence: Це ___ брат.
         answer: мій
@@ -152,7 +152,7 @@ inline:
           - моя
           - моє
           - мої
-        explanation: Брат is masculine.
+        explanation: Брат — чоловічого роду.
       - sentence: Це ___ мама.
         answer: моя
         options:
@@ -160,7 +160,7 @@ inline:
           - мій
           - моє
           - мої
-        explanation: Мама is feminine.
+        explanation: Мама — жіночого роду.
       - sentence: Це ___ місто.
         answer: моє
         options:
@@ -168,7 +168,7 @@ inline:
           - мій
           - моя
           - мої
-        explanation: Місто is neuter.
+        explanation: Місто — середнього роду.
       - sentence: Це ___ батьки.
         answer: мої
         options:
@@ -176,7 +176,7 @@ inline:
           - мій
           - моя
           - моє
-        explanation: Батьки is plural.
+        explanation: Батьки — множина.
       - sentence: Це ___ тато?
         answer: твій
         options:
@@ -184,7 +184,7 @@ inline:
           - твоя
           - твоє
           - твої
-        explanation: Тато is masculine even though it ends in -о.
+        explanation: Тато — чоловічого роду, хоча слово закінчується на -о.
       - sentence: Це ___ сестра?
         answer: твоя
         options:
@@ -192,7 +192,7 @@ inline:
           - твій
           - твоє
           - твої
-        explanation: Сестра is feminine.
+        explanation: Сестра — жіночого роду.
       - sentence: Це ___ прізвище?
         answer: твоє
         options:
@@ -200,7 +200,7 @@ inline:
           - твій
           - твоя
           - твої
-        explanation: Прізвище is neuter.
+        explanation: Прізвище — середнього роду.
       - sentence: Це ___ родичі?
         answer: твої
         options:
@@ -208,11 +208,11 @@ inline:
           - твій
           - твоя
           - твоє
-        explanation: Родичі is plural.
+        explanation: Родичі — множина.
 workbook:
   - type: error-correction
-    title: Choose the Ukrainian family sentence
-    instruction: Choose the safer Ukrainian line.
+    title: Обери українське родинне речення
+    instruction: Обери безпечніший український рядок.
     items:
       - sentence: Моє ім'я є Джон.
         error: Моє ім'я є Джон.
@@ -258,7 +258,7 @@ workbook:
         explanation: Брат is masculine, so the question word is чий.
   - type: fill-in
     title: Native family words
-    instruction: Fill the sentence with the native Ukrainian family word.
+    instruction: Заповни речення українським родинним словом.
     items:
       - sentence: Моя ___ — вчителька.
         answer: дружина
@@ -304,7 +304,7 @@ workbook:
         explanation: Одружений means married.
   - type: fill-in
     title: Complete the photo dialogue
-    instruction: Choose the missing word from the family conversation.
+    instruction: Обери пропущене слово з родинної розмови.
     items:
       - sentence: Це ___ сім'я на фотографії.
         answer: моя
@@ -319,7 +319,7 @@ workbook:
           - Хто
           - Що
           - Де
-        explanation: Use хто for a person.
+        explanation: Для людини вживай хто.
       - sentence: Це моя сестра. ___ звати Катя.
         answer: Її
         options:
@@ -343,7 +343,7 @@ workbook:
         explanation: Бабуся is feminine.
   - type: translate
     title: Family vocabulary quick check
-    instruction: Choose the English meaning.
+    instruction: Обери англійське значення.
     items:
       - source: сім'я
         options:

--- a/curriculum/l2-uk-en/a1/my-family/module.md
+++ b/curriculum/l2-uk-en/a1/my-family/module.md
@@ -1,8 +1,10 @@
-# My Family
+# Моя сім'я
+
+**Це моя́ сім'я́. У ме́не є брат.** — This is my family. I have a brother.
 
 Family is the first topic where you introduce other people, not only yourself.
 Keep the Ukrainian small and photo-based. Point to a person, say who it is,
-and add one simple line with **У мене є...** or **Це мій / моя...**.
+and add one simple line with **У ме́не є...** or **Це мій / моя́...**.
 
 By the end, you can:
 
@@ -18,34 +20,59 @@ By the end, you can:
   family or kin circle;
 - recognize a formal patronymic greeting without producing patronymics yet.
 
-## Dialogues
+## Діало́ги
 
-Read the dialogue first as a photo exchange. You do not need the whole grammar
-of possession. Treat **У мене є** and **У тебе є** as whole chunks.
+Read the Ukrainian first as a photo exchange. You do not need the whole grammar
+of possession. Treat **У ме́не є** and **У те́бе є** as whole chunks.
 
-<DialogueBox uk="Оля: Привіт, Марку! Це фото моєї сім'ї." en="Olia: Hi, Marko! This is a photo of my family." />
-<DialogueBox uk="Марк: Класно! У тебе є брати чи сестри?" en="Marko: Nice! Do you have brothers or sisters?" />
-<DialogueBox uk="Оля: Так, у мене є два брати і одна сестра." en="Olia: Yes, I have two brothers and one sister." />
-<DialogueBox uk="Марк: Ого! У мене тільки один брат." en="Marko: Wow! I have only one brother." />
-<DialogueBox uk="Оля: Як його звати?" en="Olia: What is his name?" />
-<DialogueBox uk="Марк: Його звати Коля." en="Marko: His name is Kolia." />
+```text
+О́ля: Приві́т, Ма́рку! Це фо́то моє́ї сім'ї́.
+Марк: Кла́сно! У те́бе є брати́ чи се́стри?
+О́ля: Так, у ме́не є два брати́ і одна́ сестра́.
+Марк: Ого́! У ме́не ті́льки оди́н брат.
+О́ля: Як його́ зва́ти?
+Марк: Його́ зва́ти Ко́ля.
+```
+
+Support after the dialogue:
+
+| Українська | English support |
+| --- | --- |
+| **Це фо́то моє́ї сім'ї́.** | This is a photo of my family. |
+| **У те́бе є брати́ чи се́стри?** | Do you have brothers or sisters? |
+| **У ме́не є два брати́ і одна́ сестра́.** | I have two brothers and one sister. |
+| **Як його́ зва́ти?** | What is his name? |
 
 Now use **це** to identify people in a family photo.
 
-<DialogueBox uk="Даша: Це моя сім'я на фотографії." en="Dasha: This is my family in the photo." />
-<DialogueBox uk="Андрій: Хто це?" en="Andrii: Who is this?" />
-<DialogueBox uk="Даша: Це моя мама Марина. Це мій тато Євген." en="Dasha: This is my mom Maryna. This is my dad Yevhen." />
-<DialogueBox uk="Андрій: А це твоя сестра?" en="Andrii: And is this your sister?" />
-<DialogueBox uk="Даша: Так. Це моя сестра Катя і мої брати, Іван і Денис." en="Dasha: Yes. This is my sister Katia and my brothers, Ivan and Denys." />
-<DialogueBox uk="Андрій: А це твоя бабуся?" en="Andrii: And is this your grandmother?" />
-<DialogueBox uk="Даша: Так, її звати Тетяна." en="Dasha: Yes, her name is Tetiana." />
+```text
+Да́ша: Це моя́ сім'я́ на фотогра́фії.
+Андрі́й: Хто це?
+Да́ша: Це моя́ ма́ма Мари́на. Це мій та́то Євге́н.
+Андрі́й: А це твоя́ сестра́?
+Да́ша: Так. Це моя́ сестра́ Ка́тя і мої́ брати́, Іва́н і Дени́с.
+Андрі́й: А це твоя́ бабу́ся?
+Да́ша: Так, її́ зва́ти Тетя́на.
+```
+
+Support after the dialogue:
+
+| Українська | English support |
+| --- | --- |
+| **Це моя́ сім'я́.** | This is my family. |
+| **Хто це?** | Who is this? |
+| **Це моя́ ма́ма.** | This is my mom. |
+| **Це мій та́то.** | This is my dad. |
+| **її́ зва́ти Тетя́на.** | Her name is Tetiana. |
 
 A short connected answer can reuse M5 and add family:
 
-<DialogueBox uk="Привіт! Мене звати Софія." en="Hi! My name is Sofiia." />
-<DialogueBox uk="Моя мама — вчителька." en="My mom is a teacher." />
-<DialogueBox uk="Мій тато — інженер." en="My dad is an engineer." />
-<DialogueBox uk="У мене є один брат." en="I have one brother." />
+```text
+Приві́т! Мене́ зва́ти Софі́я.
+Моя́ ма́ма — вчи́телька.
+Мій та́то — інжене́р.
+У ме́не є оди́н брат.
+```
 
 Notice the question words from earlier modules: **хто?** asks about a person,
 **що?** asks about a thing, **чий?** asks whose, and **який?** can ask what
@@ -56,7 +83,7 @@ it as one memorized block before you add family information.
 
 <!-- INJECT_ACTIVITY: act-1 -->
 
-## Family
+## Сім'я́
 
 Use family words with a photo or a simple drawing. The first task is not a
 family tree; it is recognizing and saying the common people words.
@@ -103,10 +130,10 @@ level.
 
 <!-- INJECT_ACTIVITY: act-2 -->
 
-## I Have
+## У ме́не є
 
 English says "I have a brother." Ukrainian normally uses a different shape:
-**У мене є брат.** Learn it as one piece.
+**У ме́не є брат.** Learn it as one piece.
 
 | Ukrainian chunk | English use |
 | --- | --- |
@@ -138,7 +165,7 @@ requires more case grammar.
 
 <!-- INJECT_ACTIVITY: act-3 -->
 
-## My
+## Мій / моя́
 
 The Ukrainian "my" word changes to match the person or thing you own. It does
 not match the gender of the owner.
@@ -177,7 +204,7 @@ photo tool.
 
 For "whose," match the question word to the noun:
 
-| Ukrainian | English cue |
+| Українська | English support |
 | --- | --- |
 | **Чий це брат?** | Whose brother is this? |
 | **Чия це сестра?** | Whose sister is this? |
@@ -185,40 +212,54 @@ For "whose," match the question word to the noun:
 
 <!-- INJECT_ACTIVITY: act-4 -->
 
-## Textbook Check
+## Слу́хай, фо́то, зошит
 
-Before the workbook, cover the English side and say the Ukrainian aloud:
+For lawful listening, use public Ukrainian Lessons Podcast pages as listen-only
+support: Episode 6 for **сім'я́ / У ме́не є...**, Episode 7 for **мій /
+моя́**, and Episode 10 for connected review speech. Listen, repeat a short
+chunk, and come back to the page. Do not copy or transcribe paid material.
 
-| English cue | Ukrainian you say |
+For handwriting recognition, ask a teacher, tutor, or classmate to write these
+original labels beside a simple family sketch: **ма́ма**, **та́то**,
+**брат**, **сестра́**, **сім'я́**, **бабу́ся**. First compare the notebook
+label with the printed word; then write your own line.
+
+## Самопереві́рка
+
+Cover the English support and read the Ukrainian aloud:
+
+| Українська | English support |
 | --- | --- |
-| This is my family. | **Це моя сім'я.** |
-| This is my mom. | **Це моя мама.** |
-| This is my dad. | **Це мій тато.** |
-| Do you have a brother? | **У тебе є брат?** |
-| Yes, I have one brother. | **Так, у мене є один брат.** |
-| No. | **Ні.** |
-| I have two sisters. | **У мене є дві сестри.** |
-| This is my brother. His name is Kolia. | **Це мій брат. Його звати Коля.** |
-| This is my sister. Her name is Katia. | **Це моя сестра. Її звати Катя.** |
-| Whose brother is this? | **Чий це брат?** |
-| I am 20 years old. | **Мені 20 років.** |
+| **Це моя́ сім'я́.** | This is my family. |
+| **Це моя́ ма́ма.** | This is my mom. |
+| **Це мій та́то.** | This is my dad. |
+| **У те́бе є брат?** | Do you have a brother? |
+| **Так, у ме́не є оди́н брат.** | Yes, I have one brother. |
+| **Ні.** | No. |
+| **У ме́не є дві сестри́.** | I have two sisters. |
+| **Це мій брат. Його́ зва́ти Ко́ля.** | This is my brother. His name is Kolia. |
+| **Це моя́ сестра́. Її́ зва́ти Ка́тя.** | This is my sister. Her name is Katia. |
+| **Чий це брат?** | Whose brother is this? |
+| **Мені́ 20 ро́ків.** | I am 20 years old. |
 
-The age chunk can be generalized as **Мені [N] років**. If you add a job for a
-family member, keep it as one simple profession word: **актор**, **художник**,
-**співак**, or **журналіст**.
+The age chunk can be generalized as **Мені́ [N] ро́ків**. If you add a job for
+a family member, keep it as one simple profession word: **акто́р**,
+**худо́жник**, **співа́к**, or **журналі́ст**.
 
 You can now make a four-sentence family introduction:
 
-<DialogueBox uk="Мене звати Марко." en="My name is Marko." />
-<DialogueBox uk="Це моя сім'я." en="This is my family." />
-<DialogueBox uk="Моя мама — журналістка." en="My mom is a journalist." />
-<DialogueBox uk="У мене є одна сестра." en="I have one sister." />
+```text
+Мене́ зва́ти Марко́.
+Це моя́ сім'я́.
+Моя́ ма́ма — журналі́стка.
+У ме́не є одна́ сестра́.
+```
 
-Use native Ukrainian family words in the workbook: **дружина** for wife,
-**чоловік** for husband or man by context, **бабуся** for grandmother,
-**родичі** for relatives, **дитина** for child, **молодший** for younger, and
-**одружений** for married. Do not turn these into a Russian comparison lesson;
-just choose the Ukrainian word.
+Use native Ukrainian family words in the workbook: **дружи́на** for wife,
+**чолові́к** for husband or man by context, **бабу́ся** for grandmother,
+**ро́дичі** for relatives, **дити́на** for child, **моло́дший** for younger,
+and **одру́жений** for married. Do not turn these into a Russian comparison
+lesson; just choose the Ukrainian word.
 
 Use the workbook for extra practice: safer Ukrainian family sentences, native
 family-word choices, photo-dialogue blanks, and quick vocabulary recognition.

--- a/curriculum/l2-uk-en/a1/who-am-i/activities.yaml
+++ b/curriculum/l2-uk-en/a1/who-am-i/activities.yaml
@@ -140,28 +140,28 @@ workbook:
         options:
           - Я студент.
           - Я є студент.
-        explanation: In present-time identity, say Я студент or Я — студент.
+        explanation: У теперішній ідентичності кажи Я студент або Я — студент.
       - sentence: Моє ім'я є Джон.
         error: Моє ім'я є Джон.
         correction: Мене звати Джон.
         options:
           - Мене звати Джон.
           - Моє ім'я є Джон.
-        explanation: Мене звати... is the high-frequency introduction model.
+        explanation: Мене звати... — частотна модель першого представлення.
       - sentence: Я маю 20 років.
         error: Я маю 20 років.
         correction: Мені 20 років.
         options:
           - Мені 20 років.
           - Я маю 20 років.
-        explanation: Age uses a different chunk and is not the model for this lesson.
+        explanation: Вік має інший блок; це не модель цього уроку.
       - sentence: Оксана каже, "Я (жінка) лікар."
         error: Я (жінка) лікар.
         correction: Я лікарка.
         options:
           - Я лікарка.
           - Я (жінка) лікар.
-        explanation: Лікарка is the standard feminine form for a woman doctor.
+        explanation: Лікарка — стандартна жіноча форма для жінки, яка працює лікарем.
       - sentence: Воно мій тато.
         error: Воно
         correction: Це мій тато.
@@ -177,7 +177,7 @@ workbook:
           - Привіт, пане професоре!
         explanation: З професором або незнайомим дорослим уживай Добрий день.
   - type: match-up
-    title: Profession pairs
+    title: Пари професій
     instruction: З'єднай чоловічу і жіночу форму професії.
     pairs:
       - left: студент
@@ -206,42 +206,42 @@ workbook:
           - тебе
           - вас
           - це
-        explanation: Привіт points to an informal peer situation.
+        explanation: Привіт показує неформальну ситуацію з ровесником.
       - sentence: Мене ___ Олена.
         answer: звати
         options:
           - звати
           - це
           - з
-        explanation: Мене звати... is the name chunk.
+        explanation: Мене звати... — блок для імені.
       - sentence: Мене звати Марко. ___ тебе?
         answer: А
         options:
           - А
           - Хто
           - Що
-        explanation: А тебе? returns the question.
+        explanation: А тебе? повертає питання.
       - sentence: Добрий день! Як ___ звати?
         answer: вас
         options:
           - вас
           - тебе
           - я
-        explanation: Добрий день fits the formal version here.
+        explanation: Добрий день пасує до формальної версії тут.
       - sentence: Дуже ___!
         answer: приємно
         options:
           - приємно
           - Київ
           - студентка
-        explanation: Дуже приємно follows the name exchange.
+        explanation: Дуже приємно звучить після обміну іменами.
       - sentence: ___ ти? Я з Канади.
         answer: Звідки
         options:
           - Звідки
           - Хто
           - Що
-        explanation: Звідки asks where someone is from.
+        explanation: Звідки питає, звідки людина.
   - type: fill-in
     title: Обери українську норму
     instruction: Заповни речення українським вибором.
@@ -251,36 +251,36 @@ workbook:
         options:
           - тато
           - не наш A1-вибір для тата
-        explanation: Тато is the native Ukrainian choice for dad.
+        explanation: Тато — природний український вибір для слова про батька.
       - sentence: Це моя ___ Марія.
         answer: дружина
         options:
           - дружина
           - неукраїнська форма для дружини
-        explanation: Дружина is the native Ukrainian choice for wife.
+        explanation: Дружина — природний український вибір для жінки в шлюбі.
       - sentence: ___, як вас звати?
         answer: Вибачте
         options:
           - Вибачте
           - не наш A1-вибір для вибачення
-        explanation: Вибачте and пробачте are safe Ukrainian choices.
+        explanation: Вибачте і пробачте — безпечні українські вибори.
       - sentence: ___, дуже приємно!
         answer: Дякую
         options:
           - Дякую
           - не наш A1-вибір для подяки
-        explanation: Дякую and спасибі are safe Ukrainian choices.
+        explanation: Дякую і спасибі — безпечні українські вибори.
       - sentence: Мені ___ приємно.
         answer: теж
         options:
           - теж
           - не наш A1-вибір для також
-        explanation: Теж and також are safe Ukrainian choices.
+        explanation: Теж і також — безпечні українські вибори.
       - sentence: Оксана — ___.
         answer: інженерка
         options:
           - інженерка
-          - masculine generic for a woman
+          - чоловіча форма для жінки
         explanation: Для жінки вживай фемінітив, коли українська форма існує.
   - type: translate
     title: Лексика знайомства
@@ -294,7 +294,7 @@ workbook:
             correct: false
           - text: This is...
             correct: false
-        explanation: Мене звати... is the name chunk.
+        explanation: Мене звати... — блок для імені.
       - source: Як тебе звати?
         options:
           - text: What is your name? informal
@@ -303,7 +303,7 @@ workbook:
             correct: false
           - text: I am from Ukraine.
             correct: false
-        explanation: Тебе marks the informal version.
+        explanation: Тебе позначає неформальну версію.
       - source: Як вас звати?
         options:
           - text: What is your name? formal
@@ -312,7 +312,7 @@ workbook:
             correct: false
           - text: This is Kyiv.
             correct: false
-        explanation: Вас marks the formal version.
+        explanation: Вас позначає формальну версію.
       - source: Дуже приємно!
         options:
           - text: Pleased to meet you!
@@ -321,7 +321,7 @@ workbook:
             correct: false
           - text: Where from?
             correct: false
-        explanation: Дуже приємно closes the introduction politely.
+        explanation: Дуже приємно ввічливо завершує представлення.
       - source: Звідки ти?
         options:
           - text: Where are you from? informal
@@ -330,7 +330,7 @@ workbook:
             correct: false
           - text: I am a student.
             correct: false
-        explanation: Звідки asks from where.
+        explanation: Звідки питає про походження.
       - source: Я — студентка.
         options:
           - text: I am a female student.
@@ -339,4 +339,4 @@ workbook:
             correct: false
           - text: My name is...
             correct: false
-        explanation: Студентка is the feminine form.
+        explanation: Студентка — жіноча форма.

--- a/curriculum/l2-uk-en/a1/who-am-i/activities.yaml
+++ b/curriculum/l2-uk-en/a1/who-am-i/activities.yaml
@@ -1,41 +1,41 @@
 inline:
   - id: act-1
     type: quiz
-    title: Formal or informal?
-    instruction: Choose the phrase that fits the social situation.
+    title: Ти чи ви?
+    instruction: Обери фразу для ситуації.
     items:
-      - prompt: You meet a classmate your age.
+      - prompt: Ти знайомишся з однокурсником свого віку.
         options:
           - text: Як тебе звати?
             correct: true
           - text: Як вас звати?
             correct: false
-        explanation: Use тебе with one familiar peer.
-      - prompt: You meet an unknown adult at orientation.
+        explanation: З одним знайомим або рівним співрозмовником уживай тебе.
+      - prompt: Ти знайомишся з незнайомим дорослим на орієнтації.
         options:
           - text: Як вас звати?
             correct: true
           - text: Як тебе звати?
             correct: false
-        explanation: Use вас with one unknown adult or in a formal setting.
-      - prompt: A peer asks your name. You answer and return the question.
+        explanation: З незнайомим дорослим або у формальній ситуації уживай вас.
+      - prompt: Однокурсник питає твоє ім'я. Ти відповідаєш і повертаєш питання.
         options:
           - text: Мене звати Олена. А тебе?
             correct: true
           - text: Мене звати Олена. А вас?
             correct: false
-        explanation: The peer situation stays informal.
-      - prompt: An instructor asks your name. You answer and return the question.
+        explanation: Рівна ситуація залишається неформальною.
+      - prompt: Викладач питає твоє ім'я. Ти відповідаєш і повертаєш питання.
         options:
           - text: Мене звати Петро. А вас?
             correct: true
           - text: Мене звати Петро. А тебе?
             correct: false
-        explanation: The instructor situation stays formal.
+        explanation: З викладачем ситуація залишається формальною.
   - id: act-2
     type: fill-in
-    title: Build the name chunk
-    instruction: Choose the missing word or phrase.
+    title: Склади ім'я
+    instruction: Обери пропущене слово або фразу.
     items:
       - sentence: ___ звати Марко.
         answer: Мене
@@ -43,56 +43,56 @@ inline:
           - Мене
           - Ти
           - Це
-        explanation: Мене звати... is the whole chunk for my name is.
+        explanation: Мене звати... — цілий блок для представлення імені.
       - sentence: Як ___ звати?
         answer: тебе
         options:
           - тебе
           - я
           - він
-        explanation: Як тебе звати? is informal.
+        explanation: Як тебе звати? — неформальне питання.
       - sentence: Як ___ звати?
         answer: вас
         options:
           - вас
           - вона
           - ми
-        explanation: Як вас звати? is formal or plural.
+        explanation: Як вас звати? — формальне або множинне питання.
       - sentence: Дуже ___!
         answer: приємно
         options:
           - приємно
           - студент
           - звідки
-        explanation: Дуже приємно closes the introduction after names.
+        explanation: Дуже приємно звучить після обміну іменами.
       - sentence: Мене звати Олена. А ___?
         answer: тебе
         options:
           - тебе
           - Київ
           - це
-        explanation: А тебе? returns the name question informally.
+        explanation: А тебе? неформально повертає питання.
   - id: act-3
     type: match-up
-    title: This is / Who is this?
-    instruction: Match the Ukrainian phrase with the English cue.
+    title: Це / хто / що
+    instruction: З'єднай український рядок із його роботою.
     pairs:
       - left: Це Андрій.
-        right: This is Andrii.
+        right: представити людину
       - left: Це Оксана.
-        right: This is Oksana.
+        right: представити іншу людину
       - left: Хто це?
-        right: Who is this?
+        right: запитати про людину
       - left: Що це?
-        right: What is this?
+        right: запитати про річ
       - left: Це кава.
-        right: This is coffee.
+        right: назвати річ
   - id: act-4
     type: quiz
-    title: Pronoun choice
-    instruction: Choose the pronoun that fits the English cue.
+    title: Обери займенник
+    instruction: Обери займенник для української ситуації.
     items:
-      - prompt: I
+      - prompt: Мовець говорить про себе.
         options:
           - text: я
             correct: true
@@ -100,8 +100,8 @@ inline:
             correct: false
           - text: вони
             correct: false
-        explanation: Я is the speaker.
-      - prompt: you, one friend
+        explanation: Я — це мовець.
+      - prompt: Один друг або близький однокурсник.
         options:
           - text: ти
             correct: true
@@ -109,8 +109,8 @@ inline:
             correct: false
           - text: він
             correct: false
-        explanation: Ти is one informal you.
-      - prompt: you, one unknown adult
+        explanation: Ти — один неформальний співрозмовник.
+      - prompt: Один незнайомий дорослий або формальна ситуація.
         options:
           - text: ви
             correct: true
@@ -118,8 +118,8 @@ inline:
             correct: false
           - text: вона
             correct: false
-        explanation: Ви is formal for one person and also plural.
-      - prompt: she
+        explanation: Ви — формально до однієї людини, а також множина.
+      - prompt: Жінка або дівчина вже відома в розмові.
         options:
           - text: вона
             correct: true
@@ -127,12 +127,12 @@ inline:
             correct: false
           - text: я
             correct: false
-        explanation: Вона points to a woman or girl.
+        explanation: Вона вказує на жінку або дівчину.
 workbook:
   - type: error-correction
-    title: Choose the Ukrainian sentence
+    title: Обери українське речення
     anchor_id: fix-common-l2-traps
-    instruction: Choose the safer Ukrainian identity line.
+    instruction: Обери безпечніший український рядок про ідентичність.
     items:
       - sentence: Я є студент.
         error: Я є студент.
@@ -168,17 +168,17 @@ workbook:
         options:
           - Це мій тато.
           - Воно мій тато.
-        explanation: Use це for identifying a person, or він after the person is known.
+        explanation: Для першого називання людини вживай це; він можливе після цього.
       - sentence: Привіт, пане професоре!
         error: Привіт
         correction: Добрий день, пане професоре!
         options:
           - Добрий день, пане професоре!
           - Привіт, пане професоре!
-        explanation: Use Добрий день with a professor or unknown adult.
+        explanation: З професором або незнайомим дорослим уживай Добрий день.
   - type: match-up
     title: Profession pairs
-    instruction: Match the masculine and feminine profession forms.
+    instruction: З'єднай чоловічу і жіночу форму професії.
     pairs:
       - left: студент
         right: студентка
@@ -197,8 +197,8 @@ workbook:
       - left: американець
         right: американка
   - type: fill-in
-    title: Complete the dialogue
-    instruction: Choose the phrase that completes the first meeting.
+    title: Доповни діалог
+    instruction: Обери фразу, яка завершує рядок першого знайомства.
     items:
       - sentence: Привіт! Як ___ звати?
         answer: тебе
@@ -243,48 +243,48 @@ workbook:
           - Що
         explanation: Звідки asks where someone is from.
   - type: fill-in
-    title: Choose the Ukrainian norm
-    instruction: Fill the sentence with the native Ukrainian choice.
+    title: Обери українську норму
+    instruction: Заповни речення українським вибором.
     items:
       - sentence: Це мій ___.
         answer: тато
         options:
           - тато
-          - Russian-influenced dad word
+          - не наш A1-вибір для тата
         explanation: Тато is the native Ukrainian choice for dad.
       - sentence: Це моя ___ Марія.
         answer: дружина
         options:
           - дружина
-          - Russian-influenced wife word
+          - неукраїнська форма для дружини
         explanation: Дружина is the native Ukrainian choice for wife.
       - sentence: ___, як вас звати?
         answer: Вибачте
         options:
           - Вибачте
-          - Russian-influenced excuse-me word
+          - не наш A1-вибір для вибачення
         explanation: Вибачте and пробачте are safe Ukrainian choices.
       - sentence: ___, дуже приємно!
         answer: Дякую
         options:
           - Дякую
-          - Russian-style thank-you word
+          - не наш A1-вибір для подяки
         explanation: Дякую and спасибі are safe Ukrainian choices.
       - sentence: Мені ___ приємно.
         answer: теж
         options:
           - теж
-          - Russian-style also word
+          - не наш A1-вибір для також
         explanation: Теж and також are safe Ukrainian choices.
       - sentence: Оксана — ___.
         answer: інженерка
         options:
           - інженерка
           - masculine generic for a woman
-        explanation: Use the feminitive for a woman when the Ukrainian form exists.
+        explanation: Для жінки вживай фемінітив, коли українська форма існує.
   - type: translate
-    title: First-contact vocabulary
-    instruction: Choose the English meaning.
+    title: Лексика знайомства
+    instruction: Обери англійське значення.
     items:
       - source: Мене звати...
         options:

--- a/curriculum/l2-uk-en/a1/who-am-i/module.md
+++ b/curriculum/l2-uk-en/a1/who-am-i/module.md
@@ -1,274 +1,311 @@
-# Who Am I?
+# Хто я?
 
-Your first real Ukrainian conversation is short. You greet someone, ask for a
-name, answer with your own name, and turn the question back. Keep the language
-as memorized chunks first. Grammar comes only after the phrases already work in
-your mouth.
+**Приві́т! Мене́ зва́ти Марко́. А тебе́?** — Hi! My name is Marko.
+And yours?
+
+This lesson stays short and spoken. First you hear a Ukrainian line, then you
+use a small amount of English support to check the meaning. Treat the first
+phrases as whole chunks:
+
+| Українська опора | English support |
+| --- | --- |
+| **Мене́ зва́ти...** | My name is... |
+| **Як тебе́ зва́ти?** | What is your name? informal |
+| **Як вас зва́ти?** | What is your name? formal |
+| **Ду́же приє́мно!** | Nice to meet you! |
+| **Зві́дки ти?** | Where are you from? |
 
 By the end, you can:
 
-- ask **Як тебе звати?** with a peer and **Як вас звати?** with a new adult;
-- answer **Мене звати...**;
-- use **А тебе?** and **А вас?** to return the name question;
+- ask **Як тебе́ зва́ти?** with a peer and **Як вас зва́ти?** with a new adult;
+- answer **Мене́ зва́ти...**;
+- return the question with **А тебе́?** or **А вас?**;
 - point to a person or thing with **це**;
 - use **я**, **ти**, **він**, **вона**, and **ви** in simple identity lines;
-- say **Я — студент** or **Я — студентка** without adding a present-tense
+- say **Я — студе́нт** or **Я — студе́нтка** without adding a present-tense
   "am" word;
-- say where you are from with memorized phrases such as **Я з України** and
-  **Я з Канади**;
-- choose native Ukrainian identity words, including feminitives such as
-  **лікарка**, **вчителька**, and **інженерка**.
+- say where you are from with memorized phrases such as **Я з Украї́ни** and
+  **Я з Кана́ди**;
+- choose Ukrainian identity words, including **лі́карка**, **вчи́телька**, and
+  **інжене́рка**.
 
-## Dialogues
+## Діало́ги
 
-Read the dialogue first. Do not analyze every word yet. Your first target is
-the conversation shape.
+Read each Ukrainian dialogue first. Do not translate line by line while you
+read. The support table comes after the dialogue.
 
-<DialogueBox uk="Марко: Привіт! Як тебе звати?" en="Marko: Hi! What is your name?" />
-<DialogueBox uk="Олена: Мене звати Олена. А тебе?" en="Olena: My name is Olena. And yours?" />
-<DialogueBox uk="Марко: Мене звати Марко. Дуже приємно!" en="Marko: My name is Marko. Pleased to meet you!" />
-<DialogueBox uk="Олена: Дуже приємно! Звідки ти?" en="Olena: Pleased to meet you! Where are you from?" />
-<DialogueBox uk="Марко: Я з Канади. А ти?" en="Marko: I am from Canada. And you?" />
-<DialogueBox uk="Олена: Я з України." en="Olena: I am from Ukraine." />
+```text
+Марко́: Приві́т! Як тебе́ зва́ти?
+Оле́на: Мене́ зва́ти Оле́на. А тебе́?
+Марко́: Мене́ зва́ти Марко́. Ду́же приє́мно!
+Оле́на: Ду́же приє́мно! Зві́дки ти?
+Марко́: Я з Кана́ди. А ти?
+Оле́на: Я з Украї́ни.
+```
 
-Use **Привіт** with peers. Use **А тебе?** only after the other person has
-asked or answered the same name question. It is an echo pattern: short, polite,
-and easy. Do not switch to the longer pattern with **у** here; that belongs to
-a later grammar module.
+Support after the dialogue:
 
-Now compare a formal first meeting:
+| Українська | English support |
+| --- | --- |
+| **Приві́т!** | Hi! |
+| **Як тебе́ зва́ти?** | What is your name? informal |
+| **А тебе́?** | And yours? informal |
+| **Я з Кана́ди.** | I am from Canada. |
+| **Я з Украї́ни.** | I am from Ukraine. |
 
-<DialogueBox uk="Петро: Добрий день! Як вас звати?" en="Petro: Good afternoon! What is your name?" />
-<DialogueBox uk="Софія: Мене звати Софія. А вас?" en="Sofiia: My name is Sofiia. And yours?" />
-<DialogueBox uk="Петро: Мене звати Петро. Дуже приємно!" en="Petro: My name is Petro. Pleased to meet you!" />
-<DialogueBox uk="Софія: Мені також. Ви з України?" en="Sofiia: Me too. Are you from Ukraine?" />
-<DialogueBox uk="Петро: Так, я з Києва." en="Petro: Yes, I am from Kyiv." />
+Use **Приві́т** with peers. Use **А тебе́?** only after the name question is
+already active. It is an echo pattern: short, polite, and easy.
 
-The formal version changes two pieces. **Тебе** becomes **вас**. **Ти**
-becomes **ви**. English uses one word, "you"; Ukrainian asks you to choose
-relationship and politeness.
+Now read a formal first meeting:
 
-Use **Добрий день** when you meet an adult, teacher, host, or stranger. Keep
-**Привіт** for friends, classmates, children, and relaxed peer situations.
+```text
+Петро́: До́брий день! Як вас зва́ти?
+Софі́я: Мене́ зва́ти Софі́я. А вас?
+Петро́: Мене́ зва́ти Петро́. Ду́же приє́мно!
+Софі́я: Мені́ також. Ви з Украї́ни?
+Петро́: Так, я з Ки́єва.
+```
 
-The third dialogue introduces another person. Notice that two people still
-speak; it is not a monologue.
+Support after the dialogue:
 
-<DialogueBox uk="Тарас: Це Андрій. Він зі Львова." en="Taras: This is Andrii. He is from Lviv." />
-<DialogueBox uk="Наталка: Дуже приємно. А хто це?" en="Natalka: Pleased to meet you. And who is this?" />
-<DialogueBox uk="Тарас: Це Оксана. Вона з Одеси. Вона — лікарка." en="Taras: This is Oksana. She is from Odesa. She is a doctor." />
-<DialogueBox uk="Наталка: Дуже приємно, Оксано." en="Natalka: Pleased to meet you, Oksana." />
+| Українська | English support |
+| --- | --- |
+| **До́брий день!** | Good afternoon! |
+| **Як вас зва́ти?** | What is your name? formal |
+| **А вас?** | And yours? formal |
+| **Мені́ також.** | Me too. |
+| **Так, я з Ки́єва.** | Yes, I am from Kyiv. |
+
+The formal version changes two pieces. **тебе́** becomes **вас**. **ти**
+becomes **ви**. English has one everyday word, "you"; Ukrainian asks you to
+choose relationship and politeness.
+
+The third dialogue introduces another person:
+
+```text
+Тара́с: Це Андрі́й. Він зі Льво́ва.
+Ната́лка: Ду́же приє́мно. А хто це?
+Тара́с: Це Окса́на. Вона́ з Оде́си. Вона́ — лі́карка.
+Ната́лка: Ду́же приє́мно, Окса́но.
+```
+
+Support after the dialogue:
+
+| Українська | English support |
+| --- | --- |
+| **Це Андрі́й.** | This is Andrii. |
+| **Він зі Льво́ва.** | He is from Lviv. |
+| **А хто це?** | And who is this? |
+| **Вона́ — лі́карка.** | She is a doctor. |
 
 For a woman, use the feminine profession form when Ukrainian has the normal
-form: **лікарка**, **вчителька**, **інженерка**, **програмістка**,
-**студентка**. These are not decorative extras. They are standard Ukrainian
-identity words.
+form: **лі́карка**, **вчи́телька**, **інжене́рка**, **програмі́стка**,
+**студе́нтка**. These are standard Ukrainian identity words.
 
 <!-- INJECT_ACTIVITY: act-1 -->
 
-## My Name Is...
+## Мене́ зва́ти...
 
-**Мене звати...** means "My name is..." Treat it as one chunk:
+**Мене́ зва́ти...** is one chunk. You do not need the grammar of **мене́** or
+**зва́ти** yet. You need the social move: ask, answer, echo.
 
-| Ukrainian | English use |
+| Українська | English support |
 | --- | --- |
-| **Мене звати Марко.** | My name is Marko. |
-| **Мене звати Олена.** | My name is Olena. |
-| **Мене звати [ім'я].** | My name is [name]. |
-| **Як тебе звати?** | What is your name? informal |
-| **Як вас звати?** | What is your name? formal |
-| **До побачення!** | Goodbye! |
-
-These **фрази знайомства** are chunks. Do not translate the chunk word by
-word. At this level, you do not need the case of **мене** or the verb form
-behind **звати**. You need the social move: ask, answer, echo.
+| **Мене́ зва́ти Марко́.** | My name is Marko. |
+| **Мене́ зва́ти Оле́на.** | My name is Olena. |
+| **Мене́ зва́ти [ім'я́].** | My name is [name]. |
+| **Як тебе́ зва́ти?** | What is your name? informal |
+| **Як вас зва́ти?** | What is your name? formal |
+| **До поба́чення!** | Goodbye! |
 
 Name exchange order:
 
-1. **Привіт!** or **Добрий день!**
-2. **Як тебе звати?** or **Як вас звати?**
-3. **Мене звати...**
-4. **А тебе?** or **А вас?**
-5. **Дуже приємно!**
+1. **Приві́т!** or **До́брий день!**
+2. **Як тебе́ зва́ти?** or **Як вас зва́ти?**
+3. **Мене́ зва́ти...**
+4. **А тебе́?** or **А вас?**
+5. **Ду́же приє́мно!**
 
 :::tip
-For this module, **А тебе?** and **А вас?** are return buttons. Use them only
+For this module, **А тебе́?** and **А вас?** are return buttons. Use them only
 after the same question is already active in the conversation.
 :::
 
-**Дуже приємно!** comes after names are exchanged. It is the small phrase that
-closes the introduction politely.
-
 Avoid the English-shaped line "My name is..." as a Ukrainian sentence. The
-natural high-frequency Ukrainian model for a first introduction is
-**Мене звати...**.
+natural first-introduction model is **Мене́ зва́ти...**.
 
 <!-- INJECT_ACTIVITY: act-2 -->
 
-## This Is...
+## Це...
 
 **Це** is the fast pointing word. It can introduce a thing, a city, or a
 person:
 
-| Ukrainian | English |
+| Українська | English support |
 | --- | --- |
-| **Це кава.** | This is coffee. |
-| **Це Київ.** | This is Kyiv. |
-| **Це Андрій.** | This is Andrii. |
-| **Це Оксана.** | This is Oksana. |
+| **Це ка́ва.** | This is coffee. |
+| **Це Ки́їв.** | This is Kyiv. |
+| **Це Андрі́й.** | This is Andrii. |
+| **Це Окса́на.** | This is Oksana. |
 
-Use **Що це?** for a thing: **Що це? Це кава.** Use **Хто це?** for a
-person: **Хто це? Це Оксана.**
+Use **Що це?** for a thing: **Що це? Це ка́ва.** Use **Хто це?** for a
+person: **Хто це? Це Окса́на.**
 
 Keep the question word first. Ukrainian beginner questions are easier when the
-question word opens the question: **Хто це?**, **Що це?**, **Звідки ти?**
+question word opens the question: **Хто це?**, **Що це?**, **Зві́дки ти?**
 
 Use **це** instead of an English-style "it" when you identify a person in a
 photo, on the phone, or in a group:
 
-| Safer beginner line | English meaning |
+| Українська | English support |
 | --- | --- |
-| **Це мій тато.** | This is my dad. |
-| **Це моя мама.** | This is my mom. |
-| **Це моя подруга.** | This is my female friend. |
+| **Це мій та́то.** | This is my dad. |
+| **Це моя́ ма́ма.** | This is my mom. |
+| **Це моя́ подру́га.** | This is my female friend. |
 
-For people, **він** and **вона** are also possible after you know who the
-person is: **Це Андрій. Він зі Львова.** **Це Оксана. Вона — лікарка.**
+For people, **він** and **вона́** are also possible after you know who the
+person is: **Це Андрі́й. Він зі Льво́ва.** **Це Окса́на. Вона́ — лі́карка.**
 
 <!-- INJECT_ACTIVITY: act-3 -->
 
-## Personal Pronouns
+## Особо́ві займéнники
 
-Personal pronouns point to people in a conversation. Learn only the naming
-case now:
+Learn only the naming case now:
 
-| Ukrainian | Use |
+| Українська | English support |
 | --- | --- |
-| **я** | I, the speaker; **1-ша особа** |
-| **ми** | we; **1-ша особа** plural |
-| **ти** | you, one familiar person; **2-га особа**, points **на співрозмовника** |
-| **ви** | you formal, or you plural; **2-га особа**, points **на співрозмовника** |
-| **він** | he; **3-тя особа** |
-| **вона** | she; **3-тя особа** |
-| **вони** | they; **3-тя особа** |
+| **я** | I, the speaker |
+| **ми** | we |
+| **ти** | you, one familiar person |
+| **ви** | you formal, or you plural |
+| **він** | he |
+| **вона́** | she |
+| **вони́** | they |
 
-The important beginner contrast is **ти / ви**. Use **ти** **для друзів,
-дітей** and close classmates when the relationship is informal. Use **ви**
-**для викладачів, старших людей**, one unknown adult, a host, or several
+The important beginner contrast is **ти / ви**. Use **ти** **для дру́зів,
+діте́й** and close classmates when the relationship is informal. Use **ви**
+**для викладачі́в, ста́рших люде́й**, one unknown adult, a host, or several
 people.
 
 Mini-patterns:
 
-| Informal | Formal |
+| Неформально | Формально |
 | --- | --- |
-| **Як тебе звати?** | **Як вас звати?** |
-| **А тебе?** | **А вас?** |
-| **Звідки ти?** | **Звідки ви?** |
+| **Як тебе́ зва́ти?** | **Як вас зва́ти?** |
+| **А тебе́?** | **А вас?** |
+| **Зві́дки ти?** | **Зві́дки ви?** |
 
 When you write polite **Ви** to one person, Ukrainian often uses a capital
-letter. In this course page, the lower-case **ви** is enough for practice, but
+letter. In this course page, lower-case **ви** is enough for practice, but
 recognize **Ви** when you see it.
 
 <!-- INJECT_ACTIVITY: act-4 -->
 
-## I Am a Student
+## Я — студе́нт
 
 Ukrainian present-time identity lines do not need a word for English "am" or
 "is":
 
-| Ukrainian | English |
+| Українська | English support |
 | --- | --- |
-| **Я — студент.** | I am a male student. |
-| **Я — студентка.** | I am a female student. |
-| **Він — лікар.** | He is a doctor. |
-| **Вона — лікарка.** | She is a doctor. |
+| **Я — студе́нт.** | I am a male student. |
+| **Я — студе́нтка.** | I am a female student. |
+| **Він — лі́кар.** | He is a doctor. |
+| **Вона́ — лі́карка.** | She is a doctor. |
 
 The dash is a reading helper. It marks the place where English expects "am" or
-"is." In ordinary writing, you may see the same pattern without a dash, but the
-meaning is the same: **Я студент.**
-
-The grammar label is **Нульова зв'язка** or **Опущений дієслово-копула**.
-For today, that only means: do not add **бути** in present-time identity lines
-such as **Я студент**, **Я лікарка**, **Він — лікар**, and **Вона — лікарка**.
+"is." In ordinary writing, you may see the same pattern without a dash:
+**Я студе́нт.**
 
 Use profession pairs as pairs:
 
-| Masculine | Feminine |
+| Чоловіча форма | Жіноча форма |
 | --- | --- |
-| **студент** | **студентка** |
-| **вчитель** | **вчителька** |
-| **лікар** | **лікарка** |
-| **програміст** | **програмістка** |
-| **інженер** | **інженерка** |
-| **українець** | **українка** |
-| **канадієць** | **канадка** |
-| **американець** | **американка** |
+| **студе́нт** | **студе́нтка** |
+| **вчи́тель** | **вчи́телька** |
+| **лі́кар** | **лі́карка** |
+| **програмі́ст** | **програмі́стка** |
+| **інжене́р** | **інжене́рка** |
+| **украї́нець** | **украї́нка** |
+| **канаді́єць** | **кана́дка** |
+| **америка́нець** | **америка́нка** |
 
-The feminine form is the primary form for a woman. **Оксана — лікарка.**
-**Софія — студентка.** **Наталка — інженерка.** The simple classroom phrase
-**фізична реальність** means the real person guides the label: **Я
-програмістка** for a woman, **Я програміст** for a man.
+The feminine form is the primary form for a woman. **Окса́на — лі́карка.**
+**Софі́я — студе́нтка.** **Ната́лка — інжене́рка.**
 
-This is a Ukrainian-centered habit. Do not treat masculine profession words as
-universal labels for women.
+## Зві́дки?
 
-## Where From?
+**Зві́дки?** means "from where?" Use the country phrases as memorized chunks:
 
-**Звідки?** means "from where?" Use the country phrases as memorized chunks:
-
-| Question | Answer |
+| Питання | Відповідь |
 | --- | --- |
-| **Звідки ти?** | **Я з України.** |
-| **Звідки ви?** | **Я з Канади.** |
-| **Ви з України?** | **Так, я з Києва.** |
+| **Зві́дки ти?** | **Я з Украї́ни.** |
+| **Зві́дки ви?** | **Я з Кана́ди.** |
+| **Ви з Украї́ни?** | **Так, я з Ки́єва.** |
 
 Add a few prepared places:
 
-| Ukrainian | English |
+| Українська | English support |
 | --- | --- |
-| **Я з України.** | I am from Ukraine. |
-| **Я з Канади.** | I am from Canada. |
-| **Я зі Штатів.** | I am from the States. |
-| **Я з Німеччини.** | I am from Germany. |
-| **Я з Києва.** | I am from Kyiv. |
-| **Я зі Львова.** | I am from Lviv. |
-| **Я з Одеси.** | I am from Odesa. |
+| **Я з Украї́ни.** | I am from Ukraine. |
+| **Я з Кана́ди.** | I am from Canada. |
+| **Я зі Шта́тів.** | I am from the States. |
+| **Я з Німе́ччини.** | I am from Germany. |
+| **Я з Ки́єва.** | I am from Kyiv. |
+| **Я зі Льво́ва.** | I am from Lviv. |
+| **Я з Оде́си.** | I am from Odesa. |
 
 The forms after **з / зі** are memorized here. Do not open the full grammar of
 "from" yet. Your speaking goal is a natural first-contact answer.
 
 Build a three-line self-introduction:
 
-<DialogueBox uk="Добрий день. Мене звати Софія." en="Good afternoon. My name is Sofiia." />
-<DialogueBox uk="Я з України." en="I am from Ukraine." />
-<DialogueBox uk="Я — студентка." en="I am a student." />
+```text
+До́брий день. Мене́ зва́ти Софі́я.
+Я з Украї́ни.
+Я — студе́нтка.
+```
 
 Or informal:
 
-<DialogueBox uk="Привіт! Мене звати Марко." en="Hi! My name is Marko." />
-<DialogueBox uk="Я з Канади." en="I am from Canada." />
-<DialogueBox uk="Я — програміст." en="I am a programmer." />
+```text
+Приві́т! Мене́ зва́ти Марко́.
+Я з Кана́ди.
+Я — програмі́ст.
+```
 
-Native Ukrainian choices matter even in tiny introductions. Use **тато** for
-dad, **дружина** for wife, **вибачте** or **пробачте** for excuse me,
-**дякую** or **спасибі** for thank you, and **теж** or **також** for also.
+Native Ukrainian choices matter even in tiny introductions. Use **та́то** for
+dad, **дружи́на** for wife, **ви́бачте** or **проба́чте** for excuse me,
+**дя́кую** or **спаси́бі** for thank you, and **теж** or **та́кож** for also.
 
-## Textbook Check
+## Слу́хай і зошит
 
-Before the workbook, cover the English side and say the Ukrainian aloud:
+For lawful listening, use public Ukrainian Lessons Podcast pages as listen-only
+support: Episode 3 for introductions, Episode 4 for **Зві́дки?**, and Episode
+8 for professions. Listen, repeat a short chunk, and come back to the page.
+Do not copy or transcribe paid material.
 
-| English cue | Ukrainian you say |
+For handwriting recognition, ask a teacher, tutor, or classmate to write these
+original labels in a notebook: **ім'я́**, **прі́звище**, **Ки́їв**,
+**студе́нтка**, **лі́карка**. First compare the notebook label with the printed
+word; then write your own line.
+
+## Самопереві́рка
+
+Cover the English support and read the Ukrainian aloud:
+
+| Українська | English support |
 | --- | --- |
-| What is your name? informal | **Як тебе звати?** |
-| My name is... | **Мене звати...** |
-| And yours? informal | **А тебе?** |
-| And yours? formal | **А вас?** |
-| This is Oksana. | **Це Оксана.** |
-| Who is this? | **Хто це?** |
-| I am a student. female speaker | **Я — студентка.** |
-| She is a doctor. | **Вона — лікарка.** |
-| Where are you from? informal | **Звідки ти?** |
-| I am from Canada. | **Я з Канади.** |
+| **Як тебе́ зва́ти?** | What is your name? informal |
+| **Мене́ зва́ти...** | My name is... |
+| **А тебе́?** | And yours? informal |
+| **А вас?** | And yours? formal |
+| **Це Окса́на.** | This is Oksana. |
+| **Хто це?** | Who is this? |
+| **Я — студе́нтка.** | I am a female student. |
+| **Вона́ — лі́карка.** | She is a doctor. |
+| **Зві́дки ти?** | Where are you from? informal |
+| **Я з Кана́ди.** | I am from Canada. |
 
 Use the workbook for extra practice: profession pairs, dialogue fill-ins,
 safer Ukrainian sentence choices, native-form choices, and vocabulary


### PR DESCRIPTION
## Summary
- Repairs A1 M5-M7 learner-facing modules toward the Ukrainian-first Ohoiko/ULP S1 pattern.
- Replaces interleaved DialogueBox turns with Ukrainian-only dialogue/text blocks plus follow-up English support tables.
- Localizes inline activity prompts for the Lesson tab while keeping workbook translation/meaning checks in the workbook section.
- Adds lawful listen-only ULP support notes and original notebook/handwriting recognition paths.

## Scope
- curriculum/l2-uk-en/a1/who-am-i/{module.md,activities.yaml}
- curriculum/l2-uk-en/a1/my-family/{module.md,activities.yaml}
- curriculum/l2-uk-en/a1/checkpoint-first-contact/{module.md,activities.yaml}

Closes part of #2714. #2714 should remain open until the full M1-M7 closure audit is clean.

## Validation
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest -q tests/test_yaml_activities.py tests/test_generate_mdx.py tests/test_activity_helpers_flatten.py tests/test_yaml_activities_v7_types.py
- /Users/krisztiankoos/projects/learn-ukrainian/node_modules/.bin/prettier --check curriculum/l2-uk-en/a1/who-am-i/activities.yaml curriculum/l2-uk-en/a1/my-family/activities.yaml curriculum/l2-uk-en/a1/checkpoint-first-contact/activities.yaml
- npx markdownlint-cli2 --no-globs curriculum/l2-uk-en/a1/who-am-i/module.md curriculum/l2-uk-en/a1/my-family/module.md curriculum/l2-uk-en/a1/checkpoint-first-contact/module.md
- scripts/generate_mdx.py l2-uk-en a1 5/6/7 --validate, using a temporary worktree .venv symlink; generated MDX restored
- marker/id parity script for M5-M7 activities
- git diff --check
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py