### PR TITLE
policy(reviewers): Claude reviewer seat = in-session inline (never claude -p / Agent subagent)

### DIFF
--- a/.agents/skills/batch-review/SKILL.md
+++ b/.agents/skills/batch-review/SKILL.md
@@ -41,6 +41,13 @@ List the modules to review and any skipped modules.
 
 ## Dispatch Subagents (Max 4 Parallel)
 
+> **Reviewer-seat economics guard** (`rules/model-assignment.md`): each `Agent`-tool subagent reloads the full
+> project (~2–3M tokens) for its verdict, so it is ~50–150× the cost of an inline review. For a **single
+> module or a small batch (≤3), review INLINE** in this session (or defer to next session if context is heavy) —
+> do NOT spawn subagents. Subagents here are justified ONLY for a **genuinely large batch** where wall-clock +
+> context-overflow outweigh the per-subagent reload. When in doubt, prefer non-Claude dispatched reviewers
+> (DeepSeek/Codex) for the bulk and keep the Claude seat in-session.
+
 Split the reviewable modules into chunks of 2-3 modules each.
 Spawn up to 4 subagents using the Agent tool, each processing its chunk.
 

--- a/agents_extensions/shared/agents/curriculum-orchestrator.md
+++ b/agents_extensions/shared/agents/curriculum-orchestrator.md
@@ -78,9 +78,13 @@ Bad pedagogy creates durable learner errors. Strong modules beat many mediocre m
   track is currently Claude/BIO-orchestrator owned; do not duplicate BIO triage
   unless the track orchestrator asks.
 - Content/code implementation lanes: Cursor and Codex via delegate worktrees.
-- Review lanes: Claude `review-deep`, DeepSeek via Hermes delegate, Codex
-  integration review. Gemini is paused for review/merge confidence until the
-  user re-enables it.
+- Review lanes: Claude `review-deep` is the **in-session inline** seat — you (the
+  interactive orchestrator) read the artifact, verify claims, and write the verdict
+  on the main quota; never `claude -p` / `--agent claude` / an `Agent`-tool review
+  subagent (defer to the next interactive session if context is heavy). DeepSeek via
+  Hermes delegate and Codex integration review are the dispatched (non-Claude) lanes —
+  route the bulk of reviews there. See `rules/model-assignment.md` § reviewer-seat
+  economics. Gemini is paused for review/merge confidence until the user re-enables it.
 - Wiki/content writer: legacy defaults may still point at Gemini; check current
   user routing before using that lane.
 - Ukrainian linguistic verification: inline Claude via `mcp__sources__*`.

--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -11,12 +11,35 @@ Match the EXACT command — not a principle. Memory does not enforce; the dispat
 | Code Review (PR diff) — cheap second opinion | `delegate.py dispatch --agent deepseek --model deepseek-v4-flash --mode read-only` (hermes; PR #2107 adapter). Empirical winner 2026-05-17 bakeoff (A+ at 15s) |
 | Content Review with VESUM verification (load-bearing) | `delegate.py dispatch --agent deepseek --model deepseek-v4-pro` (hermes; MCP-backed: proactively calls `sources` `verify_words`, `query_cefr_level`, `check_russian_shadow`). Validated by PR #2112 write-mode dispatch on artifacts-MD feature |
 | Wiki / content writing | `delegate.py dispatch --agent gemini` (Gemini sub, unmetered) |
-| Adversarial review of design / ADR / architecture | `delegate.py dispatch --agent claude --mode read-only --model claude-opus-4-8 --effort xhigh` (headless Opus, separate billing — DROPS 2026-06-15: substitute via `scripts/config/agent_fallback_substitutions.yaml`) |
+| Adversarial review of design / ADR / architecture / code — the **Claude reviewer seat** | **IN-SESSION INLINE** — the interactive orchestrator reads the artifact, verifies claims, writes the verdict + fix notes, on the main subscription quota. **NEVER** `claude -p` / `--agent claude` / Agent-SDK / GH-Actions-Claude, and **NEVER an `Agent`-tool review subagent**. Context heavy → **DEFER** to the next interactive session's start (top-of-handoff `Claude review PENDING: <artifact>`). See the reviewer-seat economics below. |
 | Q&A or single-shot review without commit | `ab ask-codex` / `ab ask-gemini --model gemini-3.0-flash-preview` for routine, `--model gemini-3.1-pro-preview` only for deep |
 | Search / grep / "find me X" across files | `Agent` tool with `subagent_type: Explore`, `model: "haiku"` |
 | Status check on running dispatches | Monitor API curl, never inline file scans |
 
 If I'm about to write code inline and it doesn't match row 1, STOP and dispatch instead. Tooling enforces (worktree + commits) — memory does not.
+
+## Claude reviewer-seat economics (2026-06-12)
+
+There is ONE Claude Code quota. A dispatched / headless / subagent Claude competes with the interactive
+orchestrator's own seat, AND a subagent starts a fresh context that **reloads the full project (~2–3M tokens,
+~1000:1 overhead per the global `code-editing-safety` §7 rule)** to return a verdict that inline costs
+~15–25k. A subagent therefore *duplicates a session boot you pay for anyway* → ~50–150× the tokens for the
+identical verdict. So the Claude reviewer seat is fulfilled IN-SESSION:
+
+1. **Default: review INLINE, early in the session** while context is light — cheapest, full faculties, and you
+   reuse the read to write the fix.
+2. **Context heavy + a Claude review is still needed: DEFER** to the next MANUAL interactive session's start
+   (record a top-of-handoff `Claude review PENDING: <artifact>` so cold-start picks it up first). That
+   artifact's merge waits one session. Do NOT cram it into the depleted session and do NOT spawn a subagent.
+   "Next session" = the next manual interactive session, NOT a cron / scheduled cloud agent / `claude -p`
+   (those are the capped pool).
+3. **Inline-now despite heavy context** only when latency is unacceptable (the review must clear THIS session
+   to unblock something).
+
+Non-Claude reviewers are UNAFFECTED — keep routing the bulk of reviews to them: DeepSeek (rows above) for PR
+diffs + VESUM content review, Codex for novel-architecture catches. Only the *Claude* seat is in-session.
+(As of mid-June 2026 the headless `--agent claude` lane is also independently off — `@anthropic-ai/claude-code`
+recent versions fail with "native binary not installed" — but the economics above stand regardless of lane health.)
 
 The same table lives in `memory/MEMORY.md` rule #M0; this file is the deploy-rule mirror so it loads via `npm run agents:deploy` into `.claude/rules/`.
 

--- a/agents_extensions/shared/skills/batch-review/SKILL.md
+++ b/agents_extensions/shared/skills/batch-review/SKILL.md
@@ -41,6 +41,13 @@ List the modules to review and any skipped modules.
 
 ## Dispatch Subagents (Max 4 Parallel)
 
+> **Reviewer-seat economics guard** (`rules/model-assignment.md`): each `Agent`-tool subagent reloads the full
+> project (~2–3M tokens) for its verdict, so it is ~50–150× the cost of an inline review. For a **single
+> module or a small batch (≤3), review INLINE** in this session (or defer to next session if context is heavy) —
+> do NOT spawn subagents. Subagents here are justified ONLY for a **genuinely large batch** where wall-clock +
+> context-overflow outweigh the per-subagent reload. When in doubt, prefer non-Claude dispatched reviewers
+> (DeepSeek/Codex) for the bulk and keep the Claude seat in-session.
+
 Split the reviewable modules into chunks of 2-3 modules each.
 Spawn up to 4 subagents using the Agent tool, each processing its chunk.
 


### PR DESCRIPTION
## Summary
Encodes a **Claude reviewer-seat economics** policy (mirrors the convergence locked in the KubeDojo project), adapted to this project's roster.

**The rule:** the Claude/opus reviewer seat is fulfilled **IN-SESSION on the main subscription quota** — the interactive orchestrator reads the artifact → verifies claims → writes the verdict + fix notes inline.
- **Never** `claude -p` / `--agent claude` / Agent-SDK / GH-Actions-Claude for a review.
- **Never** an `Agent`-tool review subagent — it reloads the full project (~2–3M tokens, ~1000:1 overhead per the global `code-editing-safety` §7) for a verdict that inline costs ~15–25k → **50–150× the tokens for the identical verdict**, duplicating a session boot you pay for anyway.
- **Context heavy →** DEFER to the next *manual interactive* session's start (top-of-handoff `Claude review PENDING: <artifact>`), NOT a cron / scheduled cloud agent / `claude -p` (the capped pool).
- **Non-Claude reviewers UNAFFECTED** — keep routing the bulk to DeepSeek (PR diff + VESUM content) and Codex (novel-arch). Only the *Claude* seat is in-session.

## Why it holds here
This project already had the pieces — #M0 (2026-06-15) 'single Claude Code quota; dispatched Claude competes with the interactive seat' and MEMORY #2 '74% subagent token volume.' This makes the **decision rule** explicit and removes the `claude -p` review path (row 14 previously routed there; it was already marked 'DROPS 2026-06-15'). As of mid-June 2026 the headless `--agent claude` lane is also independently broken ('native binary not installed'), but the economics stand regardless.

## Changes
- `rules/model-assignment.md` — revised the adversarial-review row to in-session inline + added a 'Claude reviewer-seat economics' decision block.
- `agents/curriculum-orchestrator.md` — review-lane clarified (Claude = inline seat; DeepSeek/Codex = dispatched lanes).
- `skills/batch-review/SKILL.md` (+ `.agents` mirror) — reviewer-seat guard before the subagent step (inline/defer for ≤3 modules; subagents only for genuinely large batches).
- Companion: the auto-memory #M0 is updated separately (it is not repo-tracked).

## Gates
- `test_deploy_script_idempotency.py` → 5 passed.
- `test_lint_prompts.py` + `test_prompt_health.py` + `test_prompt_literals.py` → 78 passed, 14 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)