### PR TITLE
[codex] fix VESUM derivational base acceptance

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -8165,6 +8165,28 @@ _HERITAGE_AUTHENTIC_CLASSIFICATIONS = frozenset(
     {"authentic-archaism", "dialect", "historism", "borrowing", "standard"}
 )
 
+_HERITAGE_FALLBACK_BLOCKED_SURFACES = frozenset(
+    {
+        # Adversarial leak battery for the missing-word heritage fallback. Some
+        # have standard/dialect homographs or VESUM entries, but they must not be
+        # accepted by derivational or heritage fallback when the verifier reports
+        # the surface as missing. Contextual style handling remains outside this
+        # gate; the legacy active-participle cases below intentionally are not here.
+        "глазний",
+        "вкусний",
+        "діюча",
+        "заказувати",
+        "настаювати",
+        "находячийся",
+        "оказувати",
+        "получаючий",
+        "поступаючий",
+        "протиріччя",
+        "решати",
+        "слідувати",
+    }
+)
+
 
 def _engine_classifies_authentic(candidate: str) -> bool:
     """True iff the shared heritage classifier (#2912) attests ``candidate`` as
@@ -8233,9 +8255,10 @@ def _morphological_base_candidates(word: str) -> set[str]:
     it authentic-and-not-russianism, so coinages (``обрядознавчий``) and russianisms
     (``протиріччя``) that lemmatise to themselves stay flagged and the russianism guard
     is untouched. Empty when the analyzer is unavailable (CI), leaving the surface-form
-    + committed-allowlist checks unchanged. Secondary-imperfective aspect pairs
-    (``виворожувати``←``виворожити``) are NOT derived here — that is a separate
-    follow-up; they remain flagged for now."""
+    + committed-allowlist checks unchanged. Productive derivational bases
+    (``виворожувати``←``виворожити``) are handled by
+    ``scripts.lexicon.derivational_morphology`` and verified by the same classifier.
+    """
     candidates: set[str] = set()
     analyzer = _uk_morph_analyzer()
     if analyzer is not None:
@@ -8249,6 +8272,21 @@ def _morphological_base_candidates(word: str) -> set[str]:
     if word.startswith("не") and len(word) > 4:
         candidates.add(word[2:])
     return candidates
+
+
+def _derivational_base_candidates(word: str) -> set[str]:
+    """Full derivational base lemmas proposed for heritage-classifier verification.
+
+    The derivational module is a deterministic candidate generator only; this gate
+    keeps policy authority by requiring every proposed base to classify as authentic
+    and by preserving the direct surface russianism guard above.
+    """
+    try:
+        from scripts.lexicon.derivational_morphology import derivational_bases
+
+        return {row["base"] for row in derivational_bases(word) if row.get("base")}
+    except Exception:
+        return set()
 
 
 def _resolve_folk_heritage_attested_missing(
@@ -8275,6 +8313,8 @@ def _resolve_folk_heritage_attested_missing(
 
     attested: set[str] = set()
     for word, candidates in candidates_by_missing.items():
+        if candidates & _HERITAGE_FALLBACK_BLOCKED_SURFACES:
+            continue
         if attestation_index and any(candidate in attestation_index for candidate in candidates):
             attested.add(word)
             continue
@@ -8292,6 +8332,7 @@ def _resolve_folk_heritage_attested_missing(
         engine_candidates = set(candidates)
         for candidate in candidates:
             engine_candidates |= _morphological_base_candidates(candidate)
+            engine_candidates |= _derivational_base_candidates(candidate)
         if any(_engine_classifies_authentic(candidate) for candidate in engine_candidates):
             attested.add(word)
     return attested

--- a/scripts/lexicon/derivational_morphology.py
+++ b/scripts/lexicon/derivational_morphology.py
@@ -1,0 +1,151 @@
+"""Small deterministic derivational base candidates for VESUM gaps.
+
+This module is deliberately not an authenticity oracle. It only proposes full
+base lemmas for a narrow set of productive Ukrainian derivations; callers must
+verify each base with the heritage classifier before accepting a surface form.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import Any
+
+_ACUTE_RE = re.compile("[\u0301\u0300]")
+_UK_MORPH_ANALYZER: Any = None
+_UK_MORPH_ANALYZER_TRIED = False
+
+
+def derivational_bases(surface: str) -> list[dict[str, str]]:
+    """Return deterministic derivational base evidence rows for ``surface``.
+
+    Rows have ``surface``, ``rule``, and ``base`` keys. The function first
+    lemmatises with pymorphy3, then applies a small suffix-rule table to the
+    lemma. If pymorphy3 is unavailable, it returns no candidates so the VESUM
+    gate degrades to its existing surface/allowlist behavior.
+
+    TODO(stage-2): extend this table for folk-song affective morphology
+    (diminutives/augmentatives such as ``ніженьки`` and ``горілонька``) and
+    prefixal iteratives (``по-...-увати`` such as ``почитувати``).
+    """
+    normalized_surface = _normalize(surface)
+    if not normalized_surface:
+        return []
+
+    rows: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for lemma, tag in _lemma_candidates(normalized_surface):
+        if not lemma or "Dist" in tag:
+            continue
+        for rule, base in _bases_for_lemma(lemma, tag):
+            if base == lemma or not _looks_like_single_ukrainian_token(base):
+                continue
+            key = (rule, base)
+            if key in seen:
+                continue
+            seen.add(key)
+            rows.append({"surface": normalized_surface, "rule": rule, "base": base})
+    return rows
+
+
+def _bases_for_lemma(lemma: str, tag: str) -> Iterable[tuple[str, str]]:
+    if "ADJF" in tag:
+        yield from _denominal_adjective_bases(lemma)
+        yield from _deverbal_adjective_bases(lemma)
+    if "VERB" in tag or "INFN" in tag:
+        yield from _secondary_imperfective_bases(lemma)
+
+
+def _denominal_adjective_bases(lemma: str) -> Iterable[tuple[str, str]]:
+    if lemma.endswith("овий") and len(lemma) > len("овий") + 2:
+        stem = lemma[: -len("овий")]
+        if stem.endswith(("к", "г", "х", "ц", "ч", "ж", "ш")):
+            yield "denominal-adjective:-овий->-а", f"{stem}а"
+        yield "denominal-adjective:-овий->consonant", stem
+
+    if lemma.endswith("евий") and len(lemma) > len("евий") + 2:
+        stem = lemma[: -len("евий")]
+        if stem.endswith("л"):
+            yield "denominal-adjective:-евий->-ь", f"{stem}ь"
+        yield "denominal-adjective:-евий->consonant", stem
+
+    if lemma.endswith("ний") and len(lemma) > len("ний") + 4:
+        stem = lemma[: -len("ний")]
+        yield "denominal-adjective:-ний->consonant", stem
+
+    if lemma.endswith("ський") and len(lemma) > len("ський") + 2:
+        stem = lemma[: -len("ський")]
+        yield "denominal-adjective:-ський->consonant", stem
+
+
+def _deverbal_adjective_bases(lemma: str) -> Iterable[tuple[str, str]]:
+    if lemma.endswith(("увальний", "ювальний")) and len(lemma) > len("вальний") + 2:
+        stem = lemma[: -len("вальний")]
+        yield "deverbal-adjective:-увальний/-ювальний->-увати/-ювати", f"{stem}вати"
+        return
+
+    if lemma.endswith("альний") and len(lemma) > len("альний") + 2:
+        stem = lemma[: -len("альний")]
+        yield "deverbal-adjective:-альний->-ати", f"{stem}ати"
+
+    if lemma.endswith("ільний") and len(lemma) > len("ьний") + 2:
+        stem = lemma[: -len("ьний")]
+        yield "deverbal-adjective:-льний->-лити", f"{stem}ити"
+
+
+def _secondary_imperfective_bases(lemma: str) -> Iterable[tuple[str, str]]:
+    if lemma.endswith("увати") and len(lemma) > len("увати") + 2:
+        stem = lemma[: -len("увати")]
+        if stem.endswith(("ж", "ч", "ш", "щ")):
+            yield "secondary-imperfective:-увати->-ити", f"{stem}ити"
+
+    if lemma.endswith("ювати") and len(lemma) > len("ювати") + 2:
+        stem = lemma[: -len("ювати")]
+        if stem.endswith(("ж", "ч", "ш", "щ")):
+            yield "secondary-imperfective:-ювати->-ити", f"{stem}ити"
+
+
+def _lemma_candidates(surface: str) -> list[tuple[str, str]]:
+    analyzer = _uk_morph_analyzer()
+    if analyzer is None:
+        return []
+
+    candidates: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    try:
+        parses = analyzer.parse(surface)[:5]
+    except Exception:
+        return []
+
+    for parse in parses:
+        lemma = _normalize(str(parse.normal_form or ""))
+        if not lemma or lemma in seen:
+            continue
+        tag = str(parse.tag)
+        if not any(part in tag for part in ("ADJF", "VERB", "INFN")):
+            continue
+        seen.add(lemma)
+        candidates.append((lemma, tag))
+    return candidates
+
+
+def _uk_morph_analyzer() -> Any:
+    global _UK_MORPH_ANALYZER, _UK_MORPH_ANALYZER_TRIED
+    if not _UK_MORPH_ANALYZER_TRIED:
+        _UK_MORPH_ANALYZER_TRIED = True
+        try:
+            import pymorphy3
+
+            _UK_MORPH_ANALYZER = pymorphy3.MorphAnalyzer(lang="uk")
+        except Exception:
+            _UK_MORPH_ANALYZER = None
+    return _UK_MORPH_ANALYZER
+
+
+def _normalize(text: str) -> str:
+    normalized = _ACUTE_RE.sub("", str(text or "").strip().casefold())
+    return normalized.replace("`", "ʼ").replace("'", "ʼ").replace("’", "ʼ")
+
+
+def _looks_like_single_ukrainian_token(text: str) -> bool:
+    return bool(re.fullmatch(r"[а-яєіїґʼ-]+", text))

--- a/tests/test_derivational_morphology.py
+++ b/tests/test_derivational_morphology.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pytest
+
+import scripts.lexicon.derivational_morphology as dm
+from scripts.lexicon.derivational_morphology import derivational_bases
+
+
+def _bases(surface: str) -> set[str]:
+    return {row["base"] for row in derivational_bases(surface)}
+
+
+def test_denominal_adjective_rules_emit_full_noun_bases() -> None:
+    assert "гаївка" in _bases("гаївковий")
+    assert "кришталь" in _bases("кришталевий")
+    assert "обряд" in _bases("обрядний")
+    assert "київ" in _bases("київський")
+
+
+def test_deverbal_adjective_rules_emit_full_infinitive_bases() -> None:
+    assert "знеособлювати" in _bases("знеособлювальними")
+    assert "читати" in _bases("читальний")
+    assert "розподілити" in _bases("розподільний")
+
+
+def test_secondary_imperfective_rule_emits_perfective_base_from_lemma() -> None:
+    assert _bases("виворожувати") == {"виворожити"}
+    assert _bases("виворожують") == {"виворожити"}
+
+
+def test_active_participle_suffixes_are_not_rescued() -> None:
+    for surface in ("получаючий", "поступаючий", "находячийся"):
+        assert _bases(surface) == set()
+
+
+@pytest.mark.parametrize(
+    "surface,dangerous_base",
+    [
+        ("глазний", "глаз"),
+        ("вкусний", "вкус"),
+        ("слідувати", "слідити"),
+        ("оказувати", "оказити"),
+        ("заказувати", "заказити"),
+        ("настаювати", "настаїти"),
+        ("решати", "рішити"),
+    ],
+)
+def test_russianism_leak_surfaces_do_not_emit_dangerous_bases(
+    surface: str,
+    dangerous_base: str,
+) -> None:
+    assert dangerous_base not in _bases(surface)
+
+
+def test_coinages_do_not_emit_broad_stem_fragment_rescues() -> None:
+    assert _bases("двохоровий") == {"двохор"}
+    assert _bases("обрядознавчий") == set()
+    assert _bases("городалька") == set()
+
+
+def test_derivational_bases_degrades_without_morph_analyzer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(dm, "_UK_MORPH_ANALYZER", None)
+    monkeypatch.setattr(dm, "_UK_MORPH_ANALYZER_TRIED", True)
+
+    assert derivational_bases("гаївковий") == []

--- a/tests/test_vesum_heritage_attestation.py
+++ b/tests/test_vesum_heritage_attestation.py
@@ -178,6 +178,15 @@ def test_folk_vesum_gate_accepts_negated_participles_of_standard_bases() -> None
 
 
 @requires_sources_db
+def test_folk_vesum_gate_accepts_productive_derivational_bases() -> None:
+    gate = _gate("гаївковий знеособлювальними виворожувати виворожують другоє ягілки гагілку незгладжений")
+
+    assert gate["passed"] is True
+    assert gate["missing"] == []
+    assert gate["heritage_attested"] == 8
+
+
+@requires_sources_db
 def test_morphology_fallback_does_not_leak_russianism_via_verb_root() -> None:
     # CRITICAL teeth check: `діюча` is a russianism (→ чинна/дійова) whose lemma is
     # the *standard* verb `діяти`. The russianism guard must stop the morphology
@@ -186,6 +195,47 @@ def test_morphology_fallback_does_not_leak_russianism_via_verb_root() -> None:
 
     assert gate["passed"] is False
     assert gate["missing"] == ["діюча"]
+    assert gate["heritage_attested"] == 0
+
+
+@requires_sources_db
+def test_derivational_fallback_does_not_leak_adversarial_russianisms() -> None:
+    leak_words = [
+        "діюча",
+        "протиріччя",
+        "получаючий",
+        "поступаючий",
+        "находячийся",
+        "глазний",
+        "вкусний",
+        "слідувати",
+        "оказувати",
+        "заказувати",
+        "настаювати",
+        "решати",
+    ]
+
+    gate = _gate(" ".join(leak_words))
+
+    assert gate["passed"] is False
+    assert set(gate["missing"]) == set(leak_words)
+    assert gate["heritage_attested"] == 0
+
+
+@requires_sources_db
+def test_direct_standard_active_participle_calques_stay_existing_behavior() -> None:
+    gate = _gate("бажаючий оточуючий керуючий завідуючий слідуючий")
+
+    assert gate["passed"] is True
+    assert gate["missing"] == []
+    assert gate["heritage_attested"] == 5
+
+
+def test_derivational_fallback_does_not_accept_coinages() -> None:
+    gate = _gate("двохоровий обрядознавчий городалька")
+
+    assert gate["passed"] is False
+    assert set(gate["missing"]) == {"двохоровий", "городалька", "обрядознавчий"}
     assert gate["heritage_attested"] == 0
 
 


### PR DESCRIPTION
## Design

Implements a deterministic derivational-morphology acceptance layer for the folk/seminar VESUM heritage fallback.

- Adds `scripts/lexicon/derivational_morphology.py` with a small suffix-rule table that emits full base lemmas only: denominal adjectives, deverbal adjectives, and conservative secondary imperfectives.
- Wires those proposed bases into `_resolve_folk_heritage_attested_missing`; policy remains in the VESUM gate, which still requires classifier-authentic bases and preserves the direct surface russianism guard.
- Adds an explicit missing-word fallback block for the agreed adversarial leak battery so standard/dialect homographs are not accepted when VESUM reported the surface missing.
- Keeps direct-standard active participle/style cases at existing behavior; this layer does not implement a style gate.

## Acceptance Battery

Tool-backed in tests:

- Valid derivations accepted: `гаївковий`, `знеособлювальними`, `виворожувати`, `виворожують`, plus existing `другоє`, `ягілки`, `гагілку`, `незгладжений`.
- Russianism/leak set remains flagged: `діюча`, `протиріччя`, `получаючий`, `поступаючий`, `находячийся`, `глазний`, `вкусний`, `слідувати`, `оказувати`, `заказувати`, `настаювати`, `решати`.
- Direct-standard calques stay as today: `бажаючий`, `оточуючий`, `керуючий`, `завідуючий`, `слідуючий`.
- Coinages remain flagged: `двохоровий`, `обрядознавчий`, `городалька`.

## Stage 2, Not Implemented

TODO is left in the rule table for the next pass: affective folk morphology (`-оньк-/-еньк-/-ечк-/-иц-/-ятк-`, e.g. `ніженьки`, `горілонька`, `доріженька`) and prefixal iteratives (`по-...-увати`, e.g. `почитувати`, `походжувати`). Diminutives are expected to recur heavily in folk modules.

## Validation

```text
.venv/bin/ruff check scripts/lexicon/derivational_morphology.py scripts/build/linear_pipeline.py tests/test_vesum_heritage_attestation.py tests/test_derivational_morphology.py
All checks passed!
```

```text
.venv/bin/python -m pytest tests/test_vesum_heritage_attestation.py tests/test_derivational_morphology.py tests/test_heritage_classifier.py tests/test_vesum_verified_postfix.py -q
============================= 55 passed in 12.00s ==============================
```

```text
.venv/bin/python scripts/audit/lint_agent_trailer.py
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```