### PR TITLE
fix(audit): non-lossy postmortem INDEX regen + --check mode (#3045)

### DIFF
--- a/scripts/audit/check_postmortems.py
+++ b/scripts/audit/check_postmortems.py
@@ -306,6 +306,29 @@ def _generated_row(record: PostmortemRecord) -> IndexRow:
     )
 
 
+def _row_matches_record(row: IndexRow, record: PostmortemRecord) -> bool:
+    """True if an existing INDEX row already represents this autopsy file.
+
+    Match by FILENAME SLUG, not free-text category (#3045): a curated row whose
+    Category describes the failure class (e.g. ``ocr-pivot`` for
+    ``esum-ocr-pivot.md``) must still be recognised — otherwise a duplicate
+    generated row gets appended. Any one of three signals counts:
+
+      1. the Category cell equals the slug (generated-style rows);
+      2. the row links the file as ``<slug>.md`` (curated rows put the link in
+         the Summary, e.g. "Detail in `esum-ocr-pivot.md`.");
+      3. the Issue cell contains the record's issue (preserves prior behaviour;
+         the ``—`` placeholder never matches).
+    """
+    slug = record.slug
+    if row.category == slug:
+        return True
+    needle = f"{slug}.md"
+    if needle in row.summary or needle in row.category:
+        return True
+    return bool(record.issue and record.issue != "—" and record.issue in row.issue)
+
+
 def _index_rows(records: list[PostmortemRecord], index_text: str) -> list[IndexRow]:
     existing_rows = _parse_existing_rows(index_text)
     if not existing_rows:
@@ -314,15 +337,14 @@ def _index_rows(records: list[PostmortemRecord], index_text: str) -> list[IndexR
             key=lambda row: (row.category.lower(), row.date, row.summary.lower()),
         )
 
-    # Preserve historical rows exactly. Existing index categories sometimes
-    # describe the failure class rather than the filename slug, and multi-bug
-    # files intentionally have multiple rows. Use the table as curated data,
-    # then append generated rows only for genuinely new files.
+    # Preserve historical rows EXACTLY — curated categories often describe the
+    # failure class rather than the filename slug, and multi-incident files
+    # intentionally carry several rows. Treat the table as curated data and
+    # append a generated row only for a file that NO existing row represents
+    # (matched by slug, not free-text category — #3045).
     rows = list(existing_rows)
-    covered_categories = {row.category for row in rows}
-    covered_issues = {row.issue for row in rows if row.issue != "—"}
     for record in records:
-        if record.slug not in covered_categories and record.issue not in covered_issues:
+        if not any(_row_matches_record(row, record) for row in rows):
             rows.append(_generated_row(record))
 
     return rows
@@ -354,8 +376,13 @@ def _legacy_table_bounds(index_text: str) -> tuple[int, int] | None:
         end = next_line_start
 
 
-def regenerate_index(project_root: Path = PROJECT_ROOT) -> bool:
-    """Regenerate INDEX.md in place. Returns True if the file changed."""
+def regenerate_index(project_root: Path = PROJECT_ROOT, *, write: bool = True) -> bool:
+    """Regenerate INDEX.md in place. Returns True if the file changed.
+
+    With ``write=False`` it computes the regenerated text but does NOT write —
+    a dry-run staleness probe (returns True iff the file WOULD change). Used by
+    ``--check`` so CI can assert the index is current without mutating it.
+    """
     index_path = _index_path(project_root)
     if not index_path.exists():
         return False
@@ -379,7 +406,8 @@ def regenerate_index(project_root: Path = PROJECT_ROOT) -> bool:
 
     if new_text == index_text:
         return False
-    index_path.write_text(new_text, "utf-8")
+    if write:
+        index_path.write_text(new_text, "utf-8")
     return True
 
 
@@ -388,8 +416,9 @@ def run_check(
     project_root: Path = PROJECT_ROOT,
     regenerate: bool = True,
     regenerate_on_failure: bool = False,
+    check_index: bool = False,
 ) -> CheckResult:
-    """Validate postmortems and optionally regenerate the index."""
+    """Validate postmortems and optionally regenerate (or dry-run check) the index."""
     result = CheckResult(records=_load_postmortems(project_root))
     postmortem_dir = _postmortem_dir(project_root)
 
@@ -400,7 +429,15 @@ def run_check(
     for record in result.records:
         result.errors.extend(_check_required_fields(record, project_root))
 
-    if regenerate and (regenerate_on_failure or not result.errors):
+    if check_index:
+        # Dry-run: never write. A stale index is a failure so CI can gate on it.
+        if regenerate_index(project_root, write=False):
+            result.index_changed = True
+            result.errors.append(
+                f"{_relative(_index_path(project_root), project_root)} — "
+                "INDEX.md is stale; run `--regenerate-index`"
+            )
+    elif regenerate and (regenerate_on_failure or not result.errors):
         result.index_changed = regenerate_index(project_root)
 
     return result
@@ -420,6 +457,7 @@ def main(argv: list[str] | None = None, *, project_root: Path = PROJECT_ROOT) ->
             "  default              validate + regenerate INDEX.md when validation passes\n"
             "  --quiet              print only errors; stdout is empty on success\n"
             "  --regenerate-index   regenerate INDEX.md even if validation fails\n"
+            "  --check              verify INDEX.md is current WITHOUT writing; non-zero if stale\n"
         ),
     )
     parser.add_argument(
@@ -432,12 +470,18 @@ def main(argv: list[str] | None = None, *, project_root: Path = PROJECT_ROOT) ->
         action="store_true",
         help="Regenerate INDEX.md even if validation fails",
     )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify INDEX.md is up to date WITHOUT writing; non-zero exit if stale (for CI)",
+    )
     args = parser.parse_args(argv)
 
     result = run_check(
         project_root=project_root,
         regenerate=(not args.quiet or args.regenerate_index),
         regenerate_on_failure=args.regenerate_index,
+        check_index=args.check,
     )
 
     if args.quiet:
@@ -445,7 +489,7 @@ def main(argv: list[str] | None = None, *, project_root: Path = PROJECT_ROOT) ->
         return result.exit_code
 
     _print_errors(result.errors)
-    if result.index_changed:
+    if result.index_changed and not args.check:
         print(f"✅ regenerated {_relative(_index_path(project_root), project_root)}")
     print(f"✅ {len(result.records)} postmortems validated")
     return result.exit_code

--- a/tests/test_check_postmortems.py
+++ b/tests/test_check_postmortems.py
@@ -178,3 +178,80 @@ def test_index_regeneration_preserves_sort_order(tmp_path: Path) -> None:
 
     regenerated = (tmp_path / "docs" / "bug-autopsies" / "INDEX.md").read_text("utf-8")
     assert regenerated.index("| alpha-cache |") < regenerated.index("| zulu-cache |")
+
+
+# --- #3045: non-lossy regen (slug-mismatch dups + multi-incident + --check) ---
+
+
+_INDEX_HEADER = (
+    "# Bug Autopsy Index\n\n<!-- INDEX-START -->\n"
+    "| Date | Issue | Category | Summary |\n"
+    "|------|-------|----------|---------|\n"
+)
+
+
+def test_no_duplicate_row_for_slug_mismatched_curated_row(tmp_path: Path) -> None:
+    # A curated row whose Category ("ocr-pivot") differs from the filename slug
+    # ("esum-ocr-pivot") but links the file in its Summary must NOT get a
+    # duplicate generated row appended. The file's issue also differs from the
+    # row's, so only the `<slug>.md` summary link can match it.
+    index = (
+        _INDEX_HEADER
+        + "| 2026-05-21 | #2001 | ocr-pivot | ESUM re-OCR pivot. Detail in `esum-ocr-pivot.md`. |\n"
+        + "<!-- INDEX-END -->\n"
+    )
+    file_entry = VALID_ENTRY.replace("Issue: #1522", "Issue: #9999")
+    _write_tree(tmp_path, {"esum-ocr-pivot.md": file_entry}, index=index)
+
+    check_postmortems.main([], project_root=tmp_path)
+
+    regenerated = (tmp_path / "docs" / "bug-autopsies" / "INDEX.md").read_text("utf-8")
+    assert "| ocr-pivot |" in regenerated  # curated row preserved
+    assert "| esum-ocr-pivot |" not in regenerated  # no slug-keyed duplicate
+    assert regenerated.count("esum-ocr-pivot.md") == 1
+
+
+def test_multi_incident_rows_preserved(tmp_path: Path) -> None:
+    # A file with multiple curated rows (multi-incident autopsy) keeps all rows;
+    # regen must not collapse to one or append a duplicate.
+    index = (
+        _INDEX_HEADER
+        + "| 2026-05-10 | — | secret-leakage | Incident A. Detail in `secret-leakage.md`. |\n"
+        + "| 2026-05-19 | — | secret-leakage | Incident B. Detail in `secret-leakage.md`. |\n"
+        + "<!-- INDEX-END -->\n"
+    )
+    _write_tree(tmp_path, {"secret-leakage.md": VALID_ENTRY}, index=index)
+
+    check_postmortems.main([], project_root=tmp_path)
+
+    regenerated = (tmp_path / "docs" / "bug-autopsies" / "INDEX.md").read_text("utf-8")
+    assert regenerated.count("| secret-leakage |") == 2  # both incidents kept
+    assert "Incident A" in regenerated
+    assert "Incident B" in regenerated
+
+
+def test_check_mode_flags_stale_index_without_writing(tmp_path: Path, capsys) -> None:
+    _write_tree(tmp_path, {"cache-invalidation.md": VALID_ENTRY})
+    index_path = tmp_path / "docs" / "bug-autopsies" / "INDEX.md"
+    before = index_path.read_text("utf-8")
+
+    exit_code = check_postmortems.main(["--check"], project_root=tmp_path)
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "INDEX.md is stale" in captured.out
+    assert index_path.read_text("utf-8") == before  # dry-run: not written
+
+
+def test_check_mode_passes_when_index_current(tmp_path: Path, capsys) -> None:
+    _write_tree(tmp_path, {"cache-invalidation.md": VALID_ENTRY})
+    check_postmortems.main([], project_root=tmp_path)  # make it current
+    index_path = tmp_path / "docs" / "bug-autopsies" / "INDEX.md"
+    current = index_path.read_text("utf-8")
+
+    exit_code = check_postmortems.main(["--check"], project_root=tmp_path)
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "INDEX.md is stale" not in captured.out
+    assert index_path.read_text("utf-8") == current  # unchanged


### PR DESCRIPTION
Closes #3045.

## Problem
`check_postmortems --regenerate-index` degraded the curated `INDEX.md`:
1. **Slug-mismatch duplicates** — `_index_rows` deduped by free-text `Category`. A curated row whose category describes the failure class (`ocr-pivot`) rather than the filename slug (`esum-ocr-pivot`) was treated as "uncovered" → a duplicate generated row appended (observed: `esum-ocr-pivot`, `gemini-ocr-hallucinations`, `stanza-model-md5-flake`).
2. **Multi-incident risk** — files documenting several incidents could collapse.

## Fix
- **`_row_matches_record()`** recognises an existing row for a file by **filename slug**, any of: `Category == slug`; the row links `` `<slug>.md` `` (curated rows put the link in the Summary); or the `Issue` cell contains the record's issue. `_index_rows` appends a generated row only when **no** existing row represents the file → kills slug-mismatch dups; all curated / multi-incident rows preserved verbatim.
- **`--check` mode** (`regenerate_index(write=False)`): verify `INDEX.md` is current **without writing**, non-zero exit if stale — wireable into CI per the issue's fix direction.

## Verification
- `ruff` clean; **13 tests pass** (9 existing + 4 new: slug-mismatch no-dup, multi-incident preserved, `--check` stale-without-write, `--check` passes-when-current).
- **`--check` on the real repo `INDEX.md` → exit 0** (regen now idempotent; the previously-lossy path would have re-appended duplicates). Real INDEX untouched by the dry-run.

Note: pre-existing duplicate rows already in `INDEX.md` are *preserved* (non-lossy regen never drops rows); removing those is hand-curation, separate from this logic fix. The `--check` mode lets CI catch future drift once those are cleaned.

No auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)