### PR TITLE
fix(agent-runtime): wire cursor sources-MCP + correct grok-build model id (#3151, #3087)

### DIFF
--- a/scripts/agent_runtime/adapters/cursor.py
+++ b/scripts/agent_runtime/adapters/cursor.py
@@ -73,10 +73,14 @@ class CursorAdapter:
             cwd: Working directory for the subprocess.
             model: Model override (e.g. "composer-2.5").
             task_id: Optional task identifier.
-            session_id: Session ID to resume (passed by runner or derived).
+            session_id: Explicit session ID to resume. Fresh invocations do
+                not auto-resume from on-disk Cursor transcripts.
             tool_config: Config overrides. Supported keys:
                 - ``cursor_workspace``: overrides the ``--workspace`` path.
                 - ``approve_mcps``: bool, toggles ``--approve-mcps``.
+                - ``mcp_config_path``: source `.mcp.json` to mirror into
+                  ``{cursor_workspace}/.cursor/mcp.json``.
+                - ``mcp_server_names``: MCP servers to mirror/approve.
                 - ``cursor_mode``: "plan" | "ask", toggles ``--mode``.
                 - ``sandbox``: "enabled" | "disabled", toggles ``--sandbox``.
             effort: Logged and ignored (no cursor equivalent today).
@@ -99,17 +103,16 @@ class CursorAdapter:
 
         # Workspace resolution
         workspace = config.get("cursor_workspace") or str(cwd)
+        self._ensure_workspace_mcp_config(workspace, config)
 
         # Snapshot pre-existing transcripts to detect a new one generated during this run
         self._workspace = workspace
         self._transcripts_snapshot = self._snapshot_preexisting_transcripts(workspace)
 
-        # Resolve session ID to resume
+        # Resume only when the runner explicitly passes a session_id. Auto-
+        # selecting the newest transcript on disk bypasses runner resume-policy
+        # enforcement and can attach a fresh review to an unrelated chat.
         resolved_session_id = session_id
-        if not resolved_session_id and task_id:
-            resolved_session_id = self._find_session_id_by_task_id(task_id)
-            if not resolved_session_id:
-                resolved_session_id = self._find_session_id_on_disk(workspace)
 
         # Base argv common to all paths.
         #
@@ -140,11 +143,13 @@ class CursorAdapter:
         if mode == "read-only":
             cursor_mode = config.get("cursor_mode", "ask")
             cmd.extend(["--mode", cursor_mode])
+            if self._should_approve_mcps(config, default=False):
+                cmd.append("--approve-mcps")
         elif mode == "workspace-write":
             cursor_mode = config.get("cursor_mode", "plan")
             cmd.extend(["--mode", cursor_mode])
             # Security boundaries from Phase 2 spec
-            if config.get("approve_mcps") is not False:
+            if self._should_approve_mcps(config, default=True):
                 cmd.append("--approve-mcps")
             sandbox = config.get("sandbox", "enabled")
             cmd.extend(["--sandbox", sandbox])
@@ -158,7 +163,7 @@ class CursorAdapter:
             #
             # Use sparingly — most delegate calls should use workspace-write
             # (which blocks edits via --mode plan).
-            if config.get("approve_mcps") is not False:
+            if self._should_approve_mcps(config, default=True):
                 cmd.append("--approve-mcps")
             sandbox = config.get("sandbox", "enabled")
             cmd.extend(["--sandbox", sandbox])
@@ -170,6 +175,78 @@ class CursorAdapter:
             output_file=None,  # Cursor writes to stdout
             liveness_paths=(),  # rely on stdout streaming
         )
+
+    def _should_approve_mcps(self, config: dict, *, default: bool) -> bool:
+        if config.get("approve_mcps") is False:
+            return False
+        return bool(default or config.get("approve_mcps") is True or config.get("mcp_server_names"))
+
+    def _ensure_workspace_mcp_config(self, workspace: str, config: dict) -> None:
+        """Mirror requested MCP servers into Cursor's workspace config."""
+        requested = config.get("mcp_server_names") or []
+        if not requested:
+            return
+        if not isinstance(requested, list):
+            requested = [str(requested)]
+
+        source_path = Path(str(config.get("mcp_config_path") or ".mcp.json"))
+        source_servers = self._read_mcp_servers(source_path)
+
+        selected: dict[str, dict] = {}
+        missing: list[str] = []
+        for name in requested:
+            raw = source_servers.get(name)
+            if raw is None and name == "sources":
+                raw = {"url": "http://127.0.0.1:8766/mcp"}
+            sanitized = self._cursor_server_config(raw)
+            if sanitized is None:
+                missing.append(name)
+            else:
+                selected[name] = sanitized
+
+        if missing:
+            raise RuntimeError(
+                "CursorAdapter could not resolve MCP server config for: "
+                + ", ".join(sorted(missing))
+            )
+
+        target = Path(workspace) / ".cursor" / "mcp.json"
+        existing = self._read_mcp_file(target)
+        servers = existing.setdefault("mcpServers", {})
+        if not isinstance(servers, dict):
+            servers = {}
+            existing["mcpServers"] = servers
+        servers.update(selected)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    def _read_mcp_servers(self, path: Path) -> dict[str, object]:
+        data = self._read_mcp_file(path)
+        servers = data.get("mcpServers")
+        return servers if isinstance(servers, dict) else {}
+
+    def _read_mcp_file(self, path: Path) -> dict:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _cursor_server_config(self, raw: object) -> dict | None:
+        if not isinstance(raw, dict):
+            return None
+        url = str(raw.get("url") or raw.get("httpUrl") or "").strip()
+        if url:
+            return {"url": url}
+        command = str(raw.get("command") or "").strip()
+        if command:
+            out = {"command": command}
+            if isinstance(raw.get("args"), list):
+                out["args"] = raw["args"]
+            if isinstance(raw.get("env"), dict):
+                out["env"] = raw["env"]
+            return out
+        return None
 
     def _encode_workspace_path(self, workspace_path: str) -> str:
         """Encode workspace path into the encoded folder name used by Cursor."""
@@ -189,37 +266,6 @@ class CursorAdapter:
             except OSError:
                 pass
         return preexisting
-
-    def _find_session_id_by_task_id(self, task_id: str) -> str | None:
-        """Scan api_usage files for a session_id matching the given task_id."""
-        repo_root = Path(__file__).resolve().parents[3]
-        usage_dir = repo_root / "batch_state" / "api_usage"
-        if not usage_dir.exists():
-            return None
-
-        last_session_id = None
-        try:
-            # Sort files so we check the most recent ones first
-            for file_path in sorted(usage_dir.glob("usage_cursor-*.jsonl"), reverse=True):
-                try:
-                    with open(file_path, encoding="utf-8") as f:
-                        for line in f:
-                            line = line.strip()
-                            if not line:
-                                continue
-                            try:
-                                record = json.loads(line)
-                            except json.JSONDecodeError:
-                                continue
-                            if record.get("task_id") == task_id:
-                                sid = record.get("session_id")
-                                if sid:
-                                    last_session_id = sid
-                except OSError:
-                    continue
-        except Exception:
-            pass
-        return last_session_id
 
     def _find_session_id_on_disk(self, workspace_path: str) -> str | None:
         """Find the newest session directory on disk for this workspace."""
@@ -292,35 +338,16 @@ class CursorAdapter:
         # The final response is usually the last 'content' or 'text' event
         # in the stream. parse_json_events + normalize_tool_calls handles
         # most of this, but we need to extract the assistant's final prose.
-        response_parts: list[str] = []
-        stream_chunks: list[str] = []
-
-        def flush_stream_chunks() -> None:
-            if stream_chunks:
-                response_parts.append("".join(stream_chunks))
-                stream_chunks.clear()
-
-        def append_message_content(content: object) -> None:
-            text = _extract_text_content(content)
-            if not text:
-                return
-            flush_stream_chunks()
-            response_parts.append(text)
-
-        for event in events:
-            # Typical cursor event shape: {"type": "text", "content": "..."}
-            # or {"type": "message", "role": "assistant", "content": "..."}
-            if event.get("type") == "text":
-                stream_chunks.append(str(event.get("content", "")))
-            elif event.get("type") == "message" and event.get("role") == "assistant":
-                append_message_content(event.get("content", ""))
-            elif event.get("role") == "assistant" and isinstance(event.get("message"), dict):
-                # Cursor Agent v2026.05.27+ transcript shape:
-                # {"role": "assistant", "message": {"content": [{"type": "text", ...}]}}
-                append_message_content(event["message"].get("content", ""))
-
-        flush_stream_chunks()
-        response = "\n\n".join(part.strip() for part in response_parts if part.strip())
+        response = _extract_response_from_events(events)
+        if not response and session_id and getattr(self, "_workspace", None):
+            transcript_events = self._read_session_transcript_events(
+                self._workspace,
+                session_id,
+            )
+            transcript_response = _extract_response_from_events(transcript_events)
+            if transcript_response:
+                response = transcript_response
+                tool_calls = normalize_tool_calls(transcript_events)
 
         ok = returncode == 0 and bool(response) and not rate_limited
 
@@ -337,10 +364,65 @@ class CursorAdapter:
             tool_calls=tool_calls,
         )
 
+    def _read_session_transcript_events(
+        self,
+        workspace_path: str,
+        session_id: str,
+    ) -> list[dict]:
+        encoded = self._encode_workspace_path(workspace_path)
+        transcript = (
+            Path.home()
+            / ".cursor"
+            / "projects"
+            / encoded
+            / "agent-transcripts"
+            / session_id
+            / f"{session_id}.jsonl"
+        )
+        try:
+            text = transcript.read_text(encoding="utf-8")
+        except OSError:
+            return []
+        return parse_json_events(text, source="cursor-transcript", logger=_logger)
+
     def liveness_signal_paths(self, plan: InvocationPlan) -> tuple[Path, ...]:
         """Cursor writes to stdout; no separate liveness files."""
         _ = plan
         return ()
+
+
+def _extract_response_from_events(events: list[dict]) -> str:
+    """Extract assistant prose from cursor stream/transcript events."""
+    response_parts: list[str] = []
+    stream_chunks: list[str] = []
+
+    def flush_stream_chunks() -> None:
+        if stream_chunks:
+            response_parts.append("".join(stream_chunks))
+            stream_chunks.clear()
+
+    def append_message_content(content: object) -> None:
+        text = _extract_text_content(content)
+        if not text:
+            return
+        flush_stream_chunks()
+        response_parts.append(text)
+
+    for event in events:
+        # Typical cursor event shape: {"type": "text", "content": "..."}
+        # or {"type": "message", "role": "assistant", "content": "..."}
+        if event.get("type") == "text":
+            stream_chunks.append(str(event.get("content", "")))
+        elif event.get("type") == "message" and event.get("role") == "assistant":
+            append_message_content(event.get("content", ""))
+        elif event.get("role") == "assistant" and isinstance(event.get("message"), dict):
+            # Cursor Agent v2026.05.27+ transcript shape:
+            # {"role": "assistant", "message": {"content": [{"type": "text", ...}]}}
+            append_message_content(event["message"].get("content", ""))
+
+    flush_stream_chunks()
+
+    return "\n\n".join(part.strip() for part in response_parts if part.strip())
 
 
 def _extract_text_content(content: object) -> str:

--- a/scripts/agent_runtime/adapters/grok_build.py
+++ b/scripts/agent_runtime/adapters/grok_build.py
@@ -47,6 +47,26 @@ _MODE_PERMISSION: dict[str, str] = {
     "workspace-write": "acceptEdits",
     "danger": "bypassPermissions",
 }
+
+# MCP servers that are safe to run under an execution-capable permission mode
+# (read-only data lookups, no mutations). ONLY these may trigger the plan→exec
+# override below; any other / future write-capable server falls back to the
+# normal (safer) mode mapping rather than silently gaining execution rights.
+_READ_ONLY_MCP_SERVERS: frozenset[str] = frozenset({"sources"})
+
+# Defense-in-depth for MCP reviews: even though `bypassPermissions` auto-approves
+# tool calls so the MCP read tools execute, explicit `--deny` rules still win
+# (per grok's permission model: deny > bypass). Denying file-write + shell tools
+# means a prompt-injected review article cannot make grok mutate the filesystem
+# or run shell — it can only call the read-only MCP tools the review needs.
+_MCP_REVIEW_DENY_RULES: tuple[str, ...] = (
+    "Write",
+    "Edit",
+    "MultiEdit",
+    "NotebookEdit",
+    "search_replace",
+    "Bash",
+)
 GROK_BUILD_DEFAULT_MODEL = os.environ.get("LEARN_UK_GROK_BUILD_MODEL", "grok-build")
 GROK_BUILD_DEFAULT_EFFORT = os.environ.get("LEARN_UK_GROK_BUILD_EFFORT", "high")
 
@@ -103,18 +123,23 @@ class GrokBuildAdapter:
         cmd.extend(["--output-format", "json", "--no-alt-screen"])
         # read-only maps to grok `plan` mode, which is analysis-only and BLOCKS
         # tool execution. MCP-grounded reviews MUST execute tool calls (e.g.
-        # sources__verify_word), so when MCP servers are requested we override
-        # to an execution-capable mode. Reviews are read-only by construction
-        # (the prompt asks for no file mutations); paired with --always-approve
-        # this lets grok actually run the MCP read tools instead of cancelling
-        # with empty output. Non-MCP calls keep their normal mode mapping.
-        mcp_needed = bool(tc.get("always_approve") or tc.get("mcp_server_names"))
-        permission_mode = "bypassPermissions" if mcp_needed else _MODE_PERMISSION[mode]
+        # sources__verify_word), so when ONLY known read-only MCP servers are
+        # requested we override to an execution-capable mode. Defense-in-depth:
+        # the `--deny` rules below block file writes + shell even under bypass
+        # (deny wins over bypassPermissions), so a prompt-injected review article
+        # cannot make grok mutate the filesystem or run shell. Any non-read-only
+        # or non-MCP call keeps its normal (safer) mode mapping.
+        mcp_servers_requested = set(tc.get("mcp_server_names") or [])
+        mcp_read_only = bool(mcp_servers_requested) and mcp_servers_requested <= _READ_ONLY_MCP_SERVERS
+        permission_mode = "bypassPermissions" if mcp_read_only else _MODE_PERMISSION[mode]
         cmd.extend(["--permission-mode", permission_mode])
         cmd.extend(["--cwd", str(cwd)])
-        if mcp_needed:
+        if mcp_read_only:
             cmd.append("--always-approve")
             cmd.append("--no-plan")
+            cmd.append("--disable-web-search")
+            for rule in _MCP_REVIEW_DENY_RULES:
+                cmd.extend(["--deny", rule])
 
         effective_effort = effort or self.default_effort
         if model:

--- a/scripts/agent_runtime/adapters/grok_build.py
+++ b/scripts/agent_runtime/adapters/grok_build.py
@@ -47,7 +47,7 @@ _MODE_PERMISSION: dict[str, str] = {
     "workspace-write": "acceptEdits",
     "danger": "bypassPermissions",
 }
-GROK_BUILD_DEFAULT_MODEL = os.environ.get("LEARN_UK_GROK_BUILD_MODEL", "grok-4.20")
+GROK_BUILD_DEFAULT_MODEL = os.environ.get("LEARN_UK_GROK_BUILD_MODEL", "grok-build")
 GROK_BUILD_DEFAULT_EFFORT = os.environ.get("LEARN_UK_GROK_BUILD_EFFORT", "high")
 
 
@@ -83,6 +83,8 @@ class GrokBuildAdapter:
                 "CLI (provides `grok`) to dispatch the grok-build agent."
             )
         tc = tool_config or {}
+        if "sources" in (tc.get("mcp_server_names") or []):
+            prompt = _adapt_prompt_for_grok_build_mcp(prompt)
 
         cmd: list[str] = [grok_bin]
         # Prompt: inline via -p for the common case; a hyphen-leading prompt
@@ -101,6 +103,9 @@ class GrokBuildAdapter:
         cmd.extend(["--output-format", "json", "--no-alt-screen"])
         cmd.extend(["--permission-mode", _MODE_PERMISSION[mode]])
         cmd.extend(["--cwd", str(cwd)])
+        if tc.get("always_approve") or tc.get("mcp_server_names"):
+            cmd.append("--always-approve")
+            cmd.append("--no-plan")
 
         effective_effort = effort or self.default_effort
         if model:
@@ -192,6 +197,25 @@ class GrokBuildAdapter:
         # a liveness signal when stdout is quiet.
         grok_home = Path.home() / ".grok"
         return (grok_home,) if grok_home.exists() else ()
+
+
+def _translate_mcp_prefix_for_grok_build(prompt: str) -> str:
+    """Rewrite canonical MCP names to native grok-build tool names."""
+    return prompt.replace("mcp__sources__", "sources__")
+
+
+def _adapt_prompt_for_grok_build_mcp(prompt: str) -> str:
+    """Adapt canonical MCP review prompts for native grok-build headless."""
+    translated = _translate_mcp_prefix_for_grok_build(prompt)
+    return (
+        translated
+        + "\n\n## Native grok-build headless compatibility\n\n"
+        "You are running in native grok-build single-turn headless mode. "
+        "Do not call abstract `search_tool` or `use_tool` protocols, do not "
+        "call `read_file`, and do not describe a plan. The article text and "
+        "instructions above are sufficient for this review. Return the final "
+        "JSON object now, starting with `{` and ending with `}`.\n"
+    )
 
 
 def _parse_json_object(stdout: str) -> dict | None:

--- a/scripts/agent_runtime/adapters/grok_build.py
+++ b/scripts/agent_runtime/adapters/grok_build.py
@@ -101,9 +101,18 @@ class GrokBuildAdapter:
             cmd.extend(["-p", prompt])
 
         cmd.extend(["--output-format", "json", "--no-alt-screen"])
-        cmd.extend(["--permission-mode", _MODE_PERMISSION[mode]])
+        # read-only maps to grok `plan` mode, which is analysis-only and BLOCKS
+        # tool execution. MCP-grounded reviews MUST execute tool calls (e.g.
+        # sources__verify_word), so when MCP servers are requested we override
+        # to an execution-capable mode. Reviews are read-only by construction
+        # (the prompt asks for no file mutations); paired with --always-approve
+        # this lets grok actually run the MCP read tools instead of cancelling
+        # with empty output. Non-MCP calls keep their normal mode mapping.
+        mcp_needed = bool(tc.get("always_approve") or tc.get("mcp_server_names"))
+        permission_mode = "bypassPermissions" if mcp_needed else _MODE_PERMISSION[mode]
+        cmd.extend(["--permission-mode", permission_mode])
         cmd.extend(["--cwd", str(cwd)])
-        if tc.get("always_approve") or tc.get("mcp_server_names"):
+        if mcp_needed:
             cmd.append("--always-approve")
             cmd.append("--no-plan")
 

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -120,7 +120,7 @@ AGENTS: dict[str, AgentEntry] = {
         # `grok` entry above (different transport, different use: coding vs
         # content). Uses ~/.grok OAuth.
         "adapter": "scripts.agent_runtime.adapters.grok_build:GrokBuildAdapter",
-        "default_model": "grok-4.20",
+        "default_model": "grok-build",
         "default_effort": "high",
         "cost_tier": "medium",
         "capabilities": frozenset({

--- a/scripts/agent_runtime/tool_config.py
+++ b/scripts/agent_runtime/tool_config.py
@@ -31,6 +31,8 @@ def _canonical_agent_name(agent: str) -> str | None:
         return "gemini"
     if agent.startswith("codex"):
         return "codex"
+    if agent.startswith("grok-build"):
+        return "grok-build"
     if agent.startswith("grok"):
         return "grok"
     if agent.startswith("deepseek"):
@@ -345,6 +347,30 @@ def build_mcp_tool_config(
             ),
         )
 
+    if canonical_agent == "grok-build":
+        # Native grok-build reads MCP servers from its own local config
+        # (`grok mcp list`), not Hermes. The adapter only needs the requested
+        # names for observability and to opt into non-interactive approval.
+        if not mcp_servers:
+            return None, _basic_diagnostics(
+                mcp_config_path=Path.home() / ".grok" / "mcp.json",
+                requested_servers=mcp_servers,
+                resolved_servers=None,
+                resolution_status="config_empty",
+            )
+        return (
+            {
+                "always_approve": True,
+                "mcp_server_names": mcp_servers,
+            },
+            _basic_diagnostics(
+                mcp_config_path=Path.home() / ".grok" / "mcp.json",
+                requested_servers=mcp_servers,
+                resolved_servers=mcp_servers,
+                resolution_status="ok",
+            ),
+        )
+
     if canonical_agent == "cursor":
         # For Phase 2, the workspace value defaults to cwd of the subprocess.
         # Diagnostic config_path should point at {cwd}/.cursor/mcp.json
@@ -354,6 +380,7 @@ def build_mcp_tool_config(
             {
                 "output_format": "stream-json",
                 "approve_mcps": True,
+                "mcp_config_path": str(resolved_config_path),
                 "mcp_server_names": mcp_servers,
             },
             _basic_diagnostics(

--- a/scripts/ai_agent_bridge/_model.py
+++ b/scripts/ai_agent_bridge/_model.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from ._config import _MODEL_CACHE, _MODEL_CACHE_TTL, _PARENT_ENV, GEMINI_CLI
 
-GROK_BUILD_DEFAULT_MODEL = "grok-4.20"
+GROK_BUILD_DEFAULT_MODEL = "grok-build"
 GROK_BUILD_DEFAULT_EFFORT = "high"
 
 

--- a/tests/agent_runtime/adapters/test_cursor_adapter.py
+++ b/tests/agent_runtime/adapters/test_cursor_adapter.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 import json
+import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -50,6 +53,48 @@ def test_cursor_adapter_build_invocation_read_only(adapter, tmp_path, monkeypatc
     assert plan.stdin_payload == "Hello"
     assert "--yolo" not in plan.cmd
     assert "--force" not in plan.cmd
+
+
+def test_cursor_adapter_read_only_mcp_config_writes_workspace_file(
+    adapter,
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr("shutil.which", lambda x: "/usr/local/bin/agent" if x == "agent" else None)
+    source_config = tmp_path / ".mcp.json"
+    source_config.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "sources": {
+                        "type": "streamable-http",
+                        "url": "http://127.0.0.1:8766/mcp",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    plan = adapter.build_invocation(
+        prompt="Review this",
+        mode="read-only",
+        cwd=tmp_path,
+        model=None,
+        task_id="task-123",
+        session_id=None,
+        tool_config={
+            "approve_mcps": True,
+            "mcp_config_path": str(source_config),
+            "mcp_server_names": ["sources"],
+        },
+    )
+
+    assert "--approve-mcps" in plan.cmd
+    workspace_config = tmp_path / ".cursor" / "mcp.json"
+    assert json.loads(workspace_config.read_text(encoding="utf-8")) == {
+        "mcpServers": {"sources": {"url": "http://127.0.0.1:8766/mcp"}}
+    }
 
 
 def test_cursor_adapter_build_invocation_workspace_write(adapter, tmp_path, monkeypatch):
@@ -158,6 +203,34 @@ def test_cursor_adapter_parse_response_success(adapter):
     assert result.response == "I have fixed the bug. Done."
     assert len(result.tool_calls) == 1
     assert result.tool_calls[0]["name"] == "mcp__sources__search_text"
+
+
+def test_cursor_agent_trivial_invoke_smoke():
+    if os.environ.get("CI"):
+        pytest.skip("real cursor-agent smoke test is skipped in CI")
+    cursor_bin = shutil.which("cursor-agent") or shutil.which("agent")
+    if not cursor_bin:
+        pytest.skip("cursor-agent CLI not installed")
+
+    result = subprocess.run(
+        [
+            cursor_bin,
+            "-p",
+            "--model",
+            "auto",
+            "--output-format",
+            "stream-json",
+            "--trust",
+        ],
+        input="Reply with exactly: PONG",
+        capture_output=True,
+        text=True,
+        timeout=60,
+        cwd=Path.cwd(),
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert "PONG" in result.stdout
 
 
 def test_cursor_adapter_parse_response_rate_limited(adapter):

--- a/tests/agent_runtime/test_cursor_adapter_resume.py
+++ b/tests/agent_runtime/test_cursor_adapter_resume.py
@@ -92,7 +92,7 @@ def test_cursor_adapter_resume_explicit_session(adapter, tmp_path, monkeypatch):
     assert plan.cmd[idx + 1] == "session-explicit-123"
 
 
-def test_cursor_adapter_resume_from_disk(adapter, tmp_path, monkeypatch):
+def test_cursor_adapter_does_not_resume_from_disk(adapter, tmp_path, monkeypatch):
     monkeypatch.setattr("shutil.which", lambda _: "/usr/local/bin/cursor-agent")
 
     # Mock Path.home() so we can construct a fake .cursor directory
@@ -115,11 +115,10 @@ def test_cursor_adapter_resume_from_disk(adapter, tmp_path, monkeypatch):
         tool_config=None,
     )
 
-    idx = plan.cmd.index("--resume")
-    assert plan.cmd[idx + 1] == "session-disk-789"
+    assert "--resume" not in plan.cmd
 
 
-def test_cursor_adapter_resume_from_api_usage(adapter, tmp_path, monkeypatch):
+def test_cursor_adapter_does_not_resume_from_api_usage(adapter, tmp_path, monkeypatch):
     monkeypatch.setattr("shutil.which", lambda _: "/usr/local/bin/cursor-agent")
 
     # Create fake api_usage directory and write log
@@ -151,8 +150,7 @@ def test_cursor_adapter_resume_from_api_usage(adapter, tmp_path, monkeypatch):
             tool_config=None,
         )
 
-        idx = plan.cmd.index("--resume")
-        assert plan.cmd[idx + 1] == "session-api-usage-456"
+        assert "--resume" not in plan.cmd
     finally:
         # Clean up the test log
         if log_file.exists():
@@ -196,3 +194,74 @@ def test_cursor_adapter_parse_response_session_id_disk(adapter, tmp_path, monkey
 
     assert res.ok is True
     assert res.session_id == "session-new-999"
+
+
+def test_cursor_adapter_recovers_response_from_session_transcript(
+    adapter,
+    tmp_path,
+    monkeypatch,
+):
+    fake_home = tmp_path / "fake-home"
+    fake_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
+
+    workspace = str(tmp_path)
+    adapter._workspace = workspace
+    adapter._transcripts_snapshot = adapter._snapshot_preexisting_transcripts(workspace)
+    session_id = "session-transcript-123"
+    encoded = adapter._encode_workspace_path(workspace)
+    transcript = (
+        fake_home
+        / ".cursor"
+        / "projects"
+        / encoded
+        / "agent-transcripts"
+        / session_id
+        / f"{session_id}.jsonl"
+    )
+    transcript.parent.mkdir(parents=True)
+    transcript.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "role": "assistant",
+                        "message": {
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": '{"score": 8, "verdict": "PASS", "findings": []}',
+                                },
+                                {
+                                    "type": "tool_use",
+                                    "name": "mcp_sources_search_style_guide",
+                                    "input": {"query": "фокусування"},
+                                },
+                            ]
+                        },
+                    }
+                ),
+                json.dumps({"type": "turn_ended", "status": "success"}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    stdout = "\n".join(
+        [
+            json.dumps({"type": "system", "session_id": session_id}),
+            json.dumps({"type": "user", "message": {"content": "prompt"}}),
+        ]
+    )
+
+    res = adapter.parse_response(
+        stdout=stdout,
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert res.ok is True
+    assert res.response == '{"score": 8, "verdict": "PASS", "findings": []}'
+    assert res.session_id == session_id
+    assert res.tool_calls[0]["name"] == "mcp_sources_search_style_guide"

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -205,7 +205,7 @@ def test_agy_entry_is_well_formed():
 def test_grok_build_entry_is_well_formed():
     entry = get_agent_entry("grok-build")
     assert entry["adapter"] == "scripts.agent_runtime.adapters.grok_build:GrokBuildAdapter"
-    assert entry["default_model"] == "grok-4.20"
+    assert entry["default_model"] == "grok-build"
     assert entry["default_effort"] == "high"
     assert entry["cli_available"] is True
     assert entry["resume_policy"] == "never"

--- a/tests/test_agent_runtime_tool_config.py
+++ b/tests/test_agent_runtime_tool_config.py
@@ -67,6 +67,20 @@ def test_build_mcp_tool_config_gemini_without_servers_returns_none() -> None:
     assert diagnostics["resolution_status"] == "config_empty"
 
 
+def test_build_mcp_tool_config_grok_build_uses_native_config() -> None:
+    tool_config, diagnostics = build_mcp_tool_config(
+        "grok-build",
+        mcp_servers=["sources"],
+    )
+
+    assert tool_config == {
+        "always_approve": True,
+        "mcp_server_names": ["sources"],
+    }
+    assert diagnostics["config_path"] == str(Path.home() / ".grok" / "mcp.json")
+    assert diagnostics["resolution_status"] == "ok"
+
+
 def test_codex_tool_config_strips_claude_format_type_field(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_grok_build_adapter.py
+++ b/tests/test_grok_build_adapter.py
@@ -7,6 +7,9 @@ to be installed — `shutil.which` is mocked.
 from __future__ import annotations
 
 import json
+import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -21,7 +24,9 @@ from agent_runtime.adapters.grok_build import (
     GROK_BUILD_DEFAULT_EFFORT,
     GROK_BUILD_DEFAULT_MODEL,
     GrokBuildAdapter,
+    _adapt_prompt_for_grok_build_mcp,
     _parse_json_object,
+    _translate_mcp_prefix_for_grok_build,
 )
 
 FAKE_GROK = "/usr/local/bin/grok"
@@ -74,8 +79,8 @@ def test_unsupported_mode_raises(tmp_path):
 
 
 def test_model_and_effort_flags(tmp_path):
-    plan = _build("x", tmp_path, model="grok-4.20", effort="high")
-    assert _val(plan.cmd, "-m") == "grok-4.20"
+    plan = _build("x", tmp_path, model="grok-build", effort="high")
+    assert _val(plan.cmd, "-m") == "grok-build"
     assert _val(plan.cmd, "--effort") == "high"
 
 
@@ -98,6 +103,41 @@ def test_tool_config_allow_deny(tmp_path):
     )
     assert _val(plan.cmd, "--tools") == "Read,Grep"
     assert _val(plan.cmd, "--disallowed-tools") == "Bash"
+
+
+def test_tool_config_mcp_servers_enables_always_approve(tmp_path):
+    plan = _build("x", tmp_path, tool_config={"mcp_server_names": ["sources"]})
+
+    assert "--always-approve" in plan.cmd
+    assert "--no-plan" in plan.cmd
+
+
+def test_mcp_sources_prompt_prefix_translates_to_native_grok_tool_names(tmp_path):
+    prompt = "Use mcp__sources__search_style_guide and mcp__sources__verify_words."
+    plan = _build(prompt, tmp_path, tool_config={"mcp_server_names": ["sources"]})
+
+    assert "mcp__sources__" not in _val(plan.cmd, "-p")
+    assert "sources__search_style_guide" in _val(plan.cmd, "-p")
+    assert "sources__verify_words" in _val(plan.cmd, "-p")
+
+
+def test_translate_mcp_prefix_for_grok_build_is_scoped():
+    prompt = "mcp__sources__search_text mcp__rag__legacy"
+
+    assert _translate_mcp_prefix_for_grok_build(prompt) == (
+        "sources__search_text mcp__rag__legacy"
+    )
+
+
+def test_adapt_prompt_for_grok_build_mcp_adds_headless_suffix():
+    prompt = "Use mcp__sources__search_text."
+
+    adapted = _adapt_prompt_for_grok_build_mcp(prompt)
+
+    assert "sources__search_text" in adapted
+    assert "mcp__sources__" not in adapted
+    assert "native grok-build single-turn headless mode" in adapted
+    assert "Return the final JSON object now" in adapted
 
 
 def test_missing_grok_binary_raises(tmp_path):
@@ -161,6 +201,30 @@ def test_registry_grok_build_distinct_from_hermes_grok():
     assert gb["default_effort"] == GROK_BUILD_DEFAULT_EFFORT
     assert "code_writing" in gb["capabilities"]
     assert "grok-build" in registry.available_agents()
+
+
+def test_grok_build_default_model_is_native_cli_model_id():
+    assert registry.get_agent_entry("grok-build")["default_model"] == "grok-build"
+    assert GROK_BUILD_DEFAULT_MODEL == "grok-build"
+
+
+def test_grok_build_default_model_is_listed_by_cli():
+    if os.environ.get("CI"):
+        pytest.skip("real grok CLI smoke test is skipped in CI")
+    grok_bin = shutil.which("grok")
+    if not grok_bin:
+        pytest.skip("grok CLI not installed")
+
+    result = subprocess.run(
+        [grok_bin, "models"],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        cwd=Path.cwd(),
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert GROK_BUILD_DEFAULT_MODEL in result.stdout.split()
 
 
 def test_conforms_to_agent_adapter_protocol():

--- a/tests/test_grok_build_bridge.py
+++ b/tests/test_grok_build_bridge.py
@@ -27,7 +27,7 @@ def test_ask_grok_build_parser_accepts_first_class_args():
             "--from-model",
             "gpt-5.5",
             "--to-model",
-            "grok-4.20",
+            "grok-build",
             "--no-timeout",
             "--review",
         ]
@@ -38,7 +38,7 @@ def test_ask_grok_build_parser_accepts_first_class_args():
     assert args.new_session is True
     assert args.from_llm == "codex"
     assert args.from_model == "gpt-5.5"
-    assert args.to_model == "grok-4.20"
+    assert args.to_model == "grok-build"
     assert args.no_timeout is True
     assert args.review is True
 
@@ -63,10 +63,10 @@ def test_ask_grok_build_cli_handler_routes_to_bridge(monkeypatch, tmp_path):
             new_session=True,
             from_llm="codex",
             from_model="gpt-5.5",
-            to_model="grok-4.20",
+            to_model="grok-build",
             no_timeout=True,
             review=True,
-            model="grok-4.20",
+            model="grok-build",
         )
     )
 
@@ -77,10 +77,10 @@ def test_ask_grok_build_cli_handler_routes_to_bridge(monkeypatch, tmp_path):
     assert kwargs["new_session"] is True
     assert kwargs["from_llm"] == "codex"
     assert kwargs["from_model"] == "gpt-5.5"
-    assert kwargs["to_model"] == "grok-4.20"
+    assert kwargs["to_model"] == "grok-build"
     assert kwargs["no_timeout"] is True
     assert kwargs["review"] is True
-    assert kwargs["model"] == "grok-4.20"
+    assert kwargs["model"] == "grok-build"
 
 
 def test_process_grok_build_invokes_native_registry_key(monkeypatch):
@@ -96,7 +96,7 @@ def test_process_grok_build_invokes_native_registry_key(monkeypatch):
             "to": "grok-build",
             "type": "query",
             "content": "answer this",
-            "data": '{"to_model": "grok-4.20"}',
+            "data": '{"to_model": "grok-build"}',
             "timestamp": "now",
         },
     )
@@ -106,7 +106,7 @@ def test_process_grok_build_invokes_native_registry_key(monkeypatch):
 
     def fake_invoke(*args, **kwargs):
         invoke_calls.append((args, kwargs))
-        return SimpleNamespace(ok=True, response="native reply", session_id="sid-1", model="grok-4.20")
+        return SimpleNamespace(ok=True, response="native reply", session_id="sid-1", model="grok-build")
 
     monkeypatch.setattr(_grok_build.agent_runner, "invoke", fake_invoke)
 
@@ -114,7 +114,7 @@ def test_process_grok_build_invokes_native_registry_key(monkeypatch):
 
     args, kwargs = invoke_calls[0]
     assert args[0] == "grok-build"
-    assert kwargs["model"] == "grok-4.20"
+    assert kwargs["model"] == "grok-build"
     assert kwargs["effort"] == _grok_build.GROK_BUILD_DEFAULT_EFFORT
     assert kwargs["entrypoint"] == "bridge"
 
@@ -122,7 +122,7 @@ def test_process_grok_build_invokes_native_registry_key(monkeypatch):
 def test_grok_build_registry_key_resolves_native_adapter():
     entry = get_agent_entry("grok-build")
     assert entry["adapter"] == "scripts.agent_runtime.adapters.grok_build:GrokBuildAdapter"
-    assert entry["default_model"] == "grok-4.20"
+    assert entry["default_model"] == "grok-build"
     assert entry["default_effort"] == "high"
 
 
@@ -139,5 +139,5 @@ def test_grok_build_dispatch_start_telemetry_has_defaults():
             requested_effort=None,
         )
 
-    assert telemetry.model == "grok-4.20"
+    assert telemetry.model == "grok-build"
     assert telemetry.effort == "high"


### PR DESCRIPTION
## Summary

- Change native `grok-build` defaults from invalid Hermes model id `grok-4.20` to native CLI model id `grok-build`.
- Wire MCP-aware runtime config for native grok-build and Cursor so wiki dimensional review can produce parseable verdicts.
- Fix Cursor read-only MCP approval, workspace `.cursor/mcp.json` materialization, stale implicit resume, and transcript fallback parsing.

## Root Cause

- `grok-build` was registered with a Hermes model id, so native `grok --model grok-4.20` failed before review work could start.
- `build_mcp_tool_config("grok-build")` was also canonicalized as Hermes `grok`, so native grok-build never received native MCP approval/tool naming.
- Cursor review had `sources` configured but read-only invocations did not pass `--approve-mcps`, and Cursor sometimes wrote the final answer only to the session transcript while stdout contained only init/user events.

## Evidence

```text
$ grok models
You are logged in with grok.com.

Default model: grok-build

Available models:
  * grok-build (default)
  - grok-composer-2.5-fast
```

```text
$ .venv/bin/python -c "import sys;sys.path.insert(0,'scripts');from pathlib import Path;from wiki.review import _run_single_dim as r;a=Path('wiki/pedagogy/a1/this-and-that.md').resolve();d=r(dim='register',article_path=a,article_text=a.read_text(),primary='grok-build',fallbacks=(),cwd=Path.cwd());print('DIM_RESULT', d.verdict, d.score, (d.error or '')[:800])"
DIM_RESULT REVISE 6
```

```text
$ .venv/bin/python -c "import sys;sys.path.insert(0,'scripts');from pathlib import Path;from wiki.review import _run_single_dim as r;a=Path('wiki/pedagogy/a1/this-and-that.md').resolve();d=r(dim='register',article_path=a,article_text=a.read_text(),primary='cursor',fallbacks=(),cwd=Path.cwd());print('DIM_RESULT', d.verdict, d.score, (d.error or '')[:800])"
dispatch telemetry for cursor could not resolve effort: invocation plan had no effort flag; recording 'unknown'
dispatch telemetry for cursor could not resolve cli_version: version probe failed; recording 'unknown'
DIM_RESULT REVISE 6
```

## Validation

```text
$ .venv/bin/python -m pytest tests/agent_runtime/ -q
============================= 88 passed in 15.62s ==============================
```

```text
$ .venv/bin/ruff check scripts/ tests/
All checks passed!
```

```text
$ .venv/bin/python scripts/audit/lint_agent_trailer.py
Checking 1 commit(s) in origin/main..HEAD:

  3347ec61da  PASS  X-Agent: codex/cursor-grok-reviewer-adapters

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

Gemini local code review via bridge returned PASS with only non-blocking theoretical notes.

Closes #3151. Supports #3087.
