### PR TITLE
feat(lexicon): populate Atlas POC sections

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -15,8 +15,9 @@ no fabrication):
 - **literary_attestation** — exact-form literary corpus hit when available.
 - **synonyms** — source-attested Ukrainian candidates from clean slovnyk.me
   synonym dictionaries, with noisy legacy sources kept A1-sense allowlisted.
-- **sections.synonyms / sections.idioms** — slovnyk.me per-lemma lookup cache
-  (Караванський + Словник синонімів; Фразеологічний).
+- **sections.synonyms / sections.antonyms / sections.idioms** — slovnyk.me
+  per-lemma lookup cache and local dictionary rows (Караванський + Словник
+  синонімів; Вікісловник antonyms; Фразеологічний).
 - **heritage warning alternatives** — slovnyk.me correction dictionaries
   (Антоненко-Давидович, «Неправильно-правильно», Штепа чужослів).
 - **etymology** — Goroh cached extracts first, ЕСУМ fallback, uk.wiktionary
@@ -1183,6 +1184,88 @@ def _synonyms_slovnyk(
     }
 
 
+def _clean_atlas_chip_candidate(candidate: str, lemma: str) -> str | None:
+    term = _strip_stress(candidate)
+    term = re.sub(r"<[^>]+>", " ", term)
+    term = re.sub(r"\s+", " ", term).strip()
+    term = term.strip(' \t\r\n.,;:!?/\\[]{}«»"“”<>')
+    term = term.casefold()
+    if not term or term in _BLOCKED_SYNONYMS:
+        return None
+    if _LATIN_RE.search(term) or not _UKRAINIAN_TEXT_RE.fullmatch(term):
+        return None
+    words = term.split()
+    if len(words) > 4:
+        return None
+    for variant in _split_lemma_variants(_strip_stress(lemma)):
+        if term == variant.casefold():
+            return None
+    return term
+
+
+def _wiktionary_has_antonyms_column(conn: sqlite3.Connection) -> bool:
+    try:
+        return any(row[1] == "antonyms" for row in conn.execute("PRAGMA table_info(wiktionary)"))
+    except sqlite3.OperationalError as exc:
+        if _missing_table(exc):
+            return False
+        raise
+
+
+def _candidate_matches_entry_pos(candidate: str, entry_pos: str | None) -> bool:
+    mapped_pos = _MANIFEST_POS_TO_VESUM_POS.get(_lookup_key(entry_pos or ""))
+    if not mapped_pos or _has_whitespace(candidate):
+        return True
+    return _candidate_matches_headword_pos(candidate, mapped_pos)
+
+
+def _antonyms_wiktionary(
+    conn: sqlite3.Connection,
+    lemma: str,
+    *,
+    entry_pos: str | None = None,
+) -> dict[str, Any] | None:
+    """Antonym chips from explicit Wiktionary antonym rows, omitted when empty."""
+    if not _wiktionary_has_antonyms_column(conn):
+        return None
+
+    items: list[str] = []
+    seen: set[str] = set()
+    try:
+        for variant in _etymology_lookup_variants(_base_lemma(lemma)):
+            row = conn.execute(
+                "SELECT antonyms FROM wiktionary WHERE word = ? COLLATE NOCASE AND antonyms != '' LIMIT 1",
+                (variant,),
+            ).fetchone()
+            if not row:
+                continue
+            try:
+                candidates = json.loads(row[0] or "[]")
+            except (TypeError, ValueError):
+                candidates = []
+            if not isinstance(candidates, list):
+                continue
+            for candidate in candidates:
+                term = _clean_atlas_chip_candidate(str(candidate), lemma)
+                if term and term not in seen and _candidate_matches_entry_pos(term, entry_pos):
+                    seen.add(term)
+                    items.append(term)
+            if items:
+                break
+    except sqlite3.OperationalError as exc:
+        if _missing_table(exc):
+            return None
+        raise
+
+    if not items:
+        return None
+    return {
+        "items": items[:12],
+        "source": "Вікісловник: explicit antonym list",
+        "source_urls": [f"https://uk.wiktionary.org/wiki/{quote(_base_lemma(lemma))}"],
+    }
+
+
 def _protect_idiom_abbreviation_periods(text: str) -> str:
     protected = text
     for abbreviation in _IDIOM_ABBREVIATIONS_WITH_INTERNAL_DOTS:
@@ -1242,6 +1325,157 @@ def _idioms_slovnyk(lemma: str, cache: dict[str, Any] | None = None) -> dict[str
         "source": "slovnyk.me: Фразеологічний словник української мови",
         "source_urls": [str(row["source_url"])] if row.get("source_url") else [],
     }
+
+
+_PHRASEOLOGY_MARKUP_REPLACEMENTS = (
+    ("[']", ""),
+    ("[/']", ""),
+    ("≤", ""),
+    ("≥", ""),
+    ("{{</fras>}}", ""),
+    ("{{", ""),
+    ("}}", ""),
+)
+
+
+def _clean_phraseology_text(text: str) -> str:
+    cleaned = clean_html_entities(str(text or ""))
+    cleaned = re.sub(r"<[^>]+>", " ", cleaned)
+    for old, new in _PHRASEOLOGY_MARKUP_REPLACEMENTS:
+        cleaned = cleaned.replace(old, new)
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    return cleaned.strip()
+
+
+def _leading_phraseology_phrase(definition: str, headword: str) -> str:
+    cleaned_definition = _clean_phraseology_text(definition)
+    protected = _protect_idiom_abbreviation_periods(cleaned_definition)
+    match = re.match(r"(.{3,220}?\.)\s+", protected)
+    if match:
+        return _restore_idiom_abbreviation_periods(match.group(1)).strip(" .")
+    return _clean_phraseology_text(headword).strip(" .")
+
+
+def _phrase_contains_lemma(phrase: str, lemma: str) -> bool:
+    clean_phrase = _lookup_key(_clean_phraseology_text(phrase))
+    variants = [_lookup_key(variant) for variant in _split_lemma_variants(_base_lemma(lemma))]
+    variants = [variant for variant in variants if variant]
+    if any(_contains_whole_token(clean_phrase, variant) for variant in variants):
+        return True
+    if _has_whitespace(clean_phrase):
+        tokens = re.findall(rf"[{_CYRILLIC_WORD_CHARS}]+", clean_phrase)
+        expected = set(variants)
+        for token in tokens:
+            if any(analysis_lemma in expected for analysis_lemma, _pos in _vesum_word_analyses(token)):
+                return True
+    return False
+
+
+def _phraseology_definition_body(definition: str, phrase: str) -> str:
+    body = _clean_phraseology_text(definition)
+    if phrase:
+        pattern = re.compile(rf"^\s*{re.escape(_clean_phraseology_text(phrase))}\.?\s*", flags=re.IGNORECASE)
+        body = pattern.sub("", body, count=1).strip()
+    body = re.sub(r"^\d+\.\s*", "", body)
+    return _truncate_text(body, 650)
+
+
+def _idioms_frazeolohichnyi(conn: sqlite3.Connection, lemma: str, *, limit: int = 3) -> dict[str, Any] | None:
+    """Phraseology rows from local DB, matched on the idiom phrase not loose definition mentions."""
+    variants = [_lookup_key(variant) for variant in _split_lemma_variants(_base_lemma(lemma))]
+    variants = [variant for variant in variants if variant]
+    if not variants:
+        return None
+
+    rows: list[tuple[str, str, str]] = []
+    seen_ids: set[int] = set()
+    try:
+        for variant in variants:
+            for row in conn.execute(
+                "SELECT id, word, definition, source FROM frazeolohichnyi "
+                "WHERE lower(word) LIKE ? OR lower(definition) LIKE ? LIMIT 80",
+                (f"%{variant}%", f"%{variant}%"),
+            ):
+                row_id = int(row[0])
+                if row_id in seen_ids:
+                    continue
+                seen_ids.add(row_id)
+                rows.append((str(row[1] or ""), str(row[2] or ""), str(row[3] or "")))
+    except sqlite3.OperationalError as exc:
+        if _missing_table(exc):
+            return None
+        raise
+
+    items: list[dict[str, str]] = []
+    seen_phrases: set[str] = set()
+    for headword, definition, source in rows:
+        phrase = _leading_phraseology_phrase(definition, headword)
+        if not phrase or not _phrase_contains_lemma(phrase, lemma):
+            continue
+        phrase = _truncate_text(phrase, 160)
+        key = _lookup_key(phrase)
+        if key in seen_phrases:
+            continue
+        seen_phrases.add(key)
+        items.append(
+            {
+                "text": phrase,
+                "phrase": phrase,
+                "definition": _phraseology_definition_body(definition, phrase),
+                "source": source or "Фразеологічний словник української мови",
+                "source_url": "",
+            }
+        )
+        if len(items) >= limit:
+            break
+
+    if not items:
+        return None
+    return {
+        "items": items,
+        "source": "Фразеологічний словник української мови",
+        "source_urls": [],
+    }
+
+
+def _merge_idiom_sections(*sections: dict[str, Any] | None) -> dict[str, Any] | None:
+    items: list[dict[str, str]] = []
+    sources: list[str] = []
+    urls: list[str] = []
+    seen: set[str] = set()
+    for section in sections:
+        if not section:
+            continue
+        for item in section.get("items", []):
+            if not isinstance(item, dict):
+                continue
+            phrase = str(item.get("phrase") or item.get("text") or "").strip()
+            key = _lookup_key(phrase)
+            if not phrase or key in seen:
+                continue
+            seen.add(key)
+            items.append(item)
+        if section.get("source"):
+            sources.append(str(section["source"]))
+        urls.extend(str(url) for url in section.get("source_urls", []) if url)
+    if not items:
+        return None
+    return {
+        "items": items[:4],
+        "source": " + ".join(dict.fromkeys(sources)),
+        "source_urls": list(dict.fromkeys(urls)),
+    }
+
+
+def _idioms(
+    conn: sqlite3.Connection,
+    lemma: str,
+    cache: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    return _merge_idiom_sections(
+        _idioms_slovnyk(lemma, cache),
+        _idioms_frazeolohichnyi(conn, lemma),
+    )
 
 
 def _warning_alternatives_from_row(row: dict[str, Any], lemma: str) -> list[str]:
@@ -1847,8 +2081,17 @@ def _lookup_key(value: str) -> str:
 
 
 def _etymology_lookup_variants(lemma: str) -> list[str]:
-    variants = [lemma.strip()]
+    variants = [lemma.strip(), _lookup_key(lemma)]
     variants.extend(_split_lemma_variants(lemma))
+    for variant in list(variants):
+        key = _lookup_key(variant)
+        if not key or _has_whitespace(key):
+            continue
+        variants.extend(get_apostrophe_variants(key))
+        if key.startswith("в") and len(key) > 2:
+            variants.append("у" + key[1:])
+        if key.startswith("у") and len(key) > 2:
+            variants.append("в" + key[1:])
     seen: set[str] = set()
     return [v for v in variants if v and not (v.casefold() in seen or seen.add(v.casefold()))]
 
@@ -1958,7 +2201,7 @@ def _esum_etymology(conn: sqlite3.Connection, lemma: str) -> dict | None:
         return None
     row = None
     try:
-        for variant in _split_lemma_variants(word):
+        for variant in _etymology_lookup_variants(word):
             row = conn.execute(
                 "SELECT etymology_text, vol, page FROM esum_etymology "
                 "WHERE lemma = ? AND etymology_text != '' LIMIT 1",
@@ -2384,7 +2627,10 @@ def enrich() -> tuple[int, int]:
             synonyms = _synonyms_slovnyk(base, slovnyk_cache, entry_pos=entry.get("pos"))
             if synonyms:
                 sections["synonyms"] = synonyms
-            idioms = _idioms_slovnyk(lemma, slovnyk_cache)
+            antonyms = _antonyms_wiktionary(conn, base, entry_pos=entry.get("pos"))
+            if antonyms:
+                sections["antonyms"] = antonyms
+            idioms = _idioms(conn, lemma, slovnyk_cache)
             if idioms:
                 sections["idioms"] = idioms
             if sections:

--- a/site/src/pages/lexicon/[lemma].astro
+++ b/site/src/pages/lexicon/[lemma].astro
@@ -50,6 +50,12 @@ interface SynonymSection {
   source_urls?: string[];
 }
 
+interface AntonymSection {
+  items: string[];
+  source: string;
+  source_urls?: string[];
+}
+
 interface IdiomSection {
   items: Array<{
     text?: string;
@@ -64,6 +70,7 @@ interface IdiomSection {
 
 interface LexiconSections {
   synonyms?: SynonymSection;
+  antonyms?: AntonymSection;
   idioms?: IdiomSection;
 }
 
@@ -317,6 +324,7 @@ const courseUsage = entry.course_usage.slice().sort((a, b) => {
 const sectionSources = [
   pronunciation?.source,
   sections?.synonyms?.source,
+  sections?.antonyms?.source,
   sections?.idioms?.source,
 ].filter((source): source is string => Boolean(source));
 const wikiSources: string[] = [];
@@ -401,6 +409,7 @@ const hasDictionaryData = Boolean(
     enrichment?.literary_attestation ||
     enrichment?.translation ||
     sections?.synonyms ||
+    sections?.antonyms ||
     sections?.idioms ||
     showHeritage ||
     showEditorialSuccess ||
@@ -649,6 +658,24 @@ const frontmatter = {
           <div class="atlas-chip-line atlas-chip-line-large">
             {sections.synonyms.items.map((synonym) => (
               <span>{synonym}</span>
+            ))}
+          </div>
+        </div>
+      </section>
+    )}
+
+    {sections?.antonyms && sections.antonyms.items.length > 0 && (
+      <section class="atlas-section" aria-labelledby="atlas-antonyms-title">
+        <div class="atlas-section-head">
+          <p class="atlas-kicker">Протиставлення</p>
+          <h2 id="atlas-antonyms-title">Антоніми</h2>
+        </div>
+
+        <div class="atlas-source-card atlas-source-card-synonyms">
+          <p class="atlas-source-label">{sections.antonyms.source}</p>
+          <div class="atlas-chip-line atlas-chip-line-large">
+            {sections.antonyms.items.map((antonym) => (
+              <span>{antonym}</span>
             ))}
           </div>
         </div>

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -7,6 +7,7 @@ from scripts.lexicon import enrich_manifest as enrich_manifest_module
 from scripts.lexicon.enrich_manifest import (
     _WRONG_SENSE_SYNONYMS,
     KAIKKI_SOURCE,
+    _antonyms_wiktionary,
     _base_lemma,
     _build_paradigm,
     _cefr,
@@ -15,6 +16,9 @@ from scripts.lexicon.enrich_manifest import (
     _definition_cards,
     _dmklinger_key,
     _etymology,
+    _etymology_lookup_variants,
+    _idioms,
+    _idioms_frazeolohichnyi,
     _idioms_slovnyk,
     _kaikki_pronunciation,
     _literary_attestation,
@@ -644,6 +648,140 @@ def test_slovnyk_idioms_extract_known_phrase_card() -> None:
     assert "Причина ворожнечі" in section["items"][0]["definition"]
 
 
+def test_wiktionary_antonyms_use_explicit_antonym_column(monkeypatch) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """
+        CREATE TABLE wiktionary (
+            word TEXT NOT NULL,
+            definitions TEXT DEFAULT '',
+            synonyms TEXT DEFAULT '',
+            antonyms TEXT DEFAULT '',
+            text TEXT NOT NULL DEFAULT '',
+            source TEXT DEFAULT ''
+        )
+        """
+    )
+    conn.executemany(
+        "INSERT INTO wiktionary (word, antonyms) VALUES (?, ?)",
+        [
+            ("ніч", json.dumps(["день", "night"], ensure_ascii=False)),
+            ("день", json.dumps(["ніч"], ensure_ascii=False)),
+        ],
+    )
+    _patch_vesum_analyses(monkeypatch, {"ніч": "noun", "день": "noun"})
+
+    section = _antonyms_wiktionary(conn, "ніч", entry_pos="noun")
+
+    assert section == {
+        "items": ["день"],
+        "source": "Вікісловник: explicit antonym list",
+        "source_urls": ["https://uk.wiktionary.org/wiki/%D0%BD%D1%96%D1%87"],
+    }
+
+
+def test_frazeolohichnyi_idioms_keep_phrase_hits_and_drop_definition_noise(monkeypatch) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """
+        CREATE TABLE frazeolohichnyi (
+            id INTEGER PRIMARY KEY,
+            word TEXT NOT NULL,
+            definition TEXT NOT NULL DEFAULT '',
+            text TEXT NOT NULL DEFAULT '',
+            source TEXT DEFAULT ''
+        )
+        """
+    )
+    conn.executemany(
+        "INSERT INTO frazeolohichnyi (word, definition, text, source) VALUES (?, ?, ?, ?)",
+        [
+            (
+                "яблуко розбрату {{</fras>}}",
+                "[']я[/']блуко р[']о[/']збрату (чвар), книжн. Причина ворожнечі, суперечок.",
+                "яблуко розбрату: Причина ворожнечі.",
+                "Фразеологічний словник",
+            ),
+            (
+                "брати верх {{</fras>}}",
+                "бр[']а[/']ти верх над ким--чим. Вода була така сильна, що брала верх.",
+                "брати верх: Вода була така сильна.",
+                "Фразеологічний словник",
+            ),
+            (
+                "яблукові ніде впасти {{</fras>}}",
+                "г[']о[/']лці ([']я[/']блуку, [']я[/']блукові) н[']і[/']де вп[']а[/']сти. Дуже людно.",
+                "яблукові ніде впасти: Дуже людно.",
+                "Фразеологічний словник",
+            ),
+        ],
+    )
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "_vesum_word_analyses",
+        lambda word: (("яблуко", "noun"),) if word in {"яблуку", "яблукові"} else (),
+    )
+
+    apple = _idioms_frazeolohichnyi(conn, "яблуко")
+    water = _idioms_frazeolohichnyi(conn, "вода")
+
+    assert apple is not None
+    assert [item["phrase"] for item in apple["items"]] == [
+        "яблуко розбрату (чвар), книжн",
+        "голці (яблуку, яблукові) ніде впасти",
+    ]
+    assert "Причина ворожнечі" in apple["items"][0]["definition"]
+    assert water is None
+
+
+def test_idioms_merge_slovnyk_cache_and_frazeolohichnyi_fallback(monkeypatch) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """
+        CREATE TABLE frazeolohichnyi (
+            id INTEGER PRIMARY KEY,
+            word TEXT NOT NULL,
+            definition TEXT NOT NULL DEFAULT '',
+            text TEXT NOT NULL DEFAULT '',
+            source TEXT DEFAULT ''
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO frazeolohichnyi (word, definition, text, source) VALUES (?, ?, ?, ?)",
+        (
+            "яблукові ніде впасти {{</fras>}}",
+            "г[']о[/']лці ([']я[/']блуку, [']я[/']блукові) н[']і[/']де вп[']а[/']сти. Дуже людно.",
+            "яблукові ніде впасти: Дуже людно.",
+            "Фразеологічний словник",
+        ),
+    )
+    cache = {
+        "lookups": {
+            "phraseology": {
+                "dictionary_slug": "phraseology",
+                "dictionary_label": "Фразеологічний словник української мови",
+                "source_url": "https://slovnyk.me/dict/phraseology/яблуко",
+                "word": "яблуко",
+                "text": "яблуко я́блуко ро́збрату (чвар), книжн. Причина ворожнечі. Джерело: тест",
+            }
+        }
+    }
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "_vesum_word_analyses",
+        lambda word: (("яблуко", "noun"),) if word in {"яблуку", "яблукові"} else (),
+    )
+
+    section = _idioms(conn, "яблуко", cache)
+
+    assert section is not None
+    assert [item["phrase"] for item in section["items"]] == [
+        "яблуко розбрату (чвар), книжн",
+        "голці (яблуку, яблукові) ніде впасти",
+    ]
+
+
 def test_slovnyk_warning_merges_known_russianism_alternative() -> None:
     cache = {
         "lookups": {
@@ -1029,6 +1167,39 @@ def test_derivational_etymology_falls_back_to_base_forms(derived: str, base: str
     }
 
 
+def test_etymology_lookup_variants_include_normalised_apostrophe_and_v_u_alternates() -> None:
+    variants = _etymology_lookup_variants("Ув’язнення")
+
+    assert "ув'язнення" in variants
+    assert "вв'язнення" in variants
+
+
+def test_esum_etymology_uses_normalised_variant_match() -> None:
+    conn = _conn()
+    conn.execute(
+        """
+        CREATE TABLE esum_etymology (
+            lemma TEXT NOT NULL,
+            etymology_text TEXT NOT NULL,
+            cognates TEXT DEFAULT '',
+            vol TEXT DEFAULT '',
+            page TEXT DEFAULT ''
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO esum_etymology VALUES (?, ?, ?, ?, ?)",
+        ("ув'язнення", "Fixture ЕСУМ etymology for ув'язнення.", "[]", "1", "42"),
+    )
+
+    etymology = _etymology(conn, "Ув’язнення", {})
+
+    assert etymology == {
+        "text": "Fixture ЕСУМ etymology for ув'язнення.",
+        "source": "ЕСУМ, т. 1, с. 42",
+    }
+
+
 def test_compositional_greeting_phrases_have_no_etymology_fallback() -> None:
     conn = _conn()
     conn.execute(
@@ -1187,6 +1358,113 @@ def test_enrich_uses_base_form_for_pair_single_form_sections(monkeypatch, tmp_pa
     assert enriched["enrichment"]["etymology"]["text"] == "Goroh etymology for робота."
     assert enriched["enrichment"]["morphology"]["forms"] == [{"form": "робота", "label": "однина, жін., називний"}]
     assert verify_calls == ["робота"]
+
+
+def test_enrich_populates_antonyms_phraseology_and_variant_etymology(monkeypatch, tmp_path) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    db_path = tmp_path / "sources.sqlite"
+    before = {
+        "entries": [
+            {
+                "lemma": "Ув’язнення",
+                "gloss": "imprisonment",
+                "pos": "noun",
+            }
+        ]
+    }
+    manifest_path.write_text(json.dumps(before, ensure_ascii=False) + "\n", encoding="utf-8")
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE esum_etymology (
+            lemma TEXT NOT NULL,
+            etymology_text TEXT NOT NULL,
+            cognates TEXT DEFAULT '',
+            vol TEXT DEFAULT '',
+            page TEXT DEFAULT ''
+        );
+        CREATE TABLE wiktionary (
+            word TEXT NOT NULL,
+            definitions TEXT DEFAULT '',
+            synonyms TEXT DEFAULT '',
+            antonyms TEXT DEFAULT '',
+            text TEXT NOT NULL DEFAULT '',
+            source TEXT DEFAULT ''
+        );
+        CREATE TABLE frazeolohichnyi (
+            id INTEGER PRIMARY KEY,
+            word TEXT NOT NULL,
+            definition TEXT NOT NULL DEFAULT '',
+            text TEXT NOT NULL DEFAULT '',
+            source TEXT DEFAULT ''
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO esum_etymology VALUES (?, ?, ?, ?, ?)",
+        ("ув'язнення", "Fixture ЕСУМ etymology for ув'язнення.", "[]", "1", "42"),
+    )
+    conn.execute(
+        "INSERT INTO wiktionary (word, antonyms) VALUES (?, ?)",
+        ("Ув’язнення", json.dumps(["воля", "detention"], ensure_ascii=False)),
+    )
+    conn.execute(
+        "INSERT INTO frazeolohichnyi (word, definition, text, source) VALUES (?, ?, ?, ?)",
+        (
+            "ув'язнення духу {{</fras>}}",
+            "ув'язнення духу. Обмеження внутрішньої свободи.",
+            "ув'язнення духу: Обмеження внутрішньої свободи.",
+            "Фразеологічний словник",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(enrich_manifest_module, "MANIFEST", manifest_path)
+    monkeypatch.setattr(enrich_manifest_module, "SOURCES_DB", db_path)
+    monkeypatch.setattr(enrich_manifest_module, "_load_kaikki_lookup", lambda: {})
+    monkeypatch.setattr(enrich_manifest_module, "_slovnyk_cache", lambda lemma: {"lookups": {}})
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "classify_lemma",
+        lambda lemma: {
+            "classification": "unknown",
+            "attestations": [],
+            "is_russianism": False,
+            "russian_shadow": False,
+            "sovietization_risk": 0,
+            "calque_warning": None,
+        },
+    )
+    monkeypatch.setattr(enrich_manifest_module, "_sum11_has_flag_columns", lambda conn: True)
+    monkeypatch.setattr(enrich_manifest_module, "_definition_cards", lambda *args, **kwargs: [])
+    monkeypatch.setattr(enrich_manifest_module, "_kaikki_pronunciation", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest_module, "_idioms_slovnyk", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest_module, "_stress_display_form", lambda form: "")
+    monkeypatch.setattr(enrich_manifest_module, "_cefr", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest_module, "_morphology", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest_module, "_meaning", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest_module, "_literary_attestation", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest_module, "_translation", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "_vesum_word_analyses",
+        lambda word: ((word, "noun"),) if word in {"воля", "ув'язнення"} else (),
+    )
+
+    assert enrich_manifest_module.enrich() == (1, 1)
+
+    enriched = json.loads(manifest_path.read_text(encoding="utf-8"))["entries"][0]
+    print("UNIT SAMPLE before sections:", before["entries"][0].get("sections"))
+    print("UNIT SAMPLE after sections:", json.dumps(enriched.get("sections"), ensure_ascii=False, sort_keys=True))
+    print("UNIT SAMPLE after etymology:", json.dumps(enriched["enrichment"]["etymology"], ensure_ascii=False))
+
+    assert enriched["sections"]["antonyms"]["items"] == ["воля"]
+    assert enriched["sections"]["idioms"]["items"][0]["phrase"] == "ув'язнення духу"
+    assert enriched["enrichment"]["etymology"] == {
+        "text": "Fixture ЕСУМ etymology for ув'язнення.",
+        "source": "ЕСУМ, т. 1, с. 42",
+    }
 
 
 def test_dmklinger_key_strips_stress_and_casefolds() -> None:


### PR DESCRIPTION
## Summary

Refs #2882.

- adds deterministic Atlas `sections.antonyms` from explicit Wiktionary antonym rows, with Ukrainian/text/POS guards
- expands phraseology coverage by merging existing slovnyk.me phraseology cache with tightly matched local `frazeolohichnyi` rows
- improves ЕСУМ fallback matching with normalized/apostrophe and initial `в`/`у` etymology lookup variants
- renders antonyms on `site/src/pages/lexicon/[lemma].astro`

Generated artifact guard: `site/src/data/lexicon-manifest.json` was not regenerated or committed.

## Fresh coverage re-measurement

Command: `.venv/bin/python -m scripts.lexicon.verify_manifest`
Cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/atlas-populate-2882`

```text
=== COVERAGE (lexicon-manifest.json) ===
  entries            2190
  synonyms           794
  wiki_reference     117
  etymology          1250
  definition_cards   1457
  meaning            1477
  pronunciation      1604
  heritage_status    2190
...
=== VERDICT: clean (eyeball the sample before commit) ===
```

POC section coverage over current manifest:

```text
total entries	2190
Переклад / gloss	2190/2190	100.0%
У курсі / course_usage	2176/2190	99.4%
Морфологія	1509/2190	68.9%
Значення / meaning	1477/2190	67.4%
Картки дефініцій	1457/2190	66.5%
Вимова / pronunciation	1604/2190	73.2%
Наголос / stress	1646/2190	75.2%
CEFR	1127/2190	51.5%
Синоніми (sections)	794/2190	36.3%
Синоніми (meaning legacy)	15/2190	0.7%
Антоніми	0/2190	0.0%
Фразеологізми	551/2190	25.2%
Етимологія	1250/2190	57.1%
Літературне засвідчення	1774/2190	81.0%
Wikipedia/Wiktionary refs	117/2190	5.3%
Походження + статус	2190/2190	100.0%
```

## Unit sample output

Command: `.venv/bin/python -m pytest tests/test_lexicon_enrich_manifest.py::test_enrich_populates_antonyms_phraseology_and_variant_etymology -q -s`
Cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/atlas-populate-2882`

```text
UNIT SAMPLE before sections: None
UNIT SAMPLE after sections: {"antonyms": {"items": ["воля"], "source": "Вікісловник: explicit antonym list", "source_urls": ["https://uk.wiktionary.org/wiki/%D0%A3%D0%B2%E2%80%99%D1%8F%D0%B7%D0%BD%D0%B5%D0%BD%D0%BD%D1%8F"]}, "idioms": {"items": [{"definition": "Обмеження внутрішньої свободи.", "phrase": "ув'язнення духу", "source": "Фразеологічний словник", "source_url": "", "text": "ув'язнення духу"}], "source": "Фразеологічний словник української мови", "source_urls": []}}
UNIT SAMPLE after etymology: {"text": "Fixture ЕСУМ etymology for ув'язнення.", "source": "ЕСУМ, т. 1, с. 42"}
.
============================== 1 passed in 0.52s ===============================
```

## Validation

Command: `.venv/bin/python -m pytest -k "lexicon or enrich or etymolog or phrase" -q`
Cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/atlas-populate-2882`

```text
========= 228 passed, 5 skipped, 8434 deselected, 3 warnings in 19.47s =========
```

Command: `.venv/bin/ruff check scripts/ tests/`
Cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/atlas-populate-2882`

```text
All checks passed!
```

Command: `git status --short`
Cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/atlas-populate-2882`

```text

```

Command: `git log -1 --oneline`
Cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/atlas-populate-2882`

```text
5d423b13c3 feat(lexicon): populate Atlas POC sections — etymology variant-match + phraseology + antonyms (#2882)
```
