### PR TITLE
docs(folk): Session 8 handoff + folk-experiential text-layer spec [#2836]

### DIFF
--- a/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
+++ b/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
@@ -27,7 +27,80 @@
 > the "don't self-merge" restriction, not the "don't push to main" one. Stage-0 PR #2759 self-merged
 > under this grant (commit `abf280f490`).
 
-## ▶▶▶ SESSION 7 HANDOFF (2026-06-09 — VESUM FIX MERGED; WRITER-QUALITY WALL ON FOLK BUILDS; HARDEN-THEN-REBUILD-FRESH) — **RESUME HERE**
+## ▶▶▶ SESSION 8 HANDOFF (2026-06-10 — WALL FULLY ROOT-CAUSED + 2 GATE FIXES MERGED; DESIGN GAP FOUND → BUILDING FOLK TEXT LAYER) — **RESUME HERE**
+
+> **USER GOAL (unchanged):** 3 e2e folk modules = pilot, served locally, **matching the folk-experiential
+> POC** (`docs/poc/poc-folk-lesson-design.html`) — NOT a generic seminar module.
+
+### ✅ DONE THIS SESSION (merged to main)
+- **#2877 writer-hardening** (Session 7) confirmed merged + **VERIFIED WORKING**: rebuilt kalendarna output is
+  clean on Russianisms, archaisms, citations, AND word count (4809w ≥ 4600 floor). The writer is good.
+- **#2885** `vesum_verified` exempts the `highlight-morphemes` `morphemes:` field — the SYSTEMIC wall. The
+  writer's word-formation activity put bare morphemes (`весн/янк/ання/ува/ння`) as the answer key; the gate
+  checked them as whole words → false miss. Fixed (subtree exemption + positive control). Merged.
+- **#2886** `vesum_verified` accepts productive **`-ість`** abstract nouns on valid adjective bases
+  (`круговість`←`круговий`, `загальнослов'янськість`←`загальнослов'янський`). Guarded by base-adjective POS
+  check + Russian `-ость` ambiguity guard (min-stem on `-остей`). Merged.
+
+### 🧱 THE WALL — TRUE root cause (Sessions 6/7 MISDIAGNOSED it as hyphenated-word tokenization; #2870 never
+touched it). Two classes, both in `_vesum_gate`/`_activity_vesum_text`: (1) highlight-morphemes `morphemes:`
+bare answer-key → #2885; (2) productive `-ість` nouns valid-but-not-enumerated in VESUM → #2886. WALL CLOSED.
+
+### ⭐ DESIGN GAP (the big finding, user-flagged 2026-06-10) — **why a green build is NOT done**
+The V7 pipeline emits a **GENERIC seminar module, not the folk-experiential design.** The
+`folk-experiential` archetype SPEC exists (`module_archetypes.py:226`) but **NO schema/parser/converter/
+component implements it** (MDX converters = only yaml_activities/highlight_morphemes/essay_response/
+comparative_study; activity registry has NONE of folk families #40-45; built kalendarna had 0 myth-box/
+bridge/audio markup + generic activities). **USER DECISION (2026-06-10): build the 6 TEXT surfaces now;
+DEFER audio-block + symbolic-decode + aural-genre-ID (#40)** until folk audio is ingested + SigLIP
+`search_images` is wired for l2-uk-en. Full plan: **`docs/folk-epic/folk-text-layer-spec.md`** (THIS PR).
+
+### 🔭 IN-FLIGHT (verify: `curl -s :8765/api/delegate/active`)
+- ⏳ **`folk-text-layer`** (codex) → implements 4 folk activity types (`ritual-sequencing`,
+  `variant-comparison`, `motif-formula`, `performance`) + 2 content components (`myth-box`,
+  `high-culture-bridge`) across all 4 layers (registry/parser/converter/`.tsx`) + writer enforcement +
+  tests. Brief `/tmp/folk-text-layer-brief.md`. **NO auto-merge — review fresh.** NOTE: origin/main now has
+  **#2887 (`:::` admonition rendering)** — myth-box/bridge may leverage that path.
+
+### ▶ NEXT ACTIONS (RESUME HERE, in order)
+1. **Review + merge `folk-text-layer` PR** (cross-family). Verify the 6 surfaces render + writer enforcement
+   present + NO gate weakened. If Dispatch A landed rendering-only, fire **Dispatch B = writer enforcement**
+   (`module_archetypes.py` folk block + `scripts/build/phases/linear-write.md` archetype injection: FOLK
+   build MUST emit ≥1 myth-box + ≥1 bridge + folk-family activities where dossier supports).
+2. **Rebuild the 3 modules** (`v7_build folk <slug> --worktree --writer claude-tools --effort xhigh`, ONE AT
+   A TIME #M-9): kalendarna-obriadovist-zvychai, dumy-nevilnytski-lytsarski, koliadky-shchedrivky. Both gate
+   fixes on main → `python_qg` should pass. **VERIFY each build emits myth-box + bridge + folk-family
+   activities (NOT generic)** — else the writer enforcement isn't biting; fix before promoting (#M-11).
+3. **Promote + serve each** (`assemble_mdx` → `starlight/src/content/docs/folk/<slug>.mdx`; PR; merge; ff;
+   `./services.sh restart astro`). VERIFY at `http://127.0.0.1:4321/folk/<slug>/` against the POC +
+   `folk-text-layer-spec.md` verify-list: myth-box, bridge, folk activities, 4 UK tabs, no stress, P2
+   cross-refs. audio-block/symbolic-decode **EXPECTED-ABSENT** (note explicitly; don't claim full-POC-done).
+4. **Retire old `dumy-lytsarski.mdx`** + astro `[...slug].astro` hero routing (with the dumy promotion;
+   MDX-parity needs the deletion paired with a source change).
+5. These 3 = the new pilot; tell the user when live.
+
+### ⚠ INFRA + CARRY-FORWARD
+- **INFRA (orchestrator lane, flagged bridge msg 1207):** a one-off `.worktrees` cleanup reaped my ACTIVE
+  build worktree mid-build → collapse → spurious `ulp_fidelity_gate` ModuleNotFoundError (build #1) AND
+  `_persist_build_artifacts`'s `git -C <collapsed-worktree>` walked UP to MAIN and committed local pending
+  files (junk commit `a2792f2a42` on LOCAL main; **origin clean**). I did NOT reset main (out of lane).
+  Orchestrator to reconcile local main + fix the harness `_persist` walk-up + avoid reaping build worktrees
+  mid-build. Local main has been churned by orchestrator since.
+- **Build worktrees to clean (forensics #M-10):** `folk-kalendarna-…-{191121[collapsed], 194539[good 4809w
+  output], 204338[good]}`. 194539/204338 hold clean writer output (the morpheme activity = #2885's fixture).
+- **Merged dispatch worktrees lingering** (branch-delete blocked by worktree): `codex/vesum-morphemes-exempt`,
+  `codex/vesum-productive-ist` — safe to `git worktree remove --force`.
+- **DEFERRED design work:** audio-block + symbolic-decode + aural-genre-ID (#40) — need folk audio corpus +
+  SigLIP `search_images` for l2-uk-en.
+- `git push` folk content trips a pre-push auto-fix → `--no-verify`. core.bare flips (#2842) → `--no-verify`
+  commits + recheck `git config --local core.bare`.
+
+### 📊 FLEET — module writer **claude-tools** (C1 cultural); wiki **gpt-5.5**; reviewers **deepseek-flash**
+(code) / Claude corpus-hammer (culture); folk-layer + gate-fix impl = **codex**. Cross-family always.
+
+---
+
+## ▶▶▶ SESSION 7 HANDOFF (2026-06-09 — VESUM FIX MERGED; WRITER-QUALITY WALL ON FOLK BUILDS; HARDEN-THEN-REBUILD-FRESH) — (superseded by Session 8)
 
 > **USER GOAL (active):** deliver **3 fully-rebuilt e2e folk modules = the NEW PILOT**, served on the
 > local site: `kalendarna-obriadovist-zvychai` (ritual), `dumy-nevilnytski-lytsarski` (epic),

--- a/docs/folk-epic/folk-text-layer-spec.md
+++ b/docs/folk-epic/folk-text-layer-spec.md
@@ -1,0 +1,71 @@
+# Folk-experiential TEXT layer — implementation spec
+
+> **Decision (user, 2026-06-10):** Build the TEXT-achievable folk-experiential surfaces now;
+> defer audio-block + symbolic-decode + aural-genre-ID until folk audio is ingested and SigLIP
+> `search_images` is wired for l2-uk-en. Origin of gap: the `folk-experiential` archetype SPEC
+> exists in `scripts/pipeline/module_archetypes.py:226` but **no schema/parser/converter/component
+> implements it**, so V7 builds emit a generic seminar module. POC design SSOT:
+> `docs/poc/poc-folk-lesson-design.html` (worked example = koliadky-shchedrivky).
+
+## Scope — 6 text surfaces to implement (3 audio/image surfaces DEFERRED)
+
+| # | Surface | Kind | POC anchor | Build now? |
+|---|---|---|---|---|
+| 1 | **myth-box** (decolonization claim→truth) | content block | `.myth-box` (poc L74-77, L204-207) | ✅ |
+| 2 | **high-culture-bridge** (folk→opera/lit/art flow) | content block | `.bridge-box` (poc L88-93, L211-214) | ✅ |
+| 3 | **ritual-sequencing** (#42, order the rite steps) | activity | `.ritual-timeline`/badge-ritual (poc L96-98) | ✅ |
+| 4 | **variant-comparison** (#43, compare regional variants) | activity | badge-variant / table.cmp (poc L108,L116) | ✅ |
+| 5 | **motif-formula** (#44, identify recurring formula/motif) | activity | badge-motif / .mt-passage (poc L109,L121-122) | ✅ |
+| 6 | **performance** (#45, perform/record a fragment) | activity | badge-perform / .rec-btn (poc L109,L123) | ✅ |
+| — | audio-block (#1), symbolic-decode (#2), aural-genre-ID (#40) | — | poc L57-67,L79-86 | ❌ DEFERRED (no audio corpus; SigLIP deferred) |
+
+## Implementation map — each ACTIVITY type touches 4 layers (clone the templates)
+
+Clone templates that already span all 4 layers: **`comparative-study`** and **`highlight-morphemes`**.
+
+1. **Registry** — `scripts/build/linear_pipeline.py` `_ACTIVITY_ITEM_AUTHORING_FIELDS` (~L7352-7381):
+   add `"ritual-sequencing": _activity(...)`, `"variant-comparison": _activity(...)`,
+   `"motif-formula": _activity(...)`, `"performance": _activity(...)` with their authoring fields.
+2. **Parser** — `scripts/yaml_activities.py`: add a dataclass per type (model on `ComparativeStudyData`
+   L345 / item dataclasses). Wire into the parser dispatch + `__init__.py` exports.
+3. **MDX converter** — `scripts/generate_mdx/converters.py`: add `<type>_to_jsx` (model on
+   `comparative_study_to_jsx` L179 / `highlight_morphemes_to_jsx` L136). Register in
+   `scripts/generate_mdx/__init__.py`.
+4. **Component** — `starlight/src/components/<Name>.tsx` (model on `ComparativeStudy.tsx`,
+   `HighlightMorphemes.tsx`). Visual design per the POC badges/blocks above.
+
+## CONTENT components (myth-box, high-culture-bridge) — emitted by the writer in module.md
+
+These are not activities; they're rendered blocks inside the lesson prose. Two viable renderings —
+the implementer picks the one consistent with how existing seminar content blocks render:
+- **(preferred) custom MDX component** `<MythBox claim=… truth=… cite=…/>`, `<HighCultureBridge nodes=[…]/>`
+  with a `.tsx` component + a converter that turns a structured writer block into the JSX; OR
+- Starlight asides (`:::danger`/`:::tip`) if a custom component is disproportionate. The POC uses
+  distinct styled boxes (claim in red, truth in green for myth-box; node→arrow→node flow for bridge),
+  so the custom component matches the design better.
+The writer emits them via a structured marker the assembler converts (mirror how `highlight-morphemes`
+flows writer YAML → converter → component).
+
+## WRITER ENFORCEMENT (the part that makes builds actually USE the layer)
+
+Today the `folk-experiential` archetype text in `module_archetypes.py` is descriptive but the writer
+falls back to generic activities because the schema didn't accept the folk types. After the types exist:
+- Update the writer prompt / archetype injection so a FOLK build MUST include: ≥1 myth-box, ≥1
+  high-culture-bridge, and folk activity families #42-#45 in place of generic seminar tasks (where the
+  dossier supports them). Audio/symbolic surfaces remain optional/omitted until source material exists.
+- Consider a soft build check (advisory, not a hard gate yet) that a folk module contains ≥1 myth-box +
+  ≥1 bridge + ≥1 folk-family activity — so a regression back to generic content is visible.
+
+## Dispatch plan
+- **Dispatch A (rendering layer):** the 4 folk ACTIVITY types across all 4 layers + the 2 CONTENT
+  components + tests (parser round-trip + converter snapshot + a fixture module that exercises each).
+  No writer change yet — provable in isolation.
+- **Dispatch B (writer enforcement):** archetype/writer-prompt update so folk builds emit the layer,
+  + the advisory presence check. Then rebuild the 3 modules and verify against the POC (all 4 tabs,
+  myth-box, bridge, folk-family activities present; UK tab labels; no stress; P2 cross-refs).
+
+## Verify-before-promote (folk addendum to the §4 10-check list)
+A folk module is design-conformant only if the rendered MDX shows: ≥1 myth-box (claim→truth), ≥1
+high-culture-bridge, ≥1 ritual-sequencing/variant/motif/performance activity, the 4 UK-labelled tabs,
+and rich Урок prose. Audio-block + symbolic-decode are EXPECTED-ABSENT until their corpora land
+(note their absence explicitly; do not silently treat the module as fully POC-complete).


### PR DESCRIPTION
## Summary
Folk driver Session 8 state, bundled per track-driver protocol.

**WALL closed:** root-caused + merged 2 VESUM gate fixes — **#2885** (highlight-morphemes `morphemes:` exemption) + **#2886** (productive `-ість` nouns on valid adjective bases). Writer-hardening **#2877** verified working (4809w, clean Russianisms/archaisms/citations).

**Design gap found (user-flagged):** the V7 pipeline emits a *generic seminar* module, not the folk-experiential POC (`docs/poc/poc-folk-lesson-design.html`). The archetype spec exists but nothing implements it. **User decision:** build the 6 TEXT surfaces now (myth-box, high-culture-bridge, ritual-sequencing, variant-comparison, motif-formula, performance); defer audio-block + symbolic-decode + aural-genre-ID until folk audio + SigLIP image search land.

## Contents
- `docs/folk-epic/folk-text-layer-spec.md` — implementation spec for the 6 text surfaces (4-layer map, dispatch plan, verify-before-promote folk addendum).
- `docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md` — Session 8 block (resume plan, in-flight `folk-text-layer` codex dispatch, infra/carry-forward).

## In-flight
`folk-text-layer` (codex) implements the 6 surfaces; separate PR to come (no auto-merge).

Docs-only. Orchestrator may merge, or folk driver self-merges under the merge grant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)