### PR TITLE
feat(corpus): expand ukrlib /narod/ folk scraper (4 works → 29) to unblock #3162 folk primary-text embedding

### DIFF
--- a/scripts/rag/scrape_ukrlib.py
+++ b/scripts/rag/scrape_ukrlib.py
@@ -1090,13 +1090,70 @@ NAROD_AUTHOR = "Народна творчість"
 NAROD_PERIOD = "middle_ukrainian"  # Cossack-era oral epos (XVI–XVIII)
 NAROD_YEAR = 1600  # approximate composition era; oral tradition, no fixed date
 
-NAROD_WORKS = [
-    # genre 3 = Історичні пісні; genre 11 = Народний епос (думи)
-    {"genre_id": 3, "bookid": 5, "title": "Пісня про Байду", "genre": "folk_song"},
-    {"genre_id": 11, "bookid": 1, "title": "Втеча трьох братів з Азова", "genre": "duma"},
-    {"genre_id": 11, "bookid": 2, "title": "Дума про Олексія Поповича (Гей, не дивуйте, добрії люди)", "genre": "duma"},
-    {"genre_id": 11, "bookid": 3, "title": "Зажурилась Україна", "genre": "folk_song"},
+# Authentic-folk genre coverage on ukrlib /narod/.
+# Song genres are crawled WHOLESALE (every work listed under them is an authentic
+# folk song). Two genres need curation and are NOT crawled wholesale:
+#   • genre 11 (Народний епос) mixes in the «Велесова книга» FORGERY (bookid 0)
+#     and prose казки (bookids 11–14) → INCLUDE-list the authentic думи/пісні only.
+#   • Веснянки live under id=0, which `book.php?id=0` does NOT enumerate (id=0 is
+#     falsy server-side) → explicit allowlist (bookids verified from the /narod/ index).
+# genre_id → (label, genre_tag) for the wholesale-crawled song genres:
+NAROD_SONG_GENRES = {
+    2: ("Жниварські пісні", "harvest_song"),
+    3: ("Історичні пісні та коломийки", "historical_song"),
+    5: ("Колядки", "carol"),
+    6: ("Колядки й щедрівки", "carol"),
+}
+# Curated / non-enumerable genres: explicit (bookid, title) allowlists.
+NAROD_CURATED = [
+    {"genre_id": 0, "label": "Веснянки", "genre_tag": "spring_song", "works": [
+        (0, "Ой весна, весна, ти красна"),
+        (1, "Веснянки"),
+        (2, "Ой виорю я нивку широкую"),
+    ]},
+    {"genre_id": 11, "label": "Народний епос", "genre_tag": "duma", "works": [
+        (1, "Втеча трьох братів з Азова"),
+        (2, "Дума про Олексія Поповича (Гей, не дивуйте, добрії люди)"),
+        (3, "Зажурилась Україна"),
+        (4, "Максим козак Залізняк"),
+        (5, "Ой на горі да женці жнуть"),
+    ]},
 ]
+# Per-work hard exclusions (genre_id, bookid) — belt-and-braces against any
+# forgery/prose that a future listing change could surface in a song genre.
+NAROD_EXCLUDE = {(11, 0), (11, 11), (11, 12), (11, 13), (11, 14)}
+
+
+def _discover_narod_bookids(genre_id: int) -> list[tuple[int, str]]:
+    """Crawl `/narod/book.php?id=N` → sorted [(bookid, title), …] for every work.
+
+    Handles both single- and double-quoted `href` (ukrlib mixes the two).
+    """
+    html = fetch_page(f"{BASE_URL}/narod/book.php?id={genre_id}")
+    rx = re.compile(rf"printout\.php\?id={genre_id}&bookid=(\d+)['\"]>([^<]+)<")
+    seen: dict[int, str] = {}
+    for bid_s, title in rx.findall(html):
+        bid = int(bid_s)
+        seen.setdefault(bid, title.strip())
+    return sorted(seen.items())
+
+
+def _build_narod_worklist() -> list[dict]:
+    """Assemble the full folk worklist: song genres crawled + curated allowlists."""
+    works: list[dict] = []
+    for gid, (label, tag) in NAROD_SONG_GENRES.items():
+        for bid, title in _discover_narod_bookids(gid):
+            if (gid, bid) in NAROD_EXCLUDE:
+                continue
+            works.append({"genre_id": gid, "bookid": bid, "title": title,
+                          "genre": tag, "genre_label": label})
+    for cfg in NAROD_CURATED:
+        for bid, title in cfg["works"]:
+            if (cfg["genre_id"], bid) in NAROD_EXCLUDE:
+                continue
+            works.append({"genre_id": cfg["genre_id"], "bookid": bid, "title": title,
+                          "genre": cfg["genre_tag"], "genre_label": cfg["label"]})
+    return works
 
 
 def scrape_narod_work(genre_id: int, bookid: int) -> tuple[str, str]:
@@ -1113,24 +1170,29 @@ def scrape_narod_work(genre_id: int, bookid: int) -> tuple[str, str]:
 
 
 def scrape_narod(dry_run: bool = False) -> int:
-    """Scrape the curated народна творчість allowlist into one JSONL.
+    """Scrape the full ukrlib /narod/ folk worklist into one JSONL.
 
-    Idempotent: rewrites ukrlib-narod-dumy.jsonl each run. Folk songs are short,
-    so chunk with a low min_tokens floor so short texts aren't dropped.
+    Song genres are crawled wholesale; Народний епос and веснянки use curated
+    allowlists (forgery/prose-safe). Idempotent: rewrites ukrlib-narod-dumy.jsonl
+    each run. Folk songs are short, so chunk with a low min_tokens floor so short
+    texts aren't dropped; any work whose printout page is empty (<50 chars) is
+    skipped so a stale curated bookid silently drops out.
     """
     output_path = LITERARY_DIR / "ukrlib-narod-dumy.jsonl"
-    print(f"\n{'='*60}\n[narod] {NAROD_AUTHOR} — {len(NAROD_WORKS)} works\n{'='*60}")
+    worklist = _build_narod_worklist()
+    n = len(worklist)
+    print(f"\n{'='*60}\n[narod] {NAROD_AUTHOR} — {n} works\n{'='*60}")
 
     if dry_run:
-        for w in NAROD_WORKS:
-            print(f"    genre={w['genre_id']} bookid={w['bookid']}  {w['title']}")
+        for w in worklist:
+            print(f"    genre={w['genre_id']:>2} bookid={w['bookid']:>3}  [{w['genre']:<15}]  {w['title']}")
         return 0
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     total_chunks = 0
     with open(output_path, "w", encoding="utf-8") as f:
-        for i, w in enumerate(NAROD_WORKS, 1):
-            print(f"\n  [{i}/{len(NAROD_WORKS)}] {w['title']} (genre={w['genre_id']}, bookid={w['bookid']})")
+        for i, w in enumerate(worklist, 1):
+            print(f"\n  [{i}/{n}] {w['title']} (genre={w['genre_id']}, bookid={w['bookid']})")
             try:
                 text, source_url = scrape_narod_work(w["genre_id"], w["bookid"])
             except Exception as e:
@@ -1150,12 +1212,12 @@ def scrape_narod(dry_run: bool = False) -> int:
                     "language_period": NAROD_PERIOD,
                 })
                 f.write(json.dumps(chunk, ensure_ascii=False) + "\n")
-            print(f"    {len(text):,} chars → {len(chunks)} chunks")
+            print(f"    {len(text):,} chars → {len(chunks)} chunks  [{w['genre']}]")
             total_chunks += len(chunks)
-            if i < len(NAROD_WORKS):
+            if i < n:
                 time.sleep(DELAY_BETWEEN_WORKS)
 
-    print(f"\n  [narod] {total_chunks} chunks → {output_path.name}")
+    print(f"\n  [narod] {total_chunks} chunks from {n} works → {output_path.name}")
     return total_chunks
 
 

--- a/tests/test_rag_ingestion.py
+++ b/tests/test_rag_ingestion.py
@@ -378,3 +378,48 @@ class TestParseFmuItunes:
         assert len(result) == 1
         assert result[0]["episode"] == 15
         assert result[0]["series"] == "FMU"
+
+
+# ── scrape_ukrlib: narod folk worklist (forgery/prose exclusion) ──
+
+class TestNarodWorklist:
+    """The /narod/ folk worklist crawls song genres wholesale but must NEVER
+    surface the «Велесова книга» forgery or the prose казки misfiled under
+    Народний епос (genre 11)."""
+
+    def test_build_excludes_forgery_and_prose_includes_curated(self, monkeypatch):
+        import scrape_ukrlib as su
+
+        # Stub the live crawl so the test is network-free. Song genres only.
+        fake = {
+            2: [(0, "Жали женчики жали")],
+            3: [(5, "Пісня про Байду")],
+            5: [(2, "Як ще не було початку світа")],
+            6: [(3, "Щедрик щедрик щедрівочка")],
+        }
+        monkeypatch.setattr(su, "_discover_narod_bookids", lambda gid: fake.get(gid, []))
+        works = su._build_narod_worklist()
+        pairs = {(w["genre_id"], w["bookid"]) for w in works}
+
+        # Song genres crawled wholesale
+        assert (2, 0) in pairs and (6, 3) in pairs
+        # Curated genres (веснянки id=0 non-enumerable + epos думи) included
+        assert (0, 0) in pairs        # Ой весна, весна (веснянка)
+        assert (11, 1) in pairs       # Втеча трьох братів — authentic duma
+        # Forgery + prose казки are NEVER included (not in the curated epos list)
+        assert (11, 0) not in pairs   # «Велесова книга» forgery
+        assert (11, 14) not in pairs  # «Летючий корабель» prose казка
+        # Per-genre tags assigned
+        tags = {w["genre"] for w in works}
+        assert {"carol", "duma", "spring_song", "harvest_song", "historical_song"} <= tags
+
+    def test_exclude_set_blocks_a_song_genre_listing(self, monkeypatch):
+        import scrape_ukrlib as su
+
+        # If a bad bookid ever appears in a song-genre listing, NAROD_EXCLUDE blocks it.
+        monkeypatch.setattr(su, "_discover_narod_bookids",
+                            lambda gid: [(0, "good"), (99, "bad")] if gid == 2 else [])
+        monkeypatch.setattr(su, "NAROD_EXCLUDE", {(2, 99)})
+        pairs = {(w["genre_id"], w["bookid"]) for w in su._build_narod_worklist()}
+        assert (2, 0) in pairs
+        assert (2, 99) not in pairs


### PR DESCRIPTION
## Why
Corpus audit (PR #3174) found **folk genre primaries are essentially absent** from `literary_texts` (~8 `narod` chunks; `Щедрик щедрик щедрівочка` → **0** corpus hits). The `--narod` scraper only covered a **4-work hand-curated allowlist**. That's the concrete blocker for **#3162** (embed primary texts in folk modules) — we can't embed folk primaries we don't hold.

## What
Expands `scrape_ukrlib.py --narod` from 4 works to a **full authentic-folk genre crawl (29 works)**:
- **Song genres crawled wholesale** (every listed work is an authentic folk song): жниварські (id 2), історичні пісні/коломийки (id 3), колядки (id 5), колядки й щедрівки (id 6).
- **Народний епос (id 11): INCLUDE-list the authentic думи/пісні only** (bookids 1–5) — excludes the **«Велесова книга» forgery** (bookid 0) and the **prose казки** misfiled there (Іван-мужичий-син, Допомога Довбуша, Іван Голик, Летючий корабель — bookids 11–14).
- **Веснянки (id 0)**: `book.php?id=0` doesn't enumerate (id=0 falsy server-side) → explicit verified bookid allowlist.
- **`NAROD_EXCLUDE`**: belt-and-braces hard-exclusion against any forgery/prose surfacing in a song genre later.
- Quote-agnostic listing parser (ukrlib mixes single/double-quoted `href`).

## Verified
- **Dry-run** (`--narod --dry-run`, live crawl): **29 works**, forgery + 4 prose казки correctly excluded; per-genre tags (carol/duma/spring_song/harvest_song/historical_song).
- **+2 network-free unit tests** (monkeypatched crawl) — forgery/prose exclusion + curated inclusion. `pytest` green (54 in file), `ruff` clean.

## Run (after merge / from this branch)
```bash
# 1. scrape the full folk worklist (~1–2 min) → data/literary_texts/ukrlib-narod-dumy.jsonl
.venv/bin/python scripts/rag/scrape_ukrlib.py --narod

# 2. (safety) preview the sources.db rebuild plan — confirm it still sees all existing content
.venv/bin/python scripts/wiki/build_sources_db.py --dry-run

# 3. rebuild sqlite sources.db (literary_texts + FTS that search_literary/verify_quote read)
.venv/bin/python scripts/wiki/build_sources_db.py --force

# 4. (optional) Qdrant vectors — resumable via the .npz embed cache
.venv/bin/python scripts/rag/ingest.py --literary data/literary_texts/ukrlib-narod-dumy.jsonl
```

## Boundaries
Corpus/infra change made under direct user request. Opened, NOT self-merged. After ingest, `search_literary "Щедрик щедрик щедрівочка"` / `verify_quote` should resolve folk primaries → #3162 folk embedding unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)