### PR TITLE
chore(deps): dependabot ignore openai >=2.0.0 (capped by marker-pdf)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,3 +81,8 @@ updates:
       # cap — REMOVE this entry then. Closed PR: #3338.
       - dependency-name: "tokenizers"
         versions: [">=0.23.1"]
+      # openai is capped by marker-pdf (marker-pdf requires openai>=1.65.2,<2.0.0);
+      # the 1.x->2.x SDK is a breaking major. Block >=2.0.0 until marker-pdf
+      # supports openai 2.x — REMOVE this entry then. Closed PR: #3352.
+      - dependency-name: "openai"
+        versions: [">=2.0.0"]


### PR DESCRIPTION
Stops Dependabot re-proposing `openai 1.x->2.x`. `marker-pdf` requires `openai>=1.65.2,<2.0.0`; the major SDK bump would break marker-pdf at runtime (openai is transitive-only here — 0 direct imports — so the flat-lock CI stays green and misses it). Closed the instance as #3352.

Mirrors the `lxml`/`tokenizers`/`starlette` cap entries. **Remove when marker-pdf supports the openai 2.x SDK.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)