### PR TITLE
fix(a1): restore first-contact M01 lesson

### DIFF
--- a/curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml
+++ b/curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml
@@ -1,290 +1,448 @@
-version: '1.0'
-module: 'sounds-letters-and-hello'
-level: 'a1'
-
-inline:
-  - id: act-1
-    type: quiz
-    title: Звук чи лі́тера
-    instruction: Обери правильну опору.
+- id: act-1
+  type: quiz
+  title: Sound or letter?
+  instruction: Choose the correct answer.
+  items:
+  - prompt: What is a звук?
+    options:
+    - text: A sound you hear and say
+      correct: true
+    - text: A letter you see and write
+      correct: false
+    - text: A whole sentence
+      correct: false
+    explanation: A звук belongs to hearing and speaking.
+  - prompt: What is a лі́тера?
+    options:
+    - text: A letter you see and write
+      correct: true
+    - text: A sound you hear and say
+      correct: false
+    - text: A greeting
+      correct: false
+    explanation: A лі́тера belongs to reading and writing.
+  - prompt: How many letters are in the Ukrainian alphabet?
+    options:
+    - text: '33'
+      correct: true
+    - text: '38'
+      correct: false
+    - text: '6'
+      correct: false
+    explanation: Ukrainian has 33 letters.
+  - prompt: How many basic Ukrainian vowel sounds are there?
+    options:
+    - text: '6'
+      correct: true
+    - text: '10'
+      correct: false
+    - text: '33'
+      correct: false
+    explanation: The six basic vowel sounds are [а], [о], [у], [е], [и], [і].
+  - prompt: Does ь have its own sound?
+    options:
+    - text: 'No'
+      correct: true
+    - text: 'Yes'
+      correct: false
+    - text: Only in Приві́т
+      correct: false
+    explanation: The soft sign ь has no sound of its own.
+  - prompt: What does Приві́т mean?
+    options:
+    - text: Hi
+      correct: true
+    - text: Goodbye
+      correct: false
+    - text: Milk
+      correct: false
+    explanation: Приві́т is the informal word for Hi.
+- id: act-2
+  type: count-syllables
+  title: Count склади
+  instruction: Count vowel sounds. Each vowel sound makes one склад.
+  max_count: 3
+  items:
+  - word: день
+    correct: 1
+  - word: ма́ма
+    correct: 2
+  - word: Приві́т
+    correct: 2
+  - word: молоко́
+    correct: 3
+  - word: та́то
+    correct: 2
+  - word: о́ко
+    correct: 2
+- id: act-3
+  type: watch-and-repeat
+  title: Full alphabet pronunciation pass
+  instruction: Watch the pronunciation model, say the letter, and repeat the key word.
+  items:
+  - letter: А
+    word: анана́с
+    video: https://www.youtube.com/watch?v=hvB3VpcR3ZE
+  - letter: Б
+    word: бана́н
+    video: https://www.youtube.com/watch?v=V1hxBE_JbGg
+  - letter: В
+    word: вода́
+    video: https://www.youtube.com/watch?v=aFcvYfvQ2X4
+  - letter: Г
+    word: гора́
+    video: https://www.youtube.com/watch?v=gVnclpSI0DU
+  - letter: Ґ
+    word: ґу́дзик
+    video: https://www.youtube.com/watch?v=gNjHqjTW9WQ
+  - letter: Д
+    word: дім
+    video: https://www.youtube.com/watch?v=g4Bh-lqzd48
+  - letter: Е
+    word: екра́н
+    video: https://www.youtube.com/watch?v=KFlsroBW0dk
+  - letter: Є
+    word: єно́т
+    video: https://www.youtube.com/watch?v=O0bwRyyBQSc
+  - letter: Ж
+    word: жук
+    video: https://www.youtube.com/watch?v=dIrGVcqPwqM
+  - letter: З
+    word: зуб
+    video: https://www.youtube.com/watch?v=BhASNxitC1A
+  - letter: И
+    word: сир
+    video: https://www.youtube.com/watch?v=W-1rCu0indE
+  - letter: І
+    word: ім'я́
+    video: https://www.youtube.com/watch?v=Z9TH0H4ShGo
+  - letter: Ї
+    word: їжа́к
+    video: https://www.youtube.com/watch?v=UcjdjQXhAY8
+  - letter: Й
+    word: йо́гурт
+    video: https://www.youtube.com/watch?v=aq0cjB90s3w
+  - letter: К
+    word: кіт
+    video: https://www.youtube.com/watch?v=J7sGEI4-xJo
+  - letter: Л
+    word: лимо́н
+    video: https://www.youtube.com/watch?v=v6-3Xg52Buk
+  - letter: М
+    word: ма́ма
+    video: https://www.youtube.com/watch?v=Ez95H4ibuJo
+  - letter: Н
+    word: ніс
+    video: https://www.youtube.com/watch?v=vNUfiKHPYaU
+  - letter: О
+    word: о́ко
+    video: https://www.youtube.com/watch?v=gJFxRIPRZbI
+  - letter: П
+    word: пес
+    video: https://www.youtube.com/watch?v=JksSjjxyW5Y
+  - letter: Р
+    word: рука́
+    video: https://www.youtube.com/watch?v=fMGsQ5KPQgg
+  - letter: С
+    word: сон
+    video: https://www.youtube.com/watch?v=7UsFBgSL91E
+  - letter: Т
+    word: та́то
+    video: https://www.youtube.com/watch?v=m-jcLR_gK0k
+  - letter: У
+    word: уро́к
+    video: https://www.youtube.com/watch?v=VB1O6PmtYRU
+  - letter: Ф
+    word: фо́то
+    video: https://www.youtube.com/watch?v=haHRsFFZRQI
+  - letter: Х
+    word: ха́та
+    video: https://www.youtube.com/watch?v=vpr58zJSJKc
+  - letter: Ц
+    word: цу́кор
+    video: https://www.youtube.com/watch?v=u44eCjR2Oz8
+  - letter: Ч
+    word: час
+    video: https://www.youtube.com/watch?v=UsJkbdsY2RA
+  - letter: Ш
+    word: шко́ла
+    video: https://www.youtube.com/watch?v=1D-6MIw3OXY
+  - letter: Щ
+    word: щу́ка
+    video: https://www.youtube.com/watch?v=QmBLieIuf6Q
+  - letter: Ь
+    word: день
+    video: https://www.youtube.com/watch?v=cJlal8XKBxo
+  - letter: Ю
+    word: ю́шка
+    video: https://www.youtube.com/watch?v=9JdIBYCTWGw
+  - letter: Я
+    word: я́блуко
+    video: https://www.youtube.com/watch?v=yhSAf41LX8I
+- id: act-4
+  type: quiz
+  title: Find the useful letters
+  instruction: Choose the letter or sign that matches the clue.
+  items:
+  - question: Which letter is the hard g sound?
+    options:
+    - Ґ
+    - Г
+    - Ї
+    correct: 0
+    explanation: Ґ is the hard g sound; Г is the Ukrainian h-like sound.
+  - question: Which letter is always [йі]?
+    options:
+    - Ї
+    - І
+    - И
+    correct: 0
+    explanation: Ї is always [йі]. І is the plain [і] vowel.
+  - question: Which sign has no sound of its own?
+    options:
+    - Ь
+    - Й
+    - Я
+    correct: 0
+    explanation: Ь is the soft sign; it changes the previous consonant.
+  - question: Which letter is the clean [о] sound in молоко́?
+    options:
+    - О
+    - А
+    - У
+    correct: 0
+    explanation: Ukrainian О stays clean in молоко́.
+  - question: In Приві́т, which two vowel letters are different?
+    options:
+    - И and І
+    - О and У
+    - А and Е
+    correct: 0
+    explanation: Приві́т contains both И [и] and І [і].
+- id: act-5
+  type: fill-in
+  title: First conversations
+  instruction: Choose the phrase that completes the line.
+  items:
+  - sentence: ____! Як спра́ви?
+    answer: Приві́т
+    options:
+    - Приві́т
+    - Молоко́
+    - Лі́тера
+  - sentence: ____. А у тебе́?
+    answer: До́бре
+    options:
+    - До́бре
+    - День
+    - Звук
+  - sentence: Як тебе́ ____?
+    answer: зва́ти
+    options:
+    - зва́ти
+    - до́бре
+    - день
+  - sentence: Ме́не ____ Анна.
+    answer: зва́ти
+    options:
+    - зва́ти
+    - спра́ви
+    - звук
+  - sentence: До ____!
+    answer: поба́чення
+    options:
+    - поба́чення
+    - тебе́
+    - ма́ма
+  - sentence: На все ____!
+    answer: до́бре
+    options:
+    - до́бре
+    - лі́тера
+    - звук
+- id: act-6
+  type: true-false
+  title: Pronunciation safety check
+  instruction: Choose true or false.
+  items:
+  - statement: In молоко́, every о stays clean.
+    correct: true
+    explanation: Ukrainian о does not blur into а in this beginner model.
+  - statement: The letters и and і always sound the same.
+    correct: false
+    explanation: Приві́т contains both [и] and [і].
+  - statement: Ь has no sound of its own.
+    correct: true
+    explanation: Ь softens the previous consonant.
+  - statement: Ї is always [йі].
+    correct: true
+    explanation: Treat Ї as [йі] at this level.
+  - statement: Г and Ґ are the same letter.
+    correct: false
+    explanation: Г is h-like; Ґ is hard g.
+  - statement: Щ is [шч].
+    correct: true
+    explanation: Щ represents two sounds together.
+- id: act-7
+  type: group-sort
+  title: Vowel or consonant sound?
+  instruction: Sort the sounds, not the letters.
+  groups:
+  - label: Vowel sounds
     items:
-      - question: Звук — що ми робимо?
-        options:
-          - бачимо на сторі́нці
-          - чуємо й вимовля́ємо
-          - ставимо апо́строф
-        correct: 1
-        explanation: Звук — це те, що ми чуємо й вимовля́ємо.
-      - question: Лі́тера — що ми робимо?
-        options:
-          - бачимо й пишемо
-          - чуємо без сторі́нки
-          - рахуємо як склад
-        correct: 0
-        explanation: Лі́тера — це письмовий знак.
-      - question: Українська абе́тка — скільки лі́тер?
-        options:
-          - '38'
-          - '33'
-          - '6'
-        correct: 1
-        explanation: Стандартна українська абе́тка має 33 лі́тери.
-      - question: Я, Ю, Є, Ї — чому вони особливі?
-        options:
-          - мають більше ніж одну роботу
-          - завжди мовчать
-          - завжди є при́голосними
-        correct: 0
-        explanation: Деякі українські лі́тери мають більше ніж одну роботу.
-      - question: Ь — що правильно?
-        options:
-          - має власний голосни́й звук
-          - не має власного звука
-          - це літера О
-        correct: 1
-        explanation: Ь не має власного звука.
-      - question: Молоко́ — скільки голосних звуків?
-        options:
-          - два
-          - три
-          - один
-        correct: 1
-        explanation: 'Молоко́ має три голосні звуки: о + о + о.'
-
-  - id: act-2
-    type: count-syllables
-    title: Кількість складів
-    instruction: Рахуй голосні звуки в слові.
-    maxCount: 3
+    - '[а]'
+    - '[о]'
+    - '[у]'
+    - '[е]'
+    - '[и]'
+    - '[і]'
+  - label: Consonant sounds
     items:
-      - word: ма́ма
-        correct: 2
-      - word: молоко́
-        correct: 3
-      - word: вода́
-        correct: 2
-      - word: приві́т
-        correct: 2
-      - word: о́ко
-        correct: 2
-      - word: та́то
-        correct: 2
-
-  - id: act-3
-    type: match-up
-    title: Звук і літера
-    instruction: З'єднай літеру з її звуком або функцією.
-    pairs:
-      - left: І
-        right: '[і]'
-      - left: В
-        right: '[в]'
-      - left: А
-        right: '[а]'
-      - left: О
-        right: '[о]'
-      - left: У
-        right: '[у]'
-      - left: Н
-        right: '[н]'
-      - left: Ч
-        right: '[ч]'
-      - left: Ь
-        right: м'якшить попередній при́голосний
-      - left: Я
-        right: "[йа] або м'якшить попередній при́голосний"
-      - left: Ї
-        right: '[йі]'
-      - left: Щ
-        right: '[шч]'
-      - left: Д
-        right: '[д]'
-
-  - id: act-4
-    type: watch-and-repeat
-    title: Алфавітний повтор
-    instruction: Дивись відео, проговорюй літеру, звук і слово.
-    items:
-      - letter: А
-        word: анана́с
-        video: https://www.youtube.com/watch?v=hvB3VpcR3ZE
-      - letter: Б
-        word: банду́ра
-        video: https://www.youtube.com/watch?v=V1hxBE_JbGg
-      - letter: В
-        word: вода́
-        video: https://www.youtube.com/watch?v=aFcvYfvQ2X4
-      - letter: Г
-        word: гора́
-        video: https://www.youtube.com/watch?v=gVnclpSI0DU
-      - letter: Ґ
-        word: ґу́дзик
-        video: https://www.youtube.com/watch?v=gNjHqjTW9WQ
-      - letter: Д
-        word: дім
-        video: https://www.youtube.com/watch?v=g4Bh-lqzd48
-      - letter: Е
-        word: екра́н
-        video: https://www.youtube.com/watch?v=KFlsroBW0dk
-      - letter: Є
-        word: єно́т
-        video: https://www.youtube.com/watch?v=O0bwRyyBQSc
-      - letter: Ж
-        word: жук
-        video: https://www.youtube.com/watch?v=dIrGVcqPwqM
-      - letter: З
-        word: зуб
-        video: https://www.youtube.com/watch?v=BhASNxitC1A
-      - letter: И
-        word: сир
-        video: https://www.youtube.com/watch?v=W-1rCu0indE
-      - letter: І
-        word: ім'я́
-        video: https://www.youtube.com/watch?v=Z9TH0H4ShGo
-      - letter: Ї
-        word: їжа́к
-        video: https://www.youtube.com/watch?v=UcjdjQXhAY8
-      - letter: Й
-        word: йо́гурт
-        video: https://www.youtube.com/watch?v=aq0cjB90s3w
-      - letter: К
-        word: кіт
-        video: https://www.youtube.com/watch?v=J7sGEI4-xJo
-      - letter: Л
-        word: лис
-        video: https://www.youtube.com/watch?v=v6-3Xg52Buk
-      - letter: М
-        word: ма́ма
-        video: https://www.youtube.com/watch?v=Ez95H4ibuJo
-      - letter: Н
-        word: ніс
-        video: https://www.youtube.com/watch?v=vNUfiKHPYaU
-      - letter: О
-        word: о́ко
-        video: https://www.youtube.com/watch?v=gJFxRIPRZbI
-      - letter: П
-        word: піт
-        video: https://www.youtube.com/watch?v=JksSjjxyW5Y
-      - letter: Р
-        word: рука́
-        video: https://www.youtube.com/watch?v=fMGsQ5KPQgg
-      - letter: С
-        word: сон
-        video: https://www.youtube.com/watch?v=7UsFBgSL91E
-      - letter: Т
-        word: та́то
-        video: https://www.youtube.com/watch?v=m-jcLR_gK0k
-      - letter: У
-        word: уро́к
-        video: https://www.youtube.com/watch?v=VB1O6PmtYRU
-      - letter: Ф
-        word: фо́то
-        video: https://www.youtube.com/watch?v=haHRsFFZRQI
-      - letter: Х
-        word: ха́та
-        video: https://www.youtube.com/watch?v=vpr58zJSJKc
-      - letter: Ц
-        word: цу́кор
-        video: https://www.youtube.com/watch?v=u44eCjR2Oz8
-      - letter: Ч
-        word: час
-        video: https://www.youtube.com/watch?v=UsJkbdsY2RA
-      - letter: Ш
-        word: шко́ла
-        video: https://www.youtube.com/watch?v=1D-6MIw3OXY
-      - letter: Щ
-        word: щу́ка
-        video: https://www.youtube.com/watch?v=QmBLieIuf6Q
-      - letter: Ь
-        word: день
-        video: https://www.youtube.com/watch?v=cJlal8XKBxo
-      - letter: Ю
-        word: ю́шка
-        video: https://www.youtube.com/watch?v=9JdIBYCTWGw
-      - letter: Я
-        word: я́блуко
-        video: https://www.youtube.com/watch?v=yhSAf41LX8I
-
-  - id: act-5
-    type: fill-in
-    title: Короткий діало́г
-    instruction: Обери фра́зу, яка доповнює український рядок.
-    items:
-      - sentence: Приві́т! ___ спра́ви?
-        answer: Як
-        options:
-          - Як
-          - Що
-          - Де
-      - sentence: До́бре. ___ у тебе́?
-        answer: А
-        options:
-          - А
-          - На
-          - У
-      - sentence: Як тебе́ зва́ти? Мене́ зва́ти Анна. ___?
-        answer: А тебе́
-        options:
-          - А тебе́
-          - А у тебе́
-          - А тобі́
-      - sentence: '___ тебе́ ба́чити! (говорить жінка)'
-        answer: Рада
-        options:
-          - Рада
-          - Радий
-          - Раді
-      - sentence: '___ тебе́ ба́чити! (говорить чоловік)'
-        answer: Радий
-        options:
-          - Радий
-          - Рада
-          - Раді
-
-workbook:
-  - type: true-false
-    title: Швидка переві́рка звуків
-    instruction: Обери правда чи неправда.
-    items:
-      - statement: Звук — це те, що ми чуємо й вимовля́ємо.
-        correct: true
-        explanation: Звук — це те, що ми чуємо й вимовля́ємо.
-      - statement: Ь має власний голосни́й звук.
-        correct: false
-        explanation: Ь не має власного звука; він м'якшить попередній при́голосний.
-      - statement: Молоко́ має три голосні звуки.
-        correct: true
-        explanation: 'Голосні звуки: о + о + о.'
-      - statement: До́брий день — це вітальна фра́за.
-        correct: true
-        explanation: Це одна з перших готових фраз вітання в уро́ці.
-      - statement: У цьому модулі Щ = [ш].
-        correct: false
-        explanation: У цьому модулі Щ = [шч].
-
-  - type: order
-    title: Склади діало́г
-    instruction: Put the mini-dialogue in a natural order.
-    items:
-      - А у тебе́?
-      - Приві́т!
-      - До́бре.
-      - Як спра́ви?
-    correct_order:
-      - 1
-      - 3
-      - 2
-      - 0
-
-  - type: match-up
-    title: Друк і зошит
-    instruction: З'єднай друковану картку з підказкою в зо́шиті.
-    pairs:
-      - left: 'друк: П п'
-        right: 'зошит: учитель пише п'
-      - left: 'друк: М м'
-        right: 'зошит: учитель пише м'
-      - left: 'друк: Приві́т'
-        right: 'зошит: приві́т'
-      - left: 'друк: ма́ма'
-        right: 'зошит: ма́ма'
+    - '[п]'
+    - '[р]'
+    - '[в]'
+    - '[т]'
+    - '[м]'
+    - '[н]'
+    - '[к]'
+    - '[с]'
+- id: act-8
+  type: match-up
+  title: See a letter, hear a sound
+  instruction: Match each letter with its beginner sound clue.
+  pairs:
+  - left: А
+    right: '[а]'
+  - left: О
+    right: '[о]'
+  - left: У
+    right: '[у]'
+  - left: М
+    right: '[м]'
+  - left: Н
+    right: '[н]'
+  - left: Г
+    right: h-like [г]
+  - left: Ґ
+    right: hard [g]
+  - left: Ї
+    right: '[йі]'
+  - left: Ь
+    right: no sound
+- id: act-9
+  type: translate
+  title: Phrase meanings
+  instruction: Choose the English meaning.
+  items:
+  - source: Приві́т!
+    options:
+    - text: Hi!
+      correct: true
+    - text: Goodbye!
+      correct: false
+    - text: What is your name?
+      correct: false
+    explanation: Приві́т is the informal everyday greeting.
+  - source: До́брий день!
+    options:
+    - text: Hello! / Good day!
+      correct: true
+    - text: Milk!
+      correct: false
+    - text: And you?
+      correct: false
+    explanation: До́брий день is the neutral daytime greeting.
+  - source: Доброго ра́нку!
+    options:
+    - text: Good morning!
+      correct: true
+    - text: Good evening!
+      correct: false
+    - text: My name is Anna.
+      correct: false
+    explanation: Ра́нок means morning, so Доброго ра́нку is Good morning.
+  - source: До́брий ве́чір!
+    options:
+    - text: Good evening!
+      correct: true
+    - text: Good morning!
+      correct: false
+    - text: Fine.
+      correct: false
+    explanation: Ве́чір means evening, so До́брий ве́чір is Good evening.
+  - source: Як спра́ви?
+    options:
+    - text: How are you?
+      correct: true
+    - text: Goodbye!
+      correct: false
+    - text: Letter
+      correct: false
+    explanation: Як спра́ви? asks how someone is doing.
+  - source: До поба́чення!
+    options:
+    - text: Goodbye!
+      correct: true
+    - text: Hi!
+      correct: false
+    - text: Sound
+      correct: false
+    explanation: До поба́чення is the leaving phrase Goodbye.
+  - source: Ра́да тебе́ ба́чити.
+    options:
+    - text: Glad to see you. (female speaker)
+      correct: true
+    - text: What is your name?
+      correct: false
+    - text: Good evening!
+      correct: false
+    explanation: Ра́да is the form a female speaker uses in this phrase.
+- id: act-10
+  type: error-correction
+  title: Pronunciation traps
+  instruction: Choose the safer Ukrainian habit.
+  items:
+  - sentence: Do not call А, О, У голосними літерами.
+    error: голосними літерами
+    correction: літерами, що позначають голосні звуки
+    options:
+    - літерами, що позначають голосні звуки
+    - приголосними літерами
+    explanation: >-
+      Safer habit: sounds are голосні or приголосні. Letters represent sounds,
+      so call А, О, У letters that mark vowel sounds.
+  - sentence: Do not say м[а]локо for молоко.
+    error: м[а]локо
+    correction: молоко
+    options:
+    - молоко
+    - молоко́
+    explanation: >-
+      Safer habit: keep Ukrainian о clean. Say молоко́ with three clear о
+      sounds: мо-ло-ко́.
+  - sentence: Do not add a tiny sound after день.
+    error: add a tiny sound after день
+    correction: soften н, then stop
+    options:
+    - soften н, then stop
+    - add і after нь
+    explanation: >-
+      Safer habit: ь has no sound of its own. In день, soften н and stop;
+      do not add a tiny vowel after it.
+  - sentence: Do not treat Ї as a softening letter.
+    error: treat Ї as a softening letter
+    correction: read Ї as [йі]
+    options:
+    - read Ї as [йі]
+    - read Ї as plain [і]
+    explanation: >-
+      Safer habit: Ї is not a softening letter. Read it as [йі] every time.
+  - sentence: Do not make one fixed glad phrase for every speaker.
+    error: one fixed glad phrase
+    correction: Радий тебе бачити / Рада тебе бачити
+    options:
+    - Радий тебе бачити / Рада тебе бачити
+    - Радий тебе бачити for everyone
+    explanation: >-
+      Safer habit: match the phrase to the speaker. A male speaker says
+      Радий тебе бачити; a female speaker says Рада тебе бачити.

--- a/curriculum/l2-uk-en/a1/sounds-letters-and-hello/module.md
+++ b/curriculum/l2-uk-en/a1/sounds-letters-and-hello/module.md
@@ -1,226 +1,309 @@
-# Звуки, літери та привіт
+# Sounds, Letters, and Hello
 
-**Приві́т!** Сьогодні ви почуєте перші українські звуки, побачите
-перші літери й скажете коротке привітання.
+You do not need to read Ukrainian yet. This English-led module uses Ukrainian in small chunks so you can listen, repeat, notice, and use the first phrases safely.
 
-Починаємо повільно: **слухаємо**, **дивимося**, **повторюємо**,
-а потім говоримо одну готову фразу.
+By the end, you can:
 
-| Українська опора | Meaning |
+- say hello, goodbye, and a simple "How are you?";
+- answer with **До́бре**, **Чудо́во**, or **Норма́льно**;
+- ask and answer a name question;
+- explain the difference between a sound and a letter;
+- recognize all 33 Ukrainian letters at first-pass level;
+- know what **склад** means before the workbook asks you to count syllables;
+- avoid the first pronunciation traps: blurred **о**, confusing **и** and **і**, adding a sound after **ь**, and turning final voiced consonants into voiceless ones.
+
+## Sound First, Letter Second
+
+Keep this rule in mind from the first minute:
+
+| You hear and say | You see and write |
 | --- | --- |
-| **звук** | sound |
-| **лі́тера** | letter |
-| **абе́тка** | the alphabet |
+| a **sound** | a **letter** |
+| **звук** - sound | **лі́тера** - letter |
 
-Працюємо в такому порядку:
+A **sound** belongs to your ear and mouth. A **letter** belongs to your eyes and hand.
 
-1. **слу́хай** — listen;
-2. **диви́сь** — look;
-3. **повтори́** — repeat;
-4. **скажи́** — say it.
+Three numbers matter in Ukrainian:
 
-На сьогодні достатньо кількох надійних опор: **звук**, **лі́тера**,
-**ма́ма**, **молоко́**, **Приві́т** і **До́брий день**.
-
-## Звук і лі́тера
-
-**звук** — те, що ми чуємо й вимовляємо.
-
-**лі́тера** — те, що ми бачимо й пишемо.
-
-Не плутайте ці дві опори:
-
-| Я ба́чу | Я чу́ю |
+| Fact | Meaning |
 | --- | --- |
-| **лі́тера А** | **[а]** |
-| **лі́тера М** | **[м]** |
-| **лі́тера О** | **[о]** |
+| **33 letters** | the Ukrainian alphabet, or **абе́тка** |
+| **38 sounds** | what speakers actually hear and say |
+| **6 vowel sounds** | the open sounds you can sing |
 
-Українська абе́тка має **33 лі́тери**. У мовленні звуків більше,
-бо деякі літери можуть позначати більше ніж один звук або змінювати
-сусідній звук.
+The numbers are not the same because some letters do more than one job. For example:
 
-Три перші підказки:
+- **Я, Ю, Є, Ї** can point to more than one sound.
+- **Ь** is the soft sign. It has no sound of its own.
+- Many consonants can be hard or soft.
 
-- **Я, Ю, Є, Ї** іноді позначають **й + голосний**.
-- **Ь** не має власного звука; він пом'якшує попередній приголосний.
-- **Щ** тут читаємо як **[шч]**.
+Say this rule aloud:
+
+**Звук = I hear it. Лі́тера = I see it.**
+
+:::tip
+Start with the six clean vowel sounds: **[а] [о] [у] [е] [и] [і]**. They are the course's **heartbeat** (**серцебиття**) because every Ukrainian **склад** needs a vowel sound. Short **відеоуроки** help you see the mouth shape, especially the narrow smile for **[і]** and rounded lips for **[у]**.
+:::
 
 <!-- INJECT_ACTIVITY: act-1 -->
 
-## Голосні звуки
+## Your First Word
 
-**[а] [о] [у] [е] [и] [і]** — шість простих голосних звуків.
+Your first word is:
 
-**Голосни́й звук** — vowel sound. Голосний відкритий, його легко
-проспівати.
+**Приві́т!** - Hi!
 
-Прості голосні літери:
+Use **Приві́т!** with classmates, friends, family, or someone your age. Treat it as one whole chunk today.
 
-**А О У Е И І**
+Say it slowly:
 
-Перше правило для читання:
+**При-ві́т**
 
-**one vowel sound = one склад** — один голосний звук = один склад
+Now notice the pieces:
 
-| Слово́ | Голосні звуки | Склади́ |
+| Letter | Sound | Type |
 | --- | --- | --- |
-| **ма́ма** | **а + а** | 2 |
-| **молоко́** | **о + о + о** | 3 |
-| **Приві́т** | **и + і** | 2 |
-| **о́ко** | **о + о** | 2 |
+| **П** | [п] | consonant |
+| **р** | [р] | consonant |
+| **и** | [и] | vowel |
+| **в** | [в] | consonant |
+| **і** | [і] | vowel |
+| **т** | [т] | consonant |
 
-Важлива звичка: вимовляйте **о** чітко. У слові **молоко́** кожне
-**о** залишається **о**.
+So **Приві́т** has two vowel sounds and four consonant sounds.
+
+## Six Vowel Sounds, Ten Letters
+
+Ukrainian has six basic vowel sounds:
+
+**[а] [о] [у] [е] [и] [і]**
+
+A vowel sound is open. Your voice passes through without a block. You can hold it and sing it:
+
+- **а-а-а**
+- **о-о-о**
+- **у-у-у**
+- **і-і-і**
+
+There are six vowel sounds, but ten letters that can mark vowel sounds:
+
+| Simple vowel letters | Special vowel letters |
+| --- | --- |
+| **А О У Е И І** | **Я Ю Є Ї** |
+
+Do not worry about mastering **Я, Ю, Є, Ї** yet. For now, know their job:
+
+- **Я** can sound like **[йа]** or soften a previous consonant and mark **[а]**.
+- **Ю** can sound like **[йу]** or soften a previous consonant and mark **[у]**.
+- **Є** can sound like **[йе]** or soften a previous consonant and mark **[е]**.
+- **Ї** is special: it is always **[йі]**.
+
+Three useful words:
+
+| Word | Meaning | What to notice |
+| --- | --- | --- |
+| **ма́ма** | mother | two **а** sounds |
+| **молоко́** | milk | three clean **о** sounds |
+| **Приві́т** | hi | **и** and **і** are different sounds |
+
+Important habit: Ukrainian **о** stays clean. In **молоко́**, each **о** is still **о**. Say **мо-ло-ко́**, not a blurred English-style vowel.
+
+## What Is a Склад?
+
+A **склад** is a syllable. In Ukrainian, every syllable needs a vowel sound. That is why vowels are the "heart" of a syllable.
+
+Use this simple beginner rule:
+
+**Count vowel sounds = count syllables.**
+
+| Word | Vowel sounds | Syllables |
+| --- | --- | --- |
+| **день** | **е** | 1 склад |
+| **ма́ма** | **а + а** | 2 склади |
+| **Приві́т** | **и + і** | 2 склади |
+| **молоко́** | **о + о + о** | 3 склади |
+
+Now the workbook can ask you about **склади** because you know the idea: find the vowel sounds first.
 
 <!-- INJECT_ACTIVITY: act-2 -->
 
-## При́голосні звуки
+## Consonant Sounds
 
-**[м] [п] [т] [н]** — чотири прості приголосні звуки.
+A consonant sound uses a small block or contact in the mouth: lips, teeth, tongue, or throat.
 
-**При́голосний звук** — consonant sound. Приголосний має маленьку
-перешкоду в роті: губи, зуби, язик або горло.
+Try four:
 
-Спершу відчуйте звук:
+- **[м]** - close your lips and hum.
+- **[п]** - close your lips and release without humming.
+- **[т]** - touch your tongue behind your teeth.
+- **[н]** - touch your tongue and let sound pass through your nose.
 
-| Звук | Підказка для вимови |
+Ukrainian has 32 consonant sounds and 22 letters that usually mark consonants. Some consonants have hard and soft versions. You do not need the full system today, but you do need three first clues:
+
+Vowels give a syllable its voice. Consonants build the clear **architecture** (**архітектура**) around that voice: lips, teeth, tongue, or throat make the shape.
+
+| Sign or letter | Beginner meaning |
 | --- | --- |
-| **[м]** | закрийте губи й промовте звук через ніс |
-| **[п]** | закрийте губи й коротко відкрийте |
-| **[т]** | торкніться язиком місця за зубами |
-| **[н]** | пустіть звук через ніс |
+| **Ь ь** | **м'який знак**; no sound of its own |
+| **Г г** | Ukrainian h-like sound |
+| **Ґ ґ** | hard **g** sound |
+| **Щ щ** | two sounds together: **[шч]** |
 
-Розберімо слово **Приві́т**:
+Example:
 
-| Лі́тера | Що це? |
-| --- | --- |
-| **П** | приголосний |
-| **Р** | приголосний |
-| **И** | голосний |
-| **В** | приголосний |
-| **І** | голосний |
-| **Т** | приголосний |
+**день** - day
 
-У слові **Приві́т** є **2 голосні звуки** й **4 приголосні звуки**.
+The final **ь** does not add a new vowel. It tells you to make **н** soft.
 
-<!-- INJECT_ACTIVITY: act-3 -->
+The letters **Я, Ю, Є** are graphic **chameleons** (**хамелеони**): at the start of a word they can show **[й] + vowel**, but after a consonant they can point to softness plus one vowel. **Ї** is the strict exception: always **[йі]**.
 
-## Абетка: перше знайомство
+## Full Alphabet Pronunciation Pass
 
-**А, Б, В... Я** — повна українська абетка.
+This is your first full pass through the alphabet. The goal is not to memorize everything today. The goal is to see every letter, hear a model, and repeat once.
 
-Не треба вивчати всі 33 літери за один раз. Спершу впізнавайте
-форму літери, слухайте звук і повторюйте коротке слово.
-
-Повна абетка:
+The alphabet order is:
 
 **А Б В Г Ґ Д Е Є Ж З И І Ї Й К Л М Н О П Р С Т У Ф Х Ц Ч Ш Щ Ь Ю Я**
 
-Перші опори:
+Use the pronunciation practice below for all 33 letters. Listen first, then repeat the letter and the example word.
 
-| Лі́тера | Звук | Слово |
-| --- | --- | --- |
-| А | [а] | анана́с |
-| М | [м] | ма́ма |
-| О | [о] | о́ко |
-| П | [п] | піт |
-| Т | [т] | та́то |
-| І | [і] | ім'я́ |
-| И | [и] | сир |
-| Ь | немає власного звука | день |
+<!-- INJECT_ACTIVITY: act-3 -->
 
-У вправі нижче можна послухати всі літери по черзі. Відео потрібні
-тільки для слухання й повторення; не завантажуйте й не перевикористовуйте
-чужий аудіоматеріал.
+## Stress: Наголос
 
-**Друк і зошит** — впізнавання друкованих і рукописних форм.
+The little mark in **Приві́т** is the stress mark. Ukrainian stress is called **на́голос**.
 
-Спершу впізнавайте форму, а вже потім пишіть самостійно. Використовуйте
-текст цього уроку, власний зошит або живий почерк викладача. Не копіюйте
-чужі рукописні зразки.
+Stress tells you which syllable is strongest:
 
-| Друк | Зошит: підказка | Дія |
-| --- | --- | --- |
-| **П п** | викладач пише **п** від руки | знайдіть **П** |
-| **М м** | викладач пише **м** від руки | знайдіть **М** |
-| **Приві́т** | у зошиті написано **приві́т** | знайдіть слово |
-| **ма́ма** | у зошиті написано **ма́ма** | знайдіть слово |
-
-<!-- INJECT_ACTIVITY: act-4 -->
-
-## Приві́т: перші привітання
-
-**Приві́т!** — Hi!
-
-Спершу вчіть ці привітання як готові фрази. Граматика зачекає.
-
-| Українська | Meaning |
+| Word | How to say it |
 | --- | --- |
-| **Приві́т!** | Hi! |
-| **До́брий день!** | Hello / good day |
-| **До́брого ра́нку!** | Good morning |
-| **До́брий ве́чір!** | Good evening |
-| **До поба́чення!** | Goodbye |
-| **На все до́бре!** | All the best |
+| **Приві́т** | stress on **ві́т** |
+| **ма́ма** | stress on the first **ма́** |
+| **молоко́** | stress on **ко́** |
+| **До́брий день** | stress on **До́-** |
 
-Спершу прочитайте український діалог:
+Sometimes stress changes meaning. You do not need to use these words yet, but notice the pattern:
+
+| Stress | Meaning |
+| --- | --- |
+| **за́мок** | castle |
+| **замо́к** | lock |
+| **бра́ти** | brothers |
+| **брати́** | to take |
+
+For this course, new Ukrainian words usually show stress so you know what to say aloud.
+
+## Euphony: У/В and І/Й
+
+Ukrainian likes smooth sound flow. This is called **милозву́чність**. At A1, you only need to recognize two common pairs:
+
+| Pair | Beginner idea |
+| --- | --- |
+| **у / в** | Ukrainian may choose the smoother one for the sounds around it |
+| **і / й** | Ukrainian may choose the smoother one for the sounds around it |
+
+You do not need to choose them alone yet. Just notice the idea: Ukrainian often avoids heavy sound piles.
+
+## Your First Conversation
+
+Learn these as whole phrases.
+
+| Ukrainian | English | Use |
+| --- | --- | --- |
+| **Приві́т!** | Hi! | informal |
+| **До́брий день!** | Hello! / Good day! | neutral |
+| **До́брого ра́нку!** | Good morning! | morning |
+| **До́брий ве́чір!** | Good evening! | evening |
+| **Як спра́ви?** | How are you? | friendly |
+| **До́бре.** | Fine. | simple answer |
+| **Чудо́во.** | Great. | positive answer |
+| **Норма́льно.** | Okay. | neutral answer |
+| **А у тебе́?** | And you? | after **Як спра́ви?** |
+| **Як тебе́ зва́ти?** | What is your name? | informal |
+| **Ме́не зва́ти Анна.** | My name is Anna. | name answer |
+| **А тебе́?** | And you? | after a name question |
+| **До поба́чення!** | Goodbye! | leaving |
+| **На все до́бре!** | All the best! | friendly goodbye |
+
+Read the dialogue. Then say it aloud twice: once as Anna, once as Marko.
 
 ```text
-О́ля: Приві́т!
-Тара́с: Приві́т!
-О́ля: Як спра́ви?
-Тара́с: До́бре.
-О́ля: А у тебе́?
-Тара́с: Чудо́во!
+А́нна: Приві́т!
+Марко́: Приві́т!
+А́нна: Як спра́ви?
+Марко́: До́бре. А у тебе́?
+А́нна: Чудо́во.
 ```
 
-Підтримка англійською після діалогу:
+Support after the dialogue:
 
-| Українська | Meaning |
+| Ukrainian | English |
 | --- | --- |
-| **Як спра́ви?** | How are you? |
-| **До́бре.** | Fine / good. |
-| **А у тебе́?** | And you? |
-| **Чудо́во!** | Great! |
+| **А́нна: Приві́т!** | Anna: Hi! |
+| **Марко́: Приві́т!** | Marko: Hi! |
+| **А́нна: Як спра́ви?** | Anna: How are you? |
+| **Марко́: До́бре. А у тебе́?** | Marko: Fine. And you? |
+| **А́нна: Чудо́во.** | Anna: Great. |
 
-Після **Як спра́ви?** відповідаємо **А у тебе́?**. Коли питаємо ім'я,
-використовуємо **А тебе́?**
+Now read the name exchange.
 
 ```text
 Марко́: Як тебе́ зва́ти?
-Софі́я: Мене́ зва́ти Софі́я. А тебе́?
-Марко́: Мене́ зва́ти Марко́.
+Софія: Ме́не зва́ти Софія. А тебе́?
+Марко́: Ме́не зва́ти Марко́.
 ```
 
-Підтримка англійською після діалогу:
+Support after the name exchange:
 
-| Українська | Meaning |
+| Ukrainian | English |
 | --- | --- |
-| **Як тебе́ зва́ти?** | What is your name? |
-| **Мене́ зва́ти...** | My name is... |
-| **А тебе́?** | And you? |
+| **Марко́: Як тебе́ зва́ти?** | Marko: What is your name? |
+| **Софія: Ме́не зва́ти Софія. А тебе́?** | Sofia: My name is Sofia. And you? |
+| **Марко́: Ме́не зва́ти Марко́.** | Marko: My name is Marko. |
 
-Дві готові фрази також показують стать мовця:
+Use **А у тебе́?** after **Як спра́ви?** because you are asking about the other person's state. Use **А тебе́?** after **Як тебе́ зва́ти?** because you are asking for the other person's name.
 
-| Хто говорить | Фраза |
-| --- | --- |
-| чоловік | **Радий тебе́ ба́чити.** |
-| жінка | **Рада тебе́ ба́чити.** |
+You may also hear:
+
+| Ukrainian | English | Who says it? |
+| --- | --- | --- |
+| **Радий тебе бачити.** | Glad to see you. | a male speaker |
+| **Рада тебе бачити.** | Glad to see you. | a female speaker |
+
+Do not build grammar from this yet. Just notice that Ukrainian sometimes changes a word depending on who is speaking: use **Радий тебе бачити** if the speaker is male, and **Рада тебе бачити** if the speaker is female.
+
+The word **Привіт** is useful for your first tiny sound analysis down to the details (**на гвинтики**): **П-р-и-в-і-т**, four consonant sounds and two vowel sounds.
 
 <!-- INJECT_ACTIVITY: act-5 -->
 
-## Звички першого місяця
+## First Pronunciation Traps
 
-Тримайте цей урок малим і точним:
+Use these as safety checks:
 
-1. Вимовляйте **о** чітко в слові **молоко́**.
-2. Слухайте різницю між **и** та **і** в слові **Приві́т**.
-3. Пам'ятайте: **Ь** не має власного звука.
-4. Спершу впізнавайте друк і зошит, а вже потім пишіть швидко.
-5. Попросіть носія української або викладача послухати **Приві́т**,
-   **До́брий день** та **Мене́ зва́ти...**
+| Trap | Safer habit |
+| --- | --- |
+| Blurring **о** in **молоко́** | Keep every **о** clean: **мо-ло-ко́** |
+| Mixing **и** and **і** | In **Приві́т**, **и** and **і** are different |
+| Pronouncing **ь** as a separate sound | In **день**, **ь** only softens **н** |
+| Saying final voiced consonants as voiceless | Keep the written voiced sound; do not automatically devoice it |
+| Treating **Ї** like **І** | **Ї** is **[йі]** |
+| Mixing **Г** and **Ґ** | **Г** is h-like; **Ґ** is hard **g** |
 
-Закінчіть одним надійним рядком:
+Keep Ukrainian sound categories independent. Do not use another language as the shortcut for **И**, **Е**, **О**, or **Г**. Use the Ukrainian mouth model here: **И** has its own position, unstressed **О** stays **О**, **Добрий день** is the neutral greeting, **Привіт** is the everyday informal greeting, and **Г** is the Ukrainian h-like sound.
 
-**Приві́т! Як тебе́ зва́ти? Мене́ зва́ти Анна. А тебе́?**
+<!-- INJECT_ACTIVITY: act-6 -->
+
+## Textbook Check
+
+Before you leave the lesson tab, check that you can do these things:
+
+- Point to **Приві́т** and say "Hi."
+- Point to **До поба́чення** and say "Goodbye."
+- Answer **Як спра́ви?** with **До́бре**, **Чудо́во**, or **Норма́льно**.
+- Say whether **звук** means "sound" or "letter."
+- Say whether **лі́тера** means "sound" or "letter."
+- Explain **склад** in English.
+- Count the vowel sounds in **Приві́т**.
+- Recognize **Г**, **Ґ**, **Ї**, and **Ь** when the workbook asks for them.
+
+The workbook repeats the same ideas in different ways. It is practice for eyes, ears, and mouth.

--- a/curriculum/l2-uk-en/a1/sounds-letters-and-hello/resources.yaml
+++ b/curriculum/l2-uk-en/a1/sounds-letters-and-hello/resources.yaml
@@ -1,197 +1,201 @@
 - title: Большакова, буквар 1 клас, p. 24
   role: textbook
   chunk_id: 1-klas-bukvar-bolshakova-2018-1_s0023
-  notes: 'Vowel and consonant practice through short textbook verse.'
+  notes: 'Plan reference: голосні/приголосні через вірші; retrieved via search_text
+    because plan notes include no literal chunk_id.'
 - title: Захарійчук, буквар 1 клас (НУШ 2025), p. 13
   role: textbook
   chunk_id: 1-klas-bukvar-zaharijchuk-2025-1_s0002
-  notes: 'Textbook symbols for vowel, hard consonant, and soft consonant sounds.'
+  notes: 'Plan reference: [•] голосний, [–] твердий приголосний, [=] м''який приголосний;
+    resolved page context from corpus metadata.'
 - title: Заболотний 5 клас, p. 83
   role: textbook
   chunk_id: 5-klas-ukrmova-zabolotnyi-2023_s0084
-  notes: 'Sound-letter distinction: «Звуки ми чуємо й вимовляємо, а букви бачимо
-    й пишемо.»'
+  notes: 'Plan reference: «Звуки ми чуємо й вимовляємо, а букви бачимо й пишемо.»'
 - title: Літвінова 5 клас, p. 130
   role: textbook
   chunk_id: 5-klas-ukrmova-litvinova-2022_s0135
-  notes: 'Questions about vowel/consonant terminology and the sound-letter distinction.'
+  notes: 'Plan reference: питання про «голосна літера» / «приголосна літера» and sound-letter
+    distinction.'
 - title: ULP Season 1, Episode 1 — Informal Greetings
   role: podcast
   url: https://www.ukrainianlessons.com/episode1/
-  notes: 'Greeting and response models: Привіт, Як справи?, and short answers.'
+  notes: 'Plan reference: Привіт, Як справи?, response models; external search found
+    ULP Episode 1 material.'
 - title: Anna Ohoiko — Ukrainian alphabet overview
   role: youtube
   url: https://www.youtube.com/watch?v=ksXIXj7CXwc
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: overview for the full Ukrainian alphabet.'
+  notes: 'Plan pronunciation video: overview for the full Ukrainian alphabet.'
 - title: Anna Ohoiko — Ukrainian alphabet pronunciation playlist
   role: youtube
   url: https://www.youtube.com/playlist?list=PLpkSIXDyaJi3mlJlKXWKhdiJZj67fPXQV
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: playlist for per-letter Ukrainian pronunciation
+  notes: 'Plan pronunciation video: playlist for per-letter Ukrainian pronunciation
     practice.'
 - title: Anna Ohoiko — Letter А pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=hvB3VpcR3ZE
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: А.'
+  notes: 'Plan pronunciation video: А.'
 - title: Anna Ohoiko — Letter Б pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=V1hxBE_JbGg
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Б.'
+  notes: 'Plan pronunciation video: Б.'
 - title: Anna Ohoiko — Letter В pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=aFcvYfvQ2X4
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: В.'
+  notes: 'Plan pronunciation video: В.'
 - title: Anna Ohoiko — Letter Г pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=gVnclpSI0DU
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Г.'
+  notes: 'Plan pronunciation video: Г.'
 - title: Anna Ohoiko — Letter Ґ pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=gNjHqjTW9WQ
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Ґ.'
+  notes: 'Plan pronunciation video: Ґ.'
 - title: Anna Ohoiko — Letter Д pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=g4Bh-lqzd48
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Д.'
+  notes: 'Plan pronunciation video: Д.'
 - title: Anna Ohoiko — Letter Е pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=KFlsroBW0dk
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Е.'
+  notes: 'Plan pronunciation video: Е.'
 - title: Anna Ohoiko — Letter Є pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=O0bwRyyBQSc
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Є.'
+  notes: 'Plan pronunciation video: Є.'
 - title: Anna Ohoiko — Letter Ж pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=dIrGVcqPwqM
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Ж.'
+  notes: 'Plan pronunciation video: Ж.'
 - title: Anna Ohoiko — Letter З pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=BhASNxitC1A
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: З.'
+  notes: 'Plan pronunciation video: З.'
 - title: Anna Ohoiko — Letter И pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=W-1rCu0indE
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: И.'
+  notes: 'Plan pronunciation video: И.'
 - title: Anna Ohoiko — Letter І pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=Z9TH0H4ShGo
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: І.'
+  notes: 'Plan pronunciation video: І.'
 - title: Anna Ohoiko — Letter Ї pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=UcjdjQXhAY8
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Ї.'
+  notes: 'Plan pronunciation video: Ї.'
 - title: Anna Ohoiko — Letter Й pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=aq0cjB90s3w
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Й.'
+  notes: 'Plan pronunciation video: Й.'
 - title: Anna Ohoiko — Letter К pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=J7sGEI4-xJo
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: К.'
+  notes: 'Plan pronunciation video: К.'
 - title: Anna Ohoiko — Letter Л pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=v6-3Xg52Buk
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Л.'
+  notes: 'Plan pronunciation video: Л.'
 - title: Anna Ohoiko — Letter М pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=Ez95H4ibuJo
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: М.'
+  notes: 'Plan pronunciation video: М.'
 - title: Anna Ohoiko — Letter Н pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=vNUfiKHPYaU
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Н.'
+  notes: 'Plan pronunciation video: Н.'
 - title: Anna Ohoiko — Letter О pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=gJFxRIPRZbI
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: О.'
+  notes: 'Activity pronunciation video: О; the locked plan currently has no separate
+    О URL, but the workbook includes the stored course reference.'
 - title: Anna Ohoiko — Letter П pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=JksSjjxyW5Y
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: П.'
+  notes: 'Plan pronunciation video: П.'
 - title: Anna Ohoiko — Letter Р pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=fMGsQ5KPQgg
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Р.'
+  notes: 'Plan pronunciation video: Р.'
 - title: Anna Ohoiko — Letter С pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=7UsFBgSL91E
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: С.'
+  notes: 'Plan pronunciation video: С.'
 - title: Anna Ohoiko — Letter Т pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=m-jcLR_gK0k
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Т.'
+  notes: 'Plan pronunciation video: Т.'
 - title: Anna Ohoiko — Letter У pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=VB1O6PmtYRU
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: У.'
+  notes: 'Plan pronunciation video: У.'
 - title: Anna Ohoiko — Letter Ф pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=haHRsFFZRQI
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Ф.'
+  notes: 'Plan pronunciation video: Ф.'
 - title: Anna Ohoiko — Letter Х pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=vpr58zJSJKc
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Х.'
+  notes: 'Plan pronunciation video: Х.'
 - title: Anna Ohoiko — Letter Ц pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=u44eCjR2Oz8
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Ц.'
+  notes: 'Plan pronunciation video: Ц.'
 - title: Anna Ohoiko — Letter Ч pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=UsJkbdsY2RA
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Ч.'
+  notes: 'Plan pronunciation video: Ч.'
 - title: Anna Ohoiko — Letter Ш pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=1D-6MIw3OXY
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Ш.'
+  notes: 'Plan pronunciation video: Ш.'
 - title: Anna Ohoiko — Letter Щ pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=QmBLieIuf6Q
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Щ.'
+  notes: 'Plan pronunciation video: Щ.'
 - title: Anna Ohoiko — Letter Ь pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=cJlal8XKBxo
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Ь.'
+  notes: 'Plan pronunciation video: Ь.'
 - title: Anna Ohoiko — Letter Ю pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=9JdIBYCTWGw
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Ю.'
+  notes: 'Plan pronunciation video: Ю.'
 - title: Anna Ohoiko — Letter Я pronunciation
   role: youtube
   url: https://www.youtube.com/watch?v=yhSAf41LX8I
   channel: Ukrainian Lessons
-  notes: 'Pronunciation video: Я.'
+  notes: 'Plan pronunciation video: Я.'

--- a/curriculum/l2-uk-en/a1/sounds-letters-and-hello/vocabulary.yaml
+++ b/curriculum/l2-uk-en/a1/sounds-letters-and-hello/vocabulary.yaml
@@ -1,11 +1,11 @@
 - lemma: звук
   translation: sound
   pos: noun
-  usage: Усе починається зі звука.
+  usage: Це звук [а].
 - lemma: лі́тера
   translation: letter
   pos: noun
-  usage: Лі́тера показує, як звук записати.
+  usage: Це лі́тера П.
 - lemma: абе́тка
   translation: alphabet
   pos: noun
@@ -13,93 +13,97 @@
 - lemma: голосни́й звук
   translation: vowel sound
   pos: noun phrase
-  usage: А — голосни́й звук.
+  usage: '[а] - голосни́й звук.'
 - lemma: при́голосний звук
   translation: consonant sound
   pos: noun phrase
-  usage: П — при́голосний звук.
+  usage: '[п] - при́голосний звук.'
 - lemma: склад
   translation: syllable
   pos: noun
-  usage: Ма́ма має два склади.
+  usage: У сло́ві ма́ма два склади́.
 - lemma: на́голос
   translation: stress
   pos: noun
-  usage: У слові Приві́т наголос на «ві́т».
+  usage: У сло́ві Приві́т на́голос на і.
 - lemma: м'яки́й знак
   translation: soft sign
   pos: noun phrase
-  usage: У слові день м'яки́й знак пом'якшує [н].
+  usage: Ь - м'яки́й знак.
+- lemma: апо́строф
+  translation: apostrophe
+  pos: noun
+  usage: У сло́ві «ім'я́» є апо́строф.
 - lemma: Приві́т
-  translation: hi
+  translation: Hi
   pos: phrase
-  usage: Приві́т! Як тебе́ зва́ти?
+  usage: Приві́т!
 - lemma: До́брий день
-  translation: hello
+  translation: Hello / Good day
   pos: phrase
-  usage: До́брий день, Марко.
+  usage: До́брий день!
 - lemma: До́брого ра́нку
-  translation: good morning
+  translation: Good morning
   pos: phrase
-  usage: До́брого ра́нку, пане Іване.
+  usage: До́брого ра́нку!
 - lemma: До́брий ве́чір
-  translation: good evening
+  translation: Good evening
   pos: phrase
-  usage: До́брий ве́чір! Ласкаво просимо.
-- lemma: До поба́чення
-  translation: goodbye
-  pos: phrase
-  usage: До поба́чення! До зустрічі.
-- lemma: На все до́бре
-  translation: all the best
-  pos: phrase
-  usage: На все до́бре, Маріє.
-- lemma: Як спра́ви
-  translation: how are you
+  usage: До́брий ве́чір!
+- lemma: Як спра́ви?
+  translation: How are you?
   pos: phrase
   usage: Як спра́ви?
 - lemma: До́бре
-  translation: fine
-  pos: adverb
-  usage: До́бре. Дякую.
-- lemma: Чудо́во
-  translation: great
-  pos: adjective
-  usage: Чудо́во! Мені дуже приємно.
-- lemma: Норма́льно
-  translation: okay
-  pos: adverb
-  usage: Норма́льно. А в тебе?
-- lemma: А у тебе́
-  translation: and you
+  translation: Fine / good
   pos: phrase
-  usage: Як спра́ви? До́бре. А у тебе́?
-- lemma: Як тебе́ зва́ти
-  translation: what's your name
+  usage: До́бре.
+- lemma: Чудо́во
+  translation: Great / wonderful
+  pos: phrase
+  usage: Чудо́во.
+- lemma: Норма́льно
+  translation: Okay / normal
+  pos: phrase
+  usage: Норма́льно.
+- lemma: А у тебе́?
+  translation: And you? (after How are you?)
+  pos: phrase
+  usage: До́бре. А у тебе́?
+- lemma: Як тебе́ зва́ти?
+  translation: What is your name?
   pos: phrase
   usage: Як тебе́ зва́ти?
-- lemma: Мене́ зва́ти
-  translation: my name is
+- lemma: Ме́не зва́ти ...
+  translation: My name is ...
   pos: phrase
-  usage: Мене́ зва́ти Анна.
-- lemma: А тебе́
-  translation: and you
+  usage: Ме́не зва́ти Анна.
+- lemma: А тебе́?
+  translation: And you? (after a name question)
   pos: phrase
-  usage: Як тебе́ зва́ти? А тебе́?
-- lemma: Радий тебе́ бачити
-  translation: glad to see you (masculine)
+  usage: Ме́не зва́ти Софія. А тебе́?
+- lemma: До поба́чення
+  translation: Goodbye
   pos: phrase
-  usage: Радий тебе́ бачити.
-- lemma: Рада тебе́ бачити
-  translation: glad to see you (feminine)
+  usage: До поба́чення!
+- lemma: На все до́бре
+  translation: All the best
   pos: phrase
-  usage: Рада тебе́ бачити.
+  usage: На все до́бре!
+- lemma: Ра́дий тебе́ ба́чити
+  translation: Glad to see you (male speaker)
+  pos: phrase
+  usage: Ра́дий тебе́ ба́чити.
+- lemma: Ра́да тебе́ ба́чити
+  translation: Glad to see you (female speaker)
+  pos: phrase
+  usage: Ра́да тебе́ ба́чити.
 - lemma: ма́ма
-  translation: mom/mother
+  translation: mother
   pos: noun
   usage: Ма́ма.
 - lemma: та́то
-  translation: dad
+  translation: father
   pos: noun
   usage: Та́то.
 - lemma: молоко́
@@ -111,7 +115,7 @@
   pos: noun
   usage: О́ко.
 - lemma: дім
-  translation: home
+  translation: house / home
   pos: noun
   usage: Дім.
 - lemma: ніс
@@ -119,14 +123,6 @@
   pos: noun
   usage: Ніс.
 - lemma: сон
-  translation: sleep/dream
+  translation: sleep / dream
   pos: noun
   usage: Сон.
-- lemma: день
-  translation: day
-  pos: noun
-  usage: Сьогодні день.
-- lemma: вода́
-  translation: water
-  pos: noun
-  usage: Вода́.

--- a/starlight/astro.config.mjs
+++ b/starlight/astro.config.mjs
@@ -1,4 +1,6 @@
 // @ts-check
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import react from '@astrojs/react';
@@ -10,6 +12,8 @@ import remarkAdmonitions from './plugins/remark-admonitions.mjs';
 import vocabEtymologyLinker from './plugins/vocab-etymology-link.mjs';
 
 const remarkPlugins = [remarkDirective, remarkAdmonitions, remarkGfm, vocabEtymologyLinker];
+const starlightRoot = fileURLToPath(new URL('.', import.meta.url));
+const starlightNodeModules = realpathSync(fileURLToPath(new URL('./node_modules', import.meta.url)));
 
 // https://astro.build/config
 export default defineConfig({
@@ -25,10 +29,15 @@ export default defineConfig({
 
   // Prevent duplicate React instances (SSR + client hydration)
   vite: {
+    server: {
+      fs: {
+        allow: [starlightRoot, starlightNodeModules],
+      },
+    },
     resolve: {
       alias: {
-        '@site': new URL('.', import.meta.url).pathname,
-        '@astrojs/starlight/components': new URL('./src/starlight-compat/index.ts', import.meta.url).pathname,
+        '@site': starlightRoot,
+        '@astrojs/starlight/components': fileURLToPath(new URL('./src/starlight-compat/index.ts', import.meta.url)),
       },
       dedupe: ['react', 'react-dom'],
     },

--- a/starlight/src/content/docs/a1/sounds-letters-and-hello.mdx
+++ b/starlight/src/content/docs/a1/sounds-letters-and-hello.mdx
@@ -56,282 +56,373 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs syncKey="module-tab">
 <TabItem label="Lesson">
 
-**Приві́т!** Сьогодні ви почуєте перші українські звуки, побачите
-перші літери й скажете коротке привітання.
+You do not need to read Ukrainian yet. This English-led module uses Ukrainian in small chunks so you can listen, repeat, notice, and use the first phrases safely.
 
-Починаємо повільно: **слухаємо**, **дивимося**, **повторюємо**,
-а потім говоримо одну готову фразу.
+By the end, you can:
 
-| Українська опора | Meaning |
+- say hello, goodbye, and a simple "How are you?";
+- answer with **До́бре**, **Чудо́во**, or **Норма́льно**;
+- ask and answer a name question;
+- explain the difference between a sound and a letter;
+- recognize all 33 Ukrainian letters at first-pass level;
+- know what **склад** means before the workbook asks you to count syllables;
+- avoid the first pronunciation traps: blurred **о**, confusing **и** and **і**, adding a sound after **ь**, and turning final voiced consonants into voiceless ones.
+
+## Sound First, Letter Second
+
+Keep this rule in mind from the first minute:
+
+| You hear and say | You see and write |
 | --- | --- |
-| **звук** | sound |
-| **лі́тера** | letter |
-| **абе́тка** | the alphabet |
+| a **sound** | a **letter** |
+| **звук** - sound | **лі́тера** - letter |
 
-Працюємо в такому порядку:
+A **sound** belongs to your ear and mouth. A **letter** belongs to your eyes and hand.
 
-1. **слу́хай** — listen;
-2. **диви́сь** — look;
-3. **повтори́** — repeat;
-4. **скажи́** — say it.
+Three numbers matter in Ukrainian:
 
-На сьогодні достатньо кількох надійних опор: **звук**, **лі́тера**,
-**ма́ма**, **молоко́**, **Приві́т** і **До́брий день**.
-
-## Звук і лі́тера
-
-**звук** — те, що ми чуємо й вимовляємо.
-
-**лі́тера** — те, що ми бачимо й пишемо.
-
-Не плутайте ці дві опори:
-
-| Я ба́чу | Я чу́ю |
+| Fact | Meaning |
 | --- | --- |
-| **лі́тера А** | **[а]** |
-| **лі́тера М** | **[м]** |
-| **лі́тера О** | **[о]** |
+| **33 letters** | the Ukrainian alphabet, or **абе́тка** |
+| **38 sounds** | what speakers actually hear and say |
+| **6 vowel sounds** | the open sounds you can sing |
 
-Українська абе́тка має **33 лі́тери**. У мовленні звуків більше,
-бо деякі літери можуть позначати більше ніж один звук або змінювати
-сусідній звук.
+The numbers are not the same because some letters do more than one job. For example:
 
-Три перші підказки:
+- **Я, Ю, Є, Ї** can point to more than one sound.
+- **Ь** is the soft sign. It has no sound of its own.
+- Many consonants can be hard or soft.
 
-- **Я, Ю, Є, Ї** іноді позначають **й + голосний**.
-- **Ь** не має власного звука; він пом'якшує попередній приголосний.
-- **Щ** тут читаємо як **[шч]**.
+Say this rule aloud:
 
-### Звук чи лі́тера
+**Звук = I hear it. Лі́тера = I see it.**
 
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "Звук — що ми робимо?", "options": [{"text": "бачимо на сторі́нці", "correct": false}, {"text": "чуємо й вимовля́ємо", "correct": true}, {"text": "ставимо апо́строф", "correct": false}], "explanation": "Звук — це те, що ми чуємо й вимовля́ємо."}, {"question": "Лі́тера — що ми робимо?", "options": [{"text": "бачимо й пишемо", "correct": true}, {"text": "чуємо без сторі́нки", "correct": false}, {"text": "рахуємо як склад", "correct": false}], "explanation": "Лі́тера — це письмовий знак."}, {"question": "Українська абе́тка — скільки лі́тер?", "options": [{"text": "38", "correct": false}, {"text": "33", "correct": true}, {"text": "6", "correct": false}], "explanation": "Стандартна українська абе́тка має 33 лі́тери."}, {"question": "Я, Ю, Є, Ї — чому вони особливі?", "options": [{"text": "мають більше ніж одну роботу", "correct": true}, {"text": "завжди мовчать", "correct": false}, {"text": "завжди є при́голосними", "correct": false}], "explanation": "Деякі українські лі́тери мають більше ніж одну роботу."}, {"question": "Ь — що правильно?", "options": [{"text": "має власний голосни́й звук", "correct": false}, {"text": "не має власного звука", "correct": true}, {"text": "це літера О", "correct": false}], "explanation": "Ь не має власного звука."}, {"question": "Молоко́ — скільки голосних звуків?", "options": [{"text": "два", "correct": false}, {"text": "три", "correct": true}, {"text": "один", "correct": false}], "explanation": "Молоко́ має три голосні звуки: о + о + о."}]`)} />
+:::tip
+Start with the six clean vowel sounds: **[а] [о] [у] [е] [и] [і]**. They are the course's **heartbeat** (**серцебиття**) because every Ukrainian **склад** needs a vowel sound. Short **відеоуроки** help you see the mouth shape, especially the narrow smile for **[і]** and rounded lips for **[у]**.
+:::
 
-## Голосні звуки
+### Sound or letter?
 
-**[а] [о] [у] [е] [и] [і]** — шість простих голосних звуків.
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "What is a звук?", "options": [{"text": "A sound you hear and say", "correct": true}, {"text": "A letter you see and write", "correct": false}, {"text": "A whole sentence", "correct": false}], "explanation": "A звук belongs to hearing and speaking."}, {"question": "What is a лі́тера?", "options": [{"text": "A letter you see and write", "correct": true}, {"text": "A sound you hear and say", "correct": false}, {"text": "A greeting", "correct": false}], "explanation": "A лі́тера belongs to reading and writing."}, {"question": "How many letters are in the Ukrainian alphabet?", "options": [{"text": "33", "correct": true}, {"text": "38", "correct": false}, {"text": "6", "correct": false}], "explanation": "Ukrainian has 33 letters."}, {"question": "How many basic Ukrainian vowel sounds are there?", "options": [{"text": "6", "correct": true}, {"text": "10", "correct": false}, {"text": "33", "correct": false}], "explanation": "The six basic vowel sounds are [а], [о], [у], [е], [и], [і]."}, {"question": "Does ь have its own sound?", "options": [{"text": "No", "correct": true}, {"text": "Yes", "correct": false}, {"text": "Only in Приві́т", "correct": false}], "explanation": "The soft sign ь has no sound of its own."}, {"question": "What does Приві́т mean?", "options": [{"text": "Hi", "correct": true}, {"text": "Goodbye", "correct": false}, {"text": "Milk", "correct": false}], "explanation": "Приві́т is the informal word for Hi."}]`)} />
 
-**Голосни́й звук** — vowel sound. Голосний відкритий, його легко
-проспівати.
+## Your First Word
 
-Прості голосні літери:
+Your first word is:
 
-**А О У Е И І**
+**Приві́т!** - Hi!
 
-Перше правило для читання:
+Use **Приві́т!** with classmates, friends, family, or someone your age. Treat it as one whole chunk today.
 
-**one vowel sound = one склад** — один голосний звук = один склад
+Say it slowly:
 
-| Слово́ | Голосні звуки | Склади́ |
+**При-ві́т**
+
+Now notice the pieces:
+
+| Letter | Sound | Type |
 | --- | --- | --- |
-| **ма́ма** | **а + а** | 2 |
-| **молоко́** | **о + о + о** | 3 |
-| **Приві́т** | **и + і** | 2 |
-| **о́ко** | **о + о** | 2 |
+| **П** | [п] | consonant |
+| **р** | [р] | consonant |
+| **и** | [и] | vowel |
+| **в** | [в] | consonant |
+| **і** | [і] | vowel |
+| **т** | [т] | consonant |
 
-Важлива звичка: вимовляйте **о** чітко. У слові **молоко́** кожне
-**о** залишається **о**.
+So **Приві́т** has two vowel sounds and four consonant sounds.
 
-### Кількість складів
+## Six Vowel Sounds, Ten Letters
 
-<CountSyllables client:only='react' instruction={"Рахуй голосні звуки в слові."} items={JSON.parse(`[{"word": "ма́ма", "correct": 2}, {"word": "молоко́", "correct": 3}, {"word": "вода́", "correct": 2}, {"word": "приві́т", "correct": 2}, {"word": "о́ко", "correct": 2}, {"word": "та́то", "correct": 2}]`)} maxCount={3} />
+Ukrainian has six basic vowel sounds:
 
-## При́голосні звуки
+**[а] [о] [у] [е] [и] [і]**
 
-**[м] [п] [т] [н]** — чотири прості приголосні звуки.
+A vowel sound is open. Your voice passes through without a block. You can hold it and sing it:
 
-**При́голосний звук** — consonant sound. Приголосний має маленьку
-перешкоду в роті: губи, зуби, язик або горло.
+- **а-а-а**
+- **о-о-о**
+- **у-у-у**
+- **і-і-і**
 
-Спершу відчуйте звук:
+There are six vowel sounds, but ten letters that can mark vowel sounds:
 
-| Звук | Підказка для вимови |
+| Simple vowel letters | Special vowel letters |
 | --- | --- |
-| **[м]** | закрийте губи й промовте звук через ніс |
-| **[п]** | закрийте губи й коротко відкрийте |
-| **[т]** | торкніться язиком місця за зубами |
-| **[н]** | пустіть звук через ніс |
+| **А О У Е И І** | **Я Ю Є Ї** |
 
-Розберімо слово **Приві́т**:
+Do not worry about mastering **Я, Ю, Є, Ї** yet. For now, know their job:
 
-| Лі́тера | Що це? |
+- **Я** can sound like **[йа]** or soften a previous consonant and mark **[а]**.
+- **Ю** can sound like **[йу]** or soften a previous consonant and mark **[у]**.
+- **Є** can sound like **[йе]** or soften a previous consonant and mark **[е]**.
+- **Ї** is special: it is always **[йі]**.
+
+Three useful words:
+
+| Word | Meaning | What to notice |
+| --- | --- | --- |
+| **ма́ма** | mother | two **а** sounds |
+| **молоко́** | milk | three clean **о** sounds |
+| **Приві́т** | hi | **и** and **і** are different sounds |
+
+Important habit: Ukrainian **о** stays clean. In **молоко́**, each **о** is still **о**. Say **мо-ло-ко́**, not a blurred English-style vowel.
+
+## What Is a Склад?
+
+A **склад** is a syllable. In Ukrainian, every syllable needs a vowel sound. That is why vowels are the "heart" of a syllable.
+
+Use this simple beginner rule:
+
+**Count vowel sounds = count syllables.**
+
+| Word | Vowel sounds | Syllables |
+| --- | --- | --- |
+| **день** | **е** | 1 склад |
+| **ма́ма** | **а + а** | 2 склади |
+| **Приві́т** | **и + і** | 2 склади |
+| **молоко́** | **о + о + о** | 3 склади |
+
+Now the workbook can ask you about **склади** because you know the idea: find the vowel sounds first.
+
+### Count склади
+
+<CountSyllables client:only='react' instruction={"Count vowel sounds. Each vowel sound makes one склад."} items={JSON.parse(`[{"word": "день", "correct": 1}, {"word": "ма́ма", "correct": 2}, {"word": "Приві́т", "correct": 2}, {"word": "молоко́", "correct": 3}, {"word": "та́то", "correct": 2}, {"word": "о́ко", "correct": 2}]`)} />
+
+## Consonant Sounds
+
+A consonant sound uses a small block or contact in the mouth: lips, teeth, tongue, or throat.
+
+Try four:
+
+- **[м]** - close your lips and hum.
+- **[п]** - close your lips and release without humming.
+- **[т]** - touch your tongue behind your teeth.
+- **[н]** - touch your tongue and let sound pass through your nose.
+
+Ukrainian has 32 consonant sounds and 22 letters that usually mark consonants. Some consonants have hard and soft versions. You do not need the full system today, but you do need three first clues:
+
+Vowels give a syllable its voice. Consonants build the clear **architecture** (**архітектура**) around that voice: lips, teeth, tongue, or throat make the shape.
+
+| Sign or letter | Beginner meaning |
 | --- | --- |
-| **П** | приголосний |
-| **Р** | приголосний |
-| **И** | голосний |
-| **В** | приголосний |
-| **І** | голосний |
-| **Т** | приголосний |
+| **Ь ь** | **м'який знак**; no sound of its own |
+| **Г г** | Ukrainian h-like sound |
+| **Ґ ґ** | hard **g** sound |
+| **Щ щ** | two sounds together: **[шч]** |
 
-У слові **Приві́т** є **2 голосні звуки** й **4 приголосні звуки**.
+Example:
 
-### Звук і літера
+**день** - day
 
-<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "І", "right": "[і]"}, {"left": "В", "right": "[в]"}, {"left": "А", "right": "[а]"}, {"left": "О", "right": "[о]"}, {"left": "У", "right": "[у]"}, {"left": "Н", "right": "[н]"}, {"left": "Ч", "right": "[ч]"}, {"left": "Ь", "right": "м'якшить попередній при́голосний"}, {"left": "Я", "right": "[йа] або м'якшить попередній при́голосний"}, {"left": "Ї", "right": "[йі]"}, {"left": "Щ", "right": "[шч]"}, {"left": "Д", "right": "[д]"}]`)} />
+The final **ь** does not add a new vowel. It tells you to make **н** soft.
 
-## Абетка: перше знайомство
+The letters **Я, Ю, Є** are graphic **chameleons** (**хамелеони**): at the start of a word they can show **[й] + vowel**, but after a consonant they can point to softness plus one vowel. **Ї** is the strict exception: always **[йі]**.
 
-**А, Б, В... Я** — повна українська абетка.
+## Full Alphabet Pronunciation Pass
 
-Не треба вивчати всі 33 літери за один раз. Спершу впізнавайте
-форму літери, слухайте звук і повторюйте коротке слово.
+This is your first full pass through the alphabet. The goal is not to memorize everything today. The goal is to see every letter, hear a model, and repeat once.
 
-Повна абетка:
+The alphabet order is:
 
 **А Б В Г Ґ Д Е Є Ж З И І Ї Й К Л М Н О П Р С Т У Ф Х Ц Ч Ш Щ Ь Ю Я**
 
-Перші опори:
+Use the pronunciation practice below for all 33 letters. Listen first, then repeat the letter and the example word.
 
-| Лі́тера | Звук | Слово |
-| --- | --- | --- |
-| А | [а] | анана́с |
-| М | [м] | ма́ма |
-| О | [о] | о́ко |
-| П | [п] | піт |
-| Т | [т] | та́то |
-| І | [і] | ім'я́ |
-| И | [и] | сир |
-| Ь | немає власного звука | день |
+### Full alphabet pronunciation pass
 
-У вправі нижче можна послухати всі літери по черзі. Відео потрібні
-тільки для слухання й повторення; не завантажуйте й не перевикористовуйте
-чужий аудіоматеріал.
+<WatchAndRepeat client:only='react' items={JSON.parse(`[{"video": "https://www.youtube.com/watch?v=hvB3VpcR3ZE", "letter": "А", "word": "анана́с"}, {"video": "https://www.youtube.com/watch?v=V1hxBE_JbGg", "letter": "Б", "word": "бана́н"}, {"video": "https://www.youtube.com/watch?v=aFcvYfvQ2X4", "letter": "В", "word": "вода́"}, {"video": "https://www.youtube.com/watch?v=gVnclpSI0DU", "letter": "Г", "word": "гора́"}, {"video": "https://www.youtube.com/watch?v=gNjHqjTW9WQ", "letter": "Ґ", "word": "ґу́дзик"}, {"video": "https://www.youtube.com/watch?v=g4Bh-lqzd48", "letter": "Д", "word": "дім"}, {"video": "https://www.youtube.com/watch?v=KFlsroBW0dk", "letter": "Е", "word": "екра́н"}, {"video": "https://www.youtube.com/watch?v=O0bwRyyBQSc", "letter": "Є", "word": "єно́т"}, {"video": "https://www.youtube.com/watch?v=dIrGVcqPwqM", "letter": "Ж", "word": "жук"}, {"video": "https://www.youtube.com/watch?v=BhASNxitC1A", "letter": "З", "word": "зуб"}, {"video": "https://www.youtube.com/watch?v=W-1rCu0indE", "letter": "И", "word": "сир"}, {"video": "https://www.youtube.com/watch?v=Z9TH0H4ShGo", "letter": "І", "word": "ім'я́"}, {"video": "https://www.youtube.com/watch?v=UcjdjQXhAY8", "letter": "Ї", "word": "їжа́к"}, {"video": "https://www.youtube.com/watch?v=aq0cjB90s3w", "letter": "Й", "word": "йо́гурт"}, {"video": "https://www.youtube.com/watch?v=J7sGEI4-xJo", "letter": "К", "word": "кіт"}, {"video": "https://www.youtube.com/watch?v=v6-3Xg52Buk", "letter": "Л", "word": "лимо́н"}, {"video": "https://www.youtube.com/watch?v=Ez95H4ibuJo", "letter": "М", "word": "ма́ма"}, {"video": "https://www.youtube.com/watch?v=vNUfiKHPYaU", "letter": "Н", "word": "ніс"}, {"video": "https://www.youtube.com/watch?v=gJFxRIPRZbI", "letter": "О", "word": "о́ко"}, {"video": "https://www.youtube.com/watch?v=JksSjjxyW5Y", "letter": "П", "word": "пес"}, {"video": "https://www.youtube.com/watch?v=fMGsQ5KPQgg", "letter": "Р", "word": "рука́"}, {"video": "https://www.youtube.com/watch?v=7UsFBgSL91E", "letter": "С", "word": "сон"}, {"video": "https://www.youtube.com/watch?v=m-jcLR_gK0k", "letter": "Т", "word": "та́то"}, {"video": "https://www.youtube.com/watch?v=VB1O6PmtYRU", "letter": "У", "word": "уро́к"}, {"video": "https://www.youtube.com/watch?v=haHRsFFZRQI", "letter": "Ф", "word": "фо́то"}, {"video": "https://www.youtube.com/watch?v=vpr58zJSJKc", "letter": "Х", "word": "ха́та"}, {"video": "https://www.youtube.com/watch?v=u44eCjR2Oz8", "letter": "Ц", "word": "цу́кор"}, {"video": "https://www.youtube.com/watch?v=UsJkbdsY2RA", "letter": "Ч", "word": "час"}, {"video": "https://www.youtube.com/watch?v=1D-6MIw3OXY", "letter": "Ш", "word": "шко́ла"}, {"video": "https://www.youtube.com/watch?v=QmBLieIuf6Q", "letter": "Щ", "word": "щу́ка"}, {"video": "https://www.youtube.com/watch?v=cJlal8XKBxo", "letter": "Ь", "word": "день"}, {"video": "https://www.youtube.com/watch?v=9JdIBYCTWGw", "letter": "Ю", "word": "ю́шка"}, {"video": "https://www.youtube.com/watch?v=yhSAf41LX8I", "letter": "Я", "word": "я́блуко"}]`)} title="Full alphabet pronunciation pass" />
 
-**Друк і зошит** — впізнавання друкованих і рукописних форм.
+## Stress: Наголос
 
-Спершу впізнавайте форму, а вже потім пишіть самостійно. Використовуйте
-текст цього уроку, власний зошит або живий почерк викладача. Не копіюйте
-чужі рукописні зразки.
+The little mark in **Приві́т** is the stress mark. Ukrainian stress is called **на́голос**.
 
-| Друк | Зошит: підказка | Дія |
-| --- | --- | --- |
-| **П п** | викладач пише **п** від руки | знайдіть **П** |
-| **М м** | викладач пише **м** від руки | знайдіть **М** |
-| **Приві́т** | у зошиті написано **приві́т** | знайдіть слово |
-| **ма́ма** | у зошиті написано **ма́ма** | знайдіть слово |
+Stress tells you which syllable is strongest:
 
-### Алфавітний повтор
-
-<WatchAndRepeat client:only='react' items={JSON.parse(`[{"video": "https://www.youtube.com/watch?v=hvB3VpcR3ZE", "letter": "А", "word": "анана́с"}, {"video": "https://www.youtube.com/watch?v=V1hxBE_JbGg", "letter": "Б", "word": "банду́ра"}, {"video": "https://www.youtube.com/watch?v=aFcvYfvQ2X4", "letter": "В", "word": "вода́"}, {"video": "https://www.youtube.com/watch?v=gVnclpSI0DU", "letter": "Г", "word": "гора́"}, {"video": "https://www.youtube.com/watch?v=gNjHqjTW9WQ", "letter": "Ґ", "word": "ґу́дзик"}, {"video": "https://www.youtube.com/watch?v=g4Bh-lqzd48", "letter": "Д", "word": "дім"}, {"video": "https://www.youtube.com/watch?v=KFlsroBW0dk", "letter": "Е", "word": "екра́н"}, {"video": "https://www.youtube.com/watch?v=O0bwRyyBQSc", "letter": "Є", "word": "єно́т"}, {"video": "https://www.youtube.com/watch?v=dIrGVcqPwqM", "letter": "Ж", "word": "жук"}, {"video": "https://www.youtube.com/watch?v=BhASNxitC1A", "letter": "З", "word": "зуб"}, {"video": "https://www.youtube.com/watch?v=W-1rCu0indE", "letter": "И", "word": "сир"}, {"video": "https://www.youtube.com/watch?v=Z9TH0H4ShGo", "letter": "І", "word": "ім'я́"}, {"video": "https://www.youtube.com/watch?v=UcjdjQXhAY8", "letter": "Ї", "word": "їжа́к"}, {"video": "https://www.youtube.com/watch?v=aq0cjB90s3w", "letter": "Й", "word": "йо́гурт"}, {"video": "https://www.youtube.com/watch?v=J7sGEI4-xJo", "letter": "К", "word": "кіт"}, {"video": "https://www.youtube.com/watch?v=v6-3Xg52Buk", "letter": "Л", "word": "лис"}, {"video": "https://www.youtube.com/watch?v=Ez95H4ibuJo", "letter": "М", "word": "ма́ма"}, {"video": "https://www.youtube.com/watch?v=vNUfiKHPYaU", "letter": "Н", "word": "ніс"}, {"video": "https://www.youtube.com/watch?v=gJFxRIPRZbI", "letter": "О", "word": "о́ко"}, {"video": "https://www.youtube.com/watch?v=JksSjjxyW5Y", "letter": "П", "word": "піт"}, {"video": "https://www.youtube.com/watch?v=fMGsQ5KPQgg", "letter": "Р", "word": "рука́"}, {"video": "https://www.youtube.com/watch?v=7UsFBgSL91E", "letter": "С", "word": "сон"}, {"video": "https://www.youtube.com/watch?v=m-jcLR_gK0k", "letter": "Т", "word": "та́то"}, {"video": "https://www.youtube.com/watch?v=VB1O6PmtYRU", "letter": "У", "word": "уро́к"}, {"video": "https://www.youtube.com/watch?v=haHRsFFZRQI", "letter": "Ф", "word": "фо́то"}, {"video": "https://www.youtube.com/watch?v=vpr58zJSJKc", "letter": "Х", "word": "ха́та"}, {"video": "https://www.youtube.com/watch?v=u44eCjR2Oz8", "letter": "Ц", "word": "цу́кор"}, {"video": "https://www.youtube.com/watch?v=UsJkbdsY2RA", "letter": "Ч", "word": "час"}, {"video": "https://www.youtube.com/watch?v=1D-6MIw3OXY", "letter": "Ш", "word": "шко́ла"}, {"video": "https://www.youtube.com/watch?v=QmBLieIuf6Q", "letter": "Щ", "word": "щу́ка"}, {"video": "https://www.youtube.com/watch?v=cJlal8XKBxo", "letter": "Ь", "word": "день"}, {"video": "https://www.youtube.com/watch?v=9JdIBYCTWGw", "letter": "Ю", "word": "ю́шка"}, {"video": "https://www.youtube.com/watch?v=yhSAf41LX8I", "letter": "Я", "word": "я́блуко"}]`)} title="Алфавітний повтор" />
-
-## Приві́т: перші привітання
-
-**Приві́т!** — Hi!
-
-Спершу вчіть ці привітання як готові фрази. Граматика зачекає.
-
-| Українська | Meaning |
+| Word | How to say it |
 | --- | --- |
-| **Приві́т!** | Hi! |
-| **До́брий день!** | Hello / good day |
-| **До́брого ра́нку!** | Good morning |
-| **До́брий ве́чір!** | Good evening |
-| **До поба́чення!** | Goodbye |
-| **На все до́бре!** | All the best |
+| **Приві́т** | stress on **ві́т** |
+| **ма́ма** | stress on the first **ма́** |
+| **молоко́** | stress on **ко́** |
+| **До́брий день** | stress on **До́-** |
 
-Спершу прочитайте український діалог:
+Sometimes stress changes meaning. You do not need to use these words yet, but notice the pattern:
+
+| Stress | Meaning |
+| --- | --- |
+| **за́мок** | castle |
+| **замо́к** | lock |
+| **бра́ти** | brothers |
+| **брати́** | to take |
+
+For this course, new Ukrainian words usually show stress so you know what to say aloud.
+
+## Euphony: У/В and І/Й
+
+Ukrainian likes smooth sound flow. This is called **милозву́чність**. At A1, you only need to recognize two common pairs:
+
+| Pair | Beginner idea |
+| --- | --- |
+| **у / в** | Ukrainian may choose the smoother one for the sounds around it |
+| **і / й** | Ukrainian may choose the smoother one for the sounds around it |
+
+You do not need to choose them alone yet. Just notice the idea: Ukrainian often avoids heavy sound piles.
+
+## Your First Conversation
+
+Learn these as whole phrases.
+
+| Ukrainian | English | Use |
+| --- | --- | --- |
+| **Приві́т!** | Hi! | informal |
+| **До́брий день!** | Hello! / Good day! | neutral |
+| **До́брого ра́нку!** | Good morning! | morning |
+| **До́брий ве́чір!** | Good evening! | evening |
+| **Як спра́ви?** | How are you? | friendly |
+| **До́бре.** | Fine. | simple answer |
+| **Чудо́во.** | Great. | positive answer |
+| **Норма́льно.** | Okay. | neutral answer |
+| **А у тебе́?** | And you? | after **Як спра́ви?** |
+| **Як тебе́ зва́ти?** | What is your name? | informal |
+| **Ме́не зва́ти Анна.** | My name is Anna. | name answer |
+| **А тебе́?** | And you? | after a name question |
+| **До поба́чення!** | Goodbye! | leaving |
+| **На все до́бре!** | All the best! | friendly goodbye |
+
+Read the dialogue. Then say it aloud twice: once as Anna, once as Marko.
 
 ```text
-О́ля: Приві́т!
-Тара́с: Приві́т!
-О́ля: Як спра́ви?
-Тара́с: До́бре.
-О́ля: А у тебе́?
-Тара́с: Чудо́во!
+А́нна: Приві́т!
+Марко́: Приві́т!
+А́нна: Як спра́ви?
+Марко́: До́бре. А у тебе́?
+А́нна: Чудо́во.
 ```
 
-Підтримка англійською після діалогу:
+Support after the dialogue:
 
-| Українська | Meaning |
+| Ukrainian | English |
 | --- | --- |
-| **Як спра́ви?** | How are you? |
-| **До́бре.** | Fine / good. |
-| **А у тебе́?** | And you? |
-| **Чудо́во!** | Great! |
+| **А́нна: Приві́т!** | Anna: Hi! |
+| **Марко́: Приві́т!** | Marko: Hi! |
+| **А́нна: Як спра́ви?** | Anna: How are you? |
+| **Марко́: До́бре. А у тебе́?** | Marko: Fine. And you? |
+| **А́нна: Чудо́во.** | Anna: Great. |
 
-Після **Як спра́ви?** відповідаємо **А у тебе́?**. Коли питаємо ім'я,
-використовуємо **А тебе́?**
+Now read the name exchange.
 
 ```text
 Марко́: Як тебе́ зва́ти?
-Софі́я: Мене́ зва́ти Софі́я. А тебе́?
-Марко́: Мене́ зва́ти Марко́.
+Софія: Ме́не зва́ти Софія. А тебе́?
+Марко́: Ме́не зва́ти Марко́.
 ```
 
-Підтримка англійською після діалогу:
+Support after the name exchange:
 
-| Українська | Meaning |
+| Ukrainian | English |
 | --- | --- |
-| **Як тебе́ зва́ти?** | What is your name? |
-| **Мене́ зва́ти...** | My name is... |
-| **А тебе́?** | And you? |
+| **Марко́: Як тебе́ зва́ти?** | Marko: What is your name? |
+| **Софія: Ме́не зва́ти Софія. А тебе́?** | Sofia: My name is Sofia. And you? |
+| **Марко́: Ме́не зва́ти Марко́.** | Marko: My name is Marko. |
 
-Дві готові фрази також показують стать мовця:
+Use **А у тебе́?** after **Як спра́ви?** because you are asking about the other person's state. Use **А тебе́?** after **Як тебе́ зва́ти?** because you are asking for the other person's name.
 
-| Хто говорить | Фраза |
+You may also hear:
+
+| Ukrainian | English | Who says it? |
+| --- | --- | --- |
+| **Радий тебе бачити.** | Glad to see you. | a male speaker |
+| **Рада тебе бачити.** | Glad to see you. | a female speaker |
+
+Do not build grammar from this yet. Just notice that Ukrainian sometimes changes a word depending on who is speaking: use **Радий тебе бачити** if the speaker is male, and **Рада тебе бачити** if the speaker is female.
+
+The word **Привіт** is useful for your first tiny sound analysis down to the details (**на гвинтики**): **П-р-и-в-і-т**, four consonant sounds and two vowel sounds.
+
+### First conversations
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "____! Як спра́ви?", "answer": "Приві́т", "options": ["Приві́т", "Молоко́", "Лі́тера"]}, {"sentence": "____. А у тебе́?", "answer": "До́бре", "options": ["До́бре", "День", "Звук"]}, {"sentence": "Як тебе́ ____?", "answer": "зва́ти", "options": ["зва́ти", "до́бре", "день"]}, {"sentence": "Ме́не ____ Анна.", "answer": "зва́ти", "options": ["зва́ти", "спра́ви", "звук"]}, {"sentence": "До ____!", "answer": "поба́чення", "options": ["поба́чення", "тебе́", "ма́ма"]}, {"sentence": "На все ____!", "answer": "до́бре", "options": ["до́бре", "лі́тера", "звук"]}]`)} />
+
+## First Pronunciation Traps
+
+Use these as safety checks:
+
+| Trap | Safer habit |
 | --- | --- |
-| чоловік | **Радий тебе́ ба́чити.** |
-| жінка | **Рада тебе́ ба́чити.** |
+| Blurring **о** in **молоко́** | Keep every **о** clean: **мо-ло-ко́** |
+| Mixing **и** and **і** | In **Приві́т**, **и** and **і** are different |
+| Pronouncing **ь** as a separate sound | In **день**, **ь** only softens **н** |
+| Saying final voiced consonants as voiceless | Keep the written voiced sound; do not automatically devoice it |
+| Treating **Ї** like **І** | **Ї** is **[йі]** |
+| Mixing **Г** and **Ґ** | **Г** is h-like; **Ґ** is hard **g** |
 
-### Короткий діало́г
+Keep Ukrainian sound categories independent. Do not use another language as the shortcut for **И**, **Е**, **О**, or **Г**. Use the Ukrainian mouth model here: **И** has its own position, unstressed **О** stays **О**, **Добрий день** is the neutral greeting, **Привіт** is the everyday informal greeting, and **Г** is the Ukrainian h-like sound.
 
-<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Приві́т! ___ спра́ви?", "answer": "Як", "options": ["Як", "Що", "Де"]}, {"sentence": "До́бре. ___ у тебе́?", "answer": "А", "options": ["А", "На", "У"]}, {"sentence": "Як тебе́ зва́ти? Мене́ зва́ти Анна. ___?", "answer": "А тебе́", "options": ["А тебе́", "А у тебе́", "А тобі́"]}, {"sentence": "___ тебе́ ба́чити! (говорить жінка)", "answer": "Рада", "options": ["Рада", "Радий", "Раді"]}, {"sentence": "___ тебе́ ба́чити! (говорить чоловік)", "answer": "Радий", "options": ["Радий", "Рада", "Раді"]}]`)} />
+### Pronunciation safety check
 
-## Звички першого місяця
+<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "In молоко́, every о stays clean.", "isTrue": true, "explanation": "Ukrainian о does not blur into а in this beginner model."}, {"statement": "The letters и and і always sound the same.", "isTrue": false, "explanation": "Приві́т contains both [и] and [і]."}, {"statement": "Ь has no sound of its own.", "isTrue": true, "explanation": "Ь softens the previous consonant."}, {"statement": "Ї is always [йі].", "isTrue": true, "explanation": "Treat Ї as [йі] at this level."}, {"statement": "Г and Ґ are the same letter.", "isTrue": false, "explanation": "Г is h-like; Ґ is hard g."}, {"statement": "Щ is [шч].", "isTrue": true, "explanation": "Щ represents two sounds together."}]`)} />
 
-Тримайте цей урок малим і точним:
+## Textbook Check
 
-1. Вимовляйте **о** чітко в слові **молоко́**.
-2. Слухайте різницю між **и** та **і** в слові **Приві́т**.
-3. Пам'ятайте: **Ь** не має власного звука.
-4. Спершу впізнавайте друк і зошит, а вже потім пишіть швидко.
-5. Попросіть носія української або викладача послухати **Приві́т**,
-   **До́брий день** та **Мене́ зва́ти...**
+Before you leave the lesson tab, check that you can do these things:
 
-Закінчіть одним надійним рядком:
+- Point to **Приві́т** and say "Hi."
+- Point to **До поба́чення** and say "Goodbye."
+- Answer **Як спра́ви?** with **До́бре**, **Чудо́во**, or **Норма́льно**.
+- Say whether **звук** means "sound" or "letter."
+- Say whether **лі́тера** means "sound" or "letter."
+- Explain **склад** in English.
+- Count the vowel sounds in **Приві́т**.
+- Recognize **Г**, **Ґ**, **Ї**, and **Ь** when the workbook asks for them.
 
-**Приві́т! Як тебе́ зва́ти? Мене́ зва́ти Анна. А тебе́?**
+The workbook repeats the same ideas in different ways. It is practice for eyes, ears, and mouth.
 
 </TabItem>
 <TabItem label="Vocabulary">
 
-<VocabCard client:only="react" words={JSON.parse(`[{"word":"звук","translation":"sound","pos":"noun","example":"Усе починається зі звука.","examples":["sound","Усе починається зі звука."]},{"word":"лі́тера","translation":"letter","pos":"noun","example":"Лі́тера показує, як звук записати.","examples":["letter","Лі́тера показує, як звук записати."]},{"word":"абе́тка","translation":"alphabet","pos":"noun","example":"Украї́нська абе́тка має 33 лі́тери.","examples":["alphabet","Украї́нська абе́тка має 33 лі́тери."]},{"word":"голосни́й звук","translation":"vowel sound","pos":"noun phrase","example":"А — голосни́й звук.","examples":["vowel sound","А — голосни́й звук."]},{"word":"при́голосний звук","translation":"consonant sound","pos":"noun phrase","example":"П — при́голосний звук.","examples":["consonant sound","П — при́голосний звук."]},{"word":"склад","translation":"syllable","pos":"noun","example":"Ма́ма має два склади.","examples":["syllable","Ма́ма має два склади."]},{"word":"на́голос","translation":"stress","pos":"noun","example":"У слові Приві́т наголос на «ві́т».","examples":["stress","У слові Приві́т наголос на «ві́т»."]},{"word":"м'яки́й знак","translation":"soft sign","pos":"noun phrase","example":"У слові день м'яки́й знак пом'якшує [н].","examples":["soft sign","У слові день м'яки́й знак пом'якшує [н]."]},{"word":"Приві́т","translation":"hi","pos":"phrase","example":"Приві́т! Як тебе́ зва́ти?","examples":["hi","Приві́т! Як тебе́ зва́ти?"]},{"word":"До́брий день","translation":"hello","pos":"phrase","example":"До́брий день, Марко.","examples":["hello","До́брий день, Марко."]},{"word":"До́брого ра́нку","translation":"good morning","pos":"phrase","example":"До́брого ра́нку, пане Іване.","examples":["good morning","До́брого ра́нку, пане Іване."]},{"word":"До́брий ве́чір","translation":"good evening","pos":"phrase","example":"До́брий ве́чір! Ласкаво просимо.","examples":["good evening","До́брий ве́чір! Ласкаво просимо."]},{"word":"До поба́чення","translation":"goodbye","pos":"phrase","example":"До поба́чення! До зустрічі.","examples":["goodbye","До поба́чення! До зустрічі."]},{"word":"На все до́бре","translation":"all the best","pos":"phrase","example":"На все до́бре, Маріє.","examples":["all the best","На все до́бре, Маріє."]},{"word":"Як спра́ви","translation":"how are you","pos":"phrase","example":"Як спра́ви?","examples":["how are you","Як спра́ви?"]},{"word":"До́бре","translation":"fine","pos":"adverb","example":"До́бре. Дякую.","examples":["fine","До́бре. Дякую."]},{"word":"Чудо́во","translation":"great","pos":"adjective","example":"Чудо́во! Мені дуже приємно.","examples":["great","Чудо́во! Мені дуже приємно."]},{"word":"Норма́льно","translation":"okay","pos":"adverb","example":"Норма́льно. А в тебе?","examples":["okay","Норма́льно. А в тебе?"]},{"word":"А у тебе́","translation":"and you","pos":"phrase","example":"Як спра́ви? До́бре. А у тебе́?","examples":["and you","Як спра́ви? До́бре. А у тебе́?"]},{"word":"Як тебе́ зва́ти","translation":"what's your name","pos":"phrase","example":"Як тебе́ зва́ти?","examples":["what's your name","Як тебе́ зва́ти?"]},{"word":"Мене́ зва́ти","translation":"my name is","pos":"phrase","example":"Мене́ зва́ти Анна.","examples":["my name is","Мене́ зва́ти Анна."]},{"word":"А тебе́","translation":"and you","pos":"phrase","example":"Як тебе́ зва́ти? А тебе́?","examples":["and you","Як тебе́ зва́ти? А тебе́?"]},{"word":"Радий тебе́ бачити","translation":"glad to see you (masculine)","pos":"phrase","example":"Радий тебе́ бачити.","examples":["glad to see you (masculine)","Радий тебе́ бачити."]},{"word":"Рада тебе́ бачити","translation":"glad to see you (feminine)","pos":"phrase","example":"Рада тебе́ бачити.","examples":["glad to see you (feminine)","Рада тебе́ бачити."]},{"word":"ма́ма","translation":"mom/mother","pos":"noun","example":"Ма́ма.","examples":["mom/mother","Ма́ма."]},{"word":"та́то","translation":"dad","pos":"noun","example":"Та́то.","examples":["dad","Та́то."]},{"word":"молоко́","translation":"milk","pos":"noun","example":"Молоко́.","examples":["milk","Молоко́."]},{"word":"о́ко","translation":"eye","pos":"noun","example":"О́ко.","examples":["eye","О́ко."]},{"word":"дім","translation":"home","pos":"noun","example":"Дім.","examples":["home","Дім."]},{"word":"ніс","translation":"nose","pos":"noun","example":"Ніс.","examples":["nose","Ніс."]},{"word":"сон","translation":"sleep/dream","pos":"noun","example":"Сон.","examples":["sleep/dream","Сон."]},{"word":"день","translation":"day","pos":"noun","example":"Сьогодні день.","examples":["day","Сьогодні день."]},{"word":"вода́","translation":"water","pos":"noun","example":"Вода́.","examples":["water","Вода́."]}]`)} title="Vocabulary" />
+<VocabCard client:only="react" words={JSON.parse(`[{"word":"звук","translation":"sound","pos":"noun","example":"Це звук [а].","examples":["sound","Це звук [а]."]},{"word":"лі́тера","translation":"letter","pos":"noun","example":"Це лі́тера П.","examples":["letter","Це лі́тера П."]},{"word":"абе́тка","translation":"alphabet","pos":"noun","example":"Украї́нська абе́тка має 33 лі́тери.","examples":["alphabet","Украї́нська абе́тка має 33 лі́тери."]},{"word":"голосни́й звук","translation":"vowel sound","pos":"noun phrase","example":"[а] - голосни́й звук.","examples":["vowel sound","[а] - голосни́й звук."]},{"word":"при́голосний звук","translation":"consonant sound","pos":"noun phrase","example":"[п] - при́голосний звук.","examples":["consonant sound","[п] - при́голосний звук."]},{"word":"склад","translation":"syllable","pos":"noun","example":"У сло́ві ма́ма два склади́.","examples":["syllable","У сло́ві ма́ма два склади́."]},{"word":"на́голос","translation":"stress","pos":"noun","example":"У сло́ві Приві́т на́голос на і.","examples":["stress","У сло́ві Приві́т на́голос на і."]},{"word":"м'яки́й знак","translation":"soft sign","pos":"noun phrase","example":"Ь - м'яки́й знак.","examples":["soft sign","Ь - м'яки́й знак."]},{"word":"апо́строф","translation":"apostrophe","pos":"noun","example":"У сло́ві «ім'я́» є апо́строф.","examples":["apostrophe","У сло́ві «ім'я́» є апо́строф."]},{"word":"Приві́т","translation":"Hi","pos":"phrase","example":"Приві́т!","examples":["Hi","Приві́т!"]},{"word":"До́брий день","translation":"Hello / Good day","pos":"phrase","example":"До́брий день!","examples":["Hello / Good day","До́брий день!"]},{"word":"До́брого ра́нку","translation":"Good morning","pos":"phrase","example":"До́брого ра́нку!","examples":["Good morning","До́брого ра́нку!"]},{"word":"До́брий ве́чір","translation":"Good evening","pos":"phrase","example":"До́брий ве́чір!","examples":["Good evening","До́брий ве́чір!"]},{"word":"Як спра́ви?","translation":"How are you?","pos":"phrase","example":"Як спра́ви?","examples":["How are you?","Як спра́ви?"]},{"word":"До́бре","translation":"Fine / good","pos":"phrase","example":"До́бре.","examples":["Fine / good","До́бре."]},{"word":"Чудо́во","translation":"Great / wonderful","pos":"phrase","example":"Чудо́во.","examples":["Great / wonderful","Чудо́во."]},{"word":"Норма́льно","translation":"Okay / normal","pos":"phrase","example":"Норма́льно.","examples":["Okay / normal","Норма́льно."]},{"word":"А у тебе́?","translation":"And you? (after How are you?)","pos":"phrase","example":"До́бре. А у тебе́?","examples":["And you? (after How are you?)","До́бре. А у тебе́?"]},{"word":"Як тебе́ зва́ти?","translation":"What is your name?","pos":"phrase","example":"Як тебе́ зва́ти?","examples":["What is your name?","Як тебе́ зва́ти?"]},{"word":"Ме́не зва́ти ...","translation":"My name is ...","pos":"phrase","example":"Ме́не зва́ти Анна.","examples":["My name is ...","Ме́не зва́ти Анна."]},{"word":"А тебе́?","translation":"And you? (after a name question)","pos":"phrase","example":"Ме́не зва́ти Софія. А тебе́?","examples":["And you? (after a name question)","Ме́не зва́ти Софія. А тебе́?"]},{"word":"До поба́чення","translation":"Goodbye","pos":"phrase","example":"До поба́чення!","examples":["Goodbye","До поба́чення!"]},{"word":"На все до́бре","translation":"All the best","pos":"phrase","example":"На все до́бре!","examples":["All the best","На все до́бре!"]},{"word":"Ра́дий тебе́ ба́чити","translation":"Glad to see you (male speaker)","pos":"phrase","example":"Ра́дий тебе́ ба́чити.","examples":["Glad to see you (male speaker)","Ра́дий тебе́ ба́чити."]},{"word":"Ра́да тебе́ ба́чити","translation":"Glad to see you (female speaker)","pos":"phrase","example":"Ра́да тебе́ ба́чити.","examples":["Glad to see you (female speaker)","Ра́да тебе́ ба́чити."]},{"word":"ма́ма","translation":"mother","pos":"noun","example":"Ма́ма.","examples":["mother","Ма́ма."]},{"word":"та́то","translation":"father","pos":"noun","example":"Та́то.","examples":["father","Та́то."]},{"word":"молоко́","translation":"milk","pos":"noun","example":"Молоко́.","examples":["milk","Молоко́."]},{"word":"о́ко","translation":"eye","pos":"noun","example":"О́ко.","examples":["eye","О́ко."]},{"word":"дім","translation":"house / home","pos":"noun","example":"Дім.","examples":["house / home","Дім."]},{"word":"ніс","translation":"nose","pos":"noun","example":"Ніс.","examples":["nose","Ніс."]},{"word":"сон","translation":"sleep / dream","pos":"noun","example":"Сон.","examples":["sleep / dream","Сон."]}]`)} title="Vocabulary" />
 
-<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"звук","back":"sound"},{"front":"лі́тера","back":"letter"},{"front":"абе́тка","back":"alphabet"},{"front":"голосни́й звук","back":"vowel sound"},{"front":"при́голосний звук","back":"consonant sound"},{"front":"склад","back":"syllable"},{"front":"на́голос","back":"stress"},{"front":"м'яки́й знак","back":"soft sign"},{"front":"Приві́т","back":"hi"},{"front":"До́брий день","back":"hello"},{"front":"До́брого ра́нку","back":"good morning"},{"front":"До́брий ве́чір","back":"good evening"},{"front":"До поба́чення","back":"goodbye"},{"front":"На все до́бре","back":"all the best"},{"front":"Як спра́ви","back":"how are you"},{"front":"До́бре","back":"fine"},{"front":"Чудо́во","back":"great"},{"front":"Норма́льно","back":"okay"},{"front":"А у тебе́","back":"and you"},{"front":"Як тебе́ зва́ти","back":"what's your name"},{"front":"Мене́ зва́ти","back":"my name is"},{"front":"А тебе́","back":"and you"},{"front":"Радий тебе́ бачити","back":"glad to see you (masculine)"},{"front":"Рада тебе́ бачити","back":"glad to see you (feminine)"},{"front":"ма́ма","back":"mom/mother"},{"front":"та́то","back":"dad"},{"front":"молоко́","back":"milk"},{"front":"о́ко","back":"eye"},{"front":"дім","back":"home"},{"front":"ніс","back":"nose"},{"front":"сон","back":"sleep/dream"},{"front":"день","back":"day"},{"front":"вода́","back":"water"}]`)} />
+<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"звук","back":"sound"},{"front":"лі́тера","back":"letter"},{"front":"абе́тка","back":"alphabet"},{"front":"голосни́й звук","back":"vowel sound"},{"front":"при́голосний звук","back":"consonant sound"},{"front":"склад","back":"syllable"},{"front":"на́голос","back":"stress"},{"front":"м'яки́й знак","back":"soft sign"},{"front":"апо́строф","back":"apostrophe"},{"front":"Приві́т","back":"Hi"},{"front":"До́брий день","back":"Hello / Good day"},{"front":"До́брого ра́нку","back":"Good morning"},{"front":"До́брий ве́чір","back":"Good evening"},{"front":"Як спра́ви?","back":"How are you?"},{"front":"До́бре","back":"Fine / good"},{"front":"Чудо́во","back":"Great / wonderful"},{"front":"Норма́льно","back":"Okay / normal"},{"front":"А у тебе́?","back":"And you? (after How are you?)"},{"front":"Як тебе́ зва́ти?","back":"What is your name?"},{"front":"Ме́не зва́ти ...","back":"My name is ..."},{"front":"А тебе́?","back":"And you? (after a name question)"},{"front":"До поба́чення","back":"Goodbye"},{"front":"На все до́бре","back":"All the best"},{"front":"Ра́дий тебе́ ба́чити","back":"Glad to see you (male speaker)"},{"front":"Ра́да тебе́ ба́чити","back":"Glad to see you (female speaker)"},{"front":"ма́ма","back":"mother"},{"front":"та́то","back":"father"},{"front":"молоко́","back":"milk"},{"front":"о́ко","back":"eye"},{"front":"дім","back":"house / home"},{"front":"ніс","back":"nose"},{"front":"сон","back":"sleep / dream"}]`)} />
 
 </TabItem>
 <TabItem label="Activities">
 
-### Звук чи лі́тера
+### Sound or letter?
 
-*(see lesson, §Звук і лі́тера)*
+*(see lesson, §Sound First, Letter Second)*
 
-### Кількість складів
+### Count склади
 
-*(see lesson, §Голосні звуки)*
+*(see lesson, §What Is a Склад?)*
 
-### Звук і літера
+### Full alphabet pronunciation pass
 
-*(see lesson, §При́голосні звуки)*
+*(see lesson, §Full Alphabet Pronunciation Pass)*
 
-### Алфавітний повтор
+### Find the useful letters
 
-*(see lesson, §Абетка: перше знайомство)*
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Which letter is the hard g sound?", "options": [{"text": "Ґ", "correct": true}, {"text": "Г", "correct": false}, {"text": "Ї", "correct": false}], "explanation": "Ґ is the hard g sound; Г is the Ukrainian h-like sound."}, {"question": "Which letter is always [йі]?", "options": [{"text": "Ї", "correct": true}, {"text": "І", "correct": false}, {"text": "И", "correct": false}], "explanation": "Ї is always [йі]. І is the plain [і] vowel."}, {"question": "Which sign has no sound of its own?", "options": [{"text": "Ь", "correct": true}, {"text": "Й", "correct": false}, {"text": "Я", "correct": false}], "explanation": "Ь is the soft sign; it changes the previous consonant."}, {"question": "Which letter is the clean [о] sound in молоко́?", "options": [{"text": "О", "correct": true}, {"text": "А", "correct": false}, {"text": "У", "correct": false}], "explanation": "Ukrainian О stays clean in молоко́."}, {"question": "In Приві́т, which two vowel letters are different?", "options": [{"text": "И and І", "correct": true}, {"text": "О and У", "correct": false}, {"text": "А and Е", "correct": false}], "explanation": "Приві́т contains both И [и] and І [і]."}]`)} />
 
-### Короткий діало́г
+### First conversations
 
-*(see lesson, §Приві́т: перші привітання)*
+*(see lesson, §Your First Conversation)*
 
-### Швидка переві́рка звуків
+### Pronunciation safety check
 
-<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Звук — це те, що ми чуємо й вимовля́ємо.", "isTrue": true, "explanation": "Звук — це те, що ми чуємо й вимовля́ємо."}, {"statement": "Ь має власний голосни́й звук.", "isTrue": false, "explanation": "Ь не має власного звука; він м'якшить попередній при́голосний."}, {"statement": "Молоко́ має три голосні звуки.", "isTrue": true, "explanation": "Голосні звуки: о + о + о."}, {"statement": "До́брий день — це вітальна фра́за.", "isTrue": true, "explanation": "Це одна з перших готових фраз вітання в уро́ці."}, {"statement": "У цьому модулі Щ = [ш].", "isTrue": false, "explanation": "У цьому модулі Щ = [шч]."}]`)} />
+*(see lesson, §First Pronunciation Traps)*
 
-### Склади діало́г
+### Vowel or consonant sound?
 
-<Order client:only='react' items={JSON.parse(`["А у тебе́?", "Приві́т!", "До́бре.", "Як спра́ви?"]`)} correct_order={JSON.parse(`[1, 3, 2, 0]`)} instruction={"Put the mini-dialogue in a natural order."} isUkrainian={false} />
+<GroupSort client:only='react' groups={JSON.parse(`{"Vowel sounds": ["[а]", "[о]", "[у]", "[е]", "[и]", "[і]"], "Consonant sounds": ["[п]", "[р]", "[в]", "[т]", "[м]", "[н]", "[к]", "[с]"]}`)} />
 
-### Друк і зошит
+### See a letter, hear a sound
 
-<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "друк: П п", "right": "зошит: учитель пише п"}, {"left": "друк: М м", "right": "зошит: учитель пише м"}, {"left": "друк: Приві́т", "right": "зошит: приві́т"}, {"left": "друк: ма́ма", "right": "зошит: ма́ма"}]`)} />
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "А", "right": "[а]"}, {"left": "О", "right": "[о]"}, {"left": "У", "right": "[у]"}, {"left": "М", "right": "[м]"}, {"left": "Н", "right": "[н]"}, {"left": "Г", "right": "h-like [г]"}, {"left": "Ґ", "right": "hard [g]"}, {"left": "Ї", "right": "[йі]"}, {"left": "Ь", "right": "no sound"}]`)} />
+
+### Phrase meanings
+
+<Translate client:only='react' questions={JSON.parse(`[{"source": "Приві́т!", "options": [{"text": "Hi!", "correct": true}, {"text": "Goodbye!", "correct": false}, {"text": "What is your name?", "correct": false}], "explanation": "Приві́т is the informal everyday greeting."}, {"source": "До́брий день!", "options": [{"text": "Hello! / Good day!", "correct": true}, {"text": "Milk!", "correct": false}, {"text": "And you?", "correct": false}], "explanation": "До́брий день is the neutral daytime greeting."}, {"source": "Доброго ра́нку!", "options": [{"text": "Good morning!", "correct": true}, {"text": "Good evening!", "correct": false}, {"text": "My name is Anna.", "correct": false}], "explanation": "Ра́нок means morning, so Доброго ра́нку is Good morning."}, {"source": "До́брий ве́чір!", "options": [{"text": "Good evening!", "correct": true}, {"text": "Good morning!", "correct": false}, {"text": "Fine.", "correct": false}], "explanation": "Ве́чір means evening, so До́брий ве́чір is Good evening."}, {"source": "Як спра́ви?", "options": [{"text": "How are you?", "correct": true}, {"text": "Goodbye!", "correct": false}, {"text": "Letter", "correct": false}], "explanation": "Як спра́ви? asks how someone is doing."}, {"source": "До поба́чення!", "options": [{"text": "Goodbye!", "correct": true}, {"text": "Hi!", "correct": false}, {"text": "Sound", "correct": false}], "explanation": "До поба́чення is the leaving phrase Goodbye."}, {"source": "Ра́да тебе́ ба́чити.", "options": [{"text": "Glad to see you. (female speaker)", "correct": true}, {"text": "What is your name?", "correct": false}, {"text": "Good evening!", "correct": false}], "explanation": "Ра́да is the form a female speaker uses in this phrase."}]`)} />
+
+### Pronunciation traps
+
+<ErrorCorrection client:only='react' instruction="Choose the safer Ukrainian habit." items={JSON.parse(`[{"sentence": "Do not call А, О, У голосними літерами.", "errorWord": "голосними літерами", "correctForm": "літерами, що позначають голосні звуки", "options": ["літерами, що позначають голосні звуки", "приголосними літерами"], "explanation": "Safer habit: sounds are голосні or приголосні. Letters represent sounds, so call А, О, У letters that mark vowel sounds."}, {"sentence": "Do not say м[а]локо for молоко.", "errorWord": "м[а]локо", "correctForm": "молоко", "options": ["молоко", "молоко́"], "explanation": "Safer habit: keep Ukrainian о clean. Say молоко́ with three clear о sounds: мо-ло-ко́."}, {"sentence": "Do not add a tiny sound after день.", "errorWord": "add a tiny sound after день", "correctForm": "soften н, then stop", "options": ["soften н, then stop", "add і after нь"], "explanation": "Safer habit: ь has no sound of its own. In день, soften н and stop; do not add a tiny vowel after it."}, {"sentence": "Do not treat Ї as a softening letter.", "errorWord": "treat Ї as a softening letter", "correctForm": "read Ї as [йі]", "options": ["read Ї as [йі]", "read Ї as plain [і]"], "explanation": "Safer habit: Ї is not a softening letter. Read it as [йі] every time."}, {"sentence": "Do not make one fixed glad phrase for every speaker.", "errorWord": "one fixed glad phrase", "correctForm": "Радий тебе бачити / Рада тебе бачити", "options": ["Радий тебе бачити / Рада тебе бачити", "Радий тебе бачити for everyone"], "explanation": "Safer habit: match the phrase to the speaker. A male speaker says Радий тебе бачити; a female speaker says Рада тебе бачити."}]`)} />
 
 </TabItem>
 <TabItem label="Resources">
@@ -340,53 +431,53 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 **📚 Books:**
 - 📚 **Большакова, буквар 1 клас, p. 24**
-  Vowel and consonant practice through short textbook verse.
+  голосні/приголосні через вірші; retrieved via search_text because plan notes include no literal chunk_id.
 - 📚 **Заболотний 5 клас, p. 83**
-  Sound-letter distinction: «Звуки ми чуємо й вимовляємо, а букви бачимо й пишемо.»
+  «Звуки ми чуємо й вимовляємо, а букви бачимо й пишемо.»
 - 📚 **Захарійчук, буквар 1 клас (НУШ 2025), p. 13**
-  Textbook symbols for vowel, hard consonant, and soft consonant sounds.
+  [•] голосний, [–] твердий приголосний, [=] м'який приголосний; resolved page context from corpus metadata.
 - 📚 **Літвінова 5 клас, p. 130**
-  Questions about vowel/consonant terminology and the sound-letter distinction.
+  питання про «голосна літера» / «приголосна літера» and sound-letter distinction.
 
 **📺 Videos:**
-- 📺 [Anna Ohoiko — Letter А pronunciation](https://www.youtube.com/watch?v=hvB3VpcR3ZE) — Pronunciation video: А.
-- 📺 [Anna Ohoiko — Letter Б pronunciation](https://www.youtube.com/watch?v=V1hxBE_JbGg) — Pronunciation video: Б.
-- 📺 [Anna Ohoiko — Letter В pronunciation](https://www.youtube.com/watch?v=aFcvYfvQ2X4) — Pronunciation video: В.
-- 📺 [Anna Ohoiko — Letter Г pronunciation](https://www.youtube.com/watch?v=gVnclpSI0DU) — Pronunciation video: Г.
-- 📺 [Anna Ohoiko — Letter Д pronunciation](https://www.youtube.com/watch?v=g4Bh-lqzd48) — Pronunciation video: Д.
-- 📺 [Anna Ohoiko — Letter Е pronunciation](https://www.youtube.com/watch?v=KFlsroBW0dk) — Pronunciation video: Е.
-- 📺 [Anna Ohoiko — Letter Ж pronunciation](https://www.youtube.com/watch?v=dIrGVcqPwqM) — Pronunciation video: Ж.
-- 📺 [Anna Ohoiko — Letter З pronunciation](https://www.youtube.com/watch?v=BhASNxitC1A) — Pronunciation video: З.
-- 📺 [Anna Ohoiko — Letter И pronunciation](https://www.youtube.com/watch?v=W-1rCu0indE) — Pronunciation video: И.
-- 📺 [Anna Ohoiko — Letter Й pronunciation](https://www.youtube.com/watch?v=aq0cjB90s3w) — Pronunciation video: Й.
-- 📺 [Anna Ohoiko — Letter К pronunciation](https://www.youtube.com/watch?v=J7sGEI4-xJo) — Pronunciation video: К.
-- 📺 [Anna Ohoiko — Letter Л pronunciation](https://www.youtube.com/watch?v=v6-3Xg52Buk) — Pronunciation video: Л.
-- 📺 [Anna Ohoiko — Letter М pronunciation](https://www.youtube.com/watch?v=Ez95H4ibuJo) — Pronunciation video: М.
-- 📺 [Anna Ohoiko — Letter Н pronunciation](https://www.youtube.com/watch?v=vNUfiKHPYaU) — Pronunciation video: Н.
-- 📺 [Anna Ohoiko — Letter О pronunciation](https://www.youtube.com/watch?v=gJFxRIPRZbI) — Pronunciation video: О.
-- 📺 [Anna Ohoiko — Letter П pronunciation](https://www.youtube.com/watch?v=JksSjjxyW5Y) — Pronunciation video: П.
-- 📺 [Anna Ohoiko — Letter Р pronunciation](https://www.youtube.com/watch?v=fMGsQ5KPQgg) — Pronunciation video: Р.
-- 📺 [Anna Ohoiko — Letter С pronunciation](https://www.youtube.com/watch?v=7UsFBgSL91E) — Pronunciation video: С.
-- 📺 [Anna Ohoiko — Letter Т pronunciation](https://www.youtube.com/watch?v=m-jcLR_gK0k) — Pronunciation video: Т.
-- 📺 [Anna Ohoiko — Letter У pronunciation](https://www.youtube.com/watch?v=VB1O6PmtYRU) — Pronunciation video: У.
-- 📺 [Anna Ohoiko — Letter Ф pronunciation](https://www.youtube.com/watch?v=haHRsFFZRQI) — Pronunciation video: Ф.
-- 📺 [Anna Ohoiko — Letter Х pronunciation](https://www.youtube.com/watch?v=vpr58zJSJKc) — Pronunciation video: Х.
-- 📺 [Anna Ohoiko — Letter Ц pronunciation](https://www.youtube.com/watch?v=u44eCjR2Oz8) — Pronunciation video: Ц.
-- 📺 [Anna Ohoiko — Letter Ч pronunciation](https://www.youtube.com/watch?v=UsJkbdsY2RA) — Pronunciation video: Ч.
-- 📺 [Anna Ohoiko — Letter Ш pronunciation](https://www.youtube.com/watch?v=1D-6MIw3OXY) — Pronunciation video: Ш.
-- 📺 [Anna Ohoiko — Letter Щ pronunciation](https://www.youtube.com/watch?v=QmBLieIuf6Q) — Pronunciation video: Щ.
-- 📺 [Anna Ohoiko — Letter Ь pronunciation](https://www.youtube.com/watch?v=cJlal8XKBxo) — Pronunciation video: Ь.
-- 📺 [Anna Ohoiko — Letter Ю pronunciation](https://www.youtube.com/watch?v=9JdIBYCTWGw) — Pronunciation video: Ю.
-- 📺 [Anna Ohoiko — Letter Я pronunciation](https://www.youtube.com/watch?v=yhSAf41LX8I) — Pronunciation video: Я.
-- 📺 [Anna Ohoiko — Letter Є pronunciation](https://www.youtube.com/watch?v=O0bwRyyBQSc) — Pronunciation video: Є.
-- 📺 [Anna Ohoiko — Letter І pronunciation](https://www.youtube.com/watch?v=Z9TH0H4ShGo) — Pronunciation video: І.
-- 📺 [Anna Ohoiko — Letter Ї pronunciation](https://www.youtube.com/watch?v=UcjdjQXhAY8) — Pronunciation video: Ї.
-- 📺 [Anna Ohoiko — Letter Ґ pronunciation](https://www.youtube.com/watch?v=gNjHqjTW9WQ) — Pronunciation video: Ґ.
-- 📺 [Anna Ohoiko — Ukrainian alphabet overview](https://www.youtube.com/watch?v=ksXIXj7CXwc) — Pronunciation video: overview for the full Ukrainian alphabet.
-- 📺 [Anna Ohoiko — Ukrainian alphabet pronunciation playlist](https://www.youtube.com/playlist?list=PLpkSIXDyaJi3mlJlKXWKhdiJZj67fPXQV) — Pronunciation video: playlist for per-letter Ukrainian pronunciation practice.
+- 📺 [Anna Ohoiko — Letter А pronunciation](https://www.youtube.com/watch?v=hvB3VpcR3ZE) — Plan pronunciation video: А.
+- 📺 [Anna Ohoiko — Letter Б pronunciation](https://www.youtube.com/watch?v=V1hxBE_JbGg) — Plan pronunciation video: Б.
+- 📺 [Anna Ohoiko — Letter В pronunciation](https://www.youtube.com/watch?v=aFcvYfvQ2X4) — Plan pronunciation video: В.
+- 📺 [Anna Ohoiko — Letter Г pronunciation](https://www.youtube.com/watch?v=gVnclpSI0DU) — Plan pronunciation video: Г.
+- 📺 [Anna Ohoiko — Letter Д pronunciation](https://www.youtube.com/watch?v=g4Bh-lqzd48) — Plan pronunciation video: Д.
+- 📺 [Anna Ohoiko — Letter Е pronunciation](https://www.youtube.com/watch?v=KFlsroBW0dk) — Plan pronunciation video: Е.
+- 📺 [Anna Ohoiko — Letter Ж pronunciation](https://www.youtube.com/watch?v=dIrGVcqPwqM) — Plan pronunciation video: Ж.
+- 📺 [Anna Ohoiko — Letter З pronunciation](https://www.youtube.com/watch?v=BhASNxitC1A) — Plan pronunciation video: З.
+- 📺 [Anna Ohoiko — Letter И pronunciation](https://www.youtube.com/watch?v=W-1rCu0indE) — Plan pronunciation video: И.
+- 📺 [Anna Ohoiko — Letter Й pronunciation](https://www.youtube.com/watch?v=aq0cjB90s3w) — Plan pronunciation video: Й.
+- 📺 [Anna Ohoiko — Letter К pronunciation](https://www.youtube.com/watch?v=J7sGEI4-xJo) — Plan pronunciation video: К.
+- 📺 [Anna Ohoiko — Letter Л pronunciation](https://www.youtube.com/watch?v=v6-3Xg52Buk) — Plan pronunciation video: Л.
+- 📺 [Anna Ohoiko — Letter М pronunciation](https://www.youtube.com/watch?v=Ez95H4ibuJo) — Plan pronunciation video: М.
+- 📺 [Anna Ohoiko — Letter Н pronunciation](https://www.youtube.com/watch?v=vNUfiKHPYaU) — Plan pronunciation video: Н.
+- 📺 [Anna Ohoiko — Letter О pronunciation](https://www.youtube.com/watch?v=gJFxRIPRZbI) — Activity pronunciation video: О; the locked plan currently has no separate О URL, but the workbook includes the stored course reference.
+- 📺 [Anna Ohoiko — Letter П pronunciation](https://www.youtube.com/watch?v=JksSjjxyW5Y) — Plan pronunciation video: П.
+- 📺 [Anna Ohoiko — Letter Р pronunciation](https://www.youtube.com/watch?v=fMGsQ5KPQgg) — Plan pronunciation video: Р.
+- 📺 [Anna Ohoiko — Letter С pronunciation](https://www.youtube.com/watch?v=7UsFBgSL91E) — Plan pronunciation video: С.
+- 📺 [Anna Ohoiko — Letter Т pronunciation](https://www.youtube.com/watch?v=m-jcLR_gK0k) — Plan pronunciation video: Т.
+- 📺 [Anna Ohoiko — Letter У pronunciation](https://www.youtube.com/watch?v=VB1O6PmtYRU) — Plan pronunciation video: У.
+- 📺 [Anna Ohoiko — Letter Ф pronunciation](https://www.youtube.com/watch?v=haHRsFFZRQI) — Plan pronunciation video: Ф.
+- 📺 [Anna Ohoiko — Letter Х pronunciation](https://www.youtube.com/watch?v=vpr58zJSJKc) — Plan pronunciation video: Х.
+- 📺 [Anna Ohoiko — Letter Ц pronunciation](https://www.youtube.com/watch?v=u44eCjR2Oz8) — Plan pronunciation video: Ц.
+- 📺 [Anna Ohoiko — Letter Ч pronunciation](https://www.youtube.com/watch?v=UsJkbdsY2RA) — Plan pronunciation video: Ч.
+- 📺 [Anna Ohoiko — Letter Ш pronunciation](https://www.youtube.com/watch?v=1D-6MIw3OXY) — Plan pronunciation video: Ш.
+- 📺 [Anna Ohoiko — Letter Щ pronunciation](https://www.youtube.com/watch?v=QmBLieIuf6Q) — Plan pronunciation video: Щ.
+- 📺 [Anna Ohoiko — Letter Ь pronunciation](https://www.youtube.com/watch?v=cJlal8XKBxo) — Plan pronunciation video: Ь.
+- 📺 [Anna Ohoiko — Letter Ю pronunciation](https://www.youtube.com/watch?v=9JdIBYCTWGw) — Plan pronunciation video: Ю.
+- 📺 [Anna Ohoiko — Letter Я pronunciation](https://www.youtube.com/watch?v=yhSAf41LX8I) — Plan pronunciation video: Я.
+- 📺 [Anna Ohoiko — Letter Є pronunciation](https://www.youtube.com/watch?v=O0bwRyyBQSc) — Plan pronunciation video: Є.
+- 📺 [Anna Ohoiko — Letter І pronunciation](https://www.youtube.com/watch?v=Z9TH0H4ShGo) — Plan pronunciation video: І.
+- 📺 [Anna Ohoiko — Letter Ї pronunciation](https://www.youtube.com/watch?v=UcjdjQXhAY8) — Plan pronunciation video: Ї.
+- 📺 [Anna Ohoiko — Letter Ґ pronunciation](https://www.youtube.com/watch?v=gNjHqjTW9WQ) — Plan pronunciation video: Ґ.
+- 📺 [Anna Ohoiko — Ukrainian alphabet overview](https://www.youtube.com/watch?v=ksXIXj7CXwc) — Plan pronunciation video: overview for the full Ukrainian alphabet.
+- 📺 [Anna Ohoiko — Ukrainian alphabet pronunciation playlist](https://www.youtube.com/playlist?list=PLpkSIXDyaJi3mlJlKXWKhdiJZj67fPXQV) — Plan pronunciation video: playlist for per-letter Ukrainian pronunciation practice.
 
 **🎧 Audio:**
-- 🎧 [ULP Season 1, Episode 1 — Informal Greetings](https://www.ukrainianlessons.com/episode1/) — Greeting and response models: Привіт, Як справи?, and short answers.
+- 🎧 [ULP Season 1, Episode 1 — Informal Greetings](https://www.ukrainianlessons.com/episode1/) — Привіт, Як справи?, response models; external search found ULP Episode 1 material.
 :::
 
 </TabItem>


### PR DESCRIPTION
## Summary
- Restores A1 M01 from the post-review first-contact/Ohoiko-era snapshot (`bb4b811c5f`) instead of inventing new lesson prose.
- Keeps M01 aligned with M02/M03: M01 gives the zero-reader sound/letter foundation, first full 33-letter pronunciation pass, stress/euphony first contact, and first greeting dialogue; M02/M03 continue into reading and special signs.
- Removes stale inline DialogueBox JSX, scaffold labels, raw/internal source wording, and regenerates the M01 MDX.

## Validation
- `.venv/bin/python scripts/generate_mdx.py l2-uk-en a1 1`
- `npm exec -- markdownlint-cli2 curriculum/l2-uk-en/a1/sounds-letters-and-hello/module.md starlight/src/content/docs/a1/sounds-letters-and-hello.mdx`
- `.venv/bin/yamllint curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml curriculum/l2-uk-en/a1/sounds-letters-and-hello/vocabulary.yaml curriculum/l2-uk-en/a1/sounds-letters-and-hello/resources.yaml` (warnings only for existing missing `---`)
- `git diff --check`
- `.venv/bin/python scripts/audit/check_mdx_source_parity.py --changed-vs-base origin/main`
- `.venv/bin/python scripts/audit/check_mdx_generation_drift.py --files curriculum/l2-uk-en/a1/sounds-letters-and-hello/module.md`
- bad-pattern scan over A1 source/MDX and built A1 output: no hits
- source/generated check: 33 alphabet pronunciation items in correct order
- `npm run build:starlight`
- Playwright sweep of all 55 A1 routes on `services.sh` Astro: 55/55 loaded, zero bad-pattern hits; M01 shows zero-reader opening, full alphabet order, pronunciation pass, and no internal source note
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
