### PR TITLE
[codex] fix A1 admonition rendering and React island dev prebundle

### DIFF
--- a/starlight/astro.config.mjs
+++ b/starlight/astro.config.mjs
@@ -4,9 +4,12 @@ import mdx from '@astrojs/mdx';
 import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 import rehypeMermaid from 'rehype-mermaid';
+import remarkDirective from 'remark-directive';
 import remarkGfm from 'remark-gfm';
+import remarkAdmonitions from './plugins/remark-admonitions.mjs';
 import vocabEtymologyLinker from './plugins/vocab-etymology-link.mjs';
 
+const remarkPlugins = [remarkDirective, remarkAdmonitions, remarkGfm, vocabEtymologyLinker];
 
 // https://astro.build/config
 export default defineConfig({
@@ -16,7 +19,7 @@ export default defineConfig({
   compressHTML: true,
 
   markdown: {
-    remarkPlugins: [remarkGfm, vocabEtymologyLinker],
+    remarkPlugins,
     rehypePlugins: [rehypeMermaid],
   },
 
@@ -30,13 +33,13 @@ export default defineConfig({
       dedupe: ['react', 'react-dom'],
     },
     optimizeDeps: {
-      include: ['react', 'react-dom'],
+      include: ['react', 'react-dom', 'react/jsx-runtime', 'react/jsx-dev-runtime'],
     },
   },
 
   integrations: [
     mdx({
-      remarkPlugins: [remarkGfm, vocabEtymologyLinker],
+      remarkPlugins,
       rehypePlugins: [rehypeMermaid],
     }),
     react(),

--- a/starlight/package-lock.json
+++ b/starlight/package-lock.json
@@ -20,6 +20,7 @@
         "react": "^19.2.5",
         "react-dom": "^19.2.6",
         "rehype-mermaid": "^3.0.0",
+        "remark-directive": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "sharp": "^0.34.2",
         "typescript": "^5.9.3"
@@ -5607,6 +5608,27 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-directive": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.1.0.tgz",
+      "integrity": "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
@@ -6018,6 +6040,25 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-gfm": {
@@ -7411,6 +7452,22 @@
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-4.0.0.tgz",
+      "integrity": "sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-directive": "^3.0.0",
+        "micromark-extension-directive": "^4.0.0",
         "unified": "^11.0.0"
       },
       "funding": {

--- a/starlight/package.json
+++ b/starlight/package.json
@@ -26,6 +26,7 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.6",
     "rehype-mermaid": "^3.0.0",
+    "remark-directive": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "sharp": "^0.34.2",
     "typescript": "^5.9.3"

--- a/starlight/plugins/remark-admonitions.mjs
+++ b/starlight/plugins/remark-admonitions.mjs
@@ -1,0 +1,77 @@
+const ADMONITION_TYPES = new Set(['info', 'tip', 'caution', 'note', 'danger', 'warning']);
+
+const DEFAULT_TITLES = {
+  info: 'Info',
+  tip: 'Tip',
+  caution: 'Caution',
+  note: 'Note',
+  danger: 'Danger',
+  warning: 'Warning',
+};
+
+function visit(node, callback) {
+  if (!node || typeof node !== 'object') return;
+  callback(node);
+  if (!Array.isArray(node.children)) return;
+  for (const child of node.children) visit(child, callback);
+}
+
+function nodeText(node) {
+  if (!node || typeof node !== 'object') return '';
+  if (typeof node.value === 'string') return node.value;
+  if (!Array.isArray(node.children)) return '';
+  return node.children.map((child) => nodeText(child)).join('');
+}
+
+function cloneNode(node) {
+  if (!node || typeof node !== 'object') return node;
+
+  return {
+    ...node,
+    data: node.data ? { ...node.data } : undefined,
+    children: Array.isArray(node.children) ? node.children.map((child) => cloneNode(child)) : undefined,
+  };
+}
+
+function splitLabel(children) {
+  const label = children.find((child) => child?.data?.directiveLabel);
+  return {
+    label,
+    body: children.filter((child) => child !== label),
+  };
+}
+
+function titleNode(name, label) {
+  const hasLabel = label && nodeText(label).trim().length > 0;
+
+  return {
+    type: 'paragraph',
+    data: {
+      hProperties: {
+        className: ['admonition-title'],
+      },
+    },
+    children: hasLabel
+      ? (label.children ?? []).map((child) => cloneNode(child))
+      : [{ type: 'text', value: DEFAULT_TITLES[name] }],
+  };
+}
+
+export default function remarkAdmonitions() {
+  return function transformAdmonitions(tree) {
+    visit(tree, (node) => {
+      if (node.type !== 'containerDirective' || !ADMONITION_TYPES.has(node.name)) return;
+
+      const { label, body } = splitLabel(node.children ?? []);
+
+      node.data = {
+        ...(node.data ?? {}),
+        hName: 'aside',
+        hProperties: {
+          className: ['admonition', `admonition-${node.name}`],
+        },
+      };
+      node.children = [titleNode(node.name, label), ...body];
+    });
+  };
+}

--- a/starlight/src/css/custom.css
+++ b/starlight/src/css/custom.css
@@ -346,6 +346,71 @@ a {
 }
 
 /* ============= ADMONITIONS / ALERTS ============= */
+.admonition {
+  --admonition-accent: var(--co-info);
+  --admonition-bg: rgba(66, 133, 244, 0.08);
+  --admonition-border: rgba(66, 133, 244, 0.24);
+
+  background: var(--admonition-bg);
+  border: 1px solid var(--admonition-border);
+  border-left: 4px solid var(--admonition-accent);
+  border-radius: 8px;
+  box-shadow: var(--ifm-global-shadow-lw);
+  margin: 1.5rem 0;
+  padding: 1rem 1.25rem;
+}
+
+.admonition-info {
+  --admonition-accent: var(--co-blue-bright);
+  --admonition-bg: rgba(26, 115, 232, 0.08);
+  --admonition-border: rgba(26, 115, 232, 0.24);
+}
+
+.admonition-tip {
+  --admonition-accent: var(--co-success);
+  --admonition-bg: rgba(52, 168, 83, 0.1);
+  --admonition-border: rgba(52, 168, 83, 0.24);
+}
+
+.admonition-caution,
+.admonition-warning {
+  --admonition-accent: var(--co-warning);
+  --admonition-bg: rgba(251, 188, 4, 0.12);
+  --admonition-border: rgba(251, 188, 4, 0.3);
+}
+
+.admonition-note {
+  --admonition-accent: var(--co-gray-600);
+  --admonition-bg: rgba(95, 99, 104, 0.08);
+  --admonition-border: rgba(95, 99, 104, 0.24);
+}
+
+.admonition-danger {
+  --admonition-accent: var(--co-error);
+  --admonition-bg: rgba(234, 67, 53, 0.1);
+  --admonition-border: rgba(234, 67, 53, 0.24);
+}
+
+.admonition-title {
+  color: var(--admonition-accent);
+  font-weight: 700;
+  margin: 0 0 0.65rem;
+}
+
+.admonition > :first-child {
+  margin-top: 0;
+}
+
+.admonition > :last-child {
+  margin-bottom: 0;
+}
+
+[data-theme='dark'] .admonition-note {
+  --admonition-accent: var(--co-gray-300);
+  --admonition-bg: rgba(255, 255, 255, 0.06);
+  --admonition-border: rgba(255, 255, 255, 0.16);
+}
+
 .alert {
   border-radius: 12px;
   border-left-width: 4px;

--- a/starlight/tests/unit/build-renders.test.ts
+++ b/starlight/tests/unit/build-renders.test.ts
@@ -19,6 +19,22 @@ import { readdirSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 
 const STARLIGHT_DIR = join(__dirname, '..', '..');
+const RAW_ADMONITION_RE = /:::(info|tip|caution|note|danger|warning)/g;
+
+function collectHtmlFiles(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectHtmlFiles(path));
+    } else if (entry.name.endsWith('.html')) {
+      files.push(path);
+    }
+  }
+  return files;
+}
 
 describe('Astro build renders all pages', () => {
   let buildOutput: string;
@@ -115,5 +131,26 @@ describe('Astro build renders all pages', () => {
     expect(html).not.toContain('starlight-tab-item');
     expect((html.match(/role="tab"/g) || []).length).toBeGreaterThan(0);
     expect((html.match(/role="tabpanel"/g) || []).length).toBeGreaterThan(0);
+  });
+
+  it('renders directive admonitions instead of raw directive markers', () => {
+    const htmlFiles = [
+      ...collectHtmlFiles(join(STARLIGHT_DIR, 'dist', 'a1')),
+      ...collectHtmlFiles(join(STARLIGHT_DIR, 'dist', 'folk')),
+    ];
+    if (htmlFiles.length === 0) return;
+
+    const rawMatches: string[] = [];
+    let renderedAdmonitionCount = 0;
+
+    for (const file of htmlFiles) {
+      const html = readFileSync(file, 'utf-8');
+      const matches = html.match(RAW_ADMONITION_RE);
+      if (matches) rawMatches.push(...matches.map((match) => `${file}: ${match}`));
+      if (html.includes('class="admonition admonition-')) renderedAdmonitionCount += 1;
+    }
+
+    expect(rawMatches).toEqual([]);
+    expect(renderedAdmonitionCount).toBeGreaterThan(0);
   });
 });

--- a/starlight/tests/unit/remark-admonitions.test.ts
+++ b/starlight/tests/unit/remark-admonitions.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import rehypeStringify from 'rehype-stringify';
+import remarkDirective from 'remark-directive';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
+import { unified } from 'unified';
+
+import remarkAdmonitions from '../../plugins/remark-admonitions.mjs';
+
+async function renderMarkdown(source: string): Promise<string> {
+  const file = await unified()
+    .use(remarkParse)
+    .use(remarkDirective)
+    .use(remarkAdmonitions)
+    .use(remarkRehype)
+    .use(rehypeStringify)
+    .process(source);
+
+  return String(file);
+}
+
+describe('remark admonitions', () => {
+  it('renders a labelled info directive as an aside with title and markdown body', async () => {
+    const html = await renderMarkdown(':::info[Title]\nBody with **bold**.\n:::\n');
+
+    expect(html).toContain('<aside class="admonition admonition-info">');
+    expect(html).toContain('<p class="admonition-title">Title</p>');
+    expect(html).toContain('<p>Body with <strong>bold</strong>.</p>');
+    expect(html).not.toContain(':::info');
+  });
+
+  it('renders a plain tip directive with the default title', async () => {
+    const html = await renderMarkdown('::::tip\nKeep going.\n::::\n');
+
+    expect(html).toContain('<aside class="admonition admonition-tip">');
+    expect(html).toContain('<p class="admonition-title">Tip</p>');
+    expect(html).toContain('<p>Keep going.</p>');
+    expect(html).not.toContain('::::tip');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `remark-directive` plus a local `remark-admonitions` transformer so Starlight-style container directives render as `<aside class="admonition ...">` in both Astro Markdown and MDX content.
- Adds global admonition styling for `info`, `tip`, `caution`, `note`, `danger`, and `warning`.
- Hardens local React island dev pre-bundling by including `react/jsx-runtime` and `react/jsx-dev-runtime` in `optimizeDeps.include`; `preact` is no longer present in the install tree.
- Adds unit coverage for labelled/default admonitions and extends the build-render smoke test to reject raw directive markers in built A1/folk HTML.

## Root Cause

1. The Astro pipeline loaded `remark-gfm` and the vocabulary linker, but no directive parser. The generated A1/folk MDX therefore emitted `::::info`, `::::tip`, `::::caution`, and `::::note` as literal text instead of HTML.
2. Local Vite dev could hydrate React islands with stale or inconsistent JSX runtime pre-bundles. The stale install tree also had extraneous `preact`, so the dev dependency graph could be polluted even though the app uses React.

## Verification

### Full build

cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/a1-admonition-fix`

command:
```bash
bash -o pipefail -c 'npm run build:full --prefix starlight 2>&1 | tail -n 12'
```

raw output:
```text
23:50:07   ├─ /a1/where-to/index.html (+3ms) 
23:50:07   ├─ /a1/who-am-i/index.html (+5ms) 
23:50:07   ├─ /a1/yesterday/index.html (+4ms) 
23:50:07   ├─ /folk/dumy-lytsarski/index.html (+3ms) 
23:50:07   ├─ /folk/kalendarna-obriadovist-zvychai/index.html (+4ms) 
23:50:07   ├─ /folk/koliadky-shchedrivky/index.html (+5ms) 
23:50:07 ✓ Completed in 11.10s.

23:50:07 [build] ✓ Completed in 17.13s.
23:50:07 [@astrojs/sitemap] `sitemap-index.xml` created at `dist`
23:50:07 [build] 38037 page(s) built in 17.97s
23:50:07 [build] Complete!
```

### Raw directives removed

cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/a1-admonition-fix/starlight`

command:
```bash
grep -roE ':::(info|tip|caution|note)' dist/a1/ dist/folk/ | wc -l
```

raw output:
```text
0
```

command:
```bash
grep -roE ':::(info|tip|caution|note|danger|warning)' dist/a1 dist/folk | wc -l
```

raw output:
```text
0
```

### Built admonition asides present

cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/a1-admonition-fix/starlight`

command:
```bash
grep -o '<aside class="admonition[^"]*"' dist/a1/weather/index.html | head -n 5
```

raw output:
```text
<aside class="admonition admonition-caution"
<aside class="admonition admonition-info"
```

command:
```bash
grep -o '<aside class="admonition[^"]*"' dist/a1/sounds-letters-and-hello/index.html | head -n 5
```

raw output:
```text
<aside class="admonition admonition-info"
```

command:
```bash
grep -o '<p class="admonition-title">🎧 🔗 External Resources</p>' dist/a1/sounds-letters-and-hello/index.html | head -n 3
```

raw output:
```text
<p class="admonition-title">🎧 🔗 External Resources</p>
```

command:
```bash
grep -o '<aside class="admonition[^"]*"' dist/folk/kalendarna-obriadovist-zvychai/index.html | head -n 5
```

raw output:
```text
<aside class="admonition admonition-caution"
<aside class="admonition admonition-tip"
<aside class="admonition admonition-note"
<aside class="admonition admonition-info"
```

### React island dev server

cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/a1-admonition-fix`

command:
```bash
npm run dev --prefix starlight -- --host 127.0.0.1
```

raw startup output:
```text
> starlight@0.0.1 dev
> astro dev --host 127.0.0.1

[astro] `markdown.remarkPlugins`, `markdown.rehypePlugins`, and `markdown.remarkRehype` are deprecated. Pass them to `unified({...})` from `@astrojs/markdown-remark` directly instead.
[vite] connected.
23:45:54 [types] Generated 0ms
[vite] connected.
23:45:54 [content] Syncing content
23:45:54 [content] Synced content
23:45:54 [vite] Re-optimizing dependencies because vite config has changed
23:45:54 [vite] Port 4321 is in use, trying another one...
 astro  v6.4.2 ready in 1031 ms
┃ Local    http://127.0.0.1:4322/
23:45:54 watching for file changes...
```

raw request output:
```text
23:47:36 [200] /a1/sounds-letters-and-hello/ 1014ms
23:48:52 [200] /a1/sounds-letters-and-hello/ 17ms
```

cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/a1-admonition-fix/starlight`

command:
```bash
node --input-type=module <<'NODE_PROBE'
import { chromium } from 'playwright';

const url = 'http://127.0.0.1:4322/a1/sounds-letters-and-hello/';
const browser = await chromium.launch({ headless: true });
const page = await browser.newPage();
const consoleMessages = [];
const pageErrors = [];

page.on('console', (msg) => {
  consoleMessages.push(`${msg.type()}: ${msg.text()}`);
});
page.on('pageerror', (error) => {
  pageErrors.push(error.stack || error.message);
});

const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
await page.getByRole('tab', { name: /Словник|Vocabulary/ }).click({ timeout: 60000 });
await page.waitForSelector('[data-activity="flashcard-deck"]', { state: 'visible', timeout: 60000 });
await page.waitForTimeout(1500);

const flashcardDecks = await page.locator('[data-activity="flashcard-deck"]').count();
const visibleFlashcardDecks = await page.locator('[data-activity="flashcard-deck"]:visible').count();
const flashcards = await page.locator('[data-activity="flashcard"]').count();
const visibleFlashcards = await page.locator('[data-activity="flashcard"]:visible').count();
const jsxDevHits = [...consoleMessages, ...pageErrors].filter((line) => /jsxDEV is not a function/i.test(line));
const errorMessages = consoleMessages.filter((line) => line.startsWith('error:'));

console.log(JSON.stringify({
  url,
  status: response?.status(),
  flashcardDecks,
  visibleFlashcardDecks,
  flashcards,
  visibleFlashcards,
  jsxDevHits,
  errorMessages,
  pageErrors,
}, null, 2));

await browser.close();
NODE_PROBE
```

raw output:
```json
{
  "url": "http://127.0.0.1:4322/a1/sounds-letters-and-hello/",
  "status": 200,
  "flashcardDecks": 1,
  "visibleFlashcardDecks": 1,
  "flashcards": 33,
  "visibleFlashcards": 33,
  "jsxDevHits": [],
  "errorMessages": [],
  "pageErrors": []
}
```

### Tests

cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/a1-admonition-fix`

command:
```bash
bash -o pipefail -c 'npm test --prefix starlight 2>&1 | tail -n 10'
```

raw output:
```text
    at TLSSocket.emit (node:events:519:28)
    at emitErrorNT (node:internal/streams/destroy:170:8)
    at emitErrorCloseNT (node:internal/streams/destroy:129:3)
    at processTicksAndRejections (node:internal/process/task_queues:89:21)

 Test Files  21 passed (21)
      Tests  343 passed (343)
   Start at  23:50:29
   Duration  15.45s (transform 555ms, setup 1.08s, import 3.11s, tests 17.32s, environment 6.07s)
```

### Preact install tree

cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/a1-admonition-fix`

command:
```bash
npm ls preact --prefix starlight
```

raw output:
```text
starlight@0.0.1 /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/a1-admonition-fix/starlight
└── (empty)
```

### Commit trailer

cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/a1-admonition-fix`

command:
```bash
.venv/bin/python scripts/audit/lint_agent_trailer.py
```

raw output:
```text
Checking 1 commit(s) in origin/main..HEAD:

  204708e923  PASS  X-Agent: codex/a1-admonition-fix

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

PR is draft; no merge performed.
