### PR TITLE
chore(deps): dependabot ignore lxml >=6.1.0 (capped by inscriptis)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,3 +69,9 @@ updates:
       # PR: #2710.
       - dependency-name: "starlette"
         versions: [">=0.51.0"]
+      # lxml is capped by inscriptis (inscriptis==2.7.1 requires lxml<6.1.0);
+      # lxml 6.1.0 re-breaks the inscriptis import that #2732 fixed by pinning
+      # down to 6.0.4 (#3282). Allow 6.0.x patches but block >=6.1.0 until
+      # inscriptis supports lxml 6.1.x — REMOVE this entry then. Closed PR: #3329.
+      - dependency-name: "lxml"
+        versions: [">=6.1.0"]


### PR DESCRIPTION
Stops Dependabot re-proposing `lxml 6.0.4->6.1.0` weekly. `inscriptis==2.7.1` requires `lxml<6.1.0`; the bump reverts the deliberate #3282 down-pin (#2732 part 1) and re-breaks inscriptis. Closed the latest instance as #3329.

Mirrors the existing `starlette` cap pattern in the same `ignore:` block (allow 6.0.x patches, block >=6.1.0). **Remove this entry when inscriptis supports lxml 6.1.x.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)