### PR TITLE
fix(atlas): tolerate #2971 base-form suffix in kaikki etymology attribution gate

### DIFF
--- a/scripts/audit/validate_atlas_conformance.py
+++ b/scripts/audit/validate_atlas_conformance.py
@@ -550,6 +550,17 @@ def _has_exact_kaikki_source(section: Mapping[str, Any]) -> bool:
     return str(section.get("source") or "").strip() == KAIKKI_SOURCE
 
 
+# #2971 (derivational-base etymology) appends an informative
+# " (etymology of base form X)" suffix to the etymology source when the lemma's
+# etymology is resolved via its base form. The kaikki attribution prefix stays
+# intact ahead of the suffix, so it remains CC BY-SA-compliant — tolerate it.
+_BASE_FORM_ETYMOLOGY_SUFFIX_RE = re.compile(r"\s*\(etymology of base form .+\)$")
+
+
+def _kaikki_etymology_attribution_ok(source: str) -> bool:
+    return _BASE_FORM_ETYMOLOGY_SUFFIX_RE.sub("", source.strip()) == KAIKKI_SOURCE
+
+
 def _check_kaikki_attribution(entry: Mapping[str, Any], lemma: str, violations: list[Violation]) -> None:
     pronunciation = _pronunciation(entry)
     if isinstance(pronunciation, Mapping) and pronunciation.get("ipa") and not _has_exact_kaikki_source(pronunciation):
@@ -565,12 +576,13 @@ def _check_kaikki_attribution(entry: Mapping[str, Any], lemma: str, violations: 
     if not isinstance(etymology, Mapping):
         return
     source = str(etymology.get("source") or "").strip()
-    if "kaikki" in source.casefold() and source != KAIKKI_SOURCE:
+    if "kaikki" in source.casefold() and not _kaikki_etymology_attribution_ok(source):
         violations.append(
             Violation(
                 "kaikki_attribution_required",
                 lemma,
-                f"kaikki etymology source must be {KAIKKI_SOURCE!r}",
+                f"kaikki etymology source must be {KAIKKI_SOURCE!r} "
+                "(optionally with an ' (etymology of base form …)' suffix)",
             )
         )
 

--- a/tests/test_atlas_conformance.py
+++ b/tests/test_atlas_conformance.py
@@ -258,3 +258,32 @@ def test_kaikki_etymology_source_must_carry_cc_by_sa_attribution():
     )
 
     assert _gates_for(entry) == ["kaikki_attribution_required"]
+
+
+def test_kaikki_etymology_tolerates_base_form_suffix():
+    # #2971 appends " (etymology of base form X)" to derived-lemma etymologies;
+    # the attribution prefix is intact, so this must PASS (regression: a real
+    # re-enrich produced these and turned the conformance gate RED on main).
+    entry = _entry(
+        enrichment={
+            "etymology": {
+                "text": "From Proto-Slavic *vyględati.",
+                "source": f"{KAIKKI_SOURCE} (etymology of base form вигляд)",
+            }
+        }
+    )
+
+    assert _gates_for(entry) == []
+
+
+def test_kaikki_etymology_base_form_suffix_without_attribution_still_fails():
+    entry = _entry(
+        enrichment={
+            "etymology": {
+                "text": "From Proto-Slavic *vyględati.",
+                "source": "kaikki/Wiktionary (etymology of base form вигляд)",
+            }
+        }
+    )
+
+    assert _gates_for(entry) == ["kaikki_attribution_required"]


### PR DESCRIPTION
RED-main hotfix: the controlled re-enrich (4fabcecfc5) turned test_atlas_conformance.py::test_real_lexicon_manifest_conforms_to_atlas_gates (required) RED — ~34 kaikki_attribution_required violations, blocking all merges. Root cause: #2971 appends ' (etymology of base form X)' to the etymology source; the gate required an exact match to KAIKKI_SOURCE. #2971's fixture-only tests never exercised the real re-enriched manifest. The CC BY-SA prefix stays intact (licensing-compliant; live site fine). Fix strips the suffix before the attribution check (etymology only; pronunciation stays strict). 21/21 conformance tests pass incl. the real-manifest gate; ruff clean. Unblocks #3121/#3122 + track PRs.