### PR TITLE
fix(lexicon): de-flag протиріччя — remove from Atlas surzhyk-to-avoid (over-flag); deeper classifier issue #3342

### DIFF
--- a/scripts/lexicon/build_data_manifest.py
+++ b/scripts/lexicon/build_data_manifest.py
@@ -78,7 +78,12 @@ SURZHYK_TO_AVOID_SEEDS: list[dict[str, str | None]] = [
     {"lemma": "всьо", "gloss": "avoid: все", "pos": "pron"},
     {"lemma": "діюча", "gloss": "avoid: чинна", "pos": "adj"},
     {"lemma": "міроприємство", "gloss": "avoid: захід", "pos": "noun"},
-    {"lemma": "протиріччя", "gloss": "avoid: суперечність", "pos": "noun"},
+    # протиріччя REMOVED 2026-06-16: over-flag. СУМ-20 codifies it ("Те саме, що
+    # суперечність") with literary attestations (Донченко/Копиленко/Харчук/Багряний);
+    # NUS textbooks (Grade 6/9/10) use it; absent from Antonenko + UA-GEC;
+    # check_russian_shadow=false. Sole flag-basis was LanguageTool replace.txt + the
+    # Штепа purist diaspora dictionary — a stylistic preference, not surzhyk. Deeper
+    # classifier over-weighting of LT/Штепа vs СУМ-20+literary tracked separately.
     {"lemma": "слідуючий", "gloss": "avoid: наступний", "pos": "adj"},
 ]
 

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "b43391ac8ccd78ec28d251850f5c553d2bd2127c0d3cc228e73bfb383ee3ba7e",
+  "fingerprint": "cc655a7f9377ce6ccaccd0b193c4c65d2114a9c69872f9f8ebb00242fd59bb0b",
   "inputs": {
     "lexicon_code": [
       {
@@ -12,7 +12,7 @@
       },
       {
         "path": "scripts/lexicon/build_data_manifest.py",
-        "sha256": "0a34750044a50fcc156b40fc88c0b0c10df296f860769bc393d3eba105d86a4d"
+        "sha256": "55d7ba948e43d2c1e0a521e0d3d15b952ccf4a26cfc0348878e426a706fbb19d"
       },
       {
         "path": "scripts/lexicon/build_kaikki_lookup.py",


### PR DESCRIPTION
## De-flag протиріччя in the Word Atlas (over-flag)

The Word Atlas displayed **протиріччя** as "surzhyk to avoid → суперечність" — directly contradicting
learners' own NUS textbooks. It is **standard Ukrainian, not surzhyk**. Evidence (all tool-verified):

| Source | Verdict |
|---|---|
| **СУМ-20** | Codifies it: "ПРОТИРІ́ЧЧЯ … Те саме, що супере́чність" + literary citations (Донченко/Копиленко/Харчук) |
| **Literary corpus** | Attested (Іван Багряний) |
| **NUS textbooks** | Used as normal vocab — Grade 6 golub 2023, Grade 9 burnejko, Grade 10 karaman |
| **Антоненко-Давидович** | Not found |
| **UA-GEC** | Not found |
| **check_russian_shadow** | false (0.57 < 0.7) |

The only flag-basis was LanguageTool `replace.txt` + the Штепа purist diaspora dictionary — a stylistic
preference, not surzhyk. Кept `діюча`/`діючий`/`слідуючий`/`міроприємство` (those ARE genuine calques).

### Change
- Drop протиріччя from `SURZHYK_TO_AVOID_SEEDS` (`build_data_manifest.py`) with an explanatory comment.
- **Surgical** manifest removal of its entry (`entries` 2428→2427, `from_surzhyk_to_avoid` 8→7, seed_group
  lemma) — NOT a full regen (#3150: local `make atlas` is network-degraded). Internally consistent.
- DB-free fingerprint bump (accounts for the `build_data_manifest.py` change → Atlas Freshness stays green).

### Scope / what this does NOT fix
This removes the **user-visible Atlas mislabel**. The **classifier** still returns `russianism` for
протиріччя via `lt_replacements` weighting — the deeper root cause (classifier over-weights LT/Штепа vs
СУМ-20-codification + literary attestation; should demote them like it does Antonenko). Filed as **#3342**,
queued as a focused follow-up (broad blast radius → needs adversarial review + regression sweep).

### Tests
Affected tests pass (`test_lexicon_build_manifest` `from_surzhyk_to_avoid==len(seeds)` stays consistent at 7).
NOTE: 3 tests in `test_vesum_heritage_attestation.py` fail **locally** (live `sources.db` vs CI fixture DB) —
verified **pre-existing** (fail on clean origin/main with this change stashed), unrelated to this PR.
