### PR TITLE
fix(prompt): bound V7 writer context for A1 regressions

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -1382,7 +1382,7 @@ def _normalize_vocab_hint(item: Any) -> str:
 def _build_dictionary_context(
     plan: Mapping[str, Any],
     *,
-    max_chars: int = 6000,
+    max_chars: int = 3000,
     definition_chars: int = 200,
 ) -> str:
     """Build compact VESUM + dictionary context for plan vocabulary."""
@@ -1534,6 +1534,14 @@ _TEXTBOOK_REFERENCE_TITLE_RE = re.compile(
     r"^(?P<author>\S+)\s+Grade\s+(?P<grade>\d+),\s*p\.\s*(?P<page>\d+)$",
     re.IGNORECASE,
 )
+_CYRILLIC_TEXTBOOK_REFERENCE_TITLE_RE = re.compile(
+    r"^(?P<author>[А-ЯІЇЄҐ][А-Яа-яІіЇїЄєҐґ'’ʼ-]+)"
+    r"(?:[,\s]+[^,\n]*?)?"
+    r"\b(?P<grade>\d+)\s*клас\b"
+    r"(?:[^,\n]*?)\s*,?\s*"
+    r"(?:стор\.?|с\.|сторінка|p\.)\s*(?P<page>\d+)\b",
+    re.IGNORECASE,
+)
 
 # Cyrillic spelling-variant canonicalization. Maps non-canonical Cyrillic
 # author spellings (regional/historical variants like Литвінова or the
@@ -1564,8 +1572,11 @@ def _canonicalize_author_uk(author: str) -> str:
 
 
 def _parse_textbook_reference_title(title: str) -> tuple[str, int, int] | None:
-    match = _TEXTBOOK_REFERENCE_TITLE_RE.match(title.strip())
-    if not match:
+    text = title.strip()
+    match = _TEXTBOOK_REFERENCE_TITLE_RE.match(text)
+    if match is None:
+        match = _CYRILLIC_TEXTBOOK_REFERENCE_TITLE_RE.match(text)
+    if match is None:
         return None
     return (
         match.group("author"),
@@ -1718,6 +1729,9 @@ def _search_textbook_hits(query: str, *, level: str, limit: int = 1) -> list[dic
 def _build_textbook_excerpt_context(
     plan: Mapping[str, Any],
     level: str,
+    *,
+    max_chars: int = 4200,
+    excerpt_chars: int = 520,
 ) -> str:
     references = [str(title).strip() for title in extract_plan_reference_titles(plan) if str(title).strip()]
     if not references:
@@ -1725,6 +1739,8 @@ def _build_textbook_excerpt_context(
 
     topic_query = _plan_topic_query(plan)
     lines = ["## Textbook Excerpts (verbatim, must be cited)", ""]
+    current_chars = sum(len(line.encode("utf-8")) + 1 for line in lines)
+    omitted_count = 0
     found_any = False
     for title in references:
         query = f"{title} {topic_query}".strip()
@@ -1735,8 +1751,7 @@ def _build_textbook_excerpt_context(
             missing_reason=missing_reasons,
         )
         hits = direct_hits if direct_hits is not None else _search_textbook_hits(query, level=level, limit=1)
-        lines.append(f"### {title}")
-        lines.append("")
+        section_lines = [f"### {title}", ""]
         if not hits:
             missing_reason = missing_reasons[0] if missing_reasons else ""
             for ref in plan.get("references") or []:
@@ -1744,24 +1759,35 @@ def _build_textbook_excerpt_context(
                     ref["corpus_missing"] = True
                     if missing_reason:
                         ref["corpus_missing_reason"] = missing_reason
-            lines.append("*No textbook excerpt found for this reference.*")
-            lines.append("corpus_missing: true")
+            section_lines.append("*No textbook excerpt found for this reference.*")
+            section_lines.append("corpus_missing: true")
             if missing_reason:
-                lines.append(f"corpus_missing_reason: {missing_reason}")
-            lines.append("")
+                section_lines.append(f"corpus_missing_reason: {missing_reason}")
+            section_lines.append("")
+        else:
+            hit = hits[0]
+            text = _textbook_hit_text(hit, max_chars=excerpt_chars)
+            if not text:
+                section_lines.append("*Textbook search returned metadata without excerpt text.*")
+                section_lines.append("")
+            else:
+                found_any = True
+                section_lines.append(f"Source: {_textbook_hit_label(hit)}")
+                section_lines.append("")
+                for quote_line in text.splitlines():
+                    section_lines.append(f"> {quote_line}")
+                section_lines.append("")
+        section_chars = sum(len(line.encode("utf-8")) + 1 for line in section_lines)
+        if current_chars + section_chars > max_chars:
+            omitted_count += 1
             continue
-        hit = hits[0]
-        text = _textbook_hit_text(hit)
-        if not text:
-            lines.append("*Textbook search returned metadata without excerpt text.*")
-            lines.append("")
-            continue
-        found_any = True
-        lines.append(f"Source: {_textbook_hit_label(hit)}")
-        lines.append("")
-        for quote_line in text.splitlines():
-            lines.append(f"> {quote_line}")
-        lines.append("")
+        lines.extend(section_lines)
+        current_chars += section_chars
+    if omitted_count:
+        lines.append(
+            f"*{omitted_count} textbook reference(s) omitted from this prompt excerpt budget; "
+            "call `mcp__sources__get_chunk_context` for every plan reference before citing.*"
+        )
 
     return "\n".join(lines).rstrip() if found_any or references else ""
 
@@ -1950,6 +1976,38 @@ def render_phase_prompt(template_path: Path, context: Mapping[str, Any]) -> str:
     if unresolved:
         raise LinearPipelineError(f"Unresolved downstream prompt tokens in {template_path}: " + ", ".join(unresolved))
     return rendered
+
+
+_PROMPT_PLAN_OMIT_KEYS = frozenset(
+    {
+        "lifecycle",
+        "reviewed_at",
+        "reviewed_by",
+        "review_notes",
+        "plan_fixes",
+        "changelog",
+    }
+)
+
+
+def _prompt_plan_content(
+    plan: Mapping[str, Any],
+    raw_plan_content: str,
+) -> str:
+    """Return the writer-facing plan copy without audit/history metadata."""
+    if not any(key in plan for key in _PROMPT_PLAN_OMIT_KEYS):
+        return raw_plan_content
+    compact = {
+        key: value
+        for key, value in plan.items()
+        if key not in _PROMPT_PLAN_OMIT_KEYS
+    }
+    return yaml.safe_dump(
+        compact,
+        allow_unicode=True,
+        sort_keys=False,
+        width=4096,
+    ).strip()
 
 
 def writer_prompt_path(writer_family: str) -> Path:
@@ -3163,7 +3221,7 @@ def writer_context(
         "PHASE": str(plan.get("phase", "")),
         "WORD_TARGET": str(plan["word_target"]),
         "WRITER_SPECIFIC_DIRECTIVES": _writer_specific_directives(writer),
-        "PLAN_CONTENT": plan_content,
+        "PLAN_CONTENT": _prompt_plan_content(plan, plan_content),
         "KNOWLEDGE_PACKET": knowledge_packet,
         "WIKI_MANIFEST": wiki_manifest_text,
         "WIKI_COVERAGE_REQUIRED_ITEMS": required_items_text,

--- a/tests/build/test_v7_build_mdx_terminal.py
+++ b/tests/build/test_v7_build_mdx_terminal.py
@@ -84,6 +84,11 @@ def _install_pass_fixture(
     monkeypatch.setattr(v7_build.linear_pipeline, "write_writer_artifacts", write_artifacts)
     monkeypatch.setattr(
         v7_build.linear_pipeline,
+        "run_ulp_fidelity_with_correction",
+        lambda *_args, **_kwargs: {"passed": True},
+    )
+    monkeypatch.setattr(
+        v7_build.linear_pipeline,
         "run_python_qg_with_corrections",
         lambda *_args, **_kwargs: {"gates": {"passed": True}},
     )

--- a/tests/test_textbook_grounding.py
+++ b/tests/test_textbook_grounding.py
@@ -84,6 +84,38 @@ def test_karaman_grade10_p187_resolves_to_chunk(
     assert hits[0]["chunk_id"] == "10-klas-ukrmova-karaman-2018_s0187"
 
 
+def test_cyrillic_stor_reference_resolves_to_direct_chunk(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A1 plans often cite `Автор, ... клас, стор. N`, not `Grade N, p.N`."""
+    db_path = tmp_path / "sources.db"
+    _seed_textbook_db(
+        db_path,
+        [
+            {
+                "chunk_id": "1-klas-bukvar-bolshakova-2018_s0024",
+                "title": "Сторінка 24",
+                "text": "Голосні почуєш в пісні, і у темному лісі.",
+                "source_file": "1-klas-bukvar-bolshakova-2018",
+                "grade": "1",
+                "author": "bolshakova",
+                "author_uk": "Большакова",
+            }
+        ],
+    )
+    monkeypatch.setattr(linear_pipeline, "TEXTBOOK_SOURCES_DB_PATH", db_path)
+
+    hits = linear_pipeline._search_textbook_hits(
+        "Большакова, буквар 1 клас, стор. 24",
+        level="a1",
+        limit=1,
+    )
+
+    assert len(hits) == 1
+    assert hits[0]["chunk_id"] == "1-klas-bukvar-bolshakova-2018_s0024"
+
+
 def test_zakhariychuk_grade4_p162_reports_corpus_missing_deterministically(
     tmp_path: Path,
     monkeypatch,
@@ -433,3 +465,51 @@ def test_textbook_excerpt_context_uses_reference_title_for_direct_lookup(
 
     assert "10-klas-ukrmova-karaman-2018" in context
     assert "corpus_missing: true" not in context
+
+
+def test_textbook_excerpt_budget_still_marks_later_missing_refs(monkeypatch) -> None:
+    plan = {
+        "references": [
+            {"title": "Found Grade 1, p.1"},
+            {"title": "Missing Grade 1, p.2"},
+        ],
+        "title": "letters",
+        "subtitle": "sounds",
+        "content_outline": [{"section": "Letters", "points": ["sounds"]}],
+    }
+
+    def fake_lookup(
+        title: str,
+        *,
+        limit: int = 1,
+        missing_reason: list[str] | None = None,
+    ) -> list[dict] | None:
+        del limit
+        if title.startswith("Found"):
+            return [
+                {
+                    "chunk_id": "found_s0001",
+                    "title": "Found page",
+                    "text": "А" * 1000,
+                    "source_file": "found-source",
+                    "grade": "1",
+                    "author": "found",
+                    "page": 1,
+                }
+            ]
+        if missing_reason is not None:
+            missing_reason.append("page 2 not in corpus")
+        return []
+
+    monkeypatch.setattr(linear_pipeline, "_lookup_textbook_reference_chunk", fake_lookup)
+
+    context = linear_pipeline._build_textbook_excerpt_context(
+        plan,
+        "a1",
+        max_chars=120,
+        excerpt_chars=80,
+    )
+
+    assert "textbook reference(s) omitted from this prompt excerpt budget" in context
+    assert plan["references"][1]["corpus_missing"] is True
+    assert plan["references"][1]["corpus_missing_reason"] == "page 2 not in corpus"

--- a/tests/test_writer_prompt_size.py
+++ b/tests/test_writer_prompt_size.py
@@ -7,6 +7,7 @@ from scripts.audit.check_writer_prompt_size import (
     WRITER_PROMPT_CEILING_BYTES,
     render_fixture_writer_prompt,
 )
+from scripts.build import linear_pipeline
 
 
 def test_ceiling_is_130kb() -> None:
@@ -42,3 +43,25 @@ def test_fixture_writer_prompts_under_ceiling() -> None:
     for level, slug in FIXTURE_MODULES:
         rendered = render_fixture_writer_prompt(level, slug)
         assert len(rendered.encode("utf-8")) <= WRITER_PROMPT_CEILING_BYTES
+
+
+def test_prompt_plan_content_omits_review_history_metadata() -> None:
+    plan = {
+        "module": "a1-999",
+        "title": "Letters",
+        "content_outline": [{"section": "Core", "words": 100, "points": ["Teach letters."]}],
+        "activity_hints": [{"type": "quiz", "focus": "letters"}],
+        "references": [{"title": "Reference"}],
+        "review_notes": "Long audit narrative that belongs in the source plan only.",
+        "plan_fixes": [{"version": "1.0.1", "changes": ["historical fix"]}],
+        "changelog": [{"version": "1.0.0", "changes": ["historical note"]}],
+    }
+
+    rendered = linear_pipeline._prompt_plan_content(plan, "raw plan")
+
+    assert "content_outline:" in rendered
+    assert "activity_hints:" in rendered
+    assert "references:" in rendered
+    assert "review_notes" not in rendered
+    assert "plan_fixes" not in rendered
+    assert "changelog" not in rendered


### PR DESCRIPTION
## Summary
- Restore the V7 MDX terminal regression fixture so a successful run reaches `build_mdx` after the ULP fidelity phase was added.
- Keep A1 writer prompts under budget by bounding textbook/dictionary grounding, parsing Cyrillic textbook page references, and omitting plan review history metadata from writer prompt copies.
- Add regression coverage for Cyrillic `стор.` textbook refs, prompt metadata trimming, and missing-reference side effects under excerpt budgets.

## Gate
Refs #2380.

This is a partial regression-guard PR. The `translate` schema regression was already fixed on `main`; this branch covers the silent-exit regression guard and prompt/context-budget pressure. A1 audience-language tone and Codex tool-call-depth utilization still need empirical rebuild verification before #2380 can close.

Active delegates were checked before publishing: `0`. Open PRs were checked before publishing: no active A1/A2 lane PRs.

## Validation
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest -q tests/build/test_v7_build_mdx_terminal.py tests/test_writer_prompt_size.py tests/test_writer_prompt_render_size.py tests/test_textbook_grounding.py tests/test_wiki_packet_dictionary_context.py tests/test_writer_prompt_activity_fields.py tests/test_writer_prompt_v7_register_rules.py tests/test_agent_runtime_tool_calls.py tests/test_runner_tool_calls.py tests/test_trace_capture_no_contamination.py tests/test_mcp_init_observability.py tests/test_linear_pipeline_telemetry.py tests/test_v7_writer_dispatch.py` -> `122 passed`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check --fix scripts/build/linear_pipeline.py tests/build/test_v7_build_mdx_terminal.py tests/test_textbook_grounding.py tests/test_writer_prompt_size.py` -> `All checks passed`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/build/v7_build.py a1 my-morning --dry-run` -> exit 0, emitted `module_done`
- Prompt render sizes after fix: `a1/sounds-letters-and-hello` 126,839 bytes; `a1/my-morning` 126,745 bytes
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` -> passed
- `git diff --check` -> clean
- Generated artifact/config guard -> no matches
- `sys.executable` guard on changed files -> no matches
- Local Gemini/Codex review: one kept finding fixed; remaining findings challenged/dropped as false positives or style-only
