### PR TITLE
feat(wiki): route CORE factual_accuracy+register off Gemini → deepseek (#3087)

### DIFF
--- a/scripts/wiki/compile.py
+++ b/scripts/wiki/compile.py
@@ -608,6 +608,7 @@ def _review_article(article_path: Path, track: str, slug: str) -> None:
     import traceback as _tb
 
     from wiki.review import (
+        core_reviewer_overrides,
         max_rounds_for_domain,
         review_article,
         seminar_reviewer_overrides,
@@ -626,12 +627,12 @@ def _review_article(article_path: Path, track: str, slug: str) -> None:
     # keep the default MAX_ROUNDS.
     domain = _get_domain(track, slug)
     review_max_rounds = max_rounds_for_domain(domain)
-    # Seminar/CULTURE review must NOT use gemini for register/factual
-    # (fleet policy + folk Session-20: gemini scored bylyny register 5-7 with
-    # ±5 round-to-round noise while claude scored the SAME article 9/PASS).
-    # Route those two dims to claude for seminar domains; core a1–c2 keep the
-    # global DEFAULT_PRIMARY untouched.
-    review_overrides = seminar_reviewer_overrides(domain)
+    # Production compile applies domain-level reviewer routing without changing
+    # the global DEFAULT_PRIMARY used by standalone review CLI calls.
+    review_overrides = {
+        **core_reviewer_overrides(domain),
+        **seminar_reviewer_overrides(domain),
+    }
 
     try:
         report, final_text = review_article(

--- a/scripts/wiki/review.py
+++ b/scripts/wiki/review.py
@@ -190,6 +190,27 @@ def seminar_reviewer_overrides(domain: str) -> dict[str, str]:
     return dict.fromkeys(_SEMINAR_CULTURE_DIMS, "claude")
 
 
+#: Dims routed off the Gemini-family default for CORE domains. #3087 bakeoff
+#: measured deepseek as the most reliable reviewer for these noisy CORE dims
+#: (factual_accuracy σ 0.47, register σ 0.0, 0 errors), and this also removes
+#: agy same-family self-review when agy writes the wiki article.
+_CORE_OFF_GEMINI_DIMS: tuple[str, ...] = ("factual_accuracy", "register")
+_CORE_REVIEWER = "deepseek"
+
+
+def core_reviewer_overrides(domain: str) -> dict[str, str]:
+    """Primary-reviewer overrides for a CORE a1-c2 wiki ``domain``.
+
+    Routes #3087 bakeoff winners ``factual_accuracy`` and ``register`` to
+    ``deepseek`` for CORE domains (deepseek σ 0.47/0.0, 0 err), removing agy
+    same-family self-review from the compile production path. Seminar domains
+    return ``{}`` so :func:`seminar_reviewer_overrides` keeps its claude policy.
+    """
+    if _infer_level_from_domain(domain) == "seminar":
+        return {}
+    return dict.fromkeys(_CORE_OFF_GEMINI_DIMS, _CORE_REVIEWER)
+
+
 #: Per-call timeouts. Review prompts are bounded; 10 min is plenty.
 HARD_TIMEOUT_S = 600
 

--- a/tests/test_wiki_compiler.py
+++ b/tests/test_wiki_compiler.py
@@ -4,6 +4,7 @@ import os
 import sqlite3
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -831,6 +832,61 @@ class TestCompileCommand:
 
         assert ok is True
         review.assert_called_once_with(article_path, "a1", "demo")
+
+    @pytest.mark.parametrize(
+        ("domain", "expected_overrides"),
+        (
+            (
+                "grammar/b1/aspect",
+                {"factual_accuracy": "deepseek", "register": "deepseek"},
+            ),
+            (
+                "folk/genres",
+                {
+                    "register": "claude",
+                    "factual_accuracy": "claude",
+                    "source_grounding": "claude",
+                },
+            ),
+        ),
+    )
+    def test_review_article_combines_core_and_seminar_overrides(
+        self, tmp_path, domain, expected_overrides
+    ):
+        """Compile review applies domain overrides before calling review_article."""
+        from wiki.compile import _review_article
+
+        article_path = tmp_path / "demo.md"
+        article_text = "# Demo\n\n" + ("Body text. " * 20)
+        article_path.write_text(article_text, encoding="utf-8")
+
+        captured_overrides = []
+
+        def fake_review_article(*args, **kwargs):
+            dim_results = {
+                "source_grounding": SimpleNamespace(score=9),
+                "factual_accuracy": SimpleNamespace(score=9),
+                "ukrainian_perspective": SimpleNamespace(score=9),
+                "register": SimpleNamespace(score=9),
+            }
+            report = SimpleNamespace(
+                min_score=9,
+                failing_dim=None,
+                failing_dims=[],
+                final_verdict="PASS",
+                rounds=[SimpleNamespace(round_num=1, dim_results=dim_results)],
+                shadow_mode=True,
+            )
+            captured_overrides.append(kwargs["agent_overrides"])
+            return report, article_text
+
+        with patch("wiki.compile._get_domain", return_value=domain), \
+             patch("wiki.review.review_article", side_effect=fake_review_article), \
+             patch("wiki.review.write_report", return_value=tmp_path / "review.md"), \
+             patch("wiki.compile.log_event"):
+            _review_article(article_path, "b1", "demo")
+
+        assert captured_overrides == [expected_overrides]
 
     def test_cmd_compile_one_force_recompile_strips_mcp_warning_for_academic_writing(
         self, tmp_path, capsys

--- a/tests/test_wiki_review.py
+++ b/tests/test_wiki_review.py
@@ -15,6 +15,7 @@ from wiki.review import (
     SEMINAR_MAX_ROUNDS,
     DimResult,
     _run_round,
+    core_reviewer_overrides,
     max_rounds_for_domain,
     review_article,
     seminar_reviewer_overrides,
@@ -108,6 +109,19 @@ def test_seminar_reviewer_overrides_routes_culture_dims_to_claude() -> None:
     # Core levels keep the global default (empty override).
     for core_domain in ("a1/letters", "a2/genitive-intro", "c1/stylistics"):
         assert seminar_reviewer_overrides(core_domain) == {}
+
+
+def test_core_reviewer_overrides_routes_noisy_core_dims_to_deepseek() -> None:
+    """Core review routes factual/register off agy; seminar remains untouched."""
+    assert core_reviewer_overrides("grammar/b1/aspect") == {
+        "factual_accuracy": "deepseek",
+        "register": "deepseek",
+    }
+    assert core_reviewer_overrides("folk/genres") == {}
+
+    # Keep unrelated CORE dimensions on their global defaults.
+    assert "source_grounding" not in core_reviewer_overrides("grammar/b1/aspect")
+    assert "ukrainian_perspective" not in core_reviewer_overrides("grammar/b1/aspect")
 
 
 # ── Seminar review-loop fixes (folk Session-19/20) ─────────────────────


### PR DESCRIPTION
## Summary
- Add CORE compile-path reviewer overrides for factual_accuracy and register to deepseek.
- Keep seminar overrides on claude and keep DEFAULT_PRIMARY unchanged for standalone review CLI usage.
- Add direct override tests plus compile-path merge tests for CORE and SEMINAR.

Closes #3087.

## Evidence (#M-4)

### pytest
```text
$ pwd
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/3087-core-reviewer-deepseek
$ .venv/bin/python -m pytest tests/ -k "review or reviewer or compile" -q
========= 626 passed, 4 skipped, 8015 deselected, 3 warnings in 44.87s =========
```

### ruff
```text
$ pwd
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/3087-core-reviewer-deepseek
$ .venv/bin/ruff check scripts/ tests/
All checks passed!
```

### push
```text
$ pwd
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/3087-core-reviewer-deepseek
$ git push -u origin codex/3087-core-reviewer-deepseek
ruff (lint)..............................................................Passed
gitleaks (secret scan)...................................................Passed
check yaml syntax....................................(no files to check)Skipped
block accidentally large files...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
warn on commits missing an X-Agent trailer...............................Passed
remote: Create a pull request for 'codex/3087-core-reviewer-deepseek' on GitHub by visiting:\nremote:      https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/new/codex/3087-core-reviewer-deepseek\nTo github.com:learn-ukrainian/learn-ukrainian.github.io.git\n * [new branch]            codex/3087-core-reviewer-deepseek -> codex/3087-core-reviewer-deepseek\nbranch 'codex/3087-core-reviewer-deepseek' set up to track 'origin/codex/3087-core-reviewer-deepseek'.\n```\n\n### PR\n```text\n$ pwd\n/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/3087-core-reviewer-deepseek\n$ gh pr create --base main --head codex/3087-core-reviewer-deepseek --title "feat(wiki): route CORE factual_accuracy+register off Gemini → deepseek (#3087)" --body ...\nhttps://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/3160\n```