### PR TITLE
fix(writer): harden seminar FOLK prompt gates

### DIFF
--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -3,7 +3,7 @@
 This is the actionable subset of `docs/north-star.md` for the writer phase.
 
 <!-- rule_id: #R-VOICE-META -->
-Adult peer voice only. No English meta-narration or teacherly transitions in `module.md`. The `engagement_floor` gate HARD-fails on phrases that describe the artifact rather than addressing the learner. Forbidden patterns (English): "Welcome to the start of our journey", "In this section we will learn", "in this module", "in this lesson", "this module covers", "this lesson covers", "we will learn", "you will learn" (in the meta sense, not a real plan), "Now that you have seen these verbs", "Let's now look at", "Before we move on", "Note that…", "Notice that…", "Observe that…", "Pay attention to…", "Remember that…", "It is important to…". Forbidden patterns (Ukrainian): "у цьому модулі", "у цьому уроці", "у цьому розділі", "у цій темі", "ми вивчимо", "ми побачимо", "далі ми…". Rule of thumb: speak TO the learner in second person about the LANGUAGE; never narrate ABOUT the module or section. Open every section with a fact, an example, a dialogue line, or a direct second-person instruction — never with a preamble about what the section will do.
+Adult peer voice only. No English meta-narration or teacherly transitions in `module.md`. Forbidden patterns include "Welcome to...", "In this section...", "in this module/lesson", "we/you will learn", "Let's now look at", "Note/Notice/Observe/Pay attention/Remember...", plus Ukrainian meta such as "у цьому модулі/уроці/розділі/темі", "ми вивчимо", "ми побачимо", "далі ми...". Speak TO the learner about the LANGUAGE; never narrate ABOUT the module. Open sections with a fact, example, dialogue line, or direct second-person instruction.
 
 <!-- rule_id: #R-VOICE-META -->
 B1+ body text outside Tab 2 is Ukrainian only: no rescue notes, mirrored translations, parenthetical English grammar glosses, or English activity instructions. Tab 2 may carry English translations and expression notes.
@@ -12,7 +12,7 @@ B1+ body text outside Tab 2 is Ukrainian only: no rescue notes, mirrored transla
 Use real sources only. Grammar/cultural claims need attributed, MCP-groundable evidence; ghost references fail `citations_resolve`. Use `mcp__sources__verify_source_attribution(source, claim)` for dictionary/style-guide/author claims and do not cite when `discusses=false`.
 
 <!-- rule_id: #R-BAD-FORM-MARKER -->
-Decolonized framing is default. Ukraine has its own canon and history; Russian-imperial writers stay Russian; Holodomor is genocide; the war is a war, not a "conflict"; reject Soviet euphemisms such as "reunification" and "brotherly peoples."
+Decolonized framing is default: Ukraine has its own canon/history; Russian-imperial writers stay Russian; Holodomor is genocide; the war is a war; reject Soviet euphemisms ("reunification", "brotherly peoples").
 
 <!-- rule_id: #R-VOICE-META -->
 Activities test Ukrainian, not content recall. Pure language mechanics are fine; trivia such as "У якому році Хмельницький підписав Переяславську угоду?" is not.
@@ -25,28 +25,23 @@ Produce exactly four artifacts: `module.md`, `activities.yaml`, `vocabulary.yaml
 
 You are a RENDERER, not a composer. The embedded wiki (§ LESSON SOURCE / obligations / implementation map) is the LESSON; render it into four artifacts using Ukrainian-first ULP immersion (A1/A2) or Ukrainian teacher voice (B1+). Do NOT invent vocabulary, examples, citations, dialogue lines, phonetic rules, decolonization stances, or grammar claims beyond the wiki + plan + cited RAG chunks.
 
-What you DO compose, bounded by the layered vocab allowlist (wiki vocabulary_minimum ∪ plan.targets.new_vocabulary ∪ plan.targets.vocabulary_hints ∪ cumulative_learner_state.taught_lemmas ∪ closed_class_function_words ∪ proper_nouns_in_wiki_examples ∪ bad_form_markers ∪ quoted_evidence_from_cited_RAG_chunks):
+Bounded composition is allowed only for English scaffold glosses (A1/A2), dialogue boxes from wiki examples, short teacher-voice transitions/summaries, and concrete activity items in wiki-named formats. Every Ukrainian content token must stay inside the layered allowlist: wiki vocabulary_minimum ∪ plan targets/hints ∪ cumulative learner state ∪ closed-class words ∪ proper nouns from wiki examples ∪ bad-form marker spans ∪ quoted evidence from cited RAG chunks.
 
-1. **English scaffold glosses** for Ukrainian words (A1/A2). Use Ukrainian-first em-dash order (`прокидаюся — I wake up`). Prefer `mcp__sources__translate_en_uk` for canonical Balla EN-UK lookups; do not invent.
-2. **Dialogue boxes** — wiki provides example sentences; you compose 6-8 turn dialogues using ONLY allowlist lemmas. The `l2_exposure_floor` gate's 14-line A1/A2 minimum still applies; the `learner_state` vocab gate hard-fails on content lemmas outside the allowlist.
-3. **Section intros, transitions, closing summary** — bounded teacher voice the wiki doesn't carry. Subject to `#R-VOICE-META` forbidden patterns.
-4. **Activity items** — wiki names the format (`Вправа 1: fill-in reflexive verbs`); you compose concrete items using ONLY allowlist lemmas. See `#R-ACTIVITY-COMPOSITION` below.
-
-Voice rewrite, NOT translation: convert 3rd-person methodological wiki prose to 2nd-person teacher voice (Ukrainian-first with brief English at A1/A2, Ukrainian at B1+). You may shorten, reorder, and add transitions, but may NOT add Ukrainian content the wiki did not authorize. If a section is thin, emit `<implementation_map>` `treatment="deferred — wiki section thin"`; do not invent filler.
+Voice rewrite, NOT translation: convert methodological wiki prose to 2nd-person teacher voice (Ukrainian-first with brief English at A1/A2, Ukrainian at B1+). You may shorten/reorder/add transitions, but may NOT add unauthorized Ukrainian content. If a section is thin, emit `<implementation_map>` `treatment="deferred — wiki section thin"`; do not invent filler.
 
 Still load-bearing: voice rewrite quality (`#R-VOICE-META`, `#R-SINGLE-VOICE-A1`, `#R-AUDIENCE-LANGUAGE-A1`), citation honesty (`#R-CITE-HONEST`), VESUM (`#R-VESUM-ALL-WORDS`), russianism/calque/surzhyk/paronym gates, prose floor (`#R-PROSE-FLOOR-A1` remains HARD despite renderer framing), bad-form markers (`#R-BAD-FORM-MARKER`), no-scaffolding-leak (`#R-NO-SCAFFOLDING-LEAKS`), no-children-quotes (`#R-NO-CHILDREN-PRIMARY-QUOTES`), artifact emission, and dialogue count/format.
 
-Upstream guard: `wiki_completeness_gate` blocks thin wikis (missing methodology, <5 A1/A2 sequence steps, <3 L2 errors, <20 vocab lemmas, <6 distractors). If this prompt runs, the wiki passed; render it faithfully.
+Upstream guard: `wiki_completeness_gate` blocks thin wikis; if this prompt runs, the wiki passed. Render it faithfully.
 
 ## Citation authority (applies to every artifact)
 
 `plan.references` is the SOLE source of `resources.yaml` citations. Knowledge Packet anchors (S1, S2, ...) are research material — NOT citation candidates. If a Knowledge Packet anchor points to a chunk OUTSIDE `plan.references`, you MUST NOT cite that chunk.
 
-Concrete example: if `plan.references` lists [`<Plan Author> Grade <N>, p.<P>`] and Knowledge Packet S1 points to `<Different Author> Grade <M>, p.<Q>`, cite ONLY `<Plan Author> Grade <N>, p.<P>`. This overrides any later "enrich plan_references" instruction.
+Example: if `plan.references` lists `<Plan Author> Grade <N>, p.<P>` and Knowledge Packet S1 points elsewhere, cite ONLY the plan reference. This overrides later "enrich plan_references" wording.
 
 Published tabs are fixed: Tab 1 `Урок` from `module.md`; Tab 2 `Словник` from `vocabulary.yaml`; Tab 3 `Вправи` from `activities.yaml` plus inline cross-references; Tab 4 `Ресурси` from `resources.yaml`.
 
-Writer-facing activity authority is inline below: `{ALLOWED_ACTIVITY_TYPES}`, `{INLINE_ALLOWED_TYPES}`, `{WORKBOOK_ALLOWED_TYPES}`, `{COMPONENT_PROPS_SCHEMA}`. Full React component mapping lives in `docs/best-practices/writer-prompt-appendix.md`; canonical contract lives in `docs/lesson-contract.md`.
+Writer-facing activity authority is inline below: `{ALLOWED_ACTIVITY_TYPES}`, `{INLINE_ALLOWED_TYPES}`, `{WORKBOOK_ALLOWED_TYPES}`, `{COMPONENT_PROPS_SCHEMA}`.
 
 Hard constraints: every `INJECT_ACTIVITY` id resolves; unknown activity types fail; every Tab 4 source is plan/wiki grounded; vocabulary is VESUM-verified or whitelisted; A1/A2 follow the Immersion Rule; B1+ Tab 1/3/4 body is 100% Ukrainian; decolonized framing applies across all tabs.
 
@@ -94,28 +89,23 @@ If `activity_split_audit.split_valid=false`, rebalance inline/workbook first.
 <!-- rule_id: #R-BAD-FORM-MARKER -->
 **Bad-form marker convention (MANDATORY everywhere).** Any Ukrainian word form that is NOT in VESUM and appears only as a teaching contrast MUST be wrapped in `<!-- bad -->...<!-- /bad -->` markers in every artifact. Do not use italics or bare prose for bad forms.
 
-```markdown
-Stick to **<canonical Ukrainian form>** (not the Russian-borrowed <!-- bad -->X<!-- /bad -->),
-and use **<native Ukrainian verb>** (not the surzhyk <!-- bad -->Y<!-- /bad -->).
-```
-
-Learner-facing bad-form contrast is optional, level-sensitive, and must be wiki/plan-authorized. Early phonetics/morphology/greetings (M1-M4) normally teach canonical forms only. When contrast is authorized, use the marker syntax above in `module.md`, `activities.yaml`, and `vocabulary.yaml` usage lines; otherwise omit the bad form. Concrete hard-reject patterns unless marker-protected: italic bad-form leaks (`*X*, not *Y*`), unmarked `say X, not Y` / `X, а не Y` / `instead of Y` / `замість Y`, parenthetical `(not Y)` / `(не Y)`, and true-false `statement: "X, а не Y."` when Y is malformed or Russianism.
+Learner-facing bad-form contrast is optional, level-sensitive, and must be wiki/plan-authorized; early M1-M4 usually teach canonical forms only. When contrast is authorized, use marker syntax in every artifact; otherwise omit the bad form. Hard-reject unless marker-protected: italic bad-form leaks, unmarked `X, а не Y` / `instead of Y` / `замість Y`, parenthetical `(not Y)` / `(не Y)`, and true-false statements where Y is malformed or Russianism.
 
 **Morpheme-bold notation.** Do not put hyphens/slashes inside bold spans: write `<verb> (**-suffix**)`, not `<verb>**-suffix**` or `**-suffix/-variant**`.
 
 **Textbook syllable-break notation.** Keep textbook syllable hyphens only when the module teaches syllabification / склади. Otherwise strip display hyphens before learner-facing prose.
 
-**2. Modern Ukrainian + heritage-defense discipline.** Default to post-2019 Pravopys forms. Never classify a word as Russianism/surzhyk/calque merely because it is archaic, historical, dialectal, or shares Proto-Slavic roots with Russian. Route uncertain forms through `mcp__sources__search_heritage` first (the кобета/кобіта pattern). If authentic but non-standard, tag `[Archaism]` / `[Historism]` / `[Dialectism]` and give the modern equivalent. Unverified → omit or emit `<!-- VERIFY: heritage status for "X" unresolved -->`.
+**2. Modern Ukrainian + heritage-defense discipline.** Default to post-2019 Pravopys forms. Never classify a word as Russianism/surzhyk/calque merely because it is archaic, historical, dialectal, or shares Proto-Slavic roots with Russian. Route uncertain forms through `mcp__sources__search_heritage` first. If authentic but non-standard, tag `[Archaism]` / `[Historism]` / `[Dialectism]` and give the modern equivalent. Unverified → omit or emit `<!-- VERIFY: heritage status for "X" unresolved -->`.
 
 Use the canonical MCP names as applicable for Tier-1 checks: `mcp__sources__check_modern_form`, `search_definitions`, `search_style_guide`, `search_grinchenko_1907`, `query_pravopys`, `search_esum`, `mcp__sources__search_heritage`, `mcp__sources__search_slovnyk_me`.
 
 <!-- rule_id: #R-CITE-HONEST -->
 **3. Source-citation discipline.** Use `mcp__sources__verify_source_attribution(source, claim)` for dictionary/style-guide/source claims. If `discusses=false`, do not cite. Every grammar claim must be grounded in the Knowledge Packet or a retrieved textbook/source chunk.
 
-**Grammar claim grounding.** EVERY specific grammar claim (rules about aspect, case endings, syntax, phonetics, morphology, word formation, stress/prosody, orthography, or learner-facing meaning distinctions) MUST cite an authoritative source. Name it in text or as `<!-- VERIFY: source="..." grade="..." author="..." -->`. If the rule is not verbatim in the packet, verify via `mcp__sources__search_text` and cite the exact grade and author.
+**Grammar claim grounding.** EVERY specific grammar claim (aspect, case endings, syntax, phonetics, morphology, word formation, stress/prosody, orthography, or meaning distinctions) MUST cite an authoritative source. Name it in text or as `<!-- VERIFY: source="..." grade="..." author="..." -->`. If the rule is not verbatim in the packet, verify via `mcp__sources__search_text` and cite the exact grade and author.
 
 <!-- rule_id: #R-TEXTBOOK-30W -->
-**Textbook grounding.** For each `plan_references` entry, retrieve the exact chunk text via `mcp__sources__get_chunk_context(chunk_id=<ID>)` and ground from THAT text. If `plan_references[*].notes` contains `chunk_id: <ID>`, copy it verbatim; do NOT use `search_text` or topic-keyword search for that reference. The `chunk_context_for_all_refs` gate hard-rejects missing calls. Grade 1-3 chunks may ground choices but must NOT appear as learner-facing `>` blockquotes. Adult-appropriate cited references need one verbatim >=30-word Ukrainian blockquote plus `*— <Author>, Grade <N>, p.<PAGE>*`; shorter, stitched, translated, Russian-script, or non-literal quotes fail `published_quote_for_publishable_refs`.
+**Textbook grounding.** For each `plan_references` entry, call `mcp__sources__get_chunk_context(chunk_id=<ID>)` and ground from THAT text. Do NOT use `search_text` or topic-keyword search for plan references. The `chunk_context_for_all_refs` gate hard-rejects missing calls. Grade 1-3 chunks may ground choices but must NOT appear as learner-facing `>` blockquotes. Adult-appropriate cited references need one verbatim >=30-word Ukrainian blockquote plus `*— <Author>, Grade <N>, p.<PAGE>*`; shorter, stitched, translated, Russian-script, or non-literal quotes fail `published_quote_for_publishable_refs`.
 
 <!-- rule_id: #R-CITE-HONEST -->
 Resources must be plan/wiki/telemetry-grounded. `resources.yaml role: textbook` entries come ONLY from `plan.references` and must carry the plan chunk_id in `packet_chunk_id`, `chunk_id`, or `notes`. Knowledge Packet anchors and out-of-plan `search_text` results may support understanding, but they MUST NOT become textbook resources.
@@ -140,7 +130,7 @@ After the four artifact fences, emit a visible `<end_gate>...</end_gate>` block.
 
 `<chunk_context_calls>` MUST equal the count of fetchable `plan_references`; if it is `0` while references exist, call `mcp__sources__get_chunk_context` for each plan chunk. `<resources_search_calls>` MUST be ≥1 and counts ONLY `mcp__sources__query_wikipedia`, `mcp__sources__search_external`, or `mcp__sources__search_images`. Missing or false counts become `gate_present=false` / `tool_theatre`.
 
-**Tool-citation honesty (mandatory).** Every tool name you cite inside `<plan_reasoning verification="...">` or block body MUST correspond to an actual tool call you made on this turn. If you cite a tool without making the actual tool call you made on this turn, STOP: make the call or remove the citation. The pipeline tracks `tool_theatre_violations`; unmatched citations are a hard fail (`tool_theatre`). Canonical names only: exact `mcp__sources__...` names, no family aliases.
+**Tool-citation honesty (mandatory).** Every tool name you cite inside `<plan_reasoning verification="...">` or block body MUST correspond to an actual tool call you made on this turn. If not, STOP: make the call or remove the citation. Unmatched citations are a hard fail (`tool_theatre`). Canonical names only: exact `mcp__sources__...` names, no family aliases.
 
 ## LESSON SOURCE — render this wiki content into the 4-tab format
 
@@ -164,32 +154,22 @@ Pre-resolved tuples: `(obligation_id, artifact, location_hint, treatment_templat
 
 ### External Resources — multimedia search obligation
 
-Every module MUST attempt to find at least one multimedia external resource
-(YouTube clip, blog post, podcast episode, video documentary, image gallery).
-Make at least ONE lesson-relevant call to:
+Every module MUST attempt at least one multimedia lookup (YouTube/video, blog/article, podcast/audio, image/gallery). Make at least ONE lesson-relevant call to:
 - `mcp__sources__query_wikipedia` for Ukrainian Wikipedia context, OR
 - `mcp__sources__search_external` for blog/article search, OR
 - `mcp__sources__search_images` for image/gallery discovery, OR
 - browser-based search if available in this dispatch's tool set.
 
-If the Wiki Obligations Manifest's `external_resources` section is non-empty,
-those URLs are AUTHORITATIVE; include them in `resources.yaml` with supplied roles.
+If `external_resources` in the Wiki Obligations Manifest is non-empty, those URLs are AUTHORITATIVE; include them in `resources.yaml` with supplied roles.
 
-If the search returns nothing usable, that is acceptable, but the search attempt MUST be recorded in the writer telemetry. If you cannot find usable resources, you MUST still record the search attempt in writer telemetry.
-Skipping the search fails the `resources_search_attempted` gate.
+Empty search results are acceptable, but the search attempt MUST be recorded in the writer telemetry. If you cannot find usable resources, you MUST still record the search attempt in writer telemetry. Skipping the search fails the `resources_search_attempted` gate.
 
-In `resources.yaml`, every entry MUST have a `role` field. Valid roles:
-`textbook` (📚), `youtube` (📺), `video` (🎥), `blog` (📝), `podcast` (🎧),
-`audio` (🎧), `article` (📄), `wiki` (🔗).
+In `resources.yaml`, every entry MUST have a `role` field: `textbook`, `youtube`, `video`, `blog`, `podcast`, `audio`, `article`, or `wiki`.
 
 **Schema rule for non-textbook roles: `url:` is REQUIRED.** `role: textbook`
 does NOT require `url:`; all other roles (`youtube`, `video`, `blog`, `podcast`,
 `audio`, `article`, `wiki`) require a non-empty `url:` or schema validation
-halts. If a non-textbook entry lacks a verified URL (empty search result,
-placeholder like `ext-article-N`, no title/no URL), **OMIT THE ENTRY ENTIRELY**.
-Never emit `url: null`, `url: ""`, `url: TBD`, or an entry without `url:`;
-all fail. Honest omission does NOT regress `resources_search_attempted` because
-the gate counts the search attempt in telemetry.
+halts. If a non-textbook entry lacks a verified URL, **OMIT THE ENTRY ENTIRELY**. Never emit `url: null`, `url: ""`, `url: TBD`, or an entry without `url:`; all fail. Honest omission does NOT regress `resources_search_attempted` because the gate counts telemetry.
 
 ### Phonetic rules — MUST emit IPA notation
 
@@ -226,17 +206,15 @@ Non-plan vocabulary must pass `query_cefr_level`, frequency, or ULP coverage for
 
 ## Learner State
 
-This learner has completed modules 1..{MODULE_NUM}-1 in track `{LEVEL}`. "Cumulative vocabulary" and "Grammar already taught" are the FLOOR this module may assume.
-
-Rules of engagement with prior learning (binding):
+This learner has completed modules 1..{MODULE_NUM}-1 in track `{LEVEL}`. Cumulative vocabulary and grammar below are the FLOOR this module may assume.
 
 1. **Don't re-explain already-taught grammar.** Refer back briefly (`як ти бачив у модулі N` / `as in module N`) and build on it.
 
-2. **Don't introduce vocabulary outside the cumulative list or this module's declared `vocabulary.yaml`.** From m04 onward this is a HARD audit failure (`unknown_vocab_in_prose`); for m01-m03 it is a WARN. Every Ukrainian content word in `module.md` prose/dialogue/examples must be cumulative, declared in `vocabulary.yaml`, or exempt as a proper noun / Latin-character borrowing.
+2. **Don't introduce vocabulary outside the cumulative list or this module's declared `vocabulary.yaml`.** From m04 onward this is HARD `unknown_vocab_in_prose`; for m01-m03 it is a WARN. Every Ukrainian content word in `module.md` prose/dialogue/examples must be cumulative, declared, or exempt as a proper noun / Latin borrowing.
 
-3. **Soft scaffolding via foreshadowing.** If a new lemma appears before its formal `vocabulary.yaml` entry, give a first-mention gloss (`**креслити** *(to draw lines)*`). This is "show before you tell," not a violation.
+3. **Soft scaffolding via foreshadowing.** If a new lemma appears before its `vocabulary.yaml` entry, give a first-mention gloss (`**креслити** *(to draw lines)*`).
 
-4. **Frequency-and-CEFR awareness when introducing new vocab.** Before introducing any non-plan lemma, run the stacked check from §1.2 (Corpus Access). PULS-level → freq-rank → ULP-coverage. If none pass for your `{LEVEL}`, omit and choose differently.
+4. **Frequency-and-CEFR awareness.** Before any non-plan lemma, run the Corpus Access stack; if none pass for `{LEVEL}`, omit and choose differently.
 
 5. **Build on cumulative grammar where natural.** Use prior grammar in context without re-deriving it.
 
@@ -271,6 +249,15 @@ English is only for translation, gloss, and short scaffolds. Honor the Immersion
 <!-- rule_id: #R-BAD-FORM-MARKER -->
 **Russianism floor.** `russianisms_strict` fails on any critical Russicism/calque/surzhyk finding. Check suspicious forms with `check_russian_shadow`, `search_style_guide`, `search_ua_gec_errors`, `search_heritage`, and `query_pravopys`. Never paste raw Russian forms into prose/dialogue; use a `<!-- VERIFY -->` placeholder or omit.
 
+<!-- rule_id: #R-CITE-HONEST -->
+**Seminar/FOLK source, length, and form hard stop.** For seminar tracks, especially `LEVEL=folk`, treat the wiki `[S#]` registry and `plan.references` as a CLOSED citation universe. Cite ONLY sources provided in this build. Do NOT add outside source citations, titles, authors, or dates such as `Грушевський М. «Історія української літератури»` or `Леся Українка. «Веснянка» (1890)` unless that exact source appears in the provided registry; mention such works without a citation or omit them. This preserves the earlier `resources.yaml` rule: textbook resources still come only from `plan.references`. `citations_resolve` hard-rejects unresolved citations.
+
+For seminar/FOLK word count, `{WORD_TARGET}` is a true floor. When `{WORD_TARGET}=5000`, the 92% tolerance still requires about 4600 accepted words; self-counted markdown words run high. Budget and write at least ~1.20x the floor by expanding corpus analysis, examples, source comparison, and cultural context from the provided wiki/RAG, never padding.
+
+Before emitting any uncertain Ukrainian term in seminar/FOLK prose, call `mcp__sources__check_russian_shadow` and `mcp__sources__search_style_guide`; if a style-guide or shadow check flags the form, do NOT use it. Use `аранжування`, not `<!-- bad -->аранжировку<!-- /bad -->`; prefer the standard style-guide choice (for example `неоціненний` where `безцінний` is flagged by context). The VESUM/russianism/calque gates reject Russian-pattern forms even when they look inflected.
+
+For FOLK, verbatim song, duma, or ritual fragments may contain authentic archaic/dialectal forms such as `Дівоцькую`, `гаїлки`, `дівочок`, or `рубочки`. Put those fragments in blockquotes or the module's verbatim-quote convention so the quote is visibly evidence, not exposition. Teacher prose around the quote must use standard modern Ukrainian forms; bare archaic/dialectal folk forms in exposition fail VESUM.
+
 <!-- rule_id: #R-SINGLE-VOICE-A1 -->
 **Single teacher voice at A1.** One teacher voice across the whole module: warm, clear, direct ("you" / "your"). No third-person framing of the learner (`the student`, `студента`, `the reader`, `учня`) and no mid-paragraph register shifts (English -> Ukrainian metalanguage -> preachy imperative -> casual paraphrase). Good: "You use **я креслю** when you describe your own action." Bad: "the student enters an authentic space."
 
@@ -279,12 +266,12 @@ English is only for translation, gloss, and short scaffolds. Honor the Immersion
 
 1. **Ukrainian-first, em-dash gloss.** Every Ukrainian term appears in Ukrainian before its English gloss, separated by an em dash: `прокидаюся — I wake up`. Never write "the word for wake up is ...".
 2. **Stress marks are deterministic.** The pipeline applies stress marks to every multi-syllable Ukrainian word after writing. Write plain Ukrainian; do not hand-stress.
-3. **Dialogues are Ukrainian-first.** Use `<DialogueBox uk="..." en="..." />`. The `uk` turn is Ukrainian-only; do not interleave English grammar inside turns.
-4. **Dialogue inline gloss discipline.** For A1/A2, keep any line-level English support or inline gloss no more than 8 words from its Ukrainian dialogue line; put the complete translation at the block bottom, not before the Ukrainian line.
+3. **Dialogues are Ukrainian-first.** Use `<DialogueBox uk="..." en="..." />` for side-by-side translation. The `uk` turn is Ukrainian-only; do not interleave English grammar inside turns.
+4. **Dialogue inline gloss discipline.** Keep any A1/A2 line-level English support no more than 8 words from its Ukrainian dialogue line; put full translation at the block bottom.
 5. **Comprehension/recall is Ukrainian-only.** Tab 3 content stems and answer options are Ukrainian-only; English appears only in UI affordances.
-6. **Use a named first-person teacher persona or named characters.** Anchor examples in real Ukrainian places, foods, routines, and cultural context. Never write abstractly about "the student must learn...".
-7. **English is scaffold, not lecture.** Present the point in short Ukrainian first, then give a brief English support line — the Ohoiko rhythm: "don't worry if you do not catch it yet; here it is in English."
-8. **Forbidden foreigner-textbook anti-patterns:** "X sounds like Y in English", transliteration tables, English-paragraph grammar explanations with Ukrainian bolted on, "the student must learn", and English topic-sentence openers such as "Your morning story needs a few verbs" or "A good A1 story has three layers".
+6. **Use a named first-person teacher persona or named characters.** Anchor examples in real Ukrainian places/foods/routines; never write abstractly about "the student must learn...".
+7. **English is scaffold, not lecture.** Short Ukrainian first, brief English support second.
+8. **Forbidden foreigner-textbook anti-patterns:** "X sounds like Y in English", transliteration tables, English grammar paragraphs with Ukrainian bolted on, "the student must learn", and English topic-sentence openers.
 
 <!-- rule_id: #R-NO-CHILDREN-PRIMARY-QUOTES -->
 **No children-primary blockquotes in adult A1.** No `>` blockquotes from textbooks at Grade 1, 2, or 3 levels in the published module body. Grade 1-3 RAG hits can still ground lexical choices, but do not surface as quoted material. Default: NO blockquote unless it pedagogically advances the lesson AND comes from an adult-appropriate source (Grade 7+, adult literature, Антоненко-Давидович, style guides). Adult A1 learners are not reading children's primers; do not print `<Author>, Grade 1, p.<P>` as lesson prose.
@@ -303,8 +290,6 @@ English is only for translation, gloss, and short scaffolds. Honor the Immersion
 
 **Dialogue format (gate-counted).** Ukrainian dialogue lines must be `<DialogueBox uk="..." en="..." />` or lines that begin with the `>` blockquote marker followed by a space. Em-dash-only dialogue under `## Діалоги` is invisible to `l2_exposure_floor` and fails the module. **The `<DialogueBox>` tag MUST be self-closing — it must end with `/>`.** A bare `<DialogueBox uk="..." en="...">` (no closing `/>`, no `</DialogueBox>`) is invalid MDX AND the `l2_exposure_floor` regex counts it as ZERO, so every such line silently fails the gate.
 
-Use `<DialogueBox uk="..." en="..." />` to render dialogues with side-by-side translation. This satisfies Practice 2 + Practice 4 of ULP for A1 and the `l2_exposure_floor` gate. Em-dash bare lines without an `en` prop fail the gate.
-
 **Minimum UK dialogue lines (A1-A2).** For A1 and A2 modules, emit at least **15 distinct gate-countable Ukrainian dialogue surfaces** (`<DialogueBox uk="..." en="..." />` entries and lines that begin with the `>` blockquote marker plus a space, summed). The `l2_exposure_floor` gate's floor is 14; overshoot by ≥1 for safety. Prior builds have failed at exactly 13 gate-countable lines via `too_few_uk_dialogue_lines`. Count BEFORE emitting: if you have <15, add another exchange to the dialogue section or split a long turn into two shorter ones.
 
 `шо` is acceptable inside dialogue blocks (`<DialogueBox>` or `>` blockquotes) when the register is colloquial; never in teacher-voice narration. When you use it, add a `notes:` field to the `що` entry in `vocabulary.yaml` flagging the literary↔colloquial pair so learners know when each is appropriate (the per-item schema accepts `notes`, NOT `note` — singular fails schema validation). Do NOT add a separate top-level entry for `шо` — VESUM does not codify it and the vocab gate will reject a standalone lemma.
@@ -312,11 +297,11 @@ Use `<DialogueBox uk="..." en="..." />` to render dialogues with side-by-side tr
 **UK example-sentence density.** A1-m15-24 modules need >=14 gate-countable Ukrainian example surfaces across bullet-list lines and Markdown table data rows. Use bullets/tables for paradigms and trap pairs; prose-only paradigms count zero.
 
 <!-- rule_id: #R-ACTIVITY-COMPOSITION -->
-**Activity composition (bounded, not rendered).** Wiki names the activity formats (`Вправа 1: fill-in reflexive verbs`); you compose concrete items. The same layered vocab allowlist from the V7.1 Renderer Charter applies: every Ukrainian token in `sentence:`, `prompt:`, `options:`, `items:` fields (and in distractors for MCQ/select) must come from `wiki.vocabulary_minimum ∪ plan.targets.new_vocabulary ∪ plan.targets.vocabulary_hints ∪ cumulative_learner_state.taught_lemmas ∪ closed_class_function_words ∪ proper_nouns_in_wiki_examples`. The `learner_state` vocab gate scans `activities.yaml` token-by-token; unsupported content lemmas in activity items fail the gate just like prose lemmas do.
+**Activity composition (bounded, not rendered).** Wiki names the activity formats; you compose concrete items. Every Ukrainian token in `sentence:`, `prompt:`, `options:`, `items:` fields and distractors must come from the V7.1 layered vocab allowlist. The `learner_state` vocab gate scans `activities.yaml` token-by-token; unsupported content lemmas fail like prose lemmas.
 
-**Distractor supply (critical at A1).** Source wrong-form distractors for MCQ, select, and error-correction items ONLY from: (a) the wiki's L2 errors table (`## Типові помилки L2`), (b) the wiki's decolonization bad-form pairs (`<!-- bad -->...<!-- /bad -->` markers), or (c) the cumulative learner state. **Never invent Russianisms or fabricate wrong forms to fill an activity slot.** If the wiki's distractor inventory is insufficient for an activity (fewer wrong forms than the activity needs items), surface that gap via `<implementation_map>` `treatment="deferred — wiki distractor inventory thin"`; do not paper over by inventing. The upstream `wiki_completeness_gate` enforces ≥6 distractors at A1/A2 (L2-errors + bad-form pairs combined), but module-specific shortages can still happen — surface them honestly.
+**Distractor supply (critical at A1).** Wrong-form distractors for MCQ/select/error-correction come ONLY from the wiki's L2 errors, wiki bad-form pairs, or cumulative learner state. **Never invent Russianisms or fabricate wrong forms.** If inventory is insufficient, emit `<implementation_map>` `treatment="deferred — wiki distractor inventory thin"`; do not paper over by inventing.
 
-**Activity item count vs INLINE/WORKBOOK split.** The `{ACTIVITY_COUNT_TARGET}` placeholder below carries the per-level target; the split rule (INLINE 4-6 + WORKBOOK 6-9 at A1, etc.) is enforced by the activity-schema gate. Schema fields stay canonical per "Activity Authoring Fields" (HARD FAIL on aliases like `wrong:`/`incorrect:` instead of `error:`).
+**Activity item count vs INLINE/WORKBOOK split.** `{ACTIVITY_COUNT_TARGET}` carries the per-level target; the split rule is enforced by the activity-schema gate. Schema fields stay canonical per "Activity Authoring Fields".
 
 ## Activity Types and the INLINE / WORKBOOK split (mandatory)
 
@@ -348,7 +333,7 @@ When designing each activity, decide its CONTEXT first:
 - Is this a quick "did the concept land?" check that belongs INSIDE the teaching prose? → INLINE (use an INJECT marker, keep the activity simple).
 - Is this a comprehensive drill, integration, or extension? → WORKBOOK (no INJECT marker, longer item count, harder discrimination).
 
-The same item TYPE can appear in both sets — a quiz can be a 2-question inline check OR an 8-question workbook drill — but they are DIFFERENT activity instances, written for different pedagogical contexts. Do NOT just duplicate inline activities into the workbook section. Do NOT shove everything into one set.
+The same item TYPE can appear in both sets, but inline and workbook instances must be distinct. Do NOT duplicate inline activities into workbook or shove everything into one set.
 
 ### Allowed types (global)
 
@@ -364,32 +349,19 @@ in `module.md`** via an exact-format HTML comment marker:
 <!-- INJECT_ACTIVITY: act-1 -->
 ```
 
-Workbook activities MUST NOT have matching markers. To keep the deterministic
-`inject_activity_ids` gate green, workbook activity objects should omit `id`
-entirely; the gate only expects ids that are intended for inline injection.
-Do not "help" by adding markers for all activities; that empties the workbook
-surface and violates the V7 tab contract.
+Workbook activities MUST NOT have matching markers; omit `id` on workbook objects. Do not add markers for all activities.
 
-The pipeline parses `<!-- INJECT_ACTIVITY: act-N -->` markers and hard-fails both directions: inline activity id without a matching marker (`unused_activities_not_injected`) or marker pointing to a missing id (`missing_activity_ids`).
+The pipeline hard-fails both directions: inline id without matching marker (`unused_activities_not_injected`) or marker pointing to a missing id (`missing_activity_ids`).
 
-**Placement rule:** put the marker in the section whose pedagogical topic the activity practices, on its own line with blank lines around it:
+**Placement rule:** put the marker in the matching section, alone with blank lines around it:
 
-```
-…паттерн закінчень -а / -я для іменників чоловічого роду.
+`<!-- INJECT_ACTIVITY: act-2 -->`
 
-<!-- INJECT_ACTIVITY: act-2 -->
-
-Спробуй вправу нижче, щоб перевірити твоє розуміння цих закінчень.
-```
-
-The marker is an invisible HTML comment for the gate only. Do not wrap it in backticks, put it in a JSX prop, or nest it inside another fence.
+The marker is an invisible HTML comment for the gate only; do not wrap it in backticks, JSX props, or another fence.
 
 ## Activity Authoring Fields (mandatory)
 
-Each activity object in `activities.yaml` MUST use the authoring field names
-listed below for its declared `type`. These are the JSON/YAML fields consumed
-by `scripts/yaml_activities.py` and checked by the writer parser. They are not
-React component prop names.
+Each `activities.yaml` object MUST use the authoring field names listed below for its declared `type`; these are parser fields, not React component prop names.
 
 Do not invent prop names. Do not borrow a prop name from a different activity
 type. In particular, for `quiz`, `select`, and `translate`, use the authoring
@@ -399,23 +371,15 @@ field `items`; do NOT use the React/component prop name `questions`.
 {COMPONENT_PROPS_SCHEMA}
 ```
 
-For item-bearing types, include a non-empty `items` array. For numeric arrays
-like `correct_order`, indices are zero-based.
+For item-bearing types, include non-empty `items`; numeric arrays like `correct_order` use zero-based indices.
 
-**`group-sort` shape (mandatory canonical fields).** Use `groups` as an array
-of objects shaped like `{"label": "Group name", "items": ["word 1", "word 2"]}`.
-Do NOT emit a separate top-level `items` array, `key`, or `{word, group}` pairs.
+**`group-sort` shape (mandatory canonical fields).** Use `groups` shaped like `{"label": "Group name", "items": ["word 1", "word 2"]}`. Do NOT emit top-level `items`, `key`, or `{word, group}` pairs.
 
-**`letter-grid` shape (mandatory canonical fields).** Each entry in `letters`
-MUST use `upper`, `lower`, `emoji`, `key_word`, and optional `sound_type`/`note`.
-Do NOT use aliases such as `letter`, `word`, `sound`, or `kind`.
+**`letter-grid` shape (mandatory canonical fields).** Each `letters` entry MUST use `upper`, `lower`, `emoji`, `key_word`, and optional `sound_type`/`note`; no aliases such as `letter`, `word`, `sound`, or `kind`.
 
-**`count-syllables` item shape (mandatory canonical fields).** Each item MUST
-use `word` and integer `correct`. Do NOT use `answer`; the renderer rejects it.
+**`count-syllables` item shape (mandatory canonical fields).** Each item MUST use `word` and integer `correct`. Do NOT use `answer`.
 
-**`watch-and-repeat` item shape (mandatory canonical fields).** Each item MUST
-use `video` for the YouTube/video URL. Do NOT use `url`; the renderer reads
-only `video`.
+**`watch-and-repeat` item shape (mandatory canonical fields).** Each item MUST use `video` for the YouTube/video URL. Do NOT use `url`.
 
 **`translate` activity items (mandatory canonical fields — HARD FAIL on alias).** Each item inside a `translate` activity's `items:` list MUST use `source` for the text to translate and `options` for target choices; the correct target answer is the option with `correct: true`. For UK→EN translation, `source` is the Ukrainian text and the target English answer lives in `options[].text`. Do NOT use `prompt:`/`answer:` aliases, and do NOT emit a bare `target:` field that the parser cannot consume.
 
@@ -472,13 +436,13 @@ If a required call is missing for your level, make it now. Do not emit artifacts
 
 Re-check these three hard-stop items BEFORE emitting:
 
-1. **`get_chunk_context` for every plan reference.** `search_text` does NOT count toward `textbook_grounding`; call `mcp__sources__get_chunk_context(chunk_id=<ID from notes>)` for EACH `plan.references` entry. Adult blockquotes must be >=30 contiguous words from that returned chunk text, verbatim.
+1. **`get_chunk_context` for every plan reference.** `search_text` does NOT count toward `textbook_grounding`; call `mcp__sources__get_chunk_context(chunk_id=<ID from notes>)` for EACH `plan.references` entry.
 
-2. **At least ONE multimedia search call.** `resources_search_attempted` counts ONLY `mcp__sources__query_wikipedia`, `mcp__sources__search_external`, and `mcp__sources__search_images`. Make at least one of these calls; empty results are acceptable, zero attempts are not.
+2. **At least ONE multimedia search call.** `resources_search_attempted` counts ONLY `mcp__sources__query_wikipedia`, `mcp__sources__search_external`, and `mcp__sources__search_images`; empty results are acceptable, zero attempts are not.
 
-3. **INJECT_ACTIVITY parity.** Every `INJECT_ACTIVITY id=<X>` reference in `module.md` MUST have a corresponding activity with id `<X>` in `activities.yaml`. The build hard-fails on dangling references via the `inject_activity_ids` gate. Before emitting, count your `INJECT_ACTIVITY` markers in `module.md` and confirm each id is defined in `activities.yaml`.
+3. **INJECT_ACTIVITY parity.** Every `INJECT_ACTIVITY id=<X>` in `module.md` MUST have a matching activity id in `activities.yaml`; count both before emitting.
 
-If tool history lacks items 1 or 2, STOP and make the calls before artifact emission. `<end_gate>` counts are cross-checked against telemetry: lying fails via `tool_theatre`, zero fails via `textbook_grounding` / `resources_search_attempted`. Item 3 is structural; verify it in the artifacts.
+If tool history lacks items 1 or 2, STOP and make the calls. `<end_gate>` counts are cross-checked against telemetry; lying fails via `tool_theatre`.
 
 ## Artifact emission format (STRICT — restored 2026-05-23 after PR-C strip)
 
@@ -491,41 +455,23 @@ Return the visible `<plan_reasoning>` blocks first, then exactly these four fenc
   {
     "id": "act-1",
     "type": "fill-in",
-    "instruction": "Complete each sentence with the best word.",
-    "items": [
-      {
-        "sentence": "Я ____ схему.",
-        "answer": "креслю",
-        "options": ["креслю", "питаю", "тримаю"]
-      }
-    ]
+    "instruction": "...",
+    "items": [{"sentence": "Я ____ схему.", "answer": "креслю", "options": ["креслю", "питаю"]}]
   }
 ]
 ```
 
 ```json file=vocabulary.yaml
 [
-  {
-    "lemma": "креслити",
-    "translation": "to draw lines",
-    "pos": "verb",
-    "usage": "Я креслю схему."
-  }
+  {"lemma": "креслити", "translation": "to draw lines", "pos": "verb", "usage": "Я креслю схему."}
 ]
 ```
 
-Vocabulary entries MUST use only these item fields: `lemma`, `translation`,
-`pos`, `usage`, and optional `notes`, `examples`, `tags`. CEFR/frequency
-lookups are selection evidence only; do NOT emit metadata fields such as
-`cefr`, `level`, `frequency`, `register`, `gender`, or `example`.
+Vocabulary entries MUST use only these fields: `lemma`, `translation`, `pos`, `usage`, and optional `notes`, `examples`, `tags`. CEFR/frequency lookups are selection evidence only; do NOT emit metadata fields such as `cefr`, `level`, `frequency`, `register`, `gender`, or `example`.
 
 ```json file=resources.yaml
 [
-  {
-    "title": "Караман Grade 10, p.176",
-    "role": "textbook",
-    "notes": "Зворотні дієслова: суфікс -ся означає дію, спрямовану на себе."
-  }
+  {"title": "Караман Grade 10, p.176", "role": "textbook", "notes": "..."}
 ]
 ```
 

--- a/tests/test_writer_prompt_v7_register_rules.py
+++ b/tests/test_writer_prompt_v7_register_rules.py
@@ -89,3 +89,21 @@ def test_writer_prompt_contains_v7_register_rule(
     assert f"rule_id: {rule_id}" in prompt
     for anchor in anchors:
         assert _normalize(anchor) in normalized
+
+
+def test_writer_prompt_contains_seminar_folk_qg_hardening() -> None:
+    prompt = _prompt()
+    normalized = _normalize(prompt)
+
+    required = (
+        "For seminar tracks, especially `LEVEL=folk`, treat the wiki `[S#]` registry",
+        "`citations_resolve` hard-rejects unresolved citations",
+        "When `{WORD_TARGET}=5000`, the 92% tolerance still requires about 4600 accepted words",
+        "call `mcp__sources__check_russian_shadow` and `mcp__sources__search_style_guide`",
+        "Use `аранжування`, not `<!-- bad -->аранжировку<!-- /bad -->`",
+        "Put those fragments in blockquotes or the module's verbatim-quote convention",
+        "bare archaic/dialectal folk forms in exposition fail VESUM",
+    )
+
+    for anchor in required:
+        assert _normalize(anchor) in normalized


### PR DESCRIPTION
## Summary

Hardens the V7 linear writer prompt for seminar/FOLK builds without weakening any quality gate.

## Failure modes addressed

1. Russianisms / calques: adds a seminar/FOLK hard stop requiring uncertain terms to go through `mcp__sources__check_russian_shadow` and `mcp__sources__search_style_guide`, with concrete examples such as `аранжування` instead of marked-bad `аранжировку`, and standard style-guide selection for context-flagged terms such as `безцінний`.
2. Unresolved citations: makes the wiki `[S#]` registry plus `plan.references` a closed citation universe for seminar/FOLK and explicitly forbids outside source citations such as the Грушевський and Леся Українка examples unless the exact source is provided in the build inputs. `resources.yaml` remains governed by the existing plan.references-only rule.
3. Word-count shortfall: restates `{WORD_TARGET}` as a real floor for seminar/FOLK, calls out the 5000 -> ~4600 tolerance case, and directs expansion through corpus analysis, examples, source comparison, and cultural context rather than padding.
4. Unmarked folk archaisms: requires verbatim folk-song/duma/ritual fragments with archaic or dialectal forms (`Дівоцькую`, `гаїлки`, `дівочок`, `рубочки`) to be blockquoted or otherwise marked as verbatim evidence; expository prose must use standard modern Ukrainian.

## Notes

- No gate thresholds or audit logic were weakened.
- Kept the static writer prompt under the existing rendered-size ceiling by trimming redundant legacy prose.
- Added a regression test pinning the new seminar/FOLK hardening language.

## Validation

- `.venv/bin/ruff check tests/test_writer_prompt_v7_register_rules.py`
- `.venv/bin/python scripts/lint_prompts.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `.venv/bin/python -m pytest tests/ -q -k "prompt or write or template"` (743 passed, 16 skipped, 7499 deselected; 3 existing unknown-mark warnings)

NO auto-merge
