### PR TITLE
fix(pipeline): correct vesum violations in YAML artifacts

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -4820,6 +4820,7 @@ def render_reviewer_correction_prompt(
     gate_report: Mapping[str, Any],
     module_text: str,
     candidates: tuple[CorrectionCandidate, ...] = (),
+    artifact_texts: Mapping[str, str] | None = None,
 ) -> str:
     """Build a reviewer-as-fixer prompt for one failed Python QG gate."""
     candidate_rows = [
@@ -4846,6 +4847,30 @@ def render_reviewer_correction_prompt(
         allow_unicode=True,
         sort_keys=False,
     ).strip()
+    artifact_sections = [
+        "## Current module.md",
+        "```markdown",
+        module_text,
+        "```",
+    ]
+    if artifact_texts:
+        artifact_sections.extend(
+            [
+                "",
+                "## Additional patchable artifacts",
+                "The pipeline applies each literal fix to any listed artifact where the anchor occurs.",
+            ]
+        )
+        for artifact_name, artifact_text in artifact_texts.items():
+            artifact_sections.extend(
+                [
+                    "",
+                    f"### {artifact_name}",
+                    f"```yaml file={artifact_name}",
+                    artifact_text,
+                    "```",
+                ]
+            )
     return "\n".join(
         [
             "# Python QG correction",
@@ -4871,10 +4896,7 @@ def render_reviewer_correction_prompt(
             candidate_section,
             "```",
             "",
-            "## Current module.md",
-            "```markdown",
-            module_text,
-            "```",
+            *artifact_sections,
         ]
     )
 
@@ -5132,7 +5154,6 @@ def run_python_qg_with_corrections(
     FAIL triggers the ``previously_passed_regression`` terminal meta-gate.
     """
     attempts: set[str] = set()
-    vesum_missing_exclusions: set[str] = set()
     correction_round = 0
 
     def _run_qg() -> dict[str, Any]:
@@ -5144,7 +5165,6 @@ def run_python_qg_with_corrections(
                 plan_path,
                 verify_words_fn=verify_words_fn,
                 heritage_lookup_fn=heritage_lookup_fn,
-                ignored_vesum_missing_surfaces=vesum_missing_exclusions,
                 event_sink=event_sink,
             )
         _attach_vocab_count_gate(report, module_dir=module_dir, plan_path=plan_path)
@@ -5166,6 +5186,11 @@ def run_python_qg_with_corrections(
         correction_round += 1
 
         before = report
+        artifact_snapshot = (
+            _snapshot_correction_artifacts(module_dir)
+            if failed_gate in REVIEWER_FIX_GATES
+            else None
+        )
         handled, unmatched_anchors, correction_payload = _apply_python_qg_correction(
             failed_gate,
             report,
@@ -5195,10 +5220,7 @@ def run_python_qg_with_corrections(
             )
             return report
 
-        if failed_gate == "vesum_verified":
-            vesum_missing_exclusions.update(unmatched_anchors)
         report = _run_qg()
-        vesum_missing_exclusions.clear()
         regressions = _previously_passing_regressions(before, report)
         correction_artifact: dict[str, Any] = {
             "round": correction_round,
@@ -5210,7 +5232,61 @@ def run_python_qg_with_corrections(
             "after": report,
             "regressions": regressions,
         }
+        if artifact_snapshot is not None and correction_payload.get("yaml_invalid"):
+            _restore_correction_artifacts(module_dir, artifact_snapshot)
+            restored_report = _run_qg()
+            _annotate_correction_terminal(
+                restored_report,
+                failed_gate,
+                f"{failed_gate} correction produced invalid YAML and was rolled back",
+            )
+            correction_artifact["rolled_back"] = True
+            correction_artifact["rollback_reason"] = "yaml_invalid"
+            correction_artifact["restored_after"] = restored_report
+            _write_correction_artifact(
+                module_dir / f"python_qg_correction_r{correction_round}.json",
+                correction_artifact,
+            )
+            return restored_report
+        if (
+            failed_gate == "vesum_verified"
+            and artifact_snapshot is not None
+            and not _vesum_correction_improved(before, report)
+        ):
+            _restore_correction_artifacts(module_dir, artifact_snapshot)
+            restored_report = _run_qg()
+            _annotate_correction_terminal(
+                restored_report,
+                failed_gate,
+                "vesum_verified correction did not clear any previous missing surface and was rolled back",
+            )
+            correction_artifact["rolled_back"] = True
+            correction_artifact["rollback_reason"] = "vesum_no_improvement"
+            correction_artifact["restored_after"] = restored_report
+            _write_correction_artifact(
+                module_dir / f"python_qg_correction_r{correction_round}.json",
+                correction_artifact,
+            )
+            return restored_report
         if regressions:
+            if artifact_snapshot is not None:
+                _restore_correction_artifacts(module_dir, artifact_snapshot)
+                restored_report = _run_qg()
+                gates = restored_report.setdefault("gates", {})
+                if isinstance(gates, dict):
+                    gates["previously_passed_regression"] = {
+                        "passed": False,
+                        "regressions": regressions,
+                    }
+                    gates["passed"] = False
+                correction_artifact["rolled_back"] = True
+                correction_artifact["rollback_reason"] = "previously_passed_regression"
+                correction_artifact["restored_after"] = restored_report
+                _write_correction_artifact(
+                    module_dir / f"python_qg_correction_r{correction_round}.json",
+                    correction_artifact,
+                )
+                return restored_report
             gates = report.setdefault("gates", {})
             if isinstance(gates, dict):
                 gates["previously_passed_regression"] = {
@@ -6017,6 +6093,49 @@ def _annotate_correction_terminal(
         gates["passed"] = False
 
 
+def _snapshot_correction_artifacts(module_dir: Path) -> dict[str, str | None]:
+    snapshot: dict[str, str | None] = {}
+    for artifact in WRITER_ARTIFACTS:
+        path = module_dir / artifact
+        snapshot[artifact] = path.read_text(encoding="utf-8") if path.exists() else None
+    return snapshot
+
+
+def _restore_correction_artifacts(module_dir: Path, snapshot: Mapping[str, str | None]) -> None:
+    for artifact, text in snapshot.items():
+        path = module_dir / artifact
+        if text is None:
+            path.unlink(missing_ok=True)
+            continue
+        path.write_text(text, encoding="utf-8")
+
+
+def _normalized_vesum_missing(report: Mapping[str, Any]) -> frozenset[str]:
+    gates = report.get("gates")
+    if not isinstance(gates, Mapping):
+        return frozenset()
+    gate_report = gates.get("vesum_verified")
+    if not isinstance(gate_report, Mapping):
+        return frozenset()
+    missing = gate_report.get("missing")
+    if not isinstance(missing, Sequence) or isinstance(missing, (str, bytes)):
+        return frozenset()
+    return frozenset(
+        _normalize_for_vesum(str(surface)).lower()
+        for surface in missing
+        if str(surface).strip()
+    )
+
+
+def _vesum_correction_improved(
+    before: Mapping[str, Any],
+    after: Mapping[str, Any],
+) -> bool:
+    before_missing = _normalized_vesum_missing(before)
+    after_missing = _normalized_vesum_missing(after)
+    return bool(before_missing) and after_missing < before_missing
+
+
 def _attach_vocab_count_gate(report: dict[str, Any], *, module_dir: Path, plan_path: Path) -> None:
     gates = report.get("gates")
     if not isinstance(gates, dict) or "vocab_count" in gates:
@@ -6367,11 +6486,18 @@ def _apply_reviewer_correction(
 ) -> tuple[frozenset[str], dict[str, Any]]:
     module_path = module_dir / "module.md"
     module_text = _read_required(module_path)
+    additional_artifact_names = REVIEWER_FIX_ADDITIONAL_ARTIFACTS_BY_GATE.get(gate, ())
+    additional_artifact_texts = {
+        artifact: _read_required(module_dir / artifact)
+        for artifact in additional_artifact_names
+        if (module_dir / artifact).exists()
+    }
     prompt = render_reviewer_correction_prompt(
         gate=gate,
         gate_report=gate_report,
         module_text=module_text,
         candidates=candidates,
+        artifact_texts=additional_artifact_texts,
     )
     context = CorrectionContext(
         gate=gate,
@@ -6447,7 +6573,7 @@ def _apply_reviewer_correction(
             "rejected_fixes": rejected_fixes,
             "applied": False,
         }
-    artifact_names = ("module.md", *REVIEWER_FIX_ADDITIONAL_ARTIFACTS_BY_GATE.get(gate, ()))
+    artifact_names = ("module.md", *additional_artifact_names)
     unmatched_by_artifact: list[set[str]] = []
     artifact_results: list[dict[str, Any]] = []
     for artifact in artifact_names:
@@ -6487,6 +6613,7 @@ def _apply_reviewer_correction(
             else:
                 artifact_record["yaml_valid"] = True
         artifact_results.append(artifact_record)
+    yaml_invalid = any(record.get("yaml_valid") is False for record in artifact_results)
 
     unmatched_anchors = (
         frozenset(set.intersection(*unmatched_by_artifact))
@@ -6510,6 +6637,7 @@ def _apply_reviewer_correction(
         "rejected_fixes": rejected_fixes,
         "unmatched_anchors": sorted(unmatched_anchors),
         "artifacts": artifact_results,
+        "yaml_invalid": yaml_invalid,
         "applied": True,
     }
 

--- a/tests/build/test_vesum_artifact_correction.py
+++ b/tests/build/test_vesum_artifact_correction.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from scripts.build import linear_pipeline
+
+
+def _verify_except(missing: set[str]):
+    def verify(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        return {
+            word: ([] if word in missing else [{"lemma": word}])
+            for word in words
+        }
+
+    return verify
+
+
+def _write_artifacts(
+    module_dir: Path,
+    *,
+    module_text: str = "## Гаївки\n\nУ весняному календарі гаївки мають живий ритм.\n",
+    activities_text: str,
+) -> None:
+    module_dir.mkdir()
+    (module_dir / "module.md").write_text(module_text, encoding="utf-8")
+    (module_dir / "activities.yaml").write_text(activities_text, encoding="utf-8")
+    (module_dir / "vocabulary.yaml").write_text("[]\n", encoding="utf-8")
+    (module_dir / "resources.yaml").write_text("[]\n", encoding="utf-8")
+
+
+def _vesum_qg_report(module_dir: Path, *, missing: set[str]) -> dict[str, object]:
+    gate = linear_pipeline._vesum_gate(
+        module_text=(module_dir / "module.md").read_text(encoding="utf-8"),
+        activities=yaml.safe_load(
+            (module_dir / "activities.yaml").read_text(encoding="utf-8")
+        ),
+        vocabulary=yaml.safe_load(
+            (module_dir / "vocabulary.yaml").read_text(encoding="utf-8")
+        ),
+        resources=yaml.safe_load(
+            (module_dir / "resources.yaml").read_text(encoding="utf-8")
+        ),
+        verify_words_fn=_verify_except(missing),
+    )
+    return {"gates": {"vesum_verified": gate, "passed": gate["passed"]}}
+
+
+def _correction_artifact(module_dir: Path) -> dict[str, object]:
+    return json.loads(
+        (module_dir / "python_qg_correction_r1.json").read_text(encoding="utf-8")
+    )
+
+
+def test_vesum_correction_patches_activities_yaml_and_rerun_passes(
+    tmp_path: Path,
+) -> None:
+    module_dir = tmp_path / "module"
+    _write_artifacts(
+        module_dir,
+        activities_text='- type: custom\n  prompt: "Знайди рядок про гаівки."\n',
+    )
+
+    def reviewer_corrector(context: linear_pipeline.CorrectionContext) -> str:
+        assert context.gate == "vesum_verified"
+        assert "activities.yaml" in context.prompt
+        assert "Знайди рядок про гаівки" in context.prompt
+        return "<fixes><fix><find>гаівки</find><replace>гаївки</replace></fix></fixes>"
+
+    report = linear_pipeline.run_python_qg_with_corrections(
+        module_dir,
+        tmp_path / "plan.yaml",
+        qg_runner=lambda: _vesum_qg_report(module_dir, missing={"гаівки"}),
+        reviewer_corrector=reviewer_corrector,
+    )
+
+    activities_text = (module_dir / "activities.yaml").read_text(encoding="utf-8")
+    parsed_activities = yaml.safe_load(activities_text)
+    correction = _correction_artifact(module_dir)
+    activity_record = next(
+        item
+        for item in correction["correction"]["artifacts"]
+        if item["artifact"] == "activities.yaml"
+    )
+
+    assert report["gates"]["passed"] is True
+    assert "гаївки" in activities_text
+    assert "гаівки" not in activities_text
+    assert parsed_activities[0]["prompt"] == "Знайди рядок про гаївки."
+    assert activity_record["changed"] is True
+    assert activity_record["yaml_valid"] is True
+
+
+def test_vesum_yaml_breaking_correction_rolls_back_and_fails_round(
+    tmp_path: Path,
+) -> None:
+    module_dir = tmp_path / "module"
+    original_activities = '- type: custom\n  prompt: "Знайди гаівки."\n'
+    _write_artifacts(module_dir, activities_text=original_activities)
+
+    report = linear_pipeline.run_python_qg_with_corrections(
+        module_dir,
+        tmp_path / "plan.yaml",
+        qg_runner=lambda: _vesum_qg_report(module_dir, missing={"гаівки"}),
+        reviewer_corrector=lambda _context: (
+            "<fixes><fix>"
+            '<find>  prompt: "Знайди гаівки."</find>'
+            '<replace>  prompt: "Знайди гаївки.</replace>'
+            "</fix></fixes>"
+        ),
+    )
+
+    correction = _correction_artifact(module_dir)
+    activities_text = (module_dir / "activities.yaml").read_text(encoding="utf-8")
+
+    assert report["gates"]["passed"] is False
+    assert report["gates"]["correction_terminal"]["gate"] == "vesum_verified"
+    assert correction["rolled_back"] is True
+    assert correction["rollback_reason"] == "yaml_invalid"
+    assert activities_text == original_activities
+    assert yaml.safe_load(activities_text)[0]["prompt"] == "Знайди гаівки."
+
+
+def test_vesum_unmatched_anchor_is_not_silently_exempted(
+    tmp_path: Path,
+) -> None:
+    module_dir = tmp_path / "module"
+    stressed_typo = "гаі\u0301вки"
+    _write_artifacts(
+        module_dir,
+        activities_text=f'- type: custom\n  prompt: "Знайди рядок про {stressed_typo}."\n',
+    )
+
+    report = linear_pipeline.run_python_qg_with_corrections(
+        module_dir,
+        tmp_path / "plan.yaml",
+        qg_runner=lambda: _vesum_qg_report(module_dir, missing={"гаівки"}),
+        reviewer_corrector=lambda _context: (
+            "<fixes><fix><find>гаівки</find><replace>гаївки</replace></fix></fixes>"
+        ),
+    )
+
+    activities_text = (module_dir / "activities.yaml").read_text(encoding="utf-8")
+    missing = report["gates"]["vesum_verified"]["missing"]
+
+    assert report["gates"]["passed"] is False
+    assert "correction_terminal" in report["gates"]
+    assert stressed_typo in activities_text
+    assert {
+        linear_pipeline._normalize_for_vesum(surface).lower()
+        for surface in missing
+    } == {"гаівки"}
+
+
+def test_vesum_module_md_correction_does_not_touch_yaml_artifacts(
+    tmp_path: Path,
+) -> None:
+    module_dir = tmp_path / "module"
+    original_activities = '- type: custom\n  prompt: "Знайди рядок про гаївки."\n'
+    _write_artifacts(
+        module_dir,
+        module_text="## Гаївки\n\nПомилковий рядок згадує гаівки у прозі.\n",
+        activities_text=original_activities,
+    )
+
+    report = linear_pipeline.run_python_qg_with_corrections(
+        module_dir,
+        tmp_path / "plan.yaml",
+        qg_runner=lambda: _vesum_qg_report(module_dir, missing={"гаівки"}),
+        reviewer_corrector=lambda _context: (
+            "<fixes><fix><find>гаівки</find><replace>гаївки</replace></fix></fixes>"
+        ),
+    )
+
+    assert report["gates"]["passed"] is True
+    assert "гаївки у прозі" in (module_dir / "module.md").read_text(encoding="utf-8")
+    assert (module_dir / "activities.yaml").read_text(encoding="utf-8") == original_activities


### PR DESCRIPTION
Fixes #2991.

## Attribution approach

I chose correction-time artifact search rather than changing the `python_qg.json` schema to attribute each missing surface. The reviewer still emits ADR-007 literal `<fixes>` find/replace entries, and the deterministic applier now scans `module.md` plus the patchable YAML artifacts for the gate (`activities.yaml`, `vocabulary.yaml`, `resources.yaml` for `vesum_verified`). This keeps the current gate report stable while making the correction prompt show the actual YAML artifact text that may contain the offending anchor.

## Rollback / teeth guarantees

- YAML artifact patches are parsed and schema-smoke-validated after application. If a reviewer fix breaks YAML, that artifact patch is reverted and the correction round is marked failed.
- For `vesum_verified`, the full Python QG rerun must shrink the normalized missing-surface set (`after_missing` must be a strict subset of `before_missing`). If not, all writer artifacts are restored from the pre-round snapshot.
- The previous unmatched-anchor VESUM suppression path was removed, so an unfixed missing form cannot pass by being added to an ignored set.
- Reviewer-fix regressions restore the pre-round artifacts while preserving the `previously_passed_regression` diagnostic.

## ADR-007 / ADR-008 compliance

- No LLM regeneration path was added. The reviewer emits `<fixes>` only; the pipeline applies deterministic literal substitutions.
- The module.md writer-correction path is unchanged; new behavior is limited to reviewer-fix gates and the VESUM YAML artifacts.
- The ADR-007 no-rewrite invariant test remains green.

## Test evidence

Required pytest command:

```text
.venv/bin/python -m pytest tests/build/test_vesum_negative_example_handling.py tests/test_no_rewrite_contract.py tests/build/test_vesum_artifact_correction.py -q
============================== 41 passed in 0.66s ==============================
```

Focused repro evidence is included in `tests/build/test_vesum_artifact_correction.py`: the `гаівки` typo in `activities.yaml` is patched to `гаївки`, YAML parses, and the rerun VESUM gate passes.

Adjacent correction tests:

```text
.venv/bin/python -m pytest tests/test_reviewer_correction_diagnostics.py tests/test_writer_correction_no_op_diagnostic.py tests/test_correction_loop_surgical.py -q
============================== 44 passed in 0.56s ==============================
```

Ruff:

```text
.venv/bin/ruff check scripts/build/linear_pipeline.py tests/build/test_vesum_artifact_correction.py
All checks passed!
```

Agent trailer:

```text
.venv/bin/python scripts/audit/lint_agent_trailer.py
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

No auto-merge.
