### PR TITLE
docs(folk): #3079 Session 39 — P3-validate findings + Part C 4-class taxonomy

### DIFF
--- a/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
+++ b/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
@@ -63,7 +63,62 @@
 > the "don't self-merge" restriction, not the "don't push to main" one. Stage-0 PR #2759 self-merged
 > under this grant (commit `abf280f490`).
 
-## ▶▶▶ SESSION 38 HANDOFF (2026-06-16 — #3079 B1 BUILT+MERGED (the insert-only LLM-QG pedagogical loop is LIVE); ROLE CHANGED (#0.2: I implement infra myself); P3-validate surfaced Gap C is the real blocker → diagnosed+fixed+MERGED the first wall #2991; P3-validate RE-RUN IN FLIGHT) — **RESUME HERE**
+## ▶▶▶ SESSION 39 HANDOFF (2026-06-16 — P3-validate RAN FOR REAL (`--no-resume`) → outcome (c): python_qg's Gap-C rotating wall blocks the build BEFORE the B1 loop; root-caused the wall into a 4-class taxonomy that is MOSTLY gate false-positives; dispatched C.2a fix) — **RESUME HERE**
+
+> **⏱ HONEST SCOPE:** INFRA diagnostic + first-fix-dispatched session (per #0.2). No new folk content (modules 6/42,
+> dossiers 25/42, wikis 15/42 unchanged). B1 is STILL e2e-unproven — a fresh build can't reach the LLM-QG loop because
+> python_qg's Gap-C wall terminates first. The session's value is the SHARP diagnostic (design doc §8) + the first
+> gate-correctness fix dispatched.
+
+### 🔑 THE KEY FINDING — Session-38's "P3-validate" never validated anything (resume no-op), and the REAL P3-validate proves Gap C is gate FALSE-POSITIVES
+- **Session-38's in-flight build silently NO-OP'd.** `v7_build.py` **resumes by default** (`v7_build.py:1289`); the build
+  worktree was cut from `origin/main` where koliadky already exists at 9.2 → writer + gates SKIPPED → `module.md`/`llm_qg.json`
+  came back **byte-identical to main**. The 9.2 was STALE, not a fresh derivation. **LESSON (baked into NEXT ACTIONS): any
+  "does a fresh build self-converge" validation MUST pass `--no-resume`.**
+- **The real P3-validate** (`v7_build.py folk koliadky-shchedrivky --no-resume --worktree`, build
+  `folk-koliadky-shchedrivky-20260616-002047`) ran the writer fresh, hit `python_qg`, and **terminated there**:
+  `module_failed phase=python_qg, reason="Python QG failed after ADR-008 correction paths"` — the per-gate single-shot
+  `attempts` wall (`linear_pipeline.py:5662`) after 2 passes on the same words. **It NEVER reached the B1 LLM-QG loop.**
+- **Root-caused the 7 `vesum_verified` misses + citations + word_count into a 4-class taxonomy (design doc §8, file:line + tool-verified):**
+  - **A. Verbatim folk primary embedded in `activities.yaml`** (`нащада`,`било`,`сонінько`): the module.md blockquote exemption
+    (`_strip_quote_fidelity_verified_blockquotes`) WORKS but doesn't reach yaml `passage:`/list fields. `сонінько` has NO VESUM +
+    NO heritage → exemption is the ONLY correct fix. **= #2991 yaml-scope × #3162.**
+  - **B. Bare «X» dialectal-form citation in analysis** (`activities.yaml:97,102`): mention-not-use; existing exemption covers only `як «X»`.
+  - **C. Foreign comparative proper nouns** (`Йоль`,`Ялда`,`Ялду`): ad hoc — `Сатурналії` also absent from VESUM yet NOT flagged.
+  - **D. Genuine coinage** (`дерево-явір`,`першопочаток`): the ONLY items a fixer should rephrase.
+  - `citations_resolve`: 5 CANONICAL works (Костомаров/Чубинський/Чижевський/Попович) + the primary, cited but absent from the plan `[S#]` registry.
+  - `word_count` 4026/4600: real under-write (downstream of unblocking python_qg).
+- **STRUCTURAL CONCLUSION (refines the §4 plan order): gate-correctness is logically PRIOR to the C.3 multi-gate loop** — a loop
+  can't "fix" a verbatim primary / foreign comparison / cited dialectal form (deleting them is wrong), so A/B/C must be closed
+  as deterministic gate fixes FIRST; C.3 + the cross-model fixer then handle only D + word_count + cross-gate iteration.
+
+### ✅ DONE THIS SESSION
+- **Real P3-validate executed** (`--no-resume`) → outcome (c) above. Reaped the 2 stale build worktrees (232024 failed-run, 000802 resume-no-op); forensics retained on their `build/folk/koliadky-shchedrivky-*` branches (#M-10).
+- **Design doc §8 written** — the P3-validate findings + 4-class taxonomy + corrected Part C sequencing (C.2a→C.2b→C.2c→C.3→citations) with signal-design options. In THIS PR.
+- **C.2a DISPATCHED** — codex `folk-3079-c2a` (branch `codex/folk-3079-c2a`, base 404a4b7810): extend the verbatim-primary VESUM
+  exemption to embedded primaries in `activities.yaml`/`vocabulary.yaml` via corpus-resolution + cross-reference fast-path. Brief:
+  `/tmp/folk-3079-c2a-vesum-primary-yaml-brief.md` (scoped to Class A only; B/C/D explicitly out of scope). NO auto-merge.
+
+### ⚠ IN-FLIGHT AT HANDOFF
+- **Dispatch `folk-3079-c2a`** (codex, C.2a). Watcher: Monitor `bbdqn6r0e` (session-scoped, poll `/api/delegate/active`). **First thing
+  next session:** `curl -sS http://127.0.0.1:8765/api/delegate/active`; if gone, `gh pr list --head codex/folk-3079-c2a --state open`
+  + read `batch_state/tasks/folk-3079-c2a*` → review the PR (verify the §8-style tool-backed claims: Class-A words drop, B/C/D still
+  checked, no over-exemption regression), then it's an orchestrator-reconcile (shared pipeline infra — driver opens, never self-merges this).
+
+### ▶ NEXT ACTIONS (RESUME HERE, in order)
+1. **Land C.2a** — review/iterate the `folk-3079-c2a` PR; confirm tool-backed acceptance (Class-A exempted, B/C/D still flagged, modern-prose typo still fails).
+2. **C.2b (Class B)** — guarded dialectal-citation exemption (do NOT over-widen bare «X»). **C.2c (Class C)** — foreign-proper-noun handling (allowlist/marker; fix Сатурналії-vs-Йоль). Both deterministic, my lane (#0.2).
+3. **C.3 (Class D + word_count + the loop)** — bounded multi-gate python_qg loop + cross-model fixer (rephrase `дерево-явір`/`першопочаток`; iterate across gates). The durable structural fix.
+4. **citations_resolve** — promote the 5 canonical sources into the koliadky plan `[S#]` registry (+ consider a canonical-source resolver).
+5. **THEN re-run P3-validate** (`--no-resume`!) — once A+B+C+citations+word_count clear python_qg, confirm the B1 loop reaches pedagogical ≥8 unaided. ONLY THEN is B1 validated e2e.
+6. (Parallel content lane, unblocked) dossier #26 `narodni-lehendy` → #27 `istorychni-perekazy`.
+
+### ⚠ CARRY-FORWARD
+- **`--no-resume` is MANDATORY for any self-converge validation build** — without it, resume silently reuses main's artifacts and reports a stale pass (cost Session 38 a 2-hr no-op).
+- Build worktree to reap once C.2a lands: `folk-koliadky-shchedrivky-20260616-002047` (artifacts on its build branch). The failed-build `module.md`/`activities.yaml` there are the C.2a TEST FIXTURE — don't delete until C.2a's tests are committed.
+- B1 e2e-UNPROVEN until step 5. Role #0.2 LIVE (I implement/drive infra; never file-and-forget). Never reset/commit on `main`; folk push `--no-verify`.
+
+## ▶▶▶ SESSION 38 HANDOFF (2026-06-16 — #3079 B1 BUILT+MERGED (the insert-only LLM-QG pedagogical loop is LIVE); ROLE CHANGED (#0.2: I implement infra myself); P3-validate surfaced Gap C is the real blocker → diagnosed+fixed+MERGED the first wall #2991; P3-validate RE-RUN IN FLIGHT)
 
 > **⏱ HONEST SCOPE:** B1 (the #3079 quick win) is built + unit-tested + **MERGED to main** — but it is **NOT yet
 > e2e-validated**: a fresh seminar build can't even REACH the LLM-QG loop because python_qg dies first at the

--- a/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
+++ b/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
@@ -86,7 +86,7 @@
   - **B. Bare «X» dialectal-form citation in analysis** (`activities.yaml:97,102`): mention-not-use; existing exemption covers only `як «X»`.
   - **C. Foreign comparative proper nouns** (`Йоль`,`Ялда`,`Ялду`): ad hoc — `Сатурналії` also absent from VESUM yet NOT flagged.
   - **D. Genuine coinage** (`дерево-явір`,`першопочаток`): the ONLY items a fixer should rephrase.
-  - `citations_resolve`: 5 CANONICAL works (Костомаров/Чубинський/Чижевський/Попович) + the primary, cited but absent from the plan `[S#]` registry.
+  - `citations_resolve`: 5 CANONICAL works (Костомаров/Чубинський/Чижевський/Попович) + the primary — **ALSO a gate FALSE-POSITIVE**: they ARE in the koliadky plan `references:` (lines 93-117, `type: primary`, matching author/work) and the writer cited them correctly; the gate just fails to resolve the prose `Author «Title»` form. Fix is GATE-SIDE, not plan promotion.
   - `word_count` 4026/4600: real under-write (downstream of unblocking python_qg).
 - **STRUCTURAL CONCLUSION (refines the §4 plan order): gate-correctness is logically PRIOR to the C.3 multi-gate loop** — a loop
   can't "fix" a verbatim primary / foreign comparison / cited dialectal form (deleting them is wrong), so A/B/C must be closed
@@ -109,7 +109,7 @@
 1. **Land C.2a** — review/iterate the `folk-3079-c2a` PR; confirm tool-backed acceptance (Class-A exempted, B/C/D still flagged, modern-prose typo still fails).
 2. **C.2b (Class B)** — guarded dialectal-citation exemption (do NOT over-widen bare «X»). **C.2c (Class C)** — foreign-proper-noun handling (allowlist/marker; fix Сатурналії-vs-Йоль). Both deterministic, my lane (#0.2).
 3. **C.3 (Class D + word_count + the loop)** — bounded multi-gate python_qg loop + cross-model fixer (rephrase `дерево-явір`/`першопочаток`; iterate across gates). The durable structural fix.
-4. **citations_resolve** — promote the 5 canonical sources into the koliadky plan `[S#]` registry (+ consider a canonical-source resolver).
+4. **citations_resolve** — GATE-SIDE fix: resolve the writer's prose `Author «Title»` citations against the plan `references` (the 5 sources are ALREADY in the koliadky plan, lines 93-117; `_citation_candidates` already loads `plan_references` at L7490). NOT plan promotion.
 5. **THEN re-run P3-validate** (`--no-resume`!) — once A+B+C+citations+word_count clear python_qg, confirm the B1 loop reaches pedagogical ≥8 unaided. ONLY THEN is B1 validated e2e.
 6. (Parallel content lane, unblocked) dossier #26 `narodni-lehendy` → #27 `istorychni-perekazy`.
 

--- a/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
+++ b/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
@@ -95,7 +95,7 @@
 ### ✅ DONE THIS SESSION
 - **Real P3-validate executed** (`--no-resume`) → outcome (c) above. Reaped the 2 stale build worktrees (232024 failed-run, 000802 resume-no-op); forensics retained on their `build/folk/koliadky-shchedrivky-*` branches (#M-10).
 - **Design doc §8 written** — the P3-validate findings + 4-class taxonomy + corrected Part C sequencing (C.2a→C.2b→C.2c→C.3→citations) with signal-design options. In THIS PR.
-- **C.2a DISPATCHED → PR #3286; codex adversarial review caught a real over-exemption bug → FIX DISPATCHED (see IN-FLIGHT).** codex `folk-3079-c2a`
+- **C.2a DISPATCHED → PR #3286 → MERGED (see "✅ C.2a MERGED" below).** codex `folk-3079-c2a`
   implemented it (177 LOC + 5 tests, `linear_pipeline.py`): `_strip_vesum_verbatim_primary_spans` blanks verbatim
   primary SPANS (≥8-word window) in `activities.yaml`/`vocabulary.yaml` matched against (a) verified `module.md` blockquotes
   [fast-path] + (b) literary-corpus hits (`_search_literary_hits`). Span-scoped, seminar-gated, fail-safe. **My review (tool-backed):**
@@ -104,16 +104,20 @@
   identically on base `404a4b7810`, local-DB-vs-CI discrepancy). CI green except `Test (pytest)` (was pending at handoff).
   **Merge deferred to orchestrator — shared pipeline infra (driver opens, doesn't self-merge).** Brief: `/tmp/folk-3079-c2a-vesum-primary-yaml-brief.md`.
 
+### ✅ C.2a MERGED (PR #3286 → main `3955402947`)
+Full fleet loop, no orchestrator: codex built it → codex adversarial review caught a real cross-field-boundary over-exemption
+bug → fix dispatched (`_activity_vesum_text` now applies the primary-span strip per string LEAF, before flatten, so matches
+can't cross yaml fields) + a cross-boundary regression test → CI green → **self-merged per #M-12**. The verbatim-primary VESUM
+exemption now reaches `activities.yaml`/`vocabulary.yaml` — folk's dominant Gap-C wall is closed.
+
 ### ⚠ IN-FLIGHT AT HANDOFF
-- **PR #3286 (C.2a) — codex review = REQUEST-CHANGES (real over-exemption bug); FIX DISPATCHED `folk-3079-c2a-fix`** (Monitor
-  `bxfwet8m8`). The bug: `_strip_vesum_verbatim_primary_spans` ran on the FLATTENED activity text, so 8-token windows could cross
-  yaml field boundaries → a bare dialectal citation + adjacent field text could match a corpus hit and get blanked (the test
-  stubbed `_search_literary_hits=[]` so it missed this). Fix = confine the exemption to per-field spans + a cross-boundary
-  regression test, pushed onto the PR branch. **First thing next session:** check `folk-3079-c2a-fix` outcome → `gh pr checks 3286`
-  → verify the over-exemption regression → if green, **SELF-MERGE per the merge grant** (#M-12; don't wait on the orchestrator).
+- **C.2b DISPATCHED** — codex `folk-3079-c2b` (Monitor `b6z52t4zz`), off main (has C.2a). Class B: exempt bare «X» dialectal
+  citations whose token resolves to a verified module primary (reuses C.2a's `verified_primary_texts` — can't over-exempt
+  arbitrary forms). Brief: `/tmp/folk-3079-c2b-dialectal-citation-brief.md`. **First thing next session:** check the C.2b PR →
+  fleet-review (`ab ask-codex`) → CI-green → SELF-MERGE (#M-12).
 
 ### ▶ NEXT ACTIONS (RESUME HERE, in order)
-1. **C.2a (PR #3286)** — land the boundary fix (`folk-3079-c2a-fix`), confirm CI + the cross-boundary regression, then SELF-MERGE (fleet-reviewed, #M-12).
+1. **C.2b** — land it (review → CI → self-merge). Then **C.2c** (Class C foreign proper nouns: `Йоль`/`Ялда` allowlist or marker; fix the Сатурналії-vs-Йоль inconsistency).
 2. **C.2b (Class B)** — guarded dialectal-citation exemption (do NOT over-widen bare «X»). **C.2c (Class C)** — foreign-proper-noun handling (allowlist/marker; fix Сатурналії-vs-Йоль). Both deterministic, my lane (#0.2).
 3. **C.3 (Class D + word_count + the loop)** — bounded multi-gate python_qg loop + cross-model fixer (rephrase `дерево-явір`/`першопочаток`; iterate across gates). The durable structural fix.
 4. **citations_resolve** — GATE-SIDE fix: resolve the writer's prose `Author «Title»` citations against the plan `references` (the 5 sources are ALREADY in the koliadky plan, lines 93-117; `_citation_candidates` already loads `plan_references` at L7490). NOT plan promotion.

--- a/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
+++ b/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
@@ -95,18 +95,22 @@
 ### ✅ DONE THIS SESSION
 - **Real P3-validate executed** (`--no-resume`) → outcome (c) above. Reaped the 2 stale build worktrees (232024 failed-run, 000802 resume-no-op); forensics retained on their `build/folk/koliadky-shchedrivky-*` branches (#M-10).
 - **Design doc §8 written** — the P3-validate findings + 4-class taxonomy + corrected Part C sequencing (C.2a→C.2b→C.2c→C.3→citations) with signal-design options. In THIS PR.
-- **C.2a DISPATCHED** — codex `folk-3079-c2a` (branch `codex/folk-3079-c2a`, base 404a4b7810): extend the verbatim-primary VESUM
-  exemption to embedded primaries in `activities.yaml`/`vocabulary.yaml` via corpus-resolution + cross-reference fast-path. Brief:
-  `/tmp/folk-3079-c2a-vesum-primary-yaml-brief.md` (scoped to Class A only; B/C/D explicitly out of scope). NO auto-merge.
+- **C.2a DISPATCHED → LANDED as PR #3286, REVIEWED+APPROVED (awaiting orchestrator reconcile).** codex `folk-3079-c2a`
+  implemented it cleanly (177 LOC + 5 tests, `linear_pipeline.py`): `_strip_vesum_verbatim_primary_spans` blanks verbatim
+  primary SPANS (≥8-word window) in `activities.yaml`/`vocabulary.yaml` matched against (a) verified `module.md` blockquotes
+  [fast-path] + (b) literary-corpus hits (`_search_literary_hits`). Span-scoped, seminar-gated, fail-safe. **My review (tool-backed):**
+  Class-A `нащада`/`било`/`сонінько` exempted; out-of-scope `Йоль`/`дерево-явір`/`першопочаток` still checked; over-exemption guard
+  holds (planted `привітаннячкоз` still fails); the 3 `test_vesum_heritage_attestation` failures are VERIFIED PRE-EXISTING (fail
+  identically on base `404a4b7810`, local-DB-vs-CI discrepancy). CI green except `Test (pytest)` (was pending at handoff).
+  **Merge deferred to orchestrator — shared pipeline infra (driver opens, doesn't self-merge).** Brief: `/tmp/folk-3079-c2a-vesum-primary-yaml-brief.md`.
 
 ### ⚠ IN-FLIGHT AT HANDOFF
-- **Dispatch `folk-3079-c2a`** (codex, C.2a). Watcher: Monitor `bbdqn6r0e` (session-scoped, poll `/api/delegate/active`). **First thing
-  next session:** `curl -sS http://127.0.0.1:8765/api/delegate/active`; if gone, `gh pr list --head codex/folk-3079-c2a --state open`
-  + read `batch_state/tasks/folk-3079-c2a*` → review the PR (verify the §8-style tool-backed claims: Class-A words drop, B/C/D still
-  checked, no over-exemption regression), then it's an orchestrator-reconcile (shared pipeline infra — driver opens, never self-merges this).
+- **PR #3286 (C.2a)** — reviewed+approved by me; **awaiting orchestrator reconcile** + `Test (pytest)` CI (other checks green).
+  **First thing next session:** `gh pr checks 3286` → if pytest green and not yet merged, ping orchestrator `needs=merge` (do NOT
+  self-merge — shared pipeline infra). If pytest RED, read the failing job; the only local reds were the 3 pre-existing heritage tests.
 
 ### ▶ NEXT ACTIONS (RESUME HERE, in order)
-1. **Land C.2a** — review/iterate the `folk-3079-c2a` PR; confirm tool-backed acceptance (Class-A exempted, B/C/D still flagged, modern-prose typo still fails).
+1. **C.2a (PR #3286)** — DONE pending CI/reconcile (reviewed+approved). Confirm pytest green, ping orchestrator to merge.
 2. **C.2b (Class B)** — guarded dialectal-citation exemption (do NOT over-widen bare «X»). **C.2c (Class C)** — foreign-proper-noun handling (allowlist/marker; fix Сатурналії-vs-Йоль). Both deterministic, my lane (#0.2).
 3. **C.3 (Class D + word_count + the loop)** — bounded multi-gate python_qg loop + cross-model fixer (rephrase `дерево-явір`/`першопочаток`; iterate across gates). The durable structural fix.
 4. **citations_resolve** — GATE-SIDE fix: resolve the writer's prose `Author «Title»` citations against the plan `references` (the 5 sources are ALREADY in the koliadky plan, lines 93-117; `_citation_candidates` already loads `plan_references` at L7490). NOT plan promotion.

--- a/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
+++ b/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
@@ -95,8 +95,8 @@
 ### ✅ DONE THIS SESSION
 - **Real P3-validate executed** (`--no-resume`) → outcome (c) above. Reaped the 2 stale build worktrees (232024 failed-run, 000802 resume-no-op); forensics retained on their `build/folk/koliadky-shchedrivky-*` branches (#M-10).
 - **Design doc §8 written** — the P3-validate findings + 4-class taxonomy + corrected Part C sequencing (C.2a→C.2b→C.2c→C.3→citations) with signal-design options. In THIS PR.
-- **C.2a DISPATCHED → LANDED as PR #3286, REVIEWED+APPROVED (awaiting orchestrator reconcile).** codex `folk-3079-c2a`
-  implemented it cleanly (177 LOC + 5 tests, `linear_pipeline.py`): `_strip_vesum_verbatim_primary_spans` blanks verbatim
+- **C.2a DISPATCHED → PR #3286; codex adversarial review caught a real over-exemption bug → FIX DISPATCHED (see IN-FLIGHT).** codex `folk-3079-c2a`
+  implemented it (177 LOC + 5 tests, `linear_pipeline.py`): `_strip_vesum_verbatim_primary_spans` blanks verbatim
   primary SPANS (≥8-word window) in `activities.yaml`/`vocabulary.yaml` matched against (a) verified `module.md` blockquotes
   [fast-path] + (b) literary-corpus hits (`_search_literary_hits`). Span-scoped, seminar-gated, fail-safe. **My review (tool-backed):**
   Class-A `нащада`/`било`/`сонінько` exempted; out-of-scope `Йоль`/`дерево-явір`/`першопочаток` still checked; over-exemption guard
@@ -105,12 +105,15 @@
   **Merge deferred to orchestrator — shared pipeline infra (driver opens, doesn't self-merge).** Brief: `/tmp/folk-3079-c2a-vesum-primary-yaml-brief.md`.
 
 ### ⚠ IN-FLIGHT AT HANDOFF
-- **PR #3286 (C.2a)** — reviewed+approved by me; **awaiting orchestrator reconcile** + `Test (pytest)` CI (other checks green).
-  **First thing next session:** `gh pr checks 3286` → if pytest green and not yet merged, ping orchestrator `needs=merge` (do NOT
-  self-merge — shared pipeline infra). If pytest RED, read the failing job; the only local reds were the 3 pre-existing heritage tests.
+- **PR #3286 (C.2a) — codex review = REQUEST-CHANGES (real over-exemption bug); FIX DISPATCHED `folk-3079-c2a-fix`** (Monitor
+  `bxfwet8m8`). The bug: `_strip_vesum_verbatim_primary_spans` ran on the FLATTENED activity text, so 8-token windows could cross
+  yaml field boundaries → a bare dialectal citation + adjacent field text could match a corpus hit and get blanked (the test
+  stubbed `_search_literary_hits=[]` so it missed this). Fix = confine the exemption to per-field spans + a cross-boundary
+  regression test, pushed onto the PR branch. **First thing next session:** check `folk-3079-c2a-fix` outcome → `gh pr checks 3286`
+  → verify the over-exemption regression → if green, **SELF-MERGE per the merge grant** (#M-12; don't wait on the orchestrator).
 
 ### ▶ NEXT ACTIONS (RESUME HERE, in order)
-1. **C.2a (PR #3286)** — DONE pending CI/reconcile (reviewed+approved). Confirm pytest green, ping orchestrator to merge.
+1. **C.2a (PR #3286)** — land the boundary fix (`folk-3079-c2a-fix`), confirm CI + the cross-boundary regression, then SELF-MERGE (fleet-reviewed, #M-12).
 2. **C.2b (Class B)** — guarded dialectal-citation exemption (do NOT over-widen bare «X»). **C.2c (Class C)** — foreign-proper-noun handling (allowlist/marker; fix Сатурналії-vs-Йоль). Both deterministic, my lane (#0.2).
 3. **C.3 (Class D + word_count + the loop)** — bounded multi-gate python_qg loop + cross-model fixer (rephrase `дерево-явір`/`першопочаток`; iterate across gates). The durable structural fix.
 4. **citations_resolve** — GATE-SIDE fix: resolve the writer's prose `Author «Title»` citations against the plan `references` (the 5 sources are ALREADY in the koliadky plan, lines 93-117; `_citation_candidates` already loads `plan_references` at L7490). NOT plan promotion.
@@ -118,6 +121,12 @@
 6. (Parallel content lane, unblocked) dossier #26 `narodni-lehendy` → #27 `istorychni-perekazy`.
 
 ### ⚠ CARRY-FORWARD
+- **🆕 STANDING ORDER (user 2026-06-16, MEMORY #M-12) — USE THE AGENT FLEET; DON'T MANUFACTURE OBSTACLES.** When a PR needs
+  review, get it from the FLEET (`ab ask-codex` adversarial review / deepseek), NOT the busy human/main orchestrator — "dont
+  point to the other orchestrator he is very busy." Folk driver HAS a merge grant: **fleet-review → CI-green → SELF-MERGE**;
+  never park a clean PR "for the orchestrator." This OVERRIDES the agent-def "never merge / orchestrator reconciles" line for
+  track work (still NO direct main commits — route through a PR; still honor BLOCKING-CI #M-0.5). PROGRESS. (Cross-model review
+  earns its keep — codex caught a real over-exemption bug on #3286 that my own review missed → fix dispatched `folk-3079-c2a-fix`.)
 - **`--no-resume` is MANDATORY for any self-converge validation build** — without it, resume silently reuses main's artifacts and reports a stale pass (cost Session 38 a 2-hr no-op).
 - Build worktree to reap once C.2a lands: `folk-koliadky-shchedrivky-20260616-002047` (artifacts on its build branch). The failed-build `module.md`/`activities.yaml` there are the C.2a TEST FIXTURE — don't delete until C.2a's tests are committed.
 - B1 e2e-UNPROVEN until step 5. Role #0.2 LIVE (I implement/drive infra; never file-and-forget). Never reset/commit on `main`; folk push `--no-verify`.

--- a/docs/folk-epic/seminar-module-self-converge-3079-design.md
+++ b/docs/folk-epic/seminar-module-self-converge-3079-design.md
@@ -321,10 +321,15 @@ artifacts):
 | **D. Genuine coinage** | `дерево-явір`, `першопочаток` | `activities.yaml:170` ("світове дерево-явір"), module prose | Real descriptive compounds, not in VESUM, no quick heritage. `явір` IS in VESUM; the hyphenated compound is the writer's. These are the ONLY genuinely-fixable items — rephrase (`світове дерево — явір`) or deeper heritage-attest. | The **cross-model fixer** (Part C.3) rephrases; OR writer-correction. |
 
 `citations_resolve`: the 5 "unknown" are **canonical** Ukrainian scholarship (Костомаров «Слов'янська міфологія»,
-Чубинський, Чижевський, Попович) + the народна-творчість primary — cited by the writer but absent from the plan's
-`[S#]` registry. **Fix:** promote these canonical sources into the plan reference registry (plan-side) and/or a
-canonical-source resolver in `citations_resolve`. `word_count` 4026/4600 is a real under-write the LLM-QG/writer
-correction must close by ADDING prose — downstream of unblocking python_qg.
+Чубинський, Чижевський, Попович) + the народна-творчість primary. **CORRECTION (verified this session):** these ARE
+already in the koliadky plan `references:` (`curriculum/l2-uk-en/plans/folk/koliadky-shchedrivky.yaml:93-117`,
+`type: primary`, with matching `author:`/`work:` fields), and the writer's prose form (`Костомаров М. «Слов'янська
+міфологія»`) matches them. The gate flagged them anyway → **`citations_resolve` is ALSO a gate FALSE-POSITIVE**: its
+CHECK fails to resolve the writer's prose `Author «Title»` citation against the plan references — even though
+`_citation_candidates` (L7490) ALREADY loads `plan_references` for correction candidates. **Fix is GATE-SIDE**
+(resolve prose `Author «Title»` against the plan `references` author/work/title), NOT plan-registry promotion — the
+sources are already registered. `word_count` 4026/4600 is a real under-write the LLM-QG/writer correction must close
+by ADDING prose — downstream of unblocking python_qg.
 
 ### Structural conclusion (refines §1 Gap C and the §4 plan order)
 **Gate-correctness is logically PRIOR to the C.3 multi-gate loop.** A loop cannot "correct" a verbatim primary, a
@@ -344,9 +349,13 @@ churns/diverges on classes A/B/C. The corrected sequencing:
 3. **C.2c (Class C) — foreign-proper-noun handling** (allowlist or marker; fix the Сатурналії-vs-Йоль inconsistency).
 4. **C.3 (Class D + word_count + the loop) — bounded multi-gate python_qg loop + cross-model fixer** for the genuine
    residual coinages and to iterate across gates.
-5. **citations_resolve — plan-registry promotion of canonical sources** (+ optional canonical resolver).
+5. **citations_resolve — GATE-SIDE prose-citation resolution** (resolve `Author «Title»` against the plan
+   `references`; the sources are ALREADY registered, this is a resolution false-positive, not a registry gap).
 
 **Status this session:** C.2a dispatched for implementation (the first, highest-leverage, clearly-correct unit);
 B/C/D + citations + the loop sequenced for follow-on driving. This taxonomy supersedes §1's pre-build guess that
-Gap C was dominated by coinage churn — empirically it is dominated by **verbatim-primary + foreign-proper-noun +
-dialectal-citation false positives**, which are deterministic gate-correctness fixes, not LLM-fixer work.
+Gap C was dominated by coinage churn — empirically it is dominated by **gate FALSE POSITIVES** (verbatim-primary,
+foreign-proper-noun, dialectal-citation, AND citation-resolution), which are deterministic gate-correctness fixes,
+NOT LLM-fixer work. The ONLY genuine content issues in the whole koliadky failure are `word_count` (under-write) and
+the two Class-D coinages — everything else is the gates wrongly rejecting correct seminar content. That is the real
+shape of Gap C, and it is why the per-gate single-shot loop could never converge it.

--- a/docs/folk-epic/seminar-module-self-converge-3079-design.md
+++ b/docs/folk-epic/seminar-module-self-converge-3079-design.md
@@ -290,3 +290,63 @@ Corpus-hammer (#M-11) every embedded primary in the loop's output before any shi
 3. **Shared helper extraction (P0)** — port wiki helpers into `scripts/common/review_loop.py` so module +
    wiki share one tested loop, vs. duplicate the logic in `linear_pipeline.py`. **Recommendation: extract**
    (one tested implementation; the wiki loop is the battle-tested one).
+
+---
+
+## 8. P3-VALIDATE FINDINGS (Session 39, 2026-06-16) — the rotating wall is mostly GATE FALSE-POSITIVES, not coinages
+
+**P3-validate ran for real this session** (`v7_build.py folk koliadky-shchedrivky --no-resume --worktree`, build
+`folk-koliadky-shchedrivky-20260616-002047`). **Root-cause note on the prior "validation":** the Session-38
+in-flight build silently NO-OP'd — `v7_build.py` **resumes by default** (`v7_build.py:1289` "skip a phase iff its
+on-disk artifact exists AND reports success"), the worktree was cut from `origin/main` where koliadky already
+exists at 9.2, so the writer/gates were skipped and `module.md`/`llm_qg.json` came back **byte-identical to main**.
+The 9.2 was stale. **Any "does a fresh build self-converge" validation MUST pass `--no-resume`.**
+
+### Outcome (c): the build never reached the B1 LLM-QG loop — `python_qg` terminated first
+`module_failed phase=python_qg, reason="Python QG failed after ADR-008 correction paths"` (492s, after 2 correction
+passes on the SAME failing words → per-gate single-shot `attempts` wall at `linear_pipeline.py:5662`). The 3 failing
+gates: `word_count` (4026/4600), `vesum_verified` (7 missing), `citations_resolve` (5 unknown). So **B1 is necessary
+but unreachable on a fresh build until Gap C is closed** — exactly as §1 Gap C predicted, now with the precise
+taxonomy below.
+
+### The 7 `vesum_verified` "missing" words split into 4 classes — 3 are FALSE POSITIVES no corrector can fix
+Verified deterministically (ran `_extract_blockquote_records` + `verify_words` + `search_heritage` on the real build
+artifacts):
+
+| Class | Words (this build) | Where | Why flagged | Proper fix |
+|---|---|---|---|---|
+| **A. Verbatim folk primary embedded in `activities.yaml`** | `нащада`, `било`, `сонінько` | `activities.yaml:91` (col quoted in a compare activity), `:72` (a щедрівка `passage:`) | The module.md blockquote exemption (`_strip_quote_fidelity_verified_blockquotes`, L10188) **works** — it correctly strips these from `module.md` scope — but it does NOT reach yaml `passage`/list fields. `сонінько` is NOT in VESUM and has **no** heritage evidence → it can ONLY be handled by primary-exemption, not per-word attestation. | **Extend the verbatim-primary exemption to embedded primaries in `activities.yaml`/`vocabulary.yaml` quote fields** (#2991 yaml-scope × #3162 primary-embedding). |
+| **B. Meta-linguistic citation of dialectal forms** | `нащада`, `било`, `лем` (again) | `activities.yaml:97,102` — analysis text citing «било», «з нащада», «лем» as objects of discussion | A MENTION, not a use. The existing citation arm of `_WARNING_QUOTE_RE` (L763) exempts only `як/such as «X»`; bare «X» citation of a dialectal form in analysis is not exempted (the restriction to `як «X»` was deliberate — do NOT widen to all bare «X»). | Add a **guarded** dialectal-citation exemption: bare «X» exempt only when X also appears in a verified primary of the same module, or after an explicit `діалектн…`/`запис`/foreign-reject marker. |
+| **C. Foreign comparative proper nouns** | `Йоль`, `Ялда`, `Ялду` | module prose L32 + `activities.yaml:155` (comparing Yule/Yalda/Saturnalia) | Transliterated foreign festival names, declined into UK cases. Not Ukrainian lemmas. **Inconsistency proof:** `Сатурналії` is ALSO absent from VESUM yet was NOT flagged → the proper-noun handling is ad hoc. | Foreign-proper-noun handling — an allowlist of attested foreign cultural terms OR a writer foreign-term marker the gate honours. |
+| **D. Genuine coinage** | `дерево-явір`, `першопочаток` | `activities.yaml:170` ("світове дерево-явір"), module prose | Real descriptive compounds, not in VESUM, no quick heritage. `явір` IS in VESUM; the hyphenated compound is the writer's. These are the ONLY genuinely-fixable items — rephrase (`світове дерево — явір`) or deeper heritage-attest. | The **cross-model fixer** (Part C.3) rephrases; OR writer-correction. |
+
+`citations_resolve`: the 5 "unknown" are **canonical** Ukrainian scholarship (Костомаров «Слов'янська міфологія»,
+Чубинський, Чижевський, Попович) + the народна-творчість primary — cited by the writer but absent from the plan's
+`[S#]` registry. **Fix:** promote these canonical sources into the plan reference registry (plan-side) and/or a
+canonical-source resolver in `citations_resolve`. `word_count` 4026/4600 is a real under-write the LLM-QG/writer
+correction must close by ADDING prose — downstream of unblocking python_qg.
+
+### Structural conclusion (refines §1 Gap C and the §4 plan order)
+**Gate-correctness is logically PRIOR to the C.3 multi-gate loop.** A loop cannot "correct" a verbatim primary, a
+glossed foreign comparison, or a cited dialectal form — deleting them is wrong. So even a perfect multi-gate loop
+churns/diverges on classes A/B/C. The corrected sequencing:
+
+1. **C.2a (Class A) — extend verbatim-primary VESUM exemption to embedded primaries in `activities.yaml`/`vocabulary.yaml`.**
+   HIGHEST leverage (every folk module embeds cols/щедрівки/думи as activity passages), unambiguously correct,
+   reuses the existing `_extract_blockquote_records`/attribution machinery. **Signal design (pick the robust one):**
+   (i) cross-reference — an activity passage that reproduces a verified `module.md` primary inherits its exemption
+   (safe, but misses passages unique to activities, e.g. the `сонінько` щедрівка); (ii) **verify_quote / literary-corpus
+   resolution** — a passage that resolves to a folk/literary corpus primary is exempt (robust, can't be gamed; the
+   `_textbook_grounding_gate` already does corpus matching for textbooks, so extending to the literary/folk corpus is
+   architecturally consistent = #3162's "literary-corpus routing"); (iii) structural primary-source marker the writer
+   emits. **Recommendation: (ii) corpus-resolution, with (i) as a corroborating fast-path.**
+2. **C.2b (Class B) — guarded dialectal-citation exemption** (do not over-widen bare «X»).
+3. **C.2c (Class C) — foreign-proper-noun handling** (allowlist or marker; fix the Сатурналії-vs-Йоль inconsistency).
+4. **C.3 (Class D + word_count + the loop) — bounded multi-gate python_qg loop + cross-model fixer** for the genuine
+   residual coinages and to iterate across gates.
+5. **citations_resolve — plan-registry promotion of canonical sources** (+ optional canonical resolver).
+
+**Status this session:** C.2a dispatched for implementation (the first, highest-leverage, clearly-correct unit);
+B/C/D + citations + the loop sequenced for follow-on driving. This taxonomy supersedes §1's pre-build guess that
+Gap C was dominated by coinage churn — empirically it is dominated by **verbatim-primary + foreign-proper-noun +
+dialectal-citation false positives**, which are deterministic gate-correctness fixes, not LLM-fixer work.


### PR DESCRIPTION
## What
Driver-state PR for folk #3079 Session 39. Carries the **real P3-validate diagnostic** + refreshed driver handoff. **Docs only** — no pipeline code (the C.2a code fix is dispatched separately as `codex/folk-3079-c2a`).

## The finding (design doc §8)
Session-38's in-flight "P3-validate" silently **no-op'd** (`v7_build.py` resumes by default → the worktree reused main's koliadky at 9.2 → `module.md`/`llm_qg.json` byte-identical to main; the 9.2 was stale). The **real** validation (`--no-resume`) ran the writer fresh and **terminated at `python_qg`** before the B1 LLM-QG loop:

```
module_failed phase=python_qg, reason="Python QG failed after ADR-008 correction paths"
```

Root-caused the Gap-C wall into a **4-class taxonomy** (file:line + tool-verified), which is **mostly gate false-positives**:
- **A.** verbatim folk primaries embedded in `activities.yaml` (`нащада`/`било`/`сонінько`) — the module.md blockquote exemption works but doesn't reach yaml = #2991×#3162
- **B.** bare «X» dialectal-form citations in analysis (mention-not-use)
- **C.** foreign comparative proper nouns (`Йоль`/`Ялда`; `Сатурналії` inconsistency)
- **D.** genuine coinages (`дерево-явір`/`першопочаток`) — the only fixer-work
- plus `citations_resolve` (5 canonical works absent from the plan `[S#]` registry) and `word_count` 4026/4600.

**Structural conclusion:** gate-correctness is logically PRIOR to the C.3 multi-gate loop (a loop can't "fix" a verbatim primary / foreign comparison / cited form). Corrected sequencing C.2a→C.2b→C.2c→C.3→citations recorded in §8.

## Follow-on
- **C.2a** (Class A) dispatched → PR `codex/folk-3079-c2a` (extend verbatim-primary VESUM exemption to yaml). 
- B/C/D + citations + the multi-gate loop sequenced in the handoff for follow-on driving.

## Boundary
Track-driver PR — **opened, not merged.** Orchestrator reconciles. `--no-resume` is now documented as mandatory for any self-converge validation build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)