### PR TITLE
chore(audit): add module certification wrapper

### DIFF
--- a/scripts/audit/certify_module.py
+++ b/scripts/audit/certify_module.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""Run deterministic certification checks for one curriculum module.
+
+This wrapper intentionally does not invoke LLM/QG backends. It fails closed on
+leftover QG artifacts unless --clean-qg-artifacts removes known untracked files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+CURRICULUM_ROOT = PROJECT_ROOT / "curriculum" / "l2-uk-en"
+MDX_ROOT = PROJECT_ROOT / "site" / "src" / "content" / "docs"
+VENV_PYTHON = PROJECT_ROOT / ".venv" / "bin" / "python"
+
+if str(PROJECT_ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from manifest_utils import get_module_by_number, get_modules_for_level, parse_numbered_slug
+
+from scripts.audit import check_mdx_source_parity
+
+QG_ARTIFACT_NAMES = frozenset({"llm_qg.json", "python_qg.json"})
+QG_ARTIFACT_GLOBS = (
+    "llm-qg-*-prompt.md",
+    "llm-qg-*-response.raw.md",
+)
+
+
+@dataclass(frozen=True)
+class ModuleTarget:
+    lang_pair: str
+    level: str
+    slug: str
+    local_num: int
+
+    @property
+    def label(self) -> str:
+        return f"{self.level}/{self.slug}"
+
+    @property
+    def module_dir(self) -> Path:
+        return CURRICULUM_ROOT / self.level / self.slug
+
+    @property
+    def mdx_path(self) -> Path:
+        return MDX_ROOT / self.level / f"{self.slug}.mdx"
+
+
+@dataclass(frozen=True)
+class CommandCheck:
+    name: str
+    command: tuple[str, ...]
+    cwd: Path = PROJECT_ROOT
+
+
+@dataclass(frozen=True)
+class QGInspectionFinding:
+    code: str
+    path: Path
+    message: str
+
+
+@dataclass(frozen=True)
+class QGCleanupResult:
+    artifacts: tuple[Path, ...]
+    removed: tuple[Path, ...]
+    refused_tracked: tuple[Path, ...]
+    findings: tuple[QGInspectionFinding, ...]
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.relative_to(PROJECT_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _rel_to(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _sanitized_git_env() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if not k.startswith(("GIT_", "PRE_COMMIT"))}
+
+
+def parse_target(values: list[str]) -> ModuleTarget:
+    """Resolve supported target forms into a manifest-backed module target."""
+    if len(values) == 1:
+        value = values[0]
+        if "/" not in value:
+            raise ValueError("single-argument target must be LEVEL/slug")
+        lang_pair = "l2-uk-en"
+        level, module_ref = value.split("/", 1)
+    elif len(values) == 2:
+        lang_pair = "l2-uk-en"
+        level, module_ref = values
+    elif len(values) == 3:
+        lang_pair, level, module_ref = values
+    else:
+        raise ValueError("target must be LEVEL MODULE, LEVEL/slug, or l2-uk-en LEVEL MODULE")
+
+    lang_pair = lang_pair.strip().lower()
+    level = level.strip().lower()
+    module_ref = module_ref.strip()
+    if lang_pair != "l2-uk-en":
+        raise ValueError("only l2-uk-en is supported by the current manifest utilities")
+    if not level or not module_ref:
+        raise ValueError("level and module target are required")
+
+    if module_ref.isdigit():
+        module = get_module_by_number(level, int(module_ref))
+        if module is None:
+            raise ValueError(f"unknown module number: {level} {module_ref}")
+        return ModuleTarget(lang_pair=lang_pair, level=level, slug=module.slug, local_num=module.local_num)
+
+    _, bare_slug = parse_numbered_slug(module_ref)
+    for module in get_modules_for_level(level):
+        if module.slug == bare_slug or module.numbered_slug == module_ref:
+            return ModuleTarget(lang_pair=lang_pair, level=level, slug=module.slug, local_num=module.local_num)
+
+    raise ValueError(f"unknown module slug: {level}/{module_ref}")
+
+
+def module_source_files(target: ModuleTarget) -> list[Path]:
+    """Return existing curriculum source files that feed this module's MDX."""
+    candidates = [
+        CURRICULUM_ROOT / "plans" / target.level / f"{target.slug}.yaml",
+        target.module_dir / "module.md",
+        target.module_dir / "activities.yaml",
+        target.module_dir / "vocabulary.yaml",
+        target.module_dir / "resources.yaml",
+        CURRICULUM_ROOT / target.level / "meta" / f"{target.slug}.yaml",
+        CURRICULUM_ROOT / target.level / f"{target.slug}.md",
+        CURRICULUM_ROOT / target.level / "activities" / f"{target.slug}.yaml",
+        CURRICULUM_ROOT / target.level / "vocabulary" / f"{target.slug}.yaml",
+        CURRICULUM_ROOT / target.level / "resources" / f"{target.slug}.yaml",
+    ]
+    return [path for path in candidates if path.exists()]
+
+
+def qg_artifacts(module_dir: Path) -> tuple[Path, ...]:
+    """Return known QG artifact files directly inside a module directory."""
+    if not module_dir.exists():
+        return ()
+
+    paths: set[Path] = set()
+    for filename in QG_ARTIFACT_NAMES:
+        path = module_dir / filename
+        if path.is_file():
+            paths.add(path)
+    for pattern in QG_ARTIFACT_GLOBS:
+        paths.update(path for path in module_dir.glob(pattern) if path.is_file())
+    return tuple(sorted(paths, key=lambda path: path.name))
+
+
+def inspect_qg_artifacts(paths: tuple[Path, ...]) -> tuple[QGInspectionFinding, ...]:
+    findings: list[QGInspectionFinding] = []
+    for path in paths:
+        if path.name in QG_ARTIFACT_NAMES:
+            try:
+                raw = path.read_text(encoding="utf-8")
+            except OSError as exc:
+                findings.append(QGInspectionFinding("qg-read-error", path, str(exc)))
+                continue
+            if not raw.strip():
+                findings.append(QGInspectionFinding("empty-qg-json", path, "QG JSON artifact is empty"))
+                continue
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                findings.append(QGInspectionFinding("malformed-qg-json", path, f"QG JSON is malformed: {exc}"))
+                continue
+            if not isinstance(parsed, dict):
+                findings.append(QGInspectionFinding("malformed-qg-json", path, "QG JSON must be an object"))
+        elif path.name.endswith("-response.raw.md"):
+            try:
+                raw = path.read_text(encoding="utf-8")
+            except OSError as exc:
+                findings.append(QGInspectionFinding("qg-read-error", path, str(exc)))
+                continue
+            if not raw.strip():
+                findings.append(QGInspectionFinding("empty-qg-response", path, "QG raw response is empty"))
+    return tuple(findings)
+
+
+def tracked_paths(repo_root: Path, paths: tuple[Path, ...]) -> set[Path]:
+    if not paths:
+        return set()
+    rels = [_rel_to(path, repo_root) for path in paths]
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-files", "--", *rels],
+        check=False,
+        capture_output=True,
+        env=_sanitized_git_env(),
+        text=True,
+    )
+    if proc.returncode != 0:
+        return set()
+    by_rel = {_rel_to(path, repo_root): path for path in paths}
+    return {by_rel[line] for line in proc.stdout.splitlines() if line in by_rel}
+
+
+def clean_qg_artifacts(module_dir: Path, *, repo_root: Path = PROJECT_ROOT, dry_run: bool = False) -> QGCleanupResult:
+    artifacts = qg_artifacts(module_dir)
+    findings = inspect_qg_artifacts(artifacts)
+    tracked = tracked_paths(repo_root, artifacts)
+    removed: list[Path] = []
+    refused: list[Path] = []
+
+    for path in artifacts:
+        if path in tracked:
+            refused.append(path)
+            continue
+        removed.append(path)
+        if not dry_run:
+            path.unlink()
+
+    return QGCleanupResult(
+        artifacts=artifacts,
+        removed=tuple(removed),
+        refused_tracked=tuple(refused),
+        findings=findings,
+    )
+
+
+def run_qg_guard(target: ModuleTarget, *, clean: bool, dry_run: bool) -> int:
+    artifacts = qg_artifacts(target.module_dir)
+    if not artifacts:
+        print("[OK] QG artifact guard: no QG artifacts found")
+        return 0
+
+    findings = inspect_qg_artifacts(artifacts)
+    print("[FAIL] QG artifact guard found generated QG files:")
+    for path in artifacts:
+        print(f"  - {_rel(path)}")
+    for finding in findings:
+        print(f"  - {finding.code}: {_rel(finding.path)}: {finding.message}")
+
+    if not clean:
+        print("Re-run with --clean-qg-artifacts to remove known untracked QG leftovers.")
+        return 1
+
+    result = clean_qg_artifacts(target.module_dir, dry_run=dry_run)
+    if result.removed:
+        action = "would remove" if dry_run else "removed"
+        for path in result.removed:
+            print(f"  {action}: {_rel(path)}")
+    if result.refused_tracked:
+        print("Tracked QG artifacts were not removed:")
+        for path in result.refused_tracked:
+            print(f"  - {_rel(path)}")
+        return 1
+    if dry_run:
+        print("[FAIL] QG artifact dry-run completed; remove artifacts before certification.")
+        return 1
+    print("[OK] QG artifact guard: cleaned untracked QG artifacts")
+    return 0
+
+
+def build_checks(
+    target: ModuleTarget,
+    *,
+    site_build: bool,
+    install_site_deps: bool,
+) -> list[CommandCheck]:
+    source_files = module_source_files(target)
+    checks = [
+        CommandCheck(
+            "generate MDX",
+            (
+                str(VENV_PYTHON),
+                "scripts/generate_mdx.py",
+                target.lang_pair,
+                target.level,
+                str(target.local_num),
+                "--validate",
+            ),
+        ),
+        CommandCheck(
+            "validate activities",
+            (
+                str(VENV_PYTHON),
+                "scripts/validate_activities.py",
+                target.lang_pair,
+                target.level,
+                str(target.local_num),
+            ),
+        ),
+        CommandCheck(
+            "validate plan config",
+            (
+                str(VENV_PYTHON),
+                "scripts/validate_plan_config.py",
+                f"{target.level}/{target.slug}",
+            ),
+        ),
+        CommandCheck(
+            "check MDX generation drift",
+            (
+                str(VENV_PYTHON),
+                "scripts/audit/check_mdx_generation_drift.py",
+                "--files",
+                *(_rel(path) for path in source_files),
+            ),
+        ),
+        CommandCheck("git diff whitespace check", ("git", "diff", "--check")),
+    ]
+
+    if site_build:
+        site_dir = PROJECT_ROOT / "site"
+        if install_site_deps:
+            checks.append(CommandCheck("install site dependencies", ("npm", "ci"), cwd=site_dir))
+        checks.append(CommandCheck("production site build", ("npm", "run", "build"), cwd=site_dir))
+
+    return checks
+
+
+def run_check(check: CommandCheck) -> int:
+    print(f"\n== {check.name} ==")
+    print("$ " + shlex.join(check.command))
+    proc = subprocess.run(list(check.command), cwd=check.cwd)
+    if proc.returncode == 0:
+        print(f"[OK] {check.name}")
+    else:
+        print(f"[FAIL] {check.name} exited {proc.returncode}")
+    return proc.returncode
+
+
+def run_mdx_source_parity(target: ModuleTarget) -> int:
+    print("\n== check MDX source parity ==")
+    source_files = module_source_files(target)
+    if not source_files:
+        print(f"[FAIL] no source files found for {target.label}")
+        return 1
+    if not target.mdx_path.exists():
+        print(f"[FAIL] missing generated MDX: {_rel(target.mdx_path)}")
+        return 1
+
+    changed_files = set(source_files)
+    changed_files.add(target.mdx_path)
+    violations = check_mdx_source_parity.check_parity([target.mdx_path], changed_files)
+    for path, message in violations:
+        print(f"{_rel(path)}: {message}")
+    if violations:
+        print("[FAIL] check MDX source parity")
+        return 1
+    print("[OK] check MDX source parity")
+    return 0
+
+
+def certify(args: argparse.Namespace) -> int:
+    try:
+        target = parse_target(args.target)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if not VENV_PYTHON.exists():
+        print(f"ERROR: expected venv python at {_rel(VENV_PYTHON)}", file=sys.stderr)
+        return 2
+
+    print(f"Certifying {target.label} with deterministic checks only.")
+    rc = run_qg_guard(target, clean=args.clean_qg_artifacts, dry_run=args.dry_run_qg_cleanup)
+    if rc != 0:
+        return rc
+
+    for check in build_checks(
+        target,
+        site_build=not args.skip_site_build,
+        install_site_deps=args.install_site_deps,
+    ):
+        rc = run_check(check)
+        if rc != 0:
+            return rc
+        if check.name == "check MDX generation drift":
+            rc = run_mdx_source_parity(target)
+            if rc != 0:
+                return rc
+
+    print(f"\n[OK] {target.label} deterministic certification passed")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "target",
+        nargs="+",
+        help="Module target: LEVEL MODULE, LEVEL/slug, or l2-uk-en LEVEL MODULE",
+    )
+    parser.add_argument(
+        "--clean-qg-artifacts",
+        action="store_true",
+        help="Remove known untracked QG artifacts before running checks.",
+    )
+    parser.add_argument(
+        "--dry-run-qg-cleanup",
+        action="store_true",
+        help="Show QG artifact cleanup without deleting files; certification still fails.",
+    )
+    parser.add_argument(
+        "--skip-site-build",
+        action="store_true",
+        help="Skip npm production build in site/.",
+    )
+    parser.add_argument(
+        "--install-site-deps",
+        action="store_true",
+        help="Run npm ci in site/ before the production build.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    return certify(build_parser().parse_args(argv))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/audit/test_certify_module.py
+++ b/tests/audit/test_certify_module.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from scripts.audit import certify_module
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = {k: v for k, v in os.environ.items() if not k.startswith(("GIT_", "PRE_COMMIT"))}
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+
+def test_qg_artifacts_match_only_known_direct_files(tmp_path: Path) -> None:
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    expected = {
+        "llm_qg.json": "{}\n",
+        "python_qg.json": "{}\n",
+        "llm-qg-naturalness-prompt.md": "prompt\n",
+        "llm-qg-tone-response.raw.md": "raw\n",
+    }
+    for name, content in expected.items():
+        (module_dir / name).write_text(content, encoding="utf-8")
+    (module_dir / "llm-qg-notes.txt").write_text("keep\n", encoding="utf-8")
+    nested = module_dir / "nested"
+    nested.mkdir()
+    (nested / "llm_qg.json").write_text("{}\n", encoding="utf-8")
+
+    artifacts = certify_module.qg_artifacts(module_dir)
+
+    assert {path.name for path in artifacts} == set(expected)
+
+
+def test_inspect_qg_artifacts_flags_empty_and_malformed_outputs(tmp_path: Path) -> None:
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    malformed = module_dir / "llm_qg.json"
+    malformed.write_text("{not-json", encoding="utf-8")
+    empty_response = module_dir / "llm-qg-tone-response.raw.md"
+    empty_response.write_text(" \n\t", encoding="utf-8")
+    valid_prompt = module_dir / "llm-qg-tone-prompt.md"
+    valid_prompt.write_text("prompt\n", encoding="utf-8")
+
+    findings = certify_module.inspect_qg_artifacts(
+        (malformed, empty_response, valid_prompt)
+    )
+
+    assert {(finding.code, finding.path.name) for finding in findings} == {
+        ("malformed-qg-json", "llm_qg.json"),
+        ("empty-qg-response", "llm-qg-tone-response.raw.md"),
+    }
+
+
+def test_clean_qg_artifacts_removes_untracked_known_files_only(tmp_path: Path) -> None:
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    qg_json = module_dir / "llm_qg.json"
+    qg_json.write_text("{}\n", encoding="utf-8")
+    raw_response = module_dir / "llm-qg-tone-response.raw.md"
+    raw_response.write_text("raw\n", encoding="utf-8")
+    keep = module_dir / "llm-qg-notes.txt"
+    keep.write_text("keep\n", encoding="utf-8")
+
+    result = certify_module.clean_qg_artifacts(module_dir, repo_root=tmp_path)
+
+    assert {path.name for path in result.removed} == {
+        "llm_qg.json",
+        "llm-qg-tone-response.raw.md",
+    }
+    assert result.refused_tracked == ()
+    assert not qg_json.exists()
+    assert not raw_response.exists()
+    assert keep.read_text(encoding="utf-8") == "keep\n"
+
+
+def test_clean_qg_artifacts_refuses_tracked_files(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    module_dir = repo / "curriculum" / "l2-uk-en" / "a1" / "demo"
+    module_dir.mkdir(parents=True)
+    tracked = module_dir / "llm_qg.json"
+    tracked.write_text("{}\n", encoding="utf-8")
+    untracked = module_dir / "llm-qg-tone-response.raw.md"
+    untracked.write_text("raw\n", encoding="utf-8")
+    _git(repo, "add", str(tracked.relative_to(repo)))
+
+    result = certify_module.clean_qg_artifacts(module_dir, repo_root=repo)
+
+    assert {path.name for path in result.refused_tracked} == {"llm_qg.json"}
+    assert {path.name for path in result.removed} == {"llm-qg-tone-response.raw.md"}
+    assert tracked.exists()
+    assert not untracked.exists()
+
+
+def test_build_checks_use_project_venv_python() -> None:
+    target = certify_module.ModuleTarget(
+        lang_pair="l2-uk-en",
+        level="a1",
+        slug="my-family",
+        local_num=6,
+    )
+
+    checks = certify_module.build_checks(target, site_build=False, install_site_deps=False)
+    python_commands = [check.command for check in checks if check.command[0].endswith("/python")]
+
+    assert python_commands
+    assert all(command[0] == str(certify_module.VENV_PYTHON) for command in python_commands)
+
+
+def test_parse_target_accepts_slug_and_module_number() -> None:
+    modules = [
+        SimpleNamespace(slug="hello", local_num=1, numbered_slug="01-hello"),
+        SimpleNamespace(slug="my-family", local_num=6, numbered_slug="06-my-family"),
+    ]
+    with (
+        patch("scripts.audit.certify_module.get_modules_for_level", return_value=modules),
+        patch("scripts.audit.certify_module.get_module_by_number", return_value=modules[1]),
+    ):
+        by_slug = certify_module.parse_target(["a1/my-family"])
+        by_number = certify_module.parse_target(["l2-uk-en", "a1", "6"])
+
+    assert by_slug.slug == "my-family"
+    assert by_slug.local_num == 6
+    assert by_number.slug == "my-family"
+    assert by_number.local_num == 6


### PR DESCRIPTION
## Summary

- Add `scripts/audit/certify_module.py`, a one-command deterministic module certification wrapper.
- Add QG artifact guardrails for `llm_qg.json`, `python_qg.json`, and `llm-qg-*-{prompt,response.raw}.md` leftovers.
- Clean only known untracked QG artifacts with `--clean-qg-artifacts`; refuse tracked artifacts and flag empty/malformed QG outputs.
- Add focused unit coverage for QG artifact matching, malformed/empty response detection, tracked-file refusal, target parsing, and `.venv/bin/python` command construction.

## Validation

- `.venv/bin/python -m pytest tests/audit/test_certify_module.py`
- `.venv/bin/ruff check scripts/audit/certify_module.py tests/audit/test_certify_module.py`
- `.venv/bin/python -m py_compile scripts/audit/certify_module.py tests/audit/test_certify_module.py`
- `.venv/bin/python scripts/audit/certify_module.py a1 6 --skip-site-build`
- `.venv/bin/python scripts/audit/certify_module.py a1 6 --install-site-deps`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Commit and push hooks passed.

## Gemini CLI Review

`gemini-cli` was run against the staged diff. It returned `REQUEST_CHANGES` with two findings claiming malformed `@dataclass`/`@property` decorators at `scripts/audit/certify_module.py` lines 39, 46, 50, 54, 59, 66, and 73. Those findings were checked against the file and rejected as false positives: the decorators are normal Python decorators, and `py_compile` plus the focused pytest suite pass.
