### PR TITLE
feat(audit): implement seminar wiki-completeness gate

### DIFF
--- a/scripts/audit/wiki_completeness_gate.py
+++ b/scripts/audit/wiki_completeness_gate.py
@@ -29,6 +29,7 @@ EARLY_FOUNDATION_DECOLONIZATION_SECTION_ONLY_SLUGS = frozenset(
 )
 SEMINAR_LEVELS = frozenset(
     {
+        "folk",
         "hist",
         "istorio",
         "bio",
@@ -46,6 +47,18 @@ SEMINAR_LEVELS = frozenset(
         "ruth",
     }
 )
+SEMINAR_REQUIRED_SECTIONS = (
+    "Короткий зміст",
+    "Основний зміст",
+    "Ключові терміни",
+    "Мовні зразки",
+    "Деколонізаційна перспектива",
+    "Пов'язані статті",
+)
+SEMINAR_SECTION_HEADING_RES = {
+    heading: re.compile(rf"^##\s+{re.escape(heading)}\s*$", re.IGNORECASE)
+    for heading in SEMINAR_REQUIRED_SECTIONS
+}
 
 METHODOLOGY_HEADING_RE = re.compile(r"^##\s+Методичний\s+підхід\b", re.IGNORECASE)
 DECOLONIZATION_HEADING_RE = re.compile(r"^##\s+Деколонізаційні\s+застереження\b", re.IGNORECASE)
@@ -65,21 +78,42 @@ CHECK_TITLES = {
     "textbook_exercises": "Приклади з підручників",
     "distractor_inventory": "distractor_inventory",
     "chunk_citations_spot_check": "chunk_citations_spot_check",
+    "seminar_sections": "seminar_sections",
+    "distinct_sources": "distinct_sources",
+    "citation_resolution": "citation_resolution",
+    "source_ref_resolution": "source_ref_resolution",
+    "all_chunk_verify_quote": "all_chunk_verify_quote",
 }
-CHECK_ORDER = tuple(CHECK_TITLES)
+CHECK_ORDER = (
+    "methodology",
+    "sequence_steps",
+    "l2_errors",
+    "decolonization_pairs",
+    "vocabulary_minimum",
+    "textbook_exercises",
+    "distractor_inventory",
+    "chunk_citations_spot_check",
+)
+SEMINAR_CHECK_ORDER = (
+    "seminar_sections",
+    "distinct_sources",
+    "citation_resolution",
+    "source_ref_resolution",
+    "all_chunk_verify_quote",
+)
 
 
-def thresholds_for_level(level: str) -> dict[str, int]:
+def thresholds_for_level(level: str) -> dict[str, Any]:
     """Return V7.1 wiki completeness thresholds for implemented core levels."""
     level_key = level.lower()
     if level_key in SEMINAR_LEVELS:
-        # Seminar checks need all-chunk verification, URL resolution, and a
-        # claim/source registry. That infrastructure is intentionally deferred
-        # to the separate seminar ADR called out in the V7.1 decision.
-        raise NotImplementedError(
-            "Seminar wiki completeness checks are deferred pending all-chunk "
-            "verify_quote, URL resolution, and two-source-rule infrastructure."
-        )
+        return {
+            "required_sections": SEMINAR_REQUIRED_SECTIONS,
+            "min_distinct_sources": 2,
+            "citations_resolve": 100,
+            "source_refs_resolve": 100,
+            "all_chunk_verify_quote": 100,
+        }
     if level_key not in CORE_LEVELS:
         raise ValueError(f"Unknown level for wiki completeness gate: {level!r}")
     if level_key in {"a1", "a2"}:
@@ -103,7 +137,7 @@ def thresholds_for_level(level: str) -> dict[str, int]:
     }
 
 
-def thresholds_for_module(level: str, slug: str | None) -> dict[str, int]:
+def thresholds_for_module(level: str, slug: str | None) -> dict[str, Any]:
     """Return wiki completeness thresholds adjusted for module-level policy."""
     thresholds = thresholds_for_level(level)
     level_key = level.lower()
@@ -130,6 +164,16 @@ def check_wiki_completeness(
     slug_value = slug or str(manifest.get("slug") or path.stem)
     level_key = level.lower()
     thresholds = thresholds_for_module(level_key, slug_value)
+    if level_key in SEMINAR_LEVELS:
+        return _check_seminar_completeness(
+            text,
+            lines,
+            path,
+            level=level_key,
+            slug=slug_value,
+            thresholds=thresholds,
+            verify_quote_fn=verify_quote_fn,
+        )
 
     methodology_text = _section_text(lines, METHODOLOGY_HEADING_RE)
     decolonization_text = _section_text(lines, DECOLONIZATION_HEADING_RE)
@@ -187,6 +231,197 @@ def check_wiki_completeness(
         "checks": checks,
         "diagnostic": _diagnostic(failed[0], checks[failed[0]]) if failed else "Wiki completeness gate passed.",
     }
+
+
+def _check_seminar_completeness(
+    wiki_text: str,
+    lines: list[str],
+    wiki_path: Path,
+    *,
+    level: str,
+    slug: str,
+    thresholds: Mapping[str, Any],
+    verify_quote_fn: Callable[[str, str, Mapping[str, Any]], Mapping[str, Any] | bool] | None,
+) -> dict[str, Any]:
+    required_sections = tuple(str(section) for section in thresholds["required_sections"])
+    citations = _ordered_source_ids(wiki_text)
+    sources = _load_source_registry(wiki_path)
+
+    checks = {
+        "seminar_sections": _seminar_sections_check(lines, required_sections),
+        "distinct_sources": _minimum_check(
+            len(citations),
+            int(thresholds["min_distinct_sources"]),
+            "distinct inline source citation(s) found.",
+        ),
+        "citation_resolution": _citation_resolution_check(
+            citations,
+            sources,
+            int(thresholds["citations_resolve"]),
+        ),
+        "source_ref_resolution": _source_ref_resolution_check(
+            citations,
+            sources,
+            int(thresholds["source_refs_resolve"]),
+        ),
+        "all_chunk_verify_quote": _all_chunk_verify_quote_check(
+            wiki_text,
+            citations,
+            sources,
+            int(thresholds["all_chunk_verify_quote"]),
+            verify_quote_fn=verify_quote_fn,
+        ),
+    }
+
+    failed = [name for name in SEMINAR_CHECK_ORDER if checks[name]["verdict"] == "FAIL"]
+    return {
+        "verdict": "FAIL" if failed else "PASS",
+        "level": level,
+        "slug": slug,
+        "checks": checks,
+        "diagnostic": _diagnostic(failed[0], checks[failed[0]]) if failed else "Wiki completeness gate passed.",
+    }
+
+
+def _seminar_sections_check(lines: list[str], required_sections: tuple[str, ...]) -> dict[str, Any]:
+    missing_or_empty = [
+        heading
+        for heading in required_sections
+        if not _section_text(lines, SEMINAR_SECTION_HEADING_RES[heading]).strip()
+    ]
+    actual = len(required_sections) - len(missing_or_empty)
+    report = _minimum_check(
+        actual,
+        len(required_sections),
+        f"{actual}/{len(required_sections)} required seminar sections are present and non-empty.",
+    )
+    if missing_or_empty:
+        report["missing_or_empty"] = missing_or_empty
+        report["detail"] = "missing or empty seminar section(s): " + ", ".join(missing_or_empty)
+    return report
+
+
+def _citation_resolution_check(
+    citations: list[str],
+    sources: Mapping[str, Mapping[str, Any]],
+    minimum_percent: int,
+) -> dict[str, Any]:
+    missing = [source_id for source_id in citations if source_id not in sources]
+    resolved = len(citations) - len(missing)
+    actual_percent = _percent(resolved, len(citations))
+    verdict = "PASS" if actual_percent >= minimum_percent else "FAIL"
+    report: dict[str, Any] = {
+        "verdict": verdict,
+        "actual": actual_percent,
+        "minimum": minimum_percent,
+        "detail": f"{resolved}/{len(citations)} cited source id(s) defined in source registry.",
+    }
+    if missing:
+        report["dangling_ids"] = missing
+        report["detail"] = "dangling citation id(s): " + ", ".join(missing)
+    return report
+
+
+def _source_ref_resolution_check(
+    citations: list[str],
+    sources: Mapping[str, Mapping[str, Any]],
+    minimum_percent: int,
+) -> dict[str, Any]:
+    unresolved = [
+        source_id
+        for source_id in citations
+        if not _source_has_resolvable_reference(sources.get(source_id))
+    ]
+    resolved = len(citations) - len(unresolved)
+    actual_percent = _percent(resolved, len(citations))
+    verdict = "PASS" if actual_percent >= minimum_percent else "FAIL"
+    report: dict[str, Any] = {
+        "verdict": verdict,
+        "actual": actual_percent,
+        "minimum": minimum_percent,
+        "detail": f"{resolved}/{len(citations)} cited source reference(s) resolved.",
+    }
+    if unresolved:
+        report["unresolved_ids"] = unresolved
+        report["detail"] = "unresolved source reference id(s): " + ", ".join(unresolved)
+    return report
+
+
+def _all_chunk_verify_quote_check(
+    wiki_text: str,
+    citations: list[str],
+    sources: Mapping[str, Mapping[str, Any]],
+    minimum_percent: int,
+    *,
+    verify_quote_fn: Callable[[str, str, Mapping[str, Any]], Mapping[str, Any] | bool] | None,
+) -> dict[str, Any]:
+    if verify_quote_fn is None:
+        resolved = sum(
+            1
+            for source_id in citations
+            if source_id in sources and _source_has_resolvable_reference(sources.get(source_id))
+        )
+        actual_percent = _percent(resolved, len(citations))
+        verdict = "PASS" if actual_percent >= minimum_percent else "FAIL"
+        report: dict[str, Any] = {
+            "verdict": verdict,
+            "actual": actual_percent,
+            "minimum": minimum_percent,
+            "detail": (
+                f"{resolved}/{len(citations)} source registry ids and references resolved "
+                "(verify_quote adapter not configured)"
+            ),
+        }
+        failures = [
+            source_id
+            for source_id in citations
+            if source_id not in sources or not _source_has_resolvable_reference(sources.get(source_id))
+        ]
+        if failures:
+            report["failures"] = failures
+        return report
+
+    passed = 0
+    failures: list[str] = []
+    for source_id in citations:
+        source = sources.get(source_id)
+        if not _source_has_resolvable_reference(source):
+            failures.append(source_id)
+            continue
+        result = verify_quote_fn(source_id, _citation_context(wiki_text, source_id), source)
+        if _verification_passed(result):
+            passed += 1
+        else:
+            failures.append(source_id)
+
+    actual_percent = _percent(passed, len(citations))
+    verdict = "PASS" if actual_percent >= minimum_percent else "FAIL"
+    report = {
+        "verdict": verdict,
+        "actual": actual_percent,
+        "minimum": minimum_percent,
+        "detail": f"{passed}/{len(citations)} verify_quote returned PASS",
+    }
+    if failures:
+        report["failures"] = failures
+    return report
+
+
+def _source_has_resolvable_reference(source: Mapping[str, Any] | None) -> bool:
+    if not source:
+        return False
+    source_type = str(source.get("type") or "").strip().lower()
+    if source_type in {"literary", "textbook"}:
+        return bool(str(source.get("file") or "").strip())
+    if source_type in {"wikipedia", "external", "external_article"}:
+        return bool(str(source.get("url") or "").strip())
+    return bool(str(source.get("file") or source.get("url") or "").strip())
+
+
+def _percent(numerator: int, denominator: int) -> int:
+    if denominator <= 0:
+        return 100
+    return round((numerator / denominator) * 100)
 
 
 def _section_presence_check(section_text: str, detail: str) -> dict[str, Any]:

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -1031,11 +1031,19 @@ def run_wiki_completeness_gate(
         raise LinearPipelineError(f"No wiki article found for level={level_key!r}, slug={slug_key!r}")
     from scripts.audit.wiki_completeness_gate import check_wiki_completeness
 
+    # TODO(folk-seminar-gate): wire corpus verify_quote for seminar levels once
+    # there is an in-process function that accepts (source_id,
+    # citation_context, source_mapping). The current implementation lives at
+    # .mcp/servers/sources/server.py::handle_verify_quote and only accepts
+    # author/text search arguments, so it cannot verify registry `file` chunk
+    # ids without changing semantics.
+    verify_quote_fn = None
+
     # Current build layout resolves to a single canonical wiki article. If a
     # future module has multiple articles, each must be complete enough to act
     # as the renderer spine; fail fast on the first thin article.
     reports = [
-        check_wiki_completeness(path, level=level_key, slug=slug_key)
+        check_wiki_completeness(path, level=level_key, slug=slug_key, verify_quote_fn=verify_quote_fn)
         for path in article_paths
     ]
     if len(reports) == 1:

--- a/tests/audit/test_wiki_completeness_gate.py
+++ b/tests/audit/test_wiki_completeness_gate.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-import pytest
 import yaml
 
 from scripts.audit.wiki_completeness_gate import (
@@ -103,6 +102,60 @@ slug: fixture
     return wiki
 
 
+def _seminar_wiki(
+    tmp_path: Path,
+    *,
+    citations: str = "[S1] [S2]",
+    sources: list[dict[str, Any]] | None = None,
+    omit_sections: set[str] | None = None,
+) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    omit = omit_sections or set()
+    sections = {
+        "Короткий зміст": f"Стислий опис теми з джерелами {citations}.",
+        "Основний зміст": f"Розгорнутий виклад із контекстом {citations}.",
+        "Ключові терміни": f"- Термін — визначення {citations}.",
+        "Мовні зразки": f"1. Академічна фраза для аналізу {citations}.",
+        "Деколонізаційна перспектива": f"Пояснення без імперської рамки {citations}.",
+        "Пов'язані статті": f"- [[Суміжна тема]] {citations}.",
+    }
+    body = "\n\n".join(
+        f"## {heading}\n\n{text}"
+        for heading, text in sections.items()
+        if heading not in omit
+    )
+    wiki = tmp_path / "seminar.md"
+    wiki.write_text(
+        f"""# Seminar
+
+<!-- wiki-meta
+slug: seminar
+domain: folk/ritual
+tracks: [folk]
+-->
+
+{body}
+""",
+        encoding="utf-8",
+    )
+    wiki.with_suffix(".sources.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "sources": sources
+                if sources is not None
+                else [
+                    {"id": "S1", "file": "chunk-1", "type": "literary", "title": "Source 1"},
+                    {"id": "S2", "file": "chunk-2", "type": "textbook", "title": "Source 2"},
+                ]
+            },
+            allow_unicode=True,
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return wiki
+
+
 def test_m20_my_morning_wiki_passes_completeness_gate() -> None:
     report = check_wiki_completeness(
         ROOT / "wiki/pedagogy/a1/my-morning.md",
@@ -166,8 +219,7 @@ def test_synthetic_thin_wiki_fails_with_specific_check_name(tmp_path: Path) -> N
 def test_per_level_threshold_application_and_seminar_deferred(tmp_path: Path) -> None:
     assert thresholds_for_level("a1")["vocabulary_minimum"] == 20
     assert thresholds_for_level("b1")["vocabulary_minimum"] == 50
-    with pytest.raises(NotImplementedError, match="Seminar wiki completeness checks are deferred"):
-        thresholds_for_level("hist")
+    assert thresholds_for_level("hist")["min_distinct_sources"] == 2
 
     wiki = _full_wiki(tmp_path, vocab_count=49, decolonization_pairs=2, citation_count=5)
     report = check_wiki_completeness(
@@ -247,3 +299,129 @@ def test_missing_sections_fail_with_named_checks(tmp_path: Path) -> None:
         "distractor_inventory",
         "chunk_citations_spot_check",
     } == {name for name, check in report["checks"].items() if check["verdict"] == "FAIL"}
+
+
+def test_seminar_wiki_passes_with_required_shape_and_resolved_sources(tmp_path: Path) -> None:
+    wiki = _seminar_wiki(tmp_path)
+
+    report = check_wiki_completeness(wiki, level="hist", slug="seminar")
+
+    assert report["verdict"] == "PASS"
+    assert report["checks"]["seminar_sections"]["actual"] == 6
+    assert report["checks"]["distinct_sources"]["actual"] == 2
+    assert report["checks"]["citation_resolution"]["actual"] == 100
+    assert report["checks"]["source_ref_resolution"]["actual"] == 100
+    assert "verify_quote adapter not configured" in report["checks"]["all_chunk_verify_quote"]["detail"]
+
+
+def test_seminar_missing_required_section_fails(tmp_path: Path) -> None:
+    wiki = _seminar_wiki(tmp_path, omit_sections={"Мовні зразки"})
+
+    report = check_wiki_completeness(wiki, level="hist", slug="seminar")
+
+    assert report["verdict"] == "FAIL"
+    assert report["checks"]["seminar_sections"]["verdict"] == "FAIL"
+    assert report["checks"]["seminar_sections"]["missing_or_empty"] == ["Мовні зразки"]
+
+
+def test_seminar_requires_two_distinct_sources(tmp_path: Path) -> None:
+    wiki = _seminar_wiki(
+        tmp_path,
+        citations="[S1]",
+        sources=[{"id": "S1", "file": "chunk-1", "type": "literary", "title": "Source 1"}],
+    )
+
+    report = check_wiki_completeness(wiki, level="hist", slug="seminar")
+
+    assert report["verdict"] == "FAIL"
+    assert report["checks"]["distinct_sources"] == {
+        "verdict": "FAIL",
+        "actual": 1,
+        "minimum": 2,
+        "detail": "distinct inline source citation(s) found.",
+    }
+
+
+def test_seminar_dangling_citation_fails_resolution(tmp_path: Path) -> None:
+    wiki = _seminar_wiki(
+        tmp_path,
+        citations="[S1] [S3]",
+        sources=[{"id": "S1", "file": "chunk-1", "type": "literary", "title": "Source 1"}],
+    )
+
+    report = check_wiki_completeness(wiki, level="hist", slug="seminar")
+
+    assert report["verdict"] == "FAIL"
+    assert report["checks"]["citation_resolution"]["verdict"] == "FAIL"
+    assert report["checks"]["citation_resolution"]["dangling_ids"] == ["S3"]
+
+
+def test_seminar_source_missing_file_or_url_fails_ref_resolution(tmp_path: Path) -> None:
+    wiki = _seminar_wiki(
+        tmp_path,
+        sources=[
+            {"id": "S1", "file": "chunk-1", "type": "literary", "title": "Source 1"},
+            {"id": "S2", "type": "literary", "title": "Source 2"},
+        ],
+    )
+
+    report = check_wiki_completeness(wiki, level="hist", slug="seminar")
+
+    assert report["verdict"] == "FAIL"
+    assert report["checks"]["source_ref_resolution"]["verdict"] == "FAIL"
+    assert report["checks"]["source_ref_resolution"]["unresolved_ids"] == ["S2"]
+
+
+def test_folk_is_treated_as_seminar_level(tmp_path: Path) -> None:
+    wiki = _seminar_wiki(tmp_path)
+
+    report = check_wiki_completeness(wiki, level="folk", slug="seminar")
+
+    assert thresholds_for_level("folk")["required_sections"]
+    assert report["verdict"] == "PASS"
+    assert report["checks"]["seminar_sections"]["verdict"] == "PASS"
+
+
+def test_seminar_verify_quote_checks_every_cited_source(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def recorder(source_id: str, quote: str, source: dict[str, Any]) -> dict[str, Any]:
+        calls.append(source_id)
+        return {"verdict": "PASS", "quote": quote, "source": source}
+
+    wiki = _seminar_wiki(
+        tmp_path,
+        citations="[S1] [S8] [S10]",
+        sources=[
+            {"id": "S1", "file": "chunk-1", "type": "literary", "title": "Source 1"},
+            {"id": "S8", "file": "chunk-8", "type": "literary", "title": "Source 8"},
+            {"id": "S10", "file": "chunk-10", "type": "literary", "title": "Source 10"},
+        ],
+    )
+
+    report = check_wiki_completeness(wiki, level="folk", slug="seminar", verify_quote_fn=recorder)
+
+    assert report["verdict"] == "PASS"
+    assert report["checks"]["all_chunk_verify_quote"]["detail"] == "3/3 verify_quote returned PASS"
+    assert calls == ["S1", "S8", "S10"]
+
+
+def test_seminar_verify_quote_does_not_call_adapter_for_missing_sources(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def recorder(source_id: str, quote: str, source: dict[str, Any]) -> dict[str, Any]:
+        calls.append(source_id)
+        assert source
+        return {"verdict": "PASS", "quote": quote, "source": source}
+
+    wiki = _seminar_wiki(
+        tmp_path,
+        citations="[S1] [S3]",
+        sources=[{"id": "S1", "file": "chunk-1", "type": "literary", "title": "Source 1"}],
+    )
+
+    report = check_wiki_completeness(wiki, level="folk", slug="seminar", verify_quote_fn=recorder)
+
+    assert report["verdict"] == "FAIL"
+    assert report["checks"]["all_chunk_verify_quote"]["failures"] == ["S3"]
+    assert calls == ["S1"]


### PR DESCRIPTION
## Summary

- Registers `folk` as a seminar level in the V7 wiki-completeness gate.
- Replaces the deferred seminar `NotImplementedError` with seminar-specific thresholds and checks for section shape, two-source citation coverage, citation registry resolution, source-reference resolution, and all-cited-source verification semantics.
- Extends focused gate tests with seminar PASS/FAIL fixtures and preserves existing core gate coverage.

## New seminar checks

- `seminar_sections`: requires the six compiled seminar H2 sections to be present and non-empty.
- `distinct_sources`: enforces at least two distinct inline `[S#]` citations.
- `citation_resolution`: requires every cited `[S#]` to be defined in the sibling `.sources.yaml` registry.
- `source_ref_resolution`: requires cited literary/textbook sources to carry `file`, and cited wikipedia/external sources to carry `url`.
- `all_chunk_verify_quote`: verifies every cited source when a real adapter is supplied; otherwise degrades to source registry/reference resolution and reports `verify_quote adapter not configured`.

## Impact

cross-track infra: affects all seminar levels (bio/hist/lit*/oes/ruth/istorio/folk) — they were fully blocked (NotImplementedError) before this; this gives them a working gate, no regression,

## verify_quote wiring outcome

Not wired yet. The available in-repo implementation is `.mcp/servers/sources/server.py::handle_verify_quote`, which requires `author` and `text` search arguments and returns MCP `TextContent`; it does not provide the needed in-process `fn(source_id, citation_context, source_mapping)` entrypoint for registry `file` chunk IDs. Added `TODO(folk-seminar-gate)` in `scripts/build/linear_pipeline.py` at the call site. No fake PASS stub was added.

## Validation

- `.venv/bin/ruff check scripts/audit/wiki_completeness_gate.py scripts/build/linear_pipeline.py`
- `.venv/bin/python -m pytest tests/audit/test_wiki_completeness_gate.py -q`
- `.venv/bin/python -m scripts.audit.wiki_completeness_gate folk kalendarna-obriadovist-zvychai --wiki-path wiki/folk/ritual/kalendarna-obriadovist-zvychai.md`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

NO auto-merge — track driver + main orchestrator will review.