### PR TITLE
fix(lexicon): strip dmklinger gloss meta-junk

### DIFF
--- a/scripts/lexicon/build_kaikki_lookup.py
+++ b/scripts/lexicon/build_kaikki_lookup.py
@@ -147,6 +147,10 @@ def _clean_gloss(gloss: str) -> str:
     unchanged so good glosses keep their exact formatting.
     """
     g = gloss.strip()
+    if ":" in g:
+        prefix, suffix = g.split(":", 1)
+        if _is_meta_clause(prefix):
+            return _clean_gloss(suffix) if suffix.strip() else ""
     clauses = _CLAUSE_SPLIT_RE.split(g)
     if len(clauses) == 1:
         return "" if _is_meta_clause(g) else g

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -59,6 +59,7 @@ ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
 from scripts.lexicon.build_kaikki_lookup import KAIKKI_SOURCE
+from scripts.lexicon.build_kaikki_lookup import _clean_gloss as _clean_translation_gloss
 from scripts.lexicon.build_kaikki_lookup import lookup_key as kaikki_lookup_key
 from scripts.lexicon.calque_corrections import (
     CURATED_CALQUES,
@@ -2519,6 +2520,7 @@ def _parse_translations(raw: object) -> list[str]:
     out: list[str] = []
     for item in data:
         text = re.sub(r"\s+", " ", clean_html_entities(str(item)).strip())
+        text = _clean_translation_gloss(text)
         if text:
             out.append(text)
     return out

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "eeba55287678ee0bef787ec29ad6b13f9b99d3de3f74f3c8aff285918447b8c0",
+  "fingerprint": "77b6e9aff2c648984ab2ec685e29b57cda3e3dfed6c67b3e188f2182914e570c",
   "inputs": {
     "lexicon_code": [
       {
@@ -16,7 +16,7 @@
       },
       {
         "path": "scripts/lexicon/build_kaikki_lookup.py",
-        "sha256": "239667a7428d1d899443063169d4128cb13a034e4ba9af006edfb6ebd6da253f"
+        "sha256": "b817d96950978748ace7fa556c6ff91dd583de092aa665205df1c2a42f622039"
       },
       {
         "path": "scripts/lexicon/build_slovnyk_mirror.py",
@@ -36,7 +36,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "d08a0227aa4118f967b6d863d21ed66aa5043dea623027cfaf6814fd19a660af"
+        "sha256": "16498bb8eca0292bbb78d0b9132098eb4c5837e25e5b6f7e215ee6d0b5ccd948"
       },
       {
         "path": "scripts/lexicon/generate_vesum_aliases.py",

--- a/tests/test_build_kaikki_lookup.py
+++ b/tests/test_build_kaikki_lookup.py
@@ -46,6 +46,7 @@ def test_clean_gloss_strips_meta_clause_keeps_translation() -> None:
     assert _clean_gloss("one can, one may, alternative form of мо́жна (móžna)") == (
         "one can, one may"
     )
+    assert _clean_gloss("Alternative form of кабачо́к: zucchini") == "zucchini"
     assert _clean_gloss("what, alternative form of що (ščo)") == "what"
     assert _clean_gloss("a male patronymic; obsolete form of І́горьович") == (
         "a male patronymic"

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -29,6 +29,7 @@ from scripts.lexicon.enrich_manifest import (
     _meaning,
     _merge_slovnyk_warning,
     _morphology,
+    _parse_translations,
     _sense_correct_synonyms,
     _slovnyk_cache,
     _SlovnykTransientError,
@@ -1561,6 +1562,18 @@ def test_translation_matches_stress_stripped_dmklinger_headword(monkeypatch) -> 
         "source": "dmklinger",
         "pos": "noun",
     }
+
+
+def test_parse_translations_cleans_dmklinger_meta_glosses() -> None:
+    raw = json.dumps(
+        [
+            "Alternative form of кабачо́к: zucchini",
+            "plain translation",
+            "common misspelling of Строго́нівка (Strohónivka)",
+        ]
+    )
+
+    assert _parse_translations(raw) == ["zucchini", "plain translation"]
 
 
 def test_translation_returns_none_when_lemma_absent(monkeypatch) -> None:


### PR DESCRIPTION
Fixes #3255

## Summary
- Reuses `build_kaikki_lookup._clean_gloss` for dmklinger translation gloss parsing.
- Extends `_clean_gloss` to unwrap meta-only prefixes before a colon, e.g. `Alternative form of X: translation`.
- Drops dmklinger glosses that clean to empty instead of fabricating a replacement.

## Sample before/after
```text
before=["Alternative form of кабачо́к: zucchini", "plain translation", "common misspelling of Строго́нівка (Strohónivka)"]
after=["zucchini", "plain translation"]
```

## Validation
```text
.venv/bin/python -m pytest tests/test_enrich.py tests/test_lexicon_enrich_manifest.py tests/test_build_kaikki_lookup.py -q
======================== 96 passed, 4 skipped in 5.54s =========================
```

```text
.venv/bin/ruff check scripts/lexicon/enrich_manifest.py scripts/lexicon/build_kaikki_lookup.py tests/test_build_kaikki_lookup.py tests/test_lexicon_enrich_manifest.py
All checks passed!
```

No full manifest re-enrich was run; the orchestrator should run the controlled full re-enrich on main with the warm cache after this PR lands.