### PR TITLE
feat(gate): VESUM heritage gate consumes shared classifier (#2912) — folk unblock

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -8161,15 +8161,39 @@ def _folk_heritage_attestation_index(
     return index
 
 
+_HERITAGE_AUTHENTIC_CLASSIFICATIONS = frozenset(
+    {"authentic-archaism", "dialect", "historism", "borrowing", "standard"}
+)
+
+
+def _engine_classifies_authentic(candidate: str) -> bool:
+    """True iff the shared heritage classifier (#2912) attests ``candidate`` as
+    authentic Ukrainian (archaism / dialect / historism / borrowing / standard)
+    and NOT a russianism.
+
+    Reads ``data/sources.db`` directly via ``scripts.lexicon.heritage_classifier``.
+    A Russian-shadow morphology hit never decides on its own — the classifier
+    records it as a warning but authentic dictionary/quote evidence overrides it
+    (so поетичне ``другоє`` and dialectal ``ягілка`` pass while ``протиріччя``
+    stays a russianism). Degrades to ``False`` (committed-allowlist-only fallback)
+    when the classifier is unavailable — e.g. the corpus DB is absent on CI."""
+    try:
+        from scripts.lexicon.heritage_classifier import classify_surface_form
+
+        verdict = classify_surface_form(candidate)
+    except Exception:
+        return False
+    return (
+        verdict.get("classification") in _HERITAGE_AUTHENTIC_CLASSIFICATIONS
+        and not verdict.get("is_russianism", False)
+    )
+
+
 def _resolve_folk_heritage_attested_missing(
     missing_lc: set[str],
     unchecked_pairs: Sequence[tuple[str, str, str]],
 ) -> set[str]:
     if not missing_lc:
-        return set()
-
-    attestation_index = _folk_heritage_attestation_index()
-    if not attestation_index:
         return set()
 
     candidates_by_missing: dict[str, set[str]] = {word: {word} for word in missing_lc}
@@ -8179,11 +8203,22 @@ def _resolve_folk_heritage_attested_missing(
         candidates_by_missing[lower].add(_normalize_for_vesum(surface).lower())
         candidates_by_missing[lower].add(_normalize_for_vesum(original_case_lookup).lower())
 
-    return {
-        word
-        for word, candidates in candidates_by_missing.items()
-        if any(candidate in attestation_index for candidate in candidates)
-    }
+    # Primary authority: the shared heritage classifier (#2912). It accepts
+    # authentic archaic/dialectal/standard Ukrainian and keeps russianisms +
+    # unknown coinages flagged, replacing the per-term whack-a-mole allowlist.
+    # The committed slovnyk.me allowlist (#2899) collapses to a thin deterministic
+    # override — consulted first (cheap dict lookup) and as the offline fallback
+    # when the corpus DB is absent (CI).
+    attestation_index = _folk_heritage_attestation_index()
+
+    attested: set[str] = set()
+    for word, candidates in candidates_by_missing.items():
+        if attestation_index and any(candidate in attestation_index for candidate in candidates):
+            attested.add(word)
+            continue
+        if any(_engine_classifies_authentic(candidate) for candidate in candidates):
+            attested.add(word)
+    return attested
 
 
 def _vesum_gate(

--- a/tests/test_vesum_heritage_attestation.py
+++ b/tests/test_vesum_heritage_attestation.py
@@ -1,8 +1,20 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
 import yaml
 
 from scripts.build import linear_pipeline
+
+# Mirror the heritage-classifier convention (tests/test_heritage_classifier.py):
+# CI ships only a stub sources.db, so existence is not enough — require the full
+# ~1.7GB corpus. The engine is verified locally; these cases skip on CI.
+requires_sources_db = pytest.mark.skipif(
+    not Path("data/sources.db").exists()
+    or Path("data/sources.db").stat().st_size < 100_000_000,
+    reason="requires the full ~1.7GB corpus sources.db; CI has only a stub; heritage engine verified locally",
+)
 
 
 def _vesum_rejects_all(words: list[str]) -> dict[str, list[dict[str, str]]]:
@@ -92,4 +104,46 @@ def test_core_level_vesum_gate_does_not_use_folk_attestation_fallback() -> None:
 
     assert gate["passed"] is False
     assert gate["missing"] == ["риндзівка"]
+    assert gate["heritage_attested"] == 0
+
+
+# --- Heritage classifier consumption (#2912) -------------------------------
+# The shared classifier is now the primary authority; the committed YAML
+# allowlist (#2899) is a thin override. These cases are attested ONLY by the
+# classifier (corpus/dictionary evidence), not by the committed allowlist, so
+# they prove the gate consumes the engine rather than re-listing terms by hand.
+
+
+@requires_sources_db
+def test_folk_vesum_gate_accepts_engine_authentic_not_in_allowlist() -> None:
+    # `другоє` (poetic archaic `-оє`, verified in a 1955 Kupala song) and
+    # `Кострубонько` (ritual figure) are NOT in folk_heritage_attestations.yaml;
+    # only the classifier attests them as authentic-archaism.
+    gate = _gate("другоє Кострубонько")
+
+    assert gate["passed"] is True
+    assert gate["missing"] == []
+    assert gate["heritage_attested"] == 2
+
+
+@requires_sources_db
+def test_folk_vesum_gate_still_rejects_teaching_prose_russianisms() -> None:
+    # Teaching-prose russianisms the classifier flags is_russianism=True must
+    # keep failing the gate (→ суперечність / чинна). Gate teeth preserved.
+    gate = _gate("протиріччя діюча")
+
+    assert gate["passed"] is False
+    # _vesum_gate sorts `missing` internally; Cyrillic order: діюча < протиріччя.
+    assert gate["missing"] == ["діюча", "протиріччя"]
+    assert gate["heritage_attested"] == 0
+
+
+def test_folk_vesum_gate_still_rejects_unknown_coinage_via_engine() -> None:
+    # `городалька` is an unknown coinage (classification="unknown") — neither the
+    # allowlist nor the classifier attests it. Stays flagged with or without the
+    # corpus DB (engine degrades to False when unavailable), so no DB guard.
+    gate = _gate("городалька")
+
+    assert gate["passed"] is False
+    assert gate["missing"] == ["городалька"]
     assert gate["heritage_attested"] == 0


### PR DESCRIPTION
## What
The seminar/folk `vesum_verified` heritage-attestation step now consumes the shared **`scripts/lexicon/heritage_classifier.classify_surface_form()`** (#2912) as the **primary authority**, per `docs/best-practices/heritage-attestation-engine.md` ("consume, don't duplicate").

A VESUM-missing surface form is accepted **iff** the classifier returns `classification ∈ {authentic-archaism, dialect, historism, borrowing, standard}` **and** `is_russianism = False`. A Russian-shadow morphology hit never decides on its own (authentic dictionary/quote evidence overrides it).

The committed slovnyk.me allowlist (#2899, `data/folk_heritage_attestations.yaml`) collapses to a **thin deterministic override** — consulted first (cheap dict lookup) and as the **offline fallback** when the corpus DB is absent (CI). No more per-term whack-a-mole.

## Why this unblocks folk
Authentic archaic/poetic/dialectal Ukrainian that VESUM lacks but the corpus attests — `другоє` (poetic `-оє`, verified in a 1955 Kupala song), `Кострубонько` — are **not** in the allowlist; only the classifier attests them. This was the kalendarna `python_qg` wall.

## Validated (local, against data/sources.db)
| word | classifier | gate |
|---|---|---|
| другоє | authentic-archaism | ✅ accept |
| Кострубонько | authentic-archaism | ✅ accept |
| перекличка / гагілки | standard / dialect | ✅ accept |
| протиріччя / діюча | russianism | ⛔ flag (teeth kept) |
| городалька | unknown | ⛔ flag |

## Scope / safety
- **Seminar/folk levels only** (unchanged — gated by `_vesum_heritage_attestation_enabled`). Core a1–c2 untouched.
- Engine call wrapped — degrades to allowlist-only when the DB is unavailable (CI), so no new CI dependency.
- Tests: 3 new engine-path cases + all existing allowlist/russianism/core-level guards green — **16 passed**, ruff clean.

## NOT in this PR
- Verbatim `>` blockquote exemption in `_build_vesum_text` — no longer required (engine accepts `другоє` directly); optional defense-in-depth follow-up.

## Review
Cross-track gate change — **requesting cross-family review before merge (no self-merge).** Folk driver lane; @orchestrator this is the `_vesum_gate` consumption from the convergence — ready for kalendarna re-fire once merged.