### PR TITLE
fix(b2): add pronoun model answer

### DIFF
--- a/curriculum/l2-uk-en/plans/b2/pronoun-system-advanced.yaml
+++ b/curriculum/l2-uk-en/plans/b2/pronoun-system-advanced.yaml
@@ -2,7 +2,7 @@ module: b2-052
 level: B2
 sequence: 52
 slug: pronoun-system-advanced
-version: 1.0.2
+version: 1.0.3
 title: Складна система займенників
 subtitle: 'Складна система займенників: зворотні, взаємні, означальні'
 focus: grammar
@@ -34,6 +34,10 @@ writing_tasks:
   - мінімум 200 слів
   - вживання 'себе' у різних відмінках
   - вживання 'сам/самий'
+  model_answer: 'Есе має поєднувати особисту рефлексію з точним уживанням
+    займенників. Очікується текст на зразок: ''Щоб краще розуміти самих
+    себе, ми маємо чесно ставити собі запитання. Люди підтримують одне
+    одного тоді, коли кожний бере на себе відповідальність за власні слова''.'
   motivation: Practice using advanced pronouns to express abstract, 
     introspective thoughts.
 listening_situations:


### PR DESCRIPTION
## Summary

- Adds the missing B2+ `model_answer` for `pronoun-system-advanced` writing task.
- Bumps the plan version from `1.0.2` to `1.0.3` as required by the plan immutability hook.

## Validation

- `../../../../.venv/bin/python scripts/validate/validate_plan_ordering.py b2`
- `../../../../.venv/bin/python scripts/validate_plan_config.py b2`
- B2 slug/level/model-answer scan: `files=93 missing_slug=0 wrong_level=0 missing_model_answer=0`
- `../../../../.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `git diff origin/main --check`
- Gemini review: PASS (`b2-final-readiness-review-final`)

X-Agent: codex/b2-final-readiness-audit
