### PR TITLE
feat(lexicon): wire Переклад (§11) translation into the Word Atlas [#2985]

### DIFF
--- a/scripts/audit/validate_atlas_conformance.py
+++ b/scripts/audit/validate_atlas_conformance.py
@@ -39,6 +39,7 @@ SOURCE_REQUIRED_SECTIONS = (
     "morphology",
     "synonyms",
     "idioms",
+    "translation",
 )
 NON_STANDARD_AUTHENTIC_CLASSIFICATIONS = {
     "archaism",

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -106,6 +106,7 @@ _SLOVNYK_USER_AGENT = "learn-ukrainian-word-atlas/1.0 (noncommercial educational
 _STRESS_SOURCE = "ukrainian-word-stress"
 _CEFR_SOURCE = "PULS CEFR"
 _LITERARY_SOURCE = "literary_fts"
+_TRANSLATION_SOURCE = "dmklinger"
 _SUM20_COVERED_INITIALS = set("абвгґдеєжзиіїйклмнопр")
 _UKRAINIAN_WORD_RE = re.compile(r"^[А-Яа-яЄєІіЇїҐґ'’ʼ-]+$")
 _UKRAINIAN_VOWELS = set("аеєиіїоуюяАЕЄИІЇОУЮЯ")
@@ -1795,6 +1796,91 @@ def _cefr(conn: sqlite3.Connection, lemma: str) -> dict[str, str] | None:
     return None
 
 
+def _parse_translations(raw: object) -> list[str]:
+    """Parse a dmklinger `translations` cell (JSON array of English gloss strings)."""
+    if not raw:
+        return []
+    try:
+        data = json.loads(raw) if isinstance(raw, str) else raw
+    except (TypeError, ValueError):
+        return []
+    if not isinstance(data, list):
+        return []
+    out: list[str] = []
+    for item in data:
+        text = re.sub(r"\s+", " ", clean_html_entities(str(item)).strip())
+        if text:
+            out.append(text)
+    return out
+
+
+_DMKLINGER_INDEX: dict[str, list[tuple[str, str]]] | None = None
+
+
+def _dmklinger_key(word: str) -> str:
+    """Normalize a word for dmklinger matching: strip stress marks + casefold.
+
+    dmklinger_uk_en stores STRESSED headwords (e.g. `робо́та`, `бу́ти`) while
+    manifest lemmas are unstressed — so an exact match misses ~93%. Both sides
+    are reduced to a stress-free, casefolded key.
+    """
+    return _strip_stress(word).strip().casefold()
+
+
+def _load_dmklinger_index(conn: sqlite3.Connection) -> dict[str, list[tuple[str, str]]]:
+    """Load dmklinger_uk_en once, keyed by stress-stripped/casefolded headword."""
+    global _DMKLINGER_INDEX
+    if _DMKLINGER_INDEX is not None:
+        return _DMKLINGER_INDEX
+    index: dict[str, list[tuple[str, str]]] = {}
+    try:
+        rows = conn.execute("SELECT word, pos, translations FROM dmklinger_uk_en").fetchall()
+    except sqlite3.OperationalError as exc:
+        if _missing_table(exc):
+            _DMKLINGER_INDEX = {}
+            return _DMKLINGER_INDEX
+        raise
+    for word, pos, translations in rows:
+        key = _dmklinger_key(str(word or ""))
+        if key:
+            index.setdefault(key, []).append((pos, translations))
+    _DMKLINGER_INDEX = index
+    return index
+
+
+def _translation(conn: sqlite3.Connection, lemma: str) -> dict[str, object] | None:
+    """English translations for a Ukrainian lemma (Переклад, §11).
+
+    Source is the dmklinger UK→EN dictionary (`dmklinger_uk_en`). Балла is EN→UK
+    only — no clean reverse — so it is intentionally NOT used here; an exact
+    UK→EN match avoids the noise of reverse-lookup. Returns up to six glosses.
+    """
+    index = _load_dmklinger_index(conn)
+    if not index:
+        return None
+    for variant in _split_lemma_variants(lemma):
+        rows = index.get(_dmklinger_key(variant))
+        if not rows:
+            continue
+        english: list[str] = []
+        seen: set[str] = set()
+        pos: str | None = None
+        for row_pos, raw in rows:
+            if pos is None and row_pos:
+                pos = clean_html_entities(str(row_pos).strip())
+            for gloss in _parse_translations(raw):
+                key = gloss.casefold()
+                if key not in seen:
+                    seen.add(key)
+                    english.append(gloss)
+        if english:
+            block: dict[str, object] = {"en": english[:6], "source": _TRANSLATION_SOURCE}
+            if pos:
+                block["pos"] = pos
+            return block
+    return None
+
+
 def _fts_phrase(term: str) -> str:
     cleaned = term.replace('"', " ").strip()
     return f'"{cleaned}"' if cleaned else ""
@@ -1937,6 +2023,9 @@ def enrich() -> tuple[int, int]:
             literary = _literary_attestation(conn, lemma)
             if literary:
                 block["literary_attestation"] = literary
+            translation = _translation(conn, lemma)
+            if translation:
+                block["translation"] = translation
             if block:
                 sources = {v["source"] for v in block.values() if isinstance(v, dict) and v.get("source")}
                 for card in definition_cards:

--- a/starlight/src/pages/lexicon/[lemma].astro
+++ b/starlight/src/pages/lexicon/[lemma].astro
@@ -363,6 +363,7 @@ const hasDictionaryData = Boolean(
     definitionCards.length > 0 ||
     enrichment?.etymology ||
     enrichment?.literary_attestation ||
+    enrichment?.translation ||
     sections?.synonyms ||
     sections?.idioms ||
     showHeritage ||
@@ -652,6 +653,24 @@ const frontmatter = {
             {enrichment.literary_attestation.source}
             {enrichment.literary_attestation.chunk_id && ` · ${enrichment.literary_attestation.chunk_id}`}
           </div>
+        </div>
+      </section>
+    )}
+
+    {enrichment?.translation && enrichment.translation.en.length > 0 && (
+      <section class="atlas-section" aria-labelledby="atlas-translation-title">
+        <div class="atlas-section-head">
+          <p class="atlas-kicker">English</p>
+          <h2 id="atlas-translation-title">Переклад</h2>
+        </div>
+
+        <div class="atlas-source-card">
+          <p class="atlas-source-label">{enrichment.translation.source}</p>
+          <ol>
+            {enrichment.translation.en.map((gloss) => (
+              <li>{gloss}</li>
+            ))}
+          </ol>
         </div>
       </section>
     )}

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -7,6 +7,7 @@ from scripts.lexicon.enrich_manifest import (
     _build_paradigm,
     _cefr,
     _definition_cards,
+    _dmklinger_key,
     _etymology,
     _idioms_slovnyk,
     _kaikki_pronunciation,
@@ -16,6 +17,7 @@ from scripts.lexicon.enrich_manifest import (
     _merge_slovnyk_warning,
     _sense_correct_synonyms,
     _synonyms_slovnyk,
+    _translation,
     _warning_slovnyk,
     clean_gloss,
     clean_html_entities,
@@ -604,3 +606,39 @@ def test_kaikki_etymology_does_not_overwrite_goroh() -> None:
         "source": "Горох (за ЕСУМ)",
         "source_url": "https://goroh.pp.ua/Етимологія/книга",
     }
+
+
+def test_dmklinger_key_strips_stress_and_casefolds() -> None:
+    # dmklinger stores STRESSED headwords; manifest lemmas are unstressed.
+    # The key must reduce both sides to the same stress-free, casefolded form,
+    # otherwise exact matching misses ~93% of common words.
+    assert _dmklinger_key("робо́та") == _dmklinger_key("робота") == "робота"
+    assert _dmklinger_key("Украї́на") == "україна"
+    assert _dmklinger_key("  бу́ти ") == "бути"
+
+
+def test_translation_matches_stress_stripped_dmklinger_headword(monkeypatch) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
+    conn.execute(
+        "INSERT INTO dmklinger_uk_en (word, pos, translations) VALUES (?, ?, ?)",
+        ("робо́та", "noun", json.dumps(["work (labour)", "job", "work (labour)"])),
+    )
+    # Reset the module-level dmklinger index cache so it reloads from this DB.
+    monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
+
+    block = _translation(conn, "робота")  # unstressed manifest lemma
+
+    assert block == {
+        "en": ["work (labour)", "job"],  # deduped, order preserved
+        "source": "dmklinger",
+        "pos": "noun",
+    }
+
+
+def test_translation_returns_none_when_lemma_absent(monkeypatch) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
+    monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
+
+    assert _translation(conn, "неіснуючеслово") is None


### PR DESCRIPTION
## What

Fills a **whole 0%-coverage page-contract section**. §11 «Переклад» (English translation) was specified in `word-atlas-design.md` but never built — one of the two sections that were entirely absent (the other is §12 Wikimedia).

- **`enrich_manifest.py`** — new `_translation()` enrichment from the **dmklinger UK→EN** dictionary (`dmklinger_uk_en`, 30K entries). Балла is EN→UK only (no clean reverse), so dmklinger is the canonical UK→EN source; exact match only, no noisy reverse-lookup.
- **Stress-stripped index (the load-bearing fix)** — dmklinger stores *stressed* headwords (`робо́та`, `бу́ти`) while manifest lemmas are unstressed, so naive `WHERE word = lemma` matched only **7%**. Keying both sides through `_dmklinger_key` (strip stress + casefold) → **67% (1467/2190)**, in line with meaning/morphology coverage. Loaded once into a dict (no per-lemma SQL).
- **`[lemma].astro`** — renders the «Переклад» section, mirroring the existing meaning-list primitive; auto-omitted when empty.
- **`validate_atlas_conformance.py`** — `translation` added to `SOURCE_REQUIRED_SECTIONS` so the §8 provenance gate enforces it.
- **Manifest regenerated** — `+1467` translation blocks, **purely additive (0 deletions** — the full regen reproduced all existing data identically).

## Coverage / quality

```
робота → work (labour, employment, occupation, job)
любов  → love (strong affection); fondness
читати → read (to look at and interpret letters); to read
```
67% of A1/A2 lemmas; misses are words genuinely absent from dmklinger's 30K.

## Verification

- Conformance validator: **0 violations** (provenance gate now covers translation).
- `tests/test_atlas_conformance.py`: **19 passed**.
- All lexicon/enrich/atlas tests: **110 passed**.
- New tests: stress-strip key + match + absent-lemma (3 passed).
- ruff clean. Frontend build is the authoritative §11 render check (runs in CI here).

Part of EPIC #2985 (Word Atlas → full design conformance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)