### PR TITLE
[codex] fix seminar textbook quote fidelity routing

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -6812,7 +6812,7 @@ def run_python_qg(
         "published_quote_for_publishable_refs",
         _published_quote_for_publishable_refs_gate(module_text, plan, module_dir),
     )
-    record("textbook_quote_fidelity", _textbook_quote_fidelity_gate(module_text))
+    record("textbook_quote_fidelity", _textbook_quote_fidelity_gate(module_text, level=level))
     record(
         "resources_search_attempted",
         _resources_search_attempted_gate(
@@ -11669,22 +11669,43 @@ def _strip_frontmatter(text: str) -> str:
 def _strip_frontmatter_and_headings(text: str) -> str:
     text = _strip_frontmatter(text)
     return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
-def _textbook_quote_fidelity_gate(module_text: str) -> dict[str, Any]:
+def _textbook_quote_fidelity_gate(module_text: str, level: str | None = None) -> dict[str, Any]:
     """Verify textbook quote fidelity against the sources DB."""
     import re
 
-    from rapidfuzz import distance, fuzz
+    from rapidfuzz import distance
 
-    from scripts.wiki.sources_db import search_textbooks
+    from scripts.wiki.sources_db import search_literary, search_textbooks
 
     violations: list[dict[str, Any]] = []
     checked = 0
+    level_key = str(level or "").strip().lower()
 
     lines = module_text.splitlines()
     quotes: list[dict[str, Any]] = []
 
     current_quote: list[str] = []
     no_verify = False
+
+    def _extract_embedded_attribution(quote_lines: list[str]) -> tuple[str, str]:
+        lines_without_attr = list(quote_lines)
+        while lines_without_attr and not lines_without_attr[-1].strip():
+            lines_without_attr.pop()
+        if not lines_without_attr:
+            return "", ""
+
+        possible_attribution = lines_without_attr[-1].strip()
+        if not possible_attribution.startswith(("*", "_", "`", "~")):
+            return "\n".join(quote_lines).strip(), ""
+
+        attribution = _extract_textbook_attribution(possible_attribution)
+        if not attribution:
+            return "\n".join(quote_lines).strip(), ""
+
+        lines_without_attr.pop()
+        while lines_without_attr and not lines_without_attr[-1].strip():
+            lines_without_attr.pop()
+        return "\n".join(lines_without_attr).strip(), attribution
 
     i = 0
     while i < len(lines):
@@ -11715,14 +11736,19 @@ def _textbook_quote_fidelity_gate(module_text: str) -> dict[str, Any]:
             if j < len(lines) and not lines[j].strip():
                 j += 1
 
-            attr_line = ""
+            if level_key in SEMINAR_LEVELS:
+                quote_text, embedded_attr = _extract_embedded_attribution(current_quote)
+            else:
+                quote_text = "\n".join(current_quote).strip()
+                embedded_attr = ""
+            attr_line = embedded_attr
             if j < len(lines):
                 attr = _extract_textbook_attribution(lines[j])
                 if attr:
                     attr_line = attr
 
             quotes.append({
-                "text": "\n".join(current_quote).strip(),
+                "text": quote_text,
                 "attribution": attr_line,
                 "no_verify": no_verify
             })
@@ -11735,6 +11761,12 @@ def _textbook_quote_fidelity_gate(module_text: str) -> dict[str, Any]:
     def _normalize(s: str) -> str:
         s = re.sub(r'[^а-яіїєґА-ЯІЇЄҐ0-9]', '', s.lower())
         return s
+
+    def _is_textbook_attribution(attribution: str) -> bool:
+        return bool(
+            re.search(r"\bGrade\s+\d+\b", attribution, flags=re.IGNORECASE)
+            and re.search(r"\bp\.?\s*\d+", attribution, flags=re.IGNORECASE)
+        )
 
     for q in quotes:
         text = q["text"]
@@ -11763,8 +11795,14 @@ def _textbook_quote_fidelity_gate(module_text: str) -> dict[str, Any]:
         if not keywords:
             continue
 
+        search_fn = search_textbooks
+        corpus_name = "textbook corpus"
+        if level_key in SEMINAR_LEVELS and not _is_textbook_attribution(attr):
+            search_fn = search_literary
+            corpus_name = "literary corpus"
+
         try:
-            hits = search_textbooks(keywords, 20)
+            hits = search_fn(keywords, 20)
         except Exception:
             hits = []
 
@@ -11772,7 +11810,7 @@ def _textbook_quote_fidelity_gate(module_text: str) -> dict[str, Any]:
             violations.append({
                 "quote": text,
                 "attribution": attr,
-                "reason": "No match in textbook corpus"
+                "reason": f"No match in {corpus_name}"
             })
             continue
 

--- a/tests/test_textbook_quote_fidelity_gate.py
+++ b/tests/test_textbook_quote_fidelity_gate.py
@@ -1,11 +1,12 @@
-
 from scripts.build.linear_pipeline import _textbook_quote_fidelity_gate
 
 
 def test_match(monkeypatch):
     """Test 1 — match (happy path)"""
+
     def mock_search(keywords, limit=20):
         return [{"text": "Це тестова цитата, яка збігається ідеально."}]
+
     monkeypatch.setattr("scripts.wiki.sources_db.search_textbooks", mock_search)
 
     module_text = """
@@ -17,8 +18,10 @@ def test_match(monkeypatch):
     assert result["passed"] is True
     assert result["violations"] == []
 
+
 def test_mismatch(monkeypatch):
     """Test 2 — mismatch (m20 Кнак regression)"""
+
     source_chunk = '''Мій день
 — Сьогодні в мене багато справ, — мови-
 ло жабеня Квак. — Занотую.
@@ -30,6 +33,7 @@ def test_mismatch(monkeypatch):
 
     def mock_search(keywords, limit=20):
         return [{"text": source_chunk}]
+
     monkeypatch.setattr("scripts.wiki.sources_db.search_textbooks", mock_search)
 
     module_text = """
@@ -51,11 +55,14 @@ def test_mismatch(monkeypatch):
     assert "differs" in violation["reason"] or ">=3" in violation["reason"]
     assert "Квак" in violation["nearest_source"]
 
+
 def test_partial_mismatch(monkeypatch):
     """Test 3 — partial-mismatch below threshold"""
+
     def mock_search(keywords, limit=20):
         # 1-char difference (ы vs и), plus missing punctuation. Less than 3 chars different after normalization.
         return [{"text": "Це тестова цитата."}]
+
     monkeypatch.setattr("scripts.wiki.sources_db.search_textbooks", mock_search)
 
     module_text = """
@@ -67,6 +74,7 @@ def test_partial_mismatch(monkeypatch):
     assert result["passed"] is True
     assert result["violations"] == []
 
+
 def test_no_attribution():
     """Test 4a — no-attribution"""
     module_text = """
@@ -77,6 +85,7 @@ def test_no_attribution():
     assert len(result["violations"]) > 0
     assert "Missing attribution without NO_VERIFY" in result["violations"][0]["reason"]
 
+
 def test_no_attribution_with_opt_out():
     """Test 4b — NO_VERIFY opt-out"""
     module_text = """
@@ -86,3 +95,118 @@ def test_no_attribution_with_opt_out():
     result = _textbook_quote_fidelity_gate(module_text)
     assert result["passed"] is True
     assert result["violations"] == []
+
+
+def test_seminar_literary_source_marker_uses_literary_corpus(monkeypatch):
+    calls = {"literary": 0, "textbooks": 0}
+
+    def mock_search_literary(keywords, limit=20):
+        calls["literary"] += 1
+        return [
+            {
+                "text": "Вже весна воскресла, / Що ж сь нам принесла? / Дівоцькую красу",
+            }
+        ]
+
+    def mock_search_textbooks(keywords, limit=20):
+        calls["textbooks"] += 1
+        return []
+
+    monkeypatch.setattr("scripts.wiki.sources_db.search_literary", mock_search_literary)
+    monkeypatch.setattr("scripts.wiki.sources_db.search_textbooks", mock_search_textbooks)
+
+    module_text = """
+> Вже весна воскресла,
+> Що ж сь нам принесла?
+> Дівоцькую красу.
+>
+> *— Грушевський [S1]*
+"""
+    result = _textbook_quote_fidelity_gate(module_text, level="folk")
+
+    assert result["passed"] is True
+    assert result["violations"] == []
+    assert calls == {"literary": 1, "textbooks": 0}
+
+
+def test_seminar_textbook_attributed_fabrication_still_fails(monkeypatch):
+    calls = {"literary": 0, "textbooks": 0}
+
+    def mock_search_literary(keywords, limit=20):
+        calls["literary"] += 1
+        return [{"text": "Цей літературний корпус не має рятувати підручникову цитату."}]
+
+    def mock_search_textbooks(keywords, limit=20):
+        calls["textbooks"] += 1
+        return []
+
+    monkeypatch.setattr("scripts.wiki.sources_db.search_literary", mock_search_literary)
+    monkeypatch.setattr("scripts.wiki.sources_db.search_textbooks", mock_search_textbooks)
+
+    module_text = """
+> Вигаданий уривок, якого немає в підручнику, але він має підручникову атрибуцію.
+
+*— Заболотний, Grade 6, p.11*
+"""
+    result = _textbook_quote_fidelity_gate(module_text, level="folk")
+
+    assert result["passed"] is False
+    assert result["violations"] == [
+        {
+            "quote": "Вигаданий уривок, якого немає в підручнику, але він має підручникову атрибуцію.",
+            "attribution": "Заболотний, Grade 6, p.11",
+            "reason": "No match in textbook corpus",
+        }
+    ]
+    assert calls == {"literary": 0, "textbooks": 1}
+
+
+def test_core_level_matches_default_textbook_behavior(monkeypatch):
+    calls = {"literary": 0, "textbooks": 0}
+
+    def mock_search_literary(keywords, limit=20):
+        calls["literary"] += 1
+        return []
+
+    def mock_search_textbooks(keywords, limit=20):
+        calls["textbooks"] += 1
+        return [{"text": "Це справжня підручникова цитата."}]
+
+    monkeypatch.setattr("scripts.wiki.sources_db.search_literary", mock_search_literary)
+    monkeypatch.setattr("scripts.wiki.sources_db.search_textbooks", mock_search_textbooks)
+
+    module_text = """
+> Це справжня підручникова цитата.
+
+*— Захарійчук, Grade 1, p.24*
+"""
+    default_result = _textbook_quote_fidelity_gate(module_text)
+    core_result = _textbook_quote_fidelity_gate(module_text, level="a1")
+
+    assert core_result == default_result
+    assert core_result["passed"] is True
+    assert core_result["violations"] == []
+    assert calls == {"literary": 0, "textbooks": 2}
+
+
+def test_core_level_does_not_accept_seminar_embedded_attribution(monkeypatch):
+    calls = {"textbooks": 0}
+
+    def mock_search_textbooks(keywords, limit=20):
+        calls["textbooks"] += 1
+        return [{"text": "Це справжня підручникова цитата."}]
+
+    monkeypatch.setattr("scripts.wiki.sources_db.search_textbooks", mock_search_textbooks)
+
+    module_text = """
+> Це справжня підручникова цитата.
+>
+> *— Захарійчук, Grade 1, p.24*
+"""
+    default_result = _textbook_quote_fidelity_gate(module_text)
+    core_result = _textbook_quote_fidelity_gate(module_text, level="a1")
+
+    assert core_result == default_result
+    assert core_result["passed"] is False
+    assert core_result["violations"][0]["reason"] == "Missing attribution without NO_VERIFY"
+    assert calls == {"textbooks": 0}


### PR DESCRIPTION
## Intent

Option A was chosen: seminar primary-text blockquotes should still be verified, but against the literary corpus when they are not textbook-style `Grade N, p.X` attributions. Textbook-style seminar quotes keep the textbook-corpus path so the gate still has teeth.

## Raw Evidence (#M-4)

### Committed Scope

Command:
```bash
git show --stat --oneline --name-only --format='%h %s' HEAD
```
CWD:
```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-textbook-quote-fidelity-seminar
```
Output:
```text
7968164a4b fix(build): route seminar quotes to literary corpus

scripts/build/linear_pipeline.py
tests/test_textbook_quote_fidelity_gate.py
```

### Test Coverage Added

Command:
```bash
rg -n "def test_(seminar_literary_source_marker|seminar_textbook_attributed_fabrication|core_level_matches_default|core_level_does_not_accept)" tests/test_textbook_quote_fidelity_gate.py
```
CWD:
```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-textbook-quote-fidelity-seminar
```
Output:
```text
100:1:def test_seminar_literary_source_marker_uses_literary_corpus(monkeypatch):
132:1:def test_seminar_textbook_attributed_fabrication_still_fails(monkeypatch):
164:1:def test_core_level_matches_default_textbook_behavior(monkeypatch):
192:1:def test_core_level_does_not_accept_seminar_embedded_attribution(monkeypatch):
```

### Ruff Clean

Command:
```bash
.venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_textbook_quote_fidelity_gate.py
```
CWD:
```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-textbook-quote-fidelity-seminar
```
Output:
```text
All checks passed!
```

### Focused Pytest Pass

Command:
```bash
.venv/bin/python -m pytest tests/test_textbook_quote_fidelity_gate.py -q
```
CWD:
```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-textbook-quote-fidelity-seminar
```
Output:
```text
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-textbook-quote-fidelity-seminar
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 9 items

tests/test_textbook_quote_fidelity_gate.py .........                     [100%]

============================== 9 passed in 0.40s ===============================
```

### Folk Fixture Gate Pass

Command:
```bash
.venv/bin/python - <<'PY'
from pathlib import Path
import json
from scripts.build.linear_pipeline import _textbook_quote_fidelity_gate
path = Path('../../../builds/folk-kalendarna-obriadovist-zvychai-20260611-010346/curriculum/l2-uk-en/folk/kalendarna-obriadovist-zvychai/module.md')
result = _textbook_quote_fidelity_gate(path.read_text(encoding='utf-8'), level='folk')
print(json.dumps(result, ensure_ascii=False, indent=2))
PY
```
CWD:
```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-textbook-quote-fidelity-seminar
```
Output:
```json
{
  "passed": true,
  "checked": 4,
  "violations": [],
  "message": "verify_quote: 4 verified",
  "verdict": "PASS",
  "severity": null
}
```

### Fabricated Textbook Quote Still Rejected

Command:
```bash
.venv/bin/python - <<'PY'
import json
from scripts.build.linear_pipeline import _textbook_quote_fidelity_gate
module_text = '''
> Квазізорепадна мольфаризація флуорескує над шовкогалактикою.

*— Заболотний, Grade 6, p.11*
'''
result = _textbook_quote_fidelity_gate(module_text, level='folk')
print(json.dumps(result, ensure_ascii=False, indent=2))
PY
```
CWD:
```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-textbook-quote-fidelity-seminar
```
Output:
```json
{
  "passed": false,
  "checked": 1,
  "violations": [
    {
      "quote": "Квазізорепадна мольфаризація флуорескує над шовкогалактикою.",
      "attribution": "Заболотний, Grade 6, p.11",
      "reason": "Text differs by >=3 chars (diff: 41)",
      "nearest_source": "Гроза нарешті доповзла, і чорний дракон розкинув свої крила над \nоколицею. І тоді якось враз, блискавично над костьолом повисло \nтемно-синє шмаття авангардних хмар і грім уже забуркотів чітко, \nголосно й недвозначно. Якось враз знялася курява й завертівся перед­\nгрозовий вихор. Коротка мить — і закрапав рідкий, краплистий дощ. Милі до цього часу харківські вулиці змінилися. Ласкаве сонце \nзникло з темного неба, і тільки зрідка на брук падали перелякані \nпромінчики. 40"
    }
  ],
  "message": "verify_quote: 1 checked, 1 violations",
  "verdict": "REJECT",
  "severity": "HARD"
}
```

### `tests/build/` Attempt

Command:
```bash
.venv/bin/python -m pytest tests/test_textbook_quote_fidelity_gate.py tests/build -q
```
CWD:
```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-textbook-quote-fidelity-seminar
```
Output:
```text
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-textbook-quote-fidelity-seminar
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 412 items / 2 errors

==================================== ERRORS ====================================
_________ ERROR collecting tests/build/test_activity_retry_feedback.py _________
ImportError while importing test module '/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-textbook-quote-fidelity-seminar/tests/build/test_activity_retry_feedback.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../../../../.pyenv/versions/3.12.8/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/build/test_activity_retry_feedback.py:14: in <module>
    v6_build = importlib.import_module("build.v6_build")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../../../../../.pyenv/versions/3.12.8/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   ModuleNotFoundError: No module named 'build.v6_build'
___________ ERROR collecting tests/build/test_reviewer_dispatcher.py ___________
ImportError while importing test module '/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-textbook-quote-fidelity-seminar/tests/build/test_reviewer_dispatcher.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../../../../.pyenv/versions/3.12.8/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/build/test_reviewer_dispatcher.py:29: in <module>
    v6_build = importlib.import_module("build.v6_build")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../../../../../.pyenv/versions/3.12.8/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   ModuleNotFoundError: No module named 'build.v6_build'
=========================== short test summary info ============================
ERROR tests/build/test_activity_retry_feedback.py
ERROR tests/build/test_reviewer_dispatcher.py
!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!
============================== 2 errors in 0.86s ===============================
```
