### PR TITLE
feat(harness): #M-0.5 admin-merge guard hook — block gh pr merge --admin over failing required CI (#1908)

### DIFF
--- a/agents_extensions/shared/hooks/guard-admin-merge.py
+++ b/agents_extensions/shared/hooks/guard-admin-merge.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""PreToolUse guard — block `gh pr merge --admin` when a BLOCKING CI check is red (#M-0.5 / #1908).
+
+Reads the Claude Code hook payload on stdin (JSON with `tool_input.command`) and exits
+2 (block) when the command is a `gh pr merge ... --admin` whose target PR has any
+*blocking* (required) check in a failing state. Exit 0 (allow) otherwise — including
+`--admin` merges where ONLY *advisory* checks fail, which is the one legitimate use of
+`--admin` per #M-0.5.
+
+Why a hook (#1908): "#M-0.5 don't admin-bypass blocking CI" is advisory text in
+MEMORY.md that has been violated despite being canonical. A PreToolUse guard pushes it
+to the enforcement layer — the bypass is refused before the merge runs, not "the model
+tries to remember."
+
+FAIL-CLOSED: if the target PR or its check states can't be determined (gh error/timeout,
+no PR number), BLOCK. An anti-bypass guard must not let an *unverifiable* bypass through;
+the human can always run the merge directly if it is genuinely intended.
+
+Blocking (required) checks per #M-0.5: pytest, ruff, frontend/vitest, schema/MDX drift,
+gitleaks/secret-scan, radon/quality-gates, prompt-lint, CodeQL/Analyze. Matched by name
+substring (case-insensitive); erring toward "treat as blocking" is the safe direction here.
+"""
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+import sys
+
+# A check is treated as BLOCKING unless its name marks it explicitly advisory.
+# Rationale (anti-bypass safe direction): an allowlist of "known required" names would
+# UNDER-block — a new required check absent from the list would let an admin-bypass slip
+# through. So we invert: any FAILING check blocks --admin *unless* it is explicitly
+# advisory. Advisory-only failures don't even need --admin (a normal `gh pr merge` passes
+# non-required checks), so a Claude --admin over a failure implies bypassing something
+# required — exactly what #M-0.5 forbids. The human can still run a genuine handoff-
+# authorized advisory bypass directly.
+ADVISORY_NAME_MARKERS = ("advisory",)
+
+_FAIL_BUCKETS = {"fail", "failure", "error", "cancel", "canceled", "cancelled", "timed_out", "action_required"}
+
+
+def _is_advisory(name: str) -> bool:
+    low = name.lower()
+    return any(m in low for m in ADVISORY_NAME_MARKERS)
+
+
+def _read_payload() -> dict:
+    try:
+        return json.loads(sys.stdin.read() or "{}")
+    except json.JSONDecodeError:
+        return {}
+
+
+def _command(payload: dict) -> str:
+    return ((payload.get("tool_input") or {}).get("command") or "").strip()
+
+
+def _segments(command: str) -> list[list[str]]:
+    """Quote-aware tokenization split on shell separators (mirrors guard-branch-switch).
+
+    Ensures a `--admin` inside a quoted commit body (`git commit -m "... --admin ..."`)
+    is one argv element, not a separate command — no false block.
+    """
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        return []
+    segs: list[list[str]] = []
+    cur: list[str] = []
+    for tok in tokens:
+        if tok in ("&&", "||", ";", "|"):
+            if cur:
+                segs.append(cur)
+                cur = []
+        else:
+            cur.append(tok)
+    if cur:
+        segs.append(cur)
+    return segs
+
+
+def _admin_merge_args(seg: list[str]) -> list[str] | None:
+    """Return the args of a `gh pr merge ... --admin` segment, else None."""
+    i = 0
+    while i < len(seg) and seg[i] in {"sudo", "time", "env", "nohup"}:
+        i += 1
+    if seg[i : i + 3] != ["gh", "pr", "merge"]:
+        return None
+    args = seg[i + 3 :]
+    return args if "--admin" in args else None
+
+
+def _pr_number(args: list[str]) -> str | None:
+    """First numeric positional after `merge`, else the current branch's PR number."""
+    for a in args:
+        if not a.startswith("-") and a.isdigit():
+            return a
+    try:
+        out = subprocess.run(
+            ["gh", "pr", "view", "--json", "number", "-q", ".number"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return out.stdout.strip() or None
+    except Exception:
+        return None
+
+
+def _failing_blocking_checks(pr: str) -> list[str] | None:
+    """Failing non-advisory check names for the PR, or None if undeterminable (→ fail-closed)."""
+    try:
+        out = subprocess.run(
+            ["gh", "pr", "checks", pr, "--json", "name,bucket,state"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        rows = json.loads(out.stdout or "[]")
+    except Exception:
+        return None
+    if not isinstance(rows, list):
+        return None
+    failing: list[str] = []
+    for r in rows:
+        bucket = str(r.get("bucket") or r.get("state") or "").lower()
+        if bucket in _FAIL_BUCKETS:
+            name = str(r.get("name") or "")
+            if not _is_advisory(name):
+                failing.append(name)
+    return failing
+
+
+def _block_msg(reason: str) -> str:
+    return (
+        f"BLOCKED by guard-admin-merge (#M-0.5): {reason}.\n\n"
+        "`gh pr merge --admin` bypasses branch protection INCLUDING required CI "
+        "(pytest, ruff, frontend, schema/MDX drift, gitleaks, radon, prompt-lint, CodeQL).\n"
+        "Per #M-0.5, --admin is ONLY for explicitly-advisory failures. If a blocking check is\n"
+        "red: STOP, report, and ask — do NOT bypass. If this is a genuine advisory-only case,\n"
+        "fix the failing checks first, or the human runs the merge directly.\n\n"
+        "Hook source: .claude/hooks/guard-admin-merge.py\n"
+    )
+
+
+def main() -> int:
+    payload = _read_payload()
+    command = _command(payload)
+    # Fast path: only engage on `gh ... --admin` (leave every other command untouched).
+    if not command or "--admin" not in command or "gh" not in command:
+        return 0
+    for seg in _segments(command):
+        args = _admin_merge_args(seg)
+        if args is None:
+            continue
+        pr = _pr_number(args)
+        if not pr:
+            sys.stderr.write(_block_msg("could not determine the target PR number"))
+            return 2
+        failing = _failing_blocking_checks(pr)
+        if failing is None:
+            sys.stderr.write(_block_msg(f"could not verify PR #{pr} check states (gh error/timeout)"))
+            return 2
+        if failing:
+            sys.stderr.write(_block_msg(f"PR #{pr} has FAILING blocking checks: {', '.join(failing)}"))
+            return 2
+        # All blocking checks green (only advisory failures, if any) → allow the
+        # legitimate --admin use.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agents_extensions/shared/settings.json
+++ b/agents_extensions/shared/settings.json
@@ -648,6 +648,11 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-branch-switch-in-main.py",
             "timeout": 3
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-admin-merge.py",
+            "timeout": 30
           }
         ]
       }

--- a/tests/test_guard_admin_merge.py
+++ b/tests/test_guard_admin_merge.py
@@ -1,0 +1,110 @@
+"""Unit tests for the admin-merge guard hook (#M-0.5 / #1908).
+
+Exercises the pure decision logic in
+``agents_extensions/shared/hooks/guard-admin-merge.py``:
+
+  * `gh pr merge ... --admin` detection (incl. wrappers + a positional PR number),
+  * the quote-aware tokenizer (a `--admin` inside a quoted commit body is NOT a merge),
+  * advisory-vs-blocking classification,
+  * the fail-CLOSED `main()` decision (block on failing required check, on unknown PR,
+    and on undeterminable check states; allow on green / advisory-only).
+
+The hook filename has hyphens, so it is loaded by path via importlib. `main()` is guarded
+by `__name__ == "__main__"`, so import has no side effects. Network functions
+(`_pr_number`, `_failing_blocking_checks`) are monkeypatched — no `gh`/network in tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOK_PATH = REPO_ROOT / "agents_extensions/shared" / "hooks" / "guard-admin-merge.py"
+
+
+def _load_hook():
+    spec = importlib.util.spec_from_file_location("guard_admin_merge", HOOK_PATH)
+    assert spec and spec.loader, f"could not load hook at {HOOK_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+guard = _load_hook()
+
+
+def _run(monkeypatch, command: str, *, pr: str | None = "5", failing=()) -> int:
+    """Drive main() with a simulated stdin payload + monkeypatched network calls."""
+    payload = json.dumps({"tool_input": {"command": command}})
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    monkeypatch.setattr(guard, "_pr_number", lambda args: pr)
+    monkeypatch.setattr(
+        guard, "_failing_blocking_checks", lambda p: (list(failing) if failing is not None else None)
+    )
+    return guard.main()
+
+
+# --- detection (pure, no network) ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "seg,is_admin",
+    [
+        (["gh", "pr", "merge", "--admin"], True),
+        (["gh", "pr", "merge", "123", "--admin", "--squash"], True),
+        (["sudo", "gh", "pr", "merge", "--admin"], True),
+        (["gh", "pr", "merge", "--squash"], False),
+        (["gh", "pr", "merge", "--squash", "--delete-branch"], False),
+        (["gh", "pr", "view", "5"], False),
+        (["git", "push"], False),
+    ],
+)
+def test_admin_merge_detection(seg, is_admin):
+    assert (guard._admin_merge_args(seg) is not None) is is_admin
+
+
+def test_quoted_admin_not_detected():
+    # `--admin` inside a quoted commit body must NOT be seen as a merge command.
+    segs = guard._segments('git commit -m "ref: gh pr merge --admin notes"')
+    assert all(guard._admin_merge_args(s) is None for s in segs)
+
+
+def test_is_advisory():
+    assert guard._is_advisory("pip-audit (advisory)")
+    assert guard._is_advisory("npm-audit (advisory)")
+    assert not guard._is_advisory("Test (pytest)")
+    assert not guard._is_advisory("Lint (ruff)")
+    assert not guard._is_advisory("Frontend (build + vitest)")
+
+
+# --- main() decision (fail-closed) -----------------------------------------
+
+
+def test_non_admin_command_is_untouched(monkeypatch):
+    assert _run(monkeypatch, "gh pr merge 5 --squash --delete-branch") == 0
+
+
+def test_unrelated_command_is_untouched(monkeypatch):
+    assert _run(monkeypatch, "git push origin main") == 0
+
+
+def test_admin_with_failing_required_check_blocked(monkeypatch):
+    assert _run(monkeypatch, "gh pr merge 5 --admin", failing=["Test (pytest)"]) == 2
+
+
+def test_admin_with_only_green_or_advisory_allowed(monkeypatch):
+    # No failing *required* checks (advisory-only or all green) → the legitimate --admin.
+    assert _run(monkeypatch, "gh pr merge 5 --admin", failing=[]) == 0
+
+
+def test_admin_unknown_pr_fails_closed(monkeypatch):
+    assert _run(monkeypatch, "gh pr merge --admin", pr=None) == 2
+
+
+def test_admin_undeterminable_checks_fails_closed(monkeypatch):
+    assert _run(monkeypatch, "gh pr merge 5 --admin", failing=None) == 2


### PR DESCRIPTION
First enforcement-layer hook of the **#1908 layered-harness audit** — pushes the recurring **#M-0.5 "don't admin-bypass blocking CI"** rule from advisory MEMORY text down to a `PreToolUse(Bash)` guard that refuses the bypass *before* the merge runs.

## What it does
On a `gh pr merge … --admin` command, the hook resolves the target PR, queries `gh pr checks`, and **blocks (exit 2)** if any **failing** check is not explicitly advisory-named. Otherwise allows (exit 0) — including advisory-only failures (the one legitimate `--admin` use; though those don't even need `--admin` since a normal merge passes non-required checks).

## Design choices
- **Denylist, not allowlist** — block on any failing non-advisory check rather than matching known required-check names. An allowlist would *under*-block: a new required check absent from the list would let a bypass slip through. Wrong direction for an anti-bypass guard.
- **Fail-CLOSED** — unknown PR number or undeterminable check states (gh error/timeout) → block. An anti-bypass guard must not pass an *unverifiable* bypass; the human can run `--admin` directly for a genuine handoff-authorized exception.
- **Quote-aware** (`shlex`) — `--admin` inside a commit body is not a false block (mirrors `guard-branch-switch-in-main.py`).

## Source → deploy (per the deploy architecture)
- Source: git-tracked `agents_extensions/shared/hooks/guard-admin-merge.py` (+ registration in `agents_extensions/shared/settings.json`, `PreToolUse[Bash]`, timeout 30 for the gh calls).
- Deploys to the gitignored `.claude/`/`.codex/`/`.agent/` via `scripts/deploy_prompts.sh`. **No hand-editing of deploy targets.**

## Tests
- 15 unit tests (detection incl. wrappers/positional PR, quoted-body non-detection, advisory classification, all fail-closed `main()` paths; network monkeypatched).
- Deploy-idempotency suite green — the new hook deploys and diffs clean against source.

## Next #1908 hooks (separate PRs)
#M-7 pytest-before-push, #M-5 secret-scan (PreToolUse), V7-build-guard. This PR establishes the proven pattern.