### PR TITLE
fix(a1): certify m03 special signs

### DIFF
--- a/curriculum/l2-uk-en/a1/special-signs/activities.yaml
+++ b/curriculum/l2-uk-en/a1/special-signs/activities.yaml
@@ -3,34 +3,34 @@ inline:
   - id: act-1
     type: quiz
     title: М'яко чи розді́льно
-    instruction: Обери перше читацьке пояснення.
+    instruction: Обери пояснення для читання.
     items:
-      - prompt: Буря́к — що стається перед я?
+      - prompt: Буря́к — що відбувається перед літерою я?
         options:
-          - text: Р м'якшиться перед я.
+          - text: Р пом'якшується перед я.
             correct: true
           - text: Є апо́строф.
             correct: false
           - text: Ї завжди [йі].
             correct: false
-        explanation: У слові буря́к немає апо́строфа; р м'якшиться перед я.
+        explanation: У слові буря́к немає апо́строфа; р пом'якшується перед я.
       - prompt: Бур'я́н — що робить апо́строф?
         options:
-          - text: Р лишається твердим, потім чути [йа].
-            correct: true
           - text: Р зникає.
             correct: false
+          - text: Р залишається твердим, потім чути [йа].
+            correct: true
           - text: Додає звук [і].
             correct: false
         explanation: Апо́строф відділяє р від я.
       - prompt: Ї — що завжди правильно?
         options:
-          - text: Завжди [йі].
-            correct: true
           - text: Мовчить.
             correct: false
           - text: Це м'яки́й знак.
             correct: false
+          - text: Завжди [йі].
+            correct: true
         explanation: Ї завжди позначає [йі].
   - id: act-2
     type: match-up
@@ -38,13 +38,13 @@ inline:
     instruction: З'єднай кожне слово з підказкою про м'яки́й знак.
     pairs:
       - left: день
-        right: м'який фінальний н
+        right: м'який н у слові день
       - left: кінь
-        right: м'який фінальний н
+        right: м'який н у слові кінь
       - left: сіль
-        right: м'який фінальний л
+        right: м'який л у слові сіль
       - left: вчи́тель
-        right: м'який фінальний л
+        right: м'який л у слові вчи́тель
       - left: м'яки́й знак
         right: не має власного звука
   - id: act-3
@@ -70,24 +70,12 @@ inline:
           - "'"
           - ь
           - без знака
-      - sentence: свя́то потребує ____.
+      - sentence: У слові свя́то правильний вибір — ____.
         answer: без знака
         options:
           - без знака
           - "'"
           - ь
-      - sentence: бур_ян
-        answer: "'"
-        options:
-          - "'"
-          - ь
-          - без знака
-      - sentence: мале́нький needs ____.
-        answer: ь
-        options:
-          - ь
-          - "'"
-          - без знака
   - id: act-4
     type: error-correction
     title: Виправ пастки
@@ -98,8 +86,8 @@ inline:
         correction: сім'я́
         options:
           - сім'я́
-          - сімя без апо́строфа
-        explanation: The apostrophe is required in сім'я́.
+          - сімя
+        explanation: У слові сім'я́ потрібен апо́строф.
       - sentence: День — не пиши ден.
         error: ден
         correction: день
@@ -113,21 +101,14 @@ inline:
         options:
           - свя́то
           - св'ято
-        explanation: Свя́то — підготовлене слово без апо́строфа.
+        explanation: У слові свя́то немає апо́строфа.
       - sentence: Не пиши льожка з вигаданим м'яки́м знаком.
         error: льожка
         correction: ло́жка
         options:
           - ло́жка
-          - вигадане написання з ь
+          - льожка
         explanation: Ло́жка не має м'якого знака після л.
-      - sentence: Не роби повну паузу в слові сім'я́.
-        error: повну паузу
-        correction: плавний звук й
-        options:
-          - плавний звук й
-          - full stop
-        explanation: Апо́строф розділяє звуки, але не створює повної паузи.
   - id: act-5
     type: divide-words
     title: Практика переносу слів
@@ -136,7 +117,7 @@ inline:
       - word: Мар'я́на
         answer: Мар'-яна
       - word: дерев'я́ний
-        answer: дерев'-яний
+        answer: дере-в'яний
       - word: бур'я́н
         answer: бур'-ян
       - word: па́льці
@@ -166,13 +147,71 @@ workbook:
           - свя́то
           - цвях
           - ло́жка
+  - type: match-up
+    title: Поясни контраст
+    instruction: З'єднай слово з поясненням.
+    pairs:
+      - left: буря́к
+        right: "м'якість без апо́строфа: р + я"
+      - left: бур'я́н
+        right: 'апо́строф: р твердий, потім [йа]'
+      - left: свя́то
+        right: збіг св + я без апо́строфа
+      - left: цвях
+        right: збіг цв + я без апо́строфа
+  - type: error-correction
+    title: Виправ усі пастки
+    instruction: Обери правильну українську форму.
+    items:
+      - sentence: Не пиши сімя без апо́строфа.
+        error: сімя
+        correction: сім'я́
+        options:
+          - сім'я́
+          - сімя
+        explanation: У слові сім'я́ потрібен апо́строф.
+      - sentence: Не пиши пять без апо́строфа.
+        error: пять
+        correction: п'ять
+        options:
+          - п'ять
+          - пять
+        explanation: У слові п'ять потрібен апо́строф.
+      - sentence: Не пиши бурян без апо́строфа.
+        error: бурян
+        correction: бур'я́н
+        options:
+          - бур'я́н
+          - бурян
+        explanation: У слові бур'я́н потрібен апо́строф після р.
+      - sentence: День — не пиши ден.
+        error: ден
+        correction: день
+        options:
+          - день
+          - ден
+        explanation: День потребує м'якого знака.
+      - sentence: Не пиши св'ято з апо́строфом.
+        error: св'ято
+        correction: свя́то
+        options:
+          - свя́то
+          - св'ято
+        explanation: У слові свя́то немає апо́строфа.
+      - sentence: Не пиши льожка з вигаданим м'яки́м знаком.
+        error: льожка
+        correction: ло́жка
+        options:
+          - ло́жка
+          - льожка
+        explanation: Ло́жка не має м'якого знака після л.
   - type: true-false
     title: Факти про знаки
-    instruction: Обери правда чи неправда.
+    instruction: 'Обери: правда чи неправда.'
     items:
       - statement: Ь не має власного звука.
         correct: true
-        explanation: Він м'якшить попередній при́голосний.
+        explanation: Він пом'якшує попередній при́голосний.
       - statement: Апо́строф тримає попередній при́голосний твердим.
         correct: true
         explanation: Він відділяє при́голосний від йотованої голосної.
@@ -182,20 +221,40 @@ workbook:
       - statement: Свя́то має апо́строф.
         correct: false
         explanation: Свя́то — модельне слово без апо́строфа.
-  - type: match-up
-    title: Друк і зошит
-    instruction: З'єднай друковане слово з підказкою в зо́шиті.
-    pairs:
-      - left: 'друк: день'
-        right: 'зошит: слово з кінцевим ь'
-      - left: "друк: сім'я́"
-        right: 'зошит: apostrophe before я'
-      - left: "друк: п'ять"
-        right: 'зошит: апо́строф і кінцевий ь'
-      - left: 'друк: свя́то'
-        right: 'зошит: no apostrophe'
-      - left: "друк: бур'я́н"
-        right: 'зошит: apostrophe after р'
+  - type: fill-in
+    title: Додай знак у нових словах
+    instruction: Обери ь, апо́строф або без знака.
+    items:
+      - sentence: бур_ян
+        answer: "'"
+        options:
+          - "'"
+          - ь
+          - без знака
+      - sentence: комп_ютер
+        answer: "'"
+        options:
+          - "'"
+          - ь
+          - без знака
+      - sentence: ім_я
+        answer: "'"
+        options:
+          - "'"
+          - ь
+          - без знака
+      - sentence: У слові мален_кий потрібен ____.
+        answer: ь
+        options:
+          - ь
+          - "'"
+          - без знака
+      - sentence: У слові цвях правильний вибір — ____.
+        answer: без знака
+        options:
+          - без знака
+          - "'"
+          - ь
   - type: quiz
     title: Правильна форма
     instruction: Обери правильно написане слово.
@@ -204,20 +263,45 @@ workbook:
         options:
           - text: сім'я́
             correct: true
-          - text: сімя без апо́строфа
+          - text: сімя
             correct: false
         explanation: Сім'я́ потребує апо́строфа.
       - prompt: День — яка форма правильна?
         options:
-          - text: день
-            correct: true
           - text: ден
             correct: false
+          - text: день
+            correct: true
         explanation: День потребує м'якого знака.
       - prompt: Слово без апо́строфа?
         options:
+          - text: св'ято
+            correct: false
           - text: свя́то
             correct: true
-          - text: apostrophe spelling
-            correct: false
-        explanation: Свя́то — підготовлене слово без апо́строфа.
+        explanation: У слові свя́то немає апо́строфа.
+  - type: odd-one-out
+    title: Зайве за знаком
+    instruction: Обери слово, яке не має такого самого знака, як інші.
+    items:
+      - words:
+          - сім'я́
+          - м'я́со
+          - п'ять
+          - буря́к
+        answer: буря́к
+        explanation: Буря́к без апо́строфа; інші слова мають апо́строф.
+      - words:
+          - день
+          - кінь
+          - сіль
+          - свя́то
+        answer: свя́то
+        explanation: Свя́то без ь; інші слова мають м'який знак.
+      - words:
+          - буря́к
+          - свя́то
+          - цвях
+          - бур'я́н
+        answer: бур'я́н
+        explanation: Бур'я́н має апо́строф; інші слова тут без знака.

--- a/curriculum/l2-uk-en/a1/special-signs/module.md
+++ b/curriculum/l2-uk-en/a1/special-signs/module.md
@@ -6,11 +6,13 @@ beginner contrasts.
 The signs are small on the page, but they are not decorative. They tell your
 mouth how to read the nearby letters.
 
-Use a live or original listening pass. A native Ukrainian teacher or tutor can
-say **день**, **сім'я́**, **буря́к**, **бур'я́н**, and **свя́то** once; you
-point to the sign you hear on the page. If you record anything, record only
-your own voice or a teacher who has given permission. Do not download or copy
-third-party audio.
+Listen once before you write. A native Ukrainian teacher or tutor can say
+**день**, **сім'я́**, **буря́к**, **бур'я́н**, and **свя́то**; you point to
+the sign you hear on the page. If you are working alone, record your own voice
+and compare it with the routine below.
+
+Teacher Oksana's routine for this module is short: find the sign, say what it
+does, then read the word once.
 
 Keep the goal simple. You are not learning every spelling rule today. You are
 learning these beginner contrasts:
@@ -19,8 +21,8 @@ learning these beginner contrasts:
 - **сім'я́** — apostrophe keeps the previous consonant hard and lets you hear
   **[й]** before **я**;
 - **буря́к / бур'я́н / свя́то / цвях** — sometimes **я** softens, sometimes
-  apostrophe separates, and sometimes there is no apostrophe after a consonant
-  cluster.
+  apostrophe separates, and sometimes two consonants before **я** mean there is
+  no apostrophe.
 
 By the end, you can:
 
@@ -36,6 +38,9 @@ By the end, you can:
 
 **Я Ю Є Ї** — the four special vowel letters.
 
+Module 2 already introduced these letters. Here you only need the quick review
+that makes **ь** and apostrophe readable.
+
 At beginner level, use this rule:
 
 | Position | Beginner reading habit |
@@ -46,7 +51,7 @@ At beginner level, use this rule:
 
 Compare two words:
 
-| Слово́ | What happens |
+| Слово́ | Reading effect |
 | --- | --- |
 | **буря́к** | no apostrophe; **р** softens before **я** |
 | **бур'я́н** | apostrophe; **р** stays hard, then you hear **[йа]** |
@@ -54,10 +59,10 @@ Compare two words:
 The apostrophe is a Ukrainian reading instruction: do not soften the previous
 consonant; keep the next **й** sound.
 
-Use a hearing habit before a spelling habit. Say or hear the word slowly. Ask:
-**Чую окремий й?** — Do I hear a separate **й** before **я, ю, є, ї**? If yes,
-apostrophe may be part of the prepared spelling. If no, the vowel letter may
-simply be softening the previous consonant.
+Use one listening question before spelling. Say or hear the word slowly: do I
+hear a separate **й** before **я, ю, є, ї**? If yes, apostrophe may be part of
+the prepared spelling. If no, the vowel letter may simply soften the previous
+consonant.
 
 <!-- INJECT_ACTIVITY: act-1 -->
 
@@ -77,13 +82,14 @@ It has no sound of its own. It changes the consonant before it.
 Do not read **ь** as **і**, **й**, or a tiny extra vowel. In **день**, stop on
 soft **н**. In **сіль**, stop on soft **л**.
 
-Short contrast pairs show the job:
+Short contrast pairs show the job. Treat them as sound examples, not new
+vocabulary to memorize today:
 
 | Without soft sign | With soft sign | Reading idea |
 | --- | --- | --- |
-| **стан** | **стань** | hard ending vs soft ending |
-| **лан** | **лань** | hard ending vs soft ending |
-| **рис** | **рись** | hard final **с** vs soft final consonant |
+| **стан** | **стань** | listen only for hard **н** vs soft **нь** |
+| **лан** | **лань** | listen only for hard **н** vs soft **нь** |
+| **рис** | **рись** | listen only for hard **с** vs soft **сь** |
 
 These pairs are reading tools. You do not need to use all of them in
 conversation today.
@@ -103,7 +109,7 @@ previous consonant hard and lets the next **я, ю, є, ї** start with **[й]**
 
 The first A1 model is:
 
-**б, п, в, м, ф, р + apostrophe + я, ю, є, ї**
+**б, п, в, м, ф, р + апостроф + я, ю, є, ї**
 
 Start with these words:
 
@@ -133,7 +139,7 @@ itself.
 | --- | --- | --- |
 | softness with no apostrophe | **буря́к** | **р** softens before **я** |
 | apostrophe | **бур'я́н** | **р** stays hard, then **[йа]** |
-| consonant cluster with no apostrophe | **свя́то**, **цвях** | no apostrophe in these prepared words |
+| two consonants before **я** with no apostrophe | **свя́то**, **цвях** | no apostrophe in these prepared words |
 
 Mechanical spelling fails here. You cannot put apostrophe before every **я**.
 You also cannot ignore apostrophe when it is written.
@@ -158,13 +164,13 @@ Common learner traps:
 | inventing a soft-sign version of **ло́жка** | do not invent a soft sign or soft **л** |
 | treating apostrophe as a hard stop | keep airflow and pronounce **й** |
 
-Keep this module Ukrainian-centered. Do not explain the apostrophe through
-another alphabet or another sign. Ukrainian has its own apostrophe and its own
-soft sign.
+Stay inside Ukrainian for this lesson. The apostrophe and soft sign already
+have Ukrainian jobs, so you do not need another alphabet or another sign to
+explain them.
 
 <!-- INJECT_ACTIVITY: act-4 -->
 
-## Перенос, друк, зошит
+## Перенос і письмо
 
 You will sometimes see words split across a line in printed Ukrainian. At this
 level, use only prepared models:
@@ -172,19 +178,20 @@ level, use only prepared models:
 | Whole word | Safe line-break model |
 | --- | --- |
 | **Мар'я́на** | `Мар'-яна` |
-| **дерев'я́ний** | `дерев'-яний` |
+| **дерев'я́ний** | `дере-в'яний` |
 | **бур'я́н** | `бур'-ян` |
 | **па́льці** | `паль-ці` |
 
 The simple idea: **ь** and apostrophe stay with the letter before them. Also,
 do not leave one single letter alone on a line.
 
-**Друк / зошит** — recognition before writing.
+Reading before writing: first recognize the printed word, then copy the sign in
+a notebook cue.
 
 Use original text on this page, your own notebook, or live handwriting from a
-teacher/tutor. Do not copy a third-party handwriting sample.
+teacher/tutor.
 
-| Друк | Notebook recognition prompt |
+| Printed word | Notebook cue |
 | --- | --- |
 | **день** | find the soft sign at the end |
 | **сім'я́** | find the apostrophe before **я** |
@@ -208,12 +215,14 @@ Before you leave the lesson tab, check that you can do these things:
 - identify missing-apostrophe, missing-soft-sign, and invented-soft-sign
   errors.
 
-Use the signs as reading instructions, not decorations. A useful final routine
-is: find the sign, say what it does, then read the word once.
+Use the signs as reading instructions, not decorations. Before moving on,
+choose one word from each contrast and do a final sign check: name the sign,
+state its effect, then read the word.
 
 <!-- INJECT_ACTIVITY: act-5 -->
 
 ## Далі
 
-Тепер переходь до словника й вправ. Keep using the same small routine: find
-the sign, say what it does, then read the word.
+**Далі** means next. Go to Vocabulary and Activities; those drills reuse the
+same six contrast words: **день**, **сім'я́**, **буря́к**, **бур'я́н**,
+**свя́то**, **цвях**.

--- a/curriculum/l2-uk-en/a1/special-signs/resources.yaml
+++ b/curriculum/l2-uk-en/a1/special-signs/resources.yaml
@@ -2,11 +2,11 @@
   role: textbook
   source_ref: Захарійчук, 1 клас (НУШ 2025), p. 97
   notes: 'Plan reference: basic apostrophe rule before я, ю, є, ї.'
-- title: Авраменко, 5 клас, p. 75
-  role: textbook
-  source_ref: Авраменко, 5 клас, p. 75
-  notes: 'Plan reference: soft sign as a marker of consonant softness.'
 - title: Большакова, 2 клас, p. 58-59
   role: textbook
   source_ref: Большакова, 2 клас, p. 58-59
-  notes: 'Plan reference: apostrophe and line-break models.'
+  notes: 'Apostrophe as hard consonant + [йа], and transfer models Мар''-яна / Дере-в''яний.'
+- title: Вашуленко, 3 клас, p. 90
+  role: textbook
+  source_ref: Вашуленко, 3 клас, p. 90
+  notes: 'Line-break rule: apostrophe is not separated from the previous letter.'

--- a/curriculum/l2-uk-en/a1/special-signs/vocabulary.yaml
+++ b/curriculum/l2-uk-en/a1/special-signs/vocabulary.yaml
@@ -66,6 +66,10 @@
   translation: name
   pos: noun
   usage: Ім'я́.
+- lemma: здоро́в'я
+  translation: health
+  pos: noun
+  usage: Здоро́в'я.
 - lemma: комп'ю́тер
   translation: computer
   pos: noun
@@ -89,15 +93,11 @@
 - lemma: мале́нький
   translation: small
   pos: adjective
-  usage: Мале́нький день.
+  usage: Мале́нький знак.
 - lemma: сього́дні
   translation: today
   pos: adverb
-  usage: Сього́дні день.
-- lemma: ба́тько
-  translation: father
-  pos: noun
-  usage: Ба́тько.
+  usage: Сього́дні свя́то.
 - lemma: ло́жка
   translation: spoon
   pos: noun

--- a/site/src/content/docs/a1/special-signs.mdx
+++ b/site/src/content/docs/a1/special-signs.mdx
@@ -65,11 +65,13 @@ beginner contrasts.
 The signs are small on the page, but they are not decorative. They tell your
 mouth how to read the nearby letters.
 
-Use a live or original listening pass. A native Ukrainian teacher or tutor can
-say **день**, **сім'я́**, **буря́к**, **бур'я́н**, and **свя́то** once; you
-point to the sign you hear on the page. If you record anything, record only
-your own voice or a teacher who has given permission. Do not download or copy
-third-party audio.
+Listen once before you write. A native Ukrainian teacher or tutor can say
+**день**, **сім'я́**, **буря́к**, **бур'я́н**, and **свя́то**; you point to
+the sign you hear on the page. If you are working alone, record your own voice
+and compare it with the routine below.
+
+Teacher Oksana's routine for this module is short: find the sign, say what it
+does, then read the word once.
 
 Keep the goal simple. You are not learning every spelling rule today. You are
 learning these beginner contrasts:
@@ -78,8 +80,8 @@ learning these beginner contrasts:
 - **сім'я́** — apostrophe keeps the previous consonant hard and lets you hear
   **[й]** before **я**;
 - **буря́к / бур'я́н / свя́то / цвях** — sometimes **я** softens, sometimes
-  apostrophe separates, and sometimes there is no apostrophe after a consonant
-  cluster.
+  apostrophe separates, and sometimes two consonants before **я** mean there is
+  no apostrophe.
 
 By the end, you can:
 
@@ -95,6 +97,9 @@ By the end, you can:
 
 **Я Ю Є Ї** — the four special vowel letters.
 
+Module 2 already introduced these letters. Here you only need the quick review
+that makes **ь** and apostrophe readable.
+
 At beginner level, use this rule:
 
 | Position | Beginner reading habit |
@@ -105,7 +110,7 @@ At beginner level, use this rule:
 
 Compare two words:
 
-| Слово́ | What happens |
+| Слово́ | Reading effect |
 | --- | --- |
 | **буря́к** | no apostrophe; **р** softens before **я** |
 | **бур'я́н** | apostrophe; **р** stays hard, then you hear **[йа]** |
@@ -113,14 +118,14 @@ Compare two words:
 The apostrophe is a Ukrainian reading instruction: do not soften the previous
 consonant; keep the next **й** sound.
 
-Use a hearing habit before a spelling habit. Say or hear the word slowly. Ask:
-**Чую окремий й?** — Do I hear a separate **й** before **я, ю, є, ї**? If yes,
-apostrophe may be part of the prepared spelling. If no, the vowel letter may
-simply be softening the previous consonant.
+Use one listening question before spelling. Say or hear the word slowly: do I
+hear a separate **й** before **я, ю, є, ї**? If yes, apostrophe may be part of
+the prepared spelling. If no, the vowel letter may simply soften the previous
+consonant.
 
 ### М'яко чи розді́льно
 
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "Буря́к — що стається перед я?", "options": [{"text": "Р м'якшиться перед я.", "correct": true}, {"text": "Є апо́строф.", "correct": false}, {"text": "Ї завжди [йі].", "correct": false}], "explanation": "У слові буря́к немає апо́строфа; р м'якшиться перед я."}, {"question": "Бур'я́н — що робить апо́строф?", "options": [{"text": "Р лишається твердим, потім чути [йа].", "correct": true}, {"text": "Р зникає.", "correct": false}, {"text": "Додає звук [і].", "correct": false}], "explanation": "Апо́строф відділяє р від я."}, {"question": "Ї — що завжди правильно?", "options": [{"text": "Завжди [йі].", "correct": true}, {"text": "Мовчить.", "correct": false}, {"text": "Це м'яки́й знак.", "correct": false}], "explanation": "Ї завжди позначає [йі]."}]`)} instruction={"Обери перше читацьке пояснення."} isUkrainian={false} />
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Буря́к — що відбувається перед літерою я?", "options": [{"text": "Р пом'якшується перед я.", "correct": true}, {"text": "Є апо́строф.", "correct": false}, {"text": "Ї завжди [йі].", "correct": false}], "explanation": "У слові буря́к немає апо́строфа; р пом'якшується перед я."}, {"question": "Бур'я́н — що робить апо́строф?", "options": [{"text": "Р зникає.", "correct": false}, {"text": "Р залишається твердим, потім чути [йа].", "correct": true}, {"text": "Додає звук [і].", "correct": false}], "explanation": "Апо́строф відділяє р від я."}, {"question": "Ї — що завжди правильно?", "options": [{"text": "Мовчить.", "correct": false}, {"text": "Це м'яки́й знак.", "correct": false}, {"text": "Завжди [йі].", "correct": true}], "explanation": "Ї завжди позначає [йі]."}]`)} instruction={"Обери пояснення для читання."} isUkrainian={false} />
 
 ## М'яки́й знак
 
@@ -138,13 +143,14 @@ It has no sound of its own. It changes the consonant before it.
 Do not read **ь** as **і**, **й**, or a tiny extra vowel. In **день**, stop on
 soft **н**. In **сіль**, stop on soft **л**.
 
-Short contrast pairs show the job:
+Short contrast pairs show the job. Treat them as sound examples, not new
+vocabulary to memorize today:
 
 | Without soft sign | With soft sign | Reading idea |
 | --- | --- | --- |
-| **стан** | **стань** | hard ending vs soft ending |
-| **лан** | **лань** | hard ending vs soft ending |
-| **рис** | **рись** | hard final **с** vs soft final consonant |
+| **стан** | **стань** | listen only for hard **н** vs soft **нь** |
+| **лан** | **лань** | listen only for hard **н** vs soft **нь** |
+| **рис** | **рись** | listen only for hard **с** vs soft **сь** |
 
 These pairs are reading tools. You do not need to use all of them in
 conversation today.
@@ -155,7 +161,7 @@ conversation today.
 
 ### Що робить ь
 
-<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "день", "right": "м'який фінальний н"}, {"left": "кінь", "right": "м'який фінальний н"}, {"left": "сіль", "right": "м'який фінальний л"}, {"left": "вчи́тель", "right": "м'який фінальний л"}, {"left": "м'яки́й знак", "right": "не має власного звука"}]`)} instruction={"З'єднай кожне слово з підказкою про м'яки́й знак."} isUkrainian={false} />
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "день", "right": "м'який н у слові день"}, {"left": "кінь", "right": "м'який н у слові кінь"}, {"left": "сіль", "right": "м'який л у слові сіль"}, {"left": "вчи́тель", "right": "м'який л у слові вчи́тель"}, {"left": "м'яки́й знак", "right": "не має власного звука"}]`)} instruction={"З'єднай кожне слово з підказкою про м'яки́й знак."} isUkrainian={false} />
 
 ## Апостроф
 
@@ -166,7 +172,7 @@ previous consonant hard and lets the next **я, ю, є, ї** start with **[й]**
 
 The first A1 model is:
 
-**б, п, в, м, ф, р + apostrophe + я, ю, є, ї**
+**б, п, в, м, ф, р + апостроф + я, ю, є, ї**
 
 Start with these words:
 
@@ -188,7 +194,7 @@ itself.
 
 ### Додай знак
 
-<FillIn client:only='react' items={JSON.parse(`[{"sentence": "сім_я", "answer": "'", "options": ["'", "ь", "без знака"]}, {"sentence": "ден_", "answer": "ь", "options": ["ь", "'", "без знака"]}, {"sentence": "п_ять", "answer": "'", "options": ["'", "ь", "без знака"]}, {"sentence": "свя́то потребує ____.", "answer": "без знака", "options": ["без знака", "'", "ь"]}, {"sentence": "бур_ян", "answer": "'", "options": ["'", "ь", "без знака"]}, {"sentence": "мале́нький needs ____.", "answer": "ь", "options": ["ь", "'", "без знака"]}]`)} instruction={"Обери ь, апо́строф або без знака."} isUkrainian={false} />
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "сім_я", "answer": "'", "options": ["'", "ь", "без знака"]}, {"sentence": "ден_", "answer": "ь", "options": ["ь", "'", "без знака"]}, {"sentence": "п_ять", "answer": "'", "options": ["'", "ь", "без знака"]}, {"sentence": "У слові свя́то правильний вибір — ____.", "answer": "без знака", "options": ["без знака", "'", "ь"]}]`)} instruction={"Обери ь, апо́строф або без знака."} isUkrainian={false} />
 
 ## Контраст і пастки
 
@@ -198,7 +204,7 @@ itself.
 | --- | --- | --- |
 | softness with no apostrophe | **буря́к** | **р** softens before **я** |
 | apostrophe | **бур'я́н** | **р** stays hard, then **[йа]** |
-| consonant cluster with no apostrophe | **свя́то**, **цвях** | no apostrophe in these prepared words |
+| two consonants before **я** with no apostrophe | **свя́то**, **цвях** | no apostrophe in these prepared words |
 
 Mechanical spelling fails here. You cannot put apostrophe before every **я**.
 You also cannot ignore apostrophe when it is written.
@@ -223,15 +229,15 @@ Common learner traps:
 | inventing a soft-sign version of **ло́жка** | do not invent a soft sign or soft **л** |
 | treating apostrophe as a hard stop | keep airflow and pronounce **й** |
 
-Keep this module Ukrainian-centered. Do not explain the apostrophe through
-another alphabet or another sign. Ukrainian has its own apostrophe and its own
-soft sign.
+Stay inside Ukrainian for this lesson. The apostrophe and soft sign already
+have Ukrainian jobs, so you do not need another alphabet or another sign to
+explain them.
 
 ### Виправ пастки
 
-<ErrorCorrection client:only='react' instruction="Обери правильну українську форму." items={JSON.parse(`[{"sentence": "Не пиши сімя без апо́строфа.", "errorWord": "сімя", "correctForm": "сім'я́", "options": ["сім'я́", "сімя без апо́строфа"], "explanation": "The apostrophe is required in сім'я́."}, {"sentence": "День — не пиши ден.", "errorWord": "ден", "correctForm": "день", "options": ["день", "ден"], "explanation": "День потребує м'якого знака."}, {"sentence": "Не пиши св'ято з апо́строфом.", "errorWord": "св'ято", "correctForm": "свя́то", "options": ["свя́то", "св'ято"], "explanation": "Свя́то — підготовлене слово без апо́строфа."}, {"sentence": "Не пиши льожка з вигаданим м'яки́м знаком.", "errorWord": "льожка", "correctForm": "ло́жка", "options": ["ло́жка", "вигадане написання з ь"], "explanation": "Ло́жка не має м'якого знака після л."}, {"sentence": "Не роби повну паузу в слові сім'я́.", "errorWord": "повну паузу", "correctForm": "плавний звук й", "options": ["плавний звук й", "full stop"], "explanation": "Апо́строф розділяє звуки, але не створює повної паузи."}]`)} isUkrainian={false} />
+<ErrorCorrection client:only='react' instruction="Обери правильну українську форму." items={JSON.parse(`[{"sentence": "Не пиши сімя без апо́строфа.", "errorWord": "сімя", "correctForm": "сім'я́", "options": ["сім'я́", "сімя"], "explanation": "У слові сім'я́ потрібен апо́строф."}, {"sentence": "День — не пиши ден.", "errorWord": "ден", "correctForm": "день", "options": ["день", "ден"], "explanation": "День потребує м'якого знака."}, {"sentence": "Не пиши св'ято з апо́строфом.", "errorWord": "св'ято", "correctForm": "свя́то", "options": ["свя́то", "св'ято"], "explanation": "У слові свя́то немає апо́строфа."}, {"sentence": "Не пиши льожка з вигаданим м'яки́м знаком.", "errorWord": "льожка", "correctForm": "ло́жка", "options": ["ло́жка", "льожка"], "explanation": "Ло́жка не має м'якого знака після л."}]`)} isUkrainian={false} />
 
-## Перенос, друк, зошит
+## Перенос і письмо
 
 You will sometimes see words split across a line in printed Ukrainian. At this
 level, use only prepared models:
@@ -239,19 +245,20 @@ level, use only prepared models:
 | Whole word | Safe line-break model |
 | --- | --- |
 | **Мар'я́на** | `Мар'-яна` |
-| **дерев'я́ний** | `дерев'-яний` |
+| **дерев'я́ний** | `дере-в'яний` |
 | **бур'я́н** | `бур'-ян` |
 | **па́льці** | `паль-ці` |
 
 The simple idea: **ь** and apostrophe stay with the letter before them. Also,
 do not leave one single letter alone on a line.
 
-**Друк / зошит** — recognition before writing.
+Reading before writing: first recognize the printed word, then copy the sign in
+a notebook cue.
 
 Use original text on this page, your own notebook, or live handwriting from a
-teacher/tutor. Do not copy a third-party handwriting sample.
+teacher/tutor.
 
-| Друк | Notebook recognition prompt |
+| Printed word | Notebook cue |
 | --- | --- |
 | **день** | find the soft sign at the end |
 | **сім'я́** | find the apostrophe before **я** |
@@ -275,24 +282,26 @@ Before you leave the lesson tab, check that you can do these things:
 - identify missing-apostrophe, missing-soft-sign, and invented-soft-sign
   errors.
 
-Use the signs as reading instructions, not decorations. A useful final routine
-is: find the sign, say what it does, then read the word once.
+Use the signs as reading instructions, not decorations. Before moving on,
+choose one word from each contrast and do a final sign check: name the sign,
+state its effect, then read the word.
 
 ### Практика переносу слів
 
-<DivideWords client:only='react' instruction={"Обери підготовлену модель переносу."} items={JSON.parse(`[{"word": "Мар'я́на", "answer": "Мар'-яна"}, {"word": "дерев'я́ний", "answer": "дерев'-яний"}, {"word": "бур'я́н", "answer": "бур'-ян"}, {"word": "па́льці", "answer": "паль-ці"}]`)} />
+<DivideWords client:only='react' instruction={"Обери підготовлену модель переносу."} items={JSON.parse(`[{"word": "Мар'я́на", "answer": "Мар'-яна"}, {"word": "дерев'я́ний", "answer": "дере-в'яний"}, {"word": "бур'я́н", "answer": "бур'-ян"}, {"word": "па́льці", "answer": "паль-ці"}]`)} />
 
 ## Далі
 
-Тепер переходь до словника й вправ. Keep using the same small routine: find
-the sign, say what it does, then read the word.
+**Далі** means next. Go to Vocabulary and Activities; those drills reuse the
+same six contrast words: **день**, **сім'я́**, **буря́к**, **бур'я́н**,
+**свя́то**, **цвях**.
 
 </TabItem>
 <TabItem label="Vocabulary">
 
-<VocabCard client:only="react" words={JSON.parse(`[{"word":"м'яки́й знак","translation":"soft sign","pos":"noun phrase","example":"Ь - м'яки́й знак.","examples":["soft sign","Ь - м'яки́й знак."],"atlas_href":"/lexicon/м-яки-й-знак/"},{"word":"апо́строф","translation":"apostrophe","pos":"noun","example":"У сло́ві «сім'я́» є апо́строф.","examples":["apostrophe","У сло́ві «сім'я́» є апо́строф."],"atlas_href":"/lexicon/апо-строф/"},{"word":"знак","translation":"sign","pos":"noun","example":"Це знак.","examples":["sign","Це знак."],"atlas_href":"/lexicon/знак/"},{"word":"м'яки́й","translation":"soft","pos":"adjective","example":"Це м'яки́й звук.","examples":["soft","Це м'яки́й звук."],"atlas_href":"/lexicon/м-яки-й/"},{"word":"тверди́й","translation":"hard","pos":"adjective","example":"Це тверди́й звук.","examples":["hard","Це тверди́й звук."],"atlas_href":"/lexicon/тверди-й/"},{"word":"йото́ваний","translation":"iotated","pos":"adjective","example":"Я - йото́вана лі́тера.","examples":["iotated","Я - йото́вана лі́тера."],"atlas_href":"/lexicon/йото-ваний/"},{"word":"розді́льно","translation":"separately","pos":"adverb","example":"Чита́й розді́льно.","examples":["separately","Чита́й розді́льно."],"atlas_href":"/lexicon/розді-льно/"},{"word":"зли́то","translation":"together / smoothly","pos":"adverb","example":"Чита́й зли́то.","examples":["together / smoothly","Чита́й зли́то."],"atlas_href":"/lexicon/зли-то/"},{"word":"день","translation":"day","pos":"noun","example":"День.","examples":["day","День."],"atlas_href":"/lexicon/день/"},{"word":"кінь","translation":"horse","pos":"noun","example":"Кінь.","examples":["horse","Кінь."],"atlas_href":"/lexicon/кінь/"},{"word":"сіль","translation":"salt","pos":"noun","example":"Сіль.","examples":["salt","Сіль."],"atlas_href":"/lexicon/сіль/"},{"word":"вчи́тель","translation":"teacher","pos":"noun","example":"Вчи́тель.","examples":["teacher","Вчи́тель."],"atlas_href":"/lexicon/вчитель/"},{"word":"сім'я́","translation":"family","pos":"noun","example":"Сім'я́.","examples":["family","Сім'я́."],"atlas_href":"/lexicon/сім-я/"},{"word":"м'я́со","translation":"meat","pos":"noun","example":"М'я́со.","examples":["meat","М'я́со."],"atlas_href":"/lexicon/м-ясо/"},{"word":"п'ять","translation":"five","pos":"numeral","example":"П'ять.","examples":["five","П'ять."],"atlas_href":"/lexicon/п-ять/"},{"word":"де́в'ять","translation":"nine","pos":"numeral","example":"Де́в'ять.","examples":["nine","Де́в'ять."],"atlas_href":"/lexicon/дев-ять/"},{"word":"ім'я́","translation":"name","pos":"noun","example":"Ім'я́.","examples":["name","Ім'я́."],"atlas_href":"/lexicon/ім-я/"},{"word":"комп'ю́тер","translation":"computer","pos":"noun","example":"Комп'ю́тер.","examples":["computer","Комп'ю́тер."],"atlas_href":"/lexicon/комп-ю-тер/"},{"word":"буря́к","translation":"beetroot","pos":"noun","example":"Буря́к.","examples":["beetroot","Буря́к."],"atlas_href":"/lexicon/буряк/"},{"word":"бур'я́н","translation":"weed","pos":"noun","example":"Бур'я́н.","examples":["weed","Бур'я́н."],"atlas_href":"/lexicon/бур-я-н/"},{"word":"свя́то","translation":"holiday","pos":"noun","example":"Свя́то.","examples":["holiday","Свя́то."],"atlas_href":"/lexicon/свято/"},{"word":"цвях","translation":"nail","pos":"noun","example":"Цвях.","examples":["nail","Цвях."],"atlas_href":"/lexicon/цвях/"},{"word":"мале́нький","translation":"small","pos":"adjective","example":"Мале́нький день.","examples":["small","Мале́нький день."],"atlas_href":"/lexicon/мале-нький/"},{"word":"сього́дні","translation":"today","pos":"adverb","example":"Сього́дні день.","examples":["today","Сього́дні день."],"atlas_href":"/lexicon/сьогодні/"},{"word":"ба́тько","translation":"father","pos":"noun","example":"Ба́тько.","examples":["father","Ба́тько."],"atlas_href":"/lexicon/батько/"},{"word":"ло́жка","translation":"spoon","pos":"noun","example":"Ло́жка.","examples":["spoon","Ло́жка."],"atlas_href":"/lexicon/ло-жка/"},{"word":"Мар'я́на","translation":"Mariana","pos":"proper noun","example":"Мар'я́на.","examples":["Mariana","Мар'я́на."],"atlas_href":"/lexicon/мар-я-на/"},{"word":"дерев'я́ний","translation":"wooden","pos":"adjective","example":"Дерев'я́ний стіл.","examples":["wooden","Дерев'я́ний стіл."],"atlas_href":"/lexicon/дерев-я-ний/"},{"word":"па́льці","translation":"fingers","pos":"noun","example":"Па́льці.","examples":["fingers","Па́льці."],"atlas_href":"/lexicon/па-льці/"}]`)} title="Vocabulary" />
+<VocabCard client:only="react" words={JSON.parse(`[{"word":"м'яки́й знак","translation":"soft sign","pos":"noun phrase","example":"Ь - м'яки́й знак.","examples":["soft sign","Ь - м'яки́й знак."],"atlas_href":"/lexicon/м-яки-й-знак/"},{"word":"апо́строф","translation":"apostrophe","pos":"noun","example":"У сло́ві «сім'я́» є апо́строф.","examples":["apostrophe","У сло́ві «сім'я́» є апо́строф."],"atlas_href":"/lexicon/апо-строф/"},{"word":"знак","translation":"sign","pos":"noun","example":"Це знак.","examples":["sign","Це знак."],"atlas_href":"/lexicon/знак/"},{"word":"м'яки́й","translation":"soft","pos":"adjective","example":"Це м'яки́й звук.","examples":["soft","Це м'яки́й звук."],"atlas_href":"/lexicon/м-яки-й/"},{"word":"тверди́й","translation":"hard","pos":"adjective","example":"Це тверди́й звук.","examples":["hard","Це тверди́й звук."],"atlas_href":"/lexicon/тверди-й/"},{"word":"йото́ваний","translation":"iotated","pos":"adjective","example":"Я - йото́вана лі́тера.","examples":["iotated","Я - йото́вана лі́тера."],"atlas_href":"/lexicon/йото-ваний/"},{"word":"розді́льно","translation":"separately","pos":"adverb","example":"Чита́й розді́льно.","examples":["separately","Чита́й розді́льно."],"atlas_href":"/lexicon/розді-льно/"},{"word":"зли́то","translation":"together / smoothly","pos":"adverb","example":"Чита́й зли́то.","examples":["together / smoothly","Чита́й зли́то."]},{"word":"день","translation":"day","pos":"noun","example":"День.","examples":["day","День."],"atlas_href":"/lexicon/день/"},{"word":"кінь","translation":"horse","pos":"noun","example":"Кінь.","examples":["horse","Кінь."],"atlas_href":"/lexicon/кінь/"},{"word":"сіль","translation":"salt","pos":"noun","example":"Сіль.","examples":["salt","Сіль."],"atlas_href":"/lexicon/сіль/"},{"word":"вчи́тель","translation":"teacher","pos":"noun","example":"Вчи́тель.","examples":["teacher","Вчи́тель."],"atlas_href":"/lexicon/вчитель/"},{"word":"сім'я́","translation":"family","pos":"noun","example":"Сім'я́.","examples":["family","Сім'я́."],"atlas_href":"/lexicon/сім-я/"},{"word":"м'я́со","translation":"meat","pos":"noun","example":"М'я́со.","examples":["meat","М'я́со."],"atlas_href":"/lexicon/м-ясо/"},{"word":"п'ять","translation":"five","pos":"numeral","example":"П'ять.","examples":["five","П'ять."],"atlas_href":"/lexicon/п-ять/"},{"word":"де́в'ять","translation":"nine","pos":"numeral","example":"Де́в'ять.","examples":["nine","Де́в'ять."],"atlas_href":"/lexicon/дев-ять/"},{"word":"ім'я́","translation":"name","pos":"noun","example":"Ім'я́.","examples":["name","Ім'я́."],"atlas_href":"/lexicon/ім-я/"},{"word":"здоро́в'я","translation":"health","pos":"noun","example":"Здоро́в'я.","examples":["health","Здоро́в'я."],"atlas_href":"/lexicon/здоров-я/"},{"word":"комп'ю́тер","translation":"computer","pos":"noun","example":"Комп'ю́тер.","examples":["computer","Комп'ю́тер."],"atlas_href":"/lexicon/комп-ю-тер/"},{"word":"буря́к","translation":"beetroot","pos":"noun","example":"Буря́к.","examples":["beetroot","Буря́к."],"atlas_href":"/lexicon/буряк/"},{"word":"бур'я́н","translation":"weed","pos":"noun","example":"Бур'я́н.","examples":["weed","Бур'я́н."],"atlas_href":"/lexicon/бур-я-н/"},{"word":"свя́то","translation":"holiday","pos":"noun","example":"Свя́то.","examples":["holiday","Свя́то."],"atlas_href":"/lexicon/свято/"},{"word":"цвях","translation":"nail","pos":"noun","example":"Цвях.","examples":["nail","Цвях."],"atlas_href":"/lexicon/цвях/"},{"word":"мале́нький","translation":"small","pos":"adjective","example":"Мале́нький знак.","examples":["small","Мале́нький знак."],"atlas_href":"/lexicon/мале-нький/"},{"word":"сього́дні","translation":"today","pos":"adverb","example":"Сього́дні свя́то.","examples":["today","Сього́дні свя́то."],"atlas_href":"/lexicon/сьогодні/"},{"word":"ло́жка","translation":"spoon","pos":"noun","example":"Ло́жка.","examples":["spoon","Ло́жка."],"atlas_href":"/lexicon/ло-жка/"},{"word":"Мар'я́на","translation":"Mariana","pos":"proper noun","example":"Мар'я́на.","examples":["Mariana","Мар'я́на."],"atlas_href":"/lexicon/мар-я-на/"},{"word":"дерев'я́ний","translation":"wooden","pos":"adjective","example":"Дерев'я́ний стіл.","examples":["wooden","Дерев'я́ний стіл."],"atlas_href":"/lexicon/дерев-я-ний/"},{"word":"па́льці","translation":"fingers","pos":"noun","example":"Па́льці.","examples":["fingers","Па́льці."]}]`)} title="Vocabulary" />
 
-<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"м'яки́й знак","back":"soft sign"},{"front":"апо́строф","back":"apostrophe"},{"front":"знак","back":"sign"},{"front":"м'яки́й","back":"soft"},{"front":"тверди́й","back":"hard"},{"front":"йото́ваний","back":"iotated"},{"front":"розді́льно","back":"separately"},{"front":"зли́то","back":"together / smoothly"},{"front":"день","back":"day"},{"front":"кінь","back":"horse"},{"front":"сіль","back":"salt"},{"front":"вчи́тель","back":"teacher"},{"front":"сім'я́","back":"family"},{"front":"м'я́со","back":"meat"},{"front":"п'ять","back":"five"},{"front":"де́в'ять","back":"nine"},{"front":"ім'я́","back":"name"},{"front":"комп'ю́тер","back":"computer"},{"front":"буря́к","back":"beetroot"},{"front":"бур'я́н","back":"weed"},{"front":"свя́то","back":"holiday"},{"front":"цвях","back":"nail"},{"front":"мале́нький","back":"small"},{"front":"сього́дні","back":"today"},{"front":"ба́тько","back":"father"},{"front":"ло́жка","back":"spoon"},{"front":"Мар'я́на","back":"Mariana"},{"front":"дерев'я́ний","back":"wooden"},{"front":"па́льці","back":"fingers"}]`)} />
+<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"м'яки́й знак","back":"soft sign"},{"front":"апо́строф","back":"apostrophe"},{"front":"знак","back":"sign"},{"front":"м'яки́й","back":"soft"},{"front":"тверди́й","back":"hard"},{"front":"йото́ваний","back":"iotated"},{"front":"розді́льно","back":"separately"},{"front":"зли́то","back":"together / smoothly"},{"front":"день","back":"day"},{"front":"кінь","back":"horse"},{"front":"сіль","back":"salt"},{"front":"вчи́тель","back":"teacher"},{"front":"сім'я́","back":"family"},{"front":"м'я́со","back":"meat"},{"front":"п'ять","back":"five"},{"front":"де́в'ять","back":"nine"},{"front":"ім'я́","back":"name"},{"front":"здоро́в'я","back":"health"},{"front":"комп'ю́тер","back":"computer"},{"front":"буря́к","back":"beetroot"},{"front":"бур'я́н","back":"weed"},{"front":"свя́то","back":"holiday"},{"front":"цвях","back":"nail"},{"front":"мале́нький","back":"small"},{"front":"сього́дні","back":"today"},{"front":"ло́жка","back":"spoon"},{"front":"Мар'я́на","back":"Mariana"},{"front":"дерев'я́ний","back":"wooden"},{"front":"па́льці","back":"fingers"}]`)} />
 
 </TabItem>
 <TabItem label="Activities">
@@ -315,23 +324,35 @@ the sign, say what it does, then read the word.
 
 ### Практика переносу слів
 
-*(see lesson, §Перенос, друк, зошит)*
+*(see lesson, §Перенос і письмо)*
 
 ### Сортуй за знаком
 
 <GroupSort client:only='react' groups={JSON.parse(`{"Є ь": ["день", "кінь", "сіль", "вчи́тель", "мале́нький"], "Є апо́строф": ["сім'я́", "м'я́со", "п'ять", "комп'ю́тер", "бур'я́н"], "Немає знака": ["буря́к", "свя́то", "цвях", "ло́жка"]}`)} instruction={"Розподіли кожне слово в правильну групу."} isUkrainian={false} />
 
+### Поясни контраст
+
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "буря́к", "right": "м'якість без апо́строфа: р + я"}, {"left": "бур'я́н", "right": "апо́строф: р твердий, потім [йа]"}, {"left": "свя́то", "right": "збіг св + я без апо́строфа"}, {"left": "цвях", "right": "збіг цв + я без апо́строфа"}]`)} instruction={"З'єднай слово з поясненням."} isUkrainian={false} />
+
+### Виправ усі пастки
+
+<ErrorCorrection client:only='react' instruction="Обери правильну українську форму." items={JSON.parse(`[{"sentence": "Не пиши сімя без апо́строфа.", "errorWord": "сімя", "correctForm": "сім'я́", "options": ["сім'я́", "сімя"], "explanation": "У слові сім'я́ потрібен апо́строф."}, {"sentence": "Не пиши пять без апо́строфа.", "errorWord": "пять", "correctForm": "п'ять", "options": ["п'ять", "пять"], "explanation": "У слові п'ять потрібен апо́строф."}, {"sentence": "Не пиши бурян без апо́строфа.", "errorWord": "бурян", "correctForm": "бур'я́н", "options": ["бур'я́н", "бурян"], "explanation": "У слові бур'я́н потрібен апо́строф після р."}, {"sentence": "День — не пиши ден.", "errorWord": "ден", "correctForm": "день", "options": ["день", "ден"], "explanation": "День потребує м'якого знака."}, {"sentence": "Не пиши св'ято з апо́строфом.", "errorWord": "св'ято", "correctForm": "свя́то", "options": ["свя́то", "св'ято"], "explanation": "У слові свя́то немає апо́строфа."}, {"sentence": "Не пиши льожка з вигаданим м'яки́м знаком.", "errorWord": "льожка", "correctForm": "ло́жка", "options": ["ло́жка", "льожка"], "explanation": "Ло́жка не має м'якого знака після л."}]`)} isUkrainian={false} />
+
 ### Факти про знаки
 
-<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Ь не має власного звука.", "isTrue": true, "explanation": "Він м'якшить попередній при́голосний."}, {"statement": "Апо́строф тримає попередній при́голосний твердим.", "isTrue": true, "explanation": "Він відділяє при́голосний від йотованої голосної."}, {"statement": "Ї іноді мовчить.", "isTrue": false, "explanation": "Ї завжди читаємо як [йі]."}, {"statement": "Свя́то має апо́строф.", "isTrue": false, "explanation": "Свя́то — модельне слово без апо́строфа."}]`)} instruction={"Обери правда чи неправда."} isUkrainian={false} />
+<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Ь не має власного звука.", "isTrue": true, "explanation": "Він пом'якшує попередній при́голосний."}, {"statement": "Апо́строф тримає попередній при́голосний твердим.", "isTrue": true, "explanation": "Він відділяє при́голосний від йотованої голосної."}, {"statement": "Ї іноді мовчить.", "isTrue": false, "explanation": "Ї завжди читаємо як [йі]."}, {"statement": "Свя́то має апо́строф.", "isTrue": false, "explanation": "Свя́то — модельне слово без апо́строфа."}]`)} instruction={"Обери: правда чи неправда."} isUkrainian={false} />
 
-### Друк і зошит
+### Додай знак у нових словах
 
-<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "друк: день", "right": "зошит: слово з кінцевим ь"}, {"left": "друк: сім'я́", "right": "зошит: apostrophe before я"}, {"left": "друк: п'ять", "right": "зошит: апо́строф і кінцевий ь"}, {"left": "друк: свя́то", "right": "зошит: no apostrophe"}, {"left": "друк: бур'я́н", "right": "зошит: apostrophe after р"}]`)} instruction={"З'єднай друковане слово з підказкою в зо́шиті."} isUkrainian={false} />
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "бур_ян", "answer": "'", "options": ["'", "ь", "без знака"]}, {"sentence": "комп_ютер", "answer": "'", "options": ["'", "ь", "без знака"]}, {"sentence": "ім_я", "answer": "'", "options": ["'", "ь", "без знака"]}, {"sentence": "У слові мален_кий потрібен ____.", "answer": "ь", "options": ["ь", "'", "без знака"]}, {"sentence": "У слові цвях правильний вибір — ____.", "answer": "без знака", "options": ["без знака", "'", "ь"]}]`)} instruction={"Обери ь, апо́строф або без знака."} isUkrainian={false} />
 
 ### Правильна форма
 
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "Сім'я́ — яка форма правильна?", "options": [{"text": "сім'я́", "correct": true}, {"text": "сімя без апо́строфа", "correct": false}], "explanation": "Сім'я́ потребує апо́строфа."}, {"question": "День — яка форма правильна?", "options": [{"text": "день", "correct": true}, {"text": "ден", "correct": false}], "explanation": "День потребує м'якого знака."}, {"question": "Слово без апо́строфа?", "options": [{"text": "свя́то", "correct": true}, {"text": "apostrophe spelling", "correct": false}], "explanation": "Свя́то — підготовлене слово без апо́строфа."}]`)} instruction={"Обери правильно написане слово."} isUkrainian={false} />
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Сім'я́ — яка форма правильна?", "options": [{"text": "сім'я́", "correct": true}, {"text": "сімя", "correct": false}], "explanation": "Сім'я́ потребує апо́строфа."}, {"question": "День — яка форма правильна?", "options": [{"text": "ден", "correct": false}, {"text": "день", "correct": true}], "explanation": "День потребує м'якого знака."}, {"question": "Слово без апо́строфа?", "options": [{"text": "св'ято", "correct": false}, {"text": "свя́то", "correct": true}], "explanation": "У слові свя́то немає апо́строфа."}]`)} instruction={"Обери правильно написане слово."} isUkrainian={false} />
+
+### Зайве за знаком
+
+<OddOneOut client:only='react' instruction={"Обери слово, яке не має такого самого знака, як інші."} items={JSON.parse(`[{"words": ["сім'я́", "м'я́со", "п'ять", "буря́к"], "correct": 3, "explanation": "Буря́к без апо́строфа; інші слова мають апо́строф."}, {"words": ["день", "кінь", "сіль", "свя́то"], "correct": 3, "explanation": "Свя́то без ь; інші слова мають м'який знак."}, {"words": ["буря́к", "свя́то", "цвях", "бур'я́н"], "correct": 3, "explanation": "Бур'я́н має апо́строф; інші слова тут без знака."}]`)} />
 
 </TabItem>
 <TabItem label="Resources">
@@ -339,10 +360,10 @@ the sign, say what it does, then read the word.
 :::info[🎧 🔗 External Resources]
 
 **📚 Books:**
-- 📚 **Авраменко, 5 клас, p. 75**
-  soft sign as a marker of consonant softness.
 - 📚 **Большакова, 2 клас, p. 58-59**
-  apostrophe and line-break models.
+  Apostrophe as hard consonant + [йа], and transfer models Мар'-яна / Дере-в'яний.
+- 📚 **Вашуленко, 3 клас, p. 90**
+  Line-break rule: apostrophe is not separated from the previous letter.
 - 📚 **Захарійчук, 1 клас (НУШ 2025), p. 97**
   basic apostrophe rule before я, ю, є, ї.
 :::


### PR DESCRIPTION
## Summary

Certifies A1 M03 `special-signs` for live-content quality.

Route: `/a1/special-signs/`

Changed files:
- `curriculum/l2-uk-en/a1/special-signs/module.md`
- `curriculum/l2-uk-en/a1/special-signs/activities.yaml`
- `curriculum/l2-uk-en/a1/special-signs/vocabulary.yaml`
- `curriculum/l2-uk-en/a1/special-signs/resources.yaml`
- `site/src/content/docs/a1/special-signs.mdx`

## Content Notes

- Reworked the lesson around the locked `день / сім'я / буряк / бур'ян / свято / цвях` contrasts.
- Fixed transfer model to `дере-в'яний` and clarified apostrophe/soft-sign line-break behavior.
- Split activities into 5 inline checks and 7 workbook drills, including the plan-required contrast match-up, fill-ins, full error-correction set, group-sort, and odd-one-out practice.
- Added plan-recommended `здоро́в'я`, removed unsupported `ба́тько`, and tightened thin usage examples.
- Kept framing Ukrainian-centered without Russian-as-reference explanation.

## Quality Gates

Canonical LLM QG (`codex-tools` writer, `claude-tools` reviewer): terminal PASS
- pedagogical: 8.5 PASS
- naturalness: 8.4 PASS
- decolonization: 9.4 PASS
- engagement: 8.2 PASS
- tone: 8.3 PASS

Opus final content review: APPROVE

Agy review note: a focused Agy run approved the concrete earlier blockers; later Agy invocations produced false positives from stale non-schema rules (e.g. invented 12-item activity density / IPA requirements and claims that removed text still existed). I did not apply those because repo validators and canonical QG/Opus contradicted them.

Deterministic validation:
- `.venv/bin/python scripts/validate_plan_config.py --quiet a1` PASS
- `.venv/bin/python scripts/validate_activities.py l2-uk-en a1` PASS
- `.venv/bin/python scripts/generate_mdx.py l2-uk-en a1 3 --validate` PASS
- `.venv/bin/python scripts/audit/check_mdx_generation_drift.py --files curriculum/l2-uk-en/a1/special-signs/module.md curriculum/l2-uk-en/a1/special-signs/activities.yaml curriculum/l2-uk-en/a1/special-signs/vocabulary.yaml curriculum/l2-uk-en/a1/special-signs/resources.yaml site/src/content/docs/a1/special-signs.mdx` PASS
- `.venv/bin/python scripts/audit/check_mdx_source_parity.py --files site/src/content/docs/a1/special-signs.mdx` PASS
- `git diff --check` PASS
- `npm run build --prefix site -- --outDir /tmp/learn-ukrainian-a1-m03-dist` PASS, 2613 pages built, includes `/a1/special-signs/index.html`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` PASS

## Telemetry

- run_id: `a1-m03-special-signs-quality-20260616`
- branch: `codex/a1-m03-special-signs-quality`
- commit_sha: `478732f9d133142b09c22ec51c019393b1f42eeb`
- status: ready
- swarm_used: true
- swarm_label: thin
- swarm_note: Used required QG plus Opus and Agy reviewer passes/checks; no helper editors.