### PR TITLE
fix(a1): tighten m01 sound-letter pedagogy

### DIFF
--- a/curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml
+++ b/curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml
@@ -58,23 +58,38 @@
       correct: false
     explanation: Приві́т is the informal word for Hi.
 - id: act-2
-  type: count-syllables
-  title: Count склади
-  instruction: Count vowel sounds. Each vowel sound makes one склад.
-  maxCount: 3
+  type: quiz
+  title: Meet склади
+  instruction: Choose the safer beginner idea.
   items:
-  - word: день
+  - question: What does склад mean?
+    options:
+    - syllable
+    - letter
+    - greeting
+    correct: 0
+    explanation: Склад means syllable. M02 will teach the counting rule.
+  - question: What gives a склад its voice?
+    options:
+    - a capital letter
+    - a vowel sound
+    - an English translation
     correct: 1
-  - word: ма́ма
+    explanation: Every Ukrainian склад needs a vowel sound.
+  - question: What should you do with ма́ма today?
+    options:
+    - Memorize every syllable rule.
+    - Notice the two clear а sounds.
+    - Ignore the vowel sounds.
+    correct: 1
+    explanation: Today is a sound-first preview. M02 practices syllable counting.
+  - question: What should you listen for in молоко́?
+    options:
+    - a blurred English vowel
+    - a silent letter
+    - three clean о sounds
     correct: 2
-  - word: Приві́т
-    correct: 2
-  - word: молоко́
-    correct: 3
-  - word: та́то
-    correct: 2
-  - word: о́ко
-    correct: 2
+    explanation: Ukrainian о stays clean in молоко́.
 - id: act-3
   type: watch-and-repeat
   title: Full alphabet pronunciation pass
@@ -212,7 +227,7 @@
     - У
     correct: 0
     explanation: Ukrainian О stays clean in молоко́.
-  - question: In Приві́т, which two vowel letters are different?
+  - question: In Приві́т, which two letters mark different vowel sounds?
     options:
     - И and І
     - О and У

--- a/curriculum/l2-uk-en/a1/sounds-letters-and-hello/module.md
+++ b/curriculum/l2-uk-en/a1/sounds-letters-and-hello/module.md
@@ -2,6 +2,8 @@
 
 You do not need to read Ukrainian yet. This English-led module uses Ukrainian in small chunks so you can listen, repeat, notice, and use the first phrases safely.
 
+Use this first pass as orientation: one reliable sound rule, a small set of greetings, and enough alphabet awareness to start the workbook without guessing.
+
 By the end, you can:
 
 - say hello, goodbye, and a simple "How are you?";
@@ -9,7 +11,7 @@ By the end, you can:
 - ask and answer a name question;
 - explain the difference between a sound and a letter;
 - recognize all 33 Ukrainian letters at first-pass level;
-- know what **склад** means before the workbook asks you to count syllables;
+- know what **склад** means before the next module asks you to count syllables;
 - avoid the first pronunciation traps: blurred **о**, confusing **и** and **і**, adding a sound after **ь**, and turning final voiced consonants into voiceless ones.
 
 ## Sound First, Letter Second
@@ -42,7 +44,7 @@ Say this rule aloud:
 **Звук = I hear it. Лі́тера = I see it.**
 
 :::tip
-Start with the six clean vowel sounds: **[а] [о] [у] [е] [и] [і]**. They are the course's **heartbeat** (**серцебиття**) because every Ukrainian **склад** needs a vowel sound. Short **відеоуроки** help you see the mouth shape, especially the narrow smile for **[і]** and rounded lips for **[у]**.
+Start with the six clean vowel sounds: **[а] [о] [у] [е] [и] [і]**. They are your first guide because every Ukrainian **склад** needs a vowel sound. Short video practice helps you see the mouth shape, especially the narrow smile for **[і]** and rounded lips for **[у]**.
 :::
 
 <!-- INJECT_ACTIVITY: act-1 -->
@@ -87,16 +89,18 @@ A vowel sound is open. Your voice passes through without a block. You can hold i
 
 There are six vowel sounds, but ten letters that can mark vowel sounds:
 
-| Simple vowel letters | Special vowel letters |
+| Simple letters that mark vowel sounds | Special letters that can mark vowel sounds |
 | --- | --- |
 | **А О У Е И І** | **Я Ю Є Ї** |
 
-Do not worry about mastering **Я, Ю, Є, Ї** yet. For now, know their job:
+Do not worry about mastering **Я, Ю, Є, Ї** yet. For now, just recognize their common jobs. M02 will give you more reading practice with them.
 
-- **Я** can sound like **[йа]** or soften a previous consonant and mark **[а]**.
-- **Ю** can sound like **[йу]** or soften a previous consonant and mark **[у]**.
-- **Є** can sound like **[йе]** or soften a previous consonant and mark **[е]**.
-- **Ї** is special: it is always **[йі]**.
+| Letter | Today, notice |
+| --- | --- |
+| **Я** | can point to **[йа]** or to a softened consonant plus **[а]** |
+| **Ю** | can point to **[йу]** or to a softened consonant plus **[у]** |
+| **Є** | can point to **[йе]** or to a softened consonant plus **[е]** |
+| **Ї** | always points to **[йі]** |
 
 Three useful words:
 
@@ -112,20 +116,16 @@ Important habit: Ukrainian **о** stays clean. In **молоко́**, each **о*
 
 A **склад** is a syllable. In Ukrainian, every syllable needs a vowel sound. That is why vowels are the "heart" of a syllable.
 
-Use this simple beginner rule:
+You do not need to count syllables confidently yet. M02 teaches that reading rule. Today, just notice that the vowel sound gives each **склад** its voice.
 
-**Count vowel sounds = count syllables.**
+| Word | What to notice today |
+| --- | --- |
+| **день** | one clear **е** sound |
+| **ма́ма** | two **а** sounds |
+| **Приві́т** | **и** and **і** are different vowel sounds |
+| **молоко́** | three clean **о** sounds |
 
-| Word | Vowel sounds | Syllables |
-| --- | --- | --- |
-| **день** | **е** | 1 склад |
-| **ма́ма** | **а + а** | 2 склади |
-| **Приві́т** | **и + і** | 2 склади |
-| **молоко́** | **о + о + о** | 3 склади |
-
-Now the workbook can ask you about **склади** because you know the idea: find the vowel sounds first.
-
-<!-- INJECT_ACTIVITY: act-2 -->
+Now the word **склад** will not surprise you when the workbook previews it and the next module starts reading practice.
 
 ## Consonant Sounds
 
@@ -138,9 +138,9 @@ Try four:
 - **[т]** - touch your tongue behind your teeth.
 - **[н]** - touch your tongue and let sound pass through your nose.
 
-Ukrainian has 32 consonant sounds and 22 letters that usually mark consonants. Some consonants have hard and soft versions. You do not need the full system today, but you do need three first clues:
+Ukrainian has 32 consonant sounds and 22 letters that usually mark consonants. Some consonants have hard and soft versions. You do not need the full system today, but you do need five first clues:
 
-Vowels give a syllable its voice. Consonants build the clear **architecture** (**архітектура**) around that voice: lips, teeth, tongue, or throat make the shape.
+Vowels give a syllable its voice. Consonants make the clear shape around that voice: lips, teeth, tongue, or throat do the work.
 
 | Sign or letter | Beginner meaning |
 | --- | --- |
@@ -148,6 +148,7 @@ Vowels give a syllable its voice. Consonants build the clear **architecture** (*
 | **Г г** | Ukrainian h-like sound |
 | **Ґ ґ** | hard **g** sound |
 | **Щ щ** | two sounds together: **[шч]** |
+| **'** | **апо́строф**; a separation mark. M03 teaches the details |
 
 Example:
 
@@ -155,7 +156,7 @@ Example:
 
 The final **ь** does not add a new vowel. It tells you to make **н** soft.
 
-The letters **Я, Ю, Є** are graphic **chameleons** (**хамелеони**): at the start of a word they can show **[й] + vowel**, but after a consonant they can point to softness plus one vowel. **Ї** is the strict exception: always **[йі]**.
+The letters **Я, Ю, Є** have two common jobs: at the start of a word they can show **[й] + vowel**, and after a consonant they can point to softness plus one vowel. **Ї** is the strict exception: always **[йі]**.
 
 ## Full Alphabet Pronunciation Pass
 
@@ -204,6 +205,15 @@ Ukrainian likes smooth sound flow. This is called **милозву́чність
 
 You do not need to choose them alone yet. Just notice the idea: Ukrainian often avoids heavy sound piles.
 
+Two tiny examples:
+
+| Pair | What to notice |
+| --- | --- |
+| **у / в** | **у шко́лі** starts with **у** before **шк-**; **в Украї́ні** starts with **в** before **У-** |
+| **і / й** | **Марко́ й А́нна** puts short **й** between vowel sounds |
+
+Do not memorize these as a rule today. Just hear that Ukrainian has smoother sound choices.
+
 ## Your First Conversation
 
 Learn these as whole phrases.
@@ -224,6 +234,15 @@ Learn these as whole phrases.
 | **А тебе́?** | And you? | after a name question |
 | **До поба́чення!** | Goodbye! | leaving |
 | **На все до́бре!** | All the best! | friendly goodbye |
+
+Use the neutral version when you are not sure whether **Приві́т** is too informal:
+
+```text
+А́нна: До́брий день!
+Марко́: До́брий день!
+А́нна: Як спра́ви?
+Марко́: До́бре. А у тебе́?
+```
 
 Read the dialogue. Then say it aloud twice: once as Anna, once as Marko.
 
@@ -272,7 +291,7 @@ You may also hear:
 
 Do not build grammar from this yet. Just notice that Ukrainian sometimes changes a word depending on who is speaking: use **Радий тебе бачити** if the speaker is male, and **Рада тебе бачити** if the speaker is female.
 
-The word **Привіт** is useful for your first tiny sound analysis down to the details (**на гвинтики**): **П-р-и-в-і-т**, four consonant sounds and two vowel sounds.
+The word **Привіт** is useful for your first tiny sound analysis: **П-р-и-в-і-т**, four consonant sounds and two vowel sounds.
 
 <!-- INJECT_ACTIVITY: act-5 -->
 
@@ -307,3 +326,5 @@ Before you leave the lesson tab, check that you can do these things:
 - Recognize **Г**, **Ґ**, **Ї**, and **Ь** when the workbook asks for them.
 
 The workbook repeats the same ideas in different ways. It is practice for eyes, ears, and mouth.
+
+You have now done the first hard thing: you can greet someone, answer one friendly question, and explain why Ukrainian sounds and letters are not the same thing.

--- a/site/src/content/docs/a1/sounds-letters-and-hello.mdx
+++ b/site/src/content/docs/a1/sounds-letters-and-hello.mdx
@@ -61,6 +61,8 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 You do not need to read Ukrainian yet. This English-led module uses Ukrainian in small chunks so you can listen, repeat, notice, and use the first phrases safely.
 
+Use this first pass as orientation: one reliable sound rule, a small set of greetings, and enough alphabet awareness to start the workbook without guessing.
+
 By the end, you can:
 
 - say hello, goodbye, and a simple "How are you?";
@@ -68,7 +70,7 @@ By the end, you can:
 - ask and answer a name question;
 - explain the difference between a sound and a letter;
 - recognize all 33 Ukrainian letters at first-pass level;
-- know what **склад** means before the workbook asks you to count syllables;
+- know what **склад** means before the next module asks you to count syllables;
 - avoid the first pronunciation traps: blurred **о**, confusing **и** and **і**, adding a sound after **ь**, and turning final voiced consonants into voiceless ones.
 
 ## Sound First, Letter Second
@@ -101,7 +103,7 @@ Say this rule aloud:
 **Звук = I hear it. Лі́тера = I see it.**
 
 :::tip
-Start with the six clean vowel sounds: **[а] [о] [у] [е] [и] [і]**. They are the course's **heartbeat** (**серцебиття**) because every Ukrainian **склад** needs a vowel sound. Short **відеоуроки** help you see the mouth shape, especially the narrow smile for **[і]** and rounded lips for **[у]**.
+Start with the six clean vowel sounds: **[а] [о] [у] [е] [и] [і]**. They are your first guide because every Ukrainian **склад** needs a vowel sound. Short video practice helps you see the mouth shape, especially the narrow smile for **[і]** and rounded lips for **[у]**.
 :::
 
 ### Sound or letter?
@@ -148,16 +150,18 @@ A vowel sound is open. Your voice passes through without a block. You can hold i
 
 There are six vowel sounds, but ten letters that can mark vowel sounds:
 
-| Simple vowel letters | Special vowel letters |
+| Simple letters that mark vowel sounds | Special letters that can mark vowel sounds |
 | --- | --- |
 | **А О У Е И І** | **Я Ю Є Ї** |
 
-Do not worry about mastering **Я, Ю, Є, Ї** yet. For now, know their job:
+Do not worry about mastering **Я, Ю, Є, Ї** yet. For now, just recognize their common jobs. M02 will give you more reading practice with them.
 
-- **Я** can sound like **[йа]** or soften a previous consonant and mark **[а]**.
-- **Ю** can sound like **[йу]** or soften a previous consonant and mark **[у]**.
-- **Є** can sound like **[йе]** or soften a previous consonant and mark **[е]**.
-- **Ї** is special: it is always **[йі]**.
+| Letter | Today, notice |
+| --- | --- |
+| **Я** | can point to **[йа]** or to a softened consonant plus **[а]** |
+| **Ю** | can point to **[йу]** or to a softened consonant plus **[у]** |
+| **Є** | can point to **[йе]** or to a softened consonant plus **[е]** |
+| **Ї** | always points to **[йі]** |
 
 Three useful words:
 
@@ -173,22 +177,16 @@ Important habit: Ukrainian **о** stays clean. In **молоко́**, each **о*
 
 A **склад** is a syllable. In Ukrainian, every syllable needs a vowel sound. That is why vowels are the "heart" of a syllable.
 
-Use this simple beginner rule:
+You do not need to count syllables confidently yet. M02 teaches that reading rule. Today, just notice that the vowel sound gives each **склад** its voice.
 
-**Count vowel sounds = count syllables.**
+| Word | What to notice today |
+| --- | --- |
+| **день** | one clear **е** sound |
+| **ма́ма** | two **а** sounds |
+| **Приві́т** | **и** and **і** are different vowel sounds |
+| **молоко́** | three clean **о** sounds |
 
-| Word | Vowel sounds | Syllables |
-| --- | --- | --- |
-| **день** | **е** | 1 склад |
-| **ма́ма** | **а + а** | 2 склади |
-| **Приві́т** | **и + і** | 2 склади |
-| **молоко́** | **о + о + о** | 3 склади |
-
-Now the workbook can ask you about **склади** because you know the idea: find the vowel sounds first.
-
-### Count склади
-
-<CountSyllables client:only='react' instruction={"Count vowel sounds. Each vowel sound makes one склад."} items={JSON.parse(`[{"word": "день", "correct": 1}, {"word": "ма́ма", "correct": 2}, {"word": "Приві́т", "correct": 2}, {"word": "молоко́", "correct": 3}, {"word": "та́то", "correct": 2}, {"word": "о́ко", "correct": 2}]`)} maxCount={3} />
+Now the word **склад** will not surprise you when the workbook previews it and the next module starts reading practice.
 
 ## Consonant Sounds
 
@@ -201,9 +199,9 @@ Try four:
 - **[т]** - touch your tongue behind your teeth.
 - **[н]** - touch your tongue and let sound pass through your nose.
 
-Ukrainian has 32 consonant sounds and 22 letters that usually mark consonants. Some consonants have hard and soft versions. You do not need the full system today, but you do need three first clues:
+Ukrainian has 32 consonant sounds and 22 letters that usually mark consonants. Some consonants have hard and soft versions. You do not need the full system today, but you do need five first clues:
 
-Vowels give a syllable its voice. Consonants build the clear **architecture** (**архітектура**) around that voice: lips, teeth, tongue, or throat make the shape.
+Vowels give a syllable its voice. Consonants make the clear shape around that voice: lips, teeth, tongue, or throat do the work.
 
 | Sign or letter | Beginner meaning |
 | --- | --- |
@@ -211,6 +209,7 @@ Vowels give a syllable its voice. Consonants build the clear **architecture** (*
 | **Г г** | Ukrainian h-like sound |
 | **Ґ ґ** | hard **g** sound |
 | **Щ щ** | two sounds together: **[шч]** |
+| **'** | **апо́строф**; a separation mark. M03 teaches the details |
 
 Example:
 
@@ -218,7 +217,7 @@ Example:
 
 The final **ь** does not add a new vowel. It tells you to make **н** soft.
 
-The letters **Я, Ю, Є** are graphic **chameleons** (**хамелеони**): at the start of a word they can show **[й] + vowel**, but after a consonant they can point to softness plus one vowel. **Ї** is the strict exception: always **[йі]**.
+The letters **Я, Ю, Є** have two common jobs: at the start of a word they can show **[й] + vowel**, and after a consonant they can point to softness plus one vowel. **Ї** is the strict exception: always **[йі]**.
 
 ## Full Alphabet Pronunciation Pass
 
@@ -269,6 +268,15 @@ Ukrainian likes smooth sound flow. This is called **милозву́чність
 
 You do not need to choose them alone yet. Just notice the idea: Ukrainian often avoids heavy sound piles.
 
+Two tiny examples:
+
+| Pair | What to notice |
+| --- | --- |
+| **у / в** | **у шко́лі** starts with **у** before **шк-**; **в Украї́ні** starts with **в** before **У-** |
+| **і / й** | **Марко́ й А́нна** puts short **й** between vowel sounds |
+
+Do not memorize these as a rule today. Just hear that Ukrainian has smoother sound choices.
+
 ## Your First Conversation
 
 Learn these as whole phrases.
@@ -289,6 +297,15 @@ Learn these as whole phrases.
 | **А тебе́?** | And you? | after a name question |
 | **До поба́чення!** | Goodbye! | leaving |
 | **На все до́бре!** | All the best! | friendly goodbye |
+
+Use the neutral version when you are not sure whether **Приві́т** is too informal:
+
+```text
+А́нна: До́брий день!
+Марко́: До́брий день!
+А́нна: Як спра́ви?
+Марко́: До́бре. А у тебе́?
+```
 
 Read the dialogue. Then say it aloud twice: once as Anna, once as Marko.
 
@@ -337,7 +354,7 @@ You may also hear:
 
 Do not build grammar from this yet. Just notice that Ukrainian sometimes changes a word depending on who is speaking: use **Радий тебе бачити** if the speaker is male, and **Рада тебе бачити** if the speaker is female.
 
-The word **Привіт** is useful for your first tiny sound analysis down to the details (**на гвинтики**): **П-р-и-в-і-т**, four consonant sounds and two vowel sounds.
+The word **Привіт** is useful for your first tiny sound analysis: **П-р-и-в-і-т**, four consonant sounds and two vowel sounds.
 
 ### First conversations
 
@@ -377,6 +394,8 @@ Before you leave the lesson tab, check that you can do these things:
 
 The workbook repeats the same ideas in different ways. It is practice for eyes, ears, and mouth.
 
+You have now done the first hard thing: you can greet someone, answer one friendly question, and explain why Ukrainian sounds and letters are not the same thing.
+
 </TabItem>
 <TabItem label="Vocabulary">
 
@@ -391,9 +410,9 @@ The workbook repeats the same ideas in different ways. It is practice for eyes, 
 
 *(see lesson, §Sound First, Letter Second)*
 
-### Count склади
+### Meet склади
 
-*(see lesson, §What Is a Склад?)*
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "What does склад mean?", "options": [{"text": "syllable", "correct": true}, {"text": "letter", "correct": false}, {"text": "greeting", "correct": false}], "explanation": "Склад means syllable. M02 will teach the counting rule."}, {"question": "What gives a склад its voice?", "options": [{"text": "a capital letter", "correct": false}, {"text": "a vowel sound", "correct": true}, {"text": "an English translation", "correct": false}], "explanation": "Every Ukrainian склад needs a vowel sound."}, {"question": "What should you do with ма́ма today?", "options": [{"text": "Memorize every syllable rule.", "correct": false}, {"text": "Notice the two clear а sounds.", "correct": true}, {"text": "Ignore the vowel sounds.", "correct": false}], "explanation": "Today is a sound-first preview. M02 practices syllable counting."}, {"question": "What should you listen for in молоко́?", "options": [{"text": "a blurred English vowel", "correct": false}, {"text": "a silent letter", "correct": false}, {"text": "three clean о sounds", "correct": true}], "explanation": "Ukrainian о stays clean in молоко́."}]`)} instruction={"Choose the safer beginner idea."} isUkrainian={false} />
 
 ### Full alphabet pronunciation pass
 
@@ -401,7 +420,7 @@ The workbook repeats the same ideas in different ways. It is practice for eyes, 
 
 ### Find the useful letters
 
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "Which letter is the hard g sound?", "options": [{"text": "Ґ", "correct": true}, {"text": "Г", "correct": false}, {"text": "Ї", "correct": false}], "explanation": "Ґ is the hard g sound; Г is the Ukrainian h-like sound."}, {"question": "Which letter is always [йі]?", "options": [{"text": "Ї", "correct": true}, {"text": "І", "correct": false}, {"text": "И", "correct": false}], "explanation": "Ї is always [йі]. І is the plain [і] vowel."}, {"question": "Which sign has no sound of its own?", "options": [{"text": "Ь", "correct": true}, {"text": "Й", "correct": false}, {"text": "Я", "correct": false}], "explanation": "Ь is the soft sign; it changes the previous consonant."}, {"question": "Which letter is the clean [о] sound in молоко́?", "options": [{"text": "О", "correct": true}, {"text": "А", "correct": false}, {"text": "У", "correct": false}], "explanation": "Ukrainian О stays clean in молоко́."}, {"question": "In Приві́т, which two vowel letters are different?", "options": [{"text": "И and І", "correct": true}, {"text": "О and У", "correct": false}, {"text": "А and Е", "correct": false}], "explanation": "Приві́т contains both И [и] and І [і]."}]`)} instruction={"Choose the letter or sign that matches the clue."} isUkrainian={false} />
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Which letter is the hard g sound?", "options": [{"text": "Ґ", "correct": true}, {"text": "Г", "correct": false}, {"text": "Ї", "correct": false}], "explanation": "Ґ is the hard g sound; Г is the Ukrainian h-like sound."}, {"question": "Which letter is always [йі]?", "options": [{"text": "Ї", "correct": true}, {"text": "І", "correct": false}, {"text": "И", "correct": false}], "explanation": "Ї is always [йі]. І is the plain [і] vowel."}, {"question": "Which sign has no sound of its own?", "options": [{"text": "Ь", "correct": true}, {"text": "Й", "correct": false}, {"text": "Я", "correct": false}], "explanation": "Ь is the soft sign; it changes the previous consonant."}, {"question": "Which letter is the clean [о] sound in молоко́?", "options": [{"text": "О", "correct": true}, {"text": "А", "correct": false}, {"text": "У", "correct": false}], "explanation": "Ukrainian О stays clean in молоко́."}, {"question": "In Приві́т, which two letters mark different vowel sounds?", "options": [{"text": "И and І", "correct": true}, {"text": "О and У", "correct": false}, {"text": "А and Е", "correct": false}], "explanation": "Приві́т contains both И [и] and І [і]."}]`)} instruction={"Choose the letter or sign that matches the clue."} isUkrainian={false} />
 
 ### First conversations
 


### PR DESCRIPTION
## Module

- Level/module: A1 M01 `sounds-letters-and-hello`
- Route: `https://learn-ukrainian.github.io/a1/sounds-letters-and-hello/`
- Branch: `codex/a1-m01-sounds-letters-and-hello-quality`
- Commit: `de02735275f4dc7ed07ff10f94b5279fb9bde699`

## Changed files

- `curriculum/l2-uk-en/a1/sounds-letters-and-hello/module.md`
- `curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml`
- `site/src/content/docs/a1/sounds-letters-and-hello.mdx`

## What changed

- Tightened the sound/letter terminology so learner-facing text says "letters that mark vowel sounds" instead of category labels like "vowel letters".
- De-scoped M01 syllables from an active counting rule to a preview of `склад`; M02 keeps syllable counting and reading practice.
- Moved the `склад` preview activity out of the lesson tab into the workbook tab, giving a 4 inline / 6 workbook split.
- Removed high-cognitive-load decorative vocabulary/metaphors from the first module.
- Added a short neutral `Добрий день` exchange, tiny euphony examples, and a closing progress marker.
- Regenerated the MDX from source.

## Research basis

- Zabolotnyi Grade 5 p.83 / locked plan: sounds are heard and pronounced; letters are seen and written.
- Litvinova Grade 5 p.130 / locked plan: vowel/consonant status belongs to sounds, not letters.
- Bolshakova and Zakhariichuk Grade 1 sources: vowel/consonant sound model and `склад` preview basis.
- ULP Episode 1: first greeting/state exchange chunks.
- Anna Ohoiko alphabet/pronunciation materials: full alphabet listening pass.
- Slovnyk/SUM check for `при́голосний`: kept the dictionary-correct stress after reviewer conflict.

## QG / reviews

LLM QG parity (`writer=codex-tools`, `reviewer=claude-tools`):
- aggregate verdict: `REVISE`
- terminal_verdict: `PASS`
- min_score: `8.5`
- min_dim: `engagement`
- warning_dims: `pedagogical`
- scores: pedagogical `8.6`, naturalness `9.0`, decolonization `9.4`, engagement `8.5`, tone `8.7`
- surviving warning: plan-locked Grade 5 source attribution in resources; not learner-facing body prose.

External reviews:
- Opus final verdict: `APPROVE`
- Agy final verdict: `APPROVE`

## Validation

- `git diff --check` — passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed
- `.venv/bin/python scripts/validate_plan_config.py --quiet a1` — all 55 plans valid
- `.venv/bin/python scripts/validate_activities.py l2-uk-en a1` — all 55 A1 modules YAML/MDX passed
- `.venv/bin/python scripts/audit/check_mdx_source_parity.py --changed-vs-base origin/main` — passed
- `npm run build --prefix site -- --outDir /tmp/learn-ukrainian-a1-m01-rebased-dist` — passed, 2613 pages built including `/a1/sounds-letters-and-hello/`

## Token telemetry

- run_id: `a1-m01-sounds-letters-and-hello-quality-20260616`
- swarm_used: true
- swarm_label: thin
- swarm_note: Used required QG plus Opus and Agy reviewer passes; no helper editors.
- wall_clock_minutes: 150
- token_source: unavailable
- main: codex GPT-5, token usage unavailable
- reviewers: Claude Opus final review, Agy final review, Claude-tools QG parity; token usage unavailable
