### PR TITLE
fix(pipeline): #2991 — deterministic activities.yaml self_check normalization

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -6801,6 +6801,61 @@ def _apply_vocab_floor_correction(
     }
 
 
+def _normalize_performance_self_check_duplicates(
+    activities: Sequence[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    removed: list[dict[str, Any]] = []
+    for activity_index, activity in enumerate(activities, start=1):
+        if (
+            str(activity.get("type") or "") == "performance"
+            and "self_check" in activity
+            and not isinstance(activity.get("self_check"), list)
+            and "self_checklist" in activity
+            and isinstance(activity.get("self_checklist"), list)
+        ):
+            updated = dict(activity)
+            removed_value = updated.pop("self_check")
+            normalized.append(updated)
+            removed.append(
+                {
+                    "activity_index": activity_index,
+                    "activity_id": str(activity.get("id") or f"#{activity_index}"),
+                    "removed_type": type(removed_value).__name__,
+                    "self_checklist_count": len(activity["self_checklist"]),
+                }
+            )
+            continue
+        normalized.append(activity)
+    return normalized, {
+        "kind": "performance_self_check_duplicate",
+        "normalized_count": len(removed),
+        "normalized": removed,
+    }
+
+
+def _apply_activity_schema_correction(
+    *,
+    module_dir: Path,
+    gate_report: Mapping[str, Any],
+) -> dict[str, Any]:
+    activities_path = module_dir / "activities.yaml"
+    activities = _load_bare_activity_list(activities_path)
+    normalized, diagnostic = _normalize_performance_self_check_duplicates(activities)
+    if diagnostic["normalized_count"] > 0:
+        activities_path.write_text(
+            yaml.safe_dump(normalized, allow_unicode=True, sort_keys=False),
+            encoding="utf-8",
+        )
+    return {
+        "kind": "pipeline_activity_schema_self_check_normalization",
+        "gate": "activity_schema",
+        "gate_report": dict(gate_report),
+        "applied": bool(diagnostic["normalized_count"]),
+        "diagnostic": diagnostic,
+    }
+
+
 def _apply_python_qg_correction(
     gate: str,
     qg_report: Mapping[str, Any],
@@ -6835,6 +6890,10 @@ def _apply_python_qg_correction(
     if gate in DETERMINISTIC_VOCAB_FLOOR_GATES:
         payload = _apply_vocab_floor_correction(module_dir=module_dir, plan_path=plan_path, gate_report=gate_report)
         return True, frozenset(), payload
+    if gate == "activity_schema":
+        payload = _apply_activity_schema_correction(module_dir=module_dir, gate_report=gate_report)
+        if payload.get("applied") is True:
+            return True, frozenset(), payload
     if gate in WRITER_CORRECTION_GATES:
         payload = _apply_writer_correction(
             gate,

--- a/tests/test_activity_schema_self_check_normalization.py
+++ b/tests/test_activity_schema_self_check_normalization.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.build import linear_pipeline
+
+
+def _write_activities(module_dir: Path, activities: list[dict[str, Any]]) -> None:
+    (module_dir / "activities.yaml").write_text(
+        yaml.safe_dump(activities, allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _activity_schema_only_report(module_dir: Path) -> dict[str, Any]:
+    activities = yaml.safe_load((module_dir / "activities.yaml").read_text("utf-8"))
+    gate = linear_pipeline._activity_schema_gate(activities)
+    return {"gates": {"activity_schema": gate, "passed": gate["passed"]}}
+
+
+def test_activity_schema_correction_drops_duplicate_string_self_check(
+    tmp_path: Path,
+) -> None:
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    checklist = [
+        "Я витримав спокійний, рівний тон зачину.",
+        "Я не пришвидшив приспів.",
+    ]
+    _write_activities(
+        module_dir,
+        [
+            {
+                "id": "koliadky-performance",
+                "type": "performance",
+                "title": "Колядування",
+                "prompt": "Продекламуй зачин колядки.",
+                "fragment": "Добрий вечір тобі.",
+                "self_check": "Чи витримав ти спокійний, рівний тон зачину?",
+                "self_checklist": checklist,
+            }
+        ],
+    )
+    reports: list[dict[str, Any]] = []
+
+    def qg_runner() -> dict[str, Any]:
+        report = _activity_schema_only_report(module_dir)
+        reports.append(report)
+        return report
+
+    def writer_corrector(_context: linear_pipeline.CorrectionContext) -> str:
+        raise AssertionError("self_check normalization must not call an LLM writer")
+
+    report = linear_pipeline.run_python_qg_with_corrections(
+        module_dir,
+        tmp_path / "plan.yaml",
+        qg_runner=qg_runner,
+        writer_corrector=writer_corrector,
+    )
+
+    rewritten = yaml.safe_load((module_dir / "activities.yaml").read_text("utf-8"))
+    assert "self_check" not in rewritten[0]
+    assert rewritten[0]["self_checklist"] == checklist
+    assert linear_pipeline._activity_schema_gate(rewritten)["passed"] is True
+    assert len(reports) == 2
+    assert reports[0]["gates"]["activity_schema"]["passed"] is False
+    assert reports[1]["gates"]["activity_schema"]["passed"] is True
+    assert report["gates"]["activity_schema"]["passed"] is True
+    assert report["gates"]["passed"] is True
+    assert report["gates"].get("previously_passed_regression", {"passed": True})[
+        "passed"
+    ] is True
+
+    correction = json.loads(
+        (module_dir / "python_qg_correction_r1.json").read_text("utf-8")
+    )
+    assert correction["gate"] == "activity_schema"
+    assert correction["correction"]["applied"] is True
+    assert correction["correction"]["diagnostic"]["normalized_count"] == 1
+
+
+def test_activity_schema_self_check_normalization_negative_cases() -> None:
+    valid_list = [
+        {
+            "id": "valid-performance",
+            "type": "performance",
+            "prompt": "Продекламуй фрагмент.",
+            "self_check": ["Дикція чітка."],
+            "self_checklist": ["Дикція чітка."],
+        }
+    ]
+    missing_checklist = [
+        {
+            "id": "invalid-performance",
+            "type": "performance",
+            "prompt": "Продекламуй фрагмент.",
+            "self_check": "Дикція чітка.",
+        }
+    ]
+    non_performance = [
+        {
+            "id": "dialogue-self-check",
+            "type": "dialogue",
+            "self_check": "Дикція чітка.",
+            "self_checklist": ["Дикція чітка."],
+        }
+    ]
+
+    normalized, diagnostic = linear_pipeline._normalize_performance_self_check_duplicates(
+        valid_list
+    )
+    assert normalized == valid_list
+    assert diagnostic["normalized_count"] == 0
+    assert linear_pipeline._activity_schema_gate(normalized)["passed"] is True
+
+    normalized, diagnostic = linear_pipeline._normalize_performance_self_check_duplicates(
+        missing_checklist
+    )
+    assert normalized == missing_checklist
+    assert diagnostic["normalized_count"] == 0
+    assert linear_pipeline._activity_schema_gate(normalized)["passed"] is False
+
+    normalized, diagnostic = linear_pipeline._normalize_performance_self_check_duplicates(
+        non_performance
+    )
+    assert normalized == non_performance
+    assert diagnostic["normalized_count"] == 0


### PR DESCRIPTION
## Defect

V7 folk builds can emit a `performance` activity with a stray string `self_check` alongside the real list-valued `self_checklist`. The `activity_schema` gate fails on the string field before LLM-QG, and the existing ADR-008 writer correction path only patches `module.md`, so `activities.yaml` remains broken.

## Fix

Add a deterministic `activity_schema` correction before the writer correction fallback. It rewrites `activities.yaml` only when all of these are true:

- `type: performance`
- `self_check` is present and is not a list
- `self_checklist` is present and is a list

The correction drops only the stray `self_check` key, preserves `self_checklist`, writes the YAML back to disk with `sort_keys=False`, and lets `run_python_qg_with_corrections` re-run the gate normally.

## Tests

- `.venv/bin/python -m pytest -q -k "activity_schema or correction or yaml_activities or python_qg"`
- `.venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_activity_schema_self_check_normalization.py`
- Synthetic koliadky-shaped `activities.yaml` re-validation: before `activity_schema` fails, after deterministic rewrite it passes and `self_check` is absent.
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Scope

Two files changed: pipeline correction logic plus focused tests. No generated status/audit/review artifacts, linter configs, or Python version files are touched.
