### PR TITLE
fix(security): bump idna 3.14→3.17 (.dagger) + harden wiki comment regex

### DIFF
--- a/.dagger/uv.lock
+++ b/.dagger/uv.lock
@@ -258,11 +258,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.14"
+version = "3.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/b1/efac073e0c297ecf2fb33c346989a529d4e19164f1759102dee5953ee17e/idna-3.14.tar.gz", hash = "sha256:466d810d7a2cc1022bea9b037c39728d51ae7dad40d480fc9b7d7ecf98ba8ee3", size = 198272, upload-time = "2026-05-10T20:32:15.935Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.550Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/3c/3f62dee257eb3d6b2c1ef2a09d36d9793c7111156a73b5654d2c2305e5ce/idna-3.14-py3-none-any.whl", hash = "sha256:e677eaf072e290f7b725f9acf0b3a2bd55f9fd6f7c70abe5f0e34823d0accf69", size = 72184, upload-time = "2026-05-10T20:32:14.295Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
 ]
 
 [[package]]

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -236,7 +236,10 @@ def _clean_wiki_def(raw: str) -> str:
     """Strip Вікісловник wiki-markup noise (templates, quote leaks, refs)."""
     text = _unescape_html_entities(raw)
     text = re.sub(r"<br\s*/?>", " ", text, flags=re.IGNORECASE)
-    text = re.sub(r"<!--.*?-->", "", text)
+    # [\s\S] (not .) so multi-line comments are stripped too — `.` stops at the
+    # first newline, leaking the rest of a multi-line comment (CodeQL
+    # py/bad-tag-filter). Input is trusted Вікісловник DB text, but match fully.
+    text = re.sub(r"<!--[\s\S]*?-->", "", text)
     text = re.sub(r"\{\{[^{}]*\}\}", "", text)
     text = re.split(r"\.\s{2,}", text)[0]  # cut a leaked quotation after the def
     text = re.split(r"[|{}\[]", text)[0]  # cut residual template/ref markers


### PR DESCRIPTION
Resolves the two open GitHub security alerts.

## Dependabot #1 (medium) — idna < 3.15
IDNA-processing vuln, transitive via `dagger-io → httpx/anyio` in `.dagger/uv.lock`. Bumped to **3.17** with PyPI sdist+wheel hashes. (`uv lock` can't regen locally — `.dagger/sdk` is generated by `dagger develop` and untracked — so the `idna` entry was updated surgically; idna is a leaf dep, no graph change.)

## CodeQL #227 (high) — py/bad-tag-filter, `enrich_manifest.py:239`
`_clean_wiki_def` stripped HTML comments with `<!--.*?-->`, where `.` stops at the first newline → multi-line comments leak. Switched to `<!--[\s\S]*?-->`.

**Verified:** multi-line comment now fully stripped (`'дім житло'`); `ruff` clean; `test_lexicon_enrich_manifest.py` 2/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)