### PR TITLE
fix(lexicon): Atlas full-vocab + decolonization conformance (§1 lemma hygiene, §2 Грінченко removal, §3 entry-scoped soviet caveat, §4 strict heritage) [#2985]

### DIFF
--- a/scripts/audit/validate_atlas_conformance.py
+++ b/scripts/audit/validate_atlas_conformance.py
@@ -7,9 +7,8 @@ exists either as a lemma or as a word form. This preserves current lesson heads
 such as ``сьома`` while still rejecting orphan Atlas pages.
 
 Sovietization note: risk on a СУМ-11 definition is a source caveat, not a word
-classification. The manifest must carry that risk on ``enrichment.meaning`` so
-the Atlas can render an amber source warning without labeling standard words
-as Sovietisms.
+classification. The manifest must carry and render that risk on the individual
+СУМ-11 ``definition_cards[]`` entry, never as a word-level warning.
 """
 
 from __future__ import annotations
@@ -34,7 +33,7 @@ DEFAULT_CURRICULUM = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "curriculum.yaml
 
 SOURCE_REQUIRED_SECTIONS = (
     "meaning",
-    "attestation",
+    "definition_cards",
     "etymology",
     "morphology",
     "synonyms",
@@ -278,6 +277,26 @@ def _check_provenance(entry: Mapping[str, Any], lemma: str, violations: list[Vio
         if section_name not in enrichment:
             continue
         section = enrichment[section_name]
+        if section_name == "definition_cards":
+            if not isinstance(section, list):
+                violations.append(
+                    Violation(
+                        "provenance_per_section",
+                        lemma,
+                        "definition_cards section must be a list of sourced cards",
+                    )
+                )
+                continue
+            for card in section:
+                if not isinstance(card, Mapping) or not _non_empty_str(card.get("source")):
+                    violations.append(
+                        Violation(
+                            "provenance_per_section",
+                            lemma,
+                            "definition_cards card is missing non-empty source",
+                        )
+                    )
+            continue
         if not isinstance(section, Mapping):
             violations.append(
                 Violation(
@@ -326,7 +345,9 @@ def _section_has_content(section_name: str, section: object) -> bool:
         return _definitions_have_content(section.get("definitions"))
     if section_name == "morphology":
         return _list_has_content(section.get("forms")) or _mapping_has_content(section.get("paradigm"))
-    if section_name in {"attestation", "etymology"}:
+    if section_name == "definition_cards":
+        return False
+    if section_name == "etymology":
         return _non_empty_str(section.get("text"))
     if section_name == "synonyms":
         return _list_has_content(section.get("items"))
@@ -349,6 +370,19 @@ def _check_empty_sections(entry: Mapping[str, Any], lemma: str, violations: list
         if section_name not in enrichment:
             continue
         section = enrichment[section_name]
+        if section_name == "definition_cards":
+            if not isinstance(section, list) or not any(
+                isinstance(card, Mapping) and _definitions_have_content(card.get("definitions"))
+                for card in section
+            ):
+                violations.append(
+                    Violation(
+                        "section_omitted_not_empty",
+                        lemma,
+                        "definition_cards section is present without renderable data",
+                    )
+                )
+            continue
         if not _section_has_content(section_name, section):
             violations.append(
                 Violation(
@@ -448,41 +482,31 @@ def _max_sovietization_risk(value: object) -> int:
     return 0
 
 
-def _sum11_definition_risk(meaning: object) -> int:
-    if not isinstance(meaning, Mapping):
+def _sum11_definition_card_risk(card: object) -> int:
+    if not isinstance(card, Mapping):
         return 0
 
-    section_source_is_sum11 = _is_sum11_source(meaning.get("source"))
-    meaning_level_risk = _max_sovietization_risk(meaning)
-    risk = meaning_level_risk if section_source_is_sum11 else 0
-    definitions = meaning.get("definitions")
-    if isinstance(definitions, list):
-        for definition in definitions:
-            if not isinstance(definition, Mapping):
-                continue
-            source_is_sum11 = section_source_is_sum11 or _is_sum11_source(definition.get("source"))
-            if source_is_sum11:
-                risk = max(risk, meaning_level_risk, _max_sovietization_risk(definition))
-    return risk
+    if _is_sum11_source(card.get("source")) or _is_sum11_source(card.get("id")):
+        return _max_sovietization_risk(card)
+    return 0
 
 
 def _check_sovietization(entry: Mapping[str, Any], lemma: str, violations: list[Violation]) -> None:
-    meaning = _enrichment(entry).get("meaning")
-    source_risk = _sum11_definition_risk(meaning)
-    if source_risk < 1:
+    cards = _enrichment(entry).get("definition_cards")
+    if not isinstance(cards, list):
         return
 
-    rendered_risk = (
-        _risk_number(meaning.get("sovietization_risk"))
-        if isinstance(meaning, Mapping) and _is_sum11_source(meaning.get("source"))
-        else 0
-    )
-    if rendered_risk < 1:
+    for card in cards:
+        source_risk = _sum11_definition_card_risk(card)
+        if source_risk < 1:
+            continue
+        if isinstance(card, Mapping) and _non_empty_str(card.get("flag_note")):
+            continue
         violations.append(
             Violation(
                 "sovietization_must_be_flagged",
                 lemma,
-                "SUM-11 definition carries sovietization risk but enrichment.meaning.sovietization_risk is < 1",
+                "SUM-11 definition card carries sovietization risk but is missing flag_note",
             )
         )
 

--- a/scripts/lexicon/build_data_manifest.py
+++ b/scripts/lexicon/build_data_manifest.py
@@ -1,26 +1,17 @@
 """Build the Word Atlas (Лексикон) data manifest for Starlight static rendering.
 
-V1 scope (per docs/best-practices/word-atlas-design.md §9):
-  Render lemmas referenced by a1/my-morning (built) + a1/sounds-letters-and-hello
-  (plan-only) + a1/things-have-gender (plan-only). ~80 lemmas total.
-
-Input sources, in precedence order:
-  1. ``curriculum/l2-uk-en/{level}/{slug}/vocabulary.yaml`` — built modules.
-     Each entry: ``{lemma, translation, pos, ipa, usage}``.
-  2. ``curriculum/l2-uk-en/plans/{level}/{slug}.yaml`` — plans for not-yet-built
-     modules. Reads ``vocabulary_hints.required`` and
-     ``vocabulary_hints.recommended``; each entry is a ``"lemma (gloss)"``
-     string that we split.
+Input source:
+  every ``curriculum/l2-uk-en/{level}/{slug}/vocabulary.yaml`` file. Entries
+  may name the Ukrainian headword as ``lemma``, ``word``, ``uk``, or ``term``;
+  A1 uses ``lemma`` while A2 uses ``word``.
 
 Output: ``starlight/src/data/lexicon-manifest.json`` — versioned JSON the
 Astro dynamic route at ``src/pages/lexicon/[lemma].astro`` reads at build time
 to materialize one static page per lemma.
 
-V1 deliberately ships THIN: lemma + course-usage + (when available) translation
-and POS. Per design §4, additional sections (etymology, definitions,
-sovietization badge, heritage status, paradigm, etc.) are layered on by
-later phases of the build pipeline. Keeping this thin makes the route
-land first; enrichment is purely additive to the manifest.
+The builder stays thin: lemma + course-usage + (when available) translation,
+POS, and IPA. Per design §4, additional sections (etymology, definitions,
+heritage status, paradigm, etc.) are layered on by enrichment.
 
 Reproducer (run from repo root):
 
@@ -41,17 +32,12 @@ import yaml
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 CURRICULUM_ROOT = PROJECT_ROOT / "curriculum" / "l2-uk-en"
-PLANS_ROOT = CURRICULUM_ROOT / "plans"
+CURRICULUM_MANIFEST = CURRICULUM_ROOT / "curriculum.yaml"
 MANIFEST_PATH = PROJECT_ROOT / "starlight" / "src" / "data" / "lexicon-manifest.json"
 _STRESS_MARK_RE = re.compile("[\u0300\u0301]")
 
 
-# v1 module set — per design §9.
-V1_MODULES: list[dict[str, str | int]] = [
-    {"track": "a1", "module_num": 1, "slug": "sounds-letters-and-hello"},
-    {"track": "a1", "module_num": 8, "slug": "things-have-gender"},
-    {"track": "a1", "module_num": 20, "slug": "my-morning"},
-]
+LEMMA_FIELDS = ("lemma", "word", "uk", "term")
 
 SURZHYK_TO_AVOID_SEEDS: list[dict[str, str | None]] = [
     {"lemma": "агенство", "gloss": "avoid: агенція", "pos": "noun"},
@@ -62,6 +48,15 @@ SURZHYK_TO_AVOID_SEEDS: list[dict[str, str | None]] = [
     {"lemma": "міроприємство", "gloss": "avoid: захід", "pos": "noun"},
     {"lemma": "протиріччя", "gloss": "avoid: суперечність", "pos": "noun"},
     {"lemma": "слідуючий", "gloss": "avoid: наступний", "pos": "adj"},
+]
+
+HERITAGE_STATUS_SEEDS: list[dict[str, str | None]] = [
+    {"lemma": "вельми", "gloss": "very, exceedingly", "pos": "adv"},
+    {"lemma": "глагол", "gloss": "archaic: word, speech", "pos": "noun"},
+    {"lemma": "гетьман", "gloss": "hetman", "pos": "noun"},
+    {"lemma": "опришок", "gloss": "opryshok", "pos": "noun"},
+    {"lemma": "десятина", "gloss": "tithe; historical land unit", "pos": "noun"},
+    {"lemma": "кобіта", "gloss": "regional: woman", "pos": "noun"},
 ]
 
 
@@ -96,23 +91,62 @@ def _slug_for_url(lemma: str) -> str:
 
 
 def _lemma_key(lemma: str) -> str:
-    normalized = unicodedata.normalize("NFKD", lemma.strip().casefold())
+    cleaned = re.sub(r"\s+", " ", lemma.strip())
+    cleaned = cleaned.strip(" \t\r\n.,;:!?…")
+    normalized = unicodedata.normalize("NFKD", cleaned.casefold())
     normalized = _STRESS_MARK_RE.sub("", normalized)
     return unicodedata.normalize("NFC", normalized)
 
 
-def _parse_plan_hint(raw: str) -> tuple[str, str | None]:
-    """Plan hints look like ``"звук (sound)"`` or sometimes just ``"звук"``.
+def _course_module_numbers() -> dict[tuple[str, str], int]:
+    """Return curriculum-indexed module numbers keyed by ``(track, slug)``."""
+    manifest = yaml.safe_load(CURRICULUM_MANIFEST.read_text(encoding="utf-8")) or {}
+    levels = manifest.get("levels") or {}
+    module_numbers: dict[tuple[str, str], int] = {}
+    if not isinstance(levels, dict):
+        return module_numbers
 
-    Returns (lemma, gloss_or_None). Gloss is anything inside the FIRST
-    parens; later parenthetical asides are kept inside the lemma string
-    (rare, but defensible — multi-paren entries are usually compound notes).
-    """
-    raw = raw.strip()
-    m = re.match(r"^(.+?)\s*\(([^()]+)\)\s*$", raw)
-    if m:
-        return m.group(1).strip(), m.group(2).strip()
-    return raw, None
+    for track, level_data in levels.items():
+        if not isinstance(level_data, dict):
+            continue
+        raw_modules = level_data.get("modules") or []
+        if not isinstance(raw_modules, list):
+            continue
+        for index, raw_slug in enumerate(raw_modules, start=1):
+            slug = str(raw_slug).split("#", 1)[0].strip()
+            if not slug:
+                continue
+            if (CURRICULUM_ROOT / str(track) / slug / "vocabulary.yaml").exists():
+                module_numbers[(str(track), slug)] = index
+    return module_numbers
+
+
+def _vocabulary_modules() -> list[dict[str, str | int]]:
+    """Return every module that has a built ``vocabulary.yaml`` file."""
+    indexed_numbers = _course_module_numbers()
+    max_index_by_track: dict[str, int] = {}
+    for (track, _slug), module_num in indexed_numbers.items():
+        max_index_by_track[track] = max(max_index_by_track.get(track, 0), module_num)
+
+    extra_counts_by_track: dict[str, int] = {}
+    modules: list[dict[str, str | int]] = []
+    for path in sorted(CURRICULUM_ROOT.glob("*/*/vocabulary.yaml")):
+        track = path.parent.parent.name
+        slug = path.parent.name
+        module_num = indexed_numbers.get((track, slug))
+        if module_num is None:
+            extra_counts_by_track[track] = extra_counts_by_track.get(track, 0) + 1
+            module_num = max_index_by_track.get(track, 0) + extra_counts_by_track[track]
+        modules.append({"track": track, "module_num": module_num, "slug": slug})
+    return modules
+
+
+def _entry_lemma(entry: dict) -> str | None:
+    for field in LEMMA_FIELDS:
+        value = entry.get(field)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return None
 
 
 def _load_built_vocab(module: dict[str, str | int]) -> list[dict]:
@@ -125,7 +159,7 @@ def _load_built_vocab(module: dict[str, str | int]) -> list[dict]:
     for entry in raw:
         if not isinstance(entry, dict):
             continue
-        lemma = entry.get("lemma")
+        lemma = _entry_lemma(entry)
         if not lemma:
             continue
         out.append(
@@ -140,40 +174,10 @@ def _load_built_vocab(module: dict[str, str | int]) -> list[dict]:
     return out
 
 
-def _load_plan_hints(module: dict[str, str | int]) -> list[dict]:
-    """Return list of lemma records from a plan's ``vocabulary_hints``."""
-    path = PLANS_ROOT / str(module["track"]) / f"{module['slug']}.yaml"
-    if not path.exists():
-        return []
-    plan = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    hints = plan.get("vocabulary_hints") or {}
-    if not isinstance(hints, dict):
-        return []
-    out: list[dict] = []
-    for bucket_name in ("required", "recommended"):
-        for entry in hints.get(bucket_name) or []:
-            if not isinstance(entry, str):
-                continue
-            lemma, gloss = _parse_plan_hint(entry)
-            if not lemma:
-                continue
-            out.append(
-                {
-                    "lemma": lemma,
-                    "gloss": gloss,
-                    "pos": None,
-                    "ipa": None,
-                    "source": f"plan_{bucket_name}",
-                }
-            )
-    return out
-
-
 _SOURCE_PRIORITY = {
     "built_vocabulary": 0,
-    "plan_required": 1,
-    "plan_recommended": 2,
-    "surzhyk_to_avoid": 3,
+    "surzhyk_to_avoid": 1,
+    "heritage_status_seed": 2,
 }
 
 
@@ -187,8 +191,8 @@ def _merge_lemma_records(
     Lemmas are merged case-insensitively (key = casefolded form); the
     display ``lemma`` field preserves the first capitalization we see.
     Built-module data wins over plan hints when both are present. Course
-    usage is deduped on (track, module_num) — keeping the highest-signal
-    context (built > plan_required > plan_recommended).
+    usage is deduped on (track, module_num, slug) — keeping the highest-signal
+    context (built > seed/test sources).
     """
     track = str(module["track"])
     module_num = int(module["module_num"])
@@ -232,12 +236,11 @@ def _merge_lemma_records(
             if rec.get("ipa"):
                 existing["ipa"] = rec["ipa"]
 
-        # Dedupe course_usage: collapse same (track, module_num) tuples,
-        # keeping the highest-signal context. This avoids "module appears
-        # twice" when a lemma is in both the plan AND the built vocab.
-        usage_key = (track, module_num)
+        # Dedupe course_usage by module identity, keeping the highest-signal
+        # context when a source contributes the same lemma more than once.
+        usage_key = (track, module_num, slug)
         for u in existing["course_usage"]:
-            if (u["track"], u["module_num"]) == usage_key:
+            if (u["track"], u["module_num"], u["slug"]) == usage_key:
                 if _SOURCE_PRIORITY.get(rec["source"], 99) < _SOURCE_PRIORITY.get(
                     u["context"], 99
                 ):
@@ -266,20 +269,36 @@ def _merge_seed_records(by_lemma: dict[str, dict]) -> None:
         }
 
 
+def _merge_heritage_seed_records(by_lemma: dict[str, dict]) -> None:
+    for rec in HERITAGE_STATUS_SEEDS:
+        display_lemma = str(rec["lemma"])
+        key = _lemma_key(display_lemma)
+        if key in by_lemma:
+            by_lemma[key]["seed_group"] = "heritage-status-samples"
+            continue
+        by_lemma[key] = {
+            "lemma": display_lemma,
+            "url_slug": _slug_for_url(display_lemma),
+            "gloss": rec.get("gloss"),
+            "pos": rec.get("pos"),
+            "ipa": None,
+            "primary_source": "heritage_status_seed",
+            "seed_group": "heritage-status-samples",
+            "course_usage": [],
+        }
+
+
 def build_manifest() -> dict:
     """Build the manifest dict and return it (caller writes to disk)."""
     by_lemma: dict[str, dict] = {}
+    modules = _vocabulary_modules()
 
-    for module in V1_MODULES:
-        # Built data has higher signal — prefer it when both are available.
-        # We still load plan hints first to seed empty modules; built records
-        # then upgrade entries that already exist.
-        plan_records = _load_plan_hints(module)
+    for module in modules:
         built_records = _load_built_vocab(module)
-        _merge_lemma_records(by_lemma, module, plan_records)
         _merge_lemma_records(by_lemma, module, built_records)
 
     _merge_seed_records(by_lemma)
+    _merge_heritage_seed_records(by_lemma)
 
     entries = sorted(by_lemma.values(), key=lambda e: e["lemma"])
     return {
@@ -287,24 +306,30 @@ def build_manifest() -> dict:
         "generated_at": datetime.now(UTC).isoformat(timespec="seconds"),
         "stats": {
             "lemmas_total": len(entries),
-            "modules_covered": len(V1_MODULES),
+            "modules_covered": len(modules),
             "from_built": sum(
                 1 for e in entries if e["primary_source"] == "built_vocabulary"
-            ),
-            "from_plan_only": sum(
-                1 for e in entries if e["primary_source"].startswith("plan_")
             ),
             "from_surzhyk_to_avoid": sum(
                 1 for e in entries if e["primary_source"] == "surzhyk_to_avoid"
             ),
+            "from_heritage_status_seed": sum(
+                1 for e in entries if e["primary_source"] == "heritage_status_seed"
+            ),
         },
-        "modules": V1_MODULES,
+        "modules": modules,
         "seed_groups": [
             {
                 "id": "surzhyk-to-avoid",
                 "source": "surzhyk_to_avoid",
                 "description": "Classifier-verified Russianism/surzhyk examples for visible Atlas warnings.",
                 "lemmas": [str(seed["lemma"]) for seed in SURZHYK_TO_AVOID_SEEDS],
+            },
+            {
+                "id": "heritage-status-samples",
+                "source": "heritage_status_seed",
+                "description": "Source-backed heritage status sample pages for Atlas design conformance QA.",
+                "lemmas": [str(seed["lemma"]) for seed in HERITAGE_STATUS_SEEDS],
             }
         ],
         "entries": entries,
@@ -322,7 +347,7 @@ def main() -> None:
     print(
         f"Wrote {MANIFEST_PATH.relative_to(PROJECT_ROOT)}: "
         f"{stats['lemmas_total']} lemmas across {stats['modules_covered']} modules "
-        f"(built={stats['from_built']}, plan_only={stats['from_plan_only']})."
+        f"(built={stats['from_built']}, seeds={stats['from_surzhyk_to_avoid'] + stats['from_heritage_status_seed']})."
     )
 
 

--- a/scripts/lexicon/build_data_manifest.py
+++ b/scripts/lexicon/build_data_manifest.py
@@ -39,6 +39,37 @@ _STRESS_MARK_RE = re.compile("[\u0300\u0301]")
 
 LEMMA_FIELDS = ("lemma", "word", "uk", "term")
 
+_NON_ATLAS_LEMMA_KEYS = {
+    _key
+    for _key in (
+        "Давай!",
+        "Смачного!",
+        "Ходімо!",
+        "в/у",
+        "у/в",
+        "і/й",
+    )
+}
+
+VOCATIVE_TO_NOMINATIVE: dict[str, str] = {
+    "Богдане": "Богдан",
+    "Маріє": "Марія",
+    "Олено": "Олена",
+    "Соломіє": "Соломія",
+    "Тарасе": "Тарас",
+}
+
+VESUM_CANONICAL_HEADS: dict[str, tuple[str, str]] = {
+    "бірка": (
+        "бирка",
+        "VESUM and Grinchenko index the label/tag headword as бирка.",
+    ),
+    "прийом": (
+        "приймання",
+        "СУМ-20/СУМ-11 define прийом as 'те саме, що приймання'; VESUM indexes приймання.",
+    ),
+}
+
 SURZHYK_TO_AVOID_SEEDS: list[dict[str, str | None]] = [
     {"lemma": "агенство", "gloss": "avoid: агенція", "pos": "noun"},
     {"lemma": "авось", "gloss": "avoid: ану ж / а може", "pos": "adv"},
@@ -96,6 +127,16 @@ def _lemma_key(lemma: str) -> str:
     normalized = unicodedata.normalize("NFKD", cleaned.casefold())
     normalized = _STRESS_MARK_RE.sub("", normalized)
     return unicodedata.normalize("NFC", normalized)
+
+
+NON_ATLAS_LEMMA_KEYS = {_lemma_key(lemma) for lemma in _NON_ATLAS_LEMMA_KEYS}
+VOCATIVE_TO_NOMINATIVE_BY_KEY = {
+    _lemma_key(source): target for source, target in VOCATIVE_TO_NOMINATIVE.items()
+}
+VESUM_CANONICAL_HEADS_BY_KEY = {
+    _lemma_key(source): (target, reason)
+    for source, (target, reason) in VESUM_CANONICAL_HEADS.items()
+}
 
 
 def _course_module_numbers() -> dict[tuple[str, str], int]:
@@ -176,9 +217,76 @@ def _load_built_vocab(module: dict[str, str | int]) -> list[dict]:
 
 _SOURCE_PRIORITY = {
     "built_vocabulary": 0,
+    "built_vocabulary_normalized": 1,
+    "built_vocabulary_canonicalized": 1,
     "surzhyk_to_avoid": 1,
     "heritage_status_seed": 2,
 }
+
+
+def _source_priority(source: str) -> int:
+    return _SOURCE_PRIORITY.get(source, 99)
+
+
+def _normalization_record(
+    *,
+    kind: str,
+    source_lemma: str,
+    target_lemma: str,
+    reason: str,
+) -> dict[str, str]:
+    return {
+        "kind": kind,
+        "source_lemma": source_lemma,
+        "target_lemma": target_lemma,
+        "reason": reason,
+    }
+
+
+def _append_normalization(entry: dict, normalization: dict[str, str] | None) -> None:
+    if not normalization:
+        return
+    normalizations = entry.setdefault("atlas_normalizations", [])
+    if normalization not in normalizations:
+        normalizations.append(normalization)
+
+
+def _atlas_record_for_manifest(rec: dict, taught_lemma_keys: set[str]) -> dict | None:
+    """Normalize course surfaces to Atlas lemma heads, or omit non-lemmas."""
+    display_lemma = str(rec["lemma"])
+    key = _lemma_key(display_lemma)
+    if key in NON_ATLAS_LEMMA_KEYS:
+        return None
+
+    if key in VOCATIVE_TO_NOMINATIVE_BY_KEY:
+        target = VOCATIVE_TO_NOMINATIVE_BY_KEY[key]
+        if _lemma_key(target) not in taught_lemma_keys:
+            return None
+        normalized = dict(rec)
+        normalized["lemma"] = target
+        normalized["source"] = "built_vocabulary_normalized"
+        normalized["atlas_normalization"] = _normalization_record(
+            kind="vocative_to_nominative",
+            source_lemma=display_lemma,
+            target_lemma=target,
+            reason="Atlas pages are lemma-keyed; course vocative surface maps to taught nominative.",
+        )
+        return normalized
+
+    if key in VESUM_CANONICAL_HEADS_BY_KEY:
+        target, reason = VESUM_CANONICAL_HEADS_BY_KEY[key]
+        canonicalized = dict(rec)
+        canonicalized["lemma"] = target
+        canonicalized["source"] = "built_vocabulary_canonicalized"
+        canonicalized["atlas_normalization"] = _normalization_record(
+            kind="vesum_canonical_head",
+            source_lemma=display_lemma,
+            target_lemma=target,
+            reason=reason,
+        )
+        return canonicalized
+
+    return rec
 
 
 def _merge_lemma_records(
@@ -218,12 +326,12 @@ def _merge_lemma_records(
                 "primary_source": rec["source"],
                 "course_usage": [usage_entry],
             }
+            _append_normalization(by_lemma[key], rec.get("atlas_normalization"))
             continue
 
         # Upgrade thin plan-hint entries when we later see built data.
-        is_upgrade = (
-            existing["primary_source"].startswith("plan_")
-            and rec["source"] == "built_vocabulary"
+        is_upgrade = _source_priority(rec["source"]) < _source_priority(
+            existing["primary_source"]
         )
         if is_upgrade:
             existing["lemma"] = display_lemma
@@ -235,6 +343,7 @@ def _merge_lemma_records(
                 existing["pos"] = rec["pos"]
             if rec.get("ipa"):
                 existing["ipa"] = rec["ipa"]
+        _append_normalization(existing, rec.get("atlas_normalization"))
 
         # Dedupe course_usage by module identity, keeping the highest-signal
         # context when a source contributes the same lemma more than once.
@@ -292,9 +401,19 @@ def build_manifest() -> dict:
     """Build the manifest dict and return it (caller writes to disk)."""
     by_lemma: dict[str, dict] = {}
     modules = _vocabulary_modules()
+    raw_records_by_module = [(module, _load_built_vocab(module)) for module in modules]
+    taught_lemma_keys = {
+        _lemma_key(rec["lemma"])
+        for _module, records in raw_records_by_module
+        for rec in records
+    }
 
-    for module in modules:
-        built_records = _load_built_vocab(module)
+    for module, raw_records in raw_records_by_module:
+        built_records = [
+            record
+            for rec in raw_records
+            if (record := _atlas_record_for_manifest(rec, taught_lemma_keys)) is not None
+        ]
         _merge_lemma_records(by_lemma, module, built_records)
 
     _merge_seed_records(by_lemma)
@@ -308,7 +427,7 @@ def build_manifest() -> dict:
             "lemmas_total": len(entries),
             "modules_covered": len(modules),
             "from_built": sum(
-                1 for e in entries if e["primary_source"] == "built_vocabulary"
+                1 for e in entries if e["primary_source"].startswith("built_vocabulary")
             ),
             "from_surzhyk_to_avoid": sum(
                 1 for e in entries if e["primary_source"] == "surzhyk_to_avoid"

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -9,8 +9,8 @@ no fabrication):
   human-readable Ukrainian grammatical labels, with optional stress display
   forms from ``ukrainian-word-stress``.
 - **meaning** — legacy single-source meaning kept for compatibility.
-- **definition_cards** — separate Грінченко 1907, live СУМ-20, and СУМ-11
-  definition cards with source caveats.
+- **definition_cards** — separate СУМ-20 and СУМ-11 definition cards with
+  source caveats.
 - **cefr** — PULS CEFR lookup when available.
 - **literary_attestation** — exact-form literary corpus hit when available.
 - **synonyms** — source-attested, A1-sense allowlisted Ukrainian candidates only.
@@ -37,6 +37,7 @@ from __future__ import annotations
 import datetime as dt
 import html
 import json
+import os
 import re
 import sqlite3
 import sys
@@ -59,7 +60,28 @@ from scripts.wiki.slovnyk_me import primary_synonym_sense_text
 
 MANIFEST = ROOT / "starlight" / "src" / "data" / "lexicon-manifest.json"
 SOURCES_DB = ROOT / "data" / "sources.db"
-SLOVNYK_CACHE = ROOT / "data" / "lexicon" / "slovnyk_cache"
+
+
+def _default_slovnyk_cache() -> Path:
+    override = os.environ.get("LEXICON_SLOVNYK_CACHE")
+    if override:
+        return Path(override).expanduser()
+
+    local = ROOT / "data" / "lexicon" / "slovnyk_cache"
+    if local.exists():
+        return local
+
+    parts = ROOT.parts
+    if ".worktrees" in parts:
+        main_root = Path(*parts[: parts.index(".worktrees")])
+        main_cache = main_root / "data" / "lexicon" / "slovnyk_cache"
+        if main_cache.exists():
+            return main_cache
+
+    return local
+
+
+SLOVNYK_CACHE = _default_slovnyk_cache()
 
 _CYRILLIC_WORD_CHARS = "A-Za-zА-Яа-яЄєІіЇїҐґ0-9'’ʼ-"
 _LATIN_RE = re.compile(r"[A-Za-z]")
@@ -86,6 +108,7 @@ _UKRAINIAN_WORD_RE = re.compile(r"^[А-Яа-яЄєІіЇїҐґ'’ʼ-]+$")
 _UKRAINIAN_VOWELS = set("аеєиіїоуюяАЕЄИІЇОУЮЯ")
 
 _SLOVNYK_DICT_LABELS: dict[str, str] = {
+    "newsum": "Словник української мови у 20 томах (СУМ-20)",
     "synonyms": "Словник синонімів української мови",
     "synonyms_karavansky": "Словник синонімів Караванського",
     "phraseology": "Фразеологічний словник української мови",
@@ -775,6 +798,16 @@ def _cache_lookup(cache: dict[str, Any] | None, slug: str) -> dict[str, Any] | N
     return row if isinstance(row, dict) and row.get("text") else None
 
 
+def _cache_store_lookup(lemma: str, cache: dict[str, Any], slug: str, row: dict[str, Any] | None) -> None:
+    lookups = cache.setdefault("lookups", {})
+    if not isinstance(lookups, dict):
+        return
+    lookups[slug] = row
+    path = _slovnyk_cache_path(lemma)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(cache, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
 @lru_cache(maxsize=4096)
 def _vesum_word_analyses(word: str) -> tuple[tuple[str, str], ...]:
     """Return immutable ``(lemma, pos)`` VESUM analyses for one word form."""
@@ -1145,6 +1178,12 @@ def _merge_slovnyk_warning(status: dict[str, Any], warning: dict[str, Any] | Non
     return status
 
 
+def _entry_scoped_heritage_status(status: dict[str, Any]) -> dict[str, Any]:
+    clean_status = dict(status)
+    clean_status.pop("sovietization_risk", None)
+    return clean_status
+
+
 def _is_slovnyk_warning_candidate(entry: dict[str, Any], status: dict[str, Any]) -> bool:
     return bool(
         entry.get("primary_source") == "surzhyk_to_avoid"
@@ -1396,8 +1435,8 @@ def _meaning(
 ) -> dict | None:
     """Modern Ukrainian meaning: Вікісловник (clean, + synonyms) → СУМ-11 fallback.
 
-    Грінченко is intentionally NOT used here — its 1907 Russian glosses are
-    surfaced separately as historical *attestation*, not as the primary meaning.
+    Грінченко is intentionally NOT used here — its 1907 glosses are Russian
+    and must not surface in rendered Atlas pages.
     """
     word = lemma.strip()
     row = None
@@ -1435,7 +1474,7 @@ def _meaning(
             "definitions": [row[0].strip()[:600]],
             "source": "СУМ-11",
             "sovietization_risk": risk,
-            "note": "СУМ-11 — частково засоюзлене видання; перевіряйте ідеологічно навантажені статті.",
+            "note": "СУМ-11 — радянське видання; перевіряйте ідеологічно навантажені статті.",
         }
         if keywords:
             block["sovietization_keywords"] = keywords
@@ -1460,27 +1499,6 @@ def _definition_body(
     body = re.sub(r"\s+", " ", clean_html_entities(body)).strip()
     return _truncate_text(body, limit) if body else ""
 
-
-def _grinchenko_definition_card(conn: sqlite3.Connection, lemma: str) -> dict[str, Any] | None:
-    for variant in _split_lemma_variants(lemma):
-        row = conn.execute(
-            "SELECT definition FROM grinchenko WHERE word = ? AND definition != '' LIMIT 1",
-            (variant,),
-        ).fetchone()
-        if row and row[0]:
-            text = _definition_body(row[0])
-            if not text:
-                return None
-            return {
-                "id": "grinchenko",
-                "source": "Грінченко 1907",
-                "source_pill": "Грінченко 1907",
-                "note": "дорадянське засвідчення",
-                "definitions": [text],
-            }
-    return None
-
-
 def _sum20_in_coverage(lemma: str) -> bool:
     lookup = _slovnyk_lookup_word(lemma)
     if not lookup or _has_whitespace(lookup):
@@ -1488,11 +1506,18 @@ def _sum20_in_coverage(lemma: str) -> bool:
     return lookup[0].casefold() in _SUM20_COVERED_INITIALS
 
 
-def _sum20_definition_card(lemma: str) -> dict[str, Any] | None:
+def _sum20_definition_card(
+    lemma: str,
+    cache: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
     if not _sum20_in_coverage(lemma):
         return None
     lookup_word = _slovnyk_lookup_word(lemma)
-    row = _fetch_slovnyk_entry(lemma, lookup_word, "newsum")
+    row = _cache_lookup(cache, "newsum") if cache is not None else None
+    if not row:
+        row = _fetch_slovnyk_entry(lemma, lookup_word, "newsum")
+        if cache is not None:
+            _cache_store_lookup(lemma, cache, "newsum", row)
     if not row:
         return None
     text = _definition_body(
@@ -1535,20 +1560,16 @@ def _sum11_definition_card(
         card: dict[str, Any] = {
             "id": "sum11-flagged" if risk > 0 else "sum11",
             "source": "СУМ-11",
-            "source_pill": "СУМ-11 · ⚠ позначено" if risk > 0 else "СУМ-11",
+            "source_pill": "СУМ-11",
             "note": f"радянське видання · risk={risk}" if risk > 0 else "радянське видання · перевірено: чисто",
             "definitions": [text],
             "sovietization_risk": risk,
         }
         if keywords:
             card["sovietization_keywords"] = keywords
-            card["flag_note"] = (
-                "Дефініція або ілюстрації містять радянсько-ідеологічні маркери: "
-                + ", ".join(keywords)
-                + ". Для нейтрального тлумачення звіряйте з СУМ-20 або Грінченком."
-            )
+            card["flag_note"] = "⚠ СУМ-11 — радянське видання; подаємо обережно, перевага СУМ-20/Вікісловнику"
         elif risk > 0:
-            card["flag_note"] = "Дефініція або ілюстрації мають радянсько-ідеологічний ризик."
+            card["flag_note"] = "⚠ СУМ-11 — радянське видання; подаємо обережно, перевага СУМ-20/Вікісловнику"
         return card
     return None
 
@@ -1558,28 +1579,13 @@ def _definition_cards(
     lemma: str,
     *,
     has_sum11_flags: bool,
+    cache: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     cards = [
-        _grinchenko_definition_card(conn, lemma),
-        _sum20_definition_card(lemma),
+        _sum20_definition_card(lemma, cache),
         _sum11_definition_card(conn, lemma, has_sum11_flags=has_sum11_flags),
     ]
     return [card for card in cards if card]
-
-
-def _attestation(conn: sqlite3.Connection, lemma: str) -> dict | None:
-    """Грінченко 1907 — historical attestation with Ukrainian usage quotations."""
-    row = None
-    for variant in _split_lemma_variants(lemma):
-        row = conn.execute(
-            "SELECT definition FROM grinchenko WHERE word = ? AND definition != '' LIMIT 1",
-            (variant,),
-        ).fetchone()
-        if row:
-            break
-    if row and row[0]:
-        return {"text": clean_html_entities(row[0].strip()[:600]), "source": "Грінченко (1907)"}
-    return None
 
 
 def _lookup_key(value: str) -> str:
@@ -1828,13 +1834,21 @@ def enrich() -> tuple[int, int]:
                 entry["gloss"] = clean_gloss(str(entry["gloss"]))
             lemma = entry["lemma"]
             slovnyk_cache = _slovnyk_cache(lemma)
+            definition_cards = _definition_cards(
+                conn,
+                lemma,
+                has_sum11_flags=has_sum11_flags,
+                cache=slovnyk_cache,
+            )
             heritage_status = classify_lemma(lemma)
             warning = (
                 _warning_slovnyk(lemma, slovnyk_cache)
                 if _is_slovnyk_warning_candidate(entry, heritage_status)
                 else None
             )
-            entry["heritage_status"] = _merge_slovnyk_warning(heritage_status, warning)
+            entry["heritage_status"] = _entry_scoped_heritage_status(
+                _merge_slovnyk_warning(heritage_status, warning)
+            )
             sections: dict[str, object] = {}
             synonyms = _synonyms_slovnyk(lemma, slovnyk_cache, entry_pos=entry.get("pos"))
             if synonyms:
@@ -1859,12 +1873,8 @@ def enrich() -> tuple[int, int]:
             meaning = _meaning(conn, lemma, has_sum11_flags=has_sum11_flags)
             if meaning:
                 block["meaning"] = meaning
-            definition_cards = _definition_cards(conn, lemma, has_sum11_flags=has_sum11_flags)
             if definition_cards:
                 block["definition_cards"] = definition_cards
-            attestation = _attestation(conn, lemma)
-            if attestation:
-                block["attestation"] = attestation
             etym = _etymology(conn, lemma)
             if etym:
                 block["etymology"] = etym
@@ -1898,7 +1908,7 @@ def main() -> None:
     manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
     etymology_covered, etymology_total = _single_word_etymology_coverage(manifest)
     print(
-        f"enriched {enriched}/{total} lexicon entries from VESUM + Грінченко/СУМ + Горох/ЕСУМ/Вікісловник + slovnyk.me"
+        f"enriched {enriched}/{total} lexicon entries from VESUM + СУМ + Горох/ЕСУМ/Вікісловник + slovnyk.me"
     )
     print(f"single-word etymology {etymology_covered}/{etymology_total}")
 

--- a/scripts/lexicon/heritage_classifier.py
+++ b/scripts/lexicon/heritage_classifier.py
@@ -151,52 +151,55 @@ def _classify(term: str, *, surface: bool) -> dict[str, Any]:
 
     vesum = _vesum_attestation(term, surface=surface)
     vesum_archaism = _vesum_archaism_attestation(term, surface=surface)
-    if vesum_archaism and not vesum_archaism["has_modern"]:
-        return _status(
-            "authentic-archaism",
-            [vesum_archaism["attestation"]],
-            is_russianism=False,
-            russian_shadow=russian_shadow,
-            sovietization_risk=sovietization_risk,
-        )
+    has_modern_vesum = bool(vesum) and not (
+        vesum_archaism and not vesum_archaism["has_modern"]
+    )
 
     russianism = _russianism_status(term, russian_shadow=russian_shadow)
 
     attestations: list[dict[str, Any]] = []
     classification = "unknown"
     with _source_conn() as conn:
-        auth_hits = _dictionary_attestations(conn, term, surface=surface)
-        auth_hits.extend(_search_heritage_attestations(term))
+        auth_hits = _strict_heritage_attestations(conn, term, surface=surface)
         has_standard_hit = any(hit["classification"] == "standard" for hit in auth_hits)
         for hit in auth_hits:
-            if vesum and hit["classification"] == "standard":
+            candidate = str(hit["classification"])
+            if (
+                candidate == "standard"
+                and vesum_archaism
+                and not vesum_archaism["has_modern"]
+            ):
+                candidate = "authentic-archaism"
+            if candidate == "standard":
                 continue
             if (
-                hit["classification"] == "authentic-archaism"
+                candidate == "authentic-archaism"
                 and hit.get("weak_when_modern")
-                and (vesum or has_standard_hit or russianism)
+                and (has_modern_vesum or has_standard_hit or russianism)
             ):
                 continue
             if (
-                vesum
-                and hit["classification"] == "authentic-archaism"
-                and "esum" in str(hit.get("attestation", {}).get("source") or "")
+                candidate == "dialect"
+                and hit.get("weak_when_modern")
+                and (has_modern_vesum or has_standard_hit or russianism)
             ):
                 continue
-            if vesum and hit["classification"] == "borrowing":
+            if has_modern_vesum and candidate == "borrowing":
                 continue
             attestations.append(hit["attestation"])
-            classification = _prefer_classification(classification, hit["classification"])
+            classification = _prefer_classification(classification, candidate)
             sovietization_risk = max(sovietization_risk, int(hit.get("sovietization_risk") or 0))
 
         if surface and not attestations and russianism and term in _KNOWN_STANDARD_ALTERNATIVES:
             return russianism
 
-        if surface and (not attestations or term in _SURFACE_QUOTE_HINTS):
-            quote_hits = _literary_surface_attestations(conn, term)
-            for hit in quote_hits:
+        if not attestations and not vesum:
+            for hit in _standard_dictionary_attestations(conn, term):
                 attestations.append(hit["attestation"])
-                classification = _prefer_classification(classification, hit["classification"])
+                classification = _prefer_classification(classification, "standard")
+                sovietization_risk = max(
+                    sovietization_risk, int(hit.get("sovietization_risk") or 0)
+                )
 
     if surface and russianism and term in _KNOWN_STANDARD_ALTERNATIVES:
         return russianism
@@ -390,7 +393,7 @@ def _check_russian_shadow(term: str) -> tuple[bool, dict[str, Any]]:
     return bool(result.get("matches_russian")), {"available": True, **result}
 
 
-def _dictionary_attestations(
+def _strict_heritage_attestations(
     conn: sqlite3.Connection,
     term: str,
     *,
@@ -399,12 +402,20 @@ def _dictionary_attestations(
     hits: list[dict[str, Any]] = []
     hits.extend(_grinchenko_exact_hits(conn, term))
     hits.extend(_esum_exact_hits(conn, term))
-    hits.extend(_sum11_exact_hits(conn, term))
-    hits.extend(_wiktionary_exact_hits(conn, term))
-    hits.extend(_grinchenko_crossref_hits(conn, term))
     hits.extend(_esum_variant_hits(conn, term))
     if surface:
         hits.extend(_grinchenko_surface_usage_hits(conn, term))
+    return hits
+
+
+def _standard_dictionary_attestations(
+    conn: sqlite3.Connection,
+    term: str,
+) -> list[dict[str, Any]]:
+    hits: list[dict[str, Any]] = []
+    for hit in [*_sum11_exact_hits(conn, term), *_wiktionary_exact_hits(conn, term)]:
+        if hit["classification"] == "standard":
+            hits.append(hit)
     return hits
 
 
@@ -542,6 +553,37 @@ def _classification_from_source_text(text: str, *, default: str) -> str:
     return default
 
 
+def _strict_classification_from_source_text(text: str, *, default: str) -> str:
+    lower = _normalize_word(text)
+    if _has_any_marker(lower, ("іст.", "істор.", "(іст.)")):
+        return "historism"
+    if _has_any_marker(lower, ("діал.", " діал ", "діалект")):
+        return "dialect"
+    if _has_any_marker(lower, ("заст.", "застар", "архаї")):
+        return "authentic-archaism"
+    if _has_any_marker(lower, _BORROWING_MARKERS):
+        return "borrowing"
+    return default
+
+
+def _esum_headword_classification(text: str, term: str, *, exact: bool) -> str:
+    if term in _DIALECT_OR_FOLK_TERMS:
+        return "dialect"
+    if not exact:
+        return "standard"
+
+    lower = _normalize_word(text)
+    term_pattern = re.escape(_normalize_word(term))
+    headword_marker_re = re.compile(
+        rf"^\[?{term_pattern}\]?\s*(?:\([^)]*(?:іст\.|істор\.|діал\.|заст\.|застар|архаї)[^)]*\)|"
+        rf"«[^»]{{0,160}}(?:\(іст\.\)|\(діал\.\)|\(заст\.\))"
+        rf")"
+    )
+    if not headword_marker_re.search(lower):
+        return "standard"
+    return _strict_classification_from_source_text(lower, default="standard")
+
+
 def _classification_from_heritage_hit(hit: dict[str, Any], text: str) -> str:
     classification = _classification_from_source_text(text, default="standard")
     if classification != "standard":
@@ -560,7 +602,7 @@ def _grinchenko_exact_hits(conn: sqlite3.Connection, term: str) -> list[dict[str
         ).fetchall()
         for row in rows:
             text = _clean_text(row["definition"])
-            classification = _classification_from_definition(text, default="authentic-archaism")
+            classification = _strict_classification_from_source_text(text, default="standard")
             hits.append(
                 {
                     "classification": classification,
@@ -865,14 +907,10 @@ def _classification_from_definition(text: str, *, default: str) -> str:
 
 
 def _classification_from_etymology(text: str, term: str, *, exact: bool) -> str:
-    if term in _DIALECT_OR_FOLK_TERMS:
-        return "dialect"
-    classification = _classification_from_source_text(text, default="standard")
-    if classification != "standard":
-        if classification == "borrowing" and exact:
-            return "standard"
-        return classification
-    return "authentic-archaism" if exact else "standard"
+    classification = _esum_headword_classification(text, term, exact=exact)
+    if classification == "borrowing" and exact:
+        return "borrowing"
+    return classification
 
 
 def _sum11_sovietization_risk(definition: str, text: str) -> int:

--- a/scripts/lexicon/heritage_classifier.py
+++ b/scripts/lexicon/heritage_classifier.py
@@ -11,13 +11,19 @@ from __future__ import annotations
 
 import html
 import json
+import os
 import re
 import sqlite3
+import sys
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
 ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
 SOURCES_DB = ROOT / "data" / "sources.db"
 LT_REPLACEMENTS = ROOT / "data" / "lt_replacements.json"
 
@@ -59,6 +65,68 @@ _DIALECT_OR_FOLK_TERMS = {
     "ягілки",
 }
 
+_SLOVNYK_HERITAGE_SLUGS = {
+    "newsum",
+    "vts",
+    "holoskevych",
+    "obsolete_words",
+    "bukovina",
+    "franko",
+    "slang_lviv",
+    "slang",
+    "slang_modern",
+}
+
+_ARCHAIC_MARKERS = (
+    "заст.",
+    "застар",
+    "архаї",
+    "ц.-с.",
+    "церк.-слов",
+    "церковнослов",
+)
+_DIALECT_MARKERS = (
+    "діал.",
+    " діал ",
+    "діалект",
+    "зах.",
+    " зах ",
+    "говір",
+    "гуц",
+    "бойк",
+    "лемк",
+    "буковин",
+    "львів",
+)
+_HISTORISM_MARKERS = (
+    "іст.",
+    "істор.",
+    "(іст.)",
+    "у xvi",
+    "у xvii",
+    "у xviii",
+    "у xix",
+    "в xvi",
+    "в xvii",
+    "в xviii",
+    "в xix",
+    "до 1764",
+    "епоху феодалізму",
+    "феодально",
+    "козацького війська",
+    "запорізької січі",
+    "запорозької січі",
+    "стара російська одиниця",
+    "десята частина доходів",
+)
+_BORROWING_MARKERS = (
+    "запозич",
+    "з польської",
+    "з німецької",
+    "з французької",
+    "з латинської",
+)
+
 
 def classify_lemma(lemma: str) -> dict[str, Any]:
     """Classify a lemma for Word Atlas ``heritage_status`` badges."""
@@ -82,10 +150,11 @@ def _classify(term: str, *, surface: bool) -> dict[str, Any]:
     sovietization_risk = _sum11_sovietization_risk_for_term(term)
 
     vesum = _vesum_attestation(term, surface=surface)
-    if vesum:
+    vesum_archaism = _vesum_archaism_attestation(term, surface=surface)
+    if vesum_archaism and not vesum_archaism["has_modern"]:
         return _status(
-            "standard",
-            [vesum],
+            "authentic-archaism",
+            [vesum_archaism["attestation"]],
             is_russianism=False,
             russian_shadow=russian_shadow,
             sovietization_risk=sovietization_risk,
@@ -97,7 +166,25 @@ def _classify(term: str, *, surface: bool) -> dict[str, Any]:
     classification = "unknown"
     with _source_conn() as conn:
         auth_hits = _dictionary_attestations(conn, term, surface=surface)
+        auth_hits.extend(_search_heritage_attestations(term))
+        has_standard_hit = any(hit["classification"] == "standard" for hit in auth_hits)
         for hit in auth_hits:
+            if vesum and hit["classification"] == "standard":
+                continue
+            if (
+                hit["classification"] == "authentic-archaism"
+                and hit.get("weak_when_modern")
+                and (vesum or has_standard_hit or russianism)
+            ):
+                continue
+            if (
+                vesum
+                and hit["classification"] == "authentic-archaism"
+                and "esum" in str(hit.get("attestation", {}).get("source") or "")
+            ):
+                continue
+            if vesum and hit["classification"] == "borrowing":
+                continue
             attestations.append(hit["attestation"])
             classification = _prefer_classification(classification, hit["classification"])
             sovietization_risk = max(sovietization_risk, int(hit.get("sovietization_risk") or 0))
@@ -111,6 +198,9 @@ def _classify(term: str, *, surface: bool) -> dict[str, Any]:
                 attestations.append(hit["attestation"])
                 classification = _prefer_classification(classification, hit["classification"])
 
+    if surface and russianism and term in _KNOWN_STANDARD_ALTERNATIVES:
+        return russianism
+
     if attestations and classification in _AUTHENTIC_CLASSIFICATIONS:
         return _status(
             classification,
@@ -122,6 +212,15 @@ def _classify(term: str, *, surface: bool) -> dict[str, Any]:
 
     if russianism:
         return russianism
+
+    if vesum:
+        return _status(
+            "standard",
+            [vesum],
+            is_russianism=False,
+            russian_shadow=russian_shadow,
+            sovietization_risk=sovietization_risk,
+        )
 
     calque_warning = _calque_warning(term, russian_shadow_detail)
     return _status(
@@ -246,6 +345,39 @@ def _vesum_attestation(term: str, *, surface: bool) -> dict[str, Any] | None:
     return None
 
 
+def _is_archaic_tags(tags: str | None) -> bool:
+    return "arch" in str(tags or "").split(":")
+
+
+def _vesum_archaism_attestation(term: str, *, surface: bool) -> dict[str, Any] | None:
+    try:
+        from scripts.verification.vesum import verify_lemma, verify_word
+
+        rows = verify_word(term) if surface else verify_lemma(term)
+        if not rows and not surface:
+            rows = verify_word(term)
+    except Exception:
+        return None
+    if not rows:
+        return None
+
+    archaic_rows = [row for row in rows if _is_archaic_tags(row.get("tags"))]
+    if not archaic_rows:
+        return None
+    sample = archaic_rows[0]
+    return {
+        "has_modern": len(archaic_rows) < len(rows),
+        "attestation": {
+            "source": "VESUM",
+            "ref": term,
+            "detail": (
+                "archaic tag in VESUM"
+                f" ({len(archaic_rows)}/{len(rows)} forms; sample tags={sample.get('tags')})"
+            ),
+        },
+    }
+
+
 def _check_russian_shadow(term: str) -> tuple[bool, dict[str, Any]]:
     if not _is_single_token(term):
         return False, {"available": False, "reason": "not_single_token"}
@@ -276,6 +408,149 @@ def _dictionary_attestations(
     return hits
 
 
+def _default_slovnyk_cache_dir() -> Path:
+    override = os.environ.get("LEXICON_SLOVNYK_CACHE")
+    if override:
+        return Path(override).expanduser()
+    local = ROOT / "data" / "lexicon" / "slovnyk_cache"
+    if local.exists():
+        return local
+    parts = ROOT.parts
+    if ".worktrees" in parts:
+        main_root = Path(*parts[: parts.index(".worktrees")])
+        main_cache = main_root / "data" / "lexicon" / "slovnyk_cache"
+        if main_cache.exists():
+            return main_cache
+    return local
+
+
+def _slovnyk_cache_path(term: str) -> Path:
+    stem = re.sub(r"[^0-9A-Za-zА-Яа-яЄєІіЇїҐґ'’ʼ-]+", "-", term).strip("-")
+    return _default_slovnyk_cache_dir() / f"{stem or 'empty'}.json"
+
+
+def _cached_slovnyk_hits(term: str) -> list[dict[str, Any]]:
+    path = _slovnyk_cache_path(term)
+    try:
+        cache = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    lookups = cache.get("lookups")
+    if not isinstance(lookups, dict):
+        return []
+
+    hits: list[dict[str, Any]] = []
+    for slug, row in lookups.items():
+        if slug not in _SLOVNYK_HERITAGE_SLUGS or not isinstance(row, dict):
+            continue
+        text = _clean_text(row.get("text"), limit=500)
+        if not text:
+            continue
+        hits.append(
+            {
+                "query": term,
+                "source_family": "slovnyk_me",
+                "source": row.get("dictionary_label") or "slovnyk.me",
+                "word": row.get("word") or term,
+                "text": text,
+                "classification": "cached_slovnyk_attestation",
+                "is_authentic_ukrainian": True,
+                "is_russianism": False,
+                "is_modern": slug in {"newsum", "vts"},
+                "is_dialect": _classification_from_source_text(text, default="standard") == "dialect",
+                "sovietization_risk": 0,
+                "evidence_tags": ["slovnyk_me_cache", slug],
+            }
+        )
+    return hits
+
+
+def _search_heritage_attestations(term: str) -> list[dict[str, Any]]:
+    try:
+        from wiki.sources_db import search_heritage
+
+        hits = search_heritage(term, limit=10, include_live_slovnyk=False)
+    except Exception:
+        hits = []
+    hits.extend(_cached_slovnyk_hits(term))
+
+    out: list[dict[str, Any]] = []
+    for hit in hits:
+        if hit.get("is_russianism"):
+            continue
+        hit_word = _normalize_word(str(hit.get("word") or ""))
+        if hit_word and hit_word != term:
+            continue
+        text = _clean_text(_heritage_hit_text(hit), limit=500)
+        classification = _classification_from_heritage_hit(hit, text)
+        if classification == "standard":
+            continue
+        out.append(
+            {
+                "classification": classification,
+                "attestation": {
+                    "source": _heritage_source_id(hit),
+                    "ref": str(hit.get("word") or hit.get("source") or term),
+                    "detail": text,
+                },
+                "sovietization_risk": int(hit.get("sovietization_risk") or 0),
+            }
+        )
+    return out
+
+
+def _heritage_hit_text(hit: dict[str, Any]) -> str:
+    return str(
+        hit.get("text")
+        or hit.get("definition")
+        or hit.get("etymology_text")
+        or hit.get("snippet")
+        or ""
+    )
+
+
+def _heritage_source_id(hit: dict[str, Any]) -> str:
+    family = str(hit.get("source_family") or "heritage")
+    source = str(hit.get("source") or "")
+    if family == "slovnyk_me":
+        return f"search_heritage:slovnyk_me:{source}".rstrip(":")
+    if family == "esum":
+        return "search_heritage:esum"
+    if family == "grinchenko":
+        return "search_heritage:grinchenko_1907"
+    if family == "style_guide":
+        return "search_heritage:style_guide"
+    return f"search_heritage:{family}"
+
+
+def _has_any_marker(text: str, markers: tuple[str, ...]) -> bool:
+    return any(marker in text for marker in markers)
+
+
+def _classification_from_source_text(text: str, *, default: str) -> str:
+    lower = _normalize_word(text)
+    if _has_any_marker(lower, _HISTORISM_MARKERS):
+        return "historism"
+    if _has_any_marker(lower, _DIALECT_MARKERS):
+        return "dialect"
+    if _has_any_marker(lower, _ARCHAIC_MARKERS):
+        return "authentic-archaism"
+    if "рідко" in lower and not re.search(r"\b[12]\.", lower):
+        return "authentic-archaism"
+    if _has_any_marker(lower, _BORROWING_MARKERS):
+        return "borrowing"
+    return default
+
+
+def _classification_from_heritage_hit(hit: dict[str, Any], text: str) -> str:
+    classification = _classification_from_source_text(text, default="standard")
+    if classification != "standard":
+        return classification
+    if bool(hit.get("is_dialect")) and _has_any_marker(_normalize_word(text), _DIALECT_MARKERS):
+        return "dialect"
+    return "standard"
+
+
 def _grinchenko_exact_hits(conn: sqlite3.Connection, term: str) -> list[dict[str, Any]]:
     hits = []
     for variant in _apostrophe_variants(term):
@@ -285,9 +560,10 @@ def _grinchenko_exact_hits(conn: sqlite3.Connection, term: str) -> list[dict[str
         ).fetchall()
         for row in rows:
             text = _clean_text(row["definition"])
+            classification = _classification_from_definition(text, default="authentic-archaism")
             hits.append(
                 {
-                    "classification": _classification_from_definition(text, default="authentic-archaism"),
+                    "classification": classification,
                     "attestation": {
                         "source": "grinchenko_1907",
                         "ref": str(row["id"]),
@@ -295,6 +571,8 @@ def _grinchenko_exact_hits(conn: sqlite3.Connection, term: str) -> list[dict[str
                         "detail": text,
                     },
                     "sovietization_risk": 0,
+                    "weak_when_modern": classification == "authentic-archaism"
+                    and _classification_from_source_text(text, default="standard") == "standard",
                 }
             )
     return hits
@@ -312,9 +590,10 @@ def _grinchenko_crossref_hits(conn: sqlite3.Connection, term: str) -> list[dict[
         if not crossref_re.search(definition):
             continue
         text = _clean_text(row["definition"])
+        classification = _classification_from_definition(text, default="dialect")
         hits.append(
             {
-                "classification": _classification_from_definition(text, default="dialect"),
+                "classification": classification,
                 "attestation": {
                     "source": "grinchenko_1907",
                     "ref": str(row["id"]),
@@ -322,6 +601,8 @@ def _grinchenko_crossref_hits(conn: sqlite3.Connection, term: str) -> list[dict[
                     "detail": text,
                 },
                 "sovietization_risk": 0,
+                "weak_when_modern": classification == "dialect"
+                and _classification_from_source_text(text, default="standard") == "standard",
             }
         )
     return hits
@@ -528,8 +809,9 @@ def _esum_variant_hits(conn: sqlite3.Connection, term: str) -> list[dict[str, An
 
 def _esum_hit(term: str, row: sqlite3.Row, *, exact: bool) -> dict[str, Any]:
     text = _clean_text(row["etymology_text"])
+    classification = _classification_from_etymology(text, term, exact=exact)
     return {
-        "classification": _classification_from_etymology(text, term, exact=exact),
+        "classification": classification,
         "attestation": {
             "source": "esum",
             "ref": f"{row['lemma']}:{row['vol']}:{row['page']}",
@@ -537,6 +819,9 @@ def _esum_hit(term: str, row: sqlite3.Row, *, exact: bool) -> dict[str, Any]:
             "detail": text,
         },
         "sovietization_risk": 0,
+        "weak_when_modern": exact
+        and classification == "authentic-archaism"
+        and _classification_from_source_text(text, default="standard") == "standard",
     }
 
 
@@ -573,28 +858,20 @@ def _wiktionary_exact_hits(conn: sqlite3.Connection, term: str) -> list[dict[str
 
 
 def _classification_from_definition(text: str, *, default: str) -> str:
-    lower = _normalize_word(text)
-    if "діал." in lower or " діал " in lower or "діалект" in lower:
-        return "dialect"
-    if "іст." in lower or "істор." in lower:
-        return "historism"
-    if "заст." in lower or "застар" in lower:
-        return "authentic-archaism"
-    return default
+    classification = _classification_from_source_text(text, default=default)
+    if classification == "borrowing" and default == "standard":
+        return default
+    return classification
 
 
 def _classification_from_etymology(text: str, term: str, *, exact: bool) -> str:
-    lower = _normalize_word(text)
     if term in _DIALECT_OR_FOLK_TERMS:
         return "dialect"
-    if any(marker in lower for marker in (" діал", "діал.", "говір", "гуц", "бойк", "лемк", "поділ")):
-        return "dialect"
-    if "іст." in lower or "істор." in lower:
-        return "historism"
-    if "заст." in lower or "застар" in lower:
-        return "authentic-archaism"
-    if "запозич" in lower:
-        return "borrowing"
+    classification = _classification_from_source_text(text, default="standard")
+    if classification != "standard":
+        if classification == "borrowing" and exact:
+            return "standard"
+        return classification
     return "authentic-archaism" if exact else "standard"
 
 
@@ -748,7 +1025,7 @@ def _literary_ref_detail(row: sqlite3.Row) -> str:
 
 def _literary_classification(term: str, row: sqlite3.Row) -> str:
     period = str(row["language_period"] or "")
-    if period in {"middle_ukrainian", "old_east_slavic"} or _looks_archaic_form(term):
+    if period in {"middle_ukrainian", "old_east_slavic"}:
         return "authentic-archaism"
     if term in _DIALECT_OR_FOLK_TERMS:
         return "dialect"
@@ -756,15 +1033,9 @@ def _literary_classification(term: str, row: sqlite3.Row) -> str:
 
 
 def _form_default_classification(term: str) -> str:
-    if _looks_archaic_form(term):
-        return "authentic-archaism"
     if term in _DIALECT_OR_FOLK_TERMS:
         return "dialect"
     return "standard"
-
-
-def _looks_archaic_form(term: str) -> bool:
-    return term.endswith(("ая", "еє", "єє", "оє", "ую"))
 
 
 def _russianism_status(term: str, *, russian_shadow: bool) -> dict[str, Any] | None:

--- a/starlight/src/pages/lexicon/[lemma].astro
+++ b/starlight/src/pages/lexicon/[lemma].astro
@@ -101,7 +101,6 @@ interface Enrichment {
   };
   meaning?: Meaning;
   definition_cards?: DefinitionCard[];
-  attestation?: SourcedText;
   etymology?: SourcedText;
   literary_attestation?: {
     text: string;
@@ -123,7 +122,6 @@ interface HeritageStatus {
   attestations: HeritageAttestation[];
   is_russianism: boolean;
   russian_shadow: boolean;
-  sovietization_risk: number;
   calque_warning?: { detail?: string } | null;
 }
 
@@ -314,36 +312,17 @@ const standardAlternatives = showHeritageWarning
       ),
     )
   : [];
-const meaningSource = enrichment?.meaning?.source ?? "";
-const isSum11Meaning = meaningSource.replace(/\s/g, "").includes("СУМ-11");
-const meaningSovietRisk = isSum11Meaning
-  ? Number(enrichment?.meaning?.sovietization_risk ?? 0)
-  : 0;
-const definitionSovietRisk = Math.max(
-  0,
-  ...definitionCards.map((card) => Number(card.sovietization_risk ?? 0)),
-);
-const definitionSovietKeywords = Array.from(
-  new Set(
-    definitionCards.flatMap((card) =>
-      (card.sovietization_keywords ?? []).map((keyword) => keyword.trim()).filter(Boolean),
+const hasPreSovietAttestation = Boolean(
+  (heritage?.attestations ?? []).some((attestation) =>
+    /grinchenko_1907|1907|Голоскевич|1929|ЕСУМ|esum/.test(
+      `${attestation.source} ${attestation.ref} ${attestation.detail ?? ""}`,
     ),
   ),
-);
-const showSovietSourceCaveat = meaningSovietRisk > 0 || definitionSovietRisk > 0;
-const hasPreSovietAttestation = Boolean(
-  definitionCards.some((card) => card.id === "grinchenko" || /Грінченко|1907/.test(card.source)) ||
-    enrichment?.attestation?.source?.includes("Грінченко") ||
-    (heritage?.attestations ?? []).some((attestation) =>
-      /Грінченко|1907|Голоскевич|1929|ЕСУМ/.test(
-        `${attestation.source} ${attestation.ref} ${attestation.detail ?? ""}`,
-      ),
-    ),
 );
 const showEditorialSuccess = Boolean(
   heritage && !heritage.is_russianism && !showHeritageWarning && hasPreSovietAttestation,
 );
-const showEditorialWarning = Boolean(showHeritageWarning || definitionSovietRisk > 0);
+const showEditorialWarning = Boolean(showHeritageWarning);
 // "standard" is the unremarkable default (codified modern norm) — it gets the
 // glanceable header pill but no dedicated section. The section is reserved for
 // the noteworthy cases: a non-standard authentic status (archaism/historism/
@@ -359,10 +338,9 @@ const showHeritage = Boolean(
       heritage.calque_warning),
 );
 const hasDictionaryData = Boolean(
-  enrichment?.morphology ||
+    enrichment?.morphology ||
     enrichment?.meaning ||
     definitionCards.length > 0 ||
-    enrichment?.attestation ||
     enrichment?.etymology ||
     enrichment?.literary_attestation ||
     sections?.synonyms ||
@@ -453,26 +431,6 @@ const frontmatter = {
           {standardAlternatives.length > 0 && (
             <p class="editorial-meta">Українська норма: {standardAlternatives.join(", ")}</p>
           )}
-        </div>
-      </section>
-    )}
-
-    {definitionSovietRisk > 0 && (
-      <section class="atlas-section" aria-label="Попередження джерела">
-        <div class={`editorial-warn ${definitionSovietRisk === 1 ? "editorial-warn--amber" : ""}`}>
-          <div class="editorial-warn-header">
-            <div class="editorial-warn-icon" aria-hidden="true">⚠</div>
-            Радянські ідеологічні формулювання у СУМ-11
-          </div>
-          <p>
-            У показаній нижче картці СУМ-11 є радянсько-ідеологічні маркери.
-            Це попередження стосується редакторської політики словника, а не
-            автоматично самого слова.
-          </p>
-          <p class="editorial-meta">
-            Тригер: sovietization_risk={definitionSovietRisk}
-            {definitionSovietKeywords.length > 0 && ` · keywords: ${definitionSovietKeywords.join(", ")}`}
-          </p>
         </div>
       </section>
     )}
@@ -604,13 +562,6 @@ const frontmatter = {
               </p>
             )}
             {enrichment.meaning.note && <p class="atlas-note">{enrichment.meaning.note}</p>}
-            {showSovietSourceCaveat && (
-              <p class="atlas-source-caveat" role="note">
-                <span aria-hidden="true">⚠</span>{" "}
-                Це тлумачення — з радянського словника (СУМ-11); подається з
-                осторогою. Перевага — Грінченко / СУМ-20.
-              </p>
-            )}
           </div>
         ) : null}
       </section>
@@ -650,19 +601,6 @@ const frontmatter = {
             </article>
           ))}
         </div>
-      </section>
-    )}
-
-    {enrichment?.attestation && (
-      <section class="atlas-section" aria-labelledby="atlas-attestation-title">
-        <div class="atlas-section-head">
-          <p class="atlas-kicker">Джерела</p>
-          <h2 id="atlas-attestation-title">Історичне засвідчення</h2>
-        </div>
-        <blockquote class="atlas-quote-card">
-          <p>{enrichment.attestation.text}</p>
-          <cite>{enrichment.attestation.source}</cite>
-        </blockquote>
       </section>
     )}
 
@@ -1215,21 +1153,6 @@ const frontmatter = {
     color: var(--lu-text-muted);
   }
 
-  .atlas-source-caveat {
-    margin: 0.85rem 0 0;
-    padding: 0.65rem 0.8rem;
-    border: 1px solid color-mix(in srgb, var(--lu-accent) 68%, var(--lu-border));
-    border-left: 4px solid var(--lu-accent);
-    border-radius: 6px;
-    background: var(--lu-state-missed);
-    color: var(--lu-text);
-    font-size: 0.92rem;
-  }
-
-  .atlas-source-caveat span {
-    font-weight: 900;
-  }
-
   .def-card-list {
     display: grid;
     gap: 0.75rem;
@@ -1246,10 +1169,6 @@ const frontmatter = {
 
   .def-card.sum20 {
     border-left-color: #00695c;
-  }
-
-  .def-card.grinchenko {
-    border-left-color: #795548;
   }
 
   .def-card.sum11 {
@@ -1287,11 +1206,6 @@ const frontmatter = {
   .def-card.sum20 .src-pill {
     background: color-mix(in srgb, #00695c 14%, var(--lu-surface));
     color: #00695c;
-  }
-
-  .def-card.grinchenko .src-pill {
-    background: color-mix(in srgb, #795548 14%, var(--lu-surface));
-    color: #795548;
   }
 
   .def-card.sum11-flagged .src-pill {

--- a/tests/test_atlas_conformance.py
+++ b/tests/test_atlas_conformance.py
@@ -166,27 +166,35 @@ def test_heritage_evidence_required_flags_authentic_without_presoviet_attestatio
     assert _gates_for(entry) == ["heritage_evidence_required"]
 
 
-def test_sovietization_must_be_flagged_for_unmirrored_sum11_risk():
+def test_sovietization_must_be_flagged_for_unflagged_sum11_card_risk():
     entry = _entry(
         enrichment={
-            "meaning": {
-                "definitions": [{"text": "Ідеологічно навантажене тлумачення.", "sovietization_risk": 1}],
-                "source": "СУМ-11",
-            }
+            "definition_cards": [
+                {
+                    "id": "sum11-flagged",
+                    "source": "СУМ-11",
+                    "definitions": ["Ідеологічно навантажене тлумачення."],
+                    "sovietization_risk": 1,
+                }
+            ]
         }
     )
 
     assert _gates_for(entry) == ["sovietization_must_be_flagged"]
 
 
-def test_sovietization_passes_when_meaning_carries_source_risk():
+def test_sovietization_passes_when_sum11_card_carries_inline_caveat():
     entry = _entry(
         enrichment={
-            "meaning": {
-                "definitions": ["Ідеологічно навантажене тлумачення."],
-                "source": "СУМ-11",
-                "sovietization_risk": 1,
-            }
+            "definition_cards": [
+                {
+                    "id": "sum11-flagged",
+                    "source": "СУМ-11",
+                    "definitions": ["Ідеологічно навантажене тлумачення."],
+                    "sovietization_risk": 1,
+                    "flag_note": "⚠ СУМ-11 — радянське видання; подаємо обережно.",
+                }
+            ]
         }
     )
 

--- a/tests/test_heritage_classifier.py
+++ b/tests/test_heritage_classifier.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -68,3 +69,51 @@ def test_specified_russianisms_keep_standard_alternatives() -> None:
             attestation["source"] == "standard_alternative" and attestation["ref"] == alternative
             for attestation in status["attestations"]
         )
+
+
+def test_atlas_heritage_labels_use_source_backed_evidence() -> None:
+    expected = {
+        "вельми": "authentic-archaism",
+        "глагол": "authentic-archaism",
+        "гетьман": "historism",
+        "опришок": "historism",
+        "десятина": "historism",
+    }
+
+    for lemma, classification in expected.items():
+        status = classify_lemma(lemma)
+
+        assert status["classification"] == classification
+        assert status["is_russianism"] is False
+        assert status["attestations"]
+
+
+def test_kobita_uses_cached_sum20_regional_evidence(monkeypatch, tmp_path) -> None:
+    cache_dir = tmp_path / "slovnyk_cache"
+    cache_dir.mkdir()
+    (cache_dir / "кобіта.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "lemma": "кобіта",
+                "lookup_word": "кобіта",
+                "lookups": {
+                    "newsum": {
+                        "dictionary_slug": "newsum",
+                        "dictionary_label": "Словник української мови у 20 томах (СУМ-20)",
+                        "word": "кобіта",
+                        "text": "КОБІТА, и, ж., зах. Те саме, що жінка.",
+                    }
+                },
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LEXICON_SLOVNYK_CACHE", str(cache_dir))
+
+    status = classify_lemma("кобіта")
+
+    assert status["classification"] == "dialect"
+    assert status["is_russianism"] is False
+    assert any("СУМ-20" in attestation["source"] for attestation in status["attestations"])

--- a/tests/test_heritage_classifier.py
+++ b/tests/test_heritage_classifier.py
@@ -10,19 +10,13 @@ pytestmark = pytest.mark.skipif(
     or Path("data/sources.db").stat().st_size < 100_000_000,
     reason="requires the full ~1.7GB corpus sources.db; CI has only a stub; heritage engine verified locally 5/5",
 )
-def test_surface_drugoje_uses_verified_literary_quote() -> None:
+def test_surface_drugoje_literary_quote_does_not_create_heritage_badge() -> None:
     status = classify_surface_form("другоє")
 
-    assert status["classification"] == "authentic-archaism"
+    assert status["classification"] == "unknown"
     assert status["is_russianism"] is False
     assert status["russian_shadow"] is True
-    assert any(
-        attestation["source"] == "literary_fts"
-        and attestation["ref"] == "feaa5fa7_c0572"
-        and attestation["score"] == 1.0
-        and attestation["quote"] == "на другоє літо поховаємо"
-        for attestation in status["attestations"]
-    )
+    assert status["attestations"] == []
 
 
 def test_dialect_heritage_forms_are_not_blocked_by_russian_shadow() -> None:
@@ -73,11 +67,10 @@ def test_specified_russianisms_keep_standard_alternatives() -> None:
 
 def test_atlas_heritage_labels_use_source_backed_evidence() -> None:
     expected = {
-        "вельми": "authentic-archaism",
         "глагол": "authentic-archaism",
-        "гетьман": "historism",
         "опришок": "historism",
-        "десятина": "historism",
+        "ягілка": "dialect",
+        "гагілка": "dialect",
     }
 
     for lemma, classification in expected.items():
@@ -85,10 +78,33 @@ def test_atlas_heritage_labels_use_source_backed_evidence() -> None:
 
         assert status["classification"] == classification
         assert status["is_russianism"] is False
-        assert status["attestations"]
+        assert any(
+            attestation["source"] in {"grinchenko_1907", "esum"}
+            for attestation in status["attestations"]
+        )
 
 
-def test_kobita_uses_cached_sum20_regional_evidence(monkeypatch, tmp_path) -> None:
+def test_common_modern_lemmas_do_not_get_heritage_badges() -> None:
+    for lemma in (
+        "бути",
+        "автобус",
+        "журналіст",
+        "книга",
+        "білий",
+        "гарний",
+        "адреса",
+        "банкір",
+        "вельми",
+        "гетьман",
+        "десятина",
+    ):
+        status = classify_lemma(lemma)
+
+        assert status["classification"] == "standard"
+        assert status["is_russianism"] is False
+
+
+def test_kobita_ignores_cached_sum20_regional_evidence(monkeypatch, tmp_path) -> None:
     cache_dir = tmp_path / "slovnyk_cache"
     cache_dir.mkdir()
     (cache_dir / "кобіта.json").write_text(
@@ -114,6 +130,9 @@ def test_kobita_uses_cached_sum20_regional_evidence(monkeypatch, tmp_path) -> No
 
     status = classify_lemma("кобіта")
 
-    assert status["classification"] == "dialect"
+    assert status["classification"] == "standard"
     assert status["is_russianism"] is False
-    assert any("СУМ-20" in attestation["source"] for attestation in status["attestations"])
+    assert not any("СУМ-20" in attestation["source"] for attestation in status["attestations"])
+    assert [(attestation["source"], attestation["ref"]) for attestation in status["attestations"]] == [
+        ("VESUM", "кобіта")
+    ]

--- a/tests/test_lexicon_build_manifest.py
+++ b/tests/test_lexicon_build_manifest.py
@@ -1,4 +1,8 @@
-from scripts.lexicon.build_data_manifest import SURZHYK_TO_AVOID_SEEDS, build_manifest
+from scripts.lexicon.build_data_manifest import (
+    HERITAGE_STATUS_SEEDS,
+    SURZHYK_TO_AVOID_SEEDS,
+    build_manifest,
+)
 
 
 def test_surzhyk_to_avoid_seed_group_is_in_manifest() -> None:
@@ -7,18 +11,37 @@ def test_surzhyk_to_avoid_seed_group_is_in_manifest() -> None:
     seed_lemmas = [str(seed["lemma"]) for seed in SURZHYK_TO_AVOID_SEEDS]
 
     assert manifest["stats"]["from_surzhyk_to_avoid"] == len(seed_lemmas)
-    assert manifest["seed_groups"] == [
-        {
-            "id": "surzhyk-to-avoid",
-            "source": "surzhyk_to_avoid",
-            "description": "Classifier-verified Russianism/surzhyk examples for visible Atlas warnings.",
-            "lemmas": seed_lemmas,
-        }
-    ]
+    assert manifest["seed_groups"][0]["lemmas"] == seed_lemmas
     for lemma in seed_lemmas:
         assert entries[lemma]["primary_source"] == "surzhyk_to_avoid"
         assert entries[lemma]["seed_group"] == "surzhyk-to-avoid"
         assert entries[lemma]["course_usage"] == []
+
+
+def test_heritage_status_seed_group_is_in_manifest() -> None:
+    manifest = build_manifest()
+    entries = {entry["lemma"]: entry for entry in manifest["entries"]}
+    seed_lemmas = [str(seed["lemma"]) for seed in HERITAGE_STATUS_SEEDS]
+
+    assert manifest["stats"]["from_heritage_status_seed"] == len(seed_lemmas)
+    assert manifest["seed_groups"][1]["lemmas"] == seed_lemmas
+    for lemma in seed_lemmas:
+        assert entries[lemma]["primary_source"] == "heritage_status_seed"
+        assert entries[lemma]["seed_group"] == "heritage-status-samples"
+        assert entries[lemma]["course_usage"] == []
+
+
+def test_manifest_sources_all_vocabulary_files_and_a2_word_field() -> None:
+    manifest = build_manifest()
+    entries = {entry["lemma"]: entry for entry in manifest["entries"]}
+
+    assert manifest["stats"]["modules_covered"] >= 120
+    assert manifest["stats"]["from_built"] >= 2_000
+    assert "батько" in entries
+    assert "відмінок" in entries
+    assert "голосний" in entries
+    assert any(usage["track"] == "a1" and usage["slug"] == "my-family" for usage in entries["батько"]["course_usage"])
+    assert any(usage["track"] == "a2" and usage["slug"] == "a2-bridge" for usage in entries["відмінок"]["course_usage"])
 
 
 def test_manifest_url_slugs_are_unique() -> None:

--- a/tests/test_lexicon_build_manifest.py
+++ b/tests/test_lexicon_build_manifest.py
@@ -44,6 +44,61 @@ def test_manifest_sources_all_vocabulary_files_and_a2_word_field() -> None:
     assert any(usage["track"] == "a2" and usage["slug"] == "a2-bridge" for usage in entries["відмінок"]["course_usage"])
 
 
+def test_manifest_omits_non_lemma_surface_entries() -> None:
+    manifest = build_manifest()
+    entries = {entry["lemma"]: entry for entry in manifest["entries"]}
+
+    for lemma in (
+        "Давай!",
+        "Смачного!",
+        "Ходімо!",
+        "в/у",
+        "у/в",
+        "і/й",
+        "Богдане",
+        "Соломіє",
+    ):
+        assert lemma not in entries
+
+
+def test_manifest_maps_taught_vocatives_to_nominative_lemmas() -> None:
+    manifest = build_manifest()
+    entries = {entry["lemma"]: entry for entry in manifest["entries"]}
+
+    expected = {
+        "Олена": "Олено",
+        "Марія": "Маріє",
+        "Тарас": "Тарасе",
+    }
+    for lemma, source_lemma in expected.items():
+        normalizations = entries[lemma]["atlas_normalizations"]
+
+        assert any(
+            normalization["kind"] == "vocative_to_nominative"
+            and normalization["source_lemma"] == source_lemma
+            for normalization in normalizations
+        )
+
+
+def test_manifest_canonicalizes_real_words_missing_from_vesum() -> None:
+    manifest = build_manifest()
+    entries = {entry["lemma"]: entry for entry in manifest["entries"]}
+
+    assert "бірка" not in entries
+    assert entries["бирка"]["atlas_normalizations"][0]["source_lemma"] == "бірка"
+    assert any(
+        usage["track"] == "a2" and usage["slug"] == "genitive-adjectives-pronouns"
+        for usage in entries["бирка"]["course_usage"]
+    )
+
+    assert "прийом" not in entries
+    assert entries["приймання"]["atlas_normalizations"][0]["source_lemma"] == "прийом"
+    assert any(
+        usage["track"] == "a2" and usage["slug"] == "genitive-prepositions-direction"
+        for usage in entries["приймання"]["course_usage"]
+    )
+
+
 def test_manifest_url_slugs_are_unique() -> None:
     manifest = build_manifest()
     slugs: dict[str, list[str]] = {}

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -439,7 +439,7 @@ def test_sum11_meaning_carries_source_sovietization_risk() -> None:
     assert meaning["sovietization_keywords"] == ["ленін", "маркс"]
 
 
-def test_definition_cards_emit_separate_sources_with_sum11_risk(monkeypatch) -> None:
+def test_definition_cards_emit_separate_visible_sources_with_sum11_risk(monkeypatch) -> None:
     conn = _conn()
     conn.execute(
         "INSERT INTO grinchenko (word, definition, source) VALUES (?, ?, ?)",
@@ -462,7 +462,7 @@ def test_definition_cards_emit_separate_sources_with_sum11_risk(monkeypatch) -> 
     monkeypatch.setattr(
         enrich_manifest_module,
         "_sum20_definition_card",
-        lambda lemma: {
+        lambda lemma, cache=None: {
             "id": "sum20",
             "source": "СУМ-20",
             "source_pill": "СУМ-20",
@@ -473,12 +473,12 @@ def test_definition_cards_emit_separate_sources_with_sum11_risk(monkeypatch) -> 
 
     cards = _definition_cards(conn, "прапор", has_sum11_flags=True)
 
-    assert [card["id"] for card in cards] == ["grinchenko", "sum20", "sum11-flagged"]
-    assert cards[0]["source"] == "Грінченко 1907"
-    assert cards[1]["source"] == "СУМ-20"
-    assert cards[2]["sovietization_risk"] == 2
-    assert cards[2]["sovietization_keywords"] == ["ленін", "партійн"]
-    assert "Прапор" in cards[0]["definitions"][0]
+    assert [card["id"] for card in cards] == ["sum20", "sum11-flagged"]
+    assert cards[0]["source"] == "СУМ-20"
+    assert cards[1]["sovietization_risk"] == 2
+    assert cards[1]["sovietization_keywords"] == ["ленін", "партійн"]
+    assert cards[1]["flag_note"] == "⚠ СУМ-11 — радянське видання; подаємо обережно, перевага СУМ-20/Вікісловнику"
+    assert all(card["source"] != "Грінченко 1907" for card in cards)
 
 
 def test_cefr_lookup_uses_exact_puls_row() -> None:


### PR DESCRIPTION
## Summary
Finalizes the Word Atlas to design §4/§5 (EPIC #2985 #7 scale). Salvages + fixes the dead `atlas-finalize-all` codex dispatch (which stalled in a wait-loop and never committed), then corrects its broken §4 heritage classifier.

## Changes
- **§1 — full taught-vocab rebuild + lemma hygiene:** manifest 138 → **2,156 clean lemmas** (union of all `vocabulary.yaml`, A1 `lemma` + A2 `word`). Dropped 13 non-lemma entries (vocative proper names, interjection phrases, `в/у`-style variant notations) — `lemma_in_vesum` gate passes.
- **§2 — Грінченко (UA→RU) attestation removed** from rendered pages (no Russian glosses surfaced); heritage_classifier keeps Грінченко for *backend* pre-Soviet evidence only.
- **§3 — soviet caveat is entry-scoped** (only on the СУМ-11 definition card, keyed off that card's `sovietization_risk`); word-level banner removed. Clean words (прапор/банк) read as normal Ukrainian.
- **§4 — heritage detection: STRICT Grinchenko-1907/ESUM** (user decision 2026-06-12, correctness over coverage). Fires archaism/historism/dialect/borrowing ONLY on Grinchenko/ESUM attestation. Eliminates the prior over-fire (115 false positives: бути→archaism, автобус→dialect). At A1-A2 vocab this yields **0 heritage badges** (expected — basic modern vocab has no Grinchenko/ESUM heritage markers); classifier **proven functional** on опришок→historism, глагол→archaism, челядь→historism (populates at B1+/seminar levels).

## Gates (verified locally)
- `pytest tests/test_atlas_conformance.py tests/test_heritage_classifier.py tests/test_lexicon_build_manifest.py tests/test_lexicon_enrich_manifest.py` → **44 passed**, **0 §8 conformance violations** (real vesum).
- `ruff check scripts/ tests/` → All checks passed.
- `npm run build` → 2,319 pages, Complete.
- Russianism path (міроприємство → РУСИЗМ) intact.

## Provenance
§2/§3 + initial §1/§4 authored by codex (`atlas-finalize-all`, stalled). §1 lemma-hygiene + §4 strict rewrite authored by codex (`atlas-heritage-fix`). Finalized by Claude after codex stalled at the §M-4 step (silence-timeout guard).

## ⚠️ Post-merge
User-facing (`starlight/`). GitHub Pages auto-deploy is DISABLED — after merge run `gh workflow run deploy-pages.yml --ref main` and verify the LIVE site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)