### PR TITLE
fix(a1): certify m04 stress and melody

### DIFF
--- a/curriculum/l2-uk-en/a1/stress-and-melody/activities.yaml
+++ b/curriculum/l2-uk-en/a1/stress-and-melody/activities.yaml
@@ -2,9 +2,9 @@ inline:
   - id: act-1
     type: quiz
     title: Де на́голос
-    instruction: Спочатку слухай, потім обери склад із позначеним на́голосом.
+    instruction: Обери склад із позначеним на́голосом.
     items:
-      - prompt: 'Слухай, потім читай: ка́ва. Де на́голос?'
+      - prompt: 'Читай: ка́ва. Де на́голос?'
         options:
           - text: перший склад
             correct: true
@@ -13,7 +13,7 @@ inline:
           - text: немає наголосу
             correct: false
         explanation: У слові ка́ва на́голос на ка́.
-      - prompt: 'Слухай, потім читай: вода́. Де на́голос?'
+      - prompt: 'Читай: вода́. Де на́голос?'
         options:
           - text: останній склад
             correct: true
@@ -22,7 +22,7 @@ inline:
           - text: усі склади однакові
             correct: false
         explanation: У слові вода́ на́голос на да́.
-      - prompt: 'Слухай, потім читай: столи́ця. Де на́голос?'
+      - prompt: 'Читай: столи́ця. Де на́голос?'
         options:
           - text: середній склад
             correct: true
@@ -74,22 +74,31 @@ inline:
             correct: false
         explanation: Оклик має сильнішу спадну мелодику.
   - id: act-3
-    type: match-up
-    title: На́голос змінює значення
-    instruction: З'єднай наголошене слово з короткою англійською підказкою.
-    pairs:
-      - left: за́мок
-        right: castle
-      - left: замо́к
-        right: lock
-      - left: а́тлас
-        right: atlas
-      - left: атла́с
-        right: satin
-      - left: о́рган
-        right: body organ
-      - left: орга́н
-        right: musical instrument
+    type: quiz
+    title: Швидкий контраст
+    instruction: Обери коротку англійську підказку.
+    items:
+      - prompt: за́мок
+        options:
+          - text: castle
+            correct: true
+          - text: lock
+            correct: false
+        explanation: За́мок із наголосом на першому складі — castle.
+      - prompt: замо́к
+        options:
+          - text: lock
+            correct: true
+          - text: castle
+            correct: false
+        explanation: Замо́к із наголосом на останньому складі — lock.
+      - prompt: сім'я́
+        options:
+          - text: family
+            correct: true
+          - text: seed
+            correct: false
+        explanation: Сім'я́ з фінальним наголосом — family.
   - id: act-4
     type: fill-in
     title: Пунктуація і мелодика
@@ -130,46 +139,108 @@ inline:
           - '?'
           - '!'
         explanation: Це твердження.
-workbook:
-  - type: error-correction
-    title: Виправ пастки наголосу
-    instruction: Обери безпечнішу українську читацьку звичку.
+  - id: act-5
+    type: fill-in
+    title: Типові пастки наголосу
+    instruction: Обери нормативну форму з позначеним наголосом.
     items:
-      - sentence: Молоко́ — тримай усі голосні чистими.
-        error: нечіткі перші два голосні
-        correction: мо-ло-ко́
+      - sentence: "Це мій ___ комп'ютер."
+        answer: нови́й
         options:
-          - мо-ло-ко́
-          - нечіткі голосні
-        explanation: Українські голосні залишаються чистими поза на́голосом.
-      - sentence: Кіломе́тр — став на́голос на -ме́тр.
-        error: кі́лометр
-        correction: кіломе́тр
+          - нови́й
+          - но́вий
+        explanation: У слові нови́й наголос наприкінці.
+      - sentence: "Мій дідусь ___."
+        answer: стари́й
         options:
-          - кіломе́тр
-          - кі́лометр
-        explanation: Підготовлена модель — кіломе́тр.
-      - sentence: Кни́жка / книжки́ — помічай рухомий на́голос.
-        error: кни́жки
-        correction: книжки́
-        options:
-          - книжки́
-          - кни́жки
-        explanation: У цій множинній моделі на́голос переходить на закінчення.
-      - sentence: Одина́дцять — наголос на -на́-.
-        error: о́динадцять
-        correction: одина́дцять
+          - стари́й
+          - ста́рий
+        explanation: У слові стари́й наголос наприкінці.
+      - sentence: "У мене ___ гривень."
+        answer: одина́дцять
         options:
           - одина́дцять
           - о́динадцять
-        explanation: Ціль A1 має на́голос на -на́-.
-      - sentence: Чотирна́дцять — наголос на -на́-.
-        error: чоти́рнадцять
-        correction: чотирна́дцять
+        explanation: Одина́дцять має наголос на -на́-.
+      - sentence: "Я знаю ___ нових слів."
+        answer: чотирна́дцять
         options:
           - чотирна́дцять
           - чоти́рнадцять
-        explanation: Ціль A1 має на́голос на -на́-.
+        explanation: Чотирна́дцять теж має наголос на -на́-.
+      - sentence: "Множина слова голова́: ___."
+        answer: го́лови
+        options:
+          - го́лови
+          - голови́
+        explanation: У цій словниковій парі наголос рухається.
+      - sentence: "Мене звати ___."
+        answer: Марі́я
+        options:
+          - Марі́я
+          - Ма́рія
+        explanation: У цьому імені наголос на рі́.
+workbook:
+  - type: fill-in
+    title: Типові помилки наголосу
+    instruction: Обери нормативну форму з позначеним наголосом.
+    items:
+      - sentence: "новий: ___"
+        answer: нови́й
+        options:
+          - нови́й
+          - но́вий
+        explanation: У слові нови́й наголос на останній частині.
+      - sentence: "старий: ___"
+        answer: стари́й
+        options:
+          - стари́й
+          - ста́рий
+        explanation: У слові стари́й наголос на останній частині.
+      - sentence: "одинадцять: ___"
+        answer: одина́дцять
+        options:
+          - одина́дцять
+          - о́динадцять
+        explanation: Одина́дцять має наголос на -на́-.
+      - sentence: "чотирнадцять: ___"
+        answer: чотирна́дцять
+        options:
+          - чотирна́дцять
+          - чоти́рнадцять
+        explanation: Чотирна́дцять теж має наголос на -на́-.
+      - sentence: "множина слова голова́: ___"
+        answer: го́лови
+        options:
+          - го́лови
+          - голови́
+        explanation: "У цій парі наголос рухається: голова́, але го́лови."
+      - sentence: "ім'я: ___"
+        answer: Марі́я
+        options:
+          - Марі́я
+          - Ма́рія
+        explanation: У цьому імені наголос на рі́.
+  - type: match-up
+    title: На́голос змінює значення
+    instruction: З'єднай наголошене слово з короткою англійською підказкою.
+    pairs:
+      - left: за́мок
+        right: castle
+      - left: замо́к
+        right: lock
+      - left: а́тлас
+        right: atlas
+      - left: атла́с
+        right: satin
+      - left: о́рган
+        right: body organ
+      - left: орга́н
+        right: musical instrument
+      - left: сі́м'я
+        right: seed
+      - left: сім'я́
+        right: family
   - type: group-sort
     title: Сортуй за наголосом
     instruction: Розподіли кожне слово за позначеним наголошеним складом.

--- a/curriculum/l2-uk-en/a1/stress-and-melody/module.md
+++ b/curriculum/l2-uk-en/a1/stress-and-melody/module.md
@@ -2,16 +2,13 @@
 
 **ка́ва. вода́. Це ка́ва? Де метро́?** — stress and sentence melody.
 
-First listen, then read. Use the lawful public resource already listed for
-this module: [ULP Season 1, Episode 5 — Pronunciation
-Trainer](https://www.ukrainianlessons.com/episode5/). Open the page, listen
-for the stress practice, and repeat short model words. Do not download,
-transcribe, remix, or reuse the audio; this lesson only links to it for
-listening support.
+Teacher Oksana starts with a tiny routine: listen, mark, repeat. If you have a
+teacher or tutor, let them read one word first. If you are working alone, read
+the stress mark first and then say the word slowly.
 
 Today you are not memorizing every stress pattern in Ukrainian. You are
-learning why stress matters, how to read prepared words with stress marks, and
-how to use three beginner sentence melodies.
+learning why stress matters, how to read words with stress marks, and how to
+use three beginner sentence melodies.
 
 By the end, you can:
 
@@ -26,6 +23,12 @@ By the end, you can:
   **як**;
 - read a short greeting dialogue with Ukrainian rhythm.
 
+:::tip
+If you want extra listening support, open [ULP Season 1, Episode 5 —
+Pronunciation Trainer](https://www.ukrainianlessons.com/episode5/) from the
+Resources tab and copy only short model words.
+:::
+
 ## Наголос
 
 **ка́ва. вода́. молоко́.** Listen first, then read the marks.
@@ -35,13 +38,11 @@ In learning materials, this course marks it with an accent: **ка́ва**,
 **вода́**, **молоко́**. In ordinary Ukrainian texts, the mark is usually
 absent, so you learn stress as part of each new word.
 
-Use this listening pass before the table:
+Use this quick pass before the table:
 
-1. Open the linked ULP Episode 5 page.
-2. Listen for one short stress model.
-3. Without reading the English support, point to the stronger syllable in the
-   marked word.
-4. Repeat the word once.
+1. Point to the stress mark.
+2. Say only the stronger syllable.
+3. Say the whole word once.
 
 Ukrainian stress is free. It can fall near the beginning, middle, or end of a
 word.
@@ -52,9 +53,9 @@ word.
 | final syllable | **вода́**, **зима́**, **рука́**, **метро́**, **кафе́** |
 | middle syllable | **столи́ця**, **люди́на**, **одина́дцять** |
 
-There is no useful shortcut for A1 learners. Treat stress as part of the word,
-just like spelling. When you add a word to your notebook, add its stress too:
-**ка́ва**, not just кава.
+There is no useful shortcut for A1 learners. That is normal. Treat stress as
+part of the word, just like spelling. When you add a word to your notebook,
+add its stress too: **ка́ва**, not just кава.
 
 A second habit matters just as much: do not blur unstressed vowels. In
 **молоко́**, the first two **о** sounds stay **о**. They are lighter than the
@@ -62,7 +63,7 @@ stressed final **о**, but they stay clear. Read slowly first:
 **мо-ло-ко́**. Keep every vowel clear, then speed up.
 
 Some Ukrainian words move stress when the form changes. For now, only notice
-the idea. **кни́жка** can become **книжки́** in plural. That is a future
+the idea. **голова́** can become **го́лови** in plural. That is a future
 grammar habit, but you can already hear that Ukrainian stress can move.
 
 Stress can also change meaning:
@@ -75,11 +76,21 @@ Stress can also change meaning:
 | **атла́с** | satin |
 | **о́рган** | body organ |
 | **орга́н** | musical instrument |
+| **сі́м'я** | seed |
+| **сім'я́** | family |
 
 Do not guess these from spelling alone. Use the stress mark when it is given,
 and check a dictionary such as goroh.pp.ua when you are unsure.
 
+:::tip
+You already saw **за́мок** and **замо́к**, and you already know **сім'я́**
+from Module 3. Here they are reminders, not a new memory load: the mark is
+small, but it can carry meaning.
+:::
+
 <!-- INJECT_ACTIVITY: act-1 -->
+
+<!-- INJECT_ACTIVITY: act-3 -->
 
 ## Мелодика
 
@@ -96,8 +107,6 @@ three safe models:
 
 The punctuation helps you choose the melody, but your voice must still do the
 work.
-
-<!-- INJECT_ACTIVITY: act-4 -->
 
 Now add the most important beginner exception. A question with a question word
 usually falls, not rises:
@@ -117,13 +126,20 @@ But a yes/no question rises:
 | **Це вода́?** | rising **↗** |
 | **А у те́бе?** | rising **↗** |
 
-Logical stress is the important word inside the sentence. In **Це ка́ва?**,
-you can make **ка́ва** the important word if you are checking the object. In
-**А у те́бе?**, the important part is **те́бе** because you are turning the
-question back to the other person.
+<!-- INJECT_ACTIVITY: act-4 -->
+
+Logical stress means the important word inside the sentence. Keep this simple
+today. In **Це ка́ва?**, the important word is **ка́ва** because you are
+checking the object. In **А у те́бе?**, the important part is **те́бе** because
+you are turning the question back to the other person.
 
 Keep the explanation Ukrainian-centered. Listen to the Ukrainian words, notice
 the stress, and copy the contour.
+
+:::tip
+Do not worry if your melody feels slow at first. Slow and clear is the right
+A1 target.
+:::
 
 <!-- INJECT_ACTIVITY: act-2 -->
 
@@ -201,21 +217,21 @@ English support after the Ukrainian dialogue:
 | **Ось вода́.** | Here is water. |
 | **Як га́рно!** | How nice! |
 
-<!-- INJECT_ACTIVITY: act-3 -->
-
 Common traps now become workbook habits:
 
 | Trap | Safer Ukrainian habit |
 | --- | --- |
 | blurring unstressed vowels in **молоко́** | keep **мо-ло-ко́** clear |
-| reading **кіломе́тр** with first-syllable stress | stress the **-ме́тр** part |
-| keeping stress fixed in **кни́жка / книжки́** | notice that stress can move |
+| reading **нови́й** or **стари́й** with early stress | stress the final part |
+| keeping stress fixed in **голова́ / го́лови** | notice that stress can move |
 | always emphasizing a pronoun | put logical stress on the meaningful word |
-| reading **мале́нький** with first-syllable stress | stress the middle part of **мале́нький** |
+| reading **Марі́я** with first-syllable stress | stress the **рі́** part |
 | reading **одина́дцять** or **чотирна́дцять** with early stress | stress **на́** |
 
 You do not need to produce all of these words fluently today. You need to
 recognize the safer habit and avoid building the wrong one.
+
+<!-- INJECT_ACTIVITY: act-5 -->
 
 ## Друк, зошит, голос
 
@@ -255,5 +271,9 @@ Ask a native Ukrainian teacher or tutor to listen to one read-aloud from this
 module. The feedback target is narrow: stress, clear vowels, and the direction
 of the sentence melody.
 
-The workbook adds extra practice with the same skills: clear-vowel repair,
-stress sorting, quick facts, and word recognition.
+You can now read a marked Ukrainian word, keep vowels clear, and choose the
+first safe melody for a statement or question. Next, Module 5 uses this sound
+control when you introduce yourself.
+
+The workbook adds extra practice with the same skills: stress sorting,
+stress-transfer repair, quick facts, and word recognition.

--- a/curriculum/l2-uk-en/a1/stress-and-melody/resources.yaml
+++ b/curriculum/l2-uk-en/a1/stress-and-melody/resources.yaml
@@ -11,3 +11,7 @@
   source_ref: ULP Season 1, Episode 5 — Pronunciation Trainer
   url: https://www.ukrainianlessons.com/episode5/
   notes: 'Plan reference: beginner stress practice with numerals.'
+- title: 'Wiki: pedagogy/a1/stress-and-melody (LOCKED 2026-04-23)'
+  role: wiki
+  source_ref: 'Wiki: pedagogy/a1/stress-and-melody (LOCKED 2026-04-23)'
+  notes: 'Locked pedagogical brief for stress-transfer examples and beginner intonation contours.'

--- a/curriculum/l2-uk-en/a1/stress-and-melody/vocabulary.yaml
+++ b/curriculum/l2-uk-en/a1/stress-and-melody/vocabulary.yaml
@@ -22,10 +22,6 @@
   translation: vowel
   pos: adjective / noun
   usage: Голосний звук.
-- lemma: звук
-  translation: sound
-  pos: noun
-  usage: Звук о.
 - lemma: слово
   translation: word
   pos: noun
@@ -38,14 +34,6 @@
   translation: question
   pos: noun
   usage: Це питання.
-- lemma: так
-  translation: "yes"
-  pos: particle
-  usage: Так.
-- lemma: ні
-  translation: "no"
-  pos: particle
-  usage: Ні.
 - lemma: хто
   translation: who
   pos: pronoun
@@ -66,10 +54,6 @@
   translation: how
   pos: adverb
   usage: Як спра́ви?
-- lemma: це
-  translation: this is / this
-  pos: pronoun
-  usage: Це ка́ва.
 - lemma: кава
   translation: coffee
   pos: noun
@@ -81,7 +65,7 @@
 - lemma: столиця
   translation: capital
   pos: noun
-  usage: Ки́їв - столи́ця.
+  usage: Це столи́ця.
 - lemma: замок
   translation: castle / lock
   pos: noun
@@ -94,6 +78,10 @@
   translation: organ
   pos: noun
   usage: О́рган і орга́н.
+- lemma: сім'я
+  translation: seed / family by stress
+  pos: noun
+  usage: Сі́м'я і сім'я́.
 - lemma: ранок
   translation: morning
   pos: noun
@@ -142,14 +130,14 @@
   translation: milk
   pos: noun
   usage: Молоко́.
-- lemma: книжка
-  translation: small book
+- lemma: голова
+  translation: head
   pos: noun
-  usage: Кни́жка.
-- lemma: книжки
-  translation: books
+  usage: Голова́.
+- lemma: голови
+  translation: heads
   pos: noun plural
-  usage: Книжки́.
+  usage: Го́лови.
 - lemma: людина
   translation: person
   pos: noun
@@ -162,14 +150,14 @@
   translation: rest / vacation
   pos: noun
   usage: Відпочи́нок.
-- lemma: кілометр
-  translation: kilometer
-  pos: noun
-  usage: Кіломе́тр.
-- lemma: маленький
-  translation: small
+- lemma: новий
+  translation: new
   pos: adjective
-  usage: Мале́нький.
+  usage: Нови́й.
+- lemma: старий
+  translation: old
+  pos: adjective
+  usage: Стари́й.
 - lemma: аптека
   translation: pharmacy
   pos: noun
@@ -178,35 +166,7 @@
   translation: nicely / beautiful
   pos: adverb
   usage: Як га́рно!
-- lemma: привіт
-  translation: hi
-  pos: interjection
-  usage: Приві́т!
-- lemma: справи
-  translation: things / affairs
-  pos: noun plural
-  usage: Як спра́ви?
-- lemma: добре
-  translation: good / well
-  pos: adverb
-  usage: До́бре!
-- lemma: у тебе
-  translation: and you / with you
-  pos: phrase
-  usage: А у те́бе?
-- lemma: Оля
-  translation: Olia
+- lemma: Марія
+  translation: Maria
   pos: proper noun
-  usage: О́ля.
-- lemma: Тарас
-  translation: Taras
-  pos: proper noun
-  usage: Тара́с.
-- lemma: Київ
-  translation: Kyiv
-  pos: proper noun
-  usage: Ки́їв.
-- lemma: Україна
-  translation: Ukraine
-  pos: proper noun
-  usage: Украї́на.
+  usage: Марі́я.

--- a/site/src/content/docs/a1/stress-and-melody.mdx
+++ b/site/src/content/docs/a1/stress-and-melody.mdx
@@ -61,16 +61,13 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 **ка́ва. вода́. Це ка́ва? Де метро́?** — stress and sentence melody.
 
-First listen, then read. Use the lawful public resource already listed for
-this module: [ULP Season 1, Episode 5 — Pronunciation
-Trainer](https://www.ukrainianlessons.com/episode5/). Open the page, listen
-for the stress practice, and repeat short model words. Do not download,
-transcribe, remix, or reuse the audio; this lesson only links to it for
-listening support.
+Teacher Oksana starts with a tiny routine: listen, mark, repeat. If you have a
+teacher or tutor, let them read one word first. If you are working alone, read
+the stress mark first and then say the word slowly.
 
 Today you are not memorizing every stress pattern in Ukrainian. You are
-learning why stress matters, how to read prepared words with stress marks, and
-how to use three beginner sentence melodies.
+learning why stress matters, how to read words with stress marks, and how to
+use three beginner sentence melodies.
 
 By the end, you can:
 
@@ -85,6 +82,12 @@ By the end, you can:
   **як**;
 - read a short greeting dialogue with Ukrainian rhythm.
 
+:::tip
+If you want extra listening support, open [ULP Season 1, Episode 5 —
+Pronunciation Trainer](https://www.ukrainianlessons.com/episode5/) from the
+Resources tab and copy only short model words.
+:::
+
 ## Наголос
 
 **ка́ва. вода́. молоко́.** Listen first, then read the marks.
@@ -94,13 +97,11 @@ In learning materials, this course marks it with an accent: **ка́ва**,
 **вода́**, **молоко́**. In ordinary Ukrainian texts, the mark is usually
 absent, so you learn stress as part of each new word.
 
-Use this listening pass before the table:
+Use this quick pass before the table:
 
-1. Open the linked ULP Episode 5 page.
-2. Listen for one short stress model.
-3. Without reading the English support, point to the stronger syllable in the
-   marked word.
-4. Repeat the word once.
+1. Point to the stress mark.
+2. Say only the stronger syllable.
+3. Say the whole word once.
 
 Ukrainian stress is free. It can fall near the beginning, middle, or end of a
 word.
@@ -111,9 +112,9 @@ word.
 | final syllable | **вода́**, **зима́**, **рука́**, **метро́**, **кафе́** |
 | middle syllable | **столи́ця**, **люди́на**, **одина́дцять** |
 
-There is no useful shortcut for A1 learners. Treat stress as part of the word,
-just like spelling. When you add a word to your notebook, add its stress too:
-**ка́ва**, not just кава.
+There is no useful shortcut for A1 learners. That is normal. Treat stress as
+part of the word, just like spelling. When you add a word to your notebook,
+add its stress too: **ка́ва**, not just кава.
 
 A second habit matters just as much: do not blur unstressed vowels. In
 **молоко́**, the first two **о** sounds stay **о**. They are lighter than the
@@ -121,7 +122,7 @@ stressed final **о**, but they stay clear. Read slowly first:
 **мо-ло-ко́**. Keep every vowel clear, then speed up.
 
 Some Ukrainian words move stress when the form changes. For now, only notice
-the idea. **кни́жка** can become **книжки́** in plural. That is a future
+the idea. **голова́** can become **го́лови** in plural. That is a future
 grammar habit, but you can already hear that Ukrainian stress can move.
 
 Stress can also change meaning:
@@ -134,13 +135,25 @@ Stress can also change meaning:
 | **атла́с** | satin |
 | **о́рган** | body organ |
 | **орга́н** | musical instrument |
+| **сі́м'я** | seed |
+| **сім'я́** | family |
 
 Do not guess these from spelling alone. Use the stress mark when it is given,
 and check a dictionary such as goroh.pp.ua when you are unsure.
 
+:::tip
+You already saw **за́мок** and **замо́к**, and you already know **сім'я́**
+from Module 3. Here they are reminders, not a new memory load: the mark is
+small, but it can carry meaning.
+:::
+
 ### Де на́голос
 
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "Слухай, потім читай: ка́ва. Де на́голос?", "options": [{"text": "перший склад", "correct": true}, {"text": "останній склад", "correct": false}, {"text": "немає наголосу", "correct": false}], "explanation": "У слові ка́ва на́голос на ка́."}, {"question": "Слухай, потім читай: вода́. Де на́голос?", "options": [{"text": "останній склад", "correct": true}, {"text": "перший склад", "correct": false}, {"text": "усі склади однакові", "correct": false}], "explanation": "У слові вода́ на́голос на да́."}, {"question": "Слухай, потім читай: столи́ця. Де на́голос?", "options": [{"text": "середній склад", "correct": true}, {"text": "перший склад", "correct": false}, {"text": "останній склад", "correct": false}], "explanation": "У слові столи́ця на́голос на ли́."}, {"question": "Молоко́: що робимо з ненаголошеними голосними?", "options": [{"text": "тримаємо кожен голосни́й чистим", "correct": true}, {"text": "пропускаємо перший голосни́й", "correct": false}, {"text": "читаємо кожне о як а", "correct": false}], "explanation": "Українські ненаголошені голосні залишаються чистими."}]`)} instruction={"Спочатку слухай, потім обери склад із позначеним на́голосом."} isUkrainian={false} />
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Читай: ка́ва. Де на́голос?", "options": [{"text": "перший склад", "correct": true}, {"text": "останній склад", "correct": false}, {"text": "немає наголосу", "correct": false}], "explanation": "У слові ка́ва на́голос на ка́."}, {"question": "Читай: вода́. Де на́голос?", "options": [{"text": "останній склад", "correct": true}, {"text": "перший склад", "correct": false}, {"text": "усі склади однакові", "correct": false}], "explanation": "У слові вода́ на́голос на да́."}, {"question": "Читай: столи́ця. Де на́голос?", "options": [{"text": "середній склад", "correct": true}, {"text": "перший склад", "correct": false}, {"text": "останній склад", "correct": false}], "explanation": "У слові столи́ця на́голос на ли́."}, {"question": "Молоко́: що робимо з ненаголошеними голосними?", "options": [{"text": "тримаємо кожен голосни́й чистим", "correct": true}, {"text": "пропускаємо перший голосни́й", "correct": false}, {"text": "читаємо кожне о як а", "correct": false}], "explanation": "Українські ненаголошені голосні залишаються чистими."}]`)} instruction={"Обери склад із позначеним на́голосом."} isUkrainian={false} />
+
+### Швидкий контраст
+
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "за́мок", "options": [{"text": "castle", "correct": true}, {"text": "lock", "correct": false}], "explanation": "За́мок із наголосом на першому складі — castle."}, {"question": "замо́к", "options": [{"text": "lock", "correct": true}, {"text": "castle", "correct": false}], "explanation": "Замо́к із наголосом на останньому складі — lock."}, {"question": "сім'я́", "options": [{"text": "family", "correct": true}, {"text": "seed", "correct": false}], "explanation": "Сім'я́ з фінальним наголосом — family."}]`)} instruction={"Обери коротку англійську підказку."} isUkrainian={false} />
 
 ## Мелодика
 
@@ -157,10 +170,6 @@ three safe models:
 
 The punctuation helps you choose the melody, but your voice must still do the
 work.
-
-### Пунктуація і мелодика
-
-<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Це ка́ва_", "answer": ".", "options": [".", "?", "!"]}, {"sentence": "Це метро́_", "answer": "?", "options": ["?", ".", "!"]}, {"sentence": "Де апте́ка_", "answer": "?", "options": ["?", ".", "!"]}, {"sentence": "Як га́рно_", "answer": "!", "options": ["!", "?", "."]}, {"sentence": "Так, це вода́_", "answer": ".", "options": [".", "?", "!"]}]`)} instruction={"Обери розділовий знак, який відповідає реченню."} isUkrainian={false} />
 
 Now add the most important beginner exception. A question with a question word
 usually falls, not rises:
@@ -180,13 +189,22 @@ But a yes/no question rises:
 | **Це вода́?** | rising **↗** |
 | **А у те́бе?** | rising **↗** |
 
-Logical stress is the important word inside the sentence. In **Це ка́ва?**,
-you can make **ка́ва** the important word if you are checking the object. In
-**А у те́бе?**, the important part is **те́бе** because you are turning the
-question back to the other person.
+### Пунктуація і мелодика
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Це ка́ва_", "answer": ".", "options": [".", "?", "!"]}, {"sentence": "Це метро́_", "answer": "?", "options": ["?", ".", "!"]}, {"sentence": "Де апте́ка_", "answer": "?", "options": ["?", ".", "!"]}, {"sentence": "Як га́рно_", "answer": "!", "options": ["!", "?", "."]}, {"sentence": "Так, це вода́_", "answer": ".", "options": [".", "?", "!"]}]`)} instruction={"Обери розділовий знак, який відповідає реченню."} isUkrainian={false} />
+
+Logical stress means the important word inside the sentence. Keep this simple
+today. In **Це ка́ва?**, the important word is **ка́ва** because you are
+checking the object. In **А у те́бе?**, the important part is **те́бе** because
+you are turning the question back to the other person.
 
 Keep the explanation Ukrainian-centered. Listen to the Ukrainian words, notice
 the stress, and copy the contour.
+
+:::tip
+Do not worry if your melody feels slow at first. Slow and clear is the right
+A1 target.
+:::
 
 ### Вибір мелодики
 
@@ -266,23 +284,23 @@ English support after the Ukrainian dialogue:
 | **Ось вода́.** | Here is water. |
 | **Як га́рно!** | How nice! |
 
-### На́голос змінює значення
-
-<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "за́мок", "right": "castle"}, {"left": "замо́к", "right": "lock"}, {"left": "а́тлас", "right": "atlas"}, {"left": "атла́с", "right": "satin"}, {"left": "о́рган", "right": "body organ"}, {"left": "орга́н", "right": "musical instrument"}]`)} instruction={"З'єднай наголошене слово з короткою англійською підказкою."} isUkrainian={false} />
-
 Common traps now become workbook habits:
 
 | Trap | Safer Ukrainian habit |
 | --- | --- |
 | blurring unstressed vowels in **молоко́** | keep **мо-ло-ко́** clear |
-| reading **кіломе́тр** with first-syllable stress | stress the **-ме́тр** part |
-| keeping stress fixed in **кни́жка / книжки́** | notice that stress can move |
+| reading **нови́й** or **стари́й** with early stress | stress the final part |
+| keeping stress fixed in **голова́ / го́лови** | notice that stress can move |
 | always emphasizing a pronoun | put logical stress on the meaningful word |
-| reading **мале́нький** with first-syllable stress | stress the middle part of **мале́нький** |
+| reading **Марі́я** with first-syllable stress | stress the **рі́** part |
 | reading **одина́дцять** or **чотирна́дцять** with early stress | stress **на́** |
 
 You do not need to produce all of these words fluently today. You need to
 recognize the safer habit and avoid building the wrong one.
+
+### Типові пастки наголосу
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Це мій ___ комп'ютер.", "answer": "нови́й", "options": ["нови́й", "но́вий"]}, {"sentence": "Мій дідусь ___.", "answer": "стари́й", "options": ["стари́й", "ста́рий"]}, {"sentence": "У мене ___ гривень.", "answer": "одина́дцять", "options": ["одина́дцять", "о́динадцять"]}, {"sentence": "Я знаю ___ нових слів.", "answer": "чотирна́дцять", "options": ["чотирна́дцять", "чоти́рнадцять"]}, {"sentence": "Множина слова голова́: ___.", "answer": "го́лови", "options": ["го́лови", "голови́"]}, {"sentence": "Мене звати ___.", "answer": "Марі́я", "options": ["Марі́я", "Ма́рія"]}]`)} instruction={"Обери нормативну форму з позначеним наголосом."} isUkrainian={false} />
 
 ## Друк, зошит, голос
 
@@ -322,15 +340,19 @@ Ask a native Ukrainian teacher or tutor to listen to one read-aloud from this
 module. The feedback target is narrow: stress, clear vowels, and the direction
 of the sentence melody.
 
-The workbook adds extra practice with the same skills: clear-vowel repair,
-stress sorting, quick facts, and word recognition.
+You can now read a marked Ukrainian word, keep vowels clear, and choose the
+first safe melody for a statement or question. Next, Module 5 uses this sound
+control when you introduce yourself.
+
+The workbook adds extra practice with the same skills: stress sorting,
+stress-transfer repair, quick facts, and word recognition.
 
 </TabItem>
 <TabItem label="Vocabulary">
 
-<VocabCard client:only="react" words={JSON.parse(`[{"word":"наголос","translation":"stress / accent","pos":"noun","example":"Наголос у слові ка́ва.","examples":["stress / accent","Наголос у слові ка́ва."],"atlas_href":"/lexicon/на-голос/"},{"word":"мелодика","translation":"melody / intonation","pos":"noun","example":"Мелодика речення.","examples":["melody / intonation","Мелодика речення."],"atlas_href":"/lexicon/мелодика/"},{"word":"склад","translation":"syllable","pos":"noun","example":"Один склад.","examples":["syllable","Один склад."],"atlas_href":"/lexicon/склад/"},{"word":"наголошений","translation":"stressed","pos":"adjective","example":"Наголошений склад.","examples":["stressed","Наголошений склад."],"atlas_href":"/lexicon/наголошений/"},{"word":"ненаголошений","translation":"unstressed","pos":"adjective","example":"Ненаголошений склад.","examples":["unstressed","Ненаголошений склад."],"atlas_href":"/lexicon/ненаголошений/"},{"word":"голосний","translation":"vowel","pos":"adjective / noun","example":"Голосний звук.","examples":["vowel","Голосний звук."],"atlas_href":"/lexicon/голосний/"},{"word":"звук","translation":"sound","pos":"noun","example":"Звук о.","examples":["sound","Звук о."],"atlas_href":"/lexicon/звук/"},{"word":"слово","translation":"word","pos":"noun","example":"Слово ка́ва.","examples":["word","Слово ка́ва."],"atlas_href":"/lexicon/слово/"},{"word":"речення","translation":"sentence","pos":"noun","example":"Речення має мелодику.","examples":["sentence","Речення має мелодику."],"atlas_href":"/lexicon/речення/"},{"word":"питання","translation":"question","pos":"noun","example":"Це питання.","examples":["question","Це питання."],"atlas_href":"/lexicon/питання/"},{"word":"так","translation":"yes","pos":"particle","example":"Так.","examples":["yes","Так."],"atlas_href":"/lexicon/так/"},{"word":"ні","translation":"no","pos":"particle","example":"Ні.","examples":["no","Ні."],"atlas_href":"/lexicon/ні/"},{"word":"хто","translation":"who","pos":"pronoun","example":"Хто це?","examples":["who","Хто це?"],"atlas_href":"/lexicon/хто/"},{"word":"що","translation":"what","pos":"pronoun","example":"Що це?","examples":["what","Що це?"],"atlas_href":"/lexicon/що/"},{"word":"де","translation":"where","pos":"adverb","example":"Де метро́?","examples":["where","Де метро́?"],"atlas_href":"/lexicon/де/"},{"word":"коли","translation":"when","pos":"adverb","example":"Коли?","examples":["when","Коли?"],"atlas_href":"/lexicon/коли/"},{"word":"як","translation":"how","pos":"adverb","example":"Як спра́ви?","examples":["how","Як спра́ви?"],"atlas_href":"/lexicon/як/"},{"word":"це","translation":"this is / this","pos":"pronoun","example":"Це ка́ва.","examples":["this is / this","Це ка́ва."],"atlas_href":"/lexicon/це/"},{"word":"кава","translation":"coffee","pos":"noun","example":"Ка́ва.","examples":["coffee","Ка́ва."],"atlas_href":"/lexicon/кава/"},{"word":"вода","translation":"water","pos":"noun","example":"Вода́.","examples":["water","Вода́."],"atlas_href":"/lexicon/вода/"},{"word":"столиця","translation":"capital","pos":"noun","example":"Ки́їв - столи́ця.","examples":["capital","Ки́їв - столи́ця."],"atlas_href":"/lexicon/столи-ця/"},{"word":"замок","translation":"castle / lock","pos":"noun","example":"За́мок і замо́к.","examples":["castle / lock","За́мок і замо́к."],"atlas_href":"/lexicon/замок/"},{"word":"атлас","translation":"atlas / satin","pos":"noun","example":"А́тлас і атла́с.","examples":["atlas / satin","А́тлас і атла́с."],"atlas_href":"/lexicon/атлас/"},{"word":"орган","translation":"organ","pos":"noun","example":"О́рган і орга́н.","examples":["organ","О́рган і орга́н."],"atlas_href":"/lexicon/орган/"},{"word":"ранок","translation":"morning","pos":"noun","example":"Ра́нок.","examples":["morning","Ра́нок."],"atlas_href":"/lexicon/ранок/"},{"word":"метро","translation":"metro","pos":"noun","example":"Метро́.","examples":["metro","Метро́."],"atlas_href":"/lexicon/метро/"},{"word":"фотографія","translation":"photograph","pos":"noun","example":"Фотогра́фія.","examples":["photograph","Фотогра́фія."],"atlas_href":"/lexicon/фотографія/"},{"word":"одинадцять","translation":"eleven","pos":"numeral","example":"Одина́дцять.","examples":["eleven","Одина́дцять."],"atlas_href":"/lexicon/одинадцять/"},{"word":"чотирнадцять","translation":"fourteen","pos":"numeral","example":"Чотирна́дцять.","examples":["fourteen","Чотирна́дцять."],"atlas_href":"/lexicon/чотирнадцять/"},{"word":"мама","translation":"mother","pos":"noun","example":"Ма́ма.","examples":["mother","Ма́ма."],"atlas_href":"/lexicon/мама/"},{"word":"тато","translation":"father","pos":"noun","example":"Та́то.","examples":["father","Та́то."],"atlas_href":"/lexicon/тато/"},{"word":"книга","translation":"book","pos":"noun","example":"Кни́га.","examples":["book","Кни́га."],"atlas_href":"/lexicon/книга/"},{"word":"зима","translation":"winter","pos":"noun","example":"Зима́.","examples":["winter","Зима́."],"atlas_href":"/lexicon/зима/"},{"word":"рука","translation":"hand / arm","pos":"noun","example":"Рука́.","examples":["hand / arm","Рука́."],"atlas_href":"/lexicon/рука/"},{"word":"кафе","translation":"cafe","pos":"noun","example":"Кафе́.","examples":["cafe","Кафе́."],"atlas_href":"/lexicon/кафе/"},{"word":"молоко","translation":"milk","pos":"noun","example":"Молоко́.","examples":["milk","Молоко́."],"atlas_href":"/lexicon/молоко/"},{"word":"книжка","translation":"small book","pos":"noun","example":"Кни́жка.","examples":["small book","Кни́жка."],"atlas_href":"/lexicon/книжка/"},{"word":"книжки","translation":"books","pos":"noun plural","example":"Книжки́.","examples":["books","Книжки́."],"atlas_href":"/lexicon/книжки/"},{"word":"людина","translation":"person","pos":"noun","example":"Люди́на.","examples":["person","Люди́на."],"atlas_href":"/lexicon/людина/"},{"word":"українська","translation":"Ukrainian","pos":"adjective","example":"Украї́нська мова.","examples":["Ukrainian","Украї́нська мова."],"atlas_href":"/lexicon/українська/"},{"word":"відпочинок","translation":"rest / vacation","pos":"noun","example":"Відпочи́нок.","examples":["rest / vacation","Відпочи́нок."],"atlas_href":"/lexicon/відпочинок/"},{"word":"кілометр","translation":"kilometer","pos":"noun","example":"Кіломе́тр.","examples":["kilometer","Кіломе́тр."],"atlas_href":"/lexicon/кілометр/"},{"word":"маленький","translation":"small","pos":"adjective","example":"Мале́нький.","examples":["small","Мале́нький."],"atlas_href":"/lexicon/мале-нький/"},{"word":"аптека","translation":"pharmacy","pos":"noun","example":"Апте́ка.","examples":["pharmacy","Апте́ка."],"atlas_href":"/lexicon/аптека/"},{"word":"гарно","translation":"nicely / beautiful","pos":"adverb","example":"Як га́рно!","examples":["nicely / beautiful","Як га́рно!"],"atlas_href":"/lexicon/гарно/"},{"word":"привіт","translation":"hi","pos":"interjection","example":"Приві́т!","examples":["hi","Приві́т!"],"atlas_href":"/lexicon/привіт/"},{"word":"справи","translation":"things / affairs","pos":"noun plural","example":"Як спра́ви?","examples":["things / affairs","Як спра́ви?"],"atlas_href":"/lexicon/справи/"},{"word":"добре","translation":"good / well","pos":"adverb","example":"До́бре!","examples":["good / well","До́бре!"],"atlas_href":"/lexicon/до-бре/"},{"word":"у тебе","translation":"and you / with you","pos":"phrase","example":"А у те́бе?","examples":["and you / with you","А у те́бе?"],"atlas_href":"/lexicon/у-тебе/"},{"word":"Оля","translation":"Olia","pos":"proper noun","example":"О́ля.","examples":["Olia","О́ля."],"atlas_href":"/lexicon/оля/"},{"word":"Тарас","translation":"Taras","pos":"proper noun","example":"Тара́с.","examples":["Taras","Тара́с."],"atlas_href":"/lexicon/тарас/"},{"word":"Київ","translation":"Kyiv","pos":"proper noun","example":"Ки́їв.","examples":["Kyiv","Ки́їв."],"atlas_href":"/lexicon/київ/"},{"word":"Україна","translation":"Ukraine","pos":"proper noun","example":"Украї́на.","examples":["Ukraine","Украї́на."],"atlas_href":"/lexicon/україна/"}]`)} title="Vocabulary" />
+<VocabCard client:only="react" words={JSON.parse(`[{"word":"наголос","translation":"stress / accent","pos":"noun","example":"Наголос у слові ка́ва.","examples":["stress / accent","Наголос у слові ка́ва."],"atlas_href":"/lexicon/на-голос/"},{"word":"мелодика","translation":"melody / intonation","pos":"noun","example":"Мелодика речення.","examples":["melody / intonation","Мелодика речення."],"atlas_href":"/lexicon/мелодика/"},{"word":"склад","translation":"syllable","pos":"noun","example":"Один склад.","examples":["syllable","Один склад."],"atlas_href":"/lexicon/склад/"},{"word":"наголошений","translation":"stressed","pos":"adjective","example":"Наголошений склад.","examples":["stressed","Наголошений склад."],"atlas_href":"/lexicon/наголошений/"},{"word":"ненаголошений","translation":"unstressed","pos":"adjective","example":"Ненаголошений склад.","examples":["unstressed","Ненаголошений склад."],"atlas_href":"/lexicon/ненаголошений/"},{"word":"голосний","translation":"vowel","pos":"adjective / noun","example":"Голосний звук.","examples":["vowel","Голосний звук."],"atlas_href":"/lexicon/голосний/"},{"word":"слово","translation":"word","pos":"noun","example":"Слово ка́ва.","examples":["word","Слово ка́ва."],"atlas_href":"/lexicon/слово/"},{"word":"речення","translation":"sentence","pos":"noun","example":"Речення має мелодику.","examples":["sentence","Речення має мелодику."],"atlas_href":"/lexicon/речення/"},{"word":"питання","translation":"question","pos":"noun","example":"Це питання.","examples":["question","Це питання."],"atlas_href":"/lexicon/питання/"},{"word":"хто","translation":"who","pos":"pronoun","example":"Хто це?","examples":["who","Хто це?"],"atlas_href":"/lexicon/хто/"},{"word":"що","translation":"what","pos":"pronoun","example":"Що це?","examples":["what","Що це?"],"atlas_href":"/lexicon/що/"},{"word":"де","translation":"where","pos":"adverb","example":"Де метро́?","examples":["where","Де метро́?"],"atlas_href":"/lexicon/де/"},{"word":"коли","translation":"when","pos":"adverb","example":"Коли?","examples":["when","Коли?"],"atlas_href":"/lexicon/коли/"},{"word":"як","translation":"how","pos":"adverb","example":"Як спра́ви?","examples":["how","Як спра́ви?"],"atlas_href":"/lexicon/як/"},{"word":"кава","translation":"coffee","pos":"noun","example":"Ка́ва.","examples":["coffee","Ка́ва."],"atlas_href":"/lexicon/кава/"},{"word":"вода","translation":"water","pos":"noun","example":"Вода́.","examples":["water","Вода́."],"atlas_href":"/lexicon/вода/"},{"word":"столиця","translation":"capital","pos":"noun","example":"Це столи́ця.","examples":["capital","Це столи́ця."],"atlas_href":"/lexicon/столи-ця/"},{"word":"замок","translation":"castle / lock","pos":"noun","example":"За́мок і замо́к.","examples":["castle / lock","За́мок і замо́к."],"atlas_href":"/lexicon/замок/"},{"word":"атлас","translation":"atlas / satin","pos":"noun","example":"А́тлас і атла́с.","examples":["atlas / satin","А́тлас і атла́с."],"atlas_href":"/lexicon/атлас/"},{"word":"орган","translation":"organ","pos":"noun","example":"О́рган і орга́н.","examples":["organ","О́рган і орга́н."],"atlas_href":"/lexicon/орган/"},{"word":"сім'я","translation":"seed / family by stress","pos":"noun","example":"Сі́м'я і сім'я́.","examples":["seed / family by stress","Сі́м'я і сім'я́."],"atlas_href":"/lexicon/сім-я/"},{"word":"ранок","translation":"morning","pos":"noun","example":"Ра́нок.","examples":["morning","Ра́нок."],"atlas_href":"/lexicon/ранок/"},{"word":"метро","translation":"metro","pos":"noun","example":"Метро́.","examples":["metro","Метро́."],"atlas_href":"/lexicon/метро/"},{"word":"фотографія","translation":"photograph","pos":"noun","example":"Фотогра́фія.","examples":["photograph","Фотогра́фія."],"atlas_href":"/lexicon/фотографія/"},{"word":"одинадцять","translation":"eleven","pos":"numeral","example":"Одина́дцять.","examples":["eleven","Одина́дцять."],"atlas_href":"/lexicon/одинадцять/"},{"word":"чотирнадцять","translation":"fourteen","pos":"numeral","example":"Чотирна́дцять.","examples":["fourteen","Чотирна́дцять."],"atlas_href":"/lexicon/чотирнадцять/"},{"word":"мама","translation":"mother","pos":"noun","example":"Ма́ма.","examples":["mother","Ма́ма."],"atlas_href":"/lexicon/мама/"},{"word":"тато","translation":"father","pos":"noun","example":"Та́то.","examples":["father","Та́то."],"atlas_href":"/lexicon/тато/"},{"word":"книга","translation":"book","pos":"noun","example":"Кни́га.","examples":["book","Кни́га."],"atlas_href":"/lexicon/книга/"},{"word":"зима","translation":"winter","pos":"noun","example":"Зима́.","examples":["winter","Зима́."],"atlas_href":"/lexicon/зима/"},{"word":"рука","translation":"hand / arm","pos":"noun","example":"Рука́.","examples":["hand / arm","Рука́."],"atlas_href":"/lexicon/рука/"},{"word":"кафе","translation":"cafe","pos":"noun","example":"Кафе́.","examples":["cafe","Кафе́."],"atlas_href":"/lexicon/кафе/"},{"word":"молоко","translation":"milk","pos":"noun","example":"Молоко́.","examples":["milk","Молоко́."],"atlas_href":"/lexicon/молоко/"},{"word":"голова","translation":"head","pos":"noun","example":"Голова́.","examples":["head","Голова́."],"atlas_href":"/lexicon/голова/"},{"word":"голови","translation":"heads","pos":"noun plural","example":"Го́лови.","examples":["heads","Го́лови."]},{"word":"людина","translation":"person","pos":"noun","example":"Люди́на.","examples":["person","Люди́на."],"atlas_href":"/lexicon/людина/"},{"word":"українська","translation":"Ukrainian","pos":"adjective","example":"Украї́нська мова.","examples":["Ukrainian","Украї́нська мова."],"atlas_href":"/lexicon/українська/"},{"word":"відпочинок","translation":"rest / vacation","pos":"noun","example":"Відпочи́нок.","examples":["rest / vacation","Відпочи́нок."],"atlas_href":"/lexicon/відпочинок/"},{"word":"новий","translation":"new","pos":"adjective","example":"Нови́й.","examples":["new","Нови́й."],"atlas_href":"/lexicon/новий/"},{"word":"старий","translation":"old","pos":"adjective","example":"Стари́й.","examples":["old","Стари́й."],"atlas_href":"/lexicon/старий/"},{"word":"аптека","translation":"pharmacy","pos":"noun","example":"Апте́ка.","examples":["pharmacy","Апте́ка."],"atlas_href":"/lexicon/аптека/"},{"word":"гарно","translation":"nicely / beautiful","pos":"adverb","example":"Як га́рно!","examples":["nicely / beautiful","Як га́рно!"],"atlas_href":"/lexicon/гарно/"},{"word":"Марія","translation":"Maria","pos":"proper noun","example":"Марі́я.","examples":["Maria","Марі́я."],"atlas_href":"/lexicon/марія/"}]`)} title="Vocabulary" />
 
-<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"наголос","back":"stress / accent"},{"front":"мелодика","back":"melody / intonation"},{"front":"склад","back":"syllable"},{"front":"наголошений","back":"stressed"},{"front":"ненаголошений","back":"unstressed"},{"front":"голосний","back":"vowel"},{"front":"звук","back":"sound"},{"front":"слово","back":"word"},{"front":"речення","back":"sentence"},{"front":"питання","back":"question"},{"front":"так","back":"yes"},{"front":"ні","back":"no"},{"front":"хто","back":"who"},{"front":"що","back":"what"},{"front":"де","back":"where"},{"front":"коли","back":"when"},{"front":"як","back":"how"},{"front":"це","back":"this is / this"},{"front":"кава","back":"coffee"},{"front":"вода","back":"water"},{"front":"столиця","back":"capital"},{"front":"замок","back":"castle / lock"},{"front":"атлас","back":"atlas / satin"},{"front":"орган","back":"organ"},{"front":"ранок","back":"morning"},{"front":"метро","back":"metro"},{"front":"фотографія","back":"photograph"},{"front":"одинадцять","back":"eleven"},{"front":"чотирнадцять","back":"fourteen"},{"front":"мама","back":"mother"},{"front":"тато","back":"father"},{"front":"книга","back":"book"},{"front":"зима","back":"winter"},{"front":"рука","back":"hand / arm"},{"front":"кафе","back":"cafe"},{"front":"молоко","back":"milk"},{"front":"книжка","back":"small book"},{"front":"книжки","back":"books"},{"front":"людина","back":"person"},{"front":"українська","back":"Ukrainian"},{"front":"відпочинок","back":"rest / vacation"},{"front":"кілометр","back":"kilometer"},{"front":"маленький","back":"small"},{"front":"аптека","back":"pharmacy"},{"front":"гарно","back":"nicely / beautiful"},{"front":"привіт","back":"hi"},{"front":"справи","back":"things / affairs"},{"front":"добре","back":"good / well"},{"front":"у тебе","back":"and you / with you"},{"front":"Оля","back":"Olia"},{"front":"Тарас","back":"Taras"},{"front":"Київ","back":"Kyiv"},{"front":"Україна","back":"Ukraine"}]`)} />
+<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"наголос","back":"stress / accent"},{"front":"мелодика","back":"melody / intonation"},{"front":"склад","back":"syllable"},{"front":"наголошений","back":"stressed"},{"front":"ненаголошений","back":"unstressed"},{"front":"голосний","back":"vowel"},{"front":"слово","back":"word"},{"front":"речення","back":"sentence"},{"front":"питання","back":"question"},{"front":"хто","back":"who"},{"front":"що","back":"what"},{"front":"де","back":"where"},{"front":"коли","back":"when"},{"front":"як","back":"how"},{"front":"кава","back":"coffee"},{"front":"вода","back":"water"},{"front":"столиця","back":"capital"},{"front":"замок","back":"castle / lock"},{"front":"атлас","back":"atlas / satin"},{"front":"орган","back":"organ"},{"front":"сім'я","back":"seed / family by stress"},{"front":"ранок","back":"morning"},{"front":"метро","back":"metro"},{"front":"фотографія","back":"photograph"},{"front":"одинадцять","back":"eleven"},{"front":"чотирнадцять","back":"fourteen"},{"front":"мама","back":"mother"},{"front":"тато","back":"father"},{"front":"книга","back":"book"},{"front":"зима","back":"winter"},{"front":"рука","back":"hand / arm"},{"front":"кафе","back":"cafe"},{"front":"молоко","back":"milk"},{"front":"голова","back":"head"},{"front":"голови","back":"heads"},{"front":"людина","back":"person"},{"front":"українська","back":"Ukrainian"},{"front":"відпочинок","back":"rest / vacation"},{"front":"новий","back":"new"},{"front":"старий","back":"old"},{"front":"аптека","back":"pharmacy"},{"front":"гарно","back":"nicely / beautiful"},{"front":"Марія","back":"Maria"}]`)} />
 
 </TabItem>
 <TabItem label="Activities">
@@ -343,17 +365,25 @@ stress sorting, quick facts, and word recognition.
 
 *(see lesson, §Мелодика)*
 
-### На́голос змінює значення
+### Швидкий контраст
 
-*(see lesson, §Читаємо вголос)*
+*(see lesson, §Наголос)*
 
 ### Пунктуація і мелодика
 
 *(see lesson, §Мелодика)*
 
-### Виправ пастки наголосу
+### Типові пастки наголосу
 
-<ErrorCorrection client:only='react' instruction="Обери безпечнішу українську читацьку звичку." items={JSON.parse(`[{"sentence": "Молоко́ — тримай усі голосні чистими.", "errorWord": "нечіткі перші два голосні", "correctForm": "мо-ло-ко́", "options": ["мо-ло-ко́", "нечіткі голосні"], "explanation": "Українські голосні залишаються чистими поза на́голосом."}, {"sentence": "Кіломе́тр — став на́голос на -ме́тр.", "errorWord": "кі́лометр", "correctForm": "кіломе́тр", "options": ["кіломе́тр", "кі́лометр"], "explanation": "Підготовлена модель — кіломе́тр."}, {"sentence": "Кни́жка / книжки́ — помічай рухомий на́голос.", "errorWord": "кни́жки", "correctForm": "книжки́", "options": ["книжки́", "кни́жки"], "explanation": "У цій множинній моделі на́голос переходить на закінчення."}, {"sentence": "Одина́дцять — наголос на -на́-.", "errorWord": "о́динадцять", "correctForm": "одина́дцять", "options": ["одина́дцять", "о́динадцять"], "explanation": "Ціль A1 має на́голос на -на́-."}, {"sentence": "Чотирна́дцять — наголос на -на́-.", "errorWord": "чоти́рнадцять", "correctForm": "чотирна́дцять", "options": ["чотирна́дцять", "чоти́рнадцять"], "explanation": "Ціль A1 має на́голос на -на́-."}]`)} isUkrainian={false} />
+*(see lesson, §Читаємо вголос)*
+
+### Типові помилки наголосу
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "новий: ___", "answer": "нови́й", "options": ["нови́й", "но́вий"]}, {"sentence": "старий: ___", "answer": "стари́й", "options": ["стари́й", "ста́рий"]}, {"sentence": "одинадцять: ___", "answer": "одина́дцять", "options": ["одина́дцять", "о́динадцять"]}, {"sentence": "чотирнадцять: ___", "answer": "чотирна́дцять", "options": ["чотирна́дцять", "чоти́рнадцять"]}, {"sentence": "множина слова голова́: ___", "answer": "го́лови", "options": ["го́лови", "голови́"]}, {"sentence": "ім'я: ___", "answer": "Марі́я", "options": ["Марі́я", "Ма́рія"]}]`)} instruction={"Обери нормативну форму з позначеним наголосом."} isUkrainian={false} />
+
+### На́голос змінює значення
+
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "за́мок", "right": "castle"}, {"left": "замо́к", "right": "lock"}, {"left": "а́тлас", "right": "atlas"}, {"left": "атла́с", "right": "satin"}, {"left": "о́рган", "right": "body organ"}, {"left": "орга́н", "right": "musical instrument"}, {"left": "сі́м'я", "right": "seed"}, {"left": "сім'я́", "right": "family"}]`)} instruction={"З'єднай наголошене слово з короткою англійською підказкою."} isUkrainian={false} />
 
 ### Сортуй за наголосом
 


### PR DESCRIPTION
## Summary

Certifies A1 M04 `stress-and-melody` for live content quality.

Changed files:
- `curriculum/l2-uk-en/a1/stress-and-melody/module.md`
- `curriculum/l2-uk-en/a1/stress-and-melody/activities.yaml`
- `curriculum/l2-uk-en/a1/stress-and-melody/vocabulary.yaml`
- `curriculum/l2-uk-en/a1/stress-and-melody/resources.yaml`
- `site/src/content/docs/a1/stress-and-melody.mdx`

Content improvements:
- Replaced legal/resource warning opener with teacher-natural A1 scaffolding.
- Added clearer stress/melody sequencing and prior-module signposting for `за́мок/замо́к` and `сім'я́`.
- Split lesson-tab quick checks from workbook practice; added the planned stress-transfer targets (`нови́й`, `стари́й`, `одина́дцять`, `чотирна́дцять`, `го́лови`, `Марі́я`).
- Restored the full meaning-changing stress pair set in workbook practice.
- Reduced and retargeted vocabulary load; added locked wiki resource reference.
- Regenerated MDX from source.

## Quality Gate

Canonical LLM QG (`scripts/build/run_llm_qg_parity.py a1 stress-and-melody --writer codex-tools --reviewer claude-tools`): terminal PASS.

Scores:
- pedagogical: 8.0 PASS
- naturalness: 8.5 PASS
- decolonization: 9.2 PASS
- engagement: 8.5 PASS
- tone: 8.5 PASS

Remaining QG notes are non-blocking process/source-band warnings: locked-plan Grade 5 source citation and missing pre-emit audit lines.

Independent reviews:
- Opus final targeted re-check: APPROVE, no blockers after fixing the `голова́ -> го́лови` item frame.
- Agy/Gemini final review: APPROVE, no blockers; noted only that punctuation activity has 5 items while covering all required models.

## Validation

Ran:
- `.venv/bin/python scripts/generate_mdx.py l2-uk-en a1 4 --validate`
- `.venv/bin/python scripts/validate_plan_config.py --quiet a1`
- `.venv/bin/python scripts/validate_activities.py l2-uk-en a1`
- `.venv/bin/python scripts/audit/check_mdx_generation_drift.py --files curriculum/l2-uk-en/a1/stress-and-melody/module.md curriculum/l2-uk-en/a1/stress-and-melody/activities.yaml curriculum/l2-uk-en/a1/stress-and-melody/vocabulary.yaml curriculum/l2-uk-en/a1/stress-and-melody/resources.yaml site/src/content/docs/a1/stress-and-melody.mdx`
- `.venv/bin/python scripts/audit/check_mdx_source_parity.py --files site/src/content/docs/a1/stress-and-melody.mdx`
- `npm run build --prefix site -- --outDir /tmp/learn-ukrainian-a1-m04-dist`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

All passed.

## Token Telemetry

- run_id: `a1-m04-stress-and-melody-quality-20260616`
- status: ready
- swarm_used: true
- swarm_label: thin
- swarm_note: Used required canonical QG plus Opus and Agy reviewer checks; no helper editors. Opus caught and verified the final `голова́ -> го́лови` activity correction.
- token_source: unavailable
- main: codex, token_source unavailable
- reviewers: claude-tools canonical QG, Opus targeted review, Agy/Gemini final review; token_source unavailable