### PR TITLE
fix(a1): localize early module headings

### DIFF
--- a/curriculum/l2-uk-en/a1/checkpoint-first-contact/module.md
+++ b/curriculum/l2-uk-en/a1/checkpoint-first-contact/module.md
@@ -211,7 +211,7 @@ family line, and closing. That is enough for the checkpoint.
 
 <!-- INJECT_ACTIVITY: act-5 -->
 
-### Digital first contact
+### Перше знайомство онлайн
 
 A modern first contact may happen in a course chat. The same etiquette applies:
 start with a greeting, name yourself, ask one clear question, and close

--- a/curriculum/l2-uk-en/a1/colors/activities.yaml
+++ b/curriculum/l2-uk-en/a1/colors/activities.yaml
@@ -2,7 +2,7 @@
 inline:
   - id: act-1
     type: quiz
-    title: Ask about color
+    title: Запитай про колір
     instruction: Choose the natural question or short answer.
     items:
       - prompt: You point to a pencil and ask its color.
@@ -61,7 +61,7 @@ inline:
         explanation: The standard chunk is синьо-жовтий прапор.
   - id: act-2
     type: fill-in
-    title: Color endings
+    title: Закінчення кольорів
     instruction: Choose the ending or form that matches the noun.
     items:
       - sentence: червон__ олівець
@@ -136,7 +136,7 @@ inline:
         explanation: With вікно say синє.
   - id: act-3
     type: group-sort
-    title: Hard or soft color
+    title: Тверда чи м'яка форма
     instruction: Sort the color chunks by adjective pattern.
     groups:
       - label: Hard pattern -ий/-а/-е
@@ -157,7 +157,7 @@ inline:
           - сині речі
   - id: act-4
     type: quiz
-    title: Синій or блакитний
+    title: Синій чи блакитний
     instruction: Choose the better A1 color chunk.
     items:
       - prompt: A clear sky
@@ -216,7 +216,7 @@ inline:
         explanation: Treat темно-зелений as one compound color chunk.
 workbook:
   - type: match-up
-    title: Appearance chunks
+    title: Опис зовнішності
     instruction: Match each Ukrainian chunk with its natural context.
     pairs:
       - left: карі очі
@@ -232,7 +232,7 @@ workbook:
       - left: синьо-жовтий прапор
         right: Ukrainian flag colors
   - type: error-correction
-    title: Repair color traps
+    title: Виправ кольорові пастки
     instruction: Choose the standard Ukrainian correction.
     items:
       - sentence: Сукня є червона.
@@ -284,7 +284,7 @@ workbook:
           - чорний, білий
         explanation: In these common color words, stress is on the root.
   - type: fill-in
-    title: Room and clothes colors
+    title: Кольори кімнати й одягу
     instruction: Complete each practical sentence.
     items:
       - sentence: Моя кімната ___.
@@ -344,7 +344,7 @@ workbook:
           - блакитна
         explanation: Небо is neuter.
   - type: translate
-    title: Choose the Ukrainian line
+    title: Обери український рядок
     instruction: Choose the Ukrainian sentence that matches the English cue.
     items:
       - source: The dress is red.
@@ -402,7 +402,7 @@ workbook:
             correct: false
         explanation: Keep синьо-жовтий as the fixed flag color chunk.
   - type: true-false
-    title: Color checkpoint
+    title: Перевірка кольорів
     instruction: Decide if the statement is right.
     items:
       - statement: Якого кольору светр?
@@ -430,7 +430,7 @@ workbook:
         answer: true
         explanation: Keep this exact phrase.
   - type: match-up
-    title: Color chunks
+    title: Фрази з кольорами
     instruction: Match each color chunk with the object or image it best fits.
     pairs:
       - left: червоний олівець

--- a/curriculum/l2-uk-en/a1/colors/module.md
+++ b/curriculum/l2-uk-en/a1/colors/module.md
@@ -1,4 +1,4 @@
-# Colors
+# Кольори
 
 You already know how Ukrainian adjectives change with a noun:
 **новий стіл**, **нова книга**, **нове фото**, **нові речі**. Colors use the

--- a/curriculum/l2-uk-en/a1/how-many/activities.yaml
+++ b/curriculum/l2-uk-en/a1/how-many/activities.yaml
@@ -2,7 +2,7 @@
 inline:
   - id: act-1
     type: quiz
-    title: Count 0-10
+    title: Лічи від 0 до 10
     instruction: Choose the correct Ukrainian number or chunk.
     items:
       - prompt: 0
@@ -61,7 +61,7 @@ inline:
         explanation: Use дві with feminine plural chunks.
   - id: act-3
     type: match-up
-    title: Prices
+    title: Ціни
     instruction: Match the price with the Ukrainian phrase.
     pairs:
       - left: 1 UAH
@@ -82,7 +82,7 @@ inline:
         right: тисяча гривень
   - id: act-4
     type: fill-in
-    title: Age chunks
+    title: Вік у фразах
     instruction: Choose рік, роки, or років.
     items:
       - sentence: Мені двадцять один ___.
@@ -129,7 +129,7 @@ inline:
         explanation: Ask Скільки тобі років?
   - id: act-5
     type: quiz
-    title: Phone number groups
+    title: Групи номера телефону
     instruction: Choose the line that reads the number naturally.
     items:
       - prompt: 097
@@ -179,7 +179,7 @@ inline:
         explanation: Say нуль and п'ятдесят.
 workbook:
   - type: fill-in
-    title: Write the number
+    title: Напиши число
     instruction: Choose the Ukrainian written form.
     items:
       - sentence: 5 = ___
@@ -253,7 +253,7 @@ workbook:
           - дев'яносят
         explanation: Ninety is дев'яносто.
   - type: group-sort
-    title: 1 / 2-4 / 5+ chunks
+    title: Фрази 1 / 2-4 / 5+
     instruction: Sort each noun chunk by the number pattern.
     groups:
       - label: 1
@@ -275,7 +275,7 @@ workbook:
           - десять зошитів
           - шість студентів
   - type: error-correction
-    title: Repair number traps
+    title: Виправ числові пастки
     instruction: Choose the standard Ukrainian correction.
     items:
       - sentence: п'ять столи / п'ять студентів (якщо вжито як Називний множини)
@@ -327,7 +327,7 @@ workbook:
           - одне тисяча / одне мільйон
         explanation: Use тисяча and мільйон as standalone chunks.
   - type: fill-in
-    title: Numeral spell-check
+    title: Перевір правопис числівників
     instruction: Choose the standard form.
     items:
       - sentence: У мене ___ книг.
@@ -380,7 +380,7 @@ workbook:
           - половина шостого
         explanation: Use the Ukrainian time chunk пів на шосту.
   - type: translate
-    title: Choose the Ukrainian line
+    title: Обери український рядок
     instruction: Choose the Ukrainian sentence that matches the English cue.
     items:
       - source: How much does the cake cost?
@@ -438,7 +438,7 @@ workbook:
             correct: false
         explanation: Use двісті п'ятдесят гривень.
   - type: true-false
-    title: Quick number checkpoint
+    title: Швидка перевірка чисел
     instruction: Decide if the statement is right.
     items:
       - statement: П'ять зошитів.

--- a/curriculum/l2-uk-en/a1/how-many/module.md
+++ b/curriculum/l2-uk-en/a1/how-many/module.md
@@ -1,4 +1,4 @@
-# How Many?
+# Скільки?
 
 Numbers are useful immediately: prices, ages, bags, notebooks, and phone
 numbers. Ukrainian numbers also change the noun after them, so this module
@@ -187,7 +187,7 @@ repair phrase for real conversations.
 
 <!-- INJECT_ACTIVITY: act-4 -->
 
-### How old?
+### Скільки років?
 
 Use age as one ready formula:
 
@@ -238,7 +238,7 @@ of the age formula, not as a new grammar topic to unpack today.
 
 <!-- INJECT_ACTIVITY: act-5 -->
 
-### Phone numbers
+### Номери телефонів
 
 Ukrainian mobile numbers often appear as **+380 XX XXX XX XX**. When speaking,
 read them in small groups. Say **нуль**, not "oh."
@@ -275,7 +275,7 @@ number (**п'ятдесят шість**). The practical goal is clarity. Speak 
 pause between groups, and repeat the number back before you trust that you
 wrote it correctly.
 
-## Number Traps
+## Числові пастки
 
 Keep these repairs automatic:
 

--- a/curriculum/l2-uk-en/a1/special-signs/module.md
+++ b/curriculum/l2-uk-en/a1/special-signs/module.md
@@ -32,7 +32,7 @@ By the end, you can:
 - sort words into **м'яки́й знак**, **апо́строф**, and **без зна́ка**;
 - choose the safer form when a visual habit creates a mistake.
 
-## Йотовані голосні first
+## Йотовані голосні
 
 **Я Ю Є Ї** — the four special vowel letters.
 

--- a/curriculum/l2-uk-en/a1/things-have-gender/activities.yaml
+++ b/curriculum/l2-uk-en/a1/things-have-gender/activities.yaml
@@ -2,7 +2,7 @@
 inline:
   - id: act-1
     type: quiz
-    title: Who or what?
+    title: Хто чи що?
     instruction: Choose the question or pronoun that fits the noun.
     items:
       - prompt: тато
@@ -61,7 +61,7 @@ inline:
         explanation: Вікно is neuter.
   - id: act-3
     type: quiz
-    title: Він, вона, or воно?
+    title: Він, вона чи воно?
     instruction: Choose the Ukrainian gender-test word.
     items:
       - prompt: стіл
@@ -138,7 +138,7 @@ inline:
         explanation: Микола is a masculine name.
   - id: act-4
     type: fill-in
-    title: My object
+    title: Мій предмет
     instruction: Choose мій, моя, or моє.
     items:
       - sentence: Це ___ стіл.
@@ -199,7 +199,7 @@ inline:
         explanation: Фото is neuter in this lesson.
   - id: act-9
     type: quiz
-    title: Profession form check
+    title: Форми професій
     instruction: Choose the natural profession form.
     items:
       - prompt: She is a teacher.
@@ -240,7 +240,7 @@ inline:
         explanation: Акторка is the feminine profession form.
 workbook:
   - type: group-sort
-    title: Sort by gender
+    title: Сортуй за родом
     instruction: Sort each noun by its A1 gender signal.
     groups:
       - label: він / мій
@@ -265,7 +265,7 @@ workbook:
           - дзеркало
           - фото
   - type: match-up
-    title: Room and bag words
+    title: Слова для кімнати й сумки
     instruction: Match each Ukrainian noun with its English cue.
     pairs:
       - left: стіл
@@ -285,7 +285,7 @@ workbook:
       - left: зошит
         right: notebook
   - type: fill-in
-    title: I have objects
+    title: У мене є предмети
     instruction: Complete the object sentence.
     items:
       - sentence: ___ мене є стіл.
@@ -338,7 +338,7 @@ workbook:
           - Він
         explanation: Вікно is neuter, so use воно.
   - type: error-correction
-    title: Fix gender traps
+    title: Виправ пастки роду
     instruction: Choose the safer Ukrainian sentence.
     items:
       - sentence: Мій книга, мій ручка (якщо говорить чоловік).
@@ -405,7 +405,7 @@ workbook:
           - Моє ім'я є Джон.
         explanation: Мене звати... is the safe name chunk.
   - type: quiz
-    title: Gender-flip diagnostic
+    title: Перевірка роду
     instruction: Choose the Ukrainian gender-test word. These are diagnostic props, not new active vocabulary.
     items:
       - prompt: Який у мене сильний біль у плечі!

--- a/curriculum/l2-uk-en/a1/things-have-gender/module.md
+++ b/curriculum/l2-uk-en/a1/things-have-gender/module.md
@@ -1,4 +1,4 @@
-# Things Have Gender
+# Речі мають рід
 
 English has "he," "she," and "it." Ukrainian also has **він**, **вона**,
 and **воно**, but Ukrainian uses them for every noun, including things in your
@@ -33,7 +33,7 @@ You are learning to store a noun with its gender cue.
 
 <!-- INJECT_ACTIVITY: act-1 -->
 
-### Question words
+### Питальні слова
 
 Start with the noun question.
 
@@ -160,7 +160,7 @@ Support after the dialogue:
 
 <!-- INJECT_ACTIVITY: act-4 -->
 
-### My, my, my
+### Мій, моя, моє
 
 The possessive word follows the noun.
 
@@ -238,7 +238,7 @@ Some male names end in **-а**, **-я**, or **-о**: **Микола**, **Ілл�
 **Павло**. They are still **він** because they name men. Family words such as
 **тато**, **батько**, and **дядько** are also masculine.
 
-### Watch the traps
+### Пильнуй пастки
 
 Most errors come from using English habits too directly or from trusting the
 ending when the word is an exception.

--- a/curriculum/l2-uk-en/a1/what-is-it-like/activities.yaml
+++ b/curriculum/l2-uk-en/a1/what-is-it-like/activities.yaml
@@ -2,7 +2,7 @@
 inline:
   - id: act-1
     type: quiz
-    title: Which question word?
+    title: Яке питальне слово?
     instruction: Choose the question word that fits the noun.
     items:
       - prompt: стіл
@@ -61,7 +61,7 @@ inline:
         explanation: Вікно is neuter.
   - id: act-2
     type: fill-in
-    title: Finish the adjective
+    title: Заверши прикметник
     instruction: Choose the adjective ending that matches the noun.
     items:
       - sentence: велик__ стіл
@@ -136,7 +136,7 @@ inline:
         explanation: Plural A1 chunks use нові.
   - id: act-3
     type: group-sort
-    title: Sort the chunks
+    title: Сортуй фрази
     instruction: Sort each adjective-noun chunk by the question it answers.
     groups:
       - label: Який?
@@ -165,7 +165,7 @@ inline:
           - дешеві листівки
   - id: act-4
     type: match-up
-    title: Match opposites
+    title: Поєднай протилежності
     instruction: Match each adjective with its opposite.
     pairs:
       - left: великий
@@ -182,7 +182,7 @@ inline:
         right: темний
 workbook:
   - type: quiz
-    title: Sentence frame
+    title: Модель речення
     instruction: Choose the natural A1 sentence.
     items:
       - prompt: The book is new.
@@ -240,7 +240,7 @@ workbook:
             correct: false
         explanation: Plural chunks use цікаві.
   - type: fill-in
-    title: Describe the room
+    title: Опиши кімнату
     instruction: Complete the short room lines.
     items:
       - sentence: Моя кімната ___ і світла.
@@ -286,7 +286,7 @@ workbook:
           - нове
         explanation: Стіл is masculine.
   - type: error-correction
-    title: Repair adjective agreement
+    title: Виправ узгодження прикметників
     instruction: Fix the adjective or sentence frame.
     items:
       - sentence: Він є добрий студент.
@@ -338,7 +338,7 @@ workbook:
           - Це моє синє ручка.
         explanation: Ручка is feminine, and синій is a soft-stem adjective.
   - type: fill-in
-    title: Adjective trap repair
+    title: Виправ прикметникові пастки
     instruction: Choose the standard Ukrainian adjective.
     items:
       - sentence: Цей суп дуже ___.
@@ -396,7 +396,7 @@ workbook:
           - ленивий
         explanation: Use лінивий.
   - type: translate
-    title: Choose the Ukrainian line
+    title: Обери український рядок
     instruction: Choose the Ukrainian sentence that matches the English cue.
     items:
       - source: My room is small but nice.
@@ -454,7 +454,7 @@ workbook:
             correct: false
         explanation: Plural chunks use цікаві.
   - type: true-false
-    title: Quick checkpoint
+    title: Швидка перевірка
     instruction: Decide if the statement is right.
     items:
       - statement: Стіл новий.

--- a/curriculum/l2-uk-en/a1/what-is-it-like/module.md
+++ b/curriculum/l2-uk-en/a1/what-is-it-like/module.md
@@ -1,4 +1,4 @@
-# What Is It Like?
+# Який він?
 
 In the last module, you learned that every Ukrainian noun has a gender signal:
 **стіл** is **він**, **книга** is **вона**, and **вікно** is **воно**. Now you
@@ -207,7 +207,7 @@ Cover the English and answer aloud:
 - **Який стіл?** — **Новий і чистий.**
 - **Яке ліжко?** — **Старе, але зручне.**
 
-### Watch the traps
+### Пильнуй пастки
 
 Adjectives are a common interference zone. Keep Ukrainian on its own terms.
 Do not explain endings through another language, and do not trust look-alike

--- a/starlight/src/content/docs/a1/checkpoint-first-contact.mdx
+++ b/starlight/src/content/docs/a1/checkpoint-first-contact.mdx
@@ -277,7 +277,7 @@ family line, and closing. That is enough for the checkpoint.
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "___! Мене звати Богдан.", "answer": "Привіт", "options": ["Привіт", "Прізвище", "Років"]}, {"sentence": "Привіт, ___! Мене звати Соломія.", "answer": "Богдане", "options": ["Богдане", "Богдан", "Богдана"]}, {"sentence": "Дуже приємно, ___.", "answer": "Соломіє", "options": ["Соломіє", "Соломія", "Соломію"]}, {"sentence": "___ ти? Я з Дніпра.", "answer": "Звідки", "options": ["Звідки", "Хто", "Чий"]}, {"sentence": "Моя майбутня ___ — вчителька.", "answer": "професія", "options": ["професія", "прізвище", "адреса"]}, {"sentence": "У мене є сестра. ___ звати Ірина.", "answer": "Її", "options": ["Її", "Його", "Я"]}, {"sentence": "У мене є брат. ___ звати Назар.", "answer": "Його", "options": ["Його", "Її", "Вона"]}, {"sentence": "Дуже приємно ___!", "answer": "познайомитися", "options": ["познайомитися", "походження", "допомогти"]}]`)} />
 
-### Digital first contact
+### Перше знайомство онлайн
 
 A modern first contact may happen in a course chat. The same etiquette applies:
 start with a greeting, name yourself, ask one clear question, and close
@@ -381,7 +381,7 @@ spine is ready for the next module.
 
 ### Порядок знайомства
 
-*(see lesson, §Digital first contact)*
+*(see lesson, §Перше знайомство онлайн)*
 
 ### Швидкий переклад
 

--- a/starlight/src/content/docs/a1/colors.mdx
+++ b/starlight/src/content/docs/a1/colors.mdx
@@ -76,7 +76,7 @@ You are learning to ask about color and attach one color to one familiar noun.
 
 ## Діалоги
 
-### Ask about color
+### Запитай про колір
 
 <Quiz client:only='react' questions={JSON.parse(`[{"question": "You point to a pencil and ask its color.", "options": [{"text": "Якого кольору олівець?", "correct": true}, {"text": "Який колір є олівець?", "correct": false}, {"text": "Якого кольору є олівець?", "correct": false}], "explanation": "Learn Якого кольору...? as one question chunk without є."}, {"question": "Якого кольору светр?", "options": [{"text": "Синій.", "correct": true}, {"text": "Синя.", "correct": false}, {"text": "Синє.", "correct": false}], "explanation": "Светр is masculine, so the short answer is синій."}, {"question": "Якого кольору ручка?", "options": [{"text": "Червона.", "correct": true}, {"text": "Червоний.", "correct": false}, {"text": "Червоне.", "correct": false}], "explanation": "Ручка is feminine."}, {"question": "Якого кольору вікно?", "options": [{"text": "Біле.", "correct": true}, {"text": "Білий.", "correct": false}, {"text": "Біла.", "correct": false}], "explanation": "Вікно is neuter."}, {"question": "Якого кольору соняшники?", "options": [{"text": "Жовті.", "correct": true}, {"text": "Жовта.", "correct": false}, {"text": "Жовте.", "correct": false}], "explanation": "Соняшники is plural."}, {"question": "Якого кольору прапор України?", "options": [{"text": "Синьо-жовтий.", "correct": true}, {"text": "Блакитно-жовтий.", "correct": false}, {"text": "Сіро-жовтий.", "correct": false}], "explanation": "The standard chunk is синьо-жовтий прапор."}]`)} />
 
@@ -128,7 +128,7 @@ right color form.
 Repeat the question aloud before you choose an answer. The question is stable,
 and the answer is flexible.
 
-### Color endings
+### Закінчення кольорів
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "червон__ олівець", "answer": "ий", "options": ["ий", "а", "е"]}, {"sentence": "червон__ ручка", "answer": "а", "options": ["а", "ий", "е"]}, {"sentence": "червон__ яблуко", "answer": "е", "options": ["е", "а", "ий"]}, {"sentence": "біл__ светр", "answer": "ий", "options": ["ий", "а", "е"]}, {"sentence": "біл__ сорочка", "answer": "а", "options": ["а", "ий", "е"]}, {"sentence": "сір__ пальто", "answer": "е", "options": ["е", "ий", "а"]}, {"sentence": "зелен__ зошит", "answer": "ий", "options": ["ий", "а", "е"]}, {"sentence": "рожев__ листівка", "answer": "а", "options": ["а", "е", "ий"]}, {"sentence": "син__ книга", "answer": "я", "options": ["я", "ій", "є"]}, {"sentence": "син__ вікно", "answer": "є", "options": ["є", "ій", "я"]}]`)} />
 
@@ -178,7 +178,7 @@ already know: **жовта стрічка**, **зелений зошит**, **ч
 **біле вікно**. You are not building a color dictionary; you are building
 usable pairs.
 
-### Hard or soft color
+### Тверда чи м'яка форма
 
 <GroupSort client:only='react' groups={JSON.parse(`{"Hard pattern -ий/-а/-е": ["червоний олівець", "жовта стрічка", "зелене яблуко", "білий светр", "чорна сукня", "сіре пальто", "коричневі черевики", "помаранчевий олівець"], "Soft pattern -ій/-я/-є": ["синій светр", "синя ручка", "синє море", "сині речі"]}`)} />
 
@@ -237,7 +237,7 @@ You saw **чорну сукню** in that dialogue because the dress is an objec
 sentence. Do not turn that into a full case lesson today. Your productive A1
 chunks are still **чорна сукня** and **Сукня чорна**.
 
-### Синій or блакитний
+### Синій чи блакитний
 
 <Quiz client:only='react' questions={JSON.parse(`[{"question": "A clear sky", "options": [{"text": "блакитне небо", "correct": true}, {"text": "синьо-жовте небо", "correct": false}, {"text": "коричневе небо", "correct": false}], "explanation": "For a clear sky, use блакитне небо."}, {"question": "The Ukrainian flag", "options": [{"text": "синьо-жовтий прапор", "correct": true}, {"text": "блакитно-жовтий прапор", "correct": false}, {"text": "голубо-жовтий прапор", "correct": false}], "explanation": "The standard phrase is синьо-жовтий прапор."}, {"question": "A dark blue sweater", "options": [{"text": "синій светр", "correct": true}, {"text": "блакитна светр", "correct": false}, {"text": "синє светр", "correct": false}], "explanation": "Светр is masculine; синій also signals deep blue."}, {"question": "A light-blue postcard", "options": [{"text": "блакитна листівка", "correct": true}, {"text": "синій листівка", "correct": false}, {"text": "блакитне листівка", "correct": false}], "explanation": "Листівка is feminine."}, {"question": "Deep water", "options": [{"text": "синє море", "correct": true}, {"text": "блакитний море", "correct": false}, {"text": "синя море", "correct": false}], "explanation": "Море is neuter; синє море is a stable chunk."}, {"question": "A notebook that is dark green", "options": [{"text": "темно-зелений зошит", "correct": true}, {"text": "темна-зелена зошит", "correct": false}, {"text": "зелено-темний зошит", "correct": false}], "explanation": "Treat темно-зелений as one compound color chunk."}]`)} />
 
@@ -375,43 +375,43 @@ sentence about it.
 </TabItem>
 <TabItem label="Activities">
 
-### Ask about color
+### Запитай про колір
 
 *(see lesson, §Діалоги)*
 
-### Color endings
+### Закінчення кольорів
 
 *(see lesson, §Діалоги)*
 
-### Hard or soft color
+### Тверда чи м'яка форма
 
 *(see lesson, §Кольори)*
 
-### Синій or блакитний
+### Синій чи блакитний
 
 *(see lesson, §Якого кольору?)*
 
-### Appearance chunks
+### Опис зовнішності
 
 <MatchUp client:only='react' pairs={JSON.parse(`[{"left": "карі очі", "right": "brown eyes"}, {"left": "русяве волосся", "right": "fair or light-brown hair"}, {"left": "сиве волосся", "right": "grey hair"}, {"left": "руде волосся", "right": "red hair"}, {"left": "блакитне небо", "right": "light-blue sky"}, {"left": "синьо-жовтий прапор", "right": "Ukrainian flag colors"}]`)} />
 
-### Repair color traps
+### Виправ кольорові пастки
 
 <ErrorCorrection client:only='react' instruction="Choose the standard Ukrainian correction." items={JSON.parse(`[{"sentence": "Сукня є червона.", "errorWord": "Сукня є червона.", "correctForm": "Сукня червона.", "options": ["Сукня червона.", "Сукня червоний.", "Сукня є червоний."], "explanation": "In this present-tense frame, Ukrainian normally omits є."}, {"sentence": "Якого кольору є светр?", "errorWord": "Якого кольору є светр?", "correctForm": "Якого кольору светр?", "options": ["Якого кольору светр?", "Яка кольору светр?", "Якого кольору є светр?"], "explanation": "Keep Якого кольору...? as one chunk without є."}, {"sentence": "Блакитно-жовтий прапор.", "errorWord": "Блакитно-жовтий прапор.", "correctForm": "Синьо-жовтий прапор.", "options": ["Синьо-жовтий прапор.", "Блакитно-жовтий прапор.", "Жовто-блакитний прапор."], "explanation": "The standard chunk for Ukraine's flag is синьо-жовтий прапор."}, {"sentence": "У мене є синій настрій.", "errorWord": "У мене є синій настрій.", "correctForm": "Мені сумно. / У мене поганий настрій.", "options": ["Мені сумно. / У мене поганий настрій.", "У мене є синій настрій.", "Я синій сьогодні."], "explanation": "Do not copy the English color idiom. Use a Ukrainian mood phrase."}, {"sentence": "Вона має червоне волосся.", "errorWord": "Вона має червоне волосся.", "correctForm": "У неї руде волосся.", "options": ["У неї руде волосся.", "Вона має червоне волосся.", "У неї червоний волосся."], "explanation": "For red hair, use руде волосся; for possession, use У неї..."}, {"sentence": "ЧорнИй, білИй (з наголосом на закінченні)", "errorWord": "ЧорнИй, білИй (з наголосом на закінченні)", "correctForm": "ЧОрний, бІлий", "options": ["ЧОрний, бІлий", "ЧорнИй, білИй", "чорний, білий"], "explanation": "In these common color words, stress is on the root."}]`)} />
 
-### Room and clothes colors
+### Кольори кімнати й одягу
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "Моя кімната ___.", "answer": "біла", "options": ["біла", "білий", "біле"]}, {"sentence": "Стіл ___.", "answer": "коричневий", "options": ["коричневий", "коричнева", "коричневе"]}, {"sentence": "Пальто ___.", "answer": "сіре", "options": ["сіре", "сірий", "сіра"]}, {"sentence": "У мене ___ светр.", "answer": "синій", "options": ["синій", "синя", "синє"]}, {"sentence": "У неї ___ очі.", "answer": "карі", "options": ["карі", "коричневі", "каре"]}, {"sentence": "У нього ___ волосся.", "answer": "русяве", "options": ["русяве", "русявий", "русий"]}, {"sentence": "У бабусі ___ волосся.", "answer": "сиве", "options": ["сиве", "сива", "сивий"]}, {"sentence": "Це ___ небо.", "answer": "блакитне", "options": ["блакитне", "блакитний", "блакитна"]}]`)} />
 
-### Choose the Ukrainian line
+### Обери український рядок
 
 <Translate client:only='react' questions={JSON.parse(`[{"source": "The dress is red.", "options": [{"text": "Сукня червона.", "correct": true}, {"text": "Сукня є червона.", "correct": false}, {"text": "Сукня червоний.", "correct": false}], "explanation": "No є is needed, and сукня is feminine."}, {"source": "I have a blue sweater.", "options": [{"text": "У мене синій светр.", "correct": true}, {"text": "У мене синя светр.", "correct": false}, {"text": "У мене є блакитно светр.", "correct": false}], "explanation": "Светр is masculine; синій is the soft color form."}, {"source": "The sky is light blue.", "options": [{"text": "Небо блакитне.", "correct": true}, {"text": "Небо блакитний.", "correct": false}, {"text": "Небо синя.", "correct": false}], "explanation": "Небо is neuter, and блакитний means light blue."}, {"source": "She has brown eyes.", "options": [{"text": "У неї карі очі.", "correct": true}, {"text": "Вона має коричневі очі.", "correct": false}, {"text": "У неї коричневе очі.", "correct": false}], "explanation": "Use the fixed chunk карі очі."}, {"source": "He has grey hair.", "options": [{"text": "У нього сиве волосся.", "correct": true}, {"text": "У нього сіре волосся.", "correct": false}, {"text": "Він має сивий волосся.", "correct": false}], "explanation": "Use сиве волосся and the У нього... frame."}, {"source": "The flag is blue and yellow.", "options": [{"text": "Прапор синьо-жовтий.", "correct": true}, {"text": "Прапор блакитно-жовтий.", "correct": false}, {"text": "Прапор синій і жовта.", "correct": false}], "explanation": "Keep синьо-жовтий as the fixed flag color chunk."}]`)} />
 
-### Color checkpoint
+### Перевірка кольорів
 
 <TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Якого кольору светр?", "isTrue": true, "explanation": "This is the standard color question chunk."}, {"statement": "Якого кольору є светр?", "isTrue": false, "explanation": "Do not insert є into this question."}, {"statement": "Ручка синя.", "isTrue": true, "explanation": "Ручка is feminine, and синій becomes синя."}, {"statement": "Вікно синій.", "isTrue": false, "explanation": "Вікно is neuter; say Вікно синє."}, {"statement": "Синій and блакитний are both active A1 words here.", "isTrue": true, "explanation": "Синій is dark/deep blue; блакитний is light/sky blue."}, {"statement": "Голубий is a production target here.", "isTrue": false, "explanation": "It is passive recognition only here."}, {"statement": "У неї карі очі.", "isTrue": true, "explanation": "Карі очі is a natural fixed chunk."}, {"statement": "The Ukrainian flag chunk is синьо-жовтий прапор.", "isTrue": true, "explanation": "Keep this exact phrase."}]`)} />
 
-### Color chunks
+### Фрази з кольорами
 
 <MatchUp client:only='react' pairs={JSON.parse(`[{"left": "червоний олівець", "right": "red pencil"}, {"left": "червона ручка", "right": "red pen"}, {"left": "червоне яблуко", "right": "red apple"}, {"left": "блакитне небо", "right": "light-blue sky"}, {"left": "синє море", "right": "deep-blue sea"}, {"left": "чорна сукня", "right": "black dress"}, {"left": "білий светр", "right": "white sweater"}, {"left": "коричневі черевики", "right": "brown shoes"}]`)} />
 

--- a/starlight/src/content/docs/a1/how-many.mdx
+++ b/starlight/src/content/docs/a1/how-many.mdx
@@ -75,7 +75,7 @@ By the end, you can:
 
 ## Діалоги
 
-### Count 0-10
+### Лічи від 0 до 10
 
 <Quiz client:only='react' questions={JSON.parse(`[{"question": "0", "options": [{"text": "нуль", "correct": true}, {"text": "о", "correct": false}, {"text": "один", "correct": false}], "explanation": "Phone numbers use нуль, not English \\"oh.\\""}, {"question": "one pencil", "options": [{"text": "один олівець", "correct": true}, {"text": "одна олівець", "correct": false}, {"text": "одне олівець", "correct": false}], "explanation": "Олівець is masculine."}, {"question": "one pen", "options": [{"text": "одна ручка", "correct": true}, {"text": "один ручка", "correct": false}, {"text": "одне ручка", "correct": false}], "explanation": "Ручка is feminine."}, {"question": "one pastry", "options": [{"text": "одне тістечко", "correct": true}, {"text": "один тістечко", "correct": false}, {"text": "одна тістечко", "correct": false}], "explanation": "Тістечко is neuter."}, {"question": "two pencils", "options": [{"text": "два олівці", "correct": true}, {"text": "дві олівці", "correct": false}, {"text": "два олівець", "correct": false}], "explanation": "Use два with masculine plural chunks."}, {"question": "two pens", "options": [{"text": "дві ручки", "correct": true}, {"text": "два ручки", "correct": false}, {"text": "дві ручка", "correct": false}], "explanation": "Use дві with feminine plural chunks."}]`)} />
 
@@ -180,7 +180,7 @@ visible enough: **1** has one form, **2-4** has another, and **5+** has another.
 That is the same memory hook you need for **гривня**, **рік**, and everyday
 objects.
 
-### Prices
+### Ціни
 
 <MatchUp client:only='react' pairs={JSON.parse(`[{"left": "1 UAH", "right": "одна гривня"}, {"left": "2 UAH", "right": "дві гривні"}, {"left": "4 UAH", "right": "чотири гривні"}, {"left": "5 UAH", "right": "п'ять гривень"}, {"left": "50 UAH", "right": "п'ятдесят гривень"}, {"left": "150 UAH", "right": "сто п'ятдесят гривень"}, {"left": "200 UAH", "right": "двісті гривень"}, {"left": "1000 UAH", "right": "тисяча гривень"}]`)} />
 
@@ -238,11 +238,11 @@ If you miss a number in a shop, ask with one short line:
 **Повторіть, будь ласка.** You already know **будь ласка**, so this is a useful
 repair phrase for real conversations.
 
-### Age chunks
+### Вік у фразах
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "Мені двадцять один ___.", "answer": "рік", "options": ["рік", "роки", "років"]}, {"sentence": "Моїй сестрі двадцять чотири ___.", "answer": "роки", "options": ["роки", "рік", "років"]}, {"sentence": "Мені двадцять п'ять ___.", "answer": "років", "options": ["років", "рік", "роки"]}, {"sentence": "Їй вісімнадцять ___.", "answer": "років", "options": ["років", "роки", "рік"]}, {"sentence": "Бабусі вісімдесят ___.", "answer": "років", "options": ["років", "роки", "рік"]}, {"sentence": "Скільки тобі ___?", "answer": "років", "options": ["років", "год", "рік"]}]`)} />
 
-### How old?
+### Скільки років?
 
 Use age as one ready formula:
 
@@ -291,11 +291,11 @@ These are not possession sentences. English says "I am twenty-five." Ukrainian
 uses a different frame: **Мені двадцять п'ять років**. Treat **Мені** as part
 of the age formula, not as a new grammar topic to unpack today.
 
-### Phone number groups
+### Групи номера телефону
 
 <Quiz client:only='react' questions={JSON.parse(`[{"question": "097", "options": [{"text": "нуль дев'яносто сім", "correct": true}, {"text": "о дев'яносто сім", "correct": false}, {"text": "нуль дев'ятдесят сім", "correct": false}], "explanation": "Say нуль; 90 is дев'яносто."}, {"question": "45", "options": [{"text": "сорок п'ять", "correct": true}, {"text": "чотиридесят п'ять", "correct": false}, {"text": "сорок пять", "correct": false}], "explanation": "45 is сорок п'ять."}, {"question": "67", "options": [{"text": "шістдесят сім", "correct": true}, {"text": "шістьдесять сім", "correct": false}, {"text": "шістдесят семь", "correct": false}], "explanation": "Use шістдесят сім."}, {"question": "321", "options": [{"text": "три два один", "correct": true}, {"text": "триста двадцять один", "correct": false}, {"text": "три дві один", "correct": false}], "explanation": "Phone numbers may be read digit by digit in a group."}, {"question": "40", "options": [{"text": "нуль п'ятдесят", "correct": true}, {"text": "о п'ятдесят", "correct": false}, {"text": "нуль п'ятьдесять", "correct": false}], "explanation": "Say нуль and п'ятдесят."}]`)} />
 
-### Phone numbers
+### Номери телефонів
 
 Ukrainian mobile numbers often appear as **+380 XX XXX XX XX**. When speaking,
 read them in small groups. Say **нуль**, not "oh."
@@ -332,7 +332,7 @@ number (**п'ятдесят шість**). The practical goal is clarity. Speak 
 pause between groups, and repeat the number back before you trust that you
 wrote it correctly.
 
-## Number Traps
+## Числові пастки
 
 Keep these repairs automatic:
 
@@ -417,43 +417,43 @@ number, or answering a simple personal question.
 </TabItem>
 <TabItem label="Activities">
 
-### Count 0-10
+### Лічи від 0 до 10
 
 *(see lesson, §Діалоги)*
 
-### Prices
+### Ціни
 
 *(see lesson, §Числа 1-20)*
 
-### Age chunks
+### Вік у фразах
 
 *(see lesson, §Десятки і сотні)*
 
-### Phone number groups
+### Групи номера телефону
 
-*(see lesson, §How old?)*
+*(see lesson, §Скільки років?)*
 
-### Write the number
+### Напиши число
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "5 = ___", "answer": "п'ять", "options": ["п'ять", "пять", "пьять"]}, {"sentence": "6 = ___", "answer": "шість", "options": ["шість", "шесть", "шисть"]}, {"sentence": "7 = ___", "answer": "сім", "options": ["сім", "сєм", "семь"]}, {"sentence": "15 = ___", "answer": "п'ятнадцять", "options": ["п'ятнадцять", "пятьнадцять", "п'ятьнадцять"]}, {"sentence": "17 = ___", "answer": "сімнадцять", "options": ["сімнадцять", "сємнадцять", "семнадцять"]}, {"sentence": "18 = ___", "answer": "вісімнадцять", "options": ["вісімнадцять", "вісемнадцять", "вісімнацять"]}, {"sentence": "20 = ___", "answer": "двадцять", "options": ["двадцять", "дванадцять", "двадцать"]}, {"sentence": "47 = ___", "answer": "сорок сім", "options": ["сорок сім", "чотиридесят сім", "сорок семь"]}, {"sentence": "50 = ___", "answer": "п'ятдесят", "options": ["п'ятдесят", "п'ятьдесять", "пятьдесят"]}, {"sentence": "90 = ___", "answer": "дев'яносто", "options": ["дев'яносто", "дев'ятдесят", "дев'яносят"]}]`)} />
 
-### 1 / 2-4 / 5+ chunks
+### Фрази 1 / 2-4 / 5+
 
 <GroupSort client:only='react' groups={JSON.parse(`{"1": ["одна гривня", "один рік", "один олівець", "одне тістечко"], "2-4": ["дві гривні", "три роки", "чотири зошити", "дві ручки"], "5+": ["п'ять гривень", "двадцять років", "десять зошитів", "шість студентів"]}`)} />
 
-### Repair number traps
+### Виправ числові пастки
 
 <ErrorCorrection client:only='react' instruction="Choose the standard Ukrainian correction." items={JSON.parse(`[{"sentence": "п'ять столи / п'ять студентів (якщо вжито як Називний множини)", "errorWord": "п'ять столи", "correctForm": "п'ять столів / п'ять студентів", "options": ["п'ять столів / п'ять студентів", "п'ять столи / п'ять студенти", "п'ять стола / п'ять студент"], "explanation": "With 5+, use the memorized chunk п'ять столів."}, {"sentence": "Який час? / Що час?", "errorWord": "Який час? / Що час?", "correctForm": "Котра година? / О котрій годині?", "options": ["Котра година? / О котрій годині?", "Який час? / Що час?", "Скільки час?"], "explanation": "For time, use the fixed formula Котра година?"}, {"sentence": "Я маю 20 років / Я є 20 років", "errorWord": "Я маю 20 років / Я є 20 років", "correctForm": "Мені 20 років", "options": ["Мені 20 років", "Я маю 20 років", "Я є 20 років"], "explanation": "Age uses the chunk Мені ... років."}, {"sentence": "перше січень / сьоме травень", "errorWord": "перше січень / сьоме травень", "correctForm": "перше січня / сьоме травня", "options": ["перше січня / сьоме травня", "перше січень / сьоме травень", "один січня / сім травня"], "explanation": "Learn dates as fixed chunks for now."}, {"sentence": "п'ятьдесять / шістьдесять", "errorWord": "п'ятьдесять / шістьдесять", "correctForm": "п'ятдесят / шістдесят", "options": ["п'ятдесят / шістдесят", "п'ятьдесять / шістьдесять", "п'ятдесять / шістьдесят"], "explanation": "Use п'ятдесят and шістдесят."}, {"sentence": "один тисяча / один мільйон", "errorWord": "один тисяча / один мільйон", "correctForm": "тисяча / мільйон", "options": ["тисяча / мільйон", "один тисяча / один мільйон", "одне тисяча / одне мільйон"], "explanation": "Use тисяча and мільйон as standalone chunks."}]`)} />
 
-### Numeral spell-check
+### Перевір правопис числівників
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "У мене ___ книг.", "answer": "п'ять", "options": ["п'ять", "пять", "пьять"]}, {"sentence": "У нашій групі ___ студентів.", "answer": "шість", "options": ["шість", "шесть", "шисть"]}, {"sentence": "На поличці ___ книжок.", "answer": "сім", "options": ["сім", "сєм", "семь"]}, {"sentence": "На картці ___ гривень.", "answer": "сімнадцять", "options": ["сімнадцять", "сємнадцять", "семнадцять"]}, {"sentence": "Мамі ___ років.", "answer": "п'ятдесят", "options": ["п'ятдесят", "пятдесят", "пятьдесят"]}, {"sentence": "Дідусеві ___ років.", "answer": "дев'яносто", "options": ["дев'яносто", "дев'ятдесят", "дев'яносят"]}, {"sentence": "Зараз ___.", "answer": "пів на шосту", "options": ["пів на шосту", "пол-шостого", "половина шостого"]}]`)} />
 
-### Choose the Ukrainian line
+### Обери український рядок
 
 <Translate client:only='react' questions={JSON.parse(`[{"source": "How much does the cake cost?", "options": [{"text": "Скільки коштує торт?", "correct": true}, {"text": "Скільки є торт?", "correct": false}, {"text": "Який коштує торт?", "correct": false}], "explanation": "Use Скільки коштує...?"}, {"source": "Two hundred hryvnias.", "options": [{"text": "Двісті гривень.", "correct": true}, {"text": "Два сто гривні.", "correct": false}, {"text": "Двісті гривні.", "correct": false}], "explanation": "Use двісті гривень."}, {"source": "I am twenty-five years old.", "options": [{"text": "Мені двадцять п'ять років.", "correct": true}, {"text": "Я маю двадцять п'ять років.", "correct": false}, {"text": "Я є двадцять п'ять років.", "correct": false}], "explanation": "Use Мені ... років."}, {"source": "She is eighteen.", "options": [{"text": "Їй вісімнадцять.", "correct": true}, {"text": "Вона має вісімнадцять.", "correct": false}, {"text": "Її вісімнадцять.", "correct": false}], "explanation": "Use Їй for the age chunk."}, {"source": "My phone number is zero ninety-seven...", "options": [{"text": "Мій номер телефону — нуль дев'яносто сім...", "correct": true}, {"text": "Мій номер телефону — о дев'яносто сім...", "correct": false}, {"text": "Мій номер телефону — нуль дев'ятдесят сім...", "correct": false}], "explanation": "Say нуль and дев'яносто."}, {"source": "250 hryvnias.", "options": [{"text": "Двісті п'ятдесят гривень.", "correct": true}, {"text": "Двасто п'ятьдесять гривень.", "correct": false}, {"text": "Двісті п'ятдесят гривні.", "correct": false}], "explanation": "Use двісті п'ятдесят гривень."}]`)} />
 
-### Quick number checkpoint
+### Швидка перевірка чисел
 
 <TrueFalse client:only='react' items={JSON.parse(`[{"statement": "П'ять зошитів.", "isTrue": true, "explanation": "This is the safe 5+ chunk."}, {"statement": "П'ять столи.", "isTrue": false, "explanation": "Say п'ять столів."}, {"statement": "Мені двадцять один рік.", "isTrue": true, "explanation": "Numbers ending in 1 use рік, except 11."}, {"statement": "Мені двадцять чотири роки.", "isTrue": true, "explanation": "Numbers ending in 2-4 use роки, except 12-14."}, {"statement": "Я маю двадцять років.", "isTrue": false, "explanation": "Use Мені двадцять років."}, {"statement": "Нуль дев'яносто сім.", "isTrue": true, "explanation": "This is a natural phone-number group."}, {"statement": "П'ятдесят гривень.", "isTrue": true, "explanation": "П'ятдесят is the standard form for 50."}, {"statement": "Один тисяча гривень.", "isTrue": false, "explanation": "Use тисяча гривень."}]`)} />
 

--- a/starlight/src/content/docs/a1/special-signs.mdx
+++ b/starlight/src/content/docs/a1/special-signs.mdx
@@ -88,7 +88,7 @@ By the end, you can:
 - sort words into **м'яки́й знак**, **апо́строф**, and **без зна́ка**;
 - choose the safer form when a visual habit creates a mistake.
 
-## Йотовані голосні first
+## Йотовані голосні
 
 **Я Ю Є Ї** — the four special vowel letters.
 
@@ -296,7 +296,7 @@ the sign, say what it does, then read the word.
 
 ### М'яко чи розді́льно
 
-*(see lesson, §Йотовані голосні first)*
+*(see lesson, §Йотовані голосні)*
 
 ### Що робить ь
 

--- a/starlight/src/content/docs/a1/things-have-gender.mdx
+++ b/starlight/src/content/docs/a1/things-have-gender.mdx
@@ -79,11 +79,11 @@ You are learning to store a noun with its gender cue.
 
 ## Діалоги
 
-### Who or what?
+### Хто чи що?
 
 <Quiz client:only='react' questions={JSON.parse(`[{"question": "тато", "options": [{"text": "Хто це?", "correct": true}, {"text": "Що це?", "correct": false}, {"text": "Воно?", "correct": false}], "explanation": "Тато is a person word, so ask Хто це?"}, {"question": "стіл", "options": [{"text": "Що це?", "correct": true}, {"text": "Хто це?", "correct": false}, {"text": "Вона?", "correct": false}], "explanation": "Стіл is a thing word, so ask Що це?"}, {"question": "сестра", "options": [{"text": "вона", "correct": true}, {"text": "він", "correct": false}, {"text": "воно", "correct": false}], "explanation": "Сестра is feminine."}, {"question": "брат", "options": [{"text": "він", "correct": true}, {"text": "вона", "correct": false}, {"text": "воно", "correct": false}], "explanation": "Брат is masculine."}, {"question": "книга", "options": [{"text": "вона", "correct": true}, {"text": "він", "correct": false}, {"text": "воно", "correct": false}], "explanation": "Книга is feminine."}, {"question": "вікно", "options": [{"text": "воно", "correct": true}, {"text": "вона", "correct": false}, {"text": "він", "correct": false}], "explanation": "Вікно is neuter."}]`)} />
 
-### Question words
+### Питальні слова
 
 Start with the noun question.
 
@@ -149,7 +149,7 @@ Keep these chunks whole:
 Those last two chunks preview the next module. Do not turn them into a full
 adjective table yet.
 
-### Він, вона, or воно?
+### Він, вона чи воно?
 
 <Quiz client:only='react' questions={JSON.parse(`[{"question": "стіл", "options": [{"text": "він", "correct": true}, {"text": "вона", "correct": false}, {"text": "воно", "correct": false}], "explanation": "Стіл ends in a consonant and is masculine."}, {"question": "книга", "options": [{"text": "вона", "correct": true}, {"text": "він", "correct": false}, {"text": "воно", "correct": false}], "explanation": "Книга is feminine."}, {"question": "вікно", "options": [{"text": "воно", "correct": true}, {"text": "він", "correct": false}, {"text": "вона", "correct": false}], "explanation": "Вікно is neuter."}, {"question": "телефон", "options": [{"text": "він", "correct": true}, {"text": "вона", "correct": false}, {"text": "воно", "correct": false}], "explanation": "Телефон is masculine."}, {"question": "лампа", "options": [{"text": "вона", "correct": true}, {"text": "воно", "correct": false}, {"text": "він", "correct": false}], "explanation": "Лампа is feminine."}, {"question": "ліжко", "options": [{"text": "воно", "correct": true}, {"text": "вона", "correct": false}, {"text": "він", "correct": false}], "explanation": "Ліжко is neuter."}, {"question": "тато", "options": [{"text": "він", "correct": true}, {"text": "воно", "correct": false}, {"text": "вона", "correct": false}], "explanation": "Тато is masculine because it names a male person."}, {"question": "Микола", "options": [{"text": "він", "correct": true}, {"text": "вона", "correct": false}, {"text": "воно", "correct": false}], "explanation": "Микола is a masculine name."}]`)} />
 
@@ -208,11 +208,11 @@ Support after the dialogue:
 
 **Фото** is a useful beginner word. Store it as **воно**: **моє фото**.
 
-### My object
+### Мій предмет
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "Це ___ стіл.", "answer": "мій", "options": ["мій", "моя", "моє"]}, {"sentence": "Це ___ книга.", "answer": "моя", "options": ["моя", "мій", "моє"]}, {"sentence": "Це ___ вікно.", "answer": "моє", "options": ["моє", "мій", "моя"]}, {"sentence": "Це ___ кімната.", "answer": "моя", "options": ["моя", "мій", "моє"]}, {"sentence": "Це ___ ліжко.", "answer": "моє", "options": ["моє", "моя", "мій"]}, {"sentence": "Це ___ телефон.", "answer": "мій", "options": ["мій", "моя", "моє"]}, {"sentence": "Це ___ ручка.", "answer": "моя", "options": ["моя", "мій", "моє"]}, {"sentence": "Це ___ фото.", "answer": "моє", "options": ["моє", "моя", "мій"]}]`)} />
 
-### My, my, my
+### Мій, моя, моє
 
 The possessive word follows the noun.
 
@@ -282,7 +282,7 @@ For a man:
 Keep the earlier identity rule: **Я студент. Я студентка.** Do not force
 **є** into that A1 sentence.
 
-### Profession form check
+### Форми професій
 
 <Quiz client:only='react' questions={JSON.parse(`[{"question": "She is a teacher.", "options": [{"text": "Вона вчителька.", "correct": true}, {"text": "Вона вчитель.", "correct": false}, {"text": "Воно вчителька.", "correct": false}], "explanation": "Use the feminine profession form for a woman."}, {"question": "She is a doctor.", "options": [{"text": "Вона лікарка.", "correct": true}, {"text": "Вона лікар.", "correct": false}, {"text": "Він лікарка.", "correct": false}], "explanation": "Лікарка is the feminine form."}, {"question": "He is a student.", "options": [{"text": "Він студент.", "correct": true}, {"text": "Він студентка.", "correct": false}, {"text": "Вона студент.", "correct": false}], "explanation": "Студент is the masculine form."}, {"question": "She is an actor.", "options": [{"text": "Вона акторка.", "correct": true}, {"text": "Вона актор.", "correct": false}, {"text": "Воно акторка.", "correct": false}], "explanation": "Акторка is the feminine profession form."}]`)} />
 
@@ -292,7 +292,7 @@ Some male names end in **-а**, **-я**, or **-о**: **Микола**, **Ілл�
 **Павло**. They are still **він** because they name men. Family words such as
 **тато**, **батько**, and **дядько** are also masculine.
 
-### Watch the traps
+### Пильнуй пастки
 
 Most errors come from using English habits too directly or from trusting the
 ending when the word is an exception.
@@ -362,39 +362,39 @@ repair the gender traps.
 </TabItem>
 <TabItem label="Activities">
 
-### Who or what?
+### Хто чи що?
 
 *(see lesson, §Діалоги)*
 
-### Він, вона, or воно?
+### Він, вона чи воно?
 
 *(see lesson, §Він, вона, воно)*
 
-### My object
+### Мій предмет
 
 *(see lesson, §Предмети навколо)*
 
-### Profession form check
+### Форми професій
 
 *(see lesson, §Підсумок)*
 
-### Sort by gender
+### Сортуй за родом
 
 <GroupSort client:only='react' groups={JSON.parse(`{"він / мій": ["стіл", "телефон", "зошит", "ключ", "тато"], "вона / моя": ["книга", "лампа", "кімната", "ручка", "сестра"], "воно / моє": ["вікно", "ліжко", "крісло", "дзеркало", "фото"]}`)} />
 
-### Room and bag words
+### Слова для кімнати й сумки
 
 <MatchUp client:only='react' pairs={JSON.parse(`[{"left": "стіл", "right": "table"}, {"left": "книга", "right": "book"}, {"left": "вікно", "right": "window"}, {"left": "кімната", "right": "room"}, {"left": "ліжко", "right": "bed"}, {"left": "телефон", "right": "phone"}, {"left": "ручка", "right": "pen"}, {"left": "зошит", "right": "notebook"}]`)} />
 
-### I have objects
+### У мене є предмети
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "___ мене є стіл.", "answer": "У", "options": ["У", "Це", "Хто"]}, {"sentence": "У мене ___ книга.", "answer": "є", "options": ["є", "звати", "моя"]}, {"sentence": "У ___ є телефон?", "answer": "тебе", "options": ["тебе", "мене", "мій"]}, {"sentence": "У мене є ___.", "answer": "вікно", "options": ["вікно", "він", "моя"]}, {"sentence": "Де стіл? ___ тут.", "answer": "Він", "options": ["Він", "Вона", "Воно"]}, {"sentence": "Де книга? ___ тут.", "answer": "Вона", "options": ["Вона", "Він", "Воно"]}, {"sentence": "Де вікно? ___ там.", "answer": "Воно", "options": ["Воно", "Вона", "Він"]}]`)} />
 
-### Fix gender traps
+### Виправ пастки роду
 
 <ErrorCorrection client:only='react' instruction="Choose the safer Ukrainian sentence." items={JSON.parse(`[{"sentence": "Мій книга, мій ручка (якщо говорить чоловік).", "errorWord": "Мій книга, мій ручка (якщо говорить чоловік).", "correctForm": "Моя книга, моя ручка.", "options": ["Моя книга, моя ручка.", "Мій книга, мій ручка."], "explanation": "The possessive follows the nouns книга and ручка, not the speaker."}, {"sentence": "Мій книга тут.", "errorWord": "Мій книга тут.", "correctForm": "Моя книга тут.", "options": ["Моя книга тут.", "Мій книга тут."], "explanation": "Книга is feminine, so use моя."}, {"sentence": "Мій ручка там.", "errorWord": "Мій ручка там.", "correctForm": "Моя ручка там.", "options": ["Моя ручка там.", "Мій ручка там."], "explanation": "Ручка is feminine, so use моя."}, {"sentence": "Де стіл? — Воно там. (Where is the table? — It is there.)", "errorWord": "Де стіл? — Воно там. (Where is the table? — It is there.)", "correctForm": "Де стіл? — Він там.", "options": ["Де стіл? — Він там.", "Де стіл? — Воно там."], "explanation": "Стіл is masculine, so the pronoun is він."}, {"sentence": "Це моя тато.", "errorWord": "Це моя тато.", "correctForm": "Це мій тато.", "options": ["Це мій тато.", "Це моя тато."], "explanation": "Тато is masculine."}, {"sentence": "Вона Микола.", "errorWord": "Вона Микола.", "correctForm": "Він Микола.", "options": ["Він Микола.", "Вона Микола."], "explanation": "Микола is a masculine name."}, {"sentence": "Моя собака дуже гарна.", "errorWord": "Моя собака дуже гарна.", "correctForm": "Мій собака дуже гарний.", "options": ["Мій собака дуже гарний.", "Моя собака дуже гарна."], "explanation": "Собака is masculine in Ukrainian; memorize мій собака."}, {"sentence": "Я є студент.", "errorWord": "Я є студент.", "correctForm": "Я студент.", "options": ["Я студент.", "Я є студент."], "explanation": "Present identity normally omits є."}, {"sentence": "Моє ім'я є Джон.", "errorWord": "Моє ім'я є Джон.", "correctForm": "Мене звати Джон.", "options": ["Мене звати Джон.", "Моє ім'я є Джон."], "explanation": "Мене звати... is the safe name chunk."}]`)} />
 
-### Gender-flip diagnostic
+### Перевірка роду
 
 <Quiz client:only='react' questions={JSON.parse(`[{"question": "Який у мене сильний біль у плечі!", "options": [{"text": "він", "correct": true}, {"text": "вона", "correct": false}, {"text": "воно", "correct": false}], "explanation": "Біль is masculine in Ukrainian."}, {"question": "Український степ широкий і вітряний.", "options": [{"text": "він", "correct": true}, {"text": "вона", "correct": false}, {"text": "воно", "correct": false}], "explanation": "Степ is masculine in Ukrainian."}, {"question": "Цей розпис на стіні — робота українського художника.", "options": [{"text": "він", "correct": true}, {"text": "вона", "correct": false}, {"text": "воно", "correct": false}], "explanation": "Розпис is masculine in Ukrainian."}, {"question": "Давній літопис розповідає про Київську Русь.", "options": [{"text": "він", "correct": true}, {"text": "вона", "correct": false}, {"text": "воно", "correct": false}], "explanation": "Літопис is masculine in Ukrainian."}, {"question": "Книжне / урочисте: у далеку путь.", "options": [{"text": "вона", "correct": true}, {"text": "він", "correct": false}, {"text": "воно", "correct": false}], "explanation": "Путь is feminine in this diagnostic expression."}]`)} />
 

--- a/starlight/src/content/docs/a1/what-is-it-like.mdx
+++ b/starlight/src/content/docs/a1/what-is-it-like.mdx
@@ -78,7 +78,7 @@ training the first visible pattern: noun gender plus adjective ending.
 
 ## Діалоги
 
-### Which question word?
+### Яке питальне слово?
 
 <Quiz client:only='react' questions={JSON.parse(`[{"question": "стіл", "options": [{"text": "Який?", "correct": true}, {"text": "Яка?", "correct": false}, {"text": "Яке?", "correct": false}], "explanation": "Стіл is masculine, so ask Який?"}, {"question": "книга", "options": [{"text": "Яка?", "correct": true}, {"text": "Який?", "correct": false}, {"text": "Яке?", "correct": false}], "explanation": "Книга is feminine, so ask Яка?"}, {"question": "фото", "options": [{"text": "Яке?", "correct": true}, {"text": "Яка?", "correct": false}, {"text": "Який?", "correct": false}], "explanation": "Фото is neuter in this lesson, so ask Яке?"}, {"question": "кімната", "options": [{"text": "Яка?", "correct": true}, {"text": "Який?", "correct": false}, {"text": "Які?", "correct": false}], "explanation": "Кімната is feminine."}, {"question": "книги", "options": [{"text": "Які?", "correct": true}, {"text": "Яке?", "correct": false}, {"text": "Який?", "correct": false}], "explanation": "Книги is plural, so ask Які?"}, {"question": "вікно", "options": [{"text": "Яке?", "correct": true}, {"text": "Який?", "correct": false}, {"text": "Яка?", "correct": false}], "explanation": "Вікно is neuter."}]`)} />
 
@@ -126,7 +126,7 @@ Support after the Ukrainian lines:
 Notice the short answers. You do not need **є** here. Say **Книга цікава**,
 not a word-for-word English sentence with "is."
 
-### Finish the adjective
+### Заверши прикметник
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "велик__ стіл", "answer": "ий", "options": ["ий", "а", "е"]}, {"sentence": "нов__ книга", "answer": "а", "options": ["а", "ий", "е"]}, {"sentence": "чист__ вікно", "answer": "е", "options": ["е", "ий", "а"]}, {"sentence": "стар__ фото", "answer": "е", "options": ["е", "а", "ий"]}, {"sentence": "дорог__ телефон", "answer": "ий", "options": ["ий", "а", "е"]}, {"sentence": "дешев__ листівка", "answer": "а", "options": ["а", "е", "ий"]}, {"sentence": "гарн__ кімната", "answer": "а", "options": ["а", "ий", "е"]}, {"sentence": "брудн__ дзеркало", "answer": "е", "options": ["е", "а", "ий"]}, {"sentence": "світл__ плакат", "answer": "ий", "options": ["ий", "е", "а"]}, {"sentence": "нов__ книги", "answer": "і", "options": ["і", "а", "е"]}]`)} />
 
@@ -157,7 +157,7 @@ feminine, and neuter nouns all use **-і** in the plural. Ask **які?** and sa
 **нові столи**, **нові книги**, **нові фото**. Later you will meet more plural
 details; today, just recognize **які?** plus **-і**.
 
-### Sort the chunks
+### Сортуй фрази
 
 <GroupSort client:only='react' groups={JSON.parse(`{"Який?": ["великий стіл", "новий телефон", "старий атлас", "дорогий плакат"], "Яка?": ["нова книга", "гарна листівка", "чиста кімната", "дешева ручка"], "Яке?": ["старе фото", "чисте вікно", "велике ліжко", "брудне дзеркало"], "Які?": ["нові книги", "гарні речі", "старі фото", "дешеві листівки"]}`)} />
 
@@ -225,7 +225,7 @@ Use **але** when the second idea limits the first:
 - **Кімната маленька, але гарна.**
 - **Плакат великий, але дешевий.**
 
-### Match opposites
+### Поєднай протилежності
 
 <MatchUp client:only='react' pairs={JSON.parse(`[{"left": "великий", "right": "маленький"}, {"left": "новий", "right": "старий"}, {"left": "гарний", "right": "поганий"}, {"left": "чистий", "right": "брудний"}, {"left": "дорогий", "right": "дешевий"}, {"left": "світлий", "right": "темний"}]`)} />
 
@@ -259,7 +259,7 @@ Cover the English and answer aloud:
 - **Який стіл?** — **Новий і чистий.**
 - **Яке ліжко?** — **Старе, але зручне.**
 
-### Watch the traps
+### Пильнуй пастки
 
 Adjectives are a common interference zone. Keep Ukrainian on its own terms.
 Do not explain endings through another language, and do not trust look-alike
@@ -339,43 +339,43 @@ the adjective traps.
 </TabItem>
 <TabItem label="Activities">
 
-### Which question word?
+### Яке питальне слово?
 
 *(see lesson, §Діалоги)*
 
-### Finish the adjective
+### Заверши прикметник
 
 *(see lesson, §Діалоги)*
 
-### Sort the chunks
+### Сортуй фрази
 
 *(see lesson, §Який? Яка? Яке?)*
 
-### Match opposites
+### Поєднай протилежності
 
 *(see lesson, §Прикметники)*
 
-### Sentence frame
+### Модель речення
 
 <Quiz client:only='react' questions={JSON.parse(`[{"question": "The book is new.", "options": [{"text": "Книга нова.", "correct": true}, {"text": "Книга є нова.", "correct": false}, {"text": "Книга новий.", "correct": false}], "explanation": "Ukrainian usually leaves out є in this present-tense frame."}, {"question": "The table is clean.", "options": [{"text": "Стіл чистий.", "correct": true}, {"text": "Стіл чиста.", "correct": false}, {"text": "Стіл є чистий.", "correct": false}], "explanation": "Стіл is masculine, and the no-є frame is natural."}, {"question": "The window is big.", "options": [{"text": "Вікно велике.", "correct": true}, {"text": "Вікно великий.", "correct": false}, {"text": "Вікно велика.", "correct": false}], "explanation": "Вікно is neuter."}, {"question": "A nice postcard", "options": [{"text": "гарна листівка", "correct": true}, {"text": "гарний листівка", "correct": false}, {"text": "гарне листівка", "correct": false}], "explanation": "Листівка is feminine."}, {"question": "A useful atlas", "options": [{"text": "корисний атлас", "correct": true}, {"text": "корисна атлас", "correct": false}, {"text": "корисне атлас", "correct": false}], "explanation": "Атлас is masculine."}, {"question": "Interesting things", "options": [{"text": "цікаві речі", "correct": true}, {"text": "цікава речі", "correct": false}, {"text": "цікаве речі", "correct": false}], "explanation": "Plural chunks use цікаві."}]`)} />
 
-### Describe the room
+### Опиши кімнату
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "Моя кімната ___ і світла.", "answer": "маленька", "options": ["маленька", "маленький", "маленьке"]}, {"sentence": "Стіл ___ і чистий.", "answer": "новий", "options": ["новий", "нова", "нове"]}, {"sentence": "Ліжко старе, ___ зручне.", "answer": "але", "options": ["але", "який", "яка"]}, {"sentence": "Вікно ___ і чисте.", "answer": "велике", "options": ["велике", "великий", "велика"]}, {"sentence": "Книга дорога, ___ листівка дешева.", "answer": "а", "options": ["а", "і", "яке"]}, {"sentence": "У мене є ___ стіл і стара лампа.", "answer": "новий", "options": ["новий", "нова", "нове"]}]`)} />
 
-### Repair adjective agreement
+### Виправ узгодження прикметників
 
 <ErrorCorrection client:only='react' instruction="Fix the adjective or sentence frame." items={JSON.parse(`[{"sentence": "Він є добрий студент.", "errorWord": "Він є добрий студент.", "correctForm": "Він добрий студент.", "options": ["Він добрий студент.", "Він добра студент.", "Він є добра студент."], "explanation": "In this present-tense frame, Ukrainian normally omits є."}, {"sentence": "Це гарна хлопець.", "errorWord": "Це гарна хлопець.", "correctForm": "Це гарний хлопець.", "options": ["Це гарний хлопець.", "Це гарне хлопець.", "Це гарна хлопець."], "explanation": "Хлопець is masculine."}, {"sentence": "Який твоє ім'я?", "errorWord": "Який твоє ім'я?", "correctForm": "Яке твоє ім'я? (або: Як тебе звати?)", "options": ["Яке твоє ім'я? (або: Як тебе звати?)", "Яка твоє ім'я?", "Який твоє ім'я?"], "explanation": "Ім'я is neuter; in real introductions, use Як тебе звати?"}, {"sentence": "Вона читає цікавий книжку.", "errorWord": "Вона читає цікавий книжку.", "correctForm": "Вона читає цікаву книжку.", "options": ["Вона читає цікаву книжку.", "Вона читає цікавий книжку.", "Вона читає цікаве книжку."], "explanation": "This is an object form; notice that adjective and noun move together."}, {"sentence": "Моя мамалига смачний.", "errorWord": "Моя мамалига смачний.", "correctForm": "Моя мамалига смачна.", "options": ["Моя мамалига смачна.", "Моя мамалига смачний.", "Моя мамалига смачне."], "explanation": "Мамалига is feminine, so use смачна."}, {"sentence": "Це мій синій ручка.", "errorWord": "Це мій синій ручка.", "correctForm": "Це моя синя ручка.", "options": ["Це моя синя ручка.", "Це мій синій ручка.", "Це моє синє ручка."], "explanation": "Ручка is feminine, and синій is a soft-stem adjective."}]`)} />
 
-### Adjective trap repair
+### Виправ прикметникові пастки
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "Цей суп дуже ___.", "answer": "смачний", "options": ["смачний", "вкусний"]}, {"sentence": "У мене є ___ олівець.", "answer": "жовтий", "options": ["жовтий", "жолтий"]}, {"sentence": "У сусідки ___ кіт.", "answer": "чорний", "options": ["чорний", "черний"]}, {"sentence": "Прапор ___, а не білий.", "answer": "червоний", "options": ["червоний", "красний"]}, {"sentence": "Це ___ фільм.", "answer": "поганий", "options": ["поганий", "плохий"]}, {"sentence": "Це ___ відповідь на запитання.", "answer": "правильна", "options": ["правильна", "вірна"]}, {"sentence": "Дай мені, будь ласка, ___ олівець.", "answer": "будь-який", "options": ["будь-який", "любий"]}, {"sentence": "Сергій — ___ хлопчик.", "answer": "розумний", "options": ["розумний", "умний"]}, {"sentence": "Тарас — ___ учень.", "answer": "лінивий", "options": ["лінивий", "ленивий"]}]`)} />
 
-### Choose the Ukrainian line
+### Обери український рядок
 
 <Translate client:only='react' questions={JSON.parse(`[{"source": "My room is small but nice.", "options": [{"text": "Моя кімната маленька, але гарна.", "correct": true}, {"text": "Мій кімната маленький, але гарний.", "correct": false}, {"text": "Моє кімната маленьке, але гарне.", "correct": false}], "explanation": "Кімната is feminine."}, {"source": "The table is new and clean.", "options": [{"text": "Стіл новий і чистий.", "correct": true}, {"text": "Стіл нова і чиста.", "correct": false}, {"text": "Стіл нове і чисте.", "correct": false}], "explanation": "Стіл is masculine."}, {"source": "The photo is old.", "options": [{"text": "Фото старе.", "correct": true}, {"text": "Фото стара.", "correct": false}, {"text": "Фото старий.", "correct": false}], "explanation": "Фото is neuter in this lesson."}, {"source": "A cheap postcard", "options": [{"text": "дешева листівка", "correct": true}, {"text": "дешевий листівка", "correct": false}, {"text": "дешеве листівка", "correct": false}], "explanation": "Листівка is feminine."}, {"source": "Good afternoon.", "options": [{"text": "Добрий день.", "correct": true}, {"text": "Добра день.", "correct": false}, {"text": "Добре день.", "correct": false}], "explanation": "День is masculine, so the greeting is Добрий день."}, {"source": "The books are interesting.", "options": [{"text": "Книги цікаві.", "correct": true}, {"text": "Книги цікава.", "correct": false}, {"text": "Книги цікаве.", "correct": false}], "explanation": "Plural chunks use цікаві."}]`)} />
 
-### Quick checkpoint
+### Швидка перевірка
 
 <TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Стіл новий.", "isTrue": true, "explanation": "Стіл is masculine, so новий is correct."}, {"statement": "Книга нове.", "isTrue": false, "explanation": "Книга is feminine; say Книга нова."}, {"statement": "Вікно чисте.", "isTrue": true, "explanation": "Вікно is neuter."}, {"statement": "Який кімната?", "isTrue": false, "explanation": "Кімната is feminine; ask Яка кімната?"}, {"statement": "Кімната маленька, але гарна.", "isTrue": true, "explanation": "Both adjectives agree with кімната."}, {"statement": "В українській можна описати річ без є: Книга цікава.", "isTrue": true, "explanation": "This no-є present-tense frame is normal."}]`)} />
 


### PR DESCRIPTION
## Summary
- localize learner-facing headings in A1 modules 03, 07, 08, 09, 10, and 11
- localize rendered activity titles for modules 08-11
- regenerate the six affected A1 MDX pages only

## Validation
- npm exec -- markdownlint-cli2 changed module.md and MDX files
- .venv/bin/yamllint changed activities.yaml files
- .venv/bin/python scripts/audit/check_mdx_source_parity.py --changed-vs-base origin/main
- .venv/bin/python scripts/audit/check_mdx_generation_drift.py --files six touched module.md files
- git diff --check
- npm run build:starlight
- rendered sweep of all 55 A1 routes: 0 bad-pattern hits, 0 missing expected labels, rogue route 404
- Gemini no-tool diff review: PASS
- .venv/bin/python scripts/audit/lint_agent_trailer.py