### PR TITLE
[codex] fix A2 bridge external resources

### DIFF
--- a/curriculum/l2-uk-en/a2/a2-bridge/resources.yaml
+++ b/curriculum/l2-uk-en/a2/a2-bridge/resources.yaml
@@ -1,16 +1,20 @@
-- title: "Plan: A2 bridge"
-  role: internal plan
-  source_ref: "curriculum/l2-uk-en/plans/a2/a2-bridge.yaml"
-  notes: "Source plan for A2 module 1: A1 grammar review, sound alternations, euphony, and A2 roadmap."
-- title: "Wiki: grammar/a2/a2-bridge"
-  role: internal wiki
-  source_ref: "wiki/grammar/a2/a2-bridge"
-  notes: "Compiled grammar substrate for euphony and A2 bridge priorities; used selectively to avoid overloading module 1."
-- title: "Internal module A1: euphony"
-  role: prerequisite pattern
-  source_ref: "curriculum/l2-uk-en/a1/euphony/module.md"
-  notes: "Provides the A1 baseline for у/в, і/й, and з/із/зі practice."
-- title: "Internal module A1: A1 finale"
-  role: prerequisite pattern
-  source_ref: "curriculum/l2-uk-en/a1/a1-finale/module.md"
-  notes: "Provides the released A1 structure reference for integrated review and transition language."
+- title: "ULP 6-213: Милозвучність української мови"
+  role: podcast
+  source_ref: "Ukrainian Lessons Podcast episode 213"
+  url: "https://www.ukrainianlessons.com/episode213/"
+  notes: "Learner-facing listening support for Ukrainian euphony and smoother connected speech."
+- title: "Difference between Ukrainian Prepositions У (В) and На"
+  role: article
+  source_ref: "Ukrainian Lessons"
+  url: "https://www.ukrainianlessons.com/prepositions-u-na/"
+  notes: "Practical review of у/в with place language; useful after the bridge euphony section."
+- title: "Ukrainian Conjunctions"
+  role: article
+  source_ref: "Ukrainian Lessons"
+  url: "https://www.ukrainianlessons.com/ukrainian-conjunctions/"
+  notes: "Follow-up reference for simple linking words, including і/й in connected speech."
+- title: "Основні випадки чергування у-в, і-й, з-із-зі"
+  role: article
+  source_ref: "МійКлас"
+  url: "https://www.miyklas.com.ua/p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/osnovni-vipadki-cherguvannia-u-v-i-i-z-iz-zi-pravila-milozvuchnosti-41612"
+  notes: "Ukrainian-language rule reference for the euphony set practiced in this module."

--- a/docs/resources/podcasts/podcast_db.json
+++ b/docs/resources/podcasts/podcast_db.json
@@ -3268,7 +3268,7 @@
     "season": 6,
     "episode_number": 213,
     "title": "ULP 6-213 Милозвучність української мови",
-    "url": "https://www.ukrainianlessons.com/season6/ULP-6-213-mylozvuchnist-ukrainskoi-movy/",
+    "url": "https://www.ukrainianlessons.com/episode213/",
     "summary": "",
     "tags": [
       "ULP",

--- a/starlight/src/content/docs/a2/a2-bridge.mdx
+++ b/starlight/src/content/docs/a2/a2-bridge.mdx
@@ -21,11 +21,17 @@ import Select from '@site/src/components/Select';
 import Translate from '@site/src/components/Translate';
 import MarkTheWords, { MarkTheWordsActivity } from '@site/src/components/MarkTheWords';
 import HighlightMorphemes, { HighlightMorphemesActivity } from '@site/src/components/HighlightMorphemes';
+import RitualSequencing from '@site/src/components/RitualSequencing';
+import VariantComparison from '@site/src/components/VariantComparison';
+import MotifFormula from '@site/src/components/MotifFormula';
+import PerformanceActivity from '@site/src/components/PerformanceActivity';
 import EssayResponse from '@site/src/components/EssayResponse';
 import ComparativeStudy from '@site/src/components/ComparativeStudy';
 import ReadingActivity from '@site/src/components/ReadingActivity';
 import CriticalAnalysis from '@site/src/components/CriticalAnalysis';
 import AuthorialIntent from '@site/src/components/AuthorialIntent';
+import MythBuster from '@site/src/components/MythBuster';
+import HighCultureBridge from '@site/src/components/HighCultureBridge';
 import SourceEvaluation from '@site/src/components/SourceEvaluation';
 import Debate from '@site/src/components/Debate';
 import EtymologyTrace from '@site/src/components/EtymologyTrace';
@@ -565,11 +571,13 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 :::info[🎧 🔗 External Resources]
 
-**🔗 Online resources:**
-- 🔗 **Internal module A1: A1 finale** — Provides the released A1 structure reference for integrated review and transition language.
-- 🔗 **Internal module A1: euphony** — Provides the A1 baseline for у/в, і/й, and з/із/зі practice.
-- 🔗 **Plan: A2 bridge** — Source plan for A2 module 1: A1 grammar review, sound alternations, euphony, and A2 roadmap.
-- 🔗 **Wiki: grammar/a2/a2-bridge** — Compiled grammar substrate for euphony and A2 bridge priorities; used selectively to avoid overloading module 1.
+**📝 Articles:**
+- 📄 [Difference between Ukrainian Prepositions У (В) and На](https://www.ukrainianlessons.com/prepositions-u-na/) — Practical review of у/в with place language; useful after the bridge euphony section.
+- 📄 [Ukrainian Conjunctions](https://www.ukrainianlessons.com/ukrainian-conjunctions/) — Follow-up reference for simple linking words, including і/й in connected speech.
+- 📄 [Основні випадки чергування у-в, і-й, з-із-зі](https://www.miyklas.com.ua/p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/osnovni-vipadki-cherguvannia-u-v-i-i-z-iz-zi-pravila-milozvuchnosti-41612) — Ukrainian-language rule reference for the euphony set practiced in this module.
+
+**🎧 Audio:**
+- 🎧 [ULP 6-213: Милозвучність української мови](https://www.ukrainianlessons.com/episode213/) — Learner-facing listening support for Ukrainian euphony and smoother connected speech.
 :::
 
 </TabItem>


### PR DESCRIPTION
## Summary

Part of #2888.

- Replaced A2 M01 bridge resource sidecar entries that pointed at internal plans/wiki/modules with real external learner resources, following the A1 `resources.yaml` pattern.
- Updated the ULP 6-213 catalog URL from the stale season path to the current official `/episode213/` page.
- Regenerated the A2 bridge MDX so the live Resources tab shows articles/audio instead of internal references.

## Validation

- Checked all four resource URLs return HTTP 200.
- Parsed the A2 bridge resource YAML.
- Ran `git diff --check`.
- Ran `.venv/bin/python -m pytest tests/test_generate_mdx_v7_resources_vocab.py tests/test_fix_external_resources.py tests/audit/test_audit_external_resources_paths.py -q`.
- Ran `.venv/bin/python scripts/audit/audit_external_resources.py --stats`.
- Ran `.venv/bin/python scripts/audit/check_mdx_source_parity.py --changed-vs-base origin/main`.
- Ran `.venv/bin/python scripts/audit/check_mdx_generation_drift.py --changed-vs-base origin/main`.
- Ran `.venv/bin/ruff check scripts/generate_mdx/resources.py scripts/audit/audit_external_resources.py tests/test_generate_mdx_v7_resources_vocab.py tests/test_fix_external_resources.py tests/audit/test_audit_external_resources_paths.py`.
- Ran `npm run build --prefix starlight` after installing `starlight` dependencies in the worktree.
- Ran `.venv/bin/python scripts/audit/lint_agent_trailer.py`.