### PR TITLE
ci: disable Gemini Code Assist GitHub reviews

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,11 @@
+# Repository-level Gemini Code Assist for GitHub configuration.
+# Keep local Gemini CLI/agent tooling enabled, but do not let the GitHub app
+# review or summarize pull requests. Local machine-agent review remains the
+# review path for this repository.
+code_review:
+  disable: true
+  pull_request_opened:
+    help: false
+    summary: false
+    code_review: false
+    include_drafts: false

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -42,6 +42,9 @@ coordination now runs through the bridge (`scripts/ai_agent_bridge`) and
 `scripts/delegate.py`, not GitHub Actions. See
 `docs/best-practices/agent-cooperation.md`.
 
+Gemini Code Assist for GitHub PR reviews is disabled by `.gemini/config.yaml`.
+Use local machine-agent review via `scripts/delegate.py` instead.
+
 ## References
 
 - **Agent cooperation:** `docs/best-practices/agent-cooperation.md`

--- a/scripts/check_rules_deployment.sh
+++ b/scripts/check_rules_deployment.sh
@@ -71,7 +71,7 @@ check_pair \
     "config.toml" \
     "hooks.json" || drift=1
 check_pair "claude_extensions/skills" ".agents/skills" || drift=1
-check_pair "gemini_extensions" ".gemini" "docs/" "rules/" || drift=1
+check_pair "gemini_extensions" ".gemini" "config.yaml" "docs/" "rules/" || drift=1
 check_pair "claude_extensions/rules" ".gemini/rules" || drift=1
 
 exit "$drift"

--- a/scripts/deploy_prompts.sh
+++ b/scripts/deploy_prompts.sh
@@ -54,7 +54,9 @@ ORPHAN_PATHS_AGENTS=""
 ORPHAN_PATHS_CODEX="agents/curriculum-orchestrator.toml agents/curriculum-writer.toml config.toml hooks.json"
 # tmp/ — Gemini CLI runtime workspace (e.g. .gemini/tmp/learn-ukrainian/);
 #        local working state, NOT a deploy artifact. Preserve across rsync --delete.
-ORPHAN_PATHS_GEMINI="docs/ rules/ tmp/"
+# config.yaml — repository-level Gemini Code Assist for GitHub configuration.
+#        It disables GitHub PR reviews while preserving local Gemini CLI tooling.
+ORPHAN_PATHS_GEMINI="config.yaml docs/ rules/ tmp/"
 
 # Claude Code auto-loads every unscoped file in `.claude/rules/` into
 # the system prompt. These six always-load rules are now served by the

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -41,6 +41,7 @@ def _copy_repo_subset(target: Path) -> None:
         Path("scripts/lint_prompts.py"),
         Path("scripts/lint/lint_prompts.py"),
         Path("scripts/lint/lint_agent_skills.py"),
+        Path(".gemini/config.yaml"),
     ):
         destination = target / relative_path
         destination.parent.mkdir(parents=True, exist_ok=True)
@@ -100,6 +101,7 @@ def test_fresh_deploy_produces_synced_output(tmp_path: Path) -> None:
         f"stdout: {check_result.stdout}\nstderr: {check_result.stderr}"
     )
     assert (repo / CODEX_HOOK_TARGET).exists()
+    assert (repo / ".gemini/config.yaml").exists()
     deployed_claude_rules = sorted(
         path.name for path in (repo / ".claude" / "rules").glob("*.md")
     )


### PR DESCRIPTION
Closes #2834.

## Summary
- Add `.gemini/config.yaml` with `code_review.disable: true` and PR-open review/summary/help disabled.
- Preserve that repo-level config in `scripts/deploy_prompts.sh` so `.gemini` deploys do not delete it.
- Document that GitHub-hosted Gemini review is disabled and local machine-agent review via `scripts/delegate.py` is the intended path.

## Validation
- `scripts/deploy_prompts.sh --dry-run`
- `.venv/bin/python -c "import yaml; from pathlib import Path; data=yaml.safe_load(Path('.gemini/config.yaml').read_text()); assert data['code_review']['disable'] is True"`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
