### PR TITLE
fix(deps): pin lxml 6.1.0→6.0.4 to satisfy inscriptis (#2732 part 1)

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -83,7 +83,7 @@ jsonschema-specifications==2025.9.1
 jsonschema==4.26.0
 keyring==25.7.0
 librt==0.8.1
-lxml==6.1.0
+lxml==6.0.4
 lz4==4.4.5
 mando==0.8.2
 marisa-trie==1.3.1


### PR DESCRIPTION
Resolves the one **genuine, undocumented** `requirements-lock.txt` conflict (closes the actionable part of #2732 part 1).

## The conflict
`inscriptis==2.7.1` (hard runtime dep via `ir_datasets`; uses lxml for HTML parsing) requires `lxml>=5.4.0,<6.1.0`, but #1866 bumped the pin to `lxml==6.1.0`. Unlike the marker-pdf/pycookiecheat caps, this is **not** in the documented "DO NOT CHASE" set — it's a real inconsistency.

## Fix
`lxml==6.1.0` → `lxml==6.0.4` (latest 6.0.x). The 6.1.0 pin was never actually installed (venv runs 5.4.0); #1866 was a routine Dependabot bump, not security. 6.0.4 is modern and an upgrade over the installed 5.4.0.

## Verification (deterministic)
```
lxml 6.0.4 satisfies inscriptis <6.1.0,>=5.4.0: True
```
`pip install --dry-run` now resolves past lxml. The **remaining** dry-run conflicts (`marker-pdf→anthropic/regex`, `pycookiecheat→cryptography`) are the EXPECTED, documented over-strict upstream pins (`requirements.txt:54-79`, "DO NOT CHASE") — CI installs `--no-deps` and they are runtime-verified safe, so they are intentionally untouched. (That was the bug in the closed #3281, which downgraded anthropic 0.97→0.46 etc.)

## Scope
- #2732 **part 2** (`.dagger/uv.lock` idna) remains out of scope (needs dagger SDK checked out).
- Strategic root cause #1634 (pip-freeze lock-gen; isolate marker-pdf as an optional extra) is the long-term fix — separate, architectural.

CI (`--no-deps` install + pytest) validates lxml 6.0.4.