### PR TITLE
fix(v7): guard persist against primary-checkout commits + scope add [#2884]

### DIFF
--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -83,6 +83,48 @@ class WorktreeAddFailed(WorktreeSetupError):
     exit_code = 4
 
 
+class PrimaryCheckoutSafetyError(RuntimeError):
+    exit_code = 5
+
+
+class PrimaryCheckoutBuildError(PrimaryCheckoutSafetyError):
+    pass
+
+
+class PrimaryCheckoutPersistError(PrimaryCheckoutSafetyError):
+    pass
+
+
+_MODULE_ARTIFACT_NAMES = (
+    "writer_prompt.md",
+    "writer_output.raw.md",
+    "hermes.write.jsonl",
+    "writer_tool_calls.json",
+    "knowledge_packet.md",
+    "wiki_manifest.json",
+    "implementation_map.json",
+    "module.md",
+    "activities.yaml",
+    "vocabulary.yaml",
+    "resources.yaml",
+    "wiki_completeness_gate.json",
+    "stress_annotation.json",
+    "ulp_fidelity_gate.json",
+    "python_qg.json",
+    "wiki_coverage_gate.json",
+    "wiki_coverage_review.json",
+    "llm_qg.json",
+)
+_MODULE_ARTIFACT_GLOBS = (
+    "python_qg_correction_r*.json",
+    "wiki_coverage_correction_r*.json",
+    "llm-qg-*-prompt.md",
+    "llm-qg-*-response.raw.md",
+    "wiki-coverage-review-prompt.md",
+    "wiki-coverage-review-response.raw.md",
+)
+
+
 def emit_event(event: str, **fields: Any) -> None:
     linear_pipeline.emit_event(event, **fields)
 
@@ -129,7 +171,27 @@ def _run_git(
         text=True,
         check=False,
         timeout=timeout,
+        env=reap_worktrees.sanitized_git_env(),
     )
+
+
+def _format_process_failure(proc: subprocess.CompletedProcess[str]) -> str:
+    detail = (proc.stderr or proc.stdout or "").strip()
+    if detail:
+        return detail.splitlines()[-1]
+    return f"exit {proc.returncode}"
+
+
+def _git_top_level(path: Path) -> Path:
+    try:
+        proc = _run_git(["rev-parse", "--show-toplevel"], cwd=path)
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise WorktreeRepoError(f"cannot resolve git top-level for {path}: {exc}") from exc
+    if proc.returncode != 0:
+        raise WorktreeRepoError(
+            f"cannot resolve git top-level for {path}: {_format_process_failure(proc)}"
+        )
+    return Path((proc.stdout or "").strip()).resolve()
 
 
 def _repo_root_from_cwd() -> Path:
@@ -140,7 +202,7 @@ def _repo_root_from_cwd() -> Path:
             f"cwd must be inside the repository to use --worktree: {exc}"
         ) from exc
     if proc.returncode != 0:
-        detail = (proc.stderr or proc.stdout or "not a git repository").strip()
+        detail = _format_process_failure(proc)
         raise WorktreeRepoError(
             f"cwd must be inside the repository to use --worktree: {detail}"
         )
@@ -255,6 +317,103 @@ def _worktree_mdx_path(
             / f"{slug}.mdx"
         )
     return module_dir / f"{slug}.mdx"
+
+
+def _relative_to_worktree(worktree_path: Path, path: Path) -> str | None:
+    resolved_worktree = worktree_path.resolve()
+    resolved_path = path.resolve()
+    try:
+        return str(resolved_path.relative_to(resolved_worktree))
+    except ValueError:
+        return None
+
+
+def _existing_module_artifacts(module_dir: Path) -> list[Path]:
+    paths = [module_dir / name for name in _MODULE_ARTIFACT_NAMES]
+    for pattern in _MODULE_ARTIFACT_GLOBS:
+        paths.extend(sorted(module_dir.glob(pattern)))
+    return [path for path in paths if path.exists()]
+
+
+def _persist_artifact_paths(
+    worktree: BuildWorktree,
+    *,
+    level: str,
+    slug: str,
+    module_dir: Path | None = None,
+    mdx_path: Path | None = None,
+) -> list[str]:
+    level = level.lower()
+    default_module_dir = (
+        worktree.path / "curriculum" / "l2-uk-en" / level / slug
+    )
+    candidate_paths: list[Path] = []
+    artifact_dirs = [default_module_dir]
+    if module_dir is not None and module_dir != default_module_dir:
+        artifact_dirs.append(module_dir)
+    for artifact_dir in artifact_dirs:
+        candidate_paths.extend(_existing_module_artifacts(artifact_dir))
+
+    # Gemini-routed writes can place the Hermes trace at the repository root.
+    candidate_paths.append(worktree.path / "hermes.write.jsonl")
+
+    default_mdx = (
+        worktree.path
+        / "starlight"
+        / "src"
+        / "content"
+        / "docs"
+        / level
+        / f"{slug}.mdx"
+    )
+    for path in (mdx_path, default_mdx):
+        if path is not None and path.exists():
+            candidate_paths.append(path)
+
+    archive_dir = run_archive.archive_dir_for(
+        worktree.path,
+        level=level,
+        slug=slug,
+        run_id=worktree.run_id,
+    )
+    if archive_dir.exists():
+        candidate_paths.extend(
+            path for path in sorted(archive_dir.rglob("*")) if path.is_file()
+        )
+
+    rel_paths = []
+    seen = set()
+    for path in candidate_paths:
+        if not path.exists():
+            continue
+        relative = _relative_to_worktree(worktree.path, path)
+        if relative is None or relative in seen:
+            continue
+        rel_paths.append(relative)
+        seen.add(relative)
+    return rel_paths
+
+
+def _ensure_persist_target_is_not_primary_checkout(worktree: BuildWorktree) -> None:
+    target_top_level = _git_top_level(worktree.path)
+    primary_checkout = reap_worktrees.primary_checkout_root(worktree.repo_root).resolve()
+    if target_top_level == primary_checkout:
+        raise PrimaryCheckoutPersistError(
+            "Refusing to persist v7_build artifacts in the primary checkout; "
+            "target git top-level is the primary checkout. Pass --worktree so "
+            "artifacts are committed in an isolated worktree. See #2884."
+        )
+
+
+def _ensure_top_level_invocation_is_not_primary_checkout() -> None:
+    cwd_top_level = _git_top_level(Path.cwd())
+    primary_checkout = reap_worktrees.primary_checkout_root(cwd_top_level).resolve()
+    if cwd_top_level == primary_checkout:
+        raise PrimaryCheckoutBuildError(
+            "Refusing to run v7_build in the primary checkout; pass --worktree "
+            "(artifacts are committed and must land in an isolated worktree). "
+            "See #2884."
+        )
 
 
 def _writer_model_effort(writer: str, effort_override: str | None) -> tuple[str, str]:
@@ -431,8 +590,10 @@ def _persist_build_artifacts(
     level: str,
     slug: str,
     result: str,
+    module_dir: Path | None = None,
+    mdx_path: Path | None = None,
 ) -> bool:
-    """Commit ALL build artifacts to the worktree's build branch.
+    """Commit scoped build artifacts to the worktree's build branch.
 
     Build artifacts (writer_prompt.md, writer_output.raw.md, hermes.write.jsonl,
     writer_tool_calls.json, knowledge_packet.md, implementation_map.json, the
@@ -443,8 +604,8 @@ def _persist_build_artifacts(
     the 2026-05-19→20 incident where 7 worktrees were cleaned up and today's
     diagnostic artifacts were lost).
 
-    Strategy: from inside the worktree's working tree, ``git add -A &&
-    git commit --allow-empty -m "build(level/slug): artifacts (<result>)"``.
+    Strategy: from inside the worktree's working tree, explicitly add the
+    known artifact paths and then commit with ``--allow-empty``.
     The build branch is private to this worktree (created from origin/main in
     ``_setup_worktree`` with the unique timestamped suffix) so the commit
     cannot collide with another build of the same module. We deliberately
@@ -452,21 +613,35 @@ def _persist_build_artifacts(
     want shareable provenance for a specific build can push that branch
     manually.
 
-    Errors here are non-fatal: persistence is best-effort. A failure to
-    commit (e.g. git config not set, hooks blocking) prints a warning and
-    returns. Better to leave the worktree dir as-is than to crash the
-    wrapper after the actual build already finished.
+    Ordinary git errors here are non-fatal: persistence is best-effort. The
+    primary-checkout guard is fatal because committing build artifacts on main
+    is worse than crashing this wrapper.
     """
+    _ensure_persist_target_is_not_primary_checkout(worktree)
+    artifact_paths = _persist_artifact_paths(
+        worktree,
+        level=level,
+        slug=slug,
+        module_dir=module_dir,
+        mdx_path=mdx_path,
+    )
     try:
-        # Stage every file in the worktree relative to its working tree.
-        # The worktree was created from origin/main with no local edits,
-        # so any staged change here came from the build run.
-        subprocess.run(
-            ["git", "-C", str(worktree.path), "add", "-A"],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
+        if artifact_paths:
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(worktree.path),
+                    "add",
+                    "--force",
+                    "--",
+                    *artifact_paths,
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env=reap_worktrees.sanitized_git_env(),
+            )
         # --allow-empty so empty builds (rare, e.g. dry-run paths or
         # failed-before-writer setups) still leave a commit on the branch
         # marking that the worktree was used. Caller can prune later.
@@ -484,6 +659,7 @@ def _persist_build_artifacts(
             check=True,
             capture_output=True,
             text=True,
+            env=reap_worktrees.sanitized_git_env(),
         )
         return True
     except (subprocess.CalledProcessError, OSError) as exc:
@@ -510,7 +686,7 @@ def _run_in_worktree(args: argparse.Namespace, raw_argv: list[str]) -> int:
 
     model, effort = _writer_model_effort(writer, args.effort)
     archive = run_archive.RunArchive.start(
-        project_root=worktree.repo_root,
+        project_root=worktree.path,
         worktree_path=worktree.path,
         level=level,
         slug=slug,
@@ -563,12 +739,18 @@ def _run_in_worktree(args: argparse.Namespace, raw_argv: list[str]) -> int:
         # the writer_prompt + partial writer_output remain queryable via
         # the build branch SHA. Without this, `git worktree remove`
         # silently destroys forensic evidence.
-        persisted = _persist_build_artifacts(
-            worktree,
-            level=level,
-            slug=slug,
-            result=result,
-        )
+        try:
+            persisted = _persist_build_artifacts(
+                worktree,
+                level=level,
+                slug=slug,
+                result=result,
+                module_dir=module_dir,
+                mdx_path=mdx_path,
+            )
+        except PrimaryCheckoutSafetyError as exc:
+            print(f"v7_build: error — {exc}", file=sys.stderr)
+            return exc.exit_code
         cleanup_result = None
         if result == "success" and persisted and not args.keep_worktree:
             cleanup_result = reap_worktrees.reap_success_worktree(
@@ -906,6 +1088,7 @@ def build_parser() -> argparse.ArgumentParser:
             "  2 on command-line usage errors from argparse or --worktree outside this repo.\n"
             "  3 when the requested --worktree path already exists.\n"
             "  4 when git worktree add fails.\n\n"
+            "  5 when a primary-checkout safety guard refuses the run.\n\n"
             "  124 when a writer subprocess is killed after --writer-timeout "
             "seconds of stdout silence.\n\n"
             "Related:\n"
@@ -1051,6 +1234,12 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(raw_argv)
     if args.worktree is not None:
         return _run_in_worktree(args, raw_argv)
+    if run_archive.ENV_KEY not in os.environ:
+        try:
+            _ensure_top_level_invocation_is_not_primary_checkout()
+        except PrimaryCheckoutSafetyError as exc:
+            print(str(exc), file=sys.stderr)
+            return exc.exit_code
     telemetry_out = _resolve_project_path(args.telemetry_out)
     with linear_pipeline.telemetry_event_sink(telemetry_out):
         return _run(args)

--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -63,7 +63,7 @@ class ReapResult:
     error: str | None = None
 
 
-def _sanitized_git_env() -> dict[str, str]:
+def sanitized_git_env() -> dict[str, str]:
     return {
         key: value
         for key, value in os.environ.items()
@@ -84,7 +84,7 @@ def _run(
         text=True,
         check=False,
         timeout=timeout,
-        env=_sanitized_git_env(),
+        env=sanitized_git_env(),
     )
 
 
@@ -188,7 +188,7 @@ def _worktrees_root(repo_root: Path) -> Path:
     return (repo_root / ".worktrees").resolve()
 
 
-def _is_under_worktrees(repo_root: Path, path: Path) -> bool:
+def is_under_worktrees(repo_root: Path, path: Path) -> bool:
     try:
         path.resolve().relative_to(_worktrees_root(repo_root))
     except ValueError:
@@ -467,7 +467,7 @@ def reap_worktrees(
     for info in list_git_worktrees(repo_root):
         if targets is not None and info.path.resolve() not in targets:
             continue
-        if not _is_under_worktrees(repo_root, info.path):
+        if not is_under_worktrees(repo_root, info.path):
             results.append(
                 ReapResult(
                     path=str(info.path),
@@ -574,7 +574,7 @@ def reap_success_worktree(
         )
 
     info = matching[0]
-    if not _is_under_worktrees(repo_root, info.path):
+    if not is_under_worktrees(repo_root, info.path):
         return ReapResult(
             path=str(info.path),
             branch=info.branch,

--- a/tests/test_v7_build_persist_guard.py
+++ b/tests/test_v7_build_persist_guard.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.build import run_archive, v7_build
+
+_REAL_RUN = subprocess.run
+_RUN_ID = "20260611-120000"
+
+
+def git_env() -> dict[str, str]:
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_") and not key.startswith("PRE_COMMIT")
+    }
+
+
+def git(cwd: Path, *args: str) -> str:
+    proc = _REAL_RUN(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=git_env(),
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    return (proc.stdout or "").strip()
+
+
+def init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    git(tmp_path, "init", "--initial-branch=main", str(repo))
+    git(repo, "config", "user.email", "tester@example.com")
+    git(repo, "config", "user.name", "Test User")
+    (repo / ".gitignore").write_text(
+        ".worktrees/\ncurriculum/l2-uk-en/_orchestration/\n",
+        encoding="utf-8",
+    )
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    git(repo, "add", ".gitignore", "README.md")
+    git(repo, "commit", "-m", "base")
+    return repo
+
+
+def add_build_worktree(repo: Path, branch: str = "build/a1/foo") -> Path:
+    worktree = repo / ".worktrees" / "builds" / branch.replace("/", "-")
+    worktree.parent.mkdir(parents=True, exist_ok=True)
+    git(repo, "worktree", "add", "-b", branch, str(worktree), "main")
+    git(worktree, "config", "user.email", "tester@example.com")
+    git(worktree, "config", "user.name", "Test User")
+    return worktree
+
+
+def build_worktree(repo: Path, path: Path, branch: str = "build/a1/foo") -> v7_build.BuildWorktree:
+    return v7_build.BuildWorktree(
+        path=path,
+        branch=branch,
+        base_sha=git(path, "rev-parse", "--short", "HEAD"),
+        repo_root=repo,
+        run_id=_RUN_ID,
+    )
+
+
+def seed_artifacts(root: Path, *, level: str = "a1", slug: str = "foo") -> None:
+    module_dir = root / "curriculum" / "l2-uk-en" / level / slug
+    module_dir.mkdir(parents=True, exist_ok=True)
+    for name, content in {
+        "writer_prompt.md": "prompt\n",
+        "writer_output.raw.md": "raw\n",
+        "hermes.write.jsonl": "{}\n",
+        "writer_tool_calls.json": "[]\n",
+        "knowledge_packet.md": "packet\n",
+        "implementation_map.json": "{}\n",
+        "module.md": "# Module\n",
+        "activities.yaml": "[]\n",
+        "vocabulary.yaml": "[]\n",
+        "resources.yaml": "[]\n",
+    }.items():
+        (module_dir / name).write_text(content, encoding="utf-8")
+
+    mdx_path = root / "starlight" / "src" / "content" / "docs" / level / f"{slug}.mdx"
+    mdx_path.parent.mkdir(parents=True, exist_ok=True)
+    mdx_path.write_text("---\ntitle: Foo\n---\n", encoding="utf-8")
+
+    archive_dir = run_archive.archive_dir_for(
+        root,
+        level=level,
+        slug=slug,
+        run_id=_RUN_ID,
+    )
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    (archive_dir / "state.json").write_text('{"status": "complete"}\n', encoding="utf-8")
+
+
+def test_persist_refuses_primary_checkout_and_creates_no_commit(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    seed_artifacts(repo)
+    worktree = build_worktree(repo, repo, branch="main")
+    before = git(repo, "rev-parse", "HEAD")
+
+    with pytest.raises(v7_build.PrimaryCheckoutPersistError):
+        v7_build._persist_build_artifacts(
+            worktree,
+            level="a1",
+            slug="foo",
+            result="failed",
+        )
+
+    assert git(repo, "rev-parse", "HEAD") == before
+    assert git(repo, "rev-list", "--count", "HEAD") == "1"
+
+
+def test_persist_allows_real_worktree_child(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    child = add_build_worktree(repo)
+    seed_artifacts(child)
+    worktree = build_worktree(repo, child)
+    monkeypatch.setenv("GIT_DIR", str(repo / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(repo))
+
+    assert (
+        v7_build._persist_build_artifacts(
+            worktree,
+            level="a1",
+            slug="foo",
+            result="success",
+        )
+        is True
+    )
+
+    assert git(child, "log", "-1", "--format=%s") == "build(a1/foo): artifacts (success)"
+    committed = git(child, "show", "--name-only", "--format=", "HEAD")
+    assert "curriculum/l2-uk-en/a1/foo/writer_prompt.md" in committed
+    assert "curriculum/l2-uk-en/_orchestration/a1/foo/runs/" in committed
+    assert "starlight/src/content/docs/a1/foo.mdx" in committed
+
+
+def test_persist_scoped_add_leaves_unrelated_untracked_file_out(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    child = add_build_worktree(repo)
+    seed_artifacts(child)
+    (child / "scratch-notes.txt").write_text("do not commit\n", encoding="utf-8")
+    worktree = build_worktree(repo, child)
+
+    assert (
+        v7_build._persist_build_artifacts(
+            worktree,
+            level="a1",
+            slug="foo",
+            result="failed",
+        )
+        is True
+    )
+
+    stat = git(child, "show", "--stat", "--oneline", "HEAD")
+    assert "writer_prompt.md" in stat
+    assert "scratch-notes.txt" not in stat
+    assert "?? scratch-notes.txt" in git(child, "status", "--short")
+
+
+def test_main_guard_refuses_primary_checkout_but_allows_archive_child(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = init_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    monkeypatch.delenv(run_archive.ENV_KEY, raising=False)
+    calls: list[Any] = []
+    monkeypatch.setattr(v7_build, "_run", lambda args: calls.append(args) or 0)
+
+    exit_code = v7_build.main(["a1", "foo", "--dry-run"])
+
+    captured = capsys.readouterr()
+    assert exit_code == v7_build.PrimaryCheckoutSafetyError.exit_code
+    assert calls == []
+    assert "Refusing to run v7_build in the primary checkout" in captured.err
+    assert "See #2884" in captured.err
+
+    monkeypatch.setenv(run_archive.ENV_KEY, "test-child")
+    assert v7_build.main(["a1", "foo", "--dry-run"]) == 0
+    assert len(calls) == 1

--- a/tests/test_v7_build_worktree.py
+++ b/tests/test_v7_build_worktree.py
@@ -26,9 +26,12 @@ def _install_fake_subprocess_run(
         timeout: int | None = None,
         env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
-        del cwd, capture_output, text, check, timeout, env
+        del capture_output, text, check, timeout, env
         calls.append(cmd)
         if cmd[:2] == ["git", "rev-parse"] and "--show-toplevel" in cmd:
+            top_level = Path(cwd).resolve() if cwd is not None else repo
+            if str(top_level).startswith(str((repo / ".worktrees").resolve())):
+                return subprocess.CompletedProcess(cmd, 0, f"{top_level}\n", "")
             return subprocess.CompletedProcess(cmd, 0, f"{repo}\n", "")
         if cmd[:2] == ["git", "rev-parse"] and "--git-common-dir" in cmd:
             return subprocess.CompletedProcess(cmd, 0, f"{repo / '.git'}\n", "")
@@ -56,6 +59,7 @@ def _install_fake_subprocess_run(
 def _prepare_repo(monkeypatch: Any, tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     repo.mkdir()
+    (repo / ".git").mkdir()
     monkeypatch.chdir(repo)
     monkeypatch.setattr(v7_build, "PROJECT_ROOT", repo)
     monkeypatch.setattr(v7_build, "_utc_timestamp", lambda: "20260513-123456")
@@ -197,8 +201,8 @@ def test_worktree_persists_artifacts_on_success(
     them to the worktree filesystem but does NOT commit them — without this
     persist step, ``git worktree remove`` silently destroys forensic
     evidence (2026-05-19→20 incident: 7 worktrees deleted, today's
-    textbook_grounding diagnostic artifacts lost). Both ``git add -A`` and
-    ``git commit --allow-empty`` must fire in the worktree.
+    textbook_grounding diagnostic artifacts lost). Both scoped ``git add``
+    and ``git commit --allow-empty`` must fire in the worktree.
     """
     repo = _prepare_repo(monkeypatch, tmp_path)
     calls = _install_fake_subprocess_run(monkeypatch, repo, child_returncode=0)
@@ -212,7 +216,7 @@ def test_worktree_persists_artifacts_on_success(
         for cmd in calls
         if cmd[:2] == ["git", "-C"]
         and cmd[2] == str(worktree_path)
-        and cmd[3:] == ["add", "-A"]
+        and cmd[3:6] == ["add", "--force", "--"]
     )
     assert add_cmd is not None
     commit_cmd = next(

--- a/tests/test_v7_writer_dispatch.py
+++ b/tests/test_v7_writer_dispatch.py
@@ -19,6 +19,11 @@ from scripts.agent_runtime.telemetry import InvocationTelemetry
 from scripts.build import linear_pipeline, v7_build
 
 
+@pytest.fixture(autouse=True)
+def _simulate_worktree_child(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(v7_build.run_archive.ENV_KEY, "test-child")
+
+
 def _seed_sources_mcp_config(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Fixes the #2884 recurrence path without requiring top-level `--worktree` in the child process. The key trap is preserved: `_run_in_worktree()` still strips `--worktree` before re-invoking `scripts/build/v7_build.py` inside the build worktree, so the child legitimately runs with no `--worktree`. The new invariant is instead: v7 build artifact persistence must never stage or commit when the target git top-level is the primary checkout.

Changes:
- Add a fatal primary-checkout guard before `_persist_build_artifacts` can stage anything.
- Add a top-level `main()` guard: no `--worktree` + no `V7_RUN_ARCHIVE_CONTEXT` + cwd is primary checkout exits nonzero with the #2884 refusal.
- Replace `git add -A` with explicit `git add --force -- <artifact paths>` for module artifacts, run archive files, Hermes traces, and MDX output only.
- Sanitize Git subprocess environments so hook-local `GIT_DIR` / `GIT_WORK_TREE` cannot retarget nested git operations.
- Promote `reap_worktrees.is_under_worktrees()` and `sanitized_git_env()` for shared use.

Closes #2884.

## Raw Evidence

Focused guard tests:

```text
tests/test_v7_build_persist_guard.py::test_persist_refuses_primary_checkout_and_creates_no_commit PASSED [ 25%]
tests/test_v7_build_persist_guard.py::test_persist_allows_real_worktree_child PASSED [ 50%]
tests/test_v7_build_persist_guard.py::test_persist_scoped_add_leaves_unrelated_untracked_file_out PASSED [ 75%]
tests/test_v7_build_persist_guard.py::test_main_guard_refuses_primary_checkout_but_allows_archive_child PASSED [100%]
============================== 4 passed in 0.80s ===============================
```

Scoped add proof (`git show --stat` lacks `scratch-notes.txt`; status keeps it untracked):

```text
7f0e69b build(a1/foo): artifacts (failed)
 .../l2-uk-en/_orchestration/a1/foo/runs/20260611-120000/state.json     | 1 +
 curriculum/l2-uk-en/a1/foo/activities.yaml                             | 1 +
 curriculum/l2-uk-en/a1/foo/hermes.write.jsonl                          | 1 +
 curriculum/l2-uk-en/a1/foo/implementation_map.json                     | 1 +
 curriculum/l2-uk-en/a1/foo/knowledge_packet.md                         | 1 +
 curriculum/l2-uk-en/a1/foo/module.md                                   | 1 +
 curriculum/l2-uk-en/a1/foo/resources.yaml                              | 1 +
 curriculum/l2-uk-en/a1/foo/vocabulary.yaml                             | 1 +
 curriculum/l2-uk-en/a1/foo/writer_output.raw.md                        | 1 +
 curriculum/l2-uk-en/a1/foo/writer_prompt.md                            | 1 +
 curriculum/l2-uk-en/a1/foo/writer_tool_calls.json                      | 1 +
 starlight/src/content/docs/a1/foo.mdx                                  | 3 +++
 12 files changed, 14 insertions(+)
--- status --short ---
?? scratch-notes.txt
```

Requested regression slice:

```text
=============== 87 passed, 8285 deselected, 3 warnings in 32.95s ===============
```

Lint:

```text
.venv/bin/ruff check scripts/build/v7_build.py tests/test_v7_build_persist_guard.py
All checks passed!
```

Commit-hook affected tests:

```text
============================== 39 passed in 3.02s ==============================
```