### PR TITLE
fix(sources): ЕСУМ description reflects all 6 volumes, not 'vol 1 only' [#3085]

### DIFF
--- a/.mcp/servers/sources/server.py
+++ b/.mcp/servers/sources/server.py
@@ -693,8 +693,8 @@ async def list_tools() -> list[Tool]:
                 "~67K entries (~100% indexed). **NOT etymology** — this is "
                 "lexicographic (definitions + usage citations), not diachronic "
                 "word-origin analysis. True "
-                "etymology lives in `search_esum` (ЕСУМ, vol 1 А–Г live; vols 2-6 "
-                "pending #1662). **Systematic exclusion: proper nouns** — toponyms "
+                "etymology lives in `search_esum` (ЕСУМ, all 6 volumes А–Я live, "
+                "~36K entries). **Systematic exclusion: proper nouns** — toponyms "
                 "(Київ, Львів, Дніпро, Сибір) and personal names (Шевченко) are NOT "
                 "covered. Use for pre-Soviet Ukrainian usage attestation: helps "
                 "verify a word is genuinely Ukrainian, not a Soviet-era import."
@@ -712,7 +712,7 @@ async def list_tools() -> list[Tool]:
             name="search_esum",
             description=(
                 "Search ЕСУМ (Етимологічний словник української мови) etymology entries. "
-                "PoC scope: volume 1 only (А–Г); volumes 2–6 are follow-up work. "
+                "Coverage: all 6 volumes (А–Я), ~36K entries (vols 1–6 fully ingested). "
                 "Use for Ukrainian word-origin checks and cognate evidence."
             ),
             inputSchema={
@@ -721,7 +721,7 @@ async def list_tools() -> list[Tool]:
                     "query": {"type": "string", "description": "Ukrainian word or etymology term to search"},
                     "volume": {
                         "type": "integer",
-                        "description": "Optional ЕСУМ volume filter. This PoC currently supports volume 1.",
+                        "description": "Optional ЕСУМ volume filter (1–6). Omit to search all volumes.",
                     },
                     "limit": {"type": "integer", "description": "Max results (default 5)", "default": 5},
                 },

--- a/agents_extensions/shared/rules/mcp-sources-and-dictionaries.md
+++ b/agents_extensions/shared/rules/mcp-sources-and-dictionaries.md
@@ -35,7 +35,7 @@ paths:
 - `mcp__sources__query_cefr_level` — PULS CEFR vocabulary (5.9K words, A1-C1) — check level-appropriateness
 - `mcp__sources__search_definitions` — СУМ-11 (127K entries) — Ukrainian explanatory dictionary. **⚠️ Partially Sovietized for ideological terms** — see "Sovietization caveat" below. Each result row carries `sovietization_risk` (0/1/2) and `sovietization_keywords`.
 - `mcp__sources__search_grinchenko_1907` — Грінченко (67K entries) — historical Ukrainian dictionary from 1907. Use for pre-Soviet usage attestation; **NOT for word origins/etymology** — that's a separate concern handled by `search_esum` below.
-- `mcp__sources__search_esum` — ЕСУМ etymological dictionary — canonical name for ЕСУМ. PoC scope: vol. 1 (А–Г) only; vols. 2–6 are follow-up (#1662). Falls back to a goroh.pp.ua hint if word not found.
+- `mcp__sources__search_esum` — ЕСУМ etymological dictionary — canonical name for ЕСУМ. Coverage: all 6 volumes (А–Я), ~36K entries (vols 1–6 fully ingested). Optional `volume` filter (1–6); omit to search all. Falls back to a goroh.pp.ua hint if word not found.
 - `mcp__sources__search_slovnyk_me` — slovnyk.me single-source aggregator. Uses curated `sources.db` rows when present and optional live direct-entry `/dict/{slug}/{word}` fallback. Returns URL, dictionary slug, bounded snippet, `is_modern`, `is_dialect`, `is_russianism`, and `sovietization_risk`. Use when slovnyk.me specifically is required; prefer `search_heritage` for archaism-vs-Russianism decisions.
 - `mcp__sources__search_idioms` — Фразеологічний (25K entries) — Ukrainian idioms and expressions
 - `mcp__sources__search_synonyms` — Ukrajinet WordNet (122K synsets) — synonyms, antonyms. **⚠️ Synsets are largely auto-translated from Open English WordNet** per upstream README — quality audit pending (#1657 Tier 3).
@@ -108,7 +108,7 @@ Audit report at `audit/sum11_sovietization_scan_<DATE>.md`.
 | **UA-GEC** | 8.9K high-signal pairs | Human-annotated errors (calques, cases, etc.) | `data/sources.db` FTS5 |
 | **СУМ-11** | 127K (7,152 flagged Sovietized — #1659) | Ukrainian explanatory (definitions, citations) | `data/sources.db` FTS5 |
 | **Грінченко** | 67K | Historical Ukrainian (1907, lexicographic) | `data/sources.db` FTS5 |
-| **ЕСУМ** | vol. 1 (А–Г) PoC | Etymological dictionary | `data/sources.db` FTS5 via `search_esum` |
+| **ЕСУМ** | 36K entries, vols 1–6 (А–Я) | Etymological dictionary | `data/sources.db` FTS5 via `search_esum` |
 | **slovnyk.me** | bounded per-word rows + live direct lookup | Modern/regional dictionary aggregator; no bulk mirror | `data/sources.db` `slovnyk_me_entries` + live `/dict/{slug}/{word}` |
 | **Балла EN→UK** | 79K | English→Ukrainian translations | `data/sources.db` FTS5 |
 | **Антоненко-Давидович** | 342 structured + 169 prose chunks | Style guide (calques, Russianisms) — `style_guide` table (keyed entries) + `textbooks` table (source_file=`antonenko-davydovych-yak-my-hovorymo`, full-book prose) | `data/sources.db` FTS5 |

--- a/tests/test_esum_search.py
+++ b/tests/test_esum_search.py
@@ -88,12 +88,20 @@ def test_search_esum_nonexistent_word_returns_empty_list() -> None:
 
 
 def test_search_esum_sibir_is_outside_volume_one_scope() -> None:
-    """ЕСУМ vol. 1 covers А-Г only; ``сибір`` (vol. 5) must not match."""
+    """The volume=1 filter excludes ``сибір`` (a vol. 5 entry).
+
+    The DB holds all 6 volumes (А–Я); this asserts the volume filter works, not
+    that vols 2–6 are absent.
+    """
     assert search_esum("сибір", volume=1, limit=3) == []
 
 
 def test_search_esum_maty_is_outside_volume_one_scope() -> None:
-    """ЕСУМ vol. 1 covers А-Г only; ``мати`` (vol. 3) must not match."""
+    """The volume=1 filter excludes ``мати`` (a vol. 3 entry).
+
+    The DB holds all 6 volumes (А–Я); this asserts the volume filter works, not
+    that vols 2–6 are absent.
+    """
     assert search_esum("мати", volume=1, limit=3) == []
 
 


### PR DESCRIPTION
## What
The `search_esum` MCP tool description, its DB-layer docstring, and the `mcp-sources-and-dictionaries` rule all claimed **"PoC scope: volume 1 only (А–Г); volumes 2–6 are follow-up."** The DB actually serves **all 6 volumes**.

## Evidence (deterministic)
`esum_etymology_meta` volume distribution: vol1=6016, vol2=5855, vol3=5090, vol4=6607, vol5=6996, vol6=5613 — **36,177 entries total**. Confirmed `шлях`→vol6, `мрія`→vol3, `хата`→vol6, `дзвін`→vol2 resolve.

## Why it matters
An agent trusting the stale text would wrongly flag any non-А–Г etymology result as fabricated — this **nearly produced a false fabrication verdict during the #3061 agy §7 re-verify**. The rule file loads into every agent's system prompt, so this is the highest-leverage instance.

## Changes
- `.mcp/servers/sources/server.py` — `search_esum` + `search_grinchenko_1907` cross-ref + the `volume` filter param descriptions → all 6 vols (А–Я).
- `agents_extensions/shared/rules/mcp-sources-and-dictionaries.md` (**source**; deployed to `.claude/.codex/.agent`) — tool line + dictionaries table.
- `tests/test_esum_search.py` — clarified two volume-filter test docstrings (they assert the `volume=1` **filter** excludes vol-5/vol-3 words, not that the DB lacks vols 2–6). Tests were already green; docstrings were misleading.

## Tests
`tests/test_deploy_script_idempotency.py` + `tests/test_esum_search.py` → **12 passed**. Ruff clean.

Closes #3085

🤖 Generated with [Claude Code](https://claude.com/claude-code)