### PR TITLE
docs(folk): session handoff refresh — dossiers landed + engine API confirmed [#2836]

### DIFF
--- a/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
+++ b/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
@@ -29,23 +29,25 @@
 
 ## ▶▶▶ SESSION 9 HANDOFF (2026-06-10 — TEXT LAYER MERGED; VESUM WALL BROKEN via slovnyk.me HERITAGE GATE; NOW EMBEDDING PRIMARY TEXTS) — **RESUME HERE**
 
-> **⏱ LATEST STATE (2026-06-10 PM — session rollover):**
-> - **HOLD on kalendarna module re-fire** — gated on the shared **Heritage Attestation Engine** (spec on main:
->   `docs/best-practices/heritage-attestation-engine.md`, #2907 merged). Orchestrator OWNS the build + APPROVED the
->   architecture; it is **building NOW** (their `heritage-classifier` + `word-atlas-pages` codex dispatches are
->   ACTIVE — verify `curl :8765/api/delegate/active`). **Resume trigger = user signals the engine has landed** →
->   then: review+apply the classifier to `_vesum_gate` (consume, don't duplicate) + exempt verbatim `>` blockquotes
->   from the VESUM walk → re-fire kalendarna #5 → promote 04 (with source links) → 01 → dumy → queue.
-> - **WHILE WAITING: driving the folk dossier→wiki queue with codex** (user 2026-06-10: "we have lots of codex to
->   burn"; bakeoff claude-tools vs codex-tools for the folk MODULE writer is DEFERRED to post-engine).
->   **IN-FLIGHT (review per the proven loop — Claude corpus-hammer re-runs `verify_quote` on a §4 sample before
->   SHIP, NO auto-merge):** `folk-dossier-zamovliannia-zaklynannia-prymovky` (#03) + `folk-dossier-vesnianky-hayivky`
->   (#06), both codex/gpt-5.5. Briefs: `/tmp/folk-dossier-<slug>-brief.md` (template = the proven dossier loop).
-> - **QUEUE STATE:** 6 dossiers exist (narodna-kultura, narodni-viruvannia, kalendarna, koliadky, rodynna,
->   dumy-nevilnytski); **3 have wikis** (kalendarna, koliadky, dumy) → **narodna-kultura / narodni-viruvannia /
->   rodynna NEED WIKIS** (compile.py --writer gpt-5.5 from a `data/`-bearing checkout, see Session 5 note). Next
->   dossiers after the 2 in-flight: #07 kupalski-rusalni-pisni, #08 zhnyvarski-obzhynkovi-pisni, #10 vesilni-pisni,
->   #11 holosinnya, #13 dumy-sotsialno-pobutovi… (`phase-folk-queue.md`).
+> **⏱ LATEST STATE (2026-06-10 PM #2 — session rollover, all dispatches idle):**
+> - **BLOCKER — HOLD on kalendarna module re-fire** — gated on the shared **Heritage Attestation Engine**.
+>   Architecture CONFIRMED + approved by both lanes (spec on main `docs/best-practices/heritage-attestation-engine.md`,
+>   #2907 merged): one shared **`scripts/lexicon/heritage_classifier.py`** with **`classify_lemma()`** (Atlas badges)
+>   + **`classify_surface_form()`** (MY gate's `verify_quote` path); etymology evidence = **Goroh/Wiktionary** (not
+>   ЕСУМ). **Atlas/orchestrator lane OWNS the build** (their `heritage-classifier` codex dispatch has FINISHED; engine
+>   is landing — Word Atlas pages already shipping, e.g. #2916). **DO NOT duplicate the engine.**
+>   **Resume trigger = `classify_surface_form()` is importable (user/orchestrator signal).** Then: import it into
+>   `_vesum_gate` (consume) + exempt verbatim `>` blockquotes from `_build_vesum_text` → re-fire kalendarna #5 →
+>   promote 04 (with source links) → 01 → dumy → queue. `#2899` `folk_heritage_attestations.yaml` collapses to a thin override.
+> - **DOSSIER QUEUE (codex, while waiting) — 2 LANDED, AWAITING REVIEW:** `folk-dossier-zamovliannia-zaklynannia-prymovky`
+>   (#03) → **PR #2914**; `folk-dossier-vesnianky-hayivky` (#06) → **PR #2915**. Both done rc=0. **NEXT ACTION: corpus-hammer
+>   review each** (re-run `verify_quote` on a §4 sample, check §9 decolonization + russian_shadow) → SHIP/self-merge per
+>   the proven loop. **NO auto-merge until reviewed.** Then fire the next: #07 kupalski-rusalni-pisni, #08
+>   zhnyvarski-obzhynkovi-pisni, #10 vesilni-pisni, #11 holosinnya, #13 dumy-sotsialno-pobutovi… (`phase-folk-queue.md`).
+> - **WIKIS NEEDED** for 3 dossier-only topics: narodna-kultura / narodni-viruvannia / rodynna (compile.py --writer
+>   gpt-5.5 from a `data/`-bearing checkout — see Session 5 note). **MODULE-writer bakeoff** (claude-tools vs codex-tools
+>   for folk) = DEFERRED to post-engine (user: "lots of codex to burn").
+> - **Non-folk side-task done:** landing-page ULP/Anna dedup (#2911 merged — body section removed, footer keeps attribution).
 
 > **USER GOAL (2026-06-10, explicit):** get module **04 (kalendarna)** rebuilt to the folk-experiential design + verified as the **REFERENCE**, THEN build **01 (koliadky) + the rest** ("when 04 is ready start building 01 and the rest"). Served folk = quality cliff: 04 kalendarna = `linear-phase-4`; **01 koliadky + 19 dumy-lytsarski = OLD April `v6` drafts** (user spotted). Rebuild order: 04 (verify) → 01 → dumy → queue.
 >


### PR DESCRIPTION
Folk handoff rollover. Updates: (1) HOLD on kalendarna gated on the heritage engine — API CONFIRMED (`scripts/lexicon/heritage_classifier.py`: `classify_lemma()`+`classify_surface_form()`, Goroh/Wiktionary etymology); orchestrator owns the build, it's landing; (2) the 2 codex folk dossiers LANDED → PRs #2914/#2915 await corpus-hammer review (NO auto-merge); (3) wikis needed for 3 dossier-only topics; (4) landing dedup #2911 noted. Doc-only; self-merging under the folk grant.