### PR TITLE
fix(atlas): §8 lemma_in_vesum — Грінченко/ЕСУМ heritage fallback supersedes manual allowlist (#3211)

### DIFF
--- a/scripts/audit/validate_atlas_conformance.py
+++ b/scripts/audit/validate_atlas_conformance.py
@@ -29,6 +29,7 @@ import yaml
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MANIFEST = PROJECT_ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
 DEFAULT_VESUM = PROJECT_ROOT / "data" / "vesum.db"
+DEFAULT_SOURCES_DB = PROJECT_ROOT / "data" / "sources.db"
 DEFAULT_CURRICULUM = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "curriculum.yaml"
 KAIKKI_SOURCE = "kaikki/Wiktionary (CC BY-SA 3.0)"
 
@@ -123,11 +124,71 @@ class VesumLemmaLookup:
         )
 
 
-def validate(manifest: Any, *, vesum: Any, curriculum: Any) -> list[Violation]:
+class HeritageLemmaLookup:
+    """Грінченко + ЕСУМ attestation check for words absent from VESUM (#3211).
+
+    VESUM has coverage gaps; a single-dictionary miss is necessary-but-not-sufficient
+    proof of invalidity. A pre-Soviet Грінченко headword (exact word match) or an ЕСУМ
+    etymological lemma is strong evidence the word is authentic Ukrainian — absence from
+    VESUM ≠ Russianism (the кобета / блискучий / хвастливий heritage-defense lesson).
+    This supersedes the manual ``_VESUM_GAP_HERITAGE_LEMMAS`` allowlist where the
+    1.6 GB gitignored ``data/sources.db`` is present; the allowlist remains the offline
+    fallback (e.g. CI, which already skips the membership gate entirely without VESUM).
+    """
+
+    def __init__(self, db_path: Path = DEFAULT_SOURCES_DB):
+        self.db_path = Path(db_path)
+        self._conn: sqlite3.Connection | None = None
+        self._cache: dict[str, bool] = {}
+
+    def __enter__(self) -> HeritageLemmaLookup:
+        self.open()
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        self.close()
+
+    def open(self) -> None:
+        if self._conn is None:
+            if not self.db_path.exists():
+                raise FileNotFoundError(f"sources database not found: {self.db_path}")
+            self._conn = sqlite3.connect(f"file:{self.db_path}?mode=ro", uri=True)
+
+    def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+    def has_attestation(self, lemma: str) -> bool:
+        for variant in _lookup_variants(lemma):
+            if variant not in self._cache:
+                self._cache[variant] = self._query_variant(variant)
+            if self._cache[variant]:
+                return True
+        return False
+
+    def _query_variant(self, value: str) -> bool:
+        self.open()
+        assert self._conn is not None
+        # Грінченко: pre-Soviet headword (exact, lowercase-stored) — primary signal.
+        if self._conn.execute("SELECT 1 FROM grinchenko WHERE word = ? LIMIT 1", (value,)).fetchone():
+            return True
+        # ЕСУМ: etymological lemma (root-based, narrower) — secondary signal.
+        return bool(
+            self._conn.execute(
+                "SELECT 1 FROM esum_etymology WHERE lemma = ? LIMIT 1",
+                (value,),
+            ).fetchone()
+        )
+
+
+def validate(manifest: Any, *, vesum: Any, curriculum: Any, heritage: Any = None) -> list[Violation]:
     """Validate a Word Atlas manifest against deterministic section 8 gates."""
 
     lookup = _coerce_vesum_lookup(vesum)
     should_close_lookup = isinstance(lookup, VesumLemmaLookup) and lookup is not vesum
+    heritage_lookup = _coerce_heritage_lookup(heritage)
+    should_close_heritage = isinstance(heritage_lookup, HeritageLemmaLookup) and heritage_lookup is not heritage
     curriculum_modules = _curriculum_modules(curriculum)
     violations: list[Violation] = []
 
@@ -144,7 +205,7 @@ def validate(manifest: Any, *, vesum: Any, curriculum: Any) -> list[Violation]:
                 continue
 
             lemma = str(entry.get("lemma") or "").strip()
-            _check_lemma_in_vesum(entry, lemma, lookup, violations)
+            _check_lemma_in_vesum(entry, lemma, lookup, violations, heritage=heritage_lookup)
             _check_provenance(entry, lemma, violations)
             _check_empty_sections(entry, lemma, violations)
             _check_heritage_evidence(entry, lemma, violations)
@@ -156,6 +217,8 @@ def validate(manifest: Any, *, vesum: Any, curriculum: Any) -> list[Violation]:
     finally:
         if should_close_lookup:
             lookup.close()
+        if should_close_heritage:
+            heritage_lookup.close()
 
     return violations
 
@@ -166,6 +229,14 @@ def _coerce_vesum_lookup(vesum: Any) -> Any:
         lookup.open()
         return lookup
     return vesum
+
+
+def _coerce_heritage_lookup(heritage: Any) -> Any:
+    if isinstance(heritage, str | Path):
+        lookup = HeritageLemmaLookup(Path(heritage))
+        lookup.open()
+        return lookup
+    return heritage
 
 
 def _strip_stress(text: str) -> str:
@@ -227,12 +298,13 @@ def _is_genuine_multi_word(value: str) -> bool:
     return len(WORD_TOKEN_RE.findall(value)) >= 2
 
 
-# VESUM (409K lemmas) is necessary-but-not-sufficient proof of validity: it has
-# gaps where authentic Ukrainian words attested in Грінченко / ЕСУМ / СУМ-20 are
-# absent from its lemma+word-form tables. The §8 lemma_in_vesum gate must NOT flag
-# these as violations — absence from VESUM ≠ Russianism (the кобета / блискучий
-# heritage-defense lesson). Keep this allowlist TINY and per-entry cited; a
-# sources.db heritage-fallback (live Грінченко/ЕСУМ query) is the future robust fix.
+# OFFLINE FALLBACK for the VESUM-gap class (#3211): the primary mechanism is now the
+# live ``HeritageLemmaLookup`` (Грінченко/ЕСУМ via sources.db), which self-heals on any
+# VESUM-gap-but-attested word. This curated allowlist is consulted ONLY when the heritage
+# corpus is unavailable (no sources.db). VESUM membership is necessary-but-not-sufficient
+# proof of validity — absence ≠ Russianism (кобета / блискучий / хвастливий heritage-
+# defense). Keep TINY and per-entry cited; it should shrink toward empty as the heritage
+# lookup covers these cases wherever sources.db is present (local dev + the validator CLI).
 _VESUM_GAP_HERITAGE_LEMMAS: frozenset[str] = frozenset(
     {
         # Грінченко 1907: «Хвастливий, -а, -е. = хвастовитий» (Фр. Пр. 92); ЕСУМ:
@@ -250,17 +322,35 @@ def _is_proper_noun_entry(entry: Mapping[str, Any]) -> bool:
     return base_pos in {"proper noun", "proper name"}
 
 
-def _check_lemma_in_vesum(entry: Mapping[str, Any], lemma: str, vesum: Any, violations: list[Violation]) -> None:
+def _heritage_attests(heritage: Any, lemma: str) -> bool:
+    """True if ``lemma`` is attested in the heritage corpus (Грінченко/ЕСУМ).
+
+    Accepts a ``HeritageLemmaLookup``, a callable, or a set/collection of attested
+    forms (the last for tests). Returns False when no heritage source is wired.
+    """
+    if heritage is None:
+        return False
+    if hasattr(heritage, "has_attestation"):
+        return bool(heritage.has_attestation(lemma))
+    if callable(heritage):
+        return bool(heritage(lemma))
+    return any(variant in heritage for variant in _lookup_variants(lemma))
+
+
+def _check_lemma_in_vesum(
+    entry: Mapping[str, Any],
+    lemma: str,
+    vesum: Any,
+    violations: list[Violation],
+    *,
+    heritage: Any = None,
+) -> None:
     raw_lemma = str(entry.get("lemma") or "")
     if not lemma:
         violations.append(Violation("lemma_in_vesum", "", "entry is missing lemma"))
         return
 
-    if (
-        _is_deliberate_warning_entry(entry)
-        or _is_proper_noun_entry(entry)
-        or _normalize_text(raw_lemma) in _VESUM_GAP_HERITAGE_LEMMAS
-    ):
+    if _is_deliberate_warning_entry(entry) or _is_proper_noun_entry(entry):
         return
 
     if _has_whitespace(raw_lemma):
@@ -281,14 +371,25 @@ def _check_lemma_in_vesum(entry: Mapping[str, Any], lemma: str, vesum: Any, viol
         # (local dev + the validator CLI). Treating "no db" as "flag all" would be a
         # false-positive storm, not enforcement.
         return
-    if not _vesum_has_entry(vesum, lemma):
-        violations.append(
-            Violation(
-                "lemma_in_vesum",
-                lemma,
-                "single-word entry is absent from VESUM lemma and word-form tables",
-            )
+    if _vesum_has_entry(vesum, lemma):
+        return
+
+    # VESUM missed. A miss is necessary-but-not-sufficient evidence of invalidity — VESUM
+    # has coverage gaps. Consult the heritage corpus (Грінченко/ЕСУМ) before flagging: a
+    # pre-Soviet headword or etymological lemma means the word is authentic Ukrainian, not
+    # a Russianism (#3211). The curated allowlist is the offline fallback (no sources.db).
+    if _heritage_attests(heritage, lemma):
+        return
+    if heritage is None and _normalize_text(raw_lemma) in _VESUM_GAP_HERITAGE_LEMMAS:
+        return
+
+    violations.append(
+        Violation(
+            "lemma_in_vesum",
+            lemma,
+            "single-word entry is absent from VESUM and unattested in the heritage corpus (Грінченко/ЕСУМ)",
         )
+    )
 
 
 def _enrichment(entry: Mapping[str, Any]) -> Mapping[str, Any]:

--- a/scripts/lexicon/verify_manifest.py
+++ b/scripts/lexicon/verify_manifest.py
@@ -39,6 +39,7 @@ import yaml
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MANIFEST = ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
 DEFAULT_VESUM = ROOT / "data" / "vesum.db"
+DEFAULT_SOURCES_DB = ROOT / "data" / "sources.db"
 DEFAULT_CURRICULUM = ROOT / "curriculum" / "l2-uk-en" / "curriculum.yaml"
 
 # DEFINITIVELY cross-domain auto-translation junk that must never be a synonym.
@@ -117,6 +118,7 @@ def conformance(
     *,
     curriculum_path: Path = DEFAULT_CURRICULUM,
     vesum_path: Path = DEFAULT_VESUM,
+    sources_path: Path = DEFAULT_SOURCES_DB,
 ) -> list:
     """Run the deterministic §8 Atlas conformance gates on the manifest.
 
@@ -129,20 +131,27 @@ def conformance(
     Mirrors ``tests/test_atlas_conformance.py``: lemma↔VESUM membership is enforced
     only when ``data/vesum.db`` exists (967MB, gitignored). When it is absent ONLY
     the ``lemma_in_vesum`` gate is skipped; every other §8 gate still enforces.
+    A VESUM miss is cross-checked against the heritage corpus (Грінченко/ЕСУМ via
+    ``data/sources.db``) before flagging, so authentic VESUM-gap words are not
+    false-flagged (#3211); absent sources.db → the curated allowlist fallback.
     """
     if str(ROOT) not in sys.path:  # allow `python scripts/lexicon/verify_manifest.py`
         sys.path.insert(0, str(ROOT))
-    from scripts.audit.validate_atlas_conformance import VesumLemmaLookup, validate
+    from scripts.audit.validate_atlas_conformance import validate
 
     curriculum = (
         yaml.safe_load(curriculum_path.read_text(encoding="utf-8"))
         if curriculum_path.exists()
         else {}
     )
-    if vesum_path.exists():
-        with VesumLemmaLookup(vesum_path) as vesum:
-            return validate(manifest, vesum=vesum, curriculum=curriculum)
-    return validate(manifest, vesum=None, curriculum=curriculum)
+    # Pass paths, not opened lookups: validate() opens read-only VESUM/heritage
+    # lookups and closes them in its finally block.
+    return validate(
+        manifest,
+        vesum=vesum_path if vesum_path.exists() else None,
+        curriculum=curriculum,
+        heritage=sources_path if sources_path.exists() else None,
+    )
 
 
 def run(
@@ -153,6 +162,7 @@ def run(
     run_conformance: bool = False,
     curriculum_path: Path = DEFAULT_CURRICULUM,
     vesum_path: Path = DEFAULT_VESUM,
+    sources_path: Path = DEFAULT_SOURCES_DB,
 ) -> int:
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     entries = manifest.get("entries", [])
@@ -187,7 +197,9 @@ def run(
 
     conf: list = []
     if run_conformance:
-        conf = conformance(manifest, curriculum_path=curriculum_path, vesum_path=vesum_path)
+        conf = conformance(
+            manifest, curriculum_path=curriculum_path, vesum_path=vesum_path, sources_path=sources_path
+        )
         vesum_note = "" if vesum_path.exists() else " (lemma_in_vesum skipped — no data/vesum.db)"
         print(f"\n=== CONFORMANCE (§8 atlas gates){vesum_note} ===")
         if not conf:
@@ -228,6 +240,12 @@ def main() -> int:
     )
     p.add_argument("--curriculum", type=Path, default=DEFAULT_CURRICULUM, help="curriculum.yaml for cross-link gate.")
     p.add_argument("--vesum", type=Path, default=DEFAULT_VESUM, help="VESUM db for the lemma_in_vesum gate.")
+    p.add_argument(
+        "--sources",
+        type=Path,
+        default=DEFAULT_SOURCES_DB,
+        help="sources.db for the Грінченко/ЕСУМ heritage fallback on VESUM-gap lemmas (#3211).",
+    )
     args = p.parse_args()
     return run(
         args.manifest,
@@ -236,6 +254,7 @@ def main() -> int:
         run_conformance=not args.skip_conformance,
         curriculum_path=args.curriculum,
         vesum_path=args.vesum,
+        sources_path=args.sources,
     )
 
 

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "5a498df1e04103dc76296a447e6ee3b81baa1d4f6e14840a9e0ac4e78bd69d25",
+  "fingerprint": "7fc344bfa480553cda9d9427de97117faee49ad3e57edfad3b947394678d91a0",
   "inputs": {
     "lexicon_code": [
       {
@@ -48,7 +48,7 @@
       },
       {
         "path": "scripts/lexicon/verify_manifest.py",
-        "sha256": "5d8c9d05f71972c78695568658609c6554a5f27126e6d1650aefe5047dad5505"
+        "sha256": "73f4c6842805558f86b825f11529b707150a4f47cf8815e790f1c9dc99b1aefd"
       }
     ]
   },

--- a/tests/test_atlas_conformance.py
+++ b/tests/test_atlas_conformance.py
@@ -3,14 +3,16 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 import yaml
 
-from scripts.audit.validate_atlas_conformance import VesumLemmaLookup, validate
+from scripts.audit.validate_atlas_conformance import HeritageLemmaLookup, VesumLemmaLookup, validate
 from scripts.lexicon.build_kaikki_lookup import KAIKKI_SOURCE
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 MANIFEST_PATH = PROJECT_ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
 VESUM_PATH = PROJECT_ROOT / "data" / "vesum.db"
+SOURCES_PATH = PROJECT_ROOT / "data" / "sources.db"
 CURRICULUM_PATH = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "curriculum.yaml"
 
 FAKE_CURRICULUM = {"levels": {"a1": {"modules": ["known-module"]}}}
@@ -42,9 +44,13 @@ def _entry(**overrides: object) -> dict:
     return entry
 
 
-def _gates_for(entry: dict, vesum: set[str] | None = None) -> list[str]:
+def _gates_for(
+    entry: dict, vesum: set[str] | None = None, heritage: set[str] | None = None
+) -> list[str]:
     fake_vesum = vesum if vesum is not None else {"слово"}
-    violations = validate(_manifest(entry), vesum=fake_vesum, curriculum=FAKE_CURRICULUM)
+    violations = validate(
+        _manifest(entry), vesum=fake_vesum, curriculum=FAKE_CURRICULUM, heritage=heritage
+    )
     return [violation.gate for violation in violations]
 
 
@@ -108,6 +114,42 @@ def test_lemma_in_vesum_exempts_heritage_word_absent_from_vesum():
     entry = _entry(lemma="хвастливий", url_slug="хвастливий", pos="adjective")
 
     assert _gates_for(entry, vesum=set()) == []
+
+
+def test_lemma_in_vesum_heritage_fallback_exempts_attested_word():
+    # #3211: a VESUM-miss is cross-checked against the heritage corpus before flagging.
+    # A word absent from VESUM but attested in Грінченко/ЕСУМ (fake heritage set, NOT in
+    # the manual allowlist) is exempted — the gate self-heals on ANY heritage-attested
+    # VESUM gap, not only the curated ones. (кобіта = the canonical heritage-defense word.)
+    entry = _entry(lemma="кобіта", url_slug="кобіта", pos="noun")
+
+    assert _gates_for(entry, vesum=set(), heritage={"кобіта"}) == []
+
+
+def test_lemma_in_vesum_flags_when_absent_from_both_vesum_and_heritage():
+    # #3211: the gate still catches genuinely-unattested single words — absent from VESUM
+    # AND not in the heritage corpus (heritage present but empty) → violation. The allowlist
+    # is bypassed when a heritage corpus is wired.
+    entry = _entry(lemma="зызыжщ", url_slug="зызыжщ", pos="noun")
+
+    assert _gates_for(entry, vesum=set(), heritage=set()) == ["lemma_in_vesum"]
+
+
+def test_lemma_in_vesum_allowlist_is_offline_fallback_when_no_heritage():
+    # #3211: when the heritage corpus is unavailable (heritage=None, e.g. no sources.db),
+    # the curated allowlist still exempts known VESUM-gap words.
+    entry = _entry(lemma="хвастливий", url_slug="хвастливий", pos="adjective")
+
+    assert _gates_for(entry, vesum=set(), heritage=None) == []
+
+
+@pytest.mark.skipif(not SOURCES_PATH.exists(), reason="needs gitignored data/sources.db")
+def test_heritage_lemma_lookup_attests_grinchenko_word_real_db():
+    # #3211: real Грінченко/ЕСУМ lookup — хвастливий is attested (Грінченко headword),
+    # nonsense is not. Proves the live fallback resolves the VESUM gap without an allowlist.
+    with HeritageLemmaLookup(SOURCES_PATH) as heritage:
+        assert heritage.has_attestation("хвастливий") is True
+        assert heritage.has_attestation("зызыжщ") is False
 
 
 def test_lemma_in_vesum_exempts_deliberate_warning_seed():


### PR DESCRIPTION
Closes #3211. Follow-up to #3210, which exempted VESUM-gap heritage words (`хвастливий`) via a **manual curated allowlist** — a stopgap that needs a human to add each new gap.

## Fix — deterministic live heritage fallback
On a VESUM miss, cross-check the **heritage corpus** before flagging: Грінченко headword (`grinchenko.word`, exact, pre-Soviet) or ЕСУМ etymological lemma (`esum_etymology.lemma`), via `data/sources.db`. A pre-Soviet/etymological attestation means the word is authentic Ukrainian, not a Russianism — VESUM absence is necessary-but-not-sufficient (heritage-defense).

- **`HeritageLemmaLookup`** (mirrors `VesumLemmaLookup`): read-only, cached, case/apostrophe-safe via `_lookup_variants`.
- `validate()` / `verify_manifest.conformance()` thread a `heritage` lookup (path → opened+closed by `validate`, like vesum); CLI gains `--sources`.
- `_check_lemma_in_vesum`: VESUM-miss → **heritage attests?** → (offline only) allowlist? → flag.
- `_VESUM_GAP_HERITAGE_LEMMAS` retained ONLY as the offline fallback (no sources.db — e.g. CI, which already skips the gate without vesum.db). Should shrink toward empty.

## Verification (real DBs)
| check | result |
|---|---|
| real `HeritageLemmaLookup` | `хвастливий`→attested, `зызыжщ`→not |
| full manifest, vesum+heritage wired | **0 violations** |
| **self-healing: allowlist EMPTIED** | **still 0 violations** — `хвастливий` resolved by Грінченко alone |

5 new tests (4 unit incl. the flags-when-truly-unattested guard + 1 real-db, skipped without sources.db); suite 37 passed + 1 skipped → 38 with the DB; ruff clean.

The gate now **self-heals** on any heritage-attested VESUM gap instead of needing a human to allowlist each one — the proper class fix for the false-positive family in autopsy `atlas-conformance-vesum-false-positives.md`.