### PR TITLE
content(b1): update landing through m23

### DIFF
--- a/site/src/content/docs/b1/index.mdx
+++ b/site/src/content/docs/b1/index.mdx
@@ -10,9 +10,9 @@ import LevelLanding from '@site/src/components/LevelLanding';
   client:load
   level="B1"
   title="Крок вперед"
-  subtitle="Intermediate Ukrainian course — 20 learner pages available · 94 modules"
+  subtitle="Intermediate Ukrainian course — 23 learner pages available · 94 modules"
   progressTitle="B1 Build Status"
-  progressDescription="20 available · 0 reviewed · 74 planned"
+  progressDescription="23 available · 0 reviewed · 71 planned"
   moduleCount={94}
   wordTarget={4000}
   color="var(--lu-id-b1)"
@@ -45,14 +45,14 @@ import LevelLanding from '@site/src/components/LevelLanding';
         { num: 18, slug: "restaurant-and-food", title: "Ресторан і їжа", sub: "Українська кухня, замовлення у ресторані та відмінювання іменників у контексті їжі", status: "active" },
         { num: 19, slug: "noun-subclasses-feminine", title: "Жіночий рід (нульове закінчення)", sub: "III відміна — від любові до подорожі", status: "active" },
         { num: 20, slug: "pluralia-tantum", title: "Іменники у множині", sub: "Двері, окуляри, Карпати — слова без однини", status: "active" },
-        { num: 21, slug: "checkpoint-morphophonemics", title: "Контрольна робота 1", sub: "Базовий рівень та морфонеміка — перевірка модулі №1–12", status: "locked" },
+        { num: 21, slug: "checkpoint-morphophonemics", title: "Контрольна робота 1", sub: "Базовий рівень та морфонеміка — перевірка модулі №1–12", status: "active" },
       ]
     },
     {
       unit: "B1.2 [Verb System]",
       items: [
-        { num: 22, slug: "conditionals-real", title: "Умовний спосіб (реальний)", sub: "Якщо-речення та реальні умовні конструкції", status: "locked" },
-        { num: 23, slug: "conditionals-unreal", title: "Умовний спосіб (нереальний)", sub: "Якби-речення та контрфактичні умовні конструкції", status: "locked" },
+        { num: 22, slug: "conditionals-real", title: "Умовний спосіб (реальний)", sub: "Якщо-речення та реальні умовні конструкції", status: "active" },
+        { num: 23, slug: "conditionals-unreal", title: "Умовний спосіб (нереальний)", sub: "Якби-речення та контрфактичні умовні конструкції", status: "active" },
         { num: 24, slug: "aspect-in-conditionals", title: "Вид в умовних реченнях", sub: "Якщо зробиш проти якби робив — реальність і вид", status: "locked" },
         { num: 25, slug: "shopping-and-services", title: "Покупки і послуги", sub: "На ринку, в магазині, на пошті — порівняння і словотвір у дії", status: "locked" },
         { num: 26, slug: "imperative-nuances", title: "Наказовий спосіб (деталі)", sub: "Хай/нехай, ввічливі форми та вид дієслова в наказі", status: "locked" },


### PR DESCRIPTION
## Summary

Updates the B1 landing page after M21-M23 landed:

- marks M21 checkpoint-morphophonemics as active
- marks M22 conditionals-real as active
- marks M23 conditionals-unreal as active
- updates B1 availability counts from 20/74 to 23/71

Generated with `scripts/generate_landing_pages.py --track b1`.

## Validation

- `git diff --check`: PASS
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`: PASS
- `npm run build --prefix site -- --outDir /tmp/learn-ukrainian-b1-landing-site-dist && test -f /tmp/learn-ukrainian-b1-landing-site-dist/b1/index.html`: PASS

Note: `scripts/build/mdx_validate.py` is not applicable to LevelLanding index files; it flags JSX object literals in the existing generated landing shape as unescaped prose.
