### PR TITLE
docs(b2): normalize wiki lifecycle metadata batch 38

### DIFF
--- a/wiki/grammar/b2/neologisms-borrowings.md
+++ b/wiki/grammar/b2/neologisms-borrowings.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-8
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/news-analysis.md
+++ b/wiki/grammar/b2/news-analysis.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-5
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/numeral-declension-time-dates.md
+++ b/wiki/grammar/b2/numeral-declension-time-dates.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-9
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/parenthetical-expressions.md
+++ b/wiki/grammar/b2/parenthetical-expressions.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-7
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/passive-in-context.md
+++ b/wiki/grammar/b2/passive-in-context.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-3
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/past-passive-participles.md
+++ b/wiki/grammar/b2/past-passive-participles.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-7
 -->
 
 ## Вступне методичне слово для автора

--- a/wiki/grammar/b2/phonetic-stylistic-devices.md
+++ b/wiki/grammar/b2/phonetic-stylistic-devices.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-4
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/phrases-word-combinations.md
+++ b/wiki/grammar/b2/phrases-word-combinations.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-3
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/pobut-shchodenne.md
+++ b/wiki/grammar/b2/pobut-shchodenne.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-5
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/politics-government-vocabulary.md
+++ b/wiki/grammar/b2/politics-government-vocabulary.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-6
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/professional-email-basics.md
+++ b/wiki/grammar/b2/professional-email-basics.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-7
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/professional-reports.md
+++ b/wiki/grammar/b2/professional-reports.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-4
 -->
 
 ## Як це пояснюють у школі


### PR DESCRIPTION
## Summary
- Normalize B2 wiki-meta lifecycle fields for 12 already-locked grammar pages.
- Use existing paired plan lifecycle metadata as the source of truth for each page's last_reviewed and reviewed_by values.
- Metadata-only wiki comment changes; no article prose, plans, review files, generated artifacts, or config files changed.

## Validation
- PYTHONPATH="" .venv/bin/python "/scripts/wiki/quality_gate.py" --track b2: PASS
- PYTHONPATH="" .venv/bin/python -m pytest "/tests/test_wiki_sources_schema.py" "/tests/test_wiki_quality_gate.py": 20 passed
- git diff --check: PASS
- custom wiki-meta check: PASS; metadata matches existing plan lifecycle fields
- .venv/bin/python scripts/audit/lint_agent_trailer.py origin/main..codex/b2-wiki-readiness-batch-38: PASS

Refs #3190