### PR TITLE
fix(wiki): divergence-safe seminar review loop — best-round selection + safe rounds-bump [folk Session-20]

### DIFF
--- a/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
+++ b/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
@@ -27,7 +27,87 @@
 > the "don't self-merge" restriction, not the "don't push to main" one. Stage-0 PR #2759 self-merged
 > under this grant (commit `abf280f490`).
 
-## ▶▶▶ SESSION 19 HANDOFF (2026-06-12 — source_grounding NON-CONVERGENCE ROOT-CAUSED with EVIDENCE (it's MAX_ROUNDS=2, not stochasticity); LEVER CHOSEN = bump seminar review rounds. + an interrupt: node_modules-ELOOP Astro-build breakage fully root-caused + fixed + MERGED #3047) — **RESUME HERE**
+## ▶▶▶ SESSION 20 HANDOFF (2026-06-13 — Session-19 rounds-bump lever TESTED ON REAL DATA → found INSUFFICIENT + harmful; root cause re-framed: the review loop DIVERGES on dense folk prose + register/factual are gemini-reviewed (policy violation); shipped the CORRECT divergence-safe loop fix; wikis STILL 0/6, real blocker = WRITER quality + gemini seminar reviewers) — **RESUME HERE**
+
+> **⏱ HONEST SCOPE:** Modules 3/42, dossiers 15/42 (unchanged). **Wikis closed: still 0/6.** This session did NOT
+> ship a wiki. It did the #M-11 thing Session-19 skipped: it actually RAN the rounds-bump on real bylyny data
+> (two full `--review-only` recompiles, ~19 min each) and found the Session-19 lever is **wrong** — it gives a
+> DIVERGING/NOISY loop more rope to degrade the article. I caught a regression before shipping it. What I DID ship
+> is the genuinely-correct fix the evidence pointed to (best-round selection), plus the re-framed root cause.
+
+### ❌ SESSION-19's "VALIDATED-BY-DIAGNOSIS" LEVER WAS WRONG (the #M-11 catch)
+Session-19 called the rounds-bump "validated-by-diagnosis" off ONE round-2 review JSON. I ran it for real (bylyny
+`--review-only`, gpt-5.5/codex/claude/gemini reviewers, MCP up). **Measured trajectory (both runs): MIN 5→6→6→5
+across 4 rounds — round 4 was WORSE than rounds 2-3.** Per-dim it's a treadmill, NOT a convergence:
+- **source_grounding** (codex): findings 12→7→6, score 5→6→6→6. Each round the writer's broad under-citation
+  surfaces ~6 fresh real `UNSUPPORTED_CLAIM`s (all sourceable, the reviewer IS right); fixes apply cleanly
+  (`skipped_missing=0`) but there are too many to close in 4 rounds. Asymptotic, never reaches ≥8.
+- **register** (GEMINI): score 7→6→6→5, with DIFFERENT calques flagged each round («доказова умова»/«продукт» →
+  «документальний ряд»/«зустрічає матеріал»). A calque-treadmill on dense C1 prose.
+- **factual_accuracy** (GEMINI): swung 9→9→10→**5** — that 10→5 is reviewer NOISE, not the article degrading.
+**Two compounding bugs the run exposed:** (1) the ADR-001 regression guard (`any dim's score dropped → break`) fired
+on register's ±1 wobble and killed the loop at round 3 (the Session-19 WATCH note — it BIT); (2) the final verdict
+read the LAST round, so a noisy/degraded tail round (MIN5) is reported instead of the best achieved (MIN6).
+
+### ✅ SHIPPED THIS PR — the divergence-safe review loop (the fix the evidence actually supports)
+`scripts/wiki/review.py` + `scripts/wiki/compile.py` (+ 5 unit tests; **123 review/compile tests green**, ruff clean):
+1. **best-round selection (KEYSTONE):** `review_article` now reports/returns the round with the highest aggregate
+   MIN, NOT the last round. **Provably PASS-safe:** a PASS always breaks the loop immediately and an all-pass round
+   is by definition the highest-MIN round → best==last for EVERY passing run, so this never changes a PASS outcome
+   or the written-back text. It only stops a non-passing run from reporting a degraded/noisy tail. **Validated
+   deterministically on the real bylyny JSON: reports MIN 6.0 (round 2), not the degraded 5.0 (round 4).**
+2. **rounds-bump (now SAFE because of #1):** `SEMINAR_MAX_ROUNDS=4` + public `max_rounds_for_domain(domain)` helper;
+   seminar domains (folk/hist/lit/…) get 4 rounds, core a1–c2 stay at `MAX_ROUNDS=2`. Extra rounds can now only help.
+3. **MIN-based regression guard:** `_min_score_regressed` replaces `_scores_regressed` — break only when the aggregate
+   MIN regressed, so an already-passing dim's ±1 noise doesn't kill a still-converging run. (No effect on core a1–c2:
+   the guard only matters at ≥3 rounds = seminars.)
+Tests: `test_max_rounds_for_domain_seminar_vs_core`, `test_seminar_rounds_converge_to_pass`,
+`test_best_round_selected_over_degraded_tail` (replays bylyny's 6→5 shape → asserts best-round reports 6),
+`test_regression_guard_tolerates_passing_dim_wobble` (fails under the old per-dim guard).
+
+### 🧱 THE REAL WIKI-CLOSER BLOCKER (re-framed — NOT the review loop)
+The loop is now correct + safe, but **no loop change ships bylyny** — best achievable is MIN6 < 8. The blockers are:
+- **(A) WIKI WRITER QUALITY.** gpt-5.5 produces dense translationese (25+ calques) + broadly under-cites (12+
+  sourceable claims with no inline `[S#]`). A find/replace polish loop can't rewrite that in a few rounds. Fix =
+  harden the WIKI writer prompt for register-discipline + citation-completeness, OR bake-off gpt-5.5 vs claude-tools
+  for the folk WIKI (claude is the MODULE writer precisely for clean C1 Ukrainian). (Session-17/18 flagged this; the
+  discipline added so far is insufficient.)
+- **(B) GEMINI SEMINAR REVIEWERS (policy violation + noise).** `DEFAULT_PRIMARY` (review.py:93) reviews `register`
+  + `factual_accuracy` with **gemini** for ALL tracks. Fleet policy (#M0 / Session-1 decision #4): folk CULTURE
+  review = Claude/GPT ONLY, NO gemini/deepseek. gemini's ±5 round-to-round noise on dense folk prose makes
+  convergence undetectable. Fix = route seminar/culture `register`+`factual` to claude/gpt. **SHARED INFRA (all
+  tracks) → coordinate with orchestrator, do NOT unilaterally flip the global default.** TRACK-UPDATE posted.
+
+### ▶ NEXT ACTIONS (RESUME HERE, in order)
+1. **Fix the gemini seminar-reviewer policy violation (B)** — highest leverage, likely unblocks register. Make
+   `DEFAULT_PRIMARY`/per-dim agent selection seminar-aware (register+factual → claude/gpt for SEMINAR_LEVELS).
+   Shared infra → orchestrator lane or codex-impl + Claude adversarial review (teeth: a real calque still flagged).
+2. **Harden the folk WIKI writer (A)** — port the module writer's register discipline + a citation-completeness
+   rule into `compile_article.md`, OR bake-off claude-tools vs gpt-5.5 for the folk wiki writer. Then a clean
+   first-pass article + the now-correct review loop should converge.
+3. **THEN re-attempt the 6 gap wikis** (#M-9, sequential): bylyny, kobzarstvo-lirnytstvo, dumy-sotsialno-pobutovi,
+   holosinnya, vesilni-pisni, zhnyvarski-obzhynkovi-pisni. Use `--review-only` on the parked fixture first to
+   confirm convergence cheaply before a full `--force` recompile.
+4. **OR dossier #16 `istorychni-pisni`** if wikis stay blocked (unblocked queue-advancing path).
+5. **(tuning, low-pri)** `SEMINAR_MAX_ROUNDS=4` costs ~2× model calls per seminar review (~25 vs ~13 min) and bylyny
+   gained nothing from rounds 3-4 (it diverges). best-round makes 4 safe, but the orchestrator may tune it to 3 once
+   (A)+(B) land and real convergence behavior is known.
+
+### ⚠ CARRY-FORWARD
+- Forensic fixtures KEPT (untracked on main working tree): `wiki/folk/genres/bylyny-kyivskoho-tsyklu.{md,sources.yaml}`
+  + `wiki/.reviews/folk/genres/bylyny-kyivskoho-tsyklu.json` (the round-2 diagnosis). The two Session-20 validation
+  logs: `/tmp/bylyny-review-rounds-validation.log` (run 1) + `/tmp/bylyny-revalidation-bothfixes.log` (run 2, the
+  5→6→6→5 trajectory). The worktree's `.reviews/.../bylyny...json` holds run-2's full per-round findings.
+- The review needs only the sibling `.sources.yaml` + MCP `sources` (:8766) — NO `data/` symlink (chunks aren't
+  inlined; verify_quote-style checks hit the live MCP). `--review-only` on the parked fixture isolates the review
+  loop from the stochastic writer — the cheap way to test a wiki-review fix.
+- `git push` folk → `--no-verify`; `core.bare` stayed false this session.
+- This PR changes SHARED review infra (`review_article`, used by all tracks) — flagged in the PR body for
+  orchestrator scrutiny, but it's provably PASS-preserving + 123 tests green.
+
+---
+
+## ▶▶▶ SESSION 19 HANDOFF (2026-06-12 — source_grounding NON-CONVERGENCE ROOT-CAUSED with EVIDENCE (it's MAX_ROUNDS=2, not stochasticity); LEVER CHOSEN = bump seminar review rounds. + an interrupt: node_modules-ELOOP Astro-build breakage fully root-caused + fixed + MERGED #3047) — (superseded by Session 20; the lever was tested + found insufficient)
 
 > **⏱ HONEST SCOPE:** Modules 3/42, dossiers 15/42 (unchanged). **Wikis closed: still 0/6.** This session did
 > NOT ship a wiki — it (a) handled a user interrupt (Astro build broken) end-to-end, and (b) turned Session-18's

--- a/scripts/wiki/compile.py
+++ b/scripts/wiki/compile.py
@@ -593,7 +593,7 @@ def _review_article(article_path: Path, track: str, slug: str) -> None:
     """
     import traceback as _tb
 
-    from wiki.review import review_article, write_report
+    from wiki.review import max_rounds_for_domain, review_article, write_report
 
     print(f"  🔍 Reviewing: {track}/{slug}")
 
@@ -601,8 +601,17 @@ def _review_article(article_path: Path, track: str, slug: str) -> None:
         print("  ⚠️  Article missing or too short to review")
         return
 
+    # Seminar tracks (folk/hist/lit/…) get extra review rounds so the
+    # reviewer's round-2 citation-adding fixes get a confirming re-review
+    # before the final verdict (folk Session-19 root cause); core levels
+    # keep the default MAX_ROUNDS.
+    domain = _get_domain(track, slug)
+    review_max_rounds = max_rounds_for_domain(domain)
+
     try:
-        report, final_text = review_article(article_path, shadow_mode=False)
+        report, final_text = review_article(
+            article_path, shadow_mode=False, max_rounds=review_max_rounds
+        )
     except Exception as exc:
         print(f"  ⚠️  Review orchestrator failed: {type(exc).__name__}: {exc}")
         log_event(

--- a/scripts/wiki/review.py
+++ b/scripts/wiki/review.py
@@ -129,6 +129,32 @@ DIM_PROMPT_FILES: dict[str, str] = {
 #: Max review rounds. ADR-001: if score doesn't improve, stop.
 MAX_ROUNDS = 2
 
+#: Max review rounds for SEMINAR tracks (folk/hist/lit/oes/ruth/…).
+#: Seminar articles are dense, source-grounded prose: the reviewer's
+#: citation-adding fixes land in round 2, but with only ``MAX_ROUNDS=2``
+#: the loop ends BEFORE those now-applied ``[S#]`` fixes get a confirming
+#: re-review, so a properly-cited article reports as failing
+#: ``source_grounding``/``register`` (a deterministic off-by-one in
+#: terminate-after-generate, root-caused folk Session-19). Giving seminar
+#: articles extra rounds lets round-2's applied fixes be re-reviewed and
+#: converge to PASS. Core levels (a1–c2) keep ``MAX_ROUNDS``.
+SEMINAR_MAX_ROUNDS = 4
+
+
+def max_rounds_for_domain(domain: str) -> int:
+    """Pick the review-round budget for a wiki ``domain`` (path under ``wiki/``).
+
+    Seminar domains (no a1–c2 level token, e.g. ``folk/genres``) get
+    :data:`SEMINAR_MAX_ROUNDS`; core-level domains keep :data:`MAX_ROUNDS`.
+    Mirrors :func:`_infer_level_from_domain` so the rounds policy and the
+    per-dim level calibration agree on what "seminar" means.
+    """
+    return (
+        SEMINAR_MAX_ROUNDS
+        if _infer_level_from_domain(domain) == "seminar"
+        else MAX_ROUNDS
+    )
+
 #: Per-call timeouts. Review prompts are bounded; 10 min is plenty.
 HARD_TIMEOUT_S = 600
 
@@ -804,16 +830,36 @@ def review_article(
         if not merge_report.applied:
             break
 
-        # ADR-001 guard: if round N+1 scores are lower, stop.
+        # ADR-001 guard: stop only if this round made the aggregate MIN
+        # score worse. An already-passing dim's ±1 wobble must NOT kill a
+        # run where the failing/driving dim is still converging (the loop is
+        # otherwise bounded by max_rounds + the no-fixes-applied break above).
         if round_num > 1:
             prev = rounds[-2].dim_results
-            if _scores_regressed(prev, dim_results):
+            if _min_score_regressed(prev, dim_results):
                 break
 
         current_text = new_text
 
-    # Compute final verdict on the last round's dim_results
-    final_dim_results = rounds[-1].dim_results
+    # Compute the final verdict on the BEST round by aggregate MIN — NOT the
+    # last round. The fix loop can DIVERGE on dense seminar prose: later
+    # rounds' find/replace patches (and noisy gemini reviewers) can drop a
+    # dim below an earlier round, so the tail round is not necessarily the
+    # best (folk Session-20: bylyny scored MIN 5→6→6→5 across 4 rounds —
+    # round 4 was WORSE than rounds 2-3). A PASS always breaks the loop
+    # immediately (``not failing_now``), and an all-pass round is by
+    # definition the highest-MIN round, so for EVERY passing run best==last —
+    # this never changes a PASS outcome or the written-back text. For a
+    # non-passing run it reports the BEST achieved score instead of a
+    # degraded/noisy tail, which also makes a larger ``max_rounds`` budget
+    # strictly safe (extra rounds can only help). Tie-break on the EARLIEST
+    # round (fewest mutations = safest text).
+    best_idx = max(
+        range(len(rounds)),
+        key=lambda i: (aggregate_min(rounds[i].dim_results)[0], -i),
+    )
+    best_round = rounds[best_idx]
+    final_dim_results = best_round.dim_results
     failing = _failing_dims(final_dim_results, thresholds)
     final_verdict = _final_verdict(final_dim_results, failing)
     min_score, failing_dim = aggregate_min(final_dim_results)
@@ -832,7 +878,7 @@ def review_article(
         started_at=started_at,
         finished_at=finished_at,
     )
-    return report, rounds[-1].article_text_after
+    return report, best_round.article_text_after
 
 
 def _failing_dims(
@@ -881,15 +927,29 @@ def aggregate_min(
     return min_score, min_dim
 
 
-def _scores_regressed(
+def _min_score_regressed(
     prev: dict[str, DimResult],
     curr: dict[str, DimResult],
 ) -> bool:
-    """True iff ANY dim's score dropped round-over-round (ADR-001)."""
-    return any(
-        dim in prev and dr.score < prev[dim].score
-        for dim, dr in curr.items()
-    )
+    """True iff the aggregate MIN score dropped round-over-round (ADR-001).
+
+    The review gate is MIN-based (see :func:`aggregate_min`), so "did this
+    round make things worse" must be judged on the MIN, NOT on any single
+    dim. The old per-dim check (``any dim's score dropped``) was too
+    aggressive for multi-round seminar reviews: an already-passing dim
+    wobbling by ±1 within reviewer noise (e.g. ``register`` 7→6 while
+    ``source_grounding`` is still actively converging 5→6→…) would break
+    the loop BEFORE the failing dim's just-applied citation fixes ever got
+    their confirming re-review — so a converging article reported a stale
+    failure. Judging regression on the MIN lets such wobbles pass while
+    still stopping a run whose driving dim genuinely got worse. The loop is
+    bounded by ``max_rounds`` and the no-fixes-applied break, so this never
+    spins. (folk Session-20 — empirically the guard, not the off-by-one
+    alone, was what kept bylyny from converging.)
+    """
+    prev_min, _ = aggregate_min(prev)
+    curr_min, _ = aggregate_min(curr)
+    return curr_min < prev_min
 
 
 def _final_verdict(

--- a/tests/test_wiki_review.py
+++ b/tests/test_wiki_review.py
@@ -8,7 +8,17 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
-from wiki.review import DEFAULT_PRIMARY, DIMS, DimResult, _run_round
+from wiki.review import (
+    DEFAULT_PRIMARY,
+    DIMS,
+    MAX_ROUNDS,
+    SEMINAR_MAX_ROUNDS,
+    DimResult,
+    _run_round,
+    max_rounds_for_domain,
+    review_article,
+)
+from wiki.review_merger import Fix
 
 
 def test_run_round_emits_per_dim_progress_lines(tmp_path: Path, monkeypatch) -> None:
@@ -64,3 +74,265 @@ def test_run_round_emits_per_dim_progress_lines(tmp_path: Path, monkeypatch) -> 
             f"◀ {dim}" in line and "verdict=PASS, score=8" in line
             for line in logs
         )
+
+
+def test_max_rounds_for_domain_seminar_vs_core() -> None:
+    """Seminar domains get extra rounds; core levels keep MAX_ROUNDS."""
+    assert SEMINAR_MAX_ROUNDS > MAX_ROUNDS
+    # Seminar tracks (no a1–c2 level token in the domain path).
+    for seminar_domain in ("folk/genres", "folk/ritual", "hist/topics", "lit/drama"):
+        assert max_rounds_for_domain(seminar_domain) == SEMINAR_MAX_ROUNDS
+    # Core levels a1–c2 stay at the default budget.
+    for core_domain in ("a1/letters", "a2/genitive-intro", "b1/x", "c1/stylistics"):
+        assert max_rounds_for_domain(core_domain) == MAX_ROUNDS
+
+
+# ── Seminar review-loop fixes (folk Session-19/20) ─────────────────────
+#
+# review_article must: (a) give seminar articles enough rounds for the
+# reviewer's citation fixes to be confirmed (SEMINAR_MAX_ROUNDS); (b) not
+# let an already-passing dim's ±1 wobble break a still-converging run
+# (_min_score_regressed); and (c) report the BEST round, never a degraded
+# tail round (folk Session-20: bylyny scored MIN 5→6→6→5 across 4 rounds —
+# the find/replace loop + noisy reviewers made round 4 WORSE than 2-3).
+# These tests pin all three.
+
+_CONV_ARTICLE = (
+    "# Билини київського циклу\n\n"
+    "Билини виникли в Київській Русі.\n\n"
+    "Старини збереглися переважно на Півночі.\n"
+)
+_CONV_FIX_1 = Fix(
+    dim="source_grounding",
+    find="Билини виникли в Київській Русі.",
+    replace="Билини виникли в Київській Русі [S1].",
+)
+_CONV_FIX_2 = Fix(
+    dim="source_grounding",
+    find="Старини збереглися переважно на Півночі.",
+    replace="Старини збереглися переважно на Півночі [S2].",
+)
+
+
+def _convergence_fake_run_single_dim(
+    *,
+    dim: str,
+    article_path: Path,
+    article_text: str,
+    primary: str,
+    fallbacks,
+    cwd: Path,
+    event_sink=None,
+) -> DimResult:
+    """source_grounding fails (6) until BOTH citations are present, then 9.
+
+    Round state is derived from the article text itself (how many ``[S#]``
+    are already applied), so the fake is stateless and round-order-agnostic
+    — exactly mirroring how a real reviewer would re-score after a fix lands.
+    Every other dim always passes.
+    """
+    if dim != "source_grounding":
+        return DimResult(
+            dim=dim, agent=primary, model="fake", score=9, verdict="PASS",
+            findings=[], fixes=[], notes="", duration_s=0.0,
+        )
+    if "[S1]" not in article_text:
+        fixes, score = [_CONV_FIX_1], 6
+    elif "[S2]" not in article_text:
+        fixes, score = [_CONV_FIX_2], 6
+    else:
+        fixes, score = [], 9
+    return DimResult(
+        dim=dim, agent=primary, model="fake", score=score,
+        verdict="PASS" if score >= 8 else "REVISE",
+        findings=[], fixes=fixes, notes="", duration_s=0.0,
+    )
+
+
+def test_seminar_rounds_converge_to_pass(tmp_path: Path, monkeypatch) -> None:
+    """Extra rounds let the citation fixes be confirmed → PASS at round 3;
+    2 rounds never reach an all-pass round."""
+    monkeypatch.setattr(
+        "wiki.review._run_single_dim", _convergence_fake_run_single_dim
+    )
+
+    # 2 rounds: the article never reaches an all-pass round → reported failure.
+    article_2 = tmp_path / "two.md"
+    article_2.write_text(_CONV_ARTICLE, encoding="utf-8")
+    report_2, _ = review_article(article_2, max_rounds=MAX_ROUNDS)
+    assert len(report_2.rounds) == 2
+    assert report_2.final_verdict != "PASS"
+    assert report_2.min_score == 6
+    assert report_2.failing_dim == "source_grounding"
+
+    # 4 rounds (seminar budget): round-3 re-reviews the now-cited text → an
+    # all-pass round → PASS. A PASS breaks the loop immediately, so the
+    # passing (best) round is the last one and its fully-cited text is returned.
+    article_4 = tmp_path / "four.md"
+    article_4.write_text(_CONV_ARTICLE, encoding="utf-8")
+    report_4, final_4 = review_article(article_4, max_rounds=SEMINAR_MAX_ROUNDS)
+    assert report_4.final_verdict == "PASS"
+    assert report_4.min_score >= 8
+    assert len(report_4.rounds) == 3  # converged at round 3, stopped early
+    assert "[S1]" in final_4 and "[S2]" in final_4
+
+
+# best-round selection: a diverging trajectory must report the BEST round.
+_DIV_ARTICLE = "# Билини\n\nПоходження билин сягає Київської Русі.\n"
+_DIV_FIX = Fix(
+    dim="source_grounding",
+    find="Походження билин сягає Київської Русі.",
+    replace="Походження билин сягає Київської Русі [S1].",
+)
+
+
+def _divergence_fake_run_single_dim(
+    *,
+    dim: str,
+    article_path: Path,
+    article_text: str,
+    primary: str,
+    fallbacks,
+    cwd: Path,
+    event_sink=None,
+) -> DimResult:
+    """register is high (9) on the original but a noisy reviewer tanks it to
+    5 once a fix lands; source_grounding holds at 6. So MIN goes 6 (round 1)
+    → 5 (round 2): the tail round is WORSE, exactly bylyny's 5→6→6→5 shape.
+    """
+    has_fix = "[S1]" in article_text
+    if dim == "source_grounding":
+        return DimResult(
+            dim=dim, agent=primary, model="fake", score=6, verdict="REVISE",
+            findings=[], fixes=[] if has_fix else [_DIV_FIX], notes="",
+            duration_s=0.0,
+        )
+    if dim == "register":
+        score = 5 if has_fix else 9
+        return DimResult(
+            dim=dim, agent=primary, model="fake", score=score,
+            verdict="PASS" if score >= 8 else "REVISE",
+            findings=[], fixes=[], notes="", duration_s=0.0,
+        )
+    return DimResult(
+        dim=dim, agent=primary, model="fake", score=9, verdict="PASS",
+        findings=[], fixes=[], notes="", duration_s=0.0,
+    )
+
+
+def test_best_round_selected_over_degraded_tail(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "wiki.review._run_single_dim", _divergence_fake_run_single_dim
+    )
+    art = tmp_path / "div.md"
+    art.write_text(_DIV_ARTICLE, encoding="utf-8")
+
+    report, _ = review_article(art, max_rounds=SEMINAR_MAX_ROUNDS)
+
+    # Round 1 MIN=6 (register 9, sg 6); round 2 MIN=5 (register tanked to 5).
+    # The report MUST reflect the BEST round (6) and its failing set, NOT the
+    # degraded tail (5) — returning the last round would ship a worse score
+    # AND make a larger max_rounds budget unsafe.
+    assert report.min_score == 6
+    assert report.final_verdict != "PASS"
+    assert report.failing_dims == ["source_grounding"]  # round-1's set, not {sg, register}
+    assert len(report.rounds) == 2
+
+
+# ── Regression guard scoping: ±1 wobble must not kill a converging run ──
+#
+# Under the OLD guard (``any dim's score dropped``), an already-passing dim
+# wobbling 9→8 within reviewer noise broke the loop BEFORE the failing dim's
+# round-3 citation fix got its confirming round-4 re-review — a converging
+# seminar article reported a stale failure (folk Session-20: register's 7→6
+# wobble is exactly what kept bylyny from converging). The MIN-based guard
+# tolerates the wobble because the MIN (driven by the still-failing dim) did
+# not regress. This test fails under the old per-dim guard.
+
+_GUARD_ARTICLE = (
+    "# Билини\n\n"
+    "Походження билин сягає Київської Русі.\n\n"
+    "Чижевський аналізує тонічний вірш.\n\n"
+    "Попович підкреслює втрату старокиївських варіантів.\n"
+)
+_GUARD_FIXES = {
+    "[S1]": Fix(
+        dim="source_grounding",
+        find="Походження билин сягає Київської Русі.",
+        replace="Походження билин сягає Київської Русі [S1].",
+    ),
+    "[S2]": Fix(
+        dim="source_grounding",
+        find="Чижевський аналізує тонічний вірш.",
+        replace="Чижевський аналізує тонічний вірш [S2].",
+    ),
+    "[S3]": Fix(
+        dim="source_grounding",
+        find="Попович підкреслює втрату старокиївських варіантів.",
+        replace="Попович підкреслює втрату старокиївських варіантів [S3].",
+    ),
+}
+
+
+def _guard_fake_run_single_dim(
+    *,
+    dim: str,
+    article_path: Path,
+    article_text: str,
+    primary: str,
+    fallbacks,
+    cwd: Path,
+    event_sink=None,
+) -> DimResult:
+    """source_grounding needs THREE citation fixes (passes only on round 4);
+    register wobbles 9→8 (always passing) once ≥2 citations are present.
+    """
+    present = sum(tok in article_text for tok in ("[S1]", "[S2]", "[S3]"))
+    if dim == "source_grounding":
+        if present >= 3:
+            fixes, score = [], 9
+        else:
+            missing = next(t for t in ("[S1]", "[S2]", "[S3]") if t not in article_text)
+            fixes, score = [_GUARD_FIXES[missing]], 6
+        return DimResult(
+            dim=dim, agent=primary, model="fake", score=score,
+            verdict="PASS" if score >= 8 else "REVISE",
+            findings=[], fixes=fixes, notes="", duration_s=0.0,
+        )
+    if dim == "register":
+        # Already-passing, but wobbles DOWN within noise once the article
+        # picks up citations — the exact ±1 that broke the old guard.
+        score = 8 if present >= 2 else 9
+        return DimResult(
+            dim=dim, agent=primary, model="fake", score=score, verdict="PASS",
+            findings=[], fixes=[], notes="", duration_s=0.0,
+        )
+    return DimResult(
+        dim=dim, agent=primary, model="fake", score=9, verdict="PASS",
+        findings=[], fixes=[], notes="", duration_s=0.0,
+    )
+
+
+def test_regression_guard_tolerates_passing_dim_wobble(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "wiki.review._run_single_dim", _guard_fake_run_single_dim
+    )
+    article = tmp_path / "guard.md"
+    article.write_text(_GUARD_ARTICLE, encoding="utf-8")
+
+    report, final = review_article(article, max_rounds=SEMINAR_MAX_ROUNDS)
+
+    # The old per-dim guard would break at round 3 (register 9→8) and report
+    # a stale source_grounding=6 failure; the MIN-based guard runs round 4
+    # and lets source_grounding's third citation be confirmed → PASS.
+    assert report.final_verdict == "PASS"
+    assert len(report.rounds) == 4
+    assert report.min_score == 8  # driven by register's tolerated 9→8 wobble
+    # Document that the wobble actually happened (guard tolerated it):
+    assert report.rounds[1].dim_results["register"].score == 9
+    assert report.rounds[3].dim_results["register"].score == 8
+    assert all(tok in final for tok in ("[S1]", "[S2]", "[S3]"))


### PR DESCRIPTION
## What & why

Folk Session-19 chose a single lever for the un-converging folk wikis: **bump seminar review rounds** (the source_grounding/register failures were diagnosed as a `MAX_ROUNDS=2` off-by-one). This PR did the #M-11 step Session-19 skipped — **ran it on real bylyny data** — and found the lever **insufficient AND harmful**, then shipped the fix the evidence actually supports.

### Evidence (two full `--review-only` recompiles of the parked bylyny fixture)
Measured trajectory both runs: **MIN 5→6→6→5** across 4 rounds — round 4 was *worse* than 2–3. It's a treadmill/divergence, not a convergence:
- `source_grounding` (codex): findings 12→7→6 — broad real under-citation; fixes apply cleanly (`skipped_missing=0`) but too many to close in 4 rounds.
- `register` (**gemini**): 7→6→6→5, *different* calques flagged each round — a calque treadmill on dense C1 prose.
- `factual_accuracy` (**gemini**): swung 9→9→10→**5** — that 10→5 is reviewer **noise**.

Two compounding loop bugs the run exposed: (1) the ADR-001 regression guard (`any dim dropped → break`) fired on register's ±1 wobble and killed the loop at round 3; (2) the final verdict read the **last** round, so a noisy/degraded tail (MIN5) is reported instead of the best achieved (MIN6).

## Changes (`scripts/wiki/review.py`, `scripts/wiki/compile.py`)

1. **best-round selection (keystone):** `review_article` reports/returns the round with the highest aggregate MIN, not the last. **Provably PASS-preserving** — a PASS breaks the loop immediately and an all-pass round is by definition the highest-MIN round, so `best == last` for *every* passing run; this never changes a PASS outcome or the written-back text. It only stops a non-passing run from reporting a degraded/noisy tail. Validated deterministically on the real bylyny JSON: reports **MIN 6.0 (round 2)**, not 5.0 (round 4).
2. **rounds-bump (now safe because of #1):** `SEMINAR_MAX_ROUNDS=4` + public `max_rounds_for_domain(domain)`; seminar domains get 4 rounds, core a1–c2 stay at `MAX_ROUNDS=2`.
3. **MIN-based regression guard:** `_min_score_regressed` replaces `_scores_regressed` — break only on aggregate-MIN regression, so a passing dim's ±1 noise can't kill a converging run. No effect on core levels (the guard only matters at ≥3 rounds = seminars).

## Tests — 123 green, ruff clean
`test_max_rounds_for_domain_seminar_vs_core`, `test_seminar_rounds_converge_to_pass`, `test_best_round_selected_over_degraded_tail` (replays bylyny's 6→5 shape → asserts best-round reports 6), `test_regression_guard_tolerates_passing_dim_wobble` (fails under the old per-dim guard).

## ⚠️ Scope / reviewer note
- Touches **shared review infra** (`review_article`, used by all tracks) — but it's provably PASS-preserving (best==last for every PASS) and fully tested. Flagged for orchestrator scrutiny.
- **This does NOT close the folk wikis.** Best achievable is MIN6 < 8. The real blockers (handoff'd + TRACK-UPDATE'd):
  - **(A) wiki writer quality** — gpt-5.5 under-cites + writes translationese; harden the wiki writer prompt or bake-off claude-tools.
  - **(B) gemini seminar reviewers** — `DEFAULT_PRIMARY` reviews `register`+`factual` with gemini for all tracks; fleet policy bars gemini for folk culture. Route seminar register/factual to claude/gpt (shared-infra change → orchestrator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)