### PR TITLE
deps(security): bump zeroconf → 0.149.12 (CVE-2026-48045, Dependabot #129/#130)

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -215,5 +215,5 @@ yamllint==1.38.0
 yarl==1.22.0
 youtube-transcript-api==1.2.4
 yt-dlp==2026.3.17
-zeroconf==0.149.7
+zeroconf==0.149.12
 zlib-state==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,11 @@ yt-dlp>=2026.3.17
 # Build utilities
 jinja2>=3.1
 
+# Security floors (transitive deps held above their vulnerable range)
+# zeroconf comes via mcp-memory-service; CVE-2026-48045 / GHSA-9663-mqmp-p9mm
+# (unbounded TC-deferred queue → LAN-local memory exhaustion) is fixed in 0.149.12.
+zeroconf>=0.149.12
+
 # ----------------------------------------------------------------------
 # Known-harmless `pip check` warnings (DO NOT CHASE)
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## What

Resolves the two **zeroconf** Dependabot alerts (medium):
- **#129** (requirements-lock.txt) / **#130** (requirements.txt) — CVE-2026-48045 / GHSA-9663-mqmp-p9mm: python-zeroconf's unbounded TC-deferred queue allows LAN-local memory exhaustion via a spoofed-source flood. Fixed in **0.149.12**.

Changes:
- `requirements-lock.txt`: `zeroconf==0.149.7 → 0.149.12` (this is what CI installs — `pip install --no-deps -r requirements-lock.txt`).
- `requirements.txt`: documented `zeroconf>=0.149.12` security floor (zeroconf is transitive via `mcp-memory-service`) so the constraint survives a lock regen.

## Why split from Dependabot #2987

#2987 bundled torch + zeroconf and **fails CI on the torch half** (`libcublasLt.so not found` on the CPU runner). The torch bump is also pointless for security: torch alert range is `<= 2.12.0` with **`first_patched: None`** — even 2.12.0 is vulnerable. So #2987 is superseded by this clean zeroconf-only change.

## torch alerts (#125/#126, low) — handled separately

**Dismissed as `not_used`**: no patched torch exists, and CVE-2025-3000 is memory corruption via `torch.jit.script`, which we never call (verified: zero hits in `scripts/` + `tests/`; torch is used only for embeddings via transformers/sentence-transformers). Will re-open + upgrade if a fixed torch ships.

## Verification

zeroconf 0.149.12 is available on PyPI and within `mcp-memory-service`'s accepted range (lock already carried 0.149.7); #2987's non-torch checks already passed with 0.149.12. CI here runs the real `--no-deps` install + pytest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)