### PR TITLE
fix(build): accept o-linked compound adjective bases

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -8467,6 +8467,8 @@ def _vesum_gate(
         if hyphenated_missing:
             constituent_lookups: set[str] = set()
             constituent_map: dict[str, list[str]] = {}
+            compound_base_candidates_by_part: dict[str, list[str]] = {}
+            compound_base_lookups: set[str] = set()
             for compound in hyphenated_missing:
                 parts = [part for part in compound.split("-") if part]
                 if len(parts) < 2:
@@ -8474,6 +8476,11 @@ def _vesum_gate(
                 eligible_parts = [part for part in parts if len(part) >= VESUM_MIN_WORD_LENGTH]
                 constituent_lookups.update(eligible_parts)
                 constituent_map[compound] = eligible_parts
+                for part in eligible_parts[:-1]:
+                    candidates = _compound_adjective_base_candidates(part)
+                    if candidates:
+                        compound_base_candidates_by_part[part] = candidates
+                        compound_base_lookups.update(candidates)
             if constituent_lookups:
                 try:
                     constituent_verified = verify_words_fn(sorted(constituent_lookups))
@@ -8485,13 +8492,45 @@ def _vesum_gate(
                     }
             else:
                 constituent_verified = {}
+            if compound_base_lookups:
+                try:
+                    compound_base_verified = verify_words_fn(sorted(compound_base_lookups))
+                except Exception as exc:
+                    return {
+                        "passed": False,
+                        "error": str(exc),
+                        "checked": len(unchecked_pairs),
+                    }
+                verified_compound_base_adjectives = {
+                    word
+                    for word, matches in compound_base_verified.items()
+                    if any(_vesum_match_is_adjective(match) for match in matches)
+                    and not _engine_flags_russianism(word)
+                }
+            else:
+                verified_compound_base_adjectives = set()
             resolved_compounds: set[str] = set()
             for compound, parts in constituent_map.items():
                 # All eligible parts must verify. If there are zero
                 # eligible parts (every constituent below threshold),
                 # accept conservatively — the compound is a string of
                 # very short tokens we wouldn't gate individually.
-                if all(constituent_verified.get(part) for part in parts):
+                last_part_index = len(parts) - 1
+                if all(
+                    _vesum_part_verifies_as_compound_constituent(
+                        constituent_verified.get(part) or [],
+                        require_modifier=index < last_part_index
+                        and bool(compound_base_candidates_by_part.get(part)),
+                    )
+                    or (
+                        index < last_part_index
+                        and any(
+                            candidate in verified_compound_base_adjectives
+                            for candidate in compound_base_candidates_by_part.get(part, ())
+                        )
+                    )
+                    for index, part in enumerate(parts)
+                ):
                     resolved_compounds.add(compound)
             missing_lc -= resolved_compounds
     if missing_lc:
@@ -8810,8 +8849,32 @@ def _productive_ist_adjective_candidates(word: str) -> tuple[str, ...]:
     return ()
 
 
+def _compound_adjective_base_candidates(part: str) -> list[str]:
+    if not part.endswith("о"):
+        return []
+    stem = part[:-1]
+    candidates: list[str] = []
+    for ending in ("ий", "ій"):
+        candidate = f"{stem}{ending}"
+        if candidate not in candidates:
+            candidates.append(candidate)
+    return candidates
+
+
 def _vesum_match_is_adjective(match: Mapping[str, Any]) -> bool:
     return str(match.get("pos", "")).lower() in {"adj", "adjective"}
+
+
+def _vesum_part_verifies_as_compound_constituent(
+    matches: Sequence[Mapping[str, Any]],
+    *,
+    require_modifier: bool,
+) -> bool:
+    if not matches:
+        return False
+    if not require_modifier:
+        return True
+    return any(str(match.get("pos", "")).lower() in {"adj", "adjective", "adv", "adverb"} for match in matches)
 
 
 def _iter_vesum_lookup_surface_pairs(

--- a/tests/test_vesum_verified_postfix.py
+++ b/tests/test_vesum_verified_postfix.py
@@ -242,6 +242,161 @@ def test_vesum_gate_verifies_valid_hyphenated_compounds_as_whole_words() -> None
     assert not {"будьякий", "будьщо", "поперше", "купаль", "обжинк", "ськ"} & looked_up
 
 
+def test_vesum_gate_accepts_o_linked_compound_adjectives_from_adjective_bases() -> None:
+    seen: list[list[str]] = []
+    direct_valid = {
+        "економічний",
+        "західна",
+        "західний",
+        "історичний",
+        "радянська",
+        "радянський",
+        "радянській",
+        "радянську",
+    }
+    adjective_bases = {
+        "галицький",
+        "імперський",
+        "культурний",
+        "соціальний",
+    }
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        seen.append(words)
+        return {
+            word: (
+                [{"lemma": word, "pos": "adj", "tags": "adj:m:v_naz"}]
+                if word in direct_valid | adjective_bases
+                else []
+            )
+            for word in words
+        }
+
+    gate = _vesum_gate(
+        module_text=(
+            "імперсько-радянський Імперсько-радянська "
+            "імперсько-радянську імперсько-радянській "
+            "галицько-західний галицько-західна "
+            "соціально-економічний культурно-історичний"
+        ),
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    looked_up = {word for call in seen for word in call}
+    assert gate["passed"] is True
+    assert gate["missing"] == []
+    assert adjective_bases <= looked_up
+
+
+def test_vesum_gate_keeps_hyphenated_compound_missing_without_adjective_base() -> None:
+    seen: list[list[str]] = []
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        seen.append(words)
+        return {
+            word: (
+                [{"lemma": word, "pos": "adj", "tags": "adj:m:v_naz"}]
+                if word == "радянський"
+                else [{"lemma": "абракадабра", "pos": "noun", "tags": "noun:inanim:f:v_kly"}]
+                if word == "абракадабро"
+                else []
+            )
+            for word in words
+        }
+
+    gate = _vesum_gate(
+        module_text="абракадабро-радянський.",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    looked_up = {word for call in seen for word in call}
+    assert gate["passed"] is False
+    assert gate["missing"] == ["абракадабро-радянський"]
+    assert {"абракадабрий", "абракадабрій"} <= looked_up
+
+
+def test_vesum_gate_rejects_reconstructed_compound_base_that_is_not_adjective() -> None:
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        return {
+            word: (
+                [{"lemma": word, "pos": "adj", "tags": "adj:m:v_naz"}]
+                if word == "радянський"
+                else [{"lemma": word, "pos": "noun", "tags": "noun:m:v_naz"}]
+                if word == "бздумий"
+                else []
+            )
+            for word in words
+        }
+
+    gate = _vesum_gate(
+        module_text="бздумо-радянський.",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert gate["passed"] is False
+    assert gate["missing"] == ["бздумо-радянський"]
+
+
+def test_vesum_gate_requires_final_hyphenated_constituent_to_verify_directly() -> None:
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        return {
+            word: (
+                [{"lemma": word, "pos": "adj", "tags": "adj:m:v_naz"}]
+                if word == "імперський"
+                else []
+            )
+            for word in words
+        }
+
+    gate = _vesum_gate(
+        module_text="імперсько-празднічний.",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert gate["passed"] is False
+    assert gate["missing"] == ["імперсько-празднічний"]
+
+
+def test_vesum_gate_still_flags_required_coinage_battery_after_compound_fix() -> None:
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        return {
+            word: (
+                [{"lemma": word, "pos": "adj", "tags": "adj:m:v_naz"}]
+                if word == "радянський"
+                else []
+            )
+            for word in words
+        }
+
+    gate = _vesum_gate(
+        module_text="двохоровий обрядознавчий городалька абракадабро-радянський.",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+    )
+
+    assert gate["passed"] is False
+    assert set(gate["missing"]) == {
+        "абракадабро-радянський",
+        "городалька",
+        "двохоровий",
+        "обрядознавчий",
+    }
+
+
 def test_vesum_gate_accepts_productive_ist_nouns_from_valid_adjectives() -> None:
     seen: list[list[str]] = []
 


### PR DESCRIPTION
## Raw Evidence

### Changed files

```text
$ cd /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-vesum-compound-adjective
$ git show --stat --oneline HEAD
ca5551b541 fix(build): accept o-linked compound adjective bases
 scripts/build/linear_pipeline.py     |  65 ++++++++++++++-
 tests/test_vesum_verified_postfix.py | 155 +++++++++++++++++++++++++++++++++++
 2 files changed, 219 insertions(+), 1 deletion(-)
```

### VESUM constituent evidence

```text
$ cd /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-vesum-compound-adjective
$ .venv/bin/python scripts/verification/vesum.py words імперсько галицько імперський галицький радянський західний українсько-польський --json
{
  "імперсько": [],
  "галицько": [],
  "імперський": [
    {
      "lemma": "імперський",
      "pos": "adj",
      "tags": "adj:m:v_naz"
    },
    {
      "lemma": "імперський",
      "pos": "adj",
      "tags": "adj:m:v_zna:rinanim"
    },
    {
      "lemma": "імперський",
      "pos": "adj",
      "tags": "adj:m:v_kly"
    }
  ],
  "галицький": [
    {
      "lemma": "галицький",
      "pos": "adj",
      "tags": "adj:m:v_naz"
    },
    {
      "lemma": "галицький",
      "pos": "adj",
      "tags": "adj:m:v_zna:rinanim"
    },
    {
      "lemma": "галицький",
      "pos": "adj",
      "tags": "adj:m:v_kly"
    }
  ],
  "радянський": [
    {
      "lemma": "радянський",
      "pos": "adj",
      "tags": "adj:m:v_naz"
    },
    {
      "lemma": "радянський",
      "pos": "adj",
      "tags": "adj:m:v_zna:rinanim"
    },
    {
      "lemma": "радянський",
      "pos": "adj",
      "tags": "adj:m:v_kly"
    }
  ],
  "західний": [
    {
      "lemma": "західний",
      "pos": "adj",
      "tags": "adj:m:v_naz:compb"
    },
    {
      "lemma": "західний",
      "pos": "adj",
      "tags": "adj:m:v_zna:rinanim:compb"
    },
    {
      "lemma": "західний",
      "pos": "adj",
      "tags": "adj:m:v_kly:compb"
    }
  ],
  "українсько-польський": [
    {
      "lemma": "українсько-польський",
      "pos": "adj",
      "tags": "adj:m:v_naz"
    },
    {
      "lemma": "українсько-польський",
      "pos": "adj",
      "tags": "adj:m:v_zna:rinanim"
    },
    {
      "lemma": "українсько-польський",
      "pos": "adj",
      "tags": "adj:m:v_kly"
    }
  ]
}
```

### Live gate battery

```text
$ cd /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-vesum-compound-adjective
$ .venv/bin/python - <<'PY'
import json
from scripts.build.linear_pipeline import _vesum_gate
from scripts.verification.vesum import verify_words

cases = {
    "ACCEPT": "імперсько-радянський Імперсько-радянська імперсько-радянську імперсько-радянській галицько-західний галицько-західна соціально-економічний культурно-історичний",
    "STILL_FLAG": "двохоровий обрядознавчий городалька абракадабро-радянський",
    "FINAL_MISS": "імперсько-празднічний",
}
for label, text in cases.items():
    result = _vesum_gate(
        module_text=text,
        activities=[],
        vocabulary=[],
        resources=[],
        verify_words_fn=verify_words,
    )
    print(label)
    print(json.dumps({"passed": result["passed"], "missing": result.get("missing", [])}, ensure_ascii=False, indent=2))
PY
ACCEPT
{
  "passed": true,
  "missing": []
}
STILL_FLAG
{
  "passed": false,
  "missing": [
    "абракадабро-радянський",
    "городалька",
    "двохоровий",
    "обрядознавчий"
  ]
}
FINAL_MISS
{
  "passed": false,
  "missing": [
    "імперсько-празднічний"
  ]
}
```

### Ruff

```text
$ cd /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-vesum-compound-adjective
$ .venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_vesum_verified_postfix.py
All checks passed!
```

### Pytest battery

```text
$ cd /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-vesum-compound-adjective
$ .venv/bin/python -m pytest tests/test_vesum_heritage_attestation.py tests/test_derivational_morphology.py tests/test_heritage_classifier.py tests/test_vesum_verified_postfix.py -q
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-vesum-compound-adjective
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 70 items

tests/test_vesum_heritage_attestation.py ..................              [ 25%]
tests/test_derivational_morphology.py ................                   [ 48%]
tests/test_heritage_classifier.py .....                                  [ 55%]
tests/test_vesum_verified_postfix.py ...............................     [100%]

============================= 70 passed in 10.60s ==============================
```

### Agent trailer audit

```text
$ cd /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-vesum-compound-adjective
$ .venv/bin/python scripts/audit/lint_agent_trailer.py
Checking 1 commit(s) in origin/main..HEAD:

  ca5551b541  PASS  X-Agent: codex/folk-vesum-compound-adjective

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```
