### PR TITLE
feat(lexicon): make Word Atlas decolonization warnings visible (#2985)

### DIFF
--- a/docs/research/2026-06-12-atlas-moat-visible-report.md
+++ b/docs/research/2026-06-12-atlas-moat-visible-report.md
@@ -1,0 +1,378 @@
+# Word Atlas decolonization warnings visible — 2026-06-12
+
+## Before
+
+- `sum11` in `data/sources.db` had only `id, word, definition, text, source`.
+- `classify_lemma("ленінізм")` and `classify_lemma("школа")` returned `classification=standard` with `sovietization_risk=0`.
+- `classify_lemma("міроприємство")` already returned `classification=russianism`, `is_russianism=True`, alternative `захід`.
+- The committed Atlas manifest had 63 entries and no Russianism/surzhyk seed pages, so no red warning badge could render on the live site.
+
+## After
+
+- `scripts/lexicon/migrate_sum11_sovietization.py` idempotently adds `sum11.sovietization_risk` and `sum11.sovietization_keywords`, then reuses `scripts/audit/sum11_sovietization_scan.py`.
+- Local `data/sources.db` was migrated and populated: 127,069 rows scanned, 7,152 flagged.
+- `classify_lemma("ленінізм")` returns `classification=standard`, `sovietization_risk=2`.
+- `classify_lemma("школа")` returns `classification=standard`, `sovietization_risk=2`; it is not labeled a Sovietism.
+- The Atlas detail page renders:
+  - red word-level badges only for `russianism`/`sovietism`/`surzhyk` classifications;
+  - amber source caveats only on `enrichment.meaning` when the displayed meaning is a Soviet-flagged СУМ-11 fallback.
+
+## Seed List
+
+All seed entries are independently classified by `classify_lemma()` before inclusion.
+
+| Lemma | Classification | `is_russianism` | Alternatives |
+| --- | --- | --- | --- |
+| `агенство` | `russianism` | `True` | `агенція` |
+| `авось` | `russianism` | `True` | `ану ж`, `а може`, `може-таки` |
+| `автозагар` | `russianism` | `True` | `автозасмага` |
+| `всьо` | `russianism` | `True` | `все` |
+| `діюча` | `russianism` | `True` | `чинна` |
+| `міроприємство` | `russianism` | `True` | `захід` |
+| `протиріччя` | `russianism` | `True` | `суперечність`, `сперечання`, `супротивність` |
+| `слідуючий` | `russianism` | `True` | `наступний`, `черговий`, `дальший` |
+
+## Rendered Counts
+
+- Red heritage badge pages in `starlight/dist/lexicon`: 8
+- Amber СУМ-11 source-caveat pages in `starlight/dist/lexicon`: 8
+
+Red pages:
+
+```text
+starlight/dist/lexicon/автозагар/index.html
+starlight/dist/lexicon/міроприємство/index.html
+starlight/dist/lexicon/протиріччя/index.html
+starlight/dist/lexicon/авось/index.html
+starlight/dist/lexicon/агенство/index.html
+starlight/dist/lexicon/слідуючий/index.html
+starlight/dist/lexicon/всьо/index.html
+starlight/dist/lexicon/діюча/index.html
+```
+
+Amber pages:
+
+```text
+starlight/dist/lexicon/готовий/index.html
+starlight/dist/lexicon/рід/index.html
+starlight/dist/lexicon/ключ/index.html
+starlight/dist/lexicon/дім/index.html
+starlight/dist/lexicon/прокидатися/index.html
+starlight/dist/lexicon/збиратися/index.html
+starlight/dist/lexicon/навчатися/index.html
+starlight/dist/lexicon/стіна/index.html
+```
+
+## Command Log
+
+### Initial worktree check
+
+Command:
+
+```bash
+git status --short --branch
+```
+
+Cwd:
+
+```text
+/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/atlas-moat-visible
+```
+
+Output:
+
+```text
+## codex/atlas-moat-visible...origin/main
+?? node_modules
+```
+
+### Pre-migration schema check
+
+Command:
+
+```bash
+sqlite3 data/sources.db 'PRAGMA table_info(sum11);'
+```
+
+Cwd:
+
+```text
+/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/atlas-moat-visible
+```
+
+Output:
+
+```text
+0|id|INTEGER|0||1
+1|word|TEXT|1||0
+2|definition|TEXT|1|''|0
+3|text|TEXT|1|''|0
+4|source|TEXT|0|''|0
+```
+
+### Migration and scan
+
+Command:
+
+```bash
+.venv/bin/python scripts/lexicon/migrate_sum11_sovietization.py --db data/sources.db
+```
+
+Cwd:
+
+```text
+/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/atlas-moat-visible
+```
+
+Output:
+
+```text
+schema actions: add sovietization_risk, add sovietization_keywords, ensure idx_sum11_sovietization
+Updating 127069 rows (7152 flagged)...
+Scanned 127,069 rows. Flagged 7,152 (5.63% — 755 high, 6,397 low).
+```
+
+### Two-tier classifier verification
+
+Command:
+
+```bash
+.venv/bin/python - <<'PY'
+from scripts.lexicon.heritage_classifier import classify_lemma
+for lemma in ['ленінізм', 'школа', 'міроприємство']:
+    status = classify_lemma(lemma)
+    alts = [a.get('ref') for a in status.get('attestations', []) if a.get('source') == 'standard_alternative']
+    print(f"{lemma}: classification={status.get('classification')} is_russianism={status.get('is_russianism')} sovietization_risk={status.get('sovietization_risk')} alternatives={alts}")
+PY
+```
+
+Cwd:
+
+```text
+/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/atlas-moat-visible
+```
+
+Output:
+
+```text
+ленінізм: classification=standard is_russianism=False sovietization_risk=2 alternatives=[]
+школа: classification=standard is_russianism=False sovietization_risk=2 alternatives=[]
+міроприємство: classification=russianism is_russianism=True sovietization_risk=0 alternatives=['захід']
+```
+
+### Seed classifier verification
+
+Command:
+
+```bash
+.venv/bin/python - <<'PY'
+from scripts.lexicon.build_data_manifest import SURZHYK_TO_AVOID_SEEDS
+from scripts.lexicon.heritage_classifier import classify_lemma
+for seed in SURZHYK_TO_AVOID_SEEDS:
+    lemma = str(seed['lemma'])
+    status = classify_lemma(lemma)
+    alts = [a.get('ref') for a in status.get('attestations', []) if a.get('source') == 'standard_alternative']
+    print(f"{lemma}: classification={status.get('classification')} is_russianism={status.get('is_russianism')} alternatives={alts}")
+PY
+```
+
+Cwd:
+
+```text
+/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/atlas-moat-visible
+```
+
+Output:
+
+```text
+агенство: classification=russianism is_russianism=True alternatives=['агенція']
+авось: classification=russianism is_russianism=True alternatives=['ану ж', 'а може', 'може-таки']
+автозагар: classification=russianism is_russianism=True alternatives=['автозасмага']
+всьо: classification=russianism is_russianism=True alternatives=['все']
+діюча: classification=russianism is_russianism=True alternatives=['чинна']
+міроприємство: classification=russianism is_russianism=True alternatives=['захід']
+протиріччя: classification=russianism is_russianism=True alternatives=['суперечність', 'сперечання', 'супротивність']
+слідуючий: classification=russianism is_russianism=True alternatives=['наступний', 'черговий', 'дальший']
+```
+
+### Manifest rebuild
+
+Command:
+
+```bash
+.venv/bin/python -m scripts.lexicon.build_data_manifest
+```
+
+Cwd:
+
+```text
+/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/atlas-moat-visible
+```
+
+Output:
+
+```text
+Wrote starlight/src/data/lexicon-manifest.json: 138 lemmas across 3 modules (built=121, plan_only=9).
+```
+
+Command:
+
+```bash
+.venv/bin/python scripts/lexicon/enrich_manifest.py
+```
+
+Cwd:
+
+```text
+/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/atlas-moat-visible
+```
+
+Output:
+
+```text
+enriched 88/138 lexicon entries from VESUM + Грінченко/СУМ + Горох/ЕСУМ/Вікісловник
+single-word etymology 49/113
+```
+
+### Tests
+
+Command:
+
+```bash
+.venv/bin/python -m pytest tests/ -k 'lexicon or manifest or atlas or heritage or sovietization' -q
+```
+
+Cwd:
+
+```text
+/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/atlas-moat-visible
+```
+
+Output:
+
+```text
+FAILED tests/test_monitor_api_telemetry.py::test_manifest_json_adds_structured_telemetry_when_enabled
+KeyError: '_telemetry'
+```
+
+Note: this Codex session had `AGENT_NO_TELEMETRY_FOOTER=1`, which globally disables the telemetry field that this unrelated `manifest`-selected test asserts.
+
+Command:
+
+```bash
+env -u AGENT_NO_TELEMETRY_FOOTER .venv/bin/python -m pytest tests/ -k 'lexicon or manifest or atlas or heritage or sovietization' -q
+```
+
+Cwd:
+
+```text
+/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/atlas-moat-visible
+```
+
+Output:
+
+```text
+========= 153 passed, 8268 deselected, 1 xfailed, 3 warnings in 38.65s =========
+```
+
+### Ruff
+
+Command:
+
+```bash
+.venv/bin/ruff check scripts/audit/sum11_sovietization_scan.py scripts/audit/validate_atlas_conformance.py scripts/lexicon/build_data_manifest.py scripts/lexicon/enrich_manifest.py scripts/lexicon/heritage_classifier.py scripts/lexicon/migrate_sum11_sovietization.py tests/test_atlas_conformance.py tests/test_lexicon_build_manifest.py tests/test_lexicon_enrich_manifest.py tests/test_sum11_sovietization_scan.py
+```
+
+Cwd:
+
+```text
+/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/atlas-moat-visible
+```
+
+Output:
+
+```text
+All checks passed!
+```
+
+### Starlight install and build
+
+Command:
+
+```bash
+npm ci
+```
+
+Cwd:
+
+```text
+/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/atlas-moat-visible/starlight
+```
+
+Output:
+
+```text
+added 617 packages, and audited 618 packages in 6s
+found 0 vulnerabilities
+```
+
+Command:
+
+```bash
+npm run build
+```
+
+Cwd:
+
+```text
+/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/atlas-moat-visible/starlight
+```
+
+Output:
+
+```text
+> starlight@0.0.1 build
+> astro build
+
+[etymology] Skipping full ESUM dynamic routes. Set BUILD_ETYMOLOGY_ROUTES=1 for the full reference build.
+01:00:53 [build] 296 page(s) built in 15.24s
+01:00:53 [build] Complete!
+```
+
+### Dist badge counts
+
+Command:
+
+```bash
+rg -l 'atlas-heritage-pill--russism' starlight/dist/lexicon | wc -l
+```
+
+Cwd:
+
+```text
+/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/atlas-moat-visible
+```
+
+Output:
+
+```text
+8
+```
+
+Command:
+
+```bash
+rg -l 'atlas-source-caveat' starlight/dist/lexicon | wc -l
+```
+
+Cwd:
+
+```text
+/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/atlas-moat-visible
+```
+
+Output:
+
+```text
+8
+```

--- a/scripts/audit/sum11_sovietization_scan.py
+++ b/scripts/audit/sum11_sovietization_scan.py
@@ -208,16 +208,15 @@ def scan_and_update(
 
     for row_id, word, definition, text in rows:
         risk, keywords = classify_entry(definition or "", text or "")
-        if risk == 0:
-            continue
         if risk == 1:
             stats.flagged_low += 1
-        else:
+        elif risk >= 2:
             stats.flagged_high += 1
         for k in keywords:
             stats.by_keyword[k] = stats.by_keyword.get(k, 0) + 1
         update_buffer.append((risk, ",".join(keywords), row_id))
-        flagged_for_top.append((word, len(keywords), keywords))
+        if risk > 0:
+            flagged_for_top.append((word, len(keywords), keywords))
 
     # Top-50 most-Sovietized: sort by keyword-match count desc.
     flagged_for_top.sort(key=lambda x: (-x[1], x[0]))
@@ -227,10 +226,13 @@ def scan_and_update(
     ]
 
     if dry_run:
-        print(f"[dry-run] would update {len(update_buffer)} rows")
+        print(
+            f"[dry-run] would update {len(update_buffer)} rows "
+            f"({stats.flagged_total} flagged)"
+        )
         return stats
 
-    print(f"Updating {len(update_buffer)} flagged rows...")
+    print(f"Updating {len(update_buffer)} rows ({stats.flagged_total} flagged)...")
     with conn:
         conn.executemany(
             "UPDATE sum11 SET sovietization_risk = ?, "

--- a/scripts/audit/validate_atlas_conformance.py
+++ b/scripts/audit/validate_atlas_conformance.py
@@ -6,10 +6,10 @@ heritage classifier treat a single-token page head as VESUM-covered when it
 exists either as a lemma or as a word form. This preserves current lesson heads
 such as ``сьома`` while still rejecting orphan Atlas pages.
 
-Sovietization note: the current manifest carries sovietization risk only on
-``heritage_status.sovietization_risk``. This validator also understands future
-per-definition risk fields and requires those source-level risks to be mirrored
-onto ``heritage_status`` so the red editorial warning renders.
+Sovietization note: risk on a СУМ-11 definition is a source caveat, not a word
+classification. The manifest must carry that risk on ``enrichment.meaning`` so
+the Atlas can render an amber source warning without labeling standard words
+as Sovietisms.
 """
 
 from __future__ import annotations
@@ -41,6 +41,7 @@ NON_STANDARD_AUTHENTIC_CLASSIFICATIONS = {
     "borrowing",
 }
 STANDARD_OR_UNKNOWN_CLASSIFICATIONS = {"", "standard", "unknown"}
+DECOLONIZATION_WARNING_CLASSIFICATIONS = {"russianism", "sovietism", "surzhyk"}
 FRESHNESS_DATE_KEYS = (
     "freshness_date",
     "retrieved_at",
@@ -203,10 +204,17 @@ def _is_genuine_multi_word(value: str) -> bool:
     return len(WORD_TOKEN_RE.findall(value)) >= 2
 
 
+def _is_proper_noun_entry(entry: Mapping[str, Any]) -> bool:
+    return _normalize_text(entry.get("pos")).replace("_", " ") in {"proper noun", "proper name"}
+
+
 def _check_lemma_in_vesum(entry: Mapping[str, Any], lemma: str, vesum: Any, violations: list[Violation]) -> None:
     raw_lemma = str(entry.get("lemma") or "")
     if not lemma:
         violations.append(Violation("lemma_in_vesum", "", "entry is missing lemma"))
+        return
+
+    if _is_deliberate_warning_entry(entry) or _is_proper_noun_entry(entry):
         return
 
     if _has_whitespace(raw_lemma):
@@ -325,8 +333,19 @@ def _classification(status: Mapping[str, Any]) -> str:
     return _normalize_text(status.get("classification"))
 
 
+def _is_deliberate_warning_entry(entry: Mapping[str, Any]) -> bool:
+    if entry.get("primary_source") == "surzhyk_to_avoid":
+        return True
+    status = entry.get("heritage_status")
+    if not isinstance(status, Mapping):
+        return False
+    return bool(status.get("is_russianism")) or _classification(status) in DECOLONIZATION_WARNING_CLASSIFICATIONS
+
+
 def _requires_heritage_evidence(status: Mapping[str, Any]) -> bool:
     classification = _classification(status)
+    if classification in DECOLONIZATION_WARNING_CLASSIFICATIONS:
+        return False
     if classification in NON_STANDARD_AUTHENTIC_CLASSIFICATIONS:
         return True
     return status.get("is_russianism") is False and classification not in STANDARD_OR_UNKNOWN_CLASSIFICATIONS
@@ -423,14 +442,17 @@ def _check_sovietization(entry: Mapping[str, Any], lemma: str, violations: list[
     if source_risk < 1:
         return
 
-    status = entry.get("heritage_status")
-    rendered_risk = _risk_number(status.get("sovietization_risk")) if isinstance(status, Mapping) else 0
+    rendered_risk = (
+        _risk_number(meaning.get("sovietization_risk"))
+        if isinstance(meaning, Mapping) and _is_sum11_source(meaning.get("source"))
+        else 0
+    )
     if rendered_risk < 1:
         violations.append(
             Violation(
                 "sovietization_must_be_flagged",
                 lemma,
-                "SUM-11 definition carries sovietization risk but heritage_status.sovietization_risk is < 1",
+                "SUM-11 definition carries sovietization risk but enrichment.meaning.sovietization_risk is < 1",
             )
         )
 

--- a/scripts/lexicon/build_data_manifest.py
+++ b/scripts/lexicon/build_data_manifest.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import json
 import re
+import unicodedata
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -42,6 +43,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 CURRICULUM_ROOT = PROJECT_ROOT / "curriculum" / "l2-uk-en"
 PLANS_ROOT = CURRICULUM_ROOT / "plans"
 MANIFEST_PATH = PROJECT_ROOT / "starlight" / "src" / "data" / "lexicon-manifest.json"
+_STRESS_MARK_RE = re.compile("[\u0300\u0301]")
 
 
 # v1 module set — per design §9.
@@ -49,6 +51,17 @@ V1_MODULES: list[dict[str, str | int]] = [
     {"track": "a1", "module_num": 1, "slug": "sounds-letters-and-hello"},
     {"track": "a1", "module_num": 8, "slug": "things-have-gender"},
     {"track": "a1", "module_num": 20, "slug": "my-morning"},
+]
+
+SURZHYK_TO_AVOID_SEEDS: list[dict[str, str | None]] = [
+    {"lemma": "агенство", "gloss": "avoid: агенція", "pos": "noun"},
+    {"lemma": "авось", "gloss": "avoid: ану ж / а може", "pos": "adv"},
+    {"lemma": "автозагар", "gloss": "avoid: автозасмага", "pos": "noun"},
+    {"lemma": "всьо", "gloss": "avoid: все", "pos": "pron"},
+    {"lemma": "діюча", "gloss": "avoid: чинна", "pos": "adj"},
+    {"lemma": "міроприємство", "gloss": "avoid: захід", "pos": "noun"},
+    {"lemma": "протиріччя", "gloss": "avoid: суперечність", "pos": "noun"},
+    {"lemma": "слідуючий", "gloss": "avoid: наступний", "pos": "adj"},
 ]
 
 
@@ -80,6 +93,12 @@ def _slug_for_url(lemma: str) -> str:
     slug = slug.replace("_", "-")
     slug = re.sub(r"-+", "-", slug).strip("-")
     return slug
+
+
+def _lemma_key(lemma: str) -> str:
+    normalized = unicodedata.normalize("NFKD", lemma.strip().casefold())
+    normalized = _STRESS_MARK_RE.sub("", normalized)
+    return unicodedata.normalize("NFC", normalized)
 
 
 def _parse_plan_hint(raw: str) -> tuple[str, str | None]:
@@ -154,6 +173,7 @@ _SOURCE_PRIORITY = {
     "built_vocabulary": 0,
     "plan_required": 1,
     "plan_recommended": 2,
+    "surzhyk_to_avoid": 3,
 }
 
 
@@ -176,7 +196,7 @@ def _merge_lemma_records(
 
     for rec in records:
         display_lemma = rec["lemma"]
-        key = display_lemma.casefold()
+        key = _lemma_key(display_lemma)
         usage_entry = {
             "track": track,
             "module_num": module_num,
@@ -202,6 +222,8 @@ def _merge_lemma_records(
             and rec["source"] == "built_vocabulary"
         )
         if is_upgrade:
+            existing["lemma"] = display_lemma
+            existing["url_slug"] = _slug_for_url(display_lemma)
             existing["primary_source"] = rec["source"]
             if rec.get("gloss"):
                 existing["gloss"] = rec["gloss"]
@@ -225,6 +247,25 @@ def _merge_lemma_records(
             existing["course_usage"].append(usage_entry)
 
 
+def _merge_seed_records(by_lemma: dict[str, dict]) -> None:
+    for rec in SURZHYK_TO_AVOID_SEEDS:
+        display_lemma = str(rec["lemma"])
+        key = _lemma_key(display_lemma)
+        if key in by_lemma:
+            by_lemma[key]["seed_group"] = "surzhyk-to-avoid"
+            continue
+        by_lemma[key] = {
+            "lemma": display_lemma,
+            "url_slug": _slug_for_url(display_lemma),
+            "gloss": rec.get("gloss"),
+            "pos": rec.get("pos"),
+            "ipa": None,
+            "primary_source": "surzhyk_to_avoid",
+            "seed_group": "surzhyk-to-avoid",
+            "course_usage": [],
+        }
+
+
 def build_manifest() -> dict:
     """Build the manifest dict and return it (caller writes to disk)."""
     by_lemma: dict[str, dict] = {}
@@ -237,6 +278,8 @@ def build_manifest() -> dict:
         built_records = _load_built_vocab(module)
         _merge_lemma_records(by_lemma, module, plan_records)
         _merge_lemma_records(by_lemma, module, built_records)
+
+    _merge_seed_records(by_lemma)
 
     entries = sorted(by_lemma.values(), key=lambda e: e["lemma"])
     return {
@@ -251,8 +294,19 @@ def build_manifest() -> dict:
             "from_plan_only": sum(
                 1 for e in entries if e["primary_source"].startswith("plan_")
             ),
+            "from_surzhyk_to_avoid": sum(
+                1 for e in entries if e["primary_source"] == "surzhyk_to_avoid"
+            ),
         },
         "modules": V1_MODULES,
+        "seed_groups": [
+            {
+                "id": "surzhyk-to-avoid",
+                "source": "surzhyk_to_avoid",
+                "description": "Classifier-verified Russianism/surzhyk examples for visible Atlas warnings.",
+                "lemmas": [str(seed["lemma"]) for seed in SURZHYK_TO_AVOID_SEEDS],
+            }
+        ],
         "entries": entries,
     }
 

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -574,7 +574,33 @@ def _sense_correct_synonyms(conn: sqlite3.Connection, lemma: str) -> list[str]:
     return out[:6]
 
 
-def _meaning(conn: sqlite3.Connection, lemma: str) -> dict | None:
+def _sum11_has_flag_columns(conn: sqlite3.Connection) -> bool:
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(sum11);").fetchall()}
+    return {"sovietization_risk", "sovietization_keywords"}.issubset(cols)
+
+
+def _split_sum11_keywords(raw: object) -> list[str]:
+    return [part.strip() for part in str(raw or "").split(",") if part.strip()]
+
+
+def _sum11_row_flags(row: tuple, *, has_flag_columns: bool) -> tuple[int, list[str]]:
+    if has_flag_columns:
+        try:
+            return int(row[2] or 0), _split_sum11_keywords(row[3])
+        except (IndexError, TypeError, ValueError):
+            return 0, []
+
+    from scripts.audit.sum11_sovietization_scan import classify_entry
+
+    return classify_entry(str(row[0] or ""), str(row[1] or ""))
+
+
+def _meaning(
+    conn: sqlite3.Connection,
+    lemma: str,
+    *,
+    has_sum11_flags: bool | None = None,
+) -> dict | None:
     """Modern Ukrainian meaning: Вікісловник (clean, + synonyms) → СУМ-11 fallback.
 
     Грінченко is intentionally NOT used here — its 1907 Russian glosses are
@@ -598,19 +624,28 @@ def _meaning(conn: sqlite3.Connection, lemma: str) -> dict | None:
                 block["synonyms"] = syns
             return block
     row = None
+    if has_sum11_flags is None:
+        has_sum11_flags = _sum11_has_flag_columns(conn)
+    sum11_fields = "definition, text"
+    if has_sum11_flags:
+        sum11_fields += ", sovietization_risk, sovietization_keywords"
     for variant in _split_lemma_variants(word):
         row = conn.execute(
-            "SELECT definition FROM sum11 WHERE word = ? AND definition != '' LIMIT 1",
+            f"SELECT {sum11_fields} FROM sum11 WHERE word = ? AND definition != '' LIMIT 1",
             (variant,),
         ).fetchone()
         if row:
             break
     if row and row[0]:
+        risk, keywords = _sum11_row_flags(row, has_flag_columns=has_sum11_flags)
         block = {
             "definitions": [row[0].strip()[:600]],
             "source": "СУМ-11",
+            "sovietization_risk": risk,
             "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті.",
         }
+        if keywords:
+            block["sovietization_keywords"] = keywords
         syns = _sense_correct_synonyms(conn, word)
         if syns:
             block["synonyms"] = syns
@@ -783,6 +818,7 @@ def enrich() -> tuple[int, int]:
     conn = sqlite3.connect(f"file:{SOURCES_DB}?mode=ro", uri=True)
     enriched = 0
     try:
+        has_sum11_flags = _sum11_has_flag_columns(conn)
         for entry in manifest["entries"]:
             if entry.get("gloss"):
                 entry["gloss"] = clean_gloss(str(entry["gloss"]))
@@ -792,7 +828,7 @@ def enrich() -> tuple[int, int]:
             morph = _morphology(lemma)
             if morph:
                 block["morphology"] = morph
-            meaning = _meaning(conn, lemma)
+            meaning = _meaning(conn, lemma, has_sum11_flags=has_sum11_flags)
             if meaning:
                 block["meaning"] = meaning
             attestation = _attestation(conn, lemma)

--- a/scripts/lexicon/heritage_classifier.py
+++ b/scripts/lexicon/heritage_classifier.py
@@ -13,6 +13,7 @@ import html
 import json
 import re
 import sqlite3
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -78,17 +79,22 @@ def _classify(term: str, *, surface: bool) -> dict[str, Any]:
         return _status("unknown", [], is_russianism=False, russian_shadow=False)
 
     russian_shadow, russian_shadow_detail = _check_russian_shadow(term)
+    sovietization_risk = _sum11_sovietization_risk_for_term(term)
 
     vesum = _vesum_attestation(term, surface=surface)
     if vesum:
-        return _status("standard", [vesum], is_russianism=False, russian_shadow=russian_shadow)
+        return _status(
+            "standard",
+            [vesum],
+            is_russianism=False,
+            russian_shadow=russian_shadow,
+            sovietization_risk=sovietization_risk,
+        )
 
     russianism = _russianism_status(term, russian_shadow=russian_shadow)
 
     attestations: list[dict[str, Any]] = []
     classification = "unknown"
-    sovietization_risk = 0
-
     with _source_conn() as conn:
         auth_hits = _dictionary_attestations(conn, term, surface=surface)
         for hit in auth_hits:
@@ -348,14 +354,18 @@ def _grinchenko_surface_usage_hits(conn: sqlite3.Connection, term: str) -> list[
 
 def _sum11_exact_hits(conn: sqlite3.Connection, term: str) -> list[dict[str, Any]]:
     hits = []
+    has_flag_columns = _source_sum11_has_flag_columns()
+    fields = "id, word, definition, text, source"
+    if has_flag_columns:
+        fields += ", sovietization_risk, sovietization_keywords"
     for variant in _apostrophe_variants(term):
         rows = conn.execute(
-            "SELECT id, word, definition, text, source FROM sum11 WHERE lower(word) = ? LIMIT 3",
+            f"SELECT {fields} FROM sum11 WHERE lower(word) = ? LIMIT 3",
             (variant,),
         ).fetchall()
         for row in rows:
             text = _clean_text(row["definition"])
-            risk = _sum11_sovietization_risk(str(row["definition"] or ""), str(row["text"] or ""))
+            risk = _sum11_row_sovietization_risk(row, has_flag_columns=has_flag_columns)
             hits.append(
                 {
                     "classification": _classification_from_definition(text, default="standard"),
@@ -369,6 +379,84 @@ def _sum11_exact_hits(conn: sqlite3.Connection, term: str) -> list[dict[str, Any
                 }
             )
     return hits
+
+
+def _sum11_has_flag_columns(conn: sqlite3.Connection) -> bool:
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(sum11);").fetchall()}
+    return {"sovietization_risk", "sovietization_keywords"}.issubset(cols)
+
+
+@lru_cache(maxsize=8)
+def _sum11_has_flag_columns_for_db(
+    db_path: str,
+    mtime_ns: int,
+    size: int,
+) -> bool:
+    del mtime_ns, size  # cache-key invalidators; not used in the query itself.
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        return _sum11_has_flag_columns(conn)
+    finally:
+        conn.close()
+
+
+def _source_sum11_has_flag_columns() -> bool:
+    try:
+        stat = SOURCES_DB.stat()
+        return _sum11_has_flag_columns_for_db(
+            str(SOURCES_DB.resolve()),
+            stat.st_mtime_ns,
+            stat.st_size,
+        )
+    except (OSError, sqlite3.Error):
+        return False
+
+
+def _sum11_row_sovietization_risk(
+    row: sqlite3.Row,
+    *,
+    has_flag_columns: bool,
+) -> int:
+    if has_flag_columns:
+        try:
+            return int(row["sovietization_risk"] or 0)
+        except (IndexError, KeyError, TypeError, ValueError):
+            return 0
+    return _sum11_sovietization_risk(str(row["definition"] or ""), str(row["text"] or ""))
+
+
+def _sum11_sovietization_risk_for_term(term: str) -> int:
+    try:
+        has_flag_columns = _source_sum11_has_flag_columns()
+        with _source_conn() as conn:
+            if has_flag_columns:
+                risk = 0
+                for variant in _apostrophe_variants(term):
+                    row = conn.execute(
+                        "SELECT MAX(sovietization_risk) FROM sum11 WHERE lower(word) = ?",
+                        (variant,),
+                    ).fetchone()
+                    if row:
+                        risk = max(risk, int(row[0] or 0))
+                return risk
+
+            risk = 0
+            for variant in _apostrophe_variants(term):
+                rows = conn.execute(
+                    "SELECT definition, text FROM sum11 WHERE lower(word) = ? LIMIT 3",
+                    (variant,),
+                ).fetchall()
+                for row in rows:
+                    risk = max(
+                        risk,
+                        _sum11_sovietization_risk(
+                            str(row["definition"] or ""),
+                            str(row["text"] or ""),
+                        ),
+                    )
+            return risk
+    except (FileNotFoundError, sqlite3.Error):
+        return 0
 
 
 def _esum_exact_hits(conn: sqlite3.Connection, term: str) -> list[dict[str, Any]]:

--- a/scripts/lexicon/migrate_sum11_sovietization.py
+++ b/scripts/lexicon/migrate_sum11_sovietization.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Idempotently add and populate СУМ-11 Sovietization flags.
+
+This is the operational wrapper for the Word Atlas decolonization layer:
+it applies the ``sum11`` flag columns when absent, then reuses
+``scripts.audit.sum11_sovietization_scan.classify_entry`` through the scan
+module to populate every row.
+
+Run from the repo root:
+
+    .venv/bin/python scripts/lexicon/migrate_sum11_sovietization.py --db data/sources.db
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from scripts.audit.sum11_sovietization_scan import scan_and_update, write_audit_report
+
+DEFAULT_DB = ROOT / "data" / "sources.db"
+
+
+def _sum11_columns(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute("PRAGMA table_info(sum11);").fetchall()
+    if not rows:
+        raise sqlite3.OperationalError("missing required table: sum11")
+    return {str(row[1]) for row in rows}
+
+
+def ensure_sum11_sovietization_columns(
+    conn: sqlite3.Connection,
+    *,
+    dry_run: bool = False,
+) -> list[str]:
+    """Apply missing ``sum11`` sovietization schema pieces.
+
+    Returns human-readable action labels. Safe to run repeatedly.
+    """
+    cols = _sum11_columns(conn)
+    statements: list[tuple[str, str]] = []
+    if "sovietization_risk" not in cols:
+        statements.append(
+            (
+                "add sovietization_risk",
+                "ALTER TABLE sum11 "
+                "ADD COLUMN sovietization_risk INTEGER NOT NULL DEFAULT 0",
+            )
+        )
+    if "sovietization_keywords" not in cols:
+        statements.append(
+            (
+                "add sovietization_keywords",
+                "ALTER TABLE sum11 "
+                "ADD COLUMN sovietization_keywords TEXT NOT NULL DEFAULT ''",
+            )
+        )
+    statements.append(
+        (
+            "ensure idx_sum11_sovietization",
+            "CREATE INDEX IF NOT EXISTS idx_sum11_sovietization "
+            "ON sum11(sovietization_risk) WHERE sovietization_risk > 0",
+        )
+    )
+
+    actions = [label for label, _sql in statements]
+    if dry_run:
+        return actions
+
+    with conn:
+        for _label, sql in statements:
+            conn.execute(sql)
+    return actions
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Add sum11.sovietization_* columns if needed and populate them "
+            "using scripts/audit/sum11_sovietization_scan.py logic."
+        )
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=DEFAULT_DB,
+        help="Path to data/sources.db SQLite file.",
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=None,
+        help="Optional markdown report path. No report is written by default.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show schema actions and scan counts without mutating the database.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.db.exists():
+        print(f"ERROR: DB file not found: {args.db}", file=sys.stderr)
+        return 2
+
+    conn = sqlite3.connect(args.db)
+    try:
+        actions = ensure_sum11_sovietization_columns(conn, dry_run=args.dry_run)
+        if args.dry_run:
+            print("[dry-run] schema actions: " + ", ".join(actions))
+        else:
+            print("schema actions: " + ", ".join(actions))
+        stats = scan_and_update(conn, dry_run=args.dry_run)
+    except sqlite3.Error as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        conn.close()
+
+    if args.report is not None:
+        write_audit_report(stats, args.report, args.db)
+
+    print(
+        f"Scanned {stats.total_rows:,} rows. "
+        f"Flagged {stats.flagged_total:,} "
+        f"({stats.flagged_pct:.2f}% — {stats.flagged_high:,} high, "
+        f"{stats.flagged_low:,} low)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/starlight/src/data/lexicon-manifest.json
+++ b/starlight/src/data/lexicon-manifest.json
@@ -1,11 +1,12 @@
 {
   "version": "0.1",
-  "generated_at": "2026-05-22T16:19:14+00:00",
+  "generated_at": "2026-06-11T22:59:05+00:00",
   "stats": {
-    "lemmas_total": 63,
+    "lemmas_total": 138,
     "modules_covered": 3,
-    "from_built": 20,
-    "from_plan_only": 43
+    "from_built": 121,
+    "from_plan_only": 9,
+    "from_surzhyk_to_avoid": 8
   },
   "modules": [
     {
@@ -24,20 +25,225 @@
       "slug": "my-morning"
     }
   ],
+  "seed_groups": [
+    {
+      "id": "surzhyk-to-avoid",
+      "source": "surzhyk_to_avoid",
+      "description": "Classifier-verified Russianism/surzhyk examples for visible Atlas warnings.",
+      "lemmas": [
+        "агенство",
+        "авось",
+        "автозагар",
+        "всьо",
+        "діюча",
+        "міроприємство",
+        "протиріччя",
+        "слідуючий"
+      ]
+    }
+  ],
   "entries": [
     {
-      "lemma": "До побачення",
-      "url_slug": "до-побачення",
-      "gloss": "Goodbye",
-      "pos": null,
+      "lemma": "Ілля",
+      "url_slug": "ілля",
+      "gloss": "Illia",
+      "pos": "proper noun",
       "ipa": null,
-      "primary_source": "plan_required",
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "authentic-archaism",
+        "attestations": [
+          {
+            "source": "esum",
+            "ref": "ілля:2:294",
+            "word": "ілля",
+            "detail": "Ілля, [Илія], Ількд, 1Илаш, Илюсь, Илюха ЯІ, ст. Илій, Елйя (1627); — р. Илья, ст. Илия, бр. /лья, Ільяш, др. Илия, п. Еііазг, ч. слц. Еііаз, ст. Не1іа$,,болг. Илйя, м. Илща, \\Илко\\, схв. Илищ, слн. Е1і]‘а, стел Илмгі, 6ллїа, Йєлііа;—через церковнослов’янське давньоруську мову з грецької; гр. ’НАлае походить від гебр. ’ЕНіаЬй (із складання форм еІоЬіт і баЬуе) (букв.) «сила божа» або ж «мій бог Єгова».— Сл. вл. імен 211; Беринда 208; Фасмер II 128; Петровский 121; Кореспу Ргиуобсе 60; Илчев 221…"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": true,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 16,
+          "forms": [
+            {
+              "form": "Іллі",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "Ілле",
+              "label": "чол., кличний"
+            },
+            {
+              "form": "Іллє",
+              "label": "чол., кличний"
+            },
+            {
+              "form": "Іллі",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "Ілля",
+              "label": "чол., називний"
+            },
+            {
+              "form": "Іллею",
+              "label": "чол., орудний"
+            },
+            {
+              "form": "Іллєю",
+              "label": "чол., орудний"
+            },
+            {
+              "form": "Іллі",
+              "label": "чол., родовий"
+            },
+            {
+              "form": "Іллю",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "Іллям",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "Іллі",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "Іллях",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "Іллі",
+              "label": "множина, називний"
+            },
+            {
+              "form": "Іллями",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "Іллів",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "Іллів",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "Ілля",
+                "plural": "Іллі"
+              },
+              "родовий": {
+                "singular": "Іллі",
+                "plural": "Іллів"
+              },
+              "давальний": {
+                "singular": "Іллі",
+                "plural": "Іллям"
+              },
+              "знахідний": {
+                "singular": "Іллю",
+                "plural": "Іллів"
+              },
+              "орудний": {
+                "singular": "Іллею / Іллєю",
+                "plural": "Іллями"
+              },
+              "місцевий": {
+                "singular": "Іллі",
+                "plural": "Іллях"
+              },
+              "кличний": {
+                "singular": "Ілле / Іллє",
+                "plural": "Іллі"
+              }
+            }
+          }
+        },
+        "sources": [
+          "VESUM"
+        ]
+      }
+    },
+    {
+      "lemma": "А тебе́?",
+      "url_slug": "а-тебе",
+      "gloss": "And you? (after a name question)",
+      "pos": "phrase",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 1,
           "slug": "sounds-letters-and-hello",
-          "context": "plan_required"
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "unknown",
+        "attestations": [],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
+    },
+    {
+      "lemma": "А у тебе́?",
+      "url_slug": "а-у-тебе",
+      "gloss": "And you? (after How are you?)",
+      "pos": "phrase",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 1,
+          "slug": "sounds-letters-and-hello",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "unknown",
+        "attestations": [],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
+    },
+    {
+      "lemma": "До поба́чення",
+      "url_slug": "до-поба-чення",
+      "gloss": "Goodbye",
+      "pos": "phrase",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 1,
+          "slug": "sounds-letters-and-hello",
+          "context": "built_vocabulary"
         }
       ],
       "heritage_status": {
@@ -57,18 +263,48 @@
       }
     },
     {
-      "lemma": "Добрий вечір",
-      "url_slug": "добрий-вечір",
+      "lemma": "До́бре",
+      "url_slug": "до-бре",
+      "gloss": "Fine / good",
+      "pos": "phrase",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 1,
+          "slug": "sounds-letters-and-hello",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "добре",
+            "detail": "lemma match (1 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
+    },
+    {
+      "lemma": "До́брий ве́чір",
+      "url_slug": "до-брий-ве-чір",
       "gloss": "Good evening",
-      "pos": null,
+      "pos": "phrase",
       "ipa": null,
-      "primary_source": "plan_required",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 1,
           "slug": "sounds-letters-and-hello",
-          "context": "plan_required"
+          "context": "built_vocabulary"
         }
       ],
       "heritage_status": {
@@ -81,18 +317,18 @@
       }
     },
     {
-      "lemma": "Добрий день",
-      "url_slug": "добрий-день",
-      "gloss": "Good day / Hello",
-      "pos": null,
+      "lemma": "До́брий день",
+      "url_slug": "до-брий-день",
+      "gloss": "Hello / Good day",
+      "pos": "phrase",
       "ipa": null,
-      "primary_source": "plan_required",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 1,
           "slug": "sounds-letters-and-hello",
-          "context": "plan_required"
+          "context": "built_vocabulary"
         }
       ],
       "heritage_status": {
@@ -105,18 +341,18 @@
       }
     },
     {
-      "lemma": "Доброго ранку",
-      "url_slug": "доброго-ранку",
+      "lemma": "До́брого ра́нку",
+      "url_slug": "до-брого-ра-нку",
       "gloss": "Good morning",
-      "pos": null,
+      "pos": "phrase",
       "ipa": null,
-      "primary_source": "plan_required",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 1,
           "slug": "sounds-letters-and-hello",
-          "context": "plan_required"
+          "context": "built_vocabulary"
         }
       ],
       "heritage_status": {
@@ -129,18 +365,172 @@
       }
     },
     {
-      "lemma": "На все добре",
-      "url_slug": "на-все-добре",
+      "lemma": "Ме́не зва́ти ...",
+      "url_slug": "ме-не-зва-ти",
+      "gloss": "My name is ...",
+      "pos": "phrase",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 1,
+          "slug": "sounds-letters-and-hello",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "unknown",
+        "attestations": [],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
+    },
+    {
+      "lemma": "Микола",
+      "url_slug": "микола",
+      "gloss": "Mykola",
+      "pos": "proper noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "unknown",
+        "attestations": [],
+        "is_russianism": false,
+        "russian_shadow": true,
+        "sovietization_risk": 0,
+        "calque_warning": {
+          "type": "russian_shadow_only",
+          "russian_lemma": "микола",
+          "confidence": 1.0,
+          "note": "negative signal only; no Ukrainian standard alternative was found"
+        }
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 14,
+          "forms": [
+            {
+              "form": "Миколі",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "Миколо",
+              "label": "чол., кличний"
+            },
+            {
+              "form": "Миколі",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "Микола",
+              "label": "чол., називний"
+            },
+            {
+              "form": "Миколою",
+              "label": "чол., орудний"
+            },
+            {
+              "form": "Миколи",
+              "label": "чол., родовий"
+            },
+            {
+              "form": "Миколу",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "Миколам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "Миколи",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "Миколах",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "Миколи",
+              "label": "множина, називний"
+            },
+            {
+              "form": "Миколами",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "Микол",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "Микол",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "Микола",
+                "plural": "Миколи"
+              },
+              "родовий": {
+                "singular": "Миколи",
+                "plural": "Микол"
+              },
+              "давальний": {
+                "singular": "Миколі",
+                "plural": "Миколам"
+              },
+              "знахідний": {
+                "singular": "Миколу",
+                "plural": "Микол"
+              },
+              "орудний": {
+                "singular": "Миколою",
+                "plural": "Миколами"
+              },
+              "місцевий": {
+                "singular": "Миколі",
+                "plural": "Миколах"
+              },
+              "кличний": {
+                "singular": "Миколо",
+                "plural": "Миколи"
+              }
+            }
+          }
+        },
+        "sources": [
+          "VESUM"
+        ]
+      }
+    },
+    {
+      "lemma": "На все до́бре",
+      "url_slug": "на-все-до-бре",
       "gloss": "All the best",
-      "pos": null,
+      "pos": "phrase",
       "ipa": null,
-      "primary_source": "plan_recommended",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 1,
           "slug": "sounds-letters-and-hello",
-          "context": "plan_recommended"
+          "context": "built_vocabulary"
         }
       ],
       "heritage_status": {
@@ -153,18 +543,237 @@
       }
     },
     {
-      "lemma": "Рада тебе бачити",
-      "url_slug": "рада-тебе-бачити",
-      "gloss": "Glad [f] to see you",
-      "pos": null,
+      "lemma": "Норма́льно",
+      "url_slug": "норма-льно",
+      "gloss": "Okay / normal",
+      "pos": "phrase",
       "ipa": null,
-      "primary_source": "plan_recommended",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 1,
           "slug": "sounds-letters-and-hello",
-          "context": "plan_recommended"
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "нормально",
+            "detail": "lemma match (1 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
+    },
+    {
+      "lemma": "Павло",
+      "url_slug": "павло",
+      "gloss": "Pavlo",
+      "pos": "proper noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "unknown",
+        "attestations": [],
+        "is_russianism": false,
+        "russian_shadow": true,
+        "sovietization_risk": 0,
+        "calque_warning": {
+          "type": "russian_shadow_only",
+          "russian_lemma": "павло",
+          "confidence": 1.0,
+          "note": "negative signal only; no Ukrainian standard alternative was found"
+        }
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 17,
+          "forms": [
+            {
+              "form": "Павлові",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "Павлу",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "Павле",
+              "label": "чол., кличний"
+            },
+            {
+              "form": "Павлі",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "Павлові",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "Павлу",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "Павло",
+              "label": "чол., називний"
+            },
+            {
+              "form": "Павлом",
+              "label": "чол., орудний"
+            },
+            {
+              "form": "Павла",
+              "label": "чол., родовий"
+            },
+            {
+              "form": "Павла",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "Павлам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "Павли",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "Павлах",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "Павли",
+              "label": "множина, називний"
+            },
+            {
+              "form": "Павлами",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "Павлів",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "Павлів",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "Павло",
+                "plural": "Павли"
+              },
+              "родовий": {
+                "singular": "Павла",
+                "plural": "Павлів"
+              },
+              "давальний": {
+                "singular": "Павлові / Павлу",
+                "plural": "Павлам"
+              },
+              "знахідний": {
+                "singular": "Павла",
+                "plural": "Павлів"
+              },
+              "орудний": {
+                "singular": "Павлом",
+                "plural": "Павлами"
+              },
+              "місцевий": {
+                "singular": "Павлі / Павлові / Павлу",
+                "plural": "Павлах"
+              },
+              "кличний": {
+                "singular": "Павле",
+                "plural": "Павли"
+              }
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "українське чоловіче ім'я"
+          ],
+          "source": "Вікісловник"
+        },
+        "sources": [
+          "VESUM",
+          "Вікісловник"
+        ]
+      }
+    },
+    {
+      "lemma": "Приві́т",
+      "url_slug": "приві-т",
+      "gloss": "Hi",
+      "pos": "phrase",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 1,
+          "slug": "sounds-letters-and-hello",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "привіт",
+            "detail": "lemma match (17 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 1,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "etymology": {
+          "text": "псл. privětъ, утворене від дієслова privětiti «привітати», пов’язаного з větь «гілка» (первісно означало «наблизитися з гілкою як символом важливого повідомлення» або «прийняти з урочистою гілкою»); зворотне виведення псл. privětiti від privětъ (Mikl. EW 388; Фасмер ІІІ 363) малопереконливе; р. болг. приве́т, бр. прыве́тны «привітний», др. привѣтъ, ч. заст. přívět, слц. заст. prívet, м. приветлив «привітний», цсл. привѣтъ;",
+          "source": "Горох (за ЕСУМ)",
+          "source_url": "https://goroh.pp.ua/%D0%95%D1%82%D0%B8%D0%BC%D0%BE%D0%BB%D0%BE%D0%B3%D1%96%D1%8F/%D0%BF%D1%80%D0%B8%D0%B2%D1%96%D1%82"
+        },
+        "sources": [
+          "Горох (за ЕСУМ)"
+        ]
+      }
+    },
+    {
+      "lemma": "Ра́да тебе́ ба́чити",
+      "url_slug": "ра-да-тебе-ба-чити",
+      "gloss": "Glad to see you (female speaker)",
+      "pos": "phrase",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 1,
+          "slug": "sounds-letters-and-hello",
+          "context": "built_vocabulary"
         }
       ],
       "heritage_status": {
@@ -177,18 +786,18 @@
       }
     },
     {
-      "lemma": "Радий тебе бачити",
-      "url_slug": "радий-тебе-бачити",
-      "gloss": "Glad [m] to see you",
-      "pos": null,
+      "lemma": "Ра́дий тебе́ ба́чити",
+      "url_slug": "ра-дий-тебе-ба-чити",
+      "gloss": "Glad to see you (male speaker)",
+      "pos": "phrase",
       "ipa": null,
-      "primary_source": "plan_recommended",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 1,
           "slug": "sounds-letters-and-hello",
-          "context": "plan_recommended"
+          "context": "built_vocabulary"
         }
       ],
       "heritage_status": {
@@ -201,10 +810,735 @@
       }
     },
     {
-      "lemma": "вмиватися",
-      "url_slug": "вмиватися",
-      "gloss": "to wash oneself",
-      "pos": "verb",
+      "lemma": "Чудо́во",
+      "url_slug": "чудо-во",
+      "gloss": "Great / wonderful",
+      "pos": "phrase",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 1,
+          "slug": "sounds-letters-and-hello",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "чудово",
+            "detail": "lemma match (1 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
+    },
+    {
+      "lemma": "Як спра́ви?",
+      "url_slug": "як-спра-ви",
+      "gloss": "How are you?",
+      "pos": "phrase",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 1,
+          "slug": "sounds-letters-and-hello",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "unknown",
+        "attestations": [],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
+    },
+    {
+      "lemma": "Як тебе́ зва́ти?",
+      "url_slug": "як-тебе-зва-ти",
+      "gloss": "What is your name?",
+      "pos": "phrase",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 1,
+          "slug": "sounds-letters-and-hello",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "unknown",
+        "attestations": [],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
+    },
+    {
+      "lemma": "абе́тка",
+      "url_slug": "абе-тка",
+      "gloss": "alphabet",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 1,
+          "slug": "sounds-letters-and-hello",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "абетка",
+            "detail": "lemma match (14 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
+    },
+    {
+      "lemma": "авось",
+      "url_slug": "авось",
+      "gloss": "avoid: ану ж / а може",
+      "pos": "adv",
+      "ipa": null,
+      "primary_source": "surzhyk_to_avoid",
+      "seed_group": "surzhyk-to-avoid",
+      "course_usage": [],
+      "heritage_status": {
+        "classification": "russianism",
+        "attestations": [
+          {
+            "source": "standard_alternative",
+            "ref": "ану ж",
+            "detail": "Ukrainian standard alternative for авось"
+          },
+          {
+            "source": "standard_alternative",
+            "ref": "а може",
+            "detail": "Ukrainian standard alternative for авось"
+          },
+          {
+            "source": "standard_alternative",
+            "ref": "може-таки",
+            "detail": "Ukrainian standard alternative for авось"
+          },
+          {
+            "source": "lt_replacements",
+            "ref": "docs/best-practices/heritage-attestation-engine.md",
+            "detail": "local correction evidence; no authentic dictionary attestation found"
+          }
+        ],
+        "is_russianism": true,
+        "russian_shadow": true,
+        "sovietization_risk": 0,
+        "calque_warning": {
+          "standard_alternatives": [
+            "ану ж",
+            "а може",
+            "може-таки"
+          ]
+        }
+      }
+    },
+    {
+      "lemma": "автозагар",
+      "url_slug": "автозагар",
+      "gloss": "avoid: автозасмага",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "surzhyk_to_avoid",
+      "seed_group": "surzhyk-to-avoid",
+      "course_usage": [],
+      "heritage_status": {
+        "classification": "russianism",
+        "attestations": [
+          {
+            "source": "standard_alternative",
+            "ref": "автозасмага",
+            "detail": "Ukrainian standard alternative for автозагар"
+          },
+          {
+            "source": "lt_replacements",
+            "ref": "docs/best-practices/heritage-attestation-engine.md",
+            "detail": "local correction evidence; no authentic dictionary attestation found"
+          }
+        ],
+        "is_russianism": true,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": {
+          "standard_alternatives": [
+            "автозасмага"
+          ]
+        }
+      }
+    },
+    {
+      "lemma": "агенство",
+      "url_slug": "агенство",
+      "gloss": "avoid: агенція",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "surzhyk_to_avoid",
+      "seed_group": "surzhyk-to-avoid",
+      "course_usage": [],
+      "heritage_status": {
+        "classification": "russianism",
+        "attestations": [
+          {
+            "source": "standard_alternative",
+            "ref": "агенція",
+            "detail": "Ukrainian standard alternative for агенство"
+          },
+          {
+            "source": "lt_replacements",
+            "ref": "docs/best-practices/heritage-attestation-engine.md",
+            "detail": "local correction evidence; no authentic dictionary attestation found"
+          }
+        ],
+        "is_russianism": true,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": {
+          "standard_alternatives": [
+            "агенція"
+          ]
+        }
+      }
+    },
+    {
+      "lemma": "актор",
+      "url_slug": "актор",
+      "gloss": "male actor",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "актор",
+            "detail": "lemma match (18 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 18,
+          "forms": [
+            {
+              "form": "акторові",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "актору",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "акторе",
+              "label": "чол., кличний"
+            },
+            {
+              "form": "акторі",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "акторові",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "актору",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "актор",
+              "label": "чол., називний"
+            },
+            {
+              "form": "актором",
+              "label": "чол., орудний"
+            },
+            {
+              "form": "актора",
+              "label": "чол., родовий"
+            },
+            {
+              "form": "актора",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "акторам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "актори",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "акторах",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "актори",
+              "label": "множина, називний"
+            },
+            {
+              "form": "акторами",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "акторів",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "акторів",
+              "label": "множина, знахідний"
+            },
+            {
+              "form": "актори",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "актор",
+                "plural": "актори"
+              },
+              "родовий": {
+                "singular": "актора",
+                "plural": "акторів"
+              },
+              "давальний": {
+                "singular": "акторові / актору",
+                "plural": "акторам"
+              },
+              "знахідний": {
+                "singular": "актора",
+                "plural": "акторів / актори"
+              },
+              "орудний": {
+                "singular": "актором",
+                "plural": "акторами"
+              },
+              "місцевий": {
+                "singular": "акторі / акторові / актору",
+                "plural": "акторах"
+              },
+              "кличний": {
+                "singular": "акторе",
+                "plural": "актори"
+              }
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "виконавець (професіонал) ролей у театральних виставах",
+            "про людину яка показує себе не такою, якою вона є насправді"
+          ],
+          "source": "Вікісловник"
+        },
+        "attestation": {
+          "text": "АктОр и актьОр, -ра, м. Актер. Ввійшов Яким зовсім так, як от виступають актори на сцену з-за декорацій. Левиц. І. 478. Один актьор грав дуже погано... в партері почали сміятись. Левиц. Пов. 139.",
+          "source": "Грінченко (1907)"
+        },
+        "etymology": {
+          "text": "актор, акторство, акторствувати, акторувати, ст. актора (XVII ст.); — р. актер, бр. акцер, п. акіог, ч. (заст.) слц. акіег, болг. актьбр, м. актер, схв. актер, слн. акіег; — запозичена з латинської мови, можливо, через посередництво польської; лат. асіог «виконавець, актор» пов’язане з а^о «дію»; український наголос, відмінний від латинського та польського, встановився, очевидно, під впливом рос. актер з фр. асіецг.— РісЬЬагсІі 29; Шанский ЗСРЯ І 1, 68; Фасмер І 67; Горяев 3; БЕР І 7; Младенов 4.— Див. ще агент.",
+          "source": "ЕСУМ, т. 1, с. 56"
+        },
+        "sources": [
+          "VESUM",
+          "Вікісловник",
+          "Грінченко (1907)",
+          "ЕСУМ, т. 1, с. 56"
+        ]
+      }
+    },
+    {
+      "lemma": "акторка",
+      "url_slug": "акторка",
+      "gloss": "female actor",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "акторка",
+            "detail": "lemma match (15 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 15,
+          "forms": [
+            {
+              "form": "акторці",
+              "label": "жін., давальний"
+            },
+            {
+              "form": "акторко",
+              "label": "жін., кличний"
+            },
+            {
+              "form": "акторці",
+              "label": "жін., місцевий"
+            },
+            {
+              "form": "акторка",
+              "label": "жін., називний"
+            },
+            {
+              "form": "акторкою",
+              "label": "жін., орудний"
+            },
+            {
+              "form": "акторки",
+              "label": "жін., родовий"
+            },
+            {
+              "form": "акторку",
+              "label": "жін., знахідний"
+            },
+            {
+              "form": "акторкам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "акторки",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "акторках",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "акторки",
+              "label": "множина, називний"
+            },
+            {
+              "form": "акторками",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "акторок",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "акторок",
+              "label": "множина, знахідний"
+            },
+            {
+              "form": "акторки",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "акторка",
+                "plural": "акторки"
+              },
+              "родовий": {
+                "singular": "акторки",
+                "plural": "акторок"
+              },
+              "давальний": {
+                "singular": "акторці",
+                "plural": "акторкам"
+              },
+              "знахідний": {
+                "singular": "акторку",
+                "plural": "акторок / акторки"
+              },
+              "орудний": {
+                "singular": "акторкою",
+                "plural": "акторками"
+              },
+              "місцевий": {
+                "singular": "акторці",
+                "plural": "акторках"
+              },
+              "кличний": {
+                "singular": "акторко",
+                "plural": "акторки"
+              }
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "АКТО́РКА, и, ж. Жін. до акто́р, актри́са. Вона сміялась чудним сміхом, як сміються акторки на сцені (Н.-Лев., ІІІ, 1956, 130); \"За ситуаціями\" я написала під враженням гри одної великої драматичної акторки (Коб., III, 1956, 565); Моя мила двоюрідна сестричка Олена — ..талановита акторка драматичного театру (Грим., Подробиці.., 1956, 35)."
+          ],
+          "source": "СУМ-11",
+          "sovietization_risk": 0,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
+        },
+        "attestation": {
+          "text": "АктОрка и актьОрка, -ки, ж. Актриса. Желех. Чи не була вона в актьорках в театрі? Левиц. І. 465.",
+          "source": "Грінченко (1907)"
+        },
+        "sources": [
+          "VESUM",
+          "Грінченко (1907)",
+          "СУМ-11"
+        ]
+      }
+    },
+    {
+      "lemma": "апо́строф",
+      "url_slug": "апо-строф",
+      "gloss": "apostrophe",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 1,
+          "slug": "sounds-letters-and-hello",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "апостроф",
+            "detail": "lemma match (17 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
+    },
+    {
+      "lemma": "батько",
+      "url_slug": "батько",
+      "gloss": "father",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "батько",
+            "detail": "lemma match (17 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 17,
+          "forms": [
+            {
+              "form": "батькові",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "батьку",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "батьку",
+              "label": "чол., кличний"
+            },
+            {
+              "form": "батькові",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "батьку",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "батько",
+              "label": "чол., називний"
+            },
+            {
+              "form": "батьком",
+              "label": "чол., орудний"
+            },
+            {
+              "form": "батька",
+              "label": "чол., родовий"
+            },
+            {
+              "form": "батька",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "батькам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "батьки",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "батьках",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "батьки",
+              "label": "множина, називний"
+            },
+            {
+              "form": "батьками",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "батьків",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "батьків",
+              "label": "множина, знахідний"
+            },
+            {
+              "form": "батьки",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "батько",
+                "plural": "батьки"
+              },
+              "родовий": {
+                "singular": "батька",
+                "plural": "батьків"
+              },
+              "давальний": {
+                "singular": "батькові / батьку",
+                "plural": "батькам"
+              },
+              "знахідний": {
+                "singular": "батька",
+                "plural": "батьків / батьки"
+              },
+              "орудний": {
+                "singular": "батьком",
+                "plural": "батьками"
+              },
+              "місцевий": {
+                "singular": "батькові / батьку",
+                "plural": "батьках"
+              },
+              "кличний": {
+                "singular": "батьку",
+                "plural": "батьки"
+              }
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "чоловік стосовно до своїх дітей",
+            "основоположник якого-небудь учення, якої-небудь галузі науки, мистецтва і т. ін",
+            "шанобливе називання козацької старшини, отаманів тощо"
+          ],
+          "source": "Вікісловник"
+        },
+        "attestation": {
+          "text": "Батько, -ка, м. 1) Отец. Єсть у мене батько і рідная мати. Мет. 94. Я любив тебе, я кохав тебе а як батько дитину. Мет. 12. батько-мати. Родители. Жила я в батька-матері. МВ. ІІ. 33. Не при батькові-матері зросла, живу у чужій сем'ї. МВ. ІІ. 105. головатий батько. Отец на свадьбе. Маркев. 101, 108. Грин. III. 451, 454. вечернишний батько. Хозяин хаты, в которой бывают вечерниці. Грин. І. 285. брехали твого батька дочки (сини). Ты врешь. по батькові. По отчеству. Уман. у. в батька лаяти. Бранить, задевая бранью отца, напр.: біс твоєму батькові! 2) Употребл. как почтительное приветствіе пожилому",
+          "source": "Грінченко (1907)"
+        },
+        "etymology": {
+          "text": "батько, батя, [батьо Ж, батусь Ж, батюк Я1, Ібатюхна] «батенько» Я, батюшка «піп» (з рос.), бйтьківщйна СУМ, Ж, батькувати «лаяти батька; бути батьком», безбатченко «позашлюбний син», [побагпько] «прийомний батько» Ж, [побатькатися] «стати в стосунки батька й сина»; — р. батя, батька «батько», [батко] «тс.», [бат] «брат», бр. [бацька], др. батя «батько», ч. Ьаі’а (звертання до простакуватого чоловіка), слц. ЬаГа «дядько; [батько; старший брат]», болг. баща «батько», [бате] «старший брат», м. бате, батко «тс.», схв. бата «братик», бака «тс.», [бача] «батенько, свекор», баштина «батьківщина»; —",
+          "source": "ЕСУМ, т. 1, с. 151"
+        },
+        "sources": [
+          "VESUM",
+          "Вікісловник",
+          "Грінченко (1907)",
+          "ЕСУМ, т. 1, с. 151"
+        ]
+      }
+    },
+    {
+      "lemma": "будильник",
+      "url_slug": "будильник",
+      "gloss": "alarm clock",
+      "pos": "noun",
       "ipa": null,
       "primary_source": "built_vocabulary",
       "course_usage": [
@@ -215,6 +1549,170 @@
           "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "будильник",
+            "detail": "lemma match (17 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 17,
+          "forms": [
+            {
+              "form": "будильникові",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "будильнику",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "будильнику",
+              "label": "чол., кличний"
+            },
+            {
+              "form": "будильникові",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "будильнику",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "будильник",
+              "label": "чол., називний"
+            },
+            {
+              "form": "будильником",
+              "label": "чол., орудний"
+            },
+            {
+              "form": "будильника",
+              "label": "чол., родовий"
+            },
+            {
+              "form": "будильник",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "будильника",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "будильникам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "будильники",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "будильниках",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "будильники",
+              "label": "множина, називний"
+            },
+            {
+              "form": "будильниками",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "будильників",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "будильники",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "будильник",
+                "plural": "будильники"
+              },
+              "родовий": {
+                "singular": "будильника",
+                "plural": "будильників"
+              },
+              "давальний": {
+                "singular": "будильникові / будильнику",
+                "plural": "будильникам"
+              },
+              "знахідний": {
+                "singular": "будильник / будильника",
+                "plural": "будильники"
+              },
+              "орудний": {
+                "singular": "будильником",
+                "plural": "будильниками"
+              },
+              "місцевий": {
+                "singular": "будильникові / будильнику",
+                "plural": "будильниках"
+              },
+              "кличний": {
+                "singular": "будильнику",
+                "plural": "будильники"
+              }
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "годинник із спеціальним механізмом, що дзвонить у потрібний час"
+          ],
+          "source": "Вікісловник"
+        },
+        "sources": [
+          "VESUM",
+          "Вікісловник"
+        ]
+      }
+    },
+    {
+      "lemma": "вмиватися",
+      "url_slug": "вмиватися",
+      "gloss": "to wash up",
+      "pos": "infinitive",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "вмиватися",
+            "detail": "lemma match (37 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "дієслово",
@@ -419,27 +1917,13 @@
         "sources": [
           "VESUM"
         ]
-      },
-      "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "вмиватися",
-            "detail": "lemma match (37 forms)"
-          }
-        ],
-        "is_russianism": false,
-        "russian_shadow": false,
-        "sovietization_risk": 0,
-        "calque_warning": null
       }
     },
     {
-      "lemma": "вранці",
-      "url_slug": "вранці",
-      "gloss": "in the morning",
-      "pos": "adv",
+      "lemma": "вмиваюся",
+      "url_slug": "вмиваюся",
+      "gloss": "I wash up",
+      "pos": "verb form",
       "ipa": null,
       "primary_source": "built_vocabulary",
       "course_usage": [
@@ -450,6 +1934,387 @@
           "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "вмиватися",
+            "detail": "word_form match for lemma query"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
+    },
+    {
+      "lemma": "вода",
+      "url_slug": "вода",
+      "gloss": "water",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "вода",
+            "detail": "lemma match (14 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 1,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 14,
+          "forms": [
+            {
+              "form": "воді",
+              "label": "жін., давальний"
+            },
+            {
+              "form": "водо",
+              "label": "жін., кличний"
+            },
+            {
+              "form": "воді",
+              "label": "жін., місцевий"
+            },
+            {
+              "form": "вода",
+              "label": "жін., називний"
+            },
+            {
+              "form": "водою",
+              "label": "жін., орудний"
+            },
+            {
+              "form": "води",
+              "label": "жін., родовий"
+            },
+            {
+              "form": "воду",
+              "label": "жін., знахідний"
+            },
+            {
+              "form": "водам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "води",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "водах",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "води",
+              "label": "множина, називний"
+            },
+            {
+              "form": "водами",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "вод",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "води",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "вода",
+                "plural": "води"
+              },
+              "родовий": {
+                "singular": "води",
+                "plural": "вод"
+              },
+              "давальний": {
+                "singular": "воді",
+                "plural": "водам"
+              },
+              "знахідний": {
+                "singular": "воду",
+                "plural": "води"
+              },
+              "орудний": {
+                "singular": "водою",
+                "plural": "водами"
+              },
+              "місцевий": {
+                "singular": "воді",
+                "plural": "водах"
+              },
+              "кличний": {
+                "singular": "водо",
+                "plural": "води"
+              }
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "прозора, безбарвна рідина, що становить найпростішу хімічну сполуку гідрогену з оксигеном",
+            "текст, або сказане, що містить багато слів, але має мало сенсу",
+            "лікувальні мінеральні джерела, або курорт з такими джерелами"
+          ],
+          "source": "Вікісловник"
+        },
+        "attestation": {
+          "text": "ВодА, -дИ, ж. Вода. Тихо-тихо Дунай воду несе. Мет. 14. Ой я гляну в чисту воду да на свою вроду. Мет. 65. Не все те переймай, що на воді пливе. Посл. Щоб росло — як з води йшло. Мил. 43. Будь здорова як вода! По вОду пітИ. Пойти к колодезю, к реке набирать воду. Ой пійду я, да до броду по воду. Мет. 65. За водою піти. Пойти за теченіем воды, т. е. исчезнуть, пропасть. Не дав мені Господь пари, та дав мені таку долю, та й та пішла за водою. Іди, доле, за водою, а я піду за тобою. Н. п. І за холодну воду не візьметься. Решительно ничего не делает, пальцем не двинет. Увесь день Божий сидить та ґ",
+          "source": "Грінченко (1907)"
+        },
+        "etymology": {
+          "text": "вода, віднйк «діжечка для води», водник, [віднйха, віднйця] «тс.», [водавйця] «водянка, пухир на тілі з водянистою рідиною» Ж, [водівня] «водяний двигун», воднйк (орн.) «крячок звичайний, 5*егпа Ьігипдо Б.», [воднйна] «водяниста місцевість» Я, [воднякй] (ент.) «водяні жуки, НудгосапіЬагі» Ж, [воднячкаІ (ент.) «Нудгагадіпа» Ж, [водян] (ент.) «водяний жук, НудгорЬіІиз» Ж, водяник «водяний чорт», [водянйця] «каша, зварена на воді» Я, [водянка] «діжка для води; пухир на тілі, заповнений водою; хвороба», [водавий] «водяний» Ж, водний, [воднйстий] Ж, [воднянйй] «водяний» Ж, водбвий (воддва вовна «во",
+          "source": "ЕСУМ, т. 1, с. 413"
+        },
+        "sources": [
+          "VESUM",
+          "Вікісловник",
+          "Грінченко (1907)",
+          "ЕСУМ, т. 1, с. 413"
+        ]
+      }
+    },
+    {
+      "lemma": "вона",
+      "url_slug": "вона",
+      "gloss": "she / feminine gender-test word",
+      "pos": "pronoun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "вона",
+            "detail": "lemma match (10 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 10,
+          "forms": [
+            {
+              "form": "їй",
+              "label": "жін., давальний, 3 ос."
+            },
+            {
+              "form": "ній",
+              "label": "жін., місцевий, 3 ос."
+            },
+            {
+              "form": "вона",
+              "label": "жін., називний, 3 ос."
+            },
+            {
+              "form": "нею",
+              "label": "жін., орудний, 3 ос."
+            },
+            {
+              "form": "її",
+              "label": "жін., родовий, 3 ос."
+            },
+            {
+              "form": "неї",
+              "label": "жін., родовий, 3 ос."
+            },
+            {
+              "form": "єї",
+              "label": "жін., родовий, 3 ос."
+            },
+            {
+              "form": "її",
+              "label": "жін., знахідний, 3 ос."
+            },
+            {
+              "form": "неї",
+              "label": "жін., знахідний, 3 ос."
+            },
+            {
+              "form": "єї",
+              "label": "жін., знахідний, 3 ос."
+            }
+          ],
+          "source": "VESUM"
+        },
+        "meaning": {
+          "definitions": [
+            "грошова одиниця Кореї"
+          ],
+          "source": "Вікісловник"
+        },
+        "attestation": {
+          "text": "Вона, її, мест. Она. Була в мене небога; при мені вона й зросла. МВ. ІІ. 19.",
+          "source": "Грінченко (1907)"
+        },
+        "etymology": {
+          "text": "вона, вонй, воно — див. він.",
+          "source": "ЕСУМ, т. 1, с. 424"
+        },
+        "sources": [
+          "VESUM",
+          "Вікісловник",
+          "Грінченко (1907)",
+          "ЕСУМ, т. 1, с. 424"
+        ]
+      }
+    },
+    {
+      "lemma": "воно",
+      "url_slug": "воно",
+      "gloss": "it / neuter gender-test word",
+      "pos": "pronoun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "воно",
+            "detail": "lemma match (8 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 8,
+          "forms": [
+            {
+              "form": "йому",
+              "label": "сер., давальний, 3 ос."
+            },
+            {
+              "form": "ньому",
+              "label": "сер., місцевий, 3 ос."
+            },
+            {
+              "form": "воно",
+              "label": "сер., називний, 3 ос."
+            },
+            {
+              "form": "ним",
+              "label": "сер., орудний, 3 ос."
+            },
+            {
+              "form": "його",
+              "label": "сер., родовий, 3 ос."
+            },
+            {
+              "form": "нього",
+              "label": "сер., родовий, 3 ос."
+            },
+            {
+              "form": "його",
+              "label": "сер., знахідний, 3 ос."
+            },
+            {
+              "form": "нього",
+              "label": "сер., знахідний, 3 ос."
+            }
+          ],
+          "source": "VESUM"
+        },
+        "meaning": {
+          "definitions": [
+            "уживається на позначення предмета мовлення, вираженого іменником середнього роду однини в попередньому реченні або після цього займенника",
+            "уживається в значенні вказівного займенника це",
+            "уживається в значенні займенників він, вона з відтінком пестливості або зневажливості"
+          ],
+          "source": "Вікісловник"
+        },
+        "attestation": {
+          "text": "Воно, його, мест. 1) Оно. Послухає моря, що воно говорить. Шевч. 9. Употребляется для обозначенія неизвестнаго лица. Хто ж се в мене їх (коноплі) підчистив? Воно й бере, та не заразом, а потрошку.... Коли б мені його піймать та провчить, — воно б тоді одсахнулося. ЗОЮР. І. 11. В ласкательном смысле о лицах обоего пола: Гомонить він (чоловік, побравшись) до мене, а я усе мовчу Воно поміж народом пленталось, та й бачило доволі, дак і говорить до мене, а я усе соромляюсь. Г. Барв. 4. В смысле несколько презрительном: Та де ж таки йому за писаря ставати? Воно ще таке молоде та дурне. 2) Оно; это.",
+          "source": "Грінченко (1907)"
+        },
+        "sources": [
+          "VESUM",
+          "Вікісловник",
+          "Грінченко (1907)"
+        ]
+      }
+    },
+    {
+      "lemma": "вранці",
+      "url_slug": "вранці",
+      "gloss": "in the morning",
+      "pos": "adverb",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "вранці",
+            "detail": "lemma match (1 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "прислівник",
@@ -467,6 +2332,7 @@
             "ВРА́НЦІ (УРА́НЦІ), присл. У ранковий час. Увечері посумую, А вранці заплачу (Шевч., I, 1951, 10); Вранці я пішов навідатися до свого товариша (Панч, В дорозі, 1959, 98). Вра́нці-ра́но; Ра́но-вра́нці — дуже рано, на світанні. У неділю вранці-рано Поле крилося туманом (Шевч., І, 1951, 310); А другої днини рано-вранці.. Свирид та Марія вирушили в дорогу (Коцюб., І, 1955, 147)."
           ],
           "source": "СУМ-11",
+          "sovietization_risk": 0,
           "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
         },
         "etymology": {
@@ -479,20 +2345,468 @@
           "Горох (за ЕСУМ)",
           "СУМ-11"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "вставати",
+      "url_slug": "вставати",
+      "gloss": "to get up",
+      "pos": "infinitive",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
-            "ref": "вранці",
-            "detail": "lemma match (1 forms)"
+            "ref": "вставати",
+            "detail": "lemma match (24 forms)"
           }
         ],
         "is_russianism": false,
         "russian_shadow": false,
         "sovietization_risk": 0,
         "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "дієслово",
+          "form_count": 24,
+          "forms": [
+            {
+              "form": "вставатимем",
+              "label": "майбутній, множина, 1 ос."
+            },
+            {
+              "form": "вставатимемо",
+              "label": "майбутній, множина, 1 ос."
+            },
+            {
+              "form": "вставатимете",
+              "label": "майбутній, множина, 2 ос."
+            },
+            {
+              "form": "вставатимуть",
+              "label": "майбутній, множина, 3 ос."
+            },
+            {
+              "form": "вставатиму",
+              "label": "майбутній, однина, 1 ос."
+            },
+            {
+              "form": "вставатимеш",
+              "label": "майбутній, однина, 2 ос."
+            },
+            {
+              "form": "вставатиме",
+              "label": "майбутній, однина, 3 ос."
+            },
+            {
+              "form": "вставано",
+              "label": ""
+            },
+            {
+              "form": "вставаймо",
+              "label": "наказовий, множина, 1 ос."
+            },
+            {
+              "form": "вставайте",
+              "label": "наказовий, множина, 2 ос."
+            },
+            {
+              "form": "вставай",
+              "label": "наказовий, однина, 2 ос."
+            },
+            {
+              "form": "вставати",
+              "label": "інфінітив"
+            },
+            {
+              "form": "вставать",
+              "label": "інфінітив"
+            },
+            {
+              "form": "вставала",
+              "label": "минулий, жін."
+            },
+            {
+              "form": "вставав",
+              "label": "минулий, чол."
+            },
+            {
+              "form": "вставало",
+              "label": "минулий, сер."
+            },
+            {
+              "form": "вставали",
+              "label": "минулий, множина"
+            },
+            {
+              "form": "встаємо",
+              "label": "теперішній, множина, 1 ос."
+            },
+            {
+              "form": "встаєм",
+              "label": "теперішній, множина, 1 ос."
+            },
+            {
+              "form": "встаєте",
+              "label": "теперішній, множина, 2 ос."
+            },
+            {
+              "form": "встають",
+              "label": "теперішній, множина, 3 ос."
+            },
+            {
+              "form": "встаю",
+              "label": "теперішній, однина, 1 ос."
+            },
+            {
+              "form": "встаєш",
+              "label": "теперішній, однина, 2 ос."
+            },
+            {
+              "form": "встає",
+              "label": "теперішній, однина, 3 ос."
+            }
+          ],
+          "source": "VESUM"
+        },
+        "meaning": {
+          "definitions": [
+            "ВСТАВА́ТИ див. устава́ти."
+          ],
+          "source": "СУМ-11",
+          "sovietization_risk": 0,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
+        },
+        "sources": [
+          "VESUM",
+          "СУМ-11"
+        ]
+      }
+    },
+    {
+      "lemma": "всьо",
+      "url_slug": "всьо",
+      "gloss": "avoid: все",
+      "pos": "pron",
+      "ipa": null,
+      "primary_source": "surzhyk_to_avoid",
+      "seed_group": "surzhyk-to-avoid",
+      "course_usage": [],
+      "heritage_status": {
+        "classification": "russianism",
+        "attestations": [
+          {
+            "source": "standard_alternative",
+            "ref": "все",
+            "detail": "Ukrainian standard alternative for всьо"
+          },
+          {
+            "source": "lt_replacements",
+            "ref": "docs/best-practices/heritage-attestation-engine.md",
+            "detail": "local correction evidence; no authentic dictionary attestation found"
+          }
+        ],
+        "is_russianism": true,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": {
+          "standard_alternatives": [
+            "все"
+          ]
+        }
+      }
+    },
+    {
+      "lemma": "вчитель",
+      "url_slug": "вчитель",
+      "gloss": "male teacher",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "вчитель",
+            "detail": "lemma match (18 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 18,
+          "forms": [
+            {
+              "form": "вчителеві",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "вчителю",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "вчителю",
+              "label": "чол., кличний"
+            },
+            {
+              "form": "вчителеві",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "вчителі",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "вчителю",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "вчитель",
+              "label": "чол., називний"
+            },
+            {
+              "form": "вчителем",
+              "label": "чол., орудний"
+            },
+            {
+              "form": "вчителя",
+              "label": "чол., родовий"
+            },
+            {
+              "form": "вчителя",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "вчителям",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "вчителі",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "вчителях",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "вчителі",
+              "label": "множина, називний"
+            },
+            {
+              "form": "вчителями",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "вчителів",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "вчителів",
+              "label": "множина, знахідний"
+            },
+            {
+              "form": "вчителі",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "вчитель",
+                "plural": "вчителі"
+              },
+              "родовий": {
+                "singular": "вчителя",
+                "plural": "вчителів"
+              },
+              "давальний": {
+                "singular": "вчителеві / вчителю",
+                "plural": "вчителям"
+              },
+              "знахідний": {
+                "singular": "вчителя",
+                "plural": "вчителів / вчителі"
+              },
+              "орудний": {
+                "singular": "вчителем",
+                "plural": "вчителями"
+              },
+              "місцевий": {
+                "singular": "вчителеві / вчителі / вчителю",
+                "plural": "вчителях"
+              },
+              "кличний": {
+                "singular": "вчителю",
+                "plural": "вчителі"
+              }
+            }
+          }
+        },
+        "sources": [
+          "VESUM"
+        ]
+      }
+    },
+    {
+      "lemma": "вчителька",
+      "url_slug": "вчителька",
+      "gloss": "female teacher",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "вчителька",
+            "detail": "lemma match (15 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 15,
+          "forms": [
+            {
+              "form": "вчительці",
+              "label": "жін., давальний"
+            },
+            {
+              "form": "вчителько",
+              "label": "жін., кличний"
+            },
+            {
+              "form": "вчительці",
+              "label": "жін., місцевий"
+            },
+            {
+              "form": "вчителька",
+              "label": "жін., називний"
+            },
+            {
+              "form": "вчителькою",
+              "label": "жін., орудний"
+            },
+            {
+              "form": "вчительки",
+              "label": "жін., родовий"
+            },
+            {
+              "form": "вчительку",
+              "label": "жін., знахідний"
+            },
+            {
+              "form": "вчителькам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "вчительки",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "вчительках",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "вчительки",
+              "label": "множина, називний"
+            },
+            {
+              "form": "вчительками",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "вчительок",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "вчительок",
+              "label": "множина, знахідний"
+            },
+            {
+              "form": "вчительки",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "вчителька",
+                "plural": "вчительки"
+              },
+              "родовий": {
+                "singular": "вчительки",
+                "plural": "вчительок"
+              },
+              "давальний": {
+                "singular": "вчительці",
+                "plural": "вчителькам"
+              },
+              "знахідний": {
+                "singular": "вчительку",
+                "plural": "вчительок / вчительки"
+              },
+              "орудний": {
+                "singular": "вчителькою",
+                "plural": "вчительками"
+              },
+              "місцевий": {
+                "singular": "вчительці",
+                "plural": "вчительках"
+              },
+              "кличний": {
+                "singular": "вчителько",
+                "plural": "вчительки"
+              }
+            }
+          }
+        },
+        "sources": [
+          "VESUM"
+        ]
       }
     },
     {
@@ -510,29 +2824,6 @@
           "context": "plan_recommended"
         }
       ],
-      "enrichment": {
-        "meaning": {
-          "definitions": [
-            "УЧИ́ТЕЛЬКА (ВЧИ́ТЕЛЬКА), и, ж. Жін. до учи́тель. — Здрастуй… одчини школу.. я приїхала до вас за вчительку (Коцюб., І, 1955, 310); Артем звів голову і, одверто дивлячись учительці в лице, сказав: — Я вже тепер більше не буду ніколи [лаятися] (Головко, II, 1957, 251); Тут же вчителька проекзаменувала Бориса і пішла з ним до директора (Хижняк, Тамара, 1959, 212)."
-          ],
-          "source": "СУМ-11",
-          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
-        },
-        "attestation": {
-          "text": "Учителька, -ки, ж. Учительница.",
-          "source": "Грінченко (1907)"
-        },
-        "etymology": {
-          "text": "псл. učiti, пов’язане чергуванням голосних з *-vyknǫti (пор. укр. зви́кнути); корінь uk-/uč- (пор. укр. нау́ка); споріднене з дінд. úcyati «є звичним, знаходить задоволення, має звичку», ṓkas «задоволення», вірм. usanim «учусь, привчаюсь», гот. biūhts «звичний», гр. ἔυϰηλος «спокійний, звичний», прус. jaukint «тренувати, практикувати», лит. jaukìnti, jaukіnù «привчати, приручати», jaũkas «приманка», jaukùs «лагідний, тихий», лтс. jūkt «звикати»; іє. *euk-/ouk-/ūk- «привчатись, звикати, довіряти»; припускається також спорідненість з лат. uхоr «дружина» ‹ *uс-sōr, паралельного до *sve-sōr «сестр",
-          "source": "Горох (за ЕСУМ)",
-          "source_url": "https://goroh.pp.ua/%D0%95%D1%82%D0%B8%D0%BC%D0%BE%D0%BB%D0%BE%D0%B3%D1%96%D1%8F/%D1%83%D1%87%D0%B8%D1%82%D0%B5%D0%BB%D1%8C%D0%BA%D0%B0"
-        },
-        "sources": [
-          "Горох (за ЕСУМ)",
-          "Грінченко (1907)",
-          "СУМ-11"
-        ]
-      },
       "heritage_status": {
         "classification": "standard",
         "attestations": [
@@ -551,23 +2842,61 @@
         "russian_shadow": false,
         "sovietization_risk": 0,
         "calque_warning": null
+      },
+      "enrichment": {
+        "meaning": {
+          "definitions": [
+            "УЧИ́ТЕЛЬКА (ВЧИ́ТЕЛЬКА), и, ж. Жін. до учи́тель. — Здрастуй… одчини школу.. я приїхала до вас за вчительку (Коцюб., І, 1955, 310); Артем звів голову і, одверто дивлячись учительці в лице, сказав: — Я вже тепер більше не буду ніколи [лаятися] (Головко, II, 1957, 251); Тут же вчителька проекзаменувала Бориса і пішла з ним до директора (Хижняк, Тамара, 1959, 212)."
+          ],
+          "source": "СУМ-11",
+          "sovietization_risk": 0,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
+        },
+        "attestation": {
+          "text": "Учителька, -ки, ж. Учительница.",
+          "source": "Грінченко (1907)"
+        },
+        "etymology": {
+          "text": "псл. učiti, пов’язане чергуванням голосних з *-vyknǫti (пор. укр. зви́кнути); корінь uk-/uč- (пор. укр. нау́ка); споріднене з дінд. úcyati «є звичним, знаходить задоволення, має звичку», ṓkas «задоволення», вірм. usanim «учусь, привчаюсь», гот. biūhts «звичний», гр. ἔυϰηλος «спокійний, звичний», прус. jaukint «тренувати, практикувати», лит. jaukìnti, jaukіnù «привчати, приручати», jaũkas «приманка», jaukùs «лагідний, тихий», лтс. jūkt «звикати»; іє. *euk-/ouk-/ūk- «привчатись, звикати, довіряти»; припускається також спорідненість з лат. uхоr «дружина» ‹ *uс-sōr, паралельного до *sve-sōr «сестр",
+          "source": "Горох (за ЕСУМ)",
+          "source_url": "https://goroh.pp.ua/%D0%95%D1%82%D0%B8%D0%BC%D0%BE%D0%BB%D0%BE%D0%B3%D1%96%D1%8F/%D1%83%D1%87%D0%B8%D1%82%D0%B5%D0%BB%D1%8C%D0%BA%D0%B0"
+        },
+        "sources": [
+          "Горох (за ЕСУМ)",
+          "Грінченко (1907)",
+          "СУМ-11"
+        ]
       }
     },
     {
       "lemma": "вікно",
       "url_slug": "вікно",
-      "gloss": "window, n",
-      "pos": null,
+      "gloss": "window",
+      "pos": "noun",
       "ipa": null,
-      "primary_source": "plan_required",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 8,
           "slug": "things-have-gender",
-          "context": "plan_required"
+          "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "вікно",
+            "detail": "lemma match (15 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -692,38 +3021,101 @@
           "Горох (за ЕСУМ)",
           "Грінченко (1907)"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "він",
+      "url_slug": "він",
+      "gloss": "he / masculine gender-test word",
+      "pos": "pronoun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
-            "ref": "вікно",
-            "detail": "lemma match (15 forms)"
+            "ref": "він",
+            "detail": "lemma match (14 forms)"
           }
         ],
         "is_russianism": false,
         "russian_shadow": false,
         "sovietization_risk": 0,
         "calque_warning": null
-      }
-    },
-    {
-      "lemma": "він, вона, воно",
-      "url_slug": "він-вона-воно",
-      "gloss": "he, she, it — gender test words",
-      "pos": null,
-      "ipa": null,
-      "primary_source": "plan_required",
-      "course_usage": [
-        {
-          "track": "a1",
-          "module_num": 8,
-          "slug": "things-have-gender",
-          "context": "plan_required"
-        }
-      ],
+      },
       "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 14,
+          "forms": [
+            {
+              "form": "йому",
+              "label": "чол., давальний, 3 ос."
+            },
+            {
+              "form": "єму",
+              "label": "чол., давальний, 3 ос."
+            },
+            {
+              "form": "нім",
+              "label": "чол., місцевий, 3 ос."
+            },
+            {
+              "form": "ньому",
+              "label": "чол., місцевий, 3 ос."
+            },
+            {
+              "form": "він",
+              "label": "чол., називний, 3 ос."
+            },
+            {
+              "form": "ним",
+              "label": "чол., орудний, 3 ос."
+            },
+            {
+              "form": "його",
+              "label": "чол., родовий, 3 ос."
+            },
+            {
+              "form": "нього",
+              "label": "чол., родовий, 3 ос."
+            },
+            {
+              "form": "єго",
+              "label": "чол., родовий, 3 ос."
+            },
+            {
+              "form": "него",
+              "label": "чол., родовий, 3 ос."
+            },
+            {
+              "form": "його",
+              "label": "чол., знахідний, 3 ос."
+            },
+            {
+              "form": "нього",
+              "label": "чол., знахідний, 3 ос."
+            },
+            {
+              "form": "єго",
+              "label": "чол., знахідний, 3 ос."
+            },
+            {
+              "form": "него",
+              "label": "чол., знахідний, 3 ос."
+            }
+          ],
+          "source": "VESUM"
+        },
         "meaning": {
           "definitions": [
             "Уживається на означення предмета мовлення, вираженого іменником чоловічого роду однини в попередньому реченні або після цього займенника",
@@ -742,11 +3134,28 @@
           "source_url": "https://goroh.pp.ua/%D0%95%D1%82%D0%B8%D0%BC%D0%BE%D0%BB%D0%BE%D0%B3%D1%96%D1%8F/%D0%B2%D1%96%D0%BD"
         },
         "sources": [
+          "VESUM",
           "Вікісловник",
           "Горох (за ЕСУМ)",
           "Грінченко (1907)"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "він, вона, воно",
+      "url_slug": "він-вона-воно",
+      "gloss": "he, she, it — gender test words",
+      "pos": null,
+      "ipa": null,
+      "primary_source": "plan_required",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "plan_required"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
@@ -770,6 +3179,54 @@
         "russian_shadow": false,
         "sovietization_risk": 0,
         "calque_warning": null
+      },
+      "enrichment": {
+        "meaning": {
+          "definitions": [
+            "Уживається на означення предмета мовлення, вираженого іменником чоловічого роду однини в попередньому реченні або після цього займенника",
+            "Уживають у значенні присвійного займенника",
+            "Виступає в значенні частки з відтінком неозначености в словосполуках штибу «нехай (хай) йому біс», «хто (біс тощо) його знає», «чорт його бери»"
+          ],
+          "source": "Вікісловник"
+        },
+        "attestation": {
+          "text": "Він мест. Он. Він старшенький. МВ. ІІ. 8. І брови йому чорні, і уста рум'яні, і станом високий. МВ. (О. 1862. ІІІ. 44).",
+          "source": "Грінченко (1907)"
+        },
+        "etymology": {
+          "text": "споріднені з лит. anàs/ans «той, [він]», дінд. ав. ana- «цей», вірм. -n «той», гр. ἔνη (ἡμέρα) «на третій день, післязавтра», ἐκεĩνος/ κεĩνος/κηνος «той, отой» (утворено шляхом нанизування кількох вказівних займенників *ἐ-κε-ένος), хет. eni-, anni«той», двн. ëner, нвн. jener « тс. », пор. також лат. enim «саме, так» (з e-nim); псл. оnъ, ona, ono «той, та, те; він, вона, воно», що утворилися шляхом злиття синонімічних індоєвропейських часток * о- (пор. укр. отой, такий-о́, он-о́, онде-о́, ось-о́, їй відповідає лат. ев e-nim) i *- n- (пор. укр. ген); р. он, она́, оно́, о́ный «той», бр. ён, яна́,",
+          "source": "Горох (за ЕСУМ)",
+          "source_url": "https://goroh.pp.ua/%D0%95%D1%82%D0%B8%D0%BC%D0%BE%D0%BB%D0%BE%D0%B3%D1%96%D1%8F/%D0%B2%D1%96%D0%BD"
+        },
+        "sources": [
+          "Вікісловник",
+          "Горох (за ЕСУМ)",
+          "Грінченко (1907)"
+        ]
+      }
+    },
+    {
+      "lemma": "голосни́й звук",
+      "url_slug": "голосни-й-звук",
+      "gloss": "vowel sound",
+      "pos": "noun phrase",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 1,
+          "slug": "sounds-letters-and-hello",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "unknown",
+        "attestations": [],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       }
     },
     {
@@ -787,6 +3244,20 @@
           "context": "plan_required"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "голосний",
+            "detail": "lemma match (56 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "прикметник",
@@ -960,6 +3431,7 @@
             "ГОЛОСНИ́Й, а́, е́. 1. Який сильно звучить, добре чутний; гучний. Серед того шуму подекуди було чути голосну дівочу пісню (Н.-Лев., II, 1956, 97); Адміністратор сів; поштар махнув на коней батогом, задзеленчав голосний дзвоник — і тільки курява встала… (Мирний, І, 1949, 389); Гнітив його Чуприна чи Кравчина своєю галасливістю, сміхом і неймовірно швидкою й голосною розмовою (Довж., Зач. Десна, 1957, 42); // Шумливий, гомінкий. З останнього катера зійшов на берег і Самійло Вихор, та його не поглинув голосний натовп моряків (Кучер, Чорноморці, 1956, 9). Голосне́ чита́ння — читання вголос. На підп"
           ],
           "source": "СУМ-11",
+          "sovietization_risk": 0,
           "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
         },
         "attestation": {
@@ -977,37 +3449,263 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
-      },
-      "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "голосний",
-            "detail": "lemma match (56 forms)"
-          }
-        ],
-        "is_russianism": false,
-        "russian_shadow": false,
-        "sovietization_risk": 0,
-        "calque_warning": null
       }
     },
     {
-      "lemma": "дзеркало",
-      "url_slug": "дзеркало",
-      "gloss": "mirror, n",
+      "lemma": "готовий",
+      "url_slug": "готовий",
+      "gloss": "ready",
       "pos": null,
       "ipa": null,
       "primary_source": "plan_recommended",
       "course_usage": [
         {
           "track": "a1",
-          "module_num": 8,
-          "slug": "things-have-gender",
+          "module_num": 20,
+          "slug": "my-morning",
           "context": "plan_recommended"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "готовий",
+            "detail": "lemma match (41 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 1,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "прикметник",
+          "form_count": 41,
+          "forms": [
+            {
+              "form": "готовій",
+              "label": "жін., давальний"
+            },
+            {
+              "form": "готова",
+              "label": "жін., кличний"
+            },
+            {
+              "form": "готовая",
+              "label": "жін., кличний"
+            },
+            {
+              "form": "готовій",
+              "label": "жін., місцевий"
+            },
+            {
+              "form": "готова",
+              "label": "жін., називний"
+            },
+            {
+              "form": "готовая",
+              "label": "жін., називний"
+            },
+            {
+              "form": "готовою",
+              "label": "жін., орудний"
+            },
+            {
+              "form": "готової",
+              "label": "жін., родовий"
+            },
+            {
+              "form": "готову",
+              "label": "жін., знахідний"
+            },
+            {
+              "form": "готовую",
+              "label": "жін., знахідний"
+            },
+            {
+              "form": "готовому",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "готовий",
+              "label": "чол., кличний"
+            },
+            {
+              "form": "готовім",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "готовому",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "готовий",
+              "label": "чол., називний"
+            },
+            {
+              "form": "готовим",
+              "label": "чол., орудний"
+            },
+            {
+              "form": "готового",
+              "label": "чол., родовий"
+            },
+            {
+              "form": "готового",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "готовий",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "готовому",
+              "label": "сер., давальний"
+            },
+            {
+              "form": "готове",
+              "label": "сер., кличний"
+            },
+            {
+              "form": "готовеє",
+              "label": "сер., кличний"
+            },
+            {
+              "form": "готовім",
+              "label": "сер., місцевий"
+            },
+            {
+              "form": "готовому",
+              "label": "сер., місцевий"
+            },
+            {
+              "form": "готове",
+              "label": "сер., називний"
+            },
+            {
+              "form": "готовеє",
+              "label": "сер., називний"
+            },
+            {
+              "form": "готовим",
+              "label": "сер., орудний"
+            },
+            {
+              "form": "готового",
+              "label": "сер., родовий"
+            },
+            {
+              "form": "готове",
+              "label": "сер., знахідний"
+            },
+            {
+              "form": "готовеє",
+              "label": "сер., знахідний"
+            },
+            {
+              "form": "готовим",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "готові",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "готовії",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "готових",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "готові",
+              "label": "множина, називний"
+            },
+            {
+              "form": "готовії",
+              "label": "множина, називний"
+            },
+            {
+              "form": "готовими",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "готових",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "готових",
+              "label": "множина, знахідний"
+            },
+            {
+              "form": "готові",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM"
+        },
+        "meaning": {
+          "definitions": [
+            "ГОТО́ВИЙ, ГОТО́В, а, е. 1. Який зробив необхідне приготування, підготувався до чого-небудь. — Ви скажіть свойому пану, Що готовий я в дорогу (Л. Укр., І, 1951, 385); — Гине пшениця, а ми й досі не готові до жнив! (Донч., І, 1956, 76); — Ось тілько воза підмажу, та й готов (Мирний, IV, 1955, 321). ∆ Будь гото́вий! — вітання піонерів при зустрічі; Завжди́ гото́вий! — відповідь піонерів на вітання; девіз. І дзвінко лине наш девіз: До боротьби завжди готові! (Бичко, Вогнище, 1959, 272). 2. на що і з інфін. Який висловлює згоду, схильний до чого-небудь або виявляє бажання зробити що-небудь. Голод,"
+          ],
+          "source": "СУМ-11",
+          "sovietization_risk": 1,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті.",
+          "sovietization_keywords": [
+            "піонер",
+            "радянськ"
+          ]
+        },
+        "etymology": {
+          "text": "готовий, готов, [готів, готівля\\, готовість, готовність, готувач, готовити, готувати, виготовляти, заготівельний, заготівний, заготовочний, заготбвчий, заготівля, заготівельник, заготівка, заготівник, заготовач, заготовка, заготдвлювач, заготбвщик, заготувач, напоготові, підготовний, підготовчий, підготовка, підготовник; — р. готовий, бр. гатдви, др. готовий, п. §окпуу, ч. слц. Ьоіочу, вл. Ьоіотлгу, нл. £оіо^у* болг. готов, м. готов, схв. готов, слн. §оібу, стел, готовії; — псл. £о1оуь; — очевидно, споріднене з алб. §аіе «готовий», £аіиапі «готую» (Меуег Е\\\\/ 121; Вегп. І 337— 338; Кірагзку, О",
+          "source": "ЕСУМ, т. 1, с. 576"
+        },
+        "sources": [
+          "VESUM",
+          "ЕСУМ, т. 1, с. 576",
+          "СУМ-11"
+        ]
+      }
+    },
+    {
+      "lemma": "дзеркало",
+      "url_slug": "дзеркало",
+      "gloss": "mirror",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        },
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "дзеркало",
+            "detail": "lemma match (15 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -1132,14 +3830,291 @@
           "Горох (за ЕСУМ)",
           "Грінченко (1907)"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "дивитися",
+      "url_slug": "дивитися",
+      "gloss": "to watch; to look",
+      "pos": "infinitive",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
-            "ref": "дзеркало",
-            "detail": "lemma match (15 forms)"
+            "ref": "дивитися",
+            "detail": "lemma match (41 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 1,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "дієслово",
+          "form_count": 41,
+          "forms": [
+            {
+              "form": "дивитимемось",
+              "label": "майбутній, множина, 1 ос."
+            },
+            {
+              "form": "дивитимемося",
+              "label": "майбутній, множина, 1 ос."
+            },
+            {
+              "form": "дивитимемся",
+              "label": "майбутній, множина, 1 ос."
+            },
+            {
+              "form": "дивитиметесь",
+              "label": "майбутній, множина, 2 ос."
+            },
+            {
+              "form": "дивитиметеся",
+              "label": "майбутній, множина, 2 ос."
+            },
+            {
+              "form": "дивитимуться",
+              "label": "майбутній, множина, 3 ос."
+            },
+            {
+              "form": "дивитимусь",
+              "label": "майбутній, однина, 1 ос."
+            },
+            {
+              "form": "дивитимуся",
+              "label": "майбутній, однина, 1 ос."
+            },
+            {
+              "form": "дивитимешся",
+              "label": "майбутній, однина, 2 ос."
+            },
+            {
+              "form": "дивитиметься",
+              "label": "майбутній, однина, 3 ос."
+            },
+            {
+              "form": "дивімось",
+              "label": "наказовий, множина, 1 ос."
+            },
+            {
+              "form": "дивімося",
+              "label": "наказовий, множина, 1 ос."
+            },
+            {
+              "form": "дивімся",
+              "label": "наказовий, множина, 1 ос."
+            },
+            {
+              "form": "дивіться",
+              "label": "наказовий, множина, 2 ос."
+            },
+            {
+              "form": "дивітесь",
+              "label": "наказовий, множина, 2 ос."
+            },
+            {
+              "form": "дивітеся",
+              "label": "наказовий, множина, 2 ос."
+            },
+            {
+              "form": "дивіть",
+              "label": "наказовий, множина, 2 ос."
+            },
+            {
+              "form": "дивися",
+              "label": "наказовий, однина, 2 ос."
+            },
+            {
+              "form": "дивись",
+              "label": "наказовий, однина, 2 ос."
+            },
+            {
+              "form": "диви",
+              "label": "наказовий, однина, 2 ос."
+            },
+            {
+              "form": "дивитися",
+              "label": "інфінітив"
+            },
+            {
+              "form": "дивитись",
+              "label": "інфінітив"
+            },
+            {
+              "form": "дивиться",
+              "label": "інфінітив"
+            },
+            {
+              "form": "дивилась",
+              "label": "минулий, жін."
+            },
+            {
+              "form": "дивилася",
+              "label": "минулий, жін."
+            },
+            {
+              "form": "дививсь",
+              "label": "минулий, чол."
+            },
+            {
+              "form": "дивився",
+              "label": "минулий, чол."
+            },
+            {
+              "form": "дивилось",
+              "label": "минулий, сер."
+            },
+            {
+              "form": "дивилося",
+              "label": "минулий, сер."
+            },
+            {
+              "form": "дивились",
+              "label": "минулий, множина"
+            },
+            {
+              "form": "дивилися",
+              "label": "минулий, множина"
+            },
+            {
+              "form": "дивимось",
+              "label": "теперішній, множина, 1 ос."
+            },
+            {
+              "form": "дивимося",
+              "label": "теперішній, множина, 1 ос."
+            },
+            {
+              "form": "дивимся",
+              "label": "теперішній, множина, 1 ос."
+            },
+            {
+              "form": "дивитесь",
+              "label": "теперішній, множина, 2 ос."
+            },
+            {
+              "form": "дивитеся",
+              "label": "теперішній, множина, 2 ос."
+            },
+            {
+              "form": "дивляться",
+              "label": "теперішній, множина, 3 ос."
+            },
+            {
+              "form": "дивлюсь",
+              "label": "теперішній, однина, 1 ос."
+            },
+            {
+              "form": "дивлюся",
+              "label": "теперішній, однина, 1 ос."
+            },
+            {
+              "form": "дивишся",
+              "label": "теперішній, однина, 2 ос."
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "verb",
+            "infinitive": "дивитися / дивитись",
+            "tenses": {
+              "теперішній": {
+                "однина": {
+                  "1": "дивлюсь / дивлюся",
+                  "2": "дивишся",
+                  "3": "дивиться"
+                },
+                "множина": {
+                  "1": "дивимось / дивимося / дивимся",
+                  "2": "дивитесь / дивитеся",
+                  "3": "дивляться"
+                }
+              },
+              "майбутній": {
+                "однина": {
+                  "1": "дивитимусь / дивитимуся",
+                  "2": "дивитимешся",
+                  "3": "дивитиметься"
+                },
+                "множина": {
+                  "1": "дивитимемось / дивитимемося / дивитимемся",
+                  "2": "дивитиметесь / дивитиметеся",
+                  "3": "дивитимуться"
+                }
+              }
+            },
+            "imperative": {
+              "однина": {
+                "2": "дивися / дивись / диви"
+              },
+              "множина": {
+                "1": "дивімось / дивімося / дивімся",
+                "2": "дивіться / дивітесь / дивітеся / дивіть"
+              }
+            },
+            "past": {
+              "чол.": "дививсь / дивився",
+              "жін.": "дивилась / дивилася",
+              "сер.": "дивилось / дивилося",
+              "множина": "дивились / дивилися"
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "спрямовувати погляд, прагнучи побачити кого-, що-небудь",
+            "звертатися думками до кого-, чого-небудь, кудись",
+            "мати повну точку зору на що-небудь, ставитись певним чином"
+          ],
+          "source": "Вікісловник"
+        },
+        "attestation": {
+          "text": "ДивИтися, -влЮся, -вишся, гл. Смотреть, глядеть. Треба якось у очі дивитися. Ном. № 3177. Дивиться, як кошеня в каганець. Ном. № 9242. Тепер і хата її дивиться якось сторч. Хата. 103. ДивИ-но. Смотри-ка. Диви-но, вже сонце сідає. Ном. стр. 289, № 10057.",
+          "source": "Грінченко (1907)"
+        },
+        "sources": [
+          "VESUM",
+          "Вікісловник",
+          "Грінченко (1907)"
+        ]
+      }
+    },
+    {
+      "lemma": "дивлюся",
+      "url_slug": "дивлюся",
+      "gloss": "I watch; I look",
+      "pos": "verb form",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "дивитися",
+            "detail": "word_form match for lemma query"
           }
         ],
         "is_russianism": false,
@@ -1149,45 +4124,153 @@
       }
     },
     {
-      "lemma": "добре",
-      "url_slug": "добре",
-      "gloss": "fine, good",
-      "pos": null,
+      "lemma": "дядько",
+      "url_slug": "дядько",
+      "gloss": "uncle",
+      "pos": "noun",
       "ipa": null,
-      "primary_source": "plan_required",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
-          "module_num": 1,
-          "slug": "sounds-letters-and-hello",
-          "context": "plan_required"
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "дядько",
+            "detail": "lemma match (17 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
-          "pos": "прислівник",
-          "form_count": 1,
+          "pos": "іменник",
+          "form_count": 17,
           "forms": [
             {
-              "form": "добре",
-              "label": ""
+              "form": "дядькові",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "дядьку",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "дядьку",
+              "label": "чол., кличний"
+            },
+            {
+              "form": "дядькові",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "дядьку",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "дядько",
+              "label": "чол., називний"
+            },
+            {
+              "form": "дядьком",
+              "label": "чол., орудний"
+            },
+            {
+              "form": "дядька",
+              "label": "чол., родовий"
+            },
+            {
+              "form": "дядька",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "дядькам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "дядьки",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "дядьках",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "дядьки",
+              "label": "множина, називний"
+            },
+            {
+              "form": "дядьками",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "дядьків",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "дядьків",
+              "label": "множина, знахідний"
+            },
+            {
+              "form": "дядьки",
+              "label": "множина, знахідний"
             }
           ],
-          "source": "VESUM"
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "дядько",
+                "plural": "дядьки"
+              },
+              "родовий": {
+                "singular": "дядька",
+                "plural": "дядьків"
+              },
+              "давальний": {
+                "singular": "дядькові / дядьку",
+                "plural": "дядькам"
+              },
+              "знахідний": {
+                "singular": "дядька",
+                "plural": "дядьків / дядьки"
+              },
+              "орудний": {
+                "singular": "дядьком",
+                "plural": "дядьками"
+              },
+              "місцевий": {
+                "singular": "дядькові / дядьку",
+                "plural": "дядьках"
+              },
+              "кличний": {
+                "singular": "дядьку",
+                "plural": "дядьки"
+              }
+            }
+          }
         },
         "meaning": {
           "definitions": [
-            "ДО́БРЕ. 1. Присл. до до́брий; протилежне погано. А щоб збудить Хиренну волю, треба миром, Громадою обух сталить; Та добре вигострить сокиру (Шевч., II, 1953, 288); Мічурін вийшов на середину кімнати, його оточили, й він знову почував себе добре (Довж., І, 1958, 455). 2. присл.., розм. Дуже, вельми. Любка першої ночі таки добре боялась (Н.-Лев., II, 1956, 258); // Зовсім, остаточно. В той час уже добре смеркалося (Мирний, II, 1954, 239). 3. у знач. присудк. сл. Про успішний хід справ, сприятливе оточення. — А тут же вам добре? (Вовчок, І, 1955, 11); — Я певен, що все буде добре: дивись, народ у"
+            "ДЯ́ДЬКО, а, ч. 1. Брат батька або матері; чоловік тітки. — З усього роду зосталася я та рідний брат батьків — мій дядько (Мирний, І, 1954, 71); Ігор чув від батьків, що там, у Тулі, працюють його рідні тітки й дядьки (Кучер, Чорноморці, 1956, 26). 2. розм. Дорослий чоловік взагалі. Ходив на.. [досвітки] не рік, не два, Та вже й доходився, Що став ходить ще парубком Та й дядьком зробився (Щог., Поезії, 1958, 238); На алеї парку з’явився гладкий, вусатий дядько у фартусі, з мітлою в руках (Дмит., Розлука, 1957, 6); // При звертанні до старшого за віком чоловіка. Враз у двір вскочило два хлопці й"
           ],
           "source": "СУМ-11",
-          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті.",
-          "synonyms": [
-            "гаразд",
-            "нормально"
-          ]
+          "sovietization_risk": 0,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
         },
         "attestation": {
-          "text": "ДОбре нар. Хорошо; порядкомь. Добре тому дати, хто не хоче брати; а той хто бере, як по душі дере. Ном. № 4710. На Водохрищі риба табунами ходить, то на рої добре буде: Чуб. ІІІ. 4. Бийте його добре киями, щоб знав; по чому ківш лиха. Ном. № 4954. Добре побив. Циган уже їсти добре хоче. Грин. І. 120. ДОбре кАже. Дельно говорить; красно говорить. Камен. у. ГарАзд-дОбре. Достаточно, вполне хорошо. Будем радиться, чи гаразд-добре на славній Україні проживати. Мет. 381. Ум. ДОбренько, дОбречко.",
+          "text": "ДЯдько, -ка, м. 1) Дядя. 2) Человек средних лет. Из уваженія малороссіяне называют так всякаго старшаго себя летами. Чуб. VII. 355. Не впадає москаля дядьком звати. Ном. № 850. 3) — собАчий. Волк. Як собаки гавкають! Чи не пробірається до овець собачий дядько? О. 1861. V. 71. 4) дЯдька наклАсти. Перепутать основу во время снованія. А я слухаю, що вона балака, та й наклала дядька. Оксана в мене сьогодні снувала, так аж двох дядьків наклала. Одного ж я змотала, а другий зостався. За дядьків ткачі лають, як направляють полотно. Черниг. у. Ум. дЯдечко. Охріме дядечку! будь ласкав схаменись! Хата,",
           "source": "Грінченко (1907)"
         },
         "sources": [
@@ -1195,37 +4278,37 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
-      },
-      "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "добре",
-            "detail": "lemma match (1 forms)"
-          }
-        ],
-        "is_russianism": false,
-        "russian_shadow": false,
-        "sovietization_risk": 0,
-        "calque_warning": null
       }
     },
     {
       "lemma": "дім",
       "url_slug": "дім",
-      "gloss": "house",
-      "pos": null,
+      "gloss": "house / home",
+      "pos": "noun",
       "ipa": null,
-      "primary_source": "plan_recommended",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 1,
           "slug": "sounds-letters-and-hello",
-          "context": "plan_recommended"
+          "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "дім",
+            "detail": "lemma match (17 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 1,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -1340,7 +4423,12 @@
             "ДІМ, до́му, ч. 1. Будівля, признач. для житла або для розміщення різних установ; будинок. Широка, обсаджена кипарисами стежка веде до дверей у літній триклініум [трикліній] на розі двоповерхового дому (Л. Укр., II, 1951, 385); Дім у Семена Непийводи був такий веселий, що стріха на ньому, як у задерикуватого парубка шапка, була набакир (Вишня, І, 1956, 353); *Образно. Тому й дорога нам Радянська Вітчизна, Що їй віддаємо і силу, й уміння, і мрії політ, Що в ній ми будуємо сонячний дім Комунізму (Гірник, Друзі.., 1953, 9). 2. Приміщення, в якому живуть люди; житло. Цариця Клітемнестра з царським"
           ],
           "source": "СУМ-11",
+          "sovietization_risk": 1,
           "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті.",
+          "sovietization_keywords": [
+            "радянськ",
+            "срср"
+          ],
           "synonyms": [
             "будинок",
             "хата",
@@ -1362,27 +4450,46 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
-      },
-      "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "дім",
-            "detail": "lemma match (17 forms)"
-          }
-        ],
-        "is_russianism": false,
-        "russian_shadow": false,
-        "sovietization_risk": 0,
-        "calque_warning": null
       }
     },
     {
-      "lemma": "збиратися",
-      "url_slug": "збиратися",
-      "gloss": "to get ready",
-      "pos": "verb",
+      "lemma": "діюча",
+      "url_slug": "діюча",
+      "gloss": "avoid: чинна",
+      "pos": "adj",
+      "ipa": null,
+      "primary_source": "surzhyk_to_avoid",
+      "seed_group": "surzhyk-to-avoid",
+      "course_usage": [],
+      "heritage_status": {
+        "classification": "russianism",
+        "attestations": [
+          {
+            "source": "standard_alternative",
+            "ref": "чинна",
+            "detail": "Ukrainian standard alternative for діюча"
+          },
+          {
+            "source": "heritage_spec",
+            "ref": "docs/best-practices/heritage-attestation-engine.md",
+            "detail": "local correction evidence; no authentic dictionary attestation found"
+          }
+        ],
+        "is_russianism": true,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": {
+          "standard_alternatives": [
+            "чинна"
+          ]
+        }
+      }
+    },
+    {
+      "lemma": "завжди",
+      "url_slug": "завжди",
+      "gloss": "always",
+      "pos": "adverb",
       "ipa": null,
       "primary_source": "built_vocabulary",
       "course_usage": [
@@ -1393,6 +4500,80 @@
           "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "завжди",
+            "detail": "lemma match (1 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 1,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "прислівник",
+          "form_count": 1,
+          "forms": [
+            {
+              "form": "завжди",
+              "label": ""
+            }
+          ],
+          "source": "VESUM"
+        },
+        "meaning": {
+          "definitions": [
+            "повсякчас, постійно",
+            "у віках, навіки; довічно",
+            "протягом віків; споконвіку"
+          ],
+          "source": "Вікісловник"
+        },
+        "attestation": {
+          "text": "ЗАвжди нар. = завжде. Чи що зроблю, куди піду, завжди серце в тузі. Чуб. V. 277.",
+          "source": "Грінченко (1907)"
+        },
+        "sources": [
+          "VESUM",
+          "Вікісловник",
+          "Грінченко (1907)"
+        ]
+      }
+    },
+    {
+      "lemma": "збиратися",
+      "url_slug": "збиратися",
+      "gloss": "to get ready",
+      "pos": "infinitive",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "збиратися",
+            "detail": "lemma match (37 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 1,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "дієслово",
@@ -1599,20 +4780,40 @@
             "ЗБИРА́ТИСЯ, а́юся, а́єшся, недок., ЗІБРА́ТИСЯ, зберу́ся, збере́шся, док. 1. Сходитися, з’їжджатися, злітатися і т. ін. в одне місце. Десь над ставком в садку збираються хлопці та дівчата (Н.-Лев., III, 1956, 315); Хто з гетьманців не знає Красногорки? Хто не знає «Мекки», куди збиралось з цілого повіту панство? (Мирний, І, 1949, 205); Сонечко за тучу сховалося зарані, і птиця стала збиратись і чогось жде на себе (Кв.-Осн., II, 1956, 412); // в що, чим. Сходячись, з’їжджаючись, злітаючись і т. ін. докупи, розташовуватися, групуватися яким-небудь способом. Надходять люди, чоловіки й жінки,.. і з"
           ],
           "source": "СУМ-11",
-          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
+          "sovietization_risk": 1,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті.",
+          "sovietization_keywords": [
+            "ленін"
+          ]
         },
         "sources": [
           "VESUM",
           "СУМ-11"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "збираюся",
+      "url_slug": "збираюся",
+      "gloss": "I get ready",
+      "pos": "verb form",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
             "ref": "збиратися",
-            "detail": "lemma match (37 forms)"
+            "detail": "word_form match for lemma query"
           }
         ],
         "is_russianism": false,
@@ -1625,17 +4826,31 @@
       "lemma": "звук",
       "url_slug": "звук",
       "gloss": "sound",
-      "pos": null,
+      "pos": "noun",
       "ipa": null,
-      "primary_source": "plan_required",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 1,
           "slug": "sounds-letters-and-hello",
-          "context": "plan_required"
+          "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "звук",
+            "detail": "lemma match (34 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -1772,37 +4987,37 @@
           "Горох (за ЕСУМ)",
           "Грінченко (1907)"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "зошит",
+      "url_slug": "зошит",
+      "gloss": "notebook",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
-            "ref": "звук",
-            "detail": "lemma match (34 forms)"
+            "ref": "зошит",
+            "detail": "lemma match (18 forms)"
           }
         ],
         "is_russianism": false,
         "russian_shadow": false,
         "sovietization_risk": 0,
         "calque_warning": null
-      }
-    },
-    {
-      "lemma": "зошит",
-      "url_slug": "зошит",
-      "gloss": "notebook, m",
-      "pos": null,
-      "ipa": null,
-      "primary_source": "plan_recommended",
-      "course_usage": [
-        {
-          "track": "a1",
-          "module_num": 8,
-          "slug": "things-have-gender",
-          "context": "plan_recommended"
-        }
-      ],
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -1932,14 +5147,54 @@
           "Вікісловник",
           "ЕСУМ, т. 2, с. 278"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "зубна паста",
+      "url_slug": "зубна-паста",
+      "gloss": "toothpaste",
+      "pos": "noun phrase",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "unknown",
+        "attestations": [],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
+    },
+    {
+      "lemma": "йду",
+      "url_slug": "йду",
+      "gloss": "I go",
+      "pos": "verb form",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
-            "ref": "зошит",
-            "detail": "lemma match (18 forms)"
+            "ref": "йти",
+            "detail": "word_form match for lemma query"
           }
         ],
         "is_russianism": false,
@@ -1952,7 +5207,7 @@
       "lemma": "йти",
       "url_slug": "йти",
       "gloss": "to go",
-      "pos": "verb",
+      "pos": "infinitive",
       "ipa": null,
       "primary_source": "built_vocabulary",
       "course_usage": [
@@ -1963,6 +5218,20 @@
           "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "йти",
+            "detail": "lemma match (24 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "дієслово",
@@ -2133,188 +5402,37 @@
           "Горох (за ЕСУМ)",
           "Грінченко (1907)"
         ]
-      },
-      "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "йти",
-            "detail": "lemma match (24 forms)"
-          }
-        ],
-        "is_russianism": false,
-        "russian_shadow": false,
-        "sovietization_risk": 0,
-        "calque_warning": null
       }
     },
     {
-      "lemma": "кава",
-      "url_slug": "кава",
-      "gloss": "coffee",
+      "lemma": "ключ",
+      "url_slug": "ключ",
+      "gloss": "key",
       "pos": "noun",
       "ipa": null,
       "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
-          "module_num": 20,
-          "slug": "my-morning",
+          "module_num": 8,
+          "slug": "things-have-gender",
           "context": "built_vocabulary"
         }
       ],
-      "enrichment": {
-        "morphology": {
-          "pos": "іменник",
-          "form_count": 14,
-          "forms": [
-            {
-              "form": "каві",
-              "label": "жін., давальний"
-            },
-            {
-              "form": "каво",
-              "label": "жін., кличний"
-            },
-            {
-              "form": "каві",
-              "label": "жін., місцевий"
-            },
-            {
-              "form": "кава",
-              "label": "жін., називний"
-            },
-            {
-              "form": "кавою",
-              "label": "жін., орудний"
-            },
-            {
-              "form": "кави",
-              "label": "жін., родовий"
-            },
-            {
-              "form": "каву",
-              "label": "жін., знахідний"
-            },
-            {
-              "form": "кавам",
-              "label": "множина, давальний"
-            },
-            {
-              "form": "кави",
-              "label": "множина, кличний"
-            },
-            {
-              "form": "кавах",
-              "label": "множина, місцевий"
-            },
-            {
-              "form": "кави",
-              "label": "множина, називний"
-            },
-            {
-              "form": "кавами",
-              "label": "множина, орудний"
-            },
-            {
-              "form": "кав",
-              "label": "множина, родовий"
-            },
-            {
-              "form": "кави",
-              "label": "множина, знахідний"
-            }
-          ],
-          "source": "VESUM",
-          "paradigm": {
-            "kind": "noun",
-            "cases": {
-              "називний": {
-                "singular": "кава",
-                "plural": "кави"
-              },
-              "родовий": {
-                "singular": "кави",
-                "plural": "кав"
-              },
-              "давальний": {
-                "singular": "каві",
-                "plural": "кавам"
-              },
-              "знахідний": {
-                "singular": "каву",
-                "plural": "кави"
-              },
-              "орудний": {
-                "singular": "кавою",
-                "plural": "кавами"
-              },
-              "місцевий": {
-                "singular": "каві",
-                "plural": "кавах"
-              },
-              "кличний": {
-                "singular": "каво",
-                "plural": "кави"
-              }
-            }
-          }
-        },
-        "meaning": {
-          "definitions": [
-            "тропічне дерево, з насіння якого виготовляють ароматний тонізувальний напій",
-            "насіння цього дерева чи порошок із цього насіння",
-            "тонізувальний напій, який отримують із зерен кави"
-          ],
-          "source": "Вікісловник"
-        },
-        "attestation": {
-          "text": "Кава, -ви, ж. 1) Кофе. Та готуй їй чай, та готуй їй каву. Левиц. І. 318. 2) Сивая ворона. Чорні кави, чорні врани круту гору вкрили. 3) м. Род пугала. Часом Галя жахнеться і пошептом питає: — «Що ж як кава прийде?!» — Не прийде, — одказують їй усі. — «А як вовк присуне?» МВ. ІІІ. 68. Пішла б вона гуляши того таки самого вечора, коли б не той вовк невірний з лісу, а що гірш — турбував її той кава навісний, що не знає вона навіть, де він і сидить у світі — чи у лісі, чи під горою на луці, чи у Дніпрі у нурті. МВ. ІІІ. 72. Ум. кавка, кавонька, кавочка. За дівчиною всі звони зазвонили, а за козаче",
-          "source": "Грінченко (1907)"
-        },
-        "etymology": {
-          "text": "тур. kahve «кава» походить від ар. ķahva « тс. » (початково «сорт легкого вина»), утвореного від географічної назви Kaffa – місцевості в південній Ефіопії, звідки походили торгівці кавою; запозичено з арабської мови за посередництвом турецької і польської; р. ко́фе, бр. ко́фе, ка́ва, п. kawa, ст. kafa, ч. слц. káva, вл. kofej, нл. kafej, болг. кафе́, ст. каве́, м. кафе, схв. кàфа, кàва, слн. káva, kofè;",
-          "source": "Горох (за ЕСУМ)",
-          "source_url": "https://goroh.pp.ua/%D0%95%D1%82%D0%B8%D0%BC%D0%BE%D0%BB%D0%BE%D0%B3%D1%96%D1%8F/%D0%BA%D0%B0%D0%B2%D0%B0"
-        },
-        "sources": [
-          "VESUM",
-          "Вікісловник",
-          "Горох (за ЕСУМ)",
-          "Грінченко (1907)"
-        ]
-      },
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
-            "ref": "кава",
-            "detail": "lemma match (14 forms)"
+            "ref": "ключ",
+            "detail": "lemma match (18 forms)"
           }
         ],
         "is_russianism": false,
         "russian_shadow": false,
-        "sovietization_risk": 0,
+        "sovietization_risk": 1,
         "calque_warning": null
-      }
-    },
-    {
-      "lemma": "ключ",
-      "url_slug": "ключ",
-      "gloss": "key, m",
-      "pos": null,
-      "ipa": null,
-      "primary_source": "plan_recommended",
-      "course_usage": [
-        {
-          "track": "a1",
-          "module_num": 8,
-          "slug": "things-have-gender",
-          "context": "plan_recommended"
-        }
-      ],
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -2433,7 +5551,11 @@
             "КЛЮЧ¹, а́, ч. 1. Знаряддя для замикання та відмикання замка, засува та ін. Сторож брязнув ключами, одмикаючи важкий здоровий замок (Н.-Лев., II, 1956, 268); Тремтяча рука довго не могла попасти ключем у дірку, щоб відімкнути двері від покою (Фр., VII, 1951, 78); Брязнув ключ, заскиглили іржаві засуви (Кач., II, 1958, 69). 2. Знаряддя для загвинчування або відгвинчування гайок, болтів і т. ін., для накручування завідних механізмів тощо. Гайкові ключі — інструмент для загвинчування й відгвинчування гайок, болтів і гвинтів з квадратними чи шестигранними головками (Слюс. справа, 1957, 67); Старанн"
           ],
           "source": "СУМ-11",
-          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
+          "sovietization_risk": 1,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті.",
+          "sovietization_keywords": [
+            "ленін"
+          ]
         },
         "attestation": {
           "text": "Ключ, -ча, м. 1) Ключ для запиранія и отпиранія замка — металлическій или деревянный. Kolb. І. 57. Мати до церкви вихожає, срібними ключами хату замикає. Н. п. 2) Брусок, вделанный в ось колішні (плуга), посредством котораго к колішні прикрепляется дышло. Чуб. VII. 399. 3) Шест с крючком для опусканія в колодезь и вытягиванія ведра. Чи це ж тая криниченька і ключ і відро? Чуб. V. 203. 4) Снаряд для ношенія сена, то-же, что и цапар, по с четырьмя наріжниками — палками, придавливающими сено под роскопом. Шух. І. 171. 5) У гуцульских пастухов в полонинах: столб, к которому прикреплен прибор, подо",
@@ -2450,37 +5572,37 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "книга",
+      "url_slug": "книга",
+      "gloss": "book",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
-            "ref": "ключ",
-            "detail": "lemma match (18 forms)"
+            "ref": "книга",
+            "detail": "lemma match (14 forms)"
           }
         ],
         "is_russianism": false,
         "russian_shadow": false,
         "sovietization_risk": 0,
         "calque_warning": null
-      }
-    },
-    {
-      "lemma": "книга",
-      "url_slug": "книга",
-      "gloss": "book, f",
-      "pos": null,
-      "ipa": null,
-      "primary_source": "plan_required",
-      "course_usage": [
-        {
-          "track": "a1",
-          "module_num": 8,
-          "slug": "things-have-gender",
-          "context": "plan_required"
-        }
-      ],
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -2603,37 +5725,37 @@
           "Горох (за ЕСУМ)",
           "Грінченко (1907)"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "комп'ютер",
+      "url_slug": "комп-ютер",
+      "gloss": "computer",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
-            "ref": "книга",
-            "detail": "lemma match (14 forms)"
+            "ref": "комп'ютер",
+            "detail": "lemma match (18 forms)"
           }
         ],
         "is_russianism": false,
         "russian_shadow": false,
         "sovietization_risk": 0,
         "calque_warning": null
-      }
-    },
-    {
-      "lemma": "комп'ютер",
-      "url_slug": "комп-ютер",
-      "gloss": "computer, m",
-      "pos": null,
-      "ipa": null,
-      "primary_source": "plan_required",
-      "course_usage": [
-        {
-          "track": "a1",
-          "module_num": 8,
-          "slug": "things-have-gender",
-          "context": "plan_required"
-        }
-      ],
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -2752,6 +5874,7 @@
             "КОМП’Ю́ТЕР, а, ч. Одна з назв електронної обчислювальної машини (перев. в англомовних країнах). Група програмістів одного електронного концерну в Сполучених Штатах Америки створила новий комп’ютер для гри в шахи (Наука.., 4, 1975, 62); У Куйбишевському політехнічному інституті на теплоенергетичному факультеті усні екзамени з математики у абітурієнтів приймав комп’ютер (Веч. Київ. 22.VIII 1974, 3)."
           ],
           "source": "СУМ-11",
+          "sovietization_risk": 0,
           "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
         },
         "etymology": {
@@ -2764,14 +5887,274 @@
           "Вікісловник (uk.wiktionary)",
           "СУМ-11"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "користуватися",
+      "url_slug": "користуватися",
+      "gloss": "to use",
+      "pos": "infinitive",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
-            "ref": "комп'ютер",
-            "detail": "lemma match (18 forms)"
+            "ref": "користуватися",
+            "detail": "lemma match (37 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "дієслово",
+          "form_count": 37,
+          "forms": [
+            {
+              "form": "користуватимемось",
+              "label": "майбутній, множина, 1 ос."
+            },
+            {
+              "form": "користуватимемося",
+              "label": "майбутній, множина, 1 ос."
+            },
+            {
+              "form": "користуватимемся",
+              "label": "майбутній, множина, 1 ос."
+            },
+            {
+              "form": "користуватиметесь",
+              "label": "майбутній, множина, 2 ос."
+            },
+            {
+              "form": "користуватиметеся",
+              "label": "майбутній, множина, 2 ос."
+            },
+            {
+              "form": "користуватимуться",
+              "label": "майбутній, множина, 3 ос."
+            },
+            {
+              "form": "користуватимусь",
+              "label": "майбутній, однина, 1 ос."
+            },
+            {
+              "form": "користуватимуся",
+              "label": "майбутній, однина, 1 ос."
+            },
+            {
+              "form": "користуватимешся",
+              "label": "майбутній, однина, 2 ос."
+            },
+            {
+              "form": "користуватиметься",
+              "label": "майбутній, однина, 3 ос."
+            },
+            {
+              "form": "користуймось",
+              "label": "наказовий, множина, 1 ос."
+            },
+            {
+              "form": "користуймося",
+              "label": "наказовий, множина, 1 ос."
+            },
+            {
+              "form": "користуйтесь",
+              "label": "наказовий, множина, 2 ос."
+            },
+            {
+              "form": "користуйтеся",
+              "label": "наказовий, множина, 2 ос."
+            },
+            {
+              "form": "користуйсь",
+              "label": "наказовий, однина, 2 ос."
+            },
+            {
+              "form": "користуйся",
+              "label": "наказовий, однина, 2 ос."
+            },
+            {
+              "form": "користуватися",
+              "label": "інфінітив"
+            },
+            {
+              "form": "користуватись",
+              "label": "інфінітив"
+            },
+            {
+              "form": "користуваться",
+              "label": "інфінітив"
+            },
+            {
+              "form": "користувалась",
+              "label": "минулий, жін."
+            },
+            {
+              "form": "користувалася",
+              "label": "минулий, жін."
+            },
+            {
+              "form": "користувавсь",
+              "label": "минулий, чол."
+            },
+            {
+              "form": "користувався",
+              "label": "минулий, чол."
+            },
+            {
+              "form": "користувалось",
+              "label": "минулий, сер."
+            },
+            {
+              "form": "користувалося",
+              "label": "минулий, сер."
+            },
+            {
+              "form": "користувались",
+              "label": "минулий, множина"
+            },
+            {
+              "form": "користувалися",
+              "label": "минулий, множина"
+            },
+            {
+              "form": "користуємось",
+              "label": "теперішній, множина, 1 ос."
+            },
+            {
+              "form": "користуємося",
+              "label": "теперішній, множина, 1 ос."
+            },
+            {
+              "form": "користуємся",
+              "label": "теперішній, множина, 1 ос."
+            },
+            {
+              "form": "користуєтесь",
+              "label": "теперішній, множина, 2 ос."
+            },
+            {
+              "form": "користуєтеся",
+              "label": "теперішній, множина, 2 ос."
+            },
+            {
+              "form": "користуються",
+              "label": "теперішній, множина, 3 ос."
+            },
+            {
+              "form": "користуюсь",
+              "label": "теперішній, однина, 1 ос."
+            },
+            {
+              "form": "користуюся",
+              "label": "теперішній, однина, 1 ос."
+            },
+            {
+              "form": "користуєшся",
+              "label": "теперішній, однина, 2 ос."
+            },
+            {
+              "form": "користується",
+              "label": "теперішній, однина, 3 ос."
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "verb",
+            "infinitive": "користуватися / користуватись",
+            "tenses": {
+              "теперішній": {
+                "однина": {
+                  "1": "користуюсь / користуюся",
+                  "2": "користуєшся",
+                  "3": "користується"
+                },
+                "множина": {
+                  "1": "користуємось / користуємося / користуємся",
+                  "2": "користуєтесь / користуєтеся",
+                  "3": "користуються"
+                }
+              },
+              "майбутній": {
+                "однина": {
+                  "1": "користуватимусь / користуватимуся",
+                  "2": "користуватимешся",
+                  "3": "користуватиметься"
+                },
+                "множина": {
+                  "1": "користуватимемось / користуватимемося / користуватимемся",
+                  "2": "користуватиметесь / користуватиметеся",
+                  "3": "користуватимуться"
+                }
+              }
+            },
+            "imperative": {
+              "однина": {
+                "2": "користуйсь / користуйся"
+              },
+              "множина": {
+                "1": "користуймось / користуймося",
+                "2": "користуйтесь / користуйтеся"
+              }
+            },
+            "past": {
+              "чол.": "користувавсь / користувався",
+              "жін.": "користувалась / користувалася",
+              "сер.": "користувалось / користувалося",
+              "множина": "користувались / користувалися"
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "КОРИ́СТУВА́ТИСЯ, и́сту́юся, и́сту́єшся, рідко КОРИСТА́ТИСЯ, а́юся, а́єшся, недок. 1. чим і з чого. Уживати, використовувати що-небудь для власних потреб. Довелося їм користуватись тією хатою (Мирний, IV, 1955, 240); Бекір користувавсь з кожної вільної хвилини і приносив слабому свіжі новини з вулиці (Коцюб., II, 1955, 155); Ключа від нього [чорного ходу] мав батько і користався інколи (Смолич, II, 1958, 76); Користуватися послугами; // Застосовувати що-небудь. Сідла Брянського, введені спочатку в мінроті, швидко дістали визнання, і тепер ними користувалися всі полки дивізії (Гончар, І, 1954, 1"
+          ],
+          "source": "СУМ-11",
+          "sovietization_risk": 0,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
+        },
+        "sources": [
+          "VESUM",
+          "СУМ-11"
+        ]
+      }
+    },
+    {
+      "lemma": "користуюся",
+      "url_slug": "користуюся",
+      "gloss": "I use",
+      "pos": "verb form",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "користуватися",
+            "detail": "word_form match for lemma query"
           }
         ],
         "is_russianism": false,
@@ -2783,18 +6166,32 @@
     {
       "lemma": "крісло",
       "url_slug": "крісло",
-      "gloss": "armchair, n",
-      "pos": null,
+      "gloss": "armchair",
+      "pos": "noun",
       "ipa": null,
-      "primary_source": "plan_recommended",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 8,
           "slug": "things-have-gender",
-          "context": "plan_recommended"
+          "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "крісло",
+            "detail": "lemma match (15 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -2901,6 +6298,7 @@
             "КРІ́СЛО, а, с. 1. Різновид широкого, переважно м’якого стільця, з бильцями та зручною спинкою; фотель. Хшановський лежав в кріслі, задравши.. ноги на спинку стільця (Н.-Лев., II, 1956, 57); Я падаю в крісло, закриваю очі долонею… (Коцюб., І, 1955, 418); Маленький, жвавий Чиж раптом пірнув у глибоке крісло і немов заховався у ньому (Сміл., Сад, 1952, 150). 2. рідко. Те саме, що стіле́ць. Целя.. попідливала свої квітки, позмітала пил із столика, з пари крісел (Фр., II, 1950, 290); Посередині кімнати лежали два крісла.., прикриті стягненою зі столу скатертю (Кобр., Вибр., 1954, 147). 3. тільки мн"
           ],
           "source": "СУМ-11",
+          "sovietization_risk": 0,
           "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
         },
         "attestation": {
@@ -2918,37 +6316,37 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "кімната",
+      "url_slug": "кімната",
+      "gloss": "room",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
-            "ref": "крісло",
-            "detail": "lemma match (15 forms)"
+            "ref": "кімната",
+            "detail": "lemma match (14 forms)"
           }
         ],
         "is_russianism": false,
         "russian_shadow": false,
         "sovietization_risk": 0,
         "calque_warning": null
-      }
-    },
-    {
-      "lemma": "кімната",
-      "url_slug": "кімната",
-      "gloss": "room, f",
-      "pos": null,
-      "ipa": null,
-      "primary_source": "plan_required",
-      "course_usage": [
-        {
-          "track": "a1",
-          "module_num": 8,
-          "slug": "things-have-gender",
-          "context": "plan_required"
-        }
-      ],
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -3068,37 +6466,37 @@
           "Горох (за ЕСУМ)",
           "Грінченко (1907)"
         ]
-      },
-      "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "кімната",
-            "detail": "lemma match (14 forms)"
-          }
-        ],
-        "is_russianism": false,
-        "russian_shadow": false,
-        "sovietization_risk": 0,
-        "calque_warning": null
       }
     },
     {
       "lemma": "лампа",
       "url_slug": "лампа",
-      "gloss": "lamp, f",
-      "pos": null,
+      "gloss": "lamp",
+      "pos": "noun",
       "ipa": null,
-      "primary_source": "plan_required",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 8,
           "slug": "things-have-gender",
-          "context": "plan_required"
+          "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "лампа",
+            "detail": "lemma match (14 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 1,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -3214,13 +6612,29 @@
           "Вікісловник",
           "Горох (за ЕСУМ)"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "лі́тера",
+      "url_slug": "лі-тера",
+      "gloss": "letter",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 1,
+          "slug": "sounds-letters-and-hello",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
-            "ref": "лампа",
+            "ref": "літера",
             "detail": "lemma match (14 forms)"
           }
         ],
@@ -3228,23 +6642,47 @@
         "russian_shadow": false,
         "sovietization_risk": 0,
         "calque_warning": null
+      },
+      "enrichment": {
+        "etymology": {
+          "text": "запозичено з латинської мови, можливо, через польське посередництво; лат. littera, давніше lītera «буква алфавіту, лист», очевидно, пов’язане з līno «брудню, мажу, фарбую», спорідненим з дінд. lināti «тулиться, прилягає, застряє», гр. ’αλΐνω «намазую», гот. aflinnan «іти геть, відступати», дірл. len(a)id «іти слідом», кімр. canlin « тс. »; існує також думка про грецьке походження слова, оскільки латинський алфавіт був запозичений через посередництво етрусків у греків (Ernout – Meillet 363); р. ли́тера, бр. лі́тара, п. ч. слц. litera, схв. литера;",
+          "source": "Горох (за ЕСУМ)",
+          "source_url": "https://goroh.pp.ua/%D0%95%D1%82%D0%B8%D0%BC%D0%BE%D0%BB%D0%BE%D0%B3%D1%96%D1%8F/%D0%BB%D1%96%D1%82%D0%B5%D1%80%D0%B0"
+        },
+        "sources": [
+          "Горох (за ЕСУМ)"
+        ]
       }
     },
     {
       "lemma": "ліжко",
       "url_slug": "ліжко",
-      "gloss": "bed, n",
-      "pos": null,
+      "gloss": "bed",
+      "pos": "noun",
       "ipa": null,
-      "primary_source": "plan_required",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 8,
           "slug": "things-have-gender",
-          "context": "plan_required"
+          "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "ліжко",
+            "detail": "lemma match (14 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -3367,37 +6805,191 @@
           "Горох (за ЕСУМ)",
           "Грінченко (1907)"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "лікар",
+      "url_slug": "лікар",
+      "gloss": "male doctor",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
-            "ref": "ліжко",
-            "detail": "lemma match (14 forms)"
+            "ref": "лікар",
+            "detail": "lemma match (18 forms)"
           }
         ],
         "is_russianism": false,
         "russian_shadow": false,
         "sovietization_risk": 0,
         "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 18,
+          "forms": [
+            {
+              "form": "лікареві",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "лікарю",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "лікарю",
+              "label": "чол., кличний"
+            },
+            {
+              "form": "лікареві",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "лікарі",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "лікарю",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "лікар",
+              "label": "чол., називний"
+            },
+            {
+              "form": "лікарем",
+              "label": "чол., орудний"
+            },
+            {
+              "form": "лікаря",
+              "label": "чол., родовий"
+            },
+            {
+              "form": "лікаря",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "лікарям",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "лікарі",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "лікарях",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "лікарі",
+              "label": "множина, називний"
+            },
+            {
+              "form": "лікарями",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "лікарів",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "лікарів",
+              "label": "множина, знахідний"
+            },
+            {
+              "form": "лікарі",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "лікар",
+                "plural": "лікарі"
+              },
+              "родовий": {
+                "singular": "лікаря",
+                "plural": "лікарів"
+              },
+              "давальний": {
+                "singular": "лікареві / лікарю",
+                "plural": "лікарям"
+              },
+              "знахідний": {
+                "singular": "лікаря",
+                "plural": "лікарів / лікарі"
+              },
+              "орудний": {
+                "singular": "лікарем",
+                "plural": "лікарями"
+              },
+              "місцевий": {
+                "singular": "лікареві / лікарі / лікарю",
+                "plural": "лікарях"
+              },
+              "кличний": {
+                "singular": "лікарю",
+                "plural": "лікарі"
+              }
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "особа з вищою медичною освітою, що лікує хворих. , ескулап , лічець ; цілитель , зцілитель"
+          ],
+          "source": "Вікісловник"
+        },
+        "sources": [
+          "VESUM",
+          "Вікісловник"
+        ]
       }
     },
     {
       "lemma": "лікарка",
       "url_slug": "лікарка",
-      "gloss": "doctor, f — feminitive, VESUM-verified; mirror of лікар m",
-      "pos": null,
+      "gloss": "female doctor",
+      "pos": "noun",
       "ipa": null,
-      "primary_source": "plan_recommended",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 8,
           "slug": "things-have-gender",
-          "context": "plan_recommended"
+          "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "лікарка",
+            "detail": "lemma match (15 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -3504,6 +7096,7 @@
             "ЛІ́КАРКА, и, ж. Жін. до лі́кар. Стара мати кидається.. до лікарки, то знов поспішається до знахарки (Вовчок, І, 1955, 355); Вона була педіатром, цебто лікаркою по дитячих хворобах (Ю. Янов., II, 1954, 64); *Образно. О чарівнице! лікарко чудова! Ти [весна] кличеш жити й тих, хто жить не хоче (Сам., І, 1958, 118)."
           ],
           "source": "СУМ-11",
+          "sovietization_risk": 0,
           "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
         },
         "attestation": {
@@ -3521,170 +7114,26 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
-      },
-      "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "лікарка",
-            "detail": "lemma match (15 forms)"
-          }
-        ],
-        "is_russianism": false,
-        "russian_shadow": false,
-        "sovietization_risk": 0,
-        "calque_warning": null
       }
     },
     {
-      "lemma": "літера",
-      "url_slug": "літера",
-      "gloss": "letter",
-      "pos": null,
+      "lemma": "м'яки́й знак",
+      "url_slug": "м-яки-й-знак",
+      "gloss": "soft sign",
+      "pos": "noun phrase",
       "ipa": null,
-      "primary_source": "plan_required",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 1,
           "slug": "sounds-letters-and-hello",
-          "context": "plan_required"
+          "context": "built_vocabulary"
         }
       ],
-      "enrichment": {
-        "morphology": {
-          "pos": "іменник",
-          "form_count": 14,
-          "forms": [
-            {
-              "form": "літері",
-              "label": "жін., давальний"
-            },
-            {
-              "form": "літеро",
-              "label": "жін., кличний"
-            },
-            {
-              "form": "літері",
-              "label": "жін., місцевий"
-            },
-            {
-              "form": "літера",
-              "label": "жін., називний"
-            },
-            {
-              "form": "літерою",
-              "label": "жін., орудний"
-            },
-            {
-              "form": "літери",
-              "label": "жін., родовий"
-            },
-            {
-              "form": "літеру",
-              "label": "жін., знахідний"
-            },
-            {
-              "form": "літерам",
-              "label": "множина, давальний"
-            },
-            {
-              "form": "літери",
-              "label": "множина, кличний"
-            },
-            {
-              "form": "літерах",
-              "label": "множина, місцевий"
-            },
-            {
-              "form": "літери",
-              "label": "множина, називний"
-            },
-            {
-              "form": "літерами",
-              "label": "множина, орудний"
-            },
-            {
-              "form": "літер",
-              "label": "множина, родовий"
-            },
-            {
-              "form": "літери",
-              "label": "множина, знахідний"
-            }
-          ],
-          "source": "VESUM",
-          "paradigm": {
-            "kind": "noun",
-            "cases": {
-              "називний": {
-                "singular": "літера",
-                "plural": "літери"
-              },
-              "родовий": {
-                "singular": "літери",
-                "plural": "літер"
-              },
-              "давальний": {
-                "singular": "літері",
-                "plural": "літерам"
-              },
-              "знахідний": {
-                "singular": "літеру",
-                "plural": "літери"
-              },
-              "орудний": {
-                "singular": "літерою",
-                "plural": "літерами"
-              },
-              "місцевий": {
-                "singular": "літері",
-                "plural": "літерах"
-              },
-              "кличний": {
-                "singular": "літеро",
-                "plural": "літери"
-              }
-            }
-          }
-        },
-        "meaning": {
-          "definitions": [
-            "письмовий знак, що позначає звук або сполучення звуків мови; буква. ‖ металевий брусочок із випуклим зображенням цього знака, що вживався для друкарського лінотипного набору",
-            "елемент алфавіту; елемент літерного набору",
-            "суто формальне значення чого-небудь"
-          ],
-          "source": "Вікісловник",
-          "synonyms": [
-            "буква"
-          ]
-        },
-        "attestation": {
-          "text": "ЛІтера, -ри, ж. Буква. Левиц. І. 243.",
-          "source": "Грінченко (1907)"
-        },
-        "etymology": {
-          "text": "запозичено з латинської мови, можливо, через польське посередництво; лат. littera, давніше lītera «буква алфавіту, лист», очевидно, пов’язане з līno «брудню, мажу, фарбую», спорідненим з дінд. lināti «тулиться, прилягає, застряє», гр. ’αλΐνω «намазую», гот. aflinnan «іти геть, відступати», дірл. len(a)id «іти слідом», кімр. canlin « тс. »; існує також думка про грецьке походження слова, оскільки латинський алфавіт був запозичений через посередництво етрусків у греків (Ernout – Meillet 363); р. ли́тера, бр. лі́тара, п. ч. слц. litera, схв. литера;",
-          "source": "Горох (за ЕСУМ)",
-          "source_url": "https://goroh.pp.ua/%D0%95%D1%82%D0%B8%D0%BC%D0%BE%D0%BB%D0%BE%D0%B3%D1%96%D1%8F/%D0%BB%D1%96%D1%82%D0%B5%D1%80%D0%B0"
-        },
-        "sources": [
-          "VESUM",
-          "Вікісловник",
-          "Горох (за ЕСУМ)",
-          "Грінченко (1907)"
-        ]
-      },
       "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "літера",
-            "detail": "lemma match (14 forms)"
-          }
-        ],
+        "classification": "unknown",
+        "attestations": [],
         "is_russianism": false,
         "russian_shadow": false,
         "sovietization_risk": 0,
@@ -3692,165 +7141,20 @@
       }
     },
     {
-      "lemma": "мама",
-      "url_slug": "мама",
+      "lemma": "ма́ма",
+      "url_slug": "ма-ма",
       "gloss": "mother",
-      "pos": null,
+      "pos": "noun",
       "ipa": null,
-      "primary_source": "plan_required",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 1,
           "slug": "sounds-letters-and-hello",
-          "context": "plan_required"
+          "context": "built_vocabulary"
         }
       ],
-      "enrichment": {
-        "morphology": {
-          "pos": "іменник",
-          "form_count": 19,
-          "forms": [
-            {
-              "form": "мамі",
-              "label": "жін., давальний"
-            },
-            {
-              "form": "мамо",
-              "label": "жін., кличний"
-            },
-            {
-              "form": "ма",
-              "label": "жін., кличний"
-            },
-            {
-              "form": "мам",
-              "label": "жін., кличний"
-            },
-            {
-              "form": "мамі",
-              "label": "жін., місцевий"
-            },
-            {
-              "form": "мама",
-              "label": "жін., називний"
-            },
-            {
-              "form": "мамою",
-              "label": "жін., орудний"
-            },
-            {
-              "form": "мами",
-              "label": "жін., родовий"
-            },
-            {
-              "form": "маму",
-              "label": "жін., знахідний"
-            },
-            {
-              "form": "мамам",
-              "label": "множина, давальний"
-            },
-            {
-              "form": "мами",
-              "label": "множина, кличний"
-            },
-            {
-              "form": "мамах",
-              "label": "множина, місцевий"
-            },
-            {
-              "form": "мами",
-              "label": "множина, називний"
-            },
-            {
-              "form": "мамами",
-              "label": "множина, орудний"
-            },
-            {
-              "form": "мам",
-              "label": "множина, родовий"
-            },
-            {
-              "form": "мамів",
-              "label": "множина, родовий"
-            },
-            {
-              "form": "мам",
-              "label": "множина, знахідний"
-            },
-            {
-              "form": "мамів",
-              "label": "множина, знахідний"
-            },
-            {
-              "form": "мами",
-              "label": "множина, знахідний"
-            }
-          ],
-          "source": "VESUM",
-          "paradigm": {
-            "kind": "noun",
-            "cases": {
-              "називний": {
-                "singular": "мама",
-                "plural": "мами"
-              },
-              "родовий": {
-                "singular": "мами",
-                "plural": "мам / мамів"
-              },
-              "давальний": {
-                "singular": "мамі",
-                "plural": "мамам"
-              },
-              "знахідний": {
-                "singular": "маму",
-                "plural": "мам / мамів / мами"
-              },
-              "орудний": {
-                "singular": "мамою",
-                "plural": "мамами"
-              },
-              "місцевий": {
-                "singular": "мамі",
-                "plural": "мамах"
-              },
-              "кличний": {
-                "singular": "мамо / ма / мам",
-                "plural": "мами"
-              }
-            }
-          }
-        },
-        "meaning": {
-          "definitions": [
-            "ласкаве називання матері й звертання до неї",
-            "звертання до матері чоловіка або жінки",
-            "уживається як ласкаве звертання до старшої віком жінки"
-          ],
-          "source": "Вікісловник",
-          "synonyms": [
-            "мати",
-            "матуся"
-          ]
-        },
-        "attestation": {
-          "text": "МАма, ми, ж. Мама. З бідою, як з рідною мамою. Ном. № 2226. Ум. мамка, мамонька, мамочка, мамунечка, мамуня, мамусенька, мамусечка, мамуся. Ой, мамочко, ой, мамочко! ви не бийте мене, ви не лайте мене, — коли я вам докучила, то оддайте мене. Грин. III. 192. Ой таточку наш, таточку, де ти подів мамочку? Грин. III. 366. Як дочка стелила, легенько здихнула: «щоб моя мамуня здорова заснула!». Грин. III. 691. Мамунечко, я коло вас. Мир. Пов. І. 171. Мамуню ж мої рідненькі, мамусенько! Дайте ж мені раду! Грин. III. 375.",
-          "source": "Грінченко (1907)"
-        },
-        "etymology": {
-          "text": "виникло в дитячій мові шляхом повторення складу ma, подібно до ба́ба, дя́дя, та́то; іє. *mama «мати»; споріднене з лит. mamà «мати», лтс. mama « тс. », лат. mamma «тс.; груди», гр. μάμμη, μάμμα «мати, баба», алб. mëmë «мати», дінд. māma «дядько»; псл. mama; р- бр. др. болг. м. ма́ма, п. слц. вл. нл. mama, ч. слн. máma, полаб. mamoĭ, схв. мȁма;",
-          "source": "Горох (за ЕСУМ)",
-          "source_url": "https://goroh.pp.ua/%D0%95%D1%82%D0%B8%D0%BC%D0%BE%D0%BB%D0%BE%D0%B3%D1%96%D1%8F/%D0%BC%D0%B0%D0%BC%D0%B0"
-        },
-        "sources": [
-          "VESUM",
-          "Вікісловник",
-          "Горох (за ЕСУМ)",
-          "Грінченко (1907)"
-        ]
-      },
       "heritage_status": {
         "classification": "standard",
         "attestations": [
@@ -3864,85 +7168,402 @@
         "russian_shadow": false,
         "sovietization_risk": 0,
         "calque_warning": null
+      },
+      "enrichment": {
+        "etymology": {
+          "text": "виникло в дитячій мові шляхом повторення складу ma, подібно до ба́ба, дя́дя, та́то; іє. *mama «мати»; споріднене з лит. mamà «мати», лтс. mama « тс. », лат. mamma «тс.; груди», гр. μάμμη, μάμμα «мати, баба», алб. mëmë «мати», дінд. māma «дядько»; псл. mama; р- бр. др. болг. м. ма́ма, п. слц. вл. нл. mama, ч. слн. máma, полаб. mamoĭ, схв. мȁма;",
+          "source": "Горох (за ЕСУМ)",
+          "source_url": "https://goroh.pp.ua/%D0%95%D1%82%D0%B8%D0%BC%D0%BE%D0%BB%D0%BE%D0%B3%D1%96%D1%8F/%D0%BC%D0%B0%D0%BC%D0%B0"
+        },
+        "sources": [
+          "Горох (за ЕСУМ)"
+        ]
       }
     },
     {
-      "lemma": "молоко",
-      "url_slug": "молоко",
-      "gloss": "milk",
-      "pos": null,
+      "lemma": "мило",
+      "url_slug": "мило",
+      "gloss": "soap",
+      "pos": "noun",
       "ipa": null,
-      "primary_source": "plan_required",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
-          "module_num": 1,
-          "slug": "sounds-letters-and-hello",
-          "context": "plan_required"
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "мило",
+            "detail": "lemma match (16 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
-          "pos": "іменник",
-          "form_count": 8,
+          "pos": "прислівник",
+          "form_count": 16,
           "forms": [
             {
-              "form": "молоку",
+              "form": "мило",
+              "label": ""
+            },
+            {
+              "form": "милу",
               "label": "сер., давальний"
             },
             {
-              "form": "молоко",
+              "form": "мило",
               "label": "сер., кличний"
             },
             {
-              "form": "молоку",
+              "form": "милі",
               "label": "сер., місцевий"
             },
             {
-              "form": "молоці",
+              "form": "милу",
               "label": "сер., місцевий"
             },
             {
-              "form": "молоко",
+              "form": "мило",
               "label": "сер., називний"
             },
             {
-              "form": "молоком",
+              "form": "милом",
               "label": "сер., орудний"
             },
             {
-              "form": "молока",
+              "form": "мила",
               "label": "сер., родовий"
             },
             {
-              "form": "молоко",
+              "form": "мило",
               "label": "сер., знахідний"
+            },
+            {
+              "form": "милам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "мила",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "милах",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "мила",
+              "label": "множина, називний"
+            },
+            {
+              "form": "милами",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "мил",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "мила",
+              "label": "множина, знахідний"
             }
           ],
           "source": "VESUM"
         },
         "meaning": {
           "definitions": [
-            "біла рідина, що виділяється молочними залозами жінок і самиць"
+            "МИЛО¹, а, сер. 1. Тверда, напіврідка або рідка речовина — суміш жирів та лугу, що добре розчиняється у воді й уживається для миття і прання. «І що там мити?» — подумала Христя, дивлячись, як і без того тендітні та білі руки натирав панич пахучим милом (Панас Мирний, III, 1954, 154); Не мама її [сорочку] прала, а дівчата з фронтових пралень, а їм уже руки милом геть пороз’їдало... (Олесь Гончар, III, 1959, 9); // Піна, що утворюється при розчиненні цієї суміші у воді. Хомині очі каламутні, як вода з милом (Михайло Коцюбинський, II, 1955, 55); Він, ще й не втершися, ще мило на шиї та біля вух, с"
           ],
-          "source": "Вікісловник"
-        },
-        "attestation": {
-          "text": "МолокО, -ка, с. 1) Молоко. Захотів молока від бика. Ном. № 4686. 2) бугаєве молокО. Названіе молока, приготовленнаго из коноплянаго семени или маку. Kolb. І. 54. 3) песяче молокО. Раст. Euphorecia. Вх. Пч. І. 10.",
-          "source": "Грінченко (1907)"
+          "source": "СУМ-11",
+          "sovietization_risk": 0,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
         },
         "etymology": {
-          "text": "найбільш імовірним є давній зв’язок з моло́зиво (псл. *melzivo, * melzti «доїти»; іє. * melkяк звуковий варіант кореня *melğ« тс. »); вважається також запозиченням з германських мов (герм. *meluk- «молоко») (Machek ESJČ 368; Мартынов Сл.-герм. взаимод. 73–74; Hirt РВrВ 23, 341–342; Uhlenbeck AfSlPh 15, 489); здебільшого зіставляється з р. [ малоки́та ] «болото», лит. malkas «ковток», лтс. màlks, malka «пиття» і, далі, з гр. μέλκιον «джерело», гот. milhma «хмара» (іє. *melk- «мокрий, волога») (Фасмер– Трубачев II 645–646; Brükner 340; Holub–Kop. 226; Schuster-Šewc 936; Bern. II 33–34; Pokorny 7",
-          "source": "Горох (за ЕСУМ)",
-          "source_url": "https://goroh.pp.ua/%D0%95%D1%82%D0%B8%D0%BC%D0%BE%D0%BB%D0%BE%D0%B3%D1%96%D1%8F/%D0%BC%D0%BE%D0%BB%D0%BE%D0%BA%D0%BE"
+          "text": "мило, прити» Г, Нед, приятелювіти, приязнь, приятелізм, пріЯятель СУМ, Нед, вітно; пристойно»; -- р. приятньшй пріЯтельство ятьньш «прийнятний; приємний», ня СУМ, дружньо; «дружба, приятелюваприятелюванГ; друзі (зб.) Нед», [приятіль) «приятель, друг» Нед, [приЯтство[ «дружба, приятелювання; друзі (зб.)» Нед, приям[ «приятель; той, хто сприяє, допомагає» Нед, пріязний «схильний (до когось), дружній; приємний СУМ, Г», [заприязнити[ «зв'язати дружбою» Ж, Інаприяте) «придбати»",
+          "source": "ЕСУМ, т. 4, с. 583"
         },
         "sources": [
           "VESUM",
-          "Вікісловник",
-          "Горох (за ЕСУМ)",
-          "Грінченко (1907)"
+          "ЕСУМ, т. 4, с. 583",
+          "СУМ-11"
         ]
+      }
+    },
+    {
+      "lemma": "митися",
+      "url_slug": "митися",
+      "gloss": "to wash oneself",
+      "pos": "infinitive",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "митися",
+            "detail": "lemma match (37 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
       },
+      "enrichment": {
+        "morphology": {
+          "pos": "дієслово",
+          "form_count": 37,
+          "forms": [
+            {
+              "form": "митимемось",
+              "label": "майбутній, множина, 1 ос."
+            },
+            {
+              "form": "митимемося",
+              "label": "майбутній, множина, 1 ос."
+            },
+            {
+              "form": "митимемся",
+              "label": "майбутній, множина, 1 ос."
+            },
+            {
+              "form": "митиметесь",
+              "label": "майбутній, множина, 2 ос."
+            },
+            {
+              "form": "митиметеся",
+              "label": "майбутній, множина, 2 ос."
+            },
+            {
+              "form": "митимуться",
+              "label": "майбутній, множина, 3 ос."
+            },
+            {
+              "form": "митимусь",
+              "label": "майбутній, однина, 1 ос."
+            },
+            {
+              "form": "митимуся",
+              "label": "майбутній, однина, 1 ос."
+            },
+            {
+              "form": "митимешся",
+              "label": "майбутній, однина, 2 ос."
+            },
+            {
+              "form": "митиметься",
+              "label": "майбутній, однина, 3 ос."
+            },
+            {
+              "form": "миймось",
+              "label": "наказовий, множина, 1 ос."
+            },
+            {
+              "form": "миймося",
+              "label": "наказовий, множина, 1 ос."
+            },
+            {
+              "form": "мийтесь",
+              "label": "наказовий, множина, 2 ос."
+            },
+            {
+              "form": "мийтеся",
+              "label": "наказовий, множина, 2 ос."
+            },
+            {
+              "form": "мийсь",
+              "label": "наказовий, однина, 2 ос."
+            },
+            {
+              "form": "мийся",
+              "label": "наказовий, однина, 2 ос."
+            },
+            {
+              "form": "митися",
+              "label": "інфінітив"
+            },
+            {
+              "form": "митись",
+              "label": "інфінітив"
+            },
+            {
+              "form": "миться",
+              "label": "інфінітив"
+            },
+            {
+              "form": "милась",
+              "label": "минулий, жін."
+            },
+            {
+              "form": "милася",
+              "label": "минулий, жін."
+            },
+            {
+              "form": "мивсь",
+              "label": "минулий, чол."
+            },
+            {
+              "form": "мився",
+              "label": "минулий, чол."
+            },
+            {
+              "form": "милось",
+              "label": "минулий, сер."
+            },
+            {
+              "form": "милося",
+              "label": "минулий, сер."
+            },
+            {
+              "form": "мились",
+              "label": "минулий, множина"
+            },
+            {
+              "form": "милися",
+              "label": "минулий, множина"
+            },
+            {
+              "form": "миємось",
+              "label": "теперішній, множина, 1 ос."
+            },
+            {
+              "form": "миємося",
+              "label": "теперішній, множина, 1 ос."
+            },
+            {
+              "form": "миємся",
+              "label": "теперішній, множина, 1 ос."
+            },
+            {
+              "form": "миєтесь",
+              "label": "теперішній, множина, 2 ос."
+            },
+            {
+              "form": "миєтеся",
+              "label": "теперішній, множина, 2 ос."
+            },
+            {
+              "form": "миються",
+              "label": "теперішній, множина, 3 ос."
+            },
+            {
+              "form": "миюсь",
+              "label": "теперішній, однина, 1 ос."
+            },
+            {
+              "form": "миюся",
+              "label": "теперішній, однина, 1 ос."
+            },
+            {
+              "form": "миєшся",
+              "label": "теперішній, однина, 2 ос."
+            },
+            {
+              "form": "миється",
+              "label": "теперішній, однина, 3 ос."
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "verb",
+            "infinitive": "митися / митись",
+            "tenses": {
+              "теперішній": {
+                "однина": {
+                  "1": "миюсь / миюся",
+                  "2": "миєшся",
+                  "3": "миється"
+                },
+                "множина": {
+                  "1": "миємось / миємося / миємся",
+                  "2": "миєтесь / миєтеся",
+                  "3": "миються"
+                }
+              },
+              "майбутній": {
+                "однина": {
+                  "1": "митимусь / митимуся",
+                  "2": "митимешся",
+                  "3": "митиметься"
+                },
+                "множина": {
+                  "1": "митимемось / митимемося / митимемся",
+                  "2": "митиметесь / митиметеся",
+                  "3": "митимуться"
+                }
+              }
+            },
+            "imperative": {
+              "однина": {
+                "2": "мийсь / мийся"
+              },
+              "множина": {
+                "1": "миймось / миймося",
+                "2": "мийтесь / мийтеся"
+              }
+            },
+            "past": {
+              "чол.": "мивсь / мився",
+              "жін.": "милась / милася",
+              "сер.": "милось / милося",
+              "множина": "мились / милися"
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "МИ́ТИСЯ, ми́юся, ми́єшся, недок. 1. Мити себе (обличчя, руки, тіло); вмиватися, обмиватися (у 1 знач.). Увесь вечір Маруся.. мисники змивала, піч мазала, милася (Кв.-Осн., II, 1955, 54); У трофейних бочках з-під пального грілася вода, голі — як мати родила — бійці милися на сонці (Гончар, III, 1959, 127). ◊ Ми́тися сльозо́ю (слі́зьми́), нар.-поет. — гірко плакати, ридати. Як калина при долині Вранці під росою, Так Ганнуся червоніла, Милася сльозою (Шевч., І, 1963, 160); Я хочу миру між людьми, Щоб матері слізьми не мились (Павл., Бистрина, 1959, 14). 2. Ставати мокрим, вологим від води або інш"
+          ],
+          "source": "СУМ-11",
+          "sovietization_risk": 0,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
+        },
+        "attestation": {
+          "text": "МИтися, -миюся, -єшся, гл. 1) Мыться. Марусю, дусю, мийся, чешися. Ном. № 11261. 2) Иметь регулы. Що мені робити: більш году, як не миюсь.",
+          "source": "Грінченко (1907)"
+        },
+        "sources": [
+          "VESUM",
+          "Грінченко (1907)",
+          "СУМ-11"
+        ]
+      }
+    },
+    {
+      "lemma": "молоко́",
+      "url_slug": "молоко",
+      "gloss": "milk",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 1,
+          "slug": "sounds-letters-and-hello",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
@@ -3954,6 +7575,515 @@
         ],
         "is_russianism": false,
         "russian_shadow": false,
+        "sovietization_risk": 1,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "etymology": {
+          "text": "найбільш імовірним є давній зв’язок з моло́зиво (псл. *melzivo, * melzti «доїти»; іє. * melkяк звуковий варіант кореня *melğ« тс. »); вважається також запозиченням з германських мов (герм. *meluk- «молоко») (Machek ESJČ 368; Мартынов Сл.-герм. взаимод. 73–74; Hirt РВrВ 23, 341–342; Uhlenbeck AfSlPh 15, 489); здебільшого зіставляється з р. [ малоки́та ] «болото», лит. malkas «ковток», лтс. màlks, malka «пиття» і, далі, з гр. μέλκιον «джерело», гот. milhma «хмара» (іє. *melk- «мокрий, волога») (Фасмер– Трубачев II 645–646; Brükner 340; Holub–Kop. 226; Schuster-Šewc 936; Bern. II 33–34; Pokorny 7",
+          "source": "Горох (за ЕСУМ)",
+          "source_url": "https://goroh.pp.ua/%D0%95%D1%82%D0%B8%D0%BC%D0%BE%D0%BB%D0%BE%D0%B3%D1%96%D1%8F/%D0%BC%D0%BE%D0%BB%D0%BE%D0%BA%D0%BE"
+        },
+        "sources": [
+          "Горох (за ЕСУМ)"
+        ]
+      }
+    },
+    {
+      "lemma": "моя",
+      "url_slug": "моя",
+      "gloss": "my, feminine",
+      "pos": "pronoun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "мій",
+            "detail": "word_form match for lemma query"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
+    },
+    {
+      "lemma": "моє",
+      "url_slug": "моє",
+      "gloss": "my, neuter",
+      "pos": "pronoun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "мій",
+            "detail": "word_form match for lemma query"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
+    },
+    {
+      "lemma": "мій",
+      "url_slug": "мій",
+      "gloss": "my, masculine",
+      "pos": "pronoun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "мій",
+            "detail": "lemma match (47 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 1,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "прикметник",
+          "form_count": 47,
+          "forms": [
+            {
+              "form": "моїй",
+              "label": "жін., давальний"
+            },
+            {
+              "form": "моя",
+              "label": "жін., кличний"
+            },
+            {
+              "form": "моїй",
+              "label": "жін., місцевий"
+            },
+            {
+              "form": "моя",
+              "label": "жін., називний"
+            },
+            {
+              "form": "моєю",
+              "label": "жін., орудний"
+            },
+            {
+              "form": "моєї",
+              "label": "жін., родовий"
+            },
+            {
+              "form": "мою",
+              "label": "жін., знахідний"
+            },
+            {
+              "form": "моєму",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "мойму",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "мойому",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "мому",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "мій",
+              "label": "чол., кличний"
+            },
+            {
+              "form": "моєму",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "моїм",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "мойму",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "мойому",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "мому",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "мій",
+              "label": "чол., називний"
+            },
+            {
+              "form": "моїм",
+              "label": "чол., орудний"
+            },
+            {
+              "form": "мого",
+              "label": "чол., родовий"
+            },
+            {
+              "form": "мойого",
+              "label": "чол., родовий"
+            },
+            {
+              "form": "мого",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "мойого",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "мій",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "моєму",
+              "label": "сер., давальний"
+            },
+            {
+              "form": "мойму",
+              "label": "сер., давальний"
+            },
+            {
+              "form": "мойому",
+              "label": "сер., давальний"
+            },
+            {
+              "form": "мому",
+              "label": "сер., давальний"
+            },
+            {
+              "form": "моє",
+              "label": "сер., кличний"
+            },
+            {
+              "form": "моєму",
+              "label": "сер., місцевий"
+            },
+            {
+              "form": "моїм",
+              "label": "сер., місцевий"
+            },
+            {
+              "form": "мойму",
+              "label": "сер., місцевий"
+            },
+            {
+              "form": "мойому",
+              "label": "сер., місцевий"
+            },
+            {
+              "form": "мому",
+              "label": "сер., місцевий"
+            },
+            {
+              "form": "моє",
+              "label": "сер., називний"
+            },
+            {
+              "form": "моїм",
+              "label": "сер., орудний"
+            },
+            {
+              "form": "мого",
+              "label": "сер., родовий"
+            },
+            {
+              "form": "мойого",
+              "label": "сер., родовий"
+            },
+            {
+              "form": "моє",
+              "label": "сер., знахідний"
+            },
+            {
+              "form": "моїм",
+              "label": "множина, давальний"
+            }
+          ],
+          "source": "VESUM"
+        },
+        "meaning": {
+          "definitions": [
+            "що належить мені, що має відношення до мене ! друже єдиний!"
+          ],
+          "source": "Вікісловник"
+        },
+        "attestation": {
+          "text": "Мій, могО (моЄго), моЄму, (мОму, моймУ), мест. Мой.",
+          "source": "Грінченко (1907)"
+        },
+        "etymology": {
+          "text": "мій (моя, моє, мої); — р. бр. болт.",
+          "source": "ЕСУМ, т. 3, с. 473"
+        },
+        "sources": [
+          "VESUM",
+          "Вікісловник",
+          "Грінченко (1907)",
+          "ЕСУМ, т. 3, с. 473"
+        ]
+      }
+    },
+    {
+      "lemma": "міроприємство",
+      "url_slug": "міроприємство",
+      "gloss": "avoid: захід",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "surzhyk_to_avoid",
+      "seed_group": "surzhyk-to-avoid",
+      "course_usage": [],
+      "heritage_status": {
+        "classification": "russianism",
+        "attestations": [
+          {
+            "source": "standard_alternative",
+            "ref": "захід",
+            "detail": "Ukrainian standard alternative for міроприємство"
+          },
+          {
+            "source": "lt_replacements",
+            "ref": "docs/best-practices/heritage-attestation-engine.md",
+            "detail": "local correction evidence; no authentic dictionary attestation found"
+          }
+        ],
+        "is_russianism": true,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": {
+          "standard_alternatives": [
+            "захід"
+          ]
+        }
+      }
+    },
+    {
+      "lemma": "місто",
+      "url_slug": "місто",
+      "gloss": "city",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "місто",
+            "detail": "lemma match (17 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 17,
+          "forms": [
+            {
+              "form": "містові",
+              "label": "сер., давальний"
+            },
+            {
+              "form": "місту",
+              "label": "сер., давальний"
+            },
+            {
+              "form": "місто",
+              "label": "сер., кличний"
+            },
+            {
+              "form": "місті",
+              "label": "сер., місцевий"
+            },
+            {
+              "form": "містові",
+              "label": "сер., місцевий"
+            },
+            {
+              "form": "місту",
+              "label": "сер., місцевий"
+            },
+            {
+              "form": "місто",
+              "label": "сер., називний"
+            },
+            {
+              "form": "містом",
+              "label": "сер., орудний"
+            },
+            {
+              "form": "міста",
+              "label": "сер., родовий"
+            },
+            {
+              "form": "місто",
+              "label": "сер., знахідний"
+            },
+            {
+              "form": "містам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "міста",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "містах",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "міста",
+              "label": "множина, називний"
+            },
+            {
+              "form": "містами",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "міст",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "міста",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "місто",
+                "plural": "міста"
+              },
+              "родовий": {
+                "singular": "міста",
+                "plural": "міст"
+              },
+              "давальний": {
+                "singular": "містові / місту",
+                "plural": "містам"
+              },
+              "знахідний": {
+                "singular": "місто",
+                "plural": "міста"
+              },
+              "орудний": {
+                "singular": "містом",
+                "plural": "містами"
+              },
+              "місцевий": {
+                "singular": "місті / містові / місту",
+                "plural": "містах"
+              },
+              "кличний": {
+                "singular": "місто",
+                "plural": "міста"
+              }
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "МІ́СТО¹, а, с. 1. Великий населений пункт; адміністративний, промисловий, торговий і культурний центр. Жила удова коло бучного міста, де бучнії будинки громоздилися, де сяли та виблискували церкви золотохресті (Вовчок, І, 1955, 287); Я склав план реконструкції кількох площ і вулиць міста з метою його благоустрою (Довж., І, 1958, 25). 2. заст. Місце, де відбувається базар (у 1 знач.). Піднялися на місто йти бублейниці, палянишниці і ті, що кухликами пшоно, а ложками олію продають (Кв.-Осн., II, 1956, 10); — Я трохи полежу, а ти побіжи на місто та купи хліба… (Коцюб., І, 1955, 133). 3. заст. Міс"
+          ],
+          "source": "СУМ-11",
+          "sovietization_risk": 0,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
+        },
+        "etymology": {
+          "text": "МІСТО місто «великий населений пункт; (заст.) місцевість, місце», містечко «селище міського типу», [містйлище] «посудина, резервуар» Ж, містина «місце, місцевість, [містечко Ж1», [містиско] «плацента» Ж» [містйще, містій] «те.» Ж, [містич] «міщанин» Ж» Імістові] «мито за право торгівлі на базарі», [,містдчко] «містечко, ринок» Ж, [містим] «мешканець міста» Ж, [містяче] «міське мито» Ж, містянйн «мешканець міста», міщанйн, міщанство, [міщанчук] «син міщанина», [міщук] «мешканець міста, міщанин» Ж, [місто] «замість; ніби», [мість1 «замість», [мійский] «міський» Ж, Б і, [містйвий] «змістовний» Ж,",
+          "source": "ЕСУМ, т. 3, с. 482"
+        },
+        "sources": [
+          "VESUM",
+          "ЕСУМ, т. 3, с. 482",
+          "СУМ-11"
+        ]
+      }
+    },
+    {
+      "lemma": "на́голос",
+      "url_slug": "на-голос",
+      "gloss": "stress",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 1,
+          "slug": "sounds-letters-and-hello",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "наголос",
+            "detail": "lemma match (18 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
         "sovietization_risk": 0,
         "calque_warning": null
       }
@@ -3961,8 +8091,8 @@
     {
       "lemma": "навчатися",
       "url_slug": "навчатися",
-      "gloss": "to study",
-      "pos": "verb",
+      "gloss": "to study; to learn",
+      "pos": "infinitive",
       "ipa": null,
       "primary_source": "built_vocabulary",
       "course_usage": [
@@ -3973,6 +8103,20 @@
           "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "навчатися",
+            "detail": "lemma match (37 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 1,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "дієслово",
@@ -4179,7 +8323,12 @@
             "НАВЧА́ТИСЯ і НАУЧА́ТИСЯ, а́юся, а́єшся, недок., НАВЧИТИСЯ, чу́ся, чи́шся і НАУЧИ́ТИСЯ, учу́ся, у́чишся, док., без додатка, чого, рідко чому або з інфін. Набувати яких-небудь знань, вивчати, опановувати щось. — Ми, грішні люди, вік свій навчаємось, а проте і ми не до краю розумні кладемось у домовину (Вовчок, VI, 1956, 278); Не дуріте самі себе. Учітесь, читайте, І чужому научайтесь, й свого не цурайтесь (Шевч., І, 1963, 334); Я розповідала йому.. про те, як я навчалась співати циганські романси і танцювати на столі (Л. Укр., III, 1952, 707); Навчається добре бабусина внучка. Погано лише, що ро"
           ],
           "source": "СУМ-11",
+          "sovietization_risk": 1,
           "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті.",
+          "sovietization_keywords": [
+            "ленін",
+            "радянськ"
+          ],
           "synonyms": [
             "учитися",
             "вчитися"
@@ -4194,14 +8343,30 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "навчаюся",
+      "url_slug": "навчаюся",
+      "gloss": "I study; I learn",
+      "pos": "verb form",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
             "ref": "навчатися",
-            "detail": "lemma match (37 forms)"
+            "detail": "word_form match for lemma query"
           }
         ],
         "is_russianism": false,
@@ -4214,7 +8379,7 @@
       "lemma": "нарешті",
       "url_slug": "нарешті",
       "gloss": "finally",
-      "pos": "adv",
+      "pos": "sequence word",
       "ipa": null,
       "primary_source": "built_vocabulary",
       "course_usage": [
@@ -4225,6 +8390,20 @@
           "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "нарешті",
+            "detail": "lemma match (1 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "прислівник",
@@ -4262,44 +8441,44 @@
           "Горох (за ЕСУМ)",
           "Грінченко (1907)"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "ніколи",
+      "url_slug": "ніколи",
+      "gloss": "never",
+      "pos": "adverb",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
-            "ref": "нарешті",
-            "detail": "lemma match (1 forms)"
+            "ref": "ніколи",
+            "detail": "lemma match (2 forms)"
           }
         ],
         "is_russianism": false,
         "russian_shadow": false,
         "sovietization_risk": 0,
         "calque_warning": null
-      }
-    },
-    {
-      "lemma": "нормально",
-      "url_slug": "нормально",
-      "gloss": "okay",
-      "pos": null,
-      "ipa": null,
-      "primary_source": "plan_recommended",
-      "course_usage": [
-        {
-          "track": "a1",
-          "module_num": 1,
-          "slug": "sounds-letters-and-hello",
-          "context": "plan_recommended"
-        }
-      ],
+      },
       "enrichment": {
         "morphology": {
           "pos": "прислівник",
           "form_count": 1,
           "forms": [
             {
-              "form": "нормально",
+              "form": "ніколи",
               "label": ""
             }
           ],
@@ -4307,46 +8486,50 @@
         },
         "meaning": {
           "definitions": [
-            "НОРМА́ЛЬНО. Присл. до норма́льний 1. Тепер все буде краще, бо з завтрашнього дня почну працювати, значить, буду жити нормально (Коцюб., III, 1956, 408); // у знач. присудк. сл. Хіба ж це нормально, що Ліні раз у раз стає соромно за батька, її дратує ота його впевненість у власній безгрішності (Гончар, Тронка, 1963, 147)."
+            "ні в який час, ні за яких обставин"
           ],
-          "source": "СУМ-11",
-          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
+          "source": "Вікісловник"
+        },
+        "attestation": {
+          "text": "Ніколи нар. Некогда, нет времени.",
+          "source": "Грінченко (1907)"
         },
         "sources": [
           "VESUM",
-          "СУМ-11"
+          "Вікісловник",
+          "Грінченко (1907)"
         ]
-      },
-      "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "нормально",
-            "detail": "lemma match (1 forms)"
-          }
-        ],
-        "is_russianism": false,
-        "russian_shadow": false,
-        "sovietization_risk": 0,
-        "calque_warning": null
       }
     },
     {
       "lemma": "ніс",
       "url_slug": "ніс",
       "gloss": "nose",
-      "pos": null,
+      "pos": "noun",
       "ipa": null,
-      "primary_source": "plan_recommended",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 1,
           "slug": "sounds-letters-and-hello",
-          "context": "plan_recommended"
+          "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "ніс",
+            "detail": "lemma match (18 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -4481,27 +8664,53 @@
           "Горох (за ЕСУМ)",
           "Грінченко (1907)"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "о́ко",
+      "url_slug": "о-ко",
+      "gloss": "eye",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 1,
+          "slug": "sounds-letters-and-hello",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
-            "ref": "ніс",
-            "detail": "lemma match (18 forms)"
+            "ref": "око",
+            "detail": "lemma match (21 forms)"
           }
         ],
         "is_russianism": false,
         "russian_shadow": false,
-        "sovietization_risk": 0,
+        "sovietization_risk": 1,
         "calque_warning": null
+      },
+      "enrichment": {
+        "etymology": {
+          "text": "псл. oko; споріднене з лит. akìs «око», лтс. acs, прус. ackis, дінд. а́kṣī « тс. », ав. aši «очі», тох. А ak «око», В ek « тс. », вірм. akn «око; отвір, дірка», гр.ὄκκος «око», лат. oculus, гот. augō, дісл. auga, нвн. Auge, англ. eye « тс. », далі, очевидно, з гр. ὄδδομαι «бачу, дивлюся», ὀπή «отвір, дірка», ὄψομαι «побачу», ὀπτός «видний, видимий», ὤψ (род. в. ὠπός) «погляд; очі; обличчя»; іє. *oku̯- «бачити; око»; р. м. о́ко, бр. во́ка, др. око, п. ч. слц. oko, вл. нл. woko, нл. hoko, болг. око́, схв. о̏ кo, слн. okó, стсл. око;",
+          "source": "Горох (за ЕСУМ)",
+          "source_url": "https://goroh.pp.ua/%D0%95%D1%82%D0%B8%D0%BC%D0%BE%D0%BB%D0%BE%D0%B3%D1%96%D1%8F/%D0%BE%D0%BA%D0%BE"
+        },
+        "sources": [
+          "Горох (за ЕСУМ)"
+        ]
       }
     },
     {
       "lemma": "одягатися",
       "url_slug": "одягатися",
       "gloss": "to get dressed",
-      "pos": "verb",
+      "pos": "infinitive",
       "ipa": null,
       "primary_source": "built_vocabulary",
       "course_usage": [
@@ -4512,6 +8721,20 @@
           "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "одягатися",
+            "detail": "lemma match (37 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "дієслово",
@@ -4718,6 +8941,7 @@
             "ОДЯГА́ТИСЯ, а́юся, а́єшся, недок., ОДЯГТИ́СЯ і ОДЯГНУ́ТИСЯ, одягну́ся, одя́гнешся; мин. ч. одя́гся, ла́ся, ло́ся і одягну́вся, ну́лася, лося; док. 1. у що і без додатка. Покривати себе яким-небудь одягом. Наум хутко достав нову свиту, новий пояс, одягається, підперізується (Кв.-Осн., II, 1956, 55); Погас місяць, горить сонце. Гайдамаки встали, Помолились, одяглися (Шевч., І, 1963, 77); Липтак нашвидку одягнувся в старий, зношений костюм, в якому звик працювати після роботи в школі (Томч., Готель.., 1960, 39); *Образно. Щороку вона [груша] знову.. квітла, одягалася в зелені шати, обіцяючи холод"
           ],
           "source": "СУМ-11",
+          "sovietization_risk": 0,
           "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
         },
         "attestation": {
@@ -4729,191 +8953,30 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "одягаюся",
+      "url_slug": "одягаюся",
+      "gloss": "I get dressed",
+      "pos": "verb form",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
             "ref": "одягатися",
-            "detail": "lemma match (37 forms)"
-          }
-        ],
-        "is_russianism": false,
-        "russian_shadow": false,
-        "sovietization_risk": 0,
-        "calque_warning": null
-      }
-    },
-    {
-      "lemma": "око",
-      "url_slug": "око",
-      "gloss": "eye",
-      "pos": null,
-      "ipa": null,
-      "primary_source": "plan_recommended",
-      "course_usage": [
-        {
-          "track": "a1",
-          "module_num": 1,
-          "slug": "sounds-letters-and-hello",
-          "context": "plan_recommended"
-        }
-      ],
-      "enrichment": {
-        "morphology": {
-          "pos": "іменник",
-          "form_count": 21,
-          "forms": [
-            {
-              "form": "окові",
-              "label": "сер., давальний"
-            },
-            {
-              "form": "оку",
-              "label": "сер., давальний"
-            },
-            {
-              "form": "око",
-              "label": "сер., кличний"
-            },
-            {
-              "form": "оку",
-              "label": "сер., місцевий"
-            },
-            {
-              "form": "оці",
-              "label": "сер., місцевий"
-            },
-            {
-              "form": "око",
-              "label": "сер., називний"
-            },
-            {
-              "form": "оком",
-              "label": "сер., орудний"
-            },
-            {
-              "form": "ока",
-              "label": "сер., родовий"
-            },
-            {
-              "form": "око",
-              "label": "сер., знахідний"
-            },
-            {
-              "form": "очам",
-              "label": "множина, давальний"
-            },
-            {
-              "form": "очі",
-              "label": "множина, кличний"
-            },
-            {
-              "form": "очах",
-              "label": "множина, місцевий"
-            },
-            {
-              "form": "очу",
-              "label": "множина, місцевий"
-            },
-            {
-              "form": "очі",
-              "label": "множина, називний"
-            },
-            {
-              "form": "ока",
-              "label": "множина, називний"
-            },
-            {
-              "form": "очима",
-              "label": "множина, орудний"
-            },
-            {
-              "form": "очами",
-              "label": "множина, орудний"
-            },
-            {
-              "form": "очей",
-              "label": "множина, родовий"
-            },
-            {
-              "form": "вічі",
-              "label": "множина, знахідний"
-            },
-            {
-              "form": "очі",
-              "label": "множина, знахідний"
-            },
-            {
-              "form": "ока",
-              "label": "множина, знахідний"
-            }
-          ],
-          "source": "VESUM",
-          "paradigm": {
-            "kind": "noun",
-            "cases": {
-              "називний": {
-                "singular": "око",
-                "plural": "очі / ока"
-              },
-              "родовий": {
-                "singular": "ока",
-                "plural": "очей"
-              },
-              "давальний": {
-                "singular": "окові / оку",
-                "plural": "очам"
-              },
-              "знахідний": {
-                "singular": "око",
-                "plural": "вічі / очі / ока"
-              },
-              "орудний": {
-                "singular": "оком",
-                "plural": "очима / очами"
-              },
-              "місцевий": {
-                "singular": "оку / оці",
-                "plural": "очах / очу"
-              },
-              "кличний": {
-                "singular": "око",
-                "plural": "очі"
-              }
-            }
-          }
-        },
-        "meaning": {
-          "definitions": [
-            "орган зору"
-          ],
-          "source": "Вікісловник"
-        },
-        "attestation": {
-          "text": "Око, Ока, с. (мн. Очі). 1) Глаз. Сама робить, а око біжить до дитинки. МВ. І. 98. Біжить він, куди очі стоять. Грин. II. 284. Тоді я тебе забуду, як очі заплющу. Мет. 62. очі-на-очі = віч-на-віч. Ном. № 7424. на око. На вид, на взгляд. на все око. Во все глаза. Галя на все око дивиться, як хлопець пручається. Св. Л. 204. в оці бути. Быть на глазах, на виду. Тобі добре: ти у боці, а я що раз ув оці, то мені й докоряє, як що не так. Волч. у. очі довбти чим. Укорять за что. Тітка було усе мені очі паничем довбе. О. 1862. VII. 42. і очу не Явить. И глаз не показывает. Кролев. у. і в вічі не бачити",
-          "source": "Грінченко (1907)"
-        },
-        "etymology": {
-          "text": "псл. oko; споріднене з лит. akìs «око», лтс. acs, прус. ackis, дінд. а́kṣī « тс. », ав. aši «очі», тох. А ak «око», В ek « тс. », вірм. akn «око; отвір, дірка», гр.ὄκκος «око», лат. oculus, гот. augō, дісл. auga, нвн. Auge, англ. eye « тс. », далі, очевидно, з гр. ὄδδομαι «бачу, дивлюся», ὀπή «отвір, дірка», ὄψομαι «побачу», ὀπτός «видний, видимий», ὤψ (род. в. ὠπός) «погляд; очі; обличчя»; іє. *oku̯- «бачити; око»; р. м. о́ко, бр. во́ка, др. око, п. ч. слц. oko, вл. нл. woko, нл. hoko, болг. око́, схв. о̏ кo, слн. okó, стсл. око;",
-          "source": "Горох (за ЕСУМ)",
-          "source_url": "https://goroh.pp.ua/%D0%95%D1%82%D0%B8%D0%BC%D0%BE%D0%BB%D0%BE%D0%B3%D1%96%D1%8F/%D0%BE%D0%BA%D0%BE"
-        },
-        "sources": [
-          "VESUM",
-          "Вікісловник",
-          "Горох (за ЕСУМ)",
-          "Грінченко (1907)"
-        ]
-      },
-      "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "око",
-            "detail": "lemma match (21 forms)"
+            "detail": "word_form match for lemma query"
           }
         ],
         "is_russianism": false,
@@ -4926,17 +8989,31 @@
       "lemma": "повертатися",
       "url_slug": "повертатися",
       "gloss": "to return",
-      "pos": "verb",
+      "pos": null,
       "ipa": null,
-      "primary_source": "built_vocabulary",
+      "primary_source": "plan_recommended",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 20,
           "slug": "my-morning",
-          "context": "built_vocabulary"
+          "context": "plan_recommended"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "повертатися",
+            "detail": "lemma match (37 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "дієслово",
@@ -5143,6 +9220,7 @@
             "ПОВЕРТА́ТИСЯ¹, а́юся, а́єшся, недок., ПОВЕРНУ́ТИСЯ, верну́ся, ве́рнешся, док. 1. Обертаючись, вертячись, змінювати своє положення. Натиснув [Марко] обома руками ключ. Він не повертався (Мик., II, 1957, 325); На столі стояв величезний, незвичайний глобус, який сам весь час повертався (Ів., Вел. очі, 1956, 91); — Держав [Андрій] маслянку, а шестерня раптом і того… і повернулась… (Коцюб., II, 1955, 48); // Роблячи поворот, змінювати положення свого тіла (про людей, тварин). Роздягнутий по пояс, він стояв у садку в медсанбаті перед сестрою й, піднявши руки на голову, поволі повертався, вмотуючись"
           ],
           "source": "СУМ-11",
+          "sovietization_risk": 0,
           "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
         },
         "attestation": {
@@ -5154,37 +9232,37 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
-      },
-      "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "повертатися",
-            "detail": "lemma match (37 forms)"
-          }
-        ],
-        "is_russianism": false,
-        "russian_shadow": false,
-        "sovietization_risk": 0,
-        "calque_warning": null
       }
     },
     {
       "lemma": "поспішати",
       "url_slug": "поспішати",
       "gloss": "to hurry",
-      "pos": "verb",
+      "pos": null,
       "ipa": null,
-      "primary_source": "built_vocabulary",
+      "primary_source": "plan_recommended",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 20,
           "slug": "my-morning",
-          "context": "built_vocabulary"
+          "context": "plan_recommended"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "поспішати",
+            "detail": "lemma match (24 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "дієслово",
@@ -5339,6 +9417,7 @@
             "ПОСПІША́ТИ, а́ю, а́єш, недок., ПОСПІШИ́ТИ, шу́, ши́ш, док. 1. з інфін., з чим і без додатка. Старатися, намагатися якнайшвидше зробити що-небудь, виконати якусь роботу; спішити, квапитися. Вона кидалась до всього, бігала, поспішала перемивати й перетирати, щоб було вільно, коли подруга прийде, щоб побалакати з нею (Мирний, III, 1954, 175); Старий Варчук поспішав скосити перестиглий овес (Стельмах, На.. землі, 1949, 168); Хоч як поспішав Бутаков з роботою, він бачив, що раніше, ніж до Нового року, матеріали його експедиції не потраплять до столиці (Тулуб, В степу.., 1964, 431); Збоку при смолос"
           ],
           "source": "СУМ-11",
+          "sovietization_risk": 0,
           "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті.",
           "synonyms": [
             "квапитися",
@@ -5360,27 +9439,13 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
-      },
-      "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "поспішати",
-            "detail": "lemma match (24 forms)"
-          }
-        ],
-        "is_russianism": false,
-        "russian_shadow": false,
-        "sovietization_risk": 0,
-        "calque_warning": null
       }
     },
     {
       "lemma": "потім",
       "url_slug": "потім",
       "gloss": "then",
-      "pos": "adv",
+      "pos": "sequence word",
       "ipa": null,
       "primary_source": "built_vocabulary",
       "course_usage": [
@@ -5391,6 +9456,20 @@
           "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "потім",
+            "detail": "lemma match (1 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "прислівник",
@@ -5408,6 +9487,7 @@
             "ПО́ТІМ, присл. 1. Після чого-небудь (для позначення послідовності у часі). Всяк розумний по-своєму: один спершу, а другий потім (Укр.. присл.., 1955, 319); Коло осіннього Миколи, Обідрані, трохи́ не голі, Бендерським шляхом уночі ішли цигане.. Ішли, ішли, а потім стали (Шевч., II, 1963, 303); Дочка глянула на матір, потім на батька і знову перевела очі на матір (Мирний, IV, 1955, 223); Урядник люто підняв нагайку, махнув нею в повітрі, потім скочив на коня, всадив в боки шпори і, як чорт, майнув од церковної огорожі (Стельмах, І, 1962, 460); // Через деякий час, іншим разом; згодом, пізніше. Т"
           ],
           "source": "СУМ-11",
+          "sovietization_risk": 0,
           "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті.",
           "synonyms": [
             "тоді",
@@ -5429,178 +9509,26 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
-      },
-      "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "потім",
-            "detail": "lemma match (1 forms)"
-          }
-        ],
-        "is_russianism": false,
-        "russian_shadow": false,
-        "sovietization_risk": 0,
-        "calque_warning": null
       }
     },
     {
-      "lemma": "привіт",
-      "url_slug": "привіт",
-      "gloss": "hi, informal",
-      "pos": null,
+      "lemma": "при́голосний звук",
+      "url_slug": "при-голосний-звук",
+      "gloss": "consonant sound",
+      "pos": "noun phrase",
       "ipa": null,
-      "primary_source": "plan_required",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 1,
           "slug": "sounds-letters-and-hello",
-          "context": "plan_required"
+          "context": "built_vocabulary"
         }
       ],
-      "enrichment": {
-        "morphology": {
-          "pos": "іменник",
-          "form_count": 17,
-          "forms": [
-            {
-              "form": "привітові",
-              "label": "чол., давальний"
-            },
-            {
-              "form": "привіту",
-              "label": "чол., давальний"
-            },
-            {
-              "form": "привіте",
-              "label": "чол., кличний"
-            },
-            {
-              "form": "привіті",
-              "label": "чол., місцевий"
-            },
-            {
-              "form": "привітові",
-              "label": "чол., місцевий"
-            },
-            {
-              "form": "привіту",
-              "label": "чол., місцевий"
-            },
-            {
-              "form": "привіт",
-              "label": "чол., називний"
-            },
-            {
-              "form": "привітом",
-              "label": "чол., орудний"
-            },
-            {
-              "form": "привіту",
-              "label": "чол., родовий"
-            },
-            {
-              "form": "привіт",
-              "label": "чол., знахідний"
-            },
-            {
-              "form": "привітам",
-              "label": "множина, давальний"
-            },
-            {
-              "form": "привіти",
-              "label": "множина, кличний"
-            },
-            {
-              "form": "привітах",
-              "label": "множина, місцевий"
-            },
-            {
-              "form": "привіти",
-              "label": "множина, називний"
-            },
-            {
-              "form": "привітами",
-              "label": "множина, орудний"
-            },
-            {
-              "form": "привітів",
-              "label": "множина, родовий"
-            },
-            {
-              "form": "привіти",
-              "label": "множина, знахідний"
-            }
-          ],
-          "source": "VESUM",
-          "paradigm": {
-            "kind": "noun",
-            "cases": {
-              "називний": {
-                "singular": "привіт",
-                "plural": "привіти"
-              },
-              "родовий": {
-                "singular": "привіту",
-                "plural": "привітів"
-              },
-              "давальний": {
-                "singular": "привітові / привіту",
-                "plural": "привітам"
-              },
-              "знахідний": {
-                "singular": "привіт",
-                "plural": "привіти"
-              },
-              "орудний": {
-                "singular": "привітом",
-                "plural": "привітами"
-              },
-              "місцевий": {
-                "singular": "привіті / привітові / привіту",
-                "plural": "привітах"
-              },
-              "кличний": {
-                "singular": "привіте",
-                "plural": "привіти"
-              }
-            }
-          }
-        },
-        "meaning": {
-          "definitions": [
-            "ПРИВІ́Т, у, ч. 1. Вираження доброзичливого ставлення, дружніх почуттів до кого-небудь. [Грицько:] Ви ж знаєте, що наші старі й досі ворогують, — одно на одного дивитись не зможе. А от Євдокія Васильовна, спасибі їм, до мене завжди з добрим словом і привітом (Мирний, V, 1955, 151); Батько з сином замість привіту після довгої розлуки почали молотити один одного (Довж., І, 1958, 218); *Образно. Я до віконечка поліз.. Ще раз поглянути на світ Та горам кинути привіт (Граб., І, 1959, 408); // Слова, які виражають таке ставлення, такі почуття. [Xуса:] Невже тобі так тяжко привітати моїх гостей? Я ж н"
-          ],
-          "source": "СУМ-11",
-          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
-        },
-        "attestation": {
-          "text": "Привіт, -ту, м. Привет, приветствіе. Харьк. г. Мет. 242.",
-          "source": "Грінченко (1907)"
-        },
-        "etymology": {
-          "text": "псл. privětъ, утворене від дієслова privětiti «привітати», пов’язаного з větь «гілка» (первісно означало «наблизитися з гілкою як символом важливого повідомлення» або «прийняти з урочистою гілкою»); зворотне виведення псл. privětiti від privětъ (Mikl. EW 388; Фасмер ІІІ 363) малопереконливе; р. болг. приве́т, бр. прыве́тны «привітний», др. привѣтъ, ч. заст. přívět, слц. заст. prívet, м. приветлив «привітний», цсл. привѣтъ;",
-          "source": "Горох (за ЕСУМ)",
-          "source_url": "https://goroh.pp.ua/%D0%95%D1%82%D0%B8%D0%BC%D0%BE%D0%BB%D0%BE%D0%B3%D1%96%D1%8F/%D0%BF%D1%80%D0%B8%D0%B2%D1%96%D1%82"
-        },
-        "sources": [
-          "VESUM",
-          "Горох (за ЕСУМ)",
-          "Грінченко (1907)",
-          "СУМ-11"
-        ]
-      },
       "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "привіт",
-            "detail": "lemma match (17 forms)"
-          }
-        ],
+        "classification": "unknown",
+        "attestations": [],
         "is_russianism": false,
         "russian_shadow": false,
         "sovietization_risk": 0,
@@ -5622,6 +9550,20 @@
           "context": "plan_required"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "приголосний",
+            "detail": "lemma match (47 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "прикметник",
@@ -5774,27 +9716,262 @@
           "Вікісловник",
           "Горох (за ЕСУМ)"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "причісуватися",
+      "url_slug": "причісуватися",
+      "gloss": "to comb one's hair — reflexive, supplements core focus",
+      "pos": null,
+      "ipa": null,
+      "primary_source": "plan_recommended",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "plan_recommended"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
-            "ref": "приголосний",
-            "detail": "lemma match (47 forms)"
+            "ref": "причісуватися",
+            "detail": "lemma match (37 forms)"
           }
         ],
         "is_russianism": false,
         "russian_shadow": false,
         "sovietization_risk": 0,
         "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "дієслово",
+          "form_count": 37,
+          "forms": [
+            {
+              "form": "причісуватимемось",
+              "label": "майбутній, множина, 1 ос."
+            },
+            {
+              "form": "причісуватимемося",
+              "label": "майбутній, множина, 1 ос."
+            },
+            {
+              "form": "причісуватимемся",
+              "label": "майбутній, множина, 1 ос."
+            },
+            {
+              "form": "причісуватиметесь",
+              "label": "майбутній, множина, 2 ос."
+            },
+            {
+              "form": "причісуватиметеся",
+              "label": "майбутній, множина, 2 ос."
+            },
+            {
+              "form": "причісуватимуться",
+              "label": "майбутній, множина, 3 ос."
+            },
+            {
+              "form": "причісуватимусь",
+              "label": "майбутній, однина, 1 ос."
+            },
+            {
+              "form": "причісуватимуся",
+              "label": "майбутній, однина, 1 ос."
+            },
+            {
+              "form": "причісуватимешся",
+              "label": "майбутній, однина, 2 ос."
+            },
+            {
+              "form": "причісуватиметься",
+              "label": "майбутній, однина, 3 ос."
+            },
+            {
+              "form": "причісуймось",
+              "label": "наказовий, множина, 1 ос."
+            },
+            {
+              "form": "причісуймося",
+              "label": "наказовий, множина, 1 ос."
+            },
+            {
+              "form": "причісуйтесь",
+              "label": "наказовий, множина, 2 ос."
+            },
+            {
+              "form": "причісуйтеся",
+              "label": "наказовий, множина, 2 ос."
+            },
+            {
+              "form": "причісуйсь",
+              "label": "наказовий, однина, 2 ос."
+            },
+            {
+              "form": "причісуйся",
+              "label": "наказовий, однина, 2 ос."
+            },
+            {
+              "form": "причісуватися",
+              "label": "інфінітив"
+            },
+            {
+              "form": "причісуватись",
+              "label": "інфінітив"
+            },
+            {
+              "form": "причісуваться",
+              "label": "інфінітив"
+            },
+            {
+              "form": "причісувалась",
+              "label": "минулий, жін."
+            },
+            {
+              "form": "причісувалася",
+              "label": "минулий, жін."
+            },
+            {
+              "form": "причісувавсь",
+              "label": "минулий, чол."
+            },
+            {
+              "form": "причісувався",
+              "label": "минулий, чол."
+            },
+            {
+              "form": "причісувалось",
+              "label": "минулий, сер."
+            },
+            {
+              "form": "причісувалося",
+              "label": "минулий, сер."
+            },
+            {
+              "form": "причісувались",
+              "label": "минулий, множина"
+            },
+            {
+              "form": "причісувалися",
+              "label": "минулий, множина"
+            },
+            {
+              "form": "причісуємось",
+              "label": "теперішній, множина, 1 ос."
+            },
+            {
+              "form": "причісуємося",
+              "label": "теперішній, множина, 1 ос."
+            },
+            {
+              "form": "причісуємся",
+              "label": "теперішній, множина, 1 ос."
+            },
+            {
+              "form": "причісуєтесь",
+              "label": "теперішній, множина, 2 ос."
+            },
+            {
+              "form": "причісуєтеся",
+              "label": "теперішній, множина, 2 ос."
+            },
+            {
+              "form": "причісуються",
+              "label": "теперішній, множина, 3 ос."
+            },
+            {
+              "form": "причісуюсь",
+              "label": "теперішній, однина, 1 ос."
+            },
+            {
+              "form": "причісуюся",
+              "label": "теперішній, однина, 1 ос."
+            },
+            {
+              "form": "причісуєшся",
+              "label": "теперішній, однина, 2 ос."
+            },
+            {
+              "form": "причісується",
+              "label": "теперішній, однина, 3 ос."
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "verb",
+            "infinitive": "причісуватися / причісуватись",
+            "tenses": {
+              "теперішній": {
+                "однина": {
+                  "1": "причісуюсь / причісуюся",
+                  "2": "причісуєшся",
+                  "3": "причісується"
+                },
+                "множина": {
+                  "1": "причісуємось / причісуємося / причісуємся",
+                  "2": "причісуєтесь / причісуєтеся",
+                  "3": "причісуються"
+                }
+              },
+              "майбутній": {
+                "однина": {
+                  "1": "причісуватимусь / причісуватимуся",
+                  "2": "причісуватимешся",
+                  "3": "причісуватиметься"
+                },
+                "множина": {
+                  "1": "причісуватимемось / причісуватимемося / причісуватимемся",
+                  "2": "причісуватиметесь / причісуватиметеся",
+                  "3": "причісуватимуться"
+                }
+              }
+            },
+            "imperative": {
+              "однина": {
+                "2": "причісуйсь / причісуйся"
+              },
+              "множина": {
+                "1": "причісуймось / причісуймося",
+                "2": "причісуйтесь / причісуйтеся"
+              }
+            },
+            "past": {
+              "чол.": "причісувавсь / причісувався",
+              "жін.": "причісувалась / причісувалася",
+              "сер.": "причісувалось / причісувалося",
+              "множина": "причісувались / причісувалися"
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "ПРИЧІ́СУВАТИСЯ, уюся, уєшся, недок., ПРИЧЕСА́ТИСЯ, ешу́ся, е́шешся, док. Розчісувати собі волосся, пригладжувати його гребінцем. Скоріш кинулась [Софія] умиватись, причісуватись (Л. Укр., III, 1952, 540); Помившись, Ярослава переодяглася в чисту сукню, сіла причісуватись (Минко, Ясні зорі, 1951, 57); Зараз по обіді, убравшись та причесавшись, Михалчевський пішов у панський садок (Н.-Лев., II, 1956, 136); Вона вдягла своє краще плаття, причепурилась перед дзеркалом, акуратно причесалась (Донч., V, 1957, 281)."
+          ],
+          "source": "СУМ-11",
+          "sovietization_risk": 0,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
+        },
+        "attestation": {
+          "text": "Причісуватися, -суюся, -єшся, сов. в. причесАтися, -шУся, -шешся, гл. Причесываться, причесаться. Довго чепурився, вбірався та причісувався. Левиц. Пов. 205.",
+          "source": "Грінченко (1907)"
+        },
+        "sources": [
+          "VESUM",
+          "Грінченко (1907)",
+          "СУМ-11"
+        ]
       }
     },
     {
       "lemma": "прокидатися",
       "url_slug": "прокидатися",
       "gloss": "to wake up",
-      "pos": "verb",
+      "pos": "infinitive",
       "ipa": null,
       "primary_source": "built_vocabulary",
       "course_usage": [
@@ -5805,6 +9982,20 @@
           "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "прокидатися",
+            "detail": "lemma match (37 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 1,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "дієслово",
@@ -6011,7 +10202,11 @@
             "ПРОКИ́ДАТИСЯ, аюся, аєшся, док., рідко. Кидатися (у 2, 4, 6 знач.) якийсь час. ПРОКИДА́ТИСЯ, а́юся, а́єшся, недок., ПРОКИ́НУТИСЯ, нуся, нешся, док. 1. Переставати спати, дрімати; пробуджуватися від сну; будитися, просипатися. Спав [Котигорошко] день, спав ніч, прокидається, — прив’язаний (Укр.. казки, 1951, 96); Вночі прокидаюсь, сідаю на ліжко й напружено слухаю (Коцюб., ІІ,1955,231); Прокидається Іванко і до ранку не спить (Хижняк, Д. Галицький, 1958, 133); Гарматій, прокидаючись від напівсну, підтягнув обвислу нижню губу і перелякано зашамкав (Стельмах, І, 1962, 333); Життя горил має яскрав"
           ],
           "source": "СУМ-11",
-          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
+          "sovietization_risk": 1,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті.",
+          "sovietization_keywords": [
+            "ленін"
+          ]
         },
         "attestation": {
           "text": "Прокидатися, -даюся, -єшся, сов. в. прокинутися, -нуся, -нешся, гл. 1) Просыпаться, проснуться. Вночі прокинешся, — не спить Василько мій. МВ. ІІ. 9. Иногда прокинутися в знач. очнуться. МВ. (О. 1862. III. 41). Зомлів Марко, й земля задріжали... Прокинувся... до матері, — а мати вже спала. Шевч. 118. 2) Появляться, появиться; встречаться, случаться. Щоки повпадали і вже волосся прокидається біле. О. 1862. X. 8. Стали прокидатись де-где й злодіячки — новина в Пісках. Мир. ХРВ. 119. Все ж таки прокидається такий час, шо вони й гулящі бувають, і одпочинуть як слід. Драг. 171. 3) Только сов. в. ?",
@@ -6028,27 +10223,13 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
-      },
-      "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "прокидатися",
-            "detail": "lemma match (37 forms)"
-          }
-        ],
-        "is_russianism": false,
-        "russian_shadow": false,
-        "sovietization_risk": 0,
-        "calque_warning": null
       }
     },
     {
-      "lemma": "пізно",
-      "url_slug": "пізно",
-      "gloss": "late",
-      "pos": "adv",
+      "lemma": "прокидаюся",
+      "url_slug": "прокидаюся",
+      "gloss": "I wake up",
+      "pos": "verb form",
       "ipa": null,
       "primary_source": "built_vocabulary",
       "course_usage": [
@@ -6059,6 +10240,155 @@
           "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "прокидатися",
+            "detail": "word_form match for lemma query"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
+    },
+    {
+      "lemma": "прокидається",
+      "url_slug": "прокидається",
+      "gloss": "he/she wakes up",
+      "pos": "verb form",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "прокидатися",
+            "detail": "word_form match for lemma query"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
+    },
+    {
+      "lemma": "прокидаєшся",
+      "url_slug": "прокидаєшся",
+      "gloss": "you wake up",
+      "pos": "verb form",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "прокидатися",
+            "detail": "word_form match for lemma query"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
+    },
+    {
+      "lemma": "протиріччя",
+      "url_slug": "протиріччя",
+      "gloss": "avoid: суперечність",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "surzhyk_to_avoid",
+      "seed_group": "surzhyk-to-avoid",
+      "course_usage": [],
+      "heritage_status": {
+        "classification": "russianism",
+        "attestations": [
+          {
+            "source": "standard_alternative",
+            "ref": "суперечність",
+            "detail": "Ukrainian standard alternative for протиріччя"
+          },
+          {
+            "source": "standard_alternative",
+            "ref": "сперечання",
+            "detail": "Ukrainian standard alternative for протиріччя"
+          },
+          {
+            "source": "standard_alternative",
+            "ref": "супротивність",
+            "detail": "Ukrainian standard alternative for протиріччя"
+          },
+          {
+            "source": "lt_replacements",
+            "ref": "docs/best-practices/heritage-attestation-engine.md",
+            "detail": "local correction evidence; no authentic dictionary attestation found"
+          }
+        ],
+        "is_russianism": true,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": {
+          "standard_alternatives": [
+            "суперечність",
+            "сперечання",
+            "супротивність"
+          ]
+        }
+      }
+    },
+    {
+      "lemma": "пізно",
+      "url_slug": "пізно",
+      "gloss": "late",
+      "pos": "adverb",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "пізно",
+            "detail": "lemma match (1 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "прислівник",
@@ -6076,6 +10406,7 @@
             "ПІ́ЗНО. Присл. до пі́зній. Другий розказував: як п’яниця пізно увечері йшов з шинку (Кв.-Осн., II, 1956, 229); — Сосну треба рубати пізно восени, — писав Професор (Ю. Янов., II, 1958, 124); Книжки дорогою пропали, а лист прийшов дуже пізно (Л. Укр., V, 1956, 100); — Схаменешся ти, та пізно, Солопію! (Г.-Арт., Байки.., 1958, 61); // у знач. присудк. сл. Орел змахнув крильми, підвівся на весь зріст, але було вже пізно: мотузок душив його і здирав із гілки (Тулуб, В степу.., 1964, 152). ◊ Ра́но чи пі́зно — коли-небудь у майбутньому (про те, що обов’язково відбудеться, трапиться). — Я вірю, що ран"
           ],
           "source": "СУМ-11",
+          "sovietization_risk": 0,
           "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
         },
         "attestation": {
@@ -6087,27 +10418,13 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
-      },
-      "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "пізно",
-            "detail": "lemma match (1 forms)"
-          }
-        ],
-        "is_russianism": false,
-        "russian_shadow": false,
-        "sovietization_risk": 0,
-        "calque_warning": null
       }
     },
     {
       "lemma": "після цього",
       "url_slug": "після-цього",
       "gloss": "after that",
-      "pos": "phrase",
+      "pos": "sequence phrase",
       "ipa": null,
       "primary_source": "built_vocabulary",
       "course_usage": [
@@ -6128,9 +10445,69 @@
       }
     },
     {
-      "lemma": "робота",
-      "url_slug": "робота",
-      "gloss": "work",
+      "lemma": "рано",
+      "url_slug": "рано",
+      "gloss": "early",
+      "pos": "adverb",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "рано",
+            "detail": "lemma match (1 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "прислівник",
+          "form_count": 1,
+          "forms": [
+            {
+              "form": "рано",
+              "label": ""
+            }
+          ],
+          "source": "VESUM"
+        },
+        "meaning": {
+          "definitions": [
+            "РА́НО¹, присл. 1. У ранішній час. I квилить, плаче Ярославна В Путивлі рано на валу (Шевч., II, 1963, 387); — Я люблю вставати рано й сідать до роботи (Коцюб., II, 1955, 252); — Куди це так рано? — кволим і розніженим зі сну голосом запитала Юля (Тют., Вир, 1964, 225); // у знач. присудк. сл. Рано ще. Сонце тільки що схопилося, та таке пекуче, сердите, мов хто не дав йому виспатись (Мирний, І, 1949, 190). 2. На початку якого-небудь періоду, відрізку часу і т. ін. Чули ви, як напровесні рано Жайворонкова пісня бриніла? (Л. Укр., І, 1951, 26). 3. Раніше, ніж належить, ніж звичайно буває, ніж мож"
+          ],
+          "source": "СУМ-11",
+          "sovietization_risk": 0,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
+        },
+        "attestation": {
+          "text": "Рано нар. 1) Рано. Прийшов пізно, аж завізно; прийшов рано, так не дано. Ном. № 1802. Ой дівчино, збуди мене рано, так рано, щоб ще не світало. Чуб. V. 63. 2) Утром. Приложи ти, моя мила, до голови рути; клади рано і ввечері, щоб здоровій бути. Н. п. Викопайте криниченьку в вишневім саду, чи не прийде дівчинонька рано по воду. Н. п. рано-пораненьку, рано-раненько, рано-вранці. Рано утром. Ой в неділю рано-пораненьку брала дівчина льон. Чуб. V. 290. Встала вона рано-раненько, умилася біло-біленько. Чуб. V. 704. Ой у неділеньку ввесь день пила, в понеділок спала, а в вівторок снопів сорок пшенич",
+          "source": "Грінченко (1907)"
+        },
+        "sources": [
+          "VESUM",
+          "Грінченко (1907)",
+          "СУМ-11"
+        ]
+      }
+    },
+    {
+      "lemma": "ранок",
+      "url_slug": "ранок",
+      "gloss": "morning",
       "pos": "noun",
       "ipa": null,
       "primary_source": "built_vocabulary",
@@ -6142,65 +10519,87 @@
           "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "ранок",
+            "detail": "lemma match (16 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
-          "form_count": 14,
+          "form_count": 16,
           "forms": [
             {
-              "form": "роботі",
-              "label": "жін., давальний"
+              "form": "ранкові",
+              "label": "чол., давальний"
             },
             {
-              "form": "робото",
-              "label": "жін., кличний"
+              "form": "ранку",
+              "label": "чол., давальний"
             },
             {
-              "form": "роботі",
-              "label": "жін., місцевий"
+              "form": "ранку",
+              "label": "чол., кличний"
             },
             {
-              "form": "робота",
-              "label": "жін., називний"
+              "form": "ранкові",
+              "label": "чол., місцевий"
             },
             {
-              "form": "роботою",
-              "label": "жін., орудний"
+              "form": "ранку",
+              "label": "чол., місцевий"
             },
             {
-              "form": "роботи",
-              "label": "жін., родовий"
+              "form": "ранок",
+              "label": "чол., називний"
             },
             {
-              "form": "роботу",
-              "label": "жін., знахідний"
+              "form": "ранком",
+              "label": "чол., орудний"
             },
             {
-              "form": "роботам",
+              "form": "ранку",
+              "label": "чол., родовий"
+            },
+            {
+              "form": "ранок",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "ранкам",
               "label": "множина, давальний"
             },
             {
-              "form": "роботи",
+              "form": "ранки",
               "label": "множина, кличний"
             },
             {
-              "form": "роботах",
+              "form": "ранках",
               "label": "множина, місцевий"
             },
             {
-              "form": "роботи",
+              "form": "ранки",
               "label": "множина, називний"
             },
             {
-              "form": "роботами",
+              "form": "ранками",
               "label": "множина, орудний"
             },
             {
-              "form": "робіт",
+              "form": "ранків",
               "label": "множина, родовий"
             },
             {
-              "form": "роботи",
+              "form": "ранки",
               "label": "множина, знахідний"
             }
           ],
@@ -6209,49 +10608,45 @@
             "kind": "noun",
             "cases": {
               "називний": {
-                "singular": "робота",
-                "plural": "роботи"
+                "singular": "ранок",
+                "plural": "ранки"
               },
               "родовий": {
-                "singular": "роботи",
-                "plural": "робіт"
+                "singular": "ранку",
+                "plural": "ранків"
               },
               "давальний": {
-                "singular": "роботі",
-                "plural": "роботам"
+                "singular": "ранкові / ранку",
+                "plural": "ранкам"
               },
               "знахідний": {
-                "singular": "роботу",
-                "plural": "роботи"
+                "singular": "ранок",
+                "plural": "ранки"
               },
               "орудний": {
-                "singular": "роботою",
-                "plural": "роботами"
+                "singular": "ранком",
+                "plural": "ранками"
               },
               "місцевий": {
-                "singular": "роботі",
-                "plural": "роботах"
+                "singular": "ранкові / ранку",
+                "plural": "ранках"
               },
               "кличний": {
-                "singular": "робото",
-                "plural": "роботи"
+                "singular": "ранку",
+                "plural": "ранки"
               }
             }
           }
         },
         "meaning": {
           "definitions": [
-            "процес, дія, функціонування",
-            "чиєсь виконання чого-небудь, чийсь труд",
-            "та чи інша діяльність щодо виготовлення, створення, обробки чого-небудь"
+            "частина доби після ночі, початок, перші години дня",
+            "публічне ранкове зібрання, де виконуються літературні, музичні та інші твори"
           ],
-          "source": "Вікісловник",
-          "synonyms": [
-            "праця"
-          ]
+          "source": "Вікісловник"
         },
         "attestation": {
-          "text": "Робота, -ти, ж. 1) Работа, труд, дело, занятіе. Яка плата, така й робота. Ном. Субота не робота — помий, помаж та й спати ляж. Ном. 542. Цілісінький день у роботі. МВ. І. 26. 2) Изделіе, произведете, работа. По роботі пізнати майстра. Ном. № 7338. 3) соб. Работники. Одчиняй, пане, ворота, їде твоя робота. Ном. № 10000. Ум. робітка, робітонька, робіточка. Грин. III. 400, 393.",
+          "text": "Ранок, -нку, м. 1) Утро. Ой, журавко, журавко, чого кричиш по ранках? Чуб. V. 461. Я завше Бога прошу з вечора до ранку. Мет. 59. що-ранку. Каждое утро. Що-вечора, що-ранку, то й надінеш новодранку. Ном. № 11241. Ум. раночок. Чуб. V. 586. Мил. 148.",
           "source": "Грінченко (1907)"
         },
         "sources": [
@@ -6259,26 +10654,261 @@
           "Вікісловник",
           "Грінченко (1907)"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "розчісуватися",
+      "url_slug": "розчісуватися",
+      "gloss": "to comb one's hair",
+      "pos": "infinitive",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
-            "ref": "робота",
-            "detail": "lemma match (14 forms)"
+            "ref": "розчісуватися",
+            "detail": "lemma match (37 forms)"
           }
         ],
         "is_russianism": false,
         "russian_shadow": false,
         "sovietization_risk": 0,
         "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "дієслово",
+          "form_count": 37,
+          "forms": [
+            {
+              "form": "розчісуватимемось",
+              "label": "майбутній, множина, 1 ос."
+            },
+            {
+              "form": "розчісуватимемося",
+              "label": "майбутній, множина, 1 ос."
+            },
+            {
+              "form": "розчісуватимемся",
+              "label": "майбутній, множина, 1 ос."
+            },
+            {
+              "form": "розчісуватиметесь",
+              "label": "майбутній, множина, 2 ос."
+            },
+            {
+              "form": "розчісуватиметеся",
+              "label": "майбутній, множина, 2 ос."
+            },
+            {
+              "form": "розчісуватимуться",
+              "label": "майбутній, множина, 3 ос."
+            },
+            {
+              "form": "розчісуватимусь",
+              "label": "майбутній, однина, 1 ос."
+            },
+            {
+              "form": "розчісуватимуся",
+              "label": "майбутній, однина, 1 ос."
+            },
+            {
+              "form": "розчісуватимешся",
+              "label": "майбутній, однина, 2 ос."
+            },
+            {
+              "form": "розчісуватиметься",
+              "label": "майбутній, однина, 3 ос."
+            },
+            {
+              "form": "розчісуймось",
+              "label": "наказовий, множина, 1 ос."
+            },
+            {
+              "form": "розчісуймося",
+              "label": "наказовий, множина, 1 ос."
+            },
+            {
+              "form": "розчісуйтесь",
+              "label": "наказовий, множина, 2 ос."
+            },
+            {
+              "form": "розчісуйтеся",
+              "label": "наказовий, множина, 2 ос."
+            },
+            {
+              "form": "розчісуйсь",
+              "label": "наказовий, однина, 2 ос."
+            },
+            {
+              "form": "розчісуйся",
+              "label": "наказовий, однина, 2 ос."
+            },
+            {
+              "form": "розчісуватися",
+              "label": "інфінітив"
+            },
+            {
+              "form": "розчісуватись",
+              "label": "інфінітив"
+            },
+            {
+              "form": "розчісуваться",
+              "label": "інфінітив"
+            },
+            {
+              "form": "розчісувалась",
+              "label": "минулий, жін."
+            },
+            {
+              "form": "розчісувалася",
+              "label": "минулий, жін."
+            },
+            {
+              "form": "розчісувавсь",
+              "label": "минулий, чол."
+            },
+            {
+              "form": "розчісувався",
+              "label": "минулий, чол."
+            },
+            {
+              "form": "розчісувалось",
+              "label": "минулий, сер."
+            },
+            {
+              "form": "розчісувалося",
+              "label": "минулий, сер."
+            },
+            {
+              "form": "розчісувались",
+              "label": "минулий, множина"
+            },
+            {
+              "form": "розчісувалися",
+              "label": "минулий, множина"
+            },
+            {
+              "form": "розчісуємось",
+              "label": "теперішній, множина, 1 ос."
+            },
+            {
+              "form": "розчісуємося",
+              "label": "теперішній, множина, 1 ос."
+            },
+            {
+              "form": "розчісуємся",
+              "label": "теперішній, множина, 1 ос."
+            },
+            {
+              "form": "розчісуєтесь",
+              "label": "теперішній, множина, 2 ос."
+            },
+            {
+              "form": "розчісуєтеся",
+              "label": "теперішній, множина, 2 ос."
+            },
+            {
+              "form": "розчісуються",
+              "label": "теперішній, множина, 3 ос."
+            },
+            {
+              "form": "розчісуюсь",
+              "label": "теперішній, однина, 1 ос."
+            },
+            {
+              "form": "розчісуюся",
+              "label": "теперішній, однина, 1 ос."
+            },
+            {
+              "form": "розчісуєшся",
+              "label": "теперішній, однина, 2 ос."
+            },
+            {
+              "form": "розчісується",
+              "label": "теперішній, однина, 3 ос."
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "verb",
+            "infinitive": "розчісуватися / розчісуватись",
+            "tenses": {
+              "теперішній": {
+                "однина": {
+                  "1": "розчісуюсь / розчісуюся",
+                  "2": "розчісуєшся",
+                  "3": "розчісується"
+                },
+                "множина": {
+                  "1": "розчісуємось / розчісуємося / розчісуємся",
+                  "2": "розчісуєтесь / розчісуєтеся",
+                  "3": "розчісуються"
+                }
+              },
+              "майбутній": {
+                "однина": {
+                  "1": "розчісуватимусь / розчісуватимуся",
+                  "2": "розчісуватимешся",
+                  "3": "розчісуватиметься"
+                },
+                "множина": {
+                  "1": "розчісуватимемось / розчісуватимемося / розчісуватимемся",
+                  "2": "розчісуватиметесь / розчісуватиметеся",
+                  "3": "розчісуватимуться"
+                }
+              }
+            },
+            "imperative": {
+              "однина": {
+                "2": "розчісуйсь / розчісуйся"
+              },
+              "множина": {
+                "1": "розчісуймось / розчісуймося",
+                "2": "розчісуйтесь / розчісуйтеся"
+              }
+            },
+            "past": {
+              "чол.": "розчісувавсь / розчісувався",
+              "жін.": "розчісувалась / розчісувалася",
+              "сер.": "розчісувалось / розчісувалося",
+              "множина": "розчісувались / розчісувалися"
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "РОЗЧІ́СУВАТИСЯ, уюся, уєшся, недок., РОЗЧЕСА́ТИСЯ, ешу́ся, е́шешся, док. 1. Розділяти своє волосся на пасма, проводячи чим-небудь (перев. гребінцем) по всій його довжині. Знову чекають легені. А дівчина довго розчісується (Казки Буковини.., 1968, 218); Уже вона і розчесалася; вже і коси у дрібушки поплела (Кв.-Осн., II, 1956, 211). 2. тільки недок. Пас. до розчі́сувати. *Образно. Чуб, як грива на вороному коні, розчісується на льоту вітром (Кос., Новели, 1962, 9)."
+          ],
+          "source": "СУМ-11",
+          "sovietization_risk": 0,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
+        },
+        "attestation": {
+          "text": "Розчісуватися, -суюся, -єшся, сов. в. розчесАтися, -шУся, -шешся, гл. Расчесываться, расчесаться. Я змиюся і розчешуся. Мет. 76.",
+          "source": "Грінченко (1907)"
+        },
+        "sources": [
+          "VESUM",
+          "Грінченко (1907)",
+          "СУМ-11"
+        ]
       }
     },
     {
-      "lemma": "рутина",
-      "url_slug": "рутина",
-      "gloss": "routine",
+      "lemma": "руханка",
+      "url_slug": "руханка",
+      "gloss": "short exercise routine",
       "pos": "noun",
       "ipa": null,
       "primary_source": "built_vocabulary",
@@ -6290,65 +10920,79 @@
           "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "руханка",
+            "detail": "lemma match (14 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
           "form_count": 14,
           "forms": [
             {
-              "form": "рутині",
+              "form": "руханці",
               "label": "жін., давальний"
             },
             {
-              "form": "рутино",
+              "form": "руханко",
               "label": "жін., кличний"
             },
             {
-              "form": "рутині",
+              "form": "руханці",
               "label": "жін., місцевий"
             },
             {
-              "form": "рутина",
+              "form": "руханка",
               "label": "жін., називний"
             },
             {
-              "form": "рутиною",
+              "form": "руханкою",
               "label": "жін., орудний"
             },
             {
-              "form": "рутини",
+              "form": "руханки",
               "label": "жін., родовий"
             },
             {
-              "form": "рутину",
+              "form": "руханку",
               "label": "жін., знахідний"
             },
             {
-              "form": "рутинам",
+              "form": "руханкам",
               "label": "множина, давальний"
             },
             {
-              "form": "рутини",
+              "form": "руханки",
               "label": "множина, кличний"
             },
             {
-              "form": "рутинах",
+              "form": "руханках",
               "label": "множина, місцевий"
             },
             {
-              "form": "рутини",
+              "form": "руханки",
               "label": "множина, називний"
             },
             {
-              "form": "рутинами",
+              "form": "руханками",
               "label": "множина, орудний"
             },
             {
-              "form": "рутин",
+              "form": "руханок",
               "label": "множина, родовий"
             },
             {
-              "form": "рутини",
+              "form": "руханки",
               "label": "множина, знахідний"
             }
           ],
@@ -6357,60 +11001,62 @@
             "kind": "noun",
             "cases": {
               "називний": {
-                "singular": "рутина",
-                "plural": "рутини"
+                "singular": "руханка",
+                "plural": "руханки"
               },
               "родовий": {
-                "singular": "рутини",
-                "plural": "рутин"
+                "singular": "руханки",
+                "plural": "руханок"
               },
               "давальний": {
-                "singular": "рутині",
-                "plural": "рутинам"
+                "singular": "руханці",
+                "plural": "руханкам"
               },
               "знахідний": {
-                "singular": "рутину",
-                "plural": "рутини"
+                "singular": "руханку",
+                "plural": "руханки"
               },
               "орудний": {
-                "singular": "рутиною",
-                "plural": "рутинами"
+                "singular": "руханкою",
+                "plural": "руханками"
               },
               "місцевий": {
-                "singular": "рутині",
-                "plural": "рутинах"
+                "singular": "руханці",
+                "plural": "руханках"
               },
               "кличний": {
-                "singular": "рутино",
-                "plural": "рутини"
+                "singular": "руханко",
+                "plural": "руханки"
               }
             }
           }
         },
-        "meaning": {
-          "definitions": [
-            "РУТИ́НА, и, ж. Побоювання змін, відсутність почуття нового, слідування шаблону, віджилим правилам і звичкам. Неухильне прагнення вперед, сміливість думки, ясність перспективи, нетерпимість до.. рутини — ось що характеризує діяльність ленінської партії, неперевершений розмах її революційної роботи (Ком. Укр., 5, 1960, 45)."
-          ],
-          "source": "СУМ-11",
-          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
-        },
-        "etymology": {
-          "text": "запозичення з французької мови; фр. routine «рутина; навичка, вправність» є вживаною в переносному значенні формою демінутива від route «дорога», пов’язаного з лат. rupta (у виразі via rupta «виламана (в скелі) дорога»), дієприкметником від дієслова rumpere «розбивати, руйнувати»; р. болг. м. рути́на, бр. руці́на «рутина», п. rutyna «тс.; вправність, досвід», ч. rutina, routina «вправність, досвід», слц. вл. rutina «тс.; рутина», схв. рута̄ на, слн. rutína « тс. »;",
-          "source": "Горох (за ЕСУМ)",
-          "source_url": "https://goroh.pp.ua/%D0%95%D1%82%D0%B8%D0%BC%D0%BE%D0%BB%D0%BE%D0%B3%D1%96%D1%8F/%D1%80%D1%83%D1%82%D0%B8%D0%BD%D0%B0"
-        },
         "sources": [
-          "VESUM",
-          "Горох (за ЕСУМ)",
-          "СУМ-11"
+          "VESUM"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "ручка",
+      "url_slug": "ручка",
+      "gloss": "pen",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
-            "ref": "рутина",
+            "ref": "ручка",
             "detail": "lemma match (14 forms)"
           }
         ],
@@ -6418,23 +11064,7 @@
         "russian_shadow": false,
         "sovietization_risk": 0,
         "calque_warning": null
-      }
-    },
-    {
-      "lemma": "ручка",
-      "url_slug": "ручка",
-      "gloss": "pen, f",
-      "pos": null,
-      "ipa": null,
-      "primary_source": "plan_recommended",
-      "course_usage": [
-        {
-          "track": "a1",
-          "module_num": 8,
-          "slug": "things-have-gender",
-          "context": "plan_recommended"
-        }
-      ],
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -6537,6 +11167,7 @@
             "РУ́ЧКА, и, ж. 1. Зменш, до рука́ 1. [Печариця (підскакуючи):] Вашу ручку! (Подав руку). [Галя:] Ні, я не звикла під руку ходити (Мирний, V, 1955, 150); За порогом, посіпуючи довжелезну.. бороду, стояв дід і тримав за ручку маленьку дівчинку (Смолич, II, 1958, 32); *У порівн. Віти білуваті.. Ручками маляти Тягнуться в вікно (Мас., Київ. каштани, 1954, 5). ◊ Зго́рнуться (згорну́лися) ру́чки див. згорта́тися; Побра́тися за ру́чки див. побра́тися; Побра́тися по́під ру́чки див. побра́тися; Покаля́ти ру́чки див. покаля́ти; Ру́чками та пу́чками; З ру́чок та з пу́чок див. пу́чка; У ру́чки бра́тися (сх"
           ],
           "source": "СУМ-11",
+          "sovietization_risk": 0,
           "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
         },
         "attestation": {
@@ -6554,27 +11185,13 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
-      },
-      "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "ручка",
-            "detail": "lemma match (14 forms)"
-          }
-        ],
-        "is_russianism": false,
-        "russian_shadow": false,
-        "sovietization_risk": 0,
-        "calque_warning": null
       }
     },
     {
-      "lemma": "снідати",
-      "url_slug": "снідати",
-      "gloss": "to have breakfast",
-      "pos": "verb",
+      "lemma": "рушник",
+      "url_slug": "рушник",
+      "gloss": "towel",
+      "pos": "noun",
       "ipa": null,
       "primary_source": "built_vocabulary",
       "course_usage": [
@@ -6585,6 +11202,697 @@
           "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "рушник",
+            "detail": "lemma match (17 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 17,
+          "forms": [
+            {
+              "form": "рушникові",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "рушнику",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "рушнику",
+              "label": "чол., кличний"
+            },
+            {
+              "form": "рушникові",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "рушнику",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "рушник",
+              "label": "чол., називний"
+            },
+            {
+              "form": "рушником",
+              "label": "чол., орудний"
+            },
+            {
+              "form": "рушника",
+              "label": "чол., родовий"
+            },
+            {
+              "form": "рушник",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "рушника",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "рушникам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "рушники",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "рушниках",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "рушники",
+              "label": "множина, називний"
+            },
+            {
+              "form": "рушниками",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "рушників",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "рушники",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "рушник",
+                "plural": "рушники"
+              },
+              "родовий": {
+                "singular": "рушника",
+                "plural": "рушників"
+              },
+              "давальний": {
+                "singular": "рушникові / рушнику",
+                "plural": "рушникам"
+              },
+              "знахідний": {
+                "singular": "рушник / рушника",
+                "plural": "рушники"
+              },
+              "орудний": {
+                "singular": "рушником",
+                "plural": "рушниками"
+              },
+              "місцевий": {
+                "singular": "рушникові / рушнику",
+                "plural": "рушниках"
+              },
+              "кличний": {
+                "singular": "рушнику",
+                "plural": "рушники"
+              }
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "довгастий шматок тканини (бавовняної, лляної, полотняної і т. ін.) для витирання обличчя, тіла, посуду тощо. ‖ матеріал для такого витирання ‖ приспосіблення для витирання обсушення рук",
+            "шматок декоративної тканини з вишиваним або тканим орнаментом; традиційно використовується для оздоблення житла, в українських народних обрядах і т. ін"
+          ],
+          "source": "Вікісловник"
+        },
+        "attestation": {
+          "text": "Рушник, -ка, м. Полотенце. Различныя названія, смотря но употребленію: рушник-утирач — для лица и рук, — стирок — для вытиранія посуды, кілковий — богато вышитый — для украшеніи образов, картин, божник — для икон, плечевИй — богато вышитый для сватов, подарковий — дешевый для свадебных подарков и пр. Вас. 167, 168. Вода в відеречку, — братіку, вмийся; рушник на кілочку, — братіку, втрися. Чуб. V. 927. На образах рушники, шиті орлами та хмелем. Левиц. І. 27. рушники подавати. Перевязать особо для этого приготовленными полотенцами, во время обряда сватовства, сватов в знак согласія на выход заму",
+          "source": "Грінченко (1907)"
+        },
+        "sources": [
+          "VESUM",
+          "Вікісловник",
+          "Грінченко (1907)"
+        ]
+      }
+    },
+    {
+      "lemma": "рід",
+      "url_slug": "рід",
+      "gloss": "grammatical gender",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "рід",
+            "detail": "lemma match (17 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 1,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 17,
+          "forms": [
+            {
+              "form": "родові",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "роду",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "роде",
+              "label": "чол., кличний"
+            },
+            {
+              "form": "роді",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "родові",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "роду",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "рід",
+              "label": "чол., називний"
+            },
+            {
+              "form": "родом",
+              "label": "чол., орудний"
+            },
+            {
+              "form": "роду",
+              "label": "чол., родовий"
+            },
+            {
+              "form": "рід",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "родам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "роди",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "родах",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "роди",
+              "label": "множина, називний"
+            },
+            {
+              "form": "родами",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "родів",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "роди",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "рід",
+                "plural": "роди"
+              },
+              "родовий": {
+                "singular": "роду",
+                "plural": "родів"
+              },
+              "давальний": {
+                "singular": "родові / роду",
+                "plural": "родам"
+              },
+              "знахідний": {
+                "singular": "рід",
+                "plural": "роди"
+              },
+              "орудний": {
+                "singular": "родом",
+                "plural": "родами"
+              },
+              "місцевий": {
+                "singular": "роді / родові / роду",
+                "plural": "родах"
+              },
+              "кличний": {
+                "singular": "роде",
+                "plural": "роди"
+              }
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "РІД, ро́ду, ч. 1. Форма спільності людей за первіснообщинного ладу, господарське і соціальне об’єднання кровних родичів. Первісна дородова община змінилася більш високою формою організації суспільства — родовим ладом. Суспільною і економічною організацією людей став рід, який являв собою групу кровних родичів, що спільно вели своє господарство і боролися з силами природи (Іст. УРСР, І, 1953, 13); Група первісних людей, яка займалась спільною працею і була зв’язана спорідненням, називається родом (Іст. стар. світу, 1957, 10); В результаті зменшення ролі жінки в господарстві материнський рід змі"
+          ],
+          "source": "СУМ-11",
+          "sovietization_risk": 1,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті.",
+          "sovietization_keywords": [
+            "маркс",
+            "срср"
+          ]
+        },
+        "attestation": {
+          "text": "Рід, рОду, м. 1) Род, родственники, фамилія. Чи обідала, чи не обідала, аби рід відвідала. Ном. № 7274. В мене батька немає і рід не приймає. Чуб. Нема в його ні роду-родини, та нема в його ні вірної дружини. Чуб. V. 268. 2) Род, племя, происхожденіе. Козацькому роду нема переводу. Ном. № 771. Баба з пекла родом. Ном. Великого роду, а псього ходу. Ном. № 2909. 2) Порода. Родом кури чубаті. Ном. № 7982. Такий уже в їх рід, що вони всі низенькі та натоптувані. Кобел. у. 4) з-роду = зроду. Не було добра з-роду, не буде й до гробу. Ном. № 2030. 5) на роду написано. Суждено. Що написано на роду, то",
+          "source": "Грінченко (1907)"
+        },
+        "etymology": {
+          "text": "рід; народ, «народження, укр. нація» зять.",
+          "source": "ЕСУМ, т. 4, с. 52"
+        },
+        "sources": [
+          "VESUM",
+          "Грінченко (1907)",
+          "ЕСУМ, т. 4, с. 52",
+          "СУМ-11"
+        ]
+      }
+    },
+    {
+      "lemma": "склад",
+      "url_slug": "склад",
+      "gloss": "syllable",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 1,
+          "slug": "sounds-letters-and-hello",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "склад",
+            "detail": "lemma match (17 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 2,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 17,
+          "forms": [
+            {
+              "form": "складові",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "складу",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "складе",
+              "label": "чол., кличний"
+            },
+            {
+              "form": "складі",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "складові",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "складу",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "склад",
+              "label": "чол., називний"
+            },
+            {
+              "form": "складом",
+              "label": "чол., орудний"
+            },
+            {
+              "form": "складу",
+              "label": "чол., родовий"
+            },
+            {
+              "form": "склад",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "складам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "склади",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "складах",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "склади",
+              "label": "множина, називний"
+            },
+            {
+              "form": "складами",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "складів",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "склади",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "склад",
+                "plural": "склади"
+              },
+              "родовий": {
+                "singular": "складу",
+                "plural": "складів"
+              },
+              "давальний": {
+                "singular": "складові / складу",
+                "plural": "складам"
+              },
+              "знахідний": {
+                "singular": "склад",
+                "plural": "склади"
+              },
+              "орудний": {
+                "singular": "складом",
+                "plural": "складами"
+              },
+              "місцевий": {
+                "singular": "складі / складові / складу",
+                "plural": "складах"
+              },
+              "кличний": {
+                "singular": "складе",
+                "plural": "склади"
+              }
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "відповідно обладнане місце, будівля або приміщення для зберігання чого-небудь (продуктів, матеріалів)",
+            "велика кількість яких-небудь предметів, продуктів, матеріалів, зібраних і складених в одному місці, запаси чого-небудь",
+            "сукупність окремих частин, які утворюють що-небудь ціле"
+          ],
+          "source": "Вікісловник"
+        },
+        "attestation": {
+          "text": "Склад, -ду, м. 1) Состав, соединеніе. 2) Склад, складочное место. Склади медовії. 3) Склад, слог. Левиц. І. 243. По складах читає. 4) Стиль, слог, изложеніе. Росказав нам про дощ таким складом, як ніби ми були невчені селяне. К. (О. 1862. ІІІ. 30). 5) Связь, стройное соединеніе. Ані ладу, ані складу. Ном. № 13066. 6) орати у склад. Пахать, начиная с средины участка таким образом, что пласты земли ложатся внутрь участка. Нежин. у.",
+          "source": "Грінченко (1907)"
+        },
+        "sources": [
+          "VESUM",
+          "Вікісловник",
+          "Грінченко (1907)"
+        ]
+      }
+    },
+    {
+      "lemma": "слідуючий",
+      "url_slug": "слідуючий",
+      "gloss": "avoid: наступний",
+      "pos": "adj",
+      "ipa": null,
+      "primary_source": "surzhyk_to_avoid",
+      "seed_group": "surzhyk-to-avoid",
+      "course_usage": [],
+      "heritage_status": {
+        "classification": "russianism",
+        "attestations": [
+          {
+            "source": "standard_alternative",
+            "ref": "наступний",
+            "detail": "Ukrainian standard alternative for слідуючий"
+          },
+          {
+            "source": "standard_alternative",
+            "ref": "черговий",
+            "detail": "Ukrainian standard alternative for слідуючий"
+          },
+          {
+            "source": "standard_alternative",
+            "ref": "дальший",
+            "detail": "Ukrainian standard alternative for слідуючий"
+          },
+          {
+            "source": "lt_replacements",
+            "ref": "docs/best-practices/heritage-attestation-engine.md",
+            "detail": "local correction evidence; no authentic dictionary attestation found"
+          }
+        ],
+        "is_russianism": true,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": {
+          "standard_alternatives": [
+            "наступний",
+            "черговий",
+            "дальший"
+          ]
+        }
+      }
+    },
+    {
+      "lemma": "сніданок",
+      "url_slug": "сніданок",
+      "gloss": "breakfast",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "сніданок",
+            "detail": "lemma match (16 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 16,
+          "forms": [
+            {
+              "form": "сніданкові",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "сніданку",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "сніданку",
+              "label": "чол., кличний"
+            },
+            {
+              "form": "сніданкові",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "сніданку",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "сніданок",
+              "label": "чол., називний"
+            },
+            {
+              "form": "сніданком",
+              "label": "чол., орудний"
+            },
+            {
+              "form": "сніданку",
+              "label": "чол., родовий"
+            },
+            {
+              "form": "сніданок",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "сніданкам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "сніданки",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "сніданках",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "сніданки",
+              "label": "множина, називний"
+            },
+            {
+              "form": "сніданками",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "сніданків",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "сніданки",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "сніданок",
+                "plural": "сніданки"
+              },
+              "родовий": {
+                "singular": "сніданку",
+                "plural": "сніданків"
+              },
+              "давальний": {
+                "singular": "сніданкові / сніданку",
+                "plural": "сніданкам"
+              },
+              "знахідний": {
+                "singular": "сніданок",
+                "plural": "сніданки"
+              },
+              "орудний": {
+                "singular": "сніданком",
+                "plural": "сніданками"
+              },
+              "місцевий": {
+                "singular": "сніданкові / сніданку",
+                "plural": "сніданках"
+              },
+              "кличний": {
+                "singular": "сніданку",
+                "plural": "сніданки"
+              }
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "СНІДА́НОК, нку, ч. 1. Їжа, признач. для споживання вранці. З’їв [Аркадій Петрович] без апетиту сніданок і пішов по хазяйству (Коцюб., II, 1955, 396); Хазяїн збудив Шевченка о шостій годині. На столі вже чекав ситий і смачний сніданок (Тулуб, В степу.., 1964, 90). 2. Те саме, що сні́дання 1, 3. По готелях глухо гудуть вже гонги, скликаючи на сніданок (Коцюб., II, 1955, 413); Після сніданку губернатор показав гостям своїх коней (Довж., Зач. Десна, 1957, 439); // у знач. присл. сніда́нком. Коли снідають. — Ну, зараз на добраніч. Я ще маю обмізкувати цю справу, а сніданком, — стишує [Чорнокнижний]"
+          ],
+          "source": "СУМ-11",
+          "sovietization_risk": 0,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
+        },
+        "attestation": {
+          "text": "Сніданок, -нку, м. Завтрак.",
+          "source": "Грінченко (1907)"
+        },
+        "sources": [
+          "VESUM",
+          "Грінченко (1907)",
+          "СУМ-11"
+        ]
+      }
+    },
+    {
+      "lemma": "снідати",
+      "url_slug": "снідати",
+      "gloss": "to have breakfast",
+      "pos": "infinitive",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "снідати",
+            "detail": "lemma match (24 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "дієслово",
@@ -6739,6 +12047,7 @@
             "СНІ́ДАТИ, аю, аєш, недок., неперех. і розм. перех. Їсти вранці, з’їдати сніданок. — Ну, снідайте ж, поки овець позгонять. А я тим часом умиюся та зберуся, та й рушимо! (Мирний, І, 1949, 149); Ранок. Віктор з Людмилою снідають (Головко, І, 1957, 459); // чим. Їсти що-небудь уранці на сніданок. В холодку, під крислатими горіхами.., снідають [робітники], чим хто має (Коцюб., І, 1955, 210); Вітчим з синами сиділи за столом і снідали сухим хлібом з часником (Л. Укр., III, 1952, 562). Вари́ти (звари́ти, навари́ти і т. ін.) сні́дати — готувати страви на сніданок. — Буди Гаврила і Тимка. Бики у дворі"
           ],
           "source": "СУМ-11",
+          "sovietization_risk": 0,
           "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
         },
         "attestation": {
@@ -6756,14 +12065,30 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "снідаю",
+      "url_slug": "снідаю",
+      "gloss": "I have breakfast",
+      "pos": "verb form",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
             "ref": "снідати",
-            "detail": "lemma match (24 forms)"
+            "detail": "word_form match for lemma query"
           }
         ],
         "is_russianism": false,
@@ -6773,20 +12098,216 @@
       }
     },
     {
+      "lemma": "собака",
+      "url_slug": "собака",
+      "gloss": "dog",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "собака",
+            "detail": "lemma match (22 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 22,
+          "forms": [
+            {
+              "form": "собаці",
+              "label": "жін., давальний"
+            },
+            {
+              "form": "собако",
+              "label": "жін., кличний"
+            },
+            {
+              "form": "собаці",
+              "label": "жін., місцевий"
+            },
+            {
+              "form": "собака",
+              "label": "жін., називний"
+            },
+            {
+              "form": "собакою",
+              "label": "жін., орудний"
+            },
+            {
+              "form": "собаки",
+              "label": "жін., родовий"
+            },
+            {
+              "form": "собаку",
+              "label": "жін., знахідний"
+            },
+            {
+              "form": "собаці",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "собако",
+              "label": "чол., кличний"
+            },
+            {
+              "form": "собаці",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "собака",
+              "label": "чол., називний"
+            },
+            {
+              "form": "собакою",
+              "label": "чол., орудний"
+            },
+            {
+              "form": "собаки",
+              "label": "чол., родовий"
+            },
+            {
+              "form": "собаку",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "собакам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "собаки",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "собаках",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "собаки",
+              "label": "множина, називний"
+            },
+            {
+              "form": "собаками",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "собак",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "собак",
+              "label": "множина, знахідний"
+            },
+            {
+              "form": "собаки",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "собака",
+                "plural": "собаки"
+              },
+              "родовий": {
+                "singular": "собаки",
+                "plural": "собак"
+              },
+              "давальний": {
+                "singular": "собаці",
+                "plural": "собакам"
+              },
+              "знахідний": {
+                "singular": "собаку",
+                "plural": "собак / собаки"
+              },
+              "орудний": {
+                "singular": "собакою",
+                "plural": "собаками"
+              },
+              "місцевий": {
+                "singular": "собаці",
+                "plural": "собаках"
+              },
+              "кличний": {
+                "singular": "собако",
+                "plural": "собаки"
+              }
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "свійська тварина родини собачих, яку використовують для охорони, на полюванні і т. ін",
+            "зла, жорстока, недоброзичлива людина , — вилаявся дід і блиснув своїми очима у бік уланів",
+            "той, хто досяг досконалості в чому-небудь; вміла, спритна, завзята в чомусь людина"
+          ],
+          "source": "Вікісловник"
+        },
+        "attestation": {
+          "text": "Собака, -ки, м. и ж. 1) Собака. Бреше, мов собака. Ном. Гей, братці, втікайте, бо ще старий собака жив. ЗОЮР. І. 116. 2) Названіе некоторых из играющих в игру пиж. Ив. 38. 3) Тяжесть, привязываемая к концу коледезьнаго очепа. Мирг. у. Слов. Д. Эварн. 4) Род узора в вышивке. Чуб. VII. 427. Ум. собачка.",
+          "source": "Грінченко (1907)"
+        },
+        "etymology": {
+          "text": "собака, собакйр «наглядач за мис-",
+          "source": "ЕСУМ, т. 5, с. 337"
+        },
+        "sources": [
+          "VESUM",
+          "Вікісловник",
+          "Грінченко (1907)",
+          "ЕСУМ, т. 5, с. 337"
+        ]
+      }
+    },
+    {
       "lemma": "сон",
       "url_slug": "сон",
-      "gloss": "dream",
-      "pos": null,
+      "gloss": "sleep / dream",
+      "pos": "noun",
       "ipa": null,
-      "primary_source": "plan_recommended",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 1,
           "slug": "sounds-letters-and-hello",
-          "context": "plan_recommended"
+          "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "сон",
+            "detail": "lemma match (51 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -6986,27 +12507,13 @@
           "Горох (за ЕСУМ)",
           "Грінченко (1907)"
         ]
-      },
-      "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "сон",
-            "detail": "lemma match (51 forms)"
-          }
-        ],
-        "is_russianism": false,
-        "russian_shadow": false,
-        "sovietization_risk": 0,
-        "calque_warning": null
       }
     },
     {
       "lemma": "спочатку",
       "url_slug": "спочатку",
       "gloss": "first",
-      "pos": "adv",
+      "pos": "sequence word",
       "ipa": null,
       "primary_source": "built_vocabulary",
       "course_usage": [
@@ -7017,6 +12524,20 @@
           "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "спочатку",
+            "detail": "lemma match (1 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "прислівник",
@@ -7054,37 +12575,646 @@
           "Горох (за ЕСУМ)",
           "Грінченко (1907)"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "співак",
+      "url_slug": "співак",
+      "gloss": "male singer",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
-            "ref": "спочатку",
-            "detail": "lemma match (1 forms)"
+            "ref": "співак",
+            "detail": "lemma match (17 forms)"
           }
         ],
         "is_russianism": false,
         "russian_shadow": false,
         "sovietization_risk": 0,
         "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 17,
+          "forms": [
+            {
+              "form": "співакові",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "співаку",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "співаче",
+              "label": "чол., кличний"
+            },
+            {
+              "form": "співакові",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "співаку",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "співак",
+              "label": "чол., називний"
+            },
+            {
+              "form": "співаком",
+              "label": "чол., орудний"
+            },
+            {
+              "form": "співака",
+              "label": "чол., родовий"
+            },
+            {
+              "form": "співака",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "співакам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "співаки",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "співаках",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "співаки",
+              "label": "множина, називний"
+            },
+            {
+              "form": "співаками",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "співаків",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "співаків",
+              "label": "множина, знахідний"
+            },
+            {
+              "form": "співаки",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "співак",
+                "plural": "співаки"
+              },
+              "родовий": {
+                "singular": "співака",
+                "plural": "співаків"
+              },
+              "давальний": {
+                "singular": "співакові / співаку",
+                "plural": "співакам"
+              },
+              "знахідний": {
+                "singular": "співака",
+                "plural": "співаків / співаки"
+              },
+              "орудний": {
+                "singular": "співаком",
+                "plural": "співаками"
+              },
+              "місцевий": {
+                "singular": "співакові / співаку",
+                "plural": "співаках"
+              },
+              "кличний": {
+                "singular": "співаче",
+                "plural": "співаки"
+              }
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "СПІВА́К, а́, ч. 1. Людина, яка уміє й любить співати, багато співає. Козак Мамай — мандрівний запорожець ..і гультяй, жартун і філософ, бандурист і співак (Ільч., Козацьк. роду.., 1958, 61); Як він схилявся перед піснею! Як заздрив усім без винятку співакам, котрі мали сміливість роззявляти на людях рота (Ю. Янов., II, 1954, 97); Стефик усіх вуличних співаків у Львові знає (Жур., Вечір.., 1958, 254); // Той, хто співає. Зухвалий спів наближався, наростав, наче десь з далекого степу. Невдовзі на дверях з’явився і сам співак: присадкуватий карячконогий боєць (Гончар, III, 1959, 147); // Той, хто"
+          ],
+          "source": "СУМ-11",
+          "sovietization_risk": 0,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
+        },
+        "attestation": {
+          "text": "Співак, -ка, м. 1) Певец. Співак, танцюра на всі руки. Котл. Ен. IV. 11. Так ось коли побачив співака! яка мальована та штучна птиця. Греб. 391. 2) Певчій. 3) Названіе собаки. Kolb. І. 65. 4) пт. Sylvia, травник. Вх. Пч. II. 14. Ум. співаченько, співачок. Федьк. І. 28. Лівничок-співачок. Мнж. 3.",
+          "source": "Грінченко (1907)"
+        },
+        "sources": [
+          "VESUM",
+          "Грінченко (1907)",
+          "СУМ-11"
+        ]
       }
     },
     {
-      "lemma": "стіл",
-      "url_slug": "стіл",
-      "gloss": "table, m",
-      "pos": null,
+      "lemma": "співачка",
+      "url_slug": "співачка",
+      "gloss": "female singer",
+      "pos": "noun",
       "ipa": null,
-      "primary_source": "plan_required",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 8,
           "slug": "things-have-gender",
-          "context": "plan_required"
+          "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "співачка",
+            "detail": "lemma match (15 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 15,
+          "forms": [
+            {
+              "form": "співачці",
+              "label": "жін., давальний"
+            },
+            {
+              "form": "співачко",
+              "label": "жін., кличний"
+            },
+            {
+              "form": "співачці",
+              "label": "жін., місцевий"
+            },
+            {
+              "form": "співачка",
+              "label": "жін., називний"
+            },
+            {
+              "form": "співачкою",
+              "label": "жін., орудний"
+            },
+            {
+              "form": "співачки",
+              "label": "жін., родовий"
+            },
+            {
+              "form": "співачку",
+              "label": "жін., знахідний"
+            },
+            {
+              "form": "співачкам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "співачки",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "співачках",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "співачки",
+              "label": "множина, називний"
+            },
+            {
+              "form": "співачками",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "співачок",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "співачок",
+              "label": "множина, знахідний"
+            },
+            {
+              "form": "співачки",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "співачка",
+                "plural": "співачки"
+              },
+              "родовий": {
+                "singular": "співачки",
+                "plural": "співачок"
+              },
+              "давальний": {
+                "singular": "співачці",
+                "plural": "співачкам"
+              },
+              "знахідний": {
+                "singular": "співачку",
+                "plural": "співачок / співачки"
+              },
+              "орудний": {
+                "singular": "співачкою",
+                "plural": "співачками"
+              },
+              "місцевий": {
+                "singular": "співачці",
+                "plural": "співачках"
+              },
+              "кличний": {
+                "singular": "співачко",
+                "plural": "співачки"
+              }
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "СПІВА́ЧКА, и, ж. Жін. до співа́к. — А тепер, діду, заспівайте нам на прощання, бо завтра вже не побачимось,— звернулась до його [нього] молоденька учениця драмкурсів, сама неабияка співачка (Вас., II, 1959, 521); Пісня замовкла, либонь уста у співачки зайнялися іншою роботою (Л. Укр., III, 1952, 660); Скільки б не було в гурті співачок — Остап розплітав найскладніше плетиво голосів, відрізняв з-поміж них сріблясту нитку Олесиного (М. Ю. Тарн., Незр. горизонт, 1962, 80); Хтось крикнув: «букета!» — і цілі пучки квіток полетіли під ноги співачці (Мирний, III, 1954, 273); Я розповів офіцерові, що"
+          ],
+          "source": "СУМ-11",
+          "sovietization_risk": 0,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
+        },
+        "attestation": {
+          "text": "Співачка, -ки, ж. 1) Певица. 2) Певунья. Дають дівчатам-співачкам. О. 1862. IV. 24.",
+          "source": "Грінченко (1907)"
+        },
+        "sources": [
+          "VESUM",
+          "Грінченко (1907)",
+          "СУМ-11"
+        ]
+      }
+    },
+    {
+      "lemma": "студент",
+      "url_slug": "студент",
+      "gloss": "male student",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "студент",
+            "detail": "lemma match (18 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 18,
+          "forms": [
+            {
+              "form": "студентові",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "студенту",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "студенте",
+              "label": "чол., кличний"
+            },
+            {
+              "form": "студенті",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "студентові",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "студенту",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "студент",
+              "label": "чол., називний"
+            },
+            {
+              "form": "студентом",
+              "label": "чол., орудний"
+            },
+            {
+              "form": "студента",
+              "label": "чол., родовий"
+            },
+            {
+              "form": "студента",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "студентам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "студенти",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "студентах",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "студенти",
+              "label": "множина, називний"
+            },
+            {
+              "form": "студентами",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "студентів",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "студентів",
+              "label": "множина, знахідний"
+            },
+            {
+              "form": "студенти",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "студент",
+                "plural": "студенти"
+              },
+              "родовий": {
+                "singular": "студента",
+                "plural": "студентів"
+              },
+              "давальний": {
+                "singular": "студентові / студенту",
+                "plural": "студентам"
+              },
+              "знахідний": {
+                "singular": "студента",
+                "plural": "студентів / студенти"
+              },
+              "орудний": {
+                "singular": "студентом",
+                "plural": "студентами"
+              },
+              "місцевий": {
+                "singular": "студенті / студентові / студенту",
+                "plural": "студентах"
+              },
+              "кличний": {
+                "singular": "студенте",
+                "plural": "студенти"
+              }
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "той, хто навчається у вищому або середньому спеціальному навчальному закладі"
+          ],
+          "source": "Вікісловник"
+        },
+        "attestation": {
+          "text": "Студент, -та, м. 1) Ученик. Ішли три студенти до школи. Гн. І. 163. 2) Студент. Студенти, як звичайно буває, почали записувати його лекції. Левиц. Пов. 52.",
+          "source": "Грінченко (1907)"
+        },
+        "sources": [
+          "VESUM",
+          "Вікісловник",
+          "Грінченко (1907)"
+        ]
+      }
+    },
+    {
+      "lemma": "студентка",
+      "url_slug": "студентка",
+      "gloss": "female student",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "студентка",
+            "detail": "lemma match (15 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 15,
+          "forms": [
+            {
+              "form": "студентці",
+              "label": "жін., давальний"
+            },
+            {
+              "form": "студентко",
+              "label": "жін., кличний"
+            },
+            {
+              "form": "студентці",
+              "label": "жін., місцевий"
+            },
+            {
+              "form": "студентка",
+              "label": "жін., називний"
+            },
+            {
+              "form": "студенткою",
+              "label": "жін., орудний"
+            },
+            {
+              "form": "студентки",
+              "label": "жін., родовий"
+            },
+            {
+              "form": "студентку",
+              "label": "жін., знахідний"
+            },
+            {
+              "form": "студенткам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "студентки",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "студентках",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "студентки",
+              "label": "множина, називний"
+            },
+            {
+              "form": "студентками",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "студенток",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "студенток",
+              "label": "множина, знахідний"
+            },
+            {
+              "form": "студентки",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "студентка",
+                "plural": "студентки"
+              },
+              "родовий": {
+                "singular": "студентки",
+                "plural": "студенток"
+              },
+              "давальний": {
+                "singular": "студентці",
+                "plural": "студенткам"
+              },
+              "знахідний": {
+                "singular": "студентку",
+                "plural": "студенток / студентки"
+              },
+              "орудний": {
+                "singular": "студенткою",
+                "plural": "студентками"
+              },
+              "місцевий": {
+                "singular": "студентці",
+                "plural": "студентках"
+              },
+              "кличний": {
+                "singular": "студентко",
+                "plural": "студентки"
+              }
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "СТУДЕ́НТКА, и, ж. Жін. до студе́нт. — Як гарно співають, — тихо зітхнув Калінін. — Це студенти й студентки… Чудесна молодь (Довж., І, 1958, 488); Вона ж така, як студенткою хімічного інституту була, голубоока і з довгими віями (Вишня, І, 1956, 313); Три дівчини, студентки-агрономи, Йшли взимку по доріжці лісовій (Рильський, III, 1961, 207)."
+          ],
+          "source": "СУМ-11",
+          "sovietization_risk": 0,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
+        },
+        "sources": [
+          "VESUM",
+          "СУМ-11"
+        ]
+      }
+    },
+    {
+      "lemma": "стіл",
+      "url_slug": "стіл",
+      "gloss": "table",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "стіл",
+            "detail": "lemma match (19 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -7225,37 +13355,37 @@
           "Горох (за ЕСУМ)",
           "Грінченко (1907)"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "стілець",
+      "url_slug": "стілець",
+      "gloss": "chair",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
-            "ref": "стіл",
-            "detail": "lemma match (19 forms)"
+            "ref": "стілець",
+            "detail": "lemma match (18 forms)"
           }
         ],
         "is_russianism": false,
         "russian_shadow": false,
         "sovietization_risk": 0,
         "calque_warning": null
-      }
-    },
-    {
-      "lemma": "стілець",
-      "url_slug": "стілець",
-      "gloss": "chair, m",
-      "pos": null,
-      "ipa": null,
-      "primary_source": "plan_required",
-      "course_usage": [
-        {
-          "track": "a1",
-          "module_num": 8,
-          "slug": "things-have-gender",
-          "context": "plan_required"
-        }
-      ],
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -7393,37 +13523,37 @@
           "Горох (за ЕСУМ)",
           "Грінченко (1907)"
         ]
-      },
-      "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "стілець",
-            "detail": "lemma match (18 forms)"
-          }
-        ],
-        "is_russianism": false,
-        "russian_shadow": false,
-        "sovietization_risk": 0,
-        "calque_warning": null
       }
     },
     {
       "lemma": "стіна",
       "url_slug": "стіна",
-      "gloss": "wall, f",
-      "pos": null,
+      "gloss": "wall",
+      "pos": "noun",
       "ipa": null,
-      "primary_source": "plan_recommended",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 8,
           "slug": "things-have-gender",
-          "context": "plan_recommended"
+          "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "стіна",
+            "detail": "lemma match (14 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 1,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -7526,7 +13656,12 @@
             "СТІНА́, и́, ж. 1. Вертикальна частина будови, яка служить для підтримання перекрить і для розділення приміщення на частини і т. ін. Головою стіни не проб’єш (Укр.. присл.., 1955, 286); Надворі ревла сердита буря, стугоніла в стіни,.. вила в димарі, гуркотіла у вікна (Мирний, IV, 1955, 298); На стіні, проти стола, висить великий портрет Шевченка, хорошої роботи олійними фарбами (Коцюб., III, 1956, 45); Оселився я в готелі. Це — досить великий будинок, розподілений поверхами, коридорами, стінами й дверима на окремі кімнати (Ю. Янов., II, 1958, 15); *Образно. Серед зачинателів радянської літерату"
           ],
           "source": "СУМ-11",
-          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
+          "sovietization_risk": 1,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті.",
+          "sovietization_keywords": [
+            "комуністичн",
+            "радянськ"
+          ]
         },
         "attestation": {
           "text": "Стіна, -ни, ж. 1) Стена. Мовчить, як стіна. ЗОЮР. І. 147. Мила б я стіни, щоб були білі. Мет. 126. Все село як за стіну засунулось, — такі смутні всі. МВ. І. 99. 2) Стена, плетена невода. (Стрижевск.). 3) Ряд зубов в одной стороне челюсти. Ви б у Прохори поїхали, там дід замовляє (зуби); а то так усю стіну й викрутить, да й знов буде зачинатись. Г. Барв. 35. 4) Тучи на западе, за которыя заходит солнце. Як сонце заходить за стіну, то буде дощ. Грин. I. 12. 5) При кулачном бое: ряд, шеренга бойцов. Маркев. 76. Ум. стінка, стінонька, стіночка. Лежить мила, мов китайка синя, стоїть милий, як стін",
@@ -7543,164 +13678,29 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
-      },
-      "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "стіна",
-            "detail": "lemma match (14 forms)"
-          }
-        ],
-        "is_russianism": false,
-        "russian_shadow": false,
-        "sovietization_risk": 0,
-        "calque_warning": null
       }
     },
     {
-      "lemma": "субота",
-      "url_slug": "субота",
-      "gloss": "Saturday",
+      "lemma": "сумка",
+      "url_slug": "сумка",
+      "gloss": "bag",
       "pos": "noun",
       "ipa": null,
       "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
-          "module_num": 20,
-          "slug": "my-morning",
+          "module_num": 8,
+          "slug": "things-have-gender",
           "context": "built_vocabulary"
         }
       ],
-      "enrichment": {
-        "morphology": {
-          "pos": "іменник",
-          "form_count": 14,
-          "forms": [
-            {
-              "form": "суботі",
-              "label": "жін., давальний"
-            },
-            {
-              "form": "субото",
-              "label": "жін., кличний"
-            },
-            {
-              "form": "суботі",
-              "label": "жін., місцевий"
-            },
-            {
-              "form": "субота",
-              "label": "жін., називний"
-            },
-            {
-              "form": "суботою",
-              "label": "жін., орудний"
-            },
-            {
-              "form": "суботи",
-              "label": "жін., родовий"
-            },
-            {
-              "form": "суботу",
-              "label": "жін., знахідний"
-            },
-            {
-              "form": "суботам",
-              "label": "множина, давальний"
-            },
-            {
-              "form": "суботи",
-              "label": "множина, кличний"
-            },
-            {
-              "form": "суботах",
-              "label": "множина, місцевий"
-            },
-            {
-              "form": "суботи",
-              "label": "множина, називний"
-            },
-            {
-              "form": "суботами",
-              "label": "множина, орудний"
-            },
-            {
-              "form": "субот",
-              "label": "множина, родовий"
-            },
-            {
-              "form": "суботи",
-              "label": "множина, знахідний"
-            }
-          ],
-          "source": "VESUM",
-          "paradigm": {
-            "kind": "noun",
-            "cases": {
-              "називний": {
-                "singular": "субота",
-                "plural": "суботи"
-              },
-              "родовий": {
-                "singular": "суботи",
-                "plural": "субот"
-              },
-              "давальний": {
-                "singular": "суботі",
-                "plural": "суботам"
-              },
-              "знахідний": {
-                "singular": "суботу",
-                "plural": "суботи"
-              },
-              "орудний": {
-                "singular": "суботою",
-                "plural": "суботами"
-              },
-              "місцевий": {
-                "singular": "суботі",
-                "plural": "суботах"
-              },
-              "кличний": {
-                "singular": "субото",
-                "plural": "суботи"
-              }
-            }
-          }
-        },
-        "meaning": {
-          "definitions": [
-            "шостий день тижня (після і перед неділі (-ею))",
-            "суботаю",
-            "субота"
-          ],
-          "source": "Вікісловник"
-        },
-        "attestation": {
-          "text": "Субота, -ти, ж. Суббота. Субота не робота: помий та помаж та і спати ляж. посл. ум. субІтка, субІточка, суботонька.",
-          "source": "Грінченко (1907)"
-        },
-        "etymology": {
-          "text": "слово у звуковій формі субота (сл. sǫbota) здебільшого розглядається як запозичення із середньогрецької мови (Фасмер ГСЭ 196; ИОРЯС 11/2, 388; 12/2, 280; Соболевский Заимствованные слова в русском языке 14; Durnovo RÉS 6/1–2, 108; Младенов 626; Hujer LF 35, 221–222; Kiparsky GLG 130, 131; Schwarz AfSlPh 41, 124–125) або з балкансько-латинської (Skok III 299; RÉS 5, 19); сгр. *σάμβατον (мн. σάμβατα), балкансько-лат. *sambata (пор. рум. sâmbătă) зводяться до гр. σάββατον «субота», мн. σάββατα, що походить, очевидно, від арам. šabbǝtā або гебр. šabbā́ṯ «відпочинок, спокій; свято, вихідний день»,",
-          "source": "Горох (за ЕСУМ)",
-          "source_url": "https://goroh.pp.ua/%D0%95%D1%82%D0%B8%D0%BC%D0%BE%D0%BB%D0%BE%D0%B3%D1%96%D1%8F/%D1%81%D1%83%D0%B1%D0%BE%D1%82%D0%B0"
-        },
-        "sources": [
-          "VESUM",
-          "Вікісловник",
-          "Горох (за ЕСУМ)",
-          "Грінченко (1907)"
-        ]
-      },
       "heritage_status": {
         "classification": "standard",
         "attestations": [
           {
             "source": "VESUM",
-            "ref": "субота",
+            "ref": "сумка",
             "detail": "lemma match (14 forms)"
           }
         ],
@@ -7708,23 +13708,7 @@
         "russian_shadow": false,
         "sovietization_risk": 0,
         "calque_warning": null
-      }
-    },
-    {
-      "lemma": "сумка",
-      "url_slug": "сумка",
-      "gloss": "bag, f",
-      "pos": null,
-      "ipa": null,
-      "primary_source": "plan_recommended",
-      "course_usage": [
-        {
-          "track": "a1",
-          "module_num": 8,
-          "slug": "things-have-gender",
-          "context": "plan_recommended"
-        }
-      ],
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -7827,6 +13811,7 @@
             "СУ́МКА, и, ж. 1. Виріб із шкіри, тканини і т. ін., що має форму торбинки, футляра з ручками і служить для перенесення чого-небудь. На голову бриль наложив [Меркурій]; На грудях з бляхою ладунка, А ззаду з сухарями сумка (Котл., I, 1952, 80); Шкіряна сумка з листами висіла в нього на боці (Донч., VI, 1957, 54); Віктор дістав з польової сумки зошит (Автом., В. Кошик, 1954, 124); Фельдшерка розклала свою сумку-аптечку (Головко, Літа.., 1956, 165); Господарська сумка; Учнівська сумка; *Образно. — Думаєш, ніхто не знає, яка сумка в твого батька!..Го-го! багацького сина і чорт не бере (Л. Укр., III,"
           ],
           "source": "СУМ-11",
+          "sovietization_risk": 0,
           "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
         },
         "etymology": {
@@ -7839,215 +13824,29 @@
           "Горох (за ЕСУМ)",
           "СУМ-11"
         ]
-      },
-      "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "сумка",
-            "detail": "lemma match (14 forms)"
-          }
-        ],
-        "is_russianism": false,
-        "russian_shadow": false,
-        "sovietization_risk": 0,
-        "calque_warning": null
       }
     },
     {
-      "lemma": "сьома",
-      "url_slug": "сьома",
-      "gloss": "seven o'clock",
-      "pos": "numeral",
+      "lemma": "та́то",
+      "url_slug": "та-то",
+      "gloss": "father",
+      "pos": "noun",
       "ipa": null,
       "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
-          "module_num": 20,
-          "slug": "my-morning",
+          "module_num": 1,
+          "slug": "sounds-letters-and-hello",
+          "context": "built_vocabulary"
+        },
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
           "context": "built_vocabulary"
         }
       ],
-      "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "сьомий,сім",
-            "detail": "word_form match for lemma query"
-          }
-        ],
-        "is_russianism": false,
-        "russian_shadow": false,
-        "sovietization_risk": 0,
-        "calque_warning": null
-      }
-    },
-    {
-      "lemma": "тато",
-      "url_slug": "тато",
-      "gloss": "father",
-      "pos": null,
-      "ipa": null,
-      "primary_source": "plan_recommended",
-      "course_usage": [
-        {
-          "track": "a1",
-          "module_num": 1,
-          "slug": "sounds-letters-and-hello",
-          "context": "plan_recommended"
-        }
-      ],
-      "enrichment": {
-        "morphology": {
-          "pos": "іменник",
-          "form_count": 20,
-          "forms": [
-            {
-              "form": "татові",
-              "label": "чол., давальний"
-            },
-            {
-              "form": "тату",
-              "label": "чол., давальний"
-            },
-            {
-              "form": "тату",
-              "label": "чол., кличний"
-            },
-            {
-              "form": "тат",
-              "label": "чол., кличний"
-            },
-            {
-              "form": "таті",
-              "label": "чол., місцевий"
-            },
-            {
-              "form": "татові",
-              "label": "чол., місцевий"
-            },
-            {
-              "form": "тату",
-              "label": "чол., місцевий"
-            },
-            {
-              "form": "тато",
-              "label": "чол., називний"
-            },
-            {
-              "form": "татом",
-              "label": "чол., орудний"
-            },
-            {
-              "form": "тата",
-              "label": "чол., родовий"
-            },
-            {
-              "form": "тата",
-              "label": "чол., знахідний"
-            },
-            {
-              "form": "татам",
-              "label": "множина, давальний"
-            },
-            {
-              "form": "тати",
-              "label": "множина, кличний"
-            },
-            {
-              "form": "татах",
-              "label": "множина, місцевий"
-            },
-            {
-              "form": "тати",
-              "label": "множина, називний"
-            },
-            {
-              "form": "татами",
-              "label": "множина, орудний"
-            },
-            {
-              "form": "татів",
-              "label": "множина, родовий"
-            },
-            {
-              "form": "тат",
-              "label": "множина, родовий"
-            },
-            {
-              "form": "татів",
-              "label": "множина, знахідний"
-            },
-            {
-              "form": "тати",
-              "label": "множина, знахідний"
-            }
-          ],
-          "source": "VESUM",
-          "paradigm": {
-            "kind": "noun",
-            "cases": {
-              "називний": {
-                "singular": "тато",
-                "plural": "тати"
-              },
-              "родовий": {
-                "singular": "тата",
-                "plural": "татів / тат"
-              },
-              "давальний": {
-                "singular": "татові / тату",
-                "plural": "татам"
-              },
-              "знахідний": {
-                "singular": "тата",
-                "plural": "татів / тати"
-              },
-              "орудний": {
-                "singular": "татом",
-                "plural": "татами"
-              },
-              "місцевий": {
-                "singular": "таті / татові / тату",
-                "plural": "татах"
-              },
-              "кличний": {
-                "singular": "тату / тат",
-                "plural": "тати"
-              }
-            }
-          }
-        },
-        "meaning": {
-          "definitions": [
-            "ТА́ТО, а, ч., розм. Те саме, що ба́тько 1. І вчила княгиня [дитину] Тілько «мамо» вимовляти, А «тато» не вчила… (Шевч., II, 1963, 28); — Виблагай у батька дозвіл побратись — і мій тато пристане на це (Коцюб., II, 1955, 157); Оленчук надів кожушок.. Діти, відчувши якусь тривогу, обліпили його: — Тату, куди ви? (Гончар, II, 1959, 412); // Ввічливе звертання до тестя, свекра. Там [на пасіці] усе просто й більш зрозуміло, аніж дома, де чомусь нема братолюбія поміж синами, на яких він здав господарство, і не чується злагоди між Терентієм і Дариною.. — Тату, ви їсти будете? — підходить до старого Да"
-          ],
-          "source": "СУМ-11",
-          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті.",
-          "synonyms": [
-            "батько",
-            "татусь"
-          ]
-        },
-        "attestation": {
-          "text": "Тато, -та, м. Отец. Вийди, доню, на. улицю тата визирати. Лукаш. 12.5. Ум. и ласк. Татко, татенько, татечко, татонько, таточко, татульо, татуленько, татунь, татуньо, татусь, татусьо, татусик, татцьо, татценько. Гол. І. 335. Ой татоньку, мій голубоньку! Мет. 155. Ми з мамою щось порались коло печі, а татуньо були в церкві. КС. 1883. ІІ. 466. Татуся.... на той раз не було. Сим. 230.",
-          "source": "Грінченко (1907)"
-        },
-        "etymology": {
-          "text": "псл. tаta з дитячого лепету, паралельне дінд. tatáḥ «тато», tā́tаḥ «тато, син, милий», гр. τέττα, τάτᾱ (клична форма) «батько», лат. tаta «тато», корн. tаt, лит. tė˜tis, tė˜tė, лтс. tētis, tēte « тс. », прус. thetis «дідусь»; р. бр. та́та, п. слц. нл. tata, tatо, ч. táta, вл. tata, болг. м. та́те, та́тко, схв. та̏та, та́та, слн. táta, tátek, стсл. тата;",
-          "source": "Горох (за ЕСУМ)",
-          "source_url": "https://goroh.pp.ua/%D0%95%D1%82%D0%B8%D0%BC%D0%BE%D0%BB%D0%BE%D0%B3%D1%96%D1%8F/%D1%82%D0%B0%D1%82%D0%BE"
-        },
-        "sources": [
-          "VESUM",
-          "Горох (за ЕСУМ)",
-          "Грінченко (1907)",
-          "СУМ-11"
-        ]
-      },
       "heritage_status": {
         "classification": "standard",
         "attestations": [
@@ -8061,23 +13860,47 @@
         "russian_shadow": false,
         "sovietization_risk": 0,
         "calque_warning": null
+      },
+      "enrichment": {
+        "etymology": {
+          "text": "псл. tаta з дитячого лепету, паралельне дінд. tatáḥ «тато», tā́tаḥ «тато, син, милий», гр. τέττα, τάτᾱ (клична форма) «батько», лат. tаta «тато», корн. tаt, лит. tė˜tis, tė˜tė, лтс. tētis, tēte « тс. », прус. thetis «дідусь»; р. бр. та́та, п. слц. нл. tata, tatо, ч. táta, вл. tata, болг. м. та́те, та́тко, схв. та̏та, та́та, слн. táta, tátek, стсл. тата;",
+          "source": "Горох (за ЕСУМ)",
+          "source_url": "https://goroh.pp.ua/%D0%95%D1%82%D0%B8%D0%BC%D0%BE%D0%BB%D0%BE%D0%B3%D1%96%D1%8F/%D1%82%D0%B0%D1%82%D0%BE"
+        },
+        "sources": [
+          "Горох (за ЕСУМ)"
+        ]
       }
     },
     {
       "lemma": "телефон",
       "url_slug": "телефон",
-      "gloss": "phone, m",
-      "pos": null,
+      "gloss": "phone",
+      "pos": "noun",
       "ipa": null,
-      "primary_source": "plan_required",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 8,
           "slug": "things-have-gender",
-          "context": "plan_required"
+          "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "телефон",
+            "detail": "lemma match (19 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -8213,16 +14036,26 @@
           "Вікісловник",
           "Горох (за ЕСУМ)"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "у мене є",
+      "url_slug": "у-мене-є",
+      "gloss": "I have",
+      "pos": "phrase",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "телефон",
-            "detail": "lemma match (19 forms)"
-          }
-        ],
+        "classification": "unknown",
+        "attestations": [],
         "is_russianism": false,
         "russian_shadow": false,
         "sovietization_risk": 0,
@@ -8230,20 +14063,207 @@
       }
     },
     {
-      "lemma": "фото",
-      "url_slug": "фото",
-      "gloss": "photo, n",
-      "pos": null,
+      "lemma": "у тебе є",
+      "url_slug": "у-тебе-є",
+      "gloss": "do you have / you have",
+      "pos": "phrase",
       "ipa": null,
-      "primary_source": "plan_recommended",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
           "module_num": 8,
           "slug": "things-have-gender",
-          "context": "plan_recommended"
+          "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "unknown",
+        "attestations": [],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
+    },
+    {
+      "lemma": "учителька",
+      "url_slug": "учителька",
+      "gloss": "female teacher",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "учителька",
+            "detail": "lemma match (15 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 15,
+          "forms": [
+            {
+              "form": "учительці",
+              "label": "жін., давальний"
+            },
+            {
+              "form": "учителько",
+              "label": "жін., кличний"
+            },
+            {
+              "form": "учительці",
+              "label": "жін., місцевий"
+            },
+            {
+              "form": "учителька",
+              "label": "жін., називний"
+            },
+            {
+              "form": "учителькою",
+              "label": "жін., орудний"
+            },
+            {
+              "form": "учительки",
+              "label": "жін., родовий"
+            },
+            {
+              "form": "учительку",
+              "label": "жін., знахідний"
+            },
+            {
+              "form": "учителькам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "учительки",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "учительках",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "учительки",
+              "label": "множина, називний"
+            },
+            {
+              "form": "учительками",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "учительок",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "учительок",
+              "label": "множина, знахідний"
+            },
+            {
+              "form": "учительки",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "учителька",
+                "plural": "учительки"
+              },
+              "родовий": {
+                "singular": "учительки",
+                "plural": "учительок"
+              },
+              "давальний": {
+                "singular": "учительці",
+                "plural": "учителькам"
+              },
+              "знахідний": {
+                "singular": "учительку",
+                "plural": "учительок / учительки"
+              },
+              "орудний": {
+                "singular": "учителькою",
+                "plural": "учительками"
+              },
+              "місцевий": {
+                "singular": "учительці",
+                "plural": "учительках"
+              },
+              "кличний": {
+                "singular": "учителько",
+                "plural": "учительки"
+              }
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "УЧИ́ТЕЛЬКА (ВЧИ́ТЕЛЬКА), и, ж. Жін. до учи́тель. — Здрастуй… одчини школу.. я приїхала до вас за вчительку (Коцюб., І, 1955, 310); Артем звів голову і, одверто дивлячись учительці в лице, сказав: — Я вже тепер більше не буду ніколи [лаятися] (Головко, II, 1957, 251); Тут же вчителька проекзаменувала Бориса і пішла з ним до директора (Хижняк, Тамара, 1959, 212)."
+          ],
+          "source": "СУМ-11",
+          "sovietization_risk": 0,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
+        },
+        "attestation": {
+          "text": "Учителька, -ки, ж. Учительница.",
+          "source": "Грінченко (1907)"
+        },
+        "sources": [
+          "VESUM",
+          "Грінченко (1907)",
+          "СУМ-11"
+        ]
+      }
+    },
+    {
+      "lemma": "фото",
+      "url_slug": "фото",
+      "gloss": "photo",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "фото",
+            "detail": "lemma match (29 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "іменник",
@@ -8394,6 +14414,7 @@
             "ФО́ТО, невідм., с., розм. Те саме, що фотогра́фія 2. До столу вернувсь кореспондент. Подає Олені кілька фото (Головко, І, 1957, 445); Якийсь фотограф побував у нашій землянці й потім у піонерській газеті з’явилося фото (Сміл., Сашко, 1954, 237)."
           ],
           "source": "СУМ-11",
+          "sovietization_risk": 0,
           "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті.",
           "synonyms": [
             "фотографія",
@@ -8412,16 +14433,26 @@
           "Горох (за ЕСУМ)",
           "СУМ-11"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "хто це?",
+      "url_slug": "хто-це",
+      "gloss": "who is this?",
+      "pos": "phrase",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "фото",
-            "detail": "lemma match (29 forms)"
-          }
-        ],
+        "classification": "unknown",
+        "attestations": [],
         "is_russianism": false,
         "russian_shadow": false,
         "sovietization_risk": 0,
@@ -8429,27 +14460,65 @@
       }
     },
     {
-      "lemma": "чудово",
-      "url_slug": "чудово",
-      "gloss": "great, wonderful",
-      "pos": null,
+      "lemma": "чистити зуби",
+      "url_slug": "чистити-зуби",
+      "gloss": "to brush teeth",
+      "pos": "phrase",
       "ipa": null,
-      "primary_source": "plan_required",
+      "primary_source": "built_vocabulary",
       "course_usage": [
         {
           "track": "a1",
-          "module_num": 1,
-          "slug": "sounds-letters-and-hello",
-          "context": "plan_required"
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
         }
       ],
+      "heritage_status": {
+        "classification": "unknown",
+        "attestations": [],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      }
+    },
+    {
+      "lemma": "швидко",
+      "url_slug": "швидко",
+      "gloss": "quickly",
+      "pos": "adverb",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 20,
+          "slug": "my-morning",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "швидко",
+            "detail": "lemma match (1 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
       "enrichment": {
         "morphology": {
           "pos": "прислівник",
           "form_count": 1,
           "forms": [
             {
-              "form": "чудово",
+              "form": "швидко",
               "label": ""
             }
           ],
@@ -8457,18 +14526,14 @@
         },
         "meaning": {
           "definitions": [
-            "ЧУДО́ВО. 1. Присл. до чудо́вий. Музика далась Настусі дуже легко, і вона швидко вивчилась чудово грати на роялі (Н.-Лев., IV, 1956, 228); [Олеся:] Як чудово промінь сонця позолотив осокора і хутко-хутко біжить по листях (Кроп., II, 1958, 332); Надвечір в парку дихалось чудово (Мур., Повість.., 1948, 4); В просторій молдуванській хаті, вистеленій різнобарвними килимами, обвішаній чудово тканими рушниками, блимає перед образом лампадка (Коцюб., І, 1955, 228). 2. у знач. присудк. сл. Про захоплюючу навколишню красу. Гляньмо ж з міста наниз, на Рось і на Заросся, Як же там хороше, як чудово! (Н.-Л"
+            "ШВИ́ДКО. Присл. до швидки́й. Швидко, швидко летить поїзд! Красні краєвиди, мов у сні, зміняються (Л. Укр., III, 1952, 521); Троє плавців швидко наближалися до корабля (Трубл., Шхуна.., 1940, 84); Ходила вона швидко, поралась проворно, невважаючи на свою старість (Н.-Лев., III, 1956, 323); Троянці, в човни посідавши І швидко їх поодпихавши, По вітру гарно поплили (Котл., І, 1952, 158); Швидко, легко, із звичною точністю почав він накреслювати контури юрт, силуети людей між ними, коня, прив’язаного до конов’язі, очерети біля річки (Тулуб, В степу.., 1964, 176); Робота посувається швидко і найбіл"
           ],
           "source": "СУМ-11",
-          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті.",
-          "synonyms": [
-            "прекрасно",
-            "чудесно",
-            "блискуче"
-          ]
+          "sovietization_risk": 0,
+          "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті."
         },
         "attestation": {
-          "text": "Чудово нар. Чудно, Гляньмо ж з міста вниз на Рось і на Заросся. Як же там хороше, як чудово! Левиц. І. 93.",
+          "text": "Швидко нар. Скоро, быстро. Лихо швидко приходить, а поволі відходить. Ном. № 1958. Не так швидко робиться, як мовиться. Ном. № 5603. на-швИдко, на-швидку. Наскоро. Оце тобі, серденько, вчера на-швидко. Чуб. V. 217. Словце яке на-швидку перемовити. МВ. ІІ. 83.",
           "source": "Грінченко (1907)"
         },
         "sources": [
@@ -8476,16 +14541,26 @@
           "Грінченко (1907)",
           "СУМ-11"
         ]
-      },
+      }
+    },
+    {
+      "lemma": "що це?",
+      "url_slug": "що-це",
+      "gloss": "what is this?",
+      "pos": "phrase",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
       "heritage_status": {
-        "classification": "standard",
-        "attestations": [
-          {
-            "source": "VESUM",
-            "ref": "чудово",
-            "detail": "lemma match (1 forms)"
-          }
-        ],
+        "classification": "unknown",
+        "attestations": [],
         "is_russianism": false,
         "russian_shadow": false,
         "sovietization_risk": 0,
@@ -8514,6 +14589,152 @@
         "russian_shadow": false,
         "sovietization_risk": 0,
         "calque_warning": null
+      }
+    },
+    {
+      "lemma": "іменник",
+      "url_slug": "іменник",
+      "gloss": "noun",
+      "pos": "noun",
+      "ipa": null,
+      "primary_source": "built_vocabulary",
+      "course_usage": [
+        {
+          "track": "a1",
+          "module_num": 8,
+          "slug": "things-have-gender",
+          "context": "built_vocabulary"
+        }
+      ],
+      "heritage_status": {
+        "classification": "standard",
+        "attestations": [
+          {
+            "source": "VESUM",
+            "ref": "іменник",
+            "detail": "lemma match (16 forms)"
+          }
+        ],
+        "is_russianism": false,
+        "russian_shadow": false,
+        "sovietization_risk": 0,
+        "calque_warning": null
+      },
+      "enrichment": {
+        "morphology": {
+          "pos": "іменник",
+          "form_count": 16,
+          "forms": [
+            {
+              "form": "іменникові",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "іменнику",
+              "label": "чол., давальний"
+            },
+            {
+              "form": "іменнику",
+              "label": "чол., кличний"
+            },
+            {
+              "form": "іменникові",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "іменнику",
+              "label": "чол., місцевий"
+            },
+            {
+              "form": "іменник",
+              "label": "чол., називний"
+            },
+            {
+              "form": "іменником",
+              "label": "чол., орудний"
+            },
+            {
+              "form": "іменника",
+              "label": "чол., родовий"
+            },
+            {
+              "form": "іменник",
+              "label": "чол., знахідний"
+            },
+            {
+              "form": "іменникам",
+              "label": "множина, давальний"
+            },
+            {
+              "form": "іменники",
+              "label": "множина, кличний"
+            },
+            {
+              "form": "іменниках",
+              "label": "множина, місцевий"
+            },
+            {
+              "form": "іменники",
+              "label": "множина, називний"
+            },
+            {
+              "form": "іменниками",
+              "label": "множина, орудний"
+            },
+            {
+              "form": "іменників",
+              "label": "множина, родовий"
+            },
+            {
+              "form": "іменники",
+              "label": "множина, знахідний"
+            }
+          ],
+          "source": "VESUM",
+          "paradigm": {
+            "kind": "noun",
+            "cases": {
+              "називний": {
+                "singular": "іменник",
+                "plural": "іменники"
+              },
+              "родовий": {
+                "singular": "іменника",
+                "plural": "іменників"
+              },
+              "давальний": {
+                "singular": "іменникові / іменнику",
+                "plural": "іменникам"
+              },
+              "знахідний": {
+                "singular": "іменник",
+                "plural": "іменники"
+              },
+              "орудний": {
+                "singular": "іменником",
+                "plural": "іменниками"
+              },
+              "місцевий": {
+                "singular": "іменникові / іменнику",
+                "plural": "іменниках"
+              },
+              "кличний": {
+                "singular": "іменнику",
+                "plural": "іменники"
+              }
+            }
+          }
+        },
+        "meaning": {
+          "definitions": [
+            "самостійна частина мови, що означає назву предмета, поняття, явища"
+          ],
+          "source": "Вікісловник"
+        },
+        "sources": [
+          "VESUM",
+          "Вікісловник"
+        ]
       }
     }
   ],

--- a/starlight/src/pages/lexicon/[lemma].astro
+++ b/starlight/src/pages/lexicon/[lemma].astro
@@ -23,6 +23,8 @@ interface Meaning {
   source: string;
   synonyms?: string[];
   note?: string;
+  sovietization_risk?: number;
+  sovietization_keywords?: string[];
 }
 
 interface NounParadigm {
@@ -101,6 +103,8 @@ const POS_LABELS_UK: Record<string, string> = {
   conj: "сполучник",
   particle: "частка",
   interjection: "вигук",
+  "proper noun": "власна назва",
+  proper_noun: "власна назва",
   phrase: "фраза",
 };
 
@@ -123,6 +127,7 @@ const CONTEXT_LABELS_UK: Record<string, string> = {
   built_vocabulary: "вивчається",
   plan_required: "обов’язкова",
   plan_recommended: "рекомендована",
+  surzhyk_to_avoid: "остерігайтеся",
 };
 
 const CASE_ROWS = [
@@ -164,6 +169,21 @@ const HERITAGE_CLASSIFICATION_UK: Record<string, { label: string; gloss: string;
   historism: { label: "Історизм", gloss: "Слово на позначення зниклої реалії; питома українська лексика.", tone: "heritage" },
   dialect: { label: "Діалектизм", gloss: "Регіональна українська форма, засвідчена в словниках.", tone: "heritage" },
   borrowing: { label: "Запозичення", gloss: "Засвоєне запозичення в межах української норми.", tone: "heritage" },
+};
+
+const HERITAGE_WARNING_UK: Record<string, { label: string; gloss: string }> = {
+  russianism: {
+    label: "Русизм",
+    gloss: "Ця форма має ознаки русизму. Для нормативної української використовуйте відповідник нижче.",
+  },
+  sovietism: {
+    label: "Радянізм",
+    gloss: "Це радянсько-ідеологічна форма. Для нейтральної української використовуйте відповідник нижче.",
+  },
+  surzhyk: {
+    label: "Суржик",
+    gloss: "Ця форма належить до суржику. Для стандартної української використовуйте відповідник нижче.",
+  },
 };
 
 export async function getStaticPaths() {
@@ -208,29 +228,45 @@ const hasDictionaryData = Boolean(
 
 const heritage = entry.heritage_status ?? null;
 const heritageClass = heritage ? HERITAGE_CLASSIFICATION_UK[heritage.classification] ?? null : null;
-const russianAlternatives = heritage?.is_russianism
+const heritageWarning = heritage
+  ? HERITAGE_WARNING_UK[heritage.classification] ??
+    (heritage.is_russianism ? HERITAGE_WARNING_UK.russianism : null)
+  : null;
+const showHeritageWarning = Boolean(
+  heritage &&
+    heritageWarning &&
+    (heritage.is_russianism ||
+      heritage.classification === "russianism" ||
+      heritage.classification === "sovietism" ||
+      heritage.classification === "surzhyk"),
+);
+const standardAlternatives = showHeritageWarning
   ? Array.from(
       new Set(
-        heritage.attestations
+        (heritage?.attestations ?? [])
           .filter((a) => a.source === "standard_alternative" && a.ref)
           .map((a) => a.ref),
       ),
     )
   : [];
-const sovietRisk = heritage?.sovietization_risk ?? 0;
+const meaningSource = enrichment?.meaning?.source ?? "";
+const isSum11Meaning = meaningSource.replace(/\s/g, "").includes("СУМ-11");
+const meaningSovietRisk = isSum11Meaning
+  ? Number(enrichment?.meaning?.sovietization_risk ?? 0)
+  : 0;
+const showSovietSourceCaveat = meaningSovietRisk > 0;
 // "standard" is the unremarkable default (codified modern norm) — it gets the
 // glanceable header pill but no dedicated section. The section is reserved for
 // the noteworthy cases: a non-standard authentic status (archaism/historism/
-// dialect/borrowing) or any decolonization warning (русизм/shadow/soviet/calque).
+// dialect/borrowing) or any word-level decolonization warning.
 const isNoteworthyClass = Boolean(
   heritage && heritageClass && heritage.classification !== "standard",
 );
 const showHeritage = Boolean(
   heritage &&
     (isNoteworthyClass ||
-      heritage.is_russianism ||
+      showHeritageWarning ||
       heritage.russian_shadow ||
-      sovietRisk > 0 ||
       heritage.calque_warning),
 );
 
@@ -274,10 +310,12 @@ const frontmatter = {
         <span>{CONTEXT_LABELS_UK[entry.primary_source] ?? entry.primary_source}</span>
         <span>{courseUsage.length} {courseUsage.length === 1 ? "модуль" : "модулів"}</span>
         {enrichment?.morphology && <span>{enrichment.morphology.form_count} форм</span>}
-        {heritage?.is_russianism && (
-          <span class="atlas-heritage-pill atlas-heritage-pill--russism">Русизм</span>
+        {showHeritageWarning && heritageWarning && (
+          <span class="atlas-heritage-pill atlas-heritage-pill--russism">
+            {heritageWarning.label}
+          </span>
         )}
-        {!heritage?.is_russianism && heritageClass && (
+        {!showHeritageWarning && heritageClass && (
           <span class={`atlas-heritage-pill atlas-heritage-pill--${heritageClass.tone}`}>
             {heritageClass.label}
           </span>
@@ -305,17 +343,14 @@ const frontmatter = {
           <h2 id="atlas-heritage-title">Походження та статус</h2>
         </div>
 
-        {heritage?.is_russianism ? (
+        {showHeritageWarning && heritageWarning ? (
           <div class="atlas-heritage-card atlas-heritage-card--russism">
-            <p class="atlas-source-label">Русизм</p>
-            <p>
-              Ця форма має ознаки русизму. Українська норма послуговується іншим
-              словом — використовуйте відповідник нижче.
-            </p>
-            {russianAlternatives.length > 0 && (
+            <p class="atlas-source-label">{heritageWarning.label}</p>
+            <p>{heritageWarning.gloss}</p>
+            {standardAlternatives.length > 0 && (
               <p class="atlas-chip-line">
                 <strong>Українська норма:</strong>{" "}
-                {russianAlternatives.map((alt) => (
+                {standardAlternatives.map((alt) => (
                   <span>{alt}</span>
                 ))}
               </p>
@@ -333,18 +368,10 @@ const frontmatter = {
           </div>
         )}
 
-        {heritage?.russian_shadow && !heritage?.is_russianism && (
+        {heritage?.russian_shadow && !showHeritageWarning && (
           <p class="atlas-heritage-warn">
             ⚠ Морфологічна тінь російської форми — перевірте відмінювання за VESUM
             та Правописом 2019.
-          </p>
-        )}
-        {sovietRisk > 0 && (
-          <p class="atlas-heritage-warn">
-            ⚠{" "}
-            {sovietRisk >= 2
-              ? "Радянське ідеологічне трактування у словниковому джерелі — тлумачення подано нейтрально."
-              : "Радянські конотації у словниковому джерелі — тлумачення подано обережно."}
           </p>
         )}
         {heritage?.calque_warning && (
@@ -402,6 +429,13 @@ const frontmatter = {
             </p>
           )}
           {enrichment.meaning.note && <p class="atlas-note">{enrichment.meaning.note}</p>}
+          {showSovietSourceCaveat && (
+            <p class="atlas-source-caveat" role="note">
+              <span aria-hidden="true">⚠</span>{" "}
+              Це тлумачення — з радянського словника (СУМ-11); подається з
+              осторогою. Перевага — Грінченко / СУМ-20.
+            </p>
+          )}
         </div>
       </section>
     )}
@@ -855,6 +889,21 @@ const frontmatter = {
   .atlas-note,
   .atlas-provenance p {
     color: var(--lu-text-muted);
+  }
+
+  .atlas-source-caveat {
+    margin: 0.85rem 0 0;
+    padding: 0.65rem 0.8rem;
+    border: 1px solid color-mix(in srgb, var(--lu-accent) 68%, var(--lu-border));
+    border-left: 4px solid var(--lu-accent);
+    border-radius: 6px;
+    background: var(--lu-state-missed);
+    color: var(--lu-text);
+    font-size: 0.92rem;
+  }
+
+  .atlas-source-caveat span {
+    font-weight: 900;
   }
 
   .atlas-source-card {

--- a/starlight/src/pages/lexicon/index.astro
+++ b/starlight/src/pages/lexicon/index.astro
@@ -38,6 +38,7 @@ const SOURCE_LABELS_UK: Record<string, string> = {
   built_vocabulary: "вивчається",
   plan_required: "обов’язкова",
   plan_recommended: "рекомендована",
+  surzhyk_to_avoid: "остерігайтеся",
 };
 
 const TRACK_LABELS_UK: Record<string, string> = {

--- a/starlight/src/pages/lexicon/index/index.astro
+++ b/starlight/src/pages/lexicon/index/index.astro
@@ -35,6 +35,7 @@ const SOURCE_LABELS_UK: Record<string, string> = {
   built_vocabulary: "вивчається",
   plan_required: "обов’язкова",
   plan_recommended: "рекомендована",
+  surzhyk_to_avoid: "остерігайтеся",
 };
 
 const groups = new Map<string, LexiconEntry[]>();

--- a/tests/test_atlas_conformance.py
+++ b/tests/test_atlas_conformance.py
@@ -77,6 +77,30 @@ def test_lemma_in_vesum_exempts_genuine_multi_word_phrase():
     assert _gates_for(entry, vesum=set()) == []
 
 
+def test_lemma_in_vesum_exempts_proper_nouns():
+    entry = _entry(lemma="Ілля", url_slug="ілля", pos="proper noun")
+
+    assert _gates_for(entry, vesum=set()) == []
+
+
+def test_lemma_in_vesum_exempts_deliberate_warning_seed():
+    entry = _entry(
+        lemma="міроприємство",
+        url_slug="міроприємство",
+        primary_source="surzhyk_to_avoid",
+        heritage_status={
+            "classification": "russianism",
+            "attestations": [{"source": "standard_alternative", "ref": "захід"}],
+            "is_russianism": True,
+            "russian_shadow": False,
+            "sovietization_risk": 0,
+            "calque_warning": None,
+        },
+    )
+
+    assert _gates_for(entry, vesum=set()) == []
+
+
 def test_provenance_per_section_flags_missing_source():
     entry = _entry(
         enrichment={
@@ -128,6 +152,20 @@ def test_sovietization_must_be_flagged_for_unmirrored_sum11_risk():
     )
 
     assert _gates_for(entry) == ["sovietization_must_be_flagged"]
+
+
+def test_sovietization_passes_when_meaning_carries_source_risk():
+    entry = _entry(
+        enrichment={
+            "meaning": {
+                "definitions": ["Ідеологічно навантажене тлумачення."],
+                "source": "СУМ-11",
+                "sovietization_risk": 1,
+            }
+        }
+    )
+
+    assert _gates_for(entry) == []
 
 
 def test_cross_link_integrity_flags_unknown_course_slug():

--- a/tests/test_lexicon_build_manifest.py
+++ b/tests/test_lexicon_build_manifest.py
@@ -1,0 +1,32 @@
+from scripts.lexicon.build_data_manifest import SURZHYK_TO_AVOID_SEEDS, build_manifest
+
+
+def test_surzhyk_to_avoid_seed_group_is_in_manifest() -> None:
+    manifest = build_manifest()
+    entries = {entry["lemma"]: entry for entry in manifest["entries"]}
+    seed_lemmas = [str(seed["lemma"]) for seed in SURZHYK_TO_AVOID_SEEDS]
+
+    assert manifest["stats"]["from_surzhyk_to_avoid"] == len(seed_lemmas)
+    assert manifest["seed_groups"] == [
+        {
+            "id": "surzhyk-to-avoid",
+            "source": "surzhyk_to_avoid",
+            "description": "Classifier-verified Russianism/surzhyk examples for visible Atlas warnings.",
+            "lemmas": seed_lemmas,
+        }
+    ]
+    for lemma in seed_lemmas:
+        assert entries[lemma]["primary_source"] == "surzhyk_to_avoid"
+        assert entries[lemma]["seed_group"] == "surzhyk-to-avoid"
+        assert entries[lemma]["course_usage"] == []
+
+
+def test_manifest_url_slugs_are_unique() -> None:
+    manifest = build_manifest()
+    slugs: dict[str, list[str]] = {}
+    for entry in manifest["entries"]:
+        slugs.setdefault(entry["url_slug"], []).append(entry["lemma"])
+
+    duplicates = {slug: lemmas for slug, lemmas in slugs.items() if len(lemmas) > 1}
+
+    assert duplicates == {}

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -3,6 +3,7 @@ import sqlite3
 
 from scripts.lexicon.enrich_manifest import (
     _build_paradigm,
+    _meaning,
     _sense_correct_synonyms,
     clean_gloss,
     clean_html_entities,
@@ -29,7 +30,10 @@ def _conn() -> sqlite3.Connection:
         );
         CREATE TABLE sum11 (
             word TEXT NOT NULL,
-            definition TEXT NOT NULL DEFAULT ''
+            definition TEXT NOT NULL DEFAULT '',
+            text TEXT NOT NULL DEFAULT '',
+            sovietization_risk INTEGER NOT NULL DEFAULT 0,
+            sovietization_keywords TEXT NOT NULL DEFAULT ''
         );
         """
     )
@@ -192,7 +196,10 @@ def test_synonyms_filter_polluted_wordnet_rows_to_a1_sense() -> None:
             ("fine", "прекрасно", "fine: прекрасно"),
         ],
     )
-    conn.execute("INSERT INTO sum11 VALUES (?, ?)", ("чудово", "Уживається як вияв похвали; прекрасно, чудесно."))
+    conn.execute(
+        "INSERT INTO sum11 (word, definition) VALUES (?, ?)",
+        ("чудово", "Уживається як вияв похвали; прекрасно, чудесно."),
+    )
 
     assert _sense_correct_synonyms(conn, "кава") == []
     assert _sense_correct_synonyms(conn, "мама") == ["мати", "матуся"]
@@ -207,3 +214,28 @@ def test_synonyms_filter_polluted_wordnet_rows_to_a1_sense() -> None:
     ]
     assert not any(any("A" <= char <= "Z" or "a" <= char <= "z" for char in synonym) for synonym in all_synonyms)
     assert "жахливо" not in all_synonyms
+
+
+def test_sum11_meaning_carries_source_sovietization_risk() -> None:
+    conn = _conn()
+    conn.execute(
+        """
+        INSERT INTO sum11
+            (word, definition, text, sovietization_risk, sovietization_keywords)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (
+            "ленінізм",
+            "Учення В. І. Леніна, що являє собою розвиток марксизму.",
+            "",
+            2,
+            "ленін,маркс",
+        ),
+    )
+
+    meaning = _meaning(conn, "ленінізм")
+
+    assert meaning is not None
+    assert meaning["source"] == "СУМ-11"
+    assert meaning["sovietization_risk"] == 2
+    assert meaning["sovietization_keywords"] == ["ленін", "маркс"]

--- a/tests/test_sum11_sovietization_scan.py
+++ b/tests/test_sum11_sovietization_scan.py
@@ -97,8 +97,8 @@ SEED_ROWS = [
 
 
 @pytest.fixture
-def seeded_db(tmp_path):
-    """Create a small sum11-shaped DB and apply the migration."""
+def seeded_db_without_migration(tmp_path):
+    """Create a small pre-migration sum11-shaped DB."""
     db_path = tmp_path / "sum11_test.db"
     conn = sqlite3.connect(db_path)
     conn.executescript(
@@ -119,18 +119,42 @@ def seeded_db(tmp_path):
         SEED_ROWS,
     )
     conn.commit()
+    conn.close()
+    return db_path
+
+
+@pytest.fixture
+def seeded_db(seeded_db_without_migration):
+    """Create a small sum11-shaped DB and apply the migration."""
+    conn = sqlite3.connect(seeded_db_without_migration)
 
     # Apply the production migration so column shape matches.
     conn.executescript(MIGRATION_SQL.read_text())
     conn.commit()
     conn.close()
-    return db_path
+    return seeded_db_without_migration
 
 
 def test_migration_adds_required_columns(seeded_db):
     conn = sqlite3.connect(seeded_db)
     cols = {row[1] for row in conn.execute("PRAGMA table_info(sum11)").fetchall()}
     conn.close()
+    assert "sovietization_risk" in cols
+    assert "sovietization_keywords" in cols
+
+
+def test_lexicon_migration_script_adds_required_columns(seeded_db_without_migration):
+    from scripts.lexicon.migrate_sum11_sovietization import (
+        ensure_sum11_sovietization_columns,
+    )
+
+    conn = sqlite3.connect(seeded_db_without_migration)
+    actions = ensure_sum11_sovietization_columns(conn)
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(sum11)").fetchall()}
+    conn.close()
+
+    assert "add sovietization_risk" in actions
+    assert "add sovietization_keywords" in actions
     assert "sovietization_risk" in cols
     assert "sovietization_keywords" in cols
 
@@ -293,3 +317,34 @@ def test_scan_is_idempotent(seeded_db, tmp_path):
     conn.close()
 
     assert first == second
+
+
+def test_scan_clears_stale_clean_row_flags(seeded_db, tmp_path):
+    report_path = tmp_path / "report.md"
+    conn = sqlite3.connect(seeded_db)
+    conn.execute(
+        "UPDATE sum11 SET sovietization_risk = 2, sovietization_keywords = 'ленін' "
+        "WHERE word = 'західний'"
+    )
+    conn.commit()
+    conn.close()
+
+    subprocess.run(
+        [
+            str(_venv_python()),
+            str(SCAN_SCRIPT),
+            "--db",
+            str(seeded_db),
+            "--report",
+            str(report_path),
+        ],
+        check=True,
+    )
+
+    conn = sqlite3.connect(seeded_db)
+    row = conn.execute(
+        "SELECT sovietization_risk, sovietization_keywords FROM sum11 WHERE word = 'західний'"
+    ).fetchone()
+    conn.close()
+
+    assert row == (0, "")


### PR DESCRIPTION
## Summary

Makes the Word Atlas decolonization warnings render in a real static build.

- Adds an idempotent `sum11` migration/population wrapper for `sovietization_risk` and `sovietization_keywords`.
- Carries СУМ-11 source risk on `enrichment.meaning` while keeping word classification separate.
- Renders red word-level badges only for classifier-confirmed `russianism`/`sovietism`/`surzhyk` entries with alternatives.
- Renders amber meaning-source caveats for Soviet-flagged СУМ-11 fallback definitions.
- Seeds 8 classifier-confirmed Russianism/surzhyk entries so red warning pages exist in the live Atlas.

## Before / After

Before: `sum11` had no persisted Sovietization columns, `ленінізм` and `школа` returned `sovietization_risk=0`, and the Atlas manifest contained no Russianism pages, so zero red badges rendered.

After:

- `classify_lemma('ленінізм')` → `classification=standard`, `sovietization_risk=2`
- `classify_lemma('школа')` → `classification=standard`, `sovietization_risk=2` (not labeled a Sovietism)
- `classify_lemma('міроприємство')` → `classification=russianism`, alternative `захід`

## Rendered Page Counts

Built with `cd starlight && npm ci && npm run build`.

- Red badge pages: 8
- Amber СУМ-11 source-caveat pages: 8

## Report

Full command log, seed classifier output, and page-count proof:

- `docs/research/2026-06-12-atlas-moat-visible-report.md`

## Validation

- `.venv/bin/python scripts/lexicon/migrate_sum11_sovietization.py --db data/sources.db`
- `.venv/bin/python -m scripts.lexicon.build_data_manifest`
- `.venv/bin/python scripts/lexicon/enrich_manifest.py`
- `env -u AGENT_NO_TELEMETRY_FOOTER .venv/bin/python -m pytest tests/ -k 'lexicon or manifest or atlas or heritage or sovietization' -q` → 153 passed, 1 xfailed
- `.venv/bin/ruff check ...` → clean
- `cd starlight && npm ci` → clean install, 0 vulnerabilities
- `cd starlight && npm run build` → 296 pages built
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` → pass
