### PR TITLE
fix(atlas): §8 lemma_in_vesum false-positives on capitalized + heritage lemmas

### DIFF
--- a/scripts/audit/validate_atlas_conformance.py
+++ b/scripts/audit/validate_atlas_conformance.py
@@ -180,12 +180,24 @@ def _normalize_text(value: object) -> str:
     return re.sub(r"\s+", " ", cleaned).strip()
 
 
+def _normalize_preserve_case(value: object) -> str:
+    """Same normalization as ``_normalize_text`` but WITHOUT casefolding.
+
+    VESUM stores proper nouns and abbreviations in their canonical capitalized form
+    (``Афіни``, ``Чернівці``, ``УЗД``). Casefolding the query before the exact-match
+    SELECT misses them — SQLite's NOCASE collation folds only ASCII, not Cyrillic —
+    so the lookup must also probe the case-preserved form (#3197 follow-up).
+    """
+    cleaned = unicodedata.normalize("NFKC", str(value or "")).translate(APOSTROPHE_TRANSLATION)
+    cleaned = _strip_stress(cleaned)
+    return re.sub(r"\s+", " ", cleaned).strip()
+
+
 def _lookup_variants(lemma: str) -> list[str]:
-    normalized = _normalize_text(lemma)
-    variants = {normalized}
-    if "'" in normalized:
+    variants = {_normalize_text(lemma), _normalize_preserve_case(lemma)}
+    for base in {variant for variant in variants if "'" in variant}:
         for replacement in ("'", "’", "ʼ"):
-            variants.add(normalized.replace("'", replacement))
+            variants.add(base.replace("'", replacement))
     return sorted(variant for variant in variants if variant)
 
 
@@ -215,8 +227,27 @@ def _is_genuine_multi_word(value: str) -> bool:
     return len(WORD_TOKEN_RE.findall(value)) >= 2
 
 
+# VESUM (409K lemmas) is necessary-but-not-sufficient proof of validity: it has
+# gaps where authentic Ukrainian words attested in Грінченко / ЕСУМ / СУМ-20 are
+# absent from its lemma+word-form tables. The §8 lemma_in_vesum gate must NOT flag
+# these as violations — absence from VESUM ≠ Russianism (the кобета / блискучий
+# heritage-defense lesson). Keep this allowlist TINY and per-entry cited; a
+# sources.db heritage-fallback (live Грінченко/ЕСУМ query) is the future robust fix.
+_VESUM_GAP_HERITAGE_LEMMAS: frozenset[str] = frozenset(
+    {
+        # Грінченко 1907: «Хвастливий, -а, -е. = хвастовитий» (Фр. Пр. 92); ЕСУМ:
+        # псл. *хвастати (Proto-Slavic); СУМ-20: «те саме, що хвалькуватий». Not in
+        # VESUM, but pre-Soviet + etymologically attested → authentic, keep.
+        "хвастливий",
+    }
+)
+
+
 def _is_proper_noun_entry(entry: Mapping[str, Any]) -> bool:
-    return _normalize_text(entry.get("pos")).replace("_", " ") in {"proper noun", "proper name"}
+    # Real pos tags carry a morphology suffix (e.g. ``proper noun:pl`` for Афіни /
+    # Чернівці); match on the base pos so the exemption is not defeated by it.
+    base_pos = _normalize_text(entry.get("pos")).replace("_", " ").split(":", 1)[0].strip()
+    return base_pos in {"proper noun", "proper name"}
 
 
 def _check_lemma_in_vesum(entry: Mapping[str, Any], lemma: str, vesum: Any, violations: list[Violation]) -> None:
@@ -225,7 +256,11 @@ def _check_lemma_in_vesum(entry: Mapping[str, Any], lemma: str, vesum: Any, viol
         violations.append(Violation("lemma_in_vesum", "", "entry is missing lemma"))
         return
 
-    if _is_deliberate_warning_entry(entry) or _is_proper_noun_entry(entry):
+    if (
+        _is_deliberate_warning_entry(entry)
+        or _is_proper_noun_entry(entry)
+        or _normalize_text(raw_lemma) in _VESUM_GAP_HERITAGE_LEMMAS
+    ):
         return
 
     if _has_whitespace(raw_lemma):

--- a/tests/test_atlas_conformance.py
+++ b/tests/test_atlas_conformance.py
@@ -84,6 +84,32 @@ def test_lemma_in_vesum_exempts_proper_nouns():
     assert _gates_for(entry, vesum=set()) == []
 
 
+def test_lemma_in_vesum_resolves_capitalized_vesum_entries():
+    # #3197 follow-up: VESUM stores proper nouns / abbreviations capitalized
+    # (Афіни, УЗД). The old casefold-only lookup queried "афіни"/"узд" and missed
+    # them; probing the case-preserved form must resolve them. pos is a common noun
+    # here so the proper-noun exemption does NOT mask the lookup path under test.
+    assert _gates_for(_entry(lemma="Афіни", url_slug="афіни", pos="noun"), vesum={"Афіни"}) == []
+    assert _gates_for(_entry(lemma="УЗД", url_slug="узд", pos="noun:n"), vesum={"УЗД"}) == []
+
+
+def test_lemma_in_vesum_exempts_proper_noun_with_morphology_suffix():
+    # #3197 follow-up: real proper-noun pos tags carry a :pl/:m suffix
+    # ("proper noun:pl" for Афіни/Чернівці); the exemption must match the base pos.
+    entry = _entry(lemma="Чернівці", url_slug="чернівці", pos="proper noun:pl")
+
+    assert _gates_for(entry, vesum=set()) == []
+
+
+def test_lemma_in_vesum_exempts_heritage_word_absent_from_vesum():
+    # #3197 follow-up: хвастливий is authentic Ukrainian (Грінченко 1907 «=
+    # хвастовитий» + ЕСУМ Proto-Slavic + СУМ-20) but absent from VESUM. VESUM
+    # membership is necessary-but-not-sufficient; the heritage allowlist exempts it.
+    entry = _entry(lemma="хвастливий", url_slug="хвастливий", pos="adjective")
+
+    assert _gates_for(entry, vesum=set()) == []
+
+
 def test_lemma_in_vesum_exempts_deliberate_warning_seed():
     entry = _entry(
         lemma="міроприємство",


### PR DESCRIPTION
## Problem
A full `make atlas` regen (to ship the #3197 antonym cleanup live + refresh stale vocab) surfaced **4 §8 conformance violations** that `verify_manifest` blocked the commit on. Investigation (tool-grounded) shows **all 4 are gate false-positives, zero content bugs**:

| lemma | reality | why the gate misfired |
|---|---|---|
| `Афіни`, `Чернівці` | in VESUM (capitalized), pos=`proper noun:pl` | casefold lookup queried `афіни`/`чернівці` (miss); proper-noun exemption didn't strip the `:pl` suffix |
| `УЗД` | in VESUM ×12 (capitalized abbreviation), pos=`noun:n` | casefold lookup queried `узд` (miss) |
| `хвастливий` | authentic Ukrainian, absent from VESUM | Грінченко 1907 «= хвастовитий» + ЕСУМ Proto-Slavic + СУМ-20 attest it; VESUM has a gap |

Root cause: the VESUM membership lookup casefolds before an exact-match SELECT, but **VESUM stores proper nouns/abbreviations capitalized** and SQLite `NOCASE` folds only ASCII, not Cyrillic. Plus the proper-noun exemption was suffix-blind, and there was no allowance for VESUM gaps (absence ≠ Russianism — the кобета/блискучий heritage-defense lesson).

## Fix
1. `_lookup_variants` probes **both** the casefolded and case-preserved form → resolves Афіни/Чернівці/УЗД.
2. `_is_proper_noun_entry` matches the **base** pos (strips `:suffix`) → exempts `proper noun:pl` (defense-in-depth).
3. `_VESUM_GAP_HERITAGE_LEMMAS`: a **tiny, per-entry-cited** allowlist for VESUM-gap-but-attested words → `хвастливий`.

Every change only **reduces** false-positives — a genuinely-absent, non-heritage word still flags.

## Verification (deterministic)
- Real regenerated manifest + real VESUM: **4 violations → 0** under the fixed gate.
- `verify_words` confirms Афіни/Чернівці/УЗД are in VESUM (capitalized); `search_heritage`/Грінченко/ЕСУМ/СУМ-20 confirm `хвастливий` authentic.
- 3 new tests lock each fix; `test_atlas_conformance` suite 24 passed; ruff clean.

## Follow-up
The robust fix for the VESUM-gap class is a **sources.db heritage-fallback** (live Грінченко/ЕСУМ query) instead of a manual allowlist — noted in code + here for a future issue.

**Unblocks** the periodic `make atlas` regen (which ships the #3197 antonym noise removal live + clears ~120K lines of accumulated vocab drift). Manifest regen-commit to main follows once this lands.