### PR TITLE
feat(lexicon): atlas etymology + §7 synonym enrichment (#2971, #3092)

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -276,6 +276,67 @@ _BLOCKED_SYNONYMS = {
     "флористська хризантема",
 }
 
+_COMPOSITIONAL_ETYMOLOGY_EXCLUSIONS = {
+    "а тебе?",
+    "а у тебе?",
+    "до побачення!",
+    "добрий вечір",
+    "доброго ранку",
+    "добрий день",
+    "дуже приємно",
+    "на все добре",
+    "як справи?",
+}
+
+_DERIVATIONAL_ETYMLOGY_BASES: dict[str, tuple[str, ...]] = {
+    "добре": ("добрий", "добро"),
+    "чудово": ("чудо", "чудовий"),
+    "пізно": ("пізній",),
+    "нормально": ("нормальний", "норма"),
+    "сьома": ("сьомий", "сім"),
+    "сьомий": ("сім",),
+    "навчатися": ("навчати", "вчити", "учити"),
+    "навчати": ("вчити", "учити"),
+    "вмиватися": ("вмивати", "мити"),
+    "вмивати": ("мити",),
+    "збиратися": ("збирати", "брати"),
+    "збирати": ("брати",),
+    "одягатися": ("одягати", "одяг"),
+    "одягати": ("одяг",),
+    "повертатися": ("повертати", "вертати"),
+    "повертати": ("вертати",),
+}
+
+_ORDINAL_ETYMLOGY_BASES: dict[str, tuple[str, ...]] = {
+    "перша": ("перший", "один"),
+    "перше": ("перший", "один"),
+    "перший": ("один",),
+    "друга": ("другий", "два"),
+    "друге": ("другий", "два"),
+    "другий": ("два",),
+    "третя": ("третій", "три"),
+    "третє": ("третій", "три"),
+    "третій": ("три",),
+    "четверта": ("четвертий", "чотири"),
+    "четверте": ("четвертий", "чотири"),
+    "четвертий": ("чотири",),
+    "п'ята": ("п'ятий", "п'ять"),
+    "п'яте": ("п'ятий", "п'ять"),
+    "п'ятий": ("п'ять",),
+    "шоста": ("шостий", "шість"),
+    "шосте": ("шостий", "шість"),
+    "шостий": ("шість",),
+    "сьома": ("сьомий", "сім"),
+    "сьоме": ("сьомий", "сім"),
+    "сьомий": ("сім",),
+    "восьма": ("восьмий", "вісім"),
+    "восьме": ("восьмий", "вісім"),
+    "восьмий": ("вісім",),
+    "дев'ята": ("дев'ятий", "дев'ять"),
+    "дев'яте": ("дев'ятий", "дев'ять"),
+    "дев'ятий": ("дев'ять",),
+}
+
 # VESUM tag token → human-readable Ukrainian grammatical label.
 _TAG_LABELS: dict[str, str] = {
     "v_naz": "називний",
@@ -1663,6 +1724,61 @@ def _etymology_lookup_variants(lemma: str) -> list[str]:
     return [v for v in variants if v and not (v.casefold() in seen or seen.add(v.casefold()))]
 
 
+def _append_unique_candidate(out: list[str], seen: set[str], candidate: str, original: str) -> None:
+    key = _lookup_key(candidate)
+    if not key or key == original or key in seen or _has_whitespace(key):
+        return
+    seen.add(key)
+    out.append(key)
+
+
+def _direct_etymology_base_candidates(word: str) -> list[str]:
+    candidates: list[str] = []
+    key = _lookup_key(word)
+    if not key:
+        return candidates
+    candidates.extend(_DERIVATIONAL_ETYMLOGY_BASES.get(key, ()))
+    candidates.extend(_ORDINAL_ETYMLOGY_BASES.get(key, ()))
+
+    if key.endswith(("ся", "сь")) and len(key) > 4:
+        candidates.append(key[:-2])
+    if key.endswith("е") and len(key) > 3:
+        candidates.append(f"{key[:-1]}ий")
+    if key.endswith("о") and len(key) > 3:
+        stem = key[:-1]
+        candidates.append(f"{stem}ий")
+        if stem.endswith("н"):
+            candidates.append(f"{stem}ій")
+    for prefix in ("пере", "від", "над", "під", "при", "роз", "без", "по", "за", "до", "ви", "з", "в", "у"):
+        if key.startswith(prefix) and len(key) > len(prefix) + 3:
+            candidates.append(key[len(prefix) :])
+            break
+    if key.endswith("ати") and len(key) > 5:
+        candidates.append(key[:-3])
+    if key.endswith("ити") and len(key) > 5:
+        candidates.append(key[:-3])
+    return candidates
+
+
+def _derivational_etymology_candidates(lemma: str) -> list[str]:
+    word = _lookup_key(_base_lemma(lemma))
+    if not word or _has_whitespace(word) or word in _COMPOSITIONAL_ETYMOLOGY_EXCLUSIONS:
+        return []
+    out: list[str] = []
+    seen: set[str] = {word}
+    queue: list[tuple[str, int]] = [(word, 0)]
+    while queue:
+        current, depth = queue.pop(0)
+        if depth >= 2:
+            continue
+        for candidate in _direct_etymology_base_candidates(current):
+            before = len(out)
+            _append_unique_candidate(out, seen, candidate, word)
+            if len(out) > before:
+                queue.append((_lookup_key(candidate), depth + 1))
+    return out
+
+
 def _has_whitespace(value: str) -> bool:
     return bool(re.search(r"\s", str(value or "").strip()))
 
@@ -1818,14 +1934,40 @@ def _kaikki_etymology(lookup: dict[str, dict[str, Any]], lemma: str) -> dict | N
     return {"text": text, "source": KAIKKI_SOURCE}
 
 
-def _etymology(conn: sqlite3.Connection, lemma: str, kaikki_lookup: dict[str, dict[str, Any]] | None = None) -> dict | None:
-    """Cached etymology by authority order: Goroh → ЕСУМ → uk.wiktionary → Kaikki."""
+def _source_etymology(
+    conn: sqlite3.Connection,
+    lemma: str,
+    kaikki_lookup: dict[str, dict[str, Any]] | None = None,
+) -> dict | None:
     return (
         _goroh_etymology(conn, lemma)
         or _esum_etymology(conn, lemma)
         or _wiktionary_etymology(conn, lemma)
         or _kaikki_etymology(kaikki_lookup or {}, lemma)
     )
+
+
+def _with_base_etymology_label(etymology: dict, base_form: str) -> dict:
+    labeled = dict(etymology)
+    source = str(labeled.get("source") or "").strip()
+    label = f"etymology of base form {base_form}"
+    labeled["source"] = f"{source} ({label})" if source else label
+    return labeled
+
+
+def _etymology(conn: sqlite3.Connection, lemma: str, kaikki_lookup: dict[str, dict[str, Any]] | None = None) -> dict | None:
+    """Cached etymology by authority order, with derived-lemma base fallback."""
+    lookup_word = _lookup_key(_base_lemma(lemma))
+    if lookup_word in _COMPOSITIONAL_ETYMOLOGY_EXCLUSIONS:
+        return None
+    exact = _source_etymology(conn, lemma, kaikki_lookup)
+    if exact:
+        return exact
+    for base_form in _derivational_etymology_candidates(lemma):
+        etymology = _source_etymology(conn, base_form, kaikki_lookup)
+        if etymology:
+            return _with_base_etymology_label(etymology, base_form)
+    return None
 
 
 def _cefr(conn: sqlite3.Connection, lemma: str) -> dict[str, str] | None:

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -13,7 +13,8 @@ no fabrication):
   source caveats.
 - **cefr** — PULS CEFR lookup when available.
 - **literary_attestation** — exact-form literary corpus hit when available.
-- **synonyms** — source-attested, A1-sense allowlisted Ukrainian candidates only.
+- **synonyms** — source-attested Ukrainian candidates from clean slovnyk.me
+  synonym dictionaries, with noisy legacy sources kept A1-sense allowlisted.
 - **sections.synonyms / sections.idioms** — slovnyk.me per-lemma lookup cache
   (Караванський + Словник синонімів; Фразеологічний).
 - **heritage warning alternatives** — slovnyk.me correction dictionaries
@@ -122,7 +123,7 @@ _SLOVNYK_DICT_LABELS: dict[str, str] = {
     "foreign_shtepa": "Словник чужослів Павла Штепи",
 }
 _SLOVNYK_LOOKUP_SLUGS = tuple(_SLOVNYK_DICT_LABELS)
-_SLOVNYK_SYNONYM_SLUGS = ("synonyms", "synonyms_karavansky")
+_SLOVNYK_SYNONYM_SLUGS = ("synonyms_karavansky", "synonyms")
 _SLOVNYK_WARNING_SLUGS = ("davydov", "voloschak", "foreign_shtepa")
 _SLOVNYK_BASE = "https://slovnyk.me"
 _SLOVNYK_CACHE_SCHEMA_VERSION = 2
@@ -1023,15 +1024,40 @@ def _clean_synonym_candidate(candidate: str, lemma: str) -> str | None:
     return term
 
 
-def _is_safe_slovnyk_synonym(lemma: str, candidate: str, headword_pos: str) -> bool:
-    if candidate not in _safe_synonym_set(lemma):
+def _slovnyk_synonym_group_head(row: dict[str, Any], lemma: str) -> str:
+    body = _synonym_body(
+        str(row.get("text") or ""),
+        lemma,
+        str(row.get("word") or ""),
+        str(row.get("dictionary_slug") or ""),
+    )
+    first = re.split(r"[,;(]", body, maxsplit=1)[0]
+    first = _SYNONYM_LABEL_RE.sub(" ", _strip_stress(first))
+    first = re.sub(r"\s+", " ", first).strip(' \t\r\n.,;:!?/\\[]{}«»"“”<>').casefold()
+    return first
+
+
+def _is_safe_slovnyk_synonym(
+    lemma: str,
+    candidate: str,
+    headword_pos: str,
+    *,
+    require_allowlist: bool = False,
+) -> bool:
+    if require_allowlist and candidate not in _safe_synonym_set(lemma):
         return False
     if not _candidate_matches_headword_pos(candidate, headword_pos):
         return False
     return not _candidate_is_headword_variant(lemma, candidate, headword_pos)
 
 
-def _synonyms_from_slovnyk_row(row: dict[str, Any], lemma: str, headword_pos: str) -> list[str]:
+def _synonyms_from_slovnyk_row(
+    row: dict[str, Any],
+    lemma: str,
+    headword_pos: str,
+    *,
+    require_allowlist: bool = False,
+) -> list[str]:
     body = _synonym_body(
         str(row.get("text") or ""),
         lemma,
@@ -1044,7 +1070,16 @@ def _synonyms_from_slovnyk_row(row: dict[str, Any], lemma: str, headword_pos: st
     for chunk in chunks:
         for part in re.split(r"[()]", chunk):
             term = _clean_synonym_candidate(part, lemma)
-            if term and term not in seen and _is_safe_slovnyk_synonym(lemma, term, headword_pos):
+            if (
+                term
+                and term not in seen
+                and _is_safe_slovnyk_synonym(
+                    lemma,
+                    term,
+                    headword_pos,
+                    require_allowlist=require_allowlist,
+                )
+            ):
                 seen.add(term)
                 out.append(term)
     return out
@@ -1057,10 +1092,13 @@ def _synonyms_slovnyk(
     entry_pos: str | None = None,
 ) -> dict[str, Any] | None:
     """Synonym chips from slovnyk.me synonyms dictionaries, omitted when empty."""
-    headword_pos = _headword_pos_for_synonyms(lemma, entry_pos)
-    if not headword_pos or not _safe_synonym_set(lemma):
+    lookup_lemma = _slovnyk_lookup_word(_base_lemma(lemma))
+    if not lookup_lemma or _has_whitespace(lookup_lemma):
         return None
-    cache = cache if cache is not None else _slovnyk_cache(lemma)
+    headword_pos = _headword_pos_for_synonyms(lookup_lemma, entry_pos)
+    if not headword_pos:
+        return None
+    cache = cache if cache is not None else _slovnyk_cache(lookup_lemma)
     items: list[str] = []
     seen: set[str] = set()
     sources: list[str] = []
@@ -1069,7 +1107,16 @@ def _synonyms_slovnyk(
         row = _cache_lookup(cache, slug)
         if not row:
             continue
-        row_items = _synonyms_from_slovnyk_row(row, lemma, headword_pos)
+        row_items = _synonyms_from_slovnyk_row(row, lookup_lemma, headword_pos)
+        if slug == "synonyms" and row_items:
+            group_head = _slovnyk_synonym_group_head(row, lookup_lemma)
+            allowlisted = _safe_synonym_set(lookup_lemma)
+            if (
+                group_head != lookup_lemma.casefold()
+                and not seen.intersection(row_items)
+                and not allowlisted.intersection(row_items)
+            ):
+                continue
         if not row_items:
             continue
         for synonym in row_items:
@@ -1514,10 +1561,8 @@ def _sense_correct_synonyms(conn: sqlite3.Connection, lemma: str) -> list[str]:
     """Return source-attested synonyms for the lemma's A1 sense, capped at six."""
     out: list[str] = []
     seen: set[str] = set()
-    _synonyms_from_wiktionary(conn, lemma, out, seen)
     _synonyms_from_balla(conn, lemma, out, seen)
     _synonyms_from_sum11(conn, lemma, out, seen)
-    _synonyms_from_ukrajinet(conn, lemma, out, seen)
     return out[:6]
 
 

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -719,6 +719,67 @@ def test_kaikki_etymology_is_final_fallback() -> None:
     assert etymology == {"text": "From Old East Slavic мѣсто.", "source": KAIKKI_SOURCE}
 
 
+@pytest.mark.parametrize(
+    ("derived", "base"),
+    [
+        ("добре", "добрий"),
+        ("чудово", "чудо"),
+        ("пізно", "пізній"),
+        ("нормально", "нормальний"),
+        ("сьома", "сім"),
+        ("навчатися", "вчити"),
+        ("вмиватися", "мити"),
+        ("збиратися", "брати"),
+        ("одягатися", "одяг"),
+        ("повертатися", "вертати"),
+    ],
+)
+def test_derivational_etymology_falls_back_to_base_forms(derived: str, base: str) -> None:
+    conn = _conn()
+    conn.execute(
+        """
+        CREATE TABLE goroh_etymology (
+            requested_lemma TEXT NOT NULL,
+            headword TEXT NOT NULL,
+            etymology_text TEXT NOT NULL,
+            source_url TEXT
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO goroh_etymology VALUES (?, ?, ?, ?)",
+        (base, base, f"Fixture etymology for {base}.", f"https://goroh.example/{base}"),
+    )
+
+    etymology = _etymology(conn, derived, {})
+
+    assert etymology == {
+        "text": f"Fixture etymology for {base}.",
+        "source": f"Горох (за ЕСУМ) (etymology of base form {base})",
+        "source_url": f"https://goroh.example/{base}",
+    }
+
+
+def test_compositional_greeting_phrases_have_no_etymology_fallback() -> None:
+    conn = _conn()
+    conn.execute(
+        """
+        CREATE TABLE goroh_etymology (
+            requested_lemma TEXT NOT NULL,
+            headword TEXT NOT NULL,
+            etymology_text TEXT NOT NULL,
+            source_url TEXT
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO goroh_etymology VALUES (?, ?, ?, ?)",
+        ("До побачення!", "до побачення", "Fixture phrase etymology.", "https://goroh.example/phrase"),
+    )
+
+    assert _etymology(conn, "До побачення!", {}) is None
+
+
 def test_kaikki_etymology_skips_russian_labeled_cyrillic() -> None:
     conn = _conn()
     lookup = {

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -249,7 +249,7 @@ def test_morphology_can_use_base_form_from_pair_lemma(monkeypatch) -> None:
     assert morphology["forms"][0] == {"form": "варити", "label": "інфінітив"}
 
 
-def test_synonyms_filter_polluted_wordnet_rows_to_a1_sense() -> None:
+def test_legacy_synonym_sources_drop_wordnet_and_ukrajinet_noise() -> None:
     conn = _conn()
     conn.execute(
         "INSERT INTO wiktionary VALUES (?, ?, ?)",
@@ -299,7 +299,7 @@ def test_synonyms_filter_polluted_wordnet_rows_to_a1_sense() -> None:
     assert _sense_correct_synonyms(conn, "мама") == ["мати", "матуся"]
     assert _sense_correct_synonyms(conn, "стілець") == ["крісло"]
     assert _sense_correct_synonyms(conn, "дім") == ["будинок", "хата", "домівка"]
-    assert _sense_correct_synonyms(conn, "чудово") == ["прекрасно", "чудесно", "блискуче"]
+    assert _sense_correct_synonyms(conn, "чудово") == ["прекрасно", "чудесно"]
 
     all_synonyms = [
         synonym
@@ -308,6 +308,7 @@ def test_synonyms_filter_polluted_wordnet_rows_to_a1_sense() -> None:
     ]
     assert not any(any("A" <= char <= "Z" or "a" <= char <= "z" for char in synonym) for synonym in all_synonyms)
     assert "жахливо" not in all_synonyms
+    assert "блискуче" not in all_synonyms
 
 
 def test_slovnyk_synonyms_extract_known_garnyi_word(monkeypatch) -> None:
@@ -391,6 +392,128 @@ def test_slovnyk_synonyms_omit_wrong_sense_voda(monkeypatch) -> None:
     items = section["items"] if section else []
     assert "багатослів'я" not in items
     assert "велемовність" not in items
+
+
+def test_slovnyk_synonyms_promote_clean_sources_for_sample(monkeypatch) -> None:
+    _patch_vesum_analyses(
+        monkeypatch,
+        {
+            "варити": "verb",
+            "готувати": "verb",
+            "куховарити": "verb",
+            "фальсифікувати": "verb",
+            "хата": "noun",
+            "домівка": "noun",
+            "господа": "noun",
+            "притулок": "noun",
+            "житло": "noun",
+            "оселя": "noun",
+            "помешкання": "noun",
+            "дім": "noun",
+            "бариги": "noun",
+            "шлях": "noun",
+            "дорога": "noun",
+            "маршрут": "noun",
+            "курс": "noun",
+            "путь": "noun",
+            "тракт": "noun",
+            "мрія": "noun",
+            "марення": "noun",
+            "бажання": "noun",
+            "прагнення": "noun",
+            "надія": "noun",
+        },
+    )
+    samples = {
+        "варити / зварити": (
+            "verb",
+            {
+                "lookups": {
+                    "synonyms": {
+                        "dictionary_slug": "synonyms",
+                        "dictionary_label": "Словник синонімів української мови",
+                        "source_url": "https://slovnyk.me/dict/synonyms/варити",
+                        "word": "варити",
+                        "text": "варити ВАРИТИ (про їжу), ГОТУВАТИ, КУХОВАРИТИ. — Док.: зварити. Джерело: тест",
+                    }
+                }
+            },
+            ["готувати", "куховарити"],
+        ),
+        "хата": (
+            "noun",
+            {
+                "lookups": {
+                    "synonyms_karavansky": {
+                        "dictionary_slug": "synonyms_karavansky",
+                        "dictionary_label": "Словник синонімів Караванського",
+                        "source_url": "https://slovnyk.me/dict/synonyms_karavansky/хата",
+                        "word": "хата",
+                        "text": "хата домівка, господа, притулок; П. бариги. Джерело: тест",
+                    },
+                    "synonyms": {
+                        "dictionary_slug": "synonyms",
+                        "dictionary_label": "Словник синонімів української мови",
+                        "source_url": "https://slovnyk.me/dict/synonyms/хата",
+                        "word": "хата",
+                        "text": "хата ЖИТЛО, ОСЕЛЯ, ПОМЕШКАННЯ, ДІМ, ДОМІВКА, ХАТА. Джерело: тест",
+                    },
+                }
+            },
+            ["домівка", "господа", "притулок", "житло", "оселя", "помешкання", "дім"],
+        ),
+        "шлях": (
+            "noun",
+            {
+                "lookups": {
+                    "synonyms_karavansky": {
+                        "dictionary_slug": "synonyms_karavansky",
+                        "dictionary_label": "Словник синонімів Караванського",
+                        "source_url": "https://slovnyk.me/dict/synonyms_karavansky/шлях",
+                        "word": "шлях",
+                        "text": "шлях ДОРОГА, маршрут, курс; П. спосіб. Джерело: тест",
+                    },
+                    "synonyms": {
+                        "dictionary_slug": "synonyms",
+                        "dictionary_label": "Словник синонімів української мови",
+                        "source_url": "https://slovnyk.me/dict/synonyms/шлях",
+                        "word": "шлях",
+                        "text": "шлях ДОРОГА (смуга землі), ШЛЯХ, ПУТЬ, ТРАКТ. Джерело: тест",
+                    },
+                }
+            },
+            ["дорога", "маршрут", "курс", "путь", "тракт"],
+        ),
+        "мрія": (
+            "noun",
+            {
+                "lookups": {
+                    "synonyms_karavansky": {
+                        "dictionary_slug": "synonyms_karavansky",
+                        "dictionary_label": "Словник синонімів Караванського",
+                        "source_url": "https://slovnyk.me/dict/synonyms_karavansky/мрія",
+                        "word": "мрія",
+                        "text": "мрія МАРЕННЯ, бажання, прагнення; П. ілюзія. Джерело: тест",
+                    },
+                    "synonyms": {
+                        "dictionary_slug": "synonyms",
+                        "dictionary_label": "Словник синонімів української мови",
+                        "source_url": "https://slovnyk.me/dict/synonyms/мрія",
+                        "word": "мрія",
+                        "text": "мрія БАЖАННЯ (те, чого хочеться), МРІЯ, ПРАГНЕННЯ, НАДІЯ. Джерело: тест",
+                    },
+                }
+            },
+            ["марення", "бажання", "прагнення", "надія"],
+        ),
+    }
+
+    for lemma, (entry_pos, cache, expected) in samples.items():
+        section = _synonyms_slovnyk(lemma, cache, entry_pos=entry_pos)
+
+        assert section is not None
+        assert section["items"] == expected
+        assert not {"фальсифікувати", "бариги", "java", "hot seat"}.intersection(section["items"])
 
 
 def test_slovnyk_idioms_extract_known_phrase_card() -> None:


### PR DESCRIPTION
## Summary
- Adds derivational-base etymology fallback for derived A1 lemmas, with base-form source labeling.
- Promotes Karavansky and sense-filtered slovnyk.me synonym rows for §7 while keeping balla/sum11 allowlist-gated and dropping Wiktionary/ukrajinet from that path.
- Uses mocked/in-memory fixtures only; no full manifest re-enrich was run.

## Validation

```text
$ .venv/bin/python -m pytest tests/test_enrich.py tests/test_lexicon_enrich_manifest.py -q
======================== 69 passed, 4 skipped in 5.56s =========================
```

```text
$ .venv/bin/ruff check scripts/lexicon/enrich_manifest.py tests/test_lexicon_enrich_manifest.py
All checks passed!
```

## Spot checks

```text
ETYMOLOGY добре {"source": "Горох (за ЕСУМ) (etymology of base form добрий)", "source_url": "https://goroh.example/добрий", "text": "Fixture etymology for добрий."}
ETYMOLOGY чудово {"source": "Горох (за ЕСУМ) (etymology of base form чудо)", "source_url": "https://goroh.example/чудо", "text": "Fixture etymology for чудо."}
ETYMOLOGY пізно {"source": "Горох (за ЕСУМ) (etymology of base form пізній)", "source_url": "https://goroh.example/пізній", "text": "Fixture etymology for пізній."}
ETYMOLOGY нормально {"source": "Горох (за ЕСУМ) (etymology of base form нормальний)", "source_url": "https://goroh.example/нормальний", "text": "Fixture etymology for нормальний."}
ETYMOLOGY сьома {"source": "Горох (за ЕСУМ) (etymology of base form сім)", "source_url": "https://goroh.example/сім", "text": "Fixture etymology for сім."}
ETYMOLOGY навчатися {"source": "Горох (за ЕСУМ) (etymology of base form вчити)", "source_url": "https://goroh.example/вчити", "text": "Fixture etymology for вчити."}
ETYMOLOGY вмиватися {"source": "Горох (за ЕСУМ) (etymology of base form мити)", "source_url": "https://goroh.example/мити", "text": "Fixture etymology for мити."}
ETYMOLOGY збиратися {"source": "Горох (за ЕСУМ) (etymology of base form брати)", "source_url": "https://goroh.example/брати", "text": "Fixture etymology for брати."}
ETYMOLOGY одягатися {"source": "Горох (за ЕСУМ) (etymology of base form одяг)", "source_url": "https://goroh.example/одяг", "text": "Fixture etymology for одяг."}
ETYMOLOGY повертатися {"source": "Горох (за ЕСУМ) (etymology of base form вертати)", "source_url": "https://goroh.example/вертати", "text": "Fixture etymology for вертати."}
SYNONYMS варити / зварити ["готувати", "куховарити"]
SYNONYMS хата ["домівка", "господа", "притулок", "житло", "оселя", "помешкання", "дім"]
SYNONYMS шлях ["дорога", "маршрут", "курс", "путь", "тракт"]
SYNONYMS мрія ["марення", "бажання", "прагнення", "надія"]
```
