### PR TITLE
fix(lit): mark intentional slug mismatches

### DIFF
--- a/.github/workflows/validate-yaml.yml
+++ b/.github/workflows/validate-yaml.yml
@@ -253,6 +253,9 @@ jobs:
             python scripts/validate_plan_config.py "${level}/${slug}"
           done
 
+      - name: Validate Plan Ordering
+        run: python scripts/validate_plan_ordering.py
+
   schema-check:
     name: Schema JSON Syntax
     runs-on: ubuntu-latest

--- a/curriculum/l2-uk-en/curriculum.yaml
+++ b/curriculum/l2-uk-en/curriculum.yaml
@@ -671,6 +671,7 @@ levels:
       - ukrainske-kino
       - praktyka-2-vysoke-mystetstvo
       - c1-final-checkpoint
+      - review-c1-5
   hist:
     type: track
     groups:

--- a/curriculum/l2-uk-en/plans/hist/povnomasshtabne-vtorhnessnia.yaml
+++ b/curriculum/l2-uk-en/plans/hist/povnomasshtabne-vtorhnessnia.yaml
@@ -94,6 +94,7 @@ references:
   work: 'The Russo-Ukrainian War: The Return of History'
 sequence: 132
 slug: povnomasshtabne-vtorhnennia
+slug_intentional: true
 subtitle: The Full-Scale Invasion and the Battle for Kyiv
 title: Повномасштабне вторгнення та битва за Київ
 version: '4.0'

--- a/curriculum/l2-uk-en/plans/hist/zunr.yaml
+++ b/curriculum/l2-uk-en/plans/hist/zunr.yaml
@@ -95,6 +95,7 @@ references:
   work: Нарис історії України
 sequence: 92
 slug: zunr-akt-zluky
+slug_intentional: true
 subtitle: 'ZUNR and the Act of Unification: The Birth of Unity'
 title: 'ЗУНР та Акт Злуки: Народження Соборності'
 version: '4.0'

--- a/curriculum/l2-uk-en/plans/istorio/2004-krymska-kryza.yaml
+++ b/curriculum/l2-uk-en/plans/istorio/2004-krymska-kryza.yaml
@@ -93,6 +93,7 @@ references:
   work: 'From Kuchma to Yushchenko: Ukraine''s 2004 Presidential Elections'
 sequence: 129
 slug: 2004-separatystskyi-syid
+slug_intentional: true
 subtitle: The 2004 Severodonetsk Congress and the "First Attempt" to Split Ukraine
 title: '2004: Сєвєродонецький з''їзд і "перша спроба" розколу України'
 version: '4.0'

--- a/curriculum/l2-uk-en/plans/lit-drama/karpenko-karyi-theatre.yaml
+++ b/curriculum/l2-uk-en/plans/lit-drama/karpenko-karyi-theatre.yaml
@@ -88,6 +88,7 @@ references:
   work: Історія українського письменства
 sequence: 1
 slug: karpenko-karyi-martyn-borulya
+slug_intentional: true
 subtitle: The Agony of Status and the Birth of Ukrainian Tragicomedy
 title: 'Іван Карпенко-Карий: "Мартин Боруля"'
 version: '4.0'

--- a/curriculum/l2-uk-en/plans/lit-essay/essay-synthesis-1.yaml
+++ b/curriculum/l2-uk-en/plans/lit-essay/essay-synthesis-1.yaml
@@ -88,6 +88,7 @@ references:
   type: wiki
 sequence: 51
 slug: khvylovy-ukraina-chy-malorosiia
+slug_intentional: true
 subtitle: 'Khvylovy''s Pamphlets: "Ukraine or Little Russia?"'
 title: 'Памфлети Хвильового: "Україна чи Малоросія?"'
 version: '4.0'

--- a/curriculum/l2-uk-en/plans/lit-hist-fic/shklyar-black-raven-2.yaml
+++ b/curriculum/l2-uk-en/plans/lit-hist-fic/shklyar-black-raven-2.yaml
@@ -89,6 +89,7 @@ references:
   type: wiki
 sequence: 13
 slug: shklyar-chornyy-voron
+slug_intentional: true
 subtitle: 'Коли роман стає зброєю: аналіз феномену "Чорного Ворона"'
 title: 'Василь Шкляр: "Чорний Ворон"'
 version: '4.0'

--- a/curriculum/l2-uk-en/plans/lit-war/zhadan-internat-war.yaml
+++ b/curriculum/l2-uk-en/plans/lit-war/zhadan-internat-war.yaml
@@ -88,6 +88,7 @@ references:
   work: Післячорнобильська бібліотека
 sequence: 9
 slug: zhadan-internat
+slug_intentional: true
 subtitle: Людина та вибір у "сірій зоні" війни
 title: 'Сергій Жадан: "Інтернат"'
 version: '4.0'

--- a/curriculum/l2-uk-en/plans/lit-youth/rutkivsky-dzhury-2.yaml
+++ b/curriculum/l2-uk-en/plans/lit-youth/rutkivsky-dzhury-2.yaml
@@ -92,6 +92,7 @@ references:
   work: Код української ідентичності в трилогії "Джури"
 sequence: 12
 slug: rutkivsky-dzhury
+slug_intentional: true
 subtitle: How a youth novel became a decolonization tool and a modern national myth.
 title: 'Володимир Рутківський, "Джури": Народження нації в плавнях'
 version: '4.0'

--- a/curriculum/l2-uk-en/plans/lit-youth/rutkivsky-dzhury-3.yaml
+++ b/curriculum/l2-uk-en/plans/lit-youth/rutkivsky-dzhury-3.yaml
@@ -81,6 +81,7 @@ references:
   work: Джури козака Швайки
 sequence: 27
 slug: rutkivsky-dzhury-trilogy
+slug_intentional: true
 subtitle: 'Volodymyr Rutkivsky: The ''Dzhury'' Trilogy'
 title: 'Володимир Рутківський: трилогія «Джури»'
 version: '4.0'

--- a/curriculum/l2-uk-en/plans/lit/bahrianyi-tiger-trappers.yaml
+++ b/curriculum/l2-uk-en/plans/lit/bahrianyi-tiger-trappers.yaml
@@ -86,7 +86,8 @@ references:
   type: primary
   work: Людина і звір (або інша праця про Багряного)
 sequence: 124
-slug: bahrianyi-tiger-trappers
+slug: bahrianyi-tyhrolovy
+slug_intentional: true
 subtitle: '''Tiger Trappers'' by Ivan Bahrianyi'
 title: '''Тигролови'' Івана Багряного'
 version: '4.0'

--- a/curriculum/l2-uk-en/plans/lit/black-council-plot.yaml
+++ b/curriculum/l2-uk-en/plans/lit/black-council-plot.yaml
@@ -92,7 +92,8 @@ references:
   type: secondary
   work: Історія української літератури
 sequence: 23
-slug: black-council-plot
+slug: chorna-rada-roman
+slug_intentional: true
 subtitle: 'The Black Council: The First Ukrainian Historical Novel'
 title: 'Чорна рада: Перший український історичний роман'
 version: '4.0'

--- a/curriculum/l2-uk-en/plans/lit/franko-biography.yaml
+++ b/curriculum/l2-uk-en/plans/lit/franko-biography.yaml
@@ -91,7 +91,8 @@ references:
   path: wiki/lit/ivan-franko-overview.md
   type: wiki
 sequence: 42
-slug: franko-biography
+slug: franko-titan-pratsi
+slug_intentional: true
 subtitle: 'Ivan Franko: A Titan of Labor'
 title: 'Іван Франко: Титан праці'
 version: '4.0'

--- a/curriculum/l2-uk-en/plans/lit/kotsiubynsky-apple-blossom.yaml
+++ b/curriculum/l2-uk-en/plans/lit/kotsiubynsky-apple-blossom.yaml
@@ -92,7 +92,8 @@ references:
   type: primary
   work: Міфологічний горизонт українського модернізму
 sequence: 67
-slug: kotsiubynsky-apple-blossom
+slug: kotsiubynsky-intermezzo
+slug_intentional: true
 subtitle: The Psychology of Exhaustion in Kotsiubynsky's "Intermezzo"
 title: '«Intermezzo» Михайла Коцюбинського: Психологія втоми'
 version: '4.0'

--- a/curriculum/l2-uk-en/plans/lit/lesia-in-the-catacombs.yaml
+++ b/curriculum/l2-uk-en/plans/lit/lesia-in-the-catacombs.yaml
@@ -88,7 +88,8 @@ references:
   type: primary
   work: 'Notre Dame d''Ukraine: Українка в конфлікті міфологій'
 sequence: 56
-slug: lesia-in-the-catacombs
+slug: lesia-ukrainka-kassandra
+slug_intentional: true
 subtitle: 'Kassandra: The Tragedy of Unheard Truth'
 title: 'Кассандра: Трагедія невислуханої правди'
 version: '4.0'

--- a/curriculum/l2-uk-en/plans/lit/tanja-maljartschuk-biography.yaml
+++ b/curriculum/l2-uk-en/plans/lit/tanja-maljartschuk-biography.yaml
@@ -87,7 +87,8 @@ references:
   type: primary
   work: 365. Книжка на кожен день, щоб справді нічого не встигнути
 sequence: 197
-slug: tanja-maljartschuk-biography
+slug: tanja-maljartschuk
+slug_intentional: true
 subtitle: 'Tanja Maljartschuk: Biography of an Accidental Miracle'
 title: 'Таня Малярчук: Біографія випадкового чуда'
 version: '4.0'

--- a/curriculum/l2-uk-en/plans/lit/the-ballads.yaml
+++ b/curriculum/l2-uk-en/plans/lit/the-ballads.yaml
@@ -96,7 +96,8 @@ references:
   type: primary
   work: 'Notre Dame d''Ukraine: Українка в конфлікті міфологій'
 sequence: 12
-slug: the-ballads
+slug: shevchenko-ran-balady
+slug_intentional: true
 subtitle: Містика і метаморфози в ранній творчості Шевченка
 title: 'Балади: Між світами та жанрами'
 version: '4.0'

--- a/curriculum/l2-uk-en/plans/lit/the-testament.yaml
+++ b/curriculum/l2-uk-en/plans/lit/the-testament.yaml
@@ -92,7 +92,8 @@ references:
   path: wiki/lit/shevchenko-zapovit.md
   type: wiki
 sequence: 15
-slug: the-testament
+slug: zapovit
+slug_intentional: true
 subtitle: 'The Testament: A Political and Poetic Manifesto'
 title: '"Заповіт": Політичний і поетичний маніфест'
 version: '4.0'

--- a/curriculum/l2-uk-en/plans/ruth/black-council.yaml
+++ b/curriculum/l2-uk-en/plans/ruth/black-council.yaml
@@ -93,6 +93,7 @@ references:
   type: wiki
 sequence: 80
 slug: chorna-rada
+slug_intentional: true
 subtitle: Аналіз мовної стилізації Пантелеймона Куліша
 title: Чорна Рада
 version: '4.0'

--- a/scripts/pre_commit/check_plan_immutability.py
+++ b/scripts/pre_commit/check_plan_immutability.py
@@ -13,7 +13,15 @@ import yaml
 
 PLAN_PATH_RE = re.compile(r"^curriculum/[^/]+/plans/.+\.yaml$")
 AUTO_FIX_TAG = "[auto-fix-plan-vocab]"
-METADATA_ONLY_FIELDS = {"module", "sequence", "slug", "level", "connects_to", "prerequisites"}
+METADATA_ONLY_FIELDS = {
+    "module",
+    "sequence",
+    "slug",
+    "slug_intentional",
+    "level",
+    "connects_to",
+    "prerequisites",
+}
 YAML_BACKUP_SUFFIXES = (".yaml.bak", ".yml.bak", ".yaml.orig", ".yml.orig")
 
 

--- a/scripts/validate/validate_plan_ordering.py
+++ b/scripts/validate/validate_plan_ordering.py
@@ -29,6 +29,161 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 CURRICULUM_PATH = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "curriculum.yaml"
 PLANS_DIR = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "plans"
 
+# Exact legacy exceptions that predate the blocking CI gate in #2526. Keep these
+# keyed to the observed value so future drift still fails.
+LEGACY_SLUG_MISMATCHES = {
+    ("hist", "povnomasshtabne-vtorhnessnia.yaml", "povnomasshtabne-vtorhnennia"),
+    ("hist", "zunr.yaml", "zunr-akt-zluky"),
+    ("istorio", "2004-krymska-kryza.yaml", "2004-separatystskyi-syid"),
+    ("ruth", "black-council.yaml", "chorna-rada"),
+    ("lit-essay", "essay-synthesis-1.yaml", "khvylovy-ukraina-chy-malorosiia"),
+    ("lit-hist-fic", "shklyar-black-raven-2.yaml", "shklyar-chornyy-voron"),
+    ("lit-war", "zhadan-internat-war.yaml", "zhadan-internat"),
+    ("lit-youth", "rutkivsky-dzhury-2.yaml", "rutkivsky-dzhury"),
+    ("lit-youth", "rutkivsky-dzhury-3.yaml", "rutkivsky-dzhury-trilogy"),
+    ("lit-drama", "karpenko-karyi-theatre.yaml", "karpenko-karyi-martyn-borulya"),
+}
+
+LEGACY_FIELD_MISMATCHES = {
+    ("hist", "ruska-pravda.yaml", "module", "ruska-pravda", "hist-013"),
+    (
+        "istorio",
+        "syntez-rozdorizhzhia.yaml",
+        "module",
+        "istorio-syntez-rozdorizhzhia",
+        "istorio-094",
+    ),
+    (
+        "lit-essay",
+        "lypynsky-ham-japheth.yaml",
+        "module",
+        "lypynsky-ham-japheth",
+        "lit-essay-015",
+    ),
+    ("lit-essay", "prokopovych-baroque-oratory.yaml", "sequence", "3", "2"),
+    (
+        "lit-essay",
+        "prokopovych-baroque-oratory.yaml",
+        "module",
+        "lit-essay-003",
+        "lit-essay-002",
+    ),
+    (
+        "lit-hist-fic",
+        "lepkyi-mazepa.yaml",
+        "module",
+        "lepkyi-mazepa",
+        "lit-hist-fic-003",
+    ),
+    ("ruth", "berynda-leksykon.yaml", "module", "berynda-leksykon", "ruth-102"),
+    ("lit-war", "gorlis-gorsky-kholodnyi-yar.yaml", "sequence", "1", "26"),
+    (
+        "lit-war",
+        "gorlis-gorsky-kholodnyi-yar.yaml",
+        "module",
+        "lit-war-001",
+        "lit-war-026",
+    ),
+    ("lit-war", "upa-underground-literature.yaml", "sequence", "1", "27"),
+    (
+        "lit-war",
+        "upa-underground-literature.yaml",
+        "module",
+        "lit-war-001",
+        "lit-war-027",
+    ),
+    (
+        "lit-humor",
+        "andrukhovych-postmodern-irony.yaml",
+        "module",
+        "andrukhovych-postmodern-irony",
+        "lit-humor-009",
+    ),
+    (
+        "lit-humor",
+        "modern-memes-as-folklore.yaml",
+        "module",
+        "modern-memes-as-folklore",
+        "lit-humor-013",
+    ),
+    (
+        "lit-drama",
+        "arie-chornobyl.yaml",
+        "module",
+        "arie-chornobyl",
+        "lit-drama-011",
+    ),
+    ("lit-drama", "karpenko-karyi-theatre.yaml", "sequence", "1", "13"),
+    (
+        "lit-drama",
+        "karpenko-karyi-theatre.yaml",
+        "module",
+        "lit-drama-001",
+        "lit-drama-013",
+    ),
+    (
+        "lit-drama",
+        "kulish-narodnyi-malahii.yaml",
+        "module",
+        "kulish-narodnyi-malahii",
+        "lit-drama-006",
+    ),
+    ("lit-drama", "skovoroda-dialogues-theatre.yaml", "sequence", "1", "15"),
+    (
+        "lit-drama",
+        "skovoroda-dialogues-theatre.yaml",
+        "module",
+        "lit-drama-001",
+        "lit-drama-015",
+    ),
+    ("lit-drama", "ukrainian-drama-origins.yaml", "sequence", "1", "14"),
+    (
+        "lit-drama",
+        "ukrainian-drama-origins.yaml",
+        "module",
+        "lit-drama-01",
+        "lit-drama-014",
+    ),
+    (
+        "lit-drama",
+        "vorozhbyt-bad-roads.yaml",
+        "module",
+        "lit-drama-10",
+        "lit-drama-010",
+    ),
+    ("lit-drama", "vynnychenko-european-stage.yaml", "sequence", "2", "17"),
+    (
+        "lit-drama",
+        "vynnychenko-european-stage.yaml",
+        "module",
+        "lit-drama-002",
+        "lit-drama-017",
+    ),
+}
+
+LEGACY_ORPHAN_FILES = {("c1", "review-c1-5.yaml")}
+LEGACY_MISSING_PLAN_FILES = {("c2", "pobut-i-shchodenne-zhyttia.yaml", "68")}
+
+
+def _is_legacy_slug_mismatch(level: str, filename: str, actual_slug: str) -> bool:
+    return (level, filename, actual_slug) in LEGACY_SLUG_MISMATCHES
+
+
+def _is_legacy_field_mismatch(
+    level: str,
+    filename: str,
+    field: str,
+    actual,
+    expected,
+) -> bool:
+    return (
+        level,
+        filename,
+        field,
+        str(actual),
+        str(expected),
+    ) in LEGACY_FIELD_MISMATCHES
+
 
 def load_curriculum() -> dict[str, list[str]]:
     """Load curriculum.yaml and return {level: [slug, ...]} mapping."""
@@ -187,6 +342,8 @@ def validate_track(level: str, slugs: list[str], fix: bool = False) -> tuple[lis
 
         # Check if slug is in curriculum
         if file_slug not in slug_to_seq:
+            if (level, plan_file.name) in LEGACY_ORPHAN_FILES:
+                continue
             warnings.append(f"[{level}] ORPHAN: {plan_file.name} has no curriculum.yaml entry")
             continue
 
@@ -198,14 +355,26 @@ def validate_track(level: str, slugs: list[str], fix: bool = False) -> tuple[lis
 
         # Check slug field
         plan_slug = plan.get("slug", "")
-        if plan_slug and plan_slug != file_slug:
+        if (
+            plan_slug
+            and plan_slug != file_slug
+            and plan.get("slug_intentional") is not True
+            and not _is_legacy_slug_mismatch(level, plan_file.name, plan_slug)
+        ):
             errors.append(
-                f"[{level}] {plan_file.name}: slug={plan_slug!r}, expected={file_slug!r}"
+                f"[{level}] {plan_file.name}: slug={plan_slug!r}, expected={file_slug!r}; "
+                "add slug_intentional: true if this mismatch is canonical"
             )
 
         # Check sequence field
         plan_seq = plan.get("sequence")
-        if plan_seq is not None and int(plan_seq) != expected_seq:
+        if (
+            plan_seq is not None
+            and int(plan_seq) != expected_seq
+            and not _is_legacy_field_mismatch(
+                level, plan_file.name, "sequence", plan_seq, expected_seq
+            )
+        ):
             errors.append(
                 f"[{level}] {plan_file.name}: sequence={plan_seq}, expected={expected_seq}"
             )
@@ -215,7 +384,13 @@ def validate_track(level: str, slugs: list[str], fix: bool = False) -> tuple[lis
 
         # Check module field
         plan_mod = plan.get("module", "")
-        if plan_mod and str(plan_mod) != expected_mod:
+        if (
+            plan_mod
+            and str(plan_mod) != expected_mod
+            and not _is_legacy_field_mismatch(
+                level, plan_file.name, "module", plan_mod, expected_mod
+            )
+        ):
             errors.append(
                 f"[{level}] {plan_file.name}: module={plan_mod!r}, expected={expected_mod!r}"
             )
@@ -329,6 +504,8 @@ def validate_track(level: str, slugs: list[str], fix: bool = False) -> tuple[lis
     # Check for missing plan files
     for slug, seq in slug_to_seq.items():
         if slug not in found_slugs:
+            if (level, f"{slug}.yaml", str(seq)) in LEGACY_MISSING_PLAN_FILES:
+                continue
             errors.append(
                 f"[{level}] MISSING: {slug}.yaml (seq {seq}) has no plan file"
             )

--- a/scripts/validate/validate_plan_ordering.py
+++ b/scripts/validate/validate_plan_ordering.py
@@ -29,23 +29,10 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 CURRICULUM_PATH = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "curriculum.yaml"
 PLANS_DIR = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "plans"
 
-# Exact legacy exceptions that predate the blocking CI gate in #2526. Keep these
-# keyed to the observed value so future drift still fails.
-LEGACY_SLUG_MISMATCHES = {
-    ("hist", "povnomasshtabne-vtorhnessnia.yaml", "povnomasshtabne-vtorhnennia"),
-    ("hist", "zunr.yaml", "zunr-akt-zluky"),
-    ("istorio", "2004-krymska-kryza.yaml", "2004-separatystskyi-syid"),
-    ("ruth", "black-council.yaml", "chorna-rada"),
-    ("lit-essay", "essay-synthesis-1.yaml", "khvylovy-ukraina-chy-malorosiia"),
-    ("lit-hist-fic", "shklyar-black-raven-2.yaml", "shklyar-chornyy-voron"),
-    ("lit-war", "zhadan-internat-war.yaml", "zhadan-internat"),
-    ("lit-youth", "rutkivsky-dzhury-2.yaml", "rutkivsky-dzhury"),
-    ("lit-youth", "rutkivsky-dzhury-3.yaml", "rutkivsky-dzhury-trilogy"),
-    ("lit-drama", "karpenko-karyi-theatre.yaml", "karpenko-karyi-martyn-borulya"),
-}
-
 LEGACY_FIELD_MISMATCHES = {
+    # Metadata-only plan correction blocked by HIST plan immutability review.
     ("hist", "ruska-pravda.yaml", "module", "ruska-pravda", "hist-013"),
+    # Metadata-only plan correction blocked by ISTORIO plan immutability review.
     (
         "istorio",
         "syntez-rozdorizhzhia.yaml",
@@ -53,6 +40,7 @@ LEGACY_FIELD_MISMATCHES = {
         "istorio-syntez-rozdorizhzhia",
         "istorio-094",
     ),
+    # Metadata-only plan correction blocked by LIT-ESSAY plan immutability review.
     (
         "lit-essay",
         "lypynsky-ham-japheth.yaml",
@@ -60,7 +48,9 @@ LEGACY_FIELD_MISMATCHES = {
         "lypynsky-ham-japheth",
         "lit-essay-015",
     ),
+    # Renumbering blocked until the LIT-ESSAY source sequence is reconciled.
     ("lit-essay", "prokopovych-baroque-oratory.yaml", "sequence", "3", "2"),
+    # Renumbering blocked until the LIT-ESSAY source module id is reconciled.
     (
         "lit-essay",
         "prokopovych-baroque-oratory.yaml",
@@ -68,6 +58,7 @@ LEGACY_FIELD_MISMATCHES = {
         "lit-essay-003",
         "lit-essay-002",
     ),
+    # Metadata-only plan correction blocked by LIT-HIST-FIC plan immutability review.
     (
         "lit-hist-fic",
         "lepkyi-mazepa.yaml",
@@ -75,8 +66,11 @@ LEGACY_FIELD_MISMATCHES = {
         "lepkyi-mazepa",
         "lit-hist-fic-003",
     ),
+    # Metadata-only plan correction blocked by RUTH plan immutability review.
     ("ruth", "berynda-leksykon.yaml", "module", "berynda-leksykon", "ruth-102"),
+    # Renumbering blocked until the LIT-WAR source sequence is reconciled.
     ("lit-war", "gorlis-gorsky-kholodnyi-yar.yaml", "sequence", "1", "26"),
+    # Renumbering blocked until the LIT-WAR source module id is reconciled.
     (
         "lit-war",
         "gorlis-gorsky-kholodnyi-yar.yaml",
@@ -84,7 +78,9 @@ LEGACY_FIELD_MISMATCHES = {
         "lit-war-001",
         "lit-war-026",
     ),
+    # Renumbering blocked until the LIT-WAR source sequence is reconciled.
     ("lit-war", "upa-underground-literature.yaml", "sequence", "1", "27"),
+    # Renumbering blocked until the LIT-WAR source module id is reconciled.
     (
         "lit-war",
         "upa-underground-literature.yaml",
@@ -92,6 +88,7 @@ LEGACY_FIELD_MISMATCHES = {
         "lit-war-001",
         "lit-war-027",
     ),
+    # Metadata-only plan correction blocked by LIT-HUMOR plan immutability review.
     (
         "lit-humor",
         "andrukhovych-postmodern-irony.yaml",
@@ -99,6 +96,7 @@ LEGACY_FIELD_MISMATCHES = {
         "andrukhovych-postmodern-irony",
         "lit-humor-009",
     ),
+    # Metadata-only plan correction blocked by LIT-HUMOR plan immutability review.
     (
         "lit-humor",
         "modern-memes-as-folklore.yaml",
@@ -106,6 +104,7 @@ LEGACY_FIELD_MISMATCHES = {
         "modern-memes-as-folklore",
         "lit-humor-013",
     ),
+    # Metadata-only plan correction blocked by LIT-DRAMA plan immutability review.
     (
         "lit-drama",
         "arie-chornobyl.yaml",
@@ -113,7 +112,9 @@ LEGACY_FIELD_MISMATCHES = {
         "arie-chornobyl",
         "lit-drama-011",
     ),
+    # Renumbering blocked until the LIT-DRAMA source sequence is reconciled.
     ("lit-drama", "karpenko-karyi-theatre.yaml", "sequence", "1", "13"),
+    # Renumbering blocked until the LIT-DRAMA source module id is reconciled.
     (
         "lit-drama",
         "karpenko-karyi-theatre.yaml",
@@ -121,6 +122,7 @@ LEGACY_FIELD_MISMATCHES = {
         "lit-drama-001",
         "lit-drama-013",
     ),
+    # Metadata-only plan correction blocked by LIT-DRAMA plan immutability review.
     (
         "lit-drama",
         "kulish-narodnyi-malahii.yaml",
@@ -128,7 +130,9 @@ LEGACY_FIELD_MISMATCHES = {
         "kulish-narodnyi-malahii",
         "lit-drama-006",
     ),
+    # Renumbering blocked until the LIT-DRAMA source sequence is reconciled.
     ("lit-drama", "skovoroda-dialogues-theatre.yaml", "sequence", "1", "15"),
+    # Renumbering blocked until the LIT-DRAMA source module id is reconciled.
     (
         "lit-drama",
         "skovoroda-dialogues-theatre.yaml",
@@ -136,7 +140,9 @@ LEGACY_FIELD_MISMATCHES = {
         "lit-drama-001",
         "lit-drama-015",
     ),
+    # Renumbering blocked until the LIT-DRAMA source sequence is reconciled.
     ("lit-drama", "ukrainian-drama-origins.yaml", "sequence", "1", "14"),
+    # Renumbering blocked until the LIT-DRAMA source module id is reconciled.
     (
         "lit-drama",
         "ukrainian-drama-origins.yaml",
@@ -144,6 +150,7 @@ LEGACY_FIELD_MISMATCHES = {
         "lit-drama-01",
         "lit-drama-014",
     ),
+    # Metadata-only plan correction blocked by LIT-DRAMA plan immutability review.
     (
         "lit-drama",
         "vorozhbyt-bad-roads.yaml",
@@ -151,7 +158,9 @@ LEGACY_FIELD_MISMATCHES = {
         "lit-drama-10",
         "lit-drama-010",
     ),
+    # Renumbering blocked until the LIT-DRAMA source sequence is reconciled.
     ("lit-drama", "vynnychenko-european-stage.yaml", "sequence", "2", "17"),
+    # Renumbering blocked until the LIT-DRAMA source module id is reconciled.
     (
         "lit-drama",
         "vynnychenko-european-stage.yaml",
@@ -159,14 +168,18 @@ LEGACY_FIELD_MISMATCHES = {
         "lit-drama-002",
         "lit-drama-017",
     ),
+    # C1 review is indexed after existing modules; moving it to c1-072 would
+    # displace morfolohichni-stylistychni-zasoby and force a broad C1 renumber.
+    ("c1", "review-c1-5.yaml", "sequence", "72", "133"),
+    # C1 review is indexed after existing modules; c1-072 is already occupied
+    # by morfolohichni-stylistychni-zasoby pending a dedicated C1 ordering pass.
+    ("c1", "review-c1-5.yaml", "module", "c1-072", "c1-133"),
 }
 
-LEGACY_ORPHAN_FILES = {("c1", "review-c1-5.yaml")}
-LEGACY_MISSING_PLAN_FILES = {("c2", "pobut-i-shchodenne-zhyttia.yaml", "68")}
-
-
-def _is_legacy_slug_mismatch(level: str, filename: str, actual_slug: str) -> bool:
-    return (level, filename, actual_slug) in LEGACY_SLUG_MISMATCHES
+LEGACY_MISSING_PLAN_FILES = {
+    # planned-unbuilt; tracked by the C2.4 State Standard thematic redesign block.
+    ("c2", "pobut-i-shchodenne-zhyttia.yaml", "68"),
+}
 
 
 def _is_legacy_field_mismatch(
@@ -342,8 +355,6 @@ def validate_track(level: str, slugs: list[str], fix: bool = False) -> tuple[lis
 
         # Check if slug is in curriculum
         if file_slug not in slug_to_seq:
-            if (level, plan_file.name) in LEGACY_ORPHAN_FILES:
-                continue
             warnings.append(f"[{level}] ORPHAN: {plan_file.name} has no curriculum.yaml entry")
             continue
 
@@ -359,7 +370,6 @@ def validate_track(level: str, slugs: list[str], fix: bool = False) -> tuple[lis
             plan_slug
             and plan_slug != file_slug
             and plan.get("slug_intentional") is not True
-            and not _is_legacy_slug_mismatch(level, plan_file.name, plan_slug)
         ):
             errors.append(
                 f"[{level}] {plan_file.name}: slug={plan_slug!r}, expected={file_slug!r}; "

--- a/scripts/validate_plan_ordering.py
+++ b/scripts/validate_plan_ordering.py
@@ -11,3 +11,6 @@ _spec = _ilu.spec_from_file_location(
 _mod = _ilu.module_from_spec(_spec)
 _sys.modules[__name__] = _mod
 _spec.loader.exec_module(_mod)
+
+if __name__ == "__main__":
+    _sys.exit(_mod.main())

--- a/tests/test_plan_immutability_hook.py
+++ b/tests/test_plan_immutability_hook.py
@@ -163,6 +163,7 @@ def test_metadata_only_plan_edit_without_bak_passes(tmp_path: Path):
     data["module"] = "a1-002"
     data["sequence"] = 2
     data["slug"] = "test-plan-renumbered"
+    data["slug_intentional"] = True
     data["level"] = "A1"
     data["prerequisites"] = ["a1-001 (previous module)"]
     plan_file.write_text(

--- a/tests/test_validate_plan_ordering.py
+++ b/tests/test_validate_plan_ordering.py
@@ -37,16 +37,18 @@ def test_marked_slug_filename_mismatch_passes(tmp_path: Path, monkeypatch) -> No
     assert issues == []
 
 
-def test_legacy_slug_exception_is_exact(tmp_path: Path, monkeypatch) -> None:
+def test_previously_legacy_slug_mismatch_requires_marker(
+    tmp_path: Path, monkeypatch
+) -> None:
     plan_dir = tmp_path / "plans" / "hist"
     plan_dir.mkdir(parents=True)
-    _write_plan(plan_dir / "zunr.yaml", "different-zunr-slug")
+    _write_plan(plan_dir / "zunr.yaml", "zunr-akt-zluky")
     monkeypatch.setattr(validate_plan_ordering, "PLANS_DIR", tmp_path / "plans")
 
     issues, fixes = validate_plan_ordering.validate_track("hist", ["zunr"])
 
     assert fixes == 0
     assert issues == [
-        "[hist] zunr.yaml: slug='different-zunr-slug', expected='zunr'; "
+        "[hist] zunr.yaml: slug='zunr-akt-zluky', expected='zunr'; "
         "add slug_intentional: true if this mismatch is canonical"
     ]

--- a/tests/test_validate_plan_ordering.py
+++ b/tests/test_validate_plan_ordering.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.validate import validate_plan_ordering
+
+
+def _write_plan(path: Path, slug: str, *, intentional: bool = False) -> None:
+    marker = "slug_intentional: true\n" if intentional else ""
+    path.write_text(f"slug: {slug}\n{marker}", encoding="utf-8")
+
+
+def test_unmarked_slug_filename_mismatch_errors(tmp_path: Path, monkeypatch) -> None:
+    plan_dir = tmp_path / "plans" / "lit"
+    plan_dir.mkdir(parents=True)
+    _write_plan(plan_dir / "english-title.yaml", "ukrainian-title")
+    monkeypatch.setattr(validate_plan_ordering, "PLANS_DIR", tmp_path / "plans")
+
+    issues, fixes = validate_plan_ordering.validate_track("lit", ["english-title"])
+
+    assert fixes == 0
+    assert issues == [
+        "[lit] english-title.yaml: slug='ukrainian-title', expected='english-title'; "
+        "add slug_intentional: true if this mismatch is canonical"
+    ]
+
+
+def test_marked_slug_filename_mismatch_passes(tmp_path: Path, monkeypatch) -> None:
+    plan_dir = tmp_path / "plans" / "lit"
+    plan_dir.mkdir(parents=True)
+    _write_plan(plan_dir / "english-title.yaml", "ukrainian-title", intentional=True)
+    monkeypatch.setattr(validate_plan_ordering, "PLANS_DIR", tmp_path / "plans")
+
+    issues, fixes = validate_plan_ordering.validate_track("lit", ["english-title"])
+
+    assert fixes == 0
+    assert issues == []
+
+
+def test_legacy_slug_exception_is_exact(tmp_path: Path, monkeypatch) -> None:
+    plan_dir = tmp_path / "plans" / "hist"
+    plan_dir.mkdir(parents=True)
+    _write_plan(plan_dir / "zunr.yaml", "different-zunr-slug")
+    monkeypatch.setattr(validate_plan_ordering, "PLANS_DIR", tmp_path / "plans")
+
+    issues, fixes = validate_plan_ordering.validate_track("hist", ["zunr"])
+
+    assert fixes == 0
+    assert issues == [
+        "[hist] zunr.yaml: slug='different-zunr-slug', expected='zunr'; "
+        "add slug_intentional: true if this mismatch is canonical"
+    ]


### PR DESCRIPTION
Closes #2526.

## Summary
- Restores the eight LIT plan slugs to their canonical Ukrainian work identity and marks the intentional filename mismatch with `slug_intentional: true`.
- Updates `validate_plan_ordering.py` so unmarked slug mismatches still fail, marked mismatches pass, and exact legacy ordering exceptions do not block enabling the gate.
- Promotes plan ordering validation to a blocking step in the curriculum plan YAML workflow.
- Treats `slug_intentional` as metadata-only for the plan immutability hook.

## Validation
- `.venv/bin/python scripts/validate_plan_ordering.py`
- `.venv/bin/python -m pytest tests/test_validate_plan_ordering.py tests/test_plan_immutability_hook.py -q`
- `.venv/bin/ruff check scripts/validate_plan_ordering.py scripts/validate/validate_plan_ordering.py scripts/pre_commit/check_plan_immutability.py tests/test_validate_plan_ordering.py tests/test_plan_immutability_hook.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
