### PR TITLE
fix(ui): mark A1 landing as released

### DIFF
--- a/starlight/src/layouts/CourseLayout.astro
+++ b/starlight/src/layouts/CourseLayout.astro
@@ -57,7 +57,7 @@ const canonicalPath = currentPath.endsWith('/') ? currentPath : `${currentPath}/
 
 const topNav = [
   { href: '/', label: 'Home' },
-  { href: '/a1/', label: 'A1 Beta' },
+  { href: '/a1/', label: 'A1 Release' },
   { href: '/a2/', label: 'A2 Next' },
   { href: '/folk/', label: 'Folk Seminar' },
   { href: '/lexicon/', label: 'Word Atlas' },
@@ -235,7 +235,7 @@ const isActive = (href: string) => {
             </section>
             <section>
               <h3>Course</h3>
-              <a href="/a1/">A1 Beta</a>
+              <a href="/a1/">A1 Release</a>
               <a href="/a2/">A2 Next</a>
               <a href="/folk/">Folk Seminar</a>
               <a href="/lexicon/">Word Atlas</a>

--- a/starlight/src/pages/404.astro
+++ b/starlight/src/pages/404.astro
@@ -19,7 +19,7 @@ import CourseLayout from '../layouts/CourseLayout.astro';
       course surface instead of guessing around draft paths.
     </p>
     <div class="state-actions">
-      <a href="/a1/">A1 Beta</a>
+      <a href="/a1/">A1 Release</a>
       <a href="/folk/">Folk Seminar</a>
       <a href="/search/">Search</a>
       <a href="/lexicon/">Word Atlas</a>

--- a/starlight/src/pages/[...slug].astro
+++ b/starlight/src/pages/[...slug].astro
@@ -8,7 +8,7 @@ type DocsEntry = CollectionEntry<'docs'>;
 type TrackStats = Record<string, { modules?: number } | number>;
 type HeroVariant = 'core' | 'folk' | 'lexicon' | 'seminar' | 'lit' | 'history' | 'unavailable';
 type TrackFamily = 'core' | 'seminar' | 'reference';
-type TrackState = 'beta' | 'next' | 'planned' | 'test' | 'unavailable';
+type TrackState = 'released' | 'beta' | 'next' | 'planned' | 'test' | 'unavailable';
 type TrackOverview = {
   label: string;
   title: string;
@@ -50,16 +50,16 @@ const TRACKS: Record<string, TrackOverview> = {
   a1: {
     label: 'A1',
     title: 'Перші кроки · First Steps',
-    eyebrow: 'A1 beta release',
+    eyebrow: 'A1 release',
     subtitle: 'Beginner Ukrainian for sounds, reading, first conversations, everyday needs, and the A1 finale.',
-    status: 'Beta / release focus',
+    status: 'Released beginner course',
     family: 'core',
-    state: 'beta',
+    state: 'released',
     heroVariant: 'core',
     primaryAction: { href: '/a1/sounds-letters-and-hello/', label: 'Start Module 1' },
     secondaryAction: { href: '/lexicon/', label: 'Open Word Atlas' },
     points: [
-      'A1 is the public release focus and the first track learners should use today.',
+      'A1 is the released public beginner track and the first course learners should use today.',
       'Lessons keep Ukrainian first with English support where it helps beginners move.',
       'Self-study is supported, but trained native Ukrainian teachers are still the best path.',
     ],
@@ -515,7 +515,11 @@ const sidebar = props.kind === 'doc'
     <section class:list={['track-overview', `track-${props.track}`, pageTrack.family, pageTrack.state]}>
       <div class="track-status-panel">
         <span>{pageTrack.status}</span>
-        <strong>{moduleCount(props.track)} planned modules</strong>
+        <strong>
+          {moduleCount(props.track)}
+          {' '}
+          {pageTrack.state === 'released' || pageTrack.state === 'test' ? 'available modules' : 'planned modules'}
+        </strong>
       </div>
 
       <div class="track-overview-grid">
@@ -572,7 +576,7 @@ const sidebar = props.kind === 'doc'
             The learner UI keeps the route visible so navigation, search, and future publishing have
             a real template, but it does not claim this content is ready for study.
           </p>
-          <a href="/a1/">Use the available A1 beta track</a>
+          <a href="/a1/">Use the available A1 track</a>
         </section>
       ) : (
         <section class="module-preview">
@@ -719,7 +723,7 @@ const sidebar = props.kind === 'doc'
             : 'Atlas and reference indexes should communicate when a filter or future dataset has no records.'}
       </p>
       <div class="state-actions">
-        <a href="/a1/">A1 Beta</a>
+        <a href="/a1/">A1 Release</a>
         <a href="/folk/">Folk Seminar</a>
         <a href="/search/">Search</a>
         <a href="/lexicon/">Word Atlas</a>

--- a/starlight/src/pages/index.astro
+++ b/starlight/src/pages/index.astro
@@ -38,8 +38,8 @@ const seminarTracks = [
 
 <CourseLayout
   title="Learn Ukrainian"
-  description="A lightweight Ukrainian course UI for A1 beta, A2 next, and the Folk seminar test track."
-  eyebrow="A1 beta release"
+  description="A lightweight Ukrainian course UI for the released A1 course, A2 next, and the Folk seminar test track."
+  eyebrow="A1 release"
   subtitle="A practical learner course, not a generic documentation site."
   currentPath="/"
   wide
@@ -47,10 +47,10 @@ const seminarTracks = [
   <section class="home-intro">
     <div>
       <p class="home-kicker">Ukrainian for real use</p>
-      <h2>A1 is the first release track. Folk runs in parallel as the seminar test lane.</h2>
+      <h2>A1 is the released beginner track. Folk runs in parallel as the seminar test lane.</h2>
       <p>
         Start with A1 if you are learning independently. Use the Folk seminar path for advanced cultural
-        source work. A2 is next after A1 release cleanup; the broader seminar inventory is shown below
+        source work. A2 is the next core target; the broader seminar inventory is shown below
         without promising a distant publication order.
       </p>
       <div class="home-actions">
@@ -59,7 +59,7 @@ const seminarTracks = [
       </div>
     </div>
     <aside class="roadmap-panel" aria-label="Roadmap">
-      <div><strong>A1</strong><span>Beta / release focus</span></div>
+      <div><strong>A1</strong><span>Released beginner course</span></div>
       <div><strong>A2</strong><span>Next regeneration target</span></div>
       <div><strong>Folk</strong><span>Seminar test track</span></div>
       <div><strong>BIO</strong><span>Biographies planned</span></div>


### PR DESCRIPTION
## Summary

- Update the site landing page, A1 landing page, nav, footer, and route-state recovery links from A1 beta wording to A1 release wording.
- Change the A1 track status panel from planned modules to available modules while preserving planned wording for unreleased tracks.
- Keep the route structure and lesson publication surface unchanged.

## Validation

- `npm run build:starlight`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Browser smoke checks for `/` and `/a1/` at desktop and mobile widths: HTTP 200, no A1 beta/planned-module wording, release wording present, zero horizontal overflow, no page errors.