### PR TITLE
feat(telemetry): central JSONL emitter + correlation IDs + dispatch event

### DIFF
--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -69,6 +69,11 @@ from .watchdog import (
     tail_liveness_file_for_debug,
 )
 
+try:
+    from telemetry.emit import current_run_id, current_session_id
+except ImportError:  # pragma: no cover - package import path
+    from scripts.telemetry.emit import current_run_id, current_session_id
+
 # Poll interval while waiting on subprocess + watchdog. 1s is a good balance:
 # fast enough that stall detection fires within 1s of the threshold, slow
 # enough that we don't burn CPU in the wait loop.
@@ -609,7 +614,8 @@ def _build_usage_record(
     # to maintain atomic append guarantees in usage.py.
     safe_cwd = str(cwd)[-250:] if cwd else ""
     safe_task_id = task_id[:100] if task_id else None
-    safe_session_id = session_id[:100] if session_id else None
+    safe_provider_session_id = session_id[:100] if session_id else None
+    telemetry_source = os.environ.get("LU_TELEMETRY_SOURCE")
 
     return {
         "ts": datetime.now(UTC).isoformat(),
@@ -619,7 +625,13 @@ def _build_usage_record(
         "cwd": safe_cwd,
         "model": model,
         "mode": mode,
-        "session_id": safe_session_id,
+        "run_id": current_run_id()[:100],
+        "session_id": current_session_id()[:100],
+        "provider_session_id": safe_provider_session_id,
+        "level": os.environ.get("LU_TELEMETRY_LEVEL"),
+        "slug": os.environ.get("LU_TELEMETRY_SLUG"),
+        "track": os.environ.get("LU_TELEMETRY_TRACK"),
+        "source": telemetry_source[:100] if telemetry_source else None,
         "duration_s": round(duration_s, 2),
         "input_chars": input_chars,
         "output_chars": output_chars,
@@ -978,7 +990,7 @@ def _execute_invocation_plan(
                 stderr_excerpt=(
                     f"Popen failed: {type(exc).__name__}: {exc}"
                 )[:500],
-                tokens=None,
+                tokens=None,  # TODO(#3153 PR2): extract tokens for this result path.
             )
             write_record(record)
             raise AgentUnavailableError(
@@ -1214,7 +1226,7 @@ def _raise_for_kill_reason(
             rate_limited=False,
             stalled=True,
             stderr_excerpt=parse.stderr_excerpt or execution.stderr_text[:500],
-            tokens=None,
+            tokens=None,  # TODO(#3153 PR2): extract tokens for this result path.
         )
         write_record(record)
         raise AgentStalledError(
@@ -1249,7 +1261,7 @@ def _raise_for_kill_reason(
                     f"{initial_response_timeout}s"
                 )
             ),
-            tokens=None,
+            tokens=None,  # TODO(#3153 PR2): extract tokens for this result path.
         )
         write_record(record)
         raise AgentStalledError(
@@ -1280,7 +1292,7 @@ def _raise_for_kill_reason(
                 or execution.stderr_text[:500]
                 or tail_liveness_file_for_debug(execution.liveness_paths)[:500]
             ),
-            tokens=None,
+            tokens=None,  # TODO(#3153 PR2): extract tokens for this result path.
         )
         write_record(record)
         raise AgentTimeoutError(agent_name, hard_timeout)
@@ -1484,7 +1496,7 @@ def _invoke_gemini_with_fallback(
             rate_limited=False,
             stalled=False,
             stderr_excerpt=stderr_excerpt,
-            tokens=None,
+            tokens=None,  # TODO(#3153 PR2): extract tokens for this result path.
         )
         write_record(record)
         return Result(
@@ -1525,7 +1537,7 @@ def _invoke_gemini_with_fallback(
             rate_limited=True,
             stalled=False,
             stderr_excerpt=stderr_excerpt,
-            tokens=None,
+            tokens=None,  # TODO(#3153 PR2): extract tokens for this result path.
         )
         write_record(record)
         raise RateLimitedError(agent_name, record_model, reason=(stderr_excerpt or "")[:200])
@@ -1550,7 +1562,7 @@ def _invoke_gemini_with_fallback(
             rate_limited=False,
             stalled=False,
             stderr_excerpt=stderr_excerpt,
-            tokens=None,
+            tokens=None,  # TODO(#3153 PR2): extract tokens for this result path.
         )
         write_record(record)
         raise AgentTimeoutError(agent_name, hard_timeout)
@@ -1571,7 +1583,7 @@ def _invoke_gemini_with_fallback(
         rate_limited=False,
         stalled=False,
         stderr_excerpt=stderr_excerpt,
-        tokens=None,
+        tokens=None,  # TODO(#3153 PR2): extract tokens for this result path.
     )
     write_record(record)
     return Result(
@@ -1694,6 +1706,8 @@ def invoke(
             f"contamination."
         )
     effective_cwd = cwd or Path.cwd()
+    current_run_id()
+    current_session_id()
 
     # ---------- 4. Resume policy ----------
     _enforce_resume_policy(agent_name, session_id, entrypoint)
@@ -1720,7 +1734,7 @@ def invoke(
             rate_limited=True,
             stalled=False,
             stderr_excerpt=f"pre-call headroom check: {reason}",
-            tokens=None,
+            tokens=None,  # TODO(#3153 PR2): extract tokens for this result path.
         )
         write_record(record)
         raise RateLimitedError(agent_name, effective_model, reason)

--- a/scripts/config/model_pricing.yaml
+++ b/scripts/config/model_pricing.yaml
@@ -1,0 +1,40 @@
+# Strict runtime pricing table for scripts/telemetry/pricing.py.
+#
+# Only use `usd_per_1m_tokens` when the runtime's total token count can be
+# multiplied by one published per-token price without inventing an
+# input/output blend.
+
+models:
+  # Source: OpenAI model page, text-embedding-3-small "Embeddings / Per 1M tokens / Cost $0.02"
+  # https://developers.openai.com/api/docs/models/text-embedding-3-small
+  text-embedding-3-small:
+    billing_model: per_token
+    usd_per_1m_tokens: 0.02
+
+  # Source: OpenAI API pricing publishes split input/cached/output prices for
+  # gpt-5.5 and gpt-5.3-codex. This PR records only total tokens, so there is
+  # no honest single multiplier for those API models yet.
+  # https://developers.openai.com/api/docs/pricing
+  #
+  # Source: DeepSeek publishes split cache-hit/cache-miss/output prices.
+  # Total-only runtime tokens cannot be priced without a split.
+  # https://api-docs.deepseek.com/quick_start/pricing-details-usd
+
+subscription_agents:
+  # Source: OpenAI Codex pricing says Codex is included in ChatGPT plans.
+  # https://developers.openai.com/codex/pricing
+  codex:
+    billing_model: subscription
+
+  # Local subscription/unmetered CLI lanes. No per-call token price is applied.
+  # See scripts/config/agent_budgets.yaml for the repo's soft-cap accounting.
+  claude:
+    billing_model: subscription
+  gemini:
+    billing_model: subscription
+  agy:
+    billing_model: subscription
+  cursor:
+    billing_model: subscription
+  grok-build:
+    billing_model: subscription

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -85,6 +85,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
 import re
 import shlex
@@ -106,6 +107,7 @@ _TASKS_DIR = _REPO_ROOT / "batch_state" / "tasks"
 _BASH_SECRETS_PATH = Path.home() / ".bash_secrets"
 _GH_TOKEN_AGENTS = {"codex", "claude", "bridge"}
 _MONITOR_API_BASE_URL = "http://localhost:8765"
+_logger = logging.getLogger(__name__)
 
 
 def _read_github_token_from_bash_secrets(path: Path | None = None) -> str | None:
@@ -1078,6 +1080,59 @@ def _classify_final_status(
     return "failed"
 
 
+def _emit_terminal_dispatch_event(
+    *,
+    task_id: str,
+    agent: str,
+    final_state: dict[str, Any],
+    result: Any,
+    fallback_prompt_chars: int,
+) -> None:
+    """Emit the central terminal dispatch event without affecting worker exit."""
+    try:
+        try:
+            from telemetry.emit import emit_event
+            from telemetry.pricing import compute_cost
+        except ImportError:  # pragma: no cover - package import path
+            from scripts.telemetry.emit import emit_event
+            from scripts.telemetry.pricing import compute_cost
+
+        usage_record = getattr(result, "usage_record", None)
+        tokens = usage_record.get("tokens") if isinstance(usage_record, dict) else None
+        model = final_state.get("model")
+        cost = compute_cost(
+            str(model).strip() if model else None,
+            tokens,
+            agent=agent,
+        )
+        emit_event(
+            "dispatch",
+            {
+                "task_id": task_id,
+                "agent": agent,
+                "model": model,
+                "effort": final_state.get("effort"),
+                "branch": final_state.get("worktree_branch"),
+                "worktree": final_state.get("worktree_path"),
+                "status": final_state.get("status"),
+                "duration_s": final_state.get("duration_s"),
+                "result_file": final_state.get("result_file"),
+                "prompt_chars": final_state.get("prompt_chars", fallback_prompt_chars),
+                "response_chars": final_state.get("response_chars"),
+                "tokens": tokens,
+                "cost_usd": cost.cost_usd,
+                "billing_model": cost.billing_model,
+                "cost_provenance": cost.provenance,
+            },
+        )
+    except Exception as exc:  # pragma: no cover - degraded mode only
+        _logger.debug(
+            "failed to emit terminal dispatch telemetry: %s: %s",
+            type(exc).__name__,
+            exc,
+        )
+
+
 def _run_worker(
     task_id: str,
     agent: str,
@@ -1305,6 +1360,13 @@ def _run_worker(
         ),
     })
     _write_state_atomic(state_path, final_state)
+    _emit_terminal_dispatch_event(
+        task_id=task_id,
+        agent=agent,
+        final_state=final_state,
+        result=result,
+        fallback_prompt_chars=len(prompt),
+    )
 
     if timed_out:
         _append_dispatch_event(

--- a/scripts/telemetry/__init__.py
+++ b/scripts/telemetry/__init__.py
@@ -1,0 +1,1 @@
+"""Central telemetry helpers."""

--- a/scripts/telemetry/emit.py
+++ b/scripts/telemetry/emit.py
@@ -1,0 +1,124 @@
+"""Best-effort central JSONL telemetry emitter.
+
+This module is intentionally file-only: no network calls, no API posts. The
+durable source of truth for this PR is the append-only JSONL log under
+``batch_state/telemetry/events/``.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+try:
+    from secret_redactor import redact_text, redact_value
+except ImportError:  # pragma: no cover - package import path
+    from scripts.secret_redactor import redact_text, redact_value
+
+SCHEMA_VERSION = 1
+_DISABLED_ENV = "LU_TELEMETRY_DISABLED"
+_RUN_ID_ENV = "LU_RUN_ID"
+_SESSION_ID_ENV = "LU_SESSION_ID"
+_SOURCE_ENV = "LU_TELEMETRY_SOURCE"
+_RECURSION_GUARD_ENV = "LU_TELEMETRY_EMITTING"
+_logger = logging.getLogger(__name__)
+_emitting = False
+
+
+def current_run_id() -> str:
+    """Return the current run id, minting and exporting one if absent."""
+    return _current_or_new_env_id(_RUN_ID_ENV, "run")
+
+
+def current_session_id() -> str:
+    """Return the current telemetry session id, minting and exporting one if absent."""
+    return _current_or_new_env_id(_SESSION_ID_ENV, "session")
+
+
+def emit_event(
+    event_type: str,
+    payload: dict[str, Any],
+    *,
+    run_id: str | None = None,
+) -> None:
+    """Append one central telemetry event.
+
+    Telemetry is best-effort observability. This function must never fail the
+    caller, even on serialization errors, missing directories, permission
+    errors, or accidental recursive emission.
+    """
+    global _emitting
+    try:
+        if os.environ.get(_DISABLED_ENV) == "1":
+            return None
+        if _emitting or os.environ.get(_RECURSION_GUARD_ENV) == "1":
+            return None
+
+        _emitting = True
+        previous_guard = os.environ.get(_RECURSION_GUARD_ENV)
+        os.environ[_RECURSION_GUARD_ENV] = "1"
+        try:
+            event = {
+                "schema_version": SCHEMA_VERSION,
+                "ts": datetime.now(UTC).isoformat(),
+                "event_type": str(event_type),
+                "run_id": str(run_id or current_run_id()),
+                "session_id": current_session_id(),
+                "source": os.environ.get(_SOURCE_ENV) or "local",
+            }
+            event.update(payload)
+            event = redact_value(event)
+
+            path = _event_file()
+            line = (
+                json.dumps(event, ensure_ascii=False, default=str) + "\n"
+            ).encode("utf-8")
+            _write_line(path, line)
+        finally:
+            if previous_guard is None:
+                os.environ.pop(_RECURSION_GUARD_ENV, None)
+            else:
+                os.environ[_RECURSION_GUARD_ENV] = previous_guard
+            _emitting = False
+    except Exception as exc:  # pragma: no cover - degraded mode only
+        safe_exc = redact_text(str(exc)) or ""
+        _logger.debug(
+            "failed to emit telemetry event: %s: %s",
+            type(exc).__name__,
+            safe_exc,
+        )
+    return None
+
+
+def _current_or_new_env_id(env_name: str, prefix: str) -> str:
+    value = os.environ.get(env_name)
+    if value:
+        return value
+    value = f"{prefix}_{uuid.uuid4().hex}"
+    os.environ[env_name] = value
+    return value
+
+
+def _event_dir() -> Path:
+    repo_root = Path(__file__).resolve().parents[2]
+    path = repo_root / "batch_state" / "telemetry" / "events"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _event_file(day: datetime | None = None) -> Path:
+    if day is None:
+        day = datetime.now(UTC)
+    return _event_dir() / f"{day:%Y-%m-%d}.jsonl"
+
+
+def _write_line(path: Path, line: bytes) -> None:
+    fd = os.open(str(path), os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o644)
+    try:
+        os.write(fd, line)
+    finally:
+        os.close(fd)

--- a/scripts/telemetry/pricing.py
+++ b/scripts/telemetry/pricing.py
@@ -1,0 +1,122 @@
+"""Strict token-cost helper for runtime telemetry."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+BillingModel = Literal["per_token", "subscription", "unknown"]
+Provenance = Literal["priced", "no_tokens", "no_price", "subscription"]
+
+_PRICING_PATH = Path(__file__).resolve().parents[1] / "config" / "model_pricing.yaml"
+_logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class CostResult:
+    cost_usd: float | None
+    billing_model: BillingModel
+    provenance: Provenance
+
+
+def compute_cost(
+    model: str | None,
+    tokens: int | None,
+    *,
+    agent: str | None = None,
+) -> CostResult:
+    """Compute USD cost only when both tokens and a single-token price exist.
+
+    Split input/output pricing cannot be applied to the runtime's current
+    total-token-only record without guessing a blend, so those models resolve
+    to ``no_price`` until a later PR records directional token counts.
+    """
+    try:
+        table = _pricing_table()
+        model_key = _normalize_key(model)
+        model_entry = _lookup_model_entry(table, model_key)
+        if model_entry:
+            billing_model = str(model_entry.get("billing_model") or "")
+            if billing_model == "subscription":
+                return CostResult(None, "subscription", "subscription")
+            if billing_model == "per_token":
+                token_count = _nonnegative_int(tokens)
+                if token_count is None:
+                    return CostResult(None, "per_token", "no_tokens")
+                price = _positive_float(model_entry.get("usd_per_1m_tokens"))
+                if price is None:
+                    return CostResult(None, "unknown", "no_price")
+                return CostResult(
+                    cost_usd=(token_count * price) / 1_000_000,
+                    billing_model="per_token",
+                    provenance="priced",
+                )
+
+        if _agent_is_subscription(table, agent):
+            return CostResult(None, "subscription", "subscription")
+        return CostResult(None, "unknown", "no_price")
+    except Exception as exc:  # pragma: no cover - degraded mode only
+        _logger.debug("failed to compute telemetry cost: %s: %s", type(exc).__name__, exc)
+        return CostResult(None, "unknown", "no_price")
+
+
+@lru_cache(maxsize=1)
+def _pricing_table() -> dict[str, Any]:
+    data = yaml.safe_load(_PRICING_PATH.read_text(encoding="utf-8")) or {}
+    return data if isinstance(data, dict) else {}
+
+
+def _normalize_key(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _lookup_model_entry(
+    table: dict[str, Any],
+    model: str | None,
+) -> dict[str, Any] | None:
+    if not model:
+        return None
+    models = table.get("models")
+    if not isinstance(models, dict):
+        return None
+    raw = models.get(model)
+    return raw if isinstance(raw, dict) else None
+
+
+def _agent_is_subscription(table: dict[str, Any], agent: str | None) -> bool:
+    if not agent:
+        return False
+    agents = table.get("subscription_agents")
+    if not isinstance(agents, dict):
+        return False
+    raw = agents.get(str(agent).strip())
+    return isinstance(raw, dict) and raw.get("billing_model") == "subscription"
+
+
+def _positive_float(value: Any) -> float | None:
+    try:
+        price = float(value)
+    except (TypeError, ValueError):
+        return None
+    return price if price > 0 else None
+
+
+def _nonnegative_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        count = int(value)
+    except (TypeError, ValueError):
+        return None
+    return count if count >= 0 else None
+
+
+def _reset_pricing_cache_for_tests() -> None:
+    _pricing_table.cache_clear()

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -935,6 +935,84 @@ def test_run_worker_persists_runtime_telemetry(tmp_tasks_dir, tmp_path):
     assert state["cli_version"] == "2.1.89"
 
 
+def test_run_worker_emits_one_terminal_dispatch_event_with_cost_fields(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    from telemetry import emit as emit_mod
+
+    event_dir = tmp_path / "telemetry-events"
+
+    def event_dir_fn() -> Path:
+        event_dir.mkdir(parents=True, exist_ok=True)
+        return event_dir
+
+    monkeypatch.setattr(emit_mod, "_event_dir", event_dir_fn)
+    monkeypatch.setenv("LU_RUN_ID", "run-dispatch")
+    monkeypatch.setenv("LU_SESSION_ID", "session-dispatch")
+
+    state_path = delegate._state_path("worker-dispatch-event")
+    delegate._write_state_atomic(state_path, {
+        "task_id": "worker-dispatch-event",
+        "model": "unknown",
+        "effort": "unknown",
+        "cli_version": "unknown",
+        "prompt_chars": 2,
+        "worktree_branch": "deepseek/worker-dispatch-event",
+        "worktree_path": str(tmp_path),
+    })
+
+    mock_result = type(
+        "_Result",
+        (),
+        {
+            "ok": True,
+            "response": "done",
+            "stderr_excerpt": None,
+            "returncode": 0,
+            "rate_limited": False,
+            "model": "text-embedding-3-small",
+            "effort": "unknown",
+            "cli_version": "test",
+            "usage_record": {"tokens": 1_000},
+        },
+    )()
+
+    with patch("agent_runtime.runner.invoke", return_value=mock_result):
+        rc = delegate._run_worker(
+            task_id="worker-dispatch-event",
+            agent="deepseek",
+            prompt="hi",
+            mode="read-only",
+            cwd_str=str(tmp_path),
+            model=None,
+            hard_timeout=60,
+            effort=None,
+        )
+
+    assert rc == 0
+    event_files = sorted(event_dir.glob("*.jsonl"))
+    assert len(event_files) == 1
+    events = [
+        json.loads(line)
+        for line in event_files[0].read_text(encoding="utf-8").splitlines()
+    ]
+    dispatch_events = [event for event in events if event["event_type"] == "dispatch"]
+    assert len(dispatch_events) == 1
+    event = dispatch_events[0]
+    assert event["task_id"] == "worker-dispatch-event"
+    assert event["agent"] == "deepseek"
+    assert event["status"] == "done"
+    assert event["duration_s"] >= 0
+    assert event["prompt_chars"] == 2
+    assert event["response_chars"] == 4
+    assert event["tokens"] == 1_000
+    assert event["cost_usd"] == pytest.approx(0.00002)
+    assert event["billing_model"] == "per_token"
+    assert event["cost_provenance"] == "priced"
+
+
 def test_run_worker_marks_needs_finalize_for_dirty_danger_worktree(
     tmp_tasks_dir,
     tmp_path,

--- a/tests/test_dispatch_telemetry.py
+++ b/tests/test_dispatch_telemetry.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from agent_runtime.adapters.base import InvocationPlan
+from agent_runtime.result import ParseResult
 from agent_runtime.runner import invoke
 from agent_runtime.telemetry import (
     _reset_version_cache_for_tests,
@@ -122,6 +123,85 @@ def test_runner_invoke_returns_resolved_telemetry(tmp_path):
     assert result.model == "gpt-5.5"
     assert result.effort == "high"
     assert result.cli_version == "0.123.0"
+
+
+def test_runner_usage_record_includes_correlation_ids_without_prompt_change(
+    tmp_path,
+    monkeypatch,
+):
+    from agent_runtime import runner as runner_mod
+
+    monkeypatch.setenv("LU_RUN_ID", "run-123")
+    monkeypatch.setenv("LU_SESSION_ID", "session-456")
+    monkeypatch.setenv("LU_TELEMETRY_LEVEL", "b1")
+    monkeypatch.setenv("LU_TELEMETRY_SLUG", "telemetry-module")
+    monkeypatch.setenv("LU_TELEMETRY_TRACK", "core")
+    monkeypatch.setenv("LU_TELEMETRY_SOURCE", "pytest")
+
+    spy_adapter = MagicMock()
+    spy_adapter.supported_modes = frozenset({"read-only", "workspace-write", "danger"})
+    spy_adapter.default_model = "gpt-5.4"
+    fake_plan = InvocationPlan(cmd=["codex", "exec", "-m", "gpt-5.5", "-"], cwd=tmp_path)
+    spy_adapter.build_invocation.return_value = fake_plan
+    spy_adapter.liveness_signal_paths.return_value = ()
+    spy_adapter.parse_response.return_value = ParseResult(
+        ok=True,
+        response="ok",
+        stderr_excerpt=None,
+        rate_limited=False,
+        session_id=None,
+        tokens=321,
+    )
+
+    fake_proc = MagicMock()
+    fake_proc.poll.return_value = 0
+    fake_proc.returncode = 0
+    fake_proc.stdin = None
+    captured_records: list[dict] = []
+    captured_env: dict[str, str] = {}
+
+    def fake_popen(*_args, **kwargs):
+        captured_env.update(kwargs.get("env") or {})
+        return fake_proc
+
+    with patch("agent_runtime.runner._load_adapter", return_value=spy_adapter), patch(
+        "agent_runtime.runner.has_headroom",
+        return_value=(True, ""),
+    ), patch("agent_runtime.runner.write_record", side_effect=captured_records.append), patch(
+        "agent_runtime.runner.subprocess.Popen",
+        side_effect=fake_popen,
+    ), patch(
+        "agent_runtime.runner.start_watchdog",
+        return_value=(MagicMock(stdout_lines=[], stderr_lines=[]), []),
+    ), patch("agent_runtime.runner.stop_watchdog"), patch(
+        "agent_runtime.runner.resolve_invocation_telemetry",
+        return_value=runner_mod.InvocationTelemetry(
+            model="gpt-5.5",
+            effort="high",
+            cli_version="0.123.0",
+        ),
+    ):
+        result = invoke(
+            "codex",
+            "hi",
+            mode="read-only",
+            cwd=tmp_path,
+            model="gpt-5.4",
+            entrypoint="delegate",
+        )
+
+    assert result.ok is True
+    assert spy_adapter.build_invocation.call_args.kwargs["prompt"] == "hi"
+    assert captured_records == [result.usage_record]
+    record = captured_records[0]
+    assert record["run_id"] == "run-123"
+    assert record["session_id"] == "session-456"
+    assert record["level"] == "b1"
+    assert record["slug"] == "telemetry-module"
+    assert record["track"] == "core"
+    assert record["source"] == "pytest"
+    assert captured_env["LU_RUN_ID"] == "run-123"
+    assert captured_env["LU_SESSION_ID"] == "session-456"
 
 
 def setup_function() -> None:

--- a/tests/test_telemetry_emit.py
+++ b/tests/test_telemetry_emit.py
@@ -1,0 +1,117 @@
+"""Tests for the central JSONL telemetry emitter."""
+
+from __future__ import annotations
+
+import json
+import socket
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from telemetry import emit as emit_mod
+
+
+def _use_event_dir(monkeypatch, root: Path) -> Path:
+    event_dir = root / "events"
+
+    def event_dir_fn() -> Path:
+        event_dir.mkdir(parents=True, exist_ok=True)
+        return event_dir
+
+    monkeypatch.setattr(emit_mod, "_event_dir", event_dir_fn)
+    return event_dir
+
+
+def _event_lines(root: Path) -> list[dict]:
+    files = sorted(root.glob("*.jsonl"))
+    assert len(files) <= 1
+    if not files:
+        return []
+    return [
+        json.loads(line)
+        for line in files[0].read_text(encoding="utf-8").splitlines()
+    ]
+
+
+def test_emit_event_writes_durable_jsonl(tmp_path, monkeypatch):
+    event_dir = _use_event_dir(monkeypatch, tmp_path)
+    monkeypatch.setenv("LU_RUN_ID", "run-test")
+    monkeypatch.setenv("LU_SESSION_ID", "session-test")
+    monkeypatch.setenv("LU_TELEMETRY_SOURCE", "pytest")
+
+    assert emit_mod.emit_event("unit", {"ok": True}) is None
+
+    rows = _event_lines(event_dir)
+    assert len(rows) == 1
+    assert rows[0]["schema_version"] == emit_mod.SCHEMA_VERSION
+    assert rows[0]["event_type"] == "unit"
+    assert rows[0]["run_id"] == "run-test"
+    assert rows[0]["session_id"] == "session-test"
+    assert rows[0]["source"] == "pytest"
+    assert rows[0]["ok"] is True
+
+
+def test_current_ids_mint_once_and_export(monkeypatch):
+    monkeypatch.delenv("LU_RUN_ID", raising=False)
+    monkeypatch.delenv("LU_SESSION_ID", raising=False)
+
+    run_id = emit_mod.current_run_id()
+    session_id = emit_mod.current_session_id()
+
+    assert run_id.startswith("run_")
+    assert session_id.startswith("session_")
+    assert emit_mod.current_run_id() == run_id
+    assert emit_mod.current_session_id() == session_id
+    assert run_id == emit_mod.os.environ["LU_RUN_ID"]
+    assert session_id == emit_mod.os.environ["LU_SESSION_ID"]
+
+
+def test_emit_event_honors_disabled_env(tmp_path, monkeypatch):
+    event_dir = _use_event_dir(monkeypatch, tmp_path)
+    monkeypatch.setenv("LU_TELEMETRY_DISABLED", "1")
+
+    assert emit_mod.emit_event("unit", {"ok": True}) is None
+
+    assert not list(event_dir.glob("*.jsonl"))
+
+
+def test_emit_event_swallows_serialization_error(tmp_path, monkeypatch):
+    event_dir = _use_event_dir(monkeypatch, tmp_path)
+
+    def raise_type_error(*_args, **_kwargs):
+        raise TypeError("boom")
+
+    monkeypatch.setattr(emit_mod.json, "dumps", raise_type_error)
+
+    assert emit_mod.emit_event("unit", {"bad": object()}) is None
+
+    assert not list(event_dir.glob("*.jsonl"))
+
+
+def test_emit_event_recursion_guard_writes_only_outer_event(tmp_path, monkeypatch):
+    event_dir = _use_event_dir(monkeypatch, tmp_path)
+    real_write_line = emit_mod._write_line
+
+    def recursive_write(path: Path, line: bytes) -> None:
+        emit_mod.emit_event("nested", {"ok": False})
+        real_write_line(path, line)
+
+    monkeypatch.setattr(emit_mod, "_write_line", recursive_write)
+
+    assert emit_mod.emit_event("outer", {"ok": True}) is None
+
+    rows = _event_lines(event_dir)
+    assert [row["event_type"] for row in rows] == ["outer"]
+
+
+def test_emit_event_hot_path_makes_no_network_call(tmp_path, monkeypatch):
+    event_dir = _use_event_dir(monkeypatch, tmp_path)
+
+    def fail_socket(*_args, **_kwargs):
+        raise AssertionError("telemetry emit must not open sockets")
+
+    monkeypatch.setattr(socket, "socket", fail_socket)
+
+    assert emit_mod.emit_event("unit", {"ok": True}) is None
+    assert len(_event_lines(event_dir)) == 1

--- a/tests/test_telemetry_pricing.py
+++ b/tests/test_telemetry_pricing.py
@@ -1,0 +1,57 @@
+"""Tests for strict telemetry pricing."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from telemetry.pricing import compute_cost
+
+
+def test_priced_model_with_real_tokens_returns_cost():
+    result = compute_cost("text-embedding-3-small", 1_000)
+
+    assert result.billing_model == "per_token"
+    assert result.provenance == "priced"
+    assert result.cost_usd == pytest.approx(0.00002)
+
+
+def test_priced_model_without_tokens_does_not_fabricate_cost():
+    result = compute_cost("text-embedding-3-small", None)
+
+    assert result.billing_model == "per_token"
+    assert result.provenance == "no_tokens"
+    assert result.cost_usd is None
+
+
+def test_unknown_model_has_no_price():
+    result = compute_cost("definitely-not-a-model", 1_000)
+
+    assert result.billing_model == "unknown"
+    assert result.provenance == "no_price"
+    assert result.cost_usd is None
+
+
+def test_subscription_lane_has_no_per_call_cost():
+    result = compute_cost("claude-opus-4-8", 1_000, agent="claude")
+
+    assert result.billing_model == "subscription"
+    assert result.provenance == "subscription"
+    assert result.cost_usd is None
+
+
+def test_no_fabricated_dollars_without_tokens_and_table_price():
+    cases = (
+        compute_cost("text-embedding-3-small", None),
+        compute_cost("unknown", 1_000),
+        compute_cost("unknown", None),
+        compute_cost("gpt-5.5", 1_000, agent="codex"),
+    )
+
+    for result in cases:
+        if result.provenance != "priced":
+            assert result.cost_usd is None


### PR DESCRIPTION
PR1/4 for #3153. Implements only the MVP central telemetry hook; module-build events, API/data-model changes, reconciler, and prompt fallback remain out of scope for later PRs.

## Summary
- Add `scripts/telemetry/emit.py` for best-effort local JSONL telemetry events under `batch_state/telemetry/events/`, with run/session ID helpers, disable flag, recursion guard, and no network path.
- Stamp `run_id`, telemetry `session_id`, and optional `LU_TELEMETRY_*` context into existing runtime usage records while preserving the previous resume/provider value as `provider_session_id`.
- Add strict pricing support in `scripts/telemetry/pricing.py` plus `scripts/config/model_pricing.yaml`; no fabricated spend is returned without both tokens and a single citable per-token price. Subscription/unmetered lanes report subscription provenance.
- Emit one terminal `dispatch` event from `delegate.py` with status, duration, token, and cost metadata from the existing usage record.

## Validation
- `.venv/bin/python -m pytest tests/ -k "telemetry or usage or delegate or pricing" -q`
- `.venv/bin/ruff check scripts/ tests/`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Notes
- `# TODO(#3153 PR2)` markers document the existing `tokens=None` runner paths for the follow-up token extraction PR.
- Split-priced API models are cited in the pricing config but intentionally not multiplied against total-only token records.