### PR TITLE
docs(b2): normalize wiki lifecycle metadata batch 39

### DIFF
--- a/wiki/grammar/b2/proverbs-nature-time-caution.md
+++ b/wiki/grammar/b2/proverbs-nature-time-caution.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-3
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/questions-deliberative-rhetorical.md
+++ b/wiki/grammar/b2/questions-deliberative-rhetorical.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-10
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/set-expressions-combined.md
+++ b/wiki/grammar/b2/set-expressions-combined.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-9
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/sport-i-dozvillia.md
+++ b/wiki/grammar/b2/sport-i-dozvillia.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-6
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/synonymy-in-registers.md
+++ b/wiki/grammar/b2/synonymy-in-registers.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-10
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/synonymy-practice-precision.md
+++ b/wiki/grammar/b2/synonymy-practice-precision.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-8
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/syntactic-stylistic-devices.md
+++ b/wiki/grammar/b2/syntactic-stylistic-devices.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-8
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/tekhnolohii-ta-shi.md
+++ b/wiki/grammar/b2/tekhnolohii-ta-shi.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-6
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/text-analysis.md
+++ b/wiki/grammar/b2/text-analysis.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-6
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/word-formation-abstract-nouns.md
+++ b/wiki/grammar/b2/word-formation-abstract-nouns.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-9
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/word-formation-adjective-adverbs.md
+++ b/wiki/grammar/b2/word-formation-adjective-adverbs.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-3
 -->
 
 ## Як це пояснюють у школі

--- a/wiki/grammar/b2/zdorovya-i-medytsyna.md
+++ b/wiki/grammar/b2/zdorovya-i-medytsyna.md
@@ -6,6 +6,9 @@ domain: grammar/b2
 tracks: [b2, c1]
 compiled: 2026-04-26
 generated_by_model: gemini-3.1-pro-preview
+lifecycle: locked
+last_reviewed: 2026-06-15
+reviewed_by: codex/b2-wiki-readiness-batch-4
 -->
 
 ## Як це пояснюють у школі


### PR DESCRIPTION
## Summary
- Normalize B2 wiki-meta lifecycle fields for the final 12 already-locked grammar pages.
- Use existing paired plan lifecycle metadata as the source of truth for each page's last_reviewed and reviewed_by values.
- Metadata-only wiki comment changes; no article prose, plans, review files, generated artifacts, or config files changed.

## Validation
- PYTHONPATH="" .venv/bin/python "/scripts/wiki/quality_gate.py" --track b2: PASS
- PYTHONPATH="" .venv/bin/python -m pytest "/tests/test_wiki_sources_schema.py" "/tests/test_wiki_quality_gate.py": 20 passed
- git diff --check: PASS
- custom wiki-meta check: PASS; metadata matches existing plan lifecycle fields
- .venv/bin/python scripts/audit/lint_agent_trailer.py origin/main..codex/b2-wiki-readiness-batch-39: PASS

Refs #3190