### PR TITLE
feat(gate): morphology fallback — VESUM-gap inflections + negated participles (folk unblock #2)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -8189,6 +8189,68 @@ def _engine_classifies_authentic(candidate: str) -> bool:
     )
 
 
+def _engine_flags_russianism(candidate: str) -> bool:
+    """True iff the shared classifier directly flags ``candidate`` as a russianism.
+
+    Such a form must NEVER be morphology-rescued via a standard base: e.g. the
+    russianism ``діюча`` (→ чинна/дійова) lemmatises to the standard verb ``діяти``,
+    but ``діюча`` itself stays a russianism and must remain flagged. Degrades to
+    ``False`` when the classifier is unavailable (CI) — the independent russianism
+    gates still apply."""
+    try:
+        from scripts.lexicon.heritage_classifier import classify_surface_form
+
+        return bool(classify_surface_form(candidate).get("is_russianism", False))
+    except Exception:
+        return False
+
+
+_UK_MORPH_ANALYZER: Any = None
+_UK_MORPH_ANALYZER_TRIED = False
+
+
+def _uk_morph_analyzer() -> Any:
+    """Lazy Ukrainian morphological analyzer (pymorphy3); None if unavailable."""
+    global _UK_MORPH_ANALYZER, _UK_MORPH_ANALYZER_TRIED
+    if not _UK_MORPH_ANALYZER_TRIED:
+        _UK_MORPH_ANALYZER_TRIED = True
+        try:
+            import pymorphy3
+
+            _UK_MORPH_ANALYZER = pymorphy3.MorphAnalyzer(lang="uk")
+        except Exception:
+            _UK_MORPH_ANALYZER = None
+    return _UK_MORPH_ANALYZER
+
+
+def _morphological_base_candidates(word: str) -> set[str]:
+    """Derived bases offered to the heritage classifier for an authentic-vocabulary
+    surface form: the lemma (resolving oblique inflections of dialectal words, e.g.
+    ``гагілку``→``гагілка``, ``ягілками``→``ягілка``) and a regular ``не``-stripped
+    base (negated participles, e.g. ``незгладжений``→``згладжений``).
+
+    A base is only *offered* — it is accepted solely when the classifier itself rules
+    it authentic-and-not-russianism, so coinages (``обрядознавчий``) and russianisms
+    (``протиріччя``) that lemmatise to themselves stay flagged and the russianism guard
+    is untouched. Empty when the analyzer is unavailable (CI), leaving the surface-form
+    + committed-allowlist checks unchanged. Secondary-imperfective aspect pairs
+    (``виворожувати``←``виворожити``) are NOT derived here — that is a separate
+    follow-up; they remain flagged for now."""
+    candidates: set[str] = set()
+    analyzer = _uk_morph_analyzer()
+    if analyzer is not None:
+        try:
+            for parse in analyzer.parse(word)[:3]:
+                lemma = (parse.normal_form or "").strip().lower()
+                if lemma and lemma != word:
+                    candidates.add(lemma)
+        except Exception:
+            pass
+    if word.startswith("не") and len(word) > 4:
+        candidates.add(word[2:])
+    return candidates
+
+
 def _resolve_folk_heritage_attested_missing(
     missing_lc: set[str],
     unchecked_pairs: Sequence[tuple[str, str, str]],
@@ -8216,7 +8278,21 @@ def _resolve_folk_heritage_attested_missing(
         if attestation_index and any(candidate in attestation_index for candidate in candidates):
             attested.add(word)
             continue
-        if any(_engine_classifies_authentic(candidate) for candidate in candidates):
+        # Russianism guard: never morphology-rescue a form the classifier directly
+        # flags as a russianism. A russianism participle/adjective lemmatises to its
+        # standard verb root (діюча→діяти), which would otherwise leak it through —
+        # but діюча itself must stay flagged. This keeps the gate's teeth.
+        if any(_engine_flags_russianism(candidate) for candidate in candidates):
+            continue
+        # Offer each surface candidate plus its morphological bases (lemma + regular
+        # `не`-stripped base) to the classifier. This resolves oblique inflections of
+        # dialectal words (гагілку→гагілка) and negated participles of standard bases
+        # (незгладжений→згладжений) that VESUM does not enumerate — VESUM-absence of a
+        # valid inflected form, not a russianism.
+        engine_candidates = set(candidates)
+        for candidate in candidates:
+            engine_candidates |= _morphological_base_candidates(candidate)
+        if any(_engine_classifies_authentic(candidate) for candidate in engine_candidates):
             attested.add(word)
     return attested
 

--- a/tests/test_vesum_heritage_attestation.py
+++ b/tests/test_vesum_heritage_attestation.py
@@ -147,3 +147,52 @@ def test_folk_vesum_gate_still_rejects_unknown_coinage_via_engine() -> None:
     assert gate["passed"] is False
     assert gate["missing"] == ["городалька"]
     assert gate["heritage_attested"] == 0
+
+
+# --- Morphology fallback: VESUM-gap inflections + negated participles ------
+# VESUM enumerates the headword of a dialectal noun (гагілка) but not every
+# oblique case (гагілку, ягілками), and not the regular `не`-negation of a
+# standard participle (незгладжений←згладжений). The gate lemmatises / strips
+# `не` and re-checks the base via the classifier, so valid inflected Ukrainian
+# passes — while russianisms and coinages stay flagged.
+
+
+@requires_sources_db
+def test_folk_vesum_gate_accepts_oblique_inflections_of_dialect_words() -> None:
+    # гагілку (acc.sg) / ягілками (instr.pl): lemma → гагілка / ягілка → dialect.
+    gate = _gate("гагілку ягілками")
+
+    assert gate["passed"] is True
+    assert gate["missing"] == []
+    assert gate["heritage_attested"] == 2
+
+
+@requires_sources_db
+def test_folk_vesum_gate_accepts_negated_participles_of_standard_bases() -> None:
+    # незгладжений / непідперта: strip `не` → згладжений / підперта → standard.
+    gate = _gate("незгладжений непідперта")
+
+    assert gate["passed"] is True
+    assert gate["missing"] == []
+    assert gate["heritage_attested"] == 2
+
+
+@requires_sources_db
+def test_morphology_fallback_does_not_leak_russianism_via_verb_root() -> None:
+    # CRITICAL teeth check: `діюча` is a russianism (→ чинна/дійова) whose lemma is
+    # the *standard* verb `діяти`. The russianism guard must stop the morphology
+    # rescue from leaking it — `діюча` stays flagged despite a standard lemma.
+    gate = _gate("діюча")
+
+    assert gate["passed"] is False
+    assert gate["missing"] == ["діюча"]
+    assert gate["heritage_attested"] == 0
+
+
+def test_morphology_fallback_does_not_apply_to_core_levels() -> None:
+    # The heritage/morphology fallback is seminar/folk-scoped only.
+    gate = _gate("гагілку", level="a1")
+
+    assert gate["passed"] is False
+    assert gate["missing"] == ["гагілку"]
+    assert gate["heritage_attested"] == 0


### PR DESCRIPTION
## What
Extends the #2931 heritage-classifier consumption in `_vesum_gate`. VESUM enumerates a dialectal noun's headword (`гагілка`) but **not every oblique case** (`гагілку` acc., `ягілками` instr.pl.), nor the regular `не`-negation of a standard participle (`незгладжений`←`згладжений`). These are VESUM-absent **valid inflected Ukrainian**, not russianisms — the kalendarna folk rebuild failed `python_qg` on exactly this class (2 builds, classes 1+2 of the diagnosis).

## How
For a still-missing surface form, offer the classifier two **derived bases** and accept only when the classifier itself rules the base authentic-and-not-russianism:
- **lemma** (pymorphy3-uk) → resolves oblique inflections: `гагілку`→`гагілка` (dialect)
- **`не`-stripped base** → negated participles: `незгладжений`→`згладжений` (standard)

Consumes the shared engine (no duplication of classification logic — the gate just hands it better candidates, same pattern as the existing case/syllable/hyphen fallbacks). **Seminar/folk-scoped**; degrades to surface-form + allowlist checks when pymorphy3-uk or the corpus DB is absent (CI).

## ⚠️ Teeth guard (the critical bit — found during validation)
A russianism participle lemmatises to its **standard verb root** — `діюча` (→ чинна/дійова) → lemma `діяти` (standard). My first version **leaked `діюча` through**. Guard added: **never morphology-rescue a form the classifier directly flags `is_russianism`**. Verified `діюча`/`протиріччя` stay flagged.

## Validated (gate-level, against data/sources.db)
| input | result |
|---|---|
| `гагілку ягілками` (inflection) | ✅ pass, heritage_attested=2 |
| `незгладжений непідперта` (negation) | ✅ pass, heritage_attested=2 |
| `діюча` / `протиріччя` (russianism) | ⛔ flagged (teeth) |
| `обрядознавчих двохорова` (coinage) | ⛔ flagged |
| `другоє ягілки` (#2931 regression) | ✅ pass |
| `гагілку` @ a1 (core) | ⛔ flagged (no fallback) |

**69 passed** across the vesum suite, ruff clean.

## Not in scope
Secondary-imperfective aspect pairs (`виворожувати`←`виворожити`) — harder (aspect pairing); stays flagged, separate follow-up. Genuine coinages (`обрядознавчий`) correctly stay flagged → writer rephrases.

## Review
Cross-track gate change, teeth-critical — **requesting cross-family (deepseek) review before merge.** Folk driver lane; this is the gate-side morphology fallback per today's convergence (orchestrator opted gate-side). Unblocks the kalendarna re-fire.