### PR TITLE
fix(render): close shipped-but-doesn't-render gap — escape fix + mdx_render gate + verify_shippable + handoff_ready (#3137 #3138)

### DIFF
--- a/agents_extensions/shared/agents/curriculum-orchestrator.md
+++ b/agents_extensions/shared/agents/curriculum-orchestrator.md
@@ -17,6 +17,11 @@ initialPrompt: |
   4. Check `docs/decisions/pending/`; pending decisions block only their declared Scope.
   5. Then begin work. If Monitor API times out, say "API down, falling back" and read
      `docs/session-state/current.md` router -> matching `current.<agent>.md` -> `memory/MEMORY.md` -> `CLAUDE.md`.
+  6. Resume from the FRESHEST state, not stale local files: `git fetch origin`, then
+     `gh pr list --state open` (and `gh pr list --search 'author:@me' --state open`) BEFORE acting
+     on the queue or merge-train. The merge-train moves between sessions; a merged PR can have already
+     changed `main` / the open-PR set since the handoff was written. Acting on a stale picture is the
+     #01 re-collision class (2026-06-14). Read open PRs first, then drive.
 
   Standalone session = main orchestrator. Drive the queue without asking when the next
   action is obvious.
@@ -113,6 +118,23 @@ Bad pedagogy creates durable learner errors. Strong modules beat many mediocre m
 - V7 builds may be agent-run during autonomous orchestration (user direction 2026-05-13: "during development you are allowed"). Always use `--worktree` (PR #1952) so the build runs in `.worktrees/builds/{level}-{slug}-{stamp}/` and main project tree stays clean. Monitor the JSONL event stream via the `Monitor` tool, not by polling.
 - V7 builds must run in worktrees because they write curriculum artifacts and telemetry.
 - Pre-submit checklist authority is `AGENTS.md:11-26`; read it directly before PR work.
+
+## Definition of Done — render before promote (#3137/#3138)
+`python_qg`-green does NOT mean a module renders. The `mdx_render` gate is deferred and historically
+never ran, so a template-literal escape bug (#3137) shipped: on 2026-06-14 three modules went out
+python_qg-green and #01 did not render — only CI's astro build caught it, after "ready" was asserted.
+As the agent who owns final merge judgment + promotion, enforce render at the gate, and own this tooling:
+- **Before merging/promoting ANY built-module PR:** confirm render is validated — run
+  `.venv/bin/python -m scripts.build.verify_shippable <level> <slug> --astro-build` (python_qg →
+  assemble → Node `mdx_render` gate → optional full astro build) OR confirm the PR's Frontend/astro CI
+  build is green. Never promote a module on `python_qg` alone.
+- **Before declaring a session/handoff "ready":** run
+  `.venv/bin/python -m scripts.orchestration.handoff_ready --pr <N>` — tree-clean · 0 in-flight ·
+  branch pushed (local==origin) · all blocking PR checks green · handoff bundled. Any RED/UNKNOWN ⇒ not
+  ready. Run the predicate; do not assert readiness in prose (#M-4).
+- **Tooling you own (infra lane):** `scripts/build/verify_shippable.py`, `scripts/build/mdx_render_gate.py`
+  (standalone `run_mdx_render_gate` is wired into `linear_pipeline.py`), `scripts/orchestration/handoff_ready.py`.
+  The render-validation gap itself (assembler escape + deferred gate) is the latent landmine — keep it closed.
 
 ## Service Troubleshooting
 `./services.sh status` is read-only and safe. Restart only the broken service, and only after confirming no active dispatches. Do not restart all services as a session-start ritual.

--- a/agents_extensions/shared/agents/curriculum-track-orchestrator.md
+++ b/agents_extensions/shared/agents/curriculum-track-orchestrator.md
@@ -27,7 +27,13 @@ initialPrompt: |
      prompt redirects you there.)
   2. Resume from its "IN-FLIGHT" and "NEXT ACTION" sections. Verify in-flight dispatches via
      `curl -sS http://127.0.0.1:8765/api/delegate/active` before assuming anything.
-  3. `git fetch origin` (read-only) to observe where the orchestrator's `main` is. Never reset/commit onto it.
+  3. `git fetch origin` (read-only), then **resume from the FRESHEST handoff, not stale local state.**
+     The orchestrator merges your PRs into `main`, so `origin/main`'s handoff is often AHEAD of your
+     local file and a prior session's work may already be merged. Read the handoff from `origin/main`
+     (`git show origin/main:docs/<track>-epic/CLAUDE-DRIVER-HANDOFF.md`) AND list open driver PRs
+     (`gh pr list --head 'claude/<track>-' --state open`, or `gh pr list --search 'author:@me' --state open`)
+     BEFORE starting any build — this prevents re-firing a module a newer session already advanced (the
+     #01 re-collision, 2026-06-14). Never reset/commit onto `main`.
 
   ## HOW YOU DRIVE (the proven loop)
   - Fire work: `.venv/bin/python scripts/delegate.py dispatch --agent codex --task-id <id>
@@ -43,6 +49,22 @@ initialPrompt: |
     with a `-retry` task id.
   - After each batch, REFRESH your handoff and include it in that batch's PR (see KEEP YOUR STATE) —
     that is how the next track-driver session resumes cleanly.
+
+  ## DEFINITION OF DONE — verify, never assert (#3137/#3138)
+  A module is NOT shippable on `python_qg`-green alone: `python_qg` is blind to whether the *assembled
+  MDX renders* (the `mdx_render` gate is deferred and historically never ran). On 2026-06-14 three
+  modules shipped python_qg-green and #01 did not render — only CI's astro build caught it, after
+  "ready" had been asserted. So readiness is a PREDICATE you run, not prose you write:
+  - **Per module, before flipping status `locked`→`active` or opening the ship PR:** run
+    `.venv/bin/python -m scripts.build.verify_shippable <level> <slug>` from the data-bearing root —
+    it runs python_qg → assemble_mdx → the Node `mdx_render` gate and prints ONE green/red. Add
+    `--astro-build` for the full catch-all (what CI does). Then corpus-hammer (#M-11): a human read +
+    independent `verify_quote` of every embedded fragment. Done = GREEN(verify_shippable) AND
+    corpus-hammer — not before.
+  - **Before declaring "ready for handoff":** run
+    `.venv/bin/python -m scripts.orchestration.handoff_ready --pr <N>` — it checks tree-clean · 0
+    in-flight · branch pushed (local==origin) · all blocking PR checks green · handoff bundled in the
+    PR. Any RED/UNKNOWN ⇒ NOT ready (you cannot assert readiness on a check you did not run, #M-4).
 
   ## KEEP YOUR STATE — git-tracked, promoted via your PR
   Your handoff (`docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md`) is the git-tracked cross-session SSOT on

--- a/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
+++ b/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
@@ -58,7 +58,58 @@
 > the "don't self-merge" restriction, not the "don't push to main" one. Stage-0 PR #2759 self-merged
 > under this grant (commit `abf280f490`).
 
-## ▶▶▶ SESSION 28 HANDOFF (2026-06-14 — #01 module build FIRED + diagnosed: activity_schema FIXED, vesum_verified is next blocker; build preserved on a branch — RESUME #01 from there, don't re-fire) — **RESUME HERE**
+## ▶▶▶ SESSION 29 HANDOFF (2026-06-14 — BUILT the 5 "shipped-but-doesn't-render" fixes A–E (#3137 render landmine + #3138 DoD/cold-start); module work parked — RESUME #01 per Session 28) — **RESUME HERE**
+
+> **⏱ HONEST SCOPE:** This session shipped INFRA/PROCESS only — no folk content. Modules 3/42, dossiers
+> 19/42, wikis 15/42 UNCHANGED. The user directed "build all 5 since you are in context" (the post-mortem
+> of why #01 shipped python_qg-green but didn't render). All 5 built + proven INLINE in worktree
+> `claude/folk-shippable-render` → ONE PR closing #3137 + #3138. #01 module build is STILL PARKED — resume
+> per the Session 28 block below (build branch `3e69cc84f5`, vesum_verified next blocker).
+
+### ✅ DONE THIS PR — the 5 fixes (A–E), all proven deterministically (#M-4)
+- **D (render landmine, #3137) — the urgent one.** `JSON.parse(`…`)` island props embed JSON in a JS
+  **template literal**, which *consumes* backslash escapes → JSON's own `\"`/`\\`/`\n` get eaten → any
+  value with a literal `"` (etc.) corrupts the JSON → page doesn't render; `python_qg` is blind to it.
+  Fixed the escaper to double backslashes FIRST: `resources.py` (the seminar/folk VocabCard+FlashcardDeck
+  path — was backtick/`${`-only) now routes through the canonical `utils.dump_json_for_jsx` (+`compact`
+  flag); fixed the divergent flat copy in `generate_mdx_direct_renderers.py` (dropped a line that
+  *un-escaped* `\\n`/`\\"`). PROVEN: Node round-trip — old escaping throws, new round-trips; shipped folk
+  MDX (17 islands) pass; crafted under-escaped quote fails with a precise SyntaxError.
+- **E (mdx_render gate runs, #3137).** New `scripts/build/mdx_render_gate.py` Node-evaluates every
+  `JSON.parse(`…`)` in assembled MDX (the exact JS engine — no re-implementing escaping). Wired
+  `run_mdx_render_gate()` into `linear_pipeline.py` as a **standalone** post-assemble step so it runs even
+  when python_qg fails (was a permanent `passed:None` placeholder). Degrades to skip if Node absent.
+- **A (Definition-of-Done, #3138).** New `scripts/build/verify_shippable.py`:
+  `python -m scripts.build.verify_shippable <level> <slug>` → python_qg → assemble → mdx_render → ONE
+  green/red (+`--astro-build` catch-all). PROVEN: on kalendarna it showed python_qg ❌ but mdx_render ✅
+  — i.e. **render is checked even when python_qg is red** (E's whole point).
+- **B (readiness predicate, #3138).** New `scripts/orchestration/handoff_ready.py`: tree-clean · 0
+  in-flight · branch pushed (local==origin) · all-blocking PR checks green · handoff bundled → READY/NOT.
+  Run it; never assert "ready" in prose.
+- **C (cold-start freshness, #3138).** Baked into the shared agent def
+  `agents_extensions/shared/agents/curriculum-track-orchestrator.md` (ALL drivers): fetch → read handoff
+  from `origin/main` + `gh pr list --head 'claude/<track>-'` BEFORE any build (prevents the #01
+  re-collision) + a Definition-of-Done block pointing at verify_shippable/handoff_ready.
+
+### ▶ NEXT ACTIONS (RESUME HERE, in order)
+1. **Orchestrator: review + merge this PR (#3137+#3138).** D touches SHARED `scripts/generate_mdx/` (every
+   track) — that's the cross-track blast radius worth scrutiny; it's strictly-more-correct + test-locked.
+   Self-merge held (cross-track infra; pinged orchestrator).
+2. **Resume #01 narodna-kultura-yak-systema** per the Session 28 block (build branch `3e69cc84f5`,
+   vesum_verified blocker). NOTE found this session: its `-003403` activities.yaml trips an unrelated
+   `variant-comparison requires label` assemble error — fix that too before assemble. After green, gate it
+   with `verify_shippable folk narodna-kultura-yak-systema --astro-build` (now available).
+3. **#02/#03 + koliadky/dumy LLM-QG + reading-links** — unchanged from Session 28/27.
+
+### ⚠ CARRY-FORWARD
+- D is the latent class the user diagnosed for #01; proven at the unit level + on real shipped MDX. The
+  exact reverted-#01 trigger was NOT re-confirmed (the `-003403` artifacts have no `"`/`` ` ``/`${`) — do
+  not over-claim D as *the* #01 fix without the reverted-MDX repro; it IS a real landmine across all tracks.
+- `git push` folk → `--no-verify`; never reset/commit on main. Worktree: `claude/folk-shippable-render`.
+
+---
+
+## ▶▶▶ SESSION 28 HANDOFF (2026-06-14 — #01 module build FIRED + diagnosed: activity_schema FIXED, vesum_verified is next blocker; build preserved on a branch — RESUME #01 from there, don't re-fire) — (superseded by Session 29 for infra; #01 resume recipe still lives here)
 
 > **⏱ HONEST SCOPE:** Thin delta on Session 27 (read it next — full release queue + recipe). User said "kick
 > them off" → I fired the **#01 narodna-kultura-yak-systema** build; it hit the known rotating gate walls.

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -7101,7 +7101,14 @@ def run_python_qg(
     for gate_name, gate_report in _quality_fields(text_for_quality).items():
         record(gate_name, gate_report)
     gates["previously_passed_regression"] = {"passed": True, "regressions": []}
-    gates["mdx_render"] = {"passed": None, "message": "Run after publish stage"}
+    gates["mdx_render"] = {
+        "passed": None,
+        "message": (
+            "deferred — no assembled MDX at python_qg time; run the standalone "
+            "render gate after assemble_mdx (run_mdx_render_gate / "
+            "scripts.build.mdx_render_gate / verify_shippable.py). #3137"
+        ),
+    }
     gates["passed"] = all(
         gate.get("passed") is True for key, gate in gates.items() if isinstance(gate, dict) and key != "mdx_render"
     )
@@ -7172,6 +7179,25 @@ def assemble_mdx(module_dir: Path, output_path: Path, plan_path: Path) -> str:
     output_path.write_text(mdx, encoding="utf-8")  # codeql[py/clear-text-storage-sensitive-data] - .mdx curriculum content, never sensitive data
     # fmt: on
     return mdx
+
+
+def run_mdx_render_gate(mdx: str | Path) -> dict[str, Any]:
+    """Standalone ``mdx_render`` gate over assembled MDX (text or path).
+
+    The ``mdx_render`` gate is deferred inside ``run_python_qg`` (no assembled
+    MDX exists yet at that stage) and must run as its own post-assemble step so
+    it is never silently skipped — including when ``python_qg`` failed, so a
+    broken render is still surfaced rather than masked by an earlier gate (#3137).
+    """
+    from scripts.build.mdx_render_gate import check_mdx_render, check_mdx_render_path
+
+    if isinstance(mdx, Path):
+        return check_mdx_render_path(mdx)
+    text = str(mdx)
+    # Treat a short, single-line value that points at an existing file as a path.
+    if "\n" not in text and len(text) < 4096 and Path(text).exists():
+        return check_mdx_render_path(text)
+    return check_mdx_render(text)
 
 
 def write_json(path: Path, payload: Mapping[str, Any]) -> None:

--- a/scripts/build/mdx_render_gate.py
+++ b/scripts/build/mdx_render_gate.py
@@ -1,0 +1,170 @@
+"""MDX render gate — the gate that was deferred and never ran (#3137).
+
+``python_qg`` validates the *authoring artifacts* but is blind to whether the
+*assembled MDX* actually renders. The classic failure is a ``JSON.parse(`…`)``
+island prop whose embedded JSON is mis-escaped for the surrounding JS template
+literal (see ``scripts/generate_mdx/utils.dump_json_for_jsx`` / #3137): the page
+builds-syntax-OK but the prop expression throws when evaluated, so the module
+ships and does not render. Only CI's full astro build caught it.
+
+This gate closes that hole *cheaply and deterministically*: it extracts every
+``JSON.parse(`…`)`` template literal from the assembled MDX and evaluates it with
+**Node** — the real JS engine — so template-literal + JSON.parse semantics are
+exact (no re-implementation of JS string escaping, which is the very thing that
+broke). A full astro build remains the catch-all for non-island render breaks
+(wire via ``verify_shippable.py --astro-build``); this gate is the fast,
+always-on guard for the island-prop class that ``python_qg`` cannot see.
+
+Degrades gracefully: if Node is unavailable the gate reports ``passed=None``
+(skipped) rather than failing, mirroring the DB-gated checks elsewhere.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+_MARKER = "JSON.parse(`"
+
+
+def iter_template_literals(mdx_text: str) -> list[str]:
+    """Yield the raw inner text of every ``JSON.parse(`…`)`` in ``mdx_text``.
+
+    The closing backtick is the first ``\\``-unescaped backtick after the marker,
+    so escaped backticks (``\\```) inside a correctly-escaped payload do not end
+    the literal early. The inner text is returned *verbatim* (exactly as it
+    appears in the MDX) so Node re-evaluation reproduces render semantics.
+    """
+    inners: list[str] = []
+    i = 0
+    n = len(mdx_text)
+    while True:
+        idx = mdx_text.find(_MARKER, i)
+        if idx == -1:
+            break
+        start = idx + len(_MARKER)
+        j = start
+        while j < n:
+            c = mdx_text[j]
+            if c == "\\":
+                j += 2  # skip the escaped char (covers \` , \\ , \$ …)
+                continue
+            if c == "`":
+                break
+            j += 1
+        inners.append(mdx_text[start:j])
+        i = j + 1
+    return inners
+
+
+def _node_eval_one(inner: str, *, timeout: int = 30) -> str | None:
+    """Return ``None`` if ``JSON.parse(`inner`)`` evaluates, else an error line.
+
+    ``inner`` is written verbatim between backticks into a throwaway ``.mjs``
+    file, exactly reproducing the MDX source expression, then run under Node.
+    """
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".mjs", delete=False, encoding="utf-8"
+    ) as fh:
+        # Reproduce the MDX expression byte-for-byte: backtick + inner + backtick.
+        fh.write("const c = `" + inner + "`;\nJSON.parse(c);\n")
+        path = fh.name
+    try:
+        proc = subprocess.run(
+            ["node", path], capture_output=True, text=True, timeout=timeout
+        )
+        if proc.returncode == 0:
+            return None
+        stderr_lines = [ln for ln in proc.stderr.strip().splitlines() if ln.strip()]
+        # Prefer the most specific error line (SyntaxError / JSON.parse message).
+        for ln in stderr_lines:
+            if "Error" in ln or "JSON" in ln:
+                return ln.strip()[:300]
+        return (stderr_lines[-1].strip()[:300] if stderr_lines else "node error")
+    except subprocess.TimeoutExpired:
+        return "node eval timed out"
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def check_mdx_render(mdx_text: str, *, timeout: int = 30) -> dict:
+    """Render gate over assembled MDX text.
+
+    Returns a ``python_qg``-style gate report::
+
+        {"passed": True|False|None, "message": str,
+         "islands_checked": int, "failures": [{"snippet": str, "error": str}]}
+
+    ``passed=None`` means *skipped* (Node unavailable) — never a hard fail on a
+    missing toolchain.
+    """
+    if shutil.which("node") is None:
+        return {
+            "passed": None,
+            "skipped": True,
+            "message": "node unavailable — mdx_render gate skipped",
+            "islands_checked": 0,
+            "failures": [],
+        }
+
+    inners = iter_template_literals(mdx_text)
+    failures: list[dict] = []
+    for inner in inners:
+        err = _node_eval_one(inner, timeout=timeout)
+        if err is not None:
+            snippet = inner[:80].replace("\n", "\\n")
+            failures.append({"snippet": snippet, "error": err})
+
+    passed = not failures
+    if passed:
+        msg = f"all {len(inners)} JSON.parse(`…`) island prop(s) evaluate"
+    else:
+        msg = (
+            f"{len(failures)}/{len(inners)} JSON.parse(`…`) island prop(s) fail to "
+            f"evaluate — module would not render"
+        )
+    return {
+        "passed": passed,
+        "message": msg,
+        "islands_checked": len(inners),
+        "failures": failures,
+    }
+
+
+def check_mdx_render_path(mdx_path: str | Path, *, timeout: int = 30) -> dict:
+    """``check_mdx_render`` for a file path; fails closed if the file is missing."""
+    p = Path(mdx_path)
+    if not p.exists():
+        return {
+            "passed": False,
+            "message": f"assembled MDX not found: {p}",
+            "islands_checked": 0,
+            "failures": [],
+        }
+    return check_mdx_render(p.read_text(encoding="utf-8"), timeout=timeout)
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(description="MDX render gate (#3137)")
+    ap.add_argument("mdx_path", help="path to an assembled .mdx file")
+    ap.add_argument("--json", action="store_true", help="emit the raw gate report as JSON")
+    args = ap.parse_args(argv)
+
+    report = check_mdx_render_path(args.mdx_path)
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        status = {True: "✅ PASS", False: "❌ FAIL", None: "⚠️  SKIP"}[report["passed"]]
+        print(f"{status}  mdx_render  {report['message']}")
+        for f in report["failures"]:
+            print(f"   • {f['snippet']}  →  {f['error']}")
+    return 0 if report["passed"] in (True, None) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build/mdx_render_gate.py
+++ b/scripts/build/mdx_render_gate.py
@@ -47,14 +47,22 @@ def iter_template_literals(mdx_text: str) -> list[str]:
             break
         start = idx + len(_MARKER)
         j = start
+        terminated = False
         while j < n:
             c = mdx_text[j]
             if c == "\\":
                 j += 2  # skip the escaped char (covers \` , \\ , \$ …)
                 continue
             if c == "`":
+                terminated = True
                 break
             j += 1
+        if not terminated:
+            # Unterminated JSON.parse(` … = truncated/malformed MDX. Do NOT emit a
+            # phantom rest-of-file island (it could falsely pass if that suffix is
+            # valid JSON, or mis-point the error). A working assembler never emits
+            # this; astro build catches genuinely truncated MDX. Stop scanning.
+            break
         inners.append(mdx_text[start:j])
         i = j + 1
     return inners
@@ -70,14 +78,21 @@ def _node_eval_one(inner: str, *, timeout: int = 30) -> str | None:
         "w", suffix=".mjs", delete=False, encoding="utf-8"
     ) as fh:
         # Reproduce the MDX expression byte-for-byte: backtick + inner + backtick.
-        fh.write("const c = `" + inner + "`;\nJSON.parse(c);\n")
+        # The sentinel prints only AFTER JSON.parse returns: an unescaped ``${…}``
+        # in the inner would interpolate (run code / process.exit) and short-circuit
+        # before JSON.parse, so requiring the sentinel stops that from passing silently.
+        fh.write(
+            "const c = `" + inner + "`;\nJSON.parse(c);\nprocess.stdout.write('__RENDER_OK__');\n"
+        )
         path = fh.name
     try:
         proc = subprocess.run(
             ["node", path], capture_output=True, text=True, timeout=timeout
         )
-        if proc.returncode == 0:
+        if proc.returncode == 0 and "__RENDER_OK__" in proc.stdout:
             return None
+        if proc.returncode == 0:
+            return "island did not reach JSON.parse (template-literal interpolation / early exit?)"
         stderr_lines = [ln for ln in proc.stderr.strip().splitlines() if ln.strip()]
         # Prefer the most specific error line (SyntaxError / JSON.parse message).
         for ln in stderr_lines:

--- a/scripts/build/verify_shippable.py
+++ b/scripts/build/verify_shippable.py
@@ -120,8 +120,10 @@ def verify(
             "all gates green" if qg_pass else f"failed gates: {', '.join(failed) or 'unknown'}",
         )
     except Exception as exc:
+        # Do NOT short-circuit on a python_qg CRASH: a render break must still be
+        # surfaced even when python_qg fails (the #3137 design intent). Record the
+        # failure and continue to assemble + render.
         add("python_qg", False, f"run_python_qg raised: {exc!r}")
-        return _finalize(level, slug, steps)
 
     # --- 2. assemble MDX (to a temp file; do not touch site/) ---
     with tempfile.TemporaryDirectory() as td:
@@ -143,9 +145,11 @@ def verify(
     if astro_build:
         site_mdx = _site_mdx_path(level, slug)
         prior = site_mdx.read_text(encoding="utf-8") if site_mdx.exists() else None
-        site_mdx.parent.mkdir(parents=True, exist_ok=True)
-        site_mdx.write_text(mdx_text, encoding="utf-8")
         try:
+            # Write inside the try so the finally always restores, even if the
+            # write/mkdir itself raises (never leave site/ corrupted).
+            site_mdx.parent.mkdir(parents=True, exist_ok=True)
+            site_mdx.write_text(mdx_text, encoding="utf-8")
             ok, tail = _astro_build()
             add("astro_build", ok, "astro build green" if ok else f"astro build FAILED:\n{tail}")
         finally:

--- a/scripts/build/verify_shippable.py
+++ b/scripts/build/verify_shippable.py
@@ -1,0 +1,214 @@
+"""verify_shippable — one-command Definition-of-Done for a built module (#3138).
+
+A module is *not* shippable just because ``python_qg`` is green. The 2026-06-14
+incident: three modules shipped python_qg-green but #01 did not render — the
+``mdx_render`` gate is deferred and never ran, so a template-literal escape bug
+(#3137) reached ``main`` and only CI's astro build caught it. "Ready" was
+*asserted*, not *verified*.
+
+This script makes the Definition-of-Done a single deterministic predicate:
+
+    python_qg green  AND  assembled MDX renders  [AND astro build green]
+
+and prints ONE green/red verdict. Corpus-hammer (#M-11, a human reading of the
+content) remains a required ship step and is reported as an explicit TODO — this
+tool gates the machine-checkable half so a driver never declares "done" on the
+build-time gates alone.
+
+Usage:
+    python -m scripts.build.verify_shippable <level> <slug>
+    python -m scripts.build.verify_shippable folk narodna-kultura-yak-systema
+    python -m scripts.build.verify_shippable folk dumy --module-dir DIR --plan PLAN
+    python -m scripts.build.verify_shippable folk kalendarna-obriadovist-zvychai --astro-build
+
+Default render check is the fast, always-on Node island gate
+(``scripts.build.mdx_render_gate``) which catches the #3137 class deterministically
+without touching ``site/``. ``--astro-build`` additionally runs the full astro
+build (what CI does) as the catch-all for non-island render breaks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+CURRICULUM = PROJECT_ROOT / "curriculum" / "l2-uk-en"
+SITE_DOCS = PROJECT_ROOT / "site" / "src" / "content" / "docs"
+
+
+def _default_module_dir(level: str, slug: str) -> Path:
+    return CURRICULUM / level / slug
+
+
+def _default_plan_path(level: str, slug: str) -> Path:
+    return CURRICULUM / "plans" / level / f"{slug}.yaml"
+
+
+def _site_mdx_path(level: str, slug: str) -> Path:
+    return SITE_DOCS / level / f"{slug}.mdx"
+
+
+def _astro_build() -> tuple[bool, str]:
+    """Run the full astro build (what CI does). Returns (passed, last_output)."""
+    site = PROJECT_ROOT / "site"
+    try:
+        proc = subprocess.run(
+            ["npm", "run", "build"],
+            cwd=site,
+            capture_output=True,
+            text=True,
+            timeout=900,
+        )
+    except FileNotFoundError:
+        return False, "npm not found — cannot run astro build"
+    except subprocess.TimeoutExpired:
+        return False, "astro build timed out (>900s)"
+    tail = "\n".join((proc.stdout + proc.stderr).strip().splitlines()[-12:])
+    return proc.returncode == 0, tail
+
+
+def verify(
+    level: str,
+    slug: str,
+    *,
+    module_dir: Path | None = None,
+    plan_path: Path | None = None,
+    astro_build: bool = False,
+) -> dict:
+    """Run the shippability predicate. Returns a structured report dict."""
+    # Import lazily — linear_pipeline pulls in a heavy graph.
+    from scripts.build.linear_pipeline import (
+        assemble_mdx,
+        run_mdx_render_gate,
+        run_python_qg,
+    )
+
+    module_dir = module_dir or _default_module_dir(level, slug)
+    plan_path = plan_path or _default_plan_path(level, slug)
+
+    steps: list[dict] = []
+
+    def add(name: str, passed: bool | None, detail: str) -> None:
+        steps.append({"step": name, "passed": passed, "detail": detail})
+
+    # --- preconditions ---
+    if not module_dir.exists():
+        add("inputs", False, f"module dir not found: {module_dir}")
+        return _finalize(level, slug, steps)
+    if not plan_path.exists():
+        add("inputs", False, f"plan not found: {plan_path}")
+        return _finalize(level, slug, steps)
+
+    # --- 1. python_qg (deterministic build gates) ---
+    try:
+        qg = run_python_qg(module_dir, plan_path)
+        qg_gates = qg.get("gates", {})
+        qg_pass = bool(qg_gates.get("passed"))
+        failed = [
+            k
+            for k, g in qg_gates.items()
+            if isinstance(g, dict) and g.get("passed") is False
+        ]
+        add(
+            "python_qg",
+            qg_pass,
+            "all gates green" if qg_pass else f"failed gates: {', '.join(failed) or 'unknown'}",
+        )
+    except Exception as exc:
+        add("python_qg", False, f"run_python_qg raised: {exc!r}")
+        return _finalize(level, slug, steps)
+
+    # --- 2. assemble MDX (to a temp file; do not touch site/) ---
+    with tempfile.TemporaryDirectory() as td:
+        tmp_mdx = Path(td) / f"{slug}.mdx"
+        try:
+            mdx_text = assemble_mdx(module_dir, tmp_mdx, plan_path)
+            add("assemble_mdx", True, f"assembled {len(mdx_text)} chars")
+        except Exception as exc:
+            add("assemble_mdx", False, f"assemble_mdx raised: {exc!r}")
+            return _finalize(level, slug, steps)
+
+        # --- 3. render gate (Node island eval — the #3137 guard) ---
+        render = run_mdx_render_gate(mdx_text)
+        add("mdx_render", render.get("passed"), render.get("message", ""))
+        for f in render.get("failures", []):
+            steps.append({"step": "mdx_render.failure", "passed": False, "detail": f"{f['snippet']} → {f['error']}"})
+
+    # --- 4. optional full astro build (catch-all) ---
+    if astro_build:
+        site_mdx = _site_mdx_path(level, slug)
+        prior = site_mdx.read_text(encoding="utf-8") if site_mdx.exists() else None
+        site_mdx.parent.mkdir(parents=True, exist_ok=True)
+        site_mdx.write_text(mdx_text, encoding="utf-8")
+        try:
+            ok, tail = _astro_build()
+            add("astro_build", ok, "astro build green" if ok else f"astro build FAILED:\n{tail}")
+        finally:
+            if prior is None:
+                site_mdx.unlink(missing_ok=True)
+            else:
+                site_mdx.write_text(prior, encoding="utf-8")
+
+    return _finalize(level, slug, steps)
+
+
+def _finalize(level: str, slug: str, steps: list[dict]) -> dict:
+    # GREEN requires every non-skipped step to have passed (None == skipped == OK).
+    shippable = all(s["passed"] in (True, None) for s in steps) and any(
+        s["passed"] is True for s in steps
+    )
+    return {
+        "level": level,
+        "slug": slug,
+        "shippable": shippable,
+        "steps": steps,
+        "corpus_hammer_required": True,
+    }
+
+
+def _print_human(report: dict) -> None:
+    icon = {True: "✅", False: "❌", None: "⚠️ "}
+    print(f"\n  verify_shippable: {report['level']}/{report['slug']}\n")  # codeql[py/clear-text-logging-sensitive-data] - module level/slug only; no secrets (#M-5 verified)
+    for s in report["steps"]:
+        print(f"   {icon[s['passed']]} {s['step']:<22} {s['detail']}")  # codeql[py/clear-text-logging-sensitive-data] - gate name + deterministic result; no secrets
+    print()
+    if report["shippable"]:
+        print("  ✅ SHIPPABLE (machine checks green)")
+        print("  ⚠️  STILL REQUIRED before ship: corpus-hammer (#M-11) — read the")
+        print("     content + independently verify_quote every embedded fragment.")
+    else:
+        print("  ❌ NOT SHIPPABLE — fix the red step(s) above. Do NOT declare ready.")
+    print()
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Definition-of-Done predicate for a built module (#3138)")
+    ap.add_argument("level", help="track/level token, e.g. folk, a1, b1")
+    ap.add_argument("slug", help="module slug")
+    ap.add_argument("--module-dir", type=Path, default=None)
+    ap.add_argument("--plan", type=Path, default=None, dest="plan_path")
+    ap.add_argument("--astro-build", action="store_true", help="also run the full astro build (catch-all)")
+    ap.add_argument("--json", action="store_true", help="emit the raw report as JSON")
+    args = ap.parse_args(argv)
+
+    report = verify(
+        args.level,
+        args.slug,
+        module_dir=args.module_dir,
+        plan_path=args.plan_path,
+        astro_build=args.astro_build,
+    )
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2))  # codeql[py/clear-text-logging-sensitive-data] - report = gate/step results; no secrets
+    else:
+        _print_human(report)
+    return 0 if report["shippable"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/build/verify_shippable.py
+++ b/scripts/build/verify_shippable.py
@@ -53,8 +53,15 @@ def _site_mdx_path(level: str, slug: str) -> Path:
     return SITE_DOCS / level / f"{slug}.mdx"
 
 
-def _astro_build() -> tuple[bool, str]:
-    """Run the full astro build (what CI does). Returns (passed, last_output)."""
+def _astro_build(log_path: Path) -> bool:
+    """Run the full astro build (what CI does); write its raw output to ``log_path``.
+
+    The subprocess stdout/stderr is written to a FILE, never returned into the
+    printed report: npm/build logs can echo environment values, so keeping raw
+    build output out of stdout/JSON is the #M-5-safe path (and removes the
+    clear-text-logging taint CodeQL flagged). The caller prints only a fixed
+    pointer to the log, not the build output.
+    """
     site = PROJECT_ROOT / "site"
     try:
         proc = subprocess.run(
@@ -65,11 +72,13 @@ def _astro_build() -> tuple[bool, str]:
             timeout=900,
         )
     except FileNotFoundError:
-        return False, "npm not found — cannot run astro build"
+        log_path.write_text("npm not found — cannot run astro build\n", encoding="utf-8")
+        return False
     except subprocess.TimeoutExpired:
-        return False, "astro build timed out (>900s)"
-    tail = "\n".join((proc.stdout + proc.stderr).strip().splitlines()[-12:])
-    return proc.returncode == 0, tail
+        log_path.write_text("astro build timed out (>900s)\n", encoding="utf-8")
+        return False
+    log_path.write_text(proc.stdout + proc.stderr, encoding="utf-8")
+    return proc.returncode == 0
 
 
 def verify(
@@ -123,7 +132,7 @@ def verify(
         # Do NOT short-circuit on a python_qg CRASH: a render break must still be
         # surfaced even when python_qg fails (the #3137 design intent). Record the
         # failure and continue to assemble + render.
-        add("python_qg", False, f"run_python_qg raised: {exc!r}")
+        add("python_qg", False, f"run_python_qg raised: {type(exc).__name__}: {str(exc)[:200]}")
 
     # --- 2. assemble MDX (to a temp file; do not touch site/) ---
     with tempfile.TemporaryDirectory() as td:
@@ -132,7 +141,7 @@ def verify(
             mdx_text = assemble_mdx(module_dir, tmp_mdx, plan_path)
             add("assemble_mdx", True, f"assembled {len(mdx_text)} chars")
         except Exception as exc:
-            add("assemble_mdx", False, f"assemble_mdx raised: {exc!r}")
+            add("assemble_mdx", False, f"assemble_mdx raised: {type(exc).__name__}: {str(exc)[:200]}")
             return _finalize(level, slug, steps)
 
         # --- 3. render gate (Node island eval — the #3137 guard) ---
@@ -145,13 +154,15 @@ def verify(
     if astro_build:
         site_mdx = _site_mdx_path(level, slug)
         prior = site_mdx.read_text(encoding="utf-8") if site_mdx.exists() else None
+        log_path = PROJECT_ROOT / "batch_state" / "verify_shippable" / f"{level}-{slug}.astro-build.log"
         try:
             # Write inside the try so the finally always restores, even if the
             # write/mkdir itself raises (never leave site/ corrupted).
+            log_path.parent.mkdir(parents=True, exist_ok=True)
             site_mdx.parent.mkdir(parents=True, exist_ok=True)
             site_mdx.write_text(mdx_text, encoding="utf-8")
-            ok, tail = _astro_build()
-            add("astro_build", ok, "astro build green" if ok else f"astro build FAILED:\n{tail}")
+            ok = _astro_build(log_path)
+            add("astro_build", ok, "astro build green" if ok else f"astro build FAILED — full log: {log_path}")
         finally:
             if prior is None:
                 site_mdx.unlink(missing_ok=True)
@@ -162,14 +173,21 @@ def verify(
 
 
 def _finalize(level: str, slug: str, steps: list[dict]) -> dict:
-    # GREEN requires every non-skipped step to have passed (None == skipped == OK).
-    shippable = all(s["passed"] in (True, None) for s in steps) and any(
-        s["passed"] is True for s in steps
-    )
+    by_step = {s["step"]: s["passed"] for s in steps}
+    no_failures = all(s["passed"] in (True, None) for s in steps)
+    any_pass = any(s["passed"] is True for s in steps)
+    # Render must be POSITIVELY validated, never merely skipped: a None render gate
+    # (Node unavailable) does not certify render, so it must not count as shippable.
+    island_render_ok = by_step.get("mdx_render") is True
+    full_render_ok = by_step.get("astro_build") is True
+    shippable = no_failures and any_pass and (island_render_ok or full_render_ok)
     return {
         "level": level,
         "slug": slug,
         "shippable": shippable,
+        # The island gate is necessary-not-sufficient: it catches the #3137 class
+        # but not non-island JSX/render breaks. Only --astro-build is the full check.
+        "render_fully_validated": full_render_ok,
         "steps": steps,
         "corpus_hammer_required": True,
     }
@@ -177,12 +195,15 @@ def _finalize(level: str, slug: str, steps: list[dict]) -> dict:
 
 def _print_human(report: dict) -> None:
     icon = {True: "✅", False: "❌", None: "⚠️ "}
-    print(f"\n  verify_shippable: {report['level']}/{report['slug']}\n")  # codeql[py/clear-text-logging-sensitive-data] - module level/slug only; no secrets (#M-5 verified)
+    print(f"\n  verify_shippable: {report['level']}/{report['slug']}\n")
     for s in report["steps"]:
-        print(f"   {icon[s['passed']]} {s['step']:<22} {s['detail']}")  # codeql[py/clear-text-logging-sensitive-data] - gate name + deterministic result; no secrets
+        print(f"   {icon[s['passed']]} {s['step']:<22} {s['detail']}")
     print()
     if report["shippable"]:
         print("  ✅ SHIPPABLE (machine checks green)")
+        if not report.get("render_fully_validated"):
+            print("  ⚠️  island-render only — re-run with --astro-build for full render")
+            print("     validation (the island gate does not catch non-island JSX breaks).")
         print("  ⚠️  STILL REQUIRED before ship: corpus-hammer (#M-11) — read the")
         print("     content + independently verify_quote every embedded fragment.")
     else:
@@ -208,7 +229,7 @@ def main(argv: list[str] | None = None) -> int:
         astro_build=args.astro_build,
     )
     if args.json:
-        print(json.dumps(report, ensure_ascii=False, indent=2))  # codeql[py/clear-text-logging-sensitive-data] - report = gate/step results; no secrets
+        print(json.dumps(report, ensure_ascii=False, indent=2))
     else:
         _print_human(report)
     return 0 if report["shippable"] else 1

--- a/scripts/generate_mdx/generate_mdx_direct_renderers.py
+++ b/scripts/generate_mdx/generate_mdx_direct_renderers.py
@@ -11,10 +11,17 @@ from typing import Any
 
 
 def dump_json_for_jsx(obj: Any) -> str:
-    """Serialize to JSON suitable for embedding in JSX template literals."""
+    """Serialize to JSON suitable for embedding in JSX template literals.
+
+    Embedded as ``JSON.parse(`<here>`)``; a JS template literal consumes
+    backslash escapes, so the JSON's own ``\\"`` / ``\\\\`` / ``\\n`` must be
+    backslash-doubled (with `` ` `` and ``${``), backslash FIRST. The previous
+    trailing ``.replace("\\\\n", "\\n").replace('\\\\"', '\\"')`` un-did that
+    doubling and corrupted any island prop containing a newline or quote at
+    render time — removed (#3137).
+    """
     s = json.dumps(obj, ensure_ascii=False, indent=2)
     s = s.replace("\\", "\\\\").replace("`", "\\`").replace("${", "\\${")
-    s = s.replace("\\\\n", "\\n").replace('\\\\"', '\\"')
     return s
 
 

--- a/scripts/generate_mdx/generate_mdx_direct_renderers.py
+++ b/scripts/generate_mdx/generate_mdx_direct_renderers.py
@@ -20,7 +20,7 @@ def dump_json_for_jsx(obj: Any) -> str:
     doubling and corrupted any island prop containing a newline or quote at
     render time — removed (#3137).
     """
-    s = json.dumps(obj, ensure_ascii=False, indent=2)
+    s = json.dumps(obj, ensure_ascii=False, indent=2, allow_nan=False)
     s = s.replace("\\", "\\\\").replace("`", "\\`").replace("${", "\\${")
     return s
 

--- a/scripts/generate_mdx/resources.py
+++ b/scripts/generate_mdx/resources.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import yaml
 
 from .atlas_links import atlas_href_for
-from .utils import escape_jsx
+from .utils import dump_json_for_jsx, escape_jsx
 
 
 def validate_and_clean_url(url: str, title: str = '') -> str:
@@ -500,8 +500,11 @@ def vocab_items_to_components(items: list[dict], header_text: str = "Vocabulary"
         }
         words.append({key: value for key, value in entry.items() if value not in (None, "", [])})
 
-    card_json = json.dumps(cards, ensure_ascii=False, separators=(',', ':')).replace('`', '\\`').replace('${', '\\${')
-    word_json = json.dumps(words, ensure_ascii=False, separators=(',', ':')).replace('`', '\\`').replace('${', '\\${')
+    # Backslash-doubling escaper (utils.dump_json_for_jsx) — NOT a hand-rolled
+    # backtick/${-only strip, which drops the backslash-doubling and corrupts any
+    # vocab value containing a literal " at render time (#3137).
+    card_json = dump_json_for_jsx(cards, compact=True)
+    word_json = dump_json_for_jsx(words, compact=True)
     return (
         f"## {header_text}\n\n"
         f"<VocabCard client:only=\"react\" words={{JSON.parse(`{word_json}`)}} title=\"{escape_jsx(header_text)}\" />\n\n"

--- a/scripts/generate_mdx/utils.py
+++ b/scripts/generate_mdx/utils.py
@@ -33,7 +33,9 @@ def dump_json_for_jsx(data, *, compact: bool = False):
     e.g. VocabCard/FlashcardDeck word lists).
     """
     separators = (',', ':') if compact else None
-    s = json.dumps(data, ensure_ascii=False, separators=separators)
+    # allow_nan=False: NaN/Infinity are NOT valid JSON and would throw in JSON.parse
+    # at render time — fail fast at assembly rather than emit unparseable output.
+    s = json.dumps(data, ensure_ascii=False, separators=separators, allow_nan=False)
     # Escape backslashes FIRST to avoid double-escaping the chars below.
     s = s.replace('\\', '\\\\')
     # Escape backticks for template literals

--- a/scripts/generate_mdx/utils.py
+++ b/scripts/generate_mdx/utils.py
@@ -17,10 +17,24 @@ CURRICULUM_DIR = PROJECT_ROOT / "curriculum"
 STARLIGHT_DOCS_DIR = PROJECT_ROOT / "site" / "src" / "content" / "docs"
 
 
-def dump_json_for_jsx(data):
-    """Dump JSON string escaped for use inside a JSX template literal."""
-    s = json.dumps(data, ensure_ascii=False)
-    # Escape backslashes first to avoid double escaping other chars
+def dump_json_for_jsx(data, *, compact: bool = False):
+    """Dump JSON string escaped for use inside a JSX template literal.
+
+    The result is embedded as ``JSON.parse(`<result>`)``. A JS template literal
+    *consumes* backslash escapes, so the JSON's own ``\\"`` / ``\\\\`` / ``\\n``
+    sequences must be backslash-doubled (together with `` ` `` and ``${``) — and
+    backslashes MUST be doubled FIRST — or ``JSON.parse`` receives corrupted
+    input at render time. Concretely, any value containing a literal ``"`` is
+    JSON-encoded as ``\\"``; without doubling, the template literal collapses it
+    back to ``"`` and the page fails to render. This is the canonical, single
+    escaper for every JSON-in-template-literal embed — see issue #3137.
+
+    Pass ``compact=True`` for whitespace-free separators (smaller MDX payloads,
+    e.g. VocabCard/FlashcardDeck word lists).
+    """
+    separators = (',', ':') if compact else None
+    s = json.dumps(data, ensure_ascii=False, separators=separators)
+    # Escape backslashes FIRST to avoid double-escaping the chars below.
     s = s.replace('\\', '\\\\')
     # Escape backticks for template literals
     s = s.replace('`', '\\`')

--- a/scripts/orchestration/handoff_ready.py
+++ b/scripts/orchestration/handoff_ready.py
@@ -1,0 +1,195 @@
+"""handoff_ready — machine-checked handoff-readiness predicate (#3138).
+
+The 2026-06-14 failure mode: a driver *asserted* "ready for handoff" while CI was
+red and a PR was unmerged. "Ready" was narrative, not verified. This script makes
+readiness a deterministic predicate a driver runs (never asserts):
+
+  1. tree clean        — the repo working tree has no uncommitted changes
+  2. no in-flight       — /api/delegate/active reports 0 running dispatches
+  3. branch pushed      — local branch tip == origin branch tip (nothing unpushed)
+  4. pr checks green    — every BLOCKING status check on the PR is green
+  5. handoff bundled    — the driver handoff is part of the PR diff (state reaches
+                          main via review, not a stale origin/main RESUME-HERE)
+
+Any check that is RED *or* UNKNOWN ⇒ NOT READY. Unknown counts as not-ready on
+purpose: you cannot assert readiness on a check you could not run (anti-fabrication,
+mirrors MEMORY.md #M-4). Exit 0 iff READY.
+
+Usage:
+    python -m scripts.orchestration.handoff_ready --pr 3140
+    python -m scripts.orchestration.handoff_ready --branch claude/folk-x --handoff docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import urllib.request
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_HANDOFF = "docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md"
+DELEGATE_ACTIVE_URL = "http://127.0.0.1:8765/api/delegate/active"
+
+OK, RED, UNKNOWN = "ok", "red", "unknown"
+
+
+def _git(*args: str) -> tuple[int, str]:
+    proc = subprocess.run(
+        ["git", "-C", str(PROJECT_ROOT), *args],
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode, (proc.stdout + proc.stderr).strip()
+
+
+def _gh_json(*args: str) -> tuple[int, object]:
+    proc = subprocess.run(["gh", *args], capture_output=True, text=True, cwd=PROJECT_ROOT)
+    if proc.returncode != 0:
+        return proc.returncode, proc.stderr.strip()
+    try:
+        return 0, json.loads(proc.stdout or "null")
+    except json.JSONDecodeError:
+        return 1, proc.stdout.strip()
+
+
+def check_tree_clean() -> tuple[str, str]:
+    rc, out = _git("status", "--porcelain")
+    if rc != 0:
+        return UNKNOWN, f"git status failed: {out[:120]}"
+    if out:
+        n = len(out.splitlines())
+        return RED, f"{n} uncommitted change(s) in the working tree"
+    return OK, "working tree clean"
+
+
+def check_no_inflight() -> tuple[str, str]:
+    try:
+        with urllib.request.urlopen(DELEGATE_ACTIVE_URL, timeout=6) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except Exception as exc:
+        return UNKNOWN, f"delegate API unreachable: {exc!r}"
+    total = int(data.get("total", 0))
+    if total:
+        ids = ", ".join(t.get("task_id", "?") for t in data.get("tasks", [])[:5])
+        return RED, f"{total} dispatch(es) in flight: {ids}"
+    return OK, "0 dispatches in flight"
+
+
+def check_branch_pushed(branch: str) -> tuple[str, str]:
+    rc_local, local = _git("rev-parse", branch)
+    if rc_local != 0:
+        return UNKNOWN, f"no local branch {branch}"
+    rc_remote, remote = _git("ls-remote", "origin", branch)
+    if rc_remote != 0:
+        return UNKNOWN, f"git ls-remote failed: {remote[:120]}"
+    if not remote:
+        return RED, f"{branch} not pushed to origin"
+    remote_sha = remote.split()[0]
+    if remote_sha != local:
+        return RED, f"local {local[:9]} != origin {remote_sha[:9]} (unpushed commits)"
+    return OK, f"{branch} pushed (local==origin @ {local[:9]})"
+
+
+def _blocking_state(pr: int) -> tuple[str, str]:
+    rc, data = _gh_json(
+        "pr", "view", str(pr), "--json", "statusCheckRollup,mergeStateStatus,state"
+    )
+    if rc != 0 or not isinstance(data, dict):
+        return UNKNOWN, f"gh pr view failed: {str(data)[:120]}"
+    if data.get("state") == "MERGED":
+        return OK, "PR already merged"
+    rollup = data.get("statusCheckRollup") or []
+    failing = []
+    pending = []
+    for c in rollup:
+        # Check-run vs status-context have different shapes; normalize.
+        concl = (c.get("conclusion") or c.get("state") or "").upper()
+        name = c.get("name") or c.get("context") or "check"
+        if concl in ("SUCCESS", "NEUTRAL", "SKIPPED"):
+            continue
+        if concl in ("", "PENDING", "IN_PROGRESS", "QUEUED", "EXPECTED"):
+            pending.append(name)
+        else:
+            failing.append(f"{name}={concl}")
+    if failing:
+        return RED, f"failing checks: {', '.join(failing[:6])}"
+    if pending:
+        return RED, f"checks still pending: {', '.join(pending[:6])}"
+    return OK, f"all {len(rollup)} checks green ({data.get('mergeStateStatus', '?')})"
+
+
+def check_pr_checks(pr: int | None) -> tuple[str, str]:
+    if pr is None:
+        return UNKNOWN, "no PR number provided/discovered"
+    return _blocking_state(pr)
+
+
+def check_handoff_bundled(branch: str, handoff: str) -> tuple[str, str]:
+    rc, out = _git("diff", "--name-only", f"origin/main...{branch}")
+    if rc != 0:
+        return UNKNOWN, f"git diff failed: {out[:120]}"
+    files = set(out.splitlines())
+    if handoff in files:
+        return OK, f"{handoff} is in the PR diff"
+    return RED, f"{handoff} NOT in the PR diff — refreshed state won't reach main"
+
+
+def _discover_pr(branch: str) -> int | None:
+    rc, data = _gh_json("pr", "list", "--head", branch, "--state", "open", "--json", "number")
+    if rc == 0 and isinstance(data, list) and data:
+        return int(data[0]["number"])
+    return None
+
+
+def evaluate(branch: str, pr: int | None, handoff: str) -> dict:
+    if pr is None:
+        pr = _discover_pr(branch)
+    checks = {
+        "tree_clean": check_tree_clean(),
+        "no_inflight": check_no_inflight(),
+        "branch_pushed": check_branch_pushed(branch),
+        "pr_checks_green": check_pr_checks(pr),
+        "handoff_bundled": check_handoff_bundled(branch, handoff),
+    }
+    ready = all(status == OK for status, _ in checks.values())
+    return {"branch": branch, "pr": pr, "ready": ready, "checks": checks}
+
+
+def _print_human(report: dict) -> None:
+    icon = {OK: "✅", RED: "❌", UNKNOWN: "❔"}
+    print(f"\n  handoff_ready: branch={report['branch']} pr={report['pr']}\n")
+    for name, (status, detail) in report["checks"].items():
+        print(f"   {icon[status]} {name:<18} {detail}")
+    print()
+    if report["ready"]:
+        print("  ✅ READY for handoff (all predicates green).")
+    else:
+        print("  ❌ NOT READY — resolve the ❌/❔ checks. Do NOT declare ready.")
+    print()
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Machine-checked handoff-readiness predicate (#3138)")
+    ap.add_argument("--branch", default=None, help="branch to check (default: current HEAD)")
+    ap.add_argument("--pr", type=int, default=None, help="PR number (default: discover via gh)")
+    ap.add_argument("--handoff", default=DEFAULT_HANDOFF, help="driver handoff path that must be bundled")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+
+    branch = args.branch
+    if branch is None:
+        rc, out = _git("rev-parse", "--abbrev-ref", "HEAD")
+        branch = out if rc == 0 else "HEAD"
+
+    report = evaluate(branch, args.pr, args.handoff)
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        _print_human(report)
+    return 0 if report["ready"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/handoff_ready.py
+++ b/scripts/orchestration/handoff_ready.py
@@ -121,7 +121,13 @@ def _blocking_state(pr: int) -> tuple[str, str]:
         return RED, f"failing checks: {', '.join(failing[:6])}"
     if pending:
         return RED, f"checks still pending: {', '.join(pending[:6])}"
-    return OK, f"all {len(rollup)} checks green ({data.get('mergeStateStatus', '?')})"
+    # Checks green is necessary but not sufficient — enforce the merge state too:
+    # a PR can be all-green yet BLOCKED (required review), DIRTY (conflict), or
+    # BEHIND (needs update from base) and is NOT ready to hand off.
+    merge_state = (data.get("mergeStateStatus") or "").upper()
+    if merge_state in ("BLOCKED", "DIRTY", "BEHIND"):
+        return RED, f"checks green but mergeStateStatus={merge_state} (not mergeable)"
+    return OK, f"all {len(rollup)} checks green ({merge_state or '?'})"
 
 
 def check_pr_checks(pr: int | None) -> tuple[str, str]:

--- a/scripts/orchestration/handoff_ready.py
+++ b/scripts/orchestration/handoff_ready.py
@@ -101,6 +101,10 @@ def _blocking_state(pr: int) -> tuple[str, str]:
     if data.get("state") == "MERGED":
         return OK, "PR already merged"
     rollup = data.get("statusCheckRollup") or []
+    if not rollup:
+        # No checks at all ⇒ cannot confirm green. UNKNOWN ⇒ not ready (never
+        # report "all 0 checks green" as READY — anti-fabrication, #M-4).
+        return UNKNOWN, "no status checks found on the PR"
     failing = []
     pending = []
     for c in rollup:

--- a/tests/test_handoff_ready.py
+++ b/tests/test_handoff_ready.py
@@ -96,6 +96,14 @@ def test_no_inflight_logic(monkeypatch):
     assert hr.check_no_inflight()[0] == hr.RED
 
 
+def test_empty_rollup_is_unknown(monkeypatch):
+    # a PR with zero status checks must NOT report green/ready (anti-fabrication)
+    monkeypatch.setattr(
+        hr, "_gh_json", lambda *a: (0, {"statusCheckRollup": [], "state": "OPEN", "mergeStateStatus": "UNKNOWN"})
+    )
+    assert hr.check_pr_checks(5)[0] == hr.UNKNOWN
+
+
 def test_api_down_is_unknown(monkeypatch):
     def boom(*a, **k):
         raise OSError("connection refused")

--- a/tests/test_handoff_ready.py
+++ b/tests/test_handoff_ready.py
@@ -104,6 +104,26 @@ def test_empty_rollup_is_unknown(monkeypatch):
     assert hr.check_pr_checks(5)[0] == hr.UNKNOWN
 
 
+def test_merge_state_blocked_is_red(monkeypatch):
+    # all checks green but mergeStateStatus BLOCKED/DIRTY/BEHIND ⇒ not mergeable ⇒ RED
+    for state in ("BLOCKED", "DIRTY", "BEHIND"):
+        monkeypatch.setattr(
+            hr,
+            "_gh_json",
+            lambda *a, _s=state: (0, {"statusCheckRollup": [{"conclusion": "SUCCESS", "name": "ci"}], "state": "OPEN", "mergeStateStatus": _s}),
+        )
+        assert hr.check_pr_checks(5)[0] == hr.RED, state
+
+
+def test_merge_state_clean_is_ok(monkeypatch):
+    monkeypatch.setattr(
+        hr,
+        "_gh_json",
+        lambda *a: (0, {"statusCheckRollup": [{"conclusion": "SUCCESS", "name": "ci"}], "state": "OPEN", "mergeStateStatus": "CLEAN"}),
+    )
+    assert hr.check_pr_checks(5)[0] == hr.OK
+
+
 def test_api_down_is_unknown(monkeypatch):
     def boom(*a, **k):
         raise OSError("connection refused")

--- a/tests/test_handoff_ready.py
+++ b/tests/test_handoff_ready.py
@@ -1,0 +1,104 @@
+"""Tests for handoff_ready — the machine-checked readiness predicate (#3138).
+
+All git/gh/API calls are monkeypatched so the predicate logic is exercised with
+no network, no repo state, and no gh auth.
+"""
+
+from __future__ import annotations
+
+import scripts.orchestration.handoff_ready as hr
+
+
+def _all_ok(monkeypatch):
+    monkeypatch.setattr(hr, "check_tree_clean", lambda: (hr.OK, "clean"))
+    monkeypatch.setattr(hr, "check_no_inflight", lambda: (hr.OK, "0 in flight"))
+    monkeypatch.setattr(hr, "check_branch_pushed", lambda b: (hr.OK, "pushed"))
+    monkeypatch.setattr(hr, "check_pr_checks", lambda pr: (hr.OK, "green"))
+    monkeypatch.setattr(hr, "check_handoff_bundled", lambda b, h: (hr.OK, "bundled"))
+
+
+def test_ready_when_all_ok(monkeypatch):
+    _all_ok(monkeypatch)
+    rep = hr.evaluate("br", 5, "h.md")
+    assert rep["ready"] is True
+
+
+def test_red_blocks_ready(monkeypatch):
+    _all_ok(monkeypatch)
+    monkeypatch.setattr(hr, "check_tree_clean", lambda: (hr.RED, "3 uncommitted"))
+    assert hr.evaluate("br", 5, "h.md")["ready"] is False
+
+
+def test_unknown_blocks_ready(monkeypatch):
+    """Anti-fabrication: a check you could not run ⇒ NOT ready (#M-4)."""
+    _all_ok(monkeypatch)
+    monkeypatch.setattr(hr, "check_pr_checks", lambda pr: (hr.UNKNOWN, "gh unavailable"))
+    assert hr.evaluate("br", 5, "h.md")["ready"] is False
+
+
+def test_branch_pushed_logic(monkeypatch):
+    state = {"remote": ""}
+
+    def fake_git(*args):
+        if args[0] == "rev-parse":
+            return 0, "abc123def"
+        if args[0] == "ls-remote":
+            return 0, state["remote"]
+        return 1, ""
+
+    monkeypatch.setattr(hr, "_git", fake_git)
+
+    state["remote"] = "abc123def\trefs/heads/br"
+    assert hr.check_branch_pushed("br")[0] == hr.OK  # local == origin
+
+    state["remote"] = "0000000ff\trefs/heads/br"
+    assert hr.check_branch_pushed("br")[0] == hr.RED  # unpushed commits
+
+    state["remote"] = ""
+    assert hr.check_branch_pushed("br")[0] == hr.RED  # not pushed at all
+
+
+def test_handoff_bundled_logic(monkeypatch):
+    handoff = "docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md"
+    monkeypatch.setattr(hr, "_git", lambda *a: (0, f"{handoff}\nfoo.py\nbar.py"))
+    assert hr.check_handoff_bundled("br", handoff)[0] == hr.OK
+
+    monkeypatch.setattr(hr, "_git", lambda *a: (0, "foo.py\nbar.py"))
+    assert hr.check_handoff_bundled("br", handoff)[0] == hr.RED
+
+
+def test_no_inflight_logic(monkeypatch):
+    import json
+
+    class _Resp:
+        def __init__(self, payload):
+            self._p = payload.encode()
+
+        def read(self):
+            return self._p
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(
+        hr.urllib.request, "urlopen", lambda *a, **k: _Resp(json.dumps({"total": 0, "tasks": []}))
+    )
+    assert hr.check_no_inflight()[0] == hr.OK
+
+    monkeypatch.setattr(
+        hr.urllib.request,
+        "urlopen",
+        lambda *a, **k: _Resp(json.dumps({"total": 2, "tasks": [{"task_id": "t1"}, {"task_id": "t2"}]})),
+    )
+    assert hr.check_no_inflight()[0] == hr.RED
+
+
+def test_api_down_is_unknown(monkeypatch):
+    def boom(*a, **k):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(hr.urllib.request, "urlopen", boom)
+    assert hr.check_no_inflight()[0] == hr.UNKNOWN

--- a/tests/test_mdx_render_gate.py
+++ b/tests/test_mdx_render_gate.py
@@ -98,6 +98,14 @@ def test_clean_payload_passes():
 
 # --- graceful degradation -----------------------------------------------------
 
+def test_escaper_rejects_nonfinite():
+    # NaN/Infinity are invalid JSON — must fail fast at assembly, not emit bad JSON
+    with pytest.raises(ValueError):
+        dump_json_for_jsx([{"v": float("nan")}])
+    with pytest.raises(ValueError):
+        dump_json_for_jsx([{"v": float("inf")}], compact=True)
+
+
 def test_node_absent_skips_not_fails(monkeypatch):
     import scripts.build.mdx_render_gate as g
 

--- a/tests/test_mdx_render_gate.py
+++ b/tests/test_mdx_render_gate.py
@@ -36,6 +36,13 @@ def test_iter_template_literals_none_when_absent():
     assert iter_template_literals("plain text, no islands") == []
 
 
+def test_iter_template_literals_skips_unterminated():
+    # truncated JSON.parse(` with no closing backtick → no phantom rest-of-file island
+    assert iter_template_literals("x <X p={JSON.parse(`[1,2,3]") == []
+    # a terminated island before an unterminated one is still captured
+    assert iter_template_literals("<A p={JSON.parse(`[1]`)} /> <B q={JSON.parse(`[2") == ["[1]"]
+
+
 # --- the #3137 escape bug: caught by the gate --------------------------------
 
 @node_required
@@ -73,6 +80,13 @@ def test_renderers_duplicate_escaper_round_trips():
     payload = [{"w": 'він "сказав"', "m": "рядок1\nрядок2", "p": "a`b"}]
     mdx = f"<X items={{JSON.parse(`{flat_dump(payload)}`)}} />"
     assert check_mdx_render(mdx)["passed"] is True
+
+
+@node_required
+def test_sentinel_catches_template_interpolation():
+    # an unescaped ${...} that would run code (escaper bypass) must FAIL, not pass
+    mdx = "<X p={JSON.parse(`${process.exit(0)}`)} />"
+    assert check_mdx_render(mdx)["passed"] is False
 
 
 @node_required

--- a/tests/test_mdx_render_gate.py
+++ b/tests/test_mdx_render_gate.py
@@ -1,0 +1,93 @@
+"""Tests for the mdx_render gate + the template-literal escape fix (#3137).
+
+The render gate uses Node (the real JS engine) to evaluate every JSON.parse(`…`)
+island prop, so the Node-dependent tests skip cleanly where Node is unavailable.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+
+import pytest
+
+from scripts.build.mdx_render_gate import check_mdx_render, iter_template_literals
+from scripts.generate_mdx.utils import dump_json_for_jsx
+
+node_required = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node not available"
+)
+
+
+# --- extraction (pure python, no node) ---------------------------------------
+
+def test_iter_template_literals_extracts_each_inner():
+    mdx = 'a <X p={JSON.parse(`[1,2]`)} /> b <Y q={JSON.parse(`{"k":1}`)} />'
+    assert iter_template_literals(mdx) == ["[1,2]", '{"k":1}']
+
+
+def test_iter_template_literals_respects_escaped_backtick():
+    # an escaped backtick inside a correctly-escaped payload must not end it early
+    mdx = r'<X p={JSON.parse(`["a\`b"]`)} />'
+    assert iter_template_literals(mdx) == [r'["a\`b"]']
+
+
+def test_iter_template_literals_none_when_absent():
+    assert iter_template_literals("plain text, no islands") == []
+
+
+# --- the #3137 escape bug: caught by the gate --------------------------------
+
+@node_required
+def test_canonical_escaper_round_trips_every_tricky_char():
+    # " ` ${ \ and newline — each one breaks a naive template-literal embed
+    payload = [{"w": 'ка"з"ка', "n": "back\\slash", "t": "x${y}", "k": "a`b", "m": "l1\nl2"}]
+    mdx = f"<VocabCard words={{JSON.parse(`{dump_json_for_jsx(payload, compact=True)}`)}} />"
+    report = check_mdx_render(mdx)
+    assert report["passed"] is True, report
+    assert report["islands_checked"] == 1
+
+
+@node_required
+def test_under_escaped_quote_is_caught():
+    # the exact pre-#3137 resources.py bug: backtick/${-only escaping (NO backslash
+    # doubling) on a value containing a literal " — must FAIL the render gate.
+    bad = (
+        json.dumps([{"w": 'a"b'}], ensure_ascii=False, separators=(",", ":"))
+        .replace("`", "\\`")
+        .replace("${", "\\${")
+    )
+    mdx = f"<VocabCard words={{JSON.parse(`{bad}`)}} />"
+    report = check_mdx_render(mdx)
+    assert report["passed"] is False
+    assert report["failures"]
+
+
+@node_required
+def test_renderers_duplicate_escaper_round_trips():
+    # the second (flat) dump_json_for_jsx, after dropping its un-escape line (#3137)
+    from scripts.generate_mdx.generate_mdx_direct_renderers import (
+        dump_json_for_jsx as flat_dump,
+    )
+
+    payload = [{"w": 'він "сказав"', "m": "рядок1\nрядок2", "p": "a`b"}]
+    mdx = f"<X items={{JSON.parse(`{flat_dump(payload)}`)}} />"
+    assert check_mdx_render(mdx)["passed"] is True
+
+
+@node_required
+def test_clean_payload_passes():
+    payload = [{"word": "коляда", "translation": "carol"}]
+    mdx = f"<VocabCard words={{JSON.parse(`{dump_json_for_jsx(payload)}`)}} />"
+    assert check_mdx_render(mdx)["passed"] is True
+
+
+# --- graceful degradation -----------------------------------------------------
+
+def test_node_absent_skips_not_fails(monkeypatch):
+    import scripts.build.mdx_render_gate as g
+
+    monkeypatch.setattr(g.shutil, "which", lambda *_: None)
+    report = g.check_mdx_render("<X p={JSON.parse(`[1]`)} />")
+    assert report["passed"] is None
+    assert report["skipped"] is True

--- a/tests/test_verify_shippable.py
+++ b/tests/test_verify_shippable.py
@@ -56,6 +56,29 @@ def test_render_runs_even_when_python_qg_red(tmp_path, monkeypatch):
     assert steps["python_qg"] is False and steps["mdx_render"] is True
 
 
+def test_render_runs_when_python_qg_raises(tmp_path, monkeypatch):
+    """A python_qg CRASH (not just a red gate) must still reach the render check."""
+    md, plan = _mk(tmp_path)
+
+    def boom(m, p):
+        raise RuntimeError("vesum db missing")
+
+    monkeypatch.setattr(lp, "run_python_qg", boom)
+    monkeypatch.setattr(lp, "assemble_mdx", lambda m, o, p: "MDXBODY")
+    seen = {}
+
+    def render(t):
+        seen["ran"] = True
+        return {"passed": True, "message": "ok", "failures": []}
+
+    monkeypatch.setattr(lp, "run_mdx_render_gate", render)
+    rep = vs.verify("folk", "x", module_dir=md, plan_path=plan)
+    assert seen.get("ran") is True  # render ran despite python_qg crash
+    assert rep["shippable"] is False  # but the crash still blocks ship
+    steps = {s["step"]: s["passed"] for s in rep["steps"]}
+    assert steps["python_qg"] is False and steps["mdx_render"] is True
+
+
 def test_render_failure_blocks_ship(tmp_path, monkeypatch):
     md, plan = _mk(tmp_path)
     monkeypatch.setattr(lp, "run_python_qg", lambda m, p: {"gates": {"passed": True}})

--- a/tests/test_verify_shippable.py
+++ b/tests/test_verify_shippable.py
@@ -1,0 +1,87 @@
+"""Tests for verify_shippable — the Definition-of-Done predicate (#3138).
+
+The pipeline functions are heavy; these tests monkeypatch them on the source
+module (verify() imports them lazily at call time) to exercise the verdict logic
+deterministically without data/, MCP, or Node.
+"""
+
+from __future__ import annotations
+
+import scripts.build.linear_pipeline as lp
+import scripts.build.verify_shippable as vs
+
+
+def _mk(tmp_path):
+    md = tmp_path / "mod"
+    md.mkdir()
+    plan = tmp_path / "plan.yaml"
+    plan.write_text("module: x\n", encoding="utf-8")
+    return md, plan
+
+
+def test_shippable_when_all_green(tmp_path, monkeypatch):
+    md, plan = _mk(tmp_path)
+    monkeypatch.setattr(lp, "run_python_qg", lambda m, p: {"gates": {"passed": True}})
+    monkeypatch.setattr(lp, "assemble_mdx", lambda m, o, p: "MDXBODY")
+    monkeypatch.setattr(
+        lp, "run_mdx_render_gate", lambda t: {"passed": True, "message": "ok", "failures": []}
+    )
+    rep = vs.verify("folk", "x", module_dir=md, plan_path=plan)
+    assert rep["shippable"] is True
+    steps = {s["step"]: s["passed"] for s in rep["steps"]}
+    assert steps["python_qg"] and steps["assemble_mdx"] and steps["mdx_render"]
+    assert rep["corpus_hammer_required"] is True
+
+
+def test_render_runs_even_when_python_qg_red(tmp_path, monkeypatch):
+    """E's core guarantee: the render gate runs even when python_qg fails."""
+    md, plan = _mk(tmp_path)
+    monkeypatch.setattr(
+        lp,
+        "run_python_qg",
+        lambda m, p: {"gates": {"passed": False, "vesum_verified": {"passed": False}}},
+    )
+    monkeypatch.setattr(lp, "assemble_mdx", lambda m, o, p: "MDXBODY")
+    seen = {}
+
+    def render(t):
+        seen["ran"] = True
+        return {"passed": True, "message": "ok", "failures": []}
+
+    monkeypatch.setattr(lp, "run_mdx_render_gate", render)
+    rep = vs.verify("folk", "x", module_dir=md, plan_path=plan)
+    assert seen.get("ran") is True  # render evaluated despite python_qg red
+    assert rep["shippable"] is False  # but a red gate still blocks ship
+    steps = {s["step"]: s["passed"] for s in rep["steps"]}
+    assert steps["python_qg"] is False and steps["mdx_render"] is True
+
+
+def test_render_failure_blocks_ship(tmp_path, monkeypatch):
+    md, plan = _mk(tmp_path)
+    monkeypatch.setattr(lp, "run_python_qg", lambda m, p: {"gates": {"passed": True}})
+    monkeypatch.setattr(lp, "assemble_mdx", lambda m, o, p: "MDXBODY")
+    monkeypatch.setattr(
+        lp,
+        "run_mdx_render_gate",
+        lambda t: {"passed": False, "message": "boom", "failures": [{"snippet": "x", "error": "SyntaxError"}]},
+    )
+    rep = vs.verify("folk", "x", module_dir=md, plan_path=plan)
+    assert rep["shippable"] is False
+
+
+def test_assemble_crash_blocks_ship(tmp_path, monkeypatch):
+    md, plan = _mk(tmp_path)
+    monkeypatch.setattr(lp, "run_python_qg", lambda m, p: {"gates": {"passed": True}})
+
+    def boom(m, o, p):
+        raise RuntimeError("assembler exploded")
+
+    monkeypatch.setattr(lp, "assemble_mdx", boom)
+    rep = vs.verify("folk", "x", module_dir=md, plan_path=plan)
+    assert rep["shippable"] is False
+    assert any(s["step"] == "assemble_mdx" and s["passed"] is False for s in rep["steps"])
+
+
+def test_missing_inputs_not_shippable(tmp_path):
+    rep = vs.verify("folk", "x", module_dir=tmp_path / "nope", plan_path=tmp_path / "nope.yaml")
+    assert rep["shippable"] is False

--- a/tests/test_verify_shippable.py
+++ b/tests/test_verify_shippable.py
@@ -105,6 +105,21 @@ def test_assemble_crash_blocks_ship(tmp_path, monkeypatch):
     assert any(s["step"] == "assemble_mdx" and s["passed"] is False for s in rep["steps"])
 
 
+def test_skipped_render_not_shippable(tmp_path, monkeypatch):
+    """Node-absent (mdx_render=None) must NOT certify shippable — no render evidence."""
+    md, plan = _mk(tmp_path)
+    monkeypatch.setattr(lp, "run_python_qg", lambda m, p: {"gates": {"passed": True}})
+    monkeypatch.setattr(lp, "assemble_mdx", lambda m, o, p: "MDXBODY")
+    monkeypatch.setattr(
+        lp,
+        "run_mdx_render_gate",
+        lambda t: {"passed": None, "skipped": True, "message": "node unavailable", "failures": []},
+    )
+    rep = vs.verify("folk", "x", module_dir=md, plan_path=plan)
+    assert rep["shippable"] is False
+    assert rep["render_fully_validated"] is False
+
+
 def test_missing_inputs_not_shippable(tmp_path):
     rep = vs.verify("folk", "x", module_dir=tmp_path / "nope", plan_path=tmp_path / "nope.yaml")
     assert rep["shippable"] is False


### PR DESCRIPTION
## Why
`python_qg` is blind to whether the **assembled MDX renders**. On 2026-06-14 three modules shipped python_qg-green and **#01 did not render** — only CI's astro build caught it, *after* "ready" had been asserted. The `mdx_render` gate was a deferred placeholder that never ran. This PR builds all five fixes from that post-mortem (#3137 infra render gap, #3138 process DoD/cold-start).

## The five fixes
| | Fix | Lane |
|---|---|---|
| **D** | **Template-literal JSON escape (#3137).** `JSON.parse(\`{json}\`)` embeds JSON in a JS template literal, which *consumes* backslash escapes → JSON's own `\"` / `\\` / `\n` get eaten, so any value with a literal `"` breaks render. Routed `resources.py` (the seminar/folk VocabCard+FlashcardDeck path = #01) through the canonical backslash-first `utils.dump_json_for_jsx` (+`compact`); fixed the divergent flat copy in `generate_mdx_direct_renderers.py` (dropped a line that *un-escaped* `\\n`/`\\"`). | infra |
| **E** | **`mdx_render` gate now runs (#3137).** New `scripts/build/mdx_render_gate.py` **Node-evaluates** every `JSON.parse(\`…\`)` island (the exact JS engine — no re-implementing escaping). `run_mdx_render_gate` wired into `linear_pipeline.py` as a **standalone post-assemble step** so it runs even when python_qg fails (was a permanent `passed:None`). Degrades to skip if Node absent. | infra |
| **A** | **`scripts/build/verify_shippable.py` (#3138).** One-command Definition-of-Done: `python_qg → assemble → mdx_render → ONE green/red` (`--astro-build` for the full CI-equivalent catch-all). | process |
| **B** | **`scripts/orchestration/handoff_ready.py` (#3138).** Machine-checked readiness: tree-clean · 0 in-flight · branch pushed (local==origin) · all blocking PR checks green · handoff bundled. Any RED/UNKNOWN ⇒ not ready. | process |
| **C** | **Cold-start freshness + Definition-of-Done (#3138)** baked into **both** driver agent defs (`curriculum-orchestrator` + `curriculum-track-orchestrator`): fetch → read the freshest handoff/PRs before acting (prevents the #01 re-collision); never ship a module / declare "ready" without running `verify_shippable` / `handoff_ready`. | process |

## Proof (deterministic, #M-4)
- **D:** Node round-trip — old escaping **throws**, new round-trips a payload with `"` `` ` `` `${` `\` newline.
- **E:** shipped folk MDX (kalendarna/koliadky, 17 islands each) **PASS**; crafted under-escaped quote **FAILS** with a precise `SyntaxError`.
- **A:** on kalendarna, shows `python_qg ❌` but `mdx_render ✅` — render is checked **even when python_qg is red**.
- **Tests:** 20 new + 179 existing assembler + 40 pipeline + 5 ADR-008 invariants green; ruff clean; pre-commit green.

## Notes for the orchestrator (cross-track blast radius)
- **D touches shared `scripts/generate_mdx/`** (every track). It is strictly-more-correct and test-locked; existing modules without special chars are byte-identical. **Held self-merge** (cross-track infra) — please review + promote.
- **Onboarding:** the agent-def edits are *source* (`agents_extensions/shared/agents/`). To activate for the orchestrator's next session: merge → `scripts/deploy_prompts.sh` → release.
- **Recommended follow-up:** sweep existing shipped modules through `mdx_render_gate` to catch any pre-existing latent break (the gate makes this a one-liner per module).

Closes #3137, closes #3138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)