### PR TITLE
feat(bridge): full grok-build native CLI support

### DIFF
--- a/scripts/agent_runtime/adapters/grok_build.py
+++ b/scripts/agent_runtime/adapters/grok_build.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import shutil
 import tempfile
@@ -46,14 +47,16 @@ _MODE_PERMISSION: dict[str, str] = {
     "workspace-write": "acceptEdits",
     "danger": "bypassPermissions",
 }
+GROK_BUILD_DEFAULT_MODEL = os.environ.get("LEARN_UK_GROK_BUILD_MODEL", "grok-4.20")
+GROK_BUILD_DEFAULT_EFFORT = os.environ.get("LEARN_UK_GROK_BUILD_EFFORT", "high")
 
 
 class GrokBuildAdapter:
     """Adapter for the native ``grok`` CLI in single-turn headless mode."""
 
     name: str = "grok-build"
-    # None → let the grok CLI pick its own default model; override via `model`.
-    default_model: str | None = None
+    default_model: str = GROK_BUILD_DEFAULT_MODEL
+    default_effort: str = GROK_BUILD_DEFAULT_EFFORT
     supported_modes: frozenset[str] = frozenset({"read-only", "workspace-write", "danger"})
 
     def build_invocation(
@@ -99,11 +102,12 @@ class GrokBuildAdapter:
         cmd.extend(["--permission-mode", _MODE_PERMISSION[mode]])
         cmd.extend(["--cwd", str(cwd)])
 
+        effective_effort = effort or self.default_effort
         if model:
             cmd.extend(["-m", model])
-        if effort:
+        if effective_effort:
             # grok accepts the same levels as the runtime: low|medium|high|xhigh|max
-            cmd.extend(["--effort", effort])
+            cmd.extend(["--effort", effective_effort])
 
         disallowed = tc.get("disallowed_tools")
         if disallowed:
@@ -123,7 +127,7 @@ class GrokBuildAdapter:
             mode,
             _MODE_PERMISSION[mode],
             model,
-            effort,
+            effective_effort,
         )
 
         return InvocationPlan(

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -20,7 +20,7 @@ Issue: #1184
 """
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 
 class AgentEntry(TypedDict):
@@ -28,6 +28,7 @@ class AgentEntry(TypedDict):
 
     adapter: str               # fully-qualified "module:ClassName" import path
     default_model: str | None
+    default_effort: NotRequired[str | None]
     cost_tier: str             # "low" | "medium" | "high" | "unknown"
     capabilities: frozenset[str]
     cli_available: bool
@@ -117,9 +118,10 @@ AGENTS: dict[str, AgentEntry] = {
         # Native `grok` CLI ("Grok Build") in headless single-turn mode — a
         # Claude-Code-shaped agentic coding CLI. Separate from the Hermes
         # `grok` entry above (different transport, different use: coding vs
-        # content). Uses ~/.grok OAuth; model defaults to the CLI's own.
+        # content). Uses ~/.grok OAuth.
         "adapter": "scripts.agent_runtime.adapters.grok_build:GrokBuildAdapter",
-        "default_model": None,
+        "default_model": "grok-4.20",
+        "default_effort": "high",
         "cost_tier": "medium",
         "capabilities": frozenset({
             "code_writing",

--- a/scripts/agent_runtime/telemetry.py
+++ b/scripts/agent_runtime/telemetry.py
@@ -148,6 +148,12 @@ def _default_model_for(agent_name: str) -> str | None:
     return str(raw).strip() if isinstance(raw, str) and str(raw).strip() else None
 
 
+def _default_effort_for(agent_name: str) -> str | None:
+    entry = AGENTS.get(agent_name, {})
+    raw = entry.get("default_effort")
+    return str(raw).strip() if isinstance(raw, str) and str(raw).strip() else None
+
+
 def _resolve_model_from_plan(agent_name: str, plan: InvocationPlan) -> str | None:
     del agent_name
     return _arg_after(plan.cmd, "-m", "--model")
@@ -156,7 +162,7 @@ def _resolve_model_from_plan(agent_name: str, plan: InvocationPlan) -> str | Non
 def _resolve_effort_from_plan(agent_name: str, plan: InvocationPlan) -> str | None:
     if agent_name == "codex":
         return _config_override(plan.cmd, "model_reasoning_effort")
-    if agent_name == "claude":
+    if agent_name in {"claude", "grok-build"}:
         return _arg_after(plan.cmd, "--effort")
     if agent_name == "gemini":
         return None
@@ -201,6 +207,9 @@ def _resolve_effort_from_defaults(agent_name: str, requested_effort: str | None)
             _gemini_settings(),
             ("effort", "effortLevel", "reasoningEffort", "reasoning_effort"),
         )
+    default_effort = _default_effort_for(agent_name)
+    if default_effort:
+        return default_effort
     return None
 
 

--- a/scripts/ai_agent_bridge/__init__.py
+++ b/scripts/ai_agent_bridge/__init__.py
@@ -58,6 +58,7 @@ from ._github import (
     _post_review_to_github,
     _split_content,
 )
+from ._grok_build import ask_grok_build, process_for_grok_build
 from ._messaging import (
     _extract_issue_number,
     acknowledge,
@@ -76,7 +77,6 @@ from ._prompts import build_claude_prompt, build_codex_prompt, build_gemini_prom
 __all__ = [
     "CLAUDE_CMD",
     "CODEX_CLI",
-    # Config
     "DB_PATH",
     "GEMINI_CLI",
     "GEMINI_DEFAULT_MODEL",
@@ -88,10 +88,8 @@ __all__ = [
     "_PARENT_ENV",
     "_detect_model_error",
     "_extract_issue_number",
-    # GitHub
     "_format_review_chunk",
     "_gh_comment",
-    # Broker
     "_git_status_snapshot",
     "_is_task_locked",
     "_post_review_to_github",
@@ -101,28 +99,22 @@ __all__ = [
     "_write_pid_file",
     "acknowledge",
     "acknowledge_all",
-    # Claude
     "ask_claude",
     "ask_codex",
-    # Gemini
     "ask_gemini",
+    "ask_grok_build",
     "bridge_status",
     "broker_cleanup",
     "build_claude_prompt",
     "build_codex_prompt",
-    # Prompts
     "build_gemini_prompt",
-    # Messaging
     "check_inbox",
-    # Model
     "check_model",
     "detect_sender",
     "get_conversation",
     "get_db",
     "get_session",
-    # DB
     "init_db",
-    # CLI
     "interactive_mode",
     "main",
     "process_all_claude",
@@ -131,6 +123,7 @@ __all__ = [
     "process_and_respond",
     "process_for_claude",
     "process_for_codex",
+    "process_for_grok_build",
     "read_message",
     "send_message",
     "send_to_codex",

--- a/scripts/ai_agent_bridge/__main__.py
+++ b/scripts/ai_agent_bridge/__main__.py
@@ -1,4 +1,14 @@
-"""Allow running as script or package: python scripts/ai_agent_bridge/__main__.py"""
+"""AI Agent Bridge command runner.
+
+Common commands:
+  ask-codex, process-codex
+  ask-grok-build, process-grok-build
+  ask-claude, process-claude
+  ask-gemini, process
+
+Run as script or package:
+  python scripts/ai_agent_bridge/__main__.py <command>
+"""
 
 import sys
 from pathlib import Path

--- a/scripts/ai_agent_bridge/_channels.py
+++ b/scripts/ai_agent_bridge/_channels.py
@@ -75,6 +75,7 @@ VALID_AGENTS = (
     "gemini",
     "codex",
     "grok",
+    "grok-build",
     "deepseek",
     "qwen",
     "cursor",

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -69,7 +69,16 @@ def _cli_available_agent(agent: str) -> bool:
     try:
         from agent_runtime.registry import get_agent_entry
     except ImportError:
-        return agent in {"claude", "codex", "gemini", "grok", "deepseek", "qwen", "cursor"}
+        return agent in {
+            "claude",
+            "codex",
+            "gemini",
+            "grok",
+            "grok-build",
+            "deepseek",
+            "qwen",
+            "cursor",
+        }
 
     try:
         return bool(get_agent_entry(agent)["cli_available"])

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -29,6 +29,11 @@ from ._dispatch_wrappers import (
     handle_review_deep,
 )
 from ._gemini import ask_gemini, converse_gemini, process_and_respond
+from ._grok_build import (
+    GROK_BUILD_DEFAULT_MODEL,
+    ask_grok_build,
+    process_for_grok_build,
+)
 from ._hermes import HERMES_DEFAULT_MODEL, ask_hermes
 from ._messaging import (
     acknowledge,
@@ -462,6 +467,19 @@ def _build_parser() -> argparse.ArgumentParser:
     proc_codex_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true",
                                    help="Run sync without timeout")
 
+    # process-grok-build
+    proc_grok_build_parser = subparsers.add_parser(
+        "process-grok-build",
+        help="Process message with native Grok Build CLI (headless)",
+    )
+    proc_grok_build_parser.add_argument("message_id", type=int, help="Message ID for Grok Build to process")
+    proc_grok_build_parser.add_argument("--new-session", dest="new_session", action="store_true",
+                                        help="Accepted for parity; grok-build always starts fresh")
+    proc_grok_build_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true",
+                                        help="Run sync without timeout")
+    proc_grok_build_parser.add_argument("--review", action="store_true",
+                                        help="Prepend docs/review-protocol.md")
+
     # ask-claude
     ask_claude_parser = subparsers.add_parser("ask-claude", help="Send message AND invoke Claude (one-step)")
     ask_claude_parser.add_argument("content", help="Message content")
@@ -621,6 +639,29 @@ def _build_parser() -> argparse.ArgumentParser:
     ask_cursor_parser.add_argument("--from-model", dest="from_model", help="Exact sender model")
     ask_cursor_parser.add_argument("--to-model", dest="to_model", help="Target model ID")
     ask_cursor_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true")
+
+    # ask-grok-build
+    ask_grok_build_parser = subparsers.add_parser(
+        "ask-grok-build",
+        help="Send message AND invoke native Grok Build one-shot (use '-' to read from stdin)",
+    )
+    ask_grok_build_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
+    ask_grok_build_parser.add_argument("--task-id", required=True, help="Task ID")
+    ask_grok_build_parser.add_argument("--type", default="query", help="Message type")
+    ask_grok_build_parser.add_argument("--data", help="Path to data file to attach")
+    ask_grok_build_parser.add_argument("--new-session", dest="new_session", action="store_true",
+                                       help="Accepted for parity; grok-build always starts fresh")
+    ask_grok_build_parser.add_argument(
+        "--model",
+        default=GROK_BUILD_DEFAULT_MODEL,
+        help=f"Grok Build model (default {GROK_BUILD_DEFAULT_MODEL})",
+    )
+    ask_grok_build_parser.add_argument("--from", dest="from_llm", help="Sender agent family")
+    ask_grok_build_parser.add_argument("--from-model", dest="from_model", help="Exact sender model")
+    ask_grok_build_parser.add_argument("--to-model", dest="to_model", help="Target model ID")
+    ask_grok_build_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true")
+    ask_grok_build_parser.add_argument("--review", action="store_true",
+                                       help="Prepend docs/review-protocol.md")
 
     # converse — multi-turn conversation with Gemini
     converse_parser = subparsers.add_parser("converse", help="Multi-turn conversation with Gemini (includes history)")
@@ -914,6 +955,8 @@ def _dispatch_command(args):
         process_for_claude(args.message_id, args.new_session, args.fire_and_forget, args.no_timeout)
     elif args.command == "process-codex":
         process_for_codex(args.message_id, args.new_session, args.no_timeout)
+    elif args.command == "process-grok-build":
+        process_for_grok_build(args.message_id, args.new_session, args.no_timeout, args.review)
     elif args.command == "ask-claude":
         _handle_ask_claude(args)
     elif args.command == "ask-codex":
@@ -928,6 +971,8 @@ def _dispatch_command(args):
         _handle_ask_opencode(args)
     elif args.command == "ask-cursor":
         _handle_ask_cursor(args)
+    elif args.command == "ask-grok-build":
+        _handle_ask_grok_build(args)
     elif args.command == "converse":
         content = sys.stdin.read() if args.content == "-" else args.content
         converse_gemini(content, args.task_id, args.model,
@@ -1107,6 +1152,28 @@ def _handle_ask_cursor(args):
         from_model=args.from_model,
         to_model=args.to_model,
         no_timeout=args.no_timeout,
+    )
+
+
+def _handle_ask_grok_build(args):
+    """Handle ask-grok-build subcommand."""
+    data = None
+    if args.data:
+        data = Path(args.data).read_text()
+    content = sys.stdin.read() if args.content == "-" else args.content
+    from_llm = _resolve_from_llm(args)
+    ask_grok_build(
+        content,
+        args.task_id,
+        msg_type=args.type,
+        data=data,
+        new_session=args.new_session,
+        from_llm=from_llm,
+        from_model=args.from_model,
+        to_model=args.to_model,
+        no_timeout=args.no_timeout,
+        review=args.review,
+        model=args.model,
     )
 
 

--- a/scripts/ai_agent_bridge/_env.py
+++ b/scripts/ai_agent_bridge/_env.py
@@ -36,6 +36,7 @@ _SAFE_ENV_PREFIXES = (
     "CODEX_",
     "CLAUDE_",
     "GEMINI_",
+    "GROK_",
     "LEARN_UKRAINIAN_",
     "PYTHON",
 )

--- a/scripts/ai_agent_bridge/_grok_build.py
+++ b/scripts/ai_agent_bridge/_grok_build.py
@@ -1,0 +1,267 @@
+"""Grok Build bridge integration for the native ``grok`` CLI.
+
+This is the native Grok Build lane (registry key ``grok-build``), not the
+Hermes-routed ``grok`` agent. Bridge calls use ``agent_runtime.runner.invoke``
+so process management, telemetry, timeouts, and parsing stay centralized.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+from agent_runtime import runner as agent_runner
+from agent_runtime.adapters.grok_build import (
+    GROK_BUILD_DEFAULT_EFFORT,
+    GROK_BUILD_DEFAULT_MODEL,
+)
+from agent_runtime.errors import (
+    AgentStalledError,
+    AgentTimeoutError,
+    AgentUnavailableError,
+    RateLimitedError,
+)
+
+from ._config import REPO_ROOT
+from ._db import get_db, set_session
+from ._messaging import acknowledge, send_message
+from ._prompts import _prepend_review_protocol
+
+_DEFAULT_GROK_BUILD_BRIDGE_TIMEOUT_SECONDS = 900
+_NO_TIMEOUT_GROK_BUILD_BRIDGE_TIMEOUT_SECONDS = 24 * 60 * 60
+
+
+def _resolve_grok_build_bridge_timeout(no_timeout: bool = False) -> int:
+    """Resolve Grok Build hard timeout from CLI flag/env with a safe fallback."""
+    if no_timeout:
+        return _NO_TIMEOUT_GROK_BUILD_BRIDGE_TIMEOUT_SECONDS
+
+    raw = os.environ.get("GROK_BUILD_BRIDGE_TIMEOUT")
+    if raw is None:
+        return _DEFAULT_GROK_BUILD_BRIDGE_TIMEOUT_SECONDS
+
+    value = raw.strip().lower()
+    if value in {"0", "none", "off", "false", "no"}:
+        return _NO_TIMEOUT_GROK_BUILD_BRIDGE_TIMEOUT_SECONDS
+
+    try:
+        timeout = int(value)
+    except ValueError:
+        print(
+            f"Invalid GROK_BUILD_BRIDGE_TIMEOUT={raw!r}; "
+            f"falling back to {_DEFAULT_GROK_BUILD_BRIDGE_TIMEOUT_SECONDS}s"
+        )
+        return _DEFAULT_GROK_BUILD_BRIDGE_TIMEOUT_SECONDS
+
+    if timeout <= 0:
+        return _NO_TIMEOUT_GROK_BUILD_BRIDGE_TIMEOUT_SECONDS
+    return timeout
+
+
+def ask_grok_build(
+    content: str,
+    task_id: str | None = None,
+    msg_type: str = "query",
+    data: str | None = None,
+    new_session: bool = False,
+    from_llm: str = "claude",
+    from_model: str | None = None,
+    to_model: str | None = None,
+    no_timeout: bool = False,
+    review: bool = False,
+    model: str | None = None,
+) -> int:
+    """Send message to native Grok Build and invoke it to process the message."""
+    effective_model = to_model or model or GROK_BUILD_DEFAULT_MODEL
+    msg_id = send_message(
+        content,
+        task_id,
+        msg_type,
+        data,
+        from_llm=from_llm,
+        to_llm="grok-build",
+        from_model=from_model,
+        to_model=effective_model,
+    )
+    print(f"\nInvoking grok-build ({effective_model}) to process message #{msg_id}...")
+    process_for_grok_build(
+        msg_id,
+        new_session=new_session,
+        no_timeout=no_timeout,
+        review=review,
+    )
+    return msg_id
+
+
+def process_for_grok_build(
+    message_id: int,
+    new_session: bool = False,
+    no_timeout: bool = False,
+    review: bool = False,
+) -> None:
+    """Read a grok-build message, invoke the native adapter, and send a reply."""
+    msg = _fetch_grok_build_message(message_id)
+    if not msg:
+        return
+
+    _ = new_session  # grok-build resume_policy="never"; bridge calls are fresh.
+    timeout_val = _resolve_grok_build_bridge_timeout(no_timeout)
+    model = _extract_target_model(msg) or GROK_BUILD_DEFAULT_MODEL
+    prompt = _build_grok_build_prompt(msg, review)
+
+    print(f"Message #{msg['id']}")
+    print(f"   From: {msg['from']} -> To: {msg['to']}")
+    print(f"   Type: {msg['type']}")
+    print(f"   Task: {msg['task_id'] or 'N/A'}")
+    print("   Session: NEW (grok-build runtime always fresh)")
+    print(f"   Model: {model}")
+    print(f"   Effort: {GROK_BUILD_DEFAULT_EFFORT}")
+    if timeout_val == _NO_TIMEOUT_GROK_BUILD_BRIDGE_TIMEOUT_SECONDS:
+        print("   Hard timeout: no-timeout requested (24h ceiling)")
+    else:
+        print(f"   Hard timeout: {timeout_val}s")
+
+    try:
+        result = agent_runner.invoke(
+            "grok-build",
+            prompt,
+            mode="read-only",
+            cwd=REPO_ROOT,
+            model=model,
+            task_id=msg["task_id"],
+            session_id=None,
+            tool_config=None,
+            entrypoint="bridge",
+            hard_timeout=timeout_val,
+            stall_timeout=min(600, timeout_val),
+            effort=GROK_BUILD_DEFAULT_EFFORT,
+        )
+    except RateLimitedError as exc:
+        _handle_grok_build_error(msg, message_id, f"Grok Build rate limited: {exc}")
+        return
+    except AgentStalledError as exc:
+        _handle_grok_build_error(msg, message_id, f"Grok Build stalled: {exc}")
+        return
+    except AgentTimeoutError as exc:
+        _handle_grok_build_error(msg, message_id, f"Grok Build hard timeout: {exc}")
+        return
+    except AgentUnavailableError as exc:
+        _handle_grok_build_error(msg, message_id, f"Grok Build unavailable: {exc}")
+        return
+
+    if not result.ok:
+        _handle_grok_build_error(
+            msg,
+            message_id,
+            result.stderr_excerpt or "Grok Build returned no final message",
+        )
+        return
+
+    if result.session_id and msg["task_id"]:
+        set_session(msg["task_id"], "grok-build", result.session_id)
+
+    response = result.response
+    if not response:
+        _handle_grok_build_error(msg, message_id, "Grok Build returned no final message")
+        return
+
+    print(f"\nGrok Build finished ({len(response)} chars)")
+    reply_id = send_message(
+        content=response,
+        task_id=msg["task_id"],
+        msg_type="response",
+        from_llm="grok-build",
+        to_llm=msg["from"],
+        from_model=getattr(result, "model", None) or model,
+    )
+    acknowledge(message_id)
+    acknowledge(reply_id)
+
+
+def _fetch_grok_build_message(message_id: int) -> dict | None:
+    """Fetch a message addressed to native Grok Build from the database."""
+    conn = get_db()
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        SELECT id, task_id, from_llm, to_llm, message_type, content, data, timestamp
+        FROM messages
+        WHERE id = ? AND to_llm = 'grok-build'
+        """,
+        (message_id,),
+    )
+    row = cursor.fetchone()
+    conn.close()
+
+    if not row:
+        print(f"Message {message_id} not found or not addressed to Grok Build")
+        return None
+
+    return {
+        "id": row[0],
+        "task_id": row[1],
+        "from": row[2],
+        "to": row[3],
+        "type": row[4],
+        "content": row[5],
+        "data": row[6],
+        "timestamp": row[7],
+    }
+
+
+def _extract_target_model(msg: dict) -> str | None:
+    """Read optional ``to_model`` metadata written by ``send_message``."""
+    data = msg.get("data")
+    if not data:
+        return None
+    try:
+        payload = json.loads(data)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    model = payload.get("to_model")
+    return str(model) if model else None
+
+
+def _build_grok_build_prompt(msg: dict, review: bool = False) -> str:
+    """Build the native Grok Build bridge prompt."""
+    prompt = f"""You are Grok Build (native grok CLI), receiving a message from {msg['from'].title()} via the message broker.
+
+---
+Task ID: {msg['task_id'] or 'none'}
+Type: {msg['type']}
+From: {msg['from']}
+
+{msg['content']}
+"""
+    if msg["data"]:
+        prompt += f"""
+---
+Attached data:
+{msg['data']}
+"""
+    prompt += """
+
+---
+
+Standing rules for bridge Q&A:
+- Respond directly and concisely.
+- Do NOT use broker or MCP messaging tools to send your response; output it directly.
+- This is the native grok-build lane. Do not route through Hermes/OpenRouter.
+"""
+    return _prepend_review_protocol(prompt, review)
+
+
+def _handle_grok_build_error(msg: dict, message_id: int, reason: str) -> None:
+    """Record a Grok Build failure as a response message and acknowledge."""
+    print(f"\nGrok Build error for message #{message_id}: {reason}")
+    reply_id = send_message(
+        content=f"[Grok Build error] {reason}",
+        task_id=msg["task_id"],
+        msg_type="error",
+        from_llm="grok-build",
+        to_llm=msg["from"],
+    )
+    acknowledge(message_id)
+    acknowledge(reply_id)

--- a/scripts/ai_agent_bridge/_model.py
+++ b/scripts/ai_agent_bridge/_model.py
@@ -5,6 +5,9 @@ from pathlib import Path
 
 from ._config import _MODEL_CACHE, _MODEL_CACHE_TTL, _PARENT_ENV, GEMINI_CLI
 
+GROK_BUILD_DEFAULT_MODEL = "grok-4.20"
+GROK_BUILD_DEFAULT_EFFORT = "high"
+
 
 def check_model(model: str, timeout: int = 15, force: bool = False) -> bool:
     """Check if a Gemini model is available by sending a trivial prompt.

--- a/scripts/audit/lint_agent_trailer.py
+++ b/scripts/audit/lint_agent_trailer.py
@@ -44,7 +44,7 @@ Trailer format
 ``X-Agent: <agent>/<task-id>``
 
 Where ``agent`` ∈ {``claude-inline``, ``claude``, ``codex``, ``gemini``,
-``agy-inline``, ``agy``, ``grok``, ``deepseek-v4-pro``, ``cursor``,
+``agy-inline``, ``agy``, ``grok``, ``grok-build``, ``deepseek-v4-pro``, ``cursor``,
 ``dependabot``} and ``task-id`` is the dispatch task identifier or the
 ``inline`` literal for orchestrator commits. Examples::
 
@@ -69,7 +69,7 @@ import subprocess
 import sys
 
 _TRAILER_RE = re.compile(
-    r"^X-Agent:\s+(?P<agent>claude-inline|claude|codex|gemini|agy-inline|agy|grok|deepseek-v4-pro|cursor|dependabot)/(?P<task>[A-Za-z0-9._-]+)\s*$",
+    r"^X-Agent:\s+(?P<agent>claude-inline|claude|codex|gemini|agy-inline|agy|grok|grok-build|deepseek-v4-pro|cursor|dependabot)/(?P<task>[A-Za-z0-9._-]+)\s*$",
     re.MULTILINE,
 )
 

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -202,6 +202,16 @@ def test_agy_entry_is_well_formed():
     assert {"content_writing", "content_review"} <= entry["capabilities"]
 
 
+def test_grok_build_entry_is_well_formed():
+    entry = get_agent_entry("grok-build")
+    assert entry["adapter"] == "scripts.agent_runtime.adapters.grok_build:GrokBuildAdapter"
+    assert entry["default_model"] == "grok-4.20"
+    assert entry["default_effort"] == "high"
+    assert entry["cli_available"] is True
+    assert entry["resume_policy"] == "never"
+    assert {"code_writing", "code_review", "debugging"} <= entry["capabilities"]
+
+
 def test_codex_entry_has_bridge_only_resume_policy():
     assert get_agent_entry("codex")["resume_policy"] == "bridge_only"
 

--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -574,7 +574,16 @@ def test_sync_all_iterates_known_agents(monkeypatch, capsys):
     # When a new CLI agent is registered (e.g. grok via #1934, deepseek
     # via #2107, cursor via Phase 2 PR), this list tracks the registry —
     # the test guards the iteration order, not a frozen subset.
-    cli_agents = ["claude", "gemini", "codex", "grok", "deepseek", "qwen", "cursor"]
+    cli_agents = [
+        "claude",
+        "gemini",
+        "codex",
+        "grok",
+        "grok-build",
+        "deepseek",
+        "qwen",
+        "cursor",
+    ]
 
     calls: list[tuple[str, dict[str, object]]] = []
 

--- a/tests/test_grok_build_adapter.py
+++ b/tests/test_grok_build_adapter.py
@@ -17,7 +17,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from agent_runtime import registry
 from agent_runtime.adapters.base import AgentAdapter, InvocationPlan
-from agent_runtime.adapters.grok_build import GrokBuildAdapter, _parse_json_object
+from agent_runtime.adapters.grok_build import (
+    GROK_BUILD_DEFAULT_EFFORT,
+    GROK_BUILD_DEFAULT_MODEL,
+    GrokBuildAdapter,
+    _parse_json_object,
+)
 
 FAKE_GROK = "/usr/local/bin/grok"
 
@@ -74,10 +79,10 @@ def test_model_and_effort_flags(tmp_path):
     assert _val(plan.cmd, "--effort") == "high"
 
 
-def test_no_model_no_effort_by_default(tmp_path):
+def test_default_effort_is_applied(tmp_path):
     plan = _build("x", tmp_path)
     assert "-m" not in plan.cmd
-    assert "--effort" not in plan.cmd
+    assert _val(plan.cmd, "--effort") == GROK_BUILD_DEFAULT_EFFORT
 
 
 def test_hyphen_leading_prompt_uses_prompt_file(tmp_path):
@@ -152,6 +157,8 @@ def test_registry_grok_build_distinct_from_hermes_grok():
     assert "grok_build:GrokBuildAdapter" in gb["adapter"]
     assert "hermes_grok:HermesGrokAdapter" in g["adapter"]
     assert gb["adapter"] != g["adapter"]
+    assert gb["default_model"] == GROK_BUILD_DEFAULT_MODEL
+    assert gb["default_effort"] == GROK_BUILD_DEFAULT_EFFORT
     assert "code_writing" in gb["capabilities"]
     assert "grok-build" in registry.available_agents()
 

--- a/tests/test_grok_build_bridge.py
+++ b/tests/test_grok_build_bridge.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from argparse import Namespace
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from scripts.agent_runtime.registry import get_agent_entry
+from scripts.ai_agent_bridge import _cli, _grok_build
+
+
+def test_ask_grok_build_parser_accepts_first_class_args():
+    parser = _cli._build_parser()
+
+    args = parser.parse_args(
+        [
+            "ask-grok-build",
+            "hello",
+            "--task-id",
+            "task-1",
+            "--type",
+            "query",
+            "--data",
+            "payload.md",
+            "--new-session",
+            "--from",
+            "codex",
+            "--from-model",
+            "gpt-5.5",
+            "--to-model",
+            "grok-4.20",
+            "--no-timeout",
+            "--review",
+        ]
+    )
+
+    assert args.command == "ask-grok-build"
+    assert args.task_id == "task-1"
+    assert args.new_session is True
+    assert args.from_llm == "codex"
+    assert args.from_model == "gpt-5.5"
+    assert args.to_model == "grok-4.20"
+    assert args.no_timeout is True
+    assert args.review is True
+
+
+def test_ask_grok_build_cli_handler_routes_to_bridge(monkeypatch, tmp_path):
+    data_file = tmp_path / "payload.md"
+    data_file.write_text("attached", encoding="utf-8")
+    calls = []
+
+    def fake_ask(*args, **kwargs):
+        calls.append((args, kwargs))
+        return 42
+
+    monkeypatch.setattr(_cli, "ask_grok_build", fake_ask)
+
+    _cli._handle_ask_grok_build(
+        Namespace(
+            content="hello",
+            task_id="task-1",
+            type="query",
+            data=str(data_file),
+            new_session=True,
+            from_llm="codex",
+            from_model="gpt-5.5",
+            to_model="grok-4.20",
+            no_timeout=True,
+            review=True,
+            model="grok-4.20",
+        )
+    )
+
+    args, kwargs = calls[0]
+    assert args[:3] == ("hello", "task-1",)
+    assert kwargs["msg_type"] == "query"
+    assert kwargs["data"] == "attached"
+    assert kwargs["new_session"] is True
+    assert kwargs["from_llm"] == "codex"
+    assert kwargs["from_model"] == "gpt-5.5"
+    assert kwargs["to_model"] == "grok-4.20"
+    assert kwargs["no_timeout"] is True
+    assert kwargs["review"] is True
+    assert kwargs["model"] == "grok-4.20"
+
+
+def test_process_grok_build_invokes_native_registry_key(monkeypatch):
+    invoke_calls = []
+
+    monkeypatch.setattr(
+        _grok_build,
+        "_fetch_grok_build_message",
+        lambda _message_id: {
+            "id": 7,
+            "task_id": "task-1",
+            "from": "codex",
+            "to": "grok-build",
+            "type": "query",
+            "content": "answer this",
+            "data": '{"to_model": "grok-4.20"}',
+            "timestamp": "now",
+        },
+    )
+    monkeypatch.setattr(_grok_build, "send_message", lambda *args, **kwargs: 8)
+    monkeypatch.setattr(_grok_build, "acknowledge", lambda *_args: None)
+    monkeypatch.setattr(_grok_build, "set_session", lambda *_args: None)
+
+    def fake_invoke(*args, **kwargs):
+        invoke_calls.append((args, kwargs))
+        return SimpleNamespace(ok=True, response="native reply", session_id="sid-1", model="grok-4.20")
+
+    monkeypatch.setattr(_grok_build.agent_runner, "invoke", fake_invoke)
+
+    _grok_build.process_for_grok_build(7)
+
+    args, kwargs = invoke_calls[0]
+    assert args[0] == "grok-build"
+    assert kwargs["model"] == "grok-4.20"
+    assert kwargs["effort"] == _grok_build.GROK_BUILD_DEFAULT_EFFORT
+    assert kwargs["entrypoint"] == "bridge"
+
+
+def test_grok_build_registry_key_resolves_native_adapter():
+    entry = get_agent_entry("grok-build")
+    assert entry["adapter"] == "scripts.agent_runtime.adapters.grok_build:GrokBuildAdapter"
+    assert entry["default_model"] == "grok-4.20"
+    assert entry["default_effort"] == "high"
+
+
+def test_grok_build_dispatch_start_telemetry_has_defaults():
+    with patch(
+        "scripts.agent_runtime.telemetry._resolve_cli_version",
+        return_value="grok 0.0.test",
+    ):
+        from scripts.agent_runtime.telemetry import resolve_dispatch_start_telemetry
+
+        telemetry = resolve_dispatch_start_telemetry(
+            agent_name="grok-build",
+            requested_model=None,
+            requested_effort=None,
+        )
+
+    assert telemetry.model == "grok-4.20"
+    assert telemetry.effort == "high"


### PR DESCRIPTION
## Raw Evidence

### 1. Initial branch/status

Command:
```bash
pwd && git status --short --branch
```
Cwd:
```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/grok-build-bridge-support
```
Raw output:
```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/grok-build-bridge-support
## codex/grok-build-bridge-support...origin/main
```

### 2. Native grok CLI flag smoke

Command:
```bash
command -v grok && grok --help | sed -n '1,80p'
```
Cwd:
```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/grok-build-bridge-support
```
Raw output:
```text
/Users/krisztiankoos/.local/bin/grok
Grok Build TUI

Usage: grok [OPTIONS] [PROMPT] [COMMAND]

Arguments:
  [PROMPT]
          Initial prompt for the interactive session, e.g. `grok "fix the bug"` or `grok --worktree=feat "create this feature"`

Options:
      --agent <NAME>
          Agent name or definition file path

      --agents <JSON>
          Inline subagent definitions as JSON

      --allow <RULE>
          Permission allow rule (Claude Code: --allowedTools)

      --always-approve
          Auto-approve all tool executions

      --best-of-n <N>
          Run the task N ways in parallel and pick the best (headless only)

  -c, --continue
          Continue the most recent session for the current working directory

      --check
          Append a self-verification loop to the prompt (headless only)

      --compaction-detail <DETAIL>
          Segments verbatim detail [none|minimal|balanced|verbose] (default `verbose`). Only affects `--compaction-mode segments`. Sets `GROK_COMPACTION_DETAIL`

      --compaction-mode <MODE>
          Compaction mode [summary|transcript|segments]: `summary` (default) adds no pointer; `transcript` points at the raw transcript; `segments` persists per-segment markdown to grep. Sets `GROK_COMPACTION_MODE`

      --cwd <CWD>
          Working directory

      --debug
          Enable debug logging

      --debug-file <FILE>
          Write debug logs to FILE

      --deny <RULE>
          Permission deny rule (Claude Code: --disallowedTools)

      --disable-web-search
          Disable web search and web fetch tools

      --disallowed-tools <TOOLS>
          Built-in tools to remove (comma-separated)

      --effort <LEVEL>
          Effort level
          
          [possible values: low, medium, high, xhigh, max]

      --experimental-memory
          Enable cross-session memory

  -h, --help
          Print help (see a summary with '-h')

      --leader-socket <PATH>
          Use a custom leader socket path instead of the default `~/.grok/leader.sock`

  -m, --model <MODEL>
          Model ID to use

      --max-turns <N>
          Maximum number of agent turns

      --no-alt-screen
          Run inline instead of using the terminal alternate screen

      --no-memory
          Disable cross-session memory for this session
```

### 3. Tests

Command:
```bash
.venv/bin/python -m pytest tests/test_grok_build_bridge.py tests/test_grok_build_adapter.py tests/test_agent_runtime.py tests/test_bridge_inbox_cli.py -q
```
Cwd:
```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/grok-build-bridge-support
```
Raw output:
```text
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/grok-build-bridge-support
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 194 items

tests/test_grok_build_bridge.py .....                                    [  2%]
tests/test_grok_build_adapter.py ................                        [ 10%]
tests/test_agent_runtime.py ............................................ [ 33%]
........................................................................ [ 70%]
............................                                             [ 85%]
tests/test_bridge_inbox_cli.py .............................             [100%]

============================= 194 passed in 27.73s =============================
```

### 4. Ruff

Command:
```bash
.venv/bin/ruff check scripts/ai_agent_bridge/_grok_build.py scripts/ai_agent_bridge/_cli.py scripts/ai_agent_bridge/__main__.py scripts/ai_agent_bridge/__init__.py scripts/ai_agent_bridge/_model.py scripts/ai_agent_bridge/_env.py scripts/ai_agent_bridge/_channels.py scripts/ai_agent_bridge/_channels_cli.py scripts/agent_runtime/adapters/grok_build.py scripts/agent_runtime/registry.py scripts/agent_runtime/telemetry.py scripts/audit/lint_agent_trailer.py tests/test_grok_build_bridge.py tests/test_grok_build_adapter.py tests/test_agent_runtime.py tests/test_bridge_inbox_cli.py
```
Cwd:
```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/grok-build-bridge-support
```
Raw output:
```text
All checks passed!
```

### 5. ask-grok-build help

Command:
```bash
.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-grok-build --help
```
Cwd:
```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/grok-build-bridge-support
```
Raw output:
```text
usage: __main__.py ask-grok-build [-h] --task-id TASK_ID [--type TYPE]
                                  [--data DATA] [--new-session]
                                  [--model MODEL] [--from FROM_LLM]
                                  [--from-model FROM_MODEL]
                                  [--to-model TO_MODEL] [--no-timeout]
                                  [--review]
                                  content

positional arguments:
  content               Message content (use '-' to read from stdin)

options:
  -h, --help            show this help message and exit
  --task-id TASK_ID     Task ID
  --type TYPE           Message type
  --data DATA           Path to data file to attach
  --new-session         Accepted for parity; grok-build always starts fresh
  --model MODEL         Grok Build model (default grok-4.20)
  --from FROM_LLM       Sender agent family
  --from-model FROM_MODEL
                        Exact sender model
  --to-model TO_MODEL   Target model ID
  --no-timeout
  --review              Prepend docs/review-protocol.md
```

### 6. Exact dry-run dispatch from task

Command:
```bash
.venv/bin/python scripts/delegate.py dispatch --agent grok-build --task-id smoke --dry-run
```
Cwd:
```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/grok-build-bridge-support
```
Raw output:
```text
❌ --prompt or --prompt-file is required
```

### 7. Dry-run dispatch reaching telemetry path

Command:
```bash
.venv/bin/python scripts/delegate.py dispatch --agent grok-build --task-id smoke --prompt 'smoke test' --dry-run
```
Cwd:
```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/grok-build-bridge-support
```
Raw output:
```text
smoke
```

### 8. Diff whitespace

Command:
```bash
git diff --check
```
Cwd:
```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/grok-build-bridge-support
```
Raw output:
```text

```

### 9. X-Agent trailer lint

Command:
```bash
.venv/bin/python scripts/audit/lint_agent_trailer.py
```
Cwd:
```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/grok-build-bridge-support
```
Raw output:
```text
Checking 1 commit(s) in origin/main..HEAD:

  b03be88fdd  PASS  X-Agent: codex/grok-build-bridge-support

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```