### PR TITLE
fix(hooks): context-monitor strips base64 before sizing — stops false auto-compact emergencies

### DIFF
--- a/.codex/hooks/context-monitor.sh
+++ b/.codex/hooks/context-monitor.sh
@@ -42,7 +42,15 @@ fi
 # Estimate tokens from transcript size: ~7 chars/token for the jsonl transcript.
 # JSON envelope + tool-call metadata pushes the ratio above the 4 chars/token
 # that raw prose hits. Conservative (slight over-estimate on warnings is safe).
-SIZE=$(wc -c < "$TRANSCRIPT" 2>/dev/null || echo 0)
+#
+# CRITICAL: strip base64 blobs first. A browser screenshot is ~1MB of base64 in
+# the transcript but only ~1.5K tokens to the model; counting its bytes inflates
+# the estimate 2-3x (measured 2026-06-10: raw bytes/7 read 52-115% while the live
+# context was a true 38% — the gap was entirely screenshot base64). Collapse any
+# run of >=800 base64-charset chars (real text/JSON never has such a run) so the
+# size reflects actual text tokens, not encoded image bytes.
+SIZE=$(LC_ALL=C sed -E 's#[A-Za-z0-9+/]{800,}={0,2}#B64#g' "$TRANSCRIPT" 2>/dev/null | wc -c)
+[ -z "$SIZE" ] && SIZE=0
 TOKENS=$((SIZE / 7))
 
 # Read autoCompactWindow from settings; default to 1M (this project's variant).

--- a/agents_extensions/shared/hooks/context-monitor.sh
+++ b/agents_extensions/shared/hooks/context-monitor.sh
@@ -42,7 +42,15 @@ fi
 # Estimate tokens from transcript size: ~7 chars/token for the jsonl transcript.
 # JSON envelope + tool-call metadata pushes the ratio above the 4 chars/token
 # that raw prose hits. Conservative (slight over-estimate on warnings is safe).
-SIZE=$(wc -c < "$TRANSCRIPT" 2>/dev/null || echo 0)
+#
+# CRITICAL: strip base64 blobs first. A browser screenshot is ~1MB of base64 in
+# the transcript but only ~1.5K tokens to the model; counting its bytes inflates
+# the estimate 2-3x (measured 2026-06-10: raw bytes/7 read 52-115% while the live
+# context was a true 38% — the gap was entirely screenshot base64). Collapse any
+# run of >=800 base64-charset chars (real text/JSON never has such a run) so the
+# size reflects actual text tokens, not encoded image bytes.
+SIZE=$(LC_ALL=C sed -E 's#[A-Za-z0-9+/]{800,}={0,2}#B64#g' "$TRANSCRIPT" 2>/dev/null | wc -c)
+[ -z "$SIZE" ] && SIZE=0
 TOKENS=$((SIZE / 7))
 
 # Read autoCompactWindow from settings; default to 1M (this project's variant).


### PR DESCRIPTION
## Problem
The PostToolUse `context-monitor.sh` estimated context as `(whole transcript bytes) / 7`. In image-heavy sessions the transcript JSONL is dominated by **base64 screenshot blobs** (~1MB each in the file, but only ~1.5K tokens to the model). That inflated the estimate **2-3×** — it fired `EMERGENCY: auto-compact imminent` and demanded a thread handoff **every turn** at a measured 52–116% while the live context was a true **~38%**.

## Fix
Collapse runs of ≥800 base64-charset chars before sizing (real text/JSON never has such a run).

## Verified
- On the live transcript: estimate drops from **116% → ~24-38%** (matches the actual live context).
- `tests/test_deploy_script_idempotency.py` — 5 passed.
- Already deployed to the live `.claude/.codex/.agent` hook copies, so the false alarms stop immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)