### PR TITLE
docs(codex): persist prompt pack quality rule

### DIFF
--- a/agents_extensions/codex/memory/MEMORY.md
+++ b/agents_extensions/codex/memory/MEMORY.md
@@ -1,3 +1,5 @@
 # Codex Memory
 
 - **ORCHESTRATOR HYGIENE:** Resolve dirty orchestration files before feature work; delete/avoid `docs/session-state/current.md`; use Codex thread-management tools for context-threshold continuation instead of asking the user to move threads manually.
+
+- **PROMPT PACKS MUST BE FULL COPY-PASTE ARTIFACTS (2026-06-15):** When the user asks for prompts for worker/new threads, provide full standalone prompts only: one complete block per target thread. Do not answer with fragments, "add this block", shared preambles plus deltas, or advice unless the user explicitly asks for a patch. Each prompt must include task, branch/worktree, mandatory reads, swarm/subagent instructions when expected, expected files, validation, review gate, telemetry, PR behavior, parallel-safety notes, and merge/integration ordering. Before sending, QA repo name, slug, module number, branch/worktree, route, X-Agent trailer, and typos. If swarms are expected, include full swarm instructions inline and mark telemetry guidance `swarm_used: true`.


### PR DESCRIPTION
## Summary
- Persist Codex prompt-pack quality memory in `agents_extensions/codex/memory/MEMORY.md`
- Require future worker/new-thread prompts to be full standalone copy-paste artifacts with inline swarm, telemetry, validation, review, PR, and merge-ordering instructions

## Validation
- `npm run agents:deploy -- --dry-run` passed prompt lint and agent-skill lint after using a local ignored `.venv` symlink in the dispatch worktree
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Independent review: AGY Gemini 3.1 Pro High returned `PASS`

## Notes
- The tracked source of truth is `agents_extensions/`; runtime `.agent`/`.codex` dirs are deployment targets and are not committed.
- Drift check found `.codex/settings.json` and `.codex/settings.local.json` already match `agents_extensions/shared/`, and `.codex/memory/MEMORY.md` matched the tracked Codex memory before this branch.