### PR TITLE
fix(vesum): normalize apostrophe variants

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -614,6 +614,16 @@ _INJECT_RE = re.compile(r"<!--\s*INJECT_ACTIVITY:\s*([A-Za-z0-9_-]+)\s*-->")
 _HEADING_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
 _VESUM_SHORT_DECORATED_WORDS = frozenset({"ся", "сь"})
 _VESUM_STRESS_MARKS = frozenset({"\u0300", "\u0301"})
+_VESUM_APOSTROPHE_TRANSLATION = str.maketrans(
+    {
+        "\u02bc": "'",
+        "\u2019": "'",
+        "\u2018": "'",
+        "`": "'",
+        "\u00b4": "'",
+    }
+)
+_VESUM_WORD_EDGE_CHARS = "-'ʼ’‘`´"
 # O-grade plural obliques (`-остей`, `-остями`, `-остях`, `-остям`) overlap
 # Russian `-ость` forms such as `новостей`; keep that fallback to longer
 # stems so it does not pass merely because short bases like `новий` verify.
@@ -8671,11 +8681,12 @@ def _is_sung_vowel_practice_lookup(word: str) -> bool:
 
 
 def _normalize_for_vesum(lemma: str) -> str:
-    """Strip stress marks and Markdown wrappers before VESUM lookup.
+    """Strip stress marks, Markdown wrappers, and apostrophe variants before VESUM lookup.
 
     Writer output may contain combining accents such as U+0301 and local
-    emphasis like `вмива́ю**ся**`. The QG report still keeps the original
-    surface form; this helper is only for the VESUM lookup key.
+    emphasis like `вмива́ю**ся**`. VESUM stores Ukrainian apostrophe words
+    with ASCII U+0027, so lookup keys canonicalize U+02BC/curly/backtick/acute
+    apostrophes after Markdown stripping.
     """
     text = unicodedata.normalize("NFD", lemma)
     text = "".join(char for char in text if char not in _VESUM_STRESS_MARKS)
@@ -8708,7 +8719,11 @@ def _normalize_for_vesum(lemma: str) -> str:
             lambda m: _strip_morpheme_hyphen(m.group(1)),
             text,
         )
-    return text.strip()
+    return _canonicalize_vesum_apostrophes(text).strip()
+
+
+def _canonicalize_vesum_apostrophes(text: str) -> str:
+    return str(text).translate(_VESUM_APOSTROPHE_TRANSLATION)
 
 
 _VESUM_MORPHEME_HYPHEN_PARTS = frozenset(
@@ -8808,11 +8823,12 @@ def _iter_vesum_lookup_surface_pairs(
         word for word in _iter_vesum_word_surfaces(_normalize_for_vesum(text)) if len(word) >= min_word_length
     }
     decorated_by_lower: dict[str, set[tuple[str, str]]] = {}
-    for match in _VESUM_DECORATED_WORD_RE.finditer(text):
-        raw = match.group(0).strip("-'ʼ")
+    decorated_text = _canonicalize_vesum_apostrophes(text)
+    for match in _VESUM_DECORATED_WORD_RE.finditer(decorated_text):
+        raw = match.group(0).strip(_VESUM_WORD_EDGE_CHARS)
         if not raw or "__" in raw or not _has_vesum_lookup_decoration(raw):
             continue
-        if _looks_like_stem_fragment(text, match.start(), match.end()):
+        if _looks_like_stem_fragment(decorated_text, match.start(), match.end()):
             continue
         normalized = _normalize_for_vesum(raw)
         for word in _iter_vesum_candidate_words(normalized):
@@ -8842,8 +8858,9 @@ def _has_vesum_lookup_decoration(text: str) -> bool:
 
 def _iter_vesum_candidate_words(text: str) -> list[str]:
     words: list[str] = []
+    text = _canonicalize_vesum_apostrophes(text)
     for match in _UK_WORD_RE.finditer(text):
-        word = match.group(0).strip("-'ʼ")
+        word = match.group(0).strip(_VESUM_WORD_EDGE_CHARS)
         if word:
             words.append(word)
     return words
@@ -8852,6 +8869,7 @@ def _iter_vesum_candidate_words(text: str) -> list[str]:
 def _iter_vesum_word_surfaces(text: str) -> list[str]:
     """Extract Ukrainian surface forms that are meaningful VESUM candidates."""
     words: list[str] = []
+    text = _canonicalize_vesum_apostrophes(text)
     for match in _UK_WORD_RE.finditer(text):
         if _touches_blank_marker(text, match.start(), match.end()):
             continue
@@ -8873,7 +8891,7 @@ def _iter_vesum_word_surfaces(text: str) -> list[str]:
         raw = match.group(0)
         if _looks_like_elided_notation(text, match.start(), raw):
             continue
-        word = raw.strip("-'ʼ")
+        word = raw.strip(_VESUM_WORD_EDGE_CHARS)
         if not word:
             continue
         if word.lower() in _STANDALONE_POSTFIX_FRAGMENTS:

--- a/scripts/lexicon/derivational_morphology.py
+++ b/scripts/lexicon/derivational_morphology.py
@@ -14,6 +14,56 @@ from typing import Any
 _ACUTE_RE = re.compile("[\u0301\u0300]")
 _UK_MORPH_ANALYZER: Any = None
 _UK_MORPH_ANALYZER_TRIED = False
+_INFLECTED_ADJECTIVE_LEMMA_ENDINGS: tuple[tuple[str, str], ...] = (
+    ("овими", "овий"),
+    ("ового", "овий"),
+    ("овому", "овий"),
+    ("овою", "овий"),
+    ("ових", "овий"),
+    ("овим", "овий"),
+    ("ової", "овий"),
+    ("овій", "овий"),
+    ("ова", "овий"),
+    ("ове", "овий"),
+    ("ові", "овий"),
+    ("ову", "овий"),
+    ("евими", "евий"),
+    ("евого", "евий"),
+    ("евому", "евий"),
+    ("евою", "евий"),
+    ("евих", "евий"),
+    ("евим", "евий"),
+    ("евої", "евий"),
+    ("евій", "евий"),
+    ("ева", "евий"),
+    ("еве", "евий"),
+    ("еві", "евий"),
+    ("еву", "евий"),
+    ("ськими", "ський"),
+    ("ського", "ський"),
+    ("ському", "ський"),
+    ("ською", "ський"),
+    ("ських", "ський"),
+    ("ським", "ський"),
+    ("ської", "ський"),
+    ("ській", "ський"),
+    ("ська", "ський"),
+    ("ське", "ський"),
+    ("ські", "ський"),
+    ("ську", "ський"),
+    ("ними", "ний"),
+    ("ного", "ний"),
+    ("ному", "ний"),
+    ("ною", "ний"),
+    ("них", "ний"),
+    ("ним", "ний"),
+    ("ної", "ний"),
+    ("ній", "ний"),
+    ("на", "ний"),
+    ("не", "ний"),
+    ("ні", "ний"),
+    ("ну", "ний"),
+)
 
 
 def derivational_bases(surface: str) -> list[dict[str, str]]:
@@ -113,20 +163,36 @@ def _lemma_candidates(surface: str) -> list[tuple[str, str]]:
     candidates: list[tuple[str, str]] = []
     seen: set[str] = set()
     try:
-        parses = analyzer.parse(surface)[:5]
+        parses = analyzer.parse(surface)[:12]
     except Exception:
         return []
 
+    has_adjective_parse = False
     for parse in parses:
         lemma = _normalize(str(parse.normal_form or ""))
         if not lemma or lemma in seen:
             continue
         tag = str(parse.tag)
+        if "ADJF" in tag:
+            has_adjective_parse = True
         if not any(part in tag for part in ("ADJF", "VERB", "INFN")):
             continue
         seen.add(lemma)
         candidates.append((lemma, tag))
+    if has_adjective_parse:
+        for lemma in _inflected_adjective_lemma_candidates(surface):
+            if lemma in seen:
+                continue
+            seen.add(lemma)
+            candidates.append((lemma, "ADJF"))
     return candidates
+
+
+def _inflected_adjective_lemma_candidates(surface: str) -> Iterable[str]:
+    for ending, lemma_ending in _INFLECTED_ADJECTIVE_LEMMA_ENDINGS:
+        if not surface.endswith(ending) or len(surface) <= len(ending) + 2:
+            continue
+        yield f"{surface[: -len(ending)]}{lemma_ending}"
 
 
 def _uk_morph_analyzer() -> Any:

--- a/tests/test_derivational_morphology.py
+++ b/tests/test_derivational_morphology.py
@@ -17,6 +17,11 @@ def test_denominal_adjective_rules_emit_full_noun_bases() -> None:
     assert "київ" in _bases("київський")
 
 
+@pytest.mark.parametrize("surface", ["веснянкова", "веснянкове", "веснянкові"])
+def test_inflected_denominal_adjectives_emit_full_noun_base(surface: str) -> None:
+    assert "веснянка" in _bases(surface)
+
+
 def test_deverbal_adjective_rules_emit_full_infinitive_bases() -> None:
     assert "знеособлювати" in _bases("знеособлювальними")
     assert "читати" in _bases("читальний")

--- a/tests/test_vesum_heritage_attestation.py
+++ b/tests/test_vesum_heritage_attestation.py
@@ -187,6 +187,15 @@ def test_folk_vesum_gate_accepts_productive_derivational_bases() -> None:
 
 
 @requires_sources_db
+def test_folk_vesum_gate_accepts_inflected_denominal_adjectives() -> None:
+    gate = _gate("веснянкова веснянкове веснянкові")
+
+    assert gate["passed"] is True
+    assert gate["missing"] == []
+    assert gate["heritage_attested"] == 3
+
+
+@requires_sources_db
 def test_morphology_fallback_does_not_leak_russianism_via_verb_root() -> None:
     # CRITICAL teeth check: `діюча` is a russianism (→ чинна/дійова) whose lemma is
     # the *standard* verb `діяти`. The russianism guard must stop the morphology

--- a/tests/test_vesum_verified_postfix.py
+++ b/tests/test_vesum_verified_postfix.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 import yaml
 
 from scripts.build.linear_pipeline import (
@@ -89,6 +90,14 @@ def test_normalize_for_vesum_strips_stress_and_markdown() -> None:
     assert _normalize_for_vesum("по**-перше**") == "по-перше"
 
 
+def test_normalize_for_vesum_canonicalizes_apostrophe_variants() -> None:
+    assert _normalize_for_vesum("вʼють") == "в'ють"
+    assert _normalize_for_vesum("в’ють") == "в'ють"
+    assert _normalize_for_vesum("в‘ють") == "в'ють"
+    assert _normalize_for_vesum("в`ють") == "в'ють"
+    assert _normalize_for_vesum("в´ють") == "в'ють"
+
+
 def test_vesum_gate_normalizes_stress_and_markdown_before_lookup() -> None:
     seen: list[list[str]] = []
 
@@ -108,6 +117,58 @@ def test_vesum_gate_normalizes_stress_and_markdown_before_lookup() -> None:
     assert gate["passed"] is True
     assert seen == [["вмиваю", "вмиваюся", "ся", "чудов"]]
     assert gate["missing"] == []
+
+
+def test_vesum_gate_canonicalizes_apostrophes_before_lookup() -> None:
+    seen: list[list[str]] = []
+    valid = {
+        "в'ють",
+        "запам'ятавши",
+        "ім'я",
+        "об'єкт",
+        "п'ять",
+        "пам'яттю",
+        "сім'я",
+    }
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        seen.append(words)
+        return {word: ([{"lemma": word}] if word in valid else []) for word in words}
+
+    u02bc_words = "вʼють памʼяттю запамʼятавши сімʼя пʼять обʼєкт імʼя"
+    ascii_words = "в'ють пам'яттю запам'ятавши сім'я п'ять об'єкт ім'я"
+    gate = _vesum_gate(
+        module_text=f"{u02bc_words} {ascii_words}",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert gate["passed"] is True
+    assert gate["missing"] == []
+    assert seen == [sorted(valid)]
+
+
+@pytest.mark.parametrize("apostrophe", ["’", "‘", "`", "´"])
+def test_vesum_gate_does_not_split_decorated_apostrophe_variants(apostrophe: str) -> None:
+    seen: list[list[str]] = []
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        seen.append(words)
+        return {word: ([{"lemma": word}] if word == "п'ять" else []) for word in words}
+
+    gate = _vesum_gate(
+        module_text=f"п{apostrophe}**ять**",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert gate["passed"] is True
+    assert gate["missing"] == []
+    assert seen == [["п'ять"]]
 
 
 def test_vesum_gate_missing_report_preserves_decorated_surface() -> None:


### PR DESCRIPTION
## Summary

- Canonicalize Ukrainian apostrophe variants to VESUM's stored ASCII apostrophe in `_normalize_for_vesum` and token lookup paths.
- Prevent markdown-decorated apostrophe variants from creating suffix-fragment VESUM lookups.
- Add inflected denominal adjective lemma candidates for `-овий/-евий/-ний/-ський` families when pymorphy sees an adjective parse, preserving classifier verification.

## VESUM proof

Raw VESUM still stores ASCII U+0027 forms only:

```text
.venv/bin/python -m scripts.verification.vesum words 'вʼють' "в'ють" 'памʼяттю' "пам'яттю" 'запамʼятавши' "запам'ятавши"
Found: 3/6
вʼють: NOT FOUND
в'ють: FOUND
памʼяттю: NOT FOUND
пам'яттю: FOUND
запамʼятавши: NOT FOUND
запам'ятавши: FOUND
```

## Acceptance spot check

```text
apostrophe_u02bc passed= True missing= []
apostrophe_ascii passed= True missing= []
inflected_denominal passed= True missing= []
teeth_fallback passed= False missing= ['городалька', 'двохоровий', 'діюча', 'протиріччя', 'слідувати']
```

## Validation

```text
.venv/bin/ruff check --fix scripts/build/linear_pipeline.py scripts/lexicon/derivational_morphology.py tests/test_derivational_morphology.py tests/test_vesum_heritage_attestation.py tests/test_vesum_verified_postfix.py
All checks passed!

.venv/bin/python -m pytest tests/test_vesum_heritage_attestation.py tests/test_derivational_morphology.py tests/test_vesum_verified_postfix.py tests/test_heritage_classifier.py -q
============================= 65 passed in 12.82s ==============================
```

Ready for Claude review; do not merge until kalendarna is re-fired.