### PR TITLE
feat(wiki): retire gemini-cli routing to agy

### DIFF
--- a/scripts/wiki/compile.py
+++ b/scripts/wiki/compile.py
@@ -319,7 +319,7 @@ def cmd_list(track: str) -> None:
 
 def cmd_compile_one(track: str, slug: str, *, force: bool = False,
                     dry_run: bool = False, review: bool = False,
-                    writer: str = "gemini",
+                    writer: str = "agy",
                     allow_verify_markers: bool = False) -> bool:
     """Compile a single wiki article from a discovery file.
 
@@ -714,7 +714,7 @@ def cmd_review_existing(track: str, *, slug: str | None = None,
 
 def cmd_compile_all(track: str, *, limit: int | None = None,
                     force: bool = False, dry_run: bool = False,
-                    review: bool = False, writer: str = "gemini",
+                    review: bool = False, writer: str = "agy",
                     allow_verify_markers: bool = False) -> None:
     """Compile all articles for a track."""
     slugs = list_discovery_slugs(track)
@@ -979,10 +979,10 @@ def main() -> None:
     parser.add_argument(
         "--writer",
         choices=WRITER_CHOICES,
-        default="gemini",
+        default="agy",
         help=(
-            "Writer agent to use for compilation. Default: gemini (subscription, "
-            "unlimited budget). Use 'claude' for cultural/decolonization-sensitive "
+            "Writer agent to use for compilation. Default: agy (unmetered "
+            "Gemini-family, MCP-enabled). Use 'claude' for cultural/decolonization-sensitive "
             "tracks (literature, figures, periods, historiography, folk). Use "
             "'gpt-5.5' for mechanical/structural content (grammar, academic, "
             "pedagogy)."

--- a/scripts/wiki/compiler.py
+++ b/scripts/wiki/compiler.py
@@ -16,7 +16,14 @@ from pathlib import Path
 
 from ai_llm.claude_call import call_claude_with_fallback
 from ai_llm.codex_call import call_codex_with_fallback
-from ai_llm.fallback import CallResult, call_gemini_with_fallback, visible_sleep
+from ai_llm.fallback import (
+    AGY_GEMINI_MODEL,
+    AttemptRecord,
+    CallResult,
+    _run_agy_via_runtime,
+    call_gemini_with_fallback,
+    visible_sleep,
+)
 from validate.check_wiki_verify_markers import (
     assert_no_verify_markers,
     find_verify_markers_text,
@@ -52,7 +59,7 @@ DOSSIER_CHUNK_ID_RE = re.compile(
 _MCP_WARNING_PREFIX_RE = re.compile(
     r"^MCP issues detected\. Run /mcp list for status\."
 )
-WRITER_CHOICES = ("gemini", "claude", "gpt-5.5")
+WRITER_CHOICES = ("agy", "gemini", "claude", "gpt-5.5")
 
 
 def compile_article(
@@ -64,7 +71,7 @@ def compile_article(
     track: str = "",
     force: bool = False,
     dry_run: bool = False,
-    writer: str = "gemini",
+    writer: str = "agy",
     allow_verify_markers: bool = False,
     dossier_text: str | None = None,
 ) -> Path | None:
@@ -78,7 +85,7 @@ def compile_article(
         track: Track name (e.g., "a1", "folk") — selects the prompt template.
         force: Recompile even if already compiled.
         dry_run: Print prompt but don't call the writer.
-        writer: Writer agent key: "gemini", "claude", or "gpt-5.5".
+        writer: Writer agent key: "agy", "gemini", "claude", or "gpt-5.5".
         dossier_text: Verified research dossier text for authoritative grounding.
 
     Returns:
@@ -1017,6 +1024,46 @@ def _visible_sleep(seconds: int, reason: str) -> None:
 
 def _call_writer(prompt: str, *, writer: str, max_retries: int = 3) -> CallResult:
     """Dispatch wiki-compiler prompt to the chosen writer."""
+    if writer == "agy":
+        outcome = _run_agy_via_runtime(
+            prompt,
+            task_name="wiki compiler",
+            timeout_s=None,
+            cwd=Path(__file__).resolve().parents[2],
+        )
+        record = AttemptRecord(
+            rung_index=1,
+            rung_total=1,
+            model=AGY_GEMINI_MODEL,
+            auth_mode=None,
+            attempt_index=1,
+            max_retries=1,
+            status=outcome.status,
+            elapsed_s=outcome.elapsed_s,
+            returncode=outcome.returncode,
+            stderr_excerpt=outcome.stderr_excerpt,
+            note=outcome.note,
+            response_chars=len(outcome.response_text or ""),
+            cli="agy-cli",
+        )
+        if outcome.status == "success":
+            return CallResult(
+                response_text=outcome.response_text,
+                model_used=AGY_GEMINI_MODEL,
+                auth_mode_used=None,
+                elapsed_s=outcome.elapsed_s,
+                cli_used="agy-cli",
+                attempts=[record],
+            )
+        return CallResult(
+            response_text=None,
+            model_used=None,
+            auth_mode_used=None,
+            elapsed_s=outcome.elapsed_s,
+            cli_used="agy-cli",
+            attempts=[record],
+            error_message=outcome.stderr_excerpt or "agy returned no response",
+        )
     if writer == "gemini":
         return call_gemini_with_fallback(
             prompt,

--- a/scripts/wiki/review.py
+++ b/scripts/wiki/review.py
@@ -92,18 +92,18 @@ DIMS: tuple[str, ...] = (
 #: Default primary agent per dim (§3b). Pending seeded benchmark (§7b).
 DEFAULT_PRIMARY: dict[str, str] = {
     "source_grounding": "codex",
-    "factual_accuracy": "gemini",
+    "factual_accuracy": "agy",
     "ukrainian_perspective": "claude",
-    "register": "gemini",
+    "register": "agy",
 }
 
 #: Fallback chain per dim. On primary failure (RateLimited, Timeout,
 #: invalid JSON), orchestrator tries fallbacks in order. Resilience
 #: requirement per user direction 2026-04-18 (§3b).
 DEFAULT_FALLBACKS: dict[str, tuple[str, ...]] = {
-    "source_grounding": ("claude", "gemini"),
+    "source_grounding": ("claude", "agy"),
     "factual_accuracy": ("claude", "codex"),
-    "ukrainian_perspective": ("gemini",),
+    "ukrainian_perspective": ("agy",),
     "register": ("claude", "codex"),
 }
 

--- a/tests/test_wiki_compiler.py
+++ b/tests/test_wiki_compiler.py
@@ -805,7 +805,7 @@ class TestCompileCommand:
             force=False,
             dry_run=False,
             review=False,
-            writer="gemini",
+            writer="agy",
             allow_verify_markers=False,
         )
 

--- a/tests/test_wiki_compiler_writer_dispatch.py
+++ b/tests/test_wiki_compiler_writer_dispatch.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -29,6 +30,25 @@ def test_call_writer_routes_gemini_to_call_gemini():
         result = _call_writer("prompt", writer="gemini")
 
     assert result.response_text == "ok"
+    call.assert_called_once()
+
+
+def test_call_writer_routes_agy_to_runtime():
+    with patch(
+        "wiki.compiler._run_agy_via_runtime",
+        return_value=SimpleNamespace(
+            status="success",
+            elapsed_s=1.0,
+            response_text="ok",
+            stderr_excerpt=None,
+            returncode=0,
+            note=None,
+        ),
+    ) as call:
+        result = _call_writer("prompt", writer="agy")
+
+    assert result.response_text == "ok"
+    assert result.cli_used == "agy-cli"
     call.assert_called_once()
 
 

--- a/tests/test_wiki_review.py
+++ b/tests/test_wiki_review.py
@@ -92,9 +92,9 @@ def test_seminar_reviewer_overrides_routes_culture_dims_to_claude() -> None:
     """Seminar domains route register+factual+source_grounding to claude;
     core levels untouched."""
     # These are NOT claude by default — the override is what changes them
-    # (register/factual default to gemini, source_grounding to codex).
-    assert DEFAULT_PRIMARY["register"] == "gemini"
-    assert DEFAULT_PRIMARY["factual_accuracy"] == "gemini"
+    # (register/factual default to agy, source_grounding to codex).
+    assert DEFAULT_PRIMARY["register"] == "agy"
+    assert DEFAULT_PRIMARY["factual_accuracy"] == "agy"
     assert DEFAULT_PRIMARY["source_grounding"] == "codex"
     expected = {
         "register": "claude",


### PR DESCRIPTION
## Summary

- Retires wiki review default/fallback routing from `gemini` to `agy` for the like-for-like Gemini-family lane swap requested in #3061.
- Changes wiki compile writer defaults to `agy` and updates `--writer` help text to describe the new unmetered, MCP-enabled default.
- Adds `agy` as a valid wiki compiler writer dispatch path so the new default runs through the existing agent runtime instead of falling through as an unknown writer.

This builds on the verified context from #3060: agy ↔ `sources` MCP works, and agy §7-fabrication was re-verified PASS on 2026-06-13 by grounding factual claims in ЕСУМ/WordNet and abstaining with `NO SOURCE` rather than inventing.

Closes #3061.

## Gemini routes intentionally left

- `scripts/wiki/compiler.py`: explicit `writer="gemini"` support remains as an opt-in legacy writer path, including Gemini session recovery and `GEMINI_CLI`; it is no longer the default wiki lane.
- `scripts/ai_llm/fallback.py` and `scripts/agent_runtime/adapters/gemini.py`: dedicated Gemini CLI fallback/adapter implementation, intentionally gemini-cli-specific runtime infrastructure.
- `scripts/ai_agent_bridge/**` and `scripts/batch_gemini_runner/**`: Gemini bridge/session/runner tooling, intentionally tied to the Gemini agent identity.
- `scripts/audit/review_plan.py`, `scripts/audit/judge_calibration_matrix.py`, `scripts/audit/code_review_benchmark.py`, and related audit calibration files: explicit Gemini judge/benchmark routes, outside the wiki default pipeline swap.
- `scripts/tools/*gemini*`, `scripts/tools/append_summary_section.py`, `scripts/tools/enrich_summary_points.py`, `scripts/tools/analyze_textbook_pages.py`, and `scripts/etymology/bulk_ocr_gemini.py`: direct one-off Gemini CLI utilities/OCR tools, not generic wiki Gemini-family lane routing.
- `scripts/build/v7_build.py`, `scripts/build/v7_review.py`, `scripts/build/dispatch.py`, and related lesson-build routing/session files: legacy lesson build `gemini`/`gemini-tools` labels outside the #3061 wiki pipeline scope.

## Validation

- `.venv/bin/python -m pytest tests/ -q -k "wiki or review or compile or routing"`
- `.venv/bin/ruff check scripts/wiki/review.py scripts/wiki/compile.py`
- `.venv/bin/ruff check scripts/wiki/review.py scripts/wiki/compile.py scripts/wiki/compiler.py tests/test_wiki_review.py tests/test_wiki_compiler.py tests/test_wiki_compiler_writer_dispatch.py`
- pre-commit affected tests: `49 passed in 0.29s`
