### PR TITLE
fix(v7): reviewer-fix correction patches activities/vocab/resources

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -208,6 +208,16 @@ REVIEWER_FIX_GATES = DICTIONARY_CANDIDATE_GATES | frozenset(
         "ai_slop_clean",
     }
 )
+REVIEWER_FIX_ADDITIONAL_ARTIFACTS_BY_GATE: dict[str, tuple[str, ...]] = {
+    "vesum_verified": ("activities.yaml", "vocabulary.yaml", "resources.yaml"),
+    "russianisms_clean": ("activities.yaml", "vocabulary.yaml", "resources.yaml"),
+    "surzhyk_clean": ("activities.yaml", "vocabulary.yaml", "resources.yaml"),
+    "calques_clean": ("activities.yaml", "vocabulary.yaml", "resources.yaml"),
+    "paronym_clean": ("activities.yaml", "vocabulary.yaml", "resources.yaml"),
+    "citations_resolve": ("resources.yaml",),
+    "plan_reference_match": ("resources.yaml",),
+    "ai_slop_clean": ("activities.yaml", "vocabulary.yaml", "resources.yaml"),
+}
 PIPELINE_INSERT_GATES = frozenset({"inject_activity_ids"})
 TERMINAL_ZERO_RETRY_GATES = frozenset(
     {
@@ -6424,30 +6434,60 @@ def _apply_reviewer_correction(
             "rejected_fixes": rejected_fixes,
             "applied": False,
         }
-    result = _apply_reviewer_fixes(
-        module_text,
+    artifact_names = ("module.md", *REVIEWER_FIX_ADDITIONAL_ARTIFACTS_BY_GATE.get(gate, ()))
+    unmatched_by_artifact: list[set[str]] = []
+    artifact_results: list[dict[str, Any]] = []
+    for artifact in artifact_names:
+        artifact_path = module_dir / artifact
+        if artifact != "module.md" and not artifact_path.exists():
+            continue
+        original_text = module_text if artifact == "module.md" else _read_required(artifact_path)
+        result = _apply_reviewer_fixes(
+            original_text,
+            accepted_fixes,
+            gate=gate,
+            module_dir=module_dir,
+            plan_path=plan_path,
+            emit_unmatched_events=False,
+        )
+        unmatched_by_artifact.append(set(result.unmatched_anchors))
+        changed = result.text != original_text
+        artifact_record: dict[str, Any] = {"artifact": artifact, "changed": changed}
+        if changed:
+            artifact_path.write_text(result.text, encoding="utf-8")
+            try:
+                _validate_wiki_coverage_artifact_text(artifact, result.text)
+            except LinearPipelineError as exc:
+                artifact_path.write_text(original_text, encoding="utf-8")
+                artifact_record["changed"] = False
+                artifact_record["yaml_valid"] = False
+                emit_event(
+                    "reviewer_correction_yaml_invalid",
+                    **_correction_event_fields(
+                        gate=gate,
+                        module_dir=module_dir,
+                        plan_path=plan_path,
+                    ),
+                    artifact=artifact,
+                    error_preview=str(exc)[:800],
+                )
+            else:
+                artifact_record["yaml_valid"] = True
+        artifact_results.append(artifact_record)
+
+    unmatched_anchors = (
+        frozenset(set.intersection(*unmatched_by_artifact))
+        if unmatched_by_artifact
+        else frozenset()
+    )
+    _emit_final_reviewer_unmatched_events(
+        unmatched_anchors,
         accepted_fixes,
         gate=gate,
         module_dir=module_dir,
         plan_path=plan_path,
     )
-    if accepted_fixes:
-        module_path.write_text(result.text, encoding="utf-8")
-        try:
-            _validate_wiki_coverage_artifact_text(module_path.name, result.text)
-        except LinearPipelineError as exc:
-            module_path.write_text(module_text, encoding="utf-8")
-            emit_event(
-                "reviewer_correction_yaml_invalid",
-                **_correction_event_fields(
-                    gate=gate,
-                    module_dir=module_dir,
-                    plan_path=plan_path,
-                ),
-                artifact=module_path.name,
-                error_preview=str(exc)[:800],
-            )
-    return result.unmatched_anchors, {
+    return unmatched_anchors, {
         "kind": "reviewer",
         "gate": gate,
         "prompt": prompt,
@@ -6455,7 +6495,8 @@ def _apply_reviewer_correction(
         "fixes": fixes,
         "accepted_fixes": accepted_fixes,
         "rejected_fixes": rejected_fixes,
-        "unmatched_anchors": sorted(result.unmatched_anchors),
+        "unmatched_anchors": sorted(unmatched_anchors),
+        "artifacts": artifact_results,
         "applied": True,
     }
 
@@ -6594,6 +6635,55 @@ def _parse_reviewer_fixes_xml(body: str) -> list[dict[str, str]]:
     return fixes
 
 
+def _emit_reviewer_fix_anchor_unmatched(
+    anchor: str,
+    replacement: str | None,
+    *,
+    gate: str | None,
+    module_dir: Path | None,
+    plan_path: Path | None,
+) -> None:
+    emit_event(
+        "reviewer_fixes_anchor_unmatched",
+        **_correction_event_fields(
+            gate=gate or "",
+            module_dir=module_dir,
+            plan_path=plan_path,
+        )
+        if module_dir is not None and plan_path is not None
+        else {"gate": gate},
+        anchor_preview=_correction_preview(anchor),
+        text_preview=_correction_preview(replacement),
+    )
+
+
+def _emit_final_reviewer_unmatched_events(
+    unmatched_anchors: frozenset[str],
+    fixes: list[dict[str, str]],
+    *,
+    gate: str,
+    module_dir: Path,
+    plan_path: Path,
+) -> None:
+    if not unmatched_anchors:
+        return
+    for fix in fixes:
+        if "insert_after" in fix and "text" in fix:
+            anchor = fix["insert_after"]
+            replacement = fix["text"]
+        else:
+            anchor = fix.get("find") or ""
+            replacement = fix.get("replace")
+        if anchor in unmatched_anchors:
+            _emit_reviewer_fix_anchor_unmatched(
+                anchor,
+                replacement,
+                gate=gate,
+                module_dir=module_dir,
+                plan_path=plan_path,
+            )
+
+
 def _apply_reviewer_fixes(
     text: str,
     fixes: list[dict[str, str]],
@@ -6601,6 +6691,7 @@ def _apply_reviewer_fixes(
     gate: str | None = None,
     module_dir: Path | None = None,
     plan_path: Path | None = None,
+    emit_unmatched_events: bool = True,
 ) -> ReviewerFixApplyResult:
     updated = text
     unmatched_anchors: set[str] = set()
@@ -6611,18 +6702,14 @@ def _apply_reviewer_fixes(
                 updated = updated.replace(anchor, anchor + fix["text"], 1)
             else:
                 unmatched_anchors.add(anchor)
-                emit_event(
-                    "reviewer_fixes_anchor_unmatched",
-                    **_correction_event_fields(
-                        gate=gate or "",
+                if emit_unmatched_events:
+                    _emit_reviewer_fix_anchor_unmatched(
+                        anchor,
+                        fix["text"],
+                        gate=gate,
                         module_dir=module_dir,
                         plan_path=plan_path,
                     )
-                    if module_dir is not None and plan_path is not None
-                    else {"gate": gate},
-                    anchor_preview=_correction_preview(anchor),
-                    text_preview=_correction_preview(fix["text"]),
-                )
             continue
         find = fix.get("find")
         replace = fix.get("replace")
@@ -6630,18 +6717,14 @@ def _apply_reviewer_fixes(
             updated = updated.replace(find, replace, 1)
         elif find:
             unmatched_anchors.add(find)
-            emit_event(
-                "reviewer_fixes_anchor_unmatched",
-                **_correction_event_fields(
-                    gate=gate or "",
+            if emit_unmatched_events:
+                _emit_reviewer_fix_anchor_unmatched(
+                    find,
+                    replace,
+                    gate=gate,
                     module_dir=module_dir,
                     plan_path=plan_path,
                 )
-                if module_dir is not None and plan_path is not None
-                else {"gate": gate},
-                anchor_preview=_correction_preview(find),
-                text_preview=_correction_preview(replace),
-            )
     return ReviewerFixApplyResult(updated, frozenset(unmatched_anchors))
 
 

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -239,7 +239,7 @@ This learner has completed modules 1..{MODULE_NUM}-1 in track `{LEVEL}`. Cumulat
 ## Tone and immersion (mandatory)
 
 <!-- rule_id: #R-VOICE-META -->
-Write for an adult learner, not for a teacher reading a lesson plan. No English meta-narration; the complete forbidden phrase list is in the Writer Charter. Do not write teacher-plan narration such as "this section teaches", "learners will", or "the activity asks". Open sections directly with the grammar fact, a Ukrainian example/dialogue line, or a one-sentence English scaffold.
+Write for an adult learner, not for a teacher reading a lesson plan. No English meta-narration; the complete forbidden phrase list is in the Writer Charter. Do not write teacher-plan narration such as "Welcome to", "In this section we will learn", "this section teaches", "learners will", or "the activity asks". Open sections directly with the grammar fact, a Ukrainian example/dialogue line, or a one-sentence English scaffold.
 
 English is only for translation, gloss, and short scaffolds. Honor the Immersion Rule exactly; B1+ body text outside Tab 2 is 100% Ukrainian.
 

--- a/tests/build/test_reviewer_correction_multiartifact.py
+++ b/tests/build/test_reviewer_correction_multiartifact.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from scripts.build import linear_pipeline
+
+MODULE_TEXT = """\
+# Календарна обрядовість
+
+## Діалоги
+
+This lesson text is clean and does not contain the activity typo.
+"""
+
+ACTIVITIES_TEXT = """\
+- id: act-1
+  type: fill-in
+  title: Весняні пісні
+  items:
+  - sentence: "На уроці згадуємо гаівки."
+    answer: "гаївки"
+"""
+
+VOCABULARY_TEXT = """\
+- lemma: гаївка
+  translation: spring ritual song
+  pos: noun
+  usage: "Гаївка звучить навесні."
+"""
+
+RESOURCES_TEXT = """\
+- title: Весняні обряди
+  role: textbook
+"""
+
+
+def _write_fixture(tmp_path: Path) -> Path:
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    (module_dir / "module.md").write_text(MODULE_TEXT, encoding="utf-8")
+    (module_dir / "activities.yaml").write_text(ACTIVITIES_TEXT, encoding="utf-8")
+    (module_dir / "vocabulary.yaml").write_text(VOCABULARY_TEXT, encoding="utf-8")
+    (module_dir / "resources.yaml").write_text(RESOURCES_TEXT, encoding="utf-8")
+    return module_dir
+
+
+def _reviewer_response(find: str, replace: str) -> str:
+    return (
+        "<fixes>\n"
+        "<fix>\n"
+        f"<find>{find}</find>\n"
+        f"<replace>{replace}</replace>\n"
+        "</fix>\n"
+        "</fixes>"
+    )
+
+
+def _apply(
+    module_dir: Path,
+    plan_path: Path,
+    *,
+    gate: str,
+    find: str,
+    replace: str,
+) -> tuple[frozenset[str], dict[str, Any]]:
+    return linear_pipeline._apply_reviewer_correction(
+        gate,
+        {"passed": False, "missing": [find]},
+        qg_report={"gates": {gate: {"passed": False}}},
+        module_dir=module_dir,
+        plan_path=plan_path,
+        candidates=(),
+        reviewer_corrector=lambda _context: _reviewer_response(find, replace),
+        invoker=None,
+    )
+
+
+def _events(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_vesum_reviewer_correction_patches_activities_yaml(tmp_path: Path) -> None:
+    module_dir = _write_fixture(tmp_path)
+    plan_path = tmp_path / "plan.yaml"
+    module_before = (module_dir / "module.md").read_text(encoding="utf-8")
+
+    unmatched, payload = _apply(
+        module_dir,
+        plan_path,
+        gate="vesum_verified",
+        find="гаівки",
+        replace="гаївки",
+    )
+
+    activities = (module_dir / "activities.yaml").read_text(encoding="utf-8")
+    assert "гаївки" in activities
+    assert "гаівки" not in activities
+    assert (module_dir / "module.md").read_text(encoding="utf-8") == module_before
+    assert unmatched == frozenset()
+    assert payload["unmatched_anchors"] == []
+
+
+def test_reviewer_correction_rolls_back_invalid_yaml_artifact(tmp_path: Path) -> None:
+    module_dir = _write_fixture(tmp_path)
+    plan_path = tmp_path / "plan.yaml"
+    activities_path = module_dir / "activities.yaml"
+    activities_before = activities_path.read_text(encoding="utf-8")
+    telemetry = tmp_path / "events.jsonl"
+
+    with linear_pipeline.telemetry_event_sink(telemetry):
+        unmatched, payload = _apply(
+            module_dir,
+            plan_path,
+            gate="vesum_verified",
+            find='sentence: "На уроці згадуємо гаівки."',
+            replace="sentence: [На уроці згадуємо гаївки.",
+        )
+
+    assert activities_path.read_text(encoding="utf-8") == activities_before
+    assert unmatched == frozenset()
+    assert payload["unmatched_anchors"] == []
+    events = _events(telemetry)
+    assert events[-1]["event"] == "reviewer_correction_yaml_invalid"
+    assert events[-1]["artifact"] == "activities.yaml"
+
+
+def test_reviewer_correction_still_patches_module_md_anchor(tmp_path: Path) -> None:
+    module_dir = _write_fixture(tmp_path)
+    plan_path = tmp_path / "plan.yaml"
+    module_path = module_dir / "module.md"
+    activities_before = (module_dir / "activities.yaml").read_text(encoding="utf-8")
+    module_path.write_text(MODULE_TEXT + "\nПожалуйста, compare the forms.\n", encoding="utf-8")
+
+    unmatched, payload = _apply(
+        module_dir,
+        plan_path,
+        gate="russianisms_clean",
+        find="Пожалуйста",
+        replace="Будь ласка",
+    )
+
+    assert "Будь ласка, compare the forms." in module_path.read_text(encoding="utf-8")
+    assert (module_dir / "activities.yaml").read_text(encoding="utf-8") == activities_before
+    assert unmatched == frozenset()
+    assert payload["unmatched_anchors"] == []


### PR DESCRIPTION
## Root cause

ADR-008 reviewer-fix correction parsed accepted literal fixes, but applied them only to `module.md`. Gates such as `vesum_verified` also inspect `activities.yaml`, `vocabulary.yaml`, and `resources.yaml`, so a reviewer fix like `гаівки` -> `гаївки` was reported as an unmatched anchor when the bad form lived only in `activities.yaml`.

## Fix

- Apply accepted reviewer fixes to `module.md` plus the additional artifacts actually checked by the failed reviewer-fix gate.
- Aggregate unmatched anchors across attempted artifacts, so a fix is unmatched only when it matches nowhere.
- Validate changed YAML artifacts and roll back only the invalid artifact while emitting `reviewer_correction_yaml_invalid`.
- Added regression coverage for the `гаівки` activity typo, invalid-YAML rollback, and the existing module-anchor behavior.

## Validation

```text
======================== 147 passed, 1 skipped in 4.89s ========================
```

```text
tests/build/test_reviewer_correction_multiartifact.py::test_vesum_reviewer_correction_patches_activities_yaml PASSED [100%]
```

```text
All checks passed!
```

Additional focused guard:

```text
============================== 9 passed in 0.47s ===============================
```

## Not changed

- No gate logic weakening.
- No reviewer prompt change.
- No ADR-007 regeneration path.
- No divergence or word-count rollback change.
- YAML rollback remains teeth-preserving: invalid artifact patches are reverted, not accepted.

## Notes

Restored the existing writer prompt's explicit forbidden meta-narration example required by `test_linear_write_prompt_carries_anti_meta_narration_directive`; this does not touch the reviewer-fix prompt.
