### PR TITLE
feat(pipeline): #3079 C.3 bounded multi-gate python_qg loop

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -451,6 +451,30 @@ WIKI_COVERAGE_OVERALL_VERDICTS = {"PASS", "PARTIAL", "FAIL"}
 WIKI_COVERAGE_EVIDENCE_QUOTE_MARKERS = ('"', "“", "«")
 LLM_QG_CORE_MAX_ROUNDS = 1
 LLM_QG_SEMINAR_MAX_ROUNDS = 3
+PYTHON_QG_CORE_MAX_CORRECTION_ROUNDS = 1
+PYTHON_QG_SEMINAR_MAX_CORRECTION_ROUNDS = 4
+PYTHON_QG_MIN_REGRESSION_PATIENCE = 1
+PYTHON_QG_MALFORMED_REPORT_VIOLATIONS = 999
+PYTHON_QG_VIOLATION_COUNT_KEYS = (
+    "missing",
+    "violations",
+    "errors",
+    "findings",
+    "critical_findings",
+    "detections",
+    "regressions",
+    "invalid",
+    "missing_terms",
+    "missing_sections",
+    "malformed_callouts",
+    "missing_mandatory_callouts",
+    "unresolved",
+    "unresolved_citations",
+    "missing_required",
+    "missing_optional",
+    "missing_activity_ids",
+    "duplicate_ids",
+)
 _TELEMETRY_EVENT_SINK: Callable[..., None] | None = None
 
 
@@ -4595,6 +4619,21 @@ def llm_qg_max_rounds_for_level(level: str | None) -> int:
     )
 
 
+def python_qg_max_correction_rounds_for_level(level: str | None) -> int:
+    """Return the Python-QG correction-round budget for a curriculum level."""
+    return (
+        PYTHON_QG_SEMINAR_MAX_CORRECTION_ROUNDS
+        if str(level or "").strip().lower() in SEMINAR_LEVELS
+        else PYTHON_QG_CORE_MAX_CORRECTION_ROUNDS
+    )
+
+
+def _python_qg_level_from_plan_path(plan_path: Path) -> str | None:
+    with contextlib.suppress(LinearPipelineError, OSError, yaml.YAMLError):
+        return str(load_plan(plan_path).get("level") or "").strip().lower()
+    return None
+
+
 def _prompt_yaml_or_text(value: str | Mapping[str, Any] | None) -> str:
     if value is None:
         return "{}"
@@ -5471,6 +5510,63 @@ def _python_qg_passed(report: Mapping[str, Any]) -> bool:
     return isinstance(gates, Mapping) and gates.get("passed") is True
 
 
+def _python_qg_violation_value_count(value: Any) -> int:
+    if isinstance(value, Mapping):
+        return len(value)
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return len(value)
+    return 1 if value else 0
+
+
+def _python_qg_explicit_violation_count(gate_report: Mapping[str, Any]) -> int:
+    return sum(
+        _python_qg_violation_value_count(gate_report.get(key))
+        for key in PYTHON_QG_VIOLATION_COUNT_KEYS
+    )
+
+
+def _python_qg_gate_violation_count(gate_report: Mapping[str, Any]) -> int:
+    explicit_count = _python_qg_explicit_violation_count(gate_report)
+    if "passed" not in gate_report:
+        return max(1, explicit_count)
+    if gate_report.get("passed") is not False:
+        return 0
+    return max(1, explicit_count)
+
+
+def _python_qg_violation_count(report: Mapping[str, Any]) -> int:
+    gates = report.get("gates")
+    if not isinstance(gates, Mapping):
+        return PYTHON_QG_MALFORMED_REPORT_VIOLATIONS
+    return sum(
+        _python_qg_gate_violation_count(gate_report)
+        for gate, gate_report in gates.items()
+        if gate != "passed" and isinstance(gate_report, Mapping)
+    )
+
+
+def _python_qg_review_loop_dims(violation_count: int) -> Mapping[str, Any]:
+    return {
+        "python_qg_violations": {
+            "score": -float(violation_count),
+            "verdict": "PASS" if violation_count == 0 else "REVISE",
+        }
+    }
+
+
+def _python_qg_round_summary(round_record: Mapping[str, Any]) -> dict[str, Any]:
+    report = round_record.get("report")
+    violation_count = int(round_record.get("violation_count") or 0)
+    return {
+        "round": round_record.get("round"),
+        "correction_round": round_record.get("correction_round"),
+        "passed": _python_qg_passed(report) if isinstance(report, Mapping) else False,
+        "violation_count": violation_count,
+        "score": -violation_count,
+        "failed_gate": round_record.get("failed_gate"),
+    }
+
+
 def run_llm_qg_with_corrections(
     *,
     plan: Mapping[str, Any],
@@ -5630,6 +5726,288 @@ def run_llm_qg_with_corrections(
 
 
 def run_python_qg_with_corrections(
+    module_dir: Path,
+    plan_path: Path,
+    *,
+    verify_words_fn: Callable[[list[str]], dict[str, list[dict[str, Any]]]] | None = None,
+    heritage_lookup_fn: Callable[[str], list[dict[str, Any]]] | None = None,
+    qg_runner: Callable[[], dict[str, Any]] | None = None,
+    writer_corrector: Callable[[CorrectionContext], str | Mapping[str, str] | None] | None = None,
+    reviewer_corrector: Callable[[CorrectionContext], str | None] | None = None,
+    dictionary_lookup_fn: Callable[[str, str], list[str | Mapping[str, str]]] | None = None,
+    writer: str = "claude-tools",
+    invoker: Callable[..., Any] | None = None,
+    event_sink: Callable[..., None] | None = None,
+) -> dict[str, Any]:
+    """Run Python QG with core legacy behavior and seminar best-round selection."""
+    level = _python_qg_level_from_plan_path(plan_path)
+    if level in SEMINAR_LEVELS:
+        return _run_python_qg_with_bounded_corrections(
+            module_dir,
+            plan_path,
+            verify_words_fn=verify_words_fn,
+            heritage_lookup_fn=heritage_lookup_fn,
+            qg_runner=qg_runner,
+            writer_corrector=writer_corrector,
+            reviewer_corrector=reviewer_corrector,
+            dictionary_lookup_fn=dictionary_lookup_fn,
+            writer=writer,
+            invoker=invoker,
+            event_sink=event_sink,
+            max_correction_rounds=python_qg_max_correction_rounds_for_level(level),
+        )
+    return _run_python_qg_with_legacy_single_shot_corrections(
+        module_dir,
+        plan_path,
+        verify_words_fn=verify_words_fn,
+        heritage_lookup_fn=heritage_lookup_fn,
+        qg_runner=qg_runner,
+        writer_corrector=writer_corrector,
+        reviewer_corrector=reviewer_corrector,
+        dictionary_lookup_fn=dictionary_lookup_fn,
+        writer=writer,
+        invoker=invoker,
+        event_sink=event_sink,
+    )
+
+
+def _run_python_qg_with_bounded_corrections(
+    module_dir: Path,
+    plan_path: Path,
+    *,
+    verify_words_fn: Callable[[list[str]], dict[str, list[dict[str, Any]]]] | None = None,
+    heritage_lookup_fn: Callable[[str], list[dict[str, Any]]] | None = None,
+    qg_runner: Callable[[], dict[str, Any]] | None = None,
+    writer_corrector: Callable[[CorrectionContext], str | Mapping[str, str] | None] | None = None,
+    reviewer_corrector: Callable[[CorrectionContext], str | None] | None = None,
+    dictionary_lookup_fn: Callable[[str, str], list[str | Mapping[str, str]]] | None = None,
+    writer: str = "claude-tools",
+    invoker: Callable[..., Any] | None = None,
+    event_sink: Callable[..., None] | None = None,
+    max_correction_rounds: int = PYTHON_QG_SEMINAR_MAX_CORRECTION_ROUNDS,
+) -> dict[str, Any]:
+    """Run seminar Python QG with bounded corrections and restore the best round."""
+    correction_budget = max(1, int(max_correction_rounds))
+    rounds: list[dict[str, Any]] = []
+    corrections: list[dict[str, Any]] = []
+    stopped_reason = "max_rounds"
+    consecutive_regressions = 0
+
+    def _run_qg() -> dict[str, Any]:
+        if qg_runner is not None:
+            report = qg_runner()
+        else:
+            report = run_python_qg(
+                module_dir,
+                plan_path,
+                verify_words_fn=verify_words_fn,
+                heritage_lookup_fn=heritage_lookup_fn,
+                event_sink=event_sink,
+            )
+        _attach_vocab_count_gate(report, module_dir=module_dir, plan_path=plan_path)
+        return report
+
+    def _record_round(
+        report: dict[str, Any],
+        *,
+        correction_round: int,
+        failed_gate: str | None = None,
+    ) -> dict[str, Any]:
+        round_record = {
+            "round": len(rounds) + 1,
+            "correction_round": correction_round,
+            "report": report,
+            "artifacts": _snapshot_correction_artifacts(module_dir),
+            "violation_count": _python_qg_violation_count(report),
+            "failed_gate": failed_gate,
+        }
+        rounds.append(round_record)
+        _emit(
+            event_sink,
+            "python_qg_correction_round",
+            max_correction_rounds=correction_budget,
+            **_python_qg_round_summary(round_record),
+        )
+        return round_record
+
+    report = _run_qg()
+    _record_round(report, correction_round=0)
+    correction_round = 0
+
+    while True:
+        if _python_qg_passed(report):
+            stopped_reason = "pass"
+            break
+        if correction_round >= correction_budget:
+            stopped_reason = "max_rounds"
+            break
+
+        failed_gate = _first_failed_correctable_gate(report)
+        if failed_gate is None:
+            stopped_reason = "no_correctable_failure"
+            break
+
+        correction_round += 1
+        before = report
+        artifact_snapshot = rounds[-1]["artifacts"]
+        handled, unmatched_anchors, correction_payload = _apply_python_qg_correction(
+            failed_gate,
+            report,
+            module_dir=module_dir,
+            plan_path=plan_path,
+            writer_corrector=writer_corrector,
+            reviewer_corrector=reviewer_corrector,
+            dictionary_lookup_fn=dictionary_lookup_fn,
+            writer=writer,
+            invoker=invoker,
+        )
+        if not handled:
+            _write_correction_artifact(
+                module_dir / f"python_qg_correction_r{correction_round}.json",
+                {
+                    "round": correction_round,
+                    "gate": failed_gate,
+                    "handled": False,
+                    "before": before,
+                    "correction": correction_payload,
+                },
+            )
+            _annotate_correction_terminal(
+                report,
+                failed_gate,
+                f"{failed_gate} has no ADR-008 correction path",
+            )
+            stopped_reason = "no_correction_path"
+            break
+
+        report = _run_qg()
+        regressions = _previously_passing_regressions(before, report)
+        correction_artifact: dict[str, Any] = {
+            "round": correction_round,
+            "gate": failed_gate,
+            "handled": True,
+            "unmatched_anchors": sorted(unmatched_anchors),
+            "before": before,
+            "correction": correction_payload,
+            "after": report,
+            "regressions": regressions,
+        }
+
+        if correction_payload.get("yaml_invalid"):
+            _restore_correction_artifacts(module_dir, artifact_snapshot)
+            report = _run_qg()
+            _annotate_correction_terminal(
+                report,
+                failed_gate,
+                f"{failed_gate} correction produced invalid YAML and was rolled back",
+            )
+            correction_artifact["rolled_back"] = True
+            correction_artifact["rollback_reason"] = "yaml_invalid"
+            correction_artifact["restored_after"] = report
+            _write_correction_artifact(
+                module_dir / f"python_qg_correction_r{correction_round}.json",
+                correction_artifact,
+            )
+            corrections.append(correction_artifact)
+            _record_round(report, correction_round=correction_round, failed_gate=failed_gate)
+            stopped_reason = "yaml_invalid"
+            break
+
+        if (
+            failed_gate == "vesum_verified"
+            and not _vesum_correction_improved(before, report)
+        ):
+            _restore_correction_artifacts(module_dir, artifact_snapshot)
+            report = _run_qg()
+            _annotate_correction_terminal(
+                report,
+                failed_gate,
+                "vesum_verified correction did not clear any previous missing surface and was rolled back",
+            )
+            correction_artifact["rolled_back"] = True
+            correction_artifact["rollback_reason"] = "vesum_no_improvement"
+            correction_artifact["restored_after"] = report
+            _write_correction_artifact(
+                module_dir / f"python_qg_correction_r{correction_round}.json",
+                correction_artifact,
+            )
+            corrections.append(correction_artifact)
+            _record_round(report, correction_round=correction_round, failed_gate=failed_gate)
+            stopped_reason = "vesum_no_improvement"
+            break
+
+        if regressions:
+            _restore_correction_artifacts(module_dir, artifact_snapshot)
+            report = _run_qg()
+            gates = report.setdefault("gates", {})
+            if isinstance(gates, dict):
+                gates["previously_passed_regression"] = {
+                    "passed": False,
+                    "regressions": regressions,
+                }
+                gates["passed"] = False
+            correction_artifact["rolled_back"] = True
+            correction_artifact["rollback_reason"] = "previously_passed_regression"
+            correction_artifact["restored_after"] = report
+            _write_correction_artifact(
+                module_dir / f"python_qg_correction_r{correction_round}.json",
+                correction_artifact,
+            )
+            corrections.append(correction_artifact)
+            _record_round(report, correction_round=correction_round, failed_gate=failed_gate)
+            stopped_reason = "previously_passed_regression"
+            break
+
+        _write_correction_artifact(
+            module_dir / f"python_qg_correction_r{correction_round}.json",
+            correction_artifact,
+        )
+        corrections.append(correction_artifact)
+        current_round = _record_round(
+            report,
+            correction_round=correction_round,
+            failed_gate=failed_gate,
+        )
+        if _python_qg_passed(report):
+            stopped_reason = "pass"
+            break
+
+        best_idx = best_round_index(
+            rounds,
+            lambda item: _python_qg_review_loop_dims(int(item["violation_count"])),
+        )
+        best_round = rounds[best_idx]
+        if min_score_regressed(
+            _python_qg_review_loop_dims(int(best_round["violation_count"])),
+            _python_qg_review_loop_dims(int(current_round["violation_count"])),
+        ):
+            consecutive_regressions += 1
+            if consecutive_regressions >= PYTHON_QG_MIN_REGRESSION_PATIENCE:
+                stopped_reason = "min_score_regressed"
+                break
+        else:
+            consecutive_regressions = 0
+
+    best_idx = best_round_index(
+        rounds,
+        lambda item: _python_qg_review_loop_dims(int(item["violation_count"])),
+    )
+    best_round = rounds[best_idx]
+    _restore_correction_artifacts(module_dir, best_round["artifacts"])
+    correction_loop = {
+        "max_correction_rounds": correction_budget,
+        "rounds": [_python_qg_round_summary(item) for item in rounds],
+        "best_round": best_round["round"],
+        "stopped_reason": stopped_reason,
+        "min_regression_patience": PYTHON_QG_MIN_REGRESSION_PATIENCE,
+        "consecutive_regressions": consecutive_regressions,
+        "corrections": corrections,
+    }
+    write_json(module_dir / "python_qg_correction_loop.json", correction_loop)
+    return dict(best_round["report"])
+
+
+def _run_python_qg_with_legacy_single_shot_corrections(
     module_dir: Path,
     plan_path: Path,
     *,

--- a/tests/test_python_qg_correction_loop.py
+++ b/tests/test_python_qg_correction_loop.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.build import linear_pipeline
+
+
+def _module_dir(tmp_path: Path, module_text: str = "STATE0\n") -> Path:
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    (module_dir / "module.md").write_text(module_text, encoding="utf-8")
+    (module_dir / "activities.yaml").write_text("[]\n", encoding="utf-8")
+    (module_dir / "vocabulary.yaml").write_text("[]\n", encoding="utf-8")
+    (module_dir / "resources.yaml").write_text("[]\n", encoding="utf-8")
+    return module_dir
+
+
+def _plan_path(tmp_path: Path, level: str) -> Path:
+    path = tmp_path / f"{level}.yaml"
+    path.write_text(f"level: {level}\nsequence: 1\nslug: sample\n", encoding="utf-8")
+    return path
+
+
+def _writer_artifacts(module_text: str, *, activity_prompt: str = "state") -> dict[str, str]:
+    return {
+        "module.md": module_text,
+        "activities.yaml": yaml.safe_dump(
+            [{"type": "note", "prompt": activity_prompt}],
+            allow_unicode=True,
+            sort_keys=False,
+        ),
+        "vocabulary.yaml": "[]\n",
+        "resources.yaml": "[]\n",
+    }
+
+
+def _qg_report(
+    *,
+    word_count: bool = True,
+    plan_sections: bool = True,
+    vesum_missing: list[str] | None = None,
+) -> dict[str, Any]:
+    missing = vesum_missing or []
+    gates = {
+        "word_count": {
+            "passed": word_count,
+            "count": 120 if word_count else 90,
+            "minimum": 120,
+        },
+        "plan_sections": {
+            "passed": plan_sections,
+            "missing_headings": [] if plan_sections else ["Ключові терміни"],
+        },
+        "vesum_verified": {
+            "passed": not missing,
+            "missing": missing,
+        },
+        "vocab_count": {"passed": True},
+    }
+    gates["passed"] = all(gate["passed"] for gate in gates.values())
+    return {"gates": gates}
+
+
+def test_python_qg_seminar_restores_best_round_when_later_round_diverges(
+    tmp_path: Path,
+) -> None:
+    module_dir = _module_dir(tmp_path)
+    plan_path = _plan_path(tmp_path, "folk")
+    qg_calls = 0
+
+    def qg_runner() -> dict[str, Any]:
+        nonlocal qg_calls
+        qg_calls += 1
+        module_text = (module_dir / "module.md").read_text(encoding="utf-8")
+        if "STATE2" in module_text:
+            return _qg_report(
+                vesum_missing=["new-a", "new-b", "new-c", "new-d", "new-e"],
+            )
+        if "STATE1" in module_text:
+            return _qg_report(
+                plan_sections=False,
+                vesum_missing=["best-a", "best-b"],
+            )
+        return _qg_report(
+            word_count=False,
+            plan_sections=False,
+            vesum_missing=["old-a", "old-b", "old-c"],
+        )
+
+    def writer_corrector(context: linear_pipeline.CorrectionContext) -> dict[str, str]:
+        if context.gate == "word_count":
+            return _writer_artifacts("STATE1\n", activity_prompt="best round")
+        if context.gate == "plan_sections":
+            return _writer_artifacts("STATE2\n", activity_prompt="churned round")
+        raise AssertionError(f"unexpected correction gate: {context.gate}")
+
+    report = linear_pipeline.run_python_qg_with_corrections(
+        module_dir,
+        plan_path,
+        qg_runner=qg_runner,
+        writer_corrector=writer_corrector,
+    )
+
+    assert qg_calls == 3
+    assert report["gates"]["vesum_verified"]["missing"] == ["best-a", "best-b"]
+    assert (module_dir / "module.md").read_text(encoding="utf-8") == "STATE1\n"
+    restored_activities = yaml.safe_load(
+        (module_dir / "activities.yaml").read_text(encoding="utf-8")
+    )
+    assert restored_activities[0]["prompt"] == "best round"
+
+    loop = json.loads(
+        (module_dir / "python_qg_correction_loop.json").read_text(encoding="utf-8")
+    )
+    assert loop["best_round"] == 2
+    assert loop["stopped_reason"] == "min_score_regressed"
+    assert [item["violation_count"] for item in loop["rounds"]] == [5, 3, 5]
+
+
+def test_python_qg_seminar_breaks_immediately_on_pass(tmp_path: Path) -> None:
+    module_dir = _module_dir(tmp_path)
+    plan_path = _plan_path(tmp_path, "folk")
+    corrected_gates: list[str] = []
+
+    def qg_runner() -> dict[str, Any]:
+        module_text = (module_dir / "module.md").read_text(encoding="utf-8")
+        return _qg_report() if "PASS" in module_text else _qg_report(word_count=False)
+
+    def writer_corrector(context: linear_pipeline.CorrectionContext) -> dict[str, str]:
+        corrected_gates.append(context.gate)
+        return _writer_artifacts("PASS\n", activity_prompt="passing round")
+
+    report = linear_pipeline.run_python_qg_with_corrections(
+        module_dir,
+        plan_path,
+        qg_runner=qg_runner,
+        writer_corrector=writer_corrector,
+    )
+
+    assert report["gates"]["passed"] is True
+    assert corrected_gates == ["word_count"]
+    assert (module_dir / "module.md").read_text(encoding="utf-8") == "PASS\n"
+    loop = json.loads(
+        (module_dir / "python_qg_correction_loop.json").read_text(encoding="utf-8")
+    )
+    assert loop["best_round"] == 2
+    assert loop["stopped_reason"] == "pass"
+    assert [item["violation_count"] for item in loop["rounds"]] == [1, 0]
+
+
+def test_python_qg_seminar_regression_restores_previous_snapshot(
+    tmp_path: Path,
+) -> None:
+    module_dir = _module_dir(tmp_path)
+    plan_path = _plan_path(tmp_path, "folk")
+
+    def qg_runner() -> dict[str, Any]:
+        module_text = (module_dir / "module.md").read_text(encoding="utf-8")
+        if "STATE1" in module_text:
+            return _qg_report(vesum_missing=["regressed-vesum"])
+        return _qg_report(word_count=False)
+
+    def writer_corrector(context: linear_pipeline.CorrectionContext) -> dict[str, str]:
+        assert context.gate == "word_count"
+        return _writer_artifacts("STATE1\n", activity_prompt="dirty round")
+
+    report = linear_pipeline.run_python_qg_with_corrections(
+        module_dir,
+        plan_path,
+        qg_runner=qg_runner,
+        writer_corrector=writer_corrector,
+    )
+
+    assert report["gates"]["word_count"]["passed"] is False
+    assert (module_dir / "module.md").read_text(encoding="utf-8") == "STATE0\n"
+    assert yaml.safe_load((module_dir / "activities.yaml").read_text("utf-8")) == []
+    loop = json.loads(
+        (module_dir / "python_qg_correction_loop.json").read_text(encoding="utf-8")
+    )
+    assert loop["stopped_reason"] == "previously_passed_regression"
+    assert loop["best_round"] == 1
+
+
+def test_python_qg_core_uses_legacy_single_correction_path(tmp_path: Path) -> None:
+    module_dir = _module_dir(tmp_path)
+    plan_path = _plan_path(tmp_path, "a1")
+    qg_calls = 0
+
+    def qg_runner() -> dict[str, Any]:
+        nonlocal qg_calls
+        qg_calls += 1
+        module_text = (module_dir / "module.md").read_text(encoding="utf-8")
+        return _qg_report() if "PASS" in module_text else _qg_report(word_count=False)
+
+    def writer_corrector(context: linear_pipeline.CorrectionContext) -> dict[str, str]:
+        assert context.gate == "word_count"
+        return _writer_artifacts("PASS\n", activity_prompt="core pass")
+
+    report = linear_pipeline.run_python_qg_with_corrections(
+        module_dir,
+        plan_path,
+        qg_runner=qg_runner,
+        writer_corrector=writer_corrector,
+    )
+
+    assert qg_calls == 2
+    assert report["gates"]["passed"] is True
+    assert (module_dir / "module.md").read_text(encoding="utf-8") == "PASS\n"
+    assert not (module_dir / "python_qg_correction_loop.json").exists()
+    assert linear_pipeline.python_qg_max_correction_rounds_for_level("a1") == 1
+    assert linear_pipeline.python_qg_max_correction_rounds_for_level("folk") == 4


### PR DESCRIPTION
## Summary

- Adds a seminar-only bounded Python-QG correction loop with total correction budget, rotating gates, full-artifact round snapshots, and best-round restore.
- Scores rounds by total deterministic gate violations, restores the earliest lowest-violation round, and stops early on min-score regression.
- Keeps core A1-C2 behavior on the legacy single-shot path; this is anti-churn plumbing only.

Design ref: [`docs/folk-epic/seminar-module-self-converge-3079-design.md` §8](https://github.com/learn-ukrainian/learn-ukrainian.github.io/blob/codex/folk-3079-c3-loop/docs/folk-epic/seminar-module-self-converge-3079-design.md#L296)

Core no-op; anti-churn only — cross-model fixer + long-tail exemptions are separate follow-ons.

## Verification

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-3079-c3-loop
$ ls tests/ | grep -iE 'python_qg|linear_pipeline|rewrite'
test_linear_pipeline_telemetry.py
test_linear_pipeline_vesum_heritage_attestation.py
test_linear_pipeline_wiki_coverage.py
test_no_rewrite_contract.py
test_python_qg_correction_loop.py
```

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-3079-c3-loop
$ .venv/bin/python -m pytest tests/test_linear_pipeline*.py tests/test_python_qg*.py tests/test_no_rewrite_contract.py -m 'not skipif' -q
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-3079-c3-loop
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 42 items

tests/test_linear_pipeline_telemetry.py ........                         [ 19%]
tests/test_linear_pipeline_vesum_heritage_attestation.py ..              [ 23%]
tests/test_linear_pipeline_wiki_coverage.py .......                      [ 40%]
tests/test_python_qg_correction_loop.py ....                             [ 50%]
tests/test_no_rewrite_contract.py .....................                  [100%]

============================== 42 passed in 1.33s ==============================
```

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-3079-c3-loop
$ .venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_python_qg_correction_loop.py
All checks passed!
```

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-3079-c3-loop
$ .venv/bin/python scripts/audit/lint_agent_trailer.py
Checking 1 commit(s) in origin/main..HEAD:

  1f52f0c1c2  PASS  X-Agent: codex/folk-3079-c3-loop

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

## Review

Local code review run before commit:
- Ruff clean.
- Gemini review completed; Codex challenge kept malformed-report scoring and rollback-snapshot hardening findings.
- Applied surviving review fixes and reran verification.
