### PR TITLE
fix(a1): sync time release MDX

### DIFF
--- a/curriculum/l2-uk-en/a1/checkpoint-actions/activities.yaml
+++ b/curriculum/l2-uk-en/a1/checkpoint-actions/activities.yaml
@@ -1,3 +1,4 @@
+---
 inline:
   - id: act-1
     type: match-up

--- a/curriculum/l2-uk-en/a1/checkpoint-time-nature/activities.yaml
+++ b/curriculum/l2-uk-en/a1/checkpoint-time-nature/activities.yaml
@@ -1,3 +1,4 @@
+---
 inline:
   - id: act-1
     type: group-sort

--- a/curriculum/l2-uk-en/a1/days-and-months/activities.yaml
+++ b/curriculum/l2-uk-en/a1/days-and-months/activities.yaml
@@ -1,3 +1,4 @@
+---
 inline:
   - id: act-1
     type: order

--- a/curriculum/l2-uk-en/a1/free-time/activities.yaml
+++ b/curriculum/l2-uk-en/a1/free-time/activities.yaml
@@ -1,3 +1,4 @@
+---
 inline:
   - id: act-1
     type: true-false

--- a/curriculum/l2-uk-en/a1/my-day/activities.yaml
+++ b/curriculum/l2-uk-en/a1/my-day/activities.yaml
@@ -1,3 +1,4 @@
+---
 inline:
   - id: act-1
     type: fill-in

--- a/curriculum/l2-uk-en/a1/weather/activities.yaml
+++ b/curriculum/l2-uk-en/a1/weather/activities.yaml
@@ -1,3 +1,4 @@
+---
 inline:
   - id: act-1
     type: match-up

--- a/curriculum/l2-uk-en/a1/what-time/activities.yaml
+++ b/curriculum/l2-uk-en/a1/what-time/activities.yaml
@@ -1,3 +1,4 @@
+---
 inline:
   - id: act-1
     type: quiz

--- a/starlight/src/content/docs/a1/checkpoint-actions.mdx
+++ b/starlight/src/content/docs/a1/checkpoint-actions.mdx
@@ -350,6 +350,22 @@ and Ukrainian context clearly.
 </TabItem>
 <TabItem label="Activities">
 
+### Reading line to skill
+
+*(see lesson, §Що ми знаємо?)*
+
+### Action diagnostics
+
+*(see lesson, §Що ми знаємо?)*
+
+### Skill stations
+
+*(see lesson, §Читання)*
+
+### Roommate dialogue gaps
+
+*(see lesson, §Repair traps)*
+
 ### Find the form that does not fit
 
 <OddOneOut client:only='react' instruction={"Choose the chunk that belongs to a different checkpoint skill."} items={JSON.parse(`[{"words": ["я читаю", "ти читаєш", "вони читають", "ти говориш"], "correct": 3, "explanation": "Ти говориш is Group Two; the others are Group One читати."}, {"words": ["хочу читати", "можу готувати", "мушу працювати", "я читаю"], "correct": 3, "explanation": "Я читаю is a person form, not modal + infinitive."}, {"words": ["хто", "коли", "куди", "працюю"], "correct": 3, "explanation": "Працюю is a verb form; the others are question words."}, {"words": ["я прокидаюся", "ти вмиваєшся", "вона одягається", "я снідаю"], "correct": 3, "explanation": "Снідаю is not a -ся verb."}]`)} />

--- a/starlight/src/content/docs/a1/checkpoint-time-nature.mdx
+++ b/starlight/src/content/docs/a1/checkpoint-time-nature.mdx
@@ -405,6 +405,22 @@ Write your own six-line checkpoint answer. Include:
 </TabItem>
 <TabItem label="Activities">
 
+### A1.4 skill map
+
+*(see lesson, §Що ми знаємо?)*
+
+### Question to checkpoint answer
+
+*(see lesson, §Що ми знаємо?)*
+
+### Weekend plan gaps
+
+*(see lesson, §Читання)*
+
+### Build the Saturday trip
+
+*(see lesson, §Nature and weather description)*
+
 ### Find the unsafe checkpoint chunk
 
 <OddOneOut client:only='react' instruction={"Choose the line that does not fit the safe A1.4 pattern."} items={JSON.parse(`[{"words": ["Зустріч о п'ятій.", "Фільм о десятій годині.", "Кава об одинадцятій.", "Зустріч в п'ять годин."], "correct": 3, "explanation": "Schedule time uses о/об."}, {"words": ["Пів на восьму.", "Пів на шосту.", "Чверть на дванадцяту.", "Пів восьмої."], "correct": 3, "explanation": "The checkpoint chunk is пів на plus the next hour."}, {"words": ["Іде дощ.", "Сьогодні тепло.", "Надворі хмарно.", "Він іде дощ."], "correct": 3, "explanation": "Weather can be an impersonal Ukrainian sentence."}, {"words": ["Взимку.", "Навесні.", "Влітку.", "Весною."], "correct": 3, "explanation": "Навесні is the safe A1 season chunk in this checkpoint."}, {"words": ["Я студент.", "Мені 20 років.", "Він спортсмен.", "Я є студент."], "correct": 3, "explanation": "Ukrainian normally omits the present-tense helper here."}]`)} />

--- a/starlight/src/content/docs/a1/days-and-months.mdx
+++ b/starlight/src/content/docs/a1/days-and-months.mdx
@@ -366,6 +366,22 @@ Support after the Ukrainian lines:
 </TabItem>
 <TabItem label="Activities">
 
+### Put the week in order
+
+*(see lesson, §Діалоги)*
+
+### Clinic appointment day
+
+*(see lesson, §Діалоги)*
+
+### Day planning chunks
+
+*(see lesson, §Дні тижня)*
+
+### Calendar shelves
+
+*(see lesson, §Дні тижня)*
+
 ### Month, season, memory hook
 
 <MatchUp client:only='react' pairs={JSON.parse(`[{"left": "січень", "right": "зима"}, {"left": "березень", "right": "весна"}, {"left": "липень", "right": "літо"}, {"left": "листопад", "right": "осінь"}, {"left": "квітень", "right": "flowers"}, {"left": "липень", "right": "linden tree"}, {"left": "листопад", "right": "falling leaves"}, {"left": "березень", "right": "birch"}]`)} />

--- a/starlight/src/content/docs/a1/free-time.mdx
+++ b/starlight/src/content/docs/a1/free-time.mdx
@@ -414,6 +414,22 @@ Support after the Ukrainian lines:
 </TabItem>
 <TabItem label="Activities">
 
+### Notice board invitations
+
+*(see lesson, §Діалоги)*
+
+### Build hobby chunks
+
+*(see lesson, §Діалоги)*
+
+### Frequency and invitations
+
+*(see lesson, §Хобі і спорт)*
+
+### Choose the safe preposition
+
+*(see lesson, §Хобі і спорт)*
+
 ### From weather to plan
 
 <Order client:only='react' items={JSON.parse(`["Сьогодні субота.", "Оленко, що ти робиш у вихідні?", "Зазвичай я гуляю і читаю.", "Буде тепло.", "Давай грати у футбол о третій.", "Добре, а якщо буде дощ?", "Якщо буде дощ, ходімо в музей.", "Чудово!"]`)} correct_order={JSON.parse(`[0, 1, 2, 3, 4, 5, 6, 7]`)} instruction={"Put the planning lines into a natural order."} isUkrainian={false} />

--- a/starlight/src/content/docs/a1/my-day.mdx
+++ b/starlight/src/content/docs/a1/my-day.mdx
@@ -349,6 +349,22 @@ Support after the Ukrainian lines:
 </TabItem>
 <TabItem label="Activities">
 
+### Parts of the day in a real diary
+
+*(see lesson, §Діалоги)*
+
+### Put the diary in order
+
+*(see lesson, §Діалоги)*
+
+### Routine action to useful time
+
+*(see lesson, §Мій типовий день)*
+
+### Planning conversation choices
+
+*(see lesson, §Мій типовий день)*
+
 ### Day shelves
 
 <GroupSort client:only='react' groups={JSON.parse(`{"Morning": ["вранці", "я прокидаюся", "роблю зарядку", "снідаю"], "Day and afternoon": ["вдень", "о першій", "обідаю", "після обіду"], "Evening and night": ["ввечері", "вечеряю", "вночі", "лягаю спати"], "Planning chunks": ["я планую", "хочу читати", "маю зробити", "мені потрібно"]}`)} />

--- a/starlight/src/content/docs/a1/weather.mdx
+++ b/starlight/src/content/docs/a1/weather.mdx
@@ -376,6 +376,22 @@ Support after the Ukrainian lines:
 </TabItem>
 <TabItem label="Activities">
 
+### Weather line to real-world clue
+
+*(see lesson, §Діалоги)*
+
+### Window weather chunks
+
+*(see lesson, §Діалоги)*
+
+### Find the unsafe weather line
+
+*(see lesson, §Яка погода?)*
+
+### Season weather shelves
+
+*(see lesson, §Яка погода?)*
+
 ### Weather pattern checks
 
 <TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Холодно, тепло, сонячно, and хмарно can answer Яка погода?", "isTrue": true, "explanation": "They are safe state words for weather."}, {"statement": "Ukrainian needs це є before every weather state.", "isTrue": false, "explanation": "Say Сьогодні холодно or Надворі сонячно."}, {"statement": "Іде дощ is the safe A1 precipitation chunk.", "isTrue": true, "explanation": "It is the default spoken pattern for rain."}, {"statement": "Дощ падає зараз is the best first A1 weather line.", "isTrue": false, "explanation": "Learn Іде дощ first."}, {"statement": "Сніг and мороз naturally sort with ЗИМА in the first season map.", "isTrue": true, "explanation": "This is the basic weather-season link."}, {"statement": "Мені подобається теплий дощ is safer than Я подобаюсь теплий дощ.", "isTrue": true, "explanation": "Use Мені подобається... for likes."}]`)} />

--- a/starlight/src/content/docs/a1/what-time.mdx
+++ b/starlight/src/content/docs/a1/what-time.mdx
@@ -350,6 +350,22 @@ schedule.
 </TabItem>
 <TabItem label="Activities">
 
+### Choose the clock answer
+
+*(see lesson, §Діалоги)*
+
+### Digital time to Ukrainian chunk
+
+*(see lesson, §Діалоги)*
+
+### Schedule time gaps
+
+*(see lesson, §Котра година?)*
+
+### Full hour or duration
+
+*(see lesson, §Котра година?)*
+
 ### What job does the phrase do?
 
 <GroupSort client:only='react' groups={JSON.parse(`{"Clock answer": ["перша", "п'ята", "десята", "дванадцята"], "Schedule answer": ["о першій", "о п'ятій", "об одинадцятій", "о дванадцятій"], "Time of day": ["ранку", "дня", "вечора", "ночі"]}`)} />


### PR DESCRIPTION
## Summary

- Add YAML document starts to A1 activity sources for modules 21-27 so generated MDX has source-paired changes.
- Regenerate the matching A1 MDX pages for checkpoint-actions, what-time, days-and-months, weather, my-day, free-time, and checkpoint-time-nature.
- Finish the known A1 release-prep MDX drift cleanup under the 20-file PR cap.

## Validation

- `.venv/bin/python scripts/audit/check_mdx_generation_drift.py --files curriculum/l2-uk-en/a1/checkpoint-actions/module.md curriculum/l2-uk-en/a1/what-time/module.md curriculum/l2-uk-en/a1/days-and-months/module.md curriculum/l2-uk-en/a1/weather/module.md curriculum/l2-uk-en/a1/my-day/module.md curriculum/l2-uk-en/a1/free-time/module.md curriculum/l2-uk-en/a1/checkpoint-time-nature/module.md`
- `npm --prefix starlight exec -- markdownlint-cli2 ...`
- `.venv/bin/yamllint ...`
- `.venv/bin/python scripts/audit/check_mdx_source_parity.py --changed-vs-base origin/main`
- `git diff --check`
- `rg -n '<DialogueBox' curriculum/l2-uk-en/a1 --glob 'module.md' starlight/src/content/docs/a1` (no matches)
- A1 error-correction token invariant check
- `npm run build:starlight`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Gemini local review: no blocking findings
- Read-only Codex explorer review: no blocking findings