### PR TITLE
fix(pipeline): #3079 C.2a — VESUM verbatim-primary exemption reaches yaml

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -10194,17 +10194,22 @@ def _build_vesum_text(
         )
         module_text = _strip_quote_fidelity_verified_blockquotes(module_text, level=level)
     parts = [_strip_metalinguistic(module_text)]
+    strip_activity_field: Callable[[str], str] | None = None
+    if strip_verbatim_primaries:
+
+        def strip_activity_field(value: str) -> str:
+            return _strip_vesum_verbatim_primary_spans(
+                value,
+                level=level,
+                verified_primary_texts=verified_primary_texts,
+            )
+
     for activity in activities:
         activity_text = _activity_vesum_text(
             activity,
             emit_negative_example_events=emit_negative_example_events,
+            string_transform=strip_activity_field,
         )
-        if strip_verbatim_primaries:
-            activity_text = _strip_vesum_verbatim_primary_spans(
-                activity_text,
-                level=level,
-                verified_primary_texts=verified_primary_texts,
-            )
         parts.append(_strip_metalinguistic(activity_text))
     for entry in vocabulary:
         if isinstance(entry, dict):
@@ -10232,6 +10237,7 @@ def _activity_vesum_text(
     activity: dict[str, Any],
     *,
     emit_negative_example_events: bool = False,
+    string_transform: Callable[[str], str] | None = None,
 ) -> str:
     """Walk an activity's string values, excluding intentional-error fields.
 
@@ -10260,6 +10266,9 @@ def _activity_vesum_text(
     For highlight-morphemes activities, `morphemes:` is an answer key of bare
     sub-word units. Skip that subtree while keeping `text:`, `word:`, title,
     and instruction strings in VESUM scope.
+
+    When supplied, `string_transform` runs on each retained string leaf before
+    flattening so transforms cannot match across separate YAML fields.
     """
     activity_type = activity.get("type")
     activity_id = str(activity.get("id") or "")
@@ -10375,7 +10384,7 @@ def _activity_vesum_text(
                     item_idx=child_item_idx,
                 )
         elif isinstance(node, str):
-            out.append(node)
+            out.append(string_transform(node) if string_transform else node)
 
     walk(activity, None)
     return "\n".join(out)

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -415,6 +415,7 @@ TELEMETRY_MAX_MAPPING_CHARS = 500
 TELEMETRY_MAX_FAILED_WORDS = 5
 TELEMETRY_MAX_THEATRE_VIOLATIONS = 25
 TEXTBOOK_GROUNDING_MIN_WORDS = 30
+VESUM_PRIMARY_EXEMPTION_MIN_WORDS = 8
 
 RULE_VOICE_META = "#R-VOICE-META"
 RULE_BAD_FORM_MARKER = "#R-BAD-FORM-MARKER"
@@ -10184,22 +10185,37 @@ def _build_vesum_text(
     emit_negative_example_events: bool = False,
 ) -> str:
     """Compose the text blob that VESUM verifies, with structural exclusions."""
-    if _vesum_heritage_attestation_enabled(level):
+    strip_verbatim_primaries = _vesum_heritage_attestation_enabled(level)
+    verified_primary_texts: list[str] = []
+    if strip_verbatim_primaries:
+        verified_primary_texts = _quote_fidelity_verified_blockquote_texts(
+            module_text,
+            level=level,
+        )
         module_text = _strip_quote_fidelity_verified_blockquotes(module_text, level=level)
     parts = [_strip_metalinguistic(module_text)]
     for activity in activities:
-        parts.append(
-            _strip_metalinguistic(
-                _activity_vesum_text(
-                    activity,
-                    emit_negative_example_events=emit_negative_example_events,
-                )
-            )
+        activity_text = _activity_vesum_text(
+            activity,
+            emit_negative_example_events=emit_negative_example_events,
         )
+        if strip_verbatim_primaries:
+            activity_text = _strip_vesum_verbatim_primary_spans(
+                activity_text,
+                level=level,
+                verified_primary_texts=verified_primary_texts,
+            )
+        parts.append(_strip_metalinguistic(activity_text))
     for entry in vocabulary:
         if isinstance(entry, dict):
             parts.append(_strip_metalinguistic(str(entry.get("lemma", ""))))
             usage = _strip_usage_parentheticals(str(entry.get("usage", "")))
+            if strip_verbatim_primaries:
+                usage = _strip_vesum_verbatim_primary_spans(
+                    usage,
+                    level=level,
+                    verified_primary_texts=verified_primary_texts,
+                )
             parts.append(_strip_metalinguistic(usage))
     for entry in resources:
         if isinstance(entry, dict):
@@ -10878,6 +10894,14 @@ def _blockquote_record_is_quote_fidelity_verified(record: Mapping[str, Any]) -> 
     return bool(record.get("quote") and record.get("attribution") and not record.get("no_verify"))
 
 
+def _quote_fidelity_verified_blockquote_texts(text: str, *, level: str | None) -> list[str]:
+    return [
+        str(record["quote"])
+        for record in _extract_blockquote_records(text, level=level)
+        if _blockquote_record_is_quote_fidelity_verified(record)
+    ]
+
+
 def _strip_quote_fidelity_verified_blockquotes(text: str, *, level: str | None) -> str:
     records = _extract_blockquote_records(text, level=level)
     quote_line_numbers = {
@@ -10943,6 +10967,143 @@ def _contains_textbook_quote(blockquote: str, result_text: str) -> bool:
         if window in result_blob:
             return True
     return False
+
+
+_MATCH_TOKEN_WITH_SPAN_RE = re.compile(
+    r"[0-9A-Za-zА-Яа-яҐґЄєІіЇї][0-9A-Za-zА-Яа-яҐґЄєІіЇї'’ʼ-]*"
+)
+
+
+@dataclass(frozen=True)
+class _MatchToken:
+    text: str
+    start: int
+    end: int
+
+
+def _match_token_key(token: str) -> str:
+    normalized = _normalize_match_text(token)
+    normalized = re.sub(r"[*_`~#>|]", " ", normalized)
+    pieces = re.findall(r"[0-9A-Za-zА-Яа-яҐґЄєІіЇї'-]+", normalized.casefold())
+    if not pieces:
+        return ""
+    return _collapse_syllable_break("".join(pieces))
+
+
+def _textbook_match_token_spans(text: str) -> list[_MatchToken]:
+    tokens: list[_MatchToken] = []
+    for match in _MATCH_TOKEN_WITH_SPAN_RE.finditer(text):
+        token = _match_token_key(match.group(0))
+        if token:
+            tokens.append(_MatchToken(token, match.start(), match.end()))
+    return tokens
+
+
+def _merge_text_spans(spans: Sequence[tuple[int, int]]) -> list[tuple[int, int]]:
+    merged: list[tuple[int, int]] = []
+    for start, end in sorted(spans):
+        if start >= end:
+            continue
+        if not merged or start > merged[-1][1]:
+            merged.append((start, end))
+            continue
+        previous_start, previous_end = merged[-1]
+        merged[-1] = (previous_start, max(previous_end, end))
+    return merged
+
+
+def _matching_token_spans(
+    candidate_text: str,
+    source_text: str,
+    *,
+    min_words: int,
+) -> list[tuple[int, int]]:
+    candidate_tokens = _textbook_match_token_spans(candidate_text)
+    source_tokens = [token.text for token in _textbook_match_token_spans(source_text)]
+    if len(candidate_tokens) < min_words or len(source_tokens) < min_words:
+        return []
+
+    source_windows: dict[tuple[str, ...], list[int]] = {}
+    for source_start in range(0, len(source_tokens) - min_words + 1):
+        window = tuple(source_tokens[source_start : source_start + min_words])
+        source_windows.setdefault(window, []).append(source_start)
+
+    candidate_token_texts = [token.text for token in candidate_tokens]
+    spans: list[tuple[int, int]] = []
+    for candidate_start in range(0, len(candidate_tokens) - min_words + 1):
+        window = tuple(candidate_token_texts[candidate_start : candidate_start + min_words])
+        source_starts = source_windows.get(window)
+        if not source_starts:
+            continue
+        for source_start in source_starts:
+            match_len = min_words
+            while (
+                candidate_start + match_len < len(candidate_token_texts)
+                and source_start + match_len < len(source_tokens)
+                and candidate_token_texts[candidate_start + match_len]
+                == source_tokens[source_start + match_len]
+            ):
+                match_len += 1
+            spans.append(
+                (
+                    candidate_tokens[candidate_start].start,
+                    candidate_tokens[candidate_start + match_len - 1].end,
+                )
+            )
+            break
+    return _merge_text_spans(spans)
+
+
+def _blank_text_spans(text: str, spans: Sequence[tuple[int, int]]) -> str:
+    merged = _merge_text_spans(spans)
+    if not merged:
+        return text
+    chunks: list[str] = []
+    cursor = 0
+    for start, end in merged:
+        chunks.append(text[cursor:start])
+        removed = text[start:end]
+        chunks.append("\n" * removed.count("\n") or " ")
+        cursor = end
+    chunks.append(text[cursor:])
+    return "".join(chunks)
+
+
+def _strip_vesum_verbatim_primary_spans(
+    text: str,
+    *,
+    level: str | None,
+    verified_primary_texts: Sequence[str],
+) -> str:
+    """Blank matched seminar primary spans before modern VESUM verification."""
+    if len(_textbook_match_token_spans(text)) < VESUM_PRIMARY_EXEMPTION_MIN_WORDS:
+        return text
+
+    stripped = text
+    for source_text in verified_primary_texts:
+        spans = _matching_token_spans(
+            stripped,
+            source_text,
+            min_words=VESUM_PRIMARY_EXEMPTION_MIN_WORDS,
+        )
+        stripped = _blank_text_spans(stripped, spans)
+
+    if len(_textbook_match_token_spans(stripped)) < VESUM_PRIMARY_EXEMPTION_MIN_WORDS:
+        return stripped
+
+    corpus_spans: list[tuple[int, int]] = []
+    for hit in _search_literary_hits(stripped, level=str(level or ""), limit=20):
+        hit_text = _result_text_for_match(hit)
+        if not hit_text:
+            continue
+        corpus_spans.extend(
+            _matching_token_spans(
+                stripped,
+                hit_text,
+                min_words=VESUM_PRIMARY_EXEMPTION_MIN_WORDS,
+            )
+        )
+    return _blank_text_spans(stripped, corpus_spans)
 
 
 _TOPIC_STOPWORDS = {

--- a/tests/test_vesum_yaml_verbatim_primary_exemption.py
+++ b/tests/test_vesum_yaml_verbatim_primary_exemption.py
@@ -133,6 +133,47 @@ def test_core_level_yaml_primary_text_is_not_exempted(monkeypatch) -> None:
     assert "било" in text
 
 
+def test_literary_corpus_exemption_does_not_cross_activity_field_boundary(monkeypatch) -> None:
+    cross_field_hit = "Йоль дерево явір як першопочаток стоїть у лісі"
+
+    def literary_hit_for_cross_field_window(
+        query: str,
+        *,
+        level: str,
+        limit: int = 20,
+    ) -> list[dict[str, str]]:
+        _ = query, level, limit
+        return [
+            {
+                "source_type": "literary",
+                "corpus": "literary_texts",
+                "text": cross_field_hit,
+            }
+        ]
+
+    monkeypatch.setattr(
+        linear_pipeline,
+        "_search_literary_hits",
+        literary_hit_for_cross_field_window,
+    )
+
+    text = linear_pipeline._build_vesum_text(
+        "",
+        [
+            {
+                "type": "analysis",
+                "quote": "Йоль",
+                "prompt": "дерево явір як першопочаток стоїть у лісі",
+            }
+        ],
+        [],
+        [],
+        level="folk",
+    )
+
+    assert "Йоль" in text
+
+
 def test_modern_activity_nonword_still_fails_vesum(monkeypatch) -> None:
     monkeypatch.setattr(linear_pipeline, "_search_literary_hits", lambda *args, **kwargs: [])
     monkeypatch.setattr(

--- a/tests/test_vesum_yaml_verbatim_primary_exemption.py
+++ b/tests/test_vesum_yaml_verbatim_primary_exemption.py
@@ -1,0 +1,168 @@
+"""Regression tests for seminar primary-text VESUM exemptions in YAML artifacts."""
+
+from __future__ import annotations
+
+from scripts.build import linear_pipeline
+
+KOLIADKY_MODULE = """
+## Primary
+
+> Коли не било з нащада світа,
+> тогди не било неба, ні землі, лишень синє море.
+>
+> *— Грушевський [S1]*
+"""
+
+KOLIADKY_ACTIVITY_QUOTE = (
+    "Коли не било з нащада світа, / тогди не било неба, ні землі, лишень синє море."
+)
+
+SHCHEDRIVKA_PASSAGE = (
+    "Ясне небонько, світле сонінько, / Світле сонінько, ясен місячик"
+)
+
+
+def _literary_hit_for_shchedrivka(
+    query: str,
+    *,
+    level: str,
+    limit: int = 20,
+) -> list[dict[str, str]]:
+    _ = query, level, limit
+    return [
+        {
+            "source_type": "literary",
+            "corpus": "literary_texts",
+            "text": f"{SHCHEDRIVKA_PASSAGE}. Ой у полі криниченька.",
+        }
+    ]
+
+
+def test_yaml_primary_spans_are_stripped_but_scoped_terms_remain(monkeypatch) -> None:
+    monkeypatch.setattr(
+        linear_pipeline,
+        "_search_literary_hits",
+        _literary_hit_for_shchedrivka,
+    )
+
+    activities = [
+        {
+            "type": "analysis",
+            "passage": SHCHEDRIVKA_PASSAGE,
+            "items": [
+                {
+                    "quote": KOLIADKY_ACTIVITY_QUOTE,
+                    "prompt": "Порівняйте Йоль і дерево-явір як першопочаток.",
+                }
+            ],
+        }
+    ]
+
+    text = linear_pipeline._build_vesum_text(
+        KOLIADKY_MODULE,
+        activities,
+        [],
+        [],
+        level="folk",
+    )
+
+    for word in ("нащада", "било", "сонінько"):
+        assert word not in text
+    for word in ("Йоль", "дерево-явір", "першопочаток"):
+        assert word in text
+
+
+def test_module_primary_cross_reference_does_not_need_corpus(monkeypatch) -> None:
+    def fail_literary_search(*args: object, **kwargs: object) -> list[dict[str, str]]:
+        raise AssertionError("module-primary fast path should avoid corpus lookup")
+
+    monkeypatch.setattr(linear_pipeline, "_search_literary_hits", fail_literary_search)
+
+    text = linear_pipeline._build_vesum_text(
+        KOLIADKY_MODULE,
+        [{"type": "analysis", "passage": KOLIADKY_ACTIVITY_QUOTE}],
+        [],
+        [],
+        level="folk",
+    )
+
+    assert "нащада" not in text
+    assert "било" not in text
+
+
+def test_vocabulary_usage_primary_span_is_stripped(monkeypatch) -> None:
+    monkeypatch.setattr(
+        linear_pipeline,
+        "_search_literary_hits",
+        _literary_hit_for_shchedrivka,
+    )
+
+    text = linear_pipeline._build_vesum_text(
+        "",
+        [],
+        [
+            {
+                "lemma": "колядка",
+                "usage": f"У щедрівці: {SHCHEDRIVKA_PASSAGE}. Сучасний коментар лишається.",
+            }
+        ],
+        [],
+        level="folk",
+    )
+
+    assert "сонінько" not in text
+    assert "колядка" in text
+    assert "Сучасний коментар лишається" in text
+
+
+def test_core_level_yaml_primary_text_is_not_exempted(monkeypatch) -> None:
+    def fail_literary_search(*args: object, **kwargs: object) -> list[dict[str, str]]:
+        raise AssertionError("core levels must not use literary primary stripping")
+
+    monkeypatch.setattr(linear_pipeline, "_search_literary_hits", fail_literary_search)
+
+    text = linear_pipeline._build_vesum_text(
+        KOLIADKY_MODULE,
+        [{"type": "analysis", "passage": KOLIADKY_ACTIVITY_QUOTE}],
+        [],
+        [],
+        level="a1",
+    )
+
+    assert "нащада" in text
+    assert "било" in text
+
+
+def test_modern_activity_nonword_still_fails_vesum(monkeypatch) -> None:
+    monkeypatch.setattr(linear_pipeline, "_search_literary_hits", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        linear_pipeline,
+        "_resolve_folk_heritage_attested_missing",
+        lambda *args, **kwargs: set(),
+    )
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        return {
+            word: ([] if word == "привітаннячкоз" else [{"lemma": word}])
+            for word in words
+        }
+
+    result = linear_pipeline._vesum_gate(
+        module_text="",
+        activities=[
+            {
+                "type": "short-answer",
+                "passage": (
+                    "Сьогодні учні пишуть привітаннячкоз для друга у класі "
+                    "разом після уроку."
+                ),
+            }
+        ],
+        vocabulary=[],
+        resources=[],
+        level="folk",
+        verify_words_fn=verify_words,
+    )
+
+    assert result["passed"] is False
+    assert "привітаннячкоз" in result["missing"]


### PR DESCRIPTION
## Context

Part C.2a of #3079. See `docs/folk-epic/seminar-module-self-converge-3079-design.md` §8 for the diagnostic: verbatim folk primaries already leave VESUM scope in `module.md`, but the same embedded primaries in `activities.yaml` / `vocabulary.yaml` were still checked as modern Ukrainian.

Class A only: embedded verbatim primaries are exempted. Class B/C/D remain out of scope and sequenced separately.

## Changes

- Extends the seminar-only VESUM primary-text exemption to activity text and vocabulary `usage` text.
- Uses verified module blockquotes as the fast path and literary-corpus hits as the primary signal.
- Removes only matched token spans with an 8-token minimum window; ordinary YAML prose remains VESUM-checked.
- Adds regression coverage for Class A stripping, out-of-scope words staying checked, vocabulary usage, core-level gating, and a modern non-word still failing.

## Verification

CWD: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-3079-c2a`

### 1. Targeted test

```text
$ .venv/bin/python -m pytest tests/test_vesum_yaml_verbatim_primary_exemption.py -q
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-3079-c2a
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 5 items

tests/test_vesum_yaml_verbatim_primary_exemption.py .....                [100%]

============================== 5 passed in 0.44s ===============================
```

### 2-3. Class A drops out; out-of-scope words stay checked

```text
$ .venv/bin/python -c "from scripts.build import linear_pipeline as lp; ns={}; exec(open('tests/test_vesum_yaml_verbatim_primary_exemption.py', encoding='utf-8').read(), ns); lp._search_literary_hits=ns['_literary_hit_for_shchedrivka']; text=lp._build_vesum_text(ns['KOLIADKY_MODULE'], [{'type':'analysis','passage':ns['SHCHEDRIVKA_PASSAGE'],'items':[{'quote':ns['KOLIADKY_ACTIVITY_QUOTE'],'prompt':'Порівняйте Йоль і дерево-явір як першопочаток.'}]}], [], [], level='folk'); [print(w + ': ' + ('PRESENT' if w in text else 'ABSENT')) for w in ['нащада','било','сонінько','Йоль','дерево-явір','першопочаток']]"
нащада: ABSENT
било: ABSENT
сонінько: ABSENT
Йоль: PRESENT
дерево-явір: PRESENT
першопочаток: PRESENT
```

### 4. Modern YAML non-word is not over-exempted

```text
$ .venv/bin/python -c "from scripts.build import linear_pipeline as lp; lp._search_literary_hits=lambda *a, **k: []; lp._resolve_folk_heritage_attested_missing=lambda *a, **k: set(); verify=lambda words: {w: ([] if w == 'привітаннячкоз' else [{'lemma': w}]) for w in words}; result=lp._vesum_gate(module_text='', activities=[{'type':'short-answer','passage':'Сьогодні учні пишуть привітаннячкоз для друга у класі разом після уроку.'}], vocabulary=[], resources=[], level='folk', verify_words_fn=verify); print('passed=' + str(result['passed'])); print('missing=' + str(result['missing']))"
passed=False
missing=['привітаннячкоз']
```

### 5. Broader relevant pytest sweep

Note: there are no `tests/test_python_qg*.py` files in this worktree, so this uses Bash `nullglob`. The local machine has a full symlinked `data/sources.db`, but three pre-existing live-corpus expectations in `tests/test_vesum_heritage_attestation.py` fail because this DB does not attest `другоє`, `оточуючий`, or `слідуючий`. The CI/stub-DB-shaped sweep with `skipif` corpus tests deselected is green:

```text
$ shopt -s nullglob; files=(tests/test_python_qg*.py tests/test_linear_pipeline*.py tests/test_vesum*.py tests/test_textbook_grounding_gate.py tests/test_textbook_quote_fidelity_gate.py); printf 'pytest files:'; printf ' %s' "${files[@]}"; printf '\n'; .venv/bin/python -m pytest "${files[@]}" -m 'not skipif' -q
pytest files: tests/test_linear_pipeline_telemetry.py tests/test_linear_pipeline_vesum_heritage_attestation.py tests/test_linear_pipeline_wiki_coverage.py tests/test_vesum_blockquote_exempt.py tests/test_vesum_gate_distractor_and_phonetic.py tests/test_vesum_heritage_attestation.py tests/test_vesum_verified_postfix.py tests/test_vesum_whitelist.py tests/test_vesum_yaml_verbatim_primary_exemption.py tests/test_textbook_grounding_gate.py tests/test_textbook_quote_fidelity_gate.py
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-3079-c2a
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 145 items / 10 deselected / 135 selected

...

====================== 135 passed, 10 deselected in 5.85s ======================
```

Unfiltered local live-corpus run result for transparency:

```text
======================== 3 failed, 142 passed in 15.55s ========================
FAILED tests/test_vesum_heritage_attestation.py::test_folk_vesum_gate_accepts_engine_authentic_not_in_allowlist
FAILED tests/test_vesum_heritage_attestation.py::test_folk_vesum_gate_accepts_productive_derivational_bases
FAILED tests/test_vesum_heritage_attestation.py::test_direct_standard_active_participle_calques_stay_existing_behavior
```

### 6. Lint

```text
$ .venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_vesum_yaml_verbatim_primary_exemption.py
All checks passed!
```

Additional pre-submit:

```text
$ .venv/bin/python scripts/audit/lint_agent_trailer.py
Checking 1 commit(s) in origin/main..HEAD:

  9247bd9dae  PASS  X-Agent: codex/folk-3079-c2a

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

Class-A words `[нащада, било, сонінько]` exempted; `[Йоль, дерево-явір, першопочаток]` still checked.
