### PR TITLE
fix(agent-runtime): honest agy MCP resolution [#3060]

### DIFF
--- a/scripts/agent_runtime/adapters/agy.py
+++ b/scripts/agent_runtime/adapters/agy.py
@@ -27,14 +27,15 @@ Known behavioral facts as of agy 1.0.0 (verified locally 2026-05-20):
   slug→label is the whole fix.
 - ``agy plugin`` only exposes ``import gemini|claude``, ``install``,
   ``enable``, ``disable``. There is no plugin-marketplace browse surface,
-  and ``import gemini`` is a no-op in a default install. The adapter
-  accepts ``tool_config["mcp_server_names"]`` for API parity with
-  ``GeminiAdapter`` but does not act on it today; wire ``agy plugin
-  enable <name>`` once concrete MCP servers are available.
+  and ``import gemini`` is a no-op in a default install.
 
-MCP plugin enablement is managed by agy's local configuration rather than a
-per-invocation CLI flag. The adapter accepts tool_config for API parity but
-does not mutate agy's MCP setup.
+MCP enablement is managed by agy's global Antigravity configuration at
+``~/.gemini/antigravity-cli/mcp_config.json`` using ``httpUrl``
+streamable-HTTP server entries. Verified locally on 2026-06-13:
+``agy -p`` invoked ``mcp__sources__verify_word`` through that global config.
+The adapter still does not pass a per-invocation MCP flag because agy has
+none; ``tool_config["mcp_server_names"]`` is accepted for API parity and
+observability, while the global config is the source of truth.
 
 Differences from the kubedojo source:
 
@@ -200,9 +201,9 @@ class AgyAdapter:
         if session_id:
             cmd.append(f"--conversation={session_id}")
 
-        # Phase-2 follow-up: agy uses `agy plugin` for MCP configuration,
-        # not a per-invocation CLI flag like gemini-cli. tool_config is
-        # accepted for parity but not acted on yet.
+        # agy reads MCP servers from its global Antigravity config. There is
+        # no per-invocation MCP CLI flag to pass here; tool_config is retained
+        # for adapter API parity and resolver diagnostics.
         _ = tool_config
 
         return InvocationPlan(

--- a/scripts/agent_runtime/tool_config.py
+++ b/scripts/agent_runtime/tool_config.py
@@ -2,12 +2,15 @@
 from __future__ import annotations
 
 import json
+import os
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _DEFAULT_MCP_CONFIG_PATH = _REPO_ROOT / ".mcp.json"
+_AGY_APP_DATA_ENV = "AGY_APP_DATA_DIR"
+_DEFAULT_AGY_APP_DATA_DIR = "~/.gemini/antigravity-cli"
 _RESOLUTION_STATUSES = {"ok", "config_missing", "config_empty", "servers_not_found"}
 _CODEX_MCP_SERVER_FIELDS = frozenset(
     {
@@ -44,6 +47,12 @@ def _canonical_agent_name(agent: str) -> str | None:
 def _resolved_mcp_config_path(mcp_config_path: Path | None) -> Path:
     """Return the configured `.mcp.json` path, defaulting to repo root."""
     return (mcp_config_path or _DEFAULT_MCP_CONFIG_PATH).resolve()
+
+
+def _resolved_agy_mcp_config_path() -> Path:
+    """Return agy's global Antigravity MCP config path."""
+    app_data_dir = os.environ.get(_AGY_APP_DATA_ENV, _DEFAULT_AGY_APP_DATA_DIR)
+    return (Path(app_data_dir).expanduser() / "mcp_config.json").resolve()
 
 
 def _codex_sanitize_server_config(server_config: dict) -> dict:
@@ -152,6 +161,75 @@ def _codex_server_is_usable(server_config: Any) -> bool:
     return bool(url)
 
 
+def _agy_server_is_usable(server_config: Any) -> bool:
+    """Return true for Antigravity streamable-HTTP MCP server entries."""
+    if not isinstance(server_config, dict):
+        return False
+    http_url = str(server_config.get("httpUrl") or "").strip()
+    url = str(server_config.get("url") or "").strip()
+    return bool(http_url or url)
+
+
+def _agy_mcp_servers(
+    mcp_config_path: Path,
+    requested_servers: list[str] | None,
+) -> tuple[dict[str, list[str]] | None, dict[str, Any]]:
+    """Return agy's requested MCP server names plus resolution diagnostics."""
+    requested = list(requested_servers or [])
+
+    data = _load_mcp_config(mcp_config_path)
+    if not data:
+        return None, _basic_diagnostics(
+            mcp_config_path=mcp_config_path,
+            requested_servers=requested,
+            resolved_servers=None,
+            resolution_status="config_empty",
+        )
+
+    servers = data.get("mcpServers")
+    if not isinstance(servers, dict) or not servers:
+        return None, _basic_diagnostics(
+            mcp_config_path=mcp_config_path,
+            requested_servers=requested,
+            resolved_servers=None,
+            resolution_status="config_empty",
+        )
+
+    usable_server_names = [
+        server_name
+        for server_name, server_config in servers.items()
+        if _agy_server_is_usable(server_config)
+    ]
+    if not requested or not usable_server_names:
+        return None, _basic_diagnostics(
+            mcp_config_path=mcp_config_path,
+            requested_servers=requested,
+            resolved_servers=None,
+            resolution_status="config_empty",
+            missing_server_names=requested,
+        )
+
+    usable_servers = set(usable_server_names)
+    selected = [server_name for server_name in requested if server_name in usable_servers]
+    missing = [server_name for server_name in requested if server_name not in usable_servers]
+    if not selected:
+        return None, _basic_diagnostics(
+            mcp_config_path=mcp_config_path,
+            requested_servers=requested,
+            resolved_servers=None,
+            resolution_status="servers_not_found",
+            missing_server_names=missing,
+        )
+
+    return {"mcp_server_names": selected}, _basic_diagnostics(
+        mcp_config_path=mcp_config_path,
+        requested_servers=requested,
+        resolved_servers=selected,
+        resolution_status="ok",
+        missing_server_names=missing,
+    )
+
+
 def _basic_diagnostics(
     *,
     mcp_config_path: Path,
@@ -238,29 +316,13 @@ def build_mcp_tool_config(
         )
 
     if canonical_agent == "agy":
-        # agy 1.0.0 has no per-invocation MCP flag (Phase 2 follow-up).
-        # We mirror the Gemini path's diagnostics shape so the upstream
-        # `_runtime_tool_config` validator does not fail-fast at dispatch
-        # time; the lack of MCP wiring then surfaces at runtime as
-        # MCP_TOOLS_NEVER_INVOKED, which is the precise + intended signal
-        # for the seminar-writer bakeoff. The adapter itself ignores
-        # `mcp_server_names`; we pass it through for parity / debuggability.
-        if not mcp_servers:
-            return None, _basic_diagnostics(
-                mcp_config_path=resolved_config_path,
-                requested_servers=mcp_servers,
-                resolved_servers=None,
-                resolution_status="config_empty",
-            )
-        return (
-            {"mcp_server_names": mcp_servers},
-            _basic_diagnostics(
-                mcp_config_path=resolved_config_path,
-                requested_servers=mcp_servers,
-                resolved_servers=mcp_servers,
-                resolution_status="ok",
-            ),
-        )
+        # agy enables MCP through the global Antigravity config, not a
+        # per-invocation CLI flag. Antigravity's streamable-HTTP shape uses
+        # `httpUrl`; the adapter still receives resolved names for parity and
+        # observability. Runtime telemetry remains load-bearing:
+        # MCP_TOOLS_NEVER_INVOKED catches a configured server that is never
+        # actually called.
+        return _agy_mcp_servers(_resolved_agy_mcp_config_path(), mcp_servers)
 
     if canonical_agent in ("grok", "deepseek", "qwen"):
         # Grok, DeepSeek, and Qwen route through Hermes; tool_config translation

--- a/tests/agent_runtime/test_agy_tool_config.py
+++ b/tests/agent_runtime/test_agy_tool_config.py
@@ -1,0 +1,95 @@
+"""Focused tests for agy MCP tool_config resolution."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from agent_runtime.tool_config import _load_mcp_config, build_mcp_tool_config
+
+
+@pytest.fixture(autouse=True)
+def _clear_mcp_config_cache() -> None:
+    _load_mcp_config.cache_clear()
+    yield
+    _load_mcp_config.cache_clear()
+
+
+def _write_agy_mcp_config(app_data_dir: Path, data: dict) -> Path:
+    app_data_dir.mkdir(parents=True, exist_ok=True)
+    config_path = app_data_dir / "mcp_config.json"
+    config_path.write_text(json.dumps(data), encoding="utf-8")
+    return config_path
+
+
+def test_agy_resolves_requested_global_mcp_server(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app_data_dir = tmp_path / "antigravity-cli"
+    config_path = _write_agy_mcp_config(
+        app_data_dir,
+        {
+            "mcpServers": {
+                "sources": {"httpUrl": "http://127.0.0.1:8766/mcp"},
+            }
+        },
+    )
+    monkeypatch.setenv("AGY_APP_DATA_DIR", str(app_data_dir))
+
+    tool_config, diagnostics = build_mcp_tool_config("agy", mcp_servers=["sources"])
+
+    assert tool_config == {"mcp_server_names": ["sources"]}
+    assert diagnostics["config_path"] == str(config_path.resolve())
+    assert diagnostics["resolution_status"] == "ok"
+    assert diagnostics["resolved_servers"] == ["sources"]
+    assert diagnostics["missing_server_names"] == []
+
+
+def test_agy_reports_missing_requested_global_mcp_server(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app_data_dir = tmp_path / "antigravity-cli"
+    config_path = _write_agy_mcp_config(
+        app_data_dir,
+        {
+            "mcpServers": {
+                "sources": {"httpUrl": "http://127.0.0.1:8766/mcp"},
+            }
+        },
+    )
+    monkeypatch.setenv("AGY_APP_DATA_DIR", str(app_data_dir))
+
+    tool_config, diagnostics = build_mcp_tool_config(
+        "agy",
+        mcp_servers=["nonexistent"],
+    )
+
+    assert tool_config is None
+    assert diagnostics["config_path"] == str(config_path.resolve())
+    assert diagnostics["resolution_status"] == "servers_not_found"
+    assert diagnostics["resolved_servers"] == []
+    assert diagnostics["missing_server_names"] == ["nonexistent"]
+
+
+def test_agy_missing_global_mcp_config_is_config_empty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app_data_dir = tmp_path / "antigravity-cli"
+    monkeypatch.setenv("AGY_APP_DATA_DIR", str(app_data_dir))
+
+    tool_config, diagnostics = build_mcp_tool_config("agy", mcp_servers=["sources"])
+
+    assert tool_config is None
+    assert diagnostics["config_path"] == str(
+        (app_data_dir / "mcp_config.json").resolve()
+    )
+    assert diagnostics["resolution_status"] == "config_empty"
+    assert diagnostics["resolved_servers"] == []
+    assert diagnostics["missing_server_names"] == []

--- a/tests/test_linear_pipeline_telemetry.py
+++ b/tests/test_linear_pipeline_telemetry.py
@@ -379,7 +379,7 @@ def test_writer_rule_fired_event_emitted_on_known_failure_class(tmp_path: Path) 
     )
 
 
-def test_tools_writer_runtime_gate_still_fires_for_empty_tool_calls() -> None:
+def test_mcp_tools_writer_runtime_gate_still_fires_for_empty_tool_calls() -> None:
     with pytest.raises(
         linear_pipeline.LinearPipelineError,
         match="MCP_TOOLS_NEVER_INVOKED",

--- a/tests/test_mcp_init_observability.py
+++ b/tests/test_mcp_init_observability.py
@@ -562,11 +562,17 @@ def test_runtime_tool_config_agy_tools_emits_resolution_event_success(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """agy-tools mirrors gemini-tools diagnostics so the dispatch gate passes;
-    actual MCP wiring is a Phase-2 follow-up and the runtime MCP_TOOLS_NEVER_INVOKED
-    gate then surfaces the gap."""
-    config_path = _valid_sources_config(tmp_path / ".mcp.json")
-    monkeypatch.setattr(tool_config_mod, "_DEFAULT_MCP_CONFIG_PATH", config_path)
+    """agy-tools resolves the ``sources`` MCP from agy's global Antigravity
+    config (``AGY_APP_DATA_DIR/mcp_config.json``, ``httpUrl`` streamable-HTTP).
+    The runtime MCP_TOOLS_NEVER_INVOKED gate remains the load-bearing check
+    that a configured server is actually invoked."""
+    app_data_dir = tmp_path / "antigravity-cli"
+    app_data_dir.mkdir()
+    _write_mcp_config(
+        app_data_dir / "mcp_config.json",
+        {"mcpServers": {"sources": {"httpUrl": "http://127.0.0.1:8766/mcp"}}},
+    )
+    monkeypatch.setenv("AGY_APP_DATA_DIR", str(app_data_dir))
     events: list[tuple[str, dict[str, Any]]] = []
 
     config = linear_pipeline._runtime_tool_config(


### PR DESCRIPTION
Fixes #3060.

## Summary
- Makes `build_mcp_tool_config("agy", ...)` resolve MCP truthfully from agy's global Antigravity config at `AGY_APP_DATA_DIR` / `~/.gemini/antigravity-cli/mcp_config.json`.
- Treats Antigravity `httpUrl` streamable-HTTP entries as usable and reports `servers_not_found` when requested servers are not wired.
- Updates the agy adapter docstring/comment to reflect the verified global-config behavior while keeping the runtime `MCP_TOOLS_NEVER_INVOKED` gate load-bearing.
- Adds focused agy resolver coverage and renames the telemetry runtime-gate test so the required `-k mcp` check actually selects it.

## Proof carried forward
- agy global config is wired with `sources` at `http://127.0.0.1:8766/mcp`.
- 2026-06-13 smoke test was green: `agy -p` invoked `mcp__sources__verify_word('робота')` and returned real VESUM data.
- Transcript confirmed a real `functionCall` named `mcp__sources__verify_word` and schema load from `~/.gemini/antigravity-cli/mcp/sources/verify_word.json`.

## Validation
- `.venv/bin/python -m pytest tests/agent_runtime/ -q`
- `.venv/bin/python -m pytest tests/test_linear_pipeline_telemetry.py -q -k mcp`
- `.venv/bin/ruff check scripts/agent_runtime/tool_config.py scripts/agent_runtime/adapters/agy.py`