### PR TITLE
fix(qg): VESUM tokenizer false-positives on valid hyphenated/compound words

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -8132,6 +8132,29 @@ def _vesum_gate(
                 return {"passed": False, "error": str(exc), "checked": len(unchecked_pairs)}
             resolved_lc = {surface.lower() for surface, matches in original_case_verified.items() if matches}
             missing_lc -= resolved_lc
+    # Textbook syllable-break notation such as `за-пи-са-ний` should still
+    # resolve to the canonical VESUM form, but only after the intact whole
+    # hyphenated token has had a chance to verify. Doing this as a fallback
+    # prevents real lexical compounds like `будь-який` from being fused into
+    # non-words before lookup.
+    if missing_lc:
+        syllable_lookup_by_missing = {
+            word: collapsed
+            for word in missing_lc
+            if "-" in word
+            for collapsed in (_collapse_syllable_break(word),)
+            if collapsed != word and len(collapsed) >= VESUM_MIN_WORD_LENGTH
+        }
+        if syllable_lookup_by_missing:
+            try:
+                syllable_verified = verify_words_fn(sorted(set(syllable_lookup_by_missing.values())))
+            except Exception as exc:
+                return {"passed": False, "error": str(exc), "checked": len(unchecked_pairs)}
+            missing_lc -= {
+                word
+                for word, collapsed in syllable_lookup_by_missing.items()
+                if syllable_verified.get(collapsed)
+            }
     # Hyphenated multi-word constructions fallback (per user direction
     # 2026-05-23). Many legitimate Ukrainian forms appear as hyphenated
     # compounds that VESUM only indexes by individual lemma: adverbial
@@ -8335,17 +8358,10 @@ def _normalize_for_vesum(lemma: str) -> str:
     while previous != text:
         previous = text
         # Strip emphasis wrappers (bold/italic/code/italic-underscore).
-        # Hyphens INSIDE emphasis are conditionally stripped: pedagogical
-        # morpheme breaks like `прокида**ю-ся**` and `**-ться**` (where
-        # a hyphen splits a short morpheme fragment) collapse to the
-        # canonical VESUM lemma; real compound words like `**темно-синій**`
-        # (both halves are full-length lexemes) preserve their hyphen.
-        # The heuristic: strip the hyphen only if either side is ≤3 chars
-        # (morpheme-fragment width). 3-char threshold captures all observed
-        # Ukrainian reflexive/aspectual suffixes (`ся/сь/ть/єть/єте/ємо/...`)
-        # while keeping every Ukrainian compound noun/adjective intact
-        # (compound halves are ≥4 chars in practice: `темно`, `синій`,
-        # `жовто`, `гарячий`, …).
+        # Hyphens INSIDE emphasis are stripped only for explicit grammar
+        # morpheme notation like `прокида**ю-ся**` and `**-ться**`. Lexical
+        # hyphenated words must stay hyphenated because VESUM contains forms
+        # like `будь-що` and `по-перше` as whole entries.
         #
         # 2026-05-17 regression context: PR #2068 introduced unconditional
         # hyphen-strip-inside-emphasis to fix m20's `прокида**ю-ся**`
@@ -8369,10 +8385,42 @@ def _normalize_for_vesum(lemma: str) -> str:
     return text.strip()
 
 
-def _strip_morpheme_hyphen(emphasis_inner: str, *, fragment_max_chars: int = 3) -> str:
+_VESUM_MORPHEME_HYPHEN_PARTS = frozenset(
+    {
+        "ся",
+        "сь",
+        "тся",
+        "тсь",
+        "ться",
+        "шся",
+        "шсь",
+        "чся",
+        "чсь",
+        "ть",
+        "ш",
+        "мо",
+        "те",
+        "ю",
+        "юся",
+        "є",
+        "єш",
+        "єшся",
+        "єть",
+        "ємо",
+        "ємося",
+        "єте",
+        "єтеся",
+        "ють",
+        "ються",
+        "ється",
+        "ва",
+    }
+)
+
+
+def _strip_morpheme_hyphen(emphasis_inner: str) -> str:
     """Collapse a morpheme-break hyphen INSIDE markdown emphasis, but only
-    when at least one side of the hyphen is short enough to be a morpheme
-    fragment (≤``fragment_max_chars`` chars by default).
+    when one side is an explicit grammar morpheme fragment.
 
     See ``_normalize_for_vesum`` for the rationale + regression context.
     """
@@ -8385,7 +8433,13 @@ def _strip_morpheme_hyphen(emphasis_inner: str, *, fragment_max_chars: int = 3) 
     if len(parts) != 2:
         return emphasis_inner
     left, right = parts
-    if len(left) <= fragment_max_chars or len(right) <= fragment_max_chars:
+    if not left and right in _VESUM_MORPHEME_HYPHEN_PARTS:
+        return right
+    if not right and left in _VESUM_MORPHEME_HYPHEN_PARTS:
+        return left
+    if not left or not right:
+        return emphasis_inner
+    if left in _VESUM_MORPHEME_HYPHEN_PARTS or right in _VESUM_MORPHEME_HYPHEN_PARTS:
         return left + right
     return emphasis_inner
 
@@ -8483,7 +8537,6 @@ def _iter_vesum_word_surfaces(text: str) -> list[str]:
             continue
         if word.lower() in _STANDALONE_POSTFIX_FRAGMENTS:
             continue
-        word = _collapse_syllable_break(word)
         words.append(word)
     return words
 

--- a/tests/test_vesum_verified_postfix.py
+++ b/tests/test_vesum_verified_postfix.py
@@ -36,11 +36,17 @@ def test_reflexive_verb_not_split() -> None:
 
 
 def test_compound_hyphen_word_not_split() -> None:
-    text = "синьо-жовтий англо-український"
+    text = "синьо-жовтий англо-український будь-який будь-що по-перше"
 
     tokens = _iter_vesum_word_surfaces(text)
 
-    assert tokens == ["синьо-жовтий", "англо-український"]
+    assert tokens == [
+        "синьо-жовтий",
+        "англо-український",
+        "будь-який",
+        "будь-що",
+        "по-перше",
+    ]
 
 
 def test_em_dash_splits_sentences() -> None:
@@ -74,6 +80,13 @@ def test_normalize_for_vesum_strips_stress_and_markdown() -> None:
     assert _normalize_for_vesum("вмива́ю") == "вмиваю"
     assert _normalize_for_vesum("**ся**") == "ся"
     assert _normalize_for_vesum("чу́до**в**") == "чудов"
+    assert _normalize_for_vesum("прокида**ю-ся**") == "прокидаюся"
+    assert _normalize_for_vesum("прокида**-юся**") == "прокидаюся"
+    assert _normalize_for_vesum("**будь-що**") == "будь-що"
+    assert _normalize_for_vesum("будь**-що**") == "будь-що"
+    assert _normalize_for_vesum("будь**-який**") == "будь-який"
+    assert _normalize_for_vesum("**по-перше**") == "по-перше"
+    assert _normalize_for_vesum("по**-перше**") == "по-перше"
 
 
 def test_vesum_gate_normalizes_stress_and_markdown_before_lookup() -> None:
@@ -128,6 +141,84 @@ def test_vesum_gate_ignores_sung_vowel_practice_strings() -> None:
 
     assert gate["passed"] is False
     assert gate["missing"] == ["фейкслово"]
+
+
+def test_vesum_gate_verifies_valid_hyphenated_compounds_as_whole_words() -> None:
+    seen: list[list[str]] = []
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        seen.append(words)
+        valid = {
+            "будь-який",
+            "будь-що",
+            "по-перше",
+            "вибір",
+            "обжинки",
+            "обжинковий",
+            "день",
+            "Купала",
+            "купальський",
+            "жниварський",
+            "спів",
+        }
+        return {word: ([{"lemma": word}] if word in valid else []) for word in words}
+
+    gate = _vesum_gate(
+        module_text=(
+            "Будь-який вибір, **будь-що** і **по-перше**. "
+            "Обжинки, обжинковий день, Купала, купальський і жниварський спів."
+        ),
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    looked_up = {word for call in seen for word in call}
+    assert gate["passed"] is True
+    assert gate["missing"] == []
+    assert {"будь-який", "будь-що", "по-перше", "Купала"} <= looked_up
+    assert not {"будьякий", "будьщо", "поперше", "купаль", "обжинк", "ськ"} & looked_up
+
+
+def test_vesum_gate_still_flags_known_bad_form_after_hyphen_fix() -> None:
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        valid = {"будь-який"}
+        return {word: ([{"lemma": word}] if word in valid else []) for word in words}
+
+    gate = _vesum_gate(
+        module_text="Будь-який приклад, але празднік лишається помилкою.",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert gate["passed"] is False
+    assert "празднік" in gate["missing"]
+    assert "Будьякий" not in gate["missing"]
+
+
+def test_vesum_gate_resolves_textbook_syllable_break_after_whole_lookup() -> None:
+    seen: list[list[str]] = []
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        seen.append(words)
+        valid = {"день", "записаний", "мій", "тут", "увесь"}
+        return {word: ([{"lemma": word}] if word in valid else []) for word in words}
+
+    gate = _vesum_gate(
+        module_text="Тут за-пи-са-ний у-весь мій день.",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert gate["passed"] is True
+    assert gate["missing"] == []
+    assert "за-пи-са-ний" in seen[0]
+    assert {"записаний", "увесь"} <= set(seen[1])
 
 
 def test_vesum_gate_ignores_morphological_stem_fragments() -> None:


### PR DESCRIPTION
## Bug

The V7 python_qg `vesum_verified` gate was normalizing valid Ukrainian hyphenated words before VESUM saw the whole form. That fused forms such as `будь-який` into `будьякий` and could surface non-word fragments as missing even when the actual whole words are valid.

## Fix

- Preserve hyphenated Ukrainian surface forms for the primary VESUM lookup.
- Move textbook syllable-break collapsing (`за-пи-са-ний` -> `записаний`) into a fallback that runs only after the intact whole token misses.
- Narrow Markdown morpheme-hyphen stripping to explicit grammar fragments so lexical compounds like `будь-що` and `по-перше` stay intact, including split-emphasis forms.

## Evidence

- The failing folk build module now passes `_vesum_gate` with `missing_count: 0`.
- The reported false positives `будьякий`, `купаль`, `обжинк`, and `ськ` are absent from the missing list.
- VESUM still finds the valid whole words `будь-який`, `обжинки`, `обжинковий`, `Купала`, `купальський`, and `жниварський`.
- A known bad form, `празднік`, still fails `verify_words` and the gate reports it in `missing`.

## Validation

- `.venv/bin/ruff check scripts/audit/_judge_eval_lib.py scripts/build/linear_pipeline.py tests/test_vesum_verified_postfix.py`
- `.venv/bin/python -m pytest tests/ -q -k "vesum or judge_eval or qg"`
- Deterministic repro against `.worktrees/builds/folk-kalendarna-obriadovist-zvychai-20260609-072531/curriculum/l2-uk-en/folk/kalendarna-obriadovist-zvychai/module.md`

NO auto-merge — track driver reviews fresh.