### PR TITLE
fix(ui): drop duplicate ULP/Anna teacher note from landing body (footer keeps it)

### DIFF
--- a/starlight/src/pages/index.astro
+++ b/starlight/src/pages/index.astro
@@ -130,19 +130,6 @@ const seminarTracks = [
     </div>
   </section>
 
-  <section class="teacher-note">
-    <h2>Teachers And Inspiration</h2>
-    <p>
-      Self-study is allowed and encouraged, but trained native Ukrainian teachers are best. These materials
-      are practice support and do not replace devoted teachers.
-    </p>
-    <p>
-      We promote Ukrainian Lessons / ULP and thank Anna Ohoiko for pedagogical inspiration and help. This
-      course is independently written, with no copied or book-derived ULP content and no implied formal
-      endorsement unless explicitly granted.
-    </p>
-  </section>
-
   <style>
     .home-intro {
       display: grid;
@@ -235,13 +222,6 @@ const seminarTracks = [
     :global([data-theme='dark']) .track-badge.a1,
     :global([data-theme='dark']) .track-badge.atlas {
       color: var(--lu-on-yellow);
-    }
-    .teacher-note {
-      margin-top: 42px;
-      padding: 22px;
-      border: 2px solid var(--lu-yellow);
-      border-radius: var(--lu-radius);
-      background: var(--lu-yellow-light);
     }
     .section-heading {
       max-width: 760px;


### PR DESCRIPTION
The landing page showed the teacher note + ULP/Anna attribution **twice**: in the body (`index.astro` "Teachers And Inspiration" section) and again in the site-wide footer (`CourseLayout.astro`). Removed the redundant body section + its dead `.teacher-note` CSS. The footer keeps the attribution on every page. User-requested dedup; verified ULP/Anna now appears 0× in the landing body, 4× in the footer (intact). A1/site lane: flagging since you own the landing.