### PR TITLE
fix(audit): key folk seminar config as FOLK (was unreachable C1-folk → folk audited as A1)

### DIFF
--- a/docs/l2-uk-en/MODULE-RICHNESS-GUIDELINES-v2.md
+++ b/docs/l2-uk-en/MODULE-RICHNESS-GUIDELINES-v2.md
@@ -552,7 +552,7 @@ Each module should include review items from previous module(s) to reinforce ret
 | `C1-academic`     | 01-20                   | 3000+ | 12    | 24+   | Academic Ukrainian, morphology, syntax       |
 | `C1-professional` | 21-35                   | 3000+ | 12    | 35+   | Professional & social register               |
 | `C1-stylistics`   | 36-55                   | 3000+ | 12    | 24+   | 5 functional styles, rhetoric, argumentation |
-| `C1-folk`         | 56-80                   | 3000+ | 12    | 24+   | Folk culture, arts, dialects, Surzhyk        |
+| `FOLK`            | seminar track           | 4000+ | 1+    | 24+   | Folk-culture seminar (de-imperialized, C1 register) |
 | `C1-literature`   | 81-115                  | 3500+ | 12    | 24+   | Literary analysis: classics to contemporary  |
 | `biography`    | 36-100                  | 4000+ | 4-9   | 24+   | Biography seminar style                      |
 | `istorio`      | 101-115                 | 4000+ | 4-9   | 25+   | Historical analysis seminar style            |

--- a/scripts/audit/config.py
+++ b/scripts/audit/config.py
@@ -1028,7 +1028,12 @@ LEVEL_CONFIG = {
         'transliteration_allowed': False,
         'priority_types': {'reading', 'essay-response', 'critical-analysis', 'comparative-study'}  # Seminar
     },
-    'C1-folk': {
+    # FOLK seminar (C1-register folk-culture track). Keyed by its level_code
+    # 'FOLK' — the same track-name-is-the-key pattern as LIT/OES/RUTH — so
+    # detect_level('/folk/...') -> 'FOLK' resolves here directly. Previously
+    # keyed 'C1-folk', which was unreachable (folk plans carry level: FOLK,
+    # never 'C1'), so folk modules silently audited against the A1 defaults.
+    'FOLK': {
         'target_words': 4000,
         'min_activities': 1,
         'min_items_per_activity': 12,

--- a/scripts/audit/parsing.py
+++ b/scripts/audit/parsing.py
@@ -104,13 +104,13 @@ def detect_level(file_path: str, frontmatter_str: str) -> tuple[str, int, str]:
         level_from_path = base_level
         track_from_path = f"{base_level}{track_suffix.upper()}" if track_suffix else base_level
     else:
-        special_match = re.search(r'/(lit|oes|ruth|bio|hist|istorio)/', file_path.lower())
+        special_match = re.search(r'/(lit|oes|ruth|bio|hist|istorio|folk)/', file_path.lower())
         if special_match:
             track_name = special_match.group(1)
             _TRACK_LEVEL_MAP = {
                 'bio': 'C1', 'istorio': 'C1',
                 'hist': 'B2',
-                'lit': 'LIT', 'oes': 'OES', 'ruth': 'RUTH',
+                'lit': 'LIT', 'oes': 'OES', 'ruth': 'RUTH', 'folk': 'FOLK',
             }
             level_from_path = _TRACK_LEVEL_MAP.get(track_name, track_name.upper())
             track_from_path = track_name.upper()

--- a/tests/audit/test_config_invariants.py
+++ b/tests/audit/test_config_invariants.py
@@ -58,7 +58,7 @@ AUDIT_TO_PIPELINE_KEY: dict[str, str] = {
     "C1": "c1-core",
     "C1-academic": "c1-core",
     "C1-stylistics": "c1-core",
-    "C1-folk": "c1-core",
+    "FOLK": "c1-core",
     "C1-literature": "c1-core",
     "C1-checkpoint": "c1-core",
     "C1-capstone": "c1-core",
@@ -238,3 +238,55 @@ def test_audit_forbidden_disjoint_from_pipeline_allowed(audit_key: str, pipeline
         f"pipeline allows: {sorted(overlap)}. The writer will emit them and "
         "the audit will reject — drop one side."
     )
+
+
+# ---------------------------------------------------------------------------
+# 6. FOLK seminar resolution (regression for the C1-folk dead-key bug).
+#    folk plans carry `level: FOLK` / `phase: FOLK.B` and live under /folk/,
+#    so detect_level must yield 'FOLK' and get_level_config must land on the
+#    FOLK seminar thresholds — NOT silently default to A1 as it did while the
+#    block was keyed the unreachable 'C1-folk'.
+# ---------------------------------------------------------------------------
+def test_folk_key_is_track_named_not_level_prefixed() -> None:
+    assert "FOLK" in LEVEL_CONFIG, (
+        "FOLK seminar config missing — folk is a C1-register seminar track and "
+        "must be keyed by its level_code 'FOLK' (like LIT/OES/RUTH)."
+    )
+    assert "C1-folk" not in LEVEL_CONFIG, (
+        "'C1-folk' is the unreachable legacy key: folk plans never carry "
+        "level 'C1', so detect_level can never produce 'C1-folk'."
+    )
+
+
+def test_detect_level_recognizes_folk_track() -> None:
+    from audit.parsing import detect_level
+
+    level_code, _module_num, track_code = detect_level(
+        "curriculum/l2-uk-en/folk/kalendarna-obriadovist-zvychai/module.md",
+        "level: FOLK\nphase: FOLK.B\n",
+    )
+    assert level_code == "FOLK", (
+        f"folk module resolved to {level_code!r} (expected 'FOLK'). A non-FOLK "
+        "result means it silently falls back to the A1 default thresholds."
+    )
+    assert track_code == "FOLK"
+
+
+def test_folk_resolves_to_seminar_thresholds_not_a1() -> None:
+    from audit.config import get_level_config
+    from audit.parsing import detect_focus, detect_level
+
+    fm = "level: FOLK\nphase: FOLK.B\n"
+    fp = "curriculum/l2-uk-en/folk/kalendarna-obriadovist-zvychai/module.md"
+    level_code, module_num, _ = detect_level(fp, fm)
+    module_focus = detect_focus(fm, level_code, module_num, "", fp)
+
+    cfg = get_level_config(level_code, module_focus)
+    a1 = LEVEL_CONFIG["A1"]
+    assert cfg is not a1, (
+        "folk audited against the A1 default config — the FOLK seminar "
+        "thresholds are not being applied."
+    )
+    assert cfg["min_vocab"] == LEVEL_CONFIG["FOLK"]["min_vocab"] == 24
+    assert cfg["target_words"] == 4000
+    assert cfg["min_types_unique"] == 4


### PR DESCRIPTION
## Problem (user-flagged)

Folk seminar modules were silently audited against the **A1** default thresholds, not C1-seminar thresholds.

Root cause traced end-to-end:
- `detect_level()` (`scripts/audit/parsing.py`) recognizes seminar tracks via a hardcoded regex `/(lit|oes|ruth|bio|hist|istorio)/` — **`folk` was missing**. Folk plans carry `level: FOLK` / `phase: FOLK.B`, so `level_code` fell through to the `level_code not in LEVEL_CONFIG → 'A1'` default.
- The `LEVEL_CONFIG` block was keyed **`C1-folk`**, which is unreachable: the resolver only produces `{level}-{focus}` when `level_code ∈ (A1..C2)`, and folk's level_code is `FOLK`, never `C1`.
- Net: every folk module resolved to `LEVEL_CONFIG['A1']` (`min_vocab=1`, A1 priority_types/immersion). The plan's `word_target` masked it because `core.py` overrides `target_words` from the plan.

Empirically (before): `get_level_config("FOLK", *) → key='A1', target_words=1200, min_vocab=1`.

## Fix (mirrors LIT/OES/RUTH — track name == level_code == top-level key)

- `parsing.detect_level`: add `folk` to the seminar-track regex + `_TRACK_LEVEL_MAP` (`'folk' → 'FOLK'`).
- `audit.config`: rename `LEVEL_CONFIG['C1-folk'] → ['FOLK']` (+ explanatory comment).
- `tests/audit/test_config_invariants.py`: remap `FOLK → c1-core`; **add regression tests** asserting folk resolves to FOLK seminar thresholds (`target_words=4000`, `min_vocab=24`, `min_types_unique=4`), not A1.
- doc: `MODULE-RICHNESS-GUIDELINES-v2.md` label.

After: `get_level_config("FOLK") → target_words=4000, min_vocab=24, min_types_unique=4`.

## Validation
- `tests/audit/` — **481 pass** (incl. new regression), 29 skipped. (12 anti-menu tests pass with `.venv` present; they FileNotFound in the venv-less worktree only.)
- `ruff check` — clean.

## Follow-up (not in scope)
The audit `FOLK.priority_types` ({reading, essay-response, critical-analysis, comparative-study}) are generic-seminar, while the pipeline `folk` ACTIVITY_CONFIG emits folk-experiential types (ritual-sequencing, variant-comparison, motif-formula, performance) and lacks `reading`. Mapped to `c1-core` (which allows all four) to keep the subset invariant green; aligning audit priority_types with the folk-experiential families is a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)