### PR TITLE
fix(build): calibrate B1 source-pedagogy review

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -5067,6 +5067,16 @@ def parse_review_response(
     # raises "missing quoted excerpt" even when 3 valid quotes are present.
     if isinstance(evidence_quotes, list) and evidence_quotes:
         entry["evidence_quotes"] = evidence_quotes
+    rubric_mapping = _rubric_mapping_from_payload(payload)
+    if rubric_mapping:
+        entry["rubric_mapping"] = rubric_mapping
+    raw_flags = payload.get("flags")
+    if raw_flags is None:
+        raw_flags = payload.get("flags_raised")
+    if isinstance(raw_flags, str):
+        raw_flags = [raw_flags]
+    if isinstance(raw_flags, list) and raw_flags:
+        entry["flags"] = [_clean_telemetry_text(flag, 120) for flag in raw_flags if str(flag).strip()]
     validate_llm_review_report({**_placeholder_review_report(), dim: entry})
     if verdict not in {"PASS", "REVISE", "REJECT"}:
         raise LinearPipelineError(f"LLM QG response for {dim} has invalid verdict")

--- a/scripts/build/phases/linear-review-dim.generated.md
+++ b/scripts/build/phases/linear-review-dim.generated.md
@@ -34,7 +34,20 @@ judgment regex cannot make. For `{DIM}`:
   *quality* of engagement, not its presence.
 - `pedagogical`: does the sequencing actually teach? Are examples illuminating?
   Does each concept earn the next? Respect the learner's prior knowledge
-  (BUILD, don't REPEAT).
+  (BUILD, don't REPEAT). Source-pedagogy failures are in scope even when the
+  plan/wiki asked for them: REVISE or REJECT any grammar module that promotes a
+  metaphor, discourse heuristic, activity label, or writer-created grouping into
+  a grammar taxonomy unless Ukrainian textbook/corpus evidence explicitly
+  supports that framing. Do not reward plan adherence when the upstream
+  plan/wiki itself appears pedagogically unsupported. For example, a lesson may
+  use "background/foreground" as an optional writing heuristic after aspect is
+  taught, but if it asks learners to classify every verb as `тло`/`подія` as
+  though those are textbook grammar categories, flag
+  `unsupported_taxonomy_frame` and score the pedagogical dim below PASS.
+  Likewise, if a module teaches impersonal/no-subject forms, examples and
+  activities must preserve the no-subject property; adding an ordinary subject
+  noun to the target pattern is a pedagogical grammar error, not harmless
+  context.
 - `naturalness`: does the Ukrainian read as native? Assess flow, register, idiom
   beyond the VESUM + russianism-shadow the gate already confirmed.
 - `decolonization`: is the lesson teaching Ukrainian **on its own terms**?
@@ -128,24 +141,36 @@ Unverified items become FLAG strings in your evidence and weigh the score down.
 - **E. Rule #6.** Every claim pairs a verbatim quote with an MCP-grounded
   verification or an explicit absence-of-verification flag. A PASS with no
   grounded evidence is a reviewer-protocol failure.
-- **F. Activity split (pedagogical, engagement).** Locate
+- **F. Source-pedagogy audit (pedagogical dim; grammar modules).** Verify that
+  the lesson's named teaching frame is a source-backed way to teach the grammar,
+  not just an attractive model-generated metaphor. Search the textbook/corpus
+  layer for the key Ukrainian terms in the module's grammar frame and compare
+  the results to the generated task labels. If sources support the underlying
+  grammar but not the module's taxonomy, flag `unsupported_taxonomy_frame`. If
+  the plan/wiki introduced the unsupported frame, still flag it; do not treat
+  "the writer followed the plan" as evidence for pedagogy. Heuristics are
+  allowed only when clearly labeled as heuristics and not drilled as grammar
+  categories. For impersonal/no-subject material, verify that target examples
+  remain subjectless; a subject noun in the target pattern is
+  `impersonal_subject_intrusion`.
+- **G. Activity split (pedagogical, engagement).** Locate
   `<activity_split_audit>`; verify it is present, `inline_n` matches the
   `<!-- INJECT_ACTIVITY: act-N -->` count, `workbook_n` matches
   `len(activities.yaml) - inline_n`, and both fall in the level's ranges. A
   green audit line on broken counts (`split_valid=true` but out of range) is the
   worse failure — FLAG `activity_split_audit_lied`.
-- **G. Corpus-access (all dims).** Verify no out-of-level citations
+- **H. Corpus-access (all dims).** Verify no out-of-level citations
   (a1/a2: Grades 1-4/1-5 only; no adult literary; external limited to ULP /
   Pohribnyi). FLAG `out_of_level_textbook` / `out_of_level_literary` /
   `out_of_level_external`. Score as PEDAGOGICAL evidence-against.
-- **H. Student-aware (pedagogical, engagement, naturalness).** Verify the writer
+- **I. Student-aware (pedagogical, engagement, naturalness).** Verify the writer
   did not re-explain already-taught grammar (`re_explained_known_grammar`) and
   did not introduce unknown vocab without inline gloss
   (`unknown_vocab_unscaffolded` / `missing_foreshadowing_gloss`). Repeated
   learner-facing concepts, skills, or activity families must be explicitly
   framed as review, reuse, or deeper practice; otherwise FLAG
   `unsignposted_repetition`.
-- **I. Audit-line integrity (all dims).** Verify the three pre-emit audit lines
+- **J. Audit-line integrity (all dims).** Verify the three pre-emit audit lines
   (`implementation_map_audit`, `bad_form_audit`, `activity_split_audit`) are
   present, parseable, and consistent with the artifacts. Missing → FLAG
   `audit_line_missing`; inconsistent → FLAG `audit_line_inconsistent`.
@@ -168,7 +193,7 @@ Return only JSON:
 {"score": 0.0, "evidence_quotes": ["verbatim quote 1", "verbatim quote 2", "verbatim quote 3"], "rubric_mapping": "Quote 1: ...; Quote 2: ...; Quote 3: ...", "evidence": "\"verbatim quote from evidence_quotes\"", "flags": ["out_of_level_literary", "..."], "verdict": "REVISE"}
 ```
 
-The `flags` array MUST contain any FLAG strings (audits A-I) and any `#R-*` ids
+The `flags` array MUST contain any FLAG strings (audits A-J) and any `#R-*` ids
 (universal-rules section) that apply to your assigned dim. An empty array is fine
 when nothing fired. The `evidence` field MUST be one of the `evidence_quotes`,
 wrapped in escaped quotes; a paraphrase in any evidence field is a

--- a/scripts/build/phases/linear-review-dim.md
+++ b/scripts/build/phases/linear-review-dim.md
@@ -38,6 +38,20 @@ For `{DIM}` specifically:
 - `pedagogical`: does the sequencing actually teach? Are examples
   illuminating? Does each concept earn the next? The gate confirmed word
   budgets and section presence; you assess whether the pedagogy *works*.
+  Source-pedagogy failures are in scope even when the plan/wiki asked for
+  them: REVISE or REJECT any grammar module that promotes a metaphor,
+  discourse heuristic, activity label, or writer-created grouping into a
+  grammar taxonomy unless Ukrainian textbook/corpus evidence explicitly
+  supports that framing. Do not reward plan adherence when the upstream
+  plan/wiki itself appears pedagogically unsupported. For example, a lesson
+  may use "background/foreground" as an optional writing heuristic after
+  aspect is taught, but if it asks learners to classify every verb as
+  `тло`/`подія` as though those are textbook grammar categories, flag
+  `unsupported_taxonomy_frame` and score the pedagogical dim below PASS.
+  Likewise, if a module teaches impersonal/no-subject forms, examples and
+  activities must preserve the no-subject property; adding an ordinary subject
+  noun to the target pattern is a pedagogical grammar error, not harmless
+  context.
   REJECT-level failures mirroring writer rules:
   - Mirrors `#R-NO-SCAFFOLDING-LEAKS`: REJECT writer-side scaffolding leaks.
     Writer-side scaffolding never appears in module body. Forbidden in
@@ -237,7 +251,20 @@ E. **Reinforce rule #6.** Every claim pairs (i) a verbatim quote from the
    absence-of-verification flag. A `PASS` with no grounded evidence is a
    reviewer-protocol failure.
 
-F. **Activity split audit (pedagogical, engagement).** The writer is
+F. **Source-pedagogy audit (pedagogical dim; grammar modules).** Verify that
+   the lesson's named teaching frame is a source-backed way to teach the
+   grammar, not just an attractive model-generated metaphor. Search the
+   textbook/corpus layer for the key Ukrainian terms in the module's grammar
+   frame and compare the results to the generated task labels. If sources
+   support the underlying grammar but not the module's taxonomy, flag
+   `unsupported_taxonomy_frame`. If the plan/wiki introduced the unsupported
+   frame, still flag it; do not treat "the writer followed the plan" as
+   evidence for pedagogy. Heuristics are allowed only when clearly labeled as
+   heuristics and not drilled as grammar categories. For impersonal/no-subject
+   material, verify that target examples remain subjectless; a subject noun in
+   the target pattern is `impersonal_subject_intrusion`.
+
+G. **Activity split audit (pedagogical, engagement).** The writer is
 contracted to emit two complementary activity sets per `ACTIVITY_CONFIGS[{LEVEL}]`:
 INLINE (light, theory-time checks anchored via `<!-- INJECT_ACTIVITY: act-N -->`)
 and WORKBOOK (substantive, after-lesson drill, no INJECT marker). For A1:
@@ -267,7 +294,7 @@ theory check" purpose; WORKBOOK activities that are too trivial (single-item
 quizzes, no discrimination depth) break their drill purpose. Score the
 BALANCE-vs-PURPOSE not just the count.
 
-G. **Corpus-access audit (all dims).** The writer is gated to a level-specific
+H. **Corpus-access audit (all dims).** The writer is gated to a level-specific
 corpus surface per the Corpus Access (level-gated) table in `linear-write.md`.
 Verify the writer did not cite out-of-level sources:
 
@@ -291,7 +318,7 @@ For ANY out-of-level citation, the quote may STILL be factually correct but the
 register/source choice is wrong for the learner level. Score this as
 PEDAGOGICAL evidence-against, not as a fabrication.
 
-H. **Student-aware audit (pedagogical, engagement, naturalness).** The writer
+I. **Student-aware audit (pedagogical, engagement, naturalness).** The writer
 is given a `{LEARNER_STATE}` block listing cumulative_vocabulary +
 known_grammar from prior modules. Verify the writer:
 
@@ -327,7 +354,7 @@ module BUILD instead of REPEAT. Naturalness score: scaffolded vocabulary
 introduction reads as a real teacher's voice; un-introduced vocab feels like a
 textbook dump.
 
-I. **Pre-emit audit-line integrity (all dims).** The writer is required to
+J. **Pre-emit audit-line integrity (all dims).** The writer is required to
 emit three machine-readable audit lines BEFORE the artifact fences, in order:
 
 1. `<implementation_map_audit>manifest_obligations=N covered_in_map=M missing=[...]</implementation_map_audit>`
@@ -353,7 +380,7 @@ Return only JSON:
 {"score": 0.0, "evidence_quotes": ["verbatim quote 1", "verbatim quote 2", "verbatim quote 3"], "rubric_mapping": "Quote 1: ...; Quote 2: ...; Quote 3: ...", "evidence": "\"verbatim quote from evidence_quotes\"", "flags": ["activity_split_audit_missing", "out_of_level_literary", "..."], "verdict": "REVISE"}
 ```
 
-The `flags` array MUST contain any FLAG strings raised during audits A-I that
+The `flags` array MUST contain any FLAG strings raised during audits A-J that
 apply to your assigned dim per the per-dim labeling in §"Scope". An empty array
 is fine when no flags fired. The pipeline aggregates flags across dims and
 surfaces them in the build telemetry; the writer's self-correction loop reads

--- a/tests/test_reviewer_prompt_v7_register_rules.py
+++ b/tests/test_reviewer_prompt_v7_register_rules.py
@@ -80,3 +80,17 @@ def test_reviewer_prompt_mirrors_v7_register_rule(
     assert f"Mirrors `{rule_id}`" in prompt
     for anchor in anchors:
         assert _normalize(anchor) in normalized
+
+
+def test_reviewer_prompt_flags_unsupported_grammar_taxonomies() -> None:
+    normalized = _normalize(_prompt())
+
+    anchors = (
+        "Source-pedagogy audit",
+        "promotes a metaphor, discourse heuristic, activity label, or writer-created grouping into a grammar taxonomy",
+        "unsupported_taxonomy_frame",
+        "`тло`/`подія`",
+        "impersonal_subject_intrusion",
+    )
+    for anchor in anchors:
+        assert _normalize(anchor) in normalized

--- a/tests/test_v7_review.py
+++ b/tests/test_v7_review.py
@@ -92,6 +92,43 @@ def _events_from_stdout(stdout: str) -> list[dict[str, Any]]:
     return [json.loads(line) for line in stdout.splitlines() if line.strip()]
 
 
+def test_parse_review_response_preserves_reviewer_flags_and_mapping() -> None:
+    response = json.dumps(
+        {
+            "score": 6.4,
+            "evidence": '"classify every verb as тло or подія"',
+            "evidence_quotes": ["classify every verb as тло or подія"],
+            "rubric_mapping": "Promotes a discourse heuristic into a grammar taxonomy.",
+            "flags": ["unsupported_taxonomy_frame", "activity_split_audit_missing"],
+            "verdict": "REVISE",
+        }
+    )
+
+    parsed = linear_pipeline.parse_review_response(response, "pedagogical")
+
+    assert parsed["rubric_mapping"] == "Promotes a discourse heuristic into a grammar taxonomy."
+    assert parsed["flags"] == ["unsupported_taxonomy_frame", "activity_split_audit_missing"]
+
+
+def test_parse_review_response_preserves_wrapped_flags_raised_string() -> None:
+    response = json.dumps(
+        {
+            "pedagogical": {
+                "score": 6.4,
+                "evidence": '"classify every verb as тло or подія"',
+                "evidence_quotes": ["classify every verb as тло or подія"],
+                "rubric_mapping": "Promotes a discourse heuristic into a grammar taxonomy.",
+                "flags_raised": "unsupported_taxonomy_frame",
+                "verdict": "REVISE",
+            }
+        }
+    )
+
+    parsed = linear_pipeline.parse_review_response(response, "pedagogical")
+
+    assert parsed["flags"] == ["unsupported_taxonomy_frame"]
+
+
 def test_v7_review_refuses_self_review(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],


### PR DESCRIPTION
## Summary
- add a source-pedagogy audit to the LLM QG reviewer prompt so grammar modules can reject unsupported model-created taxonomies even when the plan/wiki requested them
- explicitly flag the known B1 M06 failure class: classifying every verb as `тло`/`подія` as if it were a textbook grammar category
- preserve reviewer `flags` and `rubric_mapping` in parsed LLM QG output so orchestration can aggregate the actual failure reasons

## Calibration Evidence
- Pre-patch M06 review missed the teacher-flagged issue and only failed on generic activity/audit issues.
- Post-prompt M06 pedagogical review returned `REVISE` with `unsupported_taxonomy_frame` on the exact `тло`/`подія` task.
- Parser check against that raw response now preserves `unsupported_taxonomy_frame` and the rubric mapping.

## Validation
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_reviewer_prompt_v7_register_rules.py tests/test_v7_review.py -q`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_v7_review.py tests/test_reviewer_prompt_v7_register_rules.py`
- `git diff --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Review Gate
Draft pending independent Gemini-family/Agy review via `ai_agent_bridge` before merge.
