### PR TITLE
feat(lexicon): accept productive noun diminutives

### DIFF
--- a/docs/best-practices/derivational-morphology-gate.md
+++ b/docs/best-practices/derivational-morphology-gate.md
@@ -36,11 +36,12 @@ derivations off an attested base.
 ## The layer (#2956)
 
 `derivational_morphology.py` exposes a small, deterministic **suffix-rule table** that, given a still-missing
-seminar/folk surface form, emits **full base lemmas only** (never bare stems) for three productive classes:
+seminar/folk surface form, emits **full base lemmas only** (never bare stems) for four productive classes:
 
 - **denominal adjectives** → noun base (`гаївковий` → `гаївка`)
 - **deverbal adjectives** → verb base (`знеособлювальний` → `знеособлювати`)
 - **conservative secondary imperfectives** → perfective base (`виворожувати` → `виворожити`)
+- **productive noun diminutives** → noun base (`гаївочка`, `гаївочку` → `гаївка`; `словечко` → `слово`)
 
 `_resolve_folk_heritage_attested_missing` feeds each proposed base to `classify_surface_form` and accepts the
 surface form **iff** a base is authentic-and-not-russianism **AND** the surface form is not itself
@@ -51,7 +52,8 @@ reported the surface missing.
 ## Regression contract (acceptance battery — `tests/test_derivational_morphology.py` + `tests/test_vesum_heritage_attestation.py`)
 
 - **VALID — must PASS the gate:** `гаївковий`, `знеособлювальними`, `виворожувати`, `виворожують`, plus existing
-  `другоє`, `ягілки`, `гагілку`, `незгладжений`.
+  `другоє`, `ягілки`, `гагілку`, `незгладжений`, and noun diminutives such as `гаївочка`, `гаївочку`,
+  `книжечка`, `словечко`.
 - **RUSSIANISM — must STAY FLAGGED:** `діюча`, `протиріччя`, `получаючий`, `поступаючий`, `находячийся`,
   `глазний`, `вкусний`, `слідувати`, `оказувати`, `заказувати`, `настаювати`, `решати`.
 - **DIRECT-STANDARD calque participles — unchanged (a separate STYLE concern, not blocked here):** `бажаючий`,
@@ -64,8 +66,7 @@ The canonical leak test is `діюча`: any base-derivation rule MUST keep `is_
 
 ## Stage 2 (not yet implemented — TODO in the rule table)
 
-- **affective folk morphology** (`-оньк-/-еньк-/-ечк-/-иц-/-ятк-`, e.g. `ніженьки`, `горілонька`, `доріженька`) —
-  expected to recur heavily in folk modules (diminutives in songs).
+- **affective folk augmentatives** — expected to recur in folk modules.
 - **prefixal iteratives** (`по-…-увати`, e.g. `почитувати`, `походжувати`).
 
 ## Why it matters beyond folk

--- a/scripts/lexicon/derivational_morphology.py
+++ b/scripts/lexicon/derivational_morphology.py
@@ -74,8 +74,7 @@ def derivational_bases(surface: str) -> list[dict[str, str]]:
     lemma. If pymorphy3 is unavailable, it returns no candidates so the VESUM
     gate degrades to its existing surface/allowlist behavior.
 
-    TODO(stage-2): extend this table for folk-song affective morphology
-    (diminutives/augmentatives such as ``ніженьки`` and ``горілонька``) and
+    TODO(stage-2): extend this table for folk-song affective augmentatives and
     prefixal iteratives (``по-...-увати`` such as ``почитувати``).
     """
     normalized_surface = _normalize(surface)
@@ -104,6 +103,8 @@ def _bases_for_lemma(lemma: str, tag: str) -> Iterable[tuple[str, str]]:
         yield from _deverbal_adjective_bases(lemma)
     if "VERB" in tag or "INFN" in tag:
         yield from _secondary_imperfective_bases(lemma)
+    if "NOUN" in tag:
+        yield from _diminutive_bases(lemma)
 
 
 def _denominal_adjective_bases(lemma: str) -> Iterable[tuple[str, str]]:
@@ -155,13 +156,66 @@ def _secondary_imperfective_bases(lemma: str) -> Iterable[tuple[str, str]]:
             yield "secondary-imperfective:-ювати->-ити", f"{stem}ити"
 
 
+def _diminutive_bases(lemma: str) -> Iterable[tuple[str, str]]:
+    min_stem_len = 3
+
+    for suffix in ("очка", "ечка"):
+        stem = _stem_before_suffix(lemma, suffix, min_stem_len)
+        if not stem:
+            continue
+        yield f"noun-diminutive:-{suffix}->-ка", f"{stem}ка"
+        yield f"noun-diminutive:-{suffix}->-а", f"{stem}а"
+
+    for suffix in ("онька", "енька"):
+        stem = _stem_before_suffix(lemma, suffix, min_stem_len)
+        if not stem:
+            continue
+        yield f"noun-diminutive:-{suffix}->-ка", f"{stem}ка"
+        yield f"noun-diminutive:-{suffix}->-а", f"{stem}а"
+        for hard_stem in _hushing_to_velar_stems(stem):
+            yield f"noun-diminutive:-{suffix}->velar-а", f"{hard_stem}а"
+
+    for suffix in ("очко", "ечко", "енько"):
+        stem = _stem_before_suffix(lemma, suffix, min_stem_len)
+        if not stem:
+            continue
+        yield f"noun-diminutive:-{suffix}->-о", f"{stem}о"
+        yield f"noun-diminutive:-{suffix}->-е", f"{stem}е"
+        yield f"noun-diminutive:-{suffix}->-це", f"{stem}це"
+
+    stem = _stem_before_suffix(lemma, "ятко", min_stem_len)
+    if stem:
+        yield "noun-diminutive:-ятко->-я", f"{stem}я"
+        yield "noun-diminutive:-ятко->-а", f"{stem}а"
+
+    stem = _stem_before_suffix(lemma, "енятко", min_stem_len)
+    if stem:
+        yield "noun-diminutive:-енятко->-еня", f"{stem}еня"
+        yield "noun-diminutive:-енятко->-ена", f"{stem}ена"
+        yield "noun-diminutive:-енятко->-я", f"{stem}я"
+        yield "noun-diminutive:-енятко->-а", f"{stem}а"
+
+
+def _stem_before_suffix(lemma: str, suffix: str, min_stem_len: int) -> str | None:
+    if not lemma.endswith(suffix) or len(lemma) < len(suffix) + min_stem_len:
+        return None
+    return lemma[: -len(suffix)]
+
+
+def _hushing_to_velar_stems(stem: str) -> Iterable[str]:
+    replacements = {"ж": "г", "ч": "к", "ш": "х"}
+    replacement = replacements.get(stem[-1:])
+    if replacement:
+        yield f"{stem[:-1]}{replacement}"
+
+
 def _lemma_candidates(surface: str) -> list[tuple[str, str]]:
     analyzer = _uk_morph_analyzer()
     if analyzer is None:
         return []
 
     candidates: list[tuple[str, str]] = []
-    seen: set[str] = set()
+    seen: set[tuple[str, str]] = set()
     try:
         parses = analyzer.parse(surface)[:12]
     except Exception:
@@ -169,23 +223,36 @@ def _lemma_candidates(surface: str) -> list[tuple[str, str]]:
 
     has_adjective_parse = False
     for parse in parses:
-        lemma = _normalize(str(parse.normal_form or ""))
-        if not lemma or lemma in seen:
-            continue
         tag = str(parse.tag)
         if "ADJF" in tag:
             has_adjective_parse = True
-        if not any(part in tag for part in ("ADJF", "VERB", "INFN")):
+        lemma = _normalize(str(parse.normal_form or ""))
+        kind = _lemma_candidate_kind(tag)
+        if not lemma or kind is None:
             continue
-        seen.add(lemma)
+        key = (lemma, kind)
+        if key in seen:
+            continue
+        seen.add(key)
         candidates.append((lemma, tag))
     if has_adjective_parse:
         for lemma in _inflected_adjective_lemma_candidates(surface):
-            if lemma in seen:
+            key = (lemma, "ADJF")
+            if key in seen:
                 continue
-            seen.add(lemma)
+            seen.add(key)
             candidates.append((lemma, "ADJF"))
     return candidates
+
+
+def _lemma_candidate_kind(tag: str) -> str | None:
+    if "ADJF" in tag:
+        return "ADJF"
+    if "VERB" in tag or "INFN" in tag:
+        return "VERB"
+    if "NOUN" in tag:
+        return "NOUN"
+    return None
 
 
 def _inflected_adjective_lemma_candidates(surface: str) -> Iterable[str]:

--- a/tests/test_derivational_morphology.py
+++ b/tests/test_derivational_morphology.py
@@ -33,6 +33,16 @@ def test_secondary_imperfective_rule_emits_perfective_base_from_lemma() -> None:
     assert _bases("виворожують") == {"виворожити"}
 
 
+def test_noun_diminutive_rules_emit_full_noun_bases() -> None:
+    assert "гаївка" in _bases("гаївочка")
+    assert "гаївка" in _bases("гаївочку")
+    assert "книжка" in _bases("книжечка")
+    assert "слово" in _bases("словечко")
+    assert "сонце" in _bases("сонечко")
+    assert "дитя" in _bases("дитятко")
+    assert "рука" in _bases("рученька")
+
+
 def test_active_participle_suffixes_are_not_rescued() -> None:
     for surface in ("получаючий", "поступаючий", "находячийся"):
         assert _bases(surface) == set()

--- a/tests/test_vesum_heritage_attestation.py
+++ b/tests/test_vesum_heritage_attestation.py
@@ -187,6 +187,48 @@ def test_folk_vesum_gate_accepts_productive_derivational_bases() -> None:
 
 
 @requires_sources_db
+def test_folk_vesum_gate_accepts_productive_noun_diminutives() -> None:
+    gate = _gate("гаївочка гаївочку книжечка словечко")
+
+    assert gate["passed"] is True
+    assert gate["missing"] == []
+    assert gate["heritage_attested"] == 4
+
+
+def test_russian_shadow_diminutive_surface_guard_blocks_derivational_rescue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from scripts.verification.check_ru_morph import is_russian_pattern
+
+    surface = "протирічечка"
+    shadow = is_russian_pattern(surface)
+    assert shadow["matches_russian"] is True
+    assert float(shadow["confidence"]) >= 0.7
+
+    monkeypatch.setattr(
+        linear_pipeline,
+        "_engine_flags_russianism",
+        lambda candidate: candidate == surface,
+    )
+    monkeypatch.setattr(
+        linear_pipeline,
+        "_derivational_base_candidates",
+        lambda word: {"суперечність"} if word == surface else set(),
+    )
+    monkeypatch.setattr(
+        linear_pipeline,
+        "_engine_classifies_authentic",
+        lambda candidate: candidate == "суперечність",
+    )
+
+    gate = _gate(surface)
+
+    assert gate["passed"] is False
+    assert gate["missing"] == [surface]
+    assert gate["heritage_attested"] == 0
+
+
+@requires_sources_db
 def test_folk_vesum_gate_accepts_inflected_denominal_adjectives() -> None:
     gate = _gate("веснянкова веснянкове веснянкові")
 


### PR DESCRIPTION
## Root cause

The derivational morphology layer only allowed ADJF/VERB/INFN parses through `_lemma_candidates`, and `_bases_for_lemma` had no NOUN branch. Valid folk diminutives like `гаївочка` / `гаївочку` therefore never proposed the attested base `гаївка`, so the VESUM heritage fallback could not verify them.

## What changed

- Let NOUN parses reach the derivational rule table while keeping pymorphy3 lemmatization.
- Added productive noun-diminutive base candidates for `-очка/-ечка`, `-онька/-енька`, `-очко/-ечко/-енько`, `-ятко/-енятко`, with short-stem guards.
- Kept the layer candidate-only: every proposed base is still verified by the existing gate/classifier before acceptance.
- Added regressions for `гаївочка` and inflected `гаївочку` -> `гаївка`, plus `книжечка`, `словечко`, `сонечко`, `дитятко`, `рученька`.
- Updated the derivational gate doc to list productive noun diminutives as implemented.

## Proof

Raw PASS lines for `гаївочка` acceptance and Russian-shadow diminutive guard:

```text
tests/test_vesum_heritage_attestation.py::test_folk_vesum_gate_accepts_productive_noun_diminutives PASSED [ 50%]
tests/test_vesum_heritage_attestation.py::test_russian_shadow_diminutive_surface_guard_blocks_derivational_rescue PASSED [100%]
```

Required pytest summary:

```text
============================= 68 passed in 16.07s ==============================
```

Ruff summary:

```text
All checks passed!
```

Trailer audit:

```text
  e43d7dbce1  PASS  X-Agent: codex/folk-derivational-diminutive
```

## Teeth preserved

- No verifier weakening: `_resolve_folk_heritage_attested_missing` still requires an authentic, non-russianism base before rescue.
- Surface guard remains authoritative: the Russian-shadow guard test pins a high-confidence shadow form (`протирічечка`, `check_ru_morph >= 0.7`) and proves a fake authentic derivational base cannot rescue it when the surface is flagged.
- Existing valid/russianism/coinage acceptance battery remains green.

## Not changed

- No VESUM allowlist expansion.
- No changes to classifier policy or `_engine_flags_russianism` / `_engine_classifies_authentic` behavior.
- No generated status/audit/review artifacts.
- No linter config or `.python-version` changes.
