### PR TITLE
feat(orchestration): reap merged worktrees safely

### DIFF
--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -29,6 +29,7 @@ from scripts.build.phases.implementation_map import (
     write_implementation_map,
 )
 from scripts.common.thresholds import QG_DIMS, terminal_dims_for
+from scripts.orchestration import reap_worktrees
 
 DEFAULT_WRITER_TIMEOUT_S = 1800
 FETCH_TIMEOUT_S = 30
@@ -395,11 +396,19 @@ def _print_worktree_summary(
     level: str,
     slug: str,
     result: str,
+    cleanup_result: reap_worktrees.ReapResult | None = None,
 ) -> None:
     print(f"BUILD_WORKTREE={worktree.path}")
     print(f"BUILD_BRANCH={worktree.branch}")
     print(f"BUILD_BASE={worktree.base_sha}")
     print(f"BUILD_RESULT={result}")
+    if cleanup_result is not None:
+        print(f"BUILD_WORKTREE_CLEANUP={cleanup_result.action}: {cleanup_result.reason}")
+        if cleanup_result.error:
+            print(f"BUILD_WORKTREE_CLEANUP_ERROR={cleanup_result.error}")
+    if cleanup_result is not None and cleanup_result.action == "removed":
+        print("Build worktree removed after artifact commit; branch retained for recovery.")
+        return
     print("Next steps if successful:")
     print(f"  cd {worktree.path}")
     print("  git status")
@@ -422,7 +431,7 @@ def _persist_build_artifacts(
     level: str,
     slug: str,
     result: str,
-) -> None:
+) -> bool:
     """Commit ALL build artifacts to the worktree's build branch.
 
     Build artifacts (writer_prompt.md, writer_output.raw.md, hermes.write.jsonl,
@@ -476,6 +485,7 @@ def _persist_build_artifacts(
             capture_output=True,
             text=True,
         )
+        return True
     except (subprocess.CalledProcessError, OSError) as exc:
         stderr_tail = ""
         if isinstance(exc, subprocess.CalledProcessError) and exc.stderr:
@@ -485,6 +495,7 @@ def _persist_build_artifacts(
             f"branch {worktree.branch!r}: {exc}. {stderr_tail}".rstrip(),
             file=sys.stderr,
         )
+        return False
 
 
 def _run_in_worktree(args: argparse.Namespace, raw_argv: list[str]) -> int:
@@ -552,8 +563,27 @@ def _run_in_worktree(args: argparse.Namespace, raw_argv: list[str]) -> int:
         # the writer_prompt + partial writer_output remain queryable via
         # the build branch SHA. Without this, `git worktree remove`
         # silently destroys forensic evidence.
-        _persist_build_artifacts(worktree, level=level, slug=slug, result=result)
-        _print_worktree_summary(worktree, level=level, slug=slug, result=result)
+        persisted = _persist_build_artifacts(
+            worktree,
+            level=level,
+            slug=slug,
+            result=result,
+        )
+        cleanup_result = None
+        if result == "success" and persisted and not args.keep_worktree:
+            cleanup_result = reap_worktrees.reap_success_worktree(
+                repo_root=worktree.repo_root,
+                worktree_path=worktree.path,
+                reason="build success after artifact commit",
+                apply=True,
+            )
+        _print_worktree_summary(
+            worktree,
+            level=level,
+            slug=slug,
+            result=result,
+            cleanup_result=cleanup_result,
+        )
     return exit_code
 
 
@@ -974,6 +1004,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "and branch build/{level}/{slug}-{YYYYMMDD-HHMMSS}. With PATH, "
             "uses that path and derives the branch from its basename when "
             "possible."
+        ),
+    )
+    parser.add_argument(
+        "--keep-worktree",
+        action="store_true",
+        help=(
+            "When --worktree succeeds, keep the build worktree instead of "
+            "reaping it after artifact persistence."
         ),
     )
     parser.add_argument(

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -746,6 +746,46 @@ def _auto_finalize_dirty_worktree(
     )
 
 
+def _reap_finished_worktree(worktree: Path) -> dict[str, Any]:
+    """Try to reap a clean successful delegate worktree, returning state metadata."""
+    if str(_REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(_REPO_ROOT))
+    from scripts.orchestration import reap_worktrees
+
+    try:
+        results = reap_worktrees.reap_worktrees(
+            repo_root=_REPO_ROOT,
+            apply=True,
+            preserve_then_reap=False,
+            target_paths=[worktree],
+        )
+    except Exception as exc:
+        return {
+            "action": "error",
+            "path": str(worktree),
+            "reason": "reaper raised",
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+
+    if not results:
+        return {
+            "action": "skipped",
+            "path": str(worktree),
+            "reason": "target path was not evaluated",
+            "error": None,
+        }
+    result = results[0]
+    return {
+        "action": result.action,
+        "path": result.path,
+        "branch": result.branch,
+        "reason": result.reason,
+        "dirty": result.dirty,
+        "pr": result.pr,
+        "error": result.error,
+    }
+
+
 def _validate_existing_worktree(
     *, path: Path, expected_branch: str, base: str,
 ) -> bool:
@@ -1024,6 +1064,7 @@ def _run_worker(
     effort: str | None = None,
     max_budget_usd: float | None = None,
     initial_response_timeout: int = DEFAULT_INITIAL_RESPONSE_TIMEOUT_S,
+    keep_worktree: bool = False,
 ) -> int:
     """Worker main loop. Invokes the runtime, updates the state file.
 
@@ -1198,6 +1239,17 @@ def _run_worker(
     if needs_finalize:
         final_status = "needs_finalize"
 
+    worktree_reap: dict[str, Any] | None = None
+    if (
+        worktree_path
+        and mode == "danger"
+        and not keep_worktree
+        and final_status == "done"
+        and returncode == 0
+        and dirty_on_exit is False
+    ):
+        worktree_reap = _reap_finished_worktree(Path(worktree_path))
+
     final_state.update({
         "model": getattr(result, "model", final_state.get("model")),
         "effort": getattr(result, "effort", final_state.get("effort")),
@@ -1212,6 +1264,8 @@ def _run_worker(
         "worktree_dirty_on_exit": dirty_on_exit,
         "commits_ahead": commits_ahead,
         "needs_finalize": needs_finalize,
+        "keep_worktree": keep_worktree,
+        "worktree_reap": worktree_reap,
         "auto_finalize": (
             {
                 "ok": auto_finalize.ok,
@@ -1265,6 +1319,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         DEFAULT_INITIAL_RESPONSE_TIMEOUT_S,
     )
     max_budget_usd = getattr(args, "max_budget_usd", None)
+    keep_worktree = bool(getattr(args, "keep_worktree", False))
 
     if args.mode == "danger" and not worktree_arg:
         print(
@@ -1388,6 +1443,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "worktree_rebased": bool(worktree_telemetry.get("rebased")),
         "worktree_reused": bool(worktree_telemetry.get("reused")),
         "worktree_layout": worktree_layout,
+        "keep_worktree": keep_worktree,
         "hard_timeout": args.hard_timeout,
         "silence_timeout": silence_timeout,
         "initial_response_timeout": initial_response_timeout,
@@ -1444,6 +1500,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "--silence-timeout", str(silence_timeout),
         "--initial-response-timeout", str(initial_response_timeout),
     ]
+    if keep_worktree:
+        cmd.append("--keep-worktree")
     if max_budget_usd is not None:
         cmd.extend(["--max-budget-usd", str(max_budget_usd)])
     if args.model:
@@ -1898,6 +1956,7 @@ def cmd_worker(args: argparse.Namespace) -> int:
             "initial_response_timeout",
             DEFAULT_INITIAL_RESPONSE_TIMEOUT_S,
         ),
+        keep_worktree=bool(getattr(args, "keep_worktree", False)),
     )
 
 
@@ -1987,6 +2046,14 @@ def build_parser() -> argparse.ArgumentParser:
             "(back-compat with existing `.worktrees/{agent}-{task}/` "
             "layout), or `--worktree` alone to auto-derive the new default "
             "`.worktrees/dispatch/{agent}/{task}/`."
+        ),
+    )
+    d.add_argument(
+        "--keep-worktree",
+        action="store_true",
+        help=(
+            "Keep a successful clean dispatch worktree instead of reaping it "
+            "after the branch is recoverable from origin or PR state."
         ),
     )
     d.add_argument(
@@ -2155,6 +2222,7 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=DEFAULT_INITIAL_RESPONSE_TIMEOUT_S,
     )
+    wk.add_argument("--keep-worktree", action="store_true")
     wk.add_argument("--max-budget-usd", type=float, default=None)
     wk.set_defaults(func=cmd_worker)
 

--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -1,0 +1,709 @@
+#!/usr/bin/env python3
+"""Safely reap finished repository worktrees.
+
+The CLI is intentionally safe by default: ``--dry-run`` is the default mode,
+only paths under the repository's ``.worktrees/`` directory are eligible, and
+dirty worktrees are preserved unless ``--preserve-then-reap`` is explicit.
+
+Suggested backstop:
+
+    .venv/bin/python scripts/orchestration/reap_worktrees.py --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_BUILD_AGE_HOURS = 6.0
+
+_GIT_ENV_DENYLIST = {
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_NAMESPACE",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+    "GIT_COMMON_DIR",
+}
+
+
+@dataclass(frozen=True)
+class WorktreeInfo:
+    path: Path
+    branch: str | None
+    head: str | None
+    detached: bool = False
+
+
+@dataclass(frozen=True)
+class PullRequestState:
+    number: int | None
+    state: str
+
+
+@dataclass(frozen=True)
+class ReapResult:
+    path: str
+    branch: str | None
+    action: str
+    reason: str
+    dirty: bool | None
+    pr: dict[str, Any] | None = None
+    error: str | None = None
+
+
+def _sanitized_git_env() -> dict[str, str]:
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if key not in _GIT_ENV_DENYLIST and not key.startswith("PRE_COMMIT")
+    }
+
+
+def _run(
+    args: list[str],
+    *,
+    cwd: Path,
+    timeout: int | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=timeout,
+        env=_sanitized_git_env(),
+    )
+
+
+def resolve_repo_root(cwd: Path | None = None) -> Path:
+    """Resolve the current git worktree root."""
+    start = cwd or Path.cwd()
+    proc = _run(["git", "rev-parse", "--show-toplevel"], cwd=start)
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "not inside a git repository").strip()
+        raise RuntimeError(detail)
+    return Path((proc.stdout or "").strip()).resolve()
+
+
+def primary_checkout_root(repo_root: Path) -> Path:
+    """Return the primary checkout root that owns the shared .git dir."""
+    git_path = repo_root / ".git"
+    if git_path.is_dir():
+        return repo_root
+    if not git_path.is_file():
+        return repo_root
+
+    try:
+        first_line = git_path.read_text(encoding="utf-8").splitlines()[0]
+    except (IndexError, OSError):
+        return repo_root
+    prefix = "gitdir:"
+    if not first_line.startswith(prefix):
+        return repo_root
+
+    git_dir = Path(first_line[len(prefix):].strip())
+    if not git_dir.is_absolute():
+        git_dir = repo_root / git_dir
+    git_dir = git_dir.resolve()
+    if git_dir.parent.name != "worktrees":
+        return repo_root
+    common_git_dir = git_dir.parent.parent
+    if common_git_dir.name != ".git":
+        return repo_root
+    return common_git_dir.parent
+
+
+def _format_failure(proc: subprocess.CompletedProcess[str]) -> str:
+    detail = (proc.stderr or proc.stdout or "").strip()
+    if detail:
+        return detail.splitlines()[-1]
+    return f"exit {proc.returncode}"
+
+
+def _branch_name(raw: str) -> str:
+    for prefix in ("refs/heads/", "refs/remotes/origin/"):
+        if raw.startswith(prefix):
+            return raw[len(prefix):]
+    return raw
+
+
+def parse_worktree_porcelain(output: str) -> list[WorktreeInfo]:
+    entries: list[WorktreeInfo] = []
+    current: dict[str, Any] | None = None
+
+    def finish() -> None:
+        nonlocal current
+        if current and current.get("path"):
+            entries.append(
+                WorktreeInfo(
+                    path=Path(current["path"]).resolve(),
+                    branch=current.get("branch"),
+                    head=current.get("head"),
+                    detached=bool(current.get("detached")),
+                )
+            )
+        current = None
+
+    for line in output.splitlines():
+        if not line:
+            finish()
+            continue
+        if line.startswith("worktree "):
+            finish()
+            current = {"path": line.removeprefix("worktree ").strip()}
+            continue
+        if current is None:
+            continue
+        if line.startswith("HEAD "):
+            current["head"] = line.removeprefix("HEAD ").strip()
+        elif line.startswith("branch "):
+            current["branch"] = _branch_name(line.removeprefix("branch ").strip())
+        elif line == "detached":
+            current["detached"] = True
+    finish()
+    return entries
+
+
+def list_git_worktrees(repo_root: Path) -> list[WorktreeInfo]:
+    proc = _run(["git", "worktree", "list", "--porcelain"], cwd=repo_root)
+    if proc.returncode != 0:
+        raise RuntimeError(f"git worktree list failed: {_format_failure(proc)}")
+    return parse_worktree_porcelain(proc.stdout or "")
+
+
+def _worktrees_root(repo_root: Path) -> Path:
+    return (repo_root / ".worktrees").resolve()
+
+
+def _is_under_worktrees(repo_root: Path, path: Path) -> bool:
+    try:
+        path.resolve().relative_to(_worktrees_root(repo_root))
+    except ValueError:
+        return False
+    return True
+
+
+def _worktree_clean(path: Path) -> bool | None:
+    proc = _run(["git", "status", "--porcelain"], cwd=path)
+    if proc.returncode != 0:
+        return None
+    return not bool((proc.stdout or "").strip())
+
+
+def _query_pr_states(repo_root: Path, branch: str | None) -> tuple[list[PullRequestState], str | None]:
+    if not branch:
+        return [], None
+    try:
+        proc = _run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--head",
+                branch,
+                "--state",
+                "all",
+                "--json",
+                "number,state",
+            ],
+            cwd=repo_root,
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError) as exc:
+        return [], f"gh pr list failed: {exc}"
+    if proc.returncode != 0:
+        return [], f"gh pr list failed: {_format_failure(proc)}"
+    try:
+        raw_items = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        return [], f"gh pr list returned invalid JSON: {exc}"
+
+    states: list[PullRequestState] = []
+    for item in raw_items:
+        if not isinstance(item, dict):
+            continue
+        state = str(item.get("state") or "").upper()
+        if not state:
+            continue
+        number = item.get("number")
+        states.append(
+            PullRequestState(
+                number=number if isinstance(number, int) else None,
+                state=state,
+            )
+        )
+    return states, None
+
+
+def _best_pr(prs: list[PullRequestState]) -> PullRequestState | None:
+    for desired in ("MERGED", "CLOSED", "OPEN"):
+        for pr_state in prs:
+            if pr_state.state == desired:
+                return pr_state
+    return prs[0] if prs else None
+
+
+def _pr_dict(pr_state: PullRequestState | None) -> dict[str, Any] | None:
+    if pr_state is None:
+        return None
+    return {"number": pr_state.number, "state": pr_state.state}
+
+
+def _origin_matches_head(path: Path, branch: str | None) -> bool:
+    if not branch:
+        return False
+    remote_ref = f"origin/{branch}"
+    verify = _run(["git", "rev-parse", "--verify", remote_ref], cwd=path)
+    if verify.returncode != 0:
+        return False
+    count = _run(
+        ["git", "rev-list", "--left-right", "--count", f"{remote_ref}...HEAD"],
+        cwd=path,
+    )
+    if count.returncode != 0:
+        return False
+    parts = (count.stdout or "").strip().split()
+    return parts == ["0", "0"]
+
+
+def _worktree_age_hours(path: Path, now: float | None = None) -> float | None:
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        return None
+    return ((now or time.time()) - mtime) / 3600
+
+
+def _qualifying_reason(
+    *,
+    repo_root: Path,
+    info: WorktreeInfo,
+    pr_state: PullRequestState | None,
+    build_age_hours: float,
+    now: float | None,
+) -> str | None:
+    if pr_state is not None:
+        pr_label = f"PR #{pr_state.number}" if pr_state.number is not None else "PR"
+        if pr_state.state == "MERGED":
+            return f"{pr_label} MERGED"
+        if pr_state.state == "CLOSED":
+            return f"{pr_label} CLOSED"
+
+    if info.branch and info.branch.startswith("build/"):
+        age_hours = _worktree_age_hours(info.path, now=now)
+        if age_hours is not None and age_hours > build_age_hours:
+            return f"build branch age {age_hours:.1f}h > {build_age_hours:g}h"
+
+    if _origin_matches_head(info.path, info.branch):
+        return f"HEAD matches origin/{info.branch}"
+
+    return None
+
+
+def _preserve_dirty_worktree(info: WorktreeInfo) -> str | None:
+    branch = info.branch or "detached"
+    add_proc = _run(["git", "add", "-A"], cwd=info.path)
+    if add_proc.returncode != 0:
+        return f"git add failed: {_format_failure(add_proc)}"
+    commit_proc = _run(
+        [
+            "git",
+            "commit",
+            "--no-verify",
+            "-m",
+            f"wip: preserve {branch} before reap [skip ci]",
+        ],
+        cwd=info.path,
+    )
+    if commit_proc.returncode != 0:
+        return f"git commit failed: {_format_failure(commit_proc)}"
+    return None
+
+
+def _remove_worktree(repo_root: Path, info: WorktreeInfo) -> str | None:
+    proc = _run(
+        ["git", "worktree", "remove", "--force", str(info.path)],
+        cwd=repo_root,
+    )
+    if proc.returncode != 0:
+        return _format_failure(proc)
+    return None
+
+
+def _prune_branch(repo_root: Path, branch: str | None) -> str | None:
+    if not branch:
+        return None
+    proc = _run(["git", "branch", "-d", branch], cwd=repo_root)
+    if proc.returncode != 0:
+        return _format_failure(proc)
+    return None
+
+
+def _reap_qualified_worktree(
+    *,
+    repo_root: Path,
+    info: WorktreeInfo,
+    reason: str,
+    dirty: bool | None,
+    pr_state: PullRequestState | None,
+    apply: bool,
+    preserve_then_reap: bool,
+    prune_merged_branches: bool,
+) -> ReapResult:
+    if dirty is None:
+        return ReapResult(
+            path=str(info.path),
+            branch=info.branch,
+            action="skipped",
+            reason="unable to determine worktree status",
+            dirty=None,
+            pr=_pr_dict(pr_state),
+        )
+    if dirty and not preserve_then_reap:
+        return ReapResult(
+            path=str(info.path),
+            branch=info.branch,
+            action="skipped",
+            reason=f"dirty; qualifies for reap because {reason}",
+            dirty=True,
+            pr=_pr_dict(pr_state),
+        )
+
+    if not apply:
+        action = "would_preserve_then_remove" if dirty else "would_remove"
+        return ReapResult(
+            path=str(info.path),
+            branch=info.branch,
+            action=action,
+            reason=reason,
+            dirty=dirty,
+            pr=_pr_dict(pr_state),
+        )
+
+    if dirty:
+        preserve_error = _preserve_dirty_worktree(info)
+        if preserve_error is not None:
+            return ReapResult(
+                path=str(info.path),
+                branch=info.branch,
+                action="error",
+                reason=f"preserve before reap failed: {reason}",
+                dirty=True,
+                pr=_pr_dict(pr_state),
+                error=preserve_error,
+            )
+
+    remove_error = _remove_worktree(repo_root, info)
+    if remove_error is not None:
+        return ReapResult(
+            path=str(info.path),
+            branch=info.branch,
+            action="error",
+            reason=reason,
+            dirty=dirty,
+            pr=_pr_dict(pr_state),
+            error=remove_error,
+        )
+
+    branch_prune_error = None
+    if prune_merged_branches and pr_state is not None and pr_state.state == "MERGED":
+        branch_prune_error = _prune_branch(repo_root, info.branch)
+
+    if branch_prune_error is not None:
+        return ReapResult(
+            path=str(info.path),
+            branch=info.branch,
+            action="removed",
+            reason=f"{reason}; branch prune failed",
+            dirty=dirty,
+            pr=_pr_dict(pr_state),
+            error=branch_prune_error,
+        )
+
+    return ReapResult(
+        path=str(info.path),
+        branch=info.branch,
+        action="preserved_then_removed" if dirty else "removed",
+        reason=reason,
+        dirty=dirty,
+        pr=_pr_dict(pr_state),
+    )
+
+
+def _target_filter(target_paths: list[Path] | None) -> set[Path] | None:
+    if target_paths is None:
+        return None
+    return {path.resolve() for path in target_paths}
+
+
+def reap_worktrees(
+    *,
+    repo_root: Path,
+    apply: bool = False,
+    build_age_hours: float = DEFAULT_BUILD_AGE_HOURS,
+    preserve_then_reap: bool = False,
+    prune_merged_branches: bool = False,
+    target_paths: list[Path] | None = None,
+    now: float | None = None,
+) -> list[ReapResult]:
+    """Evaluate and optionally reap eligible worktrees."""
+    repo_root = repo_root.resolve()
+    targets = _target_filter(target_paths)
+    results: list[ReapResult] = []
+
+    for info in list_git_worktrees(repo_root):
+        if targets is not None and info.path.resolve() not in targets:
+            continue
+        if not _is_under_worktrees(repo_root, info.path):
+            results.append(
+                ReapResult(
+                    path=str(info.path),
+                    branch=info.branch,
+                    action="skipped",
+                    reason="outside repo .worktrees/",
+                    dirty=None,
+                )
+            )
+            continue
+        if info.branch is None:
+            results.append(
+                ReapResult(
+                    path=str(info.path),
+                    branch=None,
+                    action="skipped",
+                    reason="detached or missing branch",
+                    dirty=None,
+                )
+            )
+            continue
+
+        dirty_state = _worktree_clean(info.path)
+        dirty = None if dirty_state is None else not dirty_state
+        pr_states, pr_error = _query_pr_states(repo_root, info.branch)
+        pr_state = _best_pr(pr_states)
+        reason = _qualifying_reason(
+            repo_root=repo_root,
+            info=info,
+            pr_state=pr_state,
+            build_age_hours=build_age_hours,
+            now=now,
+        )
+        if reason is None:
+            reason = (
+                f"no reap condition matched; {pr_error}"
+                if pr_error
+                else "no reap condition matched"
+            )
+            results.append(
+                ReapResult(
+                    path=str(info.path),
+                    branch=info.branch,
+                    action="skipped",
+                    reason=reason,
+                    dirty=dirty,
+                    pr=_pr_dict(pr_state),
+                )
+            )
+            continue
+
+        results.append(
+            _reap_qualified_worktree(
+                repo_root=repo_root,
+                info=info,
+                reason=reason,
+                dirty=dirty,
+                pr_state=pr_state,
+                apply=apply,
+                preserve_then_reap=preserve_then_reap,
+                prune_merged_branches=prune_merged_branches,
+            )
+        )
+
+    if targets is not None:
+        seen = {Path(result.path).resolve() for result in results}
+        for target in sorted(targets - seen):
+            results.append(
+                ReapResult(
+                    path=str(target),
+                    branch=None,
+                    action="skipped",
+                    reason="target path is not a registered git worktree",
+                    dirty=None,
+                )
+            )
+
+    return results
+
+
+def reap_success_worktree(
+    *,
+    repo_root: Path,
+    worktree_path: Path,
+    reason: str,
+    apply: bool = True,
+    preserve_then_reap: bool = False,
+) -> ReapResult:
+    """Remove one clean success worktree while keeping its branch."""
+    repo_root = repo_root.resolve()
+    target = worktree_path.resolve()
+    matching = [
+        info
+        for info in list_git_worktrees(repo_root)
+        if info.path.resolve() == target
+    ]
+    if not matching:
+        return ReapResult(
+            path=str(target),
+            branch=None,
+            action="skipped",
+            reason="target path is not a registered git worktree",
+            dirty=None,
+        )
+
+    info = matching[0]
+    if not _is_under_worktrees(repo_root, info.path):
+        return ReapResult(
+            path=str(info.path),
+            branch=info.branch,
+            action="skipped",
+            reason="outside repo .worktrees/",
+            dirty=None,
+        )
+    clean = _worktree_clean(info.path)
+    dirty = None if clean is None else not clean
+    return _reap_qualified_worktree(
+        repo_root=repo_root,
+        info=info,
+        reason=reason,
+        dirty=dirty,
+        pr_state=None,
+        apply=apply,
+        preserve_then_reap=preserve_then_reap,
+        prune_merged_branches=False,
+    )
+
+
+def _result_payload(result: ReapResult) -> dict[str, Any]:
+    return asdict(result)
+
+
+def _format_result_line(result: ReapResult) -> str:
+    branch = result.branch or "-"
+    base = f"{result.action.upper()} {result.path} branch={branch} reason={result.reason}"
+    if result.error:
+        base = f"{base} error={result.error}"
+    return base
+
+
+def format_text_results(results: list[ReapResult], *, apply: bool) -> str:
+    remove_actions = {
+        "would_remove",
+        "would_preserve_then_remove",
+        "removed",
+        "preserved_then_removed",
+    }
+    candidates = sum(1 for result in results if result.action in remove_actions)
+    skipped = sum(1 for result in results if result.action == "skipped")
+    errors = sum(1 for result in results if result.action == "error")
+    mode = "APPLY" if apply else "DRY RUN"
+    lines = [f"{mode}: {candidates} candidate(s), {skipped} skipped, {errors} error(s)"]
+    lines.extend(_format_result_line(result) for result in results)
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Safely reap completed git worktrees under .worktrees/.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root to inspect (default: current git worktree root).",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="Print candidates without changing the filesystem (default).",
+    )
+    mode.add_argument(
+        "--apply",
+        action="store_true",
+        help="Remove eligible worktrees.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON.",
+    )
+    parser.add_argument(
+        "--build-age-hours",
+        type=float,
+        default=DEFAULT_BUILD_AGE_HOURS,
+        help=f"Reap clean build/* worktrees older than this many hours (default: {DEFAULT_BUILD_AGE_HOURS:g}).",
+    )
+    parser.add_argument(
+        "--preserve-then-reap",
+        action="store_true",
+        help="Commit dirty eligible worktrees locally with --no-verify before removing them.",
+    )
+    parser.add_argument(
+        "--prune-merged-branches",
+        action="store_true",
+        help="After removing a MERGED PR worktree, run safe 'git branch -d <branch>'.",
+    )
+    parser.add_argument(
+        "--worktree",
+        action="append",
+        type=Path,
+        default=None,
+        help="Limit evaluation to a registered worktree path. Repeatable.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    repo_root = (
+        args.repo_root.resolve()
+        if args.repo_root
+        else primary_checkout_root(resolve_repo_root())
+    )
+    apply = bool(args.apply)
+    results = reap_worktrees(
+        repo_root=repo_root,
+        apply=apply,
+        build_age_hours=args.build_age_hours,
+        preserve_then_reap=bool(args.preserve_then_reap),
+        prune_merged_branches=bool(args.prune_merged_branches),
+        target_paths=args.worktree,
+    )
+    if args.json:
+        print(json.dumps([_result_payload(result) for result in results], indent=2))
+    else:
+        print(format_text_results(results, apply=apply))
+    return 1 if any(result.action == "error" for result in results) else 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except RuntimeError as exc:
+        print(f"reap_worktrees.py: {exc}", file=sys.stderr)
+        raise SystemExit(2) from None

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.orchestration import reap_worktrees as rw
+
+_REAL_RUN = subprocess.run
+
+
+def git_env() -> dict[str, str]:
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_") and not key.startswith("PRE_COMMIT")
+    }
+
+
+def git(cwd: Path, *args: str) -> str:
+    proc = _REAL_RUN(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=git_env(),
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    return (proc.stdout or "").strip()
+
+
+def init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    remote = tmp_path / "origin.git"
+    git(tmp_path, "init", "--bare", str(remote))
+    git(tmp_path, "init", "--initial-branch=main", str(repo))
+    git(repo, "config", "user.email", "tester@example.com")
+    git(repo, "config", "user.name", "Test User")
+    (repo / ".gitignore").write_text(".worktrees/\n", encoding="utf-8")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    git(repo, "add", ".gitignore", "README.md")
+    git(repo, "commit", "-m", "base")
+    git(repo, "remote", "add", "origin", str(remote))
+    git(repo, "push", "-u", "origin", "main")
+    return repo
+
+
+def add_worktree(
+    repo: Path,
+    branch: str,
+    *,
+    path: Path | None = None,
+    base: str = "main",
+) -> Path:
+    worktree = path or repo / ".worktrees" / branch.replace("/", "-")
+    worktree.parent.mkdir(parents=True, exist_ok=True)
+    git(repo, "worktree", "add", "-b", branch, str(worktree), base)
+    return worktree
+
+
+def patch_gh(
+    monkeypatch: pytest.MonkeyPatch,
+    states_by_branch: dict[str, list[dict[str, Any]]],
+) -> list[str]:
+    calls: list[str] = []
+
+    def fake_run(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if args and args[0] == "gh":
+            branch = args[args.index("--head") + 1]
+            calls.append(branch)
+            payload = states_by_branch.get(branch, [])
+            return subprocess.CompletedProcess(args, 0, json.dumps(payload), "")
+        return _REAL_RUN(args, **kwargs)
+
+    monkeypatch.setattr(rw.subprocess, "run", fake_run)
+    return calls
+
+
+def result_for(results: list[rw.ReapResult], path: Path) -> rw.ReapResult:
+    matches = [result for result in results if Path(result.path).resolve() == path.resolve()]
+    assert matches, [result.path for result in results]
+    return matches[0]
+
+
+def assert_main_checkout_unchanged(repo: Path) -> None:
+    assert git(repo, "branch", "--show-current") == "main"
+    assert git(repo, "status", "--porcelain") == ""
+
+
+def test_primary_checkout_root_resolves_from_linked_worktree(tmp_path: Path) -> None:
+    main = tmp_path / "learn-ukrainian"
+    worktree = main / ".worktrees" / "dispatch" / "codex" / "task"
+    git_dir = main / ".git" / "worktrees" / "task"
+    worktree.mkdir(parents=True)
+    git_dir.mkdir(parents=True)
+    (worktree / ".git").write_text(f"gitdir: {git_dir}\n", encoding="utf-8")
+
+    assert rw.primary_checkout_root(worktree) == main
+
+
+def test_merged_clean_removes_worktree_and_keeps_branch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    worktree = add_worktree(repo, "codex/merged")
+    patch_gh(monkeypatch, {"codex/merged": [{"number": 12, "state": "MERGED"}]})
+
+    results = rw.reap_worktrees(repo_root=repo, apply=True)
+
+    result = result_for(results, worktree)
+    assert result.action == "removed"
+    assert result.reason == "PR #12 MERGED"
+    assert not worktree.exists()
+    assert git(repo, "rev-parse", "--verify", "codex/merged")
+    assert_main_checkout_unchanged(repo)
+
+
+def test_merged_dirty_is_preserved_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    worktree = add_worktree(repo, "codex/dirty")
+    (worktree / "dirty.txt").write_text("not committed\n", encoding="utf-8")
+    patch_gh(monkeypatch, {"codex/dirty": [{"number": 13, "state": "MERGED"}]})
+
+    results = rw.reap_worktrees(repo_root=repo, apply=True)
+
+    result = result_for(results, worktree)
+    assert result.action == "skipped"
+    assert "dirty; qualifies for reap because PR #13 MERGED" in result.reason
+    assert worktree.exists()
+    assert git(worktree, "status", "--porcelain")
+    assert_main_checkout_unchanged(repo)
+
+
+def test_preserve_then_reap_commits_dirty_worktree_before_removal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    worktree = add_worktree(repo, "codex/preserve")
+    (worktree / "artifact.txt").write_text("recover me\n", encoding="utf-8")
+    patch_gh(monkeypatch, {"codex/preserve": [{"number": 14, "state": "MERGED"}]})
+
+    results = rw.reap_worktrees(
+        repo_root=repo,
+        apply=True,
+        preserve_then_reap=True,
+    )
+
+    result = result_for(results, worktree)
+    assert result.action == "preserved_then_removed"
+    assert not worktree.exists()
+
+    recovered = tmp_path / "recovered-preserve"
+    git(repo, "worktree", "add", str(recovered), "codex/preserve")
+    assert (recovered / "artifact.txt").read_text(encoding="utf-8") == "recover me\n"
+    assert (
+        git(recovered, "log", "-1", "--format=%s")
+        == "wip: preserve codex/preserve before reap [skip ci]"
+    )
+    assert_main_checkout_unchanged(repo)
+
+
+def test_build_branch_clean_and_aged_is_removed_but_branch_is_kept(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    worktree = add_worktree(repo, "build/a1/aged")
+    now = time.time()
+    old = now - 8 * 3600
+    os.utime(worktree, (old, old))
+    patch_gh(monkeypatch, {})
+
+    results = rw.reap_worktrees(
+        repo_root=repo,
+        apply=True,
+        build_age_hours=6,
+        now=now,
+    )
+
+    result = result_for(results, worktree)
+    assert result.action == "removed"
+    assert result.reason == "build branch age 8.0h > 6h"
+    assert not worktree.exists()
+    assert git(repo, "rev-parse", "--verify", "build/a1/aged")
+    assert_main_checkout_unchanged(repo)
+
+
+def test_pushed_origin_clean_worktree_is_removed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    worktree = add_worktree(repo, "codex/pushed")
+    (worktree / "pushed.txt").write_text("pushed\n", encoding="utf-8")
+    git(worktree, "add", "pushed.txt")
+    git(worktree, "commit", "-m", "feat: pushed")
+    git(worktree, "push", "-u", "origin", "codex/pushed")
+    patch_gh(monkeypatch, {})
+
+    results = rw.reap_worktrees(repo_root=repo, apply=True)
+
+    result = result_for(results, worktree)
+    assert result.action == "removed"
+    assert result.reason == "HEAD matches origin/codex/pushed"
+    assert not worktree.exists()
+    assert git(repo, "rev-parse", "--verify", "codex/pushed")
+    assert_main_checkout_unchanged(repo)
+
+
+def test_external_worktree_path_is_untouched(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    external = add_worktree(
+        repo,
+        "codex/external",
+        path=tmp_path / "external-worktree",
+    )
+    calls = patch_gh(
+        monkeypatch,
+        {"codex/external": [{"number": 15, "state": "MERGED"}]},
+    )
+
+    results = rw.reap_worktrees(repo_root=repo, apply=True)
+
+    result = result_for(results, external)
+    assert result.action == "skipped"
+    assert result.reason == "outside repo .worktrees/"
+    assert external.exists()
+    assert "codex/external" not in calls
+    assert_main_checkout_unchanged(repo)
+
+
+def test_dry_run_makes_zero_filesystem_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = init_repo(tmp_path)
+    worktree = add_worktree(repo, "codex/dry-run")
+    patch_gh(monkeypatch, {"codex/dry-run": [{"number": 16, "state": "MERGED"}]})
+
+    rc = rw.main(["--repo-root", str(repo), "--dry-run"])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "DRY RUN:" in captured.out
+    assert "WOULD_REMOVE" in captured.out
+    assert str(worktree) in captured.out
+    assert worktree.exists()
+    assert git(worktree, "status", "--porcelain") == ""
+    assert_main_checkout_unchanged(repo)


### PR DESCRIPTION
## Summary

`.worktrees/` has been growing because the build and dispatch paths printed `git worktree remove ...` suggestions instead of running safe cleanup after success. This ports the kubedojo-style reap-on-merge idea into a durable sweep keyed on current PR/branch state rather than a long-running JSONL tail watcher.

## What changed

- Added `scripts/orchestration/reap_worktrees.py` with `--dry-run` as the default, `.worktrees/` path filtering, PR-state lookup via `gh pr list --head <branch> --state all`, pushed-to-origin detection, and `build/*` age cleanup.
- Added dirty-worktree preservation via explicit `--preserve-then-reap`, using an in-worktree `git add -A && git commit --no-verify -m "wip: preserve <branch> before reap [skip ci]"` before removal.
- Wired `scripts/build/v7_build.py` to remove successful build worktrees after artifact persistence, with `--keep-worktree` as an opt-out.
- Wired `scripts/delegate.py` to attempt cleanup after clean successful danger-mode workers when the branch is recoverable from PR/origin state, also with `--keep-worktree` as an opt-out.

## Safety matrix

| State | Default behavior | Opt-in behavior |
| --- | --- | --- |
| PR `MERGED`, clean | Remove worktree, keep branch | `--prune-merged-branches` may also run safe `git branch -d` |
| PR `CLOSED`, clean | Remove worktree, keep branch | Same branch retention |
| `build/*`, clean, aged past threshold | Remove worktree, keep branch | Threshold configurable with `--build-age-hours` |
| Clean and `HEAD == origin/<branch>` | Remove worktree, keep branch | None needed |
| Dirty but otherwise eligible | Skip and report reason | `--preserve-then-reap` commits locally with `--no-verify`, then removes |
| Outside repo `.worktrees/` | Skip | Never reaped |

## Validation

- `.venv/bin/ruff check scripts/orchestration/reap_worktrees.py tests/orchestration/test_reap_worktrees.py`
- `.venv/bin/python -m pytest tests/orchestration/test_reap_worktrees.py -q`
- `.venv/bin/python -m pytest tests/test_v7_build_worktree.py tests/test_delegate.py -q`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
