### PR TITLE
fix(site): clarify landing course hierarchy

### DIFF
--- a/starlight/src/layouts/CourseLayout.astro
+++ b/starlight/src/layouts/CourseLayout.astro
@@ -59,10 +59,10 @@ const canonicalPath = currentPath.endsWith('/') ? currentPath : `${currentPath}/
 
 const topNav = [
   { href: '/', label: 'Home' },
-  { href: '/a1/', label: 'A1 Release' },
+  { href: '/a1/', label: 'A1' },
   { href: '/a2/', label: 'A2' },
-  { href: '/folk/', label: 'Folk Seminar' },
-  { href: '/lexicon/', label: 'Лексикон' },
+  { href: '/b1/', label: 'B1 Preview' },
+  { href: '/lexicon/', label: 'Word Atlas' },
   { href: '/search/', label: 'Search' },
 ];
 
@@ -280,10 +280,10 @@ const isActive = (href: string) => {
             </section>
             <section>
               <h3>Course</h3>
-              <a href="/a1/">A1 Release</a>
+              <a href="/a1/">A1</a>
               <a href="/a2/">A2</a>
-              <a href="/folk/">Folk Seminar</a>
-              <a href="/lexicon/">Лексикон</a>
+              <a href="/b1/">B1 Preview</a>
+              <a href="/lexicon/">Word Atlas</a>
             </section>
             <section>
               <h3>External</h3>

--- a/starlight/src/pages/404.astro
+++ b/starlight/src/pages/404.astro
@@ -19,8 +19,8 @@ import CourseLayout from '../layouts/CourseLayout.astro';
       course surface instead of guessing around draft paths.
     </p>
     <div class="state-actions">
-      <a href="/a1/">A1 Release</a>
-      <a href="/folk/">Folk Seminar</a>
+      <a href="/a1/">A1</a>
+      <a href="/b1/">B1 Preview</a>
       <a href="/search/">Search</a>
       <a href="/lexicon/">Word Atlas</a>
     </div>

--- a/starlight/src/pages/[...slug].astro
+++ b/starlight/src/pages/[...slug].astro
@@ -52,7 +52,7 @@ const TRACKS: Record<string, TrackOverview> = {
   a1: {
     label: 'A1',
     title: 'Перші кроки · First Steps',
-    eyebrow: 'A1 release',
+    eyebrow: 'A1 course',
     subtitle: 'Beginner Ukrainian for sounds, reading, first conversations, everyday needs, and the A1 finale.',
     status: 'Released beginner course',
     family: 'core',
@@ -88,19 +88,20 @@ const TRACKS: Record<string, TrackOverview> = {
   b1: {
     label: 'B1',
     title: 'B1 · Intermediate Ukrainian',
-    eyebrow: 'Future core track',
-    subtitle: 'Intermediate grammar, texts, register, and argumentation after A2 is regenerated.',
-    status: 'Planned / unavailable',
+    eyebrow: 'B1 preview',
+    subtitle: 'Intermediate Ukrainian is open as a preview, beginning with the baseline past-present module.',
+    status: 'Preview',
     family: 'core',
-    state: 'unavailable',
-    heroVariant: 'unavailable',
-    primaryAction: { href: '/a1/', label: 'Start With A1' },
+    state: 'beta',
+    heroVariant: 'core',
+    primaryAction: { href: '/b1/', label: 'Open B1 Preview' },
+    secondaryAction: { href: '/a1/', label: 'Start With A1' },
     points: [
-      'B1 is intentionally shown as future work, not a current learner promise.',
-      'The unavailable state keeps navigation honest while preserving the long-term course map.',
-      'Existing plan inventory remains source material for later UI slices.',
+      'B1 is available as a preview, not a complete course release.',
+      'The first module shows the Ukrainian-led intermediate style and activity contract.',
+      'The remaining B1 curriculum stays visible as a map while modules are built.',
     ],
-    pattern: ['future track notice', 'module count', 'return path', 'no stale publication claim'],
+    pattern: ['preview module', 'Ukrainian-led B1', 'module map', 'return path'],
   },
   b2: {
     label: 'B2',
@@ -167,7 +168,7 @@ const TRACKS: Record<string, TrackOverview> = {
     points: [
       'Folk proves the source-heavy seminar pattern before the wider seminar family ships.',
       'Lessons emphasize motif, context, performance, source notes, and decolonization framing.',
-      'This track is separate from beginner A1 release readiness.',
+      'This track is separate from beginner A1 course readiness.',
     ],
     pattern: ['source note', 'motif map', 'performance context', 'seminar workbook', 'resource trail'],
   },
@@ -180,7 +181,7 @@ const TRACKS: Record<string, TrackOverview> = {
     family: 'seminar',
     state: 'planned',
     heroVariant: 'seminar',
-    primaryAction: { href: '/folk/', label: 'Preview Seminar Pattern' },
+    primaryAction: { href: '/b1/', label: 'Open B1 Preview' },
     points: [
       'BIO is planned work; the learner UI shows the template without claiming finished modules.',
       'The page pattern reserves space for chronology, source conflict, and decolonization notes.',
@@ -197,7 +198,7 @@ const TRACKS: Record<string, TrackOverview> = {
     family: 'seminar',
     state: 'planned',
     heroVariant: 'history',
-    primaryAction: { href: '/folk/', label: 'Preview Seminar Pattern' },
+    primaryAction: { href: '/b1/', label: 'Open B1 Preview' },
     points: [
       'HIST is planned after the current release focus; it is not a live course lane yet.',
       'The template foregrounds evidence and interpretation rather than timeline trivia.',
@@ -214,7 +215,7 @@ const TRACKS: Record<string, TrackOverview> = {
     family: 'seminar',
     state: 'planned',
     heroVariant: 'history',
-    primaryAction: { href: '/folk/', label: 'Preview Seminar Pattern' },
+    primaryAction: { href: '/b1/', label: 'Open B1 Preview' },
     points: [
       'ISTORIO stays visible as a method-heavy seminar family.',
       'The future lesson template needs source disagreement and interpretive stakes.',
@@ -231,7 +232,7 @@ const TRACKS: Record<string, TrackOverview> = {
     family: 'seminar',
     state: 'planned',
     heroVariant: 'lit',
-    primaryAction: { href: '/folk/', label: 'Preview Seminar Pattern' },
+    primaryAction: { href: '/b1/', label: 'Open B1 Preview' },
     points: [
       'LIT and its variants share one close-reading template family.',
       'The UI supports excerpts and references without copying protected texts.',
@@ -604,7 +605,7 @@ const plannedModuleGroups = (track: string, trackOverview: TrackOverview) => {
       <div class="search-state search-empty" data-search-empty hidden>
         <span class="state-code">No Results</span>
         <h2>No matching pages.</h2>
-        <p>Try a broader term, a Ukrainian lemma, or open A1, Folk, Word Atlas, or Etymology directly.</p>
+        <p>Try a broader term, a Ukrainian lemma, or open A1, B1 Preview, Word Atlas, or Etymology directly.</p>
       </div>
 
       <section class="search-results-section" aria-live="polite">
@@ -692,8 +693,8 @@ const plannedModuleGroups = (track: string, trackOverview: TrackOverview) => {
             : 'Atlas and reference indexes should communicate when a filter or future dataset has no records.'}
       </p>
       <div class="state-actions">
-        <a href="/a1/">A1 Release</a>
-        <a href="/folk/">Folk Seminar</a>
+        <a href="/a1/">A1</a>
+        <a href="/b1/">B1 Preview</a>
         <a href="/search/">Search</a>
         <a href="/lexicon/">Word Atlas</a>
       </div>

--- a/starlight/src/pages/index.astro
+++ b/starlight/src/pages/index.astro
@@ -11,11 +11,12 @@ const moduleCount = (id: string) => {
 };
 
 const coreTracks = [
-  { id: 'a2', label: 'A2', title: 'Elementary Core', status: 'Released' },
-  { id: 'b1', label: 'B1', title: 'Intermediate Core', status: 'Planned' },
-  { id: 'b2', label: 'B2', title: 'Upper Intermediate Core', status: 'Planned' },
-  { id: 'c1', label: 'C1', title: 'Advanced Core', status: 'Planned' },
-  { id: 'c2', label: 'C2', title: 'Mastery Core', status: 'Long-range' },
+  { id: 'a1', label: 'A1', title: 'Beginner Course', status: 'Released' },
+  { id: 'a2', label: 'A2', title: 'Pre-Intermediate Course', status: 'Released' },
+  { id: 'b1', label: 'B1', title: 'Intermediate Course', status: 'Preview' },
+  { id: 'b2', label: 'B2', title: 'Upper-Intermediate Course', status: 'Planned' },
+  { id: 'c1', label: 'C1', title: 'Advanced Course', status: 'Planned' },
+  { id: 'c2', label: 'C2', title: 'Mastery Course', status: 'Long-range' },
 ];
 
 const seminarTracks = [
@@ -38,37 +39,38 @@ const seminarTracks = [
 
 <CourseLayout
   title="Learn Ukrainian"
-  description="A lightweight Ukrainian course UI for the released A1 and A2 courses, plus the Folk seminar test track."
-  eyebrow="A1 release"
-  subtitle="A practical learner course, not a generic documentation site."
+  description="An English learner interface for released A1 and A2 Ukrainian courses, a B1 preview, and the Word Atlas reference tool."
+  eyebrow="Course ladder and reference tools"
+  subtitle="A practical English interface for learning Ukrainian."
   currentPath="/"
   wide
 >
   <section class="home-intro">
     <div>
-      <p class="home-kicker">Ukrainian for real use</p>
-      <h2>A1 and A2 are released. Folk runs in parallel as the seminar test lane.</h2>
+      <p class="home-kicker">Learn Ukrainian</p>
+      <h2>Start with A1. Continue with A2. Preview B1 when you are ready.</h2>
       <p>
-        Start with A1 if you are learning independently. Use the Folk seminar path for advanced cultural
-        source work. Continue with A2 when you are ready for the full pre-intermediate course; the broader
-        seminar inventory is shown below without promising a distant publication order.
+        The released course path is A1, then A2. B1 is open as an intermediate preview so learners
+        and teachers can see the next direction without treating it as a finished release. Word Atlas
+        supports the course as a reference tool, not as a separate course track. Seminar tracks are
+        listed for context, but they are not public entry points yet.
       </p>
       <div class="home-actions">
         <a class="home-primary" href="/a1/">Start A1</a>
-        <a class="home-secondary" href="/folk/">Open Folk</a>
+        <a class="home-secondary" href="/b1/">Open B1 Preview</a>
       </div>
     </div>
     <aside class="roadmap-panel" aria-label="Roadmap">
       <div><strong>A1</strong><span>Released beginner course</span></div>
-      <div><strong>A2</strong><span>Released pre-intermediate course</span></div>
-      <div><strong>Folk</strong><span>Seminar test track</span></div>
-      <div><strong>BIO</strong><span>Biographies planned</span></div>
-      <div><strong>HIST</strong><span>History planned</span></div>
+      <div><strong>A2</strong><span>Released continuation course</span></div>
+      <div><strong>B1</strong><span>Intermediate preview</span></div>
+      <div><strong>Word Atlas</strong><span>Reference tool</span></div>
+      <div><strong>Seminars</strong><span>Not promoted yet</span></div>
     </aside>
   </section>
 
   <section>
-    <h2>Course Surfaces</h2>
+    <h2>Available Now</h2>
     <div class="lu-card-grid">
       <a class="lu-card" href="/a1/">
         <span class="track-badge a1">A1</span>
@@ -80,31 +82,32 @@ const seminarTracks = [
         <h3>Pre-Intermediate Course</h3>
         <p>69 modules take learners from the A2 bridge through everyday situations, cases, aspect, and the A2 finale.</p>
       </a>
-      <a class="lu-card" href="/folk/">
-        <span class="track-badge folk">Folk</span>
-        <h3>Seminar Test Track</h3>
-        <p>Advanced Ukrainian cultural source work with oral tradition, ritual, and decolonization framing.</p>
+      <a class="lu-card" href="/b1/">
+        <span class="track-badge b1">B1 Preview</span>
+        <h3>Intermediate Preview</h3>
+        <p>The first B1 module is open with Ukrainian-led explanations, activities, vocabulary, and resources.</p>
       </a>
       <a class="lu-card" href="/lexicon/">
-        <span class="track-badge atlas">Atlas</span>
+        <span class="track-badge atlas">Reference</span>
         <h3>Word Atlas</h3>
-        <p>A growing lexicon that links course vocabulary to morphology, etymology, and usage context.</p>
+        <p>A learner reference that goes beyond a lexicon: meanings, morphology, usage, etymology where available, and course links.</p>
       </a>
     </div>
   </section>
 
   <section class="track-inventory" aria-labelledby="upcoming-tracks">
     <div class="section-heading">
-      <h2 id="upcoming-tracks">Upcoming Tracks</h2>
+      <h2 id="upcoming-tracks">Course Map</h2>
       <p>
-        These are the active curriculum tracks in the current inventory. Publication order can change as
-        A1 release work, A2 regeneration, and seminar testing progress.
+        This map separates released courses, preview work, and future inventory. The recommended
+        learner path is A1 first, then A2, with B1 available as a preview. Seminar tracks are shown
+        for context only and are not promoted as learner entry points yet.
       </p>
     </div>
 
     <div class="track-inventory-grid">
       <section class="track-column">
-        <h3>Core Ladder</h3>
+        <h3>Course Ladder</h3>
         <ul>
           {coreTracks.map((track) => (
             <li>
@@ -215,6 +218,7 @@ const seminarTracks = [
     }
     .track-badge.a1 { background: var(--lu-green); }
     .track-badge.a2 { background: #1565C0; }
+    .track-badge.b1 { background: #E65100; }
     .track-badge.folk { background: #A4133C; }
     .track-badge.atlas { background: var(--lu-teal); }
     /* In dark mode --lu-green/--lu-teal go pale → white text fails. The folk


### PR DESCRIPTION
## Summary

Clarifies the public landing page information architecture:

- Presents A1 and A2 as the released course path.
- Presents B1 as an intermediate preview, not a completed release.
- Presents Word Atlas as a reference tool rather than just a lexicon/course track.
- Removes Folk/Seminar promotion from main entry points and recovery links.
- Keeps the public shell consistently English.

## Validation

- `npm run build`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `git diff --check`
- rendered landing-page DOM check in the in-app browser