### PR TITLE
[codex] feat(harness): #M-7 pytest-before-push guard hook (#1908)

### DIFF
--- a/agents_extensions/shared/hooks/guard-push-pytest.py
+++ b/agents_extensions/shared/hooks/guard-push-pytest.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""PreToolUse guard - require recent pytest before direct pushes from main.
+
+Reads the hook payload on stdin (JSON with ``tool_input.command``) and exits 2
+only when a real ``git push`` is about to run from ``main``, the outgoing diff
+contains pytest-triggering paths, and the branch's pytest stamp is absent or
+stale. All repository/probe errors fail open: this hook is a discipline net, not
+a security boundary.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+MARKER_MAX_AGE_SECONDS = 10 * 60
+TRIGGER_PREFIXES = (
+    "tests/",
+    "scripts/",
+    "curriculum/",
+    "agents_extensions/shared/rules/",
+    ".dagger/",
+)
+WRAPPERS = {"sudo", "time", "env", "nohup"}
+
+
+def _read_payload() -> dict:
+    try:
+        return json.loads(sys.stdin.read() or "{}")
+    except json.JSONDecodeError:
+        return {}
+
+
+def _command(payload: dict) -> str:
+    return ((payload.get("tool_input") or {}).get("command") or "").strip()
+
+
+def _segments(command: str) -> list[list[str]]:
+    """Quote-aware tokenization split on common shell separators."""
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        return []
+    segments: list[list[str]] = []
+    current: list[str] = []
+    for tok in tokens:
+        if tok in ("&&", "||", ";", "|"):
+            if current:
+                segments.append(current)
+                current = []
+        else:
+            current.append(tok)
+    if current:
+        segments.append(current)
+    return segments
+
+
+def _skip_git_global_flags(seg: list[str], i: int) -> int:
+    """Return the index of the git verb after top-level git flags."""
+    while i < len(seg) and seg[i].startswith("-"):
+        if seg[i] in {"-C", "-c", "--git-dir", "--work-tree"} and i + 1 < len(seg):
+            i += 2
+        else:
+            i += 1
+    return i
+
+
+def _push_is_dry_run(args: list[str]) -> bool:
+    for arg in args:
+        if arg == "--":
+            return False
+        if arg == "--dry-run":
+            return True
+        if len(arg) > 1 and arg.startswith("-") and not arg.startswith("--") and "n" in arg[1:]:
+            return True
+    return False
+
+
+def _push_is_help(args: list[str]) -> bool:
+    return any(arg in {"-h", "--help"} for arg in args)
+
+
+def _git_push_args(seg: list[str]) -> list[str] | None:
+    """Return args for a real ``git push`` segment, else None."""
+    i = 0
+    while i < len(seg) and seg[i] in WRAPPERS:
+        i += 1
+    if i >= len(seg) or seg[i] != "git":
+        return None
+    i = _skip_git_global_flags(seg, i + 1)
+    if i >= len(seg) or seg[i] != "push":
+        return None
+    args = seg[i + 1 :]
+    if _push_is_dry_run(args) or _push_is_help(args):
+        return None
+    return args
+
+
+def _contains_git_push(command: str) -> bool:
+    return any(_git_push_args(seg) is not None for seg in _segments(command))
+
+
+def _current_branch() -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", "branch", "--show-current"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except Exception:
+        return None
+    if out.returncode != 0:
+        return None
+    branch = out.stdout.strip()
+    return branch or None
+
+
+def _changed_paths() -> list[str] | None:
+    try:
+        out = subprocess.run(
+            ["git", "diff", "--name-only", "origin/main..HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except Exception:
+        return None
+    if out.returncode != 0:
+        return None
+    return [line.strip() for line in out.stdout.splitlines() if line.strip()]
+
+
+def _is_trigger_path(path: str) -> bool:
+    return path.endswith(".py") or any(path == prefix.rstrip("/") or path.startswith(prefix) for prefix in TRIGGER_PREFIXES)
+
+
+def _has_trigger_path(paths: list[str]) -> bool:
+    return any(_is_trigger_path(path) for path in paths)
+
+
+def _marker_path(branch: str) -> Path:
+    return Path(os.environ.get("TMPDIR") or "/tmp") / f"learn-uk-pytest.{branch}.stamp"
+
+
+def _marker_is_fresh(path: Path) -> bool | None:
+    try:
+        stat = path.stat()
+    except FileNotFoundError:
+        return False
+    except Exception:
+        return None
+    try:
+        return time.time() - stat.st_mtime <= MARKER_MAX_AGE_SECONDS
+    except Exception:
+        return None
+
+
+def _block_msg(marker: Path) -> str:
+    return (
+        "BLOCKED by guard-push-pytest (#M-7): direct push from `main` includes "
+        "Python/test-trigger changes, but no recent local pytest stamp was found.\n\n"
+        f"Marker path: {marker}\n"
+        "Run `.venv/bin/python -m pytest ...` locally, then push again within "
+        "10 minutes. To override deliberately, rerun with `SKIP_PYTEST_HOOK=1`.\n\n"
+        "Hook source: .claude/hooks/guard-push-pytest.py\n"
+    )
+
+
+def main() -> int:
+    if os.environ.get("SKIP_PYTEST_HOOK") == "1":
+        return 0
+
+    payload = _read_payload()
+    command = _command(payload)
+    if not command or not _contains_git_push(command):
+        return 0
+
+    branch = _current_branch()
+    if branch != "main":
+        return 0
+
+    paths = _changed_paths()
+    if paths is None or not _has_trigger_path(paths):
+        return 0
+
+    marker = _marker_path(branch)
+    fresh = _marker_is_fresh(marker)
+    if fresh is None or fresh:
+        return 0
+
+    sys.stderr.write(_block_msg(marker))
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agents_extensions/shared/hooks/stamp-pytest.sh
+++ b/agents_extensions/shared/hooks/stamp-pytest.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Hook: PostToolUse - stamp recent pytest runs for the #M-7 push guard.
+
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+INPUT=$(</dev/stdin)
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
+[ -n "$COMMAND" ] || exit 0
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+PYTHON="$PROJECT_DIR/.venv/bin/python"
+
+HAS_PYTEST=1
+if [ -x "$PYTHON" ]; then
+  printf '%s' "$COMMAND" | "$PYTHON" -c '
+from __future__ import annotations
+
+import shlex
+import sys
+
+command = sys.stdin.read()
+try:
+    tokens = shlex.split(command, posix=True)
+except ValueError:
+    sys.exit(1)
+
+segments = []
+current = []
+for tok in tokens:
+    if tok in ("&&", "||", ";", "|"):
+        if current:
+            segments.append(current)
+            current = []
+    else:
+        current.append(tok)
+if current:
+    segments.append(current)
+
+wrappers = {"sudo", "time", "env", "nohup"}
+for seg in segments:
+    i = 0
+    while i < len(seg) and seg[i] in wrappers:
+        i += 1
+    if i >= len(seg):
+        continue
+    if seg[i] in {".venv/bin/python", "./.venv/bin/python"} and seg[i + 1 : i + 3] == ["-m", "pytest"]:
+        sys.exit(0)
+    if seg[i] == "pytest":
+        sys.exit(0)
+    if seg[i : i + 3] == ["dagger", "call", "pytest"]:
+        sys.exit(0)
+sys.exit(1)
+'
+  HAS_PYTEST=$?
+else
+  if [[ "$COMMAND" =~ (^|[[:space:];|&])(\./)?\.venv/bin/python[[:space:]]+-m[[:space:]]+pytest($|[[:space:]]) ]] || \
+     [[ "$COMMAND" =~ (^|[[:space:];|&])pytest($|[[:space:]]) ]] || \
+     [[ "$COMMAND" =~ (^|[[:space:];|&])dagger[[:space:]]+call[[:space:]]+pytest($|[[:space:]]) ]]; then
+    HAS_PYTEST=0
+  fi
+fi
+
+[ "$HAS_PYTEST" -eq 0 ] || exit 0
+
+BRANCH=$(git branch --show-current 2>/dev/null) || exit 0
+[ -n "$BRANCH" ] || exit 0
+
+STAMP="${TMPDIR:-/tmp}/learn-uk-pytest.${BRANCH}.stamp"
+mkdir -p "$(dirname "$STAMP")" 2>/dev/null || exit 0
+touch "$STAMP" 2>/dev/null || true
+
+exit 0

--- a/tests/test_guard_push_pytest.py
+++ b/tests/test_guard_push_pytest.py
@@ -93,21 +93,28 @@ def test_hook_errors_fail_open(monkeypatch):
 
 
 def test_stamp_pytest_bash_smoke(tmp_path):
-    branch = subprocess.run(
-        ["git", "branch", "--show-current"],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
+    branch = "testbranch"
+    git_env = os.environ.copy()
+    for key in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_PREFIX"):
+        git_env.pop(key, None)
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", branch], cwd=repo, env=git_env, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, env=git_env, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, env=git_env, check=True)
+    (repo / "README.md").write_text("test repo\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo, env=git_env, check=True)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=repo, env=git_env, check=True)
+
     marker = tmp_path / f"learn-uk-pytest.{branch}.stamp"
     payload = json.dumps({"tool_input": {"command": ".venv/bin/python -m pytest tests/test_guard_push_pytest.py -q"}})
-    env = os.environ.copy()
+    env = git_env.copy()
     env["TMPDIR"] = str(tmp_path)
 
     result = subprocess.run(
         [str(STAMP_PATH)],
-        cwd=REPO_ROOT,
+        cwd=repo,
         input=payload,
         capture_output=True,
         text=True,
@@ -117,3 +124,19 @@ def test_stamp_pytest_bash_smoke(tmp_path):
 
     assert result.returncode == 0
     assert marker.exists()
+
+    marker.unlink()
+    subprocess.run(["git", "checkout", "--detach", "HEAD"], cwd=repo, env=git_env, check=True, capture_output=True, text=True)
+
+    detached_result = subprocess.run(
+        [str(STAMP_PATH)],
+        cwd=repo,
+        input=payload,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert detached_result.returncode == 0
+    assert not list(tmp_path.glob("learn-uk-pytest*.stamp"))

--- a/tests/test_guard_push_pytest.py
+++ b/tests/test_guard_push_pytest.py
@@ -1,0 +1,119 @@
+"""Unit tests for the #M-7 direct-main push pytest guard."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GUARD_PATH = REPO_ROOT / "agents_extensions/shared" / "hooks" / "guard-push-pytest.py"
+STAMP_PATH = REPO_ROOT / "agents_extensions/shared" / "hooks" / "stamp-pytest.sh"
+
+
+def _load_hook():
+    spec = importlib.util.spec_from_file_location("guard_push_pytest", GUARD_PATH)
+    assert spec and spec.loader, f"could not load hook at {GUARD_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+guard = _load_hook()
+
+
+def _run(
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    *,
+    branch: str = "main",
+    paths: tuple[str, ...] = ("tests/test_guard_push_pytest.py",),
+    marker_fresh: bool | None = False,
+) -> int:
+    payload = json.dumps({"tool_input": {"command": command}})
+    marker = Path("/tmp/learn-uk-pytest.main.stamp")
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    monkeypatch.setattr(guard, "_current_branch", lambda: branch)
+    monkeypatch.setattr(guard, "_changed_paths", lambda: list(paths))
+    monkeypatch.setattr(guard, "_marker_path", lambda _branch: marker)
+    monkeypatch.setattr(guard, "_marker_is_fresh", lambda _marker: marker_fresh)
+    monkeypatch.delenv("SKIP_PYTEST_HOOK", raising=False)
+    return guard.main()
+
+
+def test_push_to_main_with_trigger_path_and_stale_marker_blocks(monkeypatch, capsys):
+    assert _run(monkeypatch, "git push origin main") == 2
+    err = capsys.readouterr().err
+    assert "/tmp/learn-uk-pytest.main.stamp" in err
+    assert "SKIP_PYTEST_HOOK=1" in err
+
+
+def test_push_to_main_with_fresh_marker_allows(monkeypatch):
+    assert _run(monkeypatch, "git push origin main", marker_fresh=True) == 0
+
+
+def test_non_main_branch_allows(monkeypatch):
+    assert _run(monkeypatch, "git push -u origin feature", branch="feature") == 0
+
+
+def test_non_push_command_allows(monkeypatch):
+    assert _run(monkeypatch, "git status") == 0
+
+
+def test_skip_env_allows(monkeypatch):
+    payload = json.dumps({"tool_input": {"command": "git push origin main"}})
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    monkeypatch.setenv("SKIP_PYTEST_HOOK", "1")
+    assert guard.main() == 0
+
+
+def test_quoted_push_in_commit_body_allows(monkeypatch):
+    assert _run(monkeypatch, 'git commit -m "docs: mention git push origin main"') == 0
+
+
+def test_dry_run_push_allows(monkeypatch):
+    assert _run(monkeypatch, "git push --dry-run origin main") == 0
+
+
+def test_non_trigger_diff_allows(monkeypatch):
+    assert _run(monkeypatch, "git push origin main", paths=("README.md",)) == 0
+
+
+def test_hook_errors_fail_open(monkeypatch):
+    payload = json.dumps({"tool_input": {"command": "git push origin main"}})
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    monkeypatch.setattr(guard, "_current_branch", lambda: None)
+    monkeypatch.delenv("SKIP_PYTEST_HOOK", raising=False)
+    assert guard.main() == 0
+
+
+def test_stamp_pytest_bash_smoke(tmp_path):
+    branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    marker = tmp_path / f"learn-uk-pytest.{branch}.stamp"
+    payload = json.dumps({"tool_input": {"command": ".venv/bin/python -m pytest tests/test_guard_push_pytest.py -q"}})
+    env = os.environ.copy()
+    env["TMPDIR"] = str(tmp_path)
+
+    result = subprocess.run(
+        [str(STAMP_PATH)],
+        cwd=REPO_ROOT,
+        input=payload,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert marker.exists()


### PR DESCRIPTION
## Summary

Adds the #M-7 pytest-before-push enforcement hooks without editing shared settings:

- `stamp-pytest.sh` records a recent pytest marker after real pytest commands.
- `guard-push-pytest.py` blocks direct pushes from `main` when Python/test-trigger paths are being pushed without a fresh marker.
- `tests/test_guard_push_pytest.py` covers stale/fresh marker behavior, non-main pushes, skip override, quoted command bodies, dry-run pushes, fail-open behavior, and a bash smoke test for the stamper.

## Validation

- `.venv/bin/python -m pytest tests/test_guard_push_pytest.py -q` passed.
- `.venv/bin/ruff check agents_extensions/shared/hooks/guard-push-pytest.py tests/test_guard_push_pytest.py` passed.
- `git diff --cached --check` passed before commit.
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` passed.
- Pre-commit passed affected-file ruff and pytest during commit.

Note: repo-wide `.venv/bin/ruff check` currently fails on pre-existing unrelated files under `docs/reports/` and `plans/`; those files are outside this dispatch scope and were not modified.