### PR TITLE
fix(a1): sync initial published MDX

### DIFF
--- a/curriculum/l2-uk-en/a1/checkpoint-first-contact/module.md
+++ b/curriculum/l2-uk-en/a1/checkpoint-first-contact/module.md
@@ -32,9 +32,9 @@ control, greeting chunks, self-introduction, noun gender habits, vocative
 address, and modern chat etiquette. Use that order as a checklist, not as new
 grammar to memorize.
 
-<!-- INJECT_ACTIVITY: act-1 -->
-
 ## Що ми знаємо?
+
+<!-- INJECT_ACTIVITY: act-1 -->
 
 You now have six small toolkits.
 
@@ -95,7 +95,7 @@ closing.
 Ду́же приє́мно познайо́митися!
 ```
 
-Support after the text:
+English support after the Ukrainian text:
 
 | Українська | English support |
 | --- | --- |
@@ -184,7 +184,7 @@ both people use **ти**.
 Соломі́я: Мені́ теж. До поба́чення!
 ```
 
-Support after the dialogue:
+English support after the Ukrainian dialogue:
 
 | Українська | English support |
 | --- | --- |
@@ -225,7 +225,7 @@ practice.
 Том: Мені́ теж.
 ```
 
-Support after the chat:
+English support after the Ukrainian chat:
 
 | Українська | English support |
 | --- | --- |

--- a/curriculum/l2-uk-en/a1/my-family/module.md
+++ b/curriculum/l2-uk-en/a1/my-family/module.md
@@ -34,7 +34,7 @@ of possession. Treat **У ме́не є** and **У те́бе є** as whole chun
 Марк: Його́ зва́ти Ко́ля.
 ```
 
-Support after the dialogue:
+English support after the Ukrainian dialogue:
 
 | Українська | English support |
 | --- | --- |
@@ -55,7 +55,7 @@ Now use **це** to identify people in a family photo.
 Да́ша: Так, її́ зва́ти Тетя́на.
 ```
 
-Support after the dialogue:
+English support after the Ukrainian dialogue:
 
 | Українська | English support |
 | --- | --- |

--- a/curriculum/l2-uk-en/a1/sounds-letters-and-hello/module.md
+++ b/curriculum/l2-uk-en/a1/sounds-letters-and-hello/module.md
@@ -189,7 +189,7 @@ Read the Ukrainian first:
 Тара́с: Чудо́во!
 ```
 
-Support after the dialogue:
+English support after the Ukrainian dialogue:
 
 | Українська | English support |
 | --- | --- |
@@ -207,7 +207,7 @@ Use **А у тебе́?** after **Як спра́ви?**. For a name exchange, u
 Марко́: Мене́ зва́ти Марко́.
 ```
 
-Support after the dialogue:
+English support after the Ukrainian dialogue:
 
 | Українська | English support |
 | --- | --- |

--- a/curriculum/l2-uk-en/a1/stress-and-melody/module.md
+++ b/curriculum/l2-uk-en/a1/stress-and-melody/module.md
@@ -97,6 +97,8 @@ three safe models:
 The punctuation helps you choose the melody, but your voice must still do the
 work.
 
+<!-- INJECT_ACTIVITY: act-4 -->
+
 Now add the most important beginner exception. A question with a question word
 usually falls, not rises:
 
@@ -164,7 +166,7 @@ Read the Ukrainian dialogue first:
 Тара́с: До́бре! ↘
 ```
 
-Support after the dialogue:
+English support after the Ukrainian dialogue:
 
 | Українська | English support |
 | --- | --- |
@@ -188,7 +190,7 @@ Now read a second tiny exchange:
 Тара́с: Як га́рно! ↘↘
 ```
 
-Support after the dialogue:
+English support after the Ukrainian dialogue:
 
 | Українська | English support |
 | --- | --- |
@@ -255,5 +257,3 @@ of the sentence melody.
 
 The workbook adds extra practice with the same skills: clear-vowel repair,
 stress sorting, quick facts, and word recognition.
-
-<!-- INJECT_ACTIVITY: act-4 -->

--- a/curriculum/l2-uk-en/a1/who-am-i/module.md
+++ b/curriculum/l2-uk-en/a1/who-am-i/module.md
@@ -43,7 +43,7 @@ read. The support table comes after the dialogue.
 Оле́на: Я з Украї́ни.
 ```
 
-Support after the dialogue:
+English support after the Ukrainian dialogue:
 
 | Українська | English support |
 | --- | --- |
@@ -66,7 +66,7 @@ Now read a formal first meeting:
 Петро́: Так, я з Ки́єва.
 ```
 
-Support after the dialogue:
+English support after the Ukrainian dialogue:
 
 | Українська | English support |
 | --- | --- |
@@ -89,7 +89,7 @@ The third dialogue introduces another person:
 Ната́лка: Ду́же приє́мно, Окса́но.
 ```
 
-Support after the dialogue:
+English support after the Ukrainian dialogue:
 
 | Українська | English support |
 | --- | --- |

--- a/starlight/src/content/docs/a1/checkpoint-first-contact.mdx
+++ b/starlight/src/content/docs/a1/checkpoint-first-contact.mdx
@@ -56,6 +56,9 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs syncKey="module-tab">
 <TabItem label="Lesson">
 
+**Приві́т! Мене́ зва́ти Богдан. Я з Дніпра́.** — Hi! My name is Bohdan.
+I am from Dnipro.
+
 This checkpoint is a working rehearsal for the first six modules. Nothing here
 needs a new grammar rule. You are checking whether the first-contact pieces can
 move together: read Ukrainian script, greet someone, give your name, say where
@@ -77,32 +80,30 @@ By the end, you can:
 
 The checkpoint keeps a Ukrainian-first frame. Ukrainian letters, stress, and
 soft signs are explained as Ukrainian habits. The page never asks you to compare
-them to Russian letters or Russian pronunciation. Russian-influenced greetings
-and calques appear only as wrong choices inside correction practice.
+them to Russian letters or Russian pronunciation. Non-target greetings and
+calques appear only as wrong choices inside correction practice.
 
 The roadmap behind this checkpoint has six learner steps: sound and alphabet
 control, greeting chunks, self-introduction, noun gender habits, vocative
 address, and modern chat etiquette. Use that order as a checklist, not as new
 grammar to memorize.
 
-{/**/}
-
-### First-contact readiness
-
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "You greet a peer at the start of class.", "options": [{"text": "Привіт!", "correct": true}, {"text": "До побачення!", "correct": false}, {"text": "Мені теж.", "correct": false}], "explanation": "Привіт is the informal peer greeting."}, {"question": "You greet a teacher or administrator neutrally.", "options": [{"text": "Добрий день!", "correct": true}, {"text": "Бувай!", "correct": false}, {"text": "Мене звати!", "correct": false}], "explanation": "Добрий день is the safe neutral formal greeting."}, {"question": "You introduce your name.", "options": [{"text": "Мене звати Олена.", "correct": true}, {"text": "Моє ім'я є Олена.", "correct": false}, {"text": "Я звати Олена.", "correct": false}], "explanation": "Мене звати... is the canonical first-name chunk."}, {"question": "You say that you are a student.", "options": [{"text": "Я студент.", "correct": true}, {"text": "Я є студент.", "correct": false}, {"text": "Мене студент.", "correct": false}], "explanation": "Ukrainian usually omits the present-tense copula in this identity line."}, {"question": "You say your age.", "options": [{"text": "Мені 20 років.", "correct": true}, {"text": "Я маю 20 років.", "correct": false}, {"text": "Я 20 роки.", "correct": false}], "explanation": "Age uses Мені ... років."}, {"question": "You close the first meeting politely.", "options": [{"text": "Дуже приємно. До побачення!", "correct": true}, {"text": "Дуже прізвище. Привіт!", "correct": false}, {"text": "Звідки ти? Мені теж!", "correct": false}], "explanation": "Дуже приємно and До побачення close the exchange."}]`)} />
-
 ## Що ми знаємо?
+
+### Готовність до знайомства
+
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Ти вітаєш ровесника на початку заняття.", "options": [{"text": "Привіт!", "correct": true}, {"text": "До побачення!", "correct": false}, {"text": "Мені теж.", "correct": false}], "explanation": "Привіт — неформальне привітання для ровесника."}, {"question": "Ти нейтрально вітаєш викладача або адміністратора.", "options": [{"text": "Добрий день!", "correct": true}, {"text": "Бувай!", "correct": false}, {"text": "Мене звати!", "correct": false}], "explanation": "Добрий день — безпечне нейтральне формальне привітання."}, {"question": "Ти називаєш своє ім'я.", "options": [{"text": "Мене звати Олена.", "correct": true}, {"text": "Моє ім'я є Олена.", "correct": false}, {"text": "Я звати Олена.", "correct": false}], "explanation": "Мене звати... — головний блок для імені."}, {"question": "Ти кажеш, що ти студент.", "options": [{"text": "Я студент.", "correct": true}, {"text": "Я є студент.", "correct": false}, {"text": "Мене студент.", "correct": false}], "explanation": "У такому реченні українська зазвичай не додає є."}, {"question": "Ти кажеш свій вік.", "options": [{"text": "Мені 20 років.", "correct": true}, {"text": "Я маю 20 років.", "correct": false}, {"text": "Я 20 роки.", "correct": false}], "explanation": "Вік подаємо блоком Мені ... років."}, {"question": "Ти ввічливо завершуєш перше знайомство.", "options": [{"text": "Дуже приємно. До побачення!", "correct": true}, {"text": "Дуже прізвище. Привіт!", "correct": false}, {"text": "Звідки ти? Мені теж!", "correct": false}], "explanation": "Дуже приємно і До побачення завершують розмову."}]`)} />
 
 You now have six small toolkits.
 
-| Toolkit | You can do this now |
+| Опора | Що ти вже робиш |
 | --- | --- |
-| Sounds and letters | recognize Ukrainian letters, vowels, **ґ**, **ї**, **є**, **и**, **і**, **ь**, and the apostrophe |
-| Reading | read short words and syllables slowly but confidently |
-| Special signs | hear that **сім'я**, **бур'ян**, and **день** are not spelled decoration; the sign changes the sound |
-| Stress and melody | mark the stressed syllable and use a rising yes/no question melody |
-| Who am I? | say your name, origin, nationality, profession, and age |
-| My family | name close family members and use **У мене є...** |
+| **Звуки́ й лі́тери** | recognize Ukrainian letters, vowels, **ґ**, **ї**, **є**, **и**, **і**, **ь**, and the apostrophe |
+| **Чита́ння** | read short words and syllables slowly but confidently |
+| **Спеціа́льні зна́ки** | hear that **сім'я́**, **бур'я́н**, and **день** are not spelled decoration |
+| **На́голос і мело́дія** | mark the stressed syllable and use a rising yes/no question melody |
+| **Хто я?** | say your name, origin, nationality, profession, and age |
+| **Моя́ сім'я́** | name close family members and use **У ме́не є...** |
 
 A checkpoint is not a memory trick. It is a task: can you meet one new person
 and keep the exchange moving? Use short sentences. Use the chunks exactly. If
@@ -110,17 +111,17 @@ you hesitate, return to the sentence frame instead of translating from English.
 
 Keep these blocks as whole blocks:
 
-| English need | Ukrainian block |
+| Український блок | English support |
 | --- | --- |
-| What is your name? | **Як тебе звати?** |
-| My name is... | **Мене звати...** |
-| Nice to meet you. | **Дуже приємно.** |
-| Me too. | **Мені теж.** |
-| Where are you from? | **Звідки ти?** |
-| I am from... | **Я з...** |
-| I am a student. | **Я студент / студентка.** |
-| I am 20 years old. | **Мені 20 років.** |
-| I have... | **У мене є...** |
+| **Як тебе́ зва́ти?** | What is your name? |
+| **Мене́ зва́ти...** | My name is... |
+| **Ду́же приє́мно.** | Nice to meet you. |
+| **Мені́ теж.** | Me too. |
+| **Зві́дки ти?** | Where are you from? |
+| **Я з...** | I am from... |
+| **Я студе́нт / студе́нтка.** | I am a student. |
+| **Мені́ 20 ро́ків.** | I am 20 years old. |
+| **У ме́не є...** | I have... |
 
 Formal address still exists, but this checkpoint uses a peer language-course
 setting, so the main dialogue stays in **ти**. Do not mix **ти** and **Ви** in
@@ -132,7 +133,7 @@ When a line feels hard, reduce it to one chunk: **Мене звати...**, **Я
 chunks, not long translated sentences.
 :::
 
-### Questions and answers
+### Питання і відповіді
 
 <MatchUp client:only='react' pairs={JSON.parse(`[{"left": "Як тебе звати?", "right": "Мене звати Богдан."}, {"left": "Звідки ти?", "right": "Я з Дніпра."}, {"left": "Ти студентка?", "right": "Так, я студентка."}, {"left": "У тебе є брат?", "right": "Так, у мене є брат."}, {"left": "Як її звати?", "right": "Її звати Ірина."}, {"left": "Чий це словник?", "right": "Це мій словник."}, {"left": "Скільки тобі років?", "right": "Мені 20 років."}, {"left": "Дуже приємно.", "right": "Мені теж."}]`)} />
 
@@ -142,15 +143,27 @@ Read this text aloud. Use the letter and stress habits from the script modules.
 The content is only the A1.1 world: name, place, role, family, and a simple
 closing.
 
-<DialogueBox uk="Привіт! Мене звати Марко." en="Hi! My name is Marko." />
-<DialogueBox uk="Моє прізвище Коваленко." en="My surname is Kovalenko." />
-<DialogueBox uk="Я з Києва, але зараз я студент у Львові." en="I am from Kyiv, but now I am a student in Lviv." />
-<DialogueBox uk="Мені 20 років." en="I am 20 years old." />
-<DialogueBox uk="Моя професія зараз — студент." en="My profession or role now is student." />
-<DialogueBox uk="У мене є мама, тато і сестра." en="I have a mom, a dad, and a sister." />
-<DialogueBox uk="Моя мама — вчителька, а мій тато — інженер." en="My mom is a teacher, and my dad is an engineer." />
-<DialogueBox uk="Мою сестру звати Оля." en="My sister's name is Olia." />
-<DialogueBox uk="Дуже приємно познайомитися!" en="Very nice to meet you!" />
+```text
+Приві́т! Мене́ зва́ти Марко́.
+Моє́ прі́звище Ковале́нко.
+Я з Ки́єва, але́ за́раз я студе́нт у Льво́ві.
+Мені́ 20 ро́ків.
+Моя́ профе́сія за́раз — студе́нт.
+У ме́не є ма́ма, та́то і сестра́.
+Моя́ ма́ма — вчи́телька, а мій та́то — інжене́р.
+Мою́ сестру́ зва́ти О́ля.
+Ду́же приє́мно познайо́митися!
+```
+
+English support after the Ukrainian text:
+
+| Українська | English support |
+| --- | --- |
+| **Моє́ прі́звище Ковале́нко.** | My surname is Kovalenko. |
+| **Я з Ки́єва.** | I am from Kyiv. |
+| **Мені́ 20 ро́ків.** | I am 20 years old. |
+| **У ме́не є ма́ма, та́то і сестра́.** | I have a mom, dad, and sister. |
+| **Ду́же приє́мно познайо́митися!** | Very nice to meet you! |
 
 Now check the reading decisions.
 
@@ -170,7 +183,7 @@ Alphabet order is also a learner tool. If you look up **прізвище** in a
 dictionary, the first letter is not enough; after **п**, keep comparing the next
 letters. That habit matters more than speed.
 
-### Complete the review text
+### Доповни текст
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "Привіт! ___ звати Марко.", "answer": "Мене", "options": ["Мене", "Моє", "Мій"]}, {"sentence": "Моє ___ Коваленко.", "answer": "прізвище", "options": ["прізвище", "фамілія", "професія"]}, {"sentence": "Я ___ Києва.", "answer": "з", "options": ["з", "у", "це"]}, {"sentence": "Я ___.", "answer": "студент", "options": ["студент", "є студент", "мене студент"]}, {"sentence": "___ 20 років.", "answer": "Мені", "options": ["Мені", "Я маю", "Мене"]}, {"sentence": "У мене ___ сестра.", "answer": "є", "options": ["є", "звати", "з"]}, {"sentence": "Це ___ мама.", "answer": "моя", "options": ["моя", "мій", "моє"]}, {"sentence": "Дуже ___ познайомитися!", "answer": "приємно", "options": ["приємно", "прізвище", "звати"]}]`)} />
 
@@ -179,14 +192,14 @@ letters. That habit matters more than speed.
 The grammar checkpoint has six safe patterns. They are small, but they cover a
 real first meeting.
 
-| Pattern | Safe line | Watch out |
+| Опора | Безпечний рядок | Не треба зараз |
 | --- | --- | --- |
-| **Це + noun** | **Це Богдан. Це моя сестра.** | Do not overbuild the sentence. |
-| Identity without **є** | **Я студент. Вона лікарка.** | Do not say **Я є студент** in this A1 sentence. |
-| Name | **Мене звати Соломія.** | Do not build **Моє ім'я є...** from English. |
-| Origin | **Я з Канади. Я зі Львова.** | Use **з / зі** as the learned chunk. |
-| Age | **Мені 20 років.** | Do not use the English "have years" shape. |
-| Possession | **У мене є брат.** | Learn the whole chunk, not a verb for "have." |
+| **Це + noun** | **Це Богдан. Це моя́ сестра́.** | Do not overbuild the sentence. |
+| Identity without **є** | **Я студе́нт. Вона́ лі́карка.** | Do not say **Я є студент** in this A1 sentence. |
+| Name | **Мене́ зва́ти Соломі́я.** | Do not build **Моє́ ім'я́ є...** from English. |
+| Origin | **Я з Кана́ди. Я зі Льво́ва.** | Use **з / зі** as the learned chunk. |
+| Age | **Мені́ 20 ро́ків.** | Do not use the English "have years" shape. |
+| Possession | **У ме́не є брат.** | Learn the whole chunk, not a verb for "have." |
 
 For family and identity, the owned word chooses the possessive form:
 
@@ -203,14 +216,14 @@ with its gender when that helps you later: **словник** is masculine,
 system today, but you do need the habit of learning a noun with its form cues.
 
 The safe social vocabulary also stays native Ukrainian. Use **прізвище** for
-surname, not the colloquial or Russian-influenced **фамілія**. Use **тато** or
-**батько** for father in this course context, not the Russian-influenced
-**папа**. Use **Добрий день** or **Вітаю** when you need a neutral hello, and
+surname in official-style lines, not colloquial **фамілія**. Use **тато** or
+**батько** for father in this course context; keep **папа** as recognition, not
+the active A1 default. Use **Добрий день** or **Вітаю** when you need a neutral hello, and
 **До побачення** for goodbye.
 
-### Fix common A1.1 traps
+### Виправ A1.1 пастки
 
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "Name introduction", "options": [{"text": "Мене звати Джон.", "correct": true}, {"text": "Моє ім'я є Джон.", "correct": false}], "explanation": "Ukrainian introduces a name with Мене звати..."}, {"question": "Identity sentence", "options": [{"text": "Я студент.", "correct": true}, {"text": "Я є студент.", "correct": false}], "explanation": "Present identity normally omits є."}, {"question": "Age sentence", "options": [{"text": "Мені 20 років.", "correct": true}, {"text": "Я маю 20 років.", "correct": false}], "explanation": "Age uses Мені ... років."}, {"question": "Direct address", "options": [{"text": "Привіт, Максиме!", "correct": true}, {"text": "Привіт, Максим!", "correct": false}], "explanation": "Direct address uses the vocative form in the safe example."}, {"question": "Safe greeting", "options": [{"text": "Добрий день! Мене звати Оксана.", "correct": true}, {"text": "Здрастуйте! Мене звати Оксана.", "correct": false}], "explanation": "Добрий день is the safe standard greeting."}, {"question": "Surname", "options": [{"text": "Моє прізвище Сміт.", "correct": true}, {"text": "Моя фамілія Сміт.", "correct": false}], "explanation": "Прізвище is the standard Ukrainian word for surname."}, {"question": "Farewell", "options": [{"text": "До побачення!", "correct": true}, {"text": "Пока!", "correct": false}], "explanation": "До побачення is the safe standard farewell."}, {"question": "Noun gender habit", "options": [{"text": "Вивчення слова разом із його родом", "correct": true}, {"text": "Ігнорування роду іменника", "correct": false}], "explanation": "Store a Ukrainian noun with its gender cues from the beginning."}]`)} />
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Представлення імені", "options": [{"text": "Мене звати Джон.", "correct": true}, {"text": "Моє ім'я є Джон.", "correct": false}], "explanation": "Українська представляє ім'я через Мене звати..."}, {"question": "Речення ідентичності", "options": [{"text": "Я студент.", "correct": true}, {"text": "Я є студент.", "correct": false}], "explanation": "Теперішня ідентичність зазвичай не додає є."}, {"question": "Речення про вік", "options": [{"text": "Мені 20 років.", "correct": true}, {"text": "Я маю 20 років.", "correct": false}], "explanation": "Вік подаємо блоком Мені ... років."}, {"question": "Пряме звертання", "options": [{"text": "Привіт, Максиме!", "correct": true}, {"text": "Привіт, Максим!", "correct": false}], "explanation": "Пряме звертання має кличну форму в безпечному прикладі."}, {"question": "Безпечне привітання", "options": [{"text": "Добрий день! Мене звати Оксана.", "correct": true}, {"text": "Здрастуйте! Мене звати Оксана.", "correct": false}], "explanation": "Добрий день — безпечне стандартне привітання."}, {"question": "Прізвище", "options": [{"text": "Моє прізвище Сміт.", "correct": true}, {"text": "Моя фамілія Сміт.", "correct": false}], "explanation": "Прізвище — стандартне українське слово."}, {"question": "Прощання", "options": [{"text": "До побачення!", "correct": true}, {"text": "Пока!", "correct": false}], "explanation": "До побачення — безпечне стандартне прощання."}, {"question": "Звичка до роду іменника", "options": [{"text": "Вивчення слова разом із його родом", "correct": true}, {"text": "Ігнорування роду іменника", "correct": false}], "explanation": "Запам'ятовуй український іменник разом із підказками роду."}]`)} />
 
 ## Діалог
 
@@ -218,35 +231,49 @@ This is the full first-contact task. Read it once for meaning, then read it
 again aloud. The setting is a break on the first day of Ukrainian courses, so
 both people use **ти**.
 
-<DialogueBox uk="Богдан: Привіт! Мене звати Богдан." en="Bohdan: Hi! My name is Bohdan." />
-<DialogueBox uk="Соломія: Привіт, Богдане! Мене звати Соломія." en="Solomiia: Hi, Bohdane! My name is Solomiia." />
-<DialogueBox uk="Богдан: Дуже приємно, Соломіє." en="Bohdan: Very nice to meet you, Solomiie." />
-<DialogueBox uk="Соломія: Мені теж. Звідки ти?" en="Solomiia: Me too. Where are you from?" />
-<DialogueBox uk="Богдан: Я з Дніпра. А ти?" en="Bohdan: I am from Dnipro. And you?" />
-<DialogueBox uk="Соломія: Я з Тернополя." en="Solomiia: I am from Ternopil." />
-<DialogueBox uk="Богдан: Ти студентка?" en="Bohdan: Are you a student?" />
-<DialogueBox uk="Соломія: Так, я студентка. Моя майбутня професія — вчителька." en="Solomiia: Yes, I am a student. My future profession is teacher." />
-<DialogueBox uk="Богдан: Класно. Я студент, майбутній інженер." en="Bohdan: Nice. I am a student, a future engineer." />
-<DialogueBox uk="Соломія: У тебе є брати чи сестри?" en="Solomiia: Do you have brothers or sisters?" />
-<DialogueBox uk="Богдан: Так, у мене є сестра. Її звати Ірина." en="Bohdan: Yes, I have a sister. Her name is Iryna." />
-<DialogueBox uk="Соломія: У мене є брат. Його звати Назар." en="Solomiia: I have a brother. His name is Nazar." />
-<DialogueBox uk="Богдан: Дуже приємно познайомитися." en="Bohdan: Very nice to meet you." />
-<DialogueBox uk="Соломія: Мені теж. До побачення!" en="Solomiia: Me too. Goodbye!" />
+```text
+Богда́н: Приві́т! Мене́ зва́ти Богда́н.
+Соломі́я: Приві́т, Богда́не! Мене́ зва́ти Соломі́я.
+Богда́н: Ду́же приє́мно, Соломі́є.
+Соломі́я: Мені́ теж. Зві́дки ти?
+Богда́н: Я з Дніпра́. А ти?
+Соломі́я: Я з Терно́поля.
+Богда́н: Ти студе́нтка?
+Соломі́я: Так, я студе́нтка. Моя́ майбу́тня профе́сія — вчи́телька.
+Богда́н: Кла́сно. Я студе́нт, майбу́тній інжене́р.
+Соломі́я: У те́бе є брати́ чи се́стри?
+Богда́н: Так, у ме́не є сестра́. Її́ зва́ти Іри́на.
+Соломі́я: У ме́не є брат. Його́ зва́ти Наза́р.
+Богда́н: Ду́же приє́мно познайо́митися.
+Соломі́я: Мені́ теж. До поба́чення!
+```
+
+English support after the Ukrainian dialogue:
+
+| Українська | English support |
+| --- | --- |
+| **Приві́т, Богда́не!** | Hi, Bohdan! |
+| **Ду́же приє́мно, Соломі́є.** | Very nice to meet you, Solomiia. |
+| **Я з Дніпра́.** | I am from Dnipro. |
+| **У те́бе є брати́ чи се́стри?** | Do you have brothers or sisters? |
+| **До поба́чення!** | Goodbye! |
 
 Use this as your graduation speech for A1.1:
 
-<DialogueBox uk="Привіт! Мене звати Олена." en="Hi! My name is Olena." />
-<DialogueBox uk="Моє прізвище Мельник." en="My surname is Melnyk." />
-<DialogueBox uk="Я з Канади. Я канадка." en="I am from Canada. I am Canadian." />
-<DialogueBox uk="Я студентка. Моя майбутня професія — лікарка." en="I am a student. My future profession is doctor." />
-<DialogueBox uk="Моя мама — вчителька, а мій тато — інженер." en="My mom is a teacher, and my dad is an engineer." />
-<DialogueBox uk="У мене є одна сестра." en="I have one sister." />
-<DialogueBox uk="Дуже приємно познайомитися!" en="Very nice to meet you!" />
+```text
+Приві́т! Мене́ зва́ти Оле́на.
+Моє́ прі́звище Ме́льник.
+Я з Кана́ди. Я кана́дка.
+Я студе́нтка. Моя́ майбу́тня профе́сія — лі́карка.
+Моя́ ма́ма — вчи́телька, а мій та́то — інжене́р.
+У ме́не є одна́ сестра́.
+Ду́же приє́мно познайо́митися!
+```
 
 If you want a shorter answer, keep five sentences: name, origin, role, one
 family line, and closing. That is enough for the checkpoint.
 
-### Full dialogue blanks
+### Пропуски в діалозі
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "___! Мене звати Богдан.", "answer": "Привіт", "options": ["Привіт", "Прізвище", "Років"]}, {"sentence": "Привіт, ___! Мене звати Соломія.", "answer": "Богдане", "options": ["Богдане", "Богдан", "Богдана"]}, {"sentence": "Дуже приємно, ___.", "answer": "Соломіє", "options": ["Соломіє", "Соломія", "Соломію"]}, {"sentence": "___ ти? Я з Дніпра.", "answer": "Звідки", "options": ["Звідки", "Хто", "Чий"]}, {"sentence": "Моя майбутня ___ — вчителька.", "answer": "професія", "options": ["професія", "прізвище", "адреса"]}, {"sentence": "У мене є сестра. ___ звати Ірина.", "answer": "Її", "options": ["Її", "Його", "Я"]}, {"sentence": "У мене є брат. ___ звати Назар.", "answer": "Його", "options": ["Його", "Її", "Вона"]}, {"sentence": "Дуже приємно ___!", "answer": "познайомитися", "options": ["познайомитися", "походження", "допомогти"]}]`)} />
 
@@ -257,19 +284,40 @@ start with a greeting, name yourself, ask one clear question, and close
 politely. Do not hide behind emoji-only messages when the task is language
 practice.
 
-<DialogueBox uk="Привіт! Мене звати Ліна. Я з Одеси. А тебе?" en="Hi! My name is Lina. I am from Odesa. And you?" />
-<DialogueBox uk="Привіт, Ліно! Мене звати Том. Я з Канади." en="Hi, Lino! My name is Tom. I am from Canada." />
-<DialogueBox uk="Дуже приємно!" en="Very nice to meet you!" />
-<DialogueBox uk="Мені теж." en="Me too." />
+```text
+Лі́на: Приві́т! Мене́ зва́ти Лі́на. Я з Оде́си. А тебе́?
+Том: Приві́т, Лі́но! Мене́ зва́ти Том. Я з Кана́ди.
+Лі́на: Ду́же приє́мно!
+Том: Мені́ теж.
+```
+
+English support after the Ukrainian chat:
+
+| Українська | English support |
+| --- | --- |
+| **А тебе́?** | And you? |
+| **Приві́т, Лі́но!** | Hi, Lina! |
+| **Мені́ теж.** | Me too. |
 
 This chat task also reviews the borrowed-word habit from the wiki brief:
 modern Ukrainian can use international words, but your core first-contact
 grammar should stay Ukrainian. Say **чат** if the setting is a chat, but still
 say **Мене звати...**, **Я з...**, and **До побачення**.
 
-### Put the meeting in order
+### Порядок знайомства
 
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "Opening line: Привіт! Мене звати Богдан.", "options": [{"text": "Привіт, Богдане! Мене звати Соломія.", "correct": true}, {"text": "До побачення!", "correct": false}, {"text": "Мені 20 років.", "correct": false}], "explanation": "The other person answers with a greeting and name."}, {"question": "Line: Дуже приємно, Соломіє.", "options": [{"text": "Мені теж. Звідки ти?", "correct": true}, {"text": "Моє прізвище словник.", "correct": false}, {"text": "Це моя гривня.", "correct": false}], "explanation": "Мені теж gives the reciprocal answer and keeps the exchange moving."}, {"question": "Line: Я з Дніпра. А ти?", "options": [{"text": "Я з Тернополя.", "correct": true}, {"text": "Його звати Назар.", "correct": false}, {"text": "Це мій брат.", "correct": false}], "explanation": "A ти? asks the same origin question back."}, {"question": "Line: У мене є брат.", "options": [{"text": "Дуже приємно. До побачення!", "correct": true}, {"text": "Моє ім'я є брат.", "correct": false}, {"text": "Я маю брат років.", "correct": false}], "explanation": "A polite closing fits after the family line."}]`)} />
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Перший рядок: Привіт! Мене звати Богдан.", "options": [{"text": "Привіт, Богдане! Мене звати Соломія.", "correct": true}, {"text": "До побачення!", "correct": false}, {"text": "Мені 20 років.", "correct": false}], "explanation": "Інша людина відповідає привітанням та іменем."}, {"question": "Рядок: Дуже приємно, Соломіє.", "options": [{"text": "Мені теж. Звідки ти?", "correct": true}, {"text": "Моє прізвище словник.", "correct": false}, {"text": "Це моя гривня.", "correct": false}], "explanation": "Мені теж дає взаємну відповідь і рухає розмову далі."}, {"question": "Рядок: Я з Дніпра. А ти?", "options": [{"text": "Я з Тернополя.", "correct": true}, {"text": "Його звати Назар.", "correct": false}, {"text": "Це мій брат.", "correct": false}], "explanation": "А ти? повертає питання про походження."}, {"question": "Рядок: У мене є брат.", "options": [{"text": "Дуже приємно. До побачення!", "correct": true}, {"text": "Моє ім'я є брат.", "correct": false}, {"text": "Я маю брат років.", "correct": false}], "explanation": "Після родинного рядка пасує ввічливе завершення."}]`)} />
+
+## Слу́хай, зошит, підсумок
+
+For lawful listening, use Ukrainian Lessons Podcast Episode 10 as listen-only
+review support. Listen for short chunks you already know, repeat them, and
+return to this page. Do not copy or transcribe paid material.
+
+For handwriting recognition, ask a teacher, tutor, or classmate to write an
+original five-line card with **ім'я́**, **прі́звище**, **Кана́да**,
+**сестра́**, and **До поба́чення**. First compare the notebook card with the
+printed model; then write your own final card.
 
 ## 📋 Підсумок
 
@@ -289,11 +337,13 @@ Use this final self-check before you move on.
 
 Your final model can be simple:
 
-<DialogueBox uk="Добрий день! Мене звати Алекс." en="Good afternoon! My name is Alex." />
-<DialogueBox uk="Я з Канади. Я студент." en="I am from Canada. I am a student." />
-<DialogueBox uk="Мені 20 років." en="I am 20 years old." />
-<DialogueBox uk="У мене є брат." en="I have a brother." />
-<DialogueBox uk="Дуже приємно познайомитися!" en="Very nice to meet you!" />
+```text
+До́брий день! Мене́ зва́ти Алекс.
+Я з Кана́ди. Я студе́нт.
+Мені́ 20 ро́ків.
+У ме́не є брат.
+Ду́же приє́мно познайо́митися!
+```
 
 Use the workbook for extra practice: quick translation, vocabulary mapping,
 and digital chat etiquette. Passing the workbook means the A1.1 first-contact
@@ -309,15 +359,39 @@ spine is ready for the next module.
 </TabItem>
 <TabItem label="Activities">
 
-### Checkpoint quick translation
+### Готовність до знайомства
 
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "Мене звати Олена.", "options": [{"text": "My name is Olena.", "correct": true}, {"text": "I am from Olena.", "correct": false}, {"text": "Olena is my surname.", "correct": false}], "explanation": "Мене звати... gives a name."}, {"question": "Моє прізвище Мельник.", "options": [{"text": "My surname is Melnyk.", "correct": true}, {"text": "My profession is Melnyk.", "correct": false}, {"text": "My family is Melnyk.", "correct": false}], "explanation": "Прізвище means surname."}, {"question": "Я з Канади.", "options": [{"text": "I am from Canada.", "correct": true}, {"text": "I am in Canada.", "correct": false}, {"text": "I have Canada.", "correct": false}], "explanation": "Я з... gives origin."}, {"question": "Я студентка.", "options": [{"text": "I am a female student.", "correct": true}, {"text": "I have a student.", "correct": false}, {"text": "My name is student.", "correct": false}], "explanation": "Identity uses the noun directly here."}, {"question": "У мене є сестра.", "options": [{"text": "I have a sister.", "correct": true}, {"text": "You have a sister.", "correct": false}, {"text": "This is my sister.", "correct": false}], "explanation": "У мене є... is the I-have chunk."}, {"question": "Мені теж.", "options": [{"text": "Me too.", "correct": true}, {"text": "Nice to meet you.", "correct": false}, {"text": "Goodbye.", "correct": false}], "explanation": "Мені теж gives the reciprocal answer."}]`)} />
+*(see lesson, §Що ми знаємо?)*
 
-### Review vocabulary map
+### Питання і відповіді
+
+*(see lesson, §Що ми знаємо?)*
+
+### Доповни текст
+
+*(see lesson, §Читання)*
+
+### Виправ A1.1 пастки
+
+*(see lesson, §Граматика)*
+
+### Пропуски в діалозі
+
+*(see lesson, §Діалог)*
+
+### Порядок знайомства
+
+*(see lesson, §Digital first contact)*
+
+### Швидкий переклад
+
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Мене звати Олена.", "options": [{"text": "My name is Olena.", "correct": true}, {"text": "I am from Olena.", "correct": false}, {"text": "Olena is my surname.", "correct": false}], "explanation": "Мене звати... називає ім'я."}, {"question": "Моє прізвище Мельник.", "options": [{"text": "My surname is Melnyk.", "correct": true}, {"text": "My profession is Melnyk.", "correct": false}, {"text": "My family is Melnyk.", "correct": false}], "explanation": "Прізвище означає родове ім'я."}, {"question": "Я з Канади.", "options": [{"text": "I am from Canada.", "correct": true}, {"text": "I am in Canada.", "correct": false}, {"text": "I have Canada.", "correct": false}], "explanation": "Я з... подає походження."}, {"question": "Я студентка.", "options": [{"text": "I am a female student.", "correct": true}, {"text": "I have a student.", "correct": false}, {"text": "My name is student.", "correct": false}], "explanation": "У цьому реченні ідентичність виражена іменником без є."}, {"question": "У мене є сестра.", "options": [{"text": "I have a sister.", "correct": true}, {"text": "You have a sister.", "correct": false}, {"text": "This is my sister.", "correct": false}], "explanation": "У мене є... — блок для наявності."}, {"question": "Мені теж.", "options": [{"text": "Me too.", "correct": true}, {"text": "Nice to meet you.", "correct": false}, {"text": "Goodbye.", "correct": false}], "explanation": "Мені теж дає взаємну відповідь."}]`)} />
+
+### Карта лексики
 
 <MatchUp client:only='react' pairs={JSON.parse(`[{"left": "ім'я", "right": "first name"}, {"left": "прізвище", "right": "surname"}, {"left": "знайомство", "right": "acquaintance or introduction"}, {"left": "професія", "right": "profession"}, {"left": "національність", "right": "nationality"}, {"left": "походження", "right": "origin"}, {"left": "словник", "right": "dictionary"}, {"left": "адреса", "right": "address"}]`)} />
 
-### Digital chat etiquette
+### Етикет у чаті
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "___! Мене звати Ліна.", "answer": "Привіт", "options": ["Привіт", "Пока", "Прізвище"]}, {"sentence": "Я ___ Одеси.", "answer": "з", "options": ["з", "є", "моя"]}, {"sentence": "Привіт, ___!", "answer": "Ліно", "options": ["Ліно", "Ліна", "Ліну"]}, {"sentence": "Дуже ___!", "answer": "приємно", "options": ["приємно", "професія", "адреса"]}, {"sentence": "Мені ___.", "answer": "теж", "options": ["теж", "звати", "словник"]}]`)} />
 

--- a/starlight/src/content/docs/a1/my-family.mdx
+++ b/starlight/src/content/docs/a1/my-family.mdx
@@ -56,9 +56,11 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs syncKey="module-tab">
 <TabItem label="Lesson">
 
+**Це моя́ сім'я́. У ме́не є брат.** — This is my family. I have a brother.
+
 Family is the first topic where you introduce other people, not only yourself.
 Keep the Ukrainian small and photo-based. Point to a person, say who it is,
-and add one simple line with **У мене є...** or **Це мій / моя...**.
+and add one simple line with **У ме́не є...** or **Це мій / моя́...**.
 
 By the end, you can:
 
@@ -74,34 +76,59 @@ By the end, you can:
   family or kin circle;
 - recognize a formal patronymic greeting without producing patronymics yet.
 
-## Dialogues
+## Діало́ги
 
-Read the dialogue first as a photo exchange. You do not need the whole grammar
-of possession. Treat **У мене є** and **У тебе є** as whole chunks.
+Read the Ukrainian first as a photo exchange. You do not need the whole grammar
+of possession. Treat **У ме́не є** and **У те́бе є** as whole chunks.
 
-<DialogueBox uk="Оля: Привіт, Марку! Це фото моєї сім'ї." en="Olia: Hi, Marko! This is a photo of my family." />
-<DialogueBox uk="Марк: Класно! У тебе є брати чи сестри?" en="Marko: Nice! Do you have brothers or sisters?" />
-<DialogueBox uk="Оля: Так, у мене є два брати і одна сестра." en="Olia: Yes, I have two brothers and one sister." />
-<DialogueBox uk="Марк: Ого! У мене тільки один брат." en="Marko: Wow! I have only one brother." />
-<DialogueBox uk="Оля: Як його звати?" en="Olia: What is his name?" />
-<DialogueBox uk="Марк: Його звати Коля." en="Marko: His name is Kolia." />
+```text
+О́ля: Приві́т, Ма́рку! Це фо́то моє́ї сім'ї́.
+Марк: Кла́сно! У те́бе є брати́ чи се́стри?
+О́ля: Так, у ме́не є два брати́ і одна́ сестра́.
+Марк: Ого́! У ме́не ті́льки оди́н брат.
+О́ля: Як його́ зва́ти?
+Марк: Його́ зва́ти Ко́ля.
+```
+
+English support after the Ukrainian dialogue:
+
+| Українська | English support |
+| --- | --- |
+| **Це фо́то моє́ї сім'ї́.** | This is a photo of my family. |
+| **У те́бе є брати́ чи се́стри?** | Do you have brothers or sisters? |
+| **У ме́не є два брати́ і одна́ сестра́.** | I have two brothers and one sister. |
+| **Як його́ зва́ти?** | What is his name? |
 
 Now use **це** to identify people in a family photo.
 
-<DialogueBox uk="Даша: Це моя сім'я на фотографії." en="Dasha: This is my family in the photo." />
-<DialogueBox uk="Андрій: Хто це?" en="Andrii: Who is this?" />
-<DialogueBox uk="Даша: Це моя мама Марина. Це мій тато Євген." en="Dasha: This is my mom Maryna. This is my dad Yevhen." />
-<DialogueBox uk="Андрій: А це твоя сестра?" en="Andrii: And is this your sister?" />
-<DialogueBox uk="Даша: Так. Це моя сестра Катя і мої брати, Іван і Денис." en="Dasha: Yes. This is my sister Katia and my brothers, Ivan and Denys." />
-<DialogueBox uk="Андрій: А це твоя бабуся?" en="Andrii: And is this your grandmother?" />
-<DialogueBox uk="Даша: Так, її звати Тетяна." en="Dasha: Yes, her name is Tetiana." />
+```text
+Да́ша: Це моя́ сім'я́ на фотогра́фії.
+Андрі́й: Хто це?
+Да́ша: Це моя́ ма́ма Мари́на. Це мій та́то Євге́н.
+Андрі́й: А це твоя́ сестра́?
+Да́ша: Так. Це моя́ сестра́ Ка́тя і мої́ брати́, Іва́н і Дени́с.
+Андрі́й: А це твоя́ бабу́ся?
+Да́ша: Так, її́ зва́ти Тетя́на.
+```
+
+English support after the Ukrainian dialogue:
+
+| Українська | English support |
+| --- | --- |
+| **Це моя́ сім'я́.** | This is my family. |
+| **Хто це?** | Who is this? |
+| **Це моя́ ма́ма.** | This is my mom. |
+| **Це мій та́то.** | This is my dad. |
+| **її́ зва́ти Тетя́на.** | Her name is Tetiana. |
 
 A short connected answer can reuse M5 and add family:
 
-<DialogueBox uk="Привіт! Мене звати Софія." en="Hi! My name is Sofiia." />
-<DialogueBox uk="Моя мама — вчителька." en="My mom is a teacher." />
-<DialogueBox uk="Мій тато — інженер." en="My dad is an engineer." />
-<DialogueBox uk="У мене є один брат." en="I have one brother." />
+```text
+Приві́т! Мене́ зва́ти Софі́я.
+Моя́ ма́ма — вчи́телька.
+Мій та́то — інжене́р.
+У ме́не є оди́н брат.
+```
 
 Notice the question words from earlier modules: **хто?** asks about a person,
 **що?** asks about a thing, **чий?** asks whose, and **який?** can ask what
@@ -110,11 +137,11 @@ someone is like. For now, keep the answers short.
 The old name chunk still works inside family talk: **Мене звати [ім'я]**. Use
 it as one memorized block before you add family information.
 
-### Family photo questions
+### Питання до фото
 
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "You ask one peer whether they have a brother.", "options": [{"text": "У тебе є брат?", "correct": true}, {"text": "У мене є брат?", "correct": false}, {"text": "Це брат?", "correct": false}], "explanation": "У тебе є...? asks one familiar person whether they have someone."}, {"question": "You answer yes and say you have one sister.", "options": [{"text": "Так, у мене є одна сестра.", "correct": true}, {"text": "Так, у тебе є одна сестра.", "correct": false}, {"text": "Так, це одна сестра.", "correct": false}], "explanation": "У мене є... answers for yourself."}, {"question": "You answer no with the safe A1 answer.", "options": [{"text": "Ні.", "correct": true}, {"text": "У мене немає брат.", "correct": false}, {"text": "Ні є брат.", "correct": false}], "explanation": "Keep the negative answer simple at A1."}, {"question": "You ask what his name is.", "options": [{"text": "Як його звати?", "correct": true}, {"text": "Як її звати?", "correct": false}, {"text": "Що його звати?", "correct": false}], "explanation": "Його fits a brother, dad, son, or grandfather."}, {"question": "You identify your mom in a photo.", "options": [{"text": "Це моя мама.", "correct": true}, {"text": "Це мій мама.", "correct": false}, {"text": "Це моє мама.", "correct": false}], "explanation": "Мама is feminine, so use моя."}, {"question": "You identify your parents.", "options": [{"text": "Це мої батьки.", "correct": true}, {"text": "Це мій батьки.", "correct": false}, {"text": "Це моя батьки.", "correct": false}], "explanation": "Батьки is plural, so use мої."}]`)} />
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Ти питаєш одного ровесника про брата.", "options": [{"text": "У тебе є брат?", "correct": true}, {"text": "У мене є брат?", "correct": false}, {"text": "Це брат?", "correct": false}], "explanation": "У тебе є...? питає одну знайому людину."}, {"question": "Ти відповідаєш так і кажеш, що маєш одну сестру.", "options": [{"text": "Так, у мене є одна сестра.", "correct": true}, {"text": "Так, у тебе є одна сестра.", "correct": false}, {"text": "Так, це одна сестра.", "correct": false}], "explanation": "У мене є... відповідає за себе."}, {"question": "Ти відповідаєш ні короткою A1-фразою.", "options": [{"text": "Ні.", "correct": true}, {"text": "У мене немає брат.", "correct": false}, {"text": "Ні є брат.", "correct": false}], "explanation": "На A1 тримай заперечну відповідь простою."}, {"question": "Ти питаєш, як його звати.", "options": [{"text": "Як його звати?", "correct": true}, {"text": "Як її звати?", "correct": false}, {"text": "Що його звати?", "correct": false}], "explanation": "Його підходить до брата, тата, сина або дідуся."}, {"question": "Ти показуєш маму на фото.", "options": [{"text": "Це моя мама.", "correct": true}, {"text": "Це мій мама.", "correct": false}, {"text": "Це моє мама.", "correct": false}], "explanation": "Мама — жіночого роду, тому моя."}, {"question": "Ти показуєш батьків.", "options": [{"text": "Це мої батьки.", "correct": true}, {"text": "Це мій батьки.", "correct": false}, {"text": "Це моя батьки.", "correct": false}], "explanation": "Батьки — множина, тому мої."}]`)} />
 
-## Family
+## Сім'я́
 
 Use family words with a photo or a simple drawing. The first task is not a
 family tree; it is recognizing and saying the common people words.
@@ -159,14 +186,14 @@ patronymic. Patronymics are a Ukrainian naming tradition and not something to
 erase or treat as outside Ukrainian culture. Production waits until a later
 level.
 
-### Family words
+### Слова родини
 
-<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "mother", "right": "мама"}, {"left": "father", "right": "тато"}, {"left": "brother", "right": "брат"}, {"left": "sister", "right": "сестра"}, {"left": "grandmother", "right": "бабуся"}, {"left": "grandfather", "right": "дідусь"}, {"left": "parents", "right": "батьки"}, {"left": "relatives", "right": "родичі"}]`)} />
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "мама", "right": "мати"}, {"left": "тато", "right": "батько"}, {"left": "брат", "right": "син для моїх батьків"}, {"left": "сестра", "right": "дочка для моїх батьків"}, {"left": "бабуся", "right": "мама мами або тата"}, {"left": "дідусь", "right": "тато мами або тата"}, {"left": "батьки", "right": "мама і тато"}, {"left": "родичі", "right": "люди з родини"}]`)} />
 
-## I Have
+## У ме́не є
 
 English says "I have a brother." Ukrainian normally uses a different shape:
-**У мене є брат.** Learn it as one piece.
+**У ме́не є брат.** Learn it as one piece.
 
 | Ukrainian chunk | English use |
 | --- | --- |
@@ -196,11 +223,11 @@ For a negative answer, keep it simple: **Ні.** or **Ні, у мене тіль
 брат.** The full "I do not have..." pattern waits until later because it
 requires more case grammar.
 
-### Build the I-have chunk
+### Склади У мене є
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "___ мене є брат.", "answer": "У", "options": ["У", "Це", "Хто"]}, {"sentence": "У ___ є сестра.", "answer": "мене", "options": ["мене", "мій", "це"]}, {"sentence": "У ___ є брат?", "answer": "тебе", "options": ["тебе", "мене", "він"]}, {"sentence": "У ___ є діти?", "answer": "вас", "options": ["вас", "твій", "вона"]}, {"sentence": "У мене є ___ брат.", "answer": "один", "options": ["один", "одна", "дві"]}, {"sentence": "У мене є ___ сестра.", "answer": "одна", "options": ["одна", "один", "два"]}, {"sentence": "У мене є ___ брати.", "answer": "два", "options": ["два", "дві", "одна"]}, {"sentence": "У мене є ___ сестри.", "answer": "дві", "options": ["дві", "два", "один"]}]`)} />
 
-## My
+## Мій / моя́
 
 The Ukrainian "my" word changes to match the person or thing you own. It does
 not match the gender of the owner.
@@ -239,50 +266,64 @@ photo tool.
 
 For "whose," match the question word to the noun:
 
-| Ukrainian | English cue |
+| Українська | English support |
 | --- | --- |
 | **Чий це брат?** | Whose brother is this? |
 | **Чия це сестра?** | Whose sister is this? |
 | **Чи це твоя бабуся?** | Is this your grandmother? |
 
-### My or your?
+### Мій чи моя?
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "Це ___ брат.", "answer": "мій", "options": ["мій", "моя", "моє", "мої"]}, {"sentence": "Це ___ мама.", "answer": "моя", "options": ["моя", "мій", "моє", "мої"]}, {"sentence": "Це ___ місто.", "answer": "моє", "options": ["моє", "мій", "моя", "мої"]}, {"sentence": "Це ___ батьки.", "answer": "мої", "options": ["мої", "мій", "моя", "моє"]}, {"sentence": "Це ___ тато?", "answer": "твій", "options": ["твій", "твоя", "твоє", "твої"]}, {"sentence": "Це ___ сестра?", "answer": "твоя", "options": ["твоя", "твій", "твоє", "твої"]}, {"sentence": "Це ___ прізвище?", "answer": "твоє", "options": ["твоє", "твій", "твоя", "твої"]}, {"sentence": "Це ___ родичі?", "answer": "твої", "options": ["твої", "твій", "твоя", "твоє"]}]`)} />
 
-## Textbook Check
+## Слу́хай, фо́то, зошит
 
-Before the workbook, cover the English side and say the Ukrainian aloud:
+For lawful listening, use public Ukrainian Lessons Podcast pages as listen-only
+support: Episode 6 for **сім'я́ / У ме́не є...**, Episode 7 for **мій /
+моя́**, and Episode 10 for connected review speech. Listen, repeat a short
+chunk, and come back to the page. Do not copy or transcribe paid material.
 
-| English cue | Ukrainian you say |
+For handwriting recognition, ask a teacher, tutor, or classmate to write these
+original labels beside a simple family sketch: **ма́ма**, **та́то**,
+**брат**, **сестра́**, **сім'я́**, **бабу́ся**. First compare the notebook
+label with the printed word; then write your own line.
+
+## Самопереві́рка
+
+Cover the English support and read the Ukrainian aloud:
+
+| Українська | English support |
 | --- | --- |
-| This is my family. | **Це моя сім'я.** |
-| This is my mom. | **Це моя мама.** |
-| This is my dad. | **Це мій тато.** |
-| Do you have a brother? | **У тебе є брат?** |
-| Yes, I have one brother. | **Так, у мене є один брат.** |
-| No. | **Ні.** |
-| I have two sisters. | **У мене є дві сестри.** |
-| This is my brother. His name is Kolia. | **Це мій брат. Його звати Коля.** |
-| This is my sister. Her name is Katia. | **Це моя сестра. Її звати Катя.** |
-| Whose brother is this? | **Чий це брат?** |
-| I am 20 years old. | **Мені 20 років.** |
+| **Це моя́ сім'я́.** | This is my family. |
+| **Це моя́ ма́ма.** | This is my mom. |
+| **Це мій та́то.** | This is my dad. |
+| **У те́бе є брат?** | Do you have a brother? |
+| **Так, у ме́не є оди́н брат.** | Yes, I have one brother. |
+| **Ні.** | No. |
+| **У ме́не є дві сестри́.** | I have two sisters. |
+| **Це мій брат. Його́ зва́ти Ко́ля.** | This is my brother. His name is Kolia. |
+| **Це моя́ сестра́. Її́ зва́ти Ка́тя.** | This is my sister. Her name is Katia. |
+| **Чий це брат?** | Whose brother is this? |
+| **Мені́ 20 ро́ків.** | I am 20 years old. |
 
-The age chunk can be generalized as **Мені [N] років**. If you add a job for a
-family member, keep it as one simple profession word: **актор**, **художник**,
-**співак**, or **журналіст**.
+The age chunk can be generalized as **Мені́ [N] ро́ків**. If you add a job for
+a family member, keep it as one simple profession word: **акто́р**,
+**худо́жник**, **співа́к**, or **журналі́ст**.
 
 You can now make a four-sentence family introduction:
 
-<DialogueBox uk="Мене звати Марко." en="My name is Marko." />
-<DialogueBox uk="Це моя сім'я." en="This is my family." />
-<DialogueBox uk="Моя мама — журналістка." en="My mom is a journalist." />
-<DialogueBox uk="У мене є одна сестра." en="I have one sister." />
+```text
+Мене́ зва́ти Марко́.
+Це моя́ сім'я́.
+Моя́ ма́ма — журналі́стка.
+У ме́не є одна́ сестра́.
+```
 
-Use native Ukrainian family words in the workbook: **дружина** for wife,
-**чоловік** for husband or man by context, **бабуся** for grandmother,
-**родичі** for relatives, **дитина** for child, **молодший** for younger, and
-**одружений** for married. Do not turn these into a Russian comparison lesson;
-just choose the Ukrainian word.
+Use native Ukrainian family words in the workbook: **дружи́на** for wife,
+**чолові́к** for husband or man by context, **бабу́ся** for grandmother,
+**ро́дичі** for relatives, **дити́на** for child, **моло́дший** for younger,
+and **одру́жений** for married. Do not turn these into a Russian comparison
+lesson; just choose the Ukrainian word.
 
 Use the workbook for extra practice: safer Ukrainian family sentences, native
 family-word choices, photo-dialogue blanks, and quick vocabulary recognition.
@@ -297,21 +338,37 @@ family-word choices, photo-dialogue blanks, and quick vocabulary recognition.
 </TabItem>
 <TabItem label="Activities">
 
-### Choose the Ukrainian family sentence
+### Питання до фото
 
-<ErrorCorrection client:only='react' instruction="Choose the safer Ukrainian line." items={JSON.parse(`[{"sentence": "Моє ім'я є Джон.", "errorWord": "Моє ім'я є Джон.", "correctForm": "Мене звати Джон.", "options": ["Мене звати Джон.", "Моє ім'я є Джон."], "explanation": "Мене звати... is the natural first-introduction model."}, {"sentence": "Я маю 20 років.", "errorWord": "Я маю 20 років.", "correctForm": "Мені 20 років.", "options": ["Мені 20 років.", "Я маю 20 років."], "explanation": "Age uses the chunk Мені ... років."}, {"sentence": "Це мій мама.", "errorWord": "Це мій мама.", "correctForm": "Це моя мама.", "options": ["Це моя мама.", "Це мій мама."], "explanation": "Мама is feminine, so use моя."}, {"sentence": "Я є брат.", "errorWord": "Я є брат.", "correctForm": "Я брат.", "options": ["Я брат.", "Я є брат."], "explanation": "Present-time identity can omit є."}, {"sentence": "Батьки (у значенні батька)", "errorWord": "Батьки (у значенні батька)", "correctForm": "Тато / батько", "options": ["Тато / батько", "Батьки"], "explanation": "Батьки means parents, not one father."}, {"sentence": "Чия це? (про брата)", "errorWord": "Чия це? (про брата)", "correctForm": "Чий це брат?", "options": ["Чий це брат?", "Чия це?"], "explanation": "Брат is masculine, so the question word is чий."}]`)} />
+*(see lesson, §Діало́ги)*
 
-### Native family words
+### Слова родини
+
+*(see lesson, §Сім'я́)*
+
+### Склади У мене є
+
+*(see lesson, §У ме́не є)*
+
+### Мій чи моя?
+
+*(see lesson, §Мій / моя́)*
+
+### Обери українське родинне речення
+
+<ErrorCorrection client:only='react' instruction="Обери безпечніший український рядок." items={JSON.parse(`[{"sentence": "Моє ім'я є Джон.", "errorWord": "Моє ім'я є Джон.", "correctForm": "Мене звати Джон.", "options": ["Мене звати Джон.", "Моє ім'я є Джон."], "explanation": "Мене звати... — природна модель першого представлення."}, {"sentence": "Я маю 20 років.", "errorWord": "Я маю 20 років.", "correctForm": "Мені 20 років.", "options": ["Мені 20 років.", "Я маю 20 років."], "explanation": "Вік подаємо блоком Мені ... років."}, {"sentence": "Це мій мама.", "errorWord": "Це мій мама.", "correctForm": "Це моя мама.", "options": ["Це моя мама.", "Це мій мама."], "explanation": "Мама — жіночого роду, тому вживай моя."}, {"sentence": "Я є брат.", "errorWord": "Я є брат.", "correctForm": "Я брат.", "options": ["Я брат.", "Я є брат."], "explanation": "Теперішня ідентичність може не мати є."}, {"sentence": "Батьки (у значенні батька)", "errorWord": "Батьки (у значенні батька)", "correctForm": "Тато / батько", "options": ["Тато / батько", "Батьки"], "explanation": "Батьки означає маму й тата або кількох батьків, а не одного тата."}, {"sentence": "Чия це? (про брата)", "errorWord": "Чия це? (про брата)", "correctForm": "Чий це брат?", "options": ["Чий це брат?", "Чия це?"], "explanation": "Брат — чоловічого роду, тому питальне слово чий."}]`)} />
+
+### Українські родинні слова
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "Моя ___ — вчителька.", "answer": "дружина", "options": ["дружина", "сестра"]}, {"sentence": "Мій ___ працює в лікарні.", "answer": "чоловік", "options": ["чоловік", "тато"]}, {"sentence": "Це моя ___ Тетяна.", "answer": "бабуся", "options": ["бабуся", "мама"]}, {"sentence": "Це мої ___.", "answer": "родичі", "options": ["родичі", "батьки"]}, {"sentence": "Це маленька ___.", "answer": "дитина", "options": ["дитина", "сім'я"]}, {"sentence": "Це мій ___ брат.", "answer": "молодший", "options": ["молодший", "старший"]}, {"sentence": "Мій старший брат уже ___.", "answer": "одружений", "options": ["одружений", "студент"]}]`)} />
 
-### Complete the photo dialogue
+### Доповни фотодіалог
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "Це ___ сім'я на фотографії.", "answer": "моя", "options": ["моя", "мій", "моє"]}, {"sentence": "___ це? Це мій тато.", "answer": "Хто", "options": ["Хто", "Що", "Де"]}, {"sentence": "Це моя сестра. ___ звати Катя.", "answer": "Її", "options": ["Її", "Його", "Вони"]}, {"sentence": "Це мій брат. ___ звати Коля.", "answer": "Його", "options": ["Його", "Її", "Вона"]}, {"sentence": "А це ___ бабуся?", "answer": "твоя", "options": ["твоя", "твій", "твоє"]}]`)} />
 
-### Family vocabulary quick check
+### Швидка перевірка родинної лексики
 
-<Translate client:only='react' questions={JSON.parse(`[{"source": "сім'я", "options": [{"text": "family, close household", "correct": true}, {"text": "surname", "correct": false}, {"text": "profession", "correct": false}], "explanation": "Сім'я is the close family word."}, {"source": "родина", "options": [{"text": "family or kin", "correct": true}, {"text": "only one parent", "correct": false}, {"text": "first name", "correct": false}], "explanation": "Родина often sounds wider than сім'я."}, {"source": "У мене є брат.", "options": [{"text": "I have a brother.", "correct": true}, {"text": "You have a brother.", "correct": false}, {"text": "This is my brother.", "correct": false}], "explanation": "У мене є... is the I-have chunk."}, {"source": "Це моя сестра.", "options": [{"text": "This is my sister.", "correct": true}, {"text": "This is my brother.", "correct": false}, {"text": "This is her sister.", "correct": false}], "explanation": "Моя matches сестра."}, {"source": "Чий це брат?", "options": [{"text": "Whose brother is this?", "correct": true}, {"text": "Who is this sister?", "correct": false}, {"text": "Do you have a brother?", "correct": false}], "explanation": "Чий asks whose and matches брат."}]`)} />
+<Translate client:only='react' questions={JSON.parse(`[{"source": "сім'я", "options": [{"text": "family, close household", "correct": true}, {"text": "surname", "correct": false}, {"text": "profession", "correct": false}], "explanation": "Сім'я — слово для близької родини."}, {"source": "родина", "options": [{"text": "family or kin", "correct": true}, {"text": "only one parent", "correct": false}, {"text": "first name", "correct": false}], "explanation": "Родина часто звучить ширше, ніж сім'я."}, {"source": "У мене є брат.", "options": [{"text": "I have a brother.", "correct": true}, {"text": "You have a brother.", "correct": false}, {"text": "This is my brother.", "correct": false}], "explanation": "У мене є... — блок, щоб сказати, що щось або хтось є в мене."}, {"source": "Це моя сестра.", "options": [{"text": "This is my sister.", "correct": true}, {"text": "This is my brother.", "correct": false}, {"text": "This is her sister.", "correct": false}], "explanation": "Моя узгоджується зі словом сестра."}, {"source": "Чий це брат?", "options": [{"text": "Whose brother is this?", "correct": true}, {"text": "Who is this sister?", "correct": false}, {"text": "Do you have a brother?", "correct": false}], "explanation": "Чий питає про належність і узгоджується зі словом брат."}]`)} />
 
 </TabItem>
 <TabItem label="Resources">

--- a/starlight/src/content/docs/a1/sounds-letters-and-hello.mdx
+++ b/starlight/src/content/docs/a1/sounds-letters-and-hello.mdx
@@ -56,55 +56,60 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs syncKey="module-tab">
 <TabItem label="Lesson">
 
-**Звук — sound. Лі́тера — letter.** This first module starts with what you
-hear, then connects it to what you see on the page.
+**Приві́т! Звук. Лі́тера.** — Hi! Sound. Letter.
 
-Work in this order:
+Спо́чатку слуха́ємо: **звук**. Поті́м ба́чимо на сторі́нці:
+**лі́тера**. English support: hear, see, repeat, then greet.
 
-1. hear a sound;
-2. see the letter;
-3. repeat a short word;
-4. use one greeting phrase.
-
-You do not need long Ukrainian sentences yet. You need a few stable anchors:
-**звук**, **лі́тера**, **ма́ма**, **молоко́**, **Приві́т**, and
-**До́брий день**.
-
-## Звук і лі́тера
-
-**Звук — sound.** You hear it and pronounce it.
-
-**Лі́тера — letter.** You see it and write it.
-
-Keep the two ideas separate:
-
-| Ukrainian anchor | English support |
+| Українська опора | English support |
 | --- | --- |
 | **звук** | what your mouth says and your ear hears |
 | **лі́тера** | the written sign on the page |
 | **абе́тка** | the alphabet |
 
-Ukrainian has **33 letters** in the alphabet. In speech, Ukrainian uses more
-sounds because some letters can point to more than one sound or modify a nearby
-sound.
+Work in this small order:
+
+1. **слу́хай** — hear a sound;
+2. **диви́сь** — see the letter;
+3. **повтори́** — repeat one short word;
+4. **скажи́** — use one greeting phrase.
+
+You need only a few stable anchors today: **звук**, **лі́тера**,
+**ма́ма**, **молоко́**, **Приві́т**, and **До́брий день**.
+
+## Звук і лі́тера
+
+**звук** — what you hear and pronounce.
+
+**лі́тера** — what you see and write.
+
+Keep the two ideas separate:
+
+| Я ба́чу | Я чу́ю |
+| --- | --- |
+| **лі́тера А** | **[а]** |
+| **лі́тера М** | **[м]** |
+| **лі́тера О** | **[о]** |
+
+Українська абе́тка має **33 лі́тери**. In speech, Ukrainian has more
+sounds because some letters can point to more than one sound or modify a
+nearby sound.
 
 Three beginner clues:
 
-- **Я, Ю, Є, Ї** can point to a **й + vowel** sound in some positions.
+- **Я, Ю, Є, Ї** can point to **й + vowel** in some positions.
 - **Ь** has no sound of its own; it softens the previous consonant.
 - **Щ** is taught here as **[шч]**.
 
-### Sound or letter
+### Звук чи лі́тера
 
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "What do we hear and pronounce?", "options": [{"text": "лі́тера", "correct": false}, {"text": "Звук", "correct": true}, {"text": "Слово", "correct": false}], "explanation": "Звук is what we hear and pronounce."}, {"question": "What do we see in writing?", "options": [{"text": "Звук", "correct": false}, {"text": "лі́тера", "correct": true}, {"text": "Вимова", "correct": false}], "explanation": "Лі́тера is the written sign."}, {"question": "How many letters are in the Ukrainian alphabet?", "options": [{"text": "38", "correct": false}, {"text": "33", "correct": true}, {"text": "6", "correct": false}], "explanation": "The standard Ukrainian alphabet has 33 letters."}, {"question": "Why can 33 letters point to more sounds?", "options": [{"text": "Some letters have more than one job", "correct": true}, {"text": "English spelling changes Ukrainian sounds", "correct": false}, {"text": "Every letter is silent", "correct": false}], "explanation": "Some Ukrainian letters can point to more than one sound or modify a nearby sound."}, {"question": "Which sign has no sound of its own?", "options": [{"text": "А", "correct": false}, {"text": "Ь", "correct": true}, {"text": "О", "correct": false}], "explanation": "Ь has no sound of its own."}, {"question": "Which word has three vowel sounds?", "options": [{"text": "Приві́т", "correct": false}, {"text": "молоко́", "correct": true}, {"text": "Мов", "correct": false}], "explanation": "Молоко́ has three vowel sounds, о + о + о."}]`)} />
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Звук — що ми робимо?", "options": [{"text": "бачимо на сторі́нці", "correct": false}, {"text": "чуємо й вимовля́ємо", "correct": true}, {"text": "ставимо апо́строф", "correct": false}], "explanation": "Звук — це те, що ми чуємо й вимовля́ємо."}, {"question": "Лі́тера — що ми робимо?", "options": [{"text": "бачимо й пишемо", "correct": true}, {"text": "чуємо без сторі́нки", "correct": false}, {"text": "рахуємо як склад", "correct": false}], "explanation": "Лі́тера — це письмовий знак."}, {"question": "Українська абе́тка — скільки лі́тер?", "options": [{"text": "38", "correct": false}, {"text": "33", "correct": true}, {"text": "6", "correct": false}], "explanation": "Стандартна українська абе́тка має 33 лі́тери."}, {"question": "Я, Ю, Є, Ї — чому вони особливі?", "options": [{"text": "мають більше ніж одну роботу", "correct": true}, {"text": "завжди мовчать", "correct": false}, {"text": "завжди є при́голосними", "correct": false}], "explanation": "Деякі українські лі́тери мають більше ніж одну роботу."}, {"question": "Ь — що правильно?", "options": [{"text": "має власний голосни́й звук", "correct": false}, {"text": "не має власного звука", "correct": true}, {"text": "це літера О", "correct": false}], "explanation": "Ь не має власного звука."}, {"question": "Молоко́ — скільки голосних звуків?", "options": [{"text": "два", "correct": false}, {"text": "три", "correct": true}, {"text": "один", "correct": false}], "explanation": "Молоко́ має три голосні звуки: о + о + о."}]`)} />
 
 ## Голосні звуки
 
-**Голосни́й звук — vowel sound.** A vowel is open and easy to sing.
+**[а] [о] [у] [е] [и] [і]** — six simple vowel sounds.
 
-Start with six simple vowel sounds:
-
-**[а] [о] [у] [е] [и] [і]**
+**Голосни́й звук** — vowel sound. A vowel is open and easy to sing.
 
 The simple vowel letters are:
 
@@ -114,15 +119,15 @@ Use the beginner rule:
 
 **one vowel sound = one склад**
 
-| Word | Vowel sounds | Syllables |
+| Слово́ | Голосні звуки | Склади́ |
 | --- | --- | --- |
 | **ма́ма** | **а + а** | 2 |
 | **молоко́** | **о + о + о** | 3 |
 | **Приві́т** | **и + і** | 2 |
 | **о́ко** | **о + о** | 2 |
 
-Important habit: keep **о** clean. In **молоко́**, every **о** is still **о**.
-Do not blur it into an English-style reduced vowel.
+Important habit: keep **о** clear. In **молоко́**, every **о** is still
+**о**. Do not blur it into a reduced vowel.
 
 ### Кількість складів
 
@@ -130,12 +135,14 @@ Do not blur it into an English-style reduced vowel.
 
 ## При́голосні звуки
 
-**При́голосний звук — consonant sound.** A consonant uses a small block or
-contact in the mouth: lips, teeth, tongue, or throat.
+**[м] [п] [т] [н]** — four easy consonant sounds.
 
-Try four easy consonants:
+**При́голосний звук** — consonant sound. A consonant uses a small block
+or contact in the mouth: lips, teeth, tongue, or throat.
 
-| Sound | Body cue |
+Try the body cue first:
+
+| Звук | Body cue |
 | --- | --- |
 | **[м]** | close your lips and hum |
 | **[п]** | close your lips and release |
@@ -144,7 +151,7 @@ Try four easy consonants:
 
 Now take **Приві́т** apart:
 
-| Letter | Sound type |
+| Лі́тера | Type |
 | --- | --- |
 | **П** | consonant |
 | **Р** | consonant |
@@ -153,16 +160,19 @@ Now take **Приві́т** apart:
 | **І** | vowel |
 | **Т** | consonant |
 
-So **Приві́т** has **2 vowel sounds** and **4 consonant sounds**.
+**Приві́т** has **2 vowel sounds** and **4 consonant sounds**.
 
 ### Звук і літера
 
-<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "І", "right": "[і]"}, {"left": "В", "right": "[в]"}, {"left": "А", "right": "[а]"}, {"left": "О", "right": "[о]"}, {"left": "У", "right": "[у]"}, {"left": "Н", "right": "[н]"}, {"left": "Ч", "right": "[ч]"}, {"left": "Ь", "right": "softens the previous consonant"}, {"left": "Я", "right": "[йа] or softens the previous consonant"}, {"left": "Ї", "right": "[йі]"}, {"left": "Щ", "right": "[шч]"}, {"left": "Д", "right": "[д]"}]`)} />
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "І", "right": "[і]"}, {"left": "В", "right": "[в]"}, {"left": "А", "right": "[а]"}, {"left": "О", "right": "[о]"}, {"left": "У", "right": "[у]"}, {"left": "Н", "right": "[н]"}, {"left": "Ч", "right": "[ч]"}, {"left": "Ь", "right": "м'якшить попередній при́голосний"}, {"left": "Я", "right": "[йа] або м'якшить попередній при́голосний"}, {"left": "Ї", "right": "[йі]"}, {"left": "Щ", "right": "[шч]"}, {"left": "Д", "right": "[д]"}]`)} />
 
 ## Абетка: first video pass
 
-Use this table as a first full pass through the Ukrainian alphabet. Do not try
-to master all 33 letters in one sitting. Repeat a small group, then add more.
+**А, Б, В... Я** — the full Ukrainian alphabet.
+
+Use this as a first pass. Do not try to master all 33 letters in one
+sitting. Repeat a small group, then add more. The linked public videos
+are for listening and repeating; do not download or reuse the audio.
 
 | Лі́тера | Sound | Small word | Video |
 | --- | --- | --- | --- |
@@ -200,15 +210,30 @@ to master all 33 letters in one sitting. Repeat a small group, then add more.
 | Ю | [йу] | ю́шка | https://www.youtube.com/watch?v=9JdIBYCTWGw |
 | Я | [йа] | я́блуко | https://www.youtube.com/watch?v=yhSAf41LX8I |
 
+**Друк / зошит** — print / notebook recognition.
+
+Recognition comes before handwriting production. Use original text on this
+page, your own notebook, or a teacher/tutor's live handwriting. Do not copy a
+third-party handwriting sample.
+
+| Друк | Зошит: recognition cue | What to do |
+| --- | --- | --- |
+| **П п** | teacher writes **п** by hand | point to **П** |
+| **М м** | teacher writes **м** by hand | point to **М** |
+| **Приві́т** | notebook label **приві́т** | match the word |
+| **ма́ма** | notebook label **ма́ма** | match the word |
+
 ### Алфавітний повтор
 
 <WatchAndRepeat client:only='react' items={JSON.parse(`[{"video": "https://www.youtube.com/watch?v=hvB3VpcR3ZE", "letter": "А", "word": "анана́с"}, {"video": "https://www.youtube.com/watch?v=V1hxBE_JbGg", "letter": "Б", "word": "банду́ра"}, {"video": "https://www.youtube.com/watch?v=aFcvYfvQ2X4", "letter": "В", "word": "вода́"}, {"video": "https://www.youtube.com/watch?v=gVnclpSI0DU", "letter": "Г", "word": "гора́"}, {"video": "https://www.youtube.com/watch?v=gNjHqjTW9WQ", "letter": "Ґ", "word": "ґу́дзик"}, {"video": "https://www.youtube.com/watch?v=g4Bh-lqzd48", "letter": "Д", "word": "дім"}, {"video": "https://www.youtube.com/watch?v=KFlsroBW0dk", "letter": "Е", "word": "екра́н"}, {"video": "https://www.youtube.com/watch?v=O0bwRyyBQSc", "letter": "Є", "word": "єно́т"}, {"video": "https://www.youtube.com/watch?v=dIrGVcqPwqM", "letter": "Ж", "word": "жук"}, {"video": "https://www.youtube.com/watch?v=BhASNxitC1A", "letter": "З", "word": "зуб"}, {"video": "https://www.youtube.com/watch?v=W-1rCu0indE", "letter": "И", "word": "сир"}, {"video": "https://www.youtube.com/watch?v=Z9TH0H4ShGo", "letter": "І", "word": "ім'я́"}, {"video": "https://www.youtube.com/watch?v=UcjdjQXhAY8", "letter": "Ї", "word": "їжа́к"}, {"video": "https://www.youtube.com/watch?v=aq0cjB90s3w", "letter": "Й", "word": "йо́гурт"}, {"video": "https://www.youtube.com/watch?v=J7sGEI4-xJo", "letter": "К", "word": "кіт"}, {"video": "https://www.youtube.com/watch?v=v6-3Xg52Buk", "letter": "Л", "word": "лис"}, {"video": "https://www.youtube.com/watch?v=Ez95H4ibuJo", "letter": "М", "word": "ма́ма"}, {"video": "https://www.youtube.com/watch?v=vNUfiKHPYaU", "letter": "Н", "word": "ніс"}, {"video": "https://www.youtube.com/watch?v=gJFxRIPRZbI", "letter": "О", "word": "о́ко"}, {"video": "https://www.youtube.com/watch?v=JksSjjxyW5Y", "letter": "П", "word": "піт"}, {"video": "https://www.youtube.com/watch?v=fMGsQ5KPQgg", "letter": "Р", "word": "рука́"}, {"video": "https://www.youtube.com/watch?v=7UsFBgSL91E", "letter": "С", "word": "сон"}, {"video": "https://www.youtube.com/watch?v=m-jcLR_gK0k", "letter": "Т", "word": "та́то"}, {"video": "https://www.youtube.com/watch?v=VB1O6PmtYRU", "letter": "У", "word": "уро́к"}, {"video": "https://www.youtube.com/watch?v=haHRsFFZRQI", "letter": "Ф", "word": "фо́то"}, {"video": "https://www.youtube.com/watch?v=vpr58zJSJKc", "letter": "Х", "word": "ха́та"}, {"video": "https://www.youtube.com/watch?v=u44eCjR2Oz8", "letter": "Ц", "word": "цу́кор"}, {"video": "https://www.youtube.com/watch?v=UsJkbdsY2RA", "letter": "Ч", "word": "час"}, {"video": "https://www.youtube.com/watch?v=1D-6MIw3OXY", "letter": "Ш", "word": "шко́ла"}, {"video": "https://www.youtube.com/watch?v=QmBLieIuf6Q", "letter": "Щ", "word": "щу́ка"}, {"video": "https://www.youtube.com/watch?v=cJlal8XKBxo", "letter": "Ь", "word": "день"}, {"video": "https://www.youtube.com/watch?v=9JdIBYCTWGw", "letter": "Ю", "word": "ю́шка"}, {"video": "https://www.youtube.com/watch?v=yhSAf41LX8I", "letter": "Я", "word": "я́блуко"}]`)} title="Алфавітний повтор" />
 
 ## Приві́т: first greeting phrases
 
+**Приві́т!** — Hi!
+
 Use these as whole phrases first. Grammar can wait.
 
-| Ukrainian | English support |
+| Українська | English support |
 | --- | --- |
 | **Приві́т!** | Hi! |
 | **До́брий день!** | Hello / good day |
@@ -217,30 +242,53 @@ Use these as whole phrases first. Grammar can wait.
 | **До поба́чення!** | Goodbye |
 | **На все до́бре!** | All the best |
 
-Now add one short exchange:
+Read the Ukrainian first:
 
-<DialogueBox uk="Приві́т!" en="Hi!" />
-<DialogueBox uk="Як спра́ви?" en="How are you?" />
-<DialogueBox uk="До́бре." en="Fine." />
-<DialogueBox uk="А у тебе́?" en="And you?" />
+```text
+О́ля: Приві́т!
+Тара́с: Приві́т!
+О́ля: Як спра́ви?
+Тара́с: До́бре.
+О́ля: А у тебе́?
+Тара́с: Чудо́во!
+```
+
+English support after the Ukrainian dialogue:
+
+| Українська | English support |
+| --- | --- |
+| **Як спра́ви?** | How are you? |
+| **До́бре.** | Fine / good. |
+| **А у тебе́?** | And you? |
+| **Чудо́во!** | Great! |
 
 Use **А у тебе́?** after **Як спра́ви?**. For a name exchange, use
 **А тебе́?**
 
-<DialogueBox uk="Як тебе́ зва́ти?" en="What is your name?" />
-<DialogueBox uk="Мене́ зва́ти Анна." en="My name is Anna." />
-<DialogueBox uk="А тебе́?" en="And you?" />
+```text
+Марко́: Як тебе́ зва́ти?
+Софі́я: Мене́ зва́ти Софі́я. А тебе́?
+Марко́: Мене́ зва́ти Марко́.
+```
+
+English support after the Ukrainian dialogue:
+
+| Українська | English support |
+| --- | --- |
+| **Як тебе́ зва́ти?** | What is your name? |
+| **Мене́ зва́ти...** | My name is... |
+| **А тебе́?** | And you? |
 
 Two ready phrases also show speaker gender:
 
 | Speaker | Phrase |
 | --- | --- |
-| man | **Радий тебе́ бачити.** |
-| woman | **Рада тебе́ бачити.** |
+| man | **Радий тебе́ ба́чити.** |
+| woman | **Рада тебе́ ба́чити.** |
 
-### Short dialogue
+### Короткий діало́г
 
-<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Приві́т! ___ спра́ви?", "answer": "Як", "options": ["Як", "Що", "Де"]}, {"sentence": "До́бре. ___ у тебе́?", "answer": "А", "options": ["А", "На", "У"]}, {"sentence": "Як тебе́ зва́ти? Мене́ зва́ти Анна. ___?", "answer": "А тебе́", "options": ["А тебе́", "А у тебе́", "А тобі́"]}, {"sentence": "___ тебе́ бачити! (woman speaker)", "answer": "Рада", "options": ["Рада", "Радий", "Раді"]}, {"sentence": "___ тебе́ бачити! (man speaker)", "answer": "Радий", "options": ["Радий", "Рада", "Раді"]}]`)} />
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Приві́т! ___ спра́ви?", "answer": "Як", "options": ["Як", "Що", "Де"]}, {"sentence": "До́бре. ___ у тебе́?", "answer": "А", "options": ["А", "На", "У"]}, {"sentence": "Як тебе́ зва́ти? Мене́ зва́ти Анна. ___?", "answer": "А тебе́", "options": ["А тебе́", "А у тебе́", "А тобі́"]}, {"sentence": "___ тебе́ ба́чити! (говорить жінка)", "answer": "Рада", "options": ["Рада", "Радий", "Раді"]}, {"sentence": "___ тебе́ ба́чити! (говорить чоловік)", "answer": "Радий", "options": ["Радий", "Рада", "Раді"]}]`)} />
 
 ## First-month habits
 
@@ -249,7 +297,9 @@ Keep this module small and clean:
 1. Keep **о** clear in **молоко́**.
 2. Hear the difference between **и** and **і** in **Приві́т**.
 3. Remember that **Ь** has no sound of its own.
-4. Use **Приві́т**, **До́брий день**, and **Мене́ зва́ти...** as whole phrases.
+4. Match print to notebook handwriting before you try to write fast.
+5. Ask a native Ukrainian teacher or tutor to listen to **Приві́т**,
+   **До́брий день**, and **Мене́ зва́ти...**
 
 End with one reliable line:
 
@@ -265,17 +315,37 @@ End with one reliable line:
 </TabItem>
 <TabItem label="Activities">
 
-### Quick sound checks
+### Звук чи лі́тера
 
-<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Звук is what you hear and pronounce.", "isTrue": true, "explanation": "The learner hears and pronounces a sound."}, {"statement": "Ь has its own vowel sound.", "isTrue": false, "explanation": "Ь has no sound of its own; it softens the previous consonant."}, {"statement": "Молоко́ has three vowel sounds.", "isTrue": true, "explanation": "The vowels are о + о + о."}, {"statement": "До́брий день is a greeting phrase.", "isTrue": true, "explanation": "It is one of the first ready-made greetings in the lesson."}, {"statement": "In this module, Щ is taught as [ш].", "isTrue": false, "explanation": "This module teaches Щ as [шч]."}]`)} />
+*(see lesson, §Звук і лі́тера)*
 
-### Build the greeting exchange
+### Кількість складів
+
+*(see lesson, §Голосні звуки)*
+
+### Звук і літера
+
+*(see lesson, §При́голосні звуки)*
+
+### Алфавітний повтор
+
+*(see lesson, §Абетка: first video pass)*
+
+### Короткий діало́г
+
+*(see lesson, §Приві́т: first greeting phrases)*
+
+### Швидка переві́рка звуків
+
+<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Звук — це те, що ми чуємо й вимовля́ємо.", "isTrue": true, "explanation": "Звук — це те, що ми чуємо й вимовля́ємо."}, {"statement": "Ь має власний голосни́й звук.", "isTrue": false, "explanation": "Ь не має власного звука; він м'якшить попередній при́голосний."}, {"statement": "Молоко́ має три голосні звуки.", "isTrue": true, "explanation": "Голосні звуки: о + о + о."}, {"statement": "До́брий день — це вітальна фра́за.", "isTrue": true, "explanation": "Це одна з перших готових фраз вітання в уро́ці."}, {"statement": "У цьому модулі Щ = [ш].", "isTrue": false, "explanation": "У цьому модулі Щ = [шч]."}]`)} />
+
+### Склади діало́г
 
 <Order client:only='react' items={JSON.parse(`["А у тебе́?", "Приві́т!", "До́бре.", "Як спра́ви?"]`)} correct_order={JSON.parse(`[1, 3, 2, 0]`)} instruction={"Put the mini-dialogue in a natural order."} isUkrainian={false} />
 
-### Pick the right phrase
+### Друк і зошит
 
-<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Morning arrival at school: ___!", "answer": "До́брого ра́нку", "options": ["До́брого ра́нку", "До поба́чення", "На все до́бре"]}, {"sentence": "Casual hello to one friend: ___!", "answer": "Приві́т", "options": ["Приві́т", "До́брий ве́чір", "До поба́чення"]}, {"sentence": "Midday greeting to a teacher: ___!", "answer": "До́брий день", "options": ["До́брий день", "Приві́т", "На все до́бре"]}, {"sentence": "Leaving the room: ___!", "answer": "До поба́чення", "options": ["До поба́чення", "Як спра́ви", "Мене́ зва́ти"]}]`)} />
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "друк: П п", "right": "зошит: учитель пише п"}, {"left": "друк: М м", "right": "зошит: учитель пише м"}, {"left": "друк: Приві́т", "right": "зошит: приві́т"}, {"left": "друк: ма́ма", "right": "зошит: ма́ма"}]`)} />
 
 </TabItem>
 <TabItem label="Resources">

--- a/starlight/src/content/docs/a1/stress-and-melody.mdx
+++ b/starlight/src/content/docs/a1/stress-and-melody.mdx
@@ -56,61 +56,74 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs syncKey="module-tab">
 <TabItem label="Lesson">
 
-This module teaches two things you cannot see in ordinary Ukrainian spelling:
-word stress and sentence melody. A printed word usually does not show stress.
-A printed sentence shows only a small clue: **.**, **?**, or **!**. Your job
-today is to build a slow, reliable reading habit.
+**ка́ва. вода́. Це ка́ва? Де метро́?** — stress and sentence melody.
 
-Keep the target modest. You are not memorizing every stress pattern in
-Ukrainian. You are learning why stress matters, how to read prepared words with
-stress marks, and how to use three beginner sentence melodies.
+First listen, then read. Use the lawful public resource already listed for
+this module: [ULP Season 1, Episode 5 — Pronunciation
+Trainer](https://www.ukrainianlessons.com/episode5/). Open the page, listen
+for the stress practice, and repeat short model words. Do not download,
+transcribe, remix, or reuse the audio; this lesson only links to it for
+listening support.
+
+Today you are not memorizing every stress pattern in Ukrainian. You are
+learning why stress matters, how to read prepared words with stress marks, and
+how to use three beginner sentence melodies.
 
 By the end, you can:
 
-- explain that **наголос** means word stress;
-- read prepared A1 words such as **ка́ва**, **вода́**, **ра́нок**, and
-  **метро́** with the marked syllable stronger and a little longer;
-- avoid reducing clear Ukrainian vowels in unstressed syllables;
+- explain **на́голос** — word stress;
+- read **ка́ва**, **вода́**, **ра́нок**, and **метро́** with the marked syllable
+  stronger and a little longer;
+- keep Ukrainian vowels clear outside stress;
 - recognize pairs where stress changes meaning, such as **за́мок** and
   **замо́к**;
 - use falling melody for statements, rising melody for yes/no questions, and
   falling melody for questions with **хто**, **що**, **де**, **коли**, or
   **як**;
-- read a short greeting dialogue with a Ukrainian-centered rhythm.
+- read a short greeting dialogue with Ukrainian rhythm.
 
-## Stress
+## Наголос
 
-**Наголос** is the syllable you say with more force and a little more length.
+**ка́ва. вода́. молоко́.** Listen first, then read the marks.
+
+**На́голос** is the syllable you say with more force and a little more length.
 In learning materials, this course marks it with an accent: **ка́ва**,
-**вода́**, **молоко́**. In normal Ukrainian texts, the mark is usually absent,
-so you learn stress as part of each new word.
+**вода́**, **молоко́**. In ordinary Ukrainian texts, the mark is usually
+absent, so you learn stress as part of each new word.
 
-Ukrainian stress is free. That means it can fall near the beginning, middle, or
-end of a word. Compare these prepared words:
+Use this listening pass before the table:
+
+1. Open the linked ULP Episode 5 page.
+2. Listen for one short stress model.
+3. Without reading the English support, point to the stronger syllable in the
+   marked word.
+4. Repeat the word once.
+
+Ukrainian stress is free. It can fall near the beginning, middle, or end of a
+word.
 
 | Model | Read it slowly |
 | --- | --- |
 | first syllable | **ма́ма**, **та́то**, **ра́нок**, **ка́ва**, **кни́га** |
 | final syllable | **вода́**, **зима́**, **рука́**, **метро́**, **кафе́** |
-| middle syllable | **столи́ця**, **люди́на**, **оди́надцять** |
+| middle syllable | **столи́ця**, **люди́на**, **одина́дцять** |
 
 There is no useful shortcut for A1 learners. Treat stress as part of the word,
 just like spelling. When you add a word to your notebook, add its stress too:
 **ка́ва**, not just кава.
 
 A second habit matters just as much: do not blur unstressed vowels. In
-**молоко́**, the first two **о** sounds stay Ukrainian **о**. They are lighter
-than the stressed final **о**, but they do not become a neutral sound. Read
-slowly first: **мо-ло-ко́**. Keep every vowel clear, then speed up.
+**молоко́**, the first two **о** sounds stay **о**. They are lighter than the
+stressed final **о**, but they stay clear. Read slowly first:
+**мо-ло-ко́**. Keep every vowel clear, then speed up.
 
 Some Ukrainian words move stress when the form changes. For now, only notice
-the idea. A word like **кни́жка** can become **книжки́** in plural. That is a
-future grammar habit, but you can already hear that Ukrainian stress can move.
+the idea. **кни́жка** can become **книжки́** in plural. That is a future
+grammar habit, but you can already hear that Ukrainian stress can move.
 
-Stress can also change meaning. These pairs look the same until you hear the
-stress:
+Stress can also change meaning:
 
-| Pair | Meaning |
+| Pair | English support |
 | --- | --- |
 | **за́мок** | castle |
 | **замо́к** | lock |
@@ -122,11 +135,13 @@ stress:
 Do not guess these from spelling alone. Use the stress mark when it is given,
 and check a dictionary such as goroh.pp.ua when you are unsure.
 
-### Where is the stress?
+### Де на́голос
 
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "In ка́ва, where is the stress?", "options": [{"text": "first syllable", "correct": true}, {"text": "final syllable", "correct": false}, {"text": "no stress", "correct": false}], "explanation": "Ка́ва is stressed on ка́."}, {"question": "In вода́, where is the stress?", "options": [{"text": "final syllable", "correct": true}, {"text": "first syllable", "correct": false}, {"text": "every syllable equally", "correct": false}], "explanation": "Вода́ is stressed on да́."}, {"question": "In столи́ця, where is the stress?", "options": [{"text": "middle syllable", "correct": true}, {"text": "first syllable", "correct": false}, {"text": "final syllable", "correct": false}], "explanation": "Столи́ця is stressed on ли́."}, {"question": "What should you do with unstressed vowels in молоко́?", "options": [{"text": "Keep each vowel clear.", "correct": true}, {"text": "Drop the first vowel.", "correct": false}, {"text": "Read every о as а.", "correct": false}], "explanation": "Ukrainian unstressed vowels stay clear."}]`)} />
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Слухай, потім читай: ка́ва. Де на́голос?", "options": [{"text": "перший склад", "correct": true}, {"text": "останній склад", "correct": false}, {"text": "немає наголосу", "correct": false}], "explanation": "У слові ка́ва на́голос на ка́."}, {"question": "Слухай, потім читай: вода́. Де на́голос?", "options": [{"text": "останній склад", "correct": true}, {"text": "перший склад", "correct": false}, {"text": "усі склади однакові", "correct": false}], "explanation": "У слові вода́ на́голос на да́."}, {"question": "Слухай, потім читай: столи́ця. Де на́голос?", "options": [{"text": "середній склад", "correct": true}, {"text": "перший склад", "correct": false}, {"text": "останній склад", "correct": false}], "explanation": "У слові столи́ця на́голос на ли́."}, {"question": "Молоко́: що робимо з ненаголошеними голосними?", "options": [{"text": "тримаємо кожен голосни́й чистим", "correct": true}, {"text": "пропускаємо перший голосни́й", "correct": false}, {"text": "читаємо кожне о як а", "correct": false}], "explanation": "Українські ненаголошені голосні залишаються чистими."}]`)} />
 
-## Intonation
+## Мелодика
+
+**Це ка́ва. Це ка́ва? Як га́рно!** — same words can carry different melody.
 
 **Мелодика** is the movement of the voice across a whole sentence. For A1, use
 three safe models:
@@ -137,9 +152,12 @@ three safe models:
 | yes/no question | **Це ка́ва?** | rising **↗** |
 | exclamation | **Як га́рно!** | stronger falling **↘↘** |
 
-The same words can change intent when the melody changes. **Це ка́ва.** tells
-someone what it is. **Це ка́ва?** asks for confirmation. The punctuation helps
-you choose the melody, but your voice must still do the work.
+The punctuation helps you choose the melody, but your voice must still do the
+work.
+
+### Пунктуація і мелодика
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Це ка́ва_", "answer": ".", "options": [".", "?", "!"]}, {"sentence": "Це метро́_", "answer": "?", "options": ["?", ".", "!"]}, {"sentence": "Де апте́ка_", "answer": "?", "options": ["?", ".", "!"]}, {"sentence": "Як га́рно_", "answer": "!", "options": ["!", "?", "."]}, {"sentence": "Так, це вода́_", "answer": ".", "options": [".", "?", "!"]}]`)} />
 
 Now add the most important beginner exception. A question with a question word
 usually falls, not rises:
@@ -162,19 +180,18 @@ But a yes/no question rises:
 Logical stress is the important word inside the sentence. In **Це ка́ва?**,
 you can make **ка́ва** the important word if you are checking the object. In
 **А у те́бе?**, the important part is **те́бе** because you are turning the
-question back to the other person. At A1, do not overthink it. Mark the
-important word, then let the question melody rise or fall according to the
-sentence type.
+question back to the other person.
 
-Keep the explanation Ukrainian-centered. Do not compare Ukrainian rhythm to
-another language as the main teaching tool. Listen to the Ukrainian words,
-notice the stress, and copy the contour.
+Keep the explanation Ukrainian-centered. Listen to the Ukrainian words, notice
+the stress, and copy the contour.
 
-### Melody choice
+### Вибір мелодики
 
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "Це ка́ва.", "options": [{"text": "falling ↘", "correct": true}, {"text": "rising ↗", "correct": false}], "explanation": "A statement uses falling melody."}, {"question": "Це ка́ва?", "options": [{"text": "rising ↗", "correct": true}, {"text": "falling ↘", "correct": false}], "explanation": "A yes/no question uses rising melody."}, {"question": "Де метро́?", "options": [{"text": "falling ↘", "correct": true}, {"text": "rising ↗", "correct": false}], "explanation": "A question with де uses falling melody at A1."}, {"question": "Як га́рно!", "options": [{"text": "stronger falling ↘↘", "correct": true}, {"text": "rising ↗", "correct": false}], "explanation": "An exclamation uses a stronger falling contour."}]`)} />
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Це ка́ва.", "options": [{"text": "спадна ↘", "correct": true}, {"text": "висхідна ↗", "correct": false}], "explanation": "Твердження має спадну мелодику."}, {"question": "Це ка́ва?", "options": [{"text": "висхідна ↗", "correct": true}, {"text": "спадна ↘", "correct": false}], "explanation": "Так/ні питання має висхідну мелодику."}, {"question": "Де метро́?", "options": [{"text": "спадна ↘", "correct": true}, {"text": "висхідна ↗", "correct": false}], "explanation": "Питання з де на A1 має спадну мелодику."}, {"question": "Як га́рно!", "options": [{"text": "сильніша спадна ↘↘", "correct": true}, {"text": "висхідна ↗", "correct": false}], "explanation": "Оклик має сильнішу спадну мелодику."}]`)} />
 
-## Reading Aloud
+## Читаємо вголос
+
+**украї́нська. фотогра́фія. відпочи́нок.**
 
 Use this three-step routine for longer words:
 
@@ -192,11 +209,9 @@ Practice:
 | **одина́дцять** | the **на́** part is strongest |
 | **чотирна́дцять** | the **на́** part is strongest |
 
-For the full number words below, put stress on **на́**:
-**одина́дцять**, **чотирна́дцять**. This protects you from the common habit of
-pulling stress to the first syllable. When you write these in your notebook,
+For the number words below, put stress on **на́**:
+**одина́дцять**, **чотирна́дцять**. When you write these in your notebook,
 write the full word with the stress mark, then underline only the strong part.
-That keeps the spelling intact while still making the sound pattern visible.
 
 :::tip
 For this module, a stress mark is a training wheel. It is not usually printed
@@ -204,32 +219,55 @@ in ordinary Ukrainian texts, but it helps your eyes remember the sound until
 the word becomes familiar.
 :::
 
-Read the small dialogue from Module 1 with melody:
+Read the Ukrainian dialogue first:
 
-<DialogueBox uk="О́ля: Приві́т! ↘" en="Olia: Hi!" />
-<DialogueBox uk="Тара́с: Приві́т! Як спра́ви? ↘" en="Taras: Hi! How are things?" />
-<DialogueBox uk="О́ля: До́бре! А у те́бе? ↗" en="Olia: Good! And you?" />
-<DialogueBox uk="Тара́с: До́бре! ↘" en="Taras: Good!" />
+```text
+О́ля: Приві́т! ↘
+Тара́с: Приві́т! Як спра́ви? ↘
+О́ля: До́бре! А у те́бе? ↗
+Тара́с: До́бре! ↘
+```
+
+English support after the Ukrainian dialogue:
+
+| Українська | English support |
+| --- | --- |
+| **Приві́т!** | Hi! |
+| **Як спра́ви?** | How are things? |
+| **До́бре!** | Good! |
+| **А у те́бе?** | And you? |
 
 Notice two details. **Як спра́ви?** has the question word **як**, so the
 beginner model is falling. **А у те́бе?** is a yes/no-style return question, so
-it rises. Keep every vowel clear in **Приві́т**, **До́бре**, and **те́бе**.
+it rises.
 
-Now read a second tiny exchange. It uses the same words, but the punctuation
-changes your melody:
+Now read a second tiny exchange:
 
-<DialogueBox uk="О́ля: Це ка́ва. ↘" en="Olia: This is coffee." />
-<DialogueBox uk="Тара́с: Це ка́ва? ↗" en="Taras: Is this coffee?" />
-<DialogueBox uk="О́ля: Так, це ка́ва. ↘" en="Olia: Yes, this is coffee." />
-<DialogueBox uk="Тара́с: Де вода́? ↘" en="Taras: Where is the water?" />
-<DialogueBox uk="О́ля: Ось вода́. ↘" en="Olia: Here is water." />
-<DialogueBox uk="Тара́с: Як га́рно! ↘↘" en="Taras: How nice!" />
+```text
+О́ля: Це ка́ва. ↘
+Тара́с: Це ка́ва? ↗
+О́ля: Так, це ка́ва. ↘
+Тара́с: Де вода́? ↘
+О́ля: Ось вода́. ↘
+Тара́с: Як га́рно! ↘↘
+```
 
-### Stress changes meaning
+English support after the Ukrainian dialogue:
+
+| Українська | English support |
+| --- | --- |
+| **Це ка́ва.** | This is coffee. |
+| **Це ка́ва?** | Is this coffee? |
+| **Так, це ка́ва.** | Yes, this is coffee. |
+| **Де вода́?** | Where is the water? |
+| **Ось вода́.** | Here is water. |
+| **Як га́рно!** | How nice! |
+
+### На́голос змінює значення
 
 <MatchUp client:only='react' pairs={JSON.parse(`[{"left": "за́мок", "right": "castle"}, {"left": "замо́к", "right": "lock"}, {"left": "а́тлас", "right": "atlas"}, {"left": "атла́с", "right": "satin"}, {"left": "о́рган", "right": "body organ"}, {"left": "орга́н", "right": "musical instrument"}]`)} />
 
-Common L2 traps now become workbook habits:
+Common traps now become workbook habits:
 
 | Trap | Safer Ukrainian habit |
 | --- | --- |
@@ -243,27 +281,46 @@ Common L2 traps now become workbook habits:
 You do not need to produce all of these words fluently today. You need to
 recognize the safer habit and avoid building the wrong one.
 
-## Textbook Check
+## Друк, зошит, голос
+
+**Друк:** **ка́ва**, **вода́**, **молоко́**, **метро́**.
+
+**Зошит:** the same known words written by you, a teacher, or a tutor with the
+stress mark preserved.
+
+Recognition comes before fast writing. Match the notebook word to the printed
+word, then read it aloud with the stress and melody.
+
+| Друк | Notebook recognition prompt |
+| --- | --- |
+| **ка́ва** | Which notebook word has stress on the first syllable? |
+| **вода́** | Which notebook word has stress on the final syllable? |
+| **молоко́** | Which notebook word keeps all three **о** sounds clear? |
+| **метро́** | Which notebook word ends with the stressed vowel? |
+
+## Перевірка
 
 Before you leave the lesson tab, check four things aloud:
 
-- What is **наголос**?
+- What is **на́голос**?
 - Can stress change meaning? Say **за́мок** and **замо́к**.
 - Which melody do you use for **Це апте́ка?**
 - Which melody do you use for **Де метро́?**
 
 Final reading:
 
-<DialogueBox uk="Це апте́ка? ↗" en="Is this a pharmacy?" />
-<DialogueBox uk="Так, це апте́ка. ↘" en="Yes, this is a pharmacy." />
-<DialogueBox uk="Як га́рно! ↘↘" en="How nice!" />
+```text
+О́ля: Це апте́ка? ↗
+Тара́с: Так, це апте́ка. ↘
+О́ля: Як га́рно! ↘↘
+```
 
-The workbook adds extra practice with the same skills: clear-vowel error
-correction, stress sorting, quick facts, and word recognition.
+Ask a native Ukrainian teacher or tutor to listen to one read-aloud from this
+module. The feedback target is narrow: stress, clear vowels, and the direction
+of the sentence melody.
 
-### Punctuation and melody
-
-<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Це ка́ва_", "answer": ".", "options": [".", "?", "!"]}, {"sentence": "Це метро́_", "answer": "?", "options": ["?", ".", "!"]}, {"sentence": "Де апте́ка_", "answer": "?", "options": ["?", ".", "!"]}, {"sentence": "Як га́рно_", "answer": "!", "options": ["!", "?", "."]}, {"sentence": "Так, це вода́_", "answer": ".", "options": [".", "?", "!"]}]`)} />
+The workbook adds extra practice with the same skills: clear-vowel repair,
+stress sorting, quick facts, and word recognition.
 
 </TabItem>
 <TabItem label="Vocabulary">
@@ -275,21 +332,41 @@ correction, stress sorting, quick facts, and word recognition.
 </TabItem>
 <TabItem label="Activities">
 
-### Fix stress-transfer traps
+### Де на́голос
 
-<ErrorCorrection client:only='react' instruction="Choose the safer Ukrainian reading habit." items={JSON.parse(`[{"sentence": "Keep all vowels clear in молоко́.", "errorWord": "blurred first two vowels", "correctForm": "мо-ло-ко́", "options": ["мо-ло-ко́", "blurred vowels"], "explanation": "Ukrainian vowels stay clear outside stress."}, {"sentence": "Put stress on the -ме́тр part in кіломе́тр.", "errorWord": "кі́лометр", "correctForm": "кіломе́тр", "options": ["кіломе́тр", "кі́лометр"], "explanation": "The prepared model is кіломе́тр."}, {"sentence": "Notice mobile stress in кни́жка / книжки́.", "errorWord": "кни́жки", "correctForm": "книжки́", "options": ["книжки́", "кни́жки"], "explanation": "This plural model moves stress to the ending."}, {"sentence": "Stress -на́- in одина́дцять.", "errorWord": "о́динадцять", "correctForm": "одина́дцять", "options": ["одина́дцять", "о́динадцять"], "explanation": "The A1 target has stress on -на́-."}, {"sentence": "Stress -на́- in чотирна́дцять.", "errorWord": "чоти́рнадцять", "correctForm": "чотирна́дцять", "options": ["чотирна́дцять", "чоти́рнадцять"], "explanation": "The A1 target has stress on -на́-."}]`)} />
+*(see lesson, §Наголос)*
 
-### Sort by stress position
+### Вибір мелодики
 
-<GroupSort client:only='react' groups={JSON.parse(`{"First syllable": ["ма́ма", "та́то", "ра́нок", "ка́ва"], "Middle syllable": ["столи́ця", "люди́на", "одина́дцять", "чотирна́дцять"], "Final syllable": ["вода́", "зима́", "рука́", "метро́"]}`)} />
+*(see lesson, §Мелодика)*
 
-### Stress and melody facts
+### На́голос змінює значення
 
-<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Ukrainian stress can fall on different syllables.", "isTrue": true, "explanation": "Stress is free, so learn it with each word."}, {"statement": "Ordinary Ukrainian texts usually mark every stress.", "isTrue": false, "explanation": "Stress marks appear in learning materials and dictionaries, not most ordinary texts."}, {"statement": "A yes/no question such as Це вода́? rises at A1.", "isTrue": true, "explanation": "Yes/no questions use rising melody."}, {"statement": "A question with де always needs rising melody at A1.", "isTrue": false, "explanation": "A question with a question word such as де uses falling melody."}]`)} />
+*(see lesson, §Читаємо вголос)*
 
-### New stress words
+### Пунктуація і мелодика
 
-<Translate client:only='react' questions={JSON.parse(`[{"source": "наголос", "options": [{"text": "stress / accent", "correct": true}, {"text": "lock", "correct": false}, {"text": "water", "correct": false}], "explanation": "Наголос means word stress or accent."}, {"source": "ка́ва", "options": [{"text": "coffee", "correct": true}, {"text": "capital", "correct": false}, {"text": "morning", "correct": false}], "explanation": "Ка́ва means coffee."}, {"source": "вода́", "options": [{"text": "water", "correct": true}, {"text": "photograph", "correct": false}, {"text": "atlas", "correct": false}], "explanation": "Вода́ means water."}, {"source": "столи́ця", "options": [{"text": "capital", "correct": true}, {"text": "metro", "correct": false}, {"text": "family", "correct": false}], "explanation": "Столи́ця means capital."}]`)} />
+*(see lesson, §Мелодика)*
+
+### Виправ пастки наголосу
+
+<ErrorCorrection client:only='react' instruction="Обери безпечнішу українську читацьку звичку." items={JSON.parse(`[{"sentence": "Молоко́ — тримай усі голосні чистими.", "errorWord": "нечіткі перші два голосні", "correctForm": "мо-ло-ко́", "options": ["мо-ло-ко́", "нечіткі голосні"], "explanation": "Українські голосні залишаються чистими поза на́голосом."}, {"sentence": "Кіломе́тр — став на́голос на -ме́тр.", "errorWord": "кі́лометр", "correctForm": "кіломе́тр", "options": ["кіломе́тр", "кі́лометр"], "explanation": "Підготовлена модель — кіломе́тр."}, {"sentence": "Кни́жка / книжки́ — помічай рухомий на́голос.", "errorWord": "кни́жки", "correctForm": "книжки́", "options": ["книжки́", "кни́жки"], "explanation": "У цій множинній моделі на́голос переходить на закінчення."}, {"sentence": "Одина́дцять — наголос на -на́-.", "errorWord": "о́динадцять", "correctForm": "одина́дцять", "options": ["одина́дцять", "о́динадцять"], "explanation": "Ціль A1 має на́голос на -на́-."}, {"sentence": "Чотирна́дцять — наголос на -на́-.", "errorWord": "чоти́рнадцять", "correctForm": "чотирна́дцять", "options": ["чотирна́дцять", "чоти́рнадцять"], "explanation": "Ціль A1 має на́голос на -на́-."}]`)} />
+
+### Сортуй за наголосом
+
+<GroupSort client:only='react' groups={JSON.parse(`{"Перший склад": ["ма́ма", "та́то", "ра́нок", "ка́ва"], "Середній склад": ["столи́ця", "люди́на", "одина́дцять", "чотирна́дцять"], "Останній склад": ["вода́", "зима́", "рука́", "метро́"]}`)} />
+
+### Друк і зошит
+
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "друк: ка́ва", "right": "зошит: на́голос на першому складі"}, {"left": "друк: вода́", "right": "зошит: на́голос на останньому складі"}, {"left": "друк: молоко́", "right": "зошит: три чисті звуки о"}, {"left": "друк: метро́", "right": "зошит: останній наголошений голосни́й"}]`)} />
+
+### Факти про наголос і мелодику
+
+<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Український на́голос може бути на різних складах.", "isTrue": true, "explanation": "На́голос вільний, тому вчи його разом із кожним словом."}, {"statement": "Звичайні українські тексти завжди мають позначки наголосу.", "isTrue": false, "explanation": "Позначки наголосу є в навчальних матеріалах і словниках, а не в більшості звичайних текстів."}, {"statement": "Так/ні питання Це вода́? має висхідну мелодику на A1.", "isTrue": true, "explanation": "Так/ні питання має висхідну мелодику."}, {"statement": "Питання з де завжди потребує висхідної мелодики на A1.", "isTrue": false, "explanation": "Питання з питальним словом як де має спадну мелодику."}]`)} />
+
+### Слова з наголосом
+
+<Translate client:only='react' questions={JSON.parse(`[{"source": "на́голос", "options": [{"text": "stress / accent", "correct": true}, {"text": "lock", "correct": false}, {"text": "water", "correct": false}], "explanation": "На́голос — stress / accent."}, {"source": "ка́ва", "options": [{"text": "coffee", "correct": true}, {"text": "capital", "correct": false}, {"text": "morning", "correct": false}], "explanation": "Ка́ва — coffee."}, {"source": "вода́", "options": [{"text": "water", "correct": true}, {"text": "photograph", "correct": false}, {"text": "atlas", "correct": false}], "explanation": "Вода́ — water."}, {"source": "столи́ця", "options": [{"text": "capital", "correct": true}, {"text": "metro", "correct": false}, {"text": "family", "correct": false}], "explanation": "Столи́ця — capital."}]`)} />
 
 </TabItem>
 <TabItem label="Resources">

--- a/starlight/src/content/docs/a1/who-am-i.mdx
+++ b/starlight/src/content/docs/a1/who-am-i.mdx
@@ -56,283 +56,320 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs syncKey="module-tab">
 <TabItem label="Lesson">
 
-Your first real Ukrainian conversation is short. You greet someone, ask for a
-name, answer with your own name, and turn the question back. Keep the language
-as memorized chunks first. Grammar comes only after the phrases already work in
-your mouth.
+**Приві́т! Мене́ зва́ти Марко́. А тебе́?** — Hi! My name is Marko.
+And yours?
+
+This lesson stays short and spoken. First you hear a Ukrainian line, then you
+use a small amount of English support to check the meaning. Treat the first
+phrases as whole chunks:
+
+| Українська опора | English support |
+| --- | --- |
+| **Мене́ зва́ти...** | My name is... |
+| **Як тебе́ зва́ти?** | What is your name? informal |
+| **Як вас зва́ти?** | What is your name? formal |
+| **Ду́же приє́мно!** | Nice to meet you! |
+| **Зві́дки ти?** | Where are you from? |
 
 By the end, you can:
 
-- ask **Як тебе звати?** with a peer and **Як вас звати?** with a new adult;
-- answer **Мене звати...**;
-- use **А тебе?** and **А вас?** to return the name question;
+- ask **Як тебе́ зва́ти?** with a peer and **Як вас зва́ти?** with a new adult;
+- answer **Мене́ зва́ти...**;
+- return the question with **А тебе́?** or **А вас?**;
 - point to a person or thing with **це**;
 - use **я**, **ти**, **він**, **вона**, and **ви** in simple identity lines;
-- say **Я — студент** or **Я — студентка** without adding a present-tense
+- say **Я — студе́нт** or **Я — студе́нтка** without adding a present-tense
   "am" word;
-- say where you are from with memorized phrases such as **Я з України** and
-  **Я з Канади**;
-- choose native Ukrainian identity words, including feminitives such as
-  **лікарка**, **вчителька**, and **інженерка**.
+- say where you are from with memorized phrases such as **Я з Украї́ни** and
+  **Я з Кана́ди**;
+- choose Ukrainian identity words, including **лі́карка**, **вчи́телька**, and
+  **інжене́рка**.
 
-## Dialogues
+## Діало́ги
 
-Read the dialogue first. Do not analyze every word yet. Your first target is
-the conversation shape.
+Read each Ukrainian dialogue first. Do not translate line by line while you
+read. The support table comes after the dialogue.
 
-<DialogueBox uk="Марко: Привіт! Як тебе звати?" en="Marko: Hi! What is your name?" />
-<DialogueBox uk="Олена: Мене звати Олена. А тебе?" en="Olena: My name is Olena. And yours?" />
-<DialogueBox uk="Марко: Мене звати Марко. Дуже приємно!" en="Marko: My name is Marko. Pleased to meet you!" />
-<DialogueBox uk="Олена: Дуже приємно! Звідки ти?" en="Olena: Pleased to meet you! Where are you from?" />
-<DialogueBox uk="Марко: Я з Канади. А ти?" en="Marko: I am from Canada. And you?" />
-<DialogueBox uk="Олена: Я з України." en="Olena: I am from Ukraine." />
+```text
+Марко́: Приві́т! Як тебе́ зва́ти?
+Оле́на: Мене́ зва́ти Оле́на. А тебе́?
+Марко́: Мене́ зва́ти Марко́. Ду́же приє́мно!
+Оле́на: Ду́же приє́мно! Зві́дки ти?
+Марко́: Я з Кана́ди. А ти?
+Оле́на: Я з Украї́ни.
+```
 
-Use **Привіт** with peers. Use **А тебе?** only after the other person has
-asked or answered the same name question. It is an echo pattern: short, polite,
-and easy. Do not switch to the longer pattern with **у** here; that belongs to
-a later grammar module.
+English support after the Ukrainian dialogue:
 
-Now compare a formal first meeting:
+| Українська | English support |
+| --- | --- |
+| **Приві́т!** | Hi! |
+| **Як тебе́ зва́ти?** | What is your name? informal |
+| **А тебе́?** | And yours? informal |
+| **Я з Кана́ди.** | I am from Canada. |
+| **Я з Украї́ни.** | I am from Ukraine. |
 
-<DialogueBox uk="Петро: Добрий день! Як вас звати?" en="Petro: Good afternoon! What is your name?" />
-<DialogueBox uk="Софія: Мене звати Софія. А вас?" en="Sofiia: My name is Sofiia. And yours?" />
-<DialogueBox uk="Петро: Мене звати Петро. Дуже приємно!" en="Petro: My name is Petro. Pleased to meet you!" />
-<DialogueBox uk="Софія: Мені також. Ви з України?" en="Sofiia: Me too. Are you from Ukraine?" />
-<DialogueBox uk="Петро: Так, я з Києва." en="Petro: Yes, I am from Kyiv." />
+Use **Приві́т** with peers. Use **А тебе́?** only after the name question is
+already active. It is an echo pattern: short, polite, and easy.
 
-The formal version changes two pieces. **Тебе** becomes **вас**. **Ти**
-becomes **ви**. English uses one word, "you"; Ukrainian asks you to choose
-relationship and politeness.
+Now read a formal first meeting:
 
-Use **Добрий день** when you meet an adult, teacher, host, or stranger. Keep
-**Привіт** for friends, classmates, children, and relaxed peer situations.
+```text
+Петро́: До́брий день! Як вас зва́ти?
+Софі́я: Мене́ зва́ти Софі́я. А вас?
+Петро́: Мене́ зва́ти Петро́. Ду́же приє́мно!
+Софі́я: Мені́ також. Ви з Украї́ни?
+Петро́: Так, я з Ки́єва.
+```
 
-The third dialogue introduces another person. Notice that two people still
-speak; it is not a monologue.
+English support after the Ukrainian dialogue:
 
-<DialogueBox uk="Тарас: Це Андрій. Він зі Львова." en="Taras: This is Andrii. He is from Lviv." />
-<DialogueBox uk="Наталка: Дуже приємно. А хто це?" en="Natalka: Pleased to meet you. And who is this?" />
-<DialogueBox uk="Тарас: Це Оксана. Вона з Одеси. Вона — лікарка." en="Taras: This is Oksana. She is from Odesa. She is a doctor." />
-<DialogueBox uk="Наталка: Дуже приємно, Оксано." en="Natalka: Pleased to meet you, Oksana." />
+| Українська | English support |
+| --- | --- |
+| **До́брий день!** | Good afternoon! |
+| **Як вас зва́ти?** | What is your name? formal |
+| **А вас?** | And yours? formal |
+| **Мені́ також.** | Me too. |
+| **Так, я з Ки́єва.** | Yes, I am from Kyiv. |
+
+The formal version changes two pieces. **тебе́** becomes **вас**. **ти**
+becomes **ви**. English has one everyday word, "you"; Ukrainian asks you to
+choose relationship and politeness.
+
+The third dialogue introduces another person:
+
+```text
+Тара́с: Це Андрі́й. Він зі Льво́ва.
+Ната́лка: Ду́же приє́мно. А хто це?
+Тара́с: Це Окса́на. Вона́ з Оде́си. Вона́ — лі́карка.
+Ната́лка: Ду́же приє́мно, Окса́но.
+```
+
+English support after the Ukrainian dialogue:
+
+| Українська | English support |
+| --- | --- |
+| **Це Андрі́й.** | This is Andrii. |
+| **Він зі Льво́ва.** | He is from Lviv. |
+| **А хто це?** | And who is this? |
+| **Вона́ — лі́карка.** | She is a doctor. |
 
 For a woman, use the feminine profession form when Ukrainian has the normal
-form: **лікарка**, **вчителька**, **інженерка**, **програмістка**,
-**студентка**. These are not decorative extras. They are standard Ukrainian
-identity words.
+form: **лі́карка**, **вчи́телька**, **інжене́рка**, **програмі́стка**,
+**студе́нтка**. These are standard Ukrainian identity words.
 
-### Formal or informal?
+### Ти чи ви?
 
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "You meet a classmate your age.", "options": [{"text": "Як тебе звати?", "correct": true}, {"text": "Як вас звати?", "correct": false}], "explanation": "Use тебе with one familiar peer."}, {"question": "You meet an unknown adult at orientation.", "options": [{"text": "Як вас звати?", "correct": true}, {"text": "Як тебе звати?", "correct": false}], "explanation": "Use вас with one unknown adult or in a formal setting."}, {"question": "A peer asks your name. You answer and return the question.", "options": [{"text": "Мене звати Олена. А тебе?", "correct": true}, {"text": "Мене звати Олена. А вас?", "correct": false}], "explanation": "The peer situation stays informal."}, {"question": "An instructor asks your name. You answer and return the question.", "options": [{"text": "Мене звати Петро. А вас?", "correct": true}, {"text": "Мене звати Петро. А тебе?", "correct": false}], "explanation": "The instructor situation stays formal."}]`)} />
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Ти знайомишся з однокурсником свого віку.", "options": [{"text": "Як тебе звати?", "correct": true}, {"text": "Як вас звати?", "correct": false}], "explanation": "З одним знайомим або рівним співрозмовником уживай тебе."}, {"question": "Ти знайомишся з незнайомим дорослим на орієнтації.", "options": [{"text": "Як вас звати?", "correct": true}, {"text": "Як тебе звати?", "correct": false}], "explanation": "З незнайомим дорослим або у формальній ситуації уживай вас."}, {"question": "Однокурсник питає твоє ім'я. Ти відповідаєш і повертаєш питання.", "options": [{"text": "Мене звати Олена. А тебе?", "correct": true}, {"text": "Мене звати Олена. А вас?", "correct": false}], "explanation": "Рівна ситуація залишається неформальною."}, {"question": "Викладач питає твоє ім'я. Ти відповідаєш і повертаєш питання.", "options": [{"text": "Мене звати Петро. А вас?", "correct": true}, {"text": "Мене звати Петро. А тебе?", "correct": false}], "explanation": "З викладачем ситуація залишається формальною."}]`)} />
 
-## My Name Is...
+## Мене́ зва́ти...
 
-**Мене звати...** means "My name is..." Treat it as one chunk:
+**Мене́ зва́ти...** is one chunk. You do not need the grammar of **мене́** or
+**зва́ти** yet. You need the social move: ask, answer, echo.
 
-| Ukrainian | English use |
+| Українська | English support |
 | --- | --- |
-| **Мене звати Марко.** | My name is Marko. |
-| **Мене звати Олена.** | My name is Olena. |
-| **Мене звати [ім'я].** | My name is [name]. |
-| **Як тебе звати?** | What is your name? informal |
-| **Як вас звати?** | What is your name? formal |
-| **До побачення!** | Goodbye! |
-
-These **фрази знайомства** are chunks. Do not translate the chunk word by
-word. At this level, you do not need the case of **мене** or the verb form
-behind **звати**. You need the social move: ask, answer, echo.
+| **Мене́ зва́ти Марко́.** | My name is Marko. |
+| **Мене́ зва́ти Оле́на.** | My name is Olena. |
+| **Мене́ зва́ти [ім'я́].** | My name is [name]. |
+| **Як тебе́ зва́ти?** | What is your name? informal |
+| **Як вас зва́ти?** | What is your name? formal |
+| **До поба́чення!** | Goodbye! |
 
 Name exchange order:
 
-1. **Привіт!** or **Добрий день!**
-2. **Як тебе звати?** or **Як вас звати?**
-3. **Мене звати...**
-4. **А тебе?** or **А вас?**
-5. **Дуже приємно!**
+1. **Приві́т!** or **До́брий день!**
+2. **Як тебе́ зва́ти?** or **Як вас зва́ти?**
+3. **Мене́ зва́ти...**
+4. **А тебе́?** or **А вас?**
+5. **Ду́же приє́мно!**
 
 :::tip
-For this module, **А тебе?** and **А вас?** are return buttons. Use them only
+For this module, **А тебе́?** and **А вас?** are return buttons. Use them only
 after the same question is already active in the conversation.
 :::
 
-**Дуже приємно!** comes after names are exchanged. It is the small phrase that
-closes the introduction politely.
-
 Avoid the English-shaped line "My name is..." as a Ukrainian sentence. The
-natural high-frequency Ukrainian model for a first introduction is
-**Мене звати...**.
+natural first-introduction model is **Мене́ зва́ти...**.
 
-### Build the name chunk
+### Склади ім'я
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "___ звати Марко.", "answer": "Мене", "options": ["Мене", "Ти", "Це"]}, {"sentence": "Як ___ звати?", "answer": "тебе", "options": ["тебе", "я", "він"]}, {"sentence": "Як ___ звати?", "answer": "вас", "options": ["вас", "вона", "ми"]}, {"sentence": "Дуже ___!", "answer": "приємно", "options": ["приємно", "студент", "звідки"]}, {"sentence": "Мене звати Олена. А ___?", "answer": "тебе", "options": ["тебе", "Київ", "це"]}]`)} />
 
-## This Is...
+## Це...
 
 **Це** is the fast pointing word. It can introduce a thing, a city, or a
 person:
 
-| Ukrainian | English |
+| Українська | English support |
 | --- | --- |
-| **Це кава.** | This is coffee. |
-| **Це Київ.** | This is Kyiv. |
-| **Це Андрій.** | This is Andrii. |
-| **Це Оксана.** | This is Oksana. |
+| **Це ка́ва.** | This is coffee. |
+| **Це Ки́їв.** | This is Kyiv. |
+| **Це Андрі́й.** | This is Andrii. |
+| **Це Окса́на.** | This is Oksana. |
 
-Use **Що це?** for a thing: **Що це? Це кава.** Use **Хто це?** for a
-person: **Хто це? Це Оксана.**
+Use **Що це?** for a thing: **Що це? Це ка́ва.** Use **Хто це?** for a
+person: **Хто це? Це Окса́на.**
 
 Keep the question word first. Ukrainian beginner questions are easier when the
-question word opens the question: **Хто це?**, **Що це?**, **Звідки ти?**
+question word opens the question: **Хто це?**, **Що це?**, **Зві́дки ти?**
 
 Use **це** instead of an English-style "it" when you identify a person in a
 photo, on the phone, or in a group:
 
-| Safer beginner line | English meaning |
+| Українська | English support |
 | --- | --- |
-| **Це мій тато.** | This is my dad. |
-| **Це моя мама.** | This is my mom. |
-| **Це моя подруга.** | This is my female friend. |
+| **Це мій та́то.** | This is my dad. |
+| **Це моя́ ма́ма.** | This is my mom. |
+| **Це моя́ подру́га.** | This is my female friend. |
 
-For people, **він** and **вона** are also possible after you know who the
-person is: **Це Андрій. Він зі Львова.** **Це Оксана. Вона — лікарка.**
+For people, **він** and **вона́** are also possible after you know who the
+person is: **Це Андрі́й. Він зі Льво́ва.** **Це Окса́на. Вона́ — лі́карка.**
 
-### This is / Who is this?
+### Це / хто / що
 
-<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "Це Андрій.", "right": "This is Andrii."}, {"left": "Це Оксана.", "right": "This is Oksana."}, {"left": "Хто це?", "right": "Who is this?"}, {"left": "Що це?", "right": "What is this?"}, {"left": "Це кава.", "right": "This is coffee."}]`)} />
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "Це Андрій.", "right": "представити людину"}, {"left": "Це Оксана.", "right": "представити іншу людину"}, {"left": "Хто це?", "right": "запитати про людину"}, {"left": "Що це?", "right": "запитати про річ"}, {"left": "Це кава.", "right": "назвати річ"}]`)} />
 
-## Personal Pronouns
+## Особо́ві займéнники
 
-Personal pronouns point to people in a conversation. Learn only the naming
-case now:
+Learn only the naming case now:
 
-| Ukrainian | Use |
+| Українська | English support |
 | --- | --- |
-| **я** | I, the speaker; **1-ша особа** |
-| **ми** | we; **1-ша особа** plural |
-| **ти** | you, one familiar person; **2-га особа**, points **на співрозмовника** |
-| **ви** | you formal, or you plural; **2-га особа**, points **на співрозмовника** |
-| **він** | he; **3-тя особа** |
-| **вона** | she; **3-тя особа** |
-| **вони** | they; **3-тя особа** |
+| **я** | I, the speaker |
+| **ми** | we |
+| **ти** | you, one familiar person |
+| **ви** | you formal, or you plural |
+| **він** | he |
+| **вона́** | she |
+| **вони́** | they |
 
-The important beginner contrast is **ти / ви**. Use **ти** **для друзів,
-дітей** and close classmates when the relationship is informal. Use **ви**
-**для викладачів, старших людей**, one unknown adult, a host, or several
+The important beginner contrast is **ти / ви**. Use **ти** **для дру́зів,
+діте́й** and close classmates when the relationship is informal. Use **ви**
+**для викладачі́в, ста́рших люде́й**, one unknown adult, a host, or several
 people.
 
 Mini-patterns:
 
-| Informal | Formal |
+| Неформально | Формально |
 | --- | --- |
-| **Як тебе звати?** | **Як вас звати?** |
-| **А тебе?** | **А вас?** |
-| **Звідки ти?** | **Звідки ви?** |
+| **Як тебе́ зва́ти?** | **Як вас зва́ти?** |
+| **А тебе́?** | **А вас?** |
+| **Зві́дки ти?** | **Зві́дки ви?** |
 
 When you write polite **Ви** to one person, Ukrainian often uses a capital
-letter. In this course page, the lower-case **ви** is enough for practice, but
+letter. In this course page, lower-case **ви** is enough for practice, but
 recognize **Ви** when you see it.
 
-### Pronoun choice
+### Обери займенник
 
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "I", "options": [{"text": "я", "correct": true}, {"text": "ти", "correct": false}, {"text": "вони", "correct": false}], "explanation": "Я is the speaker."}, {"question": "you, one friend", "options": [{"text": "ти", "correct": true}, {"text": "ви", "correct": false}, {"text": "він", "correct": false}], "explanation": "Ти is one informal you."}, {"question": "you, one unknown adult", "options": [{"text": "ви", "correct": true}, {"text": "ти", "correct": false}, {"text": "вона", "correct": false}], "explanation": "Ви is formal for one person and also plural."}, {"question": "she", "options": [{"text": "вона", "correct": true}, {"text": "він", "correct": false}, {"text": "я", "correct": false}], "explanation": "Вона points to a woman or girl."}]`)} />
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Мовець говорить про себе.", "options": [{"text": "я", "correct": true}, {"text": "ти", "correct": false}, {"text": "вони", "correct": false}], "explanation": "Я — це мовець."}, {"question": "Один друг або близький однокурсник.", "options": [{"text": "ти", "correct": true}, {"text": "ви", "correct": false}, {"text": "він", "correct": false}], "explanation": "Ти — один неформальний співрозмовник."}, {"question": "Один незнайомий дорослий або формальна ситуація.", "options": [{"text": "ви", "correct": true}, {"text": "ти", "correct": false}, {"text": "вона", "correct": false}], "explanation": "Ви — формально до однієї людини, а також множина."}, {"question": "Жінка або дівчина вже відома в розмові.", "options": [{"text": "вона", "correct": true}, {"text": "він", "correct": false}, {"text": "я", "correct": false}], "explanation": "Вона вказує на жінку або дівчину."}]`)} />
 
-## I Am a Student
+## Я — студе́нт
 
 Ukrainian present-time identity lines do not need a word for English "am" or
 "is":
 
-| Ukrainian | English |
+| Українська | English support |
 | --- | --- |
-| **Я — студент.** | I am a male student. |
-| **Я — студентка.** | I am a female student. |
-| **Він — лікар.** | He is a doctor. |
-| **Вона — лікарка.** | She is a doctor. |
+| **Я — студе́нт.** | I am a male student. |
+| **Я — студе́нтка.** | I am a female student. |
+| **Він — лі́кар.** | He is a doctor. |
+| **Вона́ — лі́карка.** | She is a doctor. |
 
 The dash is a reading helper. It marks the place where English expects "am" or
-"is." In ordinary writing, you may see the same pattern without a dash, but the
-meaning is the same: **Я студент.**
-
-The grammar label is **Нульова зв'язка** or **Опущений дієслово-копула**.
-For today, that only means: do not add **бути** in present-time identity lines
-such as **Я студент**, **Я лікарка**, **Він — лікар**, and **Вона — лікарка**.
+"is." In ordinary writing, you may see the same pattern without a dash:
+**Я студе́нт.**
 
 Use profession pairs as pairs:
 
-| Masculine | Feminine |
+| Чоловіча форма | Жіноча форма |
 | --- | --- |
-| **студент** | **студентка** |
-| **вчитель** | **вчителька** |
-| **лікар** | **лікарка** |
-| **програміст** | **програмістка** |
-| **інженер** | **інженерка** |
-| **українець** | **українка** |
-| **канадієць** | **канадка** |
-| **американець** | **американка** |
+| **студе́нт** | **студе́нтка** |
+| **вчи́тель** | **вчи́телька** |
+| **лі́кар** | **лі́карка** |
+| **програмі́ст** | **програмі́стка** |
+| **інжене́р** | **інжене́рка** |
+| **украї́нець** | **украї́нка** |
+| **канаді́єць** | **кана́дка** |
+| **америка́нець** | **америка́нка** |
 
-The feminine form is the primary form for a woman. **Оксана — лікарка.**
-**Софія — студентка.** **Наталка — інженерка.** The simple classroom phrase
-**фізична реальність** means the real person guides the label: **Я
-програмістка** for a woman, **Я програміст** for a man.
+The feminine form is the primary form for a woman. **Окса́на — лі́карка.**
+**Софі́я — студе́нтка.** **Ната́лка — інжене́рка.**
 
-This is a Ukrainian-centered habit. Do not treat masculine profession words as
-universal labels for women.
+## Зві́дки?
 
-## Where From?
+**Зві́дки?** means "from where?" Use the country phrases as memorized chunks:
 
-**Звідки?** means "from where?" Use the country phrases as memorized chunks:
-
-| Question | Answer |
+| Питання | Відповідь |
 | --- | --- |
-| **Звідки ти?** | **Я з України.** |
-| **Звідки ви?** | **Я з Канади.** |
-| **Ви з України?** | **Так, я з Києва.** |
+| **Зві́дки ти?** | **Я з Украї́ни.** |
+| **Зві́дки ви?** | **Я з Кана́ди.** |
+| **Ви з Украї́ни?** | **Так, я з Ки́єва.** |
 
 Add a few prepared places:
 
-| Ukrainian | English |
+| Українська | English support |
 | --- | --- |
-| **Я з України.** | I am from Ukraine. |
-| **Я з Канади.** | I am from Canada. |
-| **Я зі Штатів.** | I am from the States. |
-| **Я з Німеччини.** | I am from Germany. |
-| **Я з Києва.** | I am from Kyiv. |
-| **Я зі Львова.** | I am from Lviv. |
-| **Я з Одеси.** | I am from Odesa. |
+| **Я з Украї́ни.** | I am from Ukraine. |
+| **Я з Кана́ди.** | I am from Canada. |
+| **Я зі Шта́тів.** | I am from the States. |
+| **Я з Німе́ччини.** | I am from Germany. |
+| **Я з Ки́єва.** | I am from Kyiv. |
+| **Я зі Льво́ва.** | I am from Lviv. |
+| **Я з Оде́си.** | I am from Odesa. |
 
 The forms after **з / зі** are memorized here. Do not open the full grammar of
 "from" yet. Your speaking goal is a natural first-contact answer.
 
 Build a three-line self-introduction:
 
-<DialogueBox uk="Добрий день. Мене звати Софія." en="Good afternoon. My name is Sofiia." />
-<DialogueBox uk="Я з України." en="I am from Ukraine." />
-<DialogueBox uk="Я — студентка." en="I am a student." />
+```text
+До́брий день. Мене́ зва́ти Софі́я.
+Я з Украї́ни.
+Я — студе́нтка.
+```
 
 Or informal:
 
-<DialogueBox uk="Привіт! Мене звати Марко." en="Hi! My name is Marko." />
-<DialogueBox uk="Я з Канади." en="I am from Canada." />
-<DialogueBox uk="Я — програміст." en="I am a programmer." />
+```text
+Приві́т! Мене́ зва́ти Марко́.
+Я з Кана́ди.
+Я — програмі́ст.
+```
 
-Native Ukrainian choices matter even in tiny introductions. Use **тато** for
-dad, **дружина** for wife, **вибачте** or **пробачте** for excuse me,
-**дякую** or **спасибі** for thank you, and **теж** or **також** for also.
+Native Ukrainian choices matter even in tiny introductions. Use **та́то** for
+dad, **дружи́на** for wife, **ви́бачте** or **проба́чте** for excuse me,
+**дя́кую** or **спаси́бі** for thank you, and **теж** or **та́кож** for also.
 
-## Textbook Check
+## Слу́хай і зошит
 
-Before the workbook, cover the English side and say the Ukrainian aloud:
+For lawful listening, use public Ukrainian Lessons Podcast pages as listen-only
+support: Episode 3 for introductions, Episode 4 for **Зві́дки?**, and Episode
+8 for professions. Listen, repeat a short chunk, and come back to the page.
+Do not copy or transcribe paid material.
 
-| English cue | Ukrainian you say |
+For handwriting recognition, ask a teacher, tutor, or classmate to write these
+original labels in a notebook: **ім'я́**, **прі́звище**, **Ки́їв**,
+**студе́нтка**, **лі́карка**. First compare the notebook label with the printed
+word; then write your own line.
+
+## Самопереві́рка
+
+Cover the English support and read the Ukrainian aloud:
+
+| Українська | English support |
 | --- | --- |
-| What is your name? informal | **Як тебе звати?** |
-| My name is... | **Мене звати...** |
-| And yours? informal | **А тебе?** |
-| And yours? formal | **А вас?** |
-| This is Oksana. | **Це Оксана.** |
-| Who is this? | **Хто це?** |
-| I am a student. female speaker | **Я — студентка.** |
-| She is a doctor. | **Вона — лікарка.** |
-| Where are you from? informal | **Звідки ти?** |
-| I am from Canada. | **Я з Канади.** |
+| **Як тебе́ зва́ти?** | What is your name? informal |
+| **Мене́ зва́ти...** | My name is... |
+| **А тебе́?** | And yours? informal |
+| **А вас?** | And yours? formal |
+| **Це Окса́на.** | This is Oksana. |
+| **Хто це?** | Who is this? |
+| **Я — студе́нтка.** | I am a female student. |
+| **Вона́ — лі́карка.** | She is a doctor. |
+| **Зві́дки ти?** | Where are you from? informal |
+| **Я з Кана́ди.** | I am from Canada. |
 
 Use the workbook for extra practice: profession pairs, dialogue fill-ins,
 safer Ukrainian sentence choices, native-form choices, and vocabulary
@@ -348,27 +385,43 @@ recognition.
 </TabItem>
 <TabItem label="Activities">
 
+### Ти чи ви?
+
+*(see lesson, §Діало́ги)*
+
+### Склади ім'я
+
+*(see lesson, §Мене́ зва́ти...)*
+
+### Це / хто / що
+
+*(see lesson, §Це...)*
+
+### Обери займенник
+
+*(see lesson, §Особо́ві займéнники)*
+
 <span id="fix-common-l2-traps"></span>
 
-### Choose the Ukrainian sentence
+### Обери українське речення
 
-<ErrorCorrection client:only='react' instruction="Choose the safer Ukrainian identity line." items={JSON.parse(`[{"sentence": "Я є студент.", "errorWord": "Я є студент.", "correctForm": "Я студент.", "options": ["Я студент.", "Я є студент."], "explanation": "In present-time identity, say Я студент or Я — студент."}, {"sentence": "Моє ім'я є Джон.", "errorWord": "Моє ім'я є Джон.", "correctForm": "Мене звати Джон.", "options": ["Мене звати Джон.", "Моє ім'я є Джон."], "explanation": "Мене звати... is the high-frequency introduction model."}, {"sentence": "Я маю 20 років.", "errorWord": "Я маю 20 років.", "correctForm": "Мені 20 років.", "options": ["Мені 20 років.", "Я маю 20 років."], "explanation": "Age uses a different chunk and is not the model for this lesson."}, {"sentence": "Оксана каже, \\"Я (жінка) лікар.\\"", "errorWord": "Я (жінка) лікар.", "correctForm": "Я лікарка.", "options": ["Я лікарка.", "Я (жінка) лікар."], "explanation": "Лікарка is the standard feminine form for a woman doctor."}, {"sentence": "Воно мій тато.", "errorWord": "Воно", "correctForm": "Це мій тато.", "options": ["Це мій тато.", "Воно мій тато."], "explanation": "Use це for identifying a person, or він after the person is known."}, {"sentence": "Привіт, пане професоре!", "errorWord": "Привіт", "correctForm": "Добрий день, пане професоре!", "options": ["Добрий день, пане професоре!", "Привіт, пане професоре!"], "explanation": "Use Добрий день with a professor or unknown adult."}]`)} />
+<ErrorCorrection client:only='react' instruction="Обери безпечніший український рядок про ідентичність." items={JSON.parse(`[{"sentence": "Я є студент.", "errorWord": "Я є студент.", "correctForm": "Я студент.", "options": ["Я студент.", "Я є студент."], "explanation": "У теперішній ідентичності кажи Я студент або Я — студент."}, {"sentence": "Моє ім'я є Джон.", "errorWord": "Моє ім'я є Джон.", "correctForm": "Мене звати Джон.", "options": ["Мене звати Джон.", "Моє ім'я є Джон."], "explanation": "Мене звати... — частотна модель першого представлення."}, {"sentence": "Я маю 20 років.", "errorWord": "Я маю 20 років.", "correctForm": "Мені 20 років.", "options": ["Мені 20 років.", "Я маю 20 років."], "explanation": "Вік має інший блок; це не модель цього уроку."}, {"sentence": "Оксана каже, \\"Я (жінка) лікар.\\"", "errorWord": "Я (жінка) лікар.", "correctForm": "Я лікарка.", "options": ["Я лікарка.", "Я (жінка) лікар."], "explanation": "Лікарка — стандартна жіноча форма для жінки, яка працює лікарем."}, {"sentence": "Воно мій тато.", "errorWord": "Воно", "correctForm": "Це мій тато.", "options": ["Це мій тато.", "Воно мій тато."], "explanation": "Для першого називання людини вживай це; він можливе після цього."}, {"sentence": "Привіт, пане професоре!", "errorWord": "Привіт", "correctForm": "Добрий день, пане професоре!", "options": ["Добрий день, пане професоре!", "Привіт, пане професоре!"], "explanation": "З професором або незнайомим дорослим уживай Добрий день."}]`)} />
 
-### Profession pairs
+### Пари професій
 
 <MatchUp client:only='react' pairs={JSON.parse(`[{"left": "студент", "right": "студентка"}, {"left": "вчитель", "right": "вчителька"}, {"left": "лікар", "right": "лікарка"}, {"left": "програміст", "right": "програмістка"}, {"left": "інженер", "right": "інженерка"}, {"left": "українець", "right": "українка"}, {"left": "канадієць", "right": "канадка"}, {"left": "американець", "right": "американка"}]`)} />
 
-### Complete the dialogue
+### Доповни діалог
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "Привіт! Як ___ звати?", "answer": "тебе", "options": ["тебе", "вас", "це"]}, {"sentence": "Мене ___ Олена.", "answer": "звати", "options": ["звати", "це", "з"]}, {"sentence": "Мене звати Марко. ___ тебе?", "answer": "А", "options": ["А", "Хто", "Що"]}, {"sentence": "Добрий день! Як ___ звати?", "answer": "вас", "options": ["вас", "тебе", "я"]}, {"sentence": "Дуже ___!", "answer": "приємно", "options": ["приємно", "Київ", "студентка"]}, {"sentence": "___ ти? Я з Канади.", "answer": "Звідки", "options": ["Звідки", "Хто", "Що"]}]`)} />
 
-### Choose the Ukrainian norm
+### Обери українську норму
 
-<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Це мій ___.", "answer": "тато", "options": ["тато", "Russian-influenced dad word"]}, {"sentence": "Це моя ___ Марія.", "answer": "дружина", "options": ["дружина", "Russian-influenced wife word"]}, {"sentence": "___, як вас звати?", "answer": "Вибачте", "options": ["Вибачте", "Russian-influenced excuse-me word"]}, {"sentence": "___, дуже приємно!", "answer": "Дякую", "options": ["Дякую", "Russian-style thank-you word"]}, {"sentence": "Мені ___ приємно.", "answer": "теж", "options": ["теж", "Russian-style also word"]}, {"sentence": "Оксана — ___.", "answer": "інженерка", "options": ["інженерка", "masculine generic for a woman"]}]`)} />
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Це мій ___.", "answer": "тато", "options": ["тато", "не наш A1-вибір для тата"]}, {"sentence": "Це моя ___ Марія.", "answer": "дружина", "options": ["дружина", "неукраїнська форма для дружини"]}, {"sentence": "___, як вас звати?", "answer": "Вибачте", "options": ["Вибачте", "не наш A1-вибір для вибачення"]}, {"sentence": "___, дуже приємно!", "answer": "Дякую", "options": ["Дякую", "не наш A1-вибір для подяки"]}, {"sentence": "Мені ___ приємно.", "answer": "теж", "options": ["теж", "не наш A1-вибір для також"]}, {"sentence": "Оксана — ___.", "answer": "інженерка", "options": ["інженерка", "чоловіча форма для жінки"]}]`)} />
 
-### First-contact vocabulary
+### Лексика знайомства
 
-<Translate client:only='react' questions={JSON.parse(`[{"source": "Мене звати...", "options": [{"text": "My name is...", "correct": true}, {"text": "Where are you from?", "correct": false}, {"text": "This is...", "correct": false}], "explanation": "Мене звати... is the name chunk."}, {"source": "Як тебе звати?", "options": [{"text": "What is your name? informal", "correct": true}, {"text": "Who is this?", "correct": false}, {"text": "I am from Ukraine.", "correct": false}], "explanation": "Тебе marks the informal version."}, {"source": "Як вас звати?", "options": [{"text": "What is your name? formal", "correct": true}, {"text": "And yours? informal", "correct": false}, {"text": "This is Kyiv.", "correct": false}], "explanation": "Вас marks the formal version."}, {"source": "Дуже приємно!", "options": [{"text": "Pleased to meet you!", "correct": true}, {"text": "Goodbye!", "correct": false}, {"text": "Where from?", "correct": false}], "explanation": "Дуже приємно closes the introduction politely."}, {"source": "Звідки ти?", "options": [{"text": "Where are you from? informal", "correct": true}, {"text": "What is this?", "correct": false}, {"text": "I am a student.", "correct": false}], "explanation": "Звідки asks from where."}, {"source": "Я — студентка.", "options": [{"text": "I am a female student.", "correct": true}, {"text": "She is a doctor.", "correct": false}, {"text": "My name is...", "correct": false}], "explanation": "Студентка is the feminine form."}]`)} />
+<Translate client:only='react' questions={JSON.parse(`[{"source": "Мене звати...", "options": [{"text": "My name is...", "correct": true}, {"text": "Where are you from?", "correct": false}, {"text": "This is...", "correct": false}], "explanation": "Мене звати... — блок для імені."}, {"source": "Як тебе звати?", "options": [{"text": "What is your name? informal", "correct": true}, {"text": "Who is this?", "correct": false}, {"text": "I am from Ukraine.", "correct": false}], "explanation": "Тебе позначає неформальну версію."}, {"source": "Як вас звати?", "options": [{"text": "What is your name? formal", "correct": true}, {"text": "And yours? informal", "correct": false}, {"text": "This is Kyiv.", "correct": false}], "explanation": "Вас позначає формальну версію."}, {"source": "Дуже приємно!", "options": [{"text": "Pleased to meet you!", "correct": true}, {"text": "Goodbye!", "correct": false}, {"text": "Where from?", "correct": false}], "explanation": "Дуже приємно ввічливо завершує представлення."}, {"source": "Звідки ти?", "options": [{"text": "Where are you from? informal", "correct": true}, {"text": "What is this?", "correct": false}, {"text": "I am a student.", "correct": false}], "explanation": "Звідки питає про походження."}, {"source": "Я — студентка.", "options": [{"text": "I am a female student.", "correct": true}, {"text": "She is a doctor.", "correct": false}, {"text": "My name is...", "correct": false}], "explanation": "Студентка — жіноча форма."}]`)} />
 
 </TabItem>
 <TabItem label="Resources">


### PR DESCRIPTION
## Summary
- regenerate the stale A1.1 published MDX files from source
- clarify English-support labels after Ukrainian dialogue/text/chat blocks in the matching sources
- move two activity markers so regenerated headings stay markdownlint-clean
- remove the remaining inline `<DialogueBox ... />` blocks from A1 source/published lesson content

## Notes
- No generated status/audit/review artifacts or linter config files are included.
- The diff stays under the 20-file PR limit.

## Validation
- `npx markdownlint-cli2 curriculum/l2-uk-en/a1/checkpoint-first-contact/module.md curriculum/l2-uk-en/a1/stress-and-melody/module.md curriculum/l2-uk-en/a1/sounds-letters-and-hello/module.md curriculum/l2-uk-en/a1/my-family/module.md curriculum/l2-uk-en/a1/who-am-i/module.md starlight/src/content/docs/a1/checkpoint-first-contact.mdx starlight/src/content/docs/a1/my-family.mdx starlight/src/content/docs/a1/sounds-letters-and-hello.mdx starlight/src/content/docs/a1/stress-and-melody.mdx starlight/src/content/docs/a1/who-am-i.mdx`
- `.venv/bin/python scripts/audit/check_mdx_source_parity.py --changed-vs-base origin/main`
- `.venv/bin/python scripts/audit/check_mdx_generation_drift.py --files curriculum/l2-uk-en/a1/sounds-letters-and-hello/module.md curriculum/l2-uk-en/a1/stress-and-melody/module.md curriculum/l2-uk-en/a1/who-am-i/module.md curriculum/l2-uk-en/a1/my-family/module.md curriculum/l2-uk-en/a1/checkpoint-first-contact/module.md`
- `git diff --check`
- `npm run build:starlight`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `rg -n '<DialogueBox' curriculum/l2-uk-en/a1 --glob 'module.md' starlight/src/content/docs/a1` (no matches)
- `rg -n 'Support after'` across changed source/MDX (no matches)
- Gemini diff review: APPROVE
- read-only explorer review: APPROVE

X-Agent: codex/2824-a1-mdx-drift-cleanup
