### PR TITLE
feat(folk): surface folk as preview among seminar tracks + proper 42-topic landing

### DIFF
--- a/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
+++ b/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
@@ -58,7 +58,45 @@
 > the "don't self-merge" restriction, not the "don't push to main" one. Stage-0 PR #2759 self-merged
 > under this grant (commit `abf280f490`).
 
-## ▶▶▶ SESSION 25 HANDOFF (2026-06-14 — LANDED the two waiting dossier PRs (#3103 #17 + #3107 #18) after independent #M-11 re-verification; BUILT + corpus-hammered + shipped dossier #19 kolomyiky; dossiers 18→19/42) — **RESUME HERE**
+## ▶▶▶ SESSION 26 HANDOFF (2026-06-14 — FOLK SURFACED as PREVIEW among the seminar tracks (user-directed, reverses orchestrator #3027); proper 42-topic landing rebuilt; bio count fixed 180→310 via stats regen) — **RESUME HERE**
+
+> **⏱ HONEST SCOPE:** This is a FRONTEND/surfacing change — no new content. Folk content unchanged (19 dossiers,
+> 15 wikis, 3 modules). Folk track is now PUBLIC as a clearly-labeled PREVIEW/seminar-test. **Only the 3 built
+> modules are clickable** (kalendarna #04, koliadky #05, dumy-nevilnytski-lytsarski #12); the other 39 are locked.
+
+### ✅ DONE THIS SESSION (this PR — user 2026-06-14: "build proper folk landing page... link it in now as preview/seminar test... amongst the seminar tracks... bio is 310 modules")
+- **FOLK SURFACED (reverses orchestrator #3027 "hide folk nav — too early").** Removed the two hide-gates:
+  `HIDDEN_MODULE_LINK_TRACKS` (LevelLanding.tsx) now empty → built folk module links clickable;
+  `hiddenPublicPaths` (astro.config.mjs) now empty → `/folk` routes public. **The earlier LLM-QG gate the user
+  set (Sessions 22–25: "don't un-hide until koliadky+dumy clear LLM QG") was EXPLICITLY LIFTED by the user this
+  session** in favour of a labeled preview launch.
+- **PROPER 42-topic folk landing** (`site/src/content/docs/folk/index.mdx`): rebuilt from the STALE 27-topic
+  taxonomy to the full `phase-folk-queue.md` 42-topic queue, grouped into 9 blocks (A Worldview → I Synthesis),
+  3 active (built) + 39 locked, PREVIEW/seminar-test labeling in title/subtitle/progress. Active slugs verified
+  to match the 3 built MDX files (no dead links).
+- **FOLK card added to Home.tsx Specialization Tracks** (alongside HIST/ISTORIO/BIO/LIT) with a PREVIEW pill.
+- **bio count fixed 180→310 + folk 27→42**: ROOT CAUSE was a STALE `curriculum-stats.json` — curriculum.yaml
+  already had bio=310 / folk=42, but the generated stats hadn't been regenerated. Ran
+  `scripts/generate_curriculum_stats.py` (the sanctioned regen) → synced all drifted counts (_total 1737→1833).
+- **LANE NOTE:** this is shared `site/` (infra-orchestrator territory) done under DIRECT USER ORDER (#M-1),
+  via worktree→PR. Flag the orchestrator: it reverses #3027 + touches Home/LevelLanding/astro.config.
+
+### ▶ NEXT ACTIONS (RESUME HERE, in order)
+1. **After merge: serve-verify live** — `./services.sh restart astro`, confirm HTTP 200 + content at
+   `/folk/` (the 42-topic landing) and the 3 preview module pages; confirm FOLK card shows on the home page.
+2. **Resume the dossier queue: #20 `suspilno-pobutovi-pisni`** (козацькі/чумацькі/бурлацькі/рекрутські/кріпацькі/
+   наймитські/заробітчанські) → #21 `narodni-balady`. Proven loop (corpus-pre-ground → codex/gpt-5.5 →
+   corpus-hammer → PR). Dossiers 19/42.
+3. **To make MORE folk modules clickable**, build them (claude-tools) + flip their status `locked`→`active` in
+   index.mdx. Module e2e self-converge is still GATED on #3079 (infra lane).
+4. **Carry-forward:** clean `wiki/index.md` regen (#3094, infra lane).
+
+### 📊 FLEET (unchanged) — dossier writer codex/gpt-5.5; reviewer Claude corpus-hammer (#M-11); module writer
+claude-tools; wiki gpt-5.5 + claude-routed reviewers (#3057). Frontend changes verified via Frontend CI build.
+
+---
+
+## ▶▶▶ SESSION 25 HANDOFF (2026-06-14 — LANDED the two waiting dossier PRs (#3103 #17 + #3107 #18) after independent #M-11 re-verification; BUILT + corpus-hammered + shipped dossier #19 kolomyiky; dossiers 18→19/42) — (superseded by Session 26)
 
 > **⏱ HONEST SCOPE:** Dossiers **18 → 19/42** (kolomyiky added THIS PR). Wikis 15/42, modules 3/42 UNCHANGED.
 > Folk nav still HIDDEN; surfacing still GATED on koliadky+dumy LLM QG (#3079, infra lane). This session = cleared

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -14,7 +14,9 @@ import vocabEtymologyLinker from './plugins/vocab-etymology-link.mjs';
 const remarkPlugins = [remarkDirective, remarkAdmonitions, remarkGfm, vocabEtymologyLinker];
 const starlightRoot = fileURLToPath(new URL('.', import.meta.url));
 const starlightNodeModules = realpathSync(fileURLToPath(new URL('./node_modules', import.meta.url)));
-const hiddenPublicPaths = ['/folk'];
+// Folk un-hidden 2026-06-14 for the preview/seminar-test launch (reverses
+// orchestrator #3027). Empty = nothing suppressed from public routing.
+const hiddenPublicPaths = [];
 
 const isHiddenPublicPage = (page) => {
   const pathname = page.startsWith('http') ? new URL(page).pathname : page;

--- a/site/src/components/Home.tsx
+++ b/site/src/components/Home.tsx
@@ -96,12 +96,13 @@ function Feature({ title, emoji, description }: FeatureItem) {
   );
 }
 
-function LevelCard({ level, name, description, modules, color }: {
+function LevelCard({ level, name, description, modules, color, preview }: {
   level: string;
   name: string;
   description: string;
   modules: number;
   color: string;
+  preview?: boolean;
 }) {
   return (
     <div style={{flex: '1 1 300px', marginBottom: '1.5rem'}}>
@@ -110,6 +111,15 @@ function LevelCard({ level, name, description, modules, color }: {
           <span className={styles.levelBadge} style={{ background: color }}>
             {level}
           </span>
+          {preview && (
+            <span style={{
+              marginLeft: '8px', fontSize: '0.65rem', fontWeight: 700,
+              letterSpacing: '0.06em', padding: '2px 8px', borderRadius: '999px',
+              border: `1px solid ${color}`, color, verticalAlign: 'middle',
+            }}>
+              PREVIEW
+            </span>
+          )}
           <h3 style={{marginTop: '10px'}}>{name}</h3>
           <p style={{margin: '0 0 1rem 0'}}>{description}</p>
           <span className={styles.moduleCount}>{modules} modules</span>
@@ -229,6 +239,14 @@ export default function Home(): ReactNode {
                 description="Ukrainian classics and literary analysis"
                 modules={mc('lit')}
                 color="#5D4037"
+              />
+              <LevelCard
+                level="FOLK"
+                name="Folklore"
+                description="Decolonized survey of Ukrainian folk culture — song, ritual, epic, prose, material culture"
+                modules={mc('folk')}
+                color="#A4133C"
+                preview
               />
             </div>
 

--- a/site/src/components/LevelLanding.tsx
+++ b/site/src/components/LevelLanding.tsx
@@ -42,7 +42,10 @@ type LevelLandingProps = {
   modules: UnitGroup[] | OldModuleItem[];
 };
 
-const HIDDEN_MODULE_LINK_TRACKS = new Set(['folk']);
+// Tracks whose module links are suppressed on the landing page (built modules
+// render as locked). Folk was un-hidden 2026-06-14 for the preview/seminar-test
+// launch (reverses orchestrator #3027); its 3 built modules are now clickable.
+const HIDDEN_MODULE_LINK_TRACKS = new Set<string>();
 
 function ModuleCard({ mod, level, color }: { mod: ModuleItem; level: string; color: string }) {
   const levelKey = level.toLowerCase();

--- a/site/src/content/docs/folk/index.mdx
+++ b/site/src/content/docs/folk/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "FOLK"
-description: " — 27 modules"
+description: "Folklore & Oral Tradition — Preview"
 template: splash
 ---
 
@@ -9,69 +9,99 @@ import LevelLanding from '@site/src/components/LevelLanding';
 <LevelLanding
   client:load
   level="FOLK"
-  title="FOLK"
-  subtitle=" — 0/27 modules complete"
-  moduleCount={27}
-  wordTarget={4000}
+  title="FOLK · Фольклор та усна традиція"
+  subtitle="PREVIEW / seminar test — 3 of 42 modules live · 19 research dossiers + 15 wiki articles complete"
+  moduleCount={42}
+  wordTarget={5000}
   color="var(--lu-id-folk)"
-  progressTitle="FOLK Build Status"
-  progressDescription="2 preview modules available · 25 locked"
+  progressTitle="FOLK Build Status — Preview"
+  progressDescription="A decolonized C1+ survey of Ukrainian folk culture as a living system — worldview, ritual calendar, song, epic, prose, drama, music and material culture. 3 preview modules are live; the rest are in research/build. This is an early preview shown alongside the other seminars."
   modules={[
     {
-      unit: "FOLK.1",
+      unit: "Блок A · Світогляд і основа · Worldview & Foundation",
       items: [
-        { num: 1, slug: "koliadky-shchedrivky", title: "Колядки та щедрівки: Міф про створення світу", sub: "Carols and Shchedrivky: The Cosmogonic Myth", status: "active" },
-        { num: 2, slug: "vesnianky-hayivky", title: "Веснянки та гаївки: Пробудження природи", sub: "Spring Songs and Circle Dances: Awakening of Nature", status: "locked" },
-        { num: 3, slug: "rusalni-pisni", title: "Русальні пісні: Троїцький цикл та духи природи", sub: "Rusalka Songs: Green Holidays and Nature Spirits", status: "locked" },
-        { num: 4, slug: "kupalski-pisni", title: "Купальські пісні: Магія літнього сонцестояння", sub: "Kupala Songs: Midsummer Solstice Magic", status: "locked" },
-        { num: 5, slug: "obzhynkovi-pisni", title: "Обжинкові пісні: Апофеоз хліборобської праці", sub: "Harvest Songs: Apotheosis of the Grain Grower", status: "locked" },
-        { num: 6, slug: "vesilni-pisni", title: "Весільна обрядовість: Драматизм переходу", sub: "Wedding Rituals: The Drama of Passage", status: "locked" },
-        { num: 7, slug: "holosinnya", title: "Голосіння: Поетика скорботи та плачі", sub: "Funeral Laments: The Poetics of Grief", status: "locked" },
+        { num: 1, slug: "narodna-kultura-yak-systema", title: "Народна культура як система", sub: "Folk Culture as a System", status: "locked" },
+        { num: 2, slug: "narodni-viruvannia-mifolohiia-demonolohiia", title: "Народні вірування, міфологія та демонологія", sub: "Folk Beliefs, Mythology and Demonology", status: "locked" },
+        { num: 3, slug: "zamovliannia-zaklynannia-prymovky", title: "Замовляння, заклинання, примовки", sub: "Charms, Incantations and Spells", status: "locked" },
       ]
     },
     {
-      unit: "FOLK.2",
+      unit: "Блок B · Календарна обрядовість · Calendar Ritual",
       items: [
-        { num: 8, slug: "charivni-kazky", title: "Чарівні казки: Міфологічні архетипи та ініціація", sub: "Magic Tales: Mythological Archetypes and Initiation", status: "locked" },
-        { num: 9, slug: "kazky-pro-tvaryn", title: "Казки про тварин: Від тотемізму до алегорії", sub: "Animal Tales: From Totemism to Allegory", status: "locked" },
-        { num: 10, slug: "sotsialno-pobutovi-kazky", title: "Соціально-побутові казки: Народний реалізм", sub: "Everyday Tales: Folk Realism", status: "locked" },
-        { num: 11, slug: "narodni-lehendy", title: "Народні легенди: Народне християнство", sub: "Folk Legends: Popular Christianity", status: "locked" },
-        { num: 12, slug: "istorychni-perekazy", title: "Історичні перекази: Пам'ять про минуле", sub: "Historical Legends: Memory of the Past", status: "locked" },
+        { num: 4, slug: "kalendarna-obriadovist-zvychai", title: "Календарна обрядовість і звичаї", sub: "Calendar Rites and Customs", status: "active" },
+        { num: 5, slug: "koliadky-shchedrivky", title: "Колядки та щедрівки", sub: "Carols and Shchedrivky", status: "active" },
+        { num: 6, slug: "vesnianky-hayivky", title: "Веснянки та гаївки", sub: "Spring Songs and Circle Dances", status: "locked" },
+        { num: 7, slug: "kupalski-rusalni-pisni", title: "Купальські та русальні пісні", sub: "Kupala and Rusalka Songs", status: "locked" },
+        { num: 8, slug: "zhnyvarski-obzhynkovi-pisni", title: "Жниварські та обжинкові пісні", sub: "Harvest Songs", status: "locked" },
       ]
     },
     {
-      unit: "FOLK.3",
+      unit: "Блок C · Родинна обрядовість · Family Rites",
       items: [
-        { num: 13, slug: "bylyny-kyivskoho-tsyklu", title: "Билини київського циклу: Епос княжої доби", sub: "Kyiv Cycle Byliny: Epic of the Princely Era", status: "locked" },
-        { num: 14, slug: "bohatyri-illiya-dobrynia", title: "Богатирський епос: Ілля Муромець та Добриня", sub: "Bogatyr Epic: Illia Muromets and Dobrynia", status: "locked" },
-        { num: 15, slug: "zastavy-bohatyrski", title: "Застави богатирські: Образ степового кордону", sub: "Bogatyr Outposts: The Steppe Frontier Image", status: "locked" },
-        { num: 16, slug: "bylyny-sotsialni", title: "Соціальний конфлікт в епосі: Вольга і Микула", sub: "Social Conflict in Epic: Volga and Mykula", status: "locked" },
+        { num: 9, slug: "rodynna-obriadovist-zvychai", title: "Родинна обрядовість і звичаї", sub: "Family Rites and Customs", status: "locked" },
+        { num: 10, slug: "vesilni-pisni", title: "Весільні пісні", sub: "Wedding Songs", status: "locked" },
+        { num: 11, slug: "holosinnya", title: "Голосіння", sub: "Funeral Laments", status: "locked" },
       ]
     },
     {
-      unit: "FOLK.4",
+      unit: "Блок D · Епос і кобзарство · Epic & Kobzar Tradition",
       items: [
-        { num: 17, slug: "pokhodzhennia-dum", title: "Походження та специфіка козацьких дум", sub: "Origins and Specifics of Cossack Dumas", status: "locked" },
-        { num: 18, slug: "dumy-nevilnytski", title: "Невільницькі думи: Плач бранців", sub: "Captivity Dumas: The Captives' Lament", status: "locked" },
-        { num: 19, slug: "dumy-nevilnytski-lytsarski", title: "Невільницькі та лицарські думи: Плач і героїка", sub: "Captivity and Knightly Dumas: Lament and Heroic Memory", status: "active" },
-        { num: 20, slug: "dumy-sotsialno-pobutovi", title: "Соціально-побутові думи: Родинна мораль", sub: "Domestic Dumas: Family Morality", status: "locked" },
-        { num: 21, slug: "kobzarstvo-fenomen", title: "Кобзарство як унікальний феномен", sub: "Kobzarstvo as a Unique Phenomenon", status: "locked" },
+        { num: 12, slug: "dumy-nevilnytski-lytsarski", title: "Невільницькі та лицарські думи", sub: "Captivity and Knightly Dumas", status: "active" },
+        { num: 13, slug: "dumy-sotsialno-pobutovi", title: "Соціально-побутові думи", sub: "Social Dumas", status: "locked" },
+        { num: 14, slug: "kobzarstvo-lirnytstvo", title: "Кобзарство та лірництво", sub: "Kobzars and Lirnyks", status: "locked" },
+        { num: 15, slug: "bylyny-kyivskoho-tsyklu", title: "Билини київського циклу", sub: "Byliny of the Kyiv Cycle", status: "locked" },
       ]
     },
     {
-      unit: "FOLK.2",
+      unit: "Блок E · Пісенні жанри · Song Genres",
       items: [
-        { num: 22, slug: "narodni-balady", title: "Народні балади: Трагізм і доля", sub: "Folk Ballads: Tragedy and Fate", status: "locked" },
-        { num: 23, slug: "chumatski-burlatski-pisni", title: "Чумацькі та бурлацькі пісні: Голос мандрівника", sub: "Chumak and Burlak Songs: The Wanderer's Voice", status: "locked" },
+        { num: 16, slug: "istorychni-pisni", title: "Історичні пісні", sub: "Historical Songs", status: "locked" },
+        { num: 17, slug: "striletski-povstanski-pisni", title: "Стрілецькі та повстанські пісні", sub: "Riflemen's and Insurgent Songs", status: "locked" },
+        { num: 18, slug: "rodynno-pobutovi-pisni", title: "Родинно-побутові пісні", sub: "Family and Everyday Lyric Songs", status: "locked" },
+        { num: 19, slug: "kolomyiky", title: "Коломийки", sub: "Kolomyiky (Short-Form Song/Dance)", status: "locked" },
+        { num: 20, slug: "suspilno-pobutovi-pisni", title: "Суспільно-побутові пісні", sub: "Social and Occupational Songs", status: "locked" },
+        { num: 21, slug: "narodni-balady", title: "Народні балади", sub: "Folk Ballads", status: "locked" },
+        { num: 22, slug: "pisni-literaturnoho-pokhodzhennia", title: "Пісні літературного походження", sub: "Songs of Literary Origin", status: "locked" },
       ]
     },
     {
-      unit: "FOLK.5",
+      unit: "Блок F · Проза, паремії, дитячий фольклор · Prose, Paremia, Children's Lore",
       items: [
-        { num: 24, slug: "prykazky-ta-pryslivia", title: "Приказки та прислів'я: Етика повсякдення", sub: "Proverbs and Sayings: Ethics of Everyday Life", status: "locked" },
-        { num: 25, slug: "zahadky", title: "Загадки: Метафоричне бачення світу", sub: "Riddles: A Metaphorical Worldview", status: "locked" },
-        { num: 26, slug: "narodni-anekdoty", title: "Народні анекдоти та небилиці: Сміхова культура", sub: "Folk Anecdotes and Tall Tales: Laughter Culture", status: "locked" },
-        { num: 27, slug: "rodynna-liryka-kolomyiky", title: "Родинна лірика та коломийки: Інтимний голос", sub: "Family Lyrics and Kolomyiky: The Intimate Voice", status: "locked" },
+        { num: 23, slug: "charivni-kazky", title: "Чарівні казки", sub: "Magic Tales", status: "locked" },
+        { num: 24, slug: "kazky-pro-tvaryn", title: "Казки про тварин", sub: "Animal Tales", status: "locked" },
+        { num: 25, slug: "sotsialno-pobutovi-kazky", title: "Соціально-побутові казки", sub: "Social and Everyday Tales", status: "locked" },
+        { num: 26, slug: "narodni-lehendy", title: "Народні легенди", sub: "Folk Legends", status: "locked" },
+        { num: 27, slug: "istorychni-perekazy", title: "Історичні перекази", sub: "Historical Legends", status: "locked" },
+        { num: 28, slug: "narodni-opovidannia-buvalshchyny-memoraty", title: "Народні оповідання, бувальщини, меморати", sub: "Folk Narratives, True Stories, Memorates", status: "locked" },
+        { num: 29, slug: "prykazky-ta-pryslivia", title: "Приказки та прислів'я", sub: "Proverbs and Sayings", status: "locked" },
+        { num: 30, slug: "zahadky", title: "Загадки", sub: "Riddles", status: "locked" },
+        { num: 31, slug: "narodni-anekdoty", title: "Народні анекдоти", sub: "Folk Anecdotes", status: "locked" },
+        { num: 32, slug: "dytiachyi-folklor-kolyskovi", title: "Дитячий фольклор і колискові", sub: "Children's Folklore and Lullabies", status: "locked" },
+      ]
+    },
+    {
+      unit: "Блок G · Драма, музика, танець · Drama, Music, Dance",
+      items: [
+        { num: 33, slug: "vertep-narodna-drama", title: "Вертеп і народна драма", sub: "Vertep and Folk Drama", status: "locked" },
+        { num: 34, slug: "narodni-muzychni-instrumenty", title: "Народні музичні інструменти", sub: "Folk Musical Instruments", status: "locked" },
+        { num: 35, slug: "narodni-tantsi", title: "Народні танці", sub: "Folk Dances", status: "locked" },
+      ]
+    },
+    {
+      unit: "Блок H · Матеріальна культура · Material Culture",
+      items: [
+        { num: 36, slug: "pysankarstvo", title: "Писанкарство", sub: "Pysanka Art (Decorated Eggs)", status: "locked" },
+        { num: 37, slug: "narodna-vyshyvka-rushnyk-strii", title: "Народна вишивка, рушник, стрій", sub: "Folk Embroidery, Rushnyk and Dress", status: "locked" },
+        { num: 38, slug: "narodni-remesla-ta-khudozhni-promysly", title: "Народні ремесла та художні промисли", sub: "Folk Crafts and Artistic Trades", status: "locked" },
+        { num: 39, slug: "narodne-zhytlo-sadyba-hospodarstvo", title: "Народне житло, садиба, господарство", sub: "Folk Dwelling, Homestead and Husbandry", status: "locked" },
+        { num: 40, slug: "narodna-kukhnia-obriadova-yizha", title: "Народна кухня та обрядова їжа", sub: "Folk Cuisine and Ritual Food", status: "locked" },
+      ]
+    },
+    {
+      unit: "Блок I · Синтез · Synthesis",
+      items: [
+        { num: 41, slug: "rehionalni-etnokulturni-tradytsii", title: "Регіональні етнокультурні традиції", sub: "Regional Ethnocultural Traditions", status: "locked" },
+        { num: 42, slug: "narodna-kultura-ta-vysoka-kultura-mistky", title: "Народна культура та висока культура: містки", sub: "Folk Culture and High Culture: Bridges", status: "locked" },
       ]
     },
   ]}

--- a/site/src/data/curriculum-stats.json
+++ b/site/src/data/curriculum-stats.json
@@ -3,22 +3,22 @@
     "modules": 55
   },
   "a2": {
-    "modules": 60
+    "modules": 69
   },
   "b1": {
-    "modules": 91
+    "modules": 94
   },
   "b2": {
-    "modules": 89
+    "modules": 93
   },
   "c1": {
-    "modules": 111
+    "modules": 132
   },
   "hist": {
     "modules": 140
   },
   "bio": {
-    "modules": 180
+    "modules": 310
   },
   "lit": {
     "modules": 232
@@ -26,14 +26,8 @@
   "istorio": {
     "modules": 136
   },
-  "b2-pro": {
-    "modules": 40
-  },
-  "c1-pro": {
-    "modules": 50
-  },
   "c2": {
-    "modules": 106
+    "modules": 110
   },
   "oes": {
     "modules": 102
@@ -63,7 +57,7 @@
     "modules": 17
   },
   "folk": {
-    "modules": 27
+    "modules": 42
   },
-  "_total": 1737
+  "_total": 1833
 }


### PR DESCRIPTION
## Surface folk as a PREVIEW / seminar-test (user-directed 2026-06-14)

User: *"build proper folk landing page and i think it is time to link it in now as preview/seminar test? it has to be amongst the seminar tracks anyway. and bio is 310 modules."*

**⚠ Cross-lane + reverses orchestrator #3027** ("hide folk nav — too early"). Done under direct user order (#M-1) via worktree→PR. Folk content is unchanged — this is surfacing + a proper landing.

### What changed (6 files)
| File | Change |
|---|---|
| `site/src/content/docs/folk/index.mdx` | Rebuilt from the **stale 27-topic** taxonomy to the full **42-topic** `phase-folk-queue.md` queue (9 blocks A→I). **3 built modules `active`** (kalendarna #04, koliadky #05, dumy-nevilnytski-lytsarski #12), 39 `locked`. PREVIEW/seminar-test labeling. Active slugs verified to match the 3 built MDX files (no dead links). |
| `site/src/components/LevelLanding.tsx` | `HIDDEN_MODULE_LINK_TRACKS` emptied → built folk module links clickable. |
| `site/astro.config.mjs` | `hiddenPublicPaths` emptied → `/folk` routes public. |
| `site/src/components/Home.tsx` | **FOLK card** added to *Specialization Tracks* (alongside HIST/ISTORIO/BIO/LIT) with a **PREVIEW** pill. |
| `site/src/data/curriculum-stats.json` | **Regenerated** from curriculum.yaml SSOT → **bio 180→310, folk 27→42** (the json was stale; curriculum.yaml already had the right counts). Synced all drifted counts (_total 1737→1833). |
| `docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md` | Session 26 handoff. |

### Honest preview posture
Only the 3 built modules are clickable; the other 39 are locked. The earlier "don't un-hide until koliadky+dumy clear LLM QG" gate was **explicitly lifted by the user** in favour of a clearly-labeled preview launch (matches the a2 preview posture).

### Verification
- Structural: 42 items / 3 active / 39 locked / 9 units; active slugs == built MDX; braces balanced; stats JSON valid.
- Build: **Frontend CI (build + vitest)** is the authoritative gate (no local node_modules). Post-merge: `services.sh restart astro` + confirm `/folk/` and the 3 module pages render live.

**@orchestrator** — flagging: this reverses #3027 and touches shared `site/` (Home/LevelLanding/astro.config). Self-merging on green under the folk grant + the direct user directive to ship now; revert the un-hide if you object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
