### PR TITLE
fix(wiki): resolve sources DB from deep dispatch worktrees [folk Session-20b]

### DIFF
--- a/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
+++ b/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
@@ -72,7 +72,12 @@ yaml/jsonl; `git checkout -- data/` restores).
 1. **Batch the other 5 gap wikis** (#M-9, sequential), now FULLY UNBLOCKED. From a dispatch worktree off main
    (with #3059 merged) — NO data symlink needed — run per slug:
    `compile.py --track folk --slug <slug> --writer gpt-5.5 --review --force`
-   slugs: kobzarstvo-lirnytstvo (re-compile IN FLIGHT at handoff — check `/tmp/wiki-batch-kobzarstvo2.log`),
+   slugs: **kobzarstvo-lirnytstvo** (DB-fix CONFIRMED working — writer got 27 sources + wrote a full article;
+   but it tripped a DIFFERENT gate: a surviving `<!-- VERIFY -->` marker the writer honestly emitted on ONE
+   uncertain peripheral claim — the exact execution date of kobzar Кучугура-Кучеренко, "in the control dossier
+   but no dedicated [S#] fragment". This is GOOD writer honesty (#M-4), not corpus-blindness. Resolve per-wiki:
+   re-run with `--allow-verify-markers` IF the flagged claim is genuinely peripheral+uncertain (logs it as a TODO),
+   OR have the writer cite/rephrase it. Then it reviews+converges like bylyny.),
    dumy-sotsialno-pobutovi, holosinnya, vesilni-pisni, zhnyvarski-obzhynkovi-pisni. Writer (gpt-5.5) builds the
    article + registry (DB-fix resolves the dossier chunk_ids) → claude-routed review (#3057) adds citations +
    best-round (#3054) → converges to MIN≥8 (bylyny proof: 7→8 in 2 rounds). **Corpus-hammer each (#M-11) before

--- a/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
+++ b/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
@@ -55,22 +55,42 @@ The loop added 6 new cites + corrected misattributions (33→39 inline `[S#]`); 
 (documentary chain ✓), S19=Дзюба/Павленко ✓, S24=Івакін ✓, S25/26=Наливайко (Western reception ✓). All resolve;
 claude sg actively caught + fixed the S9→S15/S30 misattributions. Shipped: `wiki/folk/genres/bylyny-kyivskoho-tsyklu.{md,sources.yaml}` + review JSON (existing `wiki/index.md` line 330 already links it — this fixes a dead link).
 
-### ▶ NEXT ACTIONS (RESUME HERE, in order)
-1. **Batch the other 5 gap wikis** through the proven path (#M-9, sequential): kobzarstvo-lirnytstvo,
-   dumy-sotsialno-pobutovi, holosinnya, vesilni-pisni, zhnyvarski-obzhynkovi-pisni. Each: they have dossiers but
-   likely NO compiled `.md` yet → `compile.py --track folk --slug <slug> --writer gpt-5.5 --review` from a
-   `data/`-bearing checkout (writer produces article → claude-routed review adds citations → converges → ship).
-   Corpus-hammer each (#M-11) before ship. ~15-20 min review each.
-2. **(durable follow-up, low-pri)** Harden the wiki writer's inline-`[S#]` citation discipline in
-   `compile_article.md` so future articles cite completely first-pass (saves the review-loop the citation work).
-   NOT blocking — the loop closes it surgically. And consider proposing the seminar reviewer routing to the
-   orchestrator for the GLOBAL `DEFAULT_PRIMARY` (it benefits hist/lit/oes/ruth too) — TRACK-UPDATE'd.
-3. **(cleanup)** `wiki/index.md` has ~17 stale dead entries from the Session-7 old-taxonomy purge + stale word
-   counts; `compile.py --update-index` regenerates cleanly (deferred — tangential to content PRs).
+### 🔧 SECOND BLOCKER FOUND + FIXED THIS SESSION — deep-worktree DB corpus-blindness (PR #3059)
+The first fresh `compile --review` (kobzarstvo) FAILED differently from bylyny: `⚠️ No source material found`,
+sg 3→2, **0-source registry** despite the dossier citing 26 chunk_ids. ROOT CAUSE (not the routing, not the
+writer): `source_attribution.py::_effective_db_path` worktree-DB fallback only matched the SHALLOW `.worktrees/
+<name>` layout, but delegate.py worktrees are `.worktrees/dispatch/<agent>/<name>` (3 deep) → fallback never
+fired → sqlite **auto-created an empty 0-byte data/sources.db** → compile ran corpus-blind. **FIX (PR #3059):**
+walk `PROJECT_ROOT.parents` up to the `.worktrees` ancestor. Validated: kobzarstvo 0→**26** chunk_ids resolved,
+bylyny 0→23 (effective path = real 1.6GB DB, 137,696 literary rows). +2 tests, 13 green. **This unblocked ALL
+deep-worktree wiki compiles (every track), not just folk.** ⚠ GOTCHA: a dispatch worktree needs NO `data/`
+symlink now — the fallback handles it; do NOT `ln -s data` (and NEVER `rm -rf data` — it deletes sparse-tracked
+yaml/jsonl; `git checkout -- data/` restores).
+
+### ▶ NEXT ACTIONS (RESUME HERE, in order) — both blockers fixed; the 5 are now PURE EXECUTION
+0. **Merge PR #3059 (DB-fix) first** if not already — every fresh wiki compile depends on it.
+1. **Batch the other 5 gap wikis** (#M-9, sequential), now FULLY UNBLOCKED. From a dispatch worktree off main
+   (with #3059 merged) — NO data symlink needed — run per slug:
+   `compile.py --track folk --slug <slug> --writer gpt-5.5 --review --force`
+   slugs: kobzarstvo-lirnytstvo (re-compile IN FLIGHT at handoff — check `/tmp/wiki-batch-kobzarstvo2.log`),
+   dumy-sotsialno-pobutovi, holosinnya, vesilni-pisni, zhnyvarski-obzhynkovi-pisni. Writer (gpt-5.5) builds the
+   article + registry (DB-fix resolves the dossier chunk_ids) → claude-routed review (#3057) adds citations +
+   best-round (#3054) → converges to MIN≥8 (bylyny proof: 7→8 in 2 rounds). **Corpus-hammer each (#M-11) before
+   ship** — read the article + spot-check the added `[S#]`→author mapping in the registry (like bylyny's
+   S15=Попович/S16=Чижевський verification). Ship each: `.md` + `.sources.yaml` + `.reviews` json. ~20 min each.
+2. **(durable follow-up, low-pri)** Harden the wiki writer's inline-`[S#]` discipline in `compile_article.md` so
+   articles cite completely first-pass (the review-loop currently adds the citations — works, but costs rounds).
+   AND the GLOBAL `DEFAULT_PRIMARY` seminar-routing (benefits hist/lit/oes/ruth) — orchestrator's call, TRACK-UPDATE'd twice.
+3. **(cleanup)** `wiki/index.md` has ~17 stale dead entries (Session-7 purge) + stale word counts;
+   `compile.py --update-index` regenerates cleanly (deferred — tangential to content PRs).
 
 ### ⚠ CARRY-FORWARD (Session-20b)
-- bylyny's passing cited article + review JSON are in this PR. The other 5 need compiling (writer run + review).
+- **Both wiki blockers are now fixed + shipping:** #3057 (reviewer routing, MERGED) + #3059 (deep-worktree DB,
+  PR). The 5 remaining wikis are mechanical repeats of a PROVEN recipe — no more unknowns.
+- **Session-20b PRs:** #3054 (loop, merged), #3057 (routing + bylyny wiki #10, merged), #3059 (DB-fix, open).
 - Reviewer routing is folk/compile-scoped (agent_overrides), global `DEFAULT_PRIMARY` untouched (boundary-respecting).
+- **CONTEXT NOTE:** this session ran very long (5+ model validation runs, deep context). A careless `rm -rf data`
+  in the worktree near the end (restored, no damage) was a rot signal — the 5-wiki batch is best run fresh.
 - `git push` folk → `--no-verify`; `core.bare` stayed false.
 
 ---

--- a/scripts/wiki/source_attribution.py
+++ b/scripts/wiki/source_attribution.py
@@ -366,10 +366,19 @@ def _effective_db_path() -> Path:
     if db_path.exists() and db_path.stat().st_size > 0:
         return db_path
 
-    if PROJECT_ROOT.parent.name == ".worktrees":
-        fallback = PROJECT_ROOT.parent.parent / "data" / db_path.name
-        if fallback.exists() and fallback.stat().st_size > 0:
-            return fallback
+    # In a dispatch worktree, data/ is sparse-excluded (or an empty 0-byte
+    # placeholder that sqlite auto-creates) — fall back to the main checkout's
+    # populated DB. Worktrees nest arbitrarily deep: delegate.py uses
+    # `.worktrees/dispatch/<agent>/<name>`, so the old `PROJECT_ROOT.parent.name
+    # == ".worktrees"` check (which only matched the shallow `.worktrees/<name>`
+    # layout) silently failed and the compile got an EMPTY DB. Walk UP to the
+    # `.worktrees` ancestor and use the repo root (its parent) as the DB home.
+    for ancestor in PROJECT_ROOT.parents:
+        if ancestor.name == ".worktrees":
+            fallback = ancestor.parent / "data" / db_path.name
+            if fallback.exists() and fallback.stat().st_size > 0:
+                return fallback
+            break
 
     return db_path
 

--- a/tests/test_wiki_source_attribution.py
+++ b/tests/test_wiki_source_attribution.py
@@ -294,3 +294,39 @@ def test_effective_db_path_falls_back_to_main_checkout_from_worktree(tmp_path, m
     monkeypatch.setattr(source_attribution, "DEFAULT_DB_PATH", local_db)
 
     assert source_attribution._effective_db_path() == shared_db
+
+
+def test_effective_db_path_falls_back_from_deep_dispatch_worktree(tmp_path, monkeypatch) -> None:
+    """delegate.py nests worktrees as .worktrees/dispatch/<agent>/<name> — the
+    fallback must walk UP to the `.worktrees` ancestor, not only match a direct
+    parent (folk Session-20b: deep worktrees silently got an EMPTY DB → wiki
+    compiles produced 0-source registries → source_grounding always failed)."""
+    from wiki import source_attribution
+
+    repo_root = tmp_path
+    worktree_root = repo_root / ".worktrees" / "dispatch" / "claude" / "folk-wiki-batch"
+    local_db = worktree_root / "data" / "sources.db"
+    shared_db = repo_root / "data" / "sources.db"
+    local_db.parent.mkdir(parents=True)
+    shared_db.parent.mkdir(parents=True)
+    local_db.write_bytes(b"")          # 0-byte placeholder sqlite auto-creates
+    shared_db.write_bytes(b"sqlite")   # populated main-checkout DB
+
+    monkeypatch.setattr(source_attribution, "PROJECT_ROOT", worktree_root)
+    monkeypatch.setattr(source_attribution, "DEFAULT_DB_PATH", local_db)
+
+    assert source_attribution._effective_db_path() == shared_db
+
+
+def test_effective_db_path_prefers_local_populated_db(tmp_path, monkeypatch) -> None:
+    """A populated local DB (main checkout, size>0) is used directly — no fallback."""
+    from wiki import source_attribution
+
+    local_db = tmp_path / "data" / "sources.db"
+    local_db.parent.mkdir(parents=True)
+    local_db.write_bytes(b"sqlite")
+
+    monkeypatch.setattr(source_attribution, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(source_attribution, "DEFAULT_DB_PATH", local_db)
+
+    assert source_attribution._effective_db_path() == local_db


### PR DESCRIPTION
## Bug
`_effective_db_path()`'s worktree fallback only matched the **shallow** `.worktrees/<name>` layout via `PROJECT_ROOT.parent.name == ".worktrees"`. But `delegate.py` nests dispatch worktrees **3 levels deep**: `.worktrees/dispatch/<agent>/<name>`. So in a dispatch worktree the fallback never fired, `data/sources.db` didn't exist (sparse-excluded), sqlite **auto-created an empty 0-byte DB**, and wiki compiles silently ran with **zero corpus** → 0-source registries → `source_grounding` always REJECT.

## How it surfaced (folk Session-20b)
A fresh `compile --review` of kobzarstvo logged `⚠️ No source material found` and sg scored 3→2, despite the dossier citing **26 chunk_ids** — all of which resolve fine once the DB path is correct.

## Fix
Walk `PROJECT_ROOT.parents` up to the `.worktrees` ancestor and use the repo root (its parent) as the DB home. A populated local DB (main checkout, size>0) is still preferred; the shallow layout still works.

**Validated:** kobzarstvo **0 → 26** chunk_ids resolved, bylyny **0 → 23**; effective path = the real 1.6GB DB (137,696 literary rows).

## Tests
+2 (deep-worktree fallback, local-preferred), existing shallow test still green — 13 total. ruff clean.

## Impact
Fixes **all** deep dispatch-worktree wiki compiles (every track), not just folk — any worktree-run `compile`/review was silently corpus-blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)