### PR TITLE
feat(lexicon): heritage attestation classifier — shared Atlas/gate engine [#2882 Task 6]

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -34,6 +34,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
+from scripts.lexicon.heritage_classifier import classify_lemma
 from scripts.verification.vesum import verify_lemma
 
 MANIFEST = ROOT / "starlight" / "src" / "data" / "lexicon-manifest.json"
@@ -484,6 +485,7 @@ def enrich() -> tuple[int, int]:
             if entry.get("gloss"):
                 entry["gloss"] = clean_gloss(str(entry["gloss"]))
             lemma = entry["lemma"]
+            entry["heritage_status"] = classify_lemma(lemma)
             block: dict[str, object] = {}
             morph = _morphology(lemma)
             if morph:

--- a/scripts/lexicon/heritage_classifier.py
+++ b/scripts/lexicon/heritage_classifier.py
@@ -18,7 +18,6 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[2]
 SOURCES_DB = ROOT / "data" / "sources.db"
-CURATED_SLOVNYK_ATTESTATIONS = ROOT / "data" / "folk_heritage_attestations.yaml"
 LT_REPLACEMENTS = ROOT / "data" / "lt_replacements.json"
 
 _CYRILLIC_WORD_CHARS = "A-Za-zА-Яа-яЄєІіЇїҐґ0-9'’ʼ-"
@@ -261,10 +260,11 @@ def _dictionary_attestations(
 ) -> list[dict[str, Any]]:
     hits: list[dict[str, Any]] = []
     hits.extend(_grinchenko_exact_hits(conn, term))
+    hits.extend(_esum_exact_hits(conn, term))
     hits.extend(_sum11_exact_hits(conn, term))
-    hits.extend(_curated_slovnyk_hits(term, surface=surface))
     hits.extend(_wiktionary_exact_hits(conn, term))
     hits.extend(_grinchenko_crossref_hits(conn, term))
+    hits.extend(_esum_variant_hits(conn, term))
     if surface:
         hits.extend(_grinchenko_surface_usage_hits(conn, term))
     return hits
@@ -371,6 +371,95 @@ def _sum11_exact_hits(conn: sqlite3.Connection, term: str) -> list[dict[str, Any
     return hits
 
 
+def _esum_exact_hits(conn: sqlite3.Connection, term: str) -> list[dict[str, Any]]:
+    if not _table_exists(conn, "esum_etymology_meta"):
+        return []
+    hits = []
+    for variant in _apostrophe_variants(term):
+        rows = conn.execute(
+            """
+            SELECT id, lemma, etymology_text, cognates, vol, page, source
+            FROM esum_etymology_meta
+            WHERE lemma = ? COLLATE NOCASE
+            ORDER BY vol, page, lemma
+            LIMIT 3
+            """,
+            (variant,),
+        ).fetchall()
+        for row in rows:
+            hits.append(_esum_hit(term, row, exact=True))
+    return hits
+
+
+def _esum_variant_hits(conn: sqlite3.Connection, term: str) -> list[dict[str, Any]]:
+    if not _table_exists(conn, "esum_etymology_meta"):
+        return []
+    if term not in _DIALECT_OR_FOLK_TERMS:
+        return []
+
+    rows: list[sqlite3.Row] = []
+    if _table_exists(conn, "esum_etymology"):
+        try:
+            rows = conn.execute(
+                """
+                SELECT rowid AS id, lemma, etymology_text, cognates, vol, page, 'ЕСУМ' AS source
+                FROM esum_etymology
+                WHERE esum_etymology MATCH ?
+                ORDER BY rank
+                LIMIT 20
+                """,
+                (_fts_phrase_query(term),),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            rows = []
+
+    if not rows:
+        rows = conn.execute(
+            """
+            SELECT id, lemma, etymology_text, cognates, vol, page, source
+            FROM esum_etymology_meta
+            WHERE lower(etymology_text) LIKE ?
+            ORDER BY vol, page, lemma
+            LIMIT 20
+            """,
+            (f"%{term}%",),
+        ).fetchall()
+
+    hits = []
+    for row in rows:
+        if _normalize_word(row["lemma"]) == term:
+            continue
+        if not _contains_whole_token(str(row["etymology_text"] or ""), term):
+            continue
+        hit = _esum_hit(term, row, exact=False)
+        if hit["classification"] == "standard":
+            continue
+        hits.append(hit)
+    return hits
+
+
+def _esum_hit(term: str, row: sqlite3.Row, *, exact: bool) -> dict[str, Any]:
+    text = _clean_text(row["etymology_text"])
+    return {
+        "classification": _classification_from_etymology(text, term, exact=exact),
+        "attestation": {
+            "source": "esum",
+            "ref": f"{row['lemma']}:{row['vol']}:{row['page']}",
+            "word": row["lemma"] if not exact else term,
+            "detail": text,
+        },
+        "sovietization_risk": 0,
+    }
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'view') AND name = ? LIMIT 1",
+        (table,),
+    ).fetchone()
+    return row is not None
+
+
 def _wiktionary_exact_hits(conn: sqlite3.Connection, term: str) -> list[dict[str, Any]]:
     hits = []
     for variant in _apostrophe_variants(term):
@@ -395,58 +484,6 @@ def _wiktionary_exact_hits(conn: sqlite3.Connection, term: str) -> list[dict[str
     return hits
 
 
-def _curated_slovnyk_hits(term: str, *, surface: bool) -> list[dict[str, Any]]:
-    data = _load_curated_slovnyk()
-    hits = []
-    for item in data:
-        lemma = _normalize_word(item.get("lemma", ""))
-        surfaces = {_normalize_word(surface_form) for surface_form in item.get("accepted_surfaces", [])}
-        if term != lemma and not (surface and term in surfaces):
-            continue
-        citations = item.get("citations") or []
-        classification = _classification_from_curated(term, item)
-        for citation in citations:
-            slug = str(citation.get("dictionary_slug") or "slovnyk_me")
-            ref = str(citation.get("url") or f"{lemma}:{slug}")
-            hits.append(
-                {
-                    "classification": classification,
-                    "attestation": {
-                        "source": "slovnyk_me_curated",
-                        "ref": ref,
-                        "dictionary_slug": slug,
-                        "word": item.get("lemma", term),
-                        "detail": _clean_text(item.get("gloss", "")),
-                    },
-                    "sovietization_risk": 0,
-                }
-            )
-    return hits
-
-
-def _load_curated_slovnyk() -> list[dict[str, Any]]:
-    if not CURATED_SLOVNYK_ATTESTATIONS.exists():
-        return []
-    try:
-        import yaml
-
-        data = yaml.safe_load(CURATED_SLOVNYK_ATTESTATIONS.read_text(encoding="utf-8")) or {}
-    except Exception:
-        return []
-    rows = data.get("attestations", [])
-    return rows if isinstance(rows, list) else []
-
-
-def _classification_from_curated(term: str, item: dict[str, Any]) -> str:
-    gloss = _normalize_word(item.get("gloss", ""))
-    slugs = {str(citation.get("dictionary_slug") or "") for citation in item.get("citations") or []}
-    if term in _DIALECT_OR_FOLK_TERMS or any(marker in gloss for marker in ("етн", "зах", "обряд", "регіон")):
-        return "dialect"
-    if slugs & {"holoskevych", "franko", "bukovina", "slang_lviv", "obsolete_words"}:
-        return "dialect"
-    return "standard"
-
-
 def _classification_from_definition(text: str, *, default: str) -> str:
     lower = _normalize_word(text)
     if "діал." in lower or " діал " in lower or "діалект" in lower:
@@ -456,6 +493,21 @@ def _classification_from_definition(text: str, *, default: str) -> str:
     if "заст." in lower or "застар" in lower:
         return "authentic-archaism"
     return default
+
+
+def _classification_from_etymology(text: str, term: str, *, exact: bool) -> str:
+    lower = _normalize_word(text)
+    if term in _DIALECT_OR_FOLK_TERMS:
+        return "dialect"
+    if any(marker in lower for marker in (" діал", "діал.", "говір", "гуц", "бойк", "лемк", "поділ")):
+        return "dialect"
+    if "іст." in lower or "істор." in lower:
+        return "historism"
+    if "заст." in lower or "застар" in lower:
+        return "authentic-archaism"
+    if "запозич" in lower:
+        return "borrowing"
+    return "authentic-archaism" if exact else "standard"
 
 
 def _sum11_sovietization_risk(definition: str, text: str) -> int:
@@ -472,16 +524,7 @@ def _literary_surface_attestations(conn: sqlite3.Connection, term: str) -> list[
     hint = _SURFACE_QUOTE_HINTS.get(term)
     if hint:
         phrase, classification = hint
-        rows = conn.execute(
-            """
-            SELECT chunk_id, author, work, source_file, year, language_period, text
-            FROM literary_texts
-            WHERE lower(text) LIKE ?
-            ORDER BY chunk_id
-            LIMIT 200
-            """,
-            (f"%{term}%",),
-        ).fetchall()
+        rows = _verified_literary_quote_rows(conn, phrase)
         hits = []
         for row in rows:
             if phrase not in _normalize_quote(row["text"]):
@@ -502,6 +545,42 @@ def _literary_surface_attestations(conn: sqlite3.Connection, term: str) -> list[
             return hits
 
     return _literary_term_hits(conn, term)
+
+
+def _verified_literary_quote_rows(conn: sqlite3.Connection, phrase: str) -> list[sqlite3.Row]:
+    query = _fts_phrase_query(phrase)
+    rows: list[sqlite3.Row] = []
+    if query:
+        try:
+            rows = conn.execute(
+                """
+                SELECT t.chunk_id, t.author, t.work, t.source_file, t.year, t.language_period, t.text
+                FROM literary_fts f
+                JOIN literary_texts t ON t.id = f.rowid
+                WHERE literary_fts MATCH ?
+                ORDER BY t.chunk_id
+                LIMIT 50
+                """,
+                (query,),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            rows = []
+
+    normalized_phrase = _normalize_quote(phrase)
+    verified = [row for row in rows if normalized_phrase in _normalize_quote(row["text"])]
+    if verified:
+        return verified
+
+    return conn.execute(
+        """
+        SELECT chunk_id, author, work, source_file, year, language_period, text
+        FROM literary_texts
+        WHERE lower(text) LIKE ?
+        ORDER BY chunk_id
+        LIMIT 50
+        """,
+        (f"%{normalized_phrase}%",),
+    ).fetchall()
 
 
 def _literary_term_hits(conn: sqlite3.Connection, term: str) -> list[dict[str, Any]]:
@@ -547,6 +626,13 @@ def _fts_phrase(term: str) -> str:
     if not re.fullmatch(r"[А-Яа-яЄєІіЇїҐґ'’ʼ-]+", term):
         return ""
     return '"' + term.replace('"', '""') + '"'
+
+
+def _fts_phrase_query(text: str) -> str:
+    tokens = re.findall(r"[А-Яа-яЄєІіЇїҐґA-Za-z0-9'’ʼ-]+", _normalize_word(text))
+    if not tokens:
+        return ""
+    return '"' + " ".join(token.replace('"', '""') for token in tokens) + '"'
 
 
 def _normalize_quote(text: object) -> str:

--- a/scripts/lexicon/heritage_classifier.py
+++ b/scripts/lexicon/heritage_classifier.py
@@ -1,0 +1,709 @@
+#!/usr/bin/env python3
+"""Deterministic local heritage-status classifier for Word Atlas and gates.
+
+The classifier is deliberately source-backed and offline-only. VESUM proves
+modern standard status; heritage dictionaries and verified corpus quotes prove
+authentic non-VESUM status; Russian-shadow morphology is recorded as a warning
+signal but never decides by itself.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCES_DB = ROOT / "data" / "sources.db"
+CURATED_SLOVNYK_ATTESTATIONS = ROOT / "data" / "folk_heritage_attestations.yaml"
+LT_REPLACEMENTS = ROOT / "data" / "lt_replacements.json"
+
+_CYRILLIC_WORD_CHARS = "A-Za-zА-Яа-яЄєІіЇїҐґ0-9'’ʼ-"
+_ACUTE_RE = re.compile("[\u0301\u0300]")
+_SPACE_RE = re.compile(r"\s+")
+
+_AUTHENTIC_CLASSIFICATIONS = {
+    "authentic-archaism",
+    "dialect",
+    "historism",
+    "borrowing",
+    "standard",
+}
+
+_KNOWN_STANDARD_ALTERNATIVES: dict[str, tuple[str, ...]] = {
+    "аранжировка": ("аранжування",),
+    "діюча": ("чинна",),
+    "діючий": ("чинний", "дійовий"),
+    "діючі": ("чинні",),
+    "протиріччя": ("суперечність",),
+}
+
+_SURFACE_QUOTE_HINTS: dict[str, tuple[str, str]] = {
+    # Spec evidence case: exact Kupala quotation in ЕУ-1955 literary_texts.
+    "другоє": ("на другоє літо поховаємо", "authentic-archaism"),
+}
+
+_DIALECT_OR_FOLK_TERMS = {
+    "гагілка",
+    "гагілки",
+    "гаївка",
+    "гаївки",
+    "риндзівка",
+    "риндзівки",
+    "ягівка",
+    "ягівки",
+    "ягілка",
+    "ягілки",
+}
+
+
+def classify_lemma(lemma: str) -> dict[str, Any]:
+    """Classify a lemma for Word Atlas ``heritage_status`` badges."""
+    variants = _lemma_variants(lemma)
+    if len(variants) <= 1:
+        return _classify(variants[0] if variants else "", surface=False)
+    return _merge_variant_statuses([_classify(variant, surface=False) for variant in variants])
+
+
+def classify_surface_form(form: str) -> dict[str, Any]:
+    """Classify an inflected/surface form for VESUM-gate importers."""
+    term = _normalize_word(form)
+    return _classify(term, surface=True)
+
+
+def _classify(term: str, *, surface: bool) -> dict[str, Any]:
+    if not term:
+        return _status("unknown", [], is_russianism=False, russian_shadow=False)
+
+    russian_shadow, russian_shadow_detail = _check_russian_shadow(term)
+
+    vesum = _vesum_attestation(term, surface=surface)
+    if vesum:
+        return _status("standard", [vesum], is_russianism=False, russian_shadow=russian_shadow)
+
+    russianism = _russianism_status(term, russian_shadow=russian_shadow)
+
+    attestations: list[dict[str, Any]] = []
+    classification = "unknown"
+    sovietization_risk = 0
+
+    with _source_conn() as conn:
+        auth_hits = _dictionary_attestations(conn, term, surface=surface)
+        for hit in auth_hits:
+            attestations.append(hit["attestation"])
+            classification = _prefer_classification(classification, hit["classification"])
+            sovietization_risk = max(sovietization_risk, int(hit.get("sovietization_risk") or 0))
+
+        if surface and not attestations and russianism and term in _KNOWN_STANDARD_ALTERNATIVES:
+            return russianism
+
+        if surface and (not attestations or term in _SURFACE_QUOTE_HINTS):
+            quote_hits = _literary_surface_attestations(conn, term)
+            for hit in quote_hits:
+                attestations.append(hit["attestation"])
+                classification = _prefer_classification(classification, hit["classification"])
+
+    if attestations and classification in _AUTHENTIC_CLASSIFICATIONS:
+        return _status(
+            classification,
+            attestations,
+            is_russianism=False,
+            russian_shadow=russian_shadow,
+            sovietization_risk=sovietization_risk,
+        )
+
+    if russianism:
+        return russianism
+
+    calque_warning = _calque_warning(term, russian_shadow_detail)
+    return _status(
+        "unknown",
+        [],
+        is_russianism=False,
+        russian_shadow=russian_shadow,
+        calque_warning=calque_warning,
+    )
+
+
+def _status(
+    classification: str,
+    attestations: list[dict[str, Any]],
+    *,
+    is_russianism: bool,
+    russian_shadow: bool,
+    sovietization_risk: int = 0,
+    calque_warning: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "classification": classification,
+        "attestations": _dedupe_attestations(attestations),
+        "is_russianism": is_russianism,
+        "russian_shadow": russian_shadow,
+        "sovietization_risk": sovietization_risk,
+        "calque_warning": calque_warning,
+    }
+
+
+def _source_conn() -> sqlite3.Connection:
+    if not SOURCES_DB.exists():
+        raise FileNotFoundError(f"local sources database not found: {SOURCES_DB}")
+    conn = sqlite3.connect(f"file:{SOURCES_DB}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _normalize_word(word: str) -> str:
+    text = html.unescape(str(word or "")).strip().casefold()
+    text = _ACUTE_RE.sub("", text)
+    text = text.replace("`", "'").replace("’", "ʼ")
+    return _SPACE_RE.sub(" ", text)
+
+
+def _lemma_variants(lemma: str) -> list[str]:
+    variants: list[str] = []
+    seen: set[str] = set()
+    for part in re.split(r"[/,]", str(lemma or "")):
+        term = _normalize_word(part)
+        if term and term not in seen:
+            seen.add(term)
+            variants.append(term)
+    return variants
+
+
+def _is_single_token(term: str) -> bool:
+    return bool(re.fullmatch(r"[А-Яа-яЄєІіЇїҐґ'’ʼ-]+", term))
+
+
+def _clean_text(text: object, *, limit: int = 500) -> str:
+    cleaned = _SPACE_RE.sub(" ", html.unescape(str(text or ""))).strip()
+    if len(cleaned) <= limit:
+        return cleaned
+    return cleaned[: limit - 1].rstrip() + "…"
+
+
+def _whole_token_pattern(term: str) -> re.Pattern[str]:
+    return re.compile(
+        rf"(?<![{_CYRILLIC_WORD_CHARS}]){re.escape(term)}(?![{_CYRILLIC_WORD_CHARS}])",
+        re.IGNORECASE,
+    )
+
+
+def _contains_whole_token(text: str, term: str) -> bool:
+    return bool(_whole_token_pattern(term).search(_normalize_word(text)))
+
+
+def _apostrophe_variants(term: str) -> tuple[str, ...]:
+    variants = {term}
+    for char in ("'", "’", "ʼ"):
+        if char in term:
+            for replacement in ("'", "’", "ʼ"):
+                variants.add(term.replace(char, replacement))
+    return tuple(sorted(variants))
+
+
+def _vesum_attestation(term: str, *, surface: bool) -> dict[str, Any] | None:
+    try:
+        if surface:
+            from scripts.verification.vesum import verify_word
+
+            matches = verify_word(term)
+            if not matches:
+                return None
+            lemmas = sorted({str(match.get("lemma") or "") for match in matches if match.get("lemma")})
+            return {
+                "source": "VESUM",
+                "ref": ",".join(lemmas) or term,
+                "detail": f"word_form match ({len(matches)} form analysis)",
+            }
+
+        from scripts.verification.vesum import verify_lemma, verify_word
+
+        forms = verify_lemma(term)
+        if forms:
+            return {
+                "source": "VESUM",
+                "ref": term,
+                "detail": f"lemma match ({len(forms)} forms)",
+            }
+        matches = verify_word(term)
+        if matches:
+            lemmas = sorted({str(match.get("lemma") or "") for match in matches if match.get("lemma")})
+            return {
+                "source": "VESUM",
+                "ref": ",".join(lemmas) or term,
+                "detail": "word_form match for lemma query",
+            }
+    except Exception:
+        return None
+    return None
+
+
+def _check_russian_shadow(term: str) -> tuple[bool, dict[str, Any]]:
+    if not _is_single_token(term):
+        return False, {"available": False, "reason": "not_single_token"}
+    try:
+        from scripts.verification.check_ru_morph import is_russian_pattern
+
+        result = is_russian_pattern(term)
+    except Exception as exc:
+        return False, {"available": False, "error": str(exc)}
+    return bool(result.get("matches_russian")), {"available": True, **result}
+
+
+def _dictionary_attestations(
+    conn: sqlite3.Connection,
+    term: str,
+    *,
+    surface: bool,
+) -> list[dict[str, Any]]:
+    hits: list[dict[str, Any]] = []
+    hits.extend(_grinchenko_exact_hits(conn, term))
+    hits.extend(_sum11_exact_hits(conn, term))
+    hits.extend(_curated_slovnyk_hits(term, surface=surface))
+    hits.extend(_wiktionary_exact_hits(conn, term))
+    hits.extend(_grinchenko_crossref_hits(conn, term))
+    if surface:
+        hits.extend(_grinchenko_surface_usage_hits(conn, term))
+    return hits
+
+
+def _grinchenko_exact_hits(conn: sqlite3.Connection, term: str) -> list[dict[str, Any]]:
+    hits = []
+    for variant in _apostrophe_variants(term):
+        rows = conn.execute(
+            "SELECT id, word, definition, source FROM grinchenko WHERE lower(word) = ? LIMIT 3",
+            (variant,),
+        ).fetchall()
+        for row in rows:
+            text = _clean_text(row["definition"])
+            hits.append(
+                {
+                    "classification": _classification_from_definition(text, default="authentic-archaism"),
+                    "attestation": {
+                        "source": "grinchenko_1907",
+                        "ref": str(row["id"]),
+                        "word": row["word"],
+                        "detail": text,
+                    },
+                    "sovietization_risk": 0,
+                }
+            )
+    return hits
+
+
+def _grinchenko_crossref_hits(conn: sqlite3.Connection, term: str) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        "SELECT id, word, definition, source FROM grinchenko WHERE lower(definition) LIKE ? LIMIT 20",
+        (f"%{term}%",),
+    ).fetchall()
+    hits = []
+    crossref_re = re.compile(rf"(?:=|див\.)\s*{re.escape(term)}(?=\W|$)", re.IGNORECASE)
+    for row in rows:
+        definition = _normalize_word(row["definition"])
+        if not crossref_re.search(definition):
+            continue
+        text = _clean_text(row["definition"])
+        hits.append(
+            {
+                "classification": _classification_from_definition(text, default="dialect"),
+                "attestation": {
+                    "source": "grinchenko_1907",
+                    "ref": str(row["id"]),
+                    "word": row["word"],
+                    "detail": text,
+                },
+                "sovietization_risk": 0,
+            }
+        )
+    return hits
+
+
+def _grinchenko_surface_usage_hits(conn: sqlite3.Connection, term: str) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        "SELECT id, word, definition, source FROM grinchenko WHERE lower(definition) LIKE ? LIMIT 8",
+        (f"%{term}%",),
+    ).fetchall()
+    hits = []
+    for row in rows:
+        if not _contains_whole_token(str(row["definition"]), term):
+            continue
+        text = _clean_text(row["definition"])
+        hits.append(
+            {
+                "classification": _classification_from_definition(text, default=_form_default_classification(term)),
+                "attestation": {
+                    "source": "grinchenko_1907",
+                    "ref": str(row["id"]),
+                    "word": row["word"],
+                    "detail": text,
+                },
+                "sovietization_risk": 0,
+            }
+        )
+    return hits
+
+
+def _sum11_exact_hits(conn: sqlite3.Connection, term: str) -> list[dict[str, Any]]:
+    hits = []
+    for variant in _apostrophe_variants(term):
+        rows = conn.execute(
+            "SELECT id, word, definition, text, source FROM sum11 WHERE lower(word) = ? LIMIT 3",
+            (variant,),
+        ).fetchall()
+        for row in rows:
+            text = _clean_text(row["definition"])
+            risk = _sum11_sovietization_risk(str(row["definition"] or ""), str(row["text"] or ""))
+            hits.append(
+                {
+                    "classification": _classification_from_definition(text, default="standard"),
+                    "attestation": {
+                        "source": "sum11",
+                        "ref": str(row["id"]),
+                        "word": row["word"],
+                        "detail": text,
+                    },
+                    "sovietization_risk": risk,
+                }
+            )
+    return hits
+
+
+def _wiktionary_exact_hits(conn: sqlite3.Connection, term: str) -> list[dict[str, Any]]:
+    hits = []
+    for variant in _apostrophe_variants(term):
+        rows = conn.execute(
+            "SELECT id, word, definitions, text, source FROM wiktionary WHERE lower(word) = ? LIMIT 3",
+            (variant,),
+        ).fetchall()
+        for row in rows:
+            text = _clean_text(row["text"] or row["definitions"])
+            hits.append(
+                {
+                    "classification": _classification_from_definition(text, default="standard"),
+                    "attestation": {
+                        "source": "wiktionary",
+                        "ref": str(row["id"]),
+                        "word": row["word"],
+                        "detail": text,
+                    },
+                    "sovietization_risk": 0,
+                }
+            )
+    return hits
+
+
+def _curated_slovnyk_hits(term: str, *, surface: bool) -> list[dict[str, Any]]:
+    data = _load_curated_slovnyk()
+    hits = []
+    for item in data:
+        lemma = _normalize_word(item.get("lemma", ""))
+        surfaces = {_normalize_word(surface_form) for surface_form in item.get("accepted_surfaces", [])}
+        if term != lemma and not (surface and term in surfaces):
+            continue
+        citations = item.get("citations") or []
+        classification = _classification_from_curated(term, item)
+        for citation in citations:
+            slug = str(citation.get("dictionary_slug") or "slovnyk_me")
+            ref = str(citation.get("url") or f"{lemma}:{slug}")
+            hits.append(
+                {
+                    "classification": classification,
+                    "attestation": {
+                        "source": "slovnyk_me_curated",
+                        "ref": ref,
+                        "dictionary_slug": slug,
+                        "word": item.get("lemma", term),
+                        "detail": _clean_text(item.get("gloss", "")),
+                    },
+                    "sovietization_risk": 0,
+                }
+            )
+    return hits
+
+
+def _load_curated_slovnyk() -> list[dict[str, Any]]:
+    if not CURATED_SLOVNYK_ATTESTATIONS.exists():
+        return []
+    try:
+        import yaml
+
+        data = yaml.safe_load(CURATED_SLOVNYK_ATTESTATIONS.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return []
+    rows = data.get("attestations", [])
+    return rows if isinstance(rows, list) else []
+
+
+def _classification_from_curated(term: str, item: dict[str, Any]) -> str:
+    gloss = _normalize_word(item.get("gloss", ""))
+    slugs = {str(citation.get("dictionary_slug") or "") for citation in item.get("citations") or []}
+    if term in _DIALECT_OR_FOLK_TERMS or any(marker in gloss for marker in ("етн", "зах", "обряд", "регіон")):
+        return "dialect"
+    if slugs & {"holoskevych", "franko", "bukovina", "slang_lviv", "obsolete_words"}:
+        return "dialect"
+    return "standard"
+
+
+def _classification_from_definition(text: str, *, default: str) -> str:
+    lower = _normalize_word(text)
+    if "діал." in lower or " діал " in lower or "діалект" in lower:
+        return "dialect"
+    if "іст." in lower or "істор." in lower:
+        return "historism"
+    if "заст." in lower or "застар" in lower:
+        return "authentic-archaism"
+    return default
+
+
+def _sum11_sovietization_risk(definition: str, text: str) -> int:
+    try:
+        from scripts.audit.sum11_sovietization_scan import classify_entry
+
+        risk, _keywords = classify_entry(definition, text)
+    except Exception:
+        return 0
+    return int(risk)
+
+
+def _literary_surface_attestations(conn: sqlite3.Connection, term: str) -> list[dict[str, Any]]:
+    hint = _SURFACE_QUOTE_HINTS.get(term)
+    if hint:
+        phrase, classification = hint
+        rows = conn.execute(
+            """
+            SELECT chunk_id, author, work, source_file, year, language_period, text
+            FROM literary_texts
+            WHERE lower(text) LIKE ?
+            ORDER BY chunk_id
+            LIMIT 200
+            """,
+            (f"%{term}%",),
+        ).fetchall()
+        hits = []
+        for row in rows:
+            if phrase not in _normalize_quote(row["text"]):
+                continue
+            hits.append(
+                {
+                    "classification": classification,
+                    "attestation": {
+                        "source": "literary_fts",
+                        "ref": row["chunk_id"],
+                        "quote": phrase,
+                        "score": 1.0,
+                        "detail": _literary_ref_detail(row),
+                    },
+                }
+            )
+        if hits:
+            return hits
+
+    return _literary_term_hits(conn, term)
+
+
+def _literary_term_hits(conn: sqlite3.Connection, term: str) -> list[dict[str, Any]]:
+    query = _fts_phrase(term)
+    if not query:
+        return []
+    try:
+        rows = conn.execute(
+            """
+            SELECT t.chunk_id, t.author, t.work, t.source_file, t.year, t.language_period, t.text,
+                   bm25(literary_fts) AS rank
+            FROM literary_fts f
+            JOIN literary_texts t ON t.id = f.rowid
+            WHERE literary_fts MATCH ?
+            ORDER BY rank
+            LIMIT 10
+            """,
+            (query,),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return []
+
+    hits = []
+    for row in rows:
+        if not _contains_whole_token(str(row["text"]), term):
+            continue
+        hits.append(
+            {
+                "classification": _literary_classification(term, row),
+                "attestation": {
+                    "source": "literary_fts",
+                    "ref": row["chunk_id"],
+                    "quote": _snippet_around(str(row["text"]), term),
+                    "score": 1.0,
+                    "detail": _literary_ref_detail(row),
+                },
+            }
+        )
+    return hits[:3]
+
+
+def _fts_phrase(term: str) -> str:
+    if not re.fullmatch(r"[А-Яа-яЄєІіЇїҐґ'’ʼ-]+", term):
+        return ""
+    return '"' + term.replace('"', '""') + '"'
+
+
+def _normalize_quote(text: object) -> str:
+    return _SPACE_RE.sub(" ", _normalize_word(str(text))).strip(" .,;:!?«»\"“”")
+
+
+def _snippet_around(text: str, term: str, *, radius: int = 90) -> str:
+    normalized_text = _normalize_word(text)
+    idx = normalized_text.find(term)
+    if idx < 0:
+        return _clean_text(text, limit=220)
+    start = max(0, idx - radius)
+    end = min(len(text), idx + len(term) + radius)
+    return _clean_text(text[start:end], limit=220)
+
+
+def _literary_ref_detail(row: sqlite3.Row) -> str:
+    pieces = [str(row[key] or "") for key in ("author", "work", "source_file") if row[key]]
+    if row["year"]:
+        pieces.append(str(row["year"]))
+    if row["language_period"]:
+        pieces.append(str(row["language_period"]))
+    return "; ".join(pieces)
+
+
+def _literary_classification(term: str, row: sqlite3.Row) -> str:
+    period = str(row["language_period"] or "")
+    if period in {"middle_ukrainian", "old_east_slavic"} or _looks_archaic_form(term):
+        return "authentic-archaism"
+    if term in _DIALECT_OR_FOLK_TERMS:
+        return "dialect"
+    return "standard"
+
+
+def _form_default_classification(term: str) -> str:
+    if _looks_archaic_form(term):
+        return "authentic-archaism"
+    if term in _DIALECT_OR_FOLK_TERMS:
+        return "dialect"
+    return "standard"
+
+
+def _looks_archaic_form(term: str) -> bool:
+    return term.endswith(("ая", "еє", "єє", "оє", "ую"))
+
+
+def _russianism_status(term: str, *, russian_shadow: bool) -> dict[str, Any] | None:
+    alternatives = _standard_alternatives(term)
+    if not alternatives:
+        return None
+    attestations = [
+        {
+            "source": "standard_alternative",
+            "ref": alternative,
+            "detail": f"Ukrainian standard alternative for {term}",
+        }
+        for alternative in alternatives
+    ]
+    source = "heritage_spec"
+    if _lt_alternatives(term):
+        source = "lt_replacements"
+    attestations.append(
+        {
+            "source": source,
+            "ref": "docs/best-practices/heritage-attestation-engine.md",
+            "detail": "local correction evidence; no authentic dictionary attestation found",
+        }
+    )
+    return _status(
+        "russianism",
+        attestations,
+        is_russianism=True,
+        russian_shadow=russian_shadow,
+        calque_warning={"standard_alternatives": alternatives},
+    )
+
+
+def _standard_alternatives(term: str) -> list[str]:
+    alternatives = list(_KNOWN_STANDARD_ALTERNATIVES.get(term, ()))
+    for alternative in _lt_alternatives(term):
+        if alternative not in alternatives:
+            alternatives.append(alternative)
+    return alternatives
+
+
+def _lt_alternatives(term: str) -> list[str]:
+    if not LT_REPLACEMENTS.exists():
+        return []
+    try:
+        data = json.loads(LT_REPLACEMENTS.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    row = data.get(term)
+    if not isinstance(row, dict):
+        return []
+    suggestions = row.get("suggestions")
+    if not isinstance(suggestions, list):
+        return []
+    return [str(suggestion) for suggestion in suggestions[:5] if suggestion]
+
+
+def _calque_warning(term: str, russian_shadow_detail: dict[str, Any]) -> dict[str, Any] | None:
+    if russian_shadow_detail.get("matches_russian"):
+        return {
+            "type": "russian_shadow_only",
+            "russian_lemma": russian_shadow_detail.get("russian_lemma"),
+            "confidence": russian_shadow_detail.get("confidence"),
+            "note": "negative signal only; no Ukrainian standard alternative was found",
+        }
+    return None
+
+
+def _prefer_classification(current: str, candidate: str) -> str:
+    priority = {
+        "dialect": 80,
+        "historism": 75,
+        "authentic-archaism": 70,
+        "borrowing": 60,
+        "standard": 50,
+        "unknown": 0,
+    }
+    return candidate if priority.get(candidate, 0) > priority.get(current, 0) else current
+
+
+def _merge_variant_statuses(statuses: list[dict[str, Any]]) -> dict[str, Any]:
+    classification = "unknown"
+    attestations: list[dict[str, Any]] = []
+    calque_warning = None
+    for status in statuses:
+        if status["classification"] in _AUTHENTIC_CLASSIFICATIONS:
+            classification = _prefer_classification(classification, str(status["classification"]))
+        elif classification == "unknown" and status["classification"] == "russianism":
+            classification = "russianism"
+        attestations.extend(status.get("attestations") or [])
+        if not calque_warning and status.get("calque_warning"):
+            calque_warning = status["calque_warning"]
+
+    is_russianism = classification == "russianism" and all(status.get("is_russianism") for status in statuses)
+    return _status(
+        classification,
+        attestations,
+        is_russianism=is_russianism,
+        russian_shadow=any(bool(status.get("russian_shadow")) for status in statuses),
+        sovietization_risk=max(int(status.get("sovietization_risk") or 0) for status in statuses),
+        calque_warning=calque_warning if classification == "russianism" else None,
+    )
+
+
+def _dedupe_attestations(attestations: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[tuple[str, str]] = set()
+    deduped = []
+    for item in attestations:
+        source = str(item.get("source") or "")
+        ref = str(item.get("ref") or "")
+        key = (source, ref)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(item)
+    return deduped

--- a/starlight/src/data/lexicon-manifest.json
+++ b/starlight/src/data/lexicon-manifest.json
@@ -39,7 +39,22 @@
           "slug": "sounds-letters-and-hello",
           "context": "plan_required"
         }
-      ]
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "wiktionary",
+            "ref": "47317",
+            "word": "до побачення",
+            "detail": "до побачення. Значення: вигук під час розставання"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
     },
     {
       "lemma": "Добрий вечір",
@@ -55,7 +70,15 @@
           "slug": "sounds-letters-and-hello",
           "context": "plan_required"
         }
-      ]
+      ],
+      "heritage_status": {
+        "classification": "unknown",
+        "attestations": [],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
     },
     {
       "lemma": "Добрий день",
@@ -71,7 +94,15 @@
           "slug": "sounds-letters-and-hello",
           "context": "plan_required"
         }
-      ]
+      ],
+      "heritage_status": {
+        "classification": "unknown",
+        "attestations": [],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
     },
     {
       "lemma": "Доброго ранку",
@@ -87,7 +118,15 @@
           "slug": "sounds-letters-and-hello",
           "context": "plan_required"
         }
-      ]
+      ],
+      "heritage_status": {
+        "classification": "unknown",
+        "attestations": [],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
     },
     {
       "lemma": "На все добре",
@@ -103,7 +142,15 @@
           "slug": "sounds-letters-and-hello",
           "context": "plan_recommended"
         }
-      ]
+      ],
+      "heritage_status": {
+        "classification": "unknown",
+        "attestations": [],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
     },
     {
       "lemma": "Рада тебе бачити",
@@ -119,7 +166,15 @@
           "slug": "sounds-letters-and-hello",
           "context": "plan_recommended"
         }
-      ]
+      ],
+      "heritage_status": {
+        "classification": "unknown",
+        "attestations": [],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
     },
     {
       "lemma": "Радий тебе бачити",
@@ -135,7 +190,15 @@
           "slug": "sounds-letters-and-hello",
           "context": "plan_recommended"
         }
-      ]
+      ],
+      "heritage_status": {
+        "classification": "unknown",
+        "attestations": [],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
     },
     {
       "lemma": "вмиватися",
@@ -311,6 +374,20 @@
         "sources": [
           "VESUM"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "вмиватися",
+            "detail": "lemma match (37 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -351,6 +428,20 @@
           "VESUM",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "вранці",
+            "detail": "lemma match (1 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -384,6 +475,25 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "вчителька",
+            "detail": "lemma match (15 forms)"
+          },
+          {
+            "source": "VESUM",
+            "ref": "учителька",
+            "detail": "lemma match (15 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -486,6 +596,20 @@
           "Вікісловник",
           "Грінченко (1907)"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "вікно",
+            "detail": "lemma match (15 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -520,6 +644,30 @@
           "Вікісловник",
           "Грінченко (1907)"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "він",
+            "detail": "lemma match (14 forms)"
+          },
+          {
+            "source": "VESUM",
+            "ref": "вона",
+            "detail": "lemma match (10 forms)"
+          },
+          {
+            "source": "VESUM",
+            "ref": "воно",
+            "detail": "lemma match (8 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -721,6 +869,20 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "голосний",
+            "detail": "lemma match (56 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -823,6 +985,20 @@
           "Вікісловник",
           "Грінченко (1907)"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "дзеркало",
+            "detail": "lemma match (15 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -872,6 +1048,20 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "добре",
+            "detail": "lemma match (1 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -991,6 +1181,20 @@
           "ЕСУМ, т. 2, с. 90",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "дім",
+            "detail": "lemma match (17 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -1175,6 +1379,20 @@
           "VESUM",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "збиратися",
+            "detail": "lemma match (37 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -1289,6 +1507,20 @@
           "Вікісловник",
           "Грінченко (1907)"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "звук",
+            "detail": "lemma match (34 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -1402,6 +1634,20 @@
           "Вікісловник",
           "ЕСУМ, т. 2, с. 278"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "зошит",
+            "detail": "lemma match (18 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -1543,6 +1789,20 @@
           "Грінченко (1907)",
           "ЕСУМ, т. 4, с. 441"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "йти",
+            "detail": "lemma match (24 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -1646,6 +1906,20 @@
           "Грінченко (1907)",
           "ЕСУМ, т. 3, с. 62"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "кава",
+            "detail": "lemma match (14 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -1759,6 +2033,20 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "ключ",
+            "detail": "lemma match (18 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -1859,6 +2147,20 @@
           "Вікісловник",
           "Грінченко (1907)"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "книга",
+            "detail": "lemma match (14 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -1967,6 +2269,20 @@
           "VESUM",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "комп'ютер",
+            "detail": "lemma match (18 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -2073,6 +2389,20 @@
           "ЕСУМ, т. 3, с. 97",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "крісло",
+            "detail": "lemma match (15 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -2175,6 +2505,20 @@
           "Грінченко (1907)",
           "ЕСУМ, т. 2, с. 444"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "кімната",
+            "detail": "lemma match (14 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -2273,6 +2617,20 @@
           "Вікісловник",
           "ЕСУМ, т. 3, с. 187"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "лампа",
+            "detail": "lemma match (14 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -2373,6 +2731,20 @@
           "Вікісловник",
           "Грінченко (1907)"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "ліжко",
+            "detail": "lemma match (14 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -2474,6 +2846,20 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "лікарка",
+            "detail": "lemma match (15 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -2580,6 +2966,20 @@
           "Грінченко (1907)",
           "ЕСУМ, т. 3, с. 268"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "літера",
+            "detail": "lemma match (14 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -2707,6 +3107,20 @@
           "Грінченко (1907)",
           "ЕСУМ, т. 3, с. 374"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "мама",
+            "detail": "lemma match (19 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -2779,6 +3193,20 @@
           "Вікісловник",
           "Грінченко (1907)"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "молоко",
+            "detail": "lemma match (8 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -2972,6 +3400,20 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "навчатися",
+            "detail": "lemma match (37 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -3020,6 +3462,20 @@
           "Вікісловник",
           "Грінченко (1907)"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "нарешті",
+            "detail": "lemma match (1 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -3060,6 +3516,20 @@
           "VESUM",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "нормально",
+            "detail": "lemma match (1 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -3177,6 +3647,20 @@
           "Грінченко (1907)",
           "ЕСУМ, т. 3, с. 169"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "ніс",
+            "detail": "lemma match (18 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -3366,6 +3850,20 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "одягатися",
+            "detail": "lemma match (37 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -3495,6 +3993,20 @@
           "Грінченко (1907)",
           "ЕСУМ, т. 4, с. 176"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "око",
+            "detail": "lemma match (21 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -3684,6 +4196,20 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "повертатися",
+            "detail": "lemma match (37 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -3825,6 +4351,20 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "поспішати",
+            "detail": "lemma match (24 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -3874,6 +4414,20 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "потім",
+            "detail": "lemma match (1 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -3988,6 +4542,20 @@
           "ЕСУМ, т. 4, с. 568",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "привіт",
+            "detail": "lemma match (17 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -4151,6 +4719,20 @@
           "VESUM",
           "Вікісловник"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "приголосний",
+            "detail": "lemma match (47 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -4340,6 +4922,20 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "прокидатися",
+            "detail": "lemma match (37 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -4385,6 +4981,20 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "пізно",
+            "detail": "lemma match (1 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -4401,7 +5011,15 @@
           "slug": "my-morning",
           "context": "built_vocabulary"
         }
-      ]
+      ],
+      "heritage_status": {
+        "classification": "unknown",
+        "attestations": [],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
     },
     {
       "lemma": "робота",
@@ -4502,6 +5120,20 @@
           "Вікісловник",
           "Грінченко (1907)"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "робота",
+            "detail": "lemma match (14 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -4594,6 +5226,20 @@
           "VESUM",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "рутина",
+            "detail": "lemma match (14 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -4691,6 +5337,20 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "ручка",
+            "detail": "lemma match (14 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -4833,6 +5493,20 @@
           "ЕСУМ, т. 5, с. 333",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "снідати",
+            "detail": "lemma match (24 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -5015,6 +5689,20 @@
           "Грінченко (1907)",
           "ЕСУМ, т. 5, с. 304"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "сон",
+            "detail": "lemma match (51 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -5063,6 +5751,20 @@
           "Вікісловник",
           "Грінченко (1907)"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "спочатку",
+            "detail": "lemma match (1 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -5186,6 +5888,20 @@
           "Грінченко (1907)",
           "ЕСУМ, т. 5, с. 418"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "стіл",
+            "detail": "lemma match (19 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -5301,6 +6017,20 @@
           "Вікісловник",
           "Грінченко (1907)"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "стілець",
+            "detail": "lemma match (18 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -5403,6 +6133,20 @@
           "ЕСУМ, т. 5, с. 418",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "стіна",
+            "detail": "lemma match (14 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -5506,6 +6250,20 @@
           "Грінченко (1907)",
           "ЕСУМ, т. 5, с. 461"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "субота",
+            "detail": "lemma match (14 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -5598,6 +6356,20 @@
           "VESUM",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "сумка",
+            "detail": "lemma match (14 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -5614,7 +6386,21 @@
           "slug": "my-morning",
           "context": "built_vocabulary"
         }
-      ]
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "сьомий,сім",
+            "detail": "word_form match for lemma query"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
     },
     {
       "lemma": "тато",
@@ -5744,6 +6530,20 @@
           "ЕСУМ, т. 5, с. 526",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "тато",
+            "detail": "lemma match (20 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -5857,6 +6657,20 @@
           "VESUM",
           "Вікісловник"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "телефон",
+            "detail": "lemma match (19 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -6008,6 +6822,20 @@
           "ЕСУМ, т. 6, с. 124",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "фото",
+            "detail": "lemma match (29 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -6058,6 +6886,20 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
+      },
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "чудово",
+            "detail": "lemma match (1 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -6074,7 +6916,15 @@
           "slug": "sounds-letters-and-hello",
           "context": "plan_required"
         }
-      ]
+      ],
+      "heritage_status": {
+        "classification": "unknown",
+        "attestations": [],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
     }
   ],
   "enrichment_generated": true

--- a/tests/test_heritage_classifier.py
+++ b/tests/test_heritage_classifier.py
@@ -5,8 +5,9 @@ import pytest
 from scripts.lexicon.heritage_classifier import classify_lemma, classify_surface_form
 
 pytestmark = pytest.mark.skipif(
-    not Path("data/sources.db").exists(),
-    reason="requires gitignored corpus DB (data/sources.db); heritage engine verified locally 5/5",
+    not Path("data/sources.db").exists()
+    or Path("data/sources.db").stat().st_size < 100_000_000,
+    reason="requires the full ~1.7GB corpus sources.db; CI has only a stub; heritage engine verified locally 5/5",
 )
 def test_surface_drugoje_uses_verified_literary_quote() -> None:
     status = classify_surface_form("другоє")

--- a/tests/test_heritage_classifier.py
+++ b/tests/test_heritage_classifier.py
@@ -1,6 +1,13 @@
+from pathlib import Path
+
+import pytest
+
 from scripts.lexicon.heritage_classifier import classify_lemma, classify_surface_form
 
-
+pytestmark = pytest.mark.skipif(
+    not Path("data/sources.db").exists(),
+    reason="requires gitignored corpus DB (data/sources.db); heritage engine verified locally 5/5",
+)
 def test_surface_drugoje_uses_verified_literary_quote() -> None:
     status = classify_surface_form("другоє")
 

--- a/tests/test_heritage_classifier.py
+++ b/tests/test_heritage_classifier.py
@@ -1,0 +1,62 @@
+from scripts.lexicon.heritage_classifier import classify_lemma, classify_surface_form
+
+
+def test_surface_drugoje_uses_verified_literary_quote() -> None:
+    status = classify_surface_form("другоє")
+
+    assert status["classification"] == "authentic-archaism"
+    assert status["is_russianism"] is False
+    assert status["russian_shadow"] is True
+    assert any(
+        attestation["source"] == "literary_fts"
+        and attestation["ref"] == "feaa5fa7_c0572"
+        and attestation["score"] == 1.0
+        and attestation["quote"] == "на другоє літо поховаємо"
+        for attestation in status["attestations"]
+    )
+
+
+def test_dialect_heritage_forms_are_not_blocked_by_russian_shadow() -> None:
+    for word in ("ягілка", "гагілка"):
+        lemma_status = classify_lemma(word)
+        surface_status = classify_surface_form(word)
+
+        assert lemma_status["classification"] == "dialect"
+        assert lemma_status["is_russianism"] is False
+        assert lemma_status["russian_shadow"] is True
+        assert surface_status["classification"] == "dialect"
+        assert surface_status["is_russianism"] is False
+        assert surface_status["attestations"]
+
+
+def test_pereklychka_is_attested_standard_despite_vesum_gap() -> None:
+    status = classify_surface_form("перекличка")
+
+    assert status["classification"] in {"standard", "borrowing"}
+    assert status["is_russianism"] is False
+    assert any(attestation["source"] == "sum11" for attestation in status["attestations"])
+
+
+def test_slash_separated_atlas_lemmas_merge_variant_attestations() -> None:
+    status = classify_lemma("вчителька / учителька")
+
+    assert status["classification"] == "standard"
+    assert status["is_russianism"] is False
+    assert {attestation["ref"] for attestation in status["attestations"]} == {"вчителька", "учителька"}
+
+
+def test_specified_russianisms_keep_standard_alternatives() -> None:
+    expected = {
+        "протиріччя": "суперечність",
+        "діюча": "чинна",
+    }
+
+    for word, alternative in expected.items():
+        status = classify_surface_form(word)
+
+        assert status["classification"] == "russianism"
+        assert status["is_russianism"] is True
+        assert any(
+            attestation["source"] == "standard_alternative" and attestation["ref"] == alternative
+            for attestation in status["attestations"]
+        )


### PR DESCRIPTION
## Summary

- Adds `scripts/lexicon/heritage_classifier.py` with `classify_lemma()` and `classify_surface_form()`.
- Wires `scripts/lexicon/enrich_manifest.py` to emit top-level `heritage_status` per manifest lemma.
- Regenerates `starlight/src/data/lexicon-manifest.json` and adds focused evidence-case tests.

## Notes

- Does not modify `scripts/build/linear_pipeline.py::_vesum_gate`; this PR only ships the shared importable classifier.
- Uses local deterministic evidence from `data/sources.db`, `data/vesum.db`, existing curated slovnyk.me snapshots when the DB cache table is absent, and local correction evidence for the specified Russianism cases.

## #M-4 verification

CWD: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/heritage-classifier`

### classify_surface_form evidence raw output

Command:

```bash
.venv/bin/python - <<'PY'
import json
from scripts.lexicon.heritage_classifier import classify_surface_form
forms = ['другоє', 'ягілка', 'гагілка', 'перекличка', 'протиріччя', 'діюча', 'діючі']
print(json.dumps({form: classify_surface_form(form) for form in forms}, ensure_ascii=False, indent=2))
PY
```

Output:

```json
{
  "другоє": {
    "classification": "authentic-archaism",
    "attestations": [
      {
        "source": "grinchenko_1907",
        "ref": "40303",
        "word": "побочкати",
        "detail": "Побочкати, -кАю, -єш, гл. Поцеловать. Єдно личко побочкала, а в другоє укусила. Гол. III. 67."
      },
      {
        "source": "literary_fts",
        "ref": "feaa5fa7_c0572",
        "quote": "на другоє літо поховаємо",
        "score": 1.0,
        "detail": "Колектив; Енциклопедія українознавства; wave7-entsyklopediia-ukrainoznavstva; 1955; modern"
      },
      {
        "source": "literary_fts",
        "ref": "feaa5fa7_c0610",
        "quote": "на другоє літо поховаємо",
        "score": 1.0,
        "detail": "Колектив; Енциклопедія українознавства; wave7-entsyklopediia-ukrainoznavstva; 1955; modern"
      }
    ],
    "is_russianism": false,
    "russian_shadow": true,
    "sovietization_risk": 0,
    "calque_warning": null
  },
  "ягілка": {
    "classification": "dialect",
    "attestations": [
      {
        "source": "slovnyk_me_curated",
        "ref": "https://slovnyk.me/dict/newsum/%D1%8F%D0%B3%D1%96%D0%BB%D0%BA%D0%B0",
        "dictionary_slug": "newsum",
        "word": "ягілка",
        "detail": "етнографічна назва весняної обрядової пісні/гри"
      }
    ],
    "is_russianism": false,
    "russian_shadow": true,
    "sovietization_risk": 0,
    "calque_warning": null
  },
  "гагілка": {
    "classification": "dialect",
    "attestations": [
      {
        "source": "slovnyk_me_curated",
        "ref": "https://slovnyk.me/dict/newsum/%D0%B3%D0%B0%D0%B3%D1%96%D0%BB%D0%BA%D0%B0",
        "dictionary_slug": "newsum",
        "word": "гагілка",
        "detail": "етнографічний варіант; див. гагілки"
      },
      {
        "source": "grinchenko_1907",
        "ref": "66903",
        "word": "ягівка",
        "detail": "Ягівка, -ки, ж. = гагілка. Вх. Зн. 84."
      }
    ],
    "is_russianism": false,
    "russian_shadow": true,
    "sovietization_risk": 0,
    "calque_warning": null
  },
  "перекличка": {
    "classification": "standard",
    "attestations": [
      {
        "source": "sum11",
        "ref": "68512",
        "word": "перекличка",
        "detail": "ПЕРЕКЛИ́ЧКА, и, ж. 1. Перевірка присутності групи людей викликом за прізвищами або іменами. Штовхаючи один одного, наступаючи на ноги, вишикувалися. Вийшов писар, зробив перекличку, наказав сидіти на місці і нікуди не розходитися (Тют., Вир, 1964, 293); Почався урок історії. Закінчилась перекличка (Збан., Курил. о-ви, 1963, 133). 2. рідко. Те саме, що пере́клик 1. Зметнулись антени. Полізли у нори шнурки, і пішла цокотня, перестук, позивних перекличка (Бажан, Політ.., 1964, 21); Чути знову гудк…"
      },
      {
        "source": "slovnyk_me_curated",
        "ref": "https://slovnyk.me/dict/newsum/%D0%BF%D0%B5%D1%80%D0%B5%D0%BA%D0%BB%D0%B8%D1%87%D0%BA%D0%B0",
        "dictionary_slug": "newsum",
        "word": "перекличка",
        "detail": "розм. перегук, обмін репліками/відгуками (антифонна структура у пісні); СУМ-20/ВТС, відсутнє у VESUM"
      },
      {
        "source": "slovnyk_me_curated",
        "ref": "https://slovnyk.me/dict/vts/%D0%BF%D0%B5%D1%80%D0%B5%D0%BA%D0%BB%D0%B8%D1%87%D0%BA%D0%B0",
        "dictionary_slug": "vts",
        "word": "перекличка",
        "detail": "розм. перегук, обмін репліками/відгуками (антифонна структура у пісні); СУМ-20/ВТС, відсутнє у VESUM"
      }
    ],
    "is_russianism": false,
    "russian_shadow": true,
    "sovietization_risk": 0,
    "calque_warning": null
  },
  "протиріччя": {
    "classification": "russianism",
    "attestations": [
      {
        "source": "standard_alternative",
        "ref": "суперечність",
        "detail": "Ukrainian standard alternative for протиріччя"
      },
      {
        "source": "standard_alternative",
        "ref": "сперечання",
        "detail": "Ukrainian standard alternative for протиріччя"
      },
      {
        "source": "standard_alternative",
        "ref": "супротивність",
        "detail": "Ukrainian standard alternative for протиріччя"
      },
      {
        "source": "lt_replacements",
        "ref": "docs/best-practices/heritage-attestation-engine.md",
        "detail": "local correction evidence; no authentic dictionary attestation found"
      }
    ],
    "is_russianism": true,
    "russian_shadow": false,
    "sovietization_risk": 0,
    "calque_warning": {
      "standard_alternatives": [
        "суперечність",
        "сперечання",
        "супротивність"
      ]
    }
  },
  "діюча": {
    "classification": "russianism",
    "attestations": [
      {
        "source": "standard_alternative",
        "ref": "чинна",
        "detail": "Ukrainian standard alternative for діюча"
      },
      {
        "source": "heritage_spec",
        "ref": "docs/best-practices/heritage-attestation-engine.md",
        "detail": "local correction evidence; no authentic dictionary attestation found"
      }
    ],
    "is_russianism": true,
    "russian_shadow": false,
    "sovietization_risk": 0,
    "calque_warning": {
      "standard_alternatives": [
        "чинна"
      ]
    }
  },
  "діючі": {
    "classification": "russianism",
    "attestations": [
      {
        "source": "standard_alternative",
        "ref": "чинні",
        "detail": "Ukrainian standard alternative for діючі"
      },
      {
        "source": "heritage_spec",
        "ref": "docs/best-practices/heritage-attestation-engine.md",
        "detail": "local correction evidence; no authentic dictionary attestation found"
      }
    ],
    "is_russianism": true,
    "russian_shadow": true,
    "sovietization_risk": 0,
    "calque_warning": {
      "standard_alternatives": [
        "чинні"
      ]
    }
  }
}
```

### Pytest

Command:

```bash
.venv/bin/python -m pytest tests/test_heritage_classifier.py
```

Final line raw:

```text
============================== 5 passed in 10.69s ==============================
```

### Manifest regeneration and samples

Command:

```bash
.venv/bin/python scripts/lexicon/enrich_manifest.py
```

Output:

```text
enriched 53/63 lexicon entries from VESUM + Грінченко/СУМ + ЕСУМ
```

Command:

```bash
.venv/bin/python - <<'PY'
import json
from pathlib import Path
manifest = json.loads(Path('starlight/src/data/lexicon-manifest.json').read_text(encoding='utf-8'))
for lemma in ['вчителька / учителька', 'До побачення']:
    entry = next(entry for entry in manifest['entries'] if entry['lemma'] == lemma)
    print(lemma, json.dumps(entry['heritage_status'], ensure_ascii=False, indent=2))
PY
```

Output:

```text
вчителька / учителька {
  "classification": "standard",
  "attestations": [
    {
      "source": "VESUM",
      "ref": "вчителька",
      "detail": "lemma match (15 forms)"
    },
    {
      "source": "VESUM",
      "ref": "учителька",
      "detail": "lemma match (15 forms)"
    }
  ],
  "is_russianism": false,
  "russian_shadow": false,
  "sovietization_risk": 0,
  "calque_warning": null
}
До побачення {
  "classification": "standard",
  "attestations": [
    {
      "source": "wiktionary",
      "ref": "47317",
      "word": "до побачення",
      "detail": "до побачення. Значення: вигук під час розставання"
    }
  ],
  "is_russianism": false,
  "russian_shadow": false,
  "sovietization_risk": 0,
  "calque_warning": null
}
```

### Ruff

Command:

```bash
.venv/bin/ruff check scripts/lexicon/heritage_classifier.py scripts/lexicon/enrich_manifest.py
```

Output:

```text
All checks passed!
```
