### PR TITLE
fix(mdx): seminar rendering - no stress, UK tab labels, P2 inline-and-aggregate cross-refs

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -43,6 +43,7 @@ CLAUDE_WRITER_AGENT_SOURCE = PROJECT_ROOT / "agents_extensions/shared" / "agents
 CLAUDE_WRITER_AGENT_TARGET = PROJECT_ROOT / ".claude" / "agents" / "curriculum-writer.md"
 
 from scripts.audit.failure_classes import FailureClass, FailureRecord
+from scripts.audit.wiki_completeness_gate import SEMINAR_LEVELS
 from scripts.build.citation_matcher import (
     CitationKey,
     citation_keys_match,
@@ -3952,6 +3953,27 @@ def run_stress_annotation(module_dir: Path) -> dict[str, Any]:
     }
 
 
+def strip_stress_marks_for_seminar(module_dir: Path) -> dict[str, Any]:
+    """Remove residual stress marks from seminar authoring artifacts."""
+    targets = ("module.md", "vocabulary.yaml", "activities.yaml")
+    counts: dict[str, int] = {}
+    for target in targets:
+        path = module_dir / target
+        text = _read_required(path)
+        count = text.count("\u0301")
+        counts[target] = count
+        if count:
+            path.write_text(text.replace("\u0301", ""), encoding="utf-8")
+    return {
+        "passed": True,
+        "phase": "stress_annotation",
+        "skipped": True,
+        "reason": "seminar level - no stress",
+        "files": counts,
+        "total_removed": sum(counts.values()),
+    }
+
+
 def run_ulp_fidelity_gate(
     module_dir: Path,
     plan_path: Path,
@@ -4001,7 +4023,12 @@ def run_ulp_fidelity_with_correction(
         "strict_json_artifacts",
         "writer_artifacts_mapping",
     }:
-        stress_annotation = run_stress_annotation(module_dir)
+        plan = plan_check(plan_path)
+        level = str(plan.get("level") or "").lower()
+        if level in SEMINAR_LEVELS:
+            stress_annotation = strip_stress_marks_for_seminar(module_dir)
+        else:
+            stress_annotation = run_stress_annotation(module_dir)
         write_json(module_dir / "stress_annotation.json", stress_annotation)
         artifact["stress_annotation"] = stress_annotation
         report = run_ulp_fidelity_gate(module_dir, plan_path, profile=profile)

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -21,6 +21,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from scripts.agent_runtime.errors import AgentStalledError
+from scripts.audit.wiki_completeness_gate import SEMINAR_LEVELS
 from scripts.build import linear_pipeline, run_archive
 from scripts.build.phases.implementation_map import (
     read_implementation_map,
@@ -1100,6 +1101,12 @@ def _phase_artifact_passes(module_dir: Path, phase: str) -> bool:
     return False
 
 
+def _run_stress_annotation_for_level(module_dir: Path, level: str) -> dict[str, Any]:
+    if level.lower() in SEMINAR_LEVELS:
+        return linear_pipeline.strip_stress_marks_for_seminar(module_dir)
+    return linear_pipeline.run_stress_annotation(module_dir)
+
+
 def _run(args: argparse.Namespace) -> int:
     level = args.level.lower()
     slug = args.slug
@@ -1348,7 +1355,13 @@ def _run(args: argparse.Namespace) -> int:
         phase = "stress_annotation"
         _phase_started(archive, phase)
         started_at = time.monotonic()
-        if (
+        if level in SEMINAR_LEVELS:
+            stress_annotation = _run_stress_annotation_for_level(module_dir, level)
+            linear_pipeline.write_json(
+                module_dir / "stress_annotation.json",
+                stress_annotation,
+            )
+        elif (
             resume_enabled
             and not force_rerun
             and _phase_artifact_passes(module_dir, "stress_annotation")
@@ -1358,7 +1371,7 @@ def _run(args: argparse.Namespace) -> int:
         else:
             if resume_enabled:
                 force_rerun = True
-            stress_annotation = linear_pipeline.run_stress_annotation(module_dir)
+            stress_annotation = _run_stress_annotation_for_level(module_dir, level)
             linear_pipeline.write_json(
                 module_dir / "stress_annotation.json",
                 stress_annotation,

--- a/scripts/generate_mdx/converters.py
+++ b/scripts/generate_mdx/converters.py
@@ -36,6 +36,20 @@ def _activity_id(activity: Activity) -> str:
     return str(getattr(activity, 'id', '') or '').strip()
 
 
+def _activity_type(activity: Activity) -> str:
+    if isinstance(activity, dict):
+        return str(activity.get('type', '') or '').strip() or 'unknown'
+    return str(getattr(activity, 'type', '') or '').strip() or 'unknown'
+
+
+def _activity_title_or_type(activity: Activity) -> str:
+    if isinstance(activity, dict):
+        title = str(activity.get('title', '') or '').strip()
+    else:
+        title = str(getattr(activity, 'title', '') or '').strip()
+    return title or _activity_type(activity)
+
+
 def activity_identity_key(activity: Activity) -> str:
     """Return a stable activity key that ignores optional renderer IDs."""
     if is_dataclass(activity):
@@ -58,12 +72,14 @@ def yaml_activities_to_jsx(
     inline_cross_ref_ids: set[str] | None = None,
     inline_cross_ref_positions: set[int] | None = None,
     inline_cross_ref_fingerprints: set[str] | None = None,
+    inline_cross_ref_section_titles: dict[str, str] | None = None,
 ) -> str:
     """Convert YAML activities to JSX components using the shared ActivityParser.
 
-    Activities already injected into the Lesson tab are omitted from the
-    workbook tab. Matching uses ID first, plus the matched list position and a
-    structural fingerprint so idless duplicates do not render in full.
+    Activities already injected into the Lesson tab render as compact
+    cross-references in the workbook tab. Matching uses ID first, plus the
+    matched list position; structural fingerprints still suppress duplicate
+    idless copies so they do not render in full.
     """
     parser = ActivityParser()
     inline_ids = {
@@ -73,22 +89,48 @@ def yaml_activities_to_jsx(
     }
     inline_positions = set(inline_cross_ref_positions or set())
     inline_fingerprints = set(inline_cross_ref_fingerprints or set())
+    section_titles = inline_cross_ref_section_titles or {}
     if not (inline_ids or inline_positions or inline_fingerprints):
         return parser.to_mdx(activities, is_ukrainian_forced)
 
     mdx_parts = []
     for index, activity in enumerate(activities):
-        if (
-            index in inline_positions
-            or _activity_id(activity) in inline_ids
-            or activity_identity_key(activity) in inline_fingerprints
-        ):
+        activity_id = _activity_id(activity)
+        if index in inline_positions or activity_id in inline_ids:
+            mdx_parts.append(
+                _inline_activity_cross_ref_to_mdx(
+                    activity,
+                    section_titles.get(activity_id, ""),
+                    is_ukrainian_forced,
+                )
+            )
+            continue
+        if activity_identity_key(activity) in inline_fingerprints:
             continue
         mdx = parser._activity_to_mdx(activity, is_ukrainian_forced)
         if not mdx:
             continue
         mdx_parts.append(mdx)
     return '\n\n'.join(mdx_parts)
+
+
+def _inline_activity_cross_ref_to_mdx(
+    activity: Activity,
+    section_title: str,
+    is_ukrainian_forced: bool,
+) -> str:
+    title = escape_jsx(_activity_title_or_type(activity))
+    section_title = section_title.strip()
+    if section_title:
+        if is_ukrainian_forced:
+            reference = f"див. урок, §{escape_jsx(section_title)}"
+        else:
+            reference = f"see lesson, §{escape_jsx(section_title)}"
+    elif is_ukrainian_forced:
+        reference = "див. вкладку «Урок»"
+    else:
+        reference = "see lesson tab"
+    return f"### {title}\n\n*({reference})*"
 
 
 def highlight_morphemes_to_jsx(item: HighlightMorphemesItem, title: str, is_ukrainian_forced: bool = False) -> str:

--- a/scripts/generate_mdx/core.py
+++ b/scripts/generate_mdx/core.py
@@ -45,6 +45,8 @@ from yaml_activities import (
     ActivityParser,
 )
 
+from scripts.audit.wiki_completeness_gate import SEMINAR_LEVELS
+
 VENV_PYTHON = PROJECT_ROOT / ".venv" / "bin" / "python"
 
 
@@ -157,6 +159,7 @@ def _activity_plans_to_jsx(plans: list[dict]) -> str:
 
 
 _INJECT_ACTIVITY_RE = re.compile(r'<!--\s*INJECT_ACTIVITY:\s*([A-Za-z0-9_-]+)\s*-->')
+_INLINE_SECTION_HEADING_RE = re.compile(r'^#{2,3}\s+(.+?)\s*#*\s*$')
 
 
 def _activity_id(activity: Activity | dict) -> str:
@@ -207,16 +210,30 @@ def backfill_missing_activity_ids(activities: list[Activity | dict]) -> list[Act
     return activities
 
 
+def _inline_activity_section_titles(body: str) -> dict[str, str]:
+    """Map inline activity ids to the nearest preceding H2/H3 section title."""
+    section_title = ""
+    titles: dict[str, str] = {}
+    for line in body.splitlines():
+        heading_match = _INLINE_SECTION_HEADING_RE.match(line.strip())
+        if heading_match:
+            section_title = heading_match.group(1).strip()
+        for marker_match in _INJECT_ACTIVITY_RE.finditer(line):
+            titles[marker_match.group(1)] = section_title
+    return titles
+
+
 def _inject_inline_activities(
     body: str,
     yaml_activities: list[Activity] | None,
     is_ukrainian_forced: bool,
-) -> tuple[str, set[str], set[int], set[str]]:
+) -> tuple[str, set[str], set[int], set[str], dict[str, str]]:
     """Replace Tab 1 INJECT_ACTIVITY markers with matching component JSX."""
     if not yaml_activities or "INJECT_ACTIVITY" not in body:
-        return body, set(), set(), set()
+        return body, set(), set(), set(), {}
 
     parser = ActivityParser()
+    section_titles = _inline_activity_section_titles(body)
     by_id = {
         _activity_id(activity): (index, activity)
         for index, activity in enumerate(yaml_activities)
@@ -237,7 +254,13 @@ def _inject_inline_activities(
         injected_fingerprints.add(activity_identity_key(activity))
         return parser._activity_to_mdx(activity, is_ukrainian_forced)
 
-    return _INJECT_ACTIVITY_RE.sub(replace_marker, body), injected_ids, injected_positions, injected_fingerprints
+    return (
+        _INJECT_ACTIVITY_RE.sub(replace_marker, body),
+        injected_ids,
+        injected_positions,
+        injected_fingerprints,
+        section_titles,
+    )
 
 
 def generate_mdx(
@@ -293,7 +316,11 @@ def generate_mdx(
     # Determine if Ukrainian headers are forced
     is_ukrainian_forced = False
     lvl = level.lower()
-    if any(lvl.startswith(p) for p in ['b2', 'c1', 'c2', 'lit']) or (lvl.startswith('b1') and module_num > 5):
+    if (
+        lvl in SEMINAR_LEVELS
+        or any(lvl.startswith(p) for p in ['b2', 'c1', 'c2', 'lit'])
+        or (lvl.startswith('b1') and module_num > 5)
+    ):
         is_ukrainian_forced = True
 
     # Component imports
@@ -390,6 +417,7 @@ sidebar:
         injected_activity_ids,
         _injected_activity_positions,
         _injected_activity_fingerprints,
+        _injected_activity_section_titles,
     ) = _inject_inline_activities(
         lesson_content,
         yaml_activities,
@@ -420,6 +448,7 @@ sidebar:
             inline_cross_ref_ids=injected_activity_ids,
             inline_cross_ref_positions=_injected_activity_positions,
             inline_cross_ref_fingerprints=_injected_activity_fingerprints,
+            inline_cross_ref_section_titles=_injected_activity_section_titles,
         )
         if not activities_content.strip() and injected_activity_ids:
             activities_content = f"*{no_workbook_msg}*"

--- a/tests/test_assemble_mdx_v7.py
+++ b/tests/test_assemble_mdx_v7.py
@@ -184,8 +184,8 @@ references:
     assert "<Cloze" in activities_tab
     assert "<TranslationCritique" in activities_tab
     assert '"text": "7"' in activities_tab
-    assert "Inline observe" not in activities_tab
-    assert "Inline true false" not in activities_tab
+    assert "### Inline observe\n\n*(see lesson tab)*" in activities_tab
+    assert "### Inline true false\n\n*(see lesson tab)*" in activities_tab
     assert "*(see lesson)*" not in activities_tab
     assert "INJECT_ACTIVITY" not in mdx
     assert "by Unknown" not in mdx

--- a/tests/test_generate_mdx.py
+++ b/tests/test_generate_mdx.py
@@ -150,7 +150,7 @@ class TestParseFrontmatter:
         assert body.strip() == "Body"
 
 
-def test_v7_tab3_omits_inline_activities_and_keeps_workbook_only(tmp_path):
+def test_v7_tab3_cross_refs_inline_activities_and_keeps_workbook_only(tmp_path):
     activities_yaml = tmp_path / "activities.yaml"
     activities_yaml.write_text(
         """
@@ -218,12 +218,83 @@ Practice there.
     assert "act-1 inline greeting" in lesson_tab
     assert "act-2 inline thanks" in lesson_tab
 
-    assert "act-1 inline greeting" not in tab3
-    assert "act-2 inline thanks" not in tab3
+    assert "### act-1 inline greeting\n\n*(see lesson, §Section One)*" in tab3
+    assert "### act-2 inline thanks\n\n*(see lesson, §Section Two)*" in tab3
     assert "### act-3 workbook yes\n\n<Quiz" in tab3
     assert "### act-4 workbook no\n\n<Quiz" in tab3
     assert "*(see lesson)*" not in tab3
     assert tab3.count("<Quiz") == 2
+
+
+def test_v7_seminar_tabs_force_ukrainian_labels(tmp_path):
+    activities_yaml = tmp_path / "activities.yaml"
+    activities_yaml.write_text("[]\n", encoding="utf-8")
+    activities = ActivityParser().parse(activities_yaml)
+    md_content = """---
+title: Seminar Labels
+subtitle: Test
+---
+# Seminar Labels
+
+## Розділ
+
+Текст.
+"""
+
+    folk_mdx = generate_mdx(md_content, 1, yaml_activities=activities, level="folk")
+    a1_mdx = generate_mdx(md_content, 1, yaml_activities=activities, level="a1")
+
+    assert '<TabItem label="Урок">' in folk_mdx
+    assert '<TabItem label="Словник">' in folk_mdx
+    assert '<TabItem label="Вправи">' in folk_mdx
+    assert '<TabItem label="Ресурси">' in folk_mdx
+    assert '<TabItem label="Lesson">' in a1_mdx
+    assert '<TabItem label="Vocabulary">' in a1_mdx
+    assert '<TabItem label="Activities">' in a1_mdx
+    assert '<TabItem label="Resources">' in a1_mdx
+
+
+def test_v7_seminar_tab3_inline_cross_refs_use_ukrainian(tmp_path):
+    activities_yaml = tmp_path / "activities.yaml"
+    activities_yaml.write_text(
+        """
+- id: act-1
+  type: quiz
+  title: Перевірка понять
+  items:
+    - question: Оберіть поняття.
+      options: [обряд, дата]
+      answer: обряд
+- id: act-2
+  type: quiz
+  title: Робоча вправа
+  items:
+    - question: Оберіть слово.
+      options: [мотив, помилка]
+      answer: мотив
+""",
+        encoding="utf-8",
+    )
+    activities = ActivityParser().parse(activities_yaml)
+    md_content = """---
+title: Семінар
+subtitle: Test
+---
+# Семінар
+
+## Постановка проблеми
+
+Текст.
+
+<!-- INJECT_ACTIVITY: act-1 -->
+"""
+
+    mdx = generate_mdx(md_content, 1, yaml_activities=activities, level="folk")
+    tab3 = mdx.split('<TabItem label="Вправи">', 1)[1].split("</TabItem>", 1)[0]
+
+    assert "### Перевірка понять\n\n*(див. урок, §Постановка проблеми)*" in tab3
+    assert "### Робоча вправа\n\n<Quiz" in tab3
+    assert tab3.count("<Quiz") == 1
 
 
 def test_generated_tabs_include_hash_target_sync_script():
@@ -287,7 +358,8 @@ Practice here.
 
     assert "Inline fill duplicate" in lesson_tab
     assert "<FillIn" in lesson_tab
-    assert "Inline fill duplicate" not in tab3
+    assert "### Inline fill duplicate\n\n*(see lesson tab)*" in tab3
+    assert tab3.count("Inline fill duplicate") == 1
     assert "<FillIn" not in tab3
     assert "Workbook-only quiz" in tab3
     assert "<Quiz" in tab3
@@ -329,9 +401,9 @@ subtitle: Test
     mdx = generate_mdx(md_content, 1, yaml_activities=activities, level="a1")
     tab3 = mdx.split('<TabItem label="Activities">', 1)[1].split("</TabItem>", 1)[0]
 
-    assert "No workbook activities for this module; see the Lesson tab." in tab3
-    assert "Inline one" not in tab3
-    assert "Inline two" not in tab3
+    assert "No workbook activities for this module; see the Lesson tab." not in tab3
+    assert "### Inline one\n\n*(see lesson tab)*" in tab3
+    assert "### Inline two\n\n*(see lesson tab)*" in tab3
     assert "<Quiz" not in tab3
     assert "*(see lesson)*" not in tab3
 

--- a/tests/test_v7_writer_dispatch.py
+++ b/tests/test_v7_writer_dispatch.py
@@ -184,6 +184,53 @@ def test_v7_build_invokes_gemini_tools_from_project_root(
     )
 
 
+def test_v7_build_seminar_stress_path_strips_combining_acute(tmp_path: Path) -> None:
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    (module_dir / "module.md").write_text("# Те́ма\n\nПро́за.\n", encoding="utf-8")
+    (module_dir / "vocabulary.yaml").write_text("- lemma: сло́во\n", encoding="utf-8")
+    (module_dir / "activities.yaml").write_text("- title: Впра́ва\n", encoding="utf-8")
+
+    result = v7_build._run_stress_annotation_for_level(module_dir, "folk")
+
+    assert result["passed"] is True
+    assert result["skipped"] is True
+    assert result["total_removed"] == 4
+    assert "\u0301" not in (module_dir / "module.md").read_text(encoding="utf-8")
+    assert "\u0301" not in (module_dir / "vocabulary.yaml").read_text(encoding="utf-8")
+    assert "\u0301" not in (module_dir / "activities.yaml").read_text(encoding="utf-8")
+
+
+def test_v7_build_core_stress_path_keeps_existing_marks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    (module_dir / "module.md").write_text("# Те́ма\n\nПро́за.\n", encoding="utf-8")
+    (module_dir / "vocabulary.yaml").write_text("- lemma: сло́во\n", encoding="utf-8")
+    (module_dir / "activities.yaml").write_text("- title: Впра́ва\n", encoding="utf-8")
+    calls: list[Path] = []
+
+    def fake_run_stress_annotation(path: Path) -> dict[str, Any]:
+        calls.append(path)
+        return {"phase": "stress_annotation", "passed": True}
+
+    monkeypatch.setattr(
+        v7_build.linear_pipeline,
+        "run_stress_annotation",
+        fake_run_stress_annotation,
+    )
+
+    result = v7_build._run_stress_annotation_for_level(module_dir, "a1")
+
+    assert result["passed"] is True
+    assert calls == [module_dir]
+    assert "\u0301" in (module_dir / "module.md").read_text(encoding="utf-8")
+    assert "\u0301" in (module_dir / "vocabulary.yaml").read_text(encoding="utf-8")
+    assert "\u0301" in (module_dir / "activities.yaml").read_text(encoding="utf-8")
+
+
 def test_v7_build_dry_run_telemetry_out_writes_file_not_stdout(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],


### PR DESCRIPTION
## Summary
- Skip seminar stress annotation using the canonical SEMINAR_LEVELS import and strip residual U+0301 from seminar module.md, vocabulary.yaml, and activities.yaml before MDX assembly.
- Force Ukrainian tab labels for canonical seminar levels in generate_mdx while preserving existing core-level behavior.
- Render inline-injected activities in the Tab 3 aggregate as compact cross-references with nearest H2/H3 section titles, while keeping workbook activities rendered in full.

## Regression Safety
- Shared seminar detection imports scripts.audit.wiki_completeness_gate.SEMINAR_LEVELS.
- Core CEFR levels still use the existing stress annotation path and A1 tab labels remain English.
- Tests cover seminar stress stripping, core stress preservation, seminar Ukrainian labels, and P2 inline-and-aggregate cross-references.

## Verification
- .venv/bin/ruff check scripts/build/ scripts/generate_mdx/
- .venv/bin/python -m pytest tests/ -q -k "mdx or generate_mdx or stress or activity"
- Reassembled the folk pilot from copied build artifacts and checked zero U+0301, Ukrainian tab labels, and inline cross-references.

NO auto-merge.