### PR TITLE
fix(qg): accept productive -ість nouns with adjective bases

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -613,6 +613,18 @@ _INJECT_RE = re.compile(r"<!--\s*INJECT_ACTIVITY:\s*([A-Za-z0-9_-]+)\s*-->")
 _HEADING_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
 _VESUM_SHORT_DECORATED_WORDS = frozenset({"ся", "сь"})
 _VESUM_STRESS_MARKS = frozenset({"\u0300", "\u0301"})
+# O-grade plural obliques (`-остей`, `-остями`, `-остях`, `-остям`) overlap
+# Russian `-ость` forms such as `новостей`; keep that fallback to longer
+# stems so it does not pass merely because short bases like `новий` verify.
+_VESUM_PRODUCTIVE_IST_ENDINGS = (
+    ("остями", 5),
+    ("остей", 5),
+    ("остях", 5),
+    ("остям", 5),
+    ("істю", 1),
+    ("ості", 1),
+    ("ість", 1),
+)
 
 # Metalinguistic content that must be stripped before VESUM lookup:
 # phonetic transcriptions like [с':а] and inline code in backticks contain
@@ -8207,6 +8219,36 @@ def _vesum_gate(
                     resolved_compounds.add(compound)
             missing_lc -= resolved_compounds
     if missing_lc:
+        ist_adjective_candidates_by_missing = {
+            word: candidates
+            for word in missing_lc
+            if (candidates := _productive_ist_adjective_candidates(word))
+        }
+        ist_adjective_lookups = {
+            candidate
+            for candidates in ist_adjective_candidates_by_missing.values()
+            for candidate in candidates
+        }
+        if ist_adjective_lookups:
+            try:
+                ist_adjective_verified = verify_words_fn(sorted(ist_adjective_lookups))
+            except Exception as exc:
+                return {
+                    "passed": False,
+                    "error": str(exc),
+                    "checked": len(unchecked_pairs),
+                }
+            verified_adjectives = {
+                word
+                for word, matches in ist_adjective_verified.items()
+                if any(_vesum_match_is_adjective(match) for match in matches)
+            }
+            missing_lc -= {
+                word
+                for word, candidates in ist_adjective_candidates_by_missing.items()
+                if any(candidate in verified_adjectives for candidate in candidates)
+            }
+    if missing_lc:
         missing_lc = {word for word in missing_lc if not _is_sung_vowel_practice_lookup(word)}
     missing = sorted({surface for surface, lower, _original in unchecked_pairs if lower in missing_lc})
     ignored_missing_lc = _vesum_missing_exclusion_keys(
@@ -8458,6 +8500,21 @@ def _vesum_missing_exclusion_keys(
             if len(word) >= min_word_length:
                 keys.add(word.lower())
     return frozenset(keys)
+
+
+def _productive_ist_adjective_candidates(word: str) -> tuple[str, ...]:
+    for ending, min_stem_length in _VESUM_PRODUCTIVE_IST_ENDINGS:
+        if not word.endswith(ending):
+            continue
+        stem = word[: -len(ending)]
+        if len(stem) < min_stem_length:
+            return ()
+        return (f"{stem}ий", f"{stem}ій")
+    return ()
+
+
+def _vesum_match_is_adjective(match: Mapping[str, Any]) -> bool:
+    return str(match.get("pos", "")).lower() in {"adj", "adjective"}
 
 
 def _iter_vesum_lookup_surface_pairs(

--- a/tests/test_vesum_verified_postfix.py
+++ b/tests/test_vesum_verified_postfix.py
@@ -181,6 +181,97 @@ def test_vesum_gate_verifies_valid_hyphenated_compounds_as_whole_words() -> None
     assert not {"будьякий", "будьщо", "поперше", "купаль", "обжинк", "ськ"} & looked_up
 
 
+def test_vesum_gate_accepts_productive_ist_nouns_from_valid_adjectives() -> None:
+    seen: list[list[str]] = []
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        seen.append(words)
+        valid_adjectives = {"круговий", "загальнослов'янський"}
+        return {
+            word: (
+                [{"lemma": word, "pos": "adj", "tags": "adj:m:v_naz"}]
+                if word in valid_adjectives
+                else []
+            )
+            for word in words
+        }
+
+    gate = _vesum_gate(
+        module_text="Круговість, круговостей і загальнослов'янськість.",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    looked_up = {word for call in seen for word in call}
+    assert gate["passed"] is True
+    assert gate["missing"] == []
+    assert {"круговий", "загальнослов'янський"} <= looked_up
+
+
+def test_vesum_gate_keeps_ist_coinage_missing_without_adjective_base() -> None:
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        return {
+            word: (
+                [{"lemma": word, "pos": "noun", "tags": "noun:m:v_naz"}]
+                if word == "бздумий"
+                else []
+            )
+            for word in words
+        }
+
+    gate = _vesum_gate(
+        module_text="бздумість.",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert gate["passed"] is False
+    assert gate["missing"] == ["бздумість"]
+
+
+def test_vesum_gate_does_not_whitelist_russian_ost_noun() -> None:
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        return {word: [] for word in words}
+
+    gate = _vesum_gate(
+        module_text="благодарность.",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert gate["passed"] is False
+    assert gate["missing"] == ["благодарность"]
+
+
+def test_vesum_gate_does_not_whitelist_russian_ostey_oblique() -> None:
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        return {
+            word: (
+                [{"lemma": word, "pos": "adj", "tags": "adj:m:v_naz"}]
+                if word == "новий"
+                else []
+            )
+            for word in words
+        }
+
+    gate = _vesum_gate(
+        module_text="новостей.",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert gate["passed"] is False
+    assert gate["missing"] == ["новостей"]
+
+
 def test_vesum_gate_still_flags_known_bad_form_after_hyphen_fix() -> None:
     def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
         valid = {"будь-який"}


### PR DESCRIPTION
## Summary

- Add a narrow `vesum_verified` fallback for productive Ukrainian `-ість` abstract nouns whose surface form is missing from VESUM.
- Derive candidate adjective bases from the `-ість` paradigm and accept the missing noun only when the candidate base verifies as a VESUM adjective (`pos=adj`).
- Preserve gate teeth with controls for fabricated `-ість` coinages, Russian `-ость`, and ambiguous Russian `-остей` obliques.

## Root cause

C1 folk builds can produce legitimate productive abstracts such as `круговість` from `круговий` and `загальнослов'янськість` from `загальнослов'янський`. VESUM verifies the adjectives but does not enumerate those derived nouns, so the all-words gate failed even though the morphology is valid Ukrainian.

## Guard

The fallback is additive and runs after the existing hyphenated-constituent fallback. It only removes a word from `missing_lc` when a derived hard or soft adjective candidate verifies as an adjective. Non-`-ість` tokens, unknown bases, and non-adjective matches stay missing.

## Tests

- `круговість` / `загальнослов'янськість` pass via `круговий` / `загальнослов'янський` adjective bases.
- `бздумість` still fails when the candidate base is not a VESUM adjective.
- `благодарность` still fails because Russian `-ость` is outside the fallback.
- `новостей` still fails even though `новий` is a valid Ukrainian adjective, protecting an ambiguous Russian `-ость` oblique.

## Validation

- `.venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_vesum_verified_postfix.py`
- `.venv/bin/python -m pytest tests/test_vesum_verified_postfix.py -q`
- `.venv/bin/python -m pytest tests/test_activity_schema_gate.py -q`