### PR TITLE
[codex] Hide fallback tracks in Monitor ops dashboards

### DIFF
--- a/dashboards/artifacts.html
+++ b/dashboards/artifacts.html
@@ -14,7 +14,7 @@ body { min-height: 100vh; }
 .btn { background:var(--bg2); border:1px solid var(--border); color:var(--text); border-radius:4px; padding:7px 12px; font:inherit; font-size:12px; cursor:pointer; }
 .btn:hover { border-color:var(--accent); color:var(--accent); }
 .btn:disabled { opacity:.55; cursor:default; }
-.wrap { max-width: 1180px; margin: 0 auto; padding: 28px 24px 72px; }
+.wrap { max-width: 1180px; margin: 0 auto; padding: 28px 24px 72px; width:100%; overflow-x:hidden; }
 .hero { border-bottom: 1.5px solid var(--text); padding-bottom: 18px; margin-bottom: 22px; display:grid; grid-template-columns: 1fr auto; gap:24px; align-items:end; }
 .hero h2 { font-family: Charter, Georgia, serif; font-size: 30px; line-height: 1.15; margin:0 0 8px; }
 .hero p { color: var(--text2); margin:0; max-width: 680px; }
@@ -41,16 +41,18 @@ body { min-height: 100vh; }
 .ops-card.runtime { border-left-color:var(--purple); }
 .filter-bar { display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:12px; flex-wrap:wrap; }
 .filter-bar .hint { color:var(--text3); font-size:12px; }
-.filters { display:grid; grid-template-columns: 1.2fr repeat(5, minmax(130px, 1fr)) auto; gap:10px; margin-bottom: 26px; }
-.filters input, .filters select { background:#fffaf0; color:var(--text); border:1px solid var(--border); border-radius:4px; padding:9px 10px; font:inherit; font-size:13px; width:100%; }
+.filters { display:grid; grid-template-columns: minmax(180px, 1.4fr) repeat(5, minmax(110px, 1fr)); gap:10px; margin-bottom: 26px; min-width:0; }
+.filters input, .filters select { background:#fffaf0; color:var(--text); border:1px solid var(--border); border-radius:4px; box-sizing:border-box; padding:9px 10px; font:inherit; font-size:13px; width:100%; min-width:0; }
 .group { margin: 26px 0 34px; }
 .group h3 { font-family: Charter, Georgia, serif; font-size:21px; border-bottom:1px solid var(--border); padding-bottom:8px; margin:0 0 14px; display:flex; justify-content:space-between; gap:12px; }
 .group h3 span { color:var(--text3); font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; font-size:12px; font-weight:500; }
-.grid { display:grid; grid-template-columns: repeat(auto-fill, minmax(290px, 1fr)); gap:14px; }
-.artifact-card { display:block; background:var(--bg2); color:var(--text); border:1px solid var(--border); border-left:3px solid var(--accent); border-radius:4px; padding:15px 16px; text-decoration:none; min-height:158px; transition: box-shadow .15s ease, border-color .15s ease; }
+.grid { display:grid; grid-template-columns: repeat(auto-fill, minmax(290px, 1fr)); gap:14px; min-width:0; }
+.artifact-card { display:block; background:var(--bg2); color:var(--text); border:1px solid var(--border); border-left:3px solid var(--accent); border-radius:4px; padding:15px 16px; text-decoration:none; min-height:158px; min-width:0; overflow:hidden; transition: box-shadow .15s ease, border-color .15s ease; }
 .artifact-card:hover { border-color:var(--accent); box-shadow:0 8px 24px rgba(122,28,32,.08); }
-.card-top { display:flex; justify-content:space-between; gap:12px; align-items:flex-start; margin-bottom:10px; }
-.card-title { font-family: Charter, Georgia, serif; font-size:17px; line-height:1.25; font-weight:700; }
+.card-top { display:flex; justify-content:space-between; gap:12px; align-items:flex-start; margin-bottom:10px; min-width:0; }
+.card-top > div:first-child { min-width:0; overflow:hidden; }
+.card-top > div:last-child { flex:0 0 auto; }
+.card-title { font-family: Charter, Georgia, serif; font-size:17px; line-height:1.25; font-weight:700; max-width:100%; overflow-wrap:anywhere; word-break:break-word; }
 .card-path { color:var(--text3); font-size:11px; margin-top:4px; word-break:break-all; }
 .pill { display:inline-flex; align-items:center; border:1px solid var(--border); border-radius:999px; padding:2px 8px; font-size:11px; font-weight:700; text-transform:uppercase; white-space:nowrap; }
 .pill.ok { color:var(--green); background:rgba(61,107,74,.12); }
@@ -58,7 +60,7 @@ body { min-height: 100vh; }
 .pill.fail { color:var(--red); background:rgba(156,40,40,.13); }
 .pill.type { color:var(--blue); background:rgba(42,86,128,.1); text-transform:none; font-weight:600; }
 .meta { color:var(--text3); font-size:12px; margin-bottom:10px; }
-.summary { color:var(--text2); font-size:13px; line-height:1.45; display:-webkit-box; -webkit-line-clamp:3; -webkit-box-orient:vertical; overflow:hidden; }
+.summary { color:var(--text2); font-size:13px; line-height:1.45; display:-webkit-box; -webkit-line-clamp:3; -webkit-box-orient:vertical; overflow:hidden; overflow-wrap:anywhere; }
 .badges { display:flex; gap:6px; flex-wrap:wrap; margin-top:12px; }
 .badge { background:var(--bg3); border:1px solid var(--border); color:var(--text2); border-radius:999px; padding:2px 8px; font-size:11px; }
 .empty, .loading { background:var(--bg2); border:1px solid var(--border); padding:22px; border-radius:4px; color:var(--text3); }

--- a/dashboards/curriculum-dashboard.html
+++ b/dashboards/curriculum-dashboard.html
@@ -33,7 +33,7 @@ a:hover { text-decoration: underline; }
 .treemap { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 16px; }
 .treemap-cell { border-radius: 6px; padding: 8px; cursor: pointer; display: flex; flex-direction: column; justify-content: center; position: relative; overflow: hidden; min-height: 60px; transition: transform 0.1s; }
 .treemap-cell:hover { transform: scale(1.02); z-index: 1; }
-.treemap-cell .name { font-weight: 700; font-size: 13px; }
+.treemap-cell .name { font-weight: 700; font-size: 13px; overflow-wrap: anywhere; }
 .treemap-cell .count { font-size: 11px; opacity: 0.8; }
 .treemap-cell.selected { outline: 2px solid var(--blue); outline-offset: -2px; }
 
@@ -174,8 +174,14 @@ function needsBuildRefresh(module) {
   return pipelineLabel(module.pipeline_version) !== 'current';
 }
 
+function operationalTracks(tracks) {
+  return (tracks || []).filter(track => track.module_source !== 'plans-fallback');
+}
+
 async function fetchOverview() {
   overviewData = await fetchJson(`${API}/overview`);
+  overviewData.tracks = operationalTracks(overviewData.tracks);
+  if (selectedTrack && !overviewData.tracks.some(track => track.id === selectedTrack)) selectedTrack = null;
   renderTreemap(overviewData.tracks);
   document.getElementById('refresh-info').textContent = `Last refresh: ${new Date().toLocaleTimeString()}`;
 }

--- a/dashboards/index.html
+++ b/dashboards/index.html
@@ -215,7 +215,61 @@ function setStat(id, text) {
   if (el) el.textContent = text || '';
 }
 
-function buildStateSummary(pv) {
+function operationalTrackIdSetFromSummary(summary) {
+  if (!summary?.tracks) return null;
+  const tracks = summary.tracks;
+  const ids = Object.entries(tracks)
+    .filter(([, track]) => track.module_source !== 'plans-fallback')
+    .map(([id]) => id);
+  return new Set(ids);
+}
+
+function filterOperationalDashboardTracks(tracks, summary) {
+  const summaryIds = operationalTrackIdSetFromSummary(summary);
+  return (tracks || []).filter(track => {
+    if (summaryIds) return summaryIds.has(track.id);
+    return track.module_source !== 'plans-fallback';
+  });
+}
+
+function sumDashboardTotals(tracks) {
+  return tracks.reduce((acc, track) => {
+    const stats = track.stats || {};
+    acc.total += track.module_count || 0;
+    acc.pass += stats.pass || 0;
+    acc.content_complete += stats.content_complete || 0;
+    return acc;
+  }, { total: 0, pass: 0, content_complete: 0 });
+}
+
+function sumSummaryTotals(summary, trackIds) {
+  if (!summary?.tracks || !trackIds) return summary?.totals || {};
+  const totals = { total: 0 };
+  for (const id of trackIds) {
+    const track = summary.tracks[id] || {};
+    for (const [key, value] of Object.entries(track)) {
+      if (typeof value !== 'number') continue;
+      totals[key] = (totals[key] || 0) + value;
+    }
+  }
+  return totals;
+}
+
+function buildStateSummary(pv, trackIds) {
+  if (trackIds && pv?.per_track) {
+    const counts = {v6:0,v5:0,v3:0,unbuilt:0};
+    for (const trackId of trackIds) {
+      const row = pv.per_track[trackId] || {};
+      for (const key of Object.keys(counts)) counts[key] += row[key] || 0;
+    }
+    const total = counts.v6 + counts.v5 + counts.v3 + counts.unbuilt;
+    const built = counts.v6 + counts.v5 + counts.v3;
+    return {
+      current: counts.v6,
+      backlog: counts.v5 + counts.v3 + counts.unbuilt,
+      builtPct: total > 0 ? Math.round(built / total * 100) : 0,
+    };
+  }
   const state = pv?.build_state || {};
   const current = pv?.current_builds ?? state.current ?? pv?.counts?.v6 ?? 0;
   const backlog = pv?.rebuild_backlog ?? state.backlog ?? pv?.needs_rebuild ?? 0;
@@ -246,8 +300,10 @@ async function loadStats() {
 
   try {
     if (!data || !pv) throw new Error('overview unavailable');
-    const t = data.totals;
-    buildState = buildStateSummary(pv);
+    const dashboardTracks = filterOperationalDashboardTracks(data.tracks, summary);
+    const operationalIds = new Set(dashboardTracks.map(track => track.id));
+    const t = sumDashboardTotals(dashboardTracks);
+    buildState = buildStateSummary(pv, operationalIds);
     pendingConsultations = cMetrics?.pending_queue || 0;
 
     document.getElementById('stats-row').innerHTML = `
@@ -260,7 +316,7 @@ async function loadStats() {
     `;
 
     document.getElementById('audit-stat').textContent = `${t.pass} passing / ${t.total} total`;
-    document.getElementById('curriculum-stat').textContent = `${data.tracks.length} tracks`;
+    document.getElementById('curriculum-stat').textContent = `${dashboardTracks.length} tracks`;
     if (pendingConsultations > 0) {
       document.getElementById('consultation-stat').textContent = `${pendingConsultations} pending proposals`;
     }
@@ -270,7 +326,11 @@ async function loadStats() {
 
   try {
     if (!summary) throw new Error('summary unavailable');
-    const t = summary.totals;
+    const dashboardTracks = filterOperationalDashboardTracks(data?.tracks || [], summary);
+    const operationalIds = dashboardTracks.length
+      ? new Set(dashboardTracks.map(track => track.id))
+      : operationalTrackIdSetFromSummary(summary);
+    const t = sumSummaryTotals(summary, operationalIds);
     const stale = t.audit_stale ? ` · ${t.audit_stale} stale audit` : '';
     document.getElementById('progress-stat').textContent =
       `${buildState.current} current · ${buildState.backlog} backlog · ${t.dossier_done ?? 0} dossiers · ${t.published_mdx ?? 0} published${stale}`;
@@ -312,7 +372,9 @@ async function loadStats() {
   }
 
   if (wiki) {
-    const totals = (wiki.tracks || []).reduce((acc, track) => {
+    const operationalIds = operationalTrackIdSetFromSummary(summary);
+    const tracks = (wiki.tracks || []).filter(track => !operationalIds || operationalIds.has(track.track));
+    const totals = tracks.reduce((acc, track) => {
       acc.compiled += track.compiled || 0;
       acc.total += track.total || 0;
       return acc;

--- a/dashboards/progress.html
+++ b/dashboards/progress.html
@@ -191,7 +191,46 @@ function isDone(phase) {
   return phase && phase.status === 'complete';
 }
 
-function buildStateSummary(pv) {
+function operationalTrackEntries(tracks) {
+  return Object.entries(tracks || {})
+    .filter(([, track]) => (track.total || 0) > 0 && track.module_source !== 'plans-fallback');
+}
+
+function operationalTrackIdSet(trackEntries) {
+  return new Set(trackEntries.map(([id]) => id));
+}
+
+function emptySummaryTotals() {
+  return {
+    total: 0, research_done: 0, content_done: 0, audit_passing: 0,
+    reviewed: 0, final_review_done: 0, dossier_done: 0,
+    published_mdx: 0, audit_stale: 0,
+  };
+}
+
+function sumSummaryTotals(trackEntries) {
+  const totals = emptySummaryTotals();
+  for (const [, track] of trackEntries) {
+    for (const [key, value] of Object.entries(track)) {
+      if (typeof value !== 'number') continue;
+      totals[key] = (totals[key] || 0) + value;
+    }
+  }
+  return totals;
+}
+
+function buildStateSummary(pv, trackIds) {
+  if (trackIds && pv?.per_track) {
+    const counts = {v6:0,v5:0,v3:0,unbuilt:0};
+    for (const trackId of trackIds) {
+      const row = pv.per_track[trackId] || {};
+      for (const key of Object.keys(counts)) counts[key] += row[key] || 0;
+    }
+    return {
+      current: counts.v6,
+      backlog: counts.v5 + counts.v3 + counts.unbuilt,
+    };
+  }
   const state = pv?.build_state || {};
   return {
     current: pv?.current_builds ?? state.current ?? pv?.counts?.v6 ?? 0,
@@ -379,7 +418,9 @@ async function load() {
       fetchJson('/api/state/pipeline-versions?fresh=true').catch(() => ({})),
     ]);
     const data = res;
-    const t = data.totals;
+    const trackEntries = operationalTrackEntries(data.tracks);
+    const t = sumSummaryTotals(trackEntries);
+    const trackIds = operationalTrackIdSet(trackEntries);
     renderFreshness(data.meta);
 
     document.getElementById('total-modules').textContent = t.total;
@@ -390,15 +431,13 @@ async function load() {
     document.getElementById('total-final-review').textContent = t.final_review_done;
     document.getElementById('total-dossier').textContent = t.dossier_done || 0;
     document.getElementById('total-published').textContent = t.published_mdx || 0;
-    const buildState = buildStateSummary(pv);
+    const buildState = buildStateSummary(pv, trackIds);
     document.getElementById('total-current-builds').textContent = `${buildState.current}`;
     document.getElementById('total-rebuild').textContent = `${buildState.backlog}`;
     document.getElementById('topbar-subtitle').textContent =
-      `Build state across all tracks — ${buildState.current} current, ${t.published_mdx || 0} published, ${buildState.backlog} in backlog`;
+      `Build state across operational tracks — ${buildState.current} current, ${t.published_mdx || 0} published, ${buildState.backlog} in backlog`;
 
     const container = document.getElementById('tracks-container');
-    const trackEntries = Object.entries(data.tracks)
-      .filter(([, v]) => v.total > 0);
 
     // Sort: seminar first, then by name
     trackEntries.sort(([a], [b]) => {

--- a/dashboards/track-health.html
+++ b/dashboards/track-health.html
@@ -194,9 +194,14 @@ async function fetchJson(url, options) {
 function pct(v, t) { return t > 0 ? Math.round(v / t * 100) : 0; }
 
 function orderedTrackIds(summaryTracks, ...trackMaps) {
-  const ids = new Set(Object.keys(summaryTracks || {}));
+  const summary = summaryTracks || {};
+  const hasSummary = Object.keys(summary).length > 0;
+  const isOperational = id => !hasSummary || summary[id]?.module_source !== 'plans-fallback';
+  const ids = new Set(Object.keys(summary).filter(isOperational));
   for (const trackMap of trackMaps) {
-    for (const id of Object.keys(trackMap || {})) ids.add(id);
+    for (const id of Object.keys(trackMap || {})) {
+      if (isOperational(id)) ids.add(id);
+    }
   }
   return Array.from(ids).filter(Boolean);
 }
@@ -270,7 +275,7 @@ async function loadOverview() {
             <span style="font-size:11px;color:var(--text2);min-width:40px">${done}/${total}</span>
           </div>
         </td>
-        <td>${building > 0 ? `<span style="color:var(--blue)">${building} active</span>` : '<span style="color:var(--text3)">—</span>'}</td>
+        <td>${building > 0 ? `<span style="color:var(--blue)">${building} building</span>` : '<span style="color:var(--text3)">—</span>'}</td>
         <td>${failed > 0 ? `<span style="color:var(--red)">${failed}</span>` : '<span style="color:var(--text3)">0</span>'}</td>
         <td class="bar-cell">
           <div style="display:flex;align-items:center;gap:8px">

--- a/dashboards/wiki.html
+++ b/dashboards/wiki.html
@@ -113,6 +113,7 @@ const API_TIMEOUT_MS = 5000;
 let refreshTimer = null;
 let selectedTrack = null;
 let tracksCache = [];
+let operationalTrackIds = null;
 
 function escapeHtml(value) {
   const node = document.createElement('span');
@@ -169,6 +170,13 @@ function initLogFilter() {
   select.innerHTML = options.map(track => `<option value="${track}">${track || 'All tracks'}</option>`).join('');
 }
 
+function operationalTrackIdSet(summary) {
+  if (!summary?.tracks) return null;
+  return new Set(Object.entries(summary?.tracks || {})
+    .filter(([, track]) => track.module_source !== 'plans-fallback')
+    .map(([track]) => track));
+}
+
 function renderProgress(tracks) {
   tracksCache = tracks.slice();
   initLogFilter();
@@ -211,8 +219,17 @@ async function selectTrack(track) {
 
 async function loadProgress() {
   try {
-    const data = await fetchJson('/api/wiki/status');
-    const tracks = Array.isArray(data.tracks) ? data.tracks.slice().sort((a, b) => b.pct - a.pct || a.track.localeCompare(b.track)) : [];
+    const [data, summary] = await Promise.all([
+      fetchJson('/api/wiki/status'),
+      fetchJson('/api/state/summary?fresh=true').catch(() => null),
+    ]);
+    operationalTrackIds = operationalTrackIdSet(summary);
+    let tracks = Array.isArray(data.tracks) ? data.tracks.slice() : [];
+    if (operationalTrackIds) {
+      tracks = tracks.filter(track => operationalTrackIds.has(track.track));
+    }
+    tracks.sort((a, b) => b.pct - a.pct || a.track.localeCompare(b.track));
+    if (selectedTrack && !tracks.some(track => track.track === selectedTrack)) selectedTrack = null;
     if (!selectedTrack && tracks.length) selectedTrack = tracks[0].track;
     renderProgress(tracks);
     setBanner('progress-banner', '');
@@ -262,7 +279,10 @@ async function loadBuildLog() {
   if (filter) params.set('track', filter);
   try {
     const data = await fetchJson(`/api/wiki/build-log?${params.toString()}`);
-    const events = Array.isArray(data.events) ? data.events : [];
+    let events = Array.isArray(data.events) ? data.events : [];
+    if (!filter && operationalTrackIds) {
+      events = events.filter(event => operationalTrackIds.has(event.track));
+    }
     if (!events.length) {
       document.getElementById('log-content').innerHTML = '<div class="empty">No build log events for the selected filter</div>';
     } else {

--- a/scripts/api/state_build.py
+++ b/scripts/api/state_build.py
@@ -61,10 +61,10 @@ def compute_build_status_track(track_id: str, level_cfg: dict) -> dict:
                 "words": f"{audit_result.get('word_count', 0)}/{audit_result.get('word_target', 0)}",
                 "ts": latest_ts,
             })
-        elif running_phase:
-            building_now.append({"num": num, "slug": slug, "phase": running_phase, "prev": furthest})
         elif audit_status == "failed":
             failed += 1
+        elif running_phase:
+            building_now.append({"num": num, "slug": slug, "phase": running_phase, "prev": furthest})
         elif furthest:
             building_now.append({"num": num, "slug": slug, "phase": f"queued-after-{furthest}", "prev": furthest})
         else:
@@ -132,21 +132,23 @@ def compute_build_status_all() -> dict:
             continue
         track_dir = CURRICULUM_ROOT / level_cfg["path"]
         total = len(plan_slugs)
-        done = building = failed = 0
+        done = building = queued = failed = 0
 
         for _num, slug in plan_slugs:
             orch_dir = safe_join(track_dir / "orchestration", slug)
             version = detect_pipeline_version(orch_dir)
-            _furthest, running_phase, _latest_ts, audit_status = scan_module_phases(orch_dir, version)
+            furthest, running_phase, _latest_ts, audit_status = scan_module_phases(orch_dir, version)
             if audit_status == "complete":
                 done += 1
             elif audit_status == "failed":
                 failed += 1
-            elif running_phase:
+            elif running_phase or furthest:
                 building += 1
+            else:
+                queued += 1
 
         tracks[track_id] = {
-            "total": total, "done": done, "building": building, "failed": failed,
+            "total": total, "done": done, "building": building, "queued": queued, "failed": failed,
             "progress": f"{done}/{total} ({round(done/total*100) if total else 0}%)",
         }
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -156,6 +156,36 @@ class TestPipelineVersionsEndpoint:
         assert "pct_current" in data
 
 
+class TestBuildStatusEndpoint:
+    """GET /api/state/build-status agrees with per-track build status."""
+
+    def test_all_tracks_matches_per_track_build_counts(self):
+        all_tracks = client.get("/api/state/build-status").json()["tracks"]
+
+        for track in ["a1", "bio", "folk"]:
+            per_track = client.get(f"/api/state/build-status/{track}").json()
+            assert all_tracks[track]["building"] == per_track["building"]
+            assert all_tracks[track]["queued"] == per_track["queued"]
+            assert all_tracks[track]["failed"] == per_track["failed"]
+
+    def test_per_track_counts_failed_audit_before_running_phase(self, monkeypatch):
+        from scripts.api import state_build
+
+        monkeypatch.setattr(state_build, "get_plan_slugs", lambda _track_id: [(1, "failed-module")])
+        monkeypatch.setattr(state_build, "detect_pipeline_version", lambda _orch_dir: "v6")
+        monkeypatch.setattr(
+            state_build,
+            "scan_module_phases",
+            lambda _orch_dir, _version: ("write", "audit(FAIL)", "2026-06-07T00:00:00Z", "failed"),
+        )
+
+        result = state_build.compute_build_status_track("folk", {"path": "folk"})
+
+        assert result["failed"] == 1
+        assert result["building"] == 0
+        assert result["queued"] == 0
+
+
 class TestDashboardOverviewEndpoint:
     """GET /api/dashboard/overview returns tracks."""
 

--- a/tests/test_monitor_ui_contracts.py
+++ b/tests/test_monitor_ui_contracts.py
@@ -186,6 +186,41 @@ def test_track_health_uses_live_track_inventory():
     assert "const TRACKS =" not in html
     assert "/api/state/summary?fresh=true" in html
     assert "orderedTrackIds" in html
+    assert "module_source !== 'plans-fallback'" in html
+
+
+def test_operational_dashboards_hide_plan_fallback_tracks():
+    dashboard_text = {
+        path.name: path.read_text(encoding="utf-8")
+        for path in [
+            DASHBOARDS / "index.html",
+            DASHBOARDS / "progress.html",
+            DASHBOARDS / "track-health.html",
+            DASHBOARDS / "curriculum-dashboard.html",
+            DASHBOARDS / "wiki.html",
+        ]
+    }
+
+    for page, html in dashboard_text.items():
+        assert "plans-fallback" in html, f"{page} must filter fallback-only plan tracks"
+
+    assert "operationalTrackIdSetFromSummary" in dashboard_text["index.html"]
+    assert "operationalTrackEntries" in dashboard_text["progress.html"]
+    assert "operationalTracks" in dashboard_text["curriculum-dashboard.html"]
+    assert "/api/state/summary?fresh=true" in dashboard_text["wiki.html"]
+
+
+def test_operational_track_filters_treat_empty_sets_as_valid():
+    index_html = (DASHBOARDS / "index.html").read_text(encoding="utf-8")
+    progress_html = (DASHBOARDS / "progress.html").read_text(encoding="utf-8")
+    wiki_html = (DASHBOARDS / "wiki.html").read_text(encoding="utf-8")
+
+    assert "if (summaryIds) return summaryIds.has(track.id)" in index_html
+    assert "dashboardTracks.length ? sumDashboardTotals" not in index_html
+    assert "trackIds?.size && pv?.per_track" not in index_html
+    assert "trackIds?.size && pv?.per_track" not in progress_html
+    assert "if (operationalTrackIds.size)" not in wiki_html
+    assert "let operationalTrackIds = null" in wiki_html
 
 
 def test_comms_recent_completions_open_build_detail_without_fake_task_ids():


### PR DESCRIPTION
## Summary

- Hide `module_source: plans-fallback` tracks from the operational Monitor dashboards while keeping them API-visible.
- Align `/api/state/build-status` all-track counts with per-track `building` / `queued` / `failed` counts.
- Fix artifact card overflow for long names and add regression coverage for fallback filtering and build-status counting.

## Why

`lit-doc` and `lit-crimea` are fallback-only plan tracks. They should remain discoverable through the public API contract, but they should not inflate operational UI totals or appear in Monitor navigation/table views.

## Validation

- `.venv/bin/python -m pytest -q tests/test_dashboards.py tests/test_monitor_ui_contracts.py tests/test_api_endpoints.py tests/test_api_state.py` -> 202 passed
- pre-commit affected tests during commit -> 75 passed
- `.venv/bin/ruff check scripts/api/state_build.py tests/test_api_endpoints.py tests/test_monitor_ui_contracts.py` -> passed
- `.venv/bin/python -m py_compile scripts/api/state_build.py` -> passed
- `git diff --check` -> passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` -> passed
- local Gemini review -> no material remaining issues
- in-app browser smoke on `/`, `/progress.html`, `/track-health.html`, `/curriculum-dashboard.html`, `/wiki.html`, `/artifacts/` -> pages opened, no fallback tracks visible, no horizontal overflow

## Notes

The working tree still has unrelated handoff/runtime files intentionally left unstaged and out of this PR.