### PR TITLE
fix(lexicon): per-lemma wrong-sense synonym exclusion (#3116) + etymology const typo

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -283,6 +283,23 @@ _BLOCKED_SYNONYMS = {
     "флористська хризантема",
 }
 
+# #3116 — curated PER-LEMMA wrong-sense synonym exclusions. Each listed word is
+# authentic Ukrainian (Грінченко/ЕСУМ-attested, NOT a Russianism) that the
+# Karavansky synset over-includes under a sense the lemma does NOT carry. It is
+# excluded only for that specific lemma — NEVER globally (cf. _BLOCKED_SYNONYMS) —
+# so the word stays valid for the lemmas where it IS correct. This is the
+# блискучий/кам'янка heritage lesson: fix the wrong (lemma, sense) pair, never
+# stoplist a valid word.
+#   шлях → кам'яниця: Грінченко = "Каменное строеніе" (stone building) / sparrow
+#          trap; ЕСУМ adds the stone-bramble berry — no road sense. The road term
+#          is кам'янка (Грінченко sense 4: "Шосе. Кам'янкою їхати").
+#   річка → звір: Грінченко звір I = "Овраг, лощина" (ravine), звір II = "зверь"
+#          (beast) — neither is a river.
+_WRONG_SENSE_SYNONYMS: dict[str, frozenset[str]] = {
+    "шлях": frozenset({"кам'яниця"}),
+    "річка": frozenset({"звір"}),
+}
+
 _COMPOSITIONAL_ETYMOLOGY_EXCLUSIONS = {
     "а тебе?",
     "а у тебе?",
@@ -295,7 +312,7 @@ _COMPOSITIONAL_ETYMOLOGY_EXCLUSIONS = {
     "як справи?",
 }
 
-_DERIVATIONAL_ETYMLOGY_BASES: dict[str, tuple[str, ...]] = {
+_DERIVATIONAL_ETYMOLOGY_BASES: dict[str, tuple[str, ...]] = {
     "добре": ("добрий", "добро"),
     "чудово": ("чудо", "чудовий"),
     "пізно": ("пізній",),
@@ -314,7 +331,7 @@ _DERIVATIONAL_ETYMLOGY_BASES: dict[str, tuple[str, ...]] = {
     "повертати": ("вертати",),
 }
 
-_ORDINAL_ETYMLOGY_BASES: dict[str, tuple[str, ...]] = {
+_ORDINAL_ETYMOLOGY_BASES: dict[str, tuple[str, ...]] = {
     "перша": ("перший", "один"),
     "перше": ("перший", "один"),
     "перший": ("один",),
@@ -1026,6 +1043,11 @@ def _clean_synonym_candidate(candidate: str, lemma: str) -> str | None:
     for variant in _split_lemma_variants(_strip_stress(lemma)):
         normalized_variant = variant.casefold()
         if term == normalized_variant or _contains_whole_token(term, normalized_variant):
+            return None
+    excluded = _WRONG_SENSE_SYNONYMS.get(_base_lemma(lemma).casefold())
+    if excluded:
+        normalized = term.replace("’", "'").replace("ʼ", "'").replace("`", "'")
+        if normalized in excluded:
             return None
     return term
 
@@ -1824,8 +1846,8 @@ def _direct_etymology_base_candidates(word: str) -> list[str]:
     key = _lookup_key(word)
     if not key:
         return candidates
-    candidates.extend(_DERIVATIONAL_ETYMLOGY_BASES.get(key, ()))
-    candidates.extend(_ORDINAL_ETYMLOGY_BASES.get(key, ()))
+    candidates.extend(_DERIVATIONAL_ETYMOLOGY_BASES.get(key, ()))
+    candidates.extend(_ORDINAL_ETYMOLOGY_BASES.get(key, ()))
 
     if key.endswith(("ся", "сь")) and len(key) > 4:
         candidates.append(key[:-2])

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -5,10 +5,12 @@ import pytest
 
 from scripts.lexicon import enrich_manifest as enrich_manifest_module
 from scripts.lexicon.enrich_manifest import (
+    _WRONG_SENSE_SYNONYMS,
     KAIKKI_SOURCE,
     _base_lemma,
     _build_paradigm,
     _cefr,
+    _clean_synonym_candidate,
     _curated_calque,
     _definition_cards,
     _dmklinger_key,
@@ -394,6 +396,32 @@ def test_slovnyk_synonyms_omit_wrong_sense_voda(monkeypatch) -> None:
     items = section["items"] if section else []
     assert "багатослів'я" not in items
     assert "велемовність" not in items
+
+
+def test_wrong_sense_synonym_excluded_per_lemma_not_globally() -> None:
+    # #3116: кам'яниця (stone building, Грінченко) and звір (ravine/beast) are
+    # authentic words the Karavansky synset over-includes for шлях/річка. They are
+    # dropped for THAT lemma only — never globally — so a stoplist that would
+    # repeat the блискучий heritage error is avoided.
+    assert _clean_synonym_candidate("кам'яниця", "шлях") is None
+    assert _clean_synonym_candidate("звір", "річка") is None
+    # valid same-sense synonyms survive
+    assert _clean_synonym_candidate("дорога", "шлях") == "дорога"
+    assert _clean_synonym_candidate("струмок", "річка") == "струмок"
+    # NOT a global block: кам'яниця stays valid as a synonym of a different lemma
+    assert _clean_synonym_candidate("кам'яниця", "будинок") == "кам'яниця"
+
+
+def test_wrong_sense_synonyms_are_authentic_not_russianisms() -> None:
+    # Contract guard: every excluded term is per-lemma sense-scoped, never a
+    # blanket entry. Keys are base lemmas; the excluded words must NOT leak into
+    # the global _BLOCKED_SYNONYMS stoplist (they are valid Ukrainian).
+    blocked = enrich_manifest_module._BLOCKED_SYNONYMS
+    for lemma, excluded in _WRONG_SENSE_SYNONYMS.items():
+        assert lemma == lemma.casefold(), f"key {lemma!r} must be casefolded"
+        assert excluded, f"{lemma} must list at least one excluded term"
+        for term in excluded:
+            assert term not in blocked, f"{term} is valid Ukrainian — must not be globally blocked"
 
 
 def test_slovnyk_synonyms_promote_clean_sources_for_sample(monkeypatch) -> None:


### PR DESCRIPTION
## #3116 — wrong-sense synonym leak

The Karavansky synset extraction over-includes an **authentic** Ukrainian word under a sense the lemma doesn't carry:

| Lemma | Leaked synonym | Why it's wrong (verified via `mcp__sources__*`) | Correct term |
|---|---|---|---|
| `шлях` | `кам'яниця` | Грінченко = "Каменное строеніе" (stone building) / sparrow-trap; ЕСУМ adds the stone-bramble berry — **no road sense** | `кам'янка` (Грінченко sense 4: "Шосе. Кам'янкою їхати") |
| `річка` | `звір` | Грінченко звір I = "Овраг, лощина" (ravine); звір II = "зверь" (beast) — **neither is a river** | — |

A prior session reclassified #3116 as "valid dialectal terms" — that **conflated кам'яниця with кам'янка**. The dictionaries settle it: both leaked words are genuinely wrong-sense.

### Fix — sense-scoped, not a stoplist
Both words are authentic Ukrainian (heritage score 96, `russianism_warning=False`), so a global block would repeat the **блискучий heritage error**. Instead: a curated `_WRONG_SENSE_SYNONYMS` map applied in `_clean_synonym_candidate`, dropping the word **only for that lemma** — never globally. Verified that `кам'яниця` is still kept as a synonym of `будинок`. The user-visible effect lands on the next re-enrich (deploy-gated).

## #3102 follow-up nit
Renamed the typo'd consts `_DERIVATIONAL_ETYMLOGY_BASES` / `_ORDINAL_ETYMLOGY_BASES` → `…_ETYMOLOGY_…` (4 occurrences, private module consts, no external refs).

## Tests
+2 tests: per-lemma exclusion incl. the not-globally-blocked guard; a contract test that excluded terms never leak into `_BLOCKED_SYNONYMS`. `ruff` clean; **85 passed** in `tests/test_lexicon_enrich_manifest.py` + `test_calque_corrections.py` + `test_enrich.py`.

No auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)