### PR TITLE
feat(orchestration): add parallel agent ledger

### DIFF
--- a/docs/architecture/agent-coordination-ledger.md
+++ b/docs/architecture/agent-coordination-ledger.md
@@ -1,0 +1,120 @@
+# Parallel Agent Coordination Ledger
+
+## Problem
+
+Shared `docs/session-state/*` files are not a safe coordination mechanism for
+parallel work. An orchestrator thread, worker threads, subagents, and external
+agent fleet runs can overwrite the same file or read stale state. That failure
+mode already caused confusion between UI work, A1 content work, and handoff
+state.
+
+## Decision
+
+Use an append-friendly runtime ledger as the operational source of truth.
+Markdown can be generated for humans, but workers must not write shared
+session-state files as their reporting channel.
+
+The first implementation slice stores task records in ignored runtime state:
+
+```text
+batch_state/agent-ledger/tasks/<task-id>.json
+```
+
+The ledger integrates with, but does not replace, `scripts/delegate.py`.
+`delegate.py` owns process lifecycle and worktree setup. The coordination
+ledger owns the orchestrator view: who is working, where, on what paths, with
+which issue/thread/branch, and with which validation/review state.
+
+## Task Record
+
+Each active or completed task records:
+
+- `task_id`
+- `issue`
+- `lane`
+- `module_family`
+- `task_family`
+- `agent`
+- `model`
+- `thread_id`
+- `branch`
+- `worktree`
+- `owned_paths`
+- `status`
+- `heartbeat_at`
+- `validation`
+- `review`
+- `ci`
+- `pr_url`
+- append-only `events`
+
+## Task Families
+
+Telemetry should be measured at least across:
+
+- `architecture`
+- `coding`
+- `code_review`
+- `design`
+- `documentation`
+- `refactoring`
+- `content_writing`
+- `creative_writing`
+- `translation_localization`
+- `operations_release`
+- `pedagogy_review`
+- `research_verification`
+
+These families let the orchestrator compare agents by real task type instead
+of one vague "best model" ranking.
+
+## Ownership
+
+Workers must declare `owned_paths`. The ledger blocks overlapping active path
+ownership unless the orchestrator explicitly allows conflicts. This supports
+parallel module families such as A1, A2, Folk, UI, BIO, infra, and review lanes
+without pretending they are one serial session.
+
+Examples:
+
+```bash
+.venv/bin/python scripts/orchestration/agent_ledger.py upsert-task \
+  --task-id 2823-ui-worker \
+  --agent codex \
+  --status running \
+  --issue 2823 \
+  --lane ui \
+  --module-family site \
+  --task-family design \
+  --thread-id 019ea418-d223-7120-8705-ba5988321e92 \
+  --branch codex/2823-lightweight-ui \
+  --worktree .worktrees/dispatch/codex/2823-lightweight-ui \
+  --owned-path starlight/src/pages \
+  --owned-path starlight/src/styles
+
+.venv/bin/python scripts/orchestration/agent_ledger.py heartbeat \
+  --task-id 2823-ui-worker \
+  --actor codex \
+  --message "browser QA passed; awaiting independent review"
+```
+
+## Monitor API
+
+The first read-only API endpoints are:
+
+- `/api/coordination/summary`
+- `/api/coordination/active`
+- `/api/coordination/tasks/{task_id}`
+
+Future slices should add write endpoints only if authentication and local-use
+constraints are clear. Until then, workers write via the local CLI.
+
+## Rules
+
+- Workers report through the ledger, their Codex thread, and their owned
+  GitHub issue or PR.
+- Workers must not write `docs/session-state/current.md`,
+  `docs/session-state/current.codex.md`, or any shared session-state file.
+- The orchestrator remains responsible for review routing, merge decisions,
+  issue hygiene, PR queue hygiene, and final summaries.
+- Independent review remains mandatory before merge.

--- a/scripts/api/coordination_router.py
+++ b/scripts/api/coordination_router.py
@@ -1,0 +1,37 @@
+"""Read-only Monitor API surface for the parallel-agent ledger."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+
+from scripts.orchestration import agent_ledger
+
+from .config import PROJECT_ROOT
+
+router = APIRouter(tags=["coordination"])
+
+
+@router.get("/summary")
+async def coordination_summary():
+    return await asyncio.to_thread(agent_ledger.summary, PROJECT_ROOT)
+
+
+@router.get("/active")
+async def coordination_active():
+    tasks = await asyncio.to_thread(agent_ledger.active_tasks, PROJECT_ROOT)
+    return {"total": len(tasks), "tasks": tasks}
+
+
+@router.get("/tasks/{task_id}")
+async def coordination_task(task_id: str):
+    task = await asyncio.to_thread(agent_ledger.get_task, PROJECT_ROOT, task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail=f"Task not found: {task_id}")
+    return task
+
+
+def ledger_state_dir() -> Path:
+    return agent_ledger.ledger_dir(PROJECT_ROOT)

--- a/scripts/api/coordination_router.py
+++ b/scripts/api/coordination_router.py
@@ -27,7 +27,10 @@ async def coordination_active():
 
 @router.get("/tasks/{task_id}")
 async def coordination_task(task_id: str):
-    task = await asyncio.to_thread(agent_ledger.get_task, PROJECT_ROOT, task_id)
+    try:
+        task = await asyncio.to_thread(agent_ledger.get_task, PROJECT_ROOT, task_id)
+    except agent_ledger.LedgerError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     if task is None:
         raise HTTPException(status_code=404, detail=f"Task not found: {task_id}")
     return task

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -51,6 +51,7 @@ from .config import (
     PROJECT_ROOT,
 )
 from .consultation_router import router as consultation_router
+from .coordination_router import router as coordination_router
 from .cost_router import router as cost_router
 from .dashboard_router import router as dashboard_router
 from .decisions_router import router as decisions_router
@@ -122,6 +123,7 @@ app.include_router(agent_router, prefix="/api/agent", tags=["agent"])
 app.include_router(artifacts_router, prefix="/api/artifacts", tags=["artifacts"])
 app.include_router(blue_router, prefix="/api/blue")
 app.include_router(comms_router, prefix="/api/comms")
+app.include_router(coordination_router, prefix="/api/coordination")
 app.include_router(consultation_router, prefix="/api/consultation")
 app.include_router(cost_router, prefix="/api/cost")
 app.include_router(cost_router, prefix="/api/analytics/cost")

--- a/scripts/api/route_contracts.py
+++ b/scripts/api/route_contracts.py
@@ -257,6 +257,16 @@ ROUTE_CONTRACTS: tuple[RouteContract, ...] = (
         "keep",
     ),
     RouteContract(
+        "/api/coordination", "prefix", "http",
+        "Parallel-agent coordination ledger summary, active task list, and task detail.",
+        "orchestration/agent-ledger/tasks/*.json written by scripts/orchestration/agent_ledger.py.",
+        "No route cache; live filesystem reads from the local coordination ledger.",
+        ("agents", "orchestrator", "future dashboards"),
+        "Complements /api/delegate process state with explicit task ownership and review metadata.",
+        "low while JSON ledger is healthy; invalid task files surface as errors instead of silent stale state",
+        "keep",
+    ),
+    RouteContract(
         "/api/worktrees", "exact", "http",
         "Active git worktree registry.",
         "git worktree list --porcelain, per-worktree git status, and git log -1.",

--- a/scripts/orchestration/agent_ledger.py
+++ b/scripts/orchestration/agent_ledger.py
@@ -10,9 +10,12 @@ events needed by the orchestrator.
 from __future__ import annotations
 
 import argparse
+import fcntl
 import json
-import os
 import re
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -71,7 +74,7 @@ def safe_id(value: str) -> str:
 
 
 def safe_path_component(value: str) -> str:
-    return re.sub(r"[^A-Za-z0-9._:-]+", "_", value).strip("._") or "task"
+    return safe_id(value)
 
 
 def ledger_dir(repo_root: Path) -> Path:
@@ -86,23 +89,44 @@ def task_path(repo_root: Path, task_id: str) -> Path:
     return tasks_dir(repo_root) / f"{safe_path_component(task_id)}.json"
 
 
+@contextmanager
+def ledger_mutation_lock(repo_root: Path) -> Iterator[None]:
+    lock_path = ledger_dir(repo_root) / ".lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle, fcntl.LOCK_UN)
+
+
 def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+    tmp = path.with_suffix(path.suffix + f".tmp.{uuid.uuid4().hex}")
     tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    os.replace(tmp, path)
+    tmp.replace(path)
 
 
 def read_json(path: Path) -> dict[str, Any] | None:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except FileNotFoundError:
         return None
+    except OSError as exc:
+        raise LedgerError(f"could not read ledger file {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise LedgerError(f"invalid JSON in ledger file {path}: {exc.msg}") from exc
+    if not isinstance(payload, dict):
+        raise LedgerError(f"ledger file must contain a JSON object: {path}")
     return payload if isinstance(payload, dict) else None
 
 
 def normalize_owned_path(path: str) -> str:
-    value = path.strip().replace("\\", "/")
+    raw = path.strip().replace("\\", "/")
+    if raw.startswith("/") or re.match(r"^[A-Za-z]:/", raw):
+        raise LedgerError(f"owned paths must be relative to the repository: {path!r}")
+    value = raw
     value = re.sub(r"/+", "/", value).strip("/")
     if not value or value.startswith("..") or "/../" in f"/{value}/":
         raise LedgerError(f"invalid owned path: {path!r}")
@@ -192,8 +216,8 @@ def upsert_task(
     repo_root: Path,
     *,
     task_id: str,
-    agent: str,
-    status: str = "planned",
+    agent: str | None = None,
+    status: str | None = None,
     issue: int | None = None,
     lane: str | None = None,
     module_family: str | None = None,
@@ -206,58 +230,71 @@ def upsert_task(
     allow_conflicts: bool = False,
     metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    task_id = safe_id(task_id)
-    if status not in VALID_STATUSES:
-        raise LedgerError(f"invalid status: {status}")
-    if task_family and task_family not in TASK_FAMILIES:
-        raise LedgerError(f"invalid task_family: {task_family}")
+    with ledger_mutation_lock(repo_root):
+        task_id = safe_id(task_id)
+        existing = get_task(repo_root, task_id) or {}
 
-    owned = normalize_owned_paths(owned_paths)
-    if status in ACTIVE_STATUSES and not allow_conflicts:
-        conflicts = _overlap_conflicts(repo_root, task_id=task_id, owned_paths=owned)
-        if conflicts:
-            raise OwnershipConflictError(task_id, conflicts)
+        effective_agent = agent or existing.get("agent")
+        if not effective_agent:
+            raise LedgerError("agent is required when creating a task")
 
-    now = isoformat_z(utc_now())
-    existing = get_task(repo_root, task_id) or {}
-    events = list(existing.get("events") or [])
-    if not existing:
-        events.append(task_event(event_type="created", actor=agent, message="task registered"))
-    elif existing.get("status") != status:
-        events.append(
-            task_event(
-                event_type="status",
-                actor=agent,
-                message=f"{existing.get('status')} -> {status}",
-            )
+        effective_status = status or existing.get("status") or "planned"
+        if effective_status not in VALID_STATUSES:
+            raise LedgerError(f"invalid status: {effective_status}")
+
+        effective_task_family = task_family if task_family is not None else existing.get("task_family")
+        if effective_task_family and effective_task_family not in TASK_FAMILIES:
+            raise LedgerError(f"invalid task_family: {effective_task_family}")
+
+        owned = (
+            list(existing.get("owned_paths") or [])
+            if owned_paths is None
+            else normalize_owned_paths(owned_paths)
         )
+        if effective_status in ACTIVE_STATUSES and not allow_conflicts:
+            conflicts = _overlap_conflicts(repo_root, task_id=task_id, owned_paths=owned)
+            if conflicts:
+                raise OwnershipConflictError(task_id, conflicts)
 
-    payload = {
-        "schema_version": SCHEMA_VERSION,
-        "task_id": task_id,
-        "issue": issue,
-        "lane": lane,
-        "module_family": module_family,
-        "task_family": task_family,
-        "agent": agent,
-        "model": model,
-        "thread_id": thread_id,
-        "branch": branch,
-        "worktree": worktree,
-        "owned_paths": owned,
-        "status": status,
-        "heartbeat_at": existing.get("heartbeat_at"),
-        "validation": existing.get("validation") or {},
-        "review": existing.get("review") or {},
-        "ci": existing.get("ci") or {},
-        "pr_url": existing.get("pr_url"),
-        "metadata": {**(existing.get("metadata") or {}), **(metadata or {})},
-        "events": events,
-        "created_at": existing.get("created_at") or now,
-        "updated_at": now,
-    }
-    write_json_atomic(task_path(repo_root, task_id), payload)
-    return payload
+        now = isoformat_z(utc_now())
+        events = list(existing.get("events") or [])
+        if not existing:
+            events.append(task_event(event_type="created", actor=effective_agent, message="task registered"))
+        elif existing.get("status") != effective_status:
+            events.append(
+                task_event(
+                    event_type="status",
+                    actor=effective_agent,
+                    message=f"{existing.get('status')} -> {effective_status}",
+                )
+            )
+
+        payload = {
+            "schema_version": SCHEMA_VERSION,
+            "task_id": task_id,
+            "issue": issue if issue is not None else existing.get("issue"),
+            "lane": lane if lane is not None else existing.get("lane"),
+            "module_family": module_family if module_family is not None else existing.get("module_family"),
+            "task_family": effective_task_family,
+            "agent": effective_agent,
+            "model": model if model is not None else existing.get("model"),
+            "thread_id": thread_id if thread_id is not None else existing.get("thread_id"),
+            "branch": branch if branch is not None else existing.get("branch"),
+            "worktree": worktree if worktree is not None else existing.get("worktree"),
+            "owned_paths": owned,
+            "status": effective_status,
+            "heartbeat_at": existing.get("heartbeat_at"),
+            "validation": existing.get("validation") or {},
+            "review": existing.get("review") or {},
+            "ci": existing.get("ci") or {},
+            "pr_url": existing.get("pr_url"),
+            "metadata": {**(existing.get("metadata") or {}), **(metadata or {})},
+            "events": events,
+            "created_at": existing.get("created_at") or now,
+            "updated_at": now,
+        }
+        write_json_atomic(task_path(repo_root, task_id), payload)
+        return payload
 
 
 def append_event(
@@ -269,28 +306,29 @@ def append_event(
     message: str = "",
     data: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    task = get_task(repo_root, task_id)
-    if task is None:
-        raise LedgerError(f"task not found: {task_id}")
-    task.setdefault("events", []).append(
-        task_event(event_type=event_type, actor=actor, message=message, data=data)
-    )
-    task["updated_at"] = isoformat_z(utc_now())
-    write_json_atomic(task_path(repo_root, task_id), task)
-    return task
+    with ledger_mutation_lock(repo_root):
+        task = get_task(repo_root, task_id)
+        if task is None:
+            raise LedgerError(f"task not found: {task_id}")
+        task.setdefault("events", []).append(
+            task_event(event_type=event_type, actor=actor, message=message, data=data)
+        )
+        task["updated_at"] = isoformat_z(utc_now())
+        write_json_atomic(task_path(repo_root, task_id), task)
+        return task
 
 
 def heartbeat(repo_root: Path, task_id: str, *, actor: str, message: str = "") -> dict[str, Any]:
-    task = append_event(
-        repo_root,
-        task_id,
-        event_type="heartbeat",
-        actor=actor,
-        message=message,
-    )
-    task["heartbeat_at"] = task["events"][-1]["timestamp"]
-    write_json_atomic(task_path(repo_root, task_id), task)
-    return task
+    with ledger_mutation_lock(repo_root):
+        task = get_task(repo_root, task_id)
+        if task is None:
+            raise LedgerError(f"task not found: {task_id}")
+        event = task_event(event_type="heartbeat", actor=actor, message=message)
+        task.setdefault("events", []).append(event)
+        task["heartbeat_at"] = event["timestamp"]
+        task["updated_at"] = isoformat_z(utc_now())
+        write_json_atomic(task_path(repo_root, task_id), task)
+        return task
 
 
 def summary(repo_root: Path) -> dict[str, Any]:
@@ -316,7 +354,10 @@ def summary(repo_root: Path) -> dict[str, Any]:
 def _json_arg(raw: str | None) -> dict[str, Any] | None:
     if not raw:
         return None
-    data = json.loads(raw)
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise LedgerError(f"invalid JSON object: {exc.msg}") from exc
     if not isinstance(data, dict):
         raise LedgerError("--metadata/--data must be a JSON object")
     return data
@@ -329,8 +370,8 @@ def build_parser() -> argparse.ArgumentParser:
 
     upsert = sub.add_parser("upsert-task")
     upsert.add_argument("--task-id", required=True)
-    upsert.add_argument("--agent", required=True)
-    upsert.add_argument("--status", default="planned", choices=sorted(VALID_STATUSES))
+    upsert.add_argument("--agent")
+    upsert.add_argument("--status", choices=sorted(VALID_STATUSES))
     upsert.add_argument("--issue", type=int)
     upsert.add_argument("--lane")
     upsert.add_argument("--module-family")
@@ -339,7 +380,7 @@ def build_parser() -> argparse.ArgumentParser:
     upsert.add_argument("--thread-id")
     upsert.add_argument("--branch")
     upsert.add_argument("--worktree")
-    upsert.add_argument("--owned-path", action="append", default=[])
+    upsert.add_argument("--owned-path", action="append")
     upsert.add_argument("--allow-conflicts", action="store_true")
     upsert.add_argument("--metadata")
 

--- a/scripts/orchestration/agent_ledger.py
+++ b/scripts/orchestration/agent_ledger.py
@@ -1,0 +1,408 @@
+"""Parallel-agent coordination ledger.
+
+This module stores runtime coordination state under ``batch_state/`` so
+parallel workers can report task state without editing shared markdown
+handoff files. It is intentionally small and local-first: delegate.py still
+owns process lifecycle, while this ledger owns task metadata, ownership, and
+events needed by the orchestrator.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+ACTIVE_STATUSES = {"planned", "queued", "running", "reviewing", "blocked"}
+TERMINAL_STATUSES = {"done", "closed", "cancelled", "failed", "timeout"}
+VALID_STATUSES = ACTIVE_STATUSES | TERMINAL_STATUSES
+TASK_FAMILIES = {
+    "architecture",
+    "code_review",
+    "coding",
+    "content_writing",
+    "creative_writing",
+    "design",
+    "documentation",
+    "operations_release",
+    "pedagogy_review",
+    "refactoring",
+    "research_verification",
+    "translation_localization",
+}
+SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+
+
+class LedgerError(ValueError):
+    """Raised for invalid ledger input."""
+
+
+class OwnershipConflictError(LedgerError):
+    """Raised when two active tasks claim overlapping owned paths."""
+
+    def __init__(self, task_id: str, conflicts: list[dict[str, Any]]) -> None:
+        super().__init__(f"task {task_id!r} conflicts with active owned paths")
+        self.task_id = task_id
+        self.conflicts = conflicts
+
+
+def repo_root_from_file() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC).replace(microsecond=0)
+
+
+def isoformat_z(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def safe_id(value: str) -> str:
+    raw = value.strip()
+    if not SAFE_ID_RE.fullmatch(raw):
+        raise LedgerError("task ids must match [A-Za-z0-9][A-Za-z0-9._:-]*")
+    return raw
+
+
+def safe_path_component(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._:-]+", "_", value).strip("._") or "task"
+
+
+def ledger_dir(repo_root: Path) -> Path:
+    return repo_root / "batch_state" / "agent-ledger"
+
+
+def tasks_dir(repo_root: Path) -> Path:
+    return ledger_dir(repo_root) / "tasks"
+
+
+def task_path(repo_root: Path, task_id: str) -> Path:
+    return tasks_dir(repo_root) / f"{safe_path_component(task_id)}.json"
+
+
+def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def normalize_owned_path(path: str) -> str:
+    value = path.strip().replace("\\", "/")
+    value = re.sub(r"/+", "/", value).strip("/")
+    if not value or value.startswith("..") or "/../" in f"/{value}/":
+        raise LedgerError(f"invalid owned path: {path!r}")
+    return value
+
+
+def normalize_owned_paths(paths: list[str] | None) -> list[str]:
+    normalized: list[str] = []
+    for path in paths or []:
+        item = normalize_owned_path(path)
+        if item not in normalized:
+            normalized.append(item)
+    return normalized
+
+
+def paths_overlap(left: str, right: str) -> bool:
+    left = normalize_owned_path(left)
+    right = normalize_owned_path(right)
+    return left == right or left.startswith(f"{right}/") or right.startswith(f"{left}/")
+
+
+def list_tasks(repo_root: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if not tasks_dir(repo_root).exists():
+        return rows
+    for path in sorted(tasks_dir(repo_root).glob("*.json")):
+        task = read_json(path)
+        if task:
+            rows.append(task)
+    rows.sort(key=lambda row: str(row.get("updated_at") or row.get("created_at") or ""), reverse=True)
+    return rows
+
+
+def get_task(repo_root: Path, task_id: str) -> dict[str, Any] | None:
+    return read_json(task_path(repo_root, safe_id(task_id)))
+
+
+def active_tasks(repo_root: Path) -> list[dict[str, Any]]:
+    return [task for task in list_tasks(repo_root) if task.get("status") in ACTIVE_STATUSES]
+
+
+def _overlap_conflicts(
+    repo_root: Path,
+    *,
+    task_id: str,
+    owned_paths: list[str],
+) -> list[dict[str, Any]]:
+    conflicts: list[dict[str, Any]] = []
+    if not owned_paths:
+        return conflicts
+    for task in active_tasks(repo_root):
+        other_id = str(task.get("task_id") or "")
+        if other_id == task_id:
+            continue
+        for left in owned_paths:
+            for right in task.get("owned_paths") or []:
+                if paths_overlap(left, str(right)):
+                    conflicts.append(
+                        {
+                            "task_id": other_id,
+                            "agent": task.get("agent"),
+                            "status": task.get("status"),
+                            "owned_path": right,
+                            "requested_path": left,
+                        }
+                    )
+    return conflicts
+
+
+def task_event(
+    *,
+    event_type: str,
+    actor: str,
+    message: str = "",
+    data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "timestamp": isoformat_z(utc_now()),
+        "type": event_type,
+        "actor": actor,
+        "message": message,
+        "data": data or {},
+    }
+
+
+def upsert_task(
+    repo_root: Path,
+    *,
+    task_id: str,
+    agent: str,
+    status: str = "planned",
+    issue: int | None = None,
+    lane: str | None = None,
+    module_family: str | None = None,
+    task_family: str | None = None,
+    model: str | None = None,
+    thread_id: str | None = None,
+    branch: str | None = None,
+    worktree: str | None = None,
+    owned_paths: list[str] | None = None,
+    allow_conflicts: bool = False,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    task_id = safe_id(task_id)
+    if status not in VALID_STATUSES:
+        raise LedgerError(f"invalid status: {status}")
+    if task_family and task_family not in TASK_FAMILIES:
+        raise LedgerError(f"invalid task_family: {task_family}")
+
+    owned = normalize_owned_paths(owned_paths)
+    if status in ACTIVE_STATUSES and not allow_conflicts:
+        conflicts = _overlap_conflicts(repo_root, task_id=task_id, owned_paths=owned)
+        if conflicts:
+            raise OwnershipConflictError(task_id, conflicts)
+
+    now = isoformat_z(utc_now())
+    existing = get_task(repo_root, task_id) or {}
+    events = list(existing.get("events") or [])
+    if not existing:
+        events.append(task_event(event_type="created", actor=agent, message="task registered"))
+    elif existing.get("status") != status:
+        events.append(
+            task_event(
+                event_type="status",
+                actor=agent,
+                message=f"{existing.get('status')} -> {status}",
+            )
+        )
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "task_id": task_id,
+        "issue": issue,
+        "lane": lane,
+        "module_family": module_family,
+        "task_family": task_family,
+        "agent": agent,
+        "model": model,
+        "thread_id": thread_id,
+        "branch": branch,
+        "worktree": worktree,
+        "owned_paths": owned,
+        "status": status,
+        "heartbeat_at": existing.get("heartbeat_at"),
+        "validation": existing.get("validation") or {},
+        "review": existing.get("review") or {},
+        "ci": existing.get("ci") or {},
+        "pr_url": existing.get("pr_url"),
+        "metadata": {**(existing.get("metadata") or {}), **(metadata or {})},
+        "events": events,
+        "created_at": existing.get("created_at") or now,
+        "updated_at": now,
+    }
+    write_json_atomic(task_path(repo_root, task_id), payload)
+    return payload
+
+
+def append_event(
+    repo_root: Path,
+    task_id: str,
+    *,
+    event_type: str,
+    actor: str,
+    message: str = "",
+    data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    task = get_task(repo_root, task_id)
+    if task is None:
+        raise LedgerError(f"task not found: {task_id}")
+    task.setdefault("events", []).append(
+        task_event(event_type=event_type, actor=actor, message=message, data=data)
+    )
+    task["updated_at"] = isoformat_z(utc_now())
+    write_json_atomic(task_path(repo_root, task_id), task)
+    return task
+
+
+def heartbeat(repo_root: Path, task_id: str, *, actor: str, message: str = "") -> dict[str, Any]:
+    task = append_event(
+        repo_root,
+        task_id,
+        event_type="heartbeat",
+        actor=actor,
+        message=message,
+    )
+    task["heartbeat_at"] = task["events"][-1]["timestamp"]
+    write_json_atomic(task_path(repo_root, task_id), task)
+    return task
+
+
+def summary(repo_root: Path) -> dict[str, Any]:
+    tasks = list_tasks(repo_root)
+    active = [task for task in tasks if task.get("status") in ACTIVE_STATUSES]
+    by_family: dict[str, int] = {}
+    by_agent: dict[str, int] = {}
+    for task in tasks:
+        family = str(task.get("task_family") or "unspecified")
+        agent = str(task.get("agent") or "unknown")
+        by_family[family] = by_family.get(family, 0) + 1
+        by_agent[agent] = by_agent.get(agent, 0) + 1
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "total": len(tasks),
+        "active": len(active),
+        "tasks": tasks,
+        "by_task_family": by_family,
+        "by_agent": by_agent,
+    }
+
+
+def _json_arg(raw: str | None) -> dict[str, Any] | None:
+    if not raw:
+        return None
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise LedgerError("--metadata/--data must be a JSON object")
+    return data
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=str(repo_root_from_file()))
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    upsert = sub.add_parser("upsert-task")
+    upsert.add_argument("--task-id", required=True)
+    upsert.add_argument("--agent", required=True)
+    upsert.add_argument("--status", default="planned", choices=sorted(VALID_STATUSES))
+    upsert.add_argument("--issue", type=int)
+    upsert.add_argument("--lane")
+    upsert.add_argument("--module-family")
+    upsert.add_argument("--task-family", choices=sorted(TASK_FAMILIES))
+    upsert.add_argument("--model")
+    upsert.add_argument("--thread-id")
+    upsert.add_argument("--branch")
+    upsert.add_argument("--worktree")
+    upsert.add_argument("--owned-path", action="append", default=[])
+    upsert.add_argument("--allow-conflicts", action="store_true")
+    upsert.add_argument("--metadata")
+
+    event = sub.add_parser("event")
+    event.add_argument("--task-id", required=True)
+    event.add_argument("--type", required=True, dest="event_type")
+    event.add_argument("--actor", required=True)
+    event.add_argument("--message", default="")
+    event.add_argument("--data")
+
+    beat = sub.add_parser("heartbeat")
+    beat.add_argument("--task-id", required=True)
+    beat.add_argument("--actor", required=True)
+    beat.add_argument("--message", default="")
+
+    sub.add_parser("summary")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo_root = Path(args.repo_root)
+    try:
+        if args.command == "upsert-task":
+            payload = upsert_task(
+                repo_root,
+                task_id=args.task_id,
+                agent=args.agent,
+                status=args.status,
+                issue=args.issue,
+                lane=args.lane,
+                module_family=args.module_family,
+                task_family=args.task_family,
+                model=args.model,
+                thread_id=args.thread_id,
+                branch=args.branch,
+                worktree=args.worktree,
+                owned_paths=args.owned_path,
+                allow_conflicts=args.allow_conflicts,
+                metadata=_json_arg(args.metadata),
+            )
+        elif args.command == "event":
+            payload = append_event(
+                repo_root,
+                args.task_id,
+                event_type=args.event_type,
+                actor=args.actor,
+                message=args.message,
+                data=_json_arg(args.data),
+            )
+        elif args.command == "heartbeat":
+            payload = heartbeat(repo_root, args.task_id, actor=args.actor, message=args.message)
+        else:
+            payload = summary(repo_root)
+    except OwnershipConflictError as exc:
+        print(json.dumps({"error": "ownership_conflict", "conflicts": exc.conflicts}, indent=2))
+        return 2
+    except LedgerError as exc:
+        print(json.dumps({"error": str(exc)}, indent=2))
+        return 2
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/orchestration/test_agent_ledger.py
+++ b/tests/orchestration/test_agent_ledger.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.orchestration import agent_ledger
+
+
+def test_upsert_task_records_parallel_agent_metadata(tmp_path: Path):
+    task = agent_ledger.upsert_task(
+        tmp_path,
+        task_id="2823-ui-worker",
+        agent="codex",
+        status="running",
+        issue=2823,
+        lane="ui",
+        module_family="site",
+        task_family="design",
+        model="gpt-5.4",
+        thread_id="thread-1",
+        branch="codex/2823-lightweight-ui",
+        worktree=".worktrees/dispatch/codex/2823-lightweight-ui",
+        owned_paths=["starlight/src/pages", "starlight/src/styles/course.css"],
+    )
+
+    assert task["issue"] == 2823
+    assert task["task_family"] == "design"
+    assert task["owned_paths"] == ["starlight/src/pages", "starlight/src/styles/course.css"]
+    assert task["events"][0]["type"] == "created"
+
+    path = agent_ledger.task_path(tmp_path, "2823-ui-worker")
+    assert json.loads(path.read_text(encoding="utf-8"))["thread_id"] == "thread-1"
+
+
+def test_active_owned_path_conflict_is_blocked(tmp_path: Path):
+    agent_ledger.upsert_task(
+        tmp_path,
+        task_id="a1-worker",
+        agent="codex",
+        status="running",
+        task_family="content_writing",
+        owned_paths=["curriculum/l2-uk-en/a1"],
+    )
+
+    try:
+        agent_ledger.upsert_task(
+            tmp_path,
+            task_id="a1-m8-worker",
+            agent="gemini",
+            status="running",
+            task_family="code_review",
+            owned_paths=["curriculum/l2-uk-en/a1/things-have-gender/module.md"],
+        )
+    except agent_ledger.OwnershipConflictError as exc:
+        assert exc.conflicts[0]["task_id"] == "a1-worker"
+        assert exc.conflicts[0]["owned_path"] == "curriculum/l2-uk-en/a1"
+    else:
+        raise AssertionError("expected active owned-path conflict")
+
+
+def test_terminal_task_does_not_block_new_owner(tmp_path: Path):
+    agent_ledger.upsert_task(
+        tmp_path,
+        task_id="old-worker",
+        agent="codex",
+        status="done",
+        owned_paths=["starlight/src/pages"],
+    )
+
+    task = agent_ledger.upsert_task(
+        tmp_path,
+        task_id="new-worker",
+        agent="codex",
+        status="running",
+        owned_paths=["starlight/src/pages/index.astro"],
+    )
+
+    assert task["task_id"] == "new-worker"
+
+
+def test_append_event_heartbeat_and_summary(tmp_path: Path):
+    agent_ledger.upsert_task(
+        tmp_path,
+        task_id="reviewer",
+        agent="gemini",
+        status="reviewing",
+        task_family="code_review",
+    )
+
+    task = agent_ledger.append_event(
+        tmp_path,
+        "reviewer",
+        event_type="review",
+        actor="gemini",
+        message="VERDICT: CLEAN",
+        data={"verdict": "clean"},
+    )
+    assert task["events"][-1]["data"]["verdict"] == "clean"
+
+    task = agent_ledger.heartbeat(tmp_path, "reviewer", actor="gemini", message="still reviewing")
+    assert task["heartbeat_at"] == task["events"][-1]["timestamp"]
+
+    summary = agent_ledger.summary(tmp_path)
+    assert summary["active"] == 1
+    assert summary["by_task_family"] == {"code_review": 1}
+    assert summary["by_agent"] == {"gemini": 1}
+
+
+def test_cli_reports_conflict(tmp_path: Path, capsys):
+    assert agent_ledger.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "upsert-task",
+            "--task-id",
+            "ui",
+            "--agent",
+            "codex",
+            "--status",
+            "running",
+            "--owned-path",
+            "starlight/src",
+        ]
+    ) == 0
+    capsys.readouterr()
+
+    rc = agent_ledger.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "upsert-task",
+            "--task-id",
+            "ui-css",
+            "--agent",
+            "codex",
+            "--status",
+            "running",
+            "--owned-path",
+            "starlight/src/styles/course.css",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    assert payload["error"] == "ownership_conflict"

--- a/tests/orchestration/test_agent_ledger.py
+++ b/tests/orchestration/test_agent_ledger.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import asyncio
 import json
+import threading
 from pathlib import Path
 
+import pytest
+from fastapi import HTTPException
+
+from scripts.api import coordination_router
 from scripts.orchestration import agent_ledger
 
 
@@ -104,6 +110,133 @@ def test_append_event_heartbeat_and_summary(tmp_path: Path):
     assert summary["active"] == 1
     assert summary["by_task_family"] == {"code_review": 1}
     assert summary["by_agent"] == {"gemini": 1}
+
+
+def test_upsert_task_preserves_fields_on_partial_update(tmp_path: Path):
+    agent_ledger.upsert_task(
+        tmp_path,
+        task_id="2823-ui-worker",
+        agent="codex",
+        status="running",
+        issue=2823,
+        lane="ui",
+        task_family="design",
+        model="gpt-5.4",
+        branch="codex/2823-lightweight-ui",
+        owned_paths=["starlight/src/pages"],
+        metadata={"phase": "foundation"},
+    )
+
+    task = agent_ledger.upsert_task(
+        tmp_path,
+        task_id="2823-ui-worker",
+        status="reviewing",
+        metadata={"review": "agy"},
+    )
+
+    assert task["agent"] == "codex"
+    assert task["issue"] == 2823
+    assert task["lane"] == "ui"
+    assert task["task_family"] == "design"
+    assert task["model"] == "gpt-5.4"
+    assert task["branch"] == "codex/2823-lightweight-ui"
+    assert task["owned_paths"] == ["starlight/src/pages"]
+    assert task["metadata"] == {"phase": "foundation", "review": "agy"}
+    assert task["events"][-1]["message"] == "running -> reviewing"
+
+
+def test_heartbeat_writes_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    agent_ledger.upsert_task(tmp_path, task_id="reviewer", agent="gemini")
+    writes: list[Path] = []
+    original_write = agent_ledger.write_json_atomic
+
+    def counting_write(path: Path, payload: dict):
+        writes.append(path)
+        original_write(path, payload)
+
+    monkeypatch.setattr(agent_ledger, "write_json_atomic", counting_write)
+
+    task = agent_ledger.heartbeat(tmp_path, "reviewer", actor="gemini")
+
+    assert task["heartbeat_at"] == task["events"][-1]["timestamp"]
+    assert len(writes) == 1
+
+
+def test_parallel_conflicting_claims_are_serialized(tmp_path: Path):
+    barrier = threading.Barrier(2)
+    outcomes: list[str] = []
+
+    def claim(task_id: str) -> None:
+        barrier.wait(timeout=5)
+        try:
+            agent_ledger.upsert_task(
+                tmp_path,
+                task_id=task_id,
+                agent="codex",
+                status="running",
+                owned_paths=["starlight/src"],
+            )
+        except agent_ledger.OwnershipConflictError:
+            outcomes.append("conflict")
+        else:
+            outcomes.append("ok")
+
+    threads = [threading.Thread(target=claim, args=(f"worker-{index}",)) for index in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert sorted(outcomes) == ["conflict", "ok"]
+
+
+def test_task_paths_do_not_collapse_valid_ids(tmp_path: Path):
+    assert agent_ledger.task_path(tmp_path, "a") != agent_ledger.task_path(tmp_path, "a.")
+
+
+def test_corrupt_task_json_is_not_silently_ignored(tmp_path: Path):
+    agent_ledger.tasks_dir(tmp_path).mkdir(parents=True)
+    agent_ledger.task_path(tmp_path, "broken").write_text("{", encoding="utf-8")
+
+    with pytest.raises(agent_ledger.LedgerError, match="invalid JSON"):
+        agent_ledger.list_tasks(tmp_path)
+
+
+def test_absolute_owned_path_is_rejected(tmp_path: Path):
+    with pytest.raises(agent_ledger.LedgerError, match="relative"):
+        agent_ledger.upsert_task(
+            tmp_path,
+            task_id="absolute-owner",
+            agent="codex",
+            owned_paths=[str(tmp_path / "starlight/src")],
+        )
+
+
+def test_coordination_task_rejects_invalid_task_id():
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(coordination_router.coordination_task("bad id"))
+
+    assert exc_info.value.status_code == 400
+
+
+def test_cli_reports_bad_json(tmp_path: Path, capsys):
+    rc = agent_ledger.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "upsert-task",
+            "--task-id",
+            "bad-json",
+            "--agent",
+            "codex",
+            "--metadata",
+            "{",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    assert "invalid JSON object" in payload["error"]
 
 
 def test_cli_reports_conflict(tmp_path: Path, capsys):


### PR DESCRIPTION
## Summary
- documents a parallel-agent coordination ledger to replace shared session handoff files as worker reporting state
- adds a JSON-backed local runtime ledger under ignored `batch_state/agent-ledger`
- exposes read-only Monitor API endpoints at `/api/coordination/summary`, `/api/coordination/active`, and `/api/coordination/tasks/{task_id}`
- adds tests for task metadata, events, heartbeats, summary output, and active owned-path conflict detection

## Validation
- `.venv/bin/python -m pytest -q tests/orchestration/test_agent_ledger.py`
- `.venv/bin/ruff check scripts/orchestration/agent_ledger.py scripts/api/coordination_router.py tests/orchestration/test_agent_ledger.py`
- API import smoke for `/api/coordination/*` routes
- `git diff --check`

## Notes
Draft until independent review and CI are clean. This is intentionally a first slice; SQLite-backed persistence and write API endpoints should be follow-up work after review.
