### PR TITLE
fix(qg): exempt highlight-morphemes morpheme answer keys

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -759,6 +759,8 @@ _ERROR_CORRECTION_TYPE = "error-correction"
 _ERROR_CORRECTION_INTENTIONAL_FIELDS = frozenset(
     {"error", "errors", "errorWord", "error_word", "explanation", "sentence"}
 )
+_HIGHLIGHT_MORPHEMES_TYPE = "highlight-morphemes"
+_HIGHLIGHT_MORPHEMES_ANSWER_KEY_FIELDS = frozenset({"morphemes"})
 _ERROR_CORRECTION_REQUIRED_ITEM_FIELDS = frozenset({"sentence", "error"})
 _ERROR_CORRECTION_OPTIONAL_ITEM_FIELDS = frozenset({"answer", "correction", "options", "explanation"})
 _ACTIVITY_ITEM_AUTHORING_FIELDS: dict[str, frozenset[str]] = {
@@ -8941,10 +8943,18 @@ def _activity_vesum_text(
     verified; missing answers fail soft by skipping the statement. True
     statements also get a narrow safety net for sentence-final negative examples
     like ``X, а не дивюся.`` where the tail is named as wrong teaching content.
+
+    For highlight-morphemes activities, `morphemes:` is an answer key of bare
+    sub-word units. Skip that subtree while keeping `text:`, `word:`, title,
+    and instruction strings in VESUM scope.
     """
     activity_type = activity.get("type")
     activity_id = str(activity.get("id") or "")
-    skip_subtree = _ERROR_CORRECTION_INTENTIONAL_FIELDS if activity_type == _ERROR_CORRECTION_TYPE else frozenset()
+    skip_subtree: set[str] = set()
+    if activity_type == _ERROR_CORRECTION_TYPE:
+        skip_subtree.update(_ERROR_CORRECTION_INTENTIONAL_FIELDS)
+    if activity_type == _HIGHLIGHT_MORPHEMES_TYPE:
+        skip_subtree.update(_HIGHLIGHT_MORPHEMES_ANSWER_KEY_FIELDS)
 
     out: list[str] = []
 

--- a/tests/test_vesum_gate_distractor_and_phonetic.py
+++ b/tests/test_vesum_gate_distractor_and_phonetic.py
@@ -99,6 +99,73 @@ def test_error_correction_sentence_not_verified() -> None:
     assert "снідаюся" not in sent_for_verification
 
 
+def test_highlight_morphemes_answer_key_not_verified() -> None:
+    """highlight-morphemes `morphemes:` values are bare answer-key fragments."""
+    activity = {
+        "type": "highlight-morphemes",
+        "text": "обрядовість посівання колядування веснянка",
+        "items": [
+            {"word": "веснянка", "morphemes": ["весн", "янк", "а"]},
+            {"word": "колядування", "morphemes": ["коляд", "ува", "ння"]},
+            {"word": "посівання", "morphemes": ["по", "сів", "ання"]},
+        ],
+    }
+    sent_for_verification: set[str] = set()
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        sent_for_verification.update(words)
+        return {word: [{"lemma": word}] for word in words}
+
+    result = _vesum_gate(
+        module_text="",
+        activities=[activity],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert result["passed"] is True
+    assert result["missing"] == []
+    assert {"весн", "янк", "коляд", "ува", "ння", "сів", "ання"}.isdisjoint(
+        sent_for_verification
+    )
+    assert {"обрядовість", "посівання", "колядування", "веснянка"}.issubset(
+        sent_for_verification
+    )
+
+
+def test_highlight_morphemes_text_still_verified() -> None:
+    """A bad form in highlight-morphemes `text:` still fails VESUM."""
+    activity = {
+        "type": "highlight-morphemes",
+        "text": "веснянка дивюся",
+        "items": [
+            {"word": "веснянка", "morphemes": ["весн", "янк", "а"]},
+        ],
+    }
+    sent_for_verification: set[str] = set()
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        sent_for_verification.update(words)
+        return {
+            word: ([{"lemma": word}] if word == "веснянка" else [])
+            for word in words
+        }
+
+    result = _vesum_gate(
+        module_text="",
+        activities=[activity],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert result["passed"] is False
+    assert result["missing"] == ["дивюся"]
+    assert "дивюся" in sent_for_verification
+    assert {"весн", "янк"}.isdisjoint(sent_for_verification)
+
+
 def test_dialect_abbreviation_not_verified() -> None:
     """Textbook abbreviation `діал.` is metadata, not a VESUM lemma."""
     sent_for_verification: set[str] = set()


### PR DESCRIPTION
## Summary

- Exempt `highlight-morphemes` activity `morphemes:` subtrees from `_activity_vesum_text` so bare answer-key fragments are not sent to `vesum_verified`.
- Keep learner-facing `text:`, `word:`, title, and instruction strings in VESUM scope.
- Add regression coverage for the kalendarna-obriadovist-zvychai failure mode where fragments like `весн`, `янк`, `ува`, `ння`, and `ання` were reported as missing.

## Root Cause

`highlight-morphemes` uses `morphemes:` as a structured answer key of roots and derivational suffix fragments. `_activity_vesum_text` previously walked those values like normal prose, so the VESUM gate treated sub-word fragments as whole-word lemmas. This matches the existing exemption class for intentional-error fields and fill-in suffix fragments, but the morpheme answer-key field had not been added to the structural skip list.

## Gate Behavior Preserved

The new skip is scoped to `activity_type == "highlight-morphemes"` and key `morphemes`, at subtree level. A regression test verifies the morpheme fragments are not sent to verification, while whole words from `text:` and `word:` still are. A positive-control test plants `дивюся` in `text:` and confirms `vesum_verified` still fails with that missing form.

## Validation

- `.venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_vesum_gate_distractor_and_phonetic.py`
- `.venv/bin/python -m pytest tests/test_vesum_gate_distractor_and_phonetic.py -q`
- `.venv/bin/python -m pytest tests/test_vesum_verified_postfix.py -q`
- standalone repro before fix: `морфеми present? True`
- standalone repro after fix: `морфеми present? False`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
