### PR TITLE
fix(a2): publish full A2.2 preview landing

### DIFF
--- a/starlight/src/content/docs/a2/index.mdx
+++ b/starlight/src/content/docs/a2/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "A2 — Pre-Intermediate Beta Preview"
-description: "Pre-Intermediate beta preview — 11 of 69 modules available"
+description: "Pre-Intermediate beta preview — 16 of 69 modules available"
 template: splash
 ---
 
@@ -10,12 +10,12 @@ import LevelLanding from '@site/src/components/LevelLanding';
   client:load
   level="A2"
   title="Перші кроки далі"
-  subtitle="Pre-Intermediate beta preview — 11/69 modules available"
+  subtitle="Pre-Intermediate beta preview — 16/69 modules available"
   moduleCount={69}
   wordTarget={2000}
   color="#1565C0"
   progressTitle="A2 Beta Preview"
-  progressDescription="11 preview modules available; 58 modules remain locked while content quality review continues."
+  progressDescription="16 preview modules available; 53 modules remain locked while content quality review continues."
   modules={[
     {
       unit: "A2.1 [Основи та вступ до виду дієслова]",
@@ -36,26 +36,11 @@ import LevelLanding from '@site/src/components/LevelLanding';
         { num: 9, slug: "genitive-prepositions-source", title: "Звідки ти? З чого це зроблено?", sub: "Прийменники з/із/зі, від, після з родовим відмінком", status: "active" },
         { num: 10, slug: "genitive-prepositions-purpose", title: "Для кого? Без чого? Біля чого?", sub: "Прийменники для, без, біля, навпроти, коло з родовим відмінком", status: "active" },
         { num: 11, slug: "genitive-prepositions-direction", title: "Куди? До якого часу?", sub: "Прийменник до з родовим відмінком для напрямку, мети та часу", status: "active" },
-        { num: 13, slug: "genitive-adjectives-pronouns", title: "Мого друга, цієї книги", sub: "Узгодження прикметників, присвійних та вказівних займенників у родовому відмінку", status: "locked" },
-        { num: 14, slug: "genitive-plural", title: "Багато книг, мало студентів", sub: "Родовий відмінок множини — найскладніша форма", status: "locked" },
-      ]
-    },
-    {
-      unit: "A2.2 [Повний родовий відмінок]",
-      items: [
-        { num: 12, slug: "euphony-advanced", title: "Милозвучність у складних контекстах", sub: "Розширені правила у/в, з/із/зі та і/й у складних реченнях", status: "locked" },
-      ]
-    },
-    {
-      unit: "A2.2 [Родовий відмінок повністю]",
-      items: [
-        { num: 15, slug: "shopping-and-health", title: "На ринку та у лікаря", sub: "Родовий відмінок у реальних ситуаціях — покупки та здоров'я", status: "locked" },
-      ]
-    },
-    {
-      unit: "А2.2 [Родовий відмінок (повністю)]",
-      items: [
-        { num: 16, slug: "checkpoint-genitive", title: "Контрольна робота — родовий відмінок", sub: "Перевірка знань з модулів модулі №8–13 — прийменники, узгодження, множина, ситуації", status: "locked" },
+        { num: 12, slug: "euphony-advanced", title: "Милозвучність у складних контекстах", sub: "Розширені правила у/в, з/із/зі та і/й у складних реченнях", status: "active" },
+        { num: 13, slug: "genitive-adjectives-pronouns", title: "Мого друга, цієї книги", sub: "Узгодження прикметників, присвійних та вказівних займенників у родовому відмінку", status: "active" },
+        { num: 14, slug: "genitive-plural", title: "Багато книг, мало студентів", sub: "Родовий відмінок множини — найскладніша форма", status: "active" },
+        { num: 15, slug: "shopping-and-health", title: "На ринку та у лікаря", sub: "Родовий відмінок у реальних ситуаціях — покупки та здоров'я", status: "active" },
+        { num: 16, slug: "checkpoint-genitive", title: "Контрольна робота — родовий відмінок", sub: "Перевірка знань з модулів 9–15: прийменники, милозвучність, узгодження, множина, покупки та здоров'я", status: "active" },
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Update the A2 beta landing count from 11/69 to 16/69 after A2.2 modules M12-M16 merged.
- Mark M12-M16 active on the landing page.
- Collapse the completed A2.2 genitive modules into one coherent landing unit.

## Validation
- git diff --check
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/check_mdx_generation_drift.py --changed-vs-base origin/main
- npm --prefix starlight run build
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py

A2 remains beta/preview only; this is not a release.