### PR TITLE
feat(lexicon): collocation calque corrections — decolonization §6 slice 2 [#3098]

### DIFF
--- a/scripts/lexicon/calque_corrections.py
+++ b/scripts/lexicon/calque_corrections.py
@@ -303,6 +303,35 @@ PHRASAL_CALQUES: dict[str, dict[str, object]] = {
     "з моєї точки зору": {"corrections": ["на мою думку"], "note": "рос. с моей точки зрения", "source": ["ua-gec", "grok-3098"]},  # ua-gec 0573, 1031
     "ні в якому разі": {"corrections": ["аж ніяк", "у жодному разі"], "note": "рос. ни в коем случае", "source": ["ua-gec", "grok-3098"]},  # ua-gec 0717, 1844
     "прийшло в голову": {"corrections": ["спало на думку"], "note": "рос. пришло в голову (F/Collocation); в голову прийшли → спали на гадку", "source": ["ua-gec", "grok-3098"]},  # ua-gec 0834
+    # §6 collocation/phrasal slice 2 (#3098) — kept only with direct correction evidence.
+    "при допомозі": {
+        "corrections": ["за допомогою"],
+        "note": "syntactic calque; use the instrumental phrase за допомогою",
+        "source": ["glazova-11"],
+        "evidence": [
+            "11-klas-ukrajinska-mova-glazova-2019_s0079: Неправильно: при допомозі; Правильно: за допомогою",
+        ],
+        "heritage_guard": "search_heritage(при допомозі, include_live_slovnyk=false): No heritage evidence found.",
+    },
+    "співпадати": {
+        "corrections": ["збігатися"],
+        "note": "рос. совпадать; дані співпадають → дані збігаються",
+        "source": ["avramenko-5"],
+        "evidence": [
+            "5-klas-ukrmova-avramenko-2022_s0038: Неправильно: дані співпадають; Правильно: дані збігаються",
+        ],
+        "heritage_guard": "search_heritage(співпадати, include_live_slovnyk=false): No heritage evidence found.",
+    },
+    "в кінці кінців": {
+        "corrections": ["кінець кінцем", "зрештою", "урешті-решт", "врешті-решт"],
+        "note": "рос. в конце концов",
+        "source": ["zabolotnyi-9", "ua-gec"],
+        "evidence": [
+            "9-klas-ukrmova-zabolotnyi-2017_s0291: Правильно: кінець кінцем; НЕправильно: в кінці кінців",
+            "UA-GEC 0935: Error: в кінці кінців; Correction: врешті-решт; Type: F/Calque",
+        ],
+        "heritage_guard": "search_heritage(в кінці кінців, include_live_slovnyk=false): No heritage evidence found.",
+    },
 }
 
 # Sense-restricted calques (#3098 grok-swarm extension) — POLYSEMES.
@@ -357,6 +386,86 @@ SENSE_RESTRICTED_CALQUES: dict[str, dict[str, object]] = {
         "authentic_sense": "to look (well/ill); to peer out (гарно виглядати; виглядати у вікно)",
         "note": "Грінченко/СУМ-20 attest 'look; peer out'; calque only when 'виглядає' replaces 'здається' (= it seems).",
         "source": ["grinchenko", "sum-20", "grok-3098"],
+    },
+    "являтися": {
+        "corrections": ["бути", "є"],
+        "calque_sense": "to be / constitute (рос. являться = 'to be')",
+        "authentic_sense": "to appear, show oneself, arrive (явитися комусь / десь)",
+        "note": "Грінченко attests являтися as 'show/appear'; calque only in copular use: являтися переможцем → бути переможцем.",
+        "source": ["grinchenko", "avramenko-9", "zabolotnyi-9", "ua-gec"],
+        "evidence": [
+            "9-klas-ukrajinska-mova-avramenko-2017_s0162: Неправильно: являтися переможцем; Правильно: бути переможцем",
+            "9-klas-ukrmova-zabolotnyi-2017_s0101: Правильно: він є студентом; НЕПРАВИЛЬНО: він являється студентом",
+            "UA-GEC 0301: Error: являється; Correction: є; Type: F/Calque",
+            "Грінченко: Являтися ... Являться, явиться, показываться, показаться.",
+        ],
+        "heritage_guard": "search_heritage(являтися, include_live_slovnyk=false): Грінченко authentic for 'appear/show'; therefore sense-restricted, not blanket.",
+    },
+    "на протязі": {
+        "corrections": ["протягом", "упродовж", "впродовж"],
+        "calque_sense": "during / over a time span (рос. на протяжении)",
+        "authentic_sense": "in a draft; along/over a distance (сидіти на протязі; на протязі кількох кілометрів)",
+        "note": "Calque only for time duration: на протязі години → протягом/упродовж години; keep the draft/distance senses.",
+        "source": ["litvinova-7", "zabolotnyi-7", "zabolotnyi-9", "ua-gec"],
+        "evidence": [
+            "7-klas-ukrmova-litvinova-2024_s0186: для тривалости використовуємо протягом, упродовж/впродовж; на протязі означає на різкому струмені повітря",
+            "7-klas-ukrmova-zabolotnyi-2024_s0229: на протязі години ненормативне; для часу вживаємо протягом або впродовж; на протязі можна сидіти / уживати для відстані",
+            "UA-GEC 0490: Error: на протязі; Correction: протягом; Type: F/Calque",
+            "UA-GEC 1730: Error: на протязі; Correction: упродовж; Type: F/Collocation",
+        ],
+        "heritage_guard": "search_heritage(на протязі, include_live_slovnyk=false): ЕСУМ row is not a time-duration clearance; textbooks explicitly preserve draft/distance senses.",
+    },
+    "дякуючи": {
+        "corrections": ["завдяки"],
+        "calque_sense": "because of / thanks to as a preposition with a cause (рос. благодаря)",
+        "authentic_sense": "adverbial participle of дякувати: while thanking someone",
+        "note": "Calque only in causal-preposition use: дякуючи підтримці → завдяки підтримці.",
+        "source": ["zabolotnyi-7"],
+        "evidence": [
+            "7-klas-ukrmova-zabolotnyi-2024_s0143: Правильно: Переміг завдяки підтримці друзів; НЕправильно: Переміг, дякуючи підтримці друзів.",
+            "7-klas-ukrmova-zabolotnyi-2024_s0229: Правильно: завдяки підтримці; НЕправильно: дякуючи підтримці",
+        ],
+        "heritage_guard": "search_heritage(дякуючи, include_live_slovnyk=false): no direct safe headword clearance for the causal-preposition use; keep sense-restricted because дієприслівник дякуючи is grammatical.",
+    },
+    "так як": {
+        "corrections": ["оскільки", "бо"],
+        "calque_sense": "because / since (рос. так как)",
+        "authentic_sense": "comparative construction так, як ('in the way that'), normally comma-marked",
+        "note": "Calque only in causal conjunction use: так як → оскільки/бо; do not confuse with так, як.",
+        "source": ["ua-gec"],
+        "evidence": [
+            "UA-GEC 0026: Error: так як; Correction: оскільки; Type: F/Calque",
+            "UA-GEC 0569: Error: так як; Correction: бо; Type: F/Calque",
+        ],
+        "heritage_guard": "search_heritage(так як, include_live_slovnyk=false): no phrase clearance; ЕСУМ hits attest components/other expressions, so this remains sense-restricted.",
+    },
+    "біля": {
+        "corrections": ["близько"],
+        "calque_sense": "approximately / about before a quantity (рос. около)",
+        "authentic_sense": "next to, near (біля школи, біля будинку)",
+        "note": "Грінченко attests біля as 'near'; calque only before approximate quantities: біля двох років → близько двох років.",
+        "source": ["grinchenko", "litvinova-7", "zabolotnyi-7", "ua-gec"],
+        "evidence": [
+            "7-klas-ukrmova-litvinova-2024_s0186: БІЛЯ: біля школи, біля будинку; БЛИЗЬКО: близько третьої години, потрібно близько двадцяти хвилин",
+            "7-klas-ukrmova-zabolotnyi-2024_s0229: Правильно: близько двох років; НЕправильно: біля двох років",
+            "UA-GEC 0385: Error: біля; Correction: близько; Type: F/Calque",
+            "Грінченко: Біля ... Подле, возле, около. Ліг біля моря одпочить.",
+        ],
+        "heritage_guard": "search_heritage(біля, include_live_slovnyk=false): Грінченко authentic for 'near'; therefore sense-restricted, not blanket.",
+    },
+    "на рахунок": {
+        "corrections": ["щодо", "стосовно"],
+        "calque_sense": "regarding / concerning (рос. насчёт)",
+        "authentic_sense": "to/onto an account, including bank-account contexts",
+        "note": "Calque only in 'regarding' use: на рахунок цього → щодо цього; keep literal account/bank uses.",
+        "source": ["avramenko-5", "zabolotnyi-9", "grinchenko", "ua-gec"],
+        "evidence": [
+            "5-klas-ukrmova-avramenko-2022_s0057: Неправильно: на рахунок цього; Правильно: щодо цього",
+            "9-klas-ukrmova-zabolotnyi-2017_s0031: Правильно: рахунок у банку; НЕПРАВИЛЬНО: счьот у банку",
+            "UA-GEC 1296: Error: на рахунок; Correction: щодо; Type: F/Calque",
+            "Грінченко: Рахунок ... Счет, разсчет. В рахунку помилився.",
+        ],
+        "heritage_guard": "search_heritage(рахунок, include_live_slovnyk=false): Грінченко authentic for account/count; therefore на рахунок is sense-restricted to the 'regarding' calque.",
     },
 }
 

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -1762,6 +1762,8 @@ def _curated_calque(lemma: str, base: str) -> dict[str, Any] | None:
                 "authentic_sense": str(row["authentic_sense"]),
                 "note": str(row["note"]),
                 "source": list(row["source"]),
+                "evidence": list(row.get("evidence", [])),
+                "heritage_guard": str(row.get("heritage_guard", "")),
             }
 
     if lemma in PHRASAL_CALQUES:

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "13f2f7c85580a8698c7b2a5b50c342612de2739cb1d15f120b582a0d8e45b41b",
+  "fingerprint": "b43391ac8ccd78ec28d251850f5c553d2bd2127c0d3cc228e73bfb383ee3ba7e",
   "inputs": {
     "lexicon_code": [
       {
@@ -24,7 +24,7 @@
       },
       {
         "path": "scripts/lexicon/calque_corrections.py",
-        "sha256": "66125f9451fb77de840edfe291684187f167ca6e3c8fe19932d2b189a40437e9"
+        "sha256": "d07e477961e20e0b4c73380c679b880674330b92cbd0db017275ec43f64934e7"
       },
       {
         "path": "scripts/lexicon/check_manifest_freshness.py",
@@ -36,7 +36,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "d819a97701daaae80f7aed977d11f20eefa1c26e1399aae2107c48ae6ae26d2f"
+        "sha256": "bb4c0b19c10ea7fe71be29ad7137037d84723c077e0d099c7e5ac7bcc2e0234d"
       },
       {
         "path": "scripts/lexicon/generate_vesum_aliases.py",

--- a/tests/test_calque_corrections.py
+++ b/tests/test_calque_corrections.py
@@ -101,6 +101,20 @@ def test_pryiniaty_uchast_has_corpus_evidence_and_alias():
         assert "search_heritage" in entry["heritage_guard"]
 
 
+def test_collocation_slice2_phrasal_entries_have_evidence():
+    """New always-flag phrase entries are direct correction pairs, not guesses."""
+    expected = {
+        "при допомозі": "за допомогою",
+        "співпадати": "збігатися",
+        "в кінці кінців": "врешті-решт",
+    }
+    for phrase, correction in expected.items():
+        entry = PHRASAL_CALQUES[phrase]
+        assert correction in entry["corrections"]
+        assert entry["evidence"]
+        assert "search_heritage" in entry["heritage_guard"]
+
+
 def test_sense_restricted_schema():
     """Polysemes carry an explicit calque_sense / authentic_sense split."""
     assert SENSE_RESTRICTED_CALQUES, "SENSE_RESTRICTED_CALQUES is empty"
@@ -115,6 +129,25 @@ def test_sense_restricted_schema():
         assert entry["calque_sense"] != entry["authentic_sense"], (
             f"SENSE_RESTRICTED_CALQUES[{headword!r}]: calque_sense == authentic_sense"
         )
+
+
+def test_collocation_slice2_sense_restricted_entries_have_guarded_senses():
+    """Polysemous phrase calques stay sense-scoped to avoid false positives."""
+    expected = {
+        "на протязі": ("протягом", "draft"),
+        "являтися": ("бути", "appear"),
+        "дякуючи": ("завдяки", "thanking"),
+        "так як": ("оскільки", "так, як"),
+        "біля": ("близько", "near"),
+        "на рахунок": ("щодо", "account"),
+    }
+    for headword, (correction, authentic_marker) in expected.items():
+        entry = SENSE_RESTRICTED_CALQUES[headword]
+        assert correction in entry["corrections"]
+        assert authentic_marker in entry["authentic_sense"]
+        assert entry["evidence"]
+        assert "search_heritage" in entry["heritage_guard"]
+        assert headword not in PHRASAL_CALQUES
 
 
 def test_buckets_are_disjoint():

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -925,6 +925,45 @@ def test_curated_calque_matches_phrasal_entry() -> None:
     assert card["source"] == ["ua-gec", "grok-3098"]
 
 
+def test_curated_calque_matches_collocation_slice2_phrasal_entries() -> None:
+    expected = {
+        "при допомозі": "за допомогою",
+        "співпадати": "збігатися",
+        "в кінці кінців": "врешті-решт",
+    }
+    for phrase, correction in expected.items():
+        card = _curated_calque(phrase, phrase)
+        assert card is not None
+        assert card["kind"] == "phrasal"
+        assert correction in card["corrections"]
+        assert card["evidence"]
+        assert "search_heritage" in card["heritage_guard"]
+
+
+def test_curated_calque_matches_collocation_slice2_sense_restricted_entries() -> None:
+    expected = {
+        "на протязі": "протягом",
+        "являтися": "бути",
+        "дякуючи": "завдяки",
+        "так як": "оскільки",
+        "біля": "близько",
+        "на рахунок": "щодо",
+    }
+    for phrase, correction in expected.items():
+        card = _curated_calque(phrase, phrase)
+        assert card is not None
+        assert card["kind"] == "sense_restricted"
+        assert correction in card["corrections"]
+        assert card["calque_sense"] != card["authentic_sense"]
+        assert card["evidence"]
+        assert "search_heritage" in card["heritage_guard"]
+
+
+def test_collocation_slice2_authentic_phrases_are_not_exact_flagged() -> None:
+    assert _curated_calque("біля школи", "біля школи") is None
+    assert _curated_calque("на рахунок у банку", "на рахунок у банку") is None
+
+
 def test_curated_calque_unknown_lemma_returns_none() -> None:
     assert _curated_calque("яблуко", "яблуко") is None
 


### PR DESCRIPTION
Refs #3098

## Scope

Broadens the §6 decolonization calque moat with source-confirmed collocation/phrasal entries only. No re-enrich or manifest JSON update included; orchestrator should run enrichment separately.

## Kept Entries

Always-flag phrasal entries:

- `при допомозі` -> `за допомогою`
  - Evidence: `11-klas-ukrajinska-mova-glazova-2019_s0079`: “Неправильно: при допомозі; Правильно: за допомогою”.
  - Heritage guard: `search_heritage(при допомозі, include_live_slovnyk=false)`: no heritage evidence found.

- `співпадати` -> `збігатися`
  - Evidence: `5-klas-ukrmova-avramenko-2022_s0038`: “Неправильно: дані співпадають; Правильно: дані збігаються”.
  - Heritage guard: `search_heritage(співпадати, include_live_slovnyk=false)`: no heritage evidence found.

- `в кінці кінців` -> `кінець кінцем`, `зрештою`, `урешті-решт`, `врешті-решт`
  - Evidence: `9-klas-ukrmova-zabolotnyi-2017_s0291`: “Правильно: кінець кінцем; НЕправильно: в кінці кінців”.
  - Evidence: UA-GEC `0935`: error `в кінці кінців` -> correction `врешті-решт`, `F/Calque`.
  - Heritage guard: `search_heritage(в кінці кінців, include_live_slovnyk=false)`: no heritage evidence found.

Sense-restricted entries:

- `являтися` -> `бути`, `є` only in copular “to be / constitute” use.
  - Authentic sense: to appear/show oneself/arrive.
  - Evidence: Avramenko 9 `являтися переможцем` -> `бути переможцем`; Zabolotnyi 9 `він являється студентом` -> `він є студентом`; UA-GEC `0301` `являється` -> `є`; Grinchenko authentic `являтися` = appear/show.

- `на протязі` -> `протягом`, `упродовж`, `впродовж` only for time duration.
  - Authentic sense: draft/air-current and distance senses remain valid.
  - Evidence: Litvinova 7 and Zabolotnyi 7 explicitly distinguish duration from draft/distance; UA-GEC `0490` -> `протягом`, `1730` -> `упродовж`.

- `дякуючи` -> `завдяки` only in causal-preposition use.
  - Authentic sense: adverbial participle of `дякувати`.
  - Evidence: Zabolotnyi 7: `Переміг завдяки підтримці друзів` vs `Переміг, дякуючи підтримці друзів`; `завдяки підтримці` vs `дякуючи підтримці`.

- `так як` -> `оскільки`, `бо` only in causal conjunction use.
  - Authentic sense: comparative `так, як` remains distinct.
  - Evidence: UA-GEC `0026` `так як` -> `оскільки`; UA-GEC `0569` `так як` -> `бо`, both `F/Calque`.

- `біля` -> `близько` only for approximate quantity.
  - Authentic sense: “next to / near” remains valid.
  - Evidence: Litvinova 7: `БІЛЯ: біля школи, біля будинку; БЛИЗЬКО: близько третьої години...`; Zabolotnyi 7: `близько двох років` vs `біля двох років`; UA-GEC `0385` `біля` -> `близько`; Grinchenko authentic `біля` = near.

- `на рахунок` -> `щодо`, `стосовно` only for “regarding”.
  - Authentic sense: literal account/bank-account contexts remain valid.
  - Evidence: Avramenko 5: `на рахунок цього` -> `щодо цього`; Zabolotnyi 9 preserves `рахунок у банку`; UA-GEC `1296` `на рахунок` -> `щодо`; Grinchenko authentic `рахунок` = account/count.

## Explicitly Dropped From This Slice

Dropped because this pass did not find explicit correction evidence or because sources showed valid usage/context risk: `в залежності від`, `відноситися до`, `по мірі`, `в той же час`. `так як`, `на протязі`, `дякуючи`, `являтися`, `біля`, and `на рахунок` are sense-restricted rather than blanket flags to avoid false positives.

## Validation

```text
.venv/bin/python -m pytest tests/test_calque_corrections.py tests/test_lexicon_enrich_manifest.py -q
78 passed in 2.45s
```

```text
.venv/bin/ruff check scripts/lexicon/calque_corrections.py scripts/lexicon/enrich_manifest.py tests/test_calque_corrections.py tests/test_lexicon_enrich_manifest.py
All checks passed!
```

Commit trailer checked:

```text
.venv/bin/python scripts/audit/lint_agent_trailer.py
PASS X-Agent: codex/calque-collocations-3098
```
