### PR TITLE
chore(autopsy): Root cause heading for atlas-conformance VESUM postmortem

### DIFF
--- a/docs/bug-autopsies/atlas-conformance-vesum-false-positives.md
+++ b/docs/bug-autopsies/atlas-conformance-vesum-false-positives.md
@@ -10,7 +10,8 @@ refresh a badly-stale committed manifest — the regen diff was +120K lines) mad
 abort the commit (`VERDICT: do NOT commit`). The 4 lemmas: `Афіни`, `Чернівці`,
 `УЗД`, `хвастливий`.
 
-## Why — all 4 were gate false-positives, zero content bugs
+## Root cause
+**All 4 were gate false-positives — zero content bugs.**
 The `lemma_in_vesum` gate (`scripts/audit/validate_atlas_conformance.py`) proves a
 single-word Atlas head is a real Ukrainian word by exact-matching it against VESUM's
 `forms` table. Three independent defects made it reject valid words:


### PR DESCRIPTION
Clears the recurring session-start hygiene flag: `docs/bug-autopsies/atlas-conformance-vesum-false-positives.md` was missing the required `## Root cause` field per `docs/best-practices/postmortem-management.md`.

The autopsy content was already complete — the root-cause analysis lived under a `## Why` heading, which the linter (`scripts/audit/check_postmortems.py` → exact heading match) doesn't accept. Renamed `## Why — all 4 were gate false-positives…` → `## Root cause` and folded the subtitle into the body.

## Verification
```
$ .venv/bin/python scripts/audit/check_postmortems.py   # exit 0, no missing-field error for this file
```
No content change; docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)