### PR TITLE
feat(lexicon): active-participle calque corrections — decolonization §6 first slice [#3098]

### DIFF
--- a/scripts/lexicon/calque_corrections.py
+++ b/scripts/lexicon/calque_corrections.py
@@ -67,37 +67,231 @@ sense-scoped soft note, never a blanket warn or auto-replace.
 from __future__ import annotations
 
 # Confirmed active-participle calques → recommended Ukrainian replacement(s).
-# Each value: corrections (ordered, best-first), a short usage note, and the
-# provenance tag(s). Corrections that are full phrases (relative clauses) are
-# kept as-is because the participle has no single-word agent-noun equivalent.
+# Each value: corrections (ordered, best-first), a short usage note, provenance
+# tags, direct source evidence, and the heritage false-positive guard result.
+# Corrections that are full phrases (relative clauses) are kept as-is because
+# the participle has no single-word agent-noun equivalent.
 CURATED_CALQUES: dict[str, dict[str, object]] = {
-    "бажаючий": {"corrections": ["охочий"], "note": "усі бажаючі → усі охочі", "source": ["davydov", "antonenko-p145"]},
-    "працюючий": {"corrections": ["працівник", "той, що працює"], "note": "agent noun or relative clause", "source": ["davydov", "antonenko-p145"]},
-    "завідуючий": {"corrections": ["завідувач"], "note": "agent noun -ач", "source": ["glazova-11", "antonenko-p145"]},
-    "мандруючий": {"corrections": ["мандрівний"], "note": "мандруючий сюжет → мандрівний сюжет", "source": ["glazova-11"]},
-    "початкуючий": {"corrections": ["початківець"], "note": "початкуючий художник → художник-початківець", "source": ["glazova-11"]},
-    "узагальнюючий": {"corrections": ["узагальнювальний"], "note": "суфікс -альн-", "source": ["glazova-11"]},
-    "зволожуючий": {"corrections": ["зволожувальний"], "note": "суфікс -альн- (зволожувальний крем)", "source": ["glazova-11"]},
-    "знеболюючий": {"corrections": ["знеболювальний"], "note": "суфікс -альн- (знеболювальні ліки)", "source": ["glazova-11"]},
-    "хвилюючий": {"corrections": ["зворушливий"], "note": "хвилюючий спогад → зворушливий спогад", "source": ["glazova-11"]},
-    "діючий": {"corrections": ["чинний"], "note": "діючий закон → чинний закон (рос. действующий)", "source": ["glazova-11", "avramenko-11", "antonenko-p145"]},
-    "підростаючий": {"corrections": ["молодий"], "note": "підростаюче покоління → молоде покоління", "source": ["glazova-11"]},
-    "потопаючий": {"corrections": ["той, що потопає"], "note": "relative clause", "source": ["glazova-11"]},
-    "головуючий": {"corrections": ["голова"], "note": "головуючий на зборах → голова зборів", "source": ["avramenko-11"]},
-    "домінуючий": {"corrections": ["основний", "панівний"], "note": "рос. доминирующий", "source": ["avramenko-11"]},
-    "оточуючий": {"corrections": ["довколишній", "навколишній"], "note": "оточуюче середовище → довкілля / навколишнє середовище", "source": ["antonenko-p145", "search_heritage"]},
-    "відпочиваючий": {"corrections": ["відпочивальник", "той, хто відпочиває"], "note": "agent noun or relative clause", "source": ["davydov", "antonenko-p145"]},
-    "завмираючий": {"corrections": ["завмерлий", "той, що завмирає"], "note": "завмираючі звуки", "source": ["avramenko-7", "antonenko-p145"]},
-    "розквітаючий": {"corrections": ["розквітлий", "той, що розквітає"], "note": "розквітаючі дерева", "source": ["avramenko-7", "antonenko-p145"]},
-    "опадаючий": {"corrections": ["опалий"], "note": "present-participle calque → past form -лий", "source": ["avramenko-7", "antonenko-p145"]},
-    "в’янучий": {"corrections": ["зів’ялий"], "note": "present-participle calque → past form -лий", "source": ["avramenko-7", "antonenko-p145"]},
-    "жовтіючий": {"corrections": ["пожовклий"], "note": "present-participle calque → past form -лий", "source": ["avramenko-7", "antonenko-p145"]},
+    "бажаючий": {
+        "corrections": ["охочий"],
+        "note": "усі бажаючі → усі охочі",
+        "source": ["antonenko-p099", "glazova-11"],
+        "evidence": [
+            "antonenko-davydovych-yak-my-hovorymo_p099: Бажаючий – що (котрий, який) бажає – охочий",
+            "11-klas-ukrajinska-mova-glazova-2019_s0072: замість бажаючий — охочий",
+        ],
+        "heritage_guard": "search_heritage(бажаючий, include_live_slovnyk=false): no matching heritage headword; ЕСУМ hit is a related охочий-family row, not an attestation of бажаючий as safe.",
+    },
+    "працюючий": {
+        "corrections": ["працівник", "той, що працює"],
+        "note": "agent noun or relative clause",
+        "source": ["antonenko-p101", "antonenko-p144", "glazova-11"],
+        "evidence": [
+            "antonenko-davydovych-yak-my-hovorymo_p101: Працюючий – що (котрий, який) працює – ... працівник",
+            "antonenko-davydovych-yak-my-hovorymo_p144: Тато, що не працює в неділю ... (instead of не працюючий тато)",
+            "11-klas-ukrajinska-mova-glazova-2019_s0072: замість працюючий — працівник",
+        ],
+        "heritage_guard": "search_heritage(працюючий, include_live_slovnyk=false): No heritage evidence found.",
+    },
+    "завідуючий": {
+        "corrections": ["завідувач"],
+        "note": "agent noun -ач",
+        "source": ["glazova-11", "zabolotnyi-7"],
+        "evidence": [
+            "11-klas-ukrajinska-mova-glazova-2019_s0072: замість завідуючий — завідувач",
+            "7-klas-ukrmova-zabolotnyi-2024_s0124: завідувач бібліотеки / завідуючий бібліотекою",
+        ],
+        "heritage_guard": "search_heritage(завідуючий, include_live_slovnyk=false): ЕСУМ rows describe зав-/завгосп as Russian-modeled abbreviations, not a safe headword attestation.",
+    },
+    "мандруючий": {
+        "corrections": ["мандрівний"],
+        "note": "мандруючий сюжет → мандрівний сюжет",
+        "source": ["glazova-11"],
+        "evidence": ["11-klas-ukrajinska-mova-glazova-2019_s0072: мандрівний (а не мандруючий) сюжет"],
+        "heritage_guard": "search_heritage(мандруючий, include_live_slovnyk=false): No heritage evidence found.",
+    },
+    "початкуючий": {
+        "corrections": ["початківець"],
+        "note": "початкуючий художник → художник-початківець",
+        "source": ["antonenko-p101", "glazova-11", "zabolotnyi-7"],
+        "evidence": [
+            "antonenko-davydovych-yak-my-hovorymo_p101: Початкуючий – початківець",
+            "11-klas-ukrajinska-mova-glazova-2019_s0072: художник-початківець (а не початкуючий художник)",
+            "7-klas-ukrmova-zabolotnyi-2024_s0124: поет-початківець / початкуючий поет",
+        ],
+        "heritage_guard": "search_heritage(початкуючий, include_live_slovnyk=false): no matching heritage headword; ЕСУМ hit is a related письменець row.",
+    },
+    "узагальнюючий": {
+        "corrections": ["узагальнювальний"],
+        "note": "суфікс -альн-",
+        "source": ["glazova-11"],
+        "evidence": ["11-klas-ukrajinska-mova-glazova-2019_s0072: узагальнювальне (а не узагальнююче) слово"],
+        "heritage_guard": "search_heritage(узагальнюючий, include_live_slovnyk=false): No heritage evidence found.",
+    },
+    "зволожуючий": {
+        "corrections": ["зволожувальний"],
+        "note": "суфікс -альн- (зволожувальний крем)",
+        "source": ["glazova-11", "zabolotnyi-7"],
+        "evidence": [
+            "11-klas-ukrajinska-mova-glazova-2019_s0072: зволожувальний (а не зволожуючий) крем",
+            "7-klas-ukrmova-zabolotnyi-2024_s0124: зволожувальний крем / зволожуючий крем",
+        ],
+        "heritage_guard": "search_heritage(зволожуючий, include_live_slovnyk=false): No heritage evidence found.",
+    },
+    "знеболюючий": {
+        "corrections": ["знеболювальний"],
+        "note": "суфікс -альн- (знеболювальні ліки)",
+        "source": ["glazova-11", "zabolotnyi-7"],
+        "evidence": [
+            "11-klas-ukrajinska-mova-glazova-2019_s0072: знеболювальні (а не знеболюючі) ліки",
+            "7-klas-ukrmova-zabolotnyi-2024_s0124: знеболювальний засіб / знеболюючий засіб",
+        ],
+        "heritage_guard": "search_heritage(знеболюючий, include_live_slovnyk=false): no matching heritage headword; ЕСУМ hit is a новокаїн definition, not a safe headword attestation.",
+    },
+    "хвилюючий": {
+        "corrections": ["зворушливий"],
+        "note": "хвилюючий спогад → зворушливий спогад",
+        "source": ["glazova-11"],
+        "evidence": ["11-klas-ukrajinska-mova-glazova-2019_s0072: зворушливий (а не хвилюючий) спогад"],
+        "heritage_guard": "search_heritage(хвилюючий, include_live_slovnyk=false): No heritage evidence found.",
+    },
+    "діючий": {
+        "corrections": ["чинний"],
+        "note": "діючий закон → чинний закон (рос. действующий)",
+        "source": ["glazova-11", "avramenko-11", "zabolotnyi-7"],
+        "evidence": [
+            "11-klas-ukrajinska-mova-glazova-2019_s0072: чинний (а не діючий) закон",
+            "7-klas-ukrmova-zabolotnyi-2024_s0124: чинний закон / діючий закон",
+        ],
+        "heritage_guard": "search_heritage(діючий, include_live_slovnyk=false): no matching heritage headword; ЕСУМ hit is the діянка family row and does not clear діючий закон.",
+    },
+    "підростаючий": {
+        "corrections": ["молодий"],
+        "note": "підростаюче покоління → молоде покоління",
+        "source": ["glazova-11"],
+        "evidence": ["11-klas-ukrajinska-mova-glazova-2019_s0072: молоде (а не підростаюче) покоління"],
+        "heritage_guard": "search_heritage(підростаючий, include_live_slovnyk=false): No heritage evidence found.",
+    },
+    "потопаючий": {
+        "corrections": ["той, що потопає"],
+        "note": "relative clause",
+        "source": ["glazova-11"],
+        "evidence": ["11-klas-ukrajinska-mova-glazova-2019_s0072: Щури тікають з корабля, що потопає (not з потопаючого корабля)"],
+        "heritage_guard": "search_heritage(потопаючий, include_live_slovnyk=false): No heritage evidence found.",
+    },
+    "головуючий": {
+        "corrections": ["голова"],
+        "note": "головуючий на зборах → голова зборів",
+        "source": ["avramenko-11"],
+        "evidence": ["11-klas-ukrajinska-mova-avramenko-2019_s0075: головуючий на зборах — голова зборів"],
+        "heritage_guard": "search_heritage(головуючий, include_live_slovnyk=false): no matching heritage headword; ЕСУМ hit is an unrelated той/prezident row.",
+    },
+    "домінуючий": {
+        "corrections": ["основний", "панівний"],
+        "note": "рос. доминирующий",
+        "source": ["avramenko-11", "antonenko-p101"],
+        "evidence": [
+            "11-klas-ukrajinska-mova-avramenko-2019_s0075: домінуючий принцип — основний принцип",
+            "antonenko-davydovych-yak-my-hovorymo_p101: пануючий суперечить духу нашої мови; слід ... панівний",
+        ],
+        "heritage_guard": "search_heritage(домінуючий, include_live_slovnyk=false): no matching calque headword; ЕСУМ has related loan-family rows, so treat only the cited register/collocation as warn-worthy.",
+    },
+    "оточуючий": {
+        "corrections": ["довколишній", "навколишній"],
+        "note": "оточуюче середовище → довкілля / навколишнє середовище",
+        "source": ["zabolotnyi-7", "zabolotnyi-11"],
+        "evidence": [
+            "7-klas-ukrmova-zabolotnyi-2024_s0124: навколишнє середовище, довкілля / оточуюче середовище",
+            "11-klas-ukrmova-zabolotnyi-2019_s0078: навколишній / оточуючий",
+        ],
+        "heritage_guard": "search_heritage(оточуючий, include_live_slovnyk=false): No heritage evidence found.",
+    },
+    "відпочиваючий": {
+        "corrections": ["відпочивальник", "той, хто відпочиває"],
+        "note": "agent noun or relative clause",
+        "source": ["antonenko-p099", "antonenko-p100", "zabolotnyi-7"],
+        "evidence": [
+            "antonenko-davydovych-yak-my-hovorymo_p099: Відпочиваючий, відпочивальник, що (котрий, який) відпочиває",
+            "antonenko-davydovych-yak-my-hovorymo_p100: ... організовано розваги відпочивальників",
+            "7-klas-ukrmova-zabolotnyi-2024_s0124: відпочивальник / відпочиваючий",
+        ],
+        "heritage_guard": "search_heritage(відпочиваючий, include_live_slovnyk=false): No heritage evidence found.",
+    },
+    "завмираючий": {
+        "corrections": ["завмерлий", "той, що завмирає"],
+        "note": "завмираючі звуки",
+        "source": ["avramenko-7", "antonenko-p144"],
+        "evidence": [
+            "7-klas-ukrmova-avramenko-2024_s0108: завмираючі звуки — завмерлі звуки",
+            "antonenko-davydovych-yak-my-hovorymo_p144: active forms require a relative clause or adverbial construction",
+        ],
+        "heritage_guard": "search_heritage(завмираючий, include_live_slovnyk=false): No heritage evidence found.",
+    },
+    "розквітаючий": {
+        "corrections": ["розквітлий", "той, що розквітає"],
+        "note": "розквітаючі дерева",
+        "source": ["avramenko-7", "antonenko-p144"],
+        "evidence": [
+            "7-klas-ukrmova-avramenko-2024_s0108: розквітаючі дерева — розквітлі дерева",
+            "antonenko-davydovych-yak-my-hovorymo_p144: active forms require a relative clause or adverbial construction",
+        ],
+        "heritage_guard": "search_heritage(розквітаючий, include_live_slovnyk=false): No heritage evidence found.",
+    },
+    "опадаючий": {
+        "corrections": ["опалий"],
+        "note": "present-participle calque → past form -лий",
+        "source": ["avramenko-7", "antonenko-p144"],
+        "evidence": [
+            "7-klas-ukrmova-avramenko-2024_s0108: опадаюче листя — опале листя",
+            "antonenko-davydovych-yak-my-hovorymo_p144: active forms require a relative clause or adverbial construction",
+        ],
+        "heritage_guard": "search_heritage(опадаючий, include_live_slovnyk=false): no matching heritage headword; ЕСУМ hit is a кулон definition, not a safe headword attestation.",
+    },
+    "в’янучий": {
+        "corrections": ["зів’ялий"],
+        "note": "present-participle calque → past form -лий",
+        "source": ["avramenko-7", "antonenko-p144"],
+        "evidence": [
+            "7-klas-ukrmova-avramenko-2024_s0108: в’янучі квіти — зів’ялі квіти",
+            "antonenko-davydovych-yak-my-hovorymo_p144: active forms require a relative clause or adverbial construction",
+        ],
+        "heritage_guard": "search_heritage(в’янучий, include_live_slovnyk=false): No heritage evidence found.",
+    },
+    "жовтіючий": {
+        "corrections": ["пожовклий"],
+        "note": "present-participle calque → past form -лий",
+        "source": ["avramenko-7", "antonenko-p144"],
+        "evidence": [
+            "7-klas-ukrmova-avramenko-2024_s0108: жовтіюче листя — пожовкле листя",
+            "antonenko-davydovych-yak-my-hovorymo_p144: active forms require a relative clause or adverbial construction",
+        ],
+        "heritage_guard": "search_heritage(жовтіючий, include_live_slovnyk=false): No heritage evidence found.",
+    },
     "бувший": {"corrections": ["колишній"], "note": "-вш- participle does not exist in Ukrainian (рос. бывший)", "source": ["avramenko-11"]},
 }
 
 # Phrasal / collocation calques (whole-phrase replacement).
 PHRASAL_CALQUES: dict[str, dict[str, object]] = {
-    "прийняти участь": {"corrections": ["взяти участь"], "note": "рос. принять участие", "source": ["issue-3098"]},
+    "прийняти участь": {
+        "corrections": ["взяти участь"],
+        "note": "рос. принять участие",
+        "source": ["antonenko-p091", "zabolotnyi-10"],
+        "evidence": [
+            "antonenko-davydovych-yak-my-hovorymo_p091: прийняли участь ... треба було написати взяли участь",
+            "10-klas-ukrmova-zabolotnyi-2018_s0027: У змаганнях треба брати участь, а не приймати.",
+        ],
+        "heritage_guard": "search_heritage(прийняти участь, include_live_slovnyk=false): phrase guard not lexical; no heritage headword can clear the collocation.",
+    },
+    "приймати участь": {
+        "corrections": ["брати участь"],
+        "note": "рос. принимать участие",
+        "source": ["antonenko-p091", "zabolotnyi-10"],
+        "evidence": [
+            "antonenko-davydovych-yak-my-hovorymo_p091: Приймати участь – брати участь",
+            "10-klas-ukrmova-zabolotnyi-2018_s0027: У змаганнях треба брати участь, а не приймати.",
+        ],
+        "heritage_guard": "search_heritage(приймати участь, include_live_slovnyk=false): phrase guard not lexical; no heritage headword can clear the collocation.",
+    },
     "недремлюче око": {"corrections": ["недремне око"], "note": "Antonenko's example", "source": ["antonenko"]},
     "сидячі місця": {"corrections": ["місця для сидіння"], "note": "ненормативний вираз", "source": ["glazova-11"]},
     "миючі засоби": {"corrections": ["мийні засоби"], "note": "ненормативний вираз", "source": ["glazova-11"]},

--- a/scripts/lexicon/calque_corrections.py
+++ b/scripts/lexicon/calque_corrections.py
@@ -156,11 +156,12 @@ CURATED_CALQUES: dict[str, dict[str, object]] = {
         "heritage_guard": "search_heritage(хвилюючий, include_live_slovnyk=false): No heritage evidence found.",
     },
     "діючий": {
-        "corrections": ["чинний"],
-        "note": "діючий закон → чинний закон (рос. действующий)",
-        "source": ["glazova-11", "avramenko-11", "zabolotnyi-7"],
+        "corrections": ["чинний", "активний"],
+        "note": "sense-split: діючий закон → чинний закон; діючий вулкан → активний вулкан (рос. действующий)",
+        "source": ["glazova-11", "avramenko-11", "avramenko-7", "zabolotnyi-7"],
         "evidence": [
             "11-klas-ukrajinska-mova-glazova-2019_s0072: чинний (а не діючий) закон",
+            "7-klas-ukrmova-avramenko-2024_s0106: синоніми ... діючий — чинний (закон) або активний (вулкан)",
             "7-klas-ukrmova-zabolotnyi-2024_s0124: чинний закон / діючий закон",
         ],
         "heritage_guard": "search_heritage(діючий, include_live_slovnyk=false): no matching heritage headword; ЕСУМ hit is the діянка family row and does not clear діючий закон.",

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -1748,6 +1748,8 @@ def _curated_calque(lemma: str, base: str) -> dict[str, Any] | None:
                 "corrections": list(row["corrections"]),
                 "note": str(row["note"]),
                 "source": list(row["source"]),
+                "evidence": list(row.get("evidence", [])),
+                "heritage_guard": str(row.get("heritage_guard", "")),
             }
 
     for key in (lemma, base):
@@ -1769,6 +1771,8 @@ def _curated_calque(lemma: str, base: str) -> dict[str, Any] | None:
             "corrections": list(row["corrections"]),
             "note": str(row["note"]),
             "source": list(row["source"]),
+            "evidence": list(row.get("evidence", [])),
+            "heritage_guard": str(row.get("heritage_guard", "")),
         }
 
     return None

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "d584598fa6982b1ce7f3b9be461a33087ce4f6f610a1917ddd1a8774d1419ddd",
+  "fingerprint": "13f2f7c85580a8698c7b2a5b50c342612de2739cb1d15f120b582a0d8e45b41b",
   "inputs": {
     "lexicon_code": [
       {
@@ -24,7 +24,7 @@
       },
       {
         "path": "scripts/lexicon/calque_corrections.py",
-        "sha256": "4c900cb2dfcd64412c8c9a225f1e75393c30bef780306b0da926985698e747fb"
+        "sha256": "66125f9451fb77de840edfe291684187f167ca6e3c8fe19932d2b189a40437e9"
       },
       {
         "path": "scripts/lexicon/check_manifest_freshness.py",
@@ -36,7 +36,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "16498bb8eca0292bbb78d0b9132098eb4c5837e25e5b6f7e215ee6d0b5ccd948"
+        "sha256": "d819a97701daaae80f7aed977d11f20eefa1c26e1399aae2107c48ae6ae26d2f"
       },
       {
         "path": "scripts/lexicon/generate_vesum_aliases.py",

--- a/tests/test_calque_corrections.py
+++ b/tests/test_calque_corrections.py
@@ -70,6 +70,37 @@ def test_correction_buckets_well_formed(name, bucket):
         )
 
 
+def test_active_participle_slice_has_evidence_and_heritage_guard():
+    """The #3098 first-slice entries carry direct corpus quotes + guard notes."""
+    for headword, entry in CURATED_CALQUES.items():
+        if not any(suffix in headword for suffix in ("учий", "ючий", "ачий", "ячий")):
+            continue
+
+        evidence = entry.get("evidence")
+        assert isinstance(evidence, list) and evidence, (
+            f"CURATED_CALQUES[{headword!r}] missing quoted evidence"
+        )
+        assert all(isinstance(item, str) and ":" in item for item in evidence), (
+            f"CURATED_CALQUES[{headword!r}] evidence must cite source refs"
+        )
+        guard = entry.get("heritage_guard")
+        assert isinstance(guard, str) and "search_heritage" in guard, (
+            f"CURATED_CALQUES[{headword!r}] missing heritage guard result"
+        )
+
+
+def test_pryiniaty_uchast_has_corpus_evidence_and_alias():
+    """The cheap collocation slice is source-backed and catches both aspects."""
+    for phrase, correction in (
+        ("прийняти участь", "взяти участь"),
+        ("приймати участь", "брати участь"),
+    ):
+        entry = PHRASAL_CALQUES[phrase]
+        assert correction in entry["corrections"]
+        assert any("antonenko-davydovych" in item for item in entry["evidence"])
+        assert "search_heritage" in entry["heritage_guard"]
+
+
 def test_sense_restricted_schema():
     """Polysemes carry an explicit calque_sense / authentic_sense split."""
     assert SENSE_RESTRICTED_CALQUES, "SENSE_RESTRICTED_CALQUES is empty"
@@ -145,4 +176,24 @@ def test_pracjujucyj_yields_section6_note_with_antonenko_citation():
     assert any("davydov" in s or "antonenko" in s for s in sources), (
         f"Antonenko/davydov citation required in sources: {sources}"
     )
+    assert any("Працюючий" in item for item in note.get("evidence", []))
+    assert "No heritage evidence found" in note.get("heritage_guard", "")
     print("GENERATED_§6_NOTE_FOR_працюючий_FROM_UNIT_TEST:", note)
+
+
+def test_requested_spot_checks_resolve_with_evidence():
+    """Pin the three requested printout forms through the production lookup."""
+    from scripts.lexicon.enrich_manifest import _curated_calque
+
+    expected = {
+        "працюючий": "працівник",
+        "оточуючий": "навколишній",
+        "прийняти участь": "взяти участь",
+    }
+    for form, correction in expected.items():
+        note = _curated_calque(form, form)
+        assert note is not None, f"no §6 note for {form}"
+        assert correction in note["corrections"]
+        assert note["evidence"], f"no evidence for {form}"
+        assert "search_heritage" in note["heritage_guard"]
+        print(f"SPOT_CHECK_{form}:", note)

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -889,12 +889,13 @@ def test_slovnyk_warning_merges_known_russianism_alternative() -> None:
 def test_curated_calque_matches_participle_entry() -> None:
     card = _curated_calque("діючий", "діючий")
 
-    assert card == {
-        "kind": "participle",
-        "corrections": ["чинний"],
-        "note": "діючий закон → чинний закон (рос. действующий)",
-        "source": ["glazova-11", "avramenko-11", "antonenko-p145"],
-    }
+    assert card is not None
+    assert card["kind"] == "participle"
+    assert card["corrections"] == ["чинний"]
+    assert card["note"] == "діючий закон → чинний закон (рос. действующий)"
+    assert "glazova-11" in card["source"]
+    assert any("чинний" in item for item in card["evidence"])
+    assert "search_heritage" in card["heritage_guard"]
 
 
 def test_curated_calque_matches_sense_restricted_entry_with_both_senses() -> None:
@@ -912,12 +913,11 @@ def test_curated_calque_matches_sense_restricted_entry_with_both_senses() -> Non
 def test_curated_calque_matches_phrasal_entry() -> None:
     card = _curated_calque("точка зору", "точка")
 
-    assert card == {
-        "kind": "phrasal",
-        "corrections": ["погляд"],
-        "note": "рос. точка зрения; цієї точки зору → цього погляду",
-        "source": ["ua-gec", "grok-3098"],
-    }
+    assert card is not None
+    assert card["kind"] == "phrasal"
+    assert card["corrections"] == ["погляд"]
+    assert card["note"] == "рос. точка зрения; цієї точки зору → цього погляду"
+    assert card["source"] == ["ua-gec", "grok-3098"]
 
 
 def test_curated_calque_unknown_lemma_returns_none() -> None:

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -891,10 +891,15 @@ def test_curated_calque_matches_participle_entry() -> None:
 
     assert card is not None
     assert card["kind"] == "participle"
-    assert card["corrections"] == ["чинний"]
-    assert card["note"] == "діючий закон → чинний закон (рос. действующий)"
+    # sense-split (#3098 review): діючий закон → чинний; діючий вулкан → активний (Avramenko Grade-7)
+    assert card["corrections"] == ["чинний", "активний"]
+    assert card["note"] == (
+        "sense-split: діючий закон → чинний закон; "
+        "діючий вулкан → активний вулкан (рос. действующий)"
+    )
     assert "glazova-11" in card["source"]
     assert any("чинний" in item for item in card["evidence"])
+    assert any("активний" in item for item in card["evidence"])
     assert "search_heritage" in card["heritage_guard"]
 
 


### PR DESCRIPTION
Refs #3098

## Summary

Adds machine-readable evidence and heritage-guard metadata to the existing §6 curated calque mechanism for the active-present-participle first slice, plus a cheap collocation alias for `приймати/прийняти участь`.

The enrich path is unchanged in shape: `_curated_calque()` still resolves from `CURATED_CALQUES` / `PHRASAL_CALQUES`, now passing through `evidence` and `heritage_guard` so §6 notes can show the source basis. No re-enrich or manifest JSON update is included.

## Curated Entry Evidence

- `бажаючий` -> `охочий`; evidence: `antonenko-davydovych-yak-my-hovorymo_p099` says `Бажаючий – ... – охочий`; `11-klas-ukrajinska-mova-glazova-2019_s0072` says `замість бажаючий — охочий`; heritage guard: no matching calque headword, related ЕСУМ row only supports the `охочий` family.
- `працюючий` -> `працівник`, `той, що працює`; evidence: `antonenko-davydovych-yak-my-hovorymo_p101` gives `Працюючий – ... – працівник`; `p144` corrects `не працюючий тато` to `Тато, що не працює`; Glazova says `замість працюючий — працівник`; heritage guard: no local heritage evidence.
- `завідуючий` -> `завідувач`; evidence: Glazova `замість завідуючий — завідувач`; Zabolotnyi `завідувач бібліотеки / завідуючий бібліотекою`; heritage guard: ЕСУМ rows describe Russian-modeled abbreviations, not a safe headword.
- `мандруючий` -> `мандрівний`; evidence: Glazova `мандрівний (а не мандруючий) сюжет`; heritage guard: no local heritage evidence.
- `початкуючий` -> `початківець`; evidence: Antonenko `Початкуючий – початківець`; Glazova `художник-початківець (а не початкуючий художник)`; Zabolotnyi `поет-початківець / початкуючий поет`; heritage guard: no matching calque headword.
- `узагальнюючий` -> `узагальнювальний`; evidence: Glazova `узагальнювальне (а не узагальнююче) слово`; heritage guard: no local heritage evidence.
- `зволожуючий` -> `зволожувальний`; evidence: Glazova/Zabolotnyi `зволожувальний крем / зволожуючий крем`; heritage guard: no local heritage evidence.
- `знеболюючий` -> `знеболювальний`; evidence: Glazova/Zabolotnyi `знеболювальні/знеболювальний ... не знеболюючі/знеболюючий`; heritage guard: ЕСУМ hit is a `новокаїн` definition, not a safe headword.
- `хвилюючий` -> `зворушливий`; evidence: Glazova `зворушливий (а не хвилюючий) спогад`; heritage guard: no local heritage evidence.
- `діючий` -> `чинний`; evidence: Glazova/Zabolotnyi `чинний закон / діючий закон`; heritage guard: no matching heritage headword; ЕСУМ `діянка` family row does not clear the `діючий закон` collocation.
- `підростаючий` -> `молодий`; evidence: Glazova `молоде (а не підростаюче) покоління`; heritage guard: no local heritage evidence.
- `потопаючий` -> `той, що потопає`; evidence: Glazova `корабля, що потопає` not `потопаючого корабля`; heritage guard: no local heritage evidence.
- `головуючий` -> `голова`; evidence: Avramenko `головуючий на зборах — голова зборів`; heritage guard: only unrelated ЕСУМ row, no matching safe headword.
- `домінуючий` -> `основний`, `панівний`; evidence: Avramenko `домінуючий принцип — основний принцип`; Antonenko p101 recommends `панівний` over `пануючий`; heritage guard: related loan-family rows mean this stays citation/collocation-scoped.
- `оточуючий` -> `довколишній`, `навколишній`; evidence: Zabolotnyi `навколишнє середовище, довкілля / оточуюче середовище`; heritage guard: no local heritage evidence.
- `відпочиваючий` -> `відпочивальник`, `той, хто відпочиває`; evidence: Antonenko p099/p100 gives `Відпочиваючий, відпочивальник, що ... відпочиває` and `розваги відпочивальників`; Zabolotnyi `відпочивальник / відпочиваючий`; heritage guard: no local heritage evidence.
- `завмираючий` -> `завмерлий`, `той, що завмирає`; evidence: Avramenko `завмираючі звуки — завмерлі звуки`; Antonenko p144 gives the active-participle replacement rule; heritage guard: no local heritage evidence.
- `розквітаючий` -> `розквітлий`, `той, що розквітає`; evidence: Avramenko `розквітаючі дерева — розквітлі дерева`; Antonenko p144 rule; heritage guard: no local heritage evidence.
- `опадаючий` -> `опалий`; evidence: Avramenko `опадаюче листя — опале листя`; Antonenko p144 rule; heritage guard: ЕСУМ hit is a `кулон` definition, not a safe headword.
- `в’янучий` -> `зів’ялий`; evidence: Avramenko `в’янучі квіти — зів’ялі квіти`; Antonenko p144 rule; heritage guard: no local heritage evidence.
- `жовтіючий` -> `пожовклий`; evidence: Avramenko `жовтіюче листя — пожовкле листя`; Antonenko p144 rule; heritage guard: no local heritage evidence.
- `прийняти участь` -> `взяти участь`; evidence: Antonenko p091 says `прийняли участь ... треба було написати взяли участь`; Zabolotnyi says `У змаганнях треба брати участь, а не приймати`; phrase guard: no heritage headword can clear a collocation.
- `приймати участь` -> `брати участь`; evidence: Antonenko p091 `Приймати участь – брати участь`; Zabolotnyi same collocation rule; phrase guard: no heritage headword can clear a collocation.

## MCP / Source Checks

- `mcp__sources.search_style_guide({query: "Приймати участь"})` returned Antonenko structured evidence: `прийняли участь ... треба було написати взяли участь`.
- `mcp__sources.search_style_guide` exact checks for `працюючий`, `оточуючий`, and `відпочиваючий` returned no structured rows; the tool itself warns absence is not evidence, so the PR uses `mcp__sources.search_text`/local source-db chunks for Antonenko prose.
- `mcp__sources.search_text({query: "Антоненко-Давидович учий ячий дієприкметники працюючий"})` returned Antonenko p144 and p101 plus textbook chunks for the active-participle rule.
- `mcp__sources.query_pravopys({topic: "дієприкметник"})` returned no section; `topic: "прикметник"` returned Pravopys 2019 §33 on adjective/participial suffix spelling, not the style replacement rule.
- `mcp__sources.search_ua_gec_errors` native F/Calque/F/Collocation checks for `працюючий`, `оточуючий`, `відпочиваючий`, and `приймати/прийняти участь` returned no rows; these entries are therefore not UA-GEC-backed.
- `mcp__sources.search_heritage(..., include_live_slovnyk=false)` was used as the false-positive guard. Matching local heritage headwords were not found for the first-slice calque forms; related ЕСУМ rows are documented in the entry-level guard notes rather than treated as safe-word clearance.

## Spot Checks

```text
FORM: працюючий
CORRECTIONS: ['працівник', 'той, що працює']
SOURCE: ['antonenko-p101', 'antonenko-p144', 'glazova-11']
HERITAGE_GUARD: search_heritage(працюючий, include_live_slovnyk=false): No heritage evidence found.

FORM: оточуючий
CORRECTIONS: ['довколишній', 'навколишній']
SOURCE: ['zabolotnyi-7', 'zabolotnyi-11']
HERITAGE_GUARD: search_heritage(оточуючий, include_live_slovnyk=false): No heritage evidence found.

FORM: прийняти участь
CORRECTIONS: ['взяти участь']
SOURCE: ['antonenko-p091', 'zabolotnyi-10']
HERITAGE_GUARD: search_heritage(прийняти участь, include_live_slovnyk=false): phrase guard not lexical; no heritage headword can clear the collocation.
```

## Validation

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/calque-participles-3098
command: .venv/bin/python -m pytest tests/test_calque_corrections.py tests/test_lexicon_enrich_manifest.py -q
result: 73 passed in 0.65s
```

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/calque-participles-3098
command: .venv/bin/ruff check scripts/lexicon/calque_corrections.py scripts/lexicon/enrich_manifest.py tests/test_calque_corrections.py tests/test_lexicon_enrich_manifest.py
result: All checks passed!
```

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/calque-participles-3098
command: .venv/bin/ruff check
result: fails on pre-existing unrelated docs/reports and plans scripts (E701/E722/SIM102/W291/F841/B007); not fixed here to keep the PR scoped.
```

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/calque-participles-3098
command: .venv/bin/python scripts/audit/lint_agent_trailer.py
result: PASS, X-Agent: codex/calque-participles-3098
```

## Follow-up

The orchestrator must run the controlled re-enrich to surface this metadata in §6. This PR intentionally does not run `make atlas` and does not commit manifest/fingerprint JSON.
