### PR TITLE
fix(audit): §8 gate accepts modern technical VESUM-gaps in both modes (#3270)

### DIFF
--- a/scripts/audit/validate_atlas_conformance.py
+++ b/scripts/audit/validate_atlas_conformance.py
@@ -314,6 +314,23 @@ _VESUM_GAP_HERITAGE_LEMMAS: frozenset[str] = frozenset(
     }
 )
 
+# MODERN technical/terminological VESUM gaps (#3270). A DIFFERENT class from the heritage
+# allowlist above: standard CONTEMPORARY terms (linguistics / grammar metalanguage) correctly
+# absent from VESUM AND from the HISTORICAL heritage corpus (Грінченко/ЕСУМ). The live heritage
+# lookup structurally CANNOT self-heal these (they postdate it), so — unlike the heritage
+# allowlist — this list is authoritative in BOTH modes (live + offline). Per-entry cited; small.
+_MODERN_TECHNICAL_LEMMAS: frozenset[str] = frozenset(
+    {
+        # морфонеміка — morphophonemics; standard linguistics subfield. Attested in
+        # Українська мова — Енциклопедія + Енциклопедія українознавства (Чижевський,
+        # «Морфонологія»). Taught in b1/checkpoint-morphophonemics; not in СУМ-11 (1970s).
+        "морфонеміка",
+        # контрфактичний — counterfactual; standard grammar metalanguage for unreal
+        # conditionals. Taught in b1/conditionals-unreal; modern term, not in СУМ-11.
+        "контрфактичний",
+    }
+)
+
 
 def _is_proper_noun_entry(entry: Mapping[str, Any]) -> bool:
     # Real pos tags carry a morphology suffix (e.g. ``proper noun:pl`` for Афіни /
@@ -379,6 +396,10 @@ def _check_lemma_in_vesum(
     # pre-Soviet headword or etymological lemma means the word is authentic Ukrainian, not
     # a Russianism (#3211). The curated allowlist is the offline fallback (no sources.db).
     if _heritage_attests(heritage, lemma):
+        return
+    # Curated modern technical terms: authoritative in BOTH modes (the live heritage lookup
+    # cannot attest contemporary terminology). #3270.
+    if _normalize_text(raw_lemma) in _MODERN_TECHNICAL_LEMMAS:
         return
     if heritage is None and _normalize_text(raw_lemma) in _VESUM_GAP_HERITAGE_LEMMAS:
         return

--- a/tests/test_atlas_conformance.py
+++ b/tests/test_atlas_conformance.py
@@ -126,6 +126,17 @@ def test_lemma_in_vesum_heritage_fallback_exempts_attested_word():
     assert _gates_for(entry, vesum=set(), heritage={"кобіта"}) == []
 
 
+def test_lemma_in_vesum_exempts_modern_technical_term_in_both_modes():
+    # #3270: морфонеміка / контрфактичний are standard MODERN terms absent from VESUM AND
+    # from the HISTORICAL heritage corpus. The live heritage lookup cannot self-heal them,
+    # so the curated modern-technical allowlist must exempt them in BOTH modes — including
+    # the live-heritage mode (heritage present but NOT attesting), which was the failing case.
+    for lemma, pos in (("морфонеміка", "noun"), ("контрфактичний", "adjective")):
+        entry = _entry(lemma=lemma, url_slug=lemma, pos=pos)
+        assert _gates_for(entry, vesum=set()) == []  # offline mode (no heritage source)
+        assert _gates_for(entry, vesum=set(), heritage=set()) == []  # live mode, not attested
+
+
 def test_lemma_in_vesum_flags_when_absent_from_both_vesum_and_heritage():
     # #3211: the gate still catches genuinely-unattested single words — absent from VESUM
     # AND not in the heritage corpus (heritage present but empty) → violation. The allowlist


### PR DESCRIPTION
## Problem
A full `make atlas` regen fails the §8 `lemma_in_vesum` gate on two **legit new B1 terms** — `контрфактичний` (counterfactual, `b1/conditionals-unreal`) and `морфонеміка` (morphophonemics, `b1/checkpoint-morphophonemics`). Both are absent from VESUM **and** from the historical Грінченко/ЕСУМ heritage corpus (they're modern terminology), so the live heritage lookup can't self-heal them.

## Root cause
The curated `_VESUM_GAP_HERITAGE_LEMMAS` allowlist is consulted **only when `sources.db` is absent** (offline/CI). With the DB present (local `make atlas`), the live heritage check runs and these modern terms fall straight through to a violation.

## Fix
Add a **separate** `_MODERN_TECHNICAL_LEMMAS` allowlist (distinct from the heritage one — a different class), checked **before** the offline branch → **authoritative in BOTH modes**. Rationale: the live Грінченко/ЕСУМ lookup structurally *cannot* attest contemporary terminology, so a curated human attestation must override in both. Per-entry cited.

## Verified
- **29 conformance tests pass**, incl. a new both-modes test (exempt even when `heritage` is *present but does not attest* — the failing live-mode case).
- **Integration:** full `build_data_manifest` (current vocab, 2437 lemmas incl. both terms) + **live-heritage** §8 check → **CLEAN, 0 violations**.
- ruff clean.

Unblocks refreshing the committed manifest to current vocab (separate follow-up — the next step toward completing lemma-keying tranche 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)