### PR TITLE
fix(corpus): propagate source_url into literary_texts (column + ingest + backfill) (#2901)

### DIFF
--- a/scripts/rag/ingest.py
+++ b/scripts/rag/ingest.py
@@ -546,7 +546,8 @@ def ingest_literary_chunks(
             "year": chunk.get("year", 0),
             "genre": chunk.get("genre", ""),
             "language_period": chunk.get("language_period", ""),
-            "source_url": chunk.get("source_url", ""),
+            # read source_url from JSONL record (NULL when absent; matches sqlite literary_texts column)
+            "source_url": chunk.get("source_url"),
             "token_count": chunk.get("token_count", 0),
         }
         if "original_text" in chunk:

--- a/scripts/rag/ingest_literary.py
+++ b/scripts/rag/ingest_literary.py
@@ -566,7 +566,8 @@ def ingest_wave(client, wave_num: int, batch_size: int = 32):
                 "year": chunk.get("year", 0),
                 "genre": chunk.get("genre", ""),
                 "language_period": chunk.get("language_period", ""),
-                "source_url": chunk.get("source_url", ""),
+                # read source_url from each JSONL record; write NULL (absent key or falsy) when the record lacks it (do not invent)
+                "source_url": chunk.get("source_url"),
                 "token_count": chunk.get("token_count", 0),
             }
             if "original_text" in chunk:

--- a/scripts/rag/migrate_add_literary_source_url.py
+++ b/scripts/rag/migrate_add_literary_source_url.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""One-shot idempotent migration: add source_url TEXT column to literary_texts
+and backfill from on-disk data/literary_texts/*.jsonl keyed by chunk_id.
+
+- ALTER guarded by PRAGMA table_info column-exists check (no drop/recreate).
+- Defaults to NULL when JSONL record lacks source_url or the wave's JSONL is absent locally.
+- For waves without local JSONL: leave NULL and log the wave (no fabrication of URLs).
+- Public-domain izbornyk/litopys work-level URLs are taken ONLY from JSONL; no re-derive
+  unless a deterministic manifest is present (none wired here; NULL otherwise).
+- Run LOCALLY only (data/sources.db is gitignored 1.6 GB). CI cannot.
+
+Audit note (per #2901): textbooks table has no source_url (and no equivalent URL col);
+provenance for textbooks is via grade + source_file (structured extraction from known
+textbook PDFs). In contrast, external_articles (url, url_normalized) and wikipedia
+( url ) DO retain URLs. Textbooks gap is non-trivial to close (would touch extraction,
+chunking, all inserts, indexes, and callers); not fixed here — follow-up issue if needed.
+
+Usage:
+    .venv/bin/python scripts/rag/migrate_add_literary_source_url.py
+    .venv/bin/python scripts/rag/migrate_add_literary_source_url.py --db-path /tmp/test-sources.db
+    .venv/bin/python scripts/rag/migrate_add_literary_source_url.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DB_PATH = PROJECT_ROOT / "data" / "sources.db"
+LITERARY_DIR = PROJECT_ROOT / "data" / "literary_texts"
+
+
+def _get_column_names(conn: sqlite3.Connection, table: str = "literary_texts") -> set[str]:
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def ensure_source_url_column(conn: sqlite3.Connection) -> bool:
+    """Idempotent: add source_url TEXT if missing. Returns True if added."""
+    existing = _get_column_names(conn)
+    if "source_url" in existing:
+        return False
+    conn.execute("ALTER TABLE literary_texts ADD COLUMN source_url TEXT")
+    return True
+
+
+def load_urls_by_chunk_id(lit_dir: Path) -> tuple[dict[str, str | None], set[str]]:
+    """Scan local JSONL files. Return (chunk_id -> source_url_or_None, set of wave stems found)."""
+    url_by_chunk: dict[str, str | None] = {}
+    present_waves: set[str] = set()
+    if not lit_dir or not lit_dir.exists():
+        return url_by_chunk, present_waves
+    for jsonl_path in sorted(lit_dir.glob("*.jsonl")):
+        wave = jsonl_path.stem
+        present_waves.add(wave)
+        try:
+            with open(jsonl_path, encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                        cid = rec.get("chunk_id")
+                        if cid:
+                            # Preserve None/empty as None; only store truthy URL
+                            url = rec.get("source_url")
+                            if url:
+                                # Prefer explicit URL if multiple entries for same cid (rare)
+                                url_by_chunk[str(cid)] = str(url).strip()
+                            elif str(cid) not in url_by_chunk:
+                                url_by_chunk[str(cid)] = None
+                    except (json.JSONDecodeError, TypeError, KeyError):
+                        continue
+        except OSError:
+            continue
+    return url_by_chunk, present_waves
+
+
+def backfill_from_jsonl(
+    conn: sqlite3.Connection,
+    url_by_chunk: dict[str, str | None],
+    present_waves: set[str],
+) -> dict[str, Any]:
+    """Backfill source_url for rows whose chunk_id is in the map from local JSONL.
+    Waves (source_file) absent from local JSONL are left NULL and reported.
+    Returns stats dict for verification and logging.
+    """
+    # Collect DB waves (source_file) to identify absent ones
+    db_rows = conn.execute(
+        "SELECT id, chunk_id, source_file FROM literary_texts ORDER BY id"
+    ).fetchall()
+    total_rows = len(db_rows)
+
+    db_waves: set[str] = {str(r[2]) for r in db_rows if r[2]}
+    absent_waves = sorted(db_waves - present_waves)
+
+    updated = 0
+    null_reasons: dict[str, int] = defaultdict(int)
+
+    # Update inside the caller's transaction
+    for row_id, chunk_id, source_file in db_rows:
+        cid = str(chunk_id) if chunk_id is not None else ""
+        sf = str(source_file) if source_file is not None else ""
+
+        if sf and sf in absent_waves:
+            null_reasons[f"no local JSONL for wave {sf}"] += 1
+            continue
+
+        url = url_by_chunk.get(cid)
+        if not url:
+            if cid and cid in url_by_chunk:
+                null_reasons["JSONL present for chunk but source_url absent/empty in record"] += 1
+            else:
+                null_reasons["chunk_id had no matching entry in any local JSONL"] += 1
+            continue
+
+        # Write only if different/NULL/empty
+        cur = conn.execute(
+            """
+            UPDATE literary_texts
+            SET source_url = ?
+            WHERE id = ?
+              AND (source_url IS NULL OR source_url = '' OR source_url != ?)
+            """,
+            (url, row_id, url),
+        )
+        if cur.rowcount:
+            updated += cur.rowcount
+
+    still_null = conn.execute(
+        "SELECT COUNT(*) FROM literary_texts WHERE source_url IS NULL OR source_url = ''"
+    ).fetchone()[0]
+
+    return {
+        "total_rows": total_rows,
+        "updated": updated,
+        "still_null": still_null,
+        "absent_waves": absent_waves,
+        "null_reasons": dict(null_reasons),
+        "present_waves_count": len(present_waves),
+    }
+
+
+def run_migration(db_path: Path, *, dry_run: bool = False) -> dict[str, Any]:
+    """Perform the column add (if needed) + backfill. Returns summary for tests/CI."""
+    if not db_path.exists():
+        return {"db_path": str(db_path), "existed": False, "added_column": False}
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        added = False
+        stats: dict[str, Any] = {}
+        with conn:
+            added = ensure_source_url_column(conn)
+            # Show pragma for evidence (caller/test can capture)
+            pragma_rows = conn.execute("PRAGMA table_info(literary_texts)").fetchall()
+
+        print(f"[migrate] DB: {db_path}")
+        print(f"[migrate] source_url column added this run: {added}")
+        print("[migrate] PRAGMA table_info(literary_texts) [after ensure]:")
+        for col in pragma_rows:
+            print(" ", col)
+
+        if dry_run:
+            print("[migrate] --dry-run: backfill skipped")
+            return {
+                "db_path": str(db_path),
+                "existed": True,
+                "added_column": added,
+                "dry_run": True,
+                "pragma_after": pragma_rows,
+            }
+
+        url_by_chunk, present_waves = load_urls_by_chunk_id(LITERARY_DIR)
+        print(f"[migrate] Loaded source_url for {len(url_by_chunk)} chunks from {len(present_waves)} local waves under {LITERARY_DIR}")
+
+        with conn:
+            stats = backfill_from_jsonl(conn, url_by_chunk, present_waves)
+
+        print("\n[backfill] Results:")
+        print(f"  total literary_texts rows: {stats['total_rows']}")
+        print(f"  rows updated with source_url: {stats['updated']}")
+        print(f"  rows left NULL/empty: {stats['still_null']}")
+        if stats.get("absent_waves"):
+            aw = stats["absent_waves"]
+            print(f"  waves absent locally (rows left NULL for these): {', '.join(aw[:8])}{' ...' if len(aw) > 8 else ''} (total {len(aw)})")
+        print("  NULL reasons (counts):")
+        for reason, count in sorted(stats.get("null_reasons", {}).items(), key=lambda kv: -kv[1]):
+            print(f"    {count}: {reason}")
+
+        return {
+            "db_path": str(db_path),
+            "existed": True,
+            "added_column": added,
+            "stats": stats,
+            "pragma_after": pragma_rows,
+        }
+    finally:
+        conn.close()
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Add source_url to literary_texts + backfill from JSONL")
+    p.add_argument("--db-path", type=Path, default=DEFAULT_DB_PATH, help="Path to sources.db (default: data/sources.db)")
+    p.add_argument("--dry-run", action="store_true", help="Add column if needed but skip UPDATE backfill")
+    return p.parse_args(argv)
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    result = run_migration(args.db_path, dry_run=args.dry_run)
+    if result.get("stats"):
+        s = result["stats"]
+        print(f"\nDONE. updated={s['updated']} still_null={s['still_null']}")
+    else:
+        print("DONE.")
+    sys.exit(0)

--- a/tests/test_migrate_literary_source_url.py
+++ b/tests/test_migrate_literary_source_url.py
@@ -1,0 +1,248 @@
+"""Unit tests for the literary source_url migration (uses TEMP sqlite fixture DB only).
+
+Covers:
+- Idempotent column add via guarded ALTER (PRAGMA check).
+- Backfill from temp JSONL dir keyed by chunk_id.
+- NULL when JSONL lacks the key, or when wave's JSONL is absent locally.
+- Reporting of updated / still-null counts + reasons.
+- No modification of real data/sources.db .
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make scripts/ importable like other migrate tests
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts"))
+
+from rag.migrate_add_literary_source_url import (
+    _get_column_names,
+    backfill_from_jsonl,
+    ensure_source_url_column,
+    load_urls_by_chunk_id,
+    run_migration,
+)
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(r, ensure_ascii=False) for r in rows) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _init_literary_table_only(conn: sqlite3.Connection) -> None:
+    """Minimal literary_texts table matching the shape used by sources.db (no FTS for this test)."""
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS literary_texts (
+            id INTEGER PRIMARY KEY,
+            chunk_id TEXT NOT NULL DEFAULT '',
+            title TEXT NOT NULL DEFAULT '',
+            text TEXT NOT NULL DEFAULT '',
+            source_file TEXT NOT NULL DEFAULT '',
+            author TEXT DEFAULT '',
+            work TEXT DEFAULT '',
+            work_id TEXT DEFAULT '',
+            year INTEGER,
+            genre TEXT DEFAULT '',
+            language_period TEXT DEFAULT '',
+            char_count INTEGER DEFAULT 0
+            -- NOTE: source_url intentionally absent here to simulate pre-migration DB
+        );
+        """
+    )
+    conn.commit()
+
+
+@pytest.fixture()
+def literary_migrate_fixture(tmp_path: Path) -> dict[str, Path]:
+    db_path = tmp_path / "test-sources.db"
+    lit_dir = tmp_path / "literary_texts"
+    lit_dir.mkdir()
+
+    conn = sqlite3.connect(str(db_path))
+    _init_literary_table_only(conn)
+
+    # Seed rows representing different situations:
+    # 1. will be backfilled from present wave jsonl that has source_url
+    # 2. chunk in present wave jsonl but no source_url key -> NULL
+    # 3. wave with no local jsonl at all -> left NULL, logged
+    # 4. chunk_id unknown even if wave present -> NULL
+    rows = [
+        (1, "c1_hash_c0001", "Title1", "Text one about Ukraine.", "wave01-present", "Anon", "Work One", "work1", 1900, "prose", "modern", 42),
+        (2, "c2_hash_c0002", "Title2", "Text two.", "wave01-present", "Anon", "Work One", "work1", 1900, "prose", "modern", 21),
+        (3, "c3_hash_c0003", "Title3", "Text three.", "wave02-missing-jsonl", "Anon", "Work Two", "work2", 1800, "chronicle", "middle_ukrainian", 99),
+        (4, "c4_hash_c0004", "Title4", "Text four unknown cid.", "wave01-present", "Anon", "Work One", "work1", 1900, "prose", "modern", 10),
+    ]
+    conn.executemany(
+        "INSERT INTO literary_texts (id, chunk_id, title, text, source_file, author, work, work_id, year, genre, language_period, char_count) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+    # JSONL for wave01-present: one with url, one without
+    _write_jsonl(
+        lit_dir / "wave01-present.jsonl",
+        [
+            {"chunk_id": "c1_hash_c0001", "text": "...", "source_url": "http://izbornyk.org.ua/work1/page1.htm", "work": "Work One"},
+            {"chunk_id": "c2_hash_c0002", "text": "...", "work": "Work One"},  # deliberately no source_url -> NULL
+        ],
+    )
+    # No JSONL for wave02-missing-jsonl on purpose
+
+    # Extra jsonl not referenced by any seeded row (should not affect counts)
+    _write_jsonl(
+        lit_dir / "wave99-orphan.jsonl",
+        [{"chunk_id": "orphan_001", "text": "x", "source_url": "http://example.com/orphan"}],
+    )
+
+    return {"db_path": db_path, "lit_dir": lit_dir}
+
+
+def test_ensure_column_idempotent_and_adds(literary_migrate_fixture: dict[str, Path]) -> None:
+    db_path = literary_migrate_fixture["db_path"]
+    conn = sqlite3.connect(str(db_path))
+
+    # Before
+    cols_before = _get_column_names(conn)
+    assert "source_url" not in cols_before
+
+    added1 = ensure_source_url_column(conn)
+    assert added1 is True
+    cols_after = _get_column_names(conn)
+    assert "source_url" in cols_after
+
+    # Idempotent
+    added2 = ensure_source_url_column(conn)
+    assert added2 is False
+
+    # PRAGMA shows the column (for evidence parity)
+    pragma = conn.execute("PRAGMA table_info(literary_texts)").fetchall()
+    names = [c[1] for c in pragma]
+    assert "source_url" in names
+    conn.close()
+
+
+def test_backfill_counts_and_null_reasons(literary_migrate_fixture: dict[str, Path], capsys: pytest.CaptureFixture[str]) -> None:
+    db_path = literary_migrate_fixture["db_path"]
+    lit_dir = literary_migrate_fixture["lit_dir"]
+
+    # Load using the real loader (against our temp lit_dir)
+    # Temporarily point? load uses global but we can call with override by patching? Simpler: call load then backfill directly.
+    # Since load_urls_by_chunk_id hardcodes LITERARY_DIR, we monkey the constant for test or reimpl call.
+    # For isolation: directly exercise the load func by temp monkey of module attr.
+    import rag.migrate_add_literary_source_url as mig
+
+    old_dir = mig.LITERARY_DIR
+    mig.LITERARY_DIR = lit_dir
+    try:
+        url_map, present = load_urls_by_chunk_id(lit_dir)  # explicit also ok, but use the func
+        # Re-call to exercise the module func
+        assert "c1_hash_c0001" in url_map
+        assert url_map["c1_hash_c0001"] == "http://izbornyk.org.ua/work1/page1.htm"
+        assert "c2_hash_c0002" in url_map and url_map["c2_hash_c0002"] is None
+        assert "wave01-present" in present
+        assert "wave02-missing-jsonl" not in present
+    finally:
+        mig.LITERARY_DIR = old_dir
+
+    # Now run full backfill via the API on a fresh conn (inside tx)
+    conn = sqlite3.connect(str(db_path))
+    # ensure col first (simulates pre-state)
+    with conn:
+        ensure_source_url_column(conn)
+
+    with conn:
+        # use the loader result from above (we have the map)
+        # rebuild map under the temp dir
+        mig.LITERARY_DIR = lit_dir
+        url_map2, present2 = load_urls_by_chunk_id(lit_dir)
+        stats = backfill_from_jsonl(conn, url_map2, present2)
+    conn.close()
+
+    assert stats["total_rows"] == 4
+    assert stats["updated"] == 1  # only the one with explicit url
+    assert stats["still_null"] >= 3
+
+    reasons = stats["null_reasons"]
+    # wave absent
+    assert any("no local JSONL for wave wave02-missing-jsonl" in k for k in reasons)
+    # chunk present but no url in record
+    assert any("JSONL present for chunk but source_url absent/empty" in k for k in reasons)
+    # unknown cid
+    assert any("chunk_id had no matching entry in any local JSONL" in k for k in reasons)
+
+    # Verify actual values in DB
+    conn = sqlite3.connect(str(db_path))
+    rows = conn.execute("SELECT chunk_id, source_url FROM literary_texts ORDER BY id").fetchall()
+    conn.close()
+
+    # row1 got the url
+    assert rows[0][1] == "http://izbornyk.org.ua/work1/page1.htm"
+    # others remain NULL (sqlite stores None as NULL)
+    assert rows[1][1] is None or rows[1][1] == ""
+    assert rows[2][1] is None or rows[2][1] == ""
+    assert rows[3][1] is None or rows[3][1] == ""
+
+
+def test_run_migration_on_temp_fixture_prints_pragma_and_counts(literary_migrate_fixture: dict[str, Path], capsys: pytest.CaptureFixture[str]) -> None:
+    """Exercise the high-level runner + capture evidence-like output (PRAGMA, backfill counts)."""
+    db_path = literary_migrate_fixture["db_path"]
+    lit_dir = literary_migrate_fixture["lit_dir"]
+
+    import rag.migrate_add_literary_source_url as mig
+
+    old_dir = mig.LITERARY_DIR
+    mig.LITERARY_DIR = lit_dir
+    try:
+        result = run_migration(db_path, dry_run=False)
+    finally:
+        mig.LITERARY_DIR = old_dir
+
+    assert result["existed"] is True
+    assert result["added_column"] in (True, False)  # first run adds
+    assert "stats" in result
+    s = result["stats"]
+    assert s["updated"] >= 1
+    assert "pragma_after" in result
+    names = [c[1] for c in result["pragma_after"]]
+    assert "source_url" in names
+
+    # stdout from inside run_migration should have been emitted
+    out = capsys.readouterr().out
+    assert "PRAGMA table_info(literary_texts) [after ensure]" in out or "source_url column added" in out
+    assert "rows updated with source_url" in out or "updated=" in out.lower()
+
+
+def test_dry_run_does_not_backfill(literary_migrate_fixture: dict[str, Path]) -> None:
+    db_path = literary_migrate_fixture["db_path"]
+    lit_dir = literary_migrate_fixture["lit_dir"]
+
+    import rag.migrate_add_literary_source_url as mig
+
+    old_dir = mig.LITERARY_DIR
+    mig.LITERARY_DIR = lit_dir
+    try:
+        result = run_migration(db_path, dry_run=True)
+    finally:
+        mig.LITERARY_DIR = old_dir
+
+    assert result.get("dry_run") is True
+    # col may be added, but no stats backfill
+    assert "stats" not in result or result.get("stats") is None
+
+    # Verify no values were written (all should still be NULL)
+    conn = sqlite3.connect(str(db_path))
+    null_count = conn.execute("SELECT COUNT(*) FROM literary_texts WHERE source_url IS NULL OR source_url = ''").fetchone()[0]
+    conn.close()
+    # Since dry-run may have added col in its tx but no updates, all 4 remain null
+    assert null_count == 4


### PR DESCRIPTION
**Fix for #2901**: literary RAG JSONL records `source_url` per chunk, but `literary_texts` table in `data/sources.db` had no column (provenance silently dropped). External + Wikipedia tables keep URLs; literary did not.

### Changes (4 files, all directly related)
- Schema: idempotent `ALTER TABLE literary_texts ADD COLUMN source_url TEXT` (guarded by `PRAGMA table_info` column check) in new one-shot migration script.
- Ingest propagation: `scripts/rag/ingest_literary.py` (and sibling `ingest.py`) now explicitly read `source_url` from JSONL records and pass through (NULL when absent; no invention of URLs).
- Backfill: `scripts/rag/migrate_add_literary_source_url.py` — local-only, tolerant (absent JSONL waves → leave NULL + log wave name; chunk missing key → NULL). Uses chunk_id key. Reports updated/NULL-with-reason.
- Test: `tests/test_migrate_literary_source_url.py` — full coverage on **TEMP sqlite fixture DB** (never touches real 1.6 GB `sources.db`). Includes before/after PRAGMA, counts, reasons, dry-run, idempotency.
- Audit: `textbooks` table lacks any URL col (by design: provenance is grade+source_file from known structured PDFs). `external_articles` (url/url_normalized) and `wikipedia` (url) retain URLs. Textbooks gap is non-trivial (extraction/ingest/callers); noted here + in script header, not expanded in this PR.

### Evidence (M-4)
- **pytest (required cmd)**: `cd /Users/krisztiankoos/projects/learn-ukrainian && .venv/bin/python -m pytest -k "literary or ingest or source_url" -q` → **226 passed, 23 skipped, 8412 deselected ... 13.75s**
  (New test also run separately inside worktree: 4/4 passed on temp-fixture.)
- **Ruff (required)**: `cd ... && .venv/bin/ruff check scripts/ tests/` → **All checks passed!**
- **git status (required)**: `cd /Users/krisztiankoos/projects/learn-ukrainian && git status --short` → (empty; no output) → **NO *.db**
  Inside worktree status also confirmed 0 *.db.
- **PRAGMA + backfill counts** (from temp-fixture run of migration logic):
  ```
  === PRAGMA BEFORE ===
  ... (12 cols, no source_url) ...
  has source_url? False
  added col: True
  === PRAGMA AFTER ADD (before backfill) ===
  ... (13 cols; source_url at index 12) ...
  === BACKFILL STATS ===
  {'total_rows': 3, 'updated': 1, 'still_null': 2, 'absent_waves': ['waveB-nojson'], 'null_reasons': {'JSONL present for chunk but source_url absent/empty in record': 1, 'no local JSONL for wave waveB-nojson': 1, ...}, ...}
  Final rows: cid1 → https://... ; cid2/cid3 → NULL (reasons logged)
  ```
  (Matches real-DB pre-state: literary_texts had 12 cols, no source_url; JSONL samples carry "source_url": "http://izbornyk.org.ua/...".)
- `git log -1 --oneline`: ed0fdeb4a0 fix(corpus): propagate source_url into literary_texts (column + ingest + backfill) (#2901)
- Trailer: `X-Agent: grok-build/literary-srcurl-2901` (lint_agent_trailer.py: PASS)
- Worktree used for **all** edits/tests/git: `.worktrees/dispatch/grok-build/literary-srcurl-2901`
- No `data/*.db` created/modified/staged.
- Pre-commit (ruff + pytest on affected) passed on commit.

Migration + backfill are one-shot/local (as specified). Rebuilds via `build_sources_db.py` already included source_url in INSERT/row builder (and CREATE). Run the migrate script on your local `sources.db` to backfill existing rows from `data/literary_texts/*.jsonl`.

Closes #2901.