### PR TITLE
docs(b2): normalize wiki lifecycle metadata batch 37

### DIFF
--- a/wiki/grammar/b2/active-participles-past.md
+++ b/wiki/grammar/b2/active-participles-past.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-1
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/advanced-case-semantics.md
+++ b/wiki/grammar/b2/advanced-case-semantics.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-2
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/advanced-conjunctions-i.md
+++ b/wiki/grammar/b2/advanced-conjunctions-i.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-10
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/aspect-nuances-secondary-imperfectivization.md
+++ b/wiki/grammar/b2/aspect-nuances-secondary-imperfectivization.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-2
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/b2-impersonal-passive.md
+++ b/wiki/grammar/b2/b2-impersonal-passive.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-2
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/checkpoint-lexicology-i.md
+++ b/wiki/grammar/b2/checkpoint-lexicology-i.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-2
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/checkpoint-morphology.md
+++ b/wiki/grammar/b2/checkpoint-morphology.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-10
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/direct-indirect-speech.md
+++ b/wiki/grammar/b2/direct-indirect-speech.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-5
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/idioms-animals.md
+++ b/wiki/grammar/b2/idioms-animals.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-8
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/kharchuvannia-i-kukhnia.md
+++ b/wiki/grammar/b2/kharchuvannia-i-kukhnia.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-5
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/modern-diaspora.md
+++ b/wiki/grammar/b2/modern-diaspora.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-7
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/multi-clause-sentences.md
+++ b/wiki/grammar/b2/multi-clause-sentences.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-9
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/mystetstvo-i-literatura.md
+++ b/wiki/grammar/b2/mystetstvo-i-literatura.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-4
 -->
 
 ## Як це пояснюють у школі


### PR DESCRIPTION
## Summary
- Normalize B2 wiki-meta lifecycle fields for 13 already-locked grammar pages.
- Use existing paired plan lifecycle metadata as the source of truth for each page's last_reviewed and reviewed_by values.
- Metadata-only wiki comment changes; no article prose, plans, review files, generated artifacts, or config files changed.

## Validation
- PYTHONPATH="" .venv/bin/python "/scripts/wiki/quality_gate.py" --track b2: PASS
- PYTHONPATH="" .venv/bin/python -m pytest "/tests/test_wiki_sources_schema.py" "/tests/test_wiki_quality_gate.py": 20 passed
- git diff --check: PASS
- custom wiki-meta check: PASS; metadata matches existing plan lifecycle fields
- .venv/bin/python scripts/audit/lint_agent_trailer.py origin/main..codex/b2-wiki-readiness-batch-37: PASS

Refs #3190