### PR TITLE
B1 landing: unlock M14-M20

### DIFF
--- a/site/src/content/docs/b1/index.mdx
+++ b/site/src/content/docs/b1/index.mdx
@@ -10,9 +10,9 @@ import LevelLanding from '@site/src/components/LevelLanding';
   client:load
   level="B1"
   title="Крок вперед"
-  subtitle="Intermediate Ukrainian course — 13 learner pages available · 94 modules"
+  subtitle="Intermediate Ukrainian course — 20 learner pages available · 94 modules"
   progressTitle="B1 Build Status"
-  progressDescription="13 available · 0 reviewed · 81 planned"
+  progressDescription="20 available · 0 reviewed · 74 planned"
   moduleCount={94}
   wordTarget={4000}
   color="var(--lu-id-b1)"
@@ -38,13 +38,13 @@ import LevelLanding from '@site/src/components/LevelLanding';
         { num: 11, slug: "alternation-vowels", title: "Чергування голосних", sub: "Коли о та е стають і — і коли зникають зовсім", status: "active" },
         { num: 12, slug: "alternation-consonants-nouns", title: "Чергування приголосних (іменники)", sub: "Друг — друже — друзі: як змінюються приголосні в іменниках", status: "active" },
         { num: 13, slug: "alternation-consonants-verbs", title: "Чергування приголосних (дієслова)", sub: "Сидіти — сиджу, плакати — плачу: приголосні в дієсловах", status: "active" },
-        { num: 14, slug: "health-at-the-doctor", title: "Здоров'я і медицина", sub: "У лікаря — від скарг до рецепта", status: "locked" },
-        { num: 15, slug: "simplification-consonants", title: "Спрощення приголосних", sub: "Щастя — щасливий: коли приголосний випадає", status: "locked" },
-        { num: 16, slug: "noun-subclasses-masculine", title: "Іменники на -ар, -яр, -ин", sub: "Пекар, школяр, киянин — хто вони і як їх відмінювати", status: "locked" },
-        { num: 17, slug: "noun-subclasses-hissing", title: "Іменники на ж, ч, ш, щ", sub: "Мішана група II відміни — від сторожа до товариша", status: "locked" },
-        { num: 18, slug: "restaurant-and-food", title: "Ресторан і їжа", sub: "Українська кухня, замовлення у ресторані та відмінювання іменників у контексті їжі", status: "locked" },
-        { num: 19, slug: "noun-subclasses-feminine", title: "Жіночий рід (нульове закінчення)", sub: "III відміна — від любові до подорожі", status: "locked" },
-        { num: 20, slug: "pluralia-tantum", title: "Іменники у множині", sub: "Двері, окуляри, Карпати — слова без однини", status: "locked" },
+        { num: 14, slug: "health-at-the-doctor", title: "Здоров'я і медицина", sub: "У лікаря — від скарг до рецепта", status: "active" },
+        { num: 15, slug: "simplification-consonants", title: "Спрощення приголосних", sub: "Щастя — щасливий: коли приголосний випадає", status: "active" },
+        { num: 16, slug: "noun-subclasses-masculine", title: "Іменники на -ар, -яр, -ин", sub: "Пекар, школяр, киянин — хто вони і як їх відмінювати", status: "active" },
+        { num: 17, slug: "noun-subclasses-hissing", title: "Іменники на ж, ч, ш, щ", sub: "Мішана група II відміни — від сторожа до товариша", status: "active" },
+        { num: 18, slug: "restaurant-and-food", title: "Ресторан і їжа", sub: "Українська кухня, замовлення у ресторані та відмінювання іменників у контексті їжі", status: "active" },
+        { num: 19, slug: "noun-subclasses-feminine", title: "Жіночий рід (нульове закінчення)", sub: "III відміна — від любові до подорожі", status: "active" },
+        { num: 20, slug: "pluralia-tantum", title: "Іменники у множині", sub: "Двері, окуляри, Карпати — слова без однини", status: "active" },
         { num: 21, slug: "checkpoint-morphophonemics", title: "Контрольна робота 1", sub: "Базовий рівень та морфонеміка — перевірка модулі №1–12", status: "locked" },
       ]
     },


### PR DESCRIPTION
## Summary
- update B1 landing availability counts from 13 to 20
- mark B1 M14-M20 active so live users can access the merged modules
- leave M21 onward locked

## Validation
- MDX validator passed for B1 index
- git diff --check passed
- site build passed with /b1/ route generated

## Review
- Independent review pending

X-Agent: codex/b1-m14-m20-live-landing