### PR TITLE
chore(infra): session-start worktree auto-reap + declare .agent/tmp orphan

### DIFF
--- a/scripts/deploy_prompts.sh
+++ b/scripts/deploy_prompts.sh
@@ -54,7 +54,10 @@ ORPHAN_PATHS_CLAUDE="scheduled_tasks.lock worktrees"
 #          .agent/ by the dispatch tooling when a dispatch fires. Runtime-only,
 #          NOT source-tracked. Without this entry the deploy aborts on any machine
 #          where a dispatch has run since the last clean .agent/ deploy.
-ORPHAN_PATHS_AGENT="wake cache prompts *-thread-bootstrap.md *-thread-handoff.md *-thread-lease.json"
+# tmp/ — runtime scratch (issue/PR draft bodies, transient tarballs) written into
+#          .agent/ by orchestration tooling. Runtime-only, NOT source-tracked.
+#          Same rationale as prompts/: declare so rsync --delete preserves it.
+ORPHAN_PATHS_AGENT="wake cache prompts tmp *-thread-bootstrap.md *-thread-handoff.md *-thread-lease.json"
 ORPHAN_PATHS_AGENTS=""
 # agents/curriculum-orchestrator.toml and agents/curriculum-writer.toml —
 # Codex agent definitions with no shared equivalent.

--- a/scripts/session_start.sh
+++ b/scripts/session_start.sh
@@ -41,6 +41,40 @@ echo -e "${BOLD}==============================================${NC}"
 echo ""
 
 # ---------------------------------------------------------------------------
+# 0. Worktree hygiene — auto-reap finished dispatch/build worktrees
+#    The disk-bleed backstop: dispatch worktrees are each a full ~700MB
+#    checkout, and delegate.py only reaps them on the happy path (danger
+#    mode + status=done + clean). Everything else (needs_finalize, crashed,
+#    dirty, review mode) leaked forever → 11GB before this was wired in.
+#    reap_worktrees.py is safe-by-default: it ONLY reaps worktrees whose PR
+#    is MERGED/CLOSED or whose HEAD matches origin/<branch>, prunes merged
+#    branches, and preserves dirty ones (surfaced below, never auto-touched).
+#    Guarded with set +e + timeout so it can never abort session start.
+# ---------------------------------------------------------------------------
+if [ -x .venv/bin/python ] && [ -f scripts/orchestration/reap_worktrees.py ]; then
+    if command -v timeout > /dev/null 2>&1; then TIMEOUT_CMD="timeout 90"
+    elif command -v gtimeout > /dev/null 2>&1; then TIMEOUT_CMD="gtimeout 90"
+    else TIMEOUT_CMD=""; fi
+    set +e
+    REAP_OUT=$($TIMEOUT_CMD .venv/bin/python scripts/orchestration/reap_worktrees.py \
+        --apply --prune-merged-branches 2>/dev/null)
+    reaped=$(printf '%s\n' "$REAP_OUT" | grep -cE '^(REMOVED|PRESERVED_THEN_REMOVED) ')
+    dirty_q=$(printf '%s\n' "$REAP_OUT" | grep -c 'dirty; qualifies for reap')
+    wt_disk=$(du -sh .worktrees 2>/dev/null | cut -f1)
+    set -e
+    if [ "${reaped:-0}" -gt 0 ]; then
+        echo -e "${BOLD}WORKTREE HYGIENE${NC}  ${GREEN}reaped ${reaped}${NC} finished worktree(s); .worktrees now ${wt_disk:-?}"
+    else
+        echo -e "${BOLD}WORKTREE HYGIENE${NC}  ${DIM}nothing to reap; .worktrees ${wt_disk:-?}${NC}"
+    fi
+    if [ "${dirty_q:-0}" -gt 0 ]; then
+        echo -e "  ${YELLOW}${dirty_q} dirty worktree(s) qualify but are preserved${NC} — save work + reclaim with:"
+        echo -e "  ${DIM}.venv/bin/python scripts/orchestration/reap_worktrees.py --apply --prune-merged-branches --preserve-then-reap${NC}"
+    fi
+    echo ""
+fi
+
+# ---------------------------------------------------------------------------
 # 1. Project totals
 # ---------------------------------------------------------------------------
 SUMMARY=$(curl -s "$API/api/state/summary")


### PR DESCRIPTION
Follow-up to #2935 (closes out the deploy-drift root cause) + finalizes a prior-session feature.

## 1. session_start.sh — worktree auto-reap
Recovered from the prior Claude session's uncommitted working tree (never on any branch; same cluster as the session's handoff docs). Adds a guarded block running reap_worktrees.py --apply --prune-merged-branches on session start to stop the dispatch/build-worktree disk bleed (~700MB each; 11GB before). Guards: set +e, timeout 90, stderr suppressed — cannot abort session start. Reaper safe-by-default (only MERGED/CLOSED/HEAD-matches; preserves dirty). Validated: --prune-merged-branches flag exists, bash -n clean, reaper verified safe.

## 2. deploy_prompts.sh — declare .agent/tmp orphan
Second undeclared orphan blocking deploy after 'prompts' (#2935). .agent/tmp holds runtime scratch (issue/PR draft bodies, tarballs). With both declared, deploy preflight passes end-to-end. Verified: dry-run 'All orphan paths are declared'; test_deploy_script_idempotency.py 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)