### PR TITLE
fix(wiki): citation strip + source_grounding gate use the authoritative registry, not retrieval count [#3083]

### DIFF
--- a/scripts/wiki/compile.py
+++ b/scripts/wiki/compile.py
@@ -477,8 +477,20 @@ def _run_discipline_checks_and_repair(
         print(f"    ⚠️  Could not read {article_path} for discipline check: {exc}")
         return
 
+    # The authoritative set of valid [S#] is the article's registry
+    # (.sources.yaml) — what the writer cited against and the reader resolves
+    # against — NOT the dense-retrieval chunk count. On dossier-only compiles
+    # those diverge (dense≈1 chunk, dossier-seeded registry≫1); keying the strip
+    # off the chunk count gutted every valid seeded citation (#3083). Validate by
+    # registry membership; ``source_count`` survives only as a no-registry fallback.
     try:
-        report = run_discipline_checks(original, source_count)
+        registry = load_sources_registry(registry_path_for(article_path))
+        valid_ids: set[str] | None = {e.id for e in registry.sources} or None
+    except Exception:
+        valid_ids = None
+
+    try:
+        report = run_discipline_checks(original, source_count, valid_ids=valid_ids)
     except Exception as exc:
         print(f"    ⚠️  Discipline check failed (non-fatal): {exc}")
         log_event(
@@ -496,7 +508,9 @@ def _run_discipline_checks_and_repair(
     repaired = original
     stripped_ids: list[str] = []
     if report.citations:
-        repaired, stripped_ids = strip_invented_citations(repaired, source_count)
+        repaired, stripped_ids = strip_invented_citations(
+            repaired, source_count, valid_ids=valid_ids
+        )
         unique_stripped = sorted(set(stripped_ids))
         print(
             f"    🧹 Stripped {len(stripped_ids)} invented citation(s): "

--- a/scripts/wiki/discipline.py
+++ b/scripts/wiki/discipline.py
@@ -156,27 +156,53 @@ def _iter_anchors(path: Path | None = None) -> list[dict[str, Any]]:
 # ─────────────────────────────────────────────────────────────────────
 
 
+def _citation_is_invented(
+    cited_num: int, source_count: int, valid_ids: set[str] | None
+) -> bool:
+    """True iff an inline ``[SN]`` does not resolve to a real source.
+
+    The authoritative criterion is **registry membership**: when ``valid_ids``
+    (the ids in the article's sibling ``.sources.yaml`` — the set the writer
+    cited against and the reader resolves against) is supplied, ``[SN]`` is
+    invented iff ``"SN"`` is not in that set. This is robust to dossier-seeding
+    (#3036), id gaps, and dense-retrieval variance.
+
+    The legacy numeric bound (``N > source_count``) is used ONLY as a fallback
+    when no registry is available (e.g. registry-less migration reruns). Keying
+    the strip off ``len(all_chunks)`` was the root cause of #3083: on dossier-
+    only compiles dense retrieval returns ~1 chunk while seeding builds a 20-30
+    source registry, so every valid seeded ``[S#]`` was wrongly stripped.
+    """
+    if valid_ids is not None:
+        return f"S{cited_num}" not in valid_ids
+    return cited_num > source_count
+
+
 def validate_citation_bound(
-    article_text: str, source_count: int
+    article_text: str,
+    source_count: int,
+    *,
+    valid_ids: set[str] | None = None,
 ) -> list[CitationViolation]:
-    """Flag every [SN] in article where N > source_count.
+    """Flag every inline [SN] that does not resolve to a real source.
 
-    These are the invented citations — writer cited a chunk that was
-    never retrieved. Post-compile the resolver marks them as
-    `type: unknown` with a bare chunk ID; catching them here, before
-    the resolver runs, means we can strip-or-flag before the reader
-    ever sees a broken citation.
+    Authoritative criterion is registry membership (``valid_ids`` = the ids in
+    the sibling ``.sources.yaml``); ``source_count`` is a legacy numeric fallback
+    used only when no registry is supplied. Catching invented citations here,
+    before the resolver runs, means we strip-or-flag before the reader ever sees
+    a broken citation.
 
-    Returns a list of CitationViolation, one per offending ID (even if
+    Returns a list of CitationViolation, one per offending occurrence (even if
     the same invented ID appears many times — callers can dedupe).
     """
     if source_count < 0:
         raise ValueError(f"source_count must be ≥0, got {source_count}")
 
+    max_legal = len(valid_ids) if valid_ids is not None else source_count
     violations: list[CitationViolation] = []
     for match in _CITATION_RE.finditer(article_text):
         cited_num = int(match.group(1))
-        if cited_num > source_count:
+        if _citation_is_invented(cited_num, source_count, valid_ids):
             start = max(0, match.start() - 40)
             end = min(len(article_text), match.end() + 40)
             context = article_text[start:end].replace("\n", " ")
@@ -184,7 +210,7 @@ def validate_citation_bound(
                 CitationViolation(
                     cited_id=f"S{cited_num}",
                     cited_number=cited_num,
-                    max_legal=source_count,
+                    max_legal=max_legal,
                     context=context,
                 )
             )
@@ -256,10 +282,18 @@ def run_discipline_checks(
     article_text: str,
     source_count: int,
     anchors_path: Path | None = None,
+    *,
+    valid_ids: set[str] | None = None,
 ) -> DisciplineReport:
-    """Run both mechanical validators and return a combined report."""
+    """Run both mechanical validators and return a combined report.
+
+    ``valid_ids`` (the registry id set) makes citation validation authoritative
+    by membership; ``source_count`` is the legacy numeric fallback. See #3083.
+    """
     return DisciplineReport(
-        citations=validate_citation_bound(article_text, source_count),
+        citations=validate_citation_bound(
+            article_text, source_count, valid_ids=valid_ids
+        ),
         anchors=validate_canonical_anchors(article_text, anchors_path),
     )
 
@@ -270,25 +304,29 @@ def run_discipline_checks(
 
 
 def strip_invented_citations(
-    article_text: str, source_count: int
+    article_text: str,
+    source_count: int,
+    *,
+    valid_ids: set[str] | None = None,
 ) -> tuple[str, list[str]]:
-    """Remove every [SN] where N > source_count from article text.
+    """Remove every inline [SN] that does not resolve to a real source.
 
-    Returns (repaired_text, stripped_ids). The stripped citations are
-    replaced with an empty string; surrounding punctuation and spaces
-    are preserved as-is — we don't try to re-flow the sentence. If a
-    paragraph ends up with nothing after `something.  .` the downstream
-    enrich/verify phases will catch it; we stay conservative.
+    Authoritative criterion is registry membership (``valid_ids``); the numeric
+    ``source_count`` bound is a fallback used only when no registry is supplied
+    (#3083). Returns (repaired_text, stripped_ids). The stripped citations are
+    replaced with an empty string; surrounding punctuation and spaces are
+    preserved as-is — we don't try to re-flow the sentence. If a paragraph ends
+    up with nothing after `something.  .` the downstream enrich/verify phases
+    will catch it; we stay conservative.
 
-    stripped_ids preserves order + duplicates, so the caller can log
-    exactly how many invented citations were removed and which chunks
-    they claimed to cite.
+    stripped_ids preserves order + duplicates, so the caller can log exactly how
+    many invented citations were removed and which chunks they claimed to cite.
     """
     stripped: list[str] = []
 
     def _repl(match: re.Match[str]) -> str:
         cited_num = int(match.group(1))
-        if cited_num > source_count:
+        if _citation_is_invented(cited_num, source_count, valid_ids):
             stripped.append(f"S{cited_num}")
             return ""
         return match.group(0)

--- a/scripts/wiki/review.py
+++ b/scripts/wiki/review.py
@@ -442,6 +442,44 @@ def _infer_level_from_domain(domain: str) -> str:
 # ── Response parsing ───────────────────────────────────────────────
 
 
+# ── source_grounding deterministic fail-closed floor (#3083) ─────────
+_INLINE_CITATION_RE = re.compile(r"\[S(\d+)\]")
+
+#: A substantial article carrying fewer than this many DISTINCT inline [S#]
+#: citations is treated as effectively ungrounded — no legitimate C1 wiki cites
+#: so few sources (real articles carry 15-40+). Tuned far below any real article
+#: so the floor is teeth-without-false-positives.
+_SG_MIN_DISTINCT_CITATIONS = 3
+_SG_MIN_BODY_CHARS = 1500
+_SG_UNGROUNDED_SCORE = 3
+
+
+def _source_grounding_floor(article_text: str, score: int) -> int:
+    """Deterministic fail-closed floor for the ``source_grounding`` dimension.
+
+    The LLM reviewer can be fooled into PASSing an effectively-uncited article —
+    it judged claims "sourceable from the registry" without noticing the inline
+    ``[S#]`` were absent (the #3083 / m20 failure: a 311s review returned
+    10/PASS, 0 findings on an article carrying 2 citations). Source-grounding is
+    by definition about inline attribution, so this is checkable deterministically:
+    a substantial article with near-zero DISTINCT inline ``[S#]`` cannot be
+    well-grounded, whatever the model said — cap it at a failing score so it can
+    never silently ship.
+
+    Mirrors the deterministic ``register`` score (``_register_score_from_findings``):
+    code overrides the LLM's unreliable holistic number. Conservative — the
+    threshold sits far below any legitimate wiki (15-40+ distinct ``[S#]``), so a
+    genuinely-cited article is never affected. Only ever LOWERS a score (never
+    rescues a fail), so it is safe for every track.
+    """
+    if len(article_text) < _SG_MIN_BODY_CHARS:
+        return score  # too short to judge grounding density meaningfully
+    distinct = len({m.group(1) for m in _INLINE_CITATION_RE.finditer(article_text)})
+    if distinct < _SG_MIN_DISTINCT_CITATIONS:
+        return min(score, _SG_UNGROUNDED_SCORE)
+    return score
+
+
 def _register_score_from_findings(findings: list[Finding]) -> int:
     """Re-derive the register score from surviving findings via the
     ``review_register.md`` severity→score table. Used after the deterministic
@@ -616,6 +654,16 @@ def _parse_dim_result(
             verdict=verdict,
             article_text=article_text,
         )
+
+    if dim == "source_grounding" and article_text:
+        floored = _source_grounding_floor(article_text, score)
+        if floored != score:
+            score = floored
+            verdict = "REJECT"
+            notes = notes or (
+                "Deterministic source_grounding floor (#3083): article carries "
+                "near-zero distinct inline [S#] citations — ungrounded, cannot PASS."
+            )
 
     return DimResult(
         dim=dim,

--- a/tests/test_wiki_discipline.py
+++ b/tests/test_wiki_discipline.py
@@ -263,6 +263,65 @@ class TestStripInventedCitations:
         assert stripped2 == []
 
 
+class TestRegistryMembershipCitations:
+    """#3083: citation validity is REGISTRY MEMBERSHIP, not a numeric bound.
+
+    Root-cause regression: dossier-only compiles passed source_count=1 (the
+    dense-retrieval chunk count) while the dossier-seeded registry held ~26 ids,
+    so the numeric bound stripped every valid [S2]..[S26]. With valid_ids
+    supplied, the strip keys off membership and the seeded citations survive.
+    """
+
+    def test_seeded_citations_survive_low_source_count_regression(self):
+        valid_ids = {f"S{n}" for n in range(1, 27)}  # S1..S26 (kobzarstvo shape)
+        text = "Lead [S1]. Body [S2] and [S26]. Bogus [S99]."
+        out, stripped = strip_invented_citations(
+            text, source_count=1, valid_ids=valid_ids
+        )
+        assert "[S1]" in out
+        assert "[S2]" in out
+        assert "[S26]" in out
+        assert "[S99]" not in out
+        assert stripped == ["S99"]
+
+    def test_validate_uses_membership_not_count(self):
+        valid_ids = {f"S{n}" for n in range(1, 27)}
+        violations = validate_citation_bound(
+            "a [S2] b [S26] c [S99]", source_count=1, valid_ids=valid_ids
+        )
+        assert [v.cited_id for v in violations] == ["S99"]
+
+    def test_id_gap_in_registry_strips_missing_id(self):
+        # Registry with a gap: S1, S3 present; S2 absent → [S2] is invented even
+        # though 2 ≤ max ordinal 3. Membership catches what a threshold can't.
+        valid_ids = {"S1", "S3"}
+        out, stripped = strip_invented_citations(
+            "x [S1] y [S2] z [S3]", source_count=3, valid_ids=valid_ids
+        )
+        assert "[S1]" in out
+        assert "[S3]" in out
+        assert "[S2]" not in out
+        assert stripped == ["S2"]
+
+    def test_falls_back_to_numeric_bound_when_no_registry(self):
+        # valid_ids=None preserves the legacy numeric behaviour exactly.
+        out, stripped = strip_invented_citations(
+            "a [S1] b [S6]", source_count=5, valid_ids=None
+        )
+        assert "[S6]" not in out
+        assert "[S1]" in out
+        assert stripped == ["S6"]
+
+    def test_run_discipline_checks_threads_valid_ids(self):
+        valid_ids = {"S1", "S2"}
+        report = run_discipline_checks(
+            "ok [S2] bad [S5]", source_count=99, valid_ids=valid_ids
+        )
+        # source_count=99 would PASS [S5] under the numeric bound; membership
+        # correctly flags it because S5 is not in the registry.
+        assert [v.cited_id for v in report.citations] == ["S5"]
+
+
 class TestFlagAnchorViolations:
     def test_noop_when_no_violations(self):
         text = "clean article"

--- a/tests/test_wiki_register_quote_exemption.py
+++ b/tests/test_wiki_register_quote_exemption.py
@@ -33,6 +33,68 @@ def _span_texts(article_text: str) -> list[str]:
     return [span.quote_text for span in find_attributed_verbatim_quote_spans(article_text)]
 
 
+def _sg_response(score: int, verdict: str, notes: str = "") -> str:
+    return json.dumps(
+        {
+            "dimension": "source_grounding",
+            "findings": [],
+            "fixes": [],
+            "score": score,
+            "verdict": verdict,
+            "notes": notes,
+        },
+        ensure_ascii=False,
+    )
+
+
+def test_source_grounding_floor_rejects_uncited_long_article() -> None:
+    """#3083/m20: a substantial article the LLM scored 10/PASS but which carries
+    near-zero inline [S#] must be deterministically REJECTED (fail-closed)."""
+    article = ("Достатньо довга наукова стаття про жанр. " * 200) + " Виноска [S1]."
+    res = _parse_dim_result(
+        dim="source_grounding",
+        agent="claude",
+        model="m",
+        response=_sg_response(10, "PASS"),
+        duration_s=1.0,
+        article_text=article,
+    )
+    assert res.score <= 3
+    assert res.verdict == "REJECT"
+    assert "3083" in res.notes
+
+
+def test_source_grounding_floor_leaves_well_cited_article() -> None:
+    """A genuinely-cited article (many distinct [S#]) is never touched by the
+    floor — teeth without false positives."""
+    cites = " ".join(f"твердження [S{n}]." for n in range(1, 21))  # 20 distinct
+    article = ("Достатньо довга наукова стаття. " * 100) + cites
+    res = _parse_dim_result(
+        dim="source_grounding",
+        agent="claude",
+        model="m",
+        response=_sg_response(9, "PASS"),
+        duration_s=1.0,
+        article_text=article,
+    )
+    assert res.score == 9
+    assert res.verdict == "PASS"
+
+
+def test_source_grounding_floor_skips_short_article() -> None:
+    """Below the body-length gate the floor does not apply (can't judge density)."""
+    res = _parse_dim_result(
+        dim="source_grounding",
+        agent="claude",
+        model="m",
+        response=_sg_response(9, "PASS"),
+        duration_s=1.0,
+        article_text="Короткий текст [S1].",
+    )
+    assert res.score == 9
+    assert res.verdict == "PASS"
+
+
 def test_attributed_guillemet_quote_is_register_exempt() -> None:
     article_text = (
         "Енциклопедія українознавства фіксує старіший правопис: "


### PR DESCRIPTION
Fixes #3083.

## Root cause (architectural, not a typo)
The wiki compile kept **two divergent notions of "the sources"**: `all_chunks` (what dense retrieval returned — `1` for dossier-only wikis) and the `.sources.yaml` **registry** (what the writer cited against and the reader resolves `[S#]` against — `26`, after dossier-seeding #3036). The citation-discipline strip was handed `source_count=len(all_chunks)` and removed every `[SN]` where `N > source_count`, so on a dossier-only compile it stripped **all** valid `[S2]–[S26]` → an uncited article. That gutted article then **false-passed** `source_grounding` (10/PASS, 0 findings — the m20 trap). Confirmed on `kobzarstvo-lirnytstvo` + `holosinnya`.

## Fix — make the registry authoritative + the gate fail-closed
Not "pass the right number to a fragile threshold" — the registry is the single source of truth:

1. **`discipline.py` — strip by registry membership, not a count.** `validate_citation_bound` / `strip_invented_citations` / `run_discipline_checks` take `valid_ids` (the registry id set). A `[SN]` is invented iff `"SN"` ∉ registry. Robust to seeding, id gaps, and retrieval variance. The numeric `source_count` survives only as a no-registry fallback.
2. **`compile.py` — load the registry in the discipline pass** (`load_sources_registry(registry_path_for(article_path))`) and thread `valid_ids` into the strip.
3. **`review.py` — deterministic `source_grounding` fail-closed floor.** A substantial article with near-zero **distinct** inline `[S#]` cannot score PASS, whatever the LLM said. Mirrors the existing deterministic `register` score; only ever **lowers** a score (never rescues a fail) → safe for every track. So a future gutting can never silently ship.

## Tests (`248 insertions`)
- `TestRegistryMembershipCitations`: the exact #3083 regression (registry=`{S1..S26}`, `source_count=1` → `[S2]/[S26]` survive, bogus `[S99]` stripped), id-gap case, numeric fallback, `run_discipline_checks` threading.
- `source_grounding` floor: rejects an uncited long article the LLM scored 10/PASS; leaves a well-cited article untouched; skips short articles.
- **65 targeted + 684 wiki tests pass; ruff clean.** (4 unrelated failures in the sparse worktree are `data/sources.db`-dependent retrieval/MLX tests — they pass on the data-bearing main checkout.)

Unblocks the folk gap-wiki batch (5 wikis) and all seminar dossier-only wiki compiles. Validated end-to-end on the real `kobzarstvo` failing case (see PR comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
