### PR TITLE
fix(agents): pin '#0.1 seek the proper, best-practice solution; fix root cause not symptom' to both orchestrator defs

### DIFF
--- a/agents_extensions/shared/agents/curriculum-orchestrator.md
+++ b/agents_extensions/shared/agents/curriculum-orchestrator.md
@@ -18,6 +18,14 @@ initialPrompt: |
     before you touch it. A want they described earlier is NOT standing authorization; never reach back
     past a "stop" to manufacture consent. Work-queue execution is free; system changes need an explicit go.
 
+  ## 🔎 #0.1 — SEEK THE PROPER, BEST-PRACTICE SOLUTION; FIX ROOT CAUSE, NOT SYMPTOM (HARD — user order 2026-06-14)
+  Never ship the first thing that works. For every fix, design, or decision: find the PROPER, best-practice
+  solution and trace the ROOT CAUSE — fix the cause, not the symptom. If you do not know the established best
+  practice, RESEARCH it before deciding: web-research current standards, read `docs/best-practices/`, check
+  prior art / existing issues / idiomatic patterns, consult authoritative sources. Do NOT guess or settle.
+  A quick patch that leaves the real problem in place is NOT done — when a fix is partial, say so plainly and
+  name the proper solution, even if it is bigger or in another lane.
+
   Cold-start sequence (do this BEFORE anything else):
 
   1. Read the parent task verbatim.

--- a/agents_extensions/shared/agents/curriculum-track-orchestrator.md
+++ b/agents_extensions/shared/agents/curriculum-track-orchestrator.md
@@ -20,6 +20,14 @@ initialPrompt: |
     before you touch it. A want they described earlier is NOT standing authorization; never reach back
     past a "stop" to manufacture consent. Work-queue execution is free; system changes need an explicit go.
 
+  ## 🔎 #0.1 — SEEK THE PROPER, BEST-PRACTICE SOLUTION; FIX ROOT CAUSE, NOT SYMPTOM (HARD — user order 2026-06-14)
+  Never ship the first thing that works. For every fix, design, or decision: find the PROPER, best-practice
+  solution and trace the ROOT CAUSE — fix the cause, not the symptom. If you do not know the established best
+  practice, RESEARCH it before deciding: web-research current standards, read `docs/best-practices/`, check
+  prior art / existing issues / idiomatic patterns, consult authoritative sources. Do NOT guess or settle.
+  A quick patch that leaves the real problem in place is NOT done — when a fix is partial, say so plainly and
+  name the proper solution, even if it is bigger or in another lane.
+
   ## ROLE + BOUNDARIES (non-negotiable)
   - The MAIN ORCHESTRATOR (Codex) owns the `main` branch and `docs/session-state/`. You do NOT.
   - **DISREGARD any auto-injected SessionStart "orchestrator handoff" brief and the orchestrator


### PR DESCRIPTION
## What
Adds a hard `#0.1` rule directly under `#0` at the top of **both** `curriculum-orchestrator` + `curriculum-track-orchestrator` initialPrompts, so it loads **every session**:

> Never ship the first thing that works. Find the PROPER, best-practice solution and fix the ROOT CAUSE, not the symptom. If you don't know the best practice, RESEARCH it before deciding (web / `docs/best-practices/` / prior art / existing issues). A partial patch is not done — name the proper solution even if it's bigger or in another lane.

## Why
Direct user order (2026-06-14). Surfaced when I proposed a quick `literary-corpus routing` patch for the missing-primary-texts problem; pressed on "is this the proper solution?", the honest answer was no — it was a symptom fix, and the proper solution is corpus-ingest of the real texts + a non-counted primary-text field. Echoes CLAUDE.md's standing "best-practice not first-workable" + "root cause first" mandates, now enforced in the agent defs themselves so they fire at the decision moment, not just as background prose.

## Scope
- Edits only the two agent-def source files; already deployed to the live (gitignored) `.claude/agents/` (effective immediately), this PR makes it durable on main.
- Track-driver opened; **not self-merged by contract** — but folk merge-grant applies; self-merge on green.

## Verify
- YAML parses for both; `#0` + `#0.1` both present; grep confirms in both deployed copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)