### PR TITLE
fix(lexicon): don't permanently cache transient slovnyk.me misses

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -125,6 +125,7 @@ _SLOVNYK_LOOKUP_SLUGS = tuple(_SLOVNYK_DICT_LABELS)
 _SLOVNYK_SYNONYM_SLUGS = ("synonyms", "synonyms_karavansky")
 _SLOVNYK_WARNING_SLUGS = ("davydov", "voloschak", "foreign_shtepa")
 _SLOVNYK_BASE = "https://slovnyk.me"
+_SLOVNYK_CACHE_SCHEMA_VERSION = 2
 _WARNING_CLASSIFICATIONS = {"russianism", "sovietism", "surzhyk"}
 
 _SYNONYM_LABEL_WORDS = {
@@ -731,6 +732,10 @@ def _parse_slovnyk_entry(
     }
 
 
+class _SlovnykTransientError(Exception):
+    """Retryable slovnyk.me lookup failure that must not be cached as a miss."""
+
+
 def _polite_slovnyk_delay() -> None:
     global _last_slovnyk_fetch
     if _last_slovnyk_fetch:
@@ -751,9 +756,12 @@ def _fetch_slovnyk_entry(lemma: str, lookup_word: str, slug: str) -> dict[str, A
         )
         if response.status_code == 404:
             return None
+        if response.status_code >= 500:
+            msg = f"transient slovnyk.me status {response.status_code} for {url}"
+            raise _SlovnykTransientError(msg)
         response.raise_for_status()
-    except requests.RequestException:
-        return None
+    except requests.RequestException as exc:
+        raise _SlovnykTransientError(f"transient slovnyk.me request failure for {url}") from exc
     return _parse_slovnyk_entry(
         response.text,
         lemma=lemma,
@@ -771,31 +779,55 @@ def _load_slovnyk_cache_file(path: Path) -> dict[str, Any] | None:
     return cache if isinstance(cache, dict) else None
 
 
+def _new_slovnyk_cache(lemma: str, lookup_word: str) -> dict[str, Any]:
+    return {
+        "schema_version": _SLOVNYK_CACHE_SCHEMA_VERSION,
+        "lemma": lemma,
+        "lookup_word": lookup_word,
+        "fetched_at": dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat(),
+        "lookups": {},
+    }
+
+
 def _slovnyk_cache(lemma: str) -> dict[str, Any]:
     """Read or populate the one-file-per-lemma slovnyk.me cache."""
     lookup_word = _slovnyk_lookup_word(lemma)
     path = _slovnyk_cache_path(lemma)
     cache = _load_slovnyk_cache_file(path)
-    if cache and cache.get("schema_version") == 1 and cache.get("lookup_word") == lookup_word:
+    changed = False
+    if cache and cache.get("lookup_word") == lookup_word:
+        if cache.get("schema_version") == 1:
+            raw_lookups = cache.get("lookups")
+            if isinstance(raw_lookups, dict):
+                cache["lookups"] = {
+                    slug: row for slug, row in raw_lookups.items() if row is not None
+                }
+            else:
+                cache["lookups"] = {}
+            cache["schema_version"] = _SLOVNYK_CACHE_SCHEMA_VERSION
+            changed = True
+        elif cache.get("schema_version") != _SLOVNYK_CACHE_SCHEMA_VERSION:
+            cache = _new_slovnyk_cache(lemma, lookup_word)
+            changed = True
         lookups = cache.setdefault("lookups", {})
+        if not isinstance(lookups, dict):
+            lookups = {}
+            cache["lookups"] = lookups
+            changed = True
     else:
-        cache = {
-            "schema_version": 1,
-            "lemma": lemma,
-            "lookup_word": lookup_word,
-            "fetched_at": dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat(),
-            "lookups": {},
-        }
+        cache = _new_slovnyk_cache(lemma, lookup_word)
         lookups = cache["lookups"]
 
-    changed = False
     for slug in _SLOVNYK_LOOKUP_SLUGS:
         if slug in lookups:
             continue
-        lookups[slug] = _fetch_slovnyk_entry(lemma, lookup_word, slug) if lookup_word else None
+        try:
+            lookups[slug] = _fetch_slovnyk_entry(lemma, lookup_word, slug) if lookup_word else None
+        except _SlovnykTransientError:
+            continue
         changed = True
 
-    if changed or not path.exists():
+    if changed:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(cache, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     return cache
@@ -1528,8 +1560,13 @@ def _sum20_definition_card(
     lookup_word = _slovnyk_lookup_word(lemma)
     row = _cache_lookup(cache, "newsum") if cache is not None else None
     if not row:
-        row = _fetch_slovnyk_entry(lemma, lookup_word, "newsum")
-        if cache is not None:
+        transient = False
+        try:
+            row = _fetch_slovnyk_entry(lemma, lookup_word, "newsum") if lookup_word else None
+        except _SlovnykTransientError:
+            transient = True
+            row = None
+        if cache is not None and not transient:
             _cache_store_lookup(lemma, cache, "newsum", row)
     if not row:
         return None

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -1,6 +1,8 @@
 import json
 import sqlite3
 
+import pytest
+
 from scripts.lexicon import enrich_manifest as enrich_manifest_module
 from scripts.lexicon.enrich_manifest import (
     KAIKKI_SOURCE,
@@ -16,6 +18,8 @@ from scripts.lexicon.enrich_manifest import (
     _meaning,
     _merge_slovnyk_warning,
     _sense_correct_synonyms,
+    _slovnyk_cache,
+    _SlovnykTransientError,
     _synonyms_slovnyk,
     _translation,
     _warning_slovnyk,
@@ -417,6 +421,126 @@ def test_slovnyk_warning_merges_known_russianism_alternative() -> None:
         attestation["source"] == "standard_alternative" and attestation["ref"] == "захід"
         for attestation in status["attestations"]
     )
+
+
+def test_fetch_slovnyk_entry_raises_transient_for_5xx(monkeypatch) -> None:
+    class FakeResponse:
+        status_code = 503
+        text = ""
+
+        def raise_for_status(self) -> None:
+            raise AssertionError("5xx should be classified before raise_for_status")
+
+    monkeypatch.setattr(enrich_manifest_module, "_polite_slovnyk_delay", lambda: None)
+    monkeypatch.setattr(enrich_manifest_module.requests, "get", lambda *args, **kwargs: FakeResponse())
+
+    with pytest.raises(_SlovnykTransientError):
+        enrich_manifest_module._fetch_slovnyk_entry("тест", "тест", "newsum")
+
+
+def test_fetch_slovnyk_entry_raises_transient_for_connection_error(monkeypatch) -> None:
+    def fake_get(*args, **kwargs):
+        raise enrich_manifest_module.requests.ConnectionError("connection timed out")
+
+    monkeypatch.setattr(enrich_manifest_module, "_polite_slovnyk_delay", lambda: None)
+    monkeypatch.setattr(enrich_manifest_module.requests, "get", fake_get)
+
+    with pytest.raises(_SlovnykTransientError):
+        enrich_manifest_module._fetch_slovnyk_entry("тест", "тест", "newsum")
+
+
+def test_slovnyk_cache_keeps_transient_slug_absent_and_refetches(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(enrich_manifest_module, "SLOVNYK_CACHE", tmp_path)
+    monkeypatch.setattr(enrich_manifest_module, "_SLOVNYK_LOOKUP_SLUGS", ("newsum", "synonyms"))
+
+    calls: list[str] = []
+
+    def fake_fetch(lemma: str, lookup_word: str, slug: str) -> dict[str, str]:
+        calls.append(slug)
+        if slug == "synonyms" and calls.count("synonyms") == 1:
+            raise _SlovnykTransientError("timeout")
+        return {"dictionary_slug": slug, "text": f"{lookup_word}:{slug}"}
+
+    monkeypatch.setattr(enrich_manifest_module, "_fetch_slovnyk_entry", fake_fetch)
+
+    first = _slovnyk_cache("тест")
+    cache_path = enrich_manifest_module._slovnyk_cache_path("тест")
+    persisted = json.loads(cache_path.read_text(encoding="utf-8"))
+
+    assert first["lookups"]["newsum"]["text"] == "тест:newsum"
+    assert "synonyms" not in first["lookups"]
+    assert "synonyms" not in persisted["lookups"]
+
+    second = _slovnyk_cache("тест")
+
+    assert calls == ["newsum", "synonyms", "synonyms"]
+    assert second["lookups"]["synonyms"]["text"] == "тест:synonyms"
+
+
+def test_slovnyk_cache_persists_genuine_none_miss_without_refetch(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(enrich_manifest_module, "SLOVNYK_CACHE", tmp_path)
+    monkeypatch.setattr(enrich_manifest_module, "_SLOVNYK_LOOKUP_SLUGS", ("newsum",))
+
+    calls: list[str] = []
+
+    def fake_fetch(lemma: str, lookup_word: str, slug: str) -> None:
+        calls.append(slug)
+        return None
+
+    monkeypatch.setattr(enrich_manifest_module, "_fetch_slovnyk_entry", fake_fetch)
+
+    first = _slovnyk_cache("немає")
+    persisted = json.loads(enrich_manifest_module._slovnyk_cache_path("немає").read_text(encoding="utf-8"))
+
+    assert first["lookups"]["newsum"] is None
+    assert persisted["lookups"]["newsum"] is None
+
+    _slovnyk_cache("немає")
+
+    assert calls == ["newsum"]
+
+
+def test_slovnyk_cache_migrates_v1_none_misses_to_retryable_absences(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(enrich_manifest_module, "SLOVNYK_CACHE", tmp_path)
+    monkeypatch.setattr(enrich_manifest_module, "_SLOVNYK_LOOKUP_SLUGS", ("newsum", "synonyms", "phraseology"))
+
+    cache_path = enrich_manifest_module._slovnyk_cache_path("слово")
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "lemma": "слово",
+                "lookup_word": "слово",
+                "fetched_at": "2026-01-01T00:00:00+00:00",
+                "lookups": {
+                    "newsum": {"dictionary_slug": "newsum", "text": "kept hit"},
+                    "synonyms": None,
+                    "phraseology": None,
+                },
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    calls: list[str] = []
+
+    def fake_fetch(lemma: str, lookup_word: str, slug: str) -> dict[str, str]:
+        calls.append(slug)
+        return {"dictionary_slug": slug, "text": f"refetched {slug}"}
+
+    monkeypatch.setattr(enrich_manifest_module, "_fetch_slovnyk_entry", fake_fetch)
+
+    cache = _slovnyk_cache("слово")
+    persisted = json.loads(cache_path.read_text(encoding="utf-8"))
+
+    assert calls == ["synonyms", "phraseology"]
+    assert cache["schema_version"] == 2
+    assert cache["lookups"]["newsum"]["text"] == "kept hit"
+    assert cache["lookups"]["synonyms"]["text"] == "refetched synonyms"
+    assert persisted["schema_version"] == 2
+    assert persisted["lookups"]["phraseology"]["text"] == "refetched phraseology"
 
 
 def test_sum11_meaning_carries_source_sovietization_risk() -> None:


### PR DESCRIPTION
Fixes #2985.

## Summary
- split slovnyk.me lookup failures into genuine cacheable misses and retryable transient failures
- keep 404 and parse-empty responses cached as `None`, but leave transient request failures and 5xx responses absent from `lookups` so the next run retries them
- bump the per-lemma slovnyk cache schema to v2 and migrate v1 caches by preserving non-`None` hits while dropping old `None` misses for one-time healing
- keep the existing polite slovnyk.me rate limiting behavior intact

## Root Cause
`_fetch_slovnyk_entry()` previously returned `None` for HTTP 404, transient network/5xx failures, and parse-empty pages. `_slovnyk_cache()` then persisted that indistinguishable `None`, and future runs skipped the slug forever because the slug key existed in `lookups`.

## Validation
- `.venv/bin/python -m pytest tests/test_lexicon_enrich_manifest.py -q`
- `.venv/bin/python -m pytest tests/ -q -k "slovnyk or enrich or lexicon or cache"`
- `.venv/bin/ruff check scripts/lexicon/enrich_manifest.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

No auto-merge requested or enabled.