### PR TITLE
fix(mdx): backfill missing activity ids

### DIFF
--- a/scripts/generate_mdx/core.py
+++ b/scripts/generate_mdx/core.py
@@ -159,6 +159,54 @@ def _activity_plans_to_jsx(plans: list[dict]) -> str:
 _INJECT_ACTIVITY_RE = re.compile(r'<!--\s*INJECT_ACTIVITY:\s*([A-Za-z0-9_-]+)\s*-->')
 
 
+def _activity_id(activity: Activity | dict) -> str:
+    activity_id = activity.get('id', '') if isinstance(activity, dict) else getattr(activity, 'id', '')
+    return '' if activity_id is None else str(activity_id).strip()
+
+
+def _activity_type(activity: Activity | dict) -> str:
+    activity_type = activity.get('type', '') if isinstance(activity, dict) else getattr(activity, 'type', '')
+    if activity_type is None:
+        return 'unknown'
+    return str(activity_type).strip() or 'unknown'
+
+
+def _set_activity_id(activity: Activity | dict, activity_id: str) -> None:
+    if isinstance(activity, dict):
+        activity['id'] = activity_id
+    else:
+        activity.id = activity_id
+
+
+def backfill_missing_activity_ids(activities: list[Activity | dict]) -> list[Activity | dict]:
+    """Assign deterministic IDs to idless activities without changing existing IDs."""
+    used_ids = {
+        activity_id
+        for activity in activities
+        if (activity_id := _activity_id(activity))
+    }
+
+    for index, activity in enumerate(activities, start=1):
+        if _activity_id(activity):
+            continue
+
+        preferred_id = f'act-{index}'
+        candidate_id = preferred_id
+        if candidate_id in used_ids:
+            candidate_id = f'{preferred_id}-{_activity_type(activity)}'
+
+        suffix = 2
+        base_id = candidate_id
+        while candidate_id in used_ids:
+            candidate_id = f'{base_id}-{suffix}'
+            suffix += 1
+
+        _set_activity_id(activity, candidate_id)
+        used_ids.add(candidate_id)
+
+    return activities
+
+
 def _inject_inline_activities(
     body: str,
     yaml_activities: list[Activity] | None,
@@ -170,9 +218,9 @@ def _inject_inline_activities(
 
     parser = ActivityParser()
     by_id = {
-        str(getattr(activity, 'id', '')): (index, activity)
+        _activity_id(activity): (index, activity)
         for index, activity in enumerate(yaml_activities)
-        if getattr(activity, 'id', '')
+        if _activity_id(activity)
     }
     injected_ids: set[str] = set()
     injected_positions: set[int] = set()
@@ -238,6 +286,9 @@ def generate_mdx(
                     body = body[heading_match.start():]
     else:
         fm, body = parse_frontmatter(md_content)
+
+    if yaml_activities:
+        yaml_activities = backfill_missing_activity_ids(list(yaml_activities))
 
     # Determine if Ukrainian headers are forced
     is_ukrainian_forced = False

--- a/scripts/yaml_activities.py
+++ b/scripts/yaml_activities.py
@@ -748,7 +748,17 @@ class ActivityParser:
 
         # If explicit blanks are provided, use them
         if explicit_blanks:
-            blanks = [ClozeBlank(id=b['id'], answer=b['answer'], options=b.get('options', [])) for b in explicit_blanks]
+            blanks = []
+            used_blank_ids = {str(b['id']) for b in explicit_blanks if isinstance(b, dict) and b.get('id') is not None}
+            next_blank_id = 0
+            for b in explicit_blanks:
+                blank_id = b.get('id')
+                if blank_id is None:
+                    while str(next_blank_id) in used_blank_ids:
+                        next_blank_id += 1
+                    blank_id = next_blank_id
+                used_blank_ids.add(str(blank_id))
+                blanks.append(ClozeBlank(id=blank_id, answer=b['answer'], options=b.get('options', [])))
         else:
             # Parse inline format: {option1|option2|option3} where first option is correct
             blanks = []
@@ -1046,7 +1056,11 @@ class ActivityParser:
 
     def _parse_translation_critique(self, data: dict) -> TranslationCritiqueActivity:
         translations = []
-        for t in data.get('translations', []):
+        for index, t in enumerate(data.get('translations', []), start=1):
+            if isinstance(t, str):
+                t = {'translator': f'Option {index}', 'text': t}
+            elif not isinstance(t, dict):
+                t = {'translator': f'Option {index}', 'text': str(t)}
             translations.append(TranslationItem(
                 translator=t.get('translator', ''),
                 text=t.get('text', ''),

--- a/tests/test_assemble_mdx_v7.py
+++ b/tests/test_assemble_mdx_v7.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import re
 
 from scripts.build.linear_pipeline import assemble_mdx
+from scripts.generate_mdx.core import backfill_missing_activity_ids
+from scripts.yaml_activities import ActivityParser
 
 _ACTIVITY_COMPONENT_RE = re.compile(
-    r"<(?:Quiz|FillIn|MatchUp|TrueFalse|GroupSort|Unjumble|Observe|Order)\b"
+    r"<(?:Quiz|FillIn|MatchUp|TrueFalse|GroupSort|Unjumble|Observe|Order|Cloze|TranslationCritique)\b"
 )
 
 
@@ -63,8 +65,7 @@ references:
   examples:
     - text: мию → миюся
     - text: одягаю → одягаюся
-- id: act-2
-  type: order
+- type: order
   title: Workbook order
   instruction: Put the actions in order.
   items: [прокидатися, вмиватися, снідати]
@@ -75,18 +76,37 @@ references:
   items:
     - statement: Настя прокидається о сьомій.
       correct: true
-- id: act-4
+- id: act-2
   type: match-up
   title: Workbook match
   pairs:
     - left: прокидатися
       right: to wake up
-- id: act-5
+- id: "  "
   type: fill-in
   title: Workbook fill
   items:
     - sentence: Я ___ о сьомій.
       answer: прокидаюся
+- type: cloze
+  title: Workbook cloze
+  passage: "Я {прокидаюся|снідаю} о сьомій і {снідаю|сплю} після уроку."
+  blanks:
+    - id: 0
+      answer: прокидаюся
+      options: [прокидаюся, снідаю]
+    - id:
+      answer: снідаю
+      options: [снідаю, сплю]
+- type: translation-critique
+  title: Workbook translation critique
+  original: Я прокидаюся о сьомій.
+  translations:
+    - I wake up at seven.
+    - I have breakfast at seven.
+    - 7
+  focus_points:
+    - Чи точно передано дію?
 """,
         encoding="utf-8",
     )
@@ -117,6 +137,29 @@ references:
         encoding="utf-8",
     )
 
+    parsed_activities = ActivityParser().parse(module_dir / "activities.yaml")
+    normalized_activities = backfill_missing_activity_ids(parsed_activities)
+    normalized_ids = [activity.id for activity in normalized_activities]
+
+    assert all(activity_id.strip() for activity_id in normalized_ids)
+    assert normalized_ids == ["act-1", "act-2-order", "act-3", "act-2", "act-5", "act-6", "act-7"]
+    assert len(normalized_ids) == len(set(normalized_ids))
+    assert [activity.id for activity in backfill_missing_activity_ids(normalized_activities)] == normalized_ids
+    cloze_activity = next(activity for activity in normalized_activities if activity.type == "cloze")
+    assert [blank.id for blank in cloze_activity.blanks] == [0, 1]
+
+    dict_activities = [
+        {"id": 0, "type": "quiz"},
+        {"type": "quiz"},
+        {"id": "act-2", "type": "fill-in"},
+    ]
+    backfill_missing_activity_ids(dict_activities)
+    assert dict_activities == [
+        {"id": 0, "type": "quiz"},
+        {"type": "quiz", "id": "act-2-quiz"},
+        {"id": "act-2", "type": "fill-in"},
+    ]
+
     mdx = assemble_mdx(module_dir, out_path, plan_path)
 
     assert "pipeline: linear-phase-4" in mdx
@@ -130,7 +173,7 @@ references:
     lesson_tab = _tab_item(mdx, "Lesson")
     activities_tab = _tab_item(mdx, "Activities")
     assert len(_ACTIVITY_COMPONENT_RE.findall(lesson_tab)) == 2
-    assert len(_ACTIVITY_COMPONENT_RE.findall(activities_tab)) == 3
+    assert len(_ACTIVITY_COMPONENT_RE.findall(activities_tab)) == 5
     assert "<Observe" in lesson_tab
     assert "<TrueFalse" in lesson_tab
     assert "<Observe" not in activities_tab
@@ -138,6 +181,9 @@ references:
     assert "<Order" in activities_tab
     assert "<MatchUp" in activities_tab
     assert "<FillIn" in activities_tab
+    assert "<Cloze" in activities_tab
+    assert "<TranslationCritique" in activities_tab
+    assert '"text": "7"' in activities_tab
     assert "Inline observe" not in activities_tab
     assert "Inline true false" not in activities_tab
     assert "*(see lesson)*" not in activities_tab
@@ -151,3 +197,4 @@ references:
     assert "writer telemetry" not in mdx
     assert "wiki_query_id" not in mdx
     assert "vesum_query_id" not in mdx
+    assert out_path.exists()


### PR DESCRIPTION
## Root cause

The V7 MDX assembly path assumed every parsed activity already had a non-empty `id`. Writer-authored workbook activities can omit `id`, while inline `module.md` markers still reference authored IDs such as `act-1` through `act-4`. Missing workbook IDs made downstream MDX assembly fragile and could abort the whole module build.

The failing pilot artifact also exposed two malformed-but-recoverable authored shapes before final MDX rendering: cloze blanks without blank IDs and `translation-critique` translations authored as bare strings.

## Fix

- Added deterministic activity ID normalization in `scripts/generate_mdx/core.py` before inline injection and workbook rendering.
- Preserves every existing non-empty activity ID unchanged.
- Backfills only missing, `None`, or whitespace activity IDs using `act-{index}`, then `act-{index}-{type}`, then numeric suffixes until unique.
- Hardened cloze blank parsing to assign collision-free positional blank IDs when omitted/null.
- Accepted bare-string/non-dict `translation-critique` entries as text options instead of crashing the parser.

## Inline ID contract

Inline marker IDs are preserved byte-for-byte. The regression fixture keeps authored inline IDs (`act-1`, `act-3`) and verifies they still inject into the Lesson tab, while idless workbook activities receive unique deterministic IDs and stay in the Activities tab.

## Pilot repro

```text
cwd=/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-mdx-activity-id-backfill
cmd=.venv/bin/python - <<'PY'
from pathlib import Path
from scripts.build.linear_pipeline import assemble_mdx

module_dir = Path('/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/builds/folk-kalendarna-obriadovist-zvychai-20260608-220114/curriculum/l2-uk-en/folk/kalendarna-obriadovist-zvychai')
plan_path = Path('/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/builds/folk-kalendarna-obriadovist-zvychai-20260608-220114/curriculum/l2-uk-en/plans/folk/kalendarna-obriadovist-zvychai.yaml')
out_path = Path('tmp/mdx-repro/kalendarna-obriadovist-zvychai.mdx')
mdx = assemble_mdx(module_dir, out_path, plan_path)
print(f'assembled={out_path}')
print(f'exists={out_path.exists()}')
print(f'bytes={out_path.stat().st_size}')
print(f'activity_components={mdx.count("client:only=\'react\'")}')
PY
output:
assembled=tmp/mdx-repro/kalendarna-obriadovist-zvychai.mdx
exists=True
bytes=73759
activity_components=16
```

NO auto-merge.