### PR TITLE
feat(pipeline): route seminar excerpts to literary corpus (#3162)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -1080,8 +1080,9 @@ def run_wiki_completeness_gate(
         raise LinearPipelineError(f"No wiki article found for level={level_key!r}, slug={slug_key!r}")
     from scripts.audit.wiki_completeness_gate import check_wiki_completeness
 
-    # TODO(folk-seminar-gate): wire corpus verify_quote for seminar levels once
-    # there is an in-process function that accepts (source_id,
+    # TODO(folk-seminar-gate): the module excerpt builder now retrieves
+    # seminar primaries from literary_texts, but this completeness gate still
+    # needs an in-process verify_quote adapter that accepts (source_id,
     # citation_context, source_mapping). The current implementation lives at
     # .mcp/servers/sources/server.py::handle_verify_quote and only accepts
     # author/text search arguments, so it cannot verify registry `file` chunk
@@ -1772,6 +1773,114 @@ def _search_textbook_hits(query: str, *, level: str, limit: int = 1) -> list[dic
     return textbook_hits[:limit]
 
 
+_SOURCE_SEARCH_TERM_RE = re.compile(r"[A-Za-zА-Яа-яІіЇїЄєҐґ0-9]{3,}")
+_PRIMARY_TEXT_QUOTE_RES = (
+    re.compile(r"«(.{8,160}?)»"),
+    re.compile(r"“(.{8,160}?)”"),
+    re.compile(r'"(.{8,160}?)"'),
+)
+
+
+def _source_search_terms(query: str) -> set[str]:
+    return {term.casefold() for term in _SOURCE_SEARCH_TERM_RE.findall(query)}
+
+
+def _literary_fallback_queries(
+    plan: Mapping[str, Any],
+    reference: Mapping[str, Any],
+    fallback_query: str,
+) -> list[str]:
+    queries: list[str] = []
+    for section in plan.get("content_outline") or []:
+        if not isinstance(section, Mapping):
+            continue
+        for point in section.get("points") or []:
+            point_text = str(point or "")
+            for quote_re in _PRIMARY_TEXT_QUOTE_RES:
+                for match in quote_re.finditer(point_text):
+                    quote = match.group(1).replace("...", " ").replace("…", " ").strip(" .,:;!?")
+                    if len(_source_search_terms(quote)) >= 2:
+                        queries.append(quote)
+
+    reference_query = " ".join(
+        str(reference.get(key) or "").strip()
+        for key in ("title", "author", "work", "note")
+        if str(reference.get(key) or "").strip()
+    )
+    if reference_query:
+        queries.append(reference_query)
+    queries.append(fallback_query)
+    return list(dict.fromkeys(queries))
+
+
+def _is_literary_source_hit(hit: Mapping[str, Any]) -> bool:
+    source_type = str(hit.get("source_type") or "").casefold()
+    source_marker = " ".join(
+        str(hit.get(key) or "").casefold()
+        for key in ("source_type", "corpus", "source", "unit_key")
+    )
+    return (
+        "textbook" not in source_marker
+        and (
+            "literary" in source_marker
+            or "literary_texts" in source_marker
+            or source_type == "primary"
+        )
+    )
+
+
+def _normalize_literary_hit(hit: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = dict(hit)
+    normalized.setdefault("source_type", "literary")
+    normalized.setdefault("corpus", "literary_texts")
+    if not normalized.get("title") and normalized.get("work"):
+        normalized["title"] = normalized["work"]
+    return normalized
+
+
+def _search_literary_hits(query: str, *, level: str, limit: int = 1) -> list[dict]:
+    try:
+        from wiki import sources_db
+    except Exception:
+        return []
+
+    candidate_limit = max(limit * 4, limit)
+    search_literary = getattr(sources_db, "search_literary", None)
+    if callable(search_literary):
+        terms = _source_search_terms(query)
+        if terms:
+            try:
+                hits = search_literary(terms, max_total=candidate_limit)
+            except TypeError:
+                try:
+                    hits = search_literary(terms, limit=candidate_limit)
+                except Exception:
+                    hits = []
+            except Exception:
+                hits = []
+            literary_hits = [
+                _normalize_literary_hit(hit)
+                for hit in hits or []
+                if isinstance(hit, Mapping) and _is_literary_source_hit(hit)
+            ]
+            if literary_hits:
+                return literary_hits[:limit]
+
+    search_sources = getattr(sources_db, "search_sources", None)
+    if not callable(search_sources):
+        return []
+    try:
+        hits = search_sources(query, track=level, limit=candidate_limit)
+    except Exception:
+        return []
+    literary_hits = [
+        _normalize_literary_hit(hit)
+        for hit in hits or []
+        if isinstance(hit, Mapping) and _is_literary_source_hit(hit)
+    ]
+    return literary_hits[:limit]
+
+
 def _build_textbook_excerpt_context(
     plan: Mapping[str, Any],
     level: str,
@@ -1782,8 +1891,16 @@ def _build_textbook_excerpt_context(
 
     topic_query = _plan_topic_query(plan)
     lines = ["## Textbook Excerpts (verbatim, must be cited)", ""]
+    level_key = str(level).lower()
+    references_by_title = {
+        str(ref.get("title") or "").strip(): ref
+        for ref in plan.get("references") or []
+        if isinstance(ref, Mapping)
+    }
     found_any = False
     for title in references:
+        reference = references_by_title.get(title, {})
+        is_primary_reference = str(reference.get("type") or "").casefold() == "primary"
         query = f"{title} {topic_query}".strip()
         missing_reasons: list[str] = []
         direct_hits = _lookup_textbook_reference_chunk(
@@ -1792,6 +1909,13 @@ def _build_textbook_excerpt_context(
             missing_reason=missing_reasons,
         )
         hits = direct_hits if direct_hits is not None else _search_textbook_hits(query, level=level, limit=1)
+        hit_source = "textbook"
+        if not hits and level_key in SEMINAR_LEVELS and is_primary_reference:
+            for literary_query in _literary_fallback_queries(plan, reference, query):
+                hits = _search_literary_hits(literary_query, level=level_key, limit=1)
+                if hits:
+                    hit_source = "literary"
+                    break
         lines.append(f"### {title}")
         lines.append("")
         if not hits:
@@ -1814,6 +1938,11 @@ def _build_textbook_excerpt_context(
             lines.append("")
             continue
         found_any = True
+        if hit_source == "literary":
+            lines.append("Primary text (literary corpus)")
+            chunk_id = str(hit.get("chunk_id") or "").strip()
+            if chunk_id:
+                lines.append(f"chunk_id: {chunk_id}")
         lines.append(f"Source: {_textbook_hit_label(hit)}")
         lines.append("")
         for quote_line in text.splitlines():
@@ -8250,10 +8379,18 @@ def _word_count(text: str) -> int:
 # rejections like deepseek-pro 1197/1200. Empirically the 8% band still
 # rejects gemini-tools 1031/1200 (14% short).
 _WORD_COUNT_TOLERANCE_BELOW = 0.08
+_PRIMARY_READING_BLOCK_RE = re.compile(
+    r"<!--\s*PRIMARY-READING\s*-->.*?<!--\s*/PRIMARY-READING\s*-->",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _strip_primary_reading_blocks(text: str) -> str:
+    return _PRIMARY_READING_BLOCK_RE.sub("", text)
 
 
 def _word_count_gate(text: str, target: int) -> dict[str, Any]:
-    count = _word_count(_strip_comments(text))
+    count = _word_count(_strip_comments(_strip_primary_reading_blocks(text)))
     min_with_tolerance = int(target * (1 - _WORD_COUNT_TOLERANCE_BELOW))
     return {
         "passed": count >= min_with_tolerance,

--- a/tests/test_pr_b_band_widening.py
+++ b/tests/test_pr_b_band_widening.py
@@ -65,6 +65,19 @@ def test_word_count_reports_tolerance_metadata() -> None:
     assert report["target"] == 1200
 
 
+def test_word_count_excludes_primary_reading_fence() -> None:
+    text = (
+        ("counted " * 10)
+        + "<!-- PRIMARY-READING -->\n"
+        + ("primary " * 100)
+        + "\n<!-- /PRIMARY-READING -->"
+    )
+
+    report = _word_count_gate(text, 20)
+
+    assert report["count"] == 10
+
+
 # ----- callout_min ------------------------------------------------------------
 
 

--- a/tests/test_textbook_grounding.py
+++ b/tests/test_textbook_grounding.py
@@ -433,3 +433,76 @@ def test_textbook_excerpt_context_uses_reference_title_for_direct_lookup(
 
     assert "10-klas-ukrmova-karaman-2018" in context
     assert "corpus_missing: true" not in context
+
+
+def test_seminar_textbook_miss_uses_literary_primary(monkeypatch) -> None:
+    from wiki import sources_db
+
+    search_sources_calls: list[tuple[str, str, int]] = []
+    search_literary_calls: list[set[str]] = []
+
+    def fake_search_sources(query: str, *, track: str, limit: int) -> list[dict]:
+        search_sources_calls.append((query, track, limit))
+        return [{"chunk_id": "external-hit", "source_type": "external", "text": "Not a primary."}]
+
+    def fake_search_literary(keywords: set[str], max_total: int = 20) -> list[dict]:
+        search_literary_calls.append(keywords)
+        return [
+            {
+                "chunk_id": "chubynsky-koliadka_c0001",
+                "corpus": "literary_texts",
+                "source_type": "literary",
+                "title": "Колядка",
+                "text": "Коли не було з нащада світа, тоді не було неба ні землі.",
+                "source_file": "chubynsky-koliadky",
+            }
+        ]
+
+    monkeypatch.setattr(sources_db, "search_sources", fake_search_sources)
+    monkeypatch.setattr(sources_db, "search_literary", fake_search_literary)
+    plan = {
+        "references": [{"title": "Чубинський колядки", "type": "primary"}],
+        "title": "Колядки та щедрівки",
+        "subtitle": "Міф про створення світу",
+        "content_outline": [{"section": "Читання", "points": ["архаїчна колядка"]}],
+    }
+
+    context = linear_pipeline._build_textbook_excerpt_context(plan, "folk")
+
+    assert search_sources_calls == [
+        (
+            "Чубинський колядки Колядки та щедрівки Міф про створення світу Читання архаїчна колядка",
+            "folk",
+            4,
+        )
+    ]
+    assert search_literary_calls
+    assert "Primary text (literary corpus)" in context
+    assert "chunk_id: chubynsky-koliadka_c0001" in context
+    assert "> Коли не було з нащада світа" in context
+    assert "corpus_missing: true" not in context
+    assert "corpus_missing" not in plan["references"][0]
+
+
+def test_core_textbook_miss_does_not_call_literary(monkeypatch) -> None:
+    from wiki import sources_db
+
+    def fake_search_sources(query: str, *, track: str, limit: int) -> list[dict]:
+        return []
+
+    def fail_search_literary(keywords: set[str], max_total: int = 20) -> list[dict]:
+        raise AssertionError("core levels must not query the literary corpus")
+
+    monkeypatch.setattr(sources_db, "search_sources", fake_search_sources)
+    monkeypatch.setattr(sources_db, "search_literary", fail_search_literary)
+    plan = {
+        "references": [{"title": "Чубинський колядки"}],
+        "title": "Morning routine",
+        "subtitle": "core sample",
+        "content_outline": [{"section": "Practice", "points": ["verbs"]}],
+    }
+
+    context = linear_pipeline._build_textbook_excerpt_context(plan, "a1")
+
+    assert "corpus_missing: true" in context
+    assert plan["references"][0]["corpus_missing"] is True


### PR DESCRIPTION
## Summary

- Route seminar `references[].type: primary` excerpt misses through the literary corpus, using `wiki.sources_db.search_literary` first and `search_sources` literary filtering as fallback.
- Label recovered seminar excerpts as `Primary text (literary corpus)` and include `chunk_id` so writers can embed the taught primary text.
- Add `<!-- PRIMARY-READING --> ... <!-- /PRIMARY-READING -->` stripping before `_word_count_gate` so long primary reading panels do not inflate module word counts.
- Update the folk seminar TODO to clarify that excerpt retrieval is wired; the remaining TODO is only the in-process completeness-gate `verify_quote` adapter.

This is SHARED pipeline infra. Core `a1`-`c2` excerpt output is unchanged, proven below by byte-identical comparison against `HEAD^` for one existing plan from each core level.

## Verification

Pytest:

```bash
.venv/bin/python -m pytest tests/test_textbook_grounding.py tests/test_pr_b_band_widening.py
```

```text
============================== 26 passed in 0.80s ==============================
```

Ruff:

```bash
.venv/bin/ruff check scripts/build/linear_pipeline.py
```

```text
All checks passed!
```

Core-track byte-identical proof:

```bash
.venv/bin/python - <<'PY'
# compares HEAD^:scripts/build/linear_pipeline.py to the committed working tree
# over one existing plan each from a1, a2, b1, b2, c1, c2
PY
```

```text
checked 6 core plans: a1/a1-finale.yaml, a2/a2-bridge.yaml, b1/adjectives-comparative.yaml, b2/academic-writing.yaml, c1/abstract-writing.yaml, c2/academic-publishing.yaml
byte-identical diff: <empty>
```

Positive seminar/folk proof:

```bash
.venv/bin/python - <<'PY'
# builds _build_textbook_excerpt_context for curriculum/l2-uk-en/plans/folk/koliadky-shchedrivky.yaml
PY
```

```text
plan: folk/koliadky-shchedrivky.yaml
title: Слов'янська міфологія
chunk_id: 61bfde21_c0000
Source: Народна творчість. Як ще не було початку світа (ukrlib-narod-dumy)
quote: > ЯК ЩЕ НЕ БУЛО ПОЧАТКУ СВІТА Як ще не було початку світа, Тогди не було неба, ні землі, А но лем було синєє море, А серед моря зелений явір. На явороньку три голубоньки, Три голубоньки радоньку радять, Радоньку радять,
```

Commit/trailer:

```bash
git log -1 --oneline
.venv/bin/python scripts/audit/lint_agent_trailer.py
```

```text
94e64457a9 feat(pipeline): route seminar module excerpt builder to literary corpus (#3162)
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

Local review:

```text
Gemini review ran. Two small fixes applied before commit: paired quote extraction and no extra plan mutation on literary success. Challenge round dropped remaining findings.
```

## Part B

Done with test: `_word_count_gate` excludes content fenced by `<!-- PRIMARY-READING --> ... <!-- /PRIMARY-READING -->`.

Refs #3162
