### PR TITLE
feat(lexicon): vocab → Word Atlas "more →" link (render-time, integrity-gated)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: starlight/src/components/{*.tsx, *.astro}
-  components_sha256: fd5b945fbe6b214a92b0d9921f2eaf2746a39201474ee2c967966f9248e31003
+  components_sha256: 5c744907bd711fa93ac70f9eca1fc5aa23f0899b5981c98778a59f45118ab9c4
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:
@@ -2218,6 +2218,12 @@ components:
         type: string
         description: Question value consumed by this component.
         ukrainian_text: 'true'
+      - name: atlas_href
+        type: string | null
+        description: 'Integrity-gated href to this lemma''s Word Atlas page,
+
+          derived at MDX-generation time. Empty/absent when the lemma has no Atlas page.'
+        ukrainian_text: 'false'
     example:
       words:
       - <VocabEntry>

--- a/scripts/generate_mdx/atlas_links.py
+++ b/scripts/generate_mdx/atlas_links.py
@@ -1,0 +1,101 @@
+"""Vocab → Word Atlas cross-linking (render-time, integrity-gated).
+
+Lesson Tab 2 ``<VocabCard>`` entries gain a "more →" link to the per-lemma
+Word Atlas page (``/lexicon/{url_slug}/``) when — and only when — that lemma
+actually has an Atlas page. The check is performed at MDX-generation time
+against ``starlight/src/data/lexicon-manifest.json`` (the same file the Astro
+``lexicon/[lemma].astro`` route enumerates), so a link is *never* emitted for a
+lemma the Atlas does not publish. This makes the lesson→Atlas direction
+integrity-safe by construction (design §7/§8 ``cross_link_integrity``; warn at
+v1 per §11 Q4 — there is nothing to warn about because broken links cannot be
+produced).
+
+Matching is conservative — exact lemma key only, after:
+  * stripping stress marks (combining acute U+0301 / grave U+0300) — dmklinger
+    and some vocab YAMLs carry stressed headwords (``робо́та``) while Atlas
+    lemmas are unstressed (``робота``);
+  * normalising apostrophe variants to U+0027;
+  * Unicode-aware case folding.
+
+Crucially it does NOT strip *all* combining marks: Ukrainian ``й``/``ї``
+decompose (NFD) to base vowel + combining breve/diaeresis, which must survive
+so ``їжак`` does not collapse to ``іжак``.
+
+The vocabulary YAML is never modified — slugs are derived here at render time.
+"""
+
+from __future__ import annotations
+
+import json
+import unicodedata
+from functools import lru_cache
+from pathlib import Path
+
+# scripts/generate_mdx/atlas_links.py -> parents[2] == repo root (worktree-aware).
+_DEFAULT_MANIFEST = (
+    Path(__file__).resolve().parents[2] / "starlight" / "src" / "data" / "lexicon-manifest.json"
+)
+
+# Stress accents to strip. Deliberately NOT the full "Mn" category — that would
+# also drop the breve/diaeresis that make й/ї, destroying valid lemmas.
+_STRESS_MARKS = {"́", "̀"}
+
+# Apostrophe-like characters normalised to a single canonical form so that
+# з'їсти / зʼїсти / з`їсти all match the same Atlas key.
+_APOSTROPHES = {"’", "ʼ", "ʹ", "`", "´", "‘"}
+
+
+def normalize_lemma(word: str) -> str:
+    """Normalise a surface word to its stress-free, case-folded Atlas key."""
+    if not word:
+        return ""
+    decomposed = unicodedata.normalize("NFD", word)
+    out: list[str] = []
+    for ch in decomposed:
+        if ch in _STRESS_MARKS:
+            continue
+        if ch in _APOSTROPHES:
+            ch = "'"
+        out.append(ch)
+    return unicodedata.normalize("NFC", "".join(out)).strip().casefold()
+
+
+@lru_cache(maxsize=4)
+def _load_index(manifest_path: str) -> dict[str, str]:
+    """Build ``{normalized_lemma: url_slug}`` from the lexicon manifest.
+
+    Cached per resolved path — production callers hit a single cached load;
+    tests pass a unique tmp path and get isolated indices.
+    """
+    try:
+        data = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+
+    index: dict[str, str] = {}
+    for entry in data.get("entries", []):
+        slug = entry.get("url_slug")
+        lemma = entry.get("lemma")
+        if not slug or not lemma:
+            continue
+        # setdefault: first writer wins on stress-only homograph collisions
+        # (за́мок / замо́к) — either maps to a valid Atlas page for that spelling.
+        index.setdefault(normalize_lemma(lemma), slug)
+        index.setdefault(normalize_lemma(slug), slug)
+    return index
+
+
+def atlas_href_for(word: str, manifest_path: str | Path | None = None) -> str | None:
+    """Return the Atlas page href for ``word`` iff a page exists, else ``None``.
+
+    Args:
+        word: the vocab surface form / lemma (may carry stress marks).
+        manifest_path: override the lexicon manifest (tests). Defaults to the
+            committed ``starlight/src/data/lexicon-manifest.json``.
+    """
+    key = normalize_lemma(word)
+    if not key:
+        return None
+    path = str(manifest_path) if manifest_path is not None else str(_DEFAULT_MANIFEST)
+    slug = _load_index(path).get(key)
+    return f"/lexicon/{slug}/" if slug else None

--- a/scripts/generate_mdx/generate_mdx_direct_content.py
+++ b/scripts/generate_mdx/generate_mdx_direct_content.py
@@ -6,6 +6,7 @@ vocabulary, grammar, checkpoint) into MDX markup. Used by generate_mdx_direct.
 
 from __future__ import annotations
 
+from atlas_links import atlas_href_for
 from generate_mdx_direct_renderers import dump_json_for_jsx, escape_jsx_string
 
 # Session grouping for abetka: letter groups by pedagogical sequence
@@ -304,6 +305,8 @@ def _render_syllable_vocab(data: dict) -> list[str]:
                     "examples": examples,
                     "category": "",
                     "question": "",
+                    # Integrity-gated Word Atlas link ("" when no Atlas page).
+                    "atlas_href": atlas_href_for(v.get("word", "")) or "",
                 }
             )
         lines.append("\n## Слова по складах\n")
@@ -397,6 +400,8 @@ def render_vocabulary_module(data: dict) -> str:
                 "examples": w.get("examples", []),
                 "category": w.get("category", ""),
                 "question": w.get("question", ""),
+                # Integrity-gated Word Atlas link ("" when no Atlas page).
+                "atlas_href": atlas_href_for(w.get("word", "")) or "",
             }
             for w in vocab
         ]

--- a/scripts/generate_mdx/resources.py
+++ b/scripts/generate_mdx/resources.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import yaml
 
+from .atlas_links import atlas_href_for
 from .utils import escape_jsx
 
 
@@ -493,6 +494,9 @@ def vocab_items_to_components(items: list[dict], header_text: str = "Vocabulary"
             "gender": item.get('gender', ''),
             "example": example,
             "examples": [value for value in (translation, example) if value],
+            # Render-time, integrity-gated link to the Word Atlas page (None when
+            # the lemma has no Atlas page → dropped by the empty-value filter below).
+            "atlas_href": atlas_href_for(lemma),
         }
         words.append({key: value for key, value in entry.items() if value not in (None, "", [])})
 

--- a/starlight/src/components/Direct.module.css
+++ b/starlight/src/components/Direct.module.css
@@ -550,6 +550,19 @@
   margin-bottom: 0.25rem;
 }
 
+.vocabCardAtlasLink {
+  display: inline-block;
+  margin-top: 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.vocabCardAtlasLink:hover {
+  text-decoration: underline;
+}
+
 /* ─── PhraseTable ─── */
 
 .phraseTableContainer {

--- a/starlight/src/components/VocabCard.tsx
+++ b/starlight/src/components/VocabCard.tsx
@@ -37,6 +37,12 @@ interface VocabEntry {
    * @ukrainianText true
    */
   question?: string;
+  /**
+   * @schemaDescription Integrity-gated href to this lemma's Word Atlas page,
+   * derived at MDX-generation time. Empty/absent when the lemma has no Atlas page.
+   * @ukrainianText false
+   */
+  atlas_href?: string | null;
 }
 
 interface VocabCardProps {
@@ -128,6 +134,16 @@ function SingleVocabCard({
               <li key={i}>{ex}</li>
             ))}
           </ul>
+        )}
+
+        {entry.atlas_href && (
+          <a
+            className={directStyles.vocabCardAtlasLink}
+            href={entry.atlas_href}
+            data-atlas-link="true"
+          >
+            {isUkrainian ? 'Докладніше →' : 'More →'}
+          </a>
         )}
       </div>
     </div>

--- a/tests/test_atlas_links.py
+++ b/tests/test_atlas_links.py
@@ -1,0 +1,124 @@
+"""Tests for vocab → Word Atlas cross-linking (render-time, integrity-gated).
+
+Covers the normalize/match helper and its integrity-gating in the live
+``vocab_items_to_components`` generator path: a link is emitted iff the lemma
+has an Atlas page, never otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts.generate_mdx import resources
+from scripts.generate_mdx.atlas_links import atlas_href_for, normalize_lemma
+
+# ── normalize_lemma ──────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("робо́та", "робота"),        # combining acute stress stripped
+        ("за́мок", "замок"),          # stress stripped
+        ("Іван", "іван"),             # case folded
+        ("  Київ  ", "київ"),         # whitespace + case
+        ("", ""),                      # empty stays empty
+    ],
+)
+def test_normalize_strips_stress_and_case(raw, expected):
+    assert normalize_lemma(raw) == expected
+
+
+def test_normalize_preserves_decomposable_ukrainian_letters():
+    # й (U+0439) and ї (U+0457) NFD-decompose to base vowel + combining
+    # breve/diaeresis. Those marks must survive — only stress is stripped —
+    # else їжак would collapse to іжак and йти to ити.
+    assert normalize_lemma("їжак") == "їжак"
+    assert normalize_lemma("йти") == "йти"
+    assert normalize_lemma("Україна") == "україна"
+
+
+def test_normalize_canonicalizes_apostrophes():
+    # Different apostrophe glyphs must collapse to one key so з'їсти matches.
+    variants = ["з'їсти", "з’їсти", "зʼїсти", "з`їсти"]
+    keys = {normalize_lemma(v) for v in variants}
+    assert len(keys) == 1
+
+
+# ── atlas_href_for (synthetic manifest) ──────────────────────────────────────
+
+@pytest.fixture
+def manifest(tmp_path):
+    path = tmp_path / "lexicon-manifest.json"
+    path.write_text(
+        json.dumps(
+            {
+                "version": "test",
+                "entries": [
+                    {"lemma": "робота", "url_slug": "робота", "gloss": "work"},
+                    {"lemma": "Іван", "url_slug": "іван", "gloss": "Ivan"},
+                    {"lemma": "їжак", "url_slug": "їжак", "gloss": "hedgehog"},
+                    {"lemma": "", "url_slug": "broken"},  # ignored (no lemma)
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def test_href_exact_match(manifest):
+    assert atlas_href_for("робота", manifest) == "/lexicon/робота/"
+
+
+def test_href_stress_stripped_match(manifest):
+    # Stressed surface form must resolve to the unstressed Atlas page.
+    assert atlas_href_for("робо́та", manifest) == "/lexicon/робота/"
+
+
+def test_href_case_insensitive_match(manifest):
+    assert atlas_href_for("іван", manifest) == "/lexicon/іван/"
+    assert atlas_href_for("ІВАН", manifest) == "/lexicon/іван/"
+
+
+def test_href_preserves_yi_letter(manifest):
+    assert atlas_href_for("їжак", manifest) == "/lexicon/їжак/"
+
+
+def test_href_no_match_returns_none(manifest):
+    assert atlas_href_for("неіснуючеслово", manifest) is None
+
+
+def test_href_empty_returns_none(manifest):
+    assert atlas_href_for("", manifest) is None
+    assert atlas_href_for("   ", manifest) is None
+
+
+def test_href_missing_manifest_is_graceful(tmp_path):
+    missing = str(tmp_path / "does-not-exist.json")
+    assert atlas_href_for("робота", missing) is None
+
+
+# ── integrity-gating inside the generator ────────────────────────────────────
+
+def test_vocab_component_links_only_lemmas_with_atlas_pages(monkeypatch):
+    """The generator emits atlas_href for lemmas that have a page, and omits it
+    entirely for lemmas that do not — never a broken link."""
+    def fake_href(word):
+        return "/lexicon/робота/" if word == "робота" else None
+
+    monkeypatch.setattr(resources, "atlas_href_for", fake_href)
+
+    out = resources.vocab_items_to_components(
+        [
+            {"lemma": "робота", "translation": "work", "example": "Я люблю роботу."},
+            {"lemma": "абракадабра", "translation": "nonsense"},
+        ]
+    )
+
+    assert "/lexicon/робота/" in out
+    assert "atlas_href" in out
+    # The un-pageable lemma must not carry an atlas_href key/value.
+    assert out.count("/lexicon/") == 1


### PR DESCRIPTION
## What

Lesson **Tab 2 VocabCard** entries now show a **«Докладніше →»** link to that lemma's per-lemma **Word Atlas** page (`/lexicon/{url_slug}/`). This completes the bidirectional **lesson⇄Atlas funnel** — the Atlas→lesson direction (`course_usage`) already shipped; this is the return path. (Word Atlas design §7 line 188; §8 `cross_link_integrity`.)

As `codex`'s B1 builds grow the Atlas, more vocab cards light up automatically — no per-module work.

## How (integrity-gated, render-time)

- **`scripts/generate_mdx/atlas_links.py`** — builds a `{normalized_lemma → url_slug}` index over `lexicon-manifest.json` `entries` (the same file the Astro `lexicon/[lemma].astro` route enumerates). Normalization strips **only** combining acute/grave stress (so `робо́та` → `робота`) + case-folds + canonicalizes apostrophes, while **preserving** decomposable `й`/`ї` (`їжак` ≠ `іжак`).
- A link is emitted **iff** the lemma has an Atlas page → the lesson→Atlas direction is **integrity-safe by construction**; a broken cross-link cannot be produced (§11 Q4 "warn at v1" is moot). `vocabulary.yaml` is **never** modified — slugs are derived at MDX-generation time.
- Wired into **all 3** VocabCard-props paths: `resources.vocab_items_to_components` + `generate_mdx_direct_content.{render_vocabulary_module,_render_syllable_vocab}`.
- **`VocabCard.tsx`** renders the link (`data-atlas-link` hook reserved for funnel analytics via the existing GoatCounter injection); **`Direct.module.css`** styles it.
- Regenerated **`docs/lesson-schema.yaml`** (new `VocabEntry.atlas_href` prop) so the `lesson-schema-drift` gate stays green.

## Tests

`tests/test_atlas_links.py` — 15 tests: normalize invariants (stress/case/apostrophe + `й`/`ї` preservation), exact/stress-stripped/case-insensitive match, no-match/empty/missing-manifest → `None`, and integrity-gating inside the generator (link emitted only for pageable lemmas). All touched generator/lesson-schema suites pass locally (`150 + 3 + 15`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)