### PR TITLE
fix(lexicon): filter Вікісловник antonym noise — per-lemma sense/pedagogy gate (#3197)

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -301,6 +301,66 @@ _WRONG_SENSE_SYNONYMS: dict[str, frozenset[str]] = {
     "річка": frozenset({"звір"}),
 }
 
+# #3197 — Вікісловник's explicit antonym column carries pedagogical noise the POS
+# gate alone can't catch: alphabet meta-pairs (а→зет), co-hyponyms / paradigm
+# members dressed as opposites (дочка→матка, він→ми), wrong-sense opposites
+# (газ→гальмо, ім'я→неслава) and Russian contamination (не→да). Mirror the #3168
+# _WRONG_SENSE_SYNONYMS lesson: curated per-lemma filter, NEVER a global stoplist.
+# Two layers, both verified via the sources MCP (СУМ-11 / VESUM / russian_shadow):
+#   _DROP_ANTONYM_LEMMAS — lemmas whose ENTIRE antonym set is noise:
+#     а→зет (letter-name sequence); брат (no lexical antonym — сестра is the
+#     gendered pair, not an opposite); він→ми (pronoun paradigm, not opposition —
+#     the contrast is вона); газ→гальмо (holds only for the accelerator-pedal
+#     sense, misleading for газ="gas"); мавпа (no opposite — оригінал/красуня are
+#     folk-insult noise); не→да (да: check_russian_shadow matches_russian=1.0 and
+#     absent from VESUM → Russian); так ("не так" are negations, the real opposite
+#     ні is absent); четвер (a weekday has no opposite — "день тижня" is a
+#     hypernym); ім'я→неслава (wrong-sense: ім'я="name", not "good repute"); шлях
+#     (same family as #3168 — стежка is a co-hyponym; obstacle terms aren't
+#     opposites of a path).
+#   _WRONG_ANTONYMS — per-lemma term drops where SOME opposites survive:
+#     дочка: keep син; drop the мати-variants + матка (СУМ-11 "плідна самиця" /
+#       uterus / queen bee, not a daughter-opposite) + батько/падчірка (relatives);
+#     друг: keep ворог/недруг; drop екс (slang) + нелюб (archaic, off-sense);
+#     село: keep місто; drop міщанство/град + город (СУМ-11 modern sense =
+#       kitchen-garden, NOT city — false friend with Russian город);
+#     тло: keep фігура (figure↔ground); drop сильвета/сильветка (silhouette).
+_DROP_ANTONYM_LEMMAS: frozenset[str] = frozenset(
+    {
+        "а",
+        "брат",
+        "він",
+        "газ",
+        "мавпа",
+        "не",
+        "так",
+        "четвер",
+        "ім'я",
+        "шлях",
+    }
+)
+
+_WRONG_ANTONYMS: dict[str, frozenset[str]] = {
+    "дочка": frozenset(
+        {
+            "мати",
+            "батько",
+            "падчірка",
+            "матка",
+            "матінка",
+            "мама",
+            "матір",
+            "матірка",
+            "матуся",
+            "матіночка",
+            "матусенька",
+        }
+    ),
+    "друг": frozenset({"екс", "нелюб"}),
+    "село": frozenset({"міщанство", "град", "город"}),
+    "тло": frozenset({"сильвета", "сильветка"}),
+}
+
 _COMPOSITIONAL_ETYMOLOGY_EXCLUSIONS = {
     "а тебе?",
     "а у тебе?",
@@ -1229,6 +1289,12 @@ def _antonyms_wiktionary(
     if not _wiktionary_has_antonyms_column(conn):
         return None
 
+    # #3197 — per-lemma pedagogy filter over the raw Вікісловник antonym column.
+    base_key = _base_lemma(lemma).casefold().replace("’", "'").replace("ʼ", "'").replace("`", "'")
+    if base_key in _DROP_ANTONYM_LEMMAS:
+        return None
+    wrong_terms = _WRONG_ANTONYMS.get(base_key)
+
     items: list[str] = []
     seen: set[str] = set()
     try:
@@ -1247,7 +1313,13 @@ def _antonyms_wiktionary(
                 continue
             for candidate in candidates:
                 term = _clean_atlas_chip_candidate(str(candidate), lemma)
-                if term and term not in seen and _candidate_matches_entry_pos(term, entry_pos):
+                if not term or term in seen:
+                    continue
+                if wrong_terms:
+                    normalized = term.replace("’", "'").replace("ʼ", "'").replace("`", "'")
+                    if normalized in wrong_terms:
+                        continue
+                if _candidate_matches_entry_pos(term, entry_pos):
                     seen.add(term)
                     items.append(term)
             if items:

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -5,6 +5,8 @@ import pytest
 
 from scripts.lexicon import enrich_manifest as enrich_manifest_module
 from scripts.lexicon.enrich_manifest import (
+    _DROP_ANTONYM_LEMMAS,
+    _WRONG_ANTONYMS,
     _WRONG_SENSE_SYNONYMS,
     KAIKKI_SOURCE,
     _antonyms_wiktionary,
@@ -678,6 +680,67 @@ def test_wiktionary_antonyms_use_explicit_antonym_column(monkeypatch) -> None:
         "source": "Вікісловник: explicit antonym list",
         "source_urls": ["https://uk.wiktionary.org/wiki/%D0%BD%D1%96%D1%87"],
     }
+
+
+def test_wiktionary_antonyms_drop_noise_only_lemma_returns_none(monkeypatch) -> None:
+    # #3197 — lemmas whose ENTIRE Вікісловник antonym set is noise yield no section:
+    # а→зет (alphabet), брат→ворог (no lexical antonym), не→да (Russian).
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """
+        CREATE TABLE wiktionary (
+            word TEXT NOT NULL,
+            antonyms TEXT DEFAULT ''
+        )
+        """
+    )
+    conn.executemany(
+        "INSERT INTO wiktionary (word, antonyms) VALUES (?, ?)",
+        [
+            ("а", json.dumps(["зет"], ensure_ascii=False)),
+            ("брат", json.dumps(["ворог"], ensure_ascii=False)),
+            ("не", json.dumps(["да"], ensure_ascii=False)),
+        ],
+    )
+    _patch_vesum_analyses(monkeypatch, {"зет": "noun", "ворог": "noun", "да": "noun"})
+
+    assert _antonyms_wiktionary(conn, "а", entry_pos="noun") is None
+    assert _antonyms_wiktionary(conn, "брат", entry_pos="noun") is None
+    assert _antonyms_wiktionary(conn, "не", entry_pos="part") is None
+
+
+def test_wiktionary_antonyms_filter_wrong_terms_keep_valid(monkeypatch) -> None:
+    # #3197 — дочка keeps the real opposite (син) and drops the co-hyponym noise
+    # (мати-variants + матка = uterus/queen bee, СУМ-11), not a global stoplist.
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """
+        CREATE TABLE wiktionary (
+            word TEXT NOT NULL,
+            antonyms TEXT DEFAULT ''
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO wiktionary (word, antonyms) VALUES (?, ?)",
+        ("дочка", json.dumps(["син", "мати", "матка", "матуся"], ensure_ascii=False)),
+    )
+    _patch_vesum_analyses(
+        monkeypatch,
+        {"син": "noun", "мати": "noun", "матка": "noun", "матуся": "noun"},
+    )
+
+    section = _antonyms_wiktionary(conn, "дочка", entry_pos="noun")
+
+    assert section is not None
+    assert section["items"] == ["син"]
+
+
+def test_antonym_filters_are_curated_per_lemma_and_disjoint() -> None:
+    # #3197 — a lemma is either whole-dropped OR per-term-filtered, never both;
+    # and every per-term filter retains at least one intended valid opposite.
+    assert not (_DROP_ANTONYM_LEMMAS & set(_WRONG_ANTONYMS))
+    assert all(terms for terms in _WRONG_ANTONYMS.values())
 
 
 def test_frazeolohichnyi_idioms_keep_phrase_hits_and_drop_definition_noise(monkeypatch) -> None:


### PR DESCRIPTION
Closes #3197.

## Problem
The raw Вікісловник `antonyms` column (surfaced by `_antonyms_wiktionary`) carries pedagogical noise the POS gate alone can't catch:
- **alphabet meta-pairs** — `а→зет`
- **co-hyponyms / paradigm members dressed as opposites** — `дочка→матка`, `він→ми`
- **wrong-sense opposites** — `газ→гальмо`, `ім'я→неслава`
- **Russian contamination** — `не→да`

## Fix (mirrors the #3168 `_WRONG_SENSE_SYNONYMS` lesson — curated per-lemma, never a global stoplist)
- `_DROP_ANTONYM_LEMMAS` (10): lemmas whose **entire** antonym set is noise (`а`, `брат`, `він`, `газ`, `мавпа`, `не`, `так`, `четвер`, `ім'я`, `шлях`).
- `_WRONG_ANTONYMS` (4): per-term drops that **keep the valid opposite** — `дочка→[син]`, `село→[місто]`, `друг→[ворог, недруг]`, `тло→[фігура]`.

## Verification (real `sources.db`, not just fixtures)
| group | result |
|---|---|
| drop-set (10) | all → `None` (incl. `ім'я` apostrophe match) |
| per-term (4) | `дочка→[син]`, `село→[місто]`, `друг→[ворог,недруг]`, `тло→[фігура]` |
| controls | `ніч→[день]`, `день→[ніч]`, `високий→[низький]`, `багато→[мало]` — unchanged |

Contestable claims tool-grounded via sources MCP: `да` → `check_russian_shadow` `matches_russian=1.0` + absent from VESUM; `город` → СУМ-11 modern sense = kitchen-garden (false friend with RU город); `матка` → СУМ-11 "плідна самиця"/uterus/queen bee.

Tests: 3 new in `test_lexicon_enrich_manifest.py` (drop-set → None; per-term keep-valid; curated-disjoint invariant). Full suite 61 passed; ruff clean.

**Code-only — `lexicon-manifest.json` NOT committed.** Orchestrator regenerates the manifest post-merge (`make atlas` / `enrich_manifest` + `verify_manifest`), per the Atlas dispatch discipline.