### PR TITLE
fix(agy): harden dispatch finalize and tool outputs

### DIFF
--- a/scripts/agent_runtime/adapters/agy.py
+++ b/scripts/agent_runtime/adapters/agy.py
@@ -82,7 +82,7 @@ _STDOUT_MARKER_RE = re.compile(
 )
 _STDOUT_RESULT_PREFIX = "⎿"
 _SAVED_OUTPUT_POINTER_RE = re.compile(
-    r"(?:The output was large and was saved to:\s*)?"
+    r"The output was large and was saved to:\s*"
     r"(?P<uri>file://[^\s)]+)",
     re.IGNORECASE,
 )

--- a/scripts/agent_runtime/adapters/agy.py
+++ b/scripts/agent_runtime/adapters/agy.py
@@ -51,6 +51,7 @@ import os
 import re
 import shutil
 import tempfile
+import urllib.parse
 import uuid
 from collections.abc import Mapping
 from pathlib import Path
@@ -80,6 +81,12 @@ _STDOUT_MARKER_RE = re.compile(
     r"^\s*●\s+(?P<tool>mcp_sources_[A-Za-z0-9_]+)\((?P<args>.*)\)\s*$"
 )
 _STDOUT_RESULT_PREFIX = "⎿"
+_SAVED_OUTPUT_POINTER_RE = re.compile(
+    r"(?:The output was large and was saved to:\s*)?"
+    r"(?P<uri>file://[^\s)]+)",
+    re.IGNORECASE,
+)
+_MAX_INLINE_TOOL_RESULT_BYTES = 1_000_000
 
 # Canonical model display strings accepted by ``agy --model`` (verbatim from
 # ``agy models``). A caller may pass a slug (``gemini-3.1-pro-high``) or the
@@ -379,6 +386,10 @@ def _parse_transcript_tool_calls(plan: InvocationPlan | None) -> list[dict[str, 
             continue
         call = pending.pop(0)
         result_text = _strip_agy_task_metadata(str(event.get("content") or ""))
+        result_text = _inline_saved_tool_result_pointer(
+            result_text,
+            transcript_path=transcript_path,
+        )
         result = [{"type": "text", "text": result_text}]
         call["output_summary"] = summarize_tool_output(result)
         call["result"] = result
@@ -473,6 +484,83 @@ def _build_tool_call(tool_name: str, args: dict[str, Any], result_text: str) -> 
     if result is not None:
         call["result"] = result
     return call
+
+
+def _inline_saved_tool_result_pointer(text: str, *, transcript_path: Path) -> str:
+    """Inline agy's safe ``file://.../steps/.../output.txt`` tool-result pointer."""
+    match = _SAVED_OUTPUT_POINTER_RE.search(text)
+    if not match:
+        return text
+
+    parsed = urllib.parse.urlparse(match.group("uri"))
+    if parsed.scheme != "file" or not parsed.path:
+        return text
+
+    path = Path(urllib.parse.unquote(parsed.path))
+    try:
+        resolved_path = path.resolve(strict=True)
+    except OSError:
+        _logger.warning("agy tool result pointer missing: %s", path)
+        return text
+
+    allowed_roots = _allowed_tool_result_roots(transcript_path)
+    if not any(_is_relative_to(resolved_path, root) for root in allowed_roots):
+        _logger.warning("agy refused unsafe tool result pointer: %s", resolved_path)
+        return text
+
+    try:
+        size = resolved_path.stat().st_size
+        with resolved_path.open("rb") as handle:
+            raw = handle.read(_MAX_INLINE_TOOL_RESULT_BYTES + 1)
+    except OSError:
+        _logger.warning("agy failed to read tool result pointer: %s", resolved_path)
+        return text
+
+    truncated = len(raw) > _MAX_INLINE_TOOL_RESULT_BYTES
+    if truncated:
+        raw = raw[:_MAX_INLINE_TOOL_RESULT_BYTES]
+    inline = raw.decode("utf-8", errors="replace")
+    if truncated:
+        inline = (
+            inline.rstrip()
+            + f"\n\n[agy tool result truncated at {_MAX_INLINE_TOOL_RESULT_BYTES} bytes]"
+        )
+        _logger.warning(
+            "agy inlined truncated tool result pointer %s (%s bytes)",
+            resolved_path,
+            size,
+        )
+    else:
+        _logger.info(
+            "agy inlined tool result pointer %s (%s bytes)",
+            resolved_path,
+            size,
+        )
+    return text[: match.start()] + inline + text[match.end():]
+
+
+def _allowed_tool_result_roots(transcript_path: Path) -> tuple[Path, ...]:
+    # transcript.jsonl lives at:
+    #   <app-data>/brain/<conversation>/.system_generated/logs/transcript.jsonl
+    # Only follow pointers inside that conversation's steps dirs.
+    conversation_root = transcript_path.parent.parent.parent
+    candidates = (
+        conversation_root / "steps",
+        conversation_root / ".system_generated" / "steps",
+    )
+    roots: list[Path] = []
+    for candidate in candidates:
+        with contextlib.suppress(OSError):
+            roots.append(candidate.resolve())
+    return tuple(roots)
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
 
 
 def _coerce_args(value: Any) -> dict[str, Any]:

--- a/scripts/audit/lint_agent_trailer.py
+++ b/scripts/audit/lint_agent_trailer.py
@@ -44,6 +44,7 @@ Trailer format
 ``X-Agent: <agent>/<task-id>``
 
 Where ``agent`` ∈ {``claude-inline``, ``claude``, ``codex``, ``gemini``,
+``agy-inline``, ``agy``, ``grok``, ``deepseek-v4-pro``, ``cursor``,
 ``dependabot``} and ``task-id`` is the dispatch task identifier or the
 ``inline`` literal for orchestrator commits. Examples::
 
@@ -68,7 +69,7 @@ import subprocess
 import sys
 
 _TRAILER_RE = re.compile(
-    r"^X-Agent:\s+(?P<agent>claude-inline|claude|codex|gemini|grok|deepseek-v4-pro|cursor|dependabot)/(?P<task>[A-Za-z0-9._-]+)\s*$",
+    r"^X-Agent:\s+(?P<agent>claude-inline|claude|codex|gemini|agy-inline|agy|grok|deepseek-v4-pro|cursor|dependabot)/(?P<task>[A-Za-z0-9._-]+)\s*$",
     re.MULTILINE,
 )
 

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -95,6 +95,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -404,6 +405,7 @@ def _resolve_sha(path: Path, ref: str = "HEAD") -> str | None:
         capture_output=True,
         text=True,
         check=False,
+        env=_sanitized_git_env(),
     )
     if proc.returncode != 0:
         return None
@@ -419,6 +421,7 @@ def _count_commits_ahead(worktree: Path, base_ref: str) -> int | None:
         capture_output=True,
         text=True,
         check=False,
+        env=_sanitized_git_env(),
     )
     if proc.returncode != 0:
         return None
@@ -426,6 +429,264 @@ def _count_commits_ahead(worktree: Path, base_ref: str) -> int | None:
         return int((proc.stdout or "").strip())
     except ValueError:
         return None
+
+
+def _origin_base_ref(base_branch: str) -> str:
+    """Return the remote ref used for ahead-count checks."""
+    if base_branch.startswith("origin/"):
+        return base_branch
+    return f"origin/{base_branch}"
+
+
+def _base_branch_name(base_branch: str) -> str:
+    """Return a PR base branch name without the remote prefix."""
+    return base_branch.removeprefix("origin/")
+
+
+def _sanitized_git_env() -> dict[str, str]:
+    """Drop ambient hook Git env so ``cwd=worktree`` resolves that repo."""
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith(("GIT_", "PRE_COMMIT"))
+    }
+
+
+@dataclass(frozen=True)
+class AutoFinalizeResult:
+    ok: bool
+    commit_sha: str | None = None
+    pr_url: str | None = None
+    error: str | None = None
+    changed_files: tuple[str, ...] = ()
+
+
+def _format_process_failure(proc: subprocess.CompletedProcess[str]) -> str:
+    detail = (proc.stderr or proc.stdout or "").strip()
+    if detail:
+        return detail.splitlines()[-1]
+    return f"exit {proc.returncode}"
+
+
+def _worktree_is_dirty(worktree: Path) -> bool | None:
+    try:
+        status_proc = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=worktree,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=_sanitized_git_env(),
+        )
+    except OSError:
+        return None
+    if status_proc.returncode != 0:
+        return None
+    return bool((status_proc.stdout or "").strip())
+
+
+def _auto_finalize_changed_files(worktree: Path) -> tuple[str, ...]:
+    tracked = subprocess.run(
+        ["git", "diff", "--name-only", "HEAD", "--"],
+        cwd=worktree,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_sanitized_git_env(),
+    )
+    untracked = subprocess.run(
+        ["git", "ls-files", "--others", "--exclude-standard"],
+        cwd=worktree,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_sanitized_git_env(),
+    )
+    if tracked.returncode != 0 or untracked.returncode != 0:
+        return ()
+    changed = {
+        path.strip()
+        for path in (*tracked.stdout.splitlines(), *untracked.stdout.splitlines())
+        if path.strip()
+    }
+    return tuple(sorted(changed))
+
+
+def _current_branch(worktree: Path) -> str | None:
+    proc = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=worktree,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_sanitized_git_env(),
+    )
+    if proc.returncode != 0:
+        return None
+    branch = (proc.stdout or "").strip()
+    return branch or None
+
+
+def _x_agent_task_id(agent: str, task_id: str) -> str:
+    normalized = _normalize_task_id(agent, task_id)
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "-", normalized).strip(".-")
+    return safe or "task"
+
+
+def _push_auto_finalize_branch(worktree: Path, branch: str) -> None:
+    proc = subprocess.run(
+        ["git", "push", "-u", "origin", branch],
+        cwd=worktree,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_sanitized_git_env(),
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"git push failed: {_format_process_failure(proc)}")
+
+
+def _create_auto_finalize_pr(
+    worktree: Path,
+    *,
+    branch: str,
+    base_branch: str,
+    title: str,
+    body: str,
+) -> str | None:
+    proc = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--draft",
+            "--base",
+            base_branch,
+            "--head",
+            branch,
+            "--title",
+            title,
+            "--body",
+            body,
+        ],
+        cwd=worktree,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_sanitized_git_env(),
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh pr create failed: {_format_process_failure(proc)}")
+    lines = [line.strip() for line in (proc.stdout or "").splitlines() if line.strip()]
+    return lines[-1] if lines else None
+
+
+def _auto_finalize_dirty_worktree(
+    *,
+    worktree: Path,
+    task_id: str,
+    agent: str,
+    branch: str | None,
+    base_branch: str,
+) -> AutoFinalizeResult:
+    """Stage, commit, push, and draft-PR a cleanly exited dirty dispatch."""
+    changed_files = _auto_finalize_changed_files(worktree)
+    if not changed_files:
+        return AutoFinalizeResult(ok=False, error="clean-tree")
+
+    resolved_branch = branch or _current_branch(worktree)
+    if not resolved_branch or resolved_branch in {"HEAD", "main", "master"}:
+        return AutoFinalizeResult(
+            ok=False,
+            error=f"unsafe or unresolved branch {resolved_branch!r}",
+            changed_files=changed_files,
+        )
+
+    safe_task = _x_agent_task_id(agent, task_id)
+    subject = f"chore(dispatch): finalize {agent} task {safe_task}"
+    body = (
+        "Auto-finalized a dirty delegate worktree after the agent exited "
+        "with returncode 0 but made no commits.\n\n"
+        f"Delegate task: {task_id}\n"
+        f"Agent: {agent}"
+    )
+
+    try:
+        add_proc = subprocess.run(
+            ["git", "add", "-A"],
+            cwd=worktree,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=_sanitized_git_env(),
+        )
+        if add_proc.returncode != 0:
+            return AutoFinalizeResult(
+                ok=False,
+                error=f"git add failed: {_format_process_failure(add_proc)}",
+                changed_files=changed_files,
+            )
+
+        commit_proc = subprocess.run(
+            [
+                "git",
+                "commit",
+                "-m",
+                subject,
+                "-m",
+                body,
+                "--trailer",
+                f"X-Agent: {agent}/{safe_task}",
+            ],
+            cwd=worktree,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=_sanitized_git_env(),
+        )
+        if commit_proc.returncode != 0:
+            subprocess.run(
+                ["git", "restore", "--staged", "--", *changed_files],
+                cwd=worktree,
+                capture_output=True,
+                text=True,
+                check=False,
+                env=_sanitized_git_env(),
+            )
+            return AutoFinalizeResult(
+                ok=False,
+                error=f"git commit failed: {_format_process_failure(commit_proc)}",
+                changed_files=changed_files,
+            )
+
+        commit_sha = _resolve_sha(worktree)
+        _push_auto_finalize_branch(worktree, resolved_branch)
+        pr_url = _create_auto_finalize_pr(
+            worktree,
+            branch=resolved_branch,
+            base_branch=_base_branch_name(base_branch),
+            title=subject,
+            body=(
+                f"Auto-finalized delegate task `{task_id}` for `{agent}`.\n\n"
+                "The agent exited with `returncode=0`, left a dirty worktree, "
+                "and had made zero commits, so delegate.py staged the work, "
+                "created the commit, pushed the branch, and opened this draft PR."
+            ),
+        )
+    except (OSError, RuntimeError) as exc:
+        return AutoFinalizeResult(
+            ok=False,
+            commit_sha=_resolve_sha(worktree),
+            error=str(exc),
+            changed_files=changed_files,
+        )
+
+    return AutoFinalizeResult(
+        ok=True,
+        commit_sha=commit_sha,
+        pr_url=pr_url,
+        changed_files=changed_files,
+    )
 
 
 def _validate_existing_worktree(
@@ -847,34 +1108,37 @@ def _run_worker(
     dirty_on_exit: bool | None = None
     worktree_path = final_state.get("worktree_path")
     if worktree_path:
-        try:
-            status_proc = subprocess.run(
-                ["git", "status", "--porcelain"],
-                cwd=worktree_path,
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            if status_proc.returncode == 0:
-                dirty_on_exit = bool((status_proc.stdout or "").strip())
-        except OSError:
-            dirty_on_exit = None
+        dirty_on_exit = _worktree_is_dirty(Path(worktree_path))
 
     commits_ahead: int | None = None
     needs_finalize = False
+    auto_finalize: AutoFinalizeResult | None = None
     if worktree_path and mode == "danger":
-        base_branch = final_state.get("worktree_base") or "main"
+        base_branch = str(final_state.get("worktree_base") or "main")
+        base_ref = _origin_base_ref(base_branch)
         commits_ahead = _count_commits_ahead(
             Path(worktree_path),
-            f"origin/{base_branch}",
+            base_ref,
         )
         if commits_ahead == 0 and dirty_on_exit:
             needs_finalize = True
 
-    if needs_finalize and (
-        final_status == "done"
-        or (final_status == "failed" and dirty_on_exit)
-    ):
+        if needs_finalize and returncode == 0:
+            auto_finalize = _auto_finalize_dirty_worktree(
+                worktree=Path(worktree_path),
+                task_id=task_id,
+                agent=agent,
+                branch=final_state.get("worktree_branch"),
+                base_branch=base_branch,
+            )
+            dirty_on_exit = _worktree_is_dirty(Path(worktree_path))
+            commits_ahead = _count_commits_ahead(Path(worktree_path), base_ref)
+            if auto_finalize.ok:
+                needs_finalize = False
+                ok_outcome = True
+                final_status = "done"
+
+    if needs_finalize:
         final_status = "needs_finalize"
 
     final_state.update({
@@ -891,6 +1155,17 @@ def _run_worker(
         "worktree_dirty_on_exit": dirty_on_exit,
         "commits_ahead": commits_ahead,
         "needs_finalize": needs_finalize,
+        "auto_finalize": (
+            {
+                "ok": auto_finalize.ok,
+                "commit_sha": auto_finalize.commit_sha,
+                "pr_url": auto_finalize.pr_url,
+                "error": auto_finalize.error,
+                "changed_files": list(auto_finalize.changed_files),
+            }
+            if auto_finalize is not None
+            else None
+        ),
     })
     _write_state_atomic(state_path, final_state)
 

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -443,12 +443,25 @@ def _base_branch_name(base_branch: str) -> str:
     return base_branch.removeprefix("origin/")
 
 
+_GIT_ENV_DENYLIST = {
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_NAMESPACE",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+    "GIT_COMMON_DIR",
+}
+
+
 def _sanitized_git_env() -> dict[str, str]:
-    """Drop ambient hook Git env so ``cwd=worktree`` resolves that repo."""
+    """Drop repo-redirecting Git env so ``cwd=worktree`` resolves that repo."""
     return {
         key: value
         for key, value in os.environ.items()
-        if not key.startswith(("GIT_", "PRE_COMMIT"))
+        if key not in _GIT_ENV_DENYLIST and not key.startswith("PRE_COMMIT")
     }
 
 
@@ -591,6 +604,28 @@ def _auto_finalize_dirty_worktree(
 ) -> AutoFinalizeResult:
     """Stage, commit, push, and draft-PR a cleanly exited dirty dispatch."""
     changed_files = _auto_finalize_changed_files(worktree)
+    try:
+        worktree_proc = subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            cwd=worktree,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=_sanitized_git_env(),
+        )
+    except OSError:
+        return AutoFinalizeResult(
+            ok=False,
+            error="not a git worktree",
+            changed_files=changed_files,
+        )
+    if worktree_proc.returncode != 0 or (worktree_proc.stdout or "").strip() != "true":
+        return AutoFinalizeResult(
+            ok=False,
+            error="not a git worktree",
+            changed_files=changed_files,
+        )
+
     if not changed_files:
         return AutoFinalizeResult(ok=False, error="clean-tree")
 
@@ -611,6 +646,7 @@ def _auto_finalize_dirty_worktree(
         f"Agent: {agent}"
     )
 
+    commit_sha: str | None = None
     try:
         add_proc = subprocess.run(
             ["git", "add", "-A"],
@@ -674,10 +710,31 @@ def _auto_finalize_dirty_worktree(
             ),
         )
     except (OSError, RuntimeError) as exc:
+        error = str(exc)
+        if commit_sha is not None:
+            try:
+                reset_proc = subprocess.run(
+                    ["git", "reset", "--soft", "HEAD~1"],
+                    cwd=worktree,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    env=_sanitized_git_env(),
+                )
+            except OSError as reset_exc:
+                error = f"{error}; git reset failed: {reset_exc}"
+            else:
+                if reset_proc.returncode != 0:
+                    error = (
+                        f"{error}; git reset failed: "
+                        f"{_format_process_failure(reset_proc)}"
+                    )
+                else:
+                    commit_sha = None
         return AutoFinalizeResult(
             ok=False,
-            commit_sha=_resolve_sha(worktree),
-            error=str(exc),
+            commit_sha=commit_sha,
+            error=error,
             changed_files=changed_files,
         )
 

--- a/tests/agent_runtime/adapters/test_agy_adapter.py
+++ b/tests/agent_runtime/adapters/test_agy_adapter.py
@@ -123,6 +123,54 @@ def test_parse_response_accepts_stdout_marker_shape() -> None:
     ]
 
 
+def test_parse_response_inlines_safe_saved_tool_result_pointer(tmp_path: Path) -> None:
+    app_data = tmp_path / "antigravity-cli"
+    log_file = tmp_path / "agy.log"
+    log_file.write_text(
+        f"I0521 printmode.go:130] Print mode: conversation={CONVERSATION_ID}, sending message\n",
+        encoding="utf-8",
+    )
+    conversation_root = app_data / "brain" / CONVERSATION_ID
+    output_file = conversation_root / "steps" / "103" / "output.txt"
+    output_file.parent.mkdir(parents=True)
+    output_file.write_text("inline result from agy steps file", encoding="utf-8")
+    transcript = conversation_root / ".system_generated" / "logs" / "transcript.jsonl"
+    transcript.parent.mkdir(parents=True)
+    transcript.write_text(
+        "\n".join(
+            [
+                (
+                    '{"created_at":"2026-05-21T14:12:12Z",'
+                    '"tool_calls":[{"name":"call_mcp_tool","args":{'
+                    '"ServerName":"\\"sources\\"",'
+                    '"ToolName":"\\"search_text\\"",'
+                    '"Arguments":"{\\"query\\":\\"ранок\\"}"}}]}'
+                ),
+                (
+                    '{"type":"MCP_TOOL","content":"The output was large and was '
+                    f'saved to: {output_file.as_uri()}"}}'
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = AgyAdapter().parse_response(
+        stdout="Final response.",
+        stderr="",
+        returncode=0,
+        output_file=None,
+        plan=_plan(tmp_path, log_file=log_file, app_data=app_data),
+    )
+
+    assert result.tool_calls[0]["result"] == [
+        {"type": "text", "text": "inline result from agy steps file"}
+    ]
+    assert result.tool_calls[0]["output_summary"] == (
+        '[{"text": "inline result from agy steps file", "type": "text"}]'
+    )
+
+
 def test_render_writer_prompt_includes_agy_specific_directives() -> None:
     plan_path = linear_pipeline.plan_path_for("a1", "my-morning")
     plan = linear_pipeline.plan_check(plan_path)

--- a/tests/agent_runtime/adapters/test_agy_adapter.py
+++ b/tests/agent_runtime/adapters/test_agy_adapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from scripts.agent_runtime.adapters import agy as agy_module
 from scripts.agent_runtime.adapters.agy import AgyAdapter
 from scripts.agent_runtime.adapters.base import InvocationPlan
 from scripts.build import linear_pipeline
@@ -169,6 +170,19 @@ def test_parse_response_inlines_safe_saved_tool_result_pointer(tmp_path: Path) -
     assert result.tool_calls[0]["output_summary"] == (
         '[{"text": "inline result from agy steps file", "type": "text"}]'
     )
+
+
+def test_saved_tool_result_pointer_requires_prefix(tmp_path: Path) -> None:
+    text = "bare pointer file:///etc/hosts"
+    transcript = tmp_path / "transcript.jsonl"
+
+    result = agy_module._inline_saved_tool_result_pointer(
+        text,
+        transcript_path=transcript,
+    )
+
+    assert result == text
+    assert agy_module._SAVED_OUTPUT_POINTER_RE.search(text) is None
 
 
 def test_render_writer_prompt_includes_agy_specific_directives() -> None:

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -45,6 +45,24 @@ def _sanitize_git_env_for_test(monkeypatch) -> None:
             monkeypatch.delenv(key, raising=False)
 
 
+def test_sanitized_git_env_keeps_benign_git_transport_env(monkeypatch):
+    monkeypatch.setenv("GIT_SSH_COMMAND", "ssh -i test-key")
+    monkeypatch.setenv("GIT_SSH_VARIANT", "ssh")
+    monkeypatch.setenv("GIT_TRACE", "1")
+    monkeypatch.setenv("GIT_DIR", "/tmp/wrong-git-dir")
+    monkeypatch.setenv("GIT_WORK_TREE", "/tmp/wrong-work-tree")
+    monkeypatch.setenv("PRE_COMMIT_HOME", "/tmp/pre-commit")
+
+    env = delegate._sanitized_git_env()
+
+    assert env["GIT_SSH_COMMAND"] == "ssh -i test-key"
+    assert env["GIT_SSH_VARIANT"] == "ssh"
+    assert env["GIT_TRACE"] == "1"
+    assert "GIT_DIR" not in env
+    assert "GIT_WORK_TREE" not in env
+    assert "PRE_COMMIT_HOME" not in env
+
+
 # ---------------------------------------------------------------------------
 # State file helpers
 # ---------------------------------------------------------------------------
@@ -1131,6 +1149,107 @@ def test_run_worker_auto_finalizes_dirty_agy_worktree(
         text=True,
     ).stdout
     assert "X-Agent: agy/auto-finalize-test" in message
+
+
+def test_auto_finalize_push_failure_soft_resets_local_commit(tmp_path, monkeypatch):
+    _sanitize_git_env_for_test(monkeypatch)
+    worktree = tmp_path / "worktree"
+    subprocess.run(
+        ["git", "init", "--initial-branch=main", str(worktree)],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "test"],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+    )
+    (worktree / "README.md").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=worktree, check=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=worktree, check=True)
+    subprocess.run(
+        ["git", "checkout", "-b", "agy/push-fails"],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+    )
+    base_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    (worktree / "artifact.txt").write_text("agy wrote this\n", encoding="utf-8")
+
+    def fail_push(_worktree: Path, _branch: str) -> None:
+        raise RuntimeError("simulated push failure")
+
+    def fail_create_pr(**_kwargs: Any) -> str:
+        pytest.fail("PR creation must not run after push failure")
+
+    monkeypatch.setattr(delegate, "_push_auto_finalize_branch", fail_push)
+    monkeypatch.setattr(delegate, "_create_auto_finalize_pr", fail_create_pr)
+
+    result = delegate._auto_finalize_dirty_worktree(
+        worktree=worktree,
+        task_id="agy-push-fails",
+        agent="agy",
+        branch="agy/push-fails",
+        base_branch="main",
+    )
+
+    status = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    log_subjects = subprocess.run(
+        ["git", "log", "--format=%s"],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+    assert status
+    assert head == base_head
+    assert "chore(dispatch): finalize agy task agy-push-fails" not in log_subjects
+    assert result.ok is False
+    assert result.error == "simulated push failure"
+    assert result.commit_sha is None
+
+
+def test_auto_finalize_rejects_non_git_worktree(tmp_path):
+    (tmp_path / "artifact.txt").write_text("not in git\n", encoding="utf-8")
+
+    result = delegate._auto_finalize_dirty_worktree(
+        worktree=tmp_path,
+        task_id="not-git",
+        agent="agy",
+        branch="agy/not-git",
+        base_branch="main",
+    )
+
+    assert result.ok is False
+    assert "worktree" in (result.error or "")
+    assert not (tmp_path / ".git").exists()
 
 
 def test_run_worker_forwards_max_budget_usd_to_runtime(tmp_tasks_dir, tmp_path):

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -39,6 +39,12 @@ def tmp_tasks_dir(tmp_path, monkeypatch):
     return tasks_dir
 
 
+def _sanitize_git_env_for_test(monkeypatch) -> None:
+    for key in tuple(os.environ):
+        if key.startswith(("GIT_", "PRE_COMMIT")):
+            monkeypatch.delenv(key, raising=False)
+
+
 # ---------------------------------------------------------------------------
 # State file helpers
 # ---------------------------------------------------------------------------
@@ -917,6 +923,7 @@ def test_run_worker_marks_needs_finalize_for_dirty_danger_worktree(
     monkeypatch,
 ):
     """Danger dispatches with edits but no commits surface needs_finalize (#2134)."""
+    _sanitize_git_env_for_test(monkeypatch)
     state_path = delegate._state_path("needs-finalize")
     subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
     subprocess.run(
@@ -954,6 +961,15 @@ def test_run_worker_marks_needs_finalize_for_dirty_danger_worktree(
     )()
 
     monkeypatch.setattr(delegate, "_count_commits_ahead", lambda *_a, **_k: 0)
+    monkeypatch.setattr(
+        delegate,
+        "_auto_finalize_dirty_worktree",
+        lambda **_kwargs: delegate.AutoFinalizeResult(
+            ok=False,
+            error="simulated finalize failure",
+            changed_files=("orphan.txt",),
+        ),
+    )
 
     with (
         patch("agent_runtime.runner.invoke", return_value=mock_result),
@@ -977,6 +993,144 @@ def test_run_worker_marks_needs_finalize_for_dirty_danger_worktree(
     assert state["needs_finalize"] is True
     assert state["commits_ahead"] == 0
     assert state["worktree_dirty_on_exit"] is True
+    assert state["auto_finalize"]["ok"] is False
+    assert state["auto_finalize"]["error"] == "simulated finalize failure"
+
+
+def test_run_worker_auto_finalizes_dirty_agy_worktree(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    """Agy dispatches with clean rc=0, dirty worktree, and zero commits finalize."""
+    _sanitize_git_env_for_test(monkeypatch)
+    origin = tmp_path / "origin.git"
+    worktree = tmp_path / "worktree"
+    subprocess.run(
+        ["git", "init", "--bare", str(origin)],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "init", "--initial-branch=main", str(worktree)],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "test"],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+    )
+    (worktree / "README.md").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=worktree, check=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=worktree, check=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", str(origin)],
+        cwd=worktree,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "push", "-u", "origin", "main"],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "checkout", "-b", "agy/auto-finalize-test"],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+    )
+
+    state_path = delegate._state_path("agy-auto-finalize-test")
+    delegate._write_state_atomic(state_path, {
+        "task_id": "agy-auto-finalize-test",
+        "worktree_path": str(worktree),
+        "worktree_branch": "agy/auto-finalize-test",
+        "worktree_base": "main",
+    })
+    (worktree / "artifact.txt").write_text("agy wrote this\n", encoding="utf-8")
+
+    pushed: list[str] = []
+    created_prs: list[dict[str, str]] = []
+
+    def fake_push(_worktree: Path, branch: str) -> None:
+        pushed.append(branch)
+
+    def fake_create_pr(
+        _worktree: Path,
+        *,
+        branch: str,
+        base_branch: str,
+        title: str,
+        body: str,
+    ) -> str:
+        created_prs.append({
+            "branch": branch,
+            "base_branch": base_branch,
+            "title": title,
+            "body": body,
+        })
+        return "https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/999"
+
+    monkeypatch.setattr(delegate, "_push_auto_finalize_branch", fake_push)
+    monkeypatch.setattr(delegate, "_create_auto_finalize_pr", fake_create_pr)
+
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": False,
+            "response": "",
+            "stderr_excerpt": None,
+            "returncode": 0,
+            "rate_limited": False,
+            "model": "gemini-3.5-flash-high",
+            "effort": "unknown",
+            "cli_version": "1.0.0",
+        },
+    )()
+
+    with patch("agent_runtime.runner.invoke", return_value=mock_result):
+        rc = delegate._run_worker(
+            task_id="agy-auto-finalize-test",
+            agent="agy",
+            prompt="hi",
+            mode="danger",
+            cwd_str=str(worktree),
+            model=None,
+            hard_timeout=60,
+            effort=None,
+        )
+
+    assert rc == 0
+    state = delegate._read_state(state_path)
+    assert state is not None
+    assert state["status"] == "done"
+    assert state["needs_finalize"] is False
+    assert state["worktree_dirty_on_exit"] is False
+    assert state["commits_ahead"] == 1
+    assert state["auto_finalize"]["ok"] is True
+    assert state["auto_finalize"]["changed_files"] == ["artifact.txt"]
+    assert pushed == ["agy/auto-finalize-test"]
+    assert created_prs[0]["branch"] == "agy/auto-finalize-test"
+    assert created_prs[0]["base_branch"] == "main"
+
+    message = subprocess.run(
+        ["git", "log", "-1", "--format=%B"],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert "X-Agent: agy/auto-finalize-test" in message
 
 
 def test_run_worker_forwards_max_budget_usd_to_runtime(tmp_tasks_dir, tmp_path):

--- a/tests/test_gemini_fallback_agy.py
+++ b/tests/test_gemini_fallback_agy.py
@@ -27,6 +27,17 @@ def test_shared_ladder_order_includes_agy_after_pro():
     assert len(ladder) == 7
 
 
+def test_lint_agent_trailer_accepts_agy():
+    from audit.lint_agent_trailer import _TRAILER_RE
+
+    sample = "X-Agent: agy/2739-gemini-takeover"
+    match = _TRAILER_RE.search(sample)
+
+    assert match is not None, "lint_agent_trailer rejected agy-authored trailer"
+    assert match.group("agent") == "agy"
+    assert match.group("task") == "2739-gemini-takeover"
+
+
 def test_agy_retryable_error_advances_to_flash_rung():
     outcomes = {
         (PRIMARY_GEMINI_MODEL, "api"): AttemptOutcome(


### PR DESCRIPTION
Closes #2739
Closes #2362

## Summary
- Allow `X-Agent: agy/<task>` and `X-Agent: agy-inline/<task>` trailers, with an agy accept test.
- Auto-finalize dirty danger-mode delegate worktrees when the agent exits with `returncode=0` and made zero commits: stage, commit with the agent trailer, push, and open a draft PR. The worker records the auto-finalize result in task state.
- Inline safe agy `file://` tool-result pointers from the conversation steps directory so `agy-tools` writer context receives the actual tool output instead of an empty pointer.

## Validation
- `.venv/bin/python -m pytest tests/test_gemini_fallback_agy.py -q`
- `.venv/bin/python -m pytest tests/agent_runtime/adapters/test_agy_adapter.py -q`
- `.venv/bin/python -m pytest tests/test_delegate.py -q`
- `.venv/bin/python -m pytest tests/test_cursor_integration.py -q`
- `.venv/bin/python -m pytest tests/test_grok_integration.py -q`
- `.venv/bin/ruff check scripts/audit/lint_agent_trailer.py tests/test_gemini_fallback_agy.py scripts/delegate.py tests/test_delegate.py scripts/agent_runtime/adapters/agy.py tests/agent_runtime/adapters/test_agy_adapter.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Human follow-up
- Do not merge until a human with the agy binary runs the skipped e2e validation: `.venv/bin/python scripts/build/v7_build.py a1 my-morning --writer agy-tools --worktree`.