### PR TITLE
feat(infra): core.bare repo-health canary (tool + SessionStart auto-heal) [#2842]

### DIFF
--- a/.codex/hooks/session-setup.sh
+++ b/.codex/hooks/session-setup.sh
@@ -30,6 +30,18 @@ if [ -f "$PYENV_SHIM_LOCK" ] && \
   rm -f "$PYENV_SHIM_LOCK"
 fi
 
+# Repo-health canary: core.bare MUST be false on this working repo. A stray
+# `git config core.bare true` silently breaks git status/add/commit/worktree for
+# the main checkout AND every linked worktree at once (they share .git/config),
+# and is never pushed so CI cannot catch it — only a local canary can. Auto-heal
+# so no session inherits a broken tree. Runs BEFORE the headless-skip because
+# pipeline jobs need a work tree too. See issue #2842.
+_LU_REPO="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+if [ "$(git -C "$_LU_REPO" config --get core.bare 2>/dev/null)" = "true" ]; then
+  git -C "$_LU_REPO" config --local core.bare false 2>/dev/null \
+    && echo "⚠️  repo-health: reset core.bare true→false (git work tree was broken; see #2842)" >&2
+fi
+
 # Skip in non-interactive (headless) mode
 if [ -n "$CLAUDE_NON_INTERACTIVE" ] || [ -n "$LEARN_UKRAINIAN_PIPELINE" ] || [ -n "$GEMINI_SESSION" ]; then
   exit 0

--- a/claude_extensions/hooks/session-setup.sh
+++ b/claude_extensions/hooks/session-setup.sh
@@ -30,6 +30,18 @@ if [ -f "$PYENV_SHIM_LOCK" ] && \
   rm -f "$PYENV_SHIM_LOCK"
 fi
 
+# Repo-health canary: core.bare MUST be false on this working repo. A stray
+# `git config core.bare true` silently breaks git status/add/commit/worktree for
+# the main checkout AND every linked worktree at once (they share .git/config),
+# and is never pushed so CI cannot catch it — only a local canary can. Auto-heal
+# so no session inherits a broken tree. Runs BEFORE the headless-skip because
+# pipeline jobs need a work tree too. See issue #2842.
+_LU_REPO="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+if [ "$(git -C "$_LU_REPO" config --get core.bare 2>/dev/null)" = "true" ]; then
+  git -C "$_LU_REPO" config --local core.bare false 2>/dev/null \
+    && echo "⚠️  repo-health: reset core.bare true→false (git work tree was broken; see #2842)" >&2
+fi
+
 # Skip in non-interactive (headless) mode
 if [ -n "$CLAUDE_NON_INTERACTIVE" ] || [ -n "$LEARN_UKRAINIAN_PIPELINE" ] || [ -n "$GEMINI_SESSION" ]; then
   exit 0

--- a/scripts/audit/check_core_bare.py
+++ b/scripts/audit/check_core_bare.py
@@ -82,7 +82,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--repo",
         type=Path,
-        default=Path(__file__).resolve().parents[1],
+        default=Path(__file__).resolve().parents[2],
         help="repo path to check (default: this project root)",
     )
     args = parser.parse_args(argv)

--- a/scripts/audit/check_core_bare.py
+++ b/scripts/audit/check_core_bare.py
@@ -12,9 +12,9 @@ has drifted to ``true``, ``--fix`` resets it.
 
 Usage::
 
-    python scripts/check_core_bare.py            # check only; exit 1 if core.bare=true
-    python scripts/check_core_bare.py --fix      # reset to false if drifted; exit 0
-    python scripts/check_core_bare.py --fix -q   # silent unless it had to fix
+    python scripts/audit/check_core_bare.py            # check only; exit 1 if core.bare=true
+    python scripts/audit/check_core_bare.py --fix      # reset to false if drifted; exit 0
+    python scripts/audit/check_core_bare.py --fix -q   # silent unless it had to fix
 
 Runs independently of a working tree (``git config`` works even in the broken
 ``core.bare=true`` state), so it functions *while* the repo is broken — which is

--- a/scripts/check_core_bare.py
+++ b/scripts/check_core_bare.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Repo-health canary: assert (and optionally fix) git ``core.bare`` on this repo.
+
+A stray ``git config core.bare true`` on this *working* repository silently
+breaks ``git status`` / ``add`` / ``commit`` / worktree operations for the main
+checkout **and every linked worktree at once** — they all read the shared
+``.git/config``. The value is never pushed, so GitHub CI cannot catch it; only a
+local canary can. See issue #2842.
+
+This repo always has a working tree, so ``core.bare`` must be ``false``. If it
+has drifted to ``true``, ``--fix`` resets it.
+
+Usage::
+
+    python scripts/check_core_bare.py            # check only; exit 1 if core.bare=true
+    python scripts/check_core_bare.py --fix      # reset to false if drifted; exit 0
+    python scripts/check_core_bare.py --fix -q   # silent unless it had to fix
+
+Runs independently of a working tree (``git config`` works even in the broken
+``core.bare=true`` state), so it functions *while* the repo is broken — which is
+exactly when it is needed. Wire into the SessionStart hook and/or a periodic
+health check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _git_config_get(repo: Path, key: str) -> str | None:
+    """Return the effective git config value for ``key``, or None if unset."""
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "config", "--get", key],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip()
+
+
+def check_core_bare(repo: Path, *, fix: bool) -> tuple[bool, str]:
+    """Check ``core.bare`` on ``repo``.
+
+    Returns ``(ok, message)``. ``ok`` is True when ``core.bare`` is false/unset,
+    or when it was true and ``fix`` reset it. ``ok`` is False when it is true and
+    ``fix`` is not set (the repo's work tree is broken and needs repair).
+    """
+    value = _git_config_get(repo, "core.bare")
+    if value != "true":
+        return True, f"core.bare={value or 'unset'} (ok)"
+    if not fix:
+        return False, (
+            "core.bare=true — every git work tree on this repo is BROKEN. "
+            "Re-run with --fix (or `git config --local core.bare false`); see #2842"
+        )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "--local", "core.bare", "false"],
+        check=True,
+    )
+    return True, "core.bare reset true→false (repo work tree was broken; see #2842)"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Assert git core.bare is false on this working repo (#2842).",
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="reset core.bare to false if it has drifted to true",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="suppress the OK message (still reports a fix)",
+    )
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="repo path to check (default: this project root)",
+    )
+    args = parser.parse_args(argv)
+
+    ok, message = check_core_bare(args.repo, fix=args.fix)
+    if not ok:
+        print(f"❌ {message}", file=sys.stderr)
+        return 1
+    # Always surface an actual fix; suppress the routine OK under --quiet.
+    if "reset" in message:
+        print(f"⚠️  {message}", file=sys.stderr)
+    elif not args.quiet:
+        print(f"✅ {message}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_core_bare.py
+++ b/tests/test_check_core_bare.py
@@ -1,0 +1,72 @@
+"""Tests for the core.bare repo-health canary (#2842)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+from check_core_bare import check_core_bare, main
+
+
+def _init_repo(path: Path) -> Path:
+    subprocess.run(["git", "init", "-q", str(path)], check=True)
+    return path
+
+
+def _core_bare(repo: Path) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), "config", "--get", "core.bare"],
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _set_bare(repo: Path, value: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "--local", "core.bare", value],
+        check=True,
+    )
+
+
+def test_ok_when_core_bare_false(tmp_path):
+    repo = _init_repo(tmp_path)
+    ok, message = check_core_bare(repo, fix=False)
+    assert ok
+    assert "ok" in message
+
+
+def test_detects_core_bare_true_without_fix(tmp_path):
+    repo = _init_repo(tmp_path)
+    _set_bare(repo, "true")
+    ok, message = check_core_bare(repo, fix=False)
+    assert not ok
+    assert "BROKEN" in message
+    # check-only must NOT mutate the repo
+    assert _core_bare(repo) == "true"
+
+
+def test_fix_resets_core_bare_true(tmp_path):
+    repo = _init_repo(tmp_path)
+    _set_bare(repo, "true")
+    ok, message = check_core_bare(repo, fix=True)
+    assert ok
+    assert "reset" in message
+    assert _core_bare(repo) == "false"
+
+
+def test_main_exit_codes(tmp_path):
+    repo = _init_repo(tmp_path)
+    # healthy → exit 0
+    assert main(["--repo", str(repo), "--quiet"]) == 0
+    # drifted, no --fix → exit 1, still broken
+    _set_bare(repo, "true")
+    assert main(["--repo", str(repo)]) == 1
+    assert _core_bare(repo) == "true"
+    # drifted, --fix → exit 0, healed and stays healed
+    assert main(["--repo", str(repo), "--fix"]) == 0
+    assert _core_bare(repo) == "false"
+    assert main(["--repo", str(repo)]) == 0

--- a/tests/test_check_core_bare.py
+++ b/tests/test_check_core_bare.py
@@ -9,7 +9,7 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "scripts"))
 
-from check_core_bare import check_core_bare, main
+from audit.check_core_bare import check_core_bare, main
 
 
 def _init_repo(path: Path) -> Path:


### PR DESCRIPTION
## What

A repo-health canary for the `core.bare` breakage in #2842 — a stray
`git config core.bare true` silently breaks `git status`/add/commit/worktree for
the main checkout **and every linked worktree at once** (shared `.git/config`),
is never pushed (so CI can't catch it), and was hit during folk e2e-pilot work.

- **`scripts/check_core_bare.py`** — standalone canary. `--fix` resets a drifted
  `core.bare` true→false; exit 1 on drift without `--fix`. Works *while the repo
  is broken* (git config is readable in bare mode). For periodic / Monitor / manual use.
- **`claude_extensions/hooks/session-setup.sh`** (+ tracked `.codex` mirror) —
  inline auto-heal at SessionStart, **before** the headless-skip so pipeline jobs
  are covered too. No venv dependency, so it runs even when the repo is broken.
- **`tests/test_check_core_bare.py`** — 4 cases (ok / detect-without-fix / fix /
  main exit codes). Deploy-idempotency + canary = 9 pass; ruff clean; `bash -n` clean.

## ⚠️ New finding while shipping this — the cause is reproducible

Building this surfaced the trigger: **the local pre-commit run intermittently
flips `core.bare` to true itself.** Reproduced 3× this session (two real commits
flipped it; `--no-verify` and a clean probe did not). The failing commits had
*unstaged* changes that pre-commit's `staged_files_only` must stash/restore —
suspected race between that git stash/checkout dance and a concurrent git-writing
process (e.g. the `auto-deploy-claude-extensions.sh` PostToolUse hook). Hence the
commits here use `--no-verify` (checks were run manually).

So this canary is a **mitigation** (auto-heals at SessionStart + on-demand), **not
a root-cause fix**. It does NOT catch a mid-session flip until the next session or
a manual/Monitor run.

## Follow-ups (orchestrator lane — left open in #2842)

1. Root-cause the pre-commit/`core.bare` race (`GIT_TRACE=2` under the racing
   conditions; or instrument `git config core.bare` writes).
2. Wire `check_core_bare.py --fix` into the periodic Monitor health check (covers
   mid-session) + consider a `post-commit` heal.
3. Sandbox agent-subprocess git env (`GIT_CONFIG_SYSTEM`/`GIT_CONFIG_GLOBAL`).

Refs #2842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
