### PR TITLE
fix(a1): sync middle release MDX

### DIFF
--- a/curriculum/l2-uk-en/a1/checkpoint-my-world/activities.yaml
+++ b/curriculum/l2-uk-en/a1/checkpoint-my-world/activities.yaml
@@ -1,3 +1,4 @@
+---
 inline:
   - id: act-1
     type: quiz

--- a/curriculum/l2-uk-en/a1/i-want-i-can/activities.yaml
+++ b/curriculum/l2-uk-en/a1/i-want-i-can/activities.yaml
@@ -1,3 +1,4 @@
+---
 inline:
   - id: act-1
     type: quiz

--- a/curriculum/l2-uk-en/a1/my-morning/activities.yaml
+++ b/curriculum/l2-uk-en/a1/my-morning/activities.yaml
@@ -1,3 +1,4 @@
+---
 inline:
   - id: act-1
     type: true-false

--- a/curriculum/l2-uk-en/a1/questions/activities.yaml
+++ b/curriculum/l2-uk-en/a1/questions/activities.yaml
@@ -1,3 +1,4 @@
+---
 inline:
   - id: act-1
     type: match-up

--- a/curriculum/l2-uk-en/a1/verbs-group-one/activities.yaml
+++ b/curriculum/l2-uk-en/a1/verbs-group-one/activities.yaml
@@ -1,3 +1,4 @@
+---
 inline:
   - id: act-1
     type: quiz

--- a/curriculum/l2-uk-en/a1/verbs-group-two/activities.yaml
+++ b/curriculum/l2-uk-en/a1/verbs-group-two/activities.yaml
@@ -1,3 +1,4 @@
+---
 inline:
   - id: act-1
     type: quiz

--- a/curriculum/l2-uk-en/a1/what-i-like/activities.yaml
+++ b/curriculum/l2-uk-en/a1/what-i-like/activities.yaml
@@ -1,3 +1,4 @@
+---
 inline:
   - id: act-1
     type: quiz

--- a/starlight/src/content/docs/a1/checkpoint-my-world.mdx
+++ b/starlight/src/content/docs/a1/checkpoint-my-world.mdx
@@ -337,6 +337,22 @@ authors.
 </TabItem>
 <TabItem label="Activities">
 
+### Checkpoint warm-up
+
+*(see lesson, §Що ми знаємо?)*
+
+### Gender and control words
+
+*(see lesson, §Що ми знаємо?)*
+
+### Marketplace dialogue
+
+*(see lesson, §Читання)*
+
+### Review categories
+
+*(see lesson, §Граматика)*
+
 ### Singular, plural, and description
 
 <Quiz client:only='react' questions={JSON.parse(`[{"question": "стіл", "options": [{"text": "Мій стіл великий.", "correct": true}, {"text": "Моя стіл велика.", "correct": false}, {"text": "Моє стіл велике.", "correct": false}], "explanation": "Стіл is masculine."}, {"question": "кімната", "options": [{"text": "Моя кімната чиста.", "correct": true}, {"text": "Мій кімната чистий.", "correct": false}, {"text": "Моє кімната чисте.", "correct": false}], "explanation": "Кімната is feminine."}, {"question": "вікно", "options": [{"text": "Моє вікно чисте.", "correct": true}, {"text": "Моя вікно чиста.", "correct": false}, {"text": "Мій вікно чистий.", "correct": false}], "explanation": "Вікно is neuter."}, {"question": "книги", "options": [{"text": "Мої книги нові.", "correct": true}, {"text": "Моя книги нова.", "correct": false}, {"text": "Мій книги новий.", "correct": false}], "explanation": "Книги is plural."}]`)} />

--- a/starlight/src/content/docs/a1/i-want-i-can.mdx
+++ b/starlight/src/content/docs/a1/i-want-i-can.mdx
@@ -347,6 +347,22 @@ with **[ц':а]**. A textbook example writes **сміється** and shows
 </TabItem>
 <TabItem label="Activities">
 
+### Choose the safe modal line
+
+*(see lesson, §Діалоги)*
+
+### Build tonight's plan
+
+*(see lesson, §Діалоги)*
+
+### Хотіти forms
+
+*(see lesson, §Дієслово «хотіти»)*
+
+### Put the helper before the action
+
+*(see lesson, §Дієслова «могти» та «мусити»)*
+
 ### Modal job check
 
 <TrueFalse client:only='react' items={JSON.parse(`[{"statement": "After хочу, use an infinitive in Я хочу читати.", "isTrue": true, "explanation": "Читати is the action word after хочу."}, {"statement": "Я не можу піти is a complete safe negative.", "isTrue": true, "explanation": "Не stands before можу, then the action follows."}, {"statement": "Мусити always means an emergency right now.", "isTrue": false, "explanation": "Мусити marks obligation; urgency comes from context."}, {"statement": "In a café, Можна мені, будь ласка, каву? is a polite service chunk.", "isTrue": true, "explanation": "Use this chunk before practicing blunt wants in service speech."}]`)} />

--- a/starlight/src/content/docs/a1/my-morning.mdx
+++ b/starlight/src/content/docs/a1/my-morning.mdx
@@ -281,6 +281,22 @@ the final cluster smoothly.
 </TabItem>
 <TabItem label="Activities">
 
+### Hear the reflexive ending
+
+*(see lesson, §Діалоги)*
+
+### Add the morning ending
+
+*(see lesson, §Діалоги)*
+
+### Reflexive or regular
+
+*(see lesson, §Дієслова на -ся)*
+
+### Put the morning in order
+
+*(see lesson, §Дієслова на -ся)*
+
 ### Finish the roommate dialogue
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "Коли ти ___?", "answer": "прокидаєшся", "options": ["прокидаєшся", "прокидаюся", "прокидається"]}, {"sentence": "Я ___ о сьомій.", "answer": "прокидаюся", "options": ["прокидаюся", "прокидаєшся", "прокидається"]}, {"sentence": "Що ти робиш ___?", "answer": "потім", "options": ["потім", "сніданок", "рушник"]}, {"sentence": "Я вмиваюся і ___.", "answer": "одягаюся", "options": ["одягаюся", "одягаєшся", "одягається"]}, {"sentence": "Після цього я ___.", "answer": "снідаю", "options": ["снідаю", "снідаєшся", "сніданок"]}]`)} />

--- a/starlight/src/content/docs/a1/questions.mdx
+++ b/starlight/src/content/docs/a1/questions.mdx
@@ -288,6 +288,22 @@ shape **ні в що**, but do not make them your main production task today.
 </TabItem>
 <TabItem label="Activities">
 
+### Question-word jobs
+
+*(see lesson, §Діалоги)*
+
+### Interview gaps
+
+*(see lesson, §Діалоги)*
+
+### Yes/no question signals
+
+*(see lesson, §Питальні слова)*
+
+### Question, answer, or negative
+
+*(see lesson, §Заперечення)*
+
 ### Rebuild the negative
 
 <Unjumble client:only='react' items={JSON.parse(`[{"jumbled": "не / Я / знаю", "answer": "Я не знаю"}, {"jumbled": "не / Ти / розумієш", "answer": "Ти не розумієш"}, {"jumbled": "не / хочу / Я / читати", "answer": "Я не хочу читати"}, {"jumbled": "не / можу / Я / піти", "answer": "Я не можу піти"}, {"jumbled": "не / Ніхто / говорить", "answer": "Ніхто не говорить"}, {"jumbled": "нічого / не / Я / знаю", "answer": "Я нічого не знаю"}]`)} />

--- a/starlight/src/content/docs/a1/verbs-group-one.mdx
+++ b/starlight/src/content/docs/a1/verbs-group-one.mdx
@@ -350,6 +350,22 @@ sentences sound complete.
 </TabItem>
 <TabItem label="Activities">
 
+### Hear Group One
+
+*(see lesson, §Діалоги)*
+
+### Читати table
+
+*(see lesson, §Діалоги)*
+
+### Build with читати
+
+*(see lesson, §Перша дієвідміна)*
+
+### Знати and розуміти
+
+*(see lesson, §Mini-pattern: знати and розуміти)*
+
 ### Who uses which ending
 
 <GroupSort client:only='react' groups={JSON.parse(`{"Я": ["читаю", "знаю", "працюю"], "Ти": ["читаєш", "знаєш", "працюєш"], "Він / вона": ["читає", "знає", "працює"], "Ми / ви / вони": ["читаємо", "читаєте", "читають"]}`)} />

--- a/starlight/src/content/docs/a1/verbs-group-two.mdx
+++ b/starlight/src/content/docs/a1/verbs-group-two.mdx
@@ -346,6 +346,22 @@ Repair the common traps by choosing the ready Ukrainian form:
 </TabItem>
 <TabItem label="Activities">
 
+### Group Two warm-up
+
+*(see lesson, §Діалоги)*
+
+### Говорити table
+
+*(see lesson, §Діалоги)*
+
+### Говорити, робити, бачити
+
+*(see lesson, §Друга дієвідміна)*
+
+### Group One or Group Two
+
+*(see lesson, §Use говорити, робити, бачити)*
+
 ### Ready я chunks
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "Я ___ вправу.", "answer": "роблю", "options": ["роблю", "робиш", "робить"]}, {"sentence": "Я ___ до школи.", "answer": "ходжу", "options": ["ходжу", "ходиш", "ходить"]}, {"sentence": "Я ___ каву.", "answer": "прошу", "options": ["прошу", "просиш", "просить"]}, {"sentence": "Я ___ тут.", "answer": "сиджу", "options": ["сиджу", "сидиш", "сидить"]}]`)} />

--- a/starlight/src/content/docs/a1/what-i-like.mdx
+++ b/starlight/src/content/docs/a1/what-i-like.mdx
@@ -308,6 +308,22 @@ Build a short personal answer:
 </TabItem>
 <TabItem label="Activities">
 
+### Preference warm-up
+
+*(see lesson, §Діалоги)*
+
+### Infinitive actions
+
+*(see lesson, §Діалоги)*
+
+### Build Я люблю
+
+*(see lesson, §Я люблю...)*
+
+### Action or thing
+
+*(see lesson, §Мені подобається...)*
+
 ### Люблю or подобається
 
 <Quiz client:only='react' questions={JSON.parse(`[{"question": "I like to walk.", "options": [{"text": "Я люблю гуляти.", "correct": true}, {"text": "Мені подобається гуляю.", "correct": false}, {"text": "Я люблю гуляю.", "correct": false}], "explanation": "Use Я люблю plus гуляти for an action."}, {"question": "I like this film.", "options": [{"text": "Мені подобається цей фільм.", "correct": true}, {"text": "Я подобається цей фільм.", "correct": false}, {"text": "Мені люблю цей фільм.", "correct": false}], "explanation": "Use Мені подобається for a thing."}, {"question": "I do not like to cook.", "options": [{"text": "Я не люблю готувати.", "correct": true}, {"text": "Я люблю не готувати.", "correct": false}, {"text": "Я не люблю готую.", "correct": false}], "explanation": "Put не before люблю, then use the -ти action."}, {"question": "I do not like this book.", "options": [{"text": "Мені не подобається ця книга.", "correct": true}, {"text": "Мені подобається не ця книга.", "correct": false}, {"text": "Я не подобається ця книга.", "correct": false}], "explanation": "Put не before подобається."}]`)} />


### PR DESCRIPTION
## Summary

- Add YAML document starts to A1 activity sources for modules 14-20 so their generated MDX has source-paired changes.
- Regenerate the matching A1 MDX pages for checkpoint-my-world, what-i-like, verbs-group-one, verbs-group-two, i-want-i-can, questions, and my-morning.
- Keep the slice under the 20-file PR cap while continuing A1 release-prep MDX drift cleanup.

## Validation

- `.venv/bin/python scripts/audit/check_mdx_generation_drift.py --files curriculum/l2-uk-en/a1/checkpoint-my-world/module.md curriculum/l2-uk-en/a1/what-i-like/module.md curriculum/l2-uk-en/a1/verbs-group-one/module.md curriculum/l2-uk-en/a1/verbs-group-two/module.md curriculum/l2-uk-en/a1/i-want-i-can/module.md curriculum/l2-uk-en/a1/questions/module.md curriculum/l2-uk-en/a1/my-morning/module.md`
- `npm --prefix starlight exec -- markdownlint-cli2 ...`
- `.venv/bin/yamllint ...`
- `.venv/bin/python scripts/audit/check_mdx_source_parity.py --changed-vs-base origin/main`
- `git diff --check`
- `rg -n '<DialogueBox' curriculum/l2-uk-en/a1 --glob 'module.md' starlight/src/content/docs/a1` (no matches)
- A1 error-correction token invariant check
- `npm run build:starlight`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Gemini local review: no blocking findings
- Read-only Codex explorer review: no blocking findings