### PR TITLE
fix(deps): resolve requirements-lock.txt conflicts for #2732 part 1

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -6,7 +6,7 @@ aiosignal==1.4.0
 aiosqlite==0.22.1
 annotated-doc==0.0.4
 annotated-types==0.7.0
-anthropic==0.97.0
+anthropic==0.46.0
 anyio==4.13.0
 APScheduler==3.11.2
 attrs==26.1.0
@@ -82,10 +82,10 @@ joserfc==1.6.5
 jsonschema-specifications==2025.9.1
 jsonschema==4.26.0
 keyring==25.7.0
-librt==0.8.1
-lxml==6.1.0
+librt==0.11.0
+lxml==6.0.4
 lz4==4.4.5
-mando==0.8.2
+mando==0.7.1
 marisa-trie==1.3.1
 markdown-it-py==4.0.0
 markdown2==2.5.5
@@ -96,7 +96,7 @@ mcp-memory-service==10.54.0
 mcp==1.27.2
 mdurl==0.1.2
 more-itertools==11.0.2
-mpmath==1.4.1
+mpmath==1.3.0
 multidict==6.7.1
 multiprocess==0.70.19
 mypy==2.1.0
@@ -113,7 +113,7 @@ pandas==3.0.1
 pathspec==1.1.1
 pdftext==0.6.3
 peft==0.18.1
-pillow==12.2.0
+pillow==10.4.0
 platformdirs==4.9.6
 playwright==1.59.0
 pluggy==1.6.0
@@ -125,7 +125,6 @@ psutil==7.2.2
 pyarrow==23.0.1
 pyasn1==0.6.3
 pyasn1_modules==0.4.2
-pycookiecheat==0.8.0
 pycparser==3.0
 pydantic-settings==2.12.0
 pydantic==2.12.5
@@ -150,7 +149,7 @@ pytest-cov==7.1.0
 pytest-xdist==3.8.0
 pytest==9.0.3
 python-dateutil==2.9.0.post0
-python-discovery==1.1.0
+python-discovery==1.4.2
 python-docx==1.2.0
 python-dotenv==1.2.2
 python-jose==3.5.0
@@ -160,7 +159,7 @@ qdrant-client==1.17.0
 radon==6.0.1
 RapidFuzz==3.14.5
 referencing==0.37.0
-regex==2026.5.9
+regex==2024.11.6
 requests==2.33.0
 rich==14.3.3
 rpds-py==0.30.0
@@ -172,7 +171,7 @@ scikit-learn==1.8.0
 scipy==1.17.0
 sentence-transformers==5.4.1
 sentencepiece==0.2.1
-setuptools==82.0.1
+setuptools==81.0.0
 shellingham==1.5.4
 six==1.17.0
 sniffio==1.3.1


### PR DESCRIPTION
## Summary

Surgically updates `requirements-lock.txt` so it resolves with pip's real resolver via:

```bash
/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/pip install --dry-run -r requirements-lock.txt
```

This intentionally does not regenerate the lock. The strategic fix remains #1634: replace the pip-freeze lock generation with a real resolver workflow.

## Pin changes and guardrail classification

- `lxml`: `6.1.0` -> `6.0.4`; forced by `inscriptis==2.7.1` requiring `lxml>=5.4.0,<6.1.0`; guardrail (b), no newer `inscriptis` release, picked latest compatible `6.0.x`. This was identified as a routine compatibility correction rather than a security downgrade.
- `pillow`: `12.2.0` -> `10.4.0`; forced by `marker-pdf==1.10.2` requiring `Pillow>=10.1.0,<11.0.0`; guardrail (b), no newer `marker-pdf` release exists. Security review needed: this lowers a likely security-bumped Pillow pin to satisfy the upstream cap.
- `anthropic`: `0.97.0` -> `0.46.0`; forced by `marker-pdf==1.10.2` requiring `anthropic>=0.46.0,<0.47.0`; guardrail (b), no newer `marker-pdf` release exists. Security/feature review needed because this reverts a newer pin.
- `regex`: `2026.5.9` -> `2024.11.6`; forced by `marker-pdf==1.10.2` requiring `regex>=2024.4.28,<2025.0.0`; guardrail (b), no newer `marker-pdf` release exists. Security/feature review needed because this reverts a newer pin.
- `setuptools`: `82.0.1` -> `81.0.0`; forced by `torch==2.11.0` requiring `setuptools<82`. `torch==2.12.0` was checked and still requires `setuptools<82`, so guardrail (b). Security/feature review needed because this reverts a newer pin.
- `mando`: `0.8.2` -> `0.7.1`; forced by `radon==6.0.1` requiring `mando>=0.6,<0.8`; guardrail (b), `radon==6.0.1` is latest. Review needed because this reverts a newer pin.
- `mpmath`: `1.4.1` -> `1.3.0`; forced by `sympy==1.14.0` requiring `mpmath>=1.1.0,<1.4`; guardrail (b), `sympy==1.14.0` is latest. Review needed because this reverts a newer pin.
- `librt`: `0.8.1` -> `0.11.0`; forced by `mypy==2.1.0` requiring `librt>=0.11.0`; resolver-forced upward correction.
- `python-discovery`: `1.1.0` -> `1.4.2`; forced by `virtualenv==21.4.2` requiring `python-discovery>=1.4`; resolver-forced upward correction.

Additional lock cleanup:

- Removed `pycookiecheat==0.8.0` from `requirements-lock.txt`. All available `pycookiecheat` releases pin old `cryptography` versions (`0.8.0` requires `cryptography==43.*`; older tested releases require `42.*`, `41.0.4`, or `3.4.6`). Keeping it would force lowering `cryptography==47.0.0` and also conflicts with `joserfc` / `mcp-memory-service`. `pip show pycookiecheat` reports no `Required-by`, so this does not remove a live transitive dependency. Follow-up risk: `scripts/wiki/fetch_external_sources.py` has an optional direct import path for browser cookie extraction; a resolver-compatible replacement or optional extra should be considered separately.

## Validation

Dry-run resolver success:

```text
Would install Authlib-1.7.2 FlagEmbedding-1.4.0 Flask-3.1.3 PyJWT-2.13.0 Werkzeug-3.1.6 accelerate-1.13.0 aiohappyeyeballs-2.6.2 aiohttp-3.14.0 anthropic-0.46.0 anyio-4.13.0 ast_serialize-0.5.0 attrs-26.1.0 build-1.5.0 chardet-7.4.3 click-8.4.0 coverage-7.14.0 curl_cffi-0.15.0 docstring_parser-0.18.0 ecdsa-0.19.2 fastapi-0.136.3 greenlet-3.5.1 grpcio-1.81.0 hf-xet-1.5.0 idna-3.17 inscriptis-2.7.1 joserfc-1.6.5 librt-0.11.0 lxml-6.0.4 markdown2-2.5.5 mcp-1.27.2 mcp-memory-service-10.54.0 more-itertools-11.0.2 mypy-2.1.0 onnxruntime-1.24.3 open_clip_torch-3.3.0 playwright-1.59.0 pre_commit-4.6.0 pyasn1-0.6.3 pyee-13.0.1 pypdf-6.13.0 pytest-9.0.3 python-discovery-1.4.2 python-dotenv-1.2.2 python-multipart-0.0.32 regex-2024.11.6 requests-2.33.0 ruff-0.15.13 setuptools-81.0.0 sqlite-vec-0.1.9 starlette-1.2.1 stevedore-5.8.0 timm-1.0.27 tqdm-4.67.3 typer-0.25.1 urllib3-2.7.0 uvicorn-0.48.0 virtualenv-21.4.2 vulture-2.16 wheel-0.47.0 zeroconf-0.149.12 zlib-state-0.1.12
EXIT:0
```

Import smoke:

```text
(5, 4, 0, 0) 10.4.0
```

No full pytest run: no code changed; task requested only the import smoke.

## Out of scope

#2732 part 2 (`.dagger/uv.lock` / idna) remains out of scope for this PR.