### PR TITLE
fix(tooling): start-claude.sh launches native install, not broken npx

### DIFF
--- a/start-claude.sh
+++ b/start-claude.sh
@@ -28,12 +28,15 @@ if [ -n "$MISSING_TOOLS" ]; then
     echo "   (These are recommended but not required to start)"
 fi
 
-# Check for npx (required to run Claude Code)
-if ! command -v npx &> /dev/null; then
-    echo "Error: npx not found (install Node.js)"
+# Locate the Claude Code NATIVE install (preferred). The npx route is broken as of
+# 2026-06-12: the npx-cached binary exits 194 ("native binary not installed").
+CLAUDE_BIN="$HOME/.local/bin/claude"
+if [ ! -x "$CLAUDE_BIN" ]; then
+    echo "Error: Claude Code native install not found at $CLAUDE_BIN"
+    echo "   Install/repair it, e.g.:  curl -fsSL https://claude.ai/install.sh | bash"
     exit 1
 fi
-echo "npx found — will launch Claude Code via npx @latest"
+echo "Claude native install: $("$CLAUDE_BIN" --version 2>/dev/null) ($CLAUDE_BIN)"
 
 # Change to project directory
 cd "$PROJECT_DIR"
@@ -119,30 +122,9 @@ echo ""
 export CLAUDE_CODE_AUTO_COMPACT_WINDOW=1000000
 export LEARN_UKRAINIAN_TELEMETRY_FOOTER="${LEARN_UKRAINIAN_TELEMETRY_FOOTER:-1}"
 
-# Self-heal: ensure Claude's native binary is wired up.
-# npx installs @anthropic-ai/claude-code (incl. the ~212MB platform binary that
-# ships in the optional dep) but in some npm/npx versions does NOT run the
-# package's postinstall (install.cjs) — so the binary is never linked into place
-# and the launcher dies with "claude native binary not installed". Detect that
-# and run the postinstall in the npx cache. Idempotent; a no-op once wired. The
-# npx cache is keyed by package spec, so this also heals other projects.
-ensure_claude_native() {
-    if npx @anthropic-ai/claude-code@latest --version >/dev/null 2>&1; then
-        return 0
-    fi
-    echo "Claude native binary not wired up — running postinstall in npx cache..."
-    for cjs in "$HOME"/.npm/_npx/*/node_modules/@anthropic-ai/claude-code/install.cjs; do
-        [ -f "$cjs" ] || continue
-        ( cd "$(dirname "$cjs")" && node install.cjs ) >/dev/null 2>&1 || true
-    done
-    if npx @anthropic-ai/claude-code@latest --version >/dev/null 2>&1; then
-        echo "Native binary wired up."
-    else
-        echo "Warning: auto-wire failed. Try: npm cache clean --force, then re-run."
-    fi
-}
-ensure_claude_native
-
-# Launch via npx to avoid cache bugs (stale binary + prompt caching issues)
-echo "Launching Claude Code via npx (cache-safe)..."
-npx @anthropic-ai/claude-code@latest --chrome --permission-mode bypassPermissions "$@"
+# Launch the NATIVE install directly. (Previously launched via
+# `npx @anthropic-ai/claude-code@latest`, but that route broke 2026-06-12 — the
+# npx-cached binary exits 194. The native install at ~/.local/bin/claude auto-updates
+# via `claude update`, so npx is no longer needed to stay current.)
+echo "Launching Claude Code (native install)..."
+exec "$CLAUDE_BIN" --chrome --permission-mode bypassPermissions "$@"


### PR DESCRIPTION
`start-claude.sh` launched Claude via `npx @anthropic-ai/claude-code@latest`, which broke 2026-06-12 (npx-cached binary exits 194, "native binary not installed"). Repointed the launch + preflight to the working native install `~/.local/bin/claude` (2.1.175, auto-updates via `claude update`); removed the obsolete npx self-heal. Verified: `--chrome` + `--permission-mode` supported, `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)