### PR TITLE
fix(pipeline): exempt 'як «X»' citation-frame foreign terms from vesum gate (#3132)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -731,15 +731,28 @@ _TF_NEGATIVE_EXAMPLE_RE = re.compile(
 # CORRECT form (the structural emphasis: "**л**" is the epenthetic
 # consonant being taught). Matching bold here would strip the very tokens
 # we want VESUM to verify.
+#
+# Citation/example frame (#3132): a foreign/Russian term CITED as an example in
+# decolonization prose — `як «лєший»`, `such as «X»`, `like «X»` — is a mention,
+# not a use, and лєший is correctly absent from VESUM (the Ukrainian is лісовик).
+# Unlike the negator frame this arm is restricted to «» guillemets (the Ukrainian
+# citation mark): the negator `не/not` already explicitly marks the form wrong, so
+# it is allowed to strip any quote style; `як/as/like` is a weaker "such as"
+# signal, so it requires the strong «»-citation mark and will NOT exempt a
+# straight-quoted or italicised span. A bare (un-cited) invalid form still fails.
 _WARNING_QUOTE_RE = re.compile(
-    # Four alternations: quotes, guillemets, closed italics, unclosed italics.
-    # The unclosed-italic arm requires the inner span to be Cyrillic-only
-    # (no asterisk, no whitespace, no punctuation) so it stops cleanly at
-    # the next boundary instead of swallowing the rest of the sentence.
-    r"\b(?:not|не)\s+(?:"
+    r"\b(?:"
+    # Negator frame ("say X, not Y") — Y is marked wrong; all three quote styles.
+    # The unclosed-italic arm requires the inner span to be Cyrillic-only (no
+    # asterisk, whitespace, or punctuation) so it stops cleanly at the next
+    # boundary instead of swallowing the rest of the sentence.
+    r"(?:not|не)\s+(?:"
     r'["«][^"»]+["»]'
     r"|\*[^*\n]+?\*"
     r"|\*[A-Za-zА-ЯІЇЄҐа-яіїєґ\'ʼ-]+"
+    r")"
+    # Citation/example frame ("як «X»", "such as «X»") — «»-guillemets only.
+    r"|(?:як|such\s+as|as|like)\s+«[^»]+»"
     r")",
     re.IGNORECASE,
 )
@@ -9306,6 +9319,8 @@ def _strip_metalinguistic(text: str) -> str:
       after bad-form marker spans have already been removed.
     - `not "форма"` / `not «форма»` — prose-quoted warning examples where the
       quoted form is explicitly marked as wrong.
+    - `як «лєший»` / `such as «X»` — a foreign/Russian term cited as an example
+      in decolonization prose (a mention, not a use). «»-guillemets only (#3132).
 
     Used by the VESUM gate to avoid false positives on fragments that aren't
     VESUM-checkable lemmas.

--- a/tests/build/test_vesum_negative_example_handling.py
+++ b/tests/build/test_vesum_negative_example_handling.py
@@ -358,3 +358,83 @@ def test_m20_style_true_false_negative_example_smoke(
         and event["forms"] == ["дивюся"]
         for event in _events(telemetry)
     )
+
+
+# --- #3132: citation/example frame ("як «X»") for cited foreign mentions ------
+
+
+def test_citation_frame_yak_guillemets_strips_cited_foreign_term() -> None:
+    # A Russian term cited as an example ("як «лєший»") is a mention, not a use —
+    # лєший is correctly absent from VESUM (the Ukrainian is лісовик). The gate
+    # must not false-flag it (was blocking folk decolonization prose).
+    seen: list[list[str]] = []
+    result = linear_pipeline._vesum_gate(
+        module_text="Довколишні духи, як «лєший», у народній демонології.",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=_verify_except({"лєший"}, seen),
+    )
+
+    assert result["passed"] is True
+    assert "лєший" not in seen[0]
+    assert "духи" in seen[0]  # surrounding valid Ukrainian still verified
+
+
+def test_citation_frame_english_such_as_guillemets_strips_term() -> None:
+    seen: list[list[str]] = []
+    result = linear_pipeline._vesum_gate(
+        module_text="Spirits such as «лєший» recur in folk demonology.",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=_verify_except({"лєший"}, seen),
+    )
+
+    assert result["passed"] is True
+    assert "лєший" not in seen[0]
+
+
+def test_uncited_invalid_form_still_fails_the_gate() -> None:
+    # Narrowness guard: a bare invalid form NOT in a citation frame still fails.
+    # The exemption must never become a blanket VESUM bypass.
+    result = linear_pipeline._vesum_gate(
+        module_text="Духи лєший живуть у темному лісі.",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=_verify_except({"лєший"}),
+    )
+
+    assert result["passed"] is False
+    assert "лєший" in result["missing"]
+
+
+def test_citation_frame_requires_guillemets_not_straight_quotes() -> None:
+    # The "як/as/like" arm is restricted to «» (the Ukrainian citation mark);
+    # straight quotes must NOT trigger it, so the invalid form still fails.
+    result = linear_pipeline._vesum_gate(
+        module_text='Духи, як "лєший", тут живуть.',
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=_verify_except({"лєший"}),
+    )
+
+    assert result["passed"] is False
+    assert "лєший" in result["missing"]
+
+
+def test_negator_frame_unchanged_by_citation_arm() -> None:
+    # Regression: the existing "не «X»" negator behavior is preserved.
+    seen: list[list[str]] = []
+    result = linear_pipeline._vesum_gate(
+        module_text="Кажемо сніданок, не «завтрак».",
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=_verify_except({"завтрак"}, seen),
+    )
+
+    assert result["passed"] is True
+    assert "завтрак" not in seen[0]


### PR DESCRIPTION
Closes #3132. Surfaced by the folk track orchestrator (blocking decolonization builds).

## Problem
The module vesum gate's anti-example exemption (`_WARNING_QUOTE_RE`, `linear_pipeline.py`) only fired after the **negator** `не`/`not` ("say X, *not* Y"). Decolonization prose cites a Russian term as an **example** — `як «лєший»` (рос. *леший*; the Ukrainian is `лісовик`) — a **mention, not a use**. The `як` (such as) frame wasn't covered, so the cited foreign term got VESUM-checked and false-flagged, blocking the build. Sibling of #2997/#2998 (verbatim `>` blockquotes), but for inline `«»` citations.

## Fix
Add an example-frame arm `(?:як|such as|as|like)\s+«[^»]+»`. **Design choice:** the example arm is restricted to `«»` **guillemets** (the Ukrainian citation mark); the negator arm keeps all three quote styles. Rationale: `не`/`not` *explicitly* marks the form wrong, so it may strip any quote style; `як`/`as`/`like` is a weaker "such as" signal, so it requires the strong `«»`-citation mark and will **not** exempt straight-quoted or italicised spans.

**Blast radius:** the change only ever *removes* tokens from VESUM scope — it can't make a passing build fail. The only loosening is the intended narrow citation case.

## Tests (+5, all green)
| Case | Expectation |
|---|---|
| `як «лєший»` / `such as «лєший»` | stripped → gate passes |
| bare `лєший` (un-cited) | **still fails** (no blanket bypass) |
| `як "лєший"` (straight quotes) | **still fails** (guillemets-only guard) |
| `не «завтрак»` | unchanged (negator regression) |

16/16 in the file; **157 passed** in the `tests/build` slice. The one failure (`test_build_knowledge_packet_reads_wiki_and_sources`) is **pre-existing + data-dependent** — confirmed identical on clean main via stash.

## Needs track validation
@folk-orchestrator: please confirm this clears the false-positive on the real `narodni-viruvannia-mifolohiia-demonolohiia` build. If you hit another frame (`так зване «X»`, `рос. «X»`, `слово «X»`), comment and I'll extend the alternation.

No auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)