### PR TITLE
[codex] A2 M01-M04 resource gate

### DIFF
--- a/curriculum/l2-uk-en/a2/a2-bridge/resources.yaml
+++ b/curriculum/l2-uk-en/a2/a2-bridge/resources.yaml
@@ -1,16 +1,15 @@
-- title: "Plan: A2 bridge"
-  role: internal plan
-  source_ref: "curriculum/l2-uk-en/plans/a2/a2-bridge.yaml"
-  notes: "Source plan for A2 module 1: A1 grammar review, sound alternations, euphony, and A2 roadmap."
-- title: "Wiki: grammar/a2/a2-bridge"
-  role: internal wiki
-  source_ref: "wiki/grammar/a2/a2-bridge"
-  notes: "Compiled grammar substrate for euphony and A2 bridge priorities; used selectively to avoid overloading module 1."
-- title: "Internal module A1: euphony"
-  role: prerequisite pattern
-  source_ref: "curriculum/l2-uk-en/a1/euphony/module.md"
-  notes: "Provides the A1 baseline for у/в, і/й, and з/із/зі practice."
-- title: "Internal module A1: A1 finale"
-  role: prerequisite pattern
-  source_ref: "curriculum/l2-uk-en/a1/a1-finale/module.md"
-  notes: "Provides the released A1 structure reference for integrated review and transition language."
+- title: "ULP: Ukrainian Cases Chart"
+  role: article
+  source_ref: "docs/resources/ulp-articles-index.yaml: /ukrainian-cases-chart/"
+  url: "https://www.ukrainianlessons.com/ukrainian-cases-chart/"
+  notes: "Learner-facing overview of the case system for students who want a map before A2 work begins."
+- title: "МійКлас: Основні випадки чергування у-в, і-й, з-із-зі"
+  role: article
+  source_ref: "docs/resources/miyklas-resources.yaml: euphony"
+  url: "https://www.miyklas.com.ua/p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/osnovni-vipadki-cherguvannia-u-v-i-i-z-iz-zi-pravila-milozvuchnosti-41612"
+  notes: "Ukrainian-language reference for у/в, і/й, and з/із/зі alternations without exposing internal course notes."
+- title: "ULP: Verb Aspect in Ukrainian"
+  role: article
+  source_ref: "docs/resources/ulp-articles-index.yaml: /verb-aspect-in-ukrainian-differences/"
+  url: "https://www.ukrainianlessons.com/verb-aspect-in-ukrainian-differences/"
+  notes: "A light preview of the process-result contrast that starts the A2 grammar path."

--- a/curriculum/l2-uk-en/a2/aspect-concept/resources.yaml
+++ b/curriculum/l2-uk-en/a2/aspect-concept/resources.yaml
@@ -1,15 +1,15 @@
 - title: "Talk Ukrainian: Verb Aspect"
   role: article
-  source_ref: "Talk Ukrainian: Verb Aspect"
+  source_ref: "docs/resources/talkukrainian/talkukrainian_db.json: tu-030"
   url: https://talkukrainian.com/verb-aspect/
   notes: "Short learner-facing overview of process vs result, useful after the lesson dialogue."
 - title: "Perfective Verbs"
   role: article
-  source_ref: "Ukrainian Lessons: Perfective Verbs"
+  source_ref: "docs/resources/ulp-articles-index.yaml: /perfective-verbs/"
   url: https://www.ukrainianlessons.com/perfective-verbs/
   notes: "Adds simple contrasts and extra examples of completed actions."
 - title: "Dobra Forma: Introduction to Verbal Aspect (Prefixed Perfective Verbs)"
   role: article
-  source_ref: "Dobra Forma 27-1"
+  source_ref: "docs/resources/dobraforma/dobraforma_db.json: df-078"
   url: https://opentext.ku.edu/dobraforma/chapter/27-1/
   notes: "Guided practice for the first contrast between imperfective and perfective verbs."

--- a/curriculum/l2-uk-en/a2/aspect-in-vocabulary/resources.yaml
+++ b/curriculum/l2-uk-en/a2/aspect-in-vocabulary/resources.yaml
@@ -1,15 +1,15 @@
 - title: "50 Verb Pairs"
   role: video
-  source_ref: "Let's Learn Ukrainian"
+  source_ref: "docs/resources/external_resources.yaml: a2-aspect-in-vocabulary"
   url: https://www.youtube.com/watch?v=iK4uNlozmFE
   notes: "Extra listening and repetition support for common aspectual pairs."
 - title: "Perfective Verbs"
   role: article
-  source_ref: "Ukrainian Lessons: Perfective Verbs"
+  source_ref: "docs/resources/ulp-articles-index.yaml: /perfective-verbs/"
   url: https://www.ukrainianlessons.com/perfective-verbs/
   notes: "Learner-facing follow-up on how completed-action verbs are formed and recognized."
 - title: "Dobra Forma: Verbal Aspect (Other Types of Aspectual Pairs)"
   role: article
-  source_ref: "Dobra Forma 27-3"
+  source_ref: "docs/resources/dobraforma/dobraforma_db.json: df-080"
   url: https://opentext.ku.edu/dobraforma/chapter/27-3/
   notes: "Practice page for less transparent pairs such as stem or suffix changes."

--- a/curriculum/l2-uk-en/a2/liudyna-i-stosunky/resources.yaml
+++ b/curriculum/l2-uk-en/a2/liudyna-i-stosunky/resources.yaml
@@ -1,15 +1,15 @@
 - title: "Common Adjectives"
   role: article
-  source_ref: "Ukrainian Lessons"
+  source_ref: "docs/resources/external_resources.yaml: a1-what-is-it-like"
   url: https://www.ukrainianlessons.com/vocabulary-adjectives/
   notes: "Learner-facing adjective vocabulary that supports short descriptions of people."
 - title: "Talk Ukrainian: Adjectives"
   role: article
-  source_ref: "Talk Ukrainian"
+  source_ref: "docs/resources/talkukrainian/talkukrainian_db.json: tu-022"
   url: https://talkukrainian.com/adjectives/
   notes: "Compact grammar reference for adjective gender and number agreement."
 - title: "Dobra Forma: Adjectives (Gender and Number in Nominative)"
   role: article
-  source_ref: "Dobra Forma 16-1"
+  source_ref: "docs/resources/dobraforma/dobraforma_db.json: df-050"
   url: https://opentext.ku.edu/dobraforma/chapter/16-1/
   notes: "Structured practice for adjective agreement in nominative descriptions."

--- a/scripts/generate_mdx/resources.py
+++ b/scripts/generate_mdx/resources.py
@@ -368,7 +368,7 @@ def _public_resource_text(value: object) -> str:
     text = _PIPELINE_METADATA_FRAGMENT_RE.sub('', text)
     text = re.sub(r'\s+', ' ', text)
     text = re.sub(r'\s+([,.;:])', r'\1', text)
-    text = re.sub(r'^[\s,.;:()/-]+|[\s,;:()/-]+$', '', text)
+    text = re.sub(r'^[\s,.;:/-]+|[\s,;:/-]+$', '', text)
     return text
 
 

--- a/starlight/src/content/docs/a2/a2-bridge.mdx
+++ b/starlight/src/content/docs/a2/a2-bridge.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 1
   label: "01. Ласкаво просимо до рівня А2"
 prev: false
-next: false
+next: aspect-concept
 ---
 
 import Quiz from '@site/src/components/Quiz';
@@ -21,11 +21,17 @@ import Select from '@site/src/components/Select';
 import Translate from '@site/src/components/Translate';
 import MarkTheWords, { MarkTheWordsActivity } from '@site/src/components/MarkTheWords';
 import HighlightMorphemes, { HighlightMorphemesActivity } from '@site/src/components/HighlightMorphemes';
+import RitualSequencing from '@site/src/components/RitualSequencing';
+import VariantComparison from '@site/src/components/VariantComparison';
+import MotifFormula from '@site/src/components/MotifFormula';
+import PerformanceActivity from '@site/src/components/PerformanceActivity';
 import EssayResponse from '@site/src/components/EssayResponse';
 import ComparativeStudy from '@site/src/components/ComparativeStudy';
 import ReadingActivity from '@site/src/components/ReadingActivity';
 import CriticalAnalysis from '@site/src/components/CriticalAnalysis';
 import AuthorialIntent from '@site/src/components/AuthorialIntent';
+import MythBuster from '@site/src/components/MythBuster';
+import HighCultureBridge from '@site/src/components/HighCultureBridge';
 import SourceEvaluation from '@site/src/components/SourceEvaluation';
 import Debate from '@site/src/components/Debate';
 import EtymologyTrace from '@site/src/components/EtymologyTrace';
@@ -565,11 +571,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 :::info[🎧 🔗 External Resources]
 
-**🔗 Online resources:**
-- 🔗 **Internal module A1: A1 finale** — Provides the released A1 structure reference for integrated review and transition language.
-- 🔗 **Internal module A1: euphony** — Provides the A1 baseline for у/в, і/й, and з/із/зі practice.
-- 🔗 **Plan: A2 bridge** — Source plan for A2 module 1: A1 grammar review, sound alternations, euphony, and A2 roadmap.
-- 🔗 **Wiki: grammar/a2/a2-bridge** — Compiled grammar substrate for euphony and A2 bridge priorities; used selectively to avoid overloading module 1.
+**📝 Articles:**
+- 📄 [ULP: Ukrainian Cases Chart](https://www.ukrainianlessons.com/ukrainian-cases-chart/) — Learner-facing overview of the case system for students who want a map before A2 work begins.
+- 📄 [ULP: Verb Aspect in Ukrainian](https://www.ukrainianlessons.com/verb-aspect-in-ukrainian-differences/) — A light preview of the process-result contrast that starts the A2 grammar path.
+- 📄 [МійКлас: Основні випадки чергування у-в, і-й, з-із-зі](https://www.miyklas.com.ua/p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/osnovni-vipadki-cherguvannia-u-v-i-i-z-iz-zi-pravila-milozvuchnosti-41612) — Ukrainian-language reference for у/в, і/й, and з/із/зі alternations without exposing internal course notes.
 :::
 
 </TabItem>

--- a/starlight/src/content/docs/a2/aspect-concept.mdx
+++ b/starlight/src/content/docs/a2/aspect-concept.mdx
@@ -386,7 +386,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 :::info[🎧 🔗 External Resources]
 
 **📝 Articles:**
-- 📄 [Dobra Forma: Introduction to Verbal Aspect (Prefixed Perfective Verbs](https://opentext.ku.edu/dobraforma/chapter/27-1/) — Guided practice for the first contrast between imperfective and perfective verbs.
+- 📄 [Dobra Forma: Introduction to Verbal Aspect (Prefixed Perfective Verbs)](https://opentext.ku.edu/dobraforma/chapter/27-1/) — Guided practice for the first contrast between imperfective and perfective verbs.
 - 📄 [Perfective Verbs](https://www.ukrainianlessons.com/perfective-verbs/) — Adds simple contrasts and extra examples of completed actions.
 - 📄 [Talk Ukrainian: Verb Aspect](https://talkukrainian.com/verb-aspect/) — Short learner-facing overview of process vs result, useful after the lesson dialogue.
 :::

--- a/starlight/src/content/docs/a2/aspect-in-vocabulary.mdx
+++ b/starlight/src/content/docs/a2/aspect-in-vocabulary.mdx
@@ -395,7 +395,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 - 🎥 [50 Verb Pairs](https://www.youtube.com/watch?v=iK4uNlozmFE) — Extra listening and repetition support for common aspectual pairs.
 
 **📝 Articles:**
-- 📄 [Dobra Forma: Verbal Aspect (Other Types of Aspectual Pairs](https://opentext.ku.edu/dobraforma/chapter/27-3/) — Practice page for less transparent pairs such as stem or suffix changes.
+- 📄 [Dobra Forma: Verbal Aspect (Other Types of Aspectual Pairs)](https://opentext.ku.edu/dobraforma/chapter/27-3/) — Practice page for less transparent pairs such as stem or suffix changes.
 - 📄 [Perfective Verbs](https://www.ukrainianlessons.com/perfective-verbs/) — Learner-facing follow-up on how completed-action verbs are formed and recognized.
 :::
 

--- a/starlight/src/content/docs/a2/liudyna-i-stosunky.mdx
+++ b/starlight/src/content/docs/a2/liudyna-i-stosunky.mdx
@@ -256,7 +256,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 **📝 Articles:**
 - 📄 [Common Adjectives](https://www.ukrainianlessons.com/vocabulary-adjectives/) — Learner-facing adjective vocabulary that supports short descriptions of people.
-- 📄 [Dobra Forma: Adjectives (Gender and Number in Nominative](https://opentext.ku.edu/dobraforma/chapter/16-1/) — Structured practice for adjective agreement in nominative descriptions.
+- 📄 [Dobra Forma: Adjectives (Gender and Number in Nominative)](https://opentext.ku.edu/dobraforma/chapter/16-1/) — Structured practice for adjective agreement in nominative descriptions.
 - 📄 [Talk Ukrainian: Adjectives](https://talkukrainian.com/adjectives/) — Compact grammar reference for adjective gender and number agreement.
 :::
 

--- a/tests/test_generate_mdx_v7_resources_vocab.py
+++ b/tests/test_generate_mdx_v7_resources_vocab.py
@@ -136,6 +136,19 @@ def test_format_resources_for_mdx_filters_internal_wiki_references():
     assert "[Wikipedia article](https://uk.wikipedia.org/wiki/Ранок)" in mdx
 
 
+def test_format_resources_for_mdx_preserves_parenthesized_titles():
+    mdx = format_resources_for_mdx([
+        {
+            "title": "ULP: Genitive Case (Родовий відмінок)",
+            "url": "https://www.ukrainianlessons.com/genitive-case/",
+            "notes": "Learner-facing overview.",
+            "role": "article",
+        },
+    ])
+
+    assert "[ULP: Genitive Case (Родовий відмінок)]" in mdx
+
+
 def test_format_resources_for_mdx_strips_pipeline_metadata_from_public_text():
     mdx = format_resources_for_mdx([
         {


### PR DESCRIPTION
## Summary
- replace A2 M01-M04 learner-facing resource refs with catalog-backed internal resource provenance
- preserve closing parentheses in generated resource link labels
- regenerate M01-M04 MDX from source

## Validation
- .venv/bin/python -m pytest tests/test_generate_mdx_v7_resources_vocab.py
- .venv/bin/python scripts/audit/check_mdx_generation_drift.py --files curriculum/l2-uk-en/a2/a2-bridge/resources.yaml curriculum/l2-uk-en/a2/aspect-concept/resources.yaml curriculum/l2-uk-en/a2/aspect-in-vocabulary/resources.yaml curriculum/l2-uk-en/a2/liudyna-i-stosunky/resources.yaml
- .venv/bin/python scripts/audit/check_mdx_source_parity.py --files starlight/src/content/docs/a2/a2-bridge.mdx starlight/src/content/docs/a2/aspect-concept.mdx starlight/src/content/docs/a2/aspect-in-vocabulary.mdx starlight/src/content/docs/a2/liudyna-i-stosunky.mdx
- npm --prefix starlight run build
- .venv/bin/python scripts/audit/lint_agent_trailer.py

## A2 final-content gate note
This PR only fixes deterministic resource/provenance and MDX title-label blockers for M01-M04. It does not claim M01-M04 are final-content-ready. Review verdicts still require content expansion/rebuild work before final readiness.