### PR TITLE
ci: keep perf smoke outside coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,10 +491,10 @@ jobs:
             tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_by_prefix \
             tests/test_api_helpers.py::TestCacheFunctions::test_cache_invalidate_default_clears_all \
             -v --tb=short --cov=scripts --cov-append --cov-report=
-          # This wall-clock smoke test is intentionally serial: xdist worker
-          # contention turns its endpoint latency budget into a runner-load probe.
+          # This wall-clock smoke test is intentionally outside coverage:
+          # coverage instrumentation skews the endpoint latency budget.
           .venv/bin/python -m pytest "$playground_perf_test" \
-            -v --tb=short --cov=scripts --cov-append --cov-report=
+            -v --tb=short
           .venv/bin/python -m pytest "${common_args[@]}" "${coverage_args[@]}"
 
       - name: Upload coverage


### PR DESCRIPTION
## Summary
- keep the playground wall-clock performance smoke test outside coverage instrumentation on main pushes
- continue deselecting that test from the xdist/coverage suite so it runs exactly once
- leave the full coverage suite and `coverage.xml` generation on the remaining tests unchanged

## Context
#3086 fixed xdist contention and passed PR CI, but the main push coverage path still failed because coverage instrumentation pushed `/api/orient` from 1.498s to 1.507s against the 1.5s wall-clock budget. That test should measure runtime latency, not coverage overhead.

## Validation
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_playground_api_stability.py::test_playground_primary_endpoints_keep_health_fast -q`
- workflow YAML parse with PyYAML
- `git diff --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Gemini workflow diff review completed; apparent double-run/main-gate findings were checked and dismissed because the existing workflow already has `--deselect="$playground_perf_test"` and `github.ref == 'refs/heads/main'` on this step.