### PR TITLE
fix(pipeline): #3079 C.3 — exempt Roman numerals + anonymous folk-primary citations

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -670,6 +670,7 @@ _VESUM_APOSTROPHE_TRANSLATION = str.maketrans(
     }
 )
 _VESUM_WORD_EDGE_CHARS = "-'ʼ’‘`´"
+_ROMAN_NUMERAL_CHARS = frozenset("xivlcdmхі")
 # O-grade plural obliques (`-остей`, `-остями`, `-остях`, `-остям`) overlap
 # Russian `-ость` forms such as `новостей`; keep that fallback to longer
 # stems so it does not pass merely because short bases like `новий` verify.
@@ -7981,7 +7982,10 @@ def run_python_qg(
             heritage_lookup_fn=heritage_lookup_fn,
         ),
     )
-    record("citations_resolve", _citation_gate(resources, plan))
+    record(
+        "citations_resolve",
+        _citation_gate(resources, plan, module_text=module_text, level=level),
+    )
     record("plan_reference_match", _plan_reference_match_gate(resources, plan))
     wiki_manifest: dict[str, Any] | None = None
     with contextlib.suppress(LinearPipelineError, ValueError):
@@ -9925,6 +9929,8 @@ def _vesum_gate(
             }
     if missing_lc:
         missing_lc = {word for word in missing_lc if not _is_sung_vowel_practice_lookup(word)}
+    if missing_lc:
+        missing_lc = {word for word in missing_lc if not _is_roman_numeral_lookup(word)}
     foreign_proper_attested_lc: set[str] = set()
     if missing_lc and _vesum_heritage_attestation_enabled(level):
         try:
@@ -10096,6 +10102,11 @@ def _bad_form_heritage_finding(
 def _is_sung_vowel_practice_lookup(word: str) -> bool:
     compact = re.sub(r"[-‐-―\s]+", "", _normalize_for_vesum(word).casefold())
     return len(compact) >= 3 and len(set(compact)) == 1 and compact[0] in "аоуеиі"
+
+
+def _is_roman_numeral_lookup(word: str) -> bool:
+    token = _normalize_for_vesum(word).casefold()
+    return len(token) >= 2 and all(char in _ROMAN_NUMERAL_CHARS for char in token)
 
 
 def _normalize_for_vesum(lemma: str) -> str:
@@ -11230,11 +11241,98 @@ def _citation_ref_resolves_by_containment(
     return False
 
 
-def _citation_gate(resources: list[dict[str, Any]], plan: Mapping[str, Any]) -> dict[str, Any]:
+_ANONYMOUS_FOLK_PRIMARY_MARKERS = (
+    "народна творчість",
+    "фольклорний запис",
+    "народна пісня",
+    "усна народна творчість",
+)
+_QUOTED_CITATION_TITLE_RE = re.compile(
+    r"«(?P<guillemet>[^»\n]{3,240})»"
+    r'|"(?P<double>[^"\n]{3,240})"'
+    r"|“(?P<curly>[^”\n]{3,240})”"
+)
+_ANONYMOUS_PRIMARY_MIN_TITLE_TOKENS = 3
+
+
+def _quoted_citation_titles(text: str) -> list[str]:
+    titles: list[str] = []
+    for match in _QUOTED_CITATION_TITLE_RE.finditer(text):
+        for group_name in ("guillemet", "double", "curly"):
+            title = match.group(group_name)
+            if title:
+                titles.append(title.strip())
+                break
+    return titles
+
+
+def _primary_excerpt_resolves_against_source(excerpt: str, source_text: str) -> bool:
+    excerpt_tokens = _textbook_match_token_spans(excerpt)
+    if len(excerpt_tokens) < _ANONYMOUS_PRIMARY_MIN_TITLE_TOKENS:
+        return False
+    return bool(
+        _matching_token_spans(
+            excerpt,
+            source_text,
+            min_words=len(excerpt_tokens),
+        )
+    )
+
+
+def _anonymous_folk_primary_citation_resolves(
+    resource: Mapping[str, Any],
+    source_ref: str,
+    *,
+    module_text: str,
+    level: str | None,
+) -> bool:
+    level_key = str(level or "").strip().casefold()
+    if level_key not in SEMINAR_LEVELS:
+        return False
+
+    marker_text = " ".join(
+        str(resource.get(field) or "")
+        for field in ("source_ref", "title")
+    )
+    marker_text = f"{marker_text} {source_ref}".casefold()
+    if not any(marker in marker_text for marker in _ANONYMOUS_FOLK_PRIMARY_MARKERS):
+        return False
+
+    quoted_titles = _quoted_citation_titles(source_ref) or _quoted_citation_titles(marker_text)
+    if not quoted_titles:
+        return False
+
+    verified_primary_texts = (
+        _quote_fidelity_verified_blockquote_texts(module_text, level=level_key)
+        if module_text
+        else []
+    )
+    for title in quoted_titles:
+        if any(
+            _primary_excerpt_resolves_against_source(title, primary_text)
+            for primary_text in verified_primary_texts
+        ):
+            return True
+        for hit in _search_literary_hits(title, level=level_key, limit=20):
+            hit_text = _result_text_for_match(hit)
+            if hit_text and _primary_excerpt_resolves_against_source(title, hit_text):
+                return True
+
+    return False
+
+
+def _citation_gate(
+    resources: list[dict[str, Any]],
+    plan: Mapping[str, Any],
+    *,
+    module_text: str = "",
+    level: str | None = None,
+) -> dict[str, Any]:
     plan_reference_records = _citation_plan_reference_records(plan)
     plan_reference_titles = [str(ref.get("title") or ref.get("work") or "") for ref in plan_reference_records]
     plan_titles = {_normalize_citation_ref(title) for title in plan_reference_titles}
     plan_keys = {key for title in plan_reference_titles if (key := extract_citation_key(title)) is not None}
+    level_key = str(level or plan.get("level") or "").strip().casefold()
     unknown = []
     for resource in resources:
         role = str(resource.get("role") or "textbook").strip()
@@ -11251,6 +11349,12 @@ def _citation_gate(resources: list[dict[str, Any]], plan: Mapping[str, Any]) -> 
                 for reference in plan_reference_records
             )
             and resource.get("packet_chunk_id") is None
+            and not _anonymous_folk_primary_citation_resolves(
+                resource,
+                source_ref,
+                module_text=module_text,
+                level=level_key,
+            )
         ):
             unknown.append(source_ref)
     return {"passed": not unknown, "unknown": unknown}

--- a/tests/test_citation_resolve.py
+++ b/tests/test_citation_resolve.py
@@ -267,6 +267,48 @@ def test_plan_references_field_is_supported() -> None:
     assert result["passed"] is True
 
 
+def test_anonymous_folk_primary_resolves_against_module_primary(monkeypatch) -> None:
+    monkeypatch.setattr(linear_pipeline, "_search_literary_hits", lambda *args, **kwargs: [])
+    module_text = """
+## Читання
+
+> Як ще не було початку світа,
+> Тогди не було неба, ні землі.
+
+— Народна творчість, «Як ще не було початку світа»
+"""
+    result = linear_pipeline._citation_gate(
+        [{"source_ref": "«Як ще не було початку світа» (народна творчість)"}],
+        {"level": "folk", "references": []},
+        module_text=module_text,
+        level="folk",
+    )
+
+    assert result["passed"] is True
+    assert result["unknown"] == []
+
+
+def test_fabricated_anonymous_folk_primary_still_rejected(monkeypatch) -> None:
+    monkeypatch.setattr(linear_pipeline, "_search_literary_hits", lambda *args, **kwargs: [])
+    module_text = """
+## Читання
+
+> Як ще не було початку світа,
+> Тогди не було неба, ні землі.
+
+— Народна творчість, «Як ще не було початку світа»
+"""
+    result = linear_pipeline._citation_gate(
+        [{"source_ref": "«Вигаданий рядок без корпусу» (народна творчість)"}],
+        {"level": "folk", "references": []},
+        module_text=module_text,
+        level="folk",
+    )
+
+    assert result["passed"] is False
+    assert result["unknown"] == ["«Вигаданий рядок без корпусу» (народна творчість)"]
+
+
 def test_my_morning_module_passes_citations_resolve() -> None:
     # Source refs must match the LIVE plan_references at curriculum/l2-uk-en/
     # plans/a1/my-morning.yaml. Citation history on this plan:

--- a/tests/test_vesum_verified_postfix.py
+++ b/tests/test_vesum_verified_postfix.py
@@ -506,6 +506,30 @@ def test_vesum_gate_still_flags_known_bad_form_after_hyphen_fix() -> None:
     assert "Будьякий" not in gate["missing"]
 
 
+def test_vesum_gate_exempts_roman_numeral_misses_only() -> None:
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        roman_or_nonword = {"іх", "празднік", "хіх"}
+        return {
+            word: ([] if word in roman_or_nonword else [{"lemma": word}])
+            for word in words
+        }
+
+    gate = _vesum_gate(
+        module_text=(
+            "У ХІХ столітті після XVIII таблиці згадано ІХ розділ, "
+            "але празднік лишається помилкою."
+        ),
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=verify_words,
+        level="hist",
+    )
+
+    assert gate["passed"] is False
+    assert gate["missing"] == ["празднік"]
+
+
 def test_vesum_gate_resolves_textbook_syllable_break_after_whole_lookup() -> None:
     seen: list[list[str]] = []
 


### PR DESCRIPTION
## Summary

Roman numerals + anonymous primaries only.

- Exempt multi-character Roman-numeral-shaped VESUM misses after lookup, so `ХІХ` / `ІХ` do not become false positives while real missing non-words still fail.
- Recognize anonymous folk-tradition primary citations only when the resource has an explicit marker (`народна творчість`, `фольклорний запис`, `народна пісня`, `усна народна творчість`) and the quoted text resolves against a verified same-module primary blockquote or the literary corpus.
- Keep ordinary unknown citations and fabricated `(народна творчість)` citations rejected.

Design §8: https://github.com/learn-ukrainian/learn-ukrainian.github.io/blob/main/docs/folk-epic/seminar-module-self-converge-3079-design.md#L312-L353

## Verification

### Explicit deterministic probe

cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-3079-c3-longtail`

command:

```bash
.venv/bin/python - <<'PY'
from scripts.build import linear_pipeline


def verify_words(words):
    missing = {"іх", "празднік", "хіх"}
    return {word: ([] if word in missing else [{"lemma": word}]) for word in words}

roman = linear_pipeline._vesum_gate(
    module_text=(
        "У ХІХ столітті після XVIII таблиці згадано ІХ розділ, "
        "але празднік лишається помилкою."
    ),
    activities=[],
    vocabulary=[],
    resources=[],
    verify_words_fn=verify_words,
    level="hist",
)
print("roman_missing=", roman["missing"])
print("roman_passed=", roman["passed"])

module_text = """
## Читання

> Як ще не було початку світа,
> Тогди не було неба, ні землі.

— Народна творчість, «Як ще не було початку світа»
"""
original_search = linear_pipeline._search_literary_hits
linear_pipeline._search_literary_hits = lambda *args, **kwargs: []
try:
    resolved = linear_pipeline._citation_gate(
        [{"source_ref": "«Як ще не було початку світа» (народна творчість)"}],
        {"level": "folk", "references": []},
        module_text=module_text,
        level="folk",
    )
    fabricated = linear_pipeline._citation_gate(
        [{"source_ref": "«Вигаданий рядок без корпусу» (народна творчість)"}],
        {"level": "folk", "references": []},
        module_text=module_text,
        level="folk",
    )
finally:
    linear_pipeline._search_literary_hits = original_search
print("anonymous_primary_resolved=", resolved)
print("anonymous_primary_fabricated=", fabricated)
PY
```

output:

```text
roman_missing= ['празднік']
roman_passed= False
anonymous_primary_resolved= {'passed': True, 'unknown': []}
anonymous_primary_fabricated= {'passed': False, 'unknown': ['«Вигаданий рядок без корпусу» (народна творчість)']}
```

### Focused regressions

cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-3079-c3-longtail`

command:

```bash
.venv/bin/python -m pytest tests/test_citation_resolve.py::test_anonymous_folk_primary_resolves_against_module_primary tests/test_citation_resolve.py::test_fabricated_anonymous_folk_primary_still_rejected tests/test_vesum_verified_postfix.py::test_vesum_gate_exempts_roman_numeral_misses_only -q
```

output:

```text
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-3079-c3-longtail
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 3 items

tests/test_citation_resolve.py ..                                        [ 66%]
tests/test_vesum_verified_postfix.py .                                   [100%]

============================== 3 passed in 1.69s ===============================
```

### Required regression suite

cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-3079-c3-longtail`

command:

```bash
.venv/bin/python -m pytest tests/test_citation*.py tests/test_vesum*.py tests/test_linear_pipeline*.py -m 'not skipif' -q
```

output:

```text
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-3079-c3-longtail
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 303 items / 10 deselected / 293 selected

tests/test_citation_check.py .................................           [ 11%]
tests/test_citation_matcher.py ................                          [ 16%]
tests/test_citation_resolution_gate.py ...                               [ 17%]
tests/test_citation_resolution_invariant.py ............................ [ 27%]
..................................................................       [ 49%]
tests/test_citation_resolve.py ................................          [ 60%]
tests/test_citation_whitespace.py ..                                     [ 61%]
tests/test_vesum_blockquote_exempt.py .......                            [ 63%]
tests/test_vesum_foreign_proper_noun_attestation.py ........             [ 66%]
tests/test_vesum_gate_distractor_and_phonetic.py ............            [ 70%]
tests/test_vesum_heritage_attestation.py ..........                      [ 74%]
tests/test_vesum_verified_postfix.py ................................    [ 84%]
tests/test_vesum_whitelist.py .................                          [ 90%]
tests/test_vesum_yaml_verbatim_primary_exemption.py ..........           [ 94%]
tests/test_linear_pipeline_telemetry.py ........                         [ 96%]
tests/test_linear_pipeline_vesum_heritage_attestation.py ..              [ 97%]
tests/test_linear_pipeline_wiki_coverage.py .......                      [100%]

===================== 293 passed, 10 deselected in 21.53s ======================
```

### Ruff

cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-3079-c3-longtail`

command:

```bash
.venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_citation_resolve.py tests/test_vesum_verified_postfix.py
```

output:

```text
All checks passed!
```

### Agent trailer

cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/folk-3079-c3-longtail`

command:

```bash
.venv/bin/python scripts/audit/lint_agent_trailer.py
```

output:

```text
Checking 1 commit(s) in origin/main..HEAD:

  01fe339831  PASS  X-Agent: codex/folk-3079-c3-longtail

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```
