### PR TITLE
feat(lexicon): 429-friendly slovnyk.me fetch + resumable mirror builder (#3097)

### DIFF
--- a/scripts/lexicon/build_slovnyk_mirror.py
+++ b/scripts/lexicon/build_slovnyk_mirror.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Build-time slovnyk.me mirror for the Word Atlas (#3097).
+
+Politely pre-populates the per-lemma slovnyk.me cache (`data/lexicon/slovnyk_cache/`,
+gitignored) for every manifest lemma, so a later `enrich_manifest` run reads cache hits
+instead of live-fetching. This converts the ~96-min-every-run live-fetch tax into a
+one-time, resumable scrape.
+
+Why this exists: slovnyk.me is Cloudflare-fronted and 429-rate-limits bursts. The old
+0.12s delay tripped it, and `_SlovnykTransientError` results were never cached, so every
+enrich re-fetched ~1000 lemmas. This builder reuses the now-429-friendly
+`enrich_manifest._fetch_slovnyk_entry` (Retry-After + exponential backoff) at a polite,
+configurable rate.
+
+Resumable: fully-cached lemmas are skipped; a partially-cached lemma fetches only its
+missing dictionary slugs. Safe to Ctrl-C and re-run — each lemma's cache is written as it
+completes.
+
+Usage:
+    .venv/bin/python -m scripts.lexicon.build_slovnyk_mirror              # full run
+    .venv/bin/python -m scripts.lexicon.build_slovnyk_mirror --limit 5    # small test batch
+    LEXICON_SLOVNYK_DELAY=0.5 .venv/bin/python -m scripts.lexicon.build_slovnyk_mirror
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+from scripts.lexicon.enrich_manifest import (
+    _SLOVNYK_LOOKUP_SLUGS,
+    MANIFEST,
+    _load_slovnyk_cache_file,
+    _slovnyk_cache,
+    _slovnyk_cache_path,
+    _slovnyk_lookup_word,
+)
+
+
+def _is_fully_cached(lemma: str) -> bool:
+    """True if every dictionary slug for ``lemma`` is already cached (any value, incl. miss)."""
+    cache = _load_slovnyk_cache_file(_slovnyk_cache_path(lemma))
+    if not cache or cache.get("lookup_word") != _slovnyk_lookup_word(lemma):
+        return False
+    lookups = cache.get("lookups")
+    if not isinstance(lookups, dict):
+        return False
+    return all(slug in lookups for slug in _SLOVNYK_LOOKUP_SLUGS)
+
+
+def _manifest_lemmas(manifest_path: Path) -> list[str]:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    seen: set[str] = set()
+    lemmas: list[str] = []
+    for entry in manifest.get("entries", []):
+        lemma = entry.get("lemma")
+        if lemma and lemma not in seen:
+            seen.add(lemma)
+            lemmas.append(lemma)
+    return lemmas
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build-time slovnyk.me mirror (#3097).")
+    parser.add_argument("--manifest", type=Path, default=MANIFEST, help="Atlas manifest JSON.")
+    parser.add_argument("--limit", type=int, default=None, help="Cap lemmas processed (testing).")
+    parser.add_argument("--progress-every", type=int, default=25, help="Progress log cadence.")
+    args = parser.parse_args(argv)
+
+    lemmas = _manifest_lemmas(args.manifest)
+    todo = [lemma for lemma in lemmas if not _is_fully_cached(lemma)]
+    print(
+        f"manifest lemmas={len(lemmas)} already-cached={len(lemmas) - len(todo)} "
+        f"to-fetch={len(todo)} slugs/lemma={len(_SLOVNYK_LOOKUP_SLUGS)}",
+        flush=True,
+    )
+    if args.limit is not None:
+        todo = todo[: args.limit]
+        print(f"--limit {args.limit}: processing {len(todo)} lemma(s)", flush=True)
+
+    fetched = errors = 0
+    start = time.monotonic()
+    for i, lemma in enumerate(todo, 1):
+        try:
+            _slovnyk_cache(lemma)
+            fetched += 1
+        except Exception as exc:  # log and continue; builder must be resumable
+            errors += 1
+            print(f"  ERROR {lemma!r}: {type(exc).__name__}: {exc}", flush=True)
+        if i % args.progress_every == 0 or i == len(todo):
+            elapsed = time.monotonic() - start
+            rate = i / elapsed if elapsed else 0.0
+            eta_min = (len(todo) - i) / rate / 60 if rate else 0.0
+            print(
+                f"  [{i}/{len(todo)}] fetched={fetched} errors={errors} "
+                f"{rate:.2f} lemma/s ETA {eta_min:.1f}m",
+                flush=True,
+            )
+
+    elapsed_min = (time.monotonic() - start) / 60
+    print(f"DONE fetched={fetched} errors={errors} of {len(todo)} in {elapsed_min:.1f}m", flush=True)
+    print(
+        "Re-run any time to fill gaps (resumable). A subsequent `make atlas` enrich now "
+        "reads cache hits instead of live-fetching.",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -41,6 +41,7 @@ import functools
 import html
 import json
 import os
+import random
 import re
 import sqlite3
 import sys
@@ -110,7 +111,14 @@ _IDIOM_ABBREVIATIONS_WITH_INTERNAL_DOTS = (
     "перев.",
     "зі сл.",
 )
-_SLOVNYK_DELAY_SECONDS = 0.12
+# slovnyk.me is Cloudflare-fronted and rate-limits bursts (429). 0.12s (~8 req/s) tripped
+# it: 429 -> _SlovnykTransientError -> never cached -> re-fetched every run (#3097). 0.34s
+# (~3 req/s) is Cloudflare-friendly for sustained scraping; the mirror builder can override
+# via LEXICON_SLOVNYK_DELAY. Paired with Retry-After + exponential backoff in _fetch_slovnyk_entry.
+_SLOVNYK_DELAY_SECONDS = float(os.environ.get("LEXICON_SLOVNYK_DELAY", "0.34"))
+_SLOVNYK_MAX_RETRIES = int(os.environ.get("LEXICON_SLOVNYK_MAX_RETRIES", "5"))
+_SLOVNYK_BACKOFF_BASE_SECONDS = 1.5
+_SLOVNYK_BACKOFF_CAP_SECONDS = 90.0
 _SLOVNYK_USER_AGENT = "learn-ukrainian-word-atlas/1.0 (noncommercial educational per-lemma lookup; issue #2985)"
 _STRESS_SOURCE = "ukrainian-word-stress"
 _CEFR_SOURCE = "PULS CEFR"
@@ -901,30 +909,64 @@ def _polite_slovnyk_delay() -> None:
     _last_slovnyk_fetch = time.monotonic()
 
 
-def _fetch_slovnyk_entry(lemma: str, lookup_word: str, slug: str) -> dict[str, Any] | None:
-    _polite_slovnyk_delay()
-    url = f"{_SLOVNYK_BASE}/dict/{slug}/{quote(lookup_word)}"
+def _parse_retry_after(value: str | None) -> float | None:
+    """Parse a ``Retry-After`` header (delta-seconds form; Cloudflare uses integers)."""
+    if not value:
+        return None
     try:
-        response = requests.get(
-            url,
-            timeout=20,
-            headers={"User-Agent": _SLOVNYK_USER_AGENT},
-        )
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _slovnyk_backoff_sleep(attempt: int, retry_after: float | None) -> None:
+    """Sleep before a retry: honor Retry-After, else exponential backoff + jitter."""
+    if retry_after is not None:
+        delay = retry_after
+    else:
+        delay = min(_SLOVNYK_BACKOFF_CAP_SECONDS, _SLOVNYK_BACKOFF_BASE_SECONDS * (2**attempt))
+    time.sleep(delay + random.uniform(0.0, 0.5))
+
+
+def _fetch_slovnyk_entry(lemma: str, lookup_word: str, slug: str) -> dict[str, Any] | None:
+    """Fetch one slovnyk.me dictionary entry, 429-friendly.
+
+    Retries 429/5xx/network errors with Retry-After + exponential backoff (so a rate-limit
+    resolves into a real result instead of a transient miss that is never cached, #3097).
+    Returns the parsed entry, ``None`` for a genuine 404 (cached as a known miss), or raises
+    ``_SlovnykTransientError`` only after exhausting retries (caller leaves the slug uncached
+    so a later run retries it).
+    """
+    url = f"{_SLOVNYK_BASE}/dict/{slug}/{quote(lookup_word)}"
+    for attempt in range(_SLOVNYK_MAX_RETRIES + 1):
+        _polite_slovnyk_delay()
+        try:
+            response = requests.get(url, timeout=20, headers={"User-Agent": _SLOVNYK_USER_AGENT})
+        except requests.RequestException as exc:
+            if attempt < _SLOVNYK_MAX_RETRIES:
+                _slovnyk_backoff_sleep(attempt, None)
+                continue
+            raise _SlovnykTransientError(f"transient slovnyk.me request failure for {url}") from exc
+
         if response.status_code == 404:
             return None
-        if response.status_code >= 500:
-            msg = f"transient slovnyk.me status {response.status_code} for {url}"
-            raise _SlovnykTransientError(msg)
-        response.raise_for_status()
-    except requests.RequestException as exc:
-        raise _SlovnykTransientError(f"transient slovnyk.me request failure for {url}") from exc
-    return _parse_slovnyk_entry(
-        response.text,
-        lemma=lemma,
-        lookup_word=lookup_word,
-        slug=slug,
-        url=url,
-    )
+        if response.status_code == 429 or response.status_code >= 500:
+            if attempt < _SLOVNYK_MAX_RETRIES:
+                _slovnyk_backoff_sleep(attempt, _parse_retry_after(response.headers.get("Retry-After")))
+                continue
+            raise _SlovnykTransientError(f"transient slovnyk.me status {response.status_code} for {url}")
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            raise _SlovnykTransientError(f"transient slovnyk.me request failure for {url}") from exc
+        return _parse_slovnyk_entry(
+            response.text,
+            lemma=lemma,
+            lookup_word=lookup_word,
+            slug=slug,
+            url=url,
+        )
+    raise _SlovnykTransientError(f"transient slovnyk.me exhausted retries for {url}")
 
 
 def _load_slovnyk_cache_file(path: Path) -> dict[str, Any] | None:

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "e872901ea85965bc10974da75c52308d2647c5b1e2339482a19f1b5cf6840ab9",
+  "fingerprint": "2e7082d706555ff9b53467456cda2659de50f3ffaca884d0e47717e8c8d4aa0b",
   "inputs": {
     "lexicon_code": [
       {
@@ -19,6 +19,10 @@
         "sha256": "239667a7428d1d899443063169d4128cb13a034e4ba9af006edfb6ebd6da253f"
       },
       {
+        "path": "scripts/lexicon/build_slovnyk_mirror.py",
+        "sha256": "065227dcaf26e86bc839ddb75a83a511459c410734adecd8beb3820bd5741231"
+      },
+      {
         "path": "scripts/lexicon/calque_corrections.py",
         "sha256": "4c900cb2dfcd64412c8c9a225f1e75393c30bef780306b0da926985698e747fb"
       },
@@ -32,7 +36,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "79fc8a23afca4fcae91d29dcb4609793e8daf9046d4825b3c0513fa137733cb5"
+        "sha256": "d08a0227aa4118f967b6d863d21ed66aa5043dea623027cfaf6814fd19a660af"
       },
       {
         "path": "scripts/lexicon/heritage_classifier.py",
@@ -55,6 +59,6 @@
   "schema_version": 1,
   "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
   "stats": {
-    "lexicon_code_files": 12
+    "lexicon_code_files": 13
   }
 }

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -1,5 +1,6 @@
 import json
 import sqlite3
+import typing
 
 import pytest
 
@@ -930,13 +931,16 @@ def test_fetch_slovnyk_entry_raises_transient_for_5xx(monkeypatch) -> None:
     class FakeResponse:
         status_code = 503
         text = ""
+        headers: typing.ClassVar[dict] = {}
 
         def raise_for_status(self) -> None:
             raise AssertionError("5xx should be classified before raise_for_status")
 
     monkeypatch.setattr(enrich_manifest_module, "_polite_slovnyk_delay", lambda: None)
+    monkeypatch.setattr(enrich_manifest_module.time, "sleep", lambda *_: None)
     monkeypatch.setattr(enrich_manifest_module.requests, "get", lambda *args, **kwargs: FakeResponse())
 
+    # 5xx now retries with backoff, then raises transient after exhausting retries (#3097).
     with pytest.raises(_SlovnykTransientError):
         enrich_manifest_module._fetch_slovnyk_entry("тест", "тест", "newsum")
 
@@ -946,6 +950,7 @@ def test_fetch_slovnyk_entry_raises_transient_for_connection_error(monkeypatch) 
         raise enrich_manifest_module.requests.ConnectionError("connection timed out")
 
     monkeypatch.setattr(enrich_manifest_module, "_polite_slovnyk_delay", lambda: None)
+    monkeypatch.setattr(enrich_manifest_module.time, "sleep", lambda *_: None)
     monkeypatch.setattr(enrich_manifest_module.requests, "get", fake_get)
 
     with pytest.raises(_SlovnykTransientError):

--- a/tests/test_slovnyk_fetch_retry.py
+++ b/tests/test_slovnyk_fetch_retry.py
@@ -1,0 +1,99 @@
+"""Tests for the 429-friendly slovnyk.me fetch + mirror builder (#3097)."""
+
+import json
+from pathlib import Path
+
+import pytest
+import requests
+
+from scripts.lexicon import build_slovnyk_mirror as mirror
+from scripts.lexicon import enrich_manifest as em
+
+
+class _FakeResp:
+    def __init__(self, status_code: int, text: str = "<html></html>", headers: dict | None = None):
+        self.status_code = status_code
+        self.text = text
+        self.headers = headers or {}
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"status {self.status_code}")
+
+
+@pytest.fixture
+def sleeps(monkeypatch):
+    """Neutralize delays; record backoff sleep durations."""
+    recorded: list[float] = []
+    monkeypatch.setattr(em, "_polite_slovnyk_delay", lambda: None)
+    monkeypatch.setattr(em.time, "sleep", recorded.append)
+    monkeypatch.setattr(em.random, "uniform", lambda a, b: 0.0)
+    return recorded
+
+
+def _queue(monkeypatch, responses: list[_FakeResp]) -> None:
+    it = iter(responses)
+    monkeypatch.setattr(em.requests, "get", lambda url, **kw: next(it))
+
+
+def test_parse_retry_after():
+    assert em._parse_retry_after("5") == 5.0
+    assert em._parse_retry_after("0") == 0.0
+    assert em._parse_retry_after("") is None
+    assert em._parse_retry_after(None) is None
+    assert em._parse_retry_after("soon") is None
+
+
+def test_retries_on_429_then_succeeds(monkeypatch, sleeps):
+    monkeypatch.setattr(em, "_parse_slovnyk_entry", lambda *a, **k: {"text": "ok"})
+    _queue(monkeypatch, [_FakeResp(429), _FakeResp(429), _FakeResp(200)])
+    assert em._fetch_slovnyk_entry("вода", "вода", "newsum") == {"text": "ok"}
+    assert len(sleeps) == 2  # two backoff sleeps before the 200
+
+
+def test_retries_on_5xx_then_succeeds(monkeypatch, sleeps):
+    monkeypatch.setattr(em, "_parse_slovnyk_entry", lambda *a, **k: {"text": "ok"})
+    _queue(monkeypatch, [_FakeResp(503), _FakeResp(200)])
+    assert em._fetch_slovnyk_entry("вода", "вода", "newsum") == {"text": "ok"}
+    assert len(sleeps) == 1
+
+
+def test_404_returns_none_without_retry(monkeypatch, sleeps):
+    _queue(monkeypatch, [_FakeResp(404)])
+    assert em._fetch_slovnyk_entry("неслово", "неслово", "newsum") is None
+    assert sleeps == []
+
+
+def test_persistent_429_raises_transient_after_max_retries(monkeypatch, sleeps):
+    _queue(monkeypatch, [_FakeResp(429)] * (em._SLOVNYK_MAX_RETRIES + 1))
+    with pytest.raises(em._SlovnykTransientError):
+        em._fetch_slovnyk_entry("вода", "вода", "newsum")
+    assert len(sleeps) == em._SLOVNYK_MAX_RETRIES  # slept between retries, not after the last
+
+
+def test_honors_retry_after_header(monkeypatch, sleeps):
+    monkeypatch.setattr(em, "_parse_slovnyk_entry", lambda *a, **k: {"text": "ok"})
+    _queue(monkeypatch, [_FakeResp(429, headers={"Retry-After": "7"}), _FakeResp(200)])
+    assert em._fetch_slovnyk_entry("вода", "вода", "newsum") == {"text": "ok"}
+    assert sleeps == [7.0]  # honored Retry-After exactly (jitter mocked to 0)
+
+
+def test_network_error_retries_then_raises(monkeypatch, sleeps):
+    def boom(url, **kw):
+        raise requests.ConnectionError("down")
+
+    monkeypatch.setattr(em.requests, "get", boom)
+    with pytest.raises(em._SlovnykTransientError):
+        em._fetch_slovnyk_entry("вода", "вода", "newsum")
+    assert len(sleeps) == em._SLOVNYK_MAX_RETRIES
+
+
+def test_manifest_lemmas_dedupes_preserving_order(tmp_path: Path):
+    manifest = tmp_path / "m.json"
+    manifest.write_text(
+        json.dumps(
+            {"entries": [{"lemma": "вода"}, {"lemma": "дім"}, {"lemma": "вода"}, {"no_lemma": 1}]}
+        ),
+        encoding="utf-8",
+    )
+    assert mirror._manifest_lemmas(manifest) == ["вода", "дім"]


### PR DESCRIPTION
## Root cause
`enrich_manifest._fetch_slovnyk_entry` fetched at 0.12s (~8 req/s) with **zero 429 handling**. slovnyk.me is Cloudflare-fronted and rate-limits bursts → 429 → `_SlovnykTransientError` → result **never cached** → re-fetched every run. The polite delay paid on every failed attempt is the bulk of the ~96-min `make atlas` enrich tax (#3097).

## Fix (root cause, not symptom)
- **`_fetch_slovnyk_entry` is now 429-friendly** — retries 429/5xx/network errors with **Retry-After + exponential backoff** (1.5s base, ×2, 90s cap, jitter), up to `LEXICON_SLOVNYK_MAX_RETRIES` (5). A rate-limit resolves into a real cached result instead of a transient miss.
- Base delay 0.12 → **0.34s** (~3 req/s, Cloudflare-friendly), env-overridable via `LEXICON_SLOVNYK_DELAY`.
- **New `scripts/lexicon/build_slovnyk_mirror.py`** — resumable build-time mirror that pre-populates the per-lemma cache (gitignored) so enrich reads cache hits. Skips fully-cached lemmas; safe to Ctrl-C + re-run; `--limit N` for testing.

## Verified (tool-backed)
- Live probe: polite spaced requests return **200** (Cloudflare) — the 0.12s burst is what tripped 429s.
- Live `--limit 5` builder run: **0 errors**, cache populates correctly.
- Cache-hit access measured at **0.2 ms/lemma** → when full, the slovnyk portion of enrich is effectively free.
- **73 tests pass** incl. new `tests/test_slovnyk_fetch_retry.py` (Retry-After honored, 429→200 retry, 5xx retry, 404→None no-retry, exhausted→transient, network-error retry). ruff clean.

## Honest scoping note
The cache turned out to be **~full already** (2666/2667) — my earlier enrich completed it (filled missing slugs in existing files; file count stayed flat). So the immediate slowness was a one-time population that's now done, and **no long mirror run is needed right now**. This PR is the **robustness fix** that keeps the cache from re-degrading on 429 bursts / newly added lemmas (e.g. dedup-to-lemma #2882), plus the tool to pre-populate those new lemmas out-of-band.

The residual ~32-min enrich cost is **deterministic CPU** (VESUM paradigms, sources.db) — a separate optimization, not slovnyk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)