### PR TITLE
fix(sources): qualify ua_gec tag_filter column (ambiguous error_type)

### DIFF
--- a/scripts/wiki/sources_db.py
+++ b/scripts/wiki/sources_db.py
@@ -1510,28 +1510,29 @@ def search_ua_gec_errors(
     except FileNotFoundError:
         return []
 
-    where_clauses = ["ua_gec_errors_fts MATCH ?"]
+    # error_type exists in BOTH the FTS table (f) and the data table (m), so
+    # every non-FTS predicate must carry its table alias — an unqualified
+    # `error_type IN (...)` raises "ambiguous column name". Build each clause
+    # already-qualified instead of prefixing the whole WHERE with `f.` (which
+    # only attached to the first clause and left the rest ambiguous).
+    where_clauses = ["f.ua_gec_errors_fts MATCH ?"]
     params = [query]
 
     if tag_filter:
         placeholders = ",".join("?" for _ in tag_filter)
-        where_clauses.append(f"error_type IN ({placeholders})")
+        where_clauses.append(f"m.error_type IN ({placeholders})")
         params.extend(tag_filter)
 
     if require_native_author:
-        where_clauses.append("is_native = 1")
+        where_clauses.append("m.is_native = 1")
 
     where_stmt = " AND ".join(where_clauses)
-
-    # We join with main table using rowid if needed, but FTS5 content table
-    # queries can be done directly on the FTS table if it has all columns?
-    # Wait, fts table only has error, correct, error_type. We should join with ua_gec_errors.
 
     sql = f"""
         SELECT m.error, m.correct, m.error_type, m.doc_id, m.is_native, m.source_lang
         FROM ua_gec_errors_fts f
         JOIN ua_gec_errors m ON f.rowid = m.id
-        WHERE f.{where_stmt}
+        WHERE {where_stmt}
         ORDER BY f.rank
         LIMIT ?
     """

--- a/tests/mcp/test_ua_gec_search.py
+++ b/tests/mcp/test_ua_gec_search.py
@@ -77,3 +77,19 @@ def test_search_ua_gec_errors_execution(server_module):
     assert "коментарій" in result[0].text
     assert "### Result 1" in result[0].text
     assert "Correction" in result[0].text
+
+
+@requires_ua_gec_data
+def test_search_ua_gec_errors_tag_filter_does_not_raise(server_module):
+    # Regression: tag_filter previously raised "ambiguous column name:
+    # error_type" because the column exists in both the FTS table (f) and the
+    # data table (m) and the predicate was unqualified. The tag_filter path
+    # had NO test, so the bug shipped. This asserts the filtered query
+    # executes and returns a well-formed payload (zero matches is acceptable).
+    arguments = {"query": "участь", "tag_filter": ["F/Calque", "F/Collocation"], "limit": 5}
+    result = _run(server_module.call_tool("search_ua_gec_errors", arguments))
+
+    assert len(result) == 1
+    assert result[0].type == "text"
+    # No OperationalError surfaced: either a Found-block or a graceful no-results line.
+    assert ("Found" in result[0].text) or ("No UA-GEC results" in result[0].text)


### PR DESCRIPTION
## Bug
`mcp__sources__search_ua_gec_errors(..., tag_filter=[...])` raised:
```
OperationalError: ambiguous column name: error_type
```
Hit live while curating the §6 decolonization calque layer (#3098), which the issue explicitly routes through UA-GEC `F/Calque` / `F/Collocation`.

## Root cause
`error_type` exists in **both** the FTS table (`f`) and the data table (`m`). The predicate was unqualified. The WHERE was also assembled as `WHERE f.{where_stmt}` — the `f.` only bound to the *first* clause, leaving the appended `error_type IN (...)` / `is_native = 1` predicates unqualified. A leftover dev comment (`# Wait, fts table only has ... error_type`) already flagged the hazard.

## Fix
Build each clause already-qualified — `f.ua_gec_errors_fts MATCH ?`, `m.error_type IN (...)`, `m.is_native = 1` — and drop the blanket `f.` prefix.

## Verification (against real sources.db)
- `tag_filter=['F/Calque']` now executes with **no error**.
- Selectivity holds: `'час'` → **19 unfiltered → 11 F/Calque**, every returned row typed `F/Calque` (e.g. `коментарій→коментар`, `написання постів→писати дописи`).
- Tag inventory confirmed: `F/Calque` 2397, `F/Collocation` 459, `G/Case` 5024, `G/Gender` 1057.

## Test
Added `test_search_ua_gec_errors_tag_filter_does_not_raise` — the tag_filter path had **zero coverage**, which is exactly why the bug shipped. `test_sources_db.py` + `test_ua_gec_search.py`: 18 passed, 2 skipped (data-gated, skip without the local DB — same pattern as the existing execution test). Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)