### PR TITLE
fix(harness): admin-guard fail-open on gh error/bogus PR (#1908)

### DIFF
--- a/agents_extensions/shared/hooks/guard-admin-merge.py
+++ b/agents_extensions/shared/hooks/guard-admin-merge.py
@@ -117,8 +117,18 @@ def _failing_blocking_checks(pr: str) -> list[str] | None:
             text=True,
             timeout=20,
         )
-        rows = json.loads(out.stdout or "[]")
     except Exception:
+        return None
+    text = (out.stdout or "").strip()
+    if not text:
+        # Empty output is ambiguous: a PR with zero checks (rc 0 → allow, nothing to
+        # bypass) vs a gh error / non-existent PR (rc != 0 → fail-CLOSED block). Without
+        # the returncode check, `json.loads("[]")` silently reads an *error* as "no
+        # failing checks" and lets the bypass through — the fail-open bug this closes.
+        return [] if out.returncode == 0 else None
+    try:
+        rows = json.loads(text)
+    except json.JSONDecodeError:
         return None
     if not isinstance(rows, list):
         return None

--- a/tests/test_guard_admin_merge.py
+++ b/tests/test_guard_admin_merge.py
@@ -108,3 +108,46 @@ def test_admin_unknown_pr_fails_closed(monkeypatch):
 
 def test_admin_undeterminable_checks_fails_closed(monkeypatch):
     assert _run(monkeypatch, "gh pr merge 5 --admin", failing=None) == 2
+
+
+# --- _failing_blocking_checks: gh-output handling (fail-open regression) -----
+
+
+def _fake_gh(monkeypatch, *, returncode: int, stdout: str):
+    import types
+
+    def fake_run(*_a, **_k):
+        return types.SimpleNamespace(returncode=returncode, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(guard.subprocess, "run", fake_run)
+
+
+def test_failing_checks_empty_output_with_error_rc_is_failclosed(monkeypatch):
+    # Regression: bogus/non-existent PR → gh errors with EMPTY stdout. Must be None
+    # (fail-closed), NOT [] — `json.loads("[]")` once silently read this as "no failing
+    # checks" and let the --admin bypass through.
+    _fake_gh(monkeypatch, returncode=1, stdout="")
+    assert guard._failing_blocking_checks("99999") is None
+
+
+def test_failing_checks_empty_output_with_ok_rc_is_no_checks(monkeypatch):
+    # PR genuinely has zero checks → rc 0, empty output → [] (nothing to bypass → allow).
+    _fake_gh(monkeypatch, returncode=0, stdout="")
+    assert guard._failing_blocking_checks("5") == []
+
+
+def test_failing_checks_reports_failing_non_advisory(monkeypatch):
+    rows = '[{"name":"Test (pytest)","bucket":"fail"},{"name":"pip-audit (advisory)","bucket":"fail"}]'
+    _fake_gh(monkeypatch, returncode=8, stdout=rows)
+    assert guard._failing_blocking_checks("5") == ["Test (pytest)"]
+
+
+def test_failing_checks_advisory_only_is_empty(monkeypatch):
+    rows = '[{"name":"pip-audit (advisory)","bucket":"fail"},{"name":"Test (pytest)","bucket":"pass"}]'
+    _fake_gh(monkeypatch, returncode=8, stdout=rows)
+    assert guard._failing_blocking_checks("5") == []
+
+
+def test_failing_checks_garbage_output_is_failclosed(monkeypatch):
+    _fake_gh(monkeypatch, returncode=0, stdout="not json")
+    assert guard._failing_blocking_checks("5") is None


### PR DESCRIPTION
Self-review (smoke-testing the deployed #3224 hook) caught a **fail-open** in the #M-0.5 admin-merge guard: `gh pr checks` on a non-existent PR / gh error returns **empty stdout**, and `json.loads(out.stdout or "[]")` read that as `[]` → "no failing checks" → **allow**. A gh hiccup during a real `--admin` would slip the bypass through — opposite of the intended fail-CLOSED.

## Fix
Check returncode before treating empty output as "no checks":
- empty + rc 0 → `[]` (PR has zero checks → nothing to bypass → allow)
- empty + rc ≠ 0 → `None` (gh error / no PR → **fail-closed block**)
- non-empty → parse; `JSONDecodeError` → `None`

## Verified
- Clean exit-code check: bogus-PR `--admin` → **exit 2** (was 0); non-admin → exit 0.
- +5 tests exercising `_failing_blocking_checks` directly with a faked `gh` (rc/stdout matrix) — the path the monkeypatched `main()` tests skipped. Suite **20 passed**, ruff clean.

Found-by: #M-11 verify-the-deployed-artifact (smoke test after deploy), not assumed.