### PR TITLE
docs(folk): wiki-compile grounding+register gap finding; park bylyny wiki [#2836]

### DIFF
--- a/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
+++ b/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
@@ -27,7 +27,7 @@
 > the "don't self-merge" restriction, not the "don't push to main" one. Stage-0 PR #2759 self-merged
 > under this grant (commit `abf280f490`).
 
-## ▶▶▶ SESSION 17 HANDOFF (2026-06-12 — DOSSIER #15 bylyny-kyivskoho-tsyklu WRITTEN + CORPUS-HAMMERED + SHIPPED (15/42 dossiers); the most de-imperialization-sensitive topic, framed honestly) — **RESUME HERE**
+## ▶▶▶ SESSION 17 HANDOFF (2026-06-12 — DOSSIER #15 bylyny-kyivskoho-tsyklu WRITTEN + CORPUS-HAMMERED + SHIPPED (15/42 dossiers); + WIKI-COMPILE grounding/register gap FOUND → wiki backlog BLOCKED on durable fix) — **RESUME HERE**
 
 > **⏱ HONEST SCOPE:** Modules built+shipped (new V7): **3/42** (kalendarna, koliadky, dumy — unchanged this
 > session). Dossiers: **15/42** (bylyny added THIS session). ~27 topics plan-stub only. Folk nav still HIDDEN
@@ -58,13 +58,26 @@ tradition continued in OTHER genres (думи/балади/колядки). The 
 reusable device. Pre-grounding the brief with my own corpus probe (exact chunk_ids + the §4 honesty protocol) is
 what made codex produce a clean first pass — no correction loop needed.
 
+### 🧱 WIKI BACKLOG IS BLOCKED — systemic compile fix needed first (Session-17 finding, THIS PR)
+Wiki gap = **6 un-wikified dossiers** (bylyny, kobzarstvo-lirnytstvo, dumy-sotsialno-pobutovi, holosinnya,
+vesilni-pisni, zhnyvarski-obzhynkovi-pisni). I compiled the FIRST (bylyny) to test the loop → it FAILS the
+`compile --review` gate on **`source_grounding` AND `register`**, both **systemic to `compile.py`** (they'll recur
+×6), so I **parked it, not shipped** (the durable fix is a re-compile that would overwrite any hand-patch). Full
+diagnosis + durable fix-spec: **`docs/folk-epic/folk-wiki-compile-grounding-register-gap.md`** (THIS PR). TL;DR of the
+durable fix (orchestrator/compile lane): (1) **seed the wiki source registry from the dossier's §4/§10 chunk_ids**
+(retrieval under-builds the registry → forces over-citation of one broad source → source_grounding fails); (2) **port
+the folk register discipline (`вербатимний→дослівний` + russianism list) into the WIKI writer prompt** (currently only
+the module writer has it); (3) **exempt attributed verbatim quotes from the wiki `register` gate** (mirror module
+#2998 — it penalizes faithful ЕУ/Білецький quotation). Until (1)–(3) land, folk wikis need per-wiki hand-surgery to
+pass — does not scale. (TRACK-UPDATE'd the orchestrator.)
+
 ### ▶ NEXT ACTIONS (RESUME HERE, in order)
-1. **Dossier #16 `istorychni-pisni`** (historical SONGS — distinct from dumy & prose perekazy; Колесса). Same proven
-   loop: pre-probe corpus → grounded brief w/ #M-4 preamble + corpus-hammer mandate + NO-auto-merge → codex/gpt-5.5
-   → corpus-hammer review → ship. Then continue queue (16→…, `phase-folk-queue.md`).
-2. **OR compile the WIKI backlog.** 15 dossiers on main but only some have compiled wikis — audit `wiki/folk/` vs
-   `docs/research/folk/` and compile gaps (`compile.py --writer gpt-5.5 --dossier docs/research/folk/<slug>.md` from a
-   data-bearing checkout). Wikis gate the eventual module builds.
+1. **Dossier #16 `istorychni-pisni`** (historical SONGS — distinct from dumy & prose perekazy; Колесса) — the UNBLOCKED
+   queue-advancing path. Same proven loop: pre-probe corpus → grounded brief w/ #M-4 preamble + corpus-hammer mandate +
+   NO-auto-merge → codex/gpt-5.5 → corpus-hammer review → ship. Then continue queue (16→…, `phase-folk-queue.md`).
+2. **WIKI backlog — BLOCKED** on the systemic compile fix above (see the findings doc). Drive the durable compile fix
+   (orchestrator lane / or dispatch) FIRST, then batch-recompile all 6 gap wikis. Do NOT hand-grind individual wikis
+   through the stochastic gate — it's non-durable (a re-compile overwrites it) and the issues recur ×6.
 3. **OR build the next module if directed** — ALWAYS run the pre-fire binary check first (`npx
    @anthropic-ai/claude-code@latest --version`; if "native binary not installed" → `node install.cjs` in
    `~/.npm/_npx/*/node_modules/@anthropic-ai/claude-code`). Recurs on every claude auto-update.

--- a/docs/folk-epic/folk-wiki-compile-grounding-register-gap.md
+++ b/docs/folk-epic/folk-wiki-compile-grounding-register-gap.md
@@ -1,0 +1,69 @@
+# Folk wiki compile — systemic grounding + register gap (Session 17 finding)
+
+> **Status:** OPEN finding, shared compile-infra (orchestrator lane). Discovered 2026-06-12 while
+> compiling the **first** folk wiki of the 6-wiki backlog (`bylyny-kyivskoho-tsyklu`). The bylyny wiki
+> was **parked, not shipped** — its content/framing are strong (factual_accuracy 9–10, ukrainian_
+> perspective 9), but it fails the compile `--review` gate on `source_grounding` AND `register`, and
+> the root causes are **systemic to `scripts/wiki/compile.py` for folk/seminar wikis** — they will
+> recur on every one of the 6 un-wikified folk dossiers, so the fix belongs in the compile pipeline,
+> not in per-wiki hand-surgery.
+
+## What happened (bylyny wiki, reproducible)
+`compile.py --track folk --slug bylyny-kyivskoho-tsyklu --writer gpt-5.5 --review` →
+`MIN 6.0/10`, failing `source_grounding` (codex 5→6). After I hand-added 3 sources + re-pointed 14
+citations, a clean `--review-only` → `MIN 5.0/10`, failing **both** `register` (gemini, REJECT 5) and
+`source_grounding` (codex, REVISE 6). Two distinct systemic causes:
+
+### 1. Registry under-retrieval → forced over-citation → `source_grounding` fail
+The compile's dense retrieval built a **6-source registry** that **omitted the scholarly chunks the
+dossier explicitly grounds on**. It retrieved ЕУ `feaa5fa7_c0620` but missed:
+- **ЕУ `feaa5fa7_c0619`** — the chunk that actually contains «дружинний епос… **не зберігся до наших
+  днів на Україні**», the старини-North note, the genre-traces list (лірницька пісня про Іллю, дума про
+  Олексія Поповича, Джурило в коломийках/весільних, Михайло й Золоті Ворота), and the XVI-c.
+  documentary memory (Бельський/Гербіній/Рей/Лясота + Чижевський's дума-displacement).
+- **Чижевський `wave4-chyzhevsky-istoriia-lit_c0163`** — the XVI–XVII documentary chain (Кміта 1574,
+  Лясота 1594, Сарніцький 1585, Чоботок, XVII-c. travelers).
+- **Попович `wave7-popovych-narys-kultury_c0176`** — the lost-variants anchor («ці твори безнадійно
+  втрачені»).
+
+Lacking `[S#]` anchors for these facts, the writer attached ~14 true, corpus-grounded claims to the
+one broad source it *did* have (ЕУ c0620) → `source_grounding` correctly flagged the misattributions.
+**All three omitted chunks are listed verbatim in the dossier's §4/§10 with chunk_ids.**
+
+**Durable fix:** seed the wiki source registry from the dossier's already-cited chunk_ids (the dossier
+§4/§10 list them). The grounding the reviewer demands is *already in the dossier* — the compile just
+isn't carrying it forward into the registry.
+
+### 2. Writer register tics + no quote-exemption → `register` fail (and review variance)
+The `register` (gemini) dim went **PASS 10 → REJECT 5** across two runs on near-identical content
+(reviewer variance), but the second pass is the more correct one — the flagged issues are **real and
+pre-existing** in the writer's output:
+- **`вербатимний`** (used ~5×) — an English import (`verbatim`); standard Ukrainian is **`дослівний`**.
+  This is the **same writer coinage tic logged in Session 11** (вербатимний→дослівний). The folk
+  MODULE writer rules already forbid it; the **wiki writer prompt does not**.
+- **`приближенням`** (CRITICAL russianism) → `наближенням`; **`виступає`** copula calque → `постає/є`.
+- **Verbatim-quote russianisms** — `акомпаньямент` (ЕУ's 1940s spelling), `в кругу` (Білецький via ЕУ):
+  these are inside **attributed verbatim quotes**, where the register gate **should exempt them** —
+  exactly the blockquote-exemption already shipped for the module vesum gate (**#2998**). The wiki
+  `register` reviewer has no equivalent exemption, so it penalizes faithful historical quotation.
+
+**Durable fix:** (a) port the folk/seminar register discipline (the `вербатимний→дослівний` class +
+russianism list) into the **wiki** writer prompt, not only the module writer; (b) exempt attributed
+verbatim `«…»`/blockquote spans from the wiki `register` russianism gate (mirror #2998); (c) note the
+gemini `register`-dim variance (10→5) — a single pass is not reliable, consistent with prior handoff
+notes on gemini reviewer variance.
+
+## Why parked, not hand-fixed
+The durable fix is a **re-compile** (seeded registry + register-hardened writer prompt), which would
+**overwrite any prose hand-fix**. Hand-patching one wiki to green through stochastic codex/gemini gates
+is low-leverage, non-durable, and the issues recur ×6. The dossier (#15, the session's primary
+deliverable) shipped clean (PR #3033); this finding + fix-spec is the wiki deliverable.
+
+## Recommended sequence (orchestrator / compile lane)
+1. **Seed the wiki registry from dossier chunk_ids** (`compile.py` — folk/seminar path). Highest leverage.
+2. **Port register discipline to the wiki writer prompt** (вербатимний→дослівний + russianism list).
+3. **Exempt attributed verbatim quotes from the wiki `register` gate** (mirror module #2998).
+4. Then **batch-recompile the 6 gap wikis**: bylyny-kyivskoho-tsyklu, kobzarstvo-lirnytstvo,
+   dumy-sotsialno-pobutovi, holosinnya, vesilni-pisni, zhnyvarski-obzhynkovi-pisni.
+
+Until (1)–(3) land, folk wikis require per-wiki hand-surgery to pass `--review`, which does not scale.


### PR DESCRIPTION
## Folk wiki-compile grounding + register gap (Session 17 finding)

Docs-only PR. Two deliverables:
1. **`docs/folk-epic/folk-wiki-compile-grounding-register-gap.md`** — diagnosis + durable fix-spec for a **systemic `compile.py` issue** that blocks the 6-wiki folk backlog.
2. **`docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md`** — Session-17 next-action update (wiki backlog marked BLOCKED on the durable fix; dossier #16 `istorychni-pisni` is the unblocked path).

### Why (discovered compiling the first gap-wiki, `bylyny-kyivskoho-tsyklu`)
The wiki compiled with strong content (factual_accuracy 9–10, ukrainian_perspective 9) but **fails the `--review` gate on `source_grounding` AND `register`**, both systemic:
- **Registry under-retrieval** → the dense retrieval built a 6-source registry that **omitted the very chunks the dossier grounds on** (ЕУ `c0619`, Чижевський `c0163`, Попович `c0176`) → writer over-cited one broad source (ЕУ `c0620`) → `source_grounding` correctly flags the misattributions. Fix: **seed the wiki registry from the dossier's §4/§10 chunk_ids.**
- **Writer register tics + no quote-exemption** → `вербатимний` (should be `дослівний` — the Session-11 coinage tic, forbidden in the *module* writer but not the *wiki* writer), `приближенням` russianism, plus verbatim ЕУ/Білецький quotes (`акомпаньямент`, `в кругу`) penalized with no exemption. Fix: **port register discipline to the wiki writer prompt + exempt attributed verbatim quotes (mirror module #2998).**

### Decision: parked the bylyny wiki, did NOT ship it
The durable fix is a **re-compile** (seeded registry + register-hardened prompt) that would overwrite any prose hand-patch — so grinding one wiki to green through the stochastic gate is non-durable and the issues recur ×6. The diagnosis + fix-spec is the deliverable. Dossier #15 (the session's primary deliverable) shipped clean in PR #3033.

Docs-only → CI green; self-merge under folk grant. [#2836]
