### PR TITLE
feat(site): hide folk nav + wire GoatCounter analytics

### DIFF
--- a/docs/research/2026-06-12-folk-hide-plus-analytics-report.md
+++ b/docs/research/2026-06-12-folk-hide-plus-analytics-report.md
@@ -1,0 +1,42 @@
+# Folk Nav Hide + GoatCounter Analytics Report
+
+Date: 2026-06-12
+
+## Folk Entry Points Removed
+
+- `starlight/src/pages/index.astro:23` removed the Folk row from the home page seminar track inventory.
+- `starlight/src/pages/[...slug].astro:166` removed the `/folk/koliadky-shchedrivky/` primary CTA from the Folk track metadata.
+- `starlight/src/pages/[...slug].astro:167` removed the `/folk/dumy-lytsarski/` secondary CTA from the Folk track metadata.
+- `starlight/src/pages/[...slug].astro` now excludes Folk from generated search result links.
+- `starlight/src/pages/[...slug].astro` now suppresses Folk breadcrumbs, lesson sidebar links, and previous/next links.
+- `starlight/src/components/LevelLanding.tsx` now renders Folk active module cards as disabled, unlinked cards, so `starlight/src/content/docs/folk/index.mdx` stays on disk without linking to `/folk/...`.
+- `starlight/astro.config.mjs` now filters `/folk` and `/folk/...` URLs out of the generated sitemap.
+
+Lexicon top nav was checked in `starlight/src/pages/lexicon/[lemma].astro`, `starlight/src/pages/lexicon/index.astro`, and `starlight/src/pages/lexicon/index/index.astro`; those pages inherit `CourseLayout` top nav, which has no Folk item.
+
+## GoatCounter Wiring
+
+- `starlight/src/layouts/CourseLayout.astro` reads `import.meta.env.PUBLIC_GOATCOUNTER_CODE`.
+- If the value is empty, no GoatCounter script is rendered.
+- If set, the shared head renders `data-goatcounter="https://CODE.goatcounter.com/count"` with `src="//gc.zgo.at/count.js"`.
+
+To activate: register a free site at goatcounter.com, set `PUBLIC_GOATCOUNTER_CODE=<your-code>` in the Starlight build environment or `starlight/.env`, then rebuild with `cd starlight && npm run build`.
+
+## Verification
+
+- `cd starlight && npm ci`
+- `cd starlight && npm run build`
+- `cd starlight && PUBLIC_GOATCOUNTER_CODE=learnukrainian-test npm run build`
+- `cd starlight && npm test`
+- Local code review: Gemini found four issues; fixes were applied for the robust sitemap filter and disabled-card affordance. The badge CSS and shared-constant suggestions were rejected as non-blocking for this scoped diff.
+
+Final no-env build checks:
+
+- `rg -n "/folk/" dist --glob '*.html' --glob '*.xml' --glob '*.js' --glob '*.json'` returned 0 matches.
+- `rg -n "goatcounter|gc\\.zgo\\.at" dist --glob '*.html'` returned 0 matches.
+- `rg -n "href=[\\\"']/(a1|a2|b1|lexicon)/[\\\"']" dist/index.html --glob '*.html'` confirmed A1, A2, B1 Preview, and Word Atlas links remain present.
+
+Dummy env build check:
+
+- `PUBLIC_GOATCOUNTER_CODE=learnukrainian-test npm run build` rendered `data-goatcounter="https://learnukrainian-test.goatcounter.com/count"` and `src="//gc.zgo.at/count.js"`.
+- The same dummy build had 0 `/folk/` matches across built HTML/XML/JS/JSON.

--- a/starlight/.env.example
+++ b/starlight/.env.example
@@ -1,3 +1,7 @@
 # Set this in production to the real Monitor API origin or route `/api/state/*`
 # through a same-origin proxy. The default client fallback is http://localhost:8765.
 PUBLIC_MONITOR_API_BASE=
+
+# Optional GoatCounter analytics: register a free site at goatcounter.com, put
+# the site code here, and rebuild. GoatCounter uses no cookies and collects no PII.
+PUBLIC_GOATCOUNTER_CODE=

--- a/starlight/astro.config.mjs
+++ b/starlight/astro.config.mjs
@@ -14,6 +14,14 @@ import vocabEtymologyLinker from './plugins/vocab-etymology-link.mjs';
 const remarkPlugins = [remarkDirective, remarkAdmonitions, remarkGfm, vocabEtymologyLinker];
 const starlightRoot = fileURLToPath(new URL('.', import.meta.url));
 const starlightNodeModules = realpathSync(fileURLToPath(new URL('./node_modules', import.meta.url)));
+const hiddenPublicPaths = ['/folk'];
+
+const isHiddenPublicPage = (page) => {
+  const pathname = page.startsWith('http') ? new URL(page).pathname : page;
+  return hiddenPublicPaths.some(
+    (hiddenPath) => pathname === hiddenPath || pathname.startsWith(`${hiddenPath}/`),
+  );
+};
 
 // https://astro.build/config
 export default defineConfig({
@@ -52,6 +60,8 @@ export default defineConfig({
       rehypePlugins: [rehypeMermaid],
     }),
     react(),
-    sitemap(),
+    sitemap({
+      filter: (page) => !isHiddenPublicPage(page),
+    }),
   ],
 });

--- a/starlight/src/components/LevelLanding.tsx
+++ b/starlight/src/components/LevelLanding.tsx
@@ -42,7 +42,14 @@ type LevelLandingProps = {
   modules: UnitGroup[] | OldModuleItem[];
 };
 
+const HIDDEN_MODULE_LINK_TRACKS = new Set(['folk']);
+
 function ModuleCard({ mod, level, color }: { mod: ModuleItem; level: string; color: string }) {
+  const levelKey = level.toLowerCase();
+  const shouldHideLink = HIDDEN_MODULE_LINK_TRACKS.has(levelKey);
+  const moduleStatus = shouldHideLink && (mod.status === 'done' || mod.status === 'active')
+    ? 'locked'
+    : mod.status;
   const statusIcons: Record<string, string> = {
     done: '\u2705',
     active: '\u25B6\uFE0F',
@@ -52,19 +59,19 @@ function ModuleCard({ mod, level, color }: { mod: ModuleItem; level: string; col
 
   const numClass = [
     styles.moduleNum,
-    mod.status === 'done' ? styles.numDone : '',
-    mod.status === 'active' ? styles.numActive : '',
-    mod.status === 'todo' || mod.status === 'locked' ? styles.numTodo : '',
+    moduleStatus === 'done' ? styles.numDone : '',
+    moduleStatus === 'active' ? styles.numActive : '',
+    moduleStatus === 'todo' || moduleStatus === 'locked' ? styles.numTodo : '',
   ].filter(Boolean).join(' ');
 
   const itemClass = [
     styles.moduleItem,
-    mod.status === 'locked' ? styles.moduleLocked : '',
+    moduleStatus === 'locked' ? styles.moduleLocked : '',
   ].filter(Boolean).join(' ');
 
-  const numStyle = mod.status === 'active'
+  const numStyle = moduleStatus === 'active'
     ? { borderColor: color, color: color }
-    : mod.status === 'done'
+    : moduleStatus === 'done'
     ? {}
     : {};
 
@@ -82,15 +89,15 @@ function ModuleCard({ mod, level, color }: { mod: ModuleItem; level: string; col
         {mod.subEn && <div className={styles.moduleSubEn}>{mod.subEn}</div>}
       </div>
       <div className={styles.moduleStatus}>
-        {level.toLowerCase() === 'a1' && (mod.status === 'done' || mod.status === 'active')
-          ? <LiveStatus track={level.toLowerCase()} num={mod.num} fallback={mod.status} />
-          : statusIcons[mod.status]}
+        {levelKey === 'a1' && (moduleStatus === 'done' || moduleStatus === 'active')
+          ? <LiveStatus track={levelKey} num={mod.num} fallback={moduleStatus} />
+          : statusIcons[moduleStatus]}
       </div>
     </div>
   );
 
-  if (mod.status === 'done' || mod.status === 'active') {
-    return <a href={`/${level.toLowerCase()}/${mod.slug}/`} style={{ textDecoration: 'none', color: 'inherit' }}>{inner}</a>;
+  if ((moduleStatus === 'done' || moduleStatus === 'active') && !shouldHideLink) {
+    return <a href={`/${levelKey}/${mod.slug}/`} style={{ textDecoration: 'none', color: 'inherit' }}>{inner}</a>;
   }
   return inner;
 }

--- a/starlight/src/layouts/CourseLayout.astro
+++ b/starlight/src/layouts/CourseLayout.astro
@@ -56,6 +56,8 @@ const sidebarPct =
     : 0;
 
 const canonicalPath = currentPath.endsWith('/') ? currentPath : `${currentPath}/`;
+const goatCounterCode = String(import.meta.env.PUBLIC_GOATCOUNTER_CODE ?? '').trim();
+const goatCounterUrl = goatCounterCode ? `https://${goatCounterCode}.goatcounter.com/count` : null;
 
 const topNav = [
   { href: '/', label: 'Home' },
@@ -123,6 +125,9 @@ const isActive = (href: string) => {
       })();
     </script>
     <script is:inline defer data-domain="learn-ukrainian.github.io" src="https://plausible.io/js/script.js"></script>
+    {goatCounterUrl && (
+      <script data-goatcounter={goatCounterUrl} async src="//gc.zgo.at/count.js"></script>
+    )}
     <style is:global>
       .lu-theme-toggle {
         display: inline-flex;

--- a/starlight/src/pages/[...slug].astro
+++ b/starlight/src/pages/[...slug].astro
@@ -163,8 +163,6 @@ const TRACKS: Record<string, TrackOverview> = {
     family: 'seminar',
     state: 'test',
     heroVariant: 'folk',
-    primaryAction: { href: '/folk/koliadky-shchedrivky/', label: 'Open First Seminar' },
-    secondaryAction: { href: '/folk/dumy-lytsarski/', label: 'Open Active Seminar' },
     points: [
       'Folk proves the source-heavy seminar pattern before the wider seminar family ships.',
       'Lessons emphasize motif, context, performance, source notes, and decolonization framing.',
@@ -277,10 +275,12 @@ const TRACKS: Record<string, TrackOverview> = {
 };
 
 const HIDDEN_DOCS = new Set(['a1/review-clears-needs-human']);
-const PUBLIC_LESSON_PREFIXES = new Set(['a1', 'a2', 'folk']);
+const HIDDEN_LINK_TRACKS = new Set(['folk']);
+const SEARCH_LESSON_PREFIXES = new Set(['a1', 'a2']);
 const normalizeId = (id: string) => id.replace(/\.mdx?$/, '').replace(/\/index$/, '');
 const hrefFromRoute = (route: string) => `/${route}/`;
 const trackIds = Object.keys(TRACKS);
+const searchTrackIds = trackIds.filter((id) => !HIDDEN_LINK_TRACKS.has(id));
 
 const allDocs = await getCollection('docs');
 const visibleDocs = allDocs.filter((entry) => {
@@ -309,7 +309,7 @@ for (const entries of deployedDocsByTrack.values()) {
 }
 
 const searchItems: SearchItem[] = [
-  ...trackIds.map((id) => {
+  ...searchTrackIds.map((id) => {
     const track = TRACKS[id];
     return {
       title: `${track.label} · ${track.title}`,
@@ -323,7 +323,7 @@ const searchItems: SearchItem[] = [
     .filter((entry) => {
       const id = normalizeId(entry.id);
       const track = id.split('/')[0];
-      return PUBLIC_LESSON_PREFIXES.has(track) && id !== track;
+      return SEARCH_LESSON_PREFIXES.has(track) && id !== track;
     })
     .map((entry) => {
       const id = normalizeId(entry.id);
@@ -415,8 +415,10 @@ if (props.kind === 'doc' || props.kind === 'landingDoc') {
   if (props.kind === 'doc') {
     const prev = props.entry.data.prev;
     const next = props.entry.data.next;
-    if (typeof prev === 'string') previousLink = { href: `/${docTrack}/${prev}/`, label: 'Previous' };
-    if (typeof next === 'string') nextLink = { href: `/${docTrack}/${next}/`, label: 'Next' };
+    if (!HIDDEN_LINK_TRACKS.has(docTrack)) {
+      if (typeof prev === 'string') previousLink = { href: `/${docTrack}/${prev}/`, label: 'Previous' };
+      if (typeof next === 'string') nextLink = { href: `/${docTrack}/${next}/`, label: 'Next' };
+    }
   }
 }
 
@@ -488,7 +490,10 @@ const pageMeta = (() => {
   };
 })();
 
-const navItems = props.kind === 'doc'
+const currentTrackId = props.kind === 'track' ? props.track : docTrack;
+const navItems = HIDDEN_LINK_TRACKS.has(currentTrackId)
+  ? [{ href: '/', label: 'Home' }]
+  : props.kind === 'doc'
   ? [
       { href: '/', label: 'Home' },
       { href: `/${docTrack}/`, label: TRACKS[docTrack]?.label ?? docTrack.toUpperCase() },
@@ -508,6 +513,7 @@ const navItems = props.kind === 'doc'
 // same per-track sorted lesson list the track landing page uses.
 const sidebar = props.kind === 'doc'
   ? (() => {
+      if (HIDDEN_LINK_TRACKS.has(docTrack)) return undefined;
       const lessons = deployedDocsByTrack.get(docTrack) ?? [];
       if (lessons.length === 0) return undefined;
       const links = lessons.map((entry) => {

--- a/starlight/src/pages/index.astro
+++ b/starlight/src/pages/index.astro
@@ -20,7 +20,6 @@ const coreTracks = [
 ];
 
 const seminarTracks = [
-  { id: 'folk', label: 'Folk', title: 'Folk Culture', status: 'Seminar test track' },
   { id: 'bio', label: 'BIO', title: 'Biographies', status: 'Planned seminar' },
   { id: 'hist', label: 'HIST', title: 'History Of Ukraine', status: 'Planned seminar' },
   { id: 'istorio', label: 'ISTORIO', title: 'Historiography', status: 'Planned seminar' },
@@ -219,10 +218,8 @@ const seminarTracks = [
     .track-badge.a1 { background: var(--lu-green); }
     .track-badge.a2 { background: #1565C0; }
     .track-badge.b1 { background: #E65100; }
-    .track-badge.folk { background: #A4133C; }
     .track-badge.atlas { background: var(--lu-teal); }
-    /* In dark mode --lu-green/--lu-teal go pale → white text fails. The folk
-       chip is a fixed dark crimson, so it keeps white text. */
+    /* In dark mode --lu-green/--lu-teal go pale, so white text fails. */
     :global([data-theme='dark']) .track-badge.a1,
     :global([data-theme='dark']) .track-badge.atlas {
       color: var(--lu-on-yellow);


### PR DESCRIPTION
## Summary
- hide Folk learner entry points from home, search, breadcrumbs, sidebars, prev/next links, module cards, and sitemap while keeping Folk pages/content on disk
- add opt-in GoatCounter analytics via PUBLIC_GOATCOUNTER_CODE in the shared CourseLayout head
- document activation and verification in docs/research/2026-06-12-folk-hide-plus-analytics-report.md

## Validation
- cd starlight && npm ci
- cd starlight && npm run build
- cd starlight && PUBLIC_GOATCOUNTER_CODE=learnukrainian-test npm run build
- cd starlight && npm test
- rg -n "/folk/" starlight/dist --glob "*.html" --glob "*.xml" --glob "*.js" --glob "*.json" returned 0 matches
- rg -n "goatcounter|gc\.zgo\.at" starlight/dist --glob "*.html" returned 0 matches after the final no-env build
- .venv/bin/python scripts/audit/lint_agent_trailer.py

Closes #2823