### PR TITLE
fix(landings): unify all track landings on LevelLanding

### DIFF
--- a/starlight/src/components/LevelLanding.module.css
+++ b/starlight/src/components/LevelLanding.module.css
@@ -122,7 +122,7 @@
 }
 
 .moduleLocked {
-  opacity: 0.5;
+  background: var(--sl-color-gray-7, var(--sl-color-bg, white));
 }
 .moduleLocked:hover {
   transform: none;
@@ -130,7 +130,14 @@
   border-color: var(--sl-color-gray-6, #eee);
 }
 .moduleLocked .moduleTitle {
+  color: var(--sl-color-gray-2);
+}
+.moduleLocked .moduleSub,
+.moduleLocked .moduleSubEn {
   color: var(--sl-color-gray-3);
+}
+.moduleLocked .moduleStatus {
+  opacity: 0.75;
 }
 
 /* Module number badges */

--- a/starlight/src/components/LevelLanding.tsx
+++ b/starlight/src/components/LevelLanding.tsx
@@ -108,14 +108,22 @@ export default function LevelLanding(props: LevelLandingProps): ReactNode {
   const totalModules = props.moduleCount || props.totalPlanned || 0;
   const wordTarget = props.wordTarget || 0;
 
-  // Color defaults per level
+  // Color defaults per track. These are gradient/background tokens; the
+  // solid accent map below is used where CSS requires an actual color.
   const defaultColors: Record<string, string> = {
-    a1: '#2E7D32', a2: '#1565C0', b1: '#E65100', b2: '#C62828',
-    c1: '#6A1B9A', c2: '#8D6E00', hist: '#BF360C', bio: '#0D47A1',
-    istorio: '#880E4F', lit: '#4A148C', oes: '#33691E', ruth: '#004D40',
-    folk: '#33691E', 'b2-pro': '#455A64', 'c1-pro': '#37474F',
+    a1: 'var(--lu-id-a1)', a2: 'var(--lu-id-a2)', b1: 'var(--lu-id-b1)',
+    b2: 'var(--lu-id-b2)', c1: 'var(--lu-id-c1)', c2: 'var(--lu-id-c2)',
+    hist: 'var(--lu-id-hist)', bio: 'var(--lu-id-bio)',
+    istorio: 'var(--lu-id-istorio)', lit: 'var(--lu-id-lit)',
+    oes: 'var(--lu-id-oes)', ruth: 'var(--lu-id-ruth)',
+    folk: 'var(--lu-id-folk)', 'b2-pro': 'var(--lu-id-b2-pro)',
+    'c1-pro': 'var(--lu-id-c1-pro)', 'lit-drama': 'var(--lu-id-lit-drama)',
+    'lit-essay': 'var(--lu-id-lit-essay)', 'lit-fantastika': 'var(--lu-id-lit-fantastika)',
+    'lit-hist-fic': 'var(--lu-id-lit-hist-fic)', 'lit-humor': 'var(--lu-id-lit-humor)',
+    'lit-war': 'var(--lu-id-lit-war)', 'lit-youth': 'var(--lu-id-lit-youth)',
   };
-  const color = props.color || defaultColors[level.toLowerCase()] || '#0057B8';
+  const color = props.color || defaultColors[level.toLowerCase()] || 'var(--lu-id-core)';
+  const accentColor = getAccentColor(level);
 
   // Normalize modules: support both old flat array and new grouped format
   let unitGroups: UnitGroup[];
@@ -141,14 +149,14 @@ export default function LevelLanding(props: LevelLandingProps): ReactNode {
   const doneCount = unitGroups.reduce((acc, g) => acc + g.items.filter(m => m.status === 'done').length, 0);
   const moduleCount = totalModules || unitGroups.reduce((acc, g) => acc + g.items.length, 0);
   const pct = moduleCount > 0 ? Math.round((doneCount / moduleCount) * 100) : 0;
-  const darkerColor = adjustColor(color, -40);
+  const heroBackground = getHeroBackground(color, accentColor);
   const progressTitle = props.progressTitle ?? 'Your Progress';
   const progressDescription = props.progressDescription ?? `${doneCount} of ${moduleCount} completed (${pct}%)`;
 
   return (
     <div className={styles.container}>
       {/* Hero */}
-      <div className={styles.hero} style={{ background: `linear-gradient(135deg, ${color}, ${darkerColor})` }}>
+      <div className={styles.hero} style={{ background: heroBackground }}>
         <span className={styles.badge}>{level.toUpperCase()} — {getBadgeLabel(level)}</span>
         <h1 className={styles.heroTitle}>{displayTitle}</h1>
         {displaySub && <div className={styles.heroSub}>{displaySub}</div>}
@@ -176,7 +184,7 @@ export default function LevelLanding(props: LevelLandingProps): ReactNode {
           <div className={styles.unitTitle}>{group.unit}</div>
           <div className={styles.moduleList}>
             {group.items.map(mod => (
-              <ModuleCard key={mod.num} mod={mod} level={level} color={color} />
+              <ModuleCard key={mod.num} mod={mod} level={level} color={accentColor} />
             ))}
           </div>
         </div>
@@ -191,6 +199,27 @@ function getBadgeLabel(level: string): string {
     B2: 'Upper-Intermediate', C1: 'Advanced', C2: 'Mastery',
   };
   return labels[level.toUpperCase()] || level;
+}
+
+function getAccentColor(level: string): string {
+  const accents: Record<string, string> = {
+    a1: '#0057B8', a2: '#0057B8', b1: '#0057B8', b2: '#0057B8',
+    c1: '#0057B8', c2: '#0057B8', 'b2-pro': '#0057B8', 'c1-pro': '#0057B8',
+    folk: '#A4133C',
+    hist: '#BF360C', istorio: '#BF360C',
+    bio: '#4E342E', oes: '#4E342E', ruth: '#4E342E',
+    lit: '#4A148C', 'lit-drama': '#4A148C', 'lit-essay': '#4A148C',
+    'lit-fantastika': '#4A148C', 'lit-hist-fic': '#4A148C',
+    'lit-humor': '#4A148C', 'lit-war': '#4A148C', 'lit-youth': '#4A148C',
+  };
+  return accents[level.toLowerCase()] || '#0057B8';
+}
+
+function getHeroBackground(color: string, fallbackColor: string): string {
+  if (/^#[0-9a-f]{6}$/i.test(color)) {
+    return `linear-gradient(135deg, ${color}, ${adjustColor(color, -40)})`;
+  }
+  return color || `linear-gradient(135deg, ${fallbackColor}, ${adjustColor(fallbackColor, -40)})`;
 }
 
 function adjustColor(hex: string, amount: number): string {

--- a/starlight/src/content.config.ts
+++ b/starlight/src/content.config.ts
@@ -3,7 +3,13 @@ import { glob } from 'astro/loaders';
 
 export const collections = {
 	docs: defineCollection({
-		loader: glob({ pattern: '{a1,a2,folk}/**/*.{md,mdx}', base: './src/content/docs' }),
+		loader: glob({
+			pattern: [
+				'{a1,a2,folk}/**/*.{md,mdx}',
+				'{b1,b2-pro,bio,c1-pro,hist,istorio,lit,lit-drama,lit-essay,lit-fantastika,lit-hist-fic,lit-humor,lit-war,lit-youth,oes,ruth}/index.{md,mdx}',
+			],
+			base: './src/content/docs',
+		}),
 		schema: z.object({
 			title: z.string(),
 			description: z.string().optional(),

--- a/starlight/src/content/docs/a1/index.mdx
+++ b/starlight/src/content/docs/a1/index.mdx
@@ -39,6 +39,8 @@ export const _modulesWithStatus = A1_UNITS.map((group) => ({
   subtitle="Ukrainian for absolute beginners — 55 modules, ~1,200 target words"
   moduleCount={55}
   wordTarget={1200}
-  color="#2E7D32"
+  color="var(--lu-id-a1)"
+  progressTitle="A1 Build Status"
+  progressDescription={`${_deployedSlugs.size} available · ${55 - _deployedSlugs.size} locked`}
   modules={_modulesWithStatus}
 />

--- a/starlight/src/content/docs/a2/index.mdx
+++ b/starlight/src/content/docs/a2/index.mdx
@@ -13,7 +13,7 @@ import LevelLanding from '@site/src/components/LevelLanding';
   subtitle="Pre-Intermediate beta preview — 16/69 modules available"
   moduleCount={69}
   wordTarget={2000}
-  color="#1565C0"
+  color="var(--lu-id-a2)"
   progressTitle="A2 Beta Preview"
   progressDescription="16 preview modules available; 53 modules remain locked while content quality review continues."
   modules={[

--- a/starlight/src/content/docs/b1/index.mdx
+++ b/starlight/src/content/docs/b1/index.mdx
@@ -15,7 +15,7 @@ import LevelLanding from '@site/src/components/LevelLanding';
   progressDescription="1 available · 0 reviewed · 93 planned"
   moduleCount={94}
   wordTarget={4000}
-  color="#6A1B9A"
+  color="var(--lu-id-b1)"
   modules={[
     {
       unit: "M01-M10 · Aspect foundations",

--- a/starlight/src/content/docs/b2-pro/index.mdx
+++ b/starlight/src/content/docs/b2-pro/index.mdx
@@ -9,10 +9,13 @@ import LevelLanding from '@site/src/components/LevelLanding';
 <LevelLanding
   client:load
   level="b2-pro"
-  levelName="B2-PRO - Професійна українська"
+  title="B2-PRO - Професійна українська"
   subtitle="Professional Track — 40 modules"
-  introduction="Professional — Business communication, technical domains"
-  totalPlanned={40}
+  moduleCount={40}
+  wordTarget={4000}
+  color="var(--lu-id-b2-pro)"
+  progressTitle="B2-PRO Build Status"
+  progressDescription="0 available · 40 planned"
   modules={[
   { num: 1, title: "business-email-foundations", slug: "business-email-foundations", status: "wip" },
   { num: 2, title: "email-requests-proposals", slug: "email-requests-proposals", status: "wip" },

--- a/starlight/src/content/docs/bio/index.mdx
+++ b/starlight/src/content/docs/bio/index.mdx
@@ -9,10 +9,13 @@ import LevelLanding from '@site/src/components/LevelLanding';
 <LevelLanding
   client:load
   level="bio"
-  levelName="BIO - Біографії українців"
+  title="BIO - Біографії українців"
   subtitle="Biography Track — 310 modules"
-  introduction="Biographies — Notable Ukrainians through history"
-  totalPlanned={310}
+  moduleCount={310}
+  wordTarget={4000}
+  color="var(--lu-id-bio)"
+  progressTitle="BIO Build Status"
+  progressDescription="0 available · 310 planned"
   modules={[
   { num: 1, title: "Княгиня Ольга: Дипломатія та реформи", slug: "knyahynia-olha", status: "wip" },
   { num: 2, title: "Князь Святослав: Воїн-завойовник", slug: "kniaz-sviatoslav", status: "wip" },

--- a/starlight/src/content/docs/c1-pro/index.mdx
+++ b/starlight/src/content/docs/c1-pro/index.mdx
@@ -9,10 +9,13 @@ import LevelLanding from '@site/src/components/LevelLanding';
 <LevelLanding
   client:load
   level="c1-pro"
-  levelName="C1-PRO - Фахова українська"
+  title="C1-PRO - Фахова українська"
   subtitle="Professional Mastery — 50 modules"
-  introduction="Professional Mastery — Executive, academic, specialized"
-  totalPlanned={50}
+  moduleCount={50}
+  wordTarget={4000}
+  color="var(--lu-id-c1-pro)"
+  progressTitle="C1-PRO Build Status"
+  progressDescription="0 available · 50 planned"
   modules={[
   { num: 1, title: "executive-email", slug: "executive-email", status: "wip" },
   { num: 2, title: "stakeholder-communication", slug: "stakeholder-communication", status: "wip" },

--- a/starlight/src/content/docs/folk/index.mdx
+++ b/starlight/src/content/docs/folk/index.mdx
@@ -13,7 +13,9 @@ import LevelLanding from '@site/src/components/LevelLanding';
   subtitle=" — 0/27 modules complete"
   moduleCount={27}
   wordTarget={4000}
-  color="#546E7A"
+  color="var(--lu-id-folk)"
+  progressTitle="FOLK Build Status"
+  progressDescription="2 preview modules available · 25 locked"
   modules={[
     {
       unit: "FOLK.1",

--- a/starlight/src/content/docs/hist/index.mdx
+++ b/starlight/src/content/docs/hist/index.mdx
@@ -9,10 +9,13 @@ import LevelLanding from '@site/src/components/LevelLanding';
 <LevelLanding
   client:load
   level="hist"
-  levelName="HIST - Історія України"
+  title="HIST - Історія України"
   subtitle="History Track — 140 modules"
-  introduction="History — Ukrainian history from origins to present"
-  totalPlanned={140}
+  moduleCount={140}
+  wordTarget={4000}
+  color="var(--lu-id-hist)"
+  progressTitle="HIST Build Status"
+  progressDescription="0 available · 140 planned"
   modules={[
   { num: 1, title: "Трипільська цивілізація", slug: "trypillian-civilization", status: "wip" },
   { num: 2, title: "Скіфи та сармати — Володарі степу", slug: "scythians-sarmatians", status: "wip" },

--- a/starlight/src/content/docs/istorio/index.mdx
+++ b/starlight/src/content/docs/istorio/index.mdx
@@ -9,10 +9,13 @@ import LevelLanding from '@site/src/components/LevelLanding';
 <LevelLanding
   client:load
   level="istorio"
-  levelName="ISTORIO - Історіографія"
+  title="ISTORIO - Історіографія"
   subtitle="Historiography Track — 136 modules"
-  introduction="Advanced History — Primary sources, imperial mechanisms, interethnic relations"
-  totalPlanned={136}
+  moduleCount={136}
+  wordTarget={4000}
+  color="var(--lu-id-istorio)"
+  progressTitle="ISTORIO Build Status"
+  progressDescription="0 available · 136 planned"
   modules={[
   { num: 1, title: "Що таке історіографія?", slug: "shcho-take-istorio", status: "wip" },
   { num: 2, title: "Українська історіографічна традиція", slug: "ukrainska-istoriohrafichna-tradytsiia", status: "wip" },

--- a/starlight/src/content/docs/lit-drama/index.mdx
+++ b/starlight/src/content/docs/lit-drama/index.mdx
@@ -13,7 +13,9 @@ import LevelLanding from '@site/src/components/LevelLanding';
   subtitle=" — 0/17 modules complete"
   moduleCount={17}
   wordTarget={4000}
-  color="#546E7A"
+  color="var(--lu-id-lit-drama)"
+  progressTitle="LIT-DRAMA Build Status"
+  progressDescription="0 available · 17 locked"
   modules={[
     {
       unit: "LIT.1 Foundation 1798-1860",

--- a/starlight/src/content/docs/lit-essay/index.mdx
+++ b/starlight/src/content/docs/lit-essay/index.mdx
@@ -13,7 +13,9 @@ import LevelLanding from '@site/src/components/LevelLanding';
   subtitle=" — 0/63 modules complete"
   moduleCount={63}
   wordTarget={4000}
-  color="#546E7A"
+  color="var(--lu-id-lit-essay)"
+  progressTitle="LIT-ESSAY Build Status"
+  progressDescription="0 available · 63 locked"
   modules={[
     {
       unit: "LIT Expansion",

--- a/starlight/src/content/docs/lit-fantastika/index.mdx
+++ b/starlight/src/content/docs/lit-fantastika/index.mdx
@@ -13,7 +13,9 @@ import LevelLanding from '@site/src/components/LevelLanding';
   subtitle=" — 0/25 modules complete"
   moduleCount={25}
   wordTarget={4000}
-  color="#546E7A"
+  color="var(--lu-id-lit-fantastika)"
+  progressTitle="LIT-FANTASTIKA Build Status"
+  progressDescription="0 available · 25 locked"
   modules={[
     {
       unit: "LIT Expansion",

--- a/starlight/src/content/docs/lit-hist-fic/index.mdx
+++ b/starlight/src/content/docs/lit-hist-fic/index.mdx
@@ -13,7 +13,9 @@ import LevelLanding from '@site/src/components/LevelLanding';
   subtitle=" — 0/23 modules complete"
   moduleCount={23}
   wordTarget={4000}
-  color="#546E7A"
+  color="var(--lu-id-lit-hist-fic)"
+  progressTitle="LIT-HIST-FIC Build Status"
+  progressDescription="0 available · 23 locked"
   modules={[
     {
       unit: "LIT Expansion",

--- a/starlight/src/content/docs/lit-humor/index.mdx
+++ b/starlight/src/content/docs/lit-humor/index.mdx
@@ -13,7 +13,9 @@ import LevelLanding from '@site/src/components/LevelLanding';
   subtitle=" — 0/14 modules complete"
   moduleCount={14}
   wordTarget={4000}
-  color="#546E7A"
+  color="var(--lu-id-lit-humor)"
+  progressTitle="LIT-HUMOR Build Status"
+  progressDescription="0 available · 14 locked"
   modules={[
     {
       unit: "LIT Expansion",

--- a/starlight/src/content/docs/lit-war/index.mdx
+++ b/starlight/src/content/docs/lit-war/index.mdx
@@ -13,7 +13,9 @@ import LevelLanding from '@site/src/components/LevelLanding';
   subtitle=" — 0/29 modules complete"
   moduleCount={29}
   wordTarget={4000}
-  color="#546E7A"
+  color="var(--lu-id-lit-war)"
+  progressTitle="LIT-WAR Build Status"
+  progressDescription="0 available · 29 locked"
   modules={[
     {
       unit: "LIT Expansion",

--- a/starlight/src/content/docs/lit-youth/index.mdx
+++ b/starlight/src/content/docs/lit-youth/index.mdx
@@ -13,7 +13,9 @@ import LevelLanding from '@site/src/components/LevelLanding';
   subtitle=" — 0/32 modules complete"
   moduleCount={32}
   wordTarget={4000}
-  color="#546E7A"
+  color="var(--lu-id-lit-youth)"
+  progressTitle="LIT-YOUTH Build Status"
+  progressDescription="0 available · 32 locked"
   modules={[
     {
       unit: "LIT Expansion",

--- a/starlight/src/content/docs/lit/index.mdx
+++ b/starlight/src/content/docs/lit/index.mdx
@@ -9,10 +9,13 @@ import LevelLanding from '@site/src/components/LevelLanding';
 <LevelLanding
   client:load
   level="lit"
-  levelName="LIT - Українська література"
+  title="LIT - Українська література"
   subtitle="Literature Track — 221 modules"
-  introduction="Literature — Ukrainian classics and literary analysis"
-  totalPlanned={221}
+  moduleCount={221}
+  wordTarget={4000}
+  color="var(--lu-id-lit)"
+  progressTitle="LIT Build Status"
+  progressDescription="0 available · 221 planned"
   modules={[
   { num: 1, title: "Феномен Івана Котляревського", slug: "introduction-to-kotliarevsky", status: "wip" },
   { num: 2, title: "Енеїда: Сміх над Безоднею (Частина I)", slug: "eneida-part-1", status: "wip" },

--- a/starlight/src/content/docs/oes/index.mdx
+++ b/starlight/src/content/docs/oes/index.mdx
@@ -9,10 +9,13 @@ import LevelLanding from '@site/src/components/LevelLanding';
 <LevelLanding
   client:load
   level="oes"
-  levelName="OES - Давньоруська мова"
+  title="OES - Давньоруська мова"
   subtitle="Old East Slavic Track — 103 modules"
-  introduction="Old East Slavic — Historical linguistics, primary sources X-XIII century"
-  totalPlanned={103}
+  moduleCount={103}
+  wordTarget={4000}
+  color="var(--lu-id-oes)"
+  progressTitle="OES Build Status"
+  progressDescription="0 available · 103 planned"
   modules={[
   { num: 1, title: "Софійські графіті: Стіни говорять", slug: "walls-speak-intro", status: "wip" },
   { num: 2, title: "Алфавіт: Від глаголиці до кирилиці", slug: "alphabet-glagolitic-cyrillic", status: "wip" },

--- a/starlight/src/content/docs/ruth/index.mdx
+++ b/starlight/src/content/docs/ruth/index.mdx
@@ -9,10 +9,13 @@ import LevelLanding from '@site/src/components/LevelLanding';
 <LevelLanding
   client:load
   level="ruth"
-  levelName="RUTH - Руська мова XIV-XVIII"
+  title="RUTH - Руська мова XIV-XVIII"
   subtitle="Ruthenian Track — 115 modules"
-  introduction="Ruthenian — Middle Ukrainian language XIV-XVIII century"
-  totalPlanned={115}
+  moduleCount={115}
+  wordTarget={4000}
+  color="var(--lu-id-ruth)"
+  progressTitle="RUTH Build Status"
+  progressDescription="0 available · 115 planned"
   modules={[
   { num: 1, title: "Вступ до руської мови", slug: "intro-to-ruth", status: "wip" },
   { num: 2, title: "Господар і держава", slug: "sovereign-state", status: "wip" },

--- a/starlight/src/css/custom.css
+++ b/starlight/src/css/custom.css
@@ -59,6 +59,26 @@
   --lu-id-lit: linear-gradient(135deg, #4A148C, #AD1457);
   --lu-id-seminar: linear-gradient(135deg, #4E342E, #00695C);
   --lu-id-history: linear-gradient(135deg, #BF360C, #6D4C41);
+  --lu-id-a1: var(--lu-id-core);
+  --lu-id-a2: var(--lu-id-core);
+  --lu-id-b1: var(--lu-id-core);
+  --lu-id-b2: var(--lu-id-core);
+  --lu-id-c1: var(--lu-id-core);
+  --lu-id-c2: var(--lu-id-core);
+  --lu-id-b2-pro: var(--lu-id-core);
+  --lu-id-c1-pro: var(--lu-id-core);
+  --lu-id-hist: var(--lu-id-history);
+  --lu-id-bio: var(--lu-id-seminar);
+  --lu-id-istorio: var(--lu-id-history);
+  --lu-id-oes: var(--lu-id-seminar);
+  --lu-id-ruth: var(--lu-id-seminar);
+  --lu-id-lit-drama: var(--lu-id-lit);
+  --lu-id-lit-essay: var(--lu-id-lit);
+  --lu-id-lit-fantastika: var(--lu-id-lit);
+  --lu-id-lit-hist-fic: var(--lu-id-lit);
+  --lu-id-lit-humor: var(--lu-id-lit);
+  --lu-id-lit-war: var(--lu-id-lit);
+  --lu-id-lit-youth: var(--lu-id-lit);
 
   /* ── Infima / Docusaurus compatibility shim ──────────────────────────────
    * Starlight does not define --ifm-* variables. Activities.module.css and

--- a/starlight/src/pages/[...slug].astro
+++ b/starlight/src/pages/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, render, type CollectionEntry } from 'astro:content';
 import CourseLayout from '../layouts/CourseLayout.astro';
+import LevelLanding from '../components/LevelLanding';
 import curriculumStats from '../data/curriculum-stats.json';
 import lexiconManifest from '../data/lexicon-manifest.json';
 
@@ -276,7 +277,6 @@ const TRACKS: Record<string, TrackOverview> = {
 
 const HIDDEN_DOCS = new Set(['a1/review-clears-needs-human']);
 const PUBLIC_LESSON_PREFIXES = new Set(['a1', 'a2', 'folk']);
-const LANDING_DOC_TRACKS = new Set(['a2']);
 const normalizeId = (id: string) => id.replace(/\.mdx?$/, '').replace(/\/index$/, '');
 const hrefFromRoute = (route: string) => `/${route}/`;
 const trackIds = Object.keys(TRACKS);
@@ -287,7 +287,7 @@ const visibleDocs = allDocs.filter((entry) => {
   const track = id.split('/')[0];
   if (HIDDEN_DOCS.has(id)) return false;
   if (entry.data.draft) return false;
-  return track in TRACKS;
+  return track in TRACKS || (id !== 'index' && id === track);
 });
 
 const deployedDocsByTrack = new Map<string, DocsEntry[]>();
@@ -296,7 +296,7 @@ for (const entry of visibleDocs) {
   const id = normalizeId(entry.id);
   const track = id.split('/')[0];
   if (id === track) {
-    if (LANDING_DOC_TRACKS.has(track)) landingDocsByTrack.set(track, entry);
+    landingDocsByTrack.set(track, entry);
     continue;
   }
   const bucket = deployedDocsByTrack.get(track) ?? [];
@@ -354,23 +354,23 @@ const searchItems: SearchItem[] = [
 export async function getStaticPaths() {
   const normalizeDocId = (id: string) => id.replace(/\.mdx?$/, '').replace(/\/index$/, '');
   const publicLessonPrefixes = new Set(['a1', 'a2', 'folk']);
-  const landingDocTracks = new Set(['a2']);
   const hiddenDocs = new Set(['a1/review-clears-needs-human']);
-  const tracks = ['a1', 'a2', 'b1', 'b2', 'c1', 'c2', 'folk', 'bio', 'hist', 'istorio', 'lit', 'oes', 'ruth'];
+  const configuredTracks = ['a1', 'a2', 'b1', 'b2', 'c1', 'c2', 'folk', 'bio', 'hist', 'istorio', 'lit', 'oes', 'ruth'];
   const pathDocs = await getCollection('docs');
   const landingDocsByPathTrack = new Map<string, DocsEntry>();
   const docs = pathDocs.filter((entry) => {
     const id = normalizeDocId(entry.id);
     const track = id.split('/')[0];
-    if (!publicLessonPrefixes.has(track)) return false;
-    if (id === track) {
-      if (landingDocTracks.has(track)) landingDocsByPathTrack.set(track, entry);
+    if (id !== 'index' && id === track) {
+      landingDocsByPathTrack.set(track, entry);
       return false;
     }
+    if (!publicLessonPrefixes.has(track)) return false;
     if (hiddenDocs.has(id)) return false;
     if (entry.data.draft) return false;
     return true;
   });
+  const tracks = [...new Set([...configuredTracks, ...landingDocsByPathTrack.keys()])];
 
   return [
     ...tracks.map((track) => ({
@@ -533,6 +533,23 @@ const sidebar = props.kind === 'doc'
       };
     })()
   : undefined;
+
+const plannedModuleGroups = (track: string, trackOverview: TrackOverview) => {
+  const count = moduleCount(track);
+  return [{
+    unit: `${trackOverview.label} planned modules`,
+    items: Array.from({ length: count }, (_, index) => {
+      const num = index + 1;
+      return {
+        num,
+        slug: `planned-${String(num).padStart(2, '0')}`,
+        title: `Planned module ${String(num).padStart(2, '0')}`,
+        sub: 'Mapped curriculum slot; not released for study yet.',
+        status: 'locked' as const,
+      };
+    }),
+  }];
+};
 ---
 
 <CourseLayout
@@ -545,112 +562,23 @@ const sidebar = props.kind === 'doc'
   navItems={navItems}
   sidebar={sidebar}
   wide={pageMeta.wide}
-  showHero={props.kind !== 'landingDoc'}
+  showHero={props.kind !== 'landingDoc' && props.kind !== 'track'}
 >
   {props.kind === 'landingDoc' && Content ? (
     <Content />
   ) : props.kind === 'track' && pageTrack ? (
-    <section class:list={['track-overview', `track-${props.track}`, pageTrack.family, pageTrack.state]}>
-      <div class="track-status-panel">
-        <span>{pageTrack.status}</span>
-        <strong>
-          {moduleCount(props.track)}
-          {' '}
-          {pageTrack.state === 'released' || pageTrack.state === 'test' ? 'available modules' : 'planned modules'}
-        </strong>
-      </div>
-
-      <div class="track-overview-grid">
-        <section class="track-lead">
-          <p class="track-family">{pageTrack.family === 'core' ? 'Core ladder' : 'Seminar track'}</p>
-          <h2>{pageTrack.title}</h2>
-          <p>{pageTrack.subtitle}</p>
-          <div class="track-actions">
-            {pageTrack.primaryAction && <a class="track-primary" href={pageTrack.primaryAction.href}>{pageTrack.primaryAction.label}</a>}
-            {pageTrack.secondaryAction && <a class="track-secondary" href={pageTrack.secondaryAction.href}>{pageTrack.secondaryAction.label}</a>}
-          </div>
-        </section>
-
-        <section class="track-notes" aria-label={`${pageTrack.label} notes`}>
-          {pageTrack.points.map((point) => (
-            <p>{point}</p>
-          ))}
-        </section>
-      </div>
-
-      <section class="track-pattern">
-        <h2>Template Pattern</h2>
-        <div class="track-pattern-grid">
-          {pageTrack.pattern.map((item) => (
-            <span>{item}</span>
-          ))}
-        </div>
-      </section>
-
-      {pageTrack.family === 'seminar' && (
-        <section class="seminar-frame">
-          <div>
-            <h2>Seminar Reading Frame</h2>
-            <p>
-              Source-heavy lessons use a different rhythm from the core ladder: evidence first,
-              interpretation second, and practice that asks learners to compare claims rather than
-              memorize isolated facts.
-            </p>
-          </div>
-          <ul>
-            <li>source note with provenance and limits</li>
-            <li>context card before claims get interpreted</li>
-            <li>decolonization or bias check where the topic requires it</li>
-            <li>workbook tasks for comparison, evaluation, and response</li>
-          </ul>
-        </section>
-      )}
-
-      {pageTrack.state === 'unavailable' || pageTrack.state === 'planned' || pageTrack.state === 'next' ? (
-        <section class="route-state-card">
-          <p class="state-code">{pageTrack.state === 'next' ? 'Next Track' : 'Unavailable Today'}</p>
-          <h2>This track is mapped, not released.</h2>
-          <p>
-            The learner UI keeps the route visible so navigation, search, and future publishing have
-            a real template, but it does not claim this content is ready for study.
-          </p>
-          <a href="/a1/">Use the available A1 track</a>
-        </section>
-      ) : (
-        <section class="module-preview">
-          <h2>Available Modules</h2>
-          <div class="module-preview-list">
-            {(deployedDocsByTrack.get(props.track) ?? []).map((entry) => {
-              const id = normalizeId(entry.id);
-              return (
-                <a href={hrefFromRoute(id)}>
-                  <span>{entry.data.sidebar?.order ? String(entry.data.sidebar.order).padStart(2, '0') : 'Lesson'}</span>
-                  <strong>{entry.data.title}</strong>
-                </a>
-              );
-            })}
-          </div>
-        </section>
-      )}
-
-      <section class="track-support">
-        <h2>Learning Support</h2>
-        <div class="track-support-grid">
-          <a href="/lexicon/">
-            <strong>Word Atlas</strong>
-            <span>Static vocabulary, morphology, etymology, and course usage pages.</span>
-          </a>
-          <a href="/search/">
-            <strong>Search</strong>
-            <span>Find lessons, track pages, Word Atlas entries, and reference surfaces.</span>
-          </a>
-          <a href="https://www.ukrainianlessons.com/">
-            <strong>Ukrainian Lessons</strong>
-            <span>Recommended external learning ecosystem; inspiration only, not copied content.</span>
-          </a>
-        </div>
-      </section>
-    </section>
+    <LevelLanding
+      client:load
+      level={pageTrack.label.toUpperCase()}
+      title={pageTrack.title}
+      subtitle={pageTrack.subtitle}
+      moduleCount={moduleCount(props.track)}
+      wordTarget={4000}
+      color={`var(--lu-id-${props.track})`}
+      progressTitle={`${pageTrack.label} Build Status`}
+      progressDescription={`0 available · ${moduleCount(props.track)} planned`}
+      modules={plannedModuleGroups(props.track, pageTrack)}
+    />
   ) : props.kind === 'search' ? (
     <section class="search-page" data-search-root>
       <form class="search-panel" role="search">

--- a/tests/test_landings_use_levellanding.py
+++ b/tests/test_landings_use_levellanding.py
@@ -1,0 +1,88 @@
+import re
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DOCS_ROOT = PROJECT_ROOT / "starlight" / "src" / "content" / "docs"
+CONTENT_CONFIG_PATH = PROJECT_ROOT / "starlight" / "src" / "content.config.ts"
+ROUTER_PATH = PROJECT_ROOT / "starlight" / "src" / "pages" / "[...slug].astro"
+
+REQUIRED_PROPS = (
+    "level",
+    "title",
+    "subtitle",
+    "moduleCount",
+    "wordTarget",
+    "color",
+    "progressTitle",
+    "progressDescription",
+    "modules",
+)
+
+LEGACY_PROPS = (
+    "levelName",
+    "introduction",
+    "totalPlanned",
+)
+
+
+def _track_landings() -> list[Path]:
+    return sorted(path for path in DOCS_ROOT.glob("*/index.mdx") if path.parent != DOCS_ROOT)
+
+
+def _has_prop(text: str, prop: str) -> bool:
+    return re.search(rf"\b{re.escape(prop)}\s*=", text) is not None
+
+
+@pytest.mark.parametrize("path", _track_landings(), ids=lambda path: path.parent.name)
+def test_track_landing_uses_levellanding_contract(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    track = path.parent.name
+
+    assert "import LevelLanding from '@site/src/components/LevelLanding';" in text
+    assert re.search(r"<LevelLanding\b", text), f"{path} must render LevelLanding"
+    assert "client:load" in text
+
+    missing = [prop for prop in REQUIRED_PROPS if not _has_prop(text, prop)]
+    assert not missing, f"{path} missing LevelLanding props: {', '.join(missing)}"
+
+    legacy = [prop for prop in LEGACY_PROPS if _has_prop(text, prop)]
+    assert not legacy, f"{path} still uses legacy LevelLanding props: {', '.join(legacy)}"
+
+    forbidden = ["CourseLayout", "CORE LADDER"]
+    matches = [marker for marker in forbidden if marker in text]
+    assert not matches, f"{path} still contains old landing markup: {', '.join(matches)}"
+
+    level_match = re.search(r'\blevel="([^"]+)"', text)
+    assert level_match is not None
+    assert level_match.group(1).lower() == track
+
+    color_match = re.search(r'\bcolor="([^"]+)"', text)
+    assert color_match is not None
+    assert color_match.group(1) == f"var(--lu-id-{track})"
+
+    module_count = re.search(r"\bmoduleCount=\{(\d+)\}", text)
+    word_target = re.search(r"\bwordTarget=\{(\d+)\}", text)
+    assert module_count is not None and int(module_count.group(1)) > 0
+    assert word_target is not None and int(word_target.group(1)) > 0
+
+
+def test_dynamic_route_uses_every_track_index_mdx_as_landing_doc() -> None:
+    text = ROUTER_PATH.read_text(encoding="utf-8")
+
+    assert "LANDING_DOC_TRACKS" not in text
+    assert "track-overview" not in text
+    assert "id !== 'index' && id === track" in text
+    assert "landingDocsByPathTrack.set(track, entry)" in text
+    assert "...landingDocsByPathTrack.keys()" in text
+    assert "<LevelLanding" in text
+    assert "showHero={props.kind !== 'landingDoc' && props.kind !== 'track'}" in text
+
+
+def test_content_collection_loads_track_index_mdx_files() -> None:
+    text = CONTENT_CONFIG_PATH.read_text(encoding="utf-8")
+    tracks = {path.parent.name for path in _track_landings()}
+
+    missing = sorted(track for track in tracks if track not in text)
+    assert not missing, f"content loader does not include track indexes: {', '.join(missing)}"


### PR DESCRIPTION
## Summary
- Routes every track landing through the `LevelLanding` pattern, using A2 as the reference for contained hero card, stat row, progress row, and numbered module list.
- Normalizes all existing `starlight/src/content/docs/*/index.mdx` track landings to the full prop contract: `title`, `subtitle`, `level`, `color`, `moduleCount`, `wordTarget`, `modules`, `progressTitle`, `progressDescription`.
- Replaces the old dynamic custom track body (`track-overview` / `module-preview` / full hero) with a `LevelLanding` fallback for tracks without MDX index docs (`b2`, `c1`, `c2`).
- Adds `tests/test_landings_use_levellanding.py` so future track `index.mdx` files must render `LevelLanding` with required props.

## Landing Enumeration
MDX track landings now using `LevelLanding` with full props:
`a1`, `a2`, `b1`, `b2-pro`, `bio`, `c1-pro`, `folk`, `hist`, `istorio`, `lit`, `lit-drama`, `lit-essay`, `lit-fantastika`, `lit-hist-fic`, `lit-humor`, `lit-war`, `lit-youth`, `oes`, `ruth`.

Custom track routes without MDX index docs now use the `LevelLanding` fallback:
`b2`, `c1`, `c2`.

`starlight/src/pages/{track}/index.astro` landings found: none. Existing Astro index pages are root, etymology, and lexicon/reference surfaces. Lexicon was intentionally left unchanged.

## Screenshots
Captured locally from the final rebased build with Playwright, one per track per mode. Manifest: `tmp/landings-unify-screenshots/manifest.json`.

Per-track files:
- `a1-light.png`, `a1-dark.png`
- `a2-light.png`, `a2-dark.png`
- `b1-light.png`, `b1-dark.png`
- `b2-light.png`, `b2-dark.png`
- `c1-light.png`, `c1-dark.png`
- `c2-light.png`, `c2-dark.png`
- `folk-light.png`, `folk-dark.png`
- `bio-light.png`, `bio-dark.png`
- `hist-light.png`, `hist-dark.png`
- `istorio-light.png`, `istorio-dark.png`
- `lit-light.png`, `lit-dark.png`
- `oes-light.png`, `oes-dark.png`
- `ruth-light.png`, `ruth-dark.png`
- `b2-pro-light.png`, `b2-pro-dark.png`
- `c1-pro-light.png`, `c1-pro-dark.png`
- `lit-drama-light.png`, `lit-drama-dark.png`
- `lit-essay-light.png`, `lit-essay-dark.png`
- `lit-fantastika-light.png`, `lit-fantastika-dark.png`
- `lit-hist-fic-light.png`, `lit-hist-fic-dark.png`
- `lit-humor-light.png`, `lit-humor-dark.png`
- `lit-war-light.png`, `lit-war-dark.png`
- `lit-youth-light.png`, `lit-youth-dark.png`

Screenshot script also asserted each rendered page had module stats, target words, a module list, the requested theme, and no `track-overview`, `CORE LADDER`, `module-preview`, or `course-hero` marker.

## Verification
`.venv/bin/python -m pytest tests/test_landings_use_levellanding.py -q`
```text
tests/test_landings_use_levellanding.py .....................            [100%]
============================== 21 passed in 0.06s ==============================
```

`npm test --prefix starlight`
```text
 Test Files  21 passed (21)
      Tests  343 passed (343)
   Start at  12:19:11
   Duration  17.29s (transform 845ms, setup 1.17s, import 3.48s, tests 19.25s, environment 4.68s)
```

`npm run build:full --prefix starlight`
```text
12:19:57 [build] ✓ Completed in 21.17s.
12:19:57 [@astrojs/sitemap] `sitemap-index.xml` created at `dist`
12:19:57 [build] 38063 page(s) built in 22.23s
12:19:57 [build] Complete!
```

Additional checks:
```text
Checking 1 commit(s) in origin/main..HEAD:

  8620098b3a  PASS  X-Agent: codex/landings-unify

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

Note: staged/committed file count is 25 because the requested scope explicitly changes every track landing plus the shared route/component/test. No generated status/audit/review artifacts, linter configs, or `.python-version` changes are included.