### PR TITLE
[codex] Harden A2 certification tooling

### DIFF
--- a/scripts/audit/certify_module.py
+++ b/scripts/audit/certify_module.py
@@ -8,6 +8,7 @@ leftover QG artifacts unless --clean-qg-artifacts removes known untracked files.
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import json
 import os
 import shlex
@@ -29,12 +30,15 @@ if str(PROJECT_ROOT) not in sys.path:
 from manifest_utils import get_module_by_number, get_modules_for_level, parse_numbered_slug
 
 from scripts.audit import check_mdx_source_parity
+from scripts.validate import validate_plans as plan_yaml_validator
 
 QG_ARTIFACT_NAMES = frozenset({"llm_qg.json", "python_qg.json"})
 QG_ARTIFACT_GLOBS = (
     "llm-qg-*-prompt.md",
     "llm-qg-*-response.raw.md",
 )
+PROTECTED_CONFIG_FILES = frozenset({".python-version", ".yamllint", ".markdownlint.json"})
+MAX_CHANGED_FILES_DEFAULT = 20
 
 
 @dataclass(frozen=True)
@@ -148,6 +152,18 @@ def module_source_files(target: ModuleTarget) -> list[Path]:
         CURRICULUM_ROOT / target.level / "activities" / f"{target.slug}.yaml",
         CURRICULUM_ROOT / target.level / "vocabulary" / f"{target.slug}.yaml",
         CURRICULUM_ROOT / target.level / "resources" / f"{target.slug}.yaml",
+    ]
+    return [path for path in candidates if path.exists()]
+
+
+def plan_source_file(target: ModuleTarget) -> Path:
+    return CURRICULUM_ROOT / "plans" / target.level / f"{target.slug}.yaml"
+
+
+def vocabulary_source_files(target: ModuleTarget) -> list[Path]:
+    candidates = [
+        target.module_dir / "vocabulary.yaml",
+        CURRICULUM_ROOT / target.level / "vocabulary" / f"{target.slug}.yaml",
     ]
     return [path for path in candidates if path.exists()]
 
@@ -271,6 +287,110 @@ def run_qg_guard(target: ModuleTarget, *, clean: bool, dry_run: bool) -> int:
     return 0
 
 
+def _git_lines(args: tuple[str, ...], repo_root: Path = PROJECT_ROOT, *, nul: bool = False) -> list[str]:
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=False,
+        capture_output=True,
+        env=_sanitized_git_env(),
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or f"git {' '.join(args)} failed")
+    parts = proc.stdout.split("\0") if nul else proc.stdout.splitlines()
+    return [part for part in parts if part]
+
+
+def changed_or_untracked_paths(repo_root: Path = PROJECT_ROOT) -> tuple[str, ...]:
+    paths = set(_git_lines(("diff", "--name-only", "-z", "HEAD", "--"), repo_root=repo_root, nul=True))
+    paths.update(_git_lines(("ls-files", "-z", "--others", "--exclude-standard"), repo_root=repo_root, nul=True))
+    return tuple(sorted(paths))
+
+
+def forbidden_diff_reason(rel_path: str) -> str | None:
+    if rel_path in PROTECTED_CONFIG_FILES:
+        return "protected repo config must stay unchanged"
+    if rel_path.startswith("data/telemetry/"):
+        return "local telemetry database/state must not be committed"
+    if rel_path.startswith("curriculum/l2-uk-en/"):
+        if "/status/" in rel_path and rel_path.endswith(".json"):
+            return "generated status JSON must not be in module PRs"
+        if "/audit/" in rel_path and rel_path.endswith("-review.md"):
+            return "generated audit review must not be in module PRs"
+        if "/review/" in rel_path and rel_path.endswith("-review.md"):
+            return "generated review file must not be in module PRs"
+        if rel_path.endswith(".errors.txt"):
+            return "validator sidecar error file is a scratch artifact"
+    if fnmatch.fnmatchcase(rel_path, "docs/*-STATUS.md"):
+        return "generated level status report must not be in module PRs"
+    return None
+
+
+def run_diff_guard(*, max_changed_files: int) -> int:
+    print("\n== artifact/diff guard ==")
+    try:
+        paths = changed_or_untracked_paths()
+    except RuntimeError as exc:
+        print(f"[FAIL] artifact/diff guard could not inspect git diff: {exc}")
+        return 1
+
+    failures: list[tuple[str, str]] = []
+    if len(paths) > max_changed_files:
+        failures.append(
+            (
+                "<diff>",
+                f"{len(paths)} changed/untracked files exceeds limit {max_changed_files}; check for generated artifacts",
+            )
+        )
+    for rel_path in paths:
+        reason = forbidden_diff_reason(rel_path)
+        if reason:
+            failures.append((rel_path, reason))
+
+    if failures:
+        print("[FAIL] artifact/diff guard found disallowed or suspicious diff entries:")
+        for rel_path, reason in failures:
+            print(f"  - {rel_path}: {reason}")
+        return 1
+
+    print(f"[OK] artifact/diff guard: {len(paths)} changed/untracked file(s), no forbidden artifacts")
+    return 0
+
+
+def run_plan_yaml_validation(target: ModuleTarget) -> int:
+    print("\n== validate plan YAML ==")
+    plan_path = plan_source_file(target)
+    if not plan_path.exists():
+        print(f"[FAIL] missing plan: {_rel(plan_path)}")
+        return 1
+    issues = plan_yaml_validator.validate_plan(plan_path)
+    errors = [issue for issue in issues if issue.get("severity") == "error"]
+    if errors:
+        print(f"[FAIL] validate plan YAML: {_rel(plan_path)}")
+        for issue in errors:
+            print(f"  - {issue.get('type', 'ERROR')}: {issue.get('message', '')}")
+        return 1
+    print(f"[OK] validate plan YAML: {_rel(plan_path)}")
+    return 0
+
+
+def run_vocabulary_presence_guard(target: ModuleTarget) -> int:
+    print("\n== vocabulary source guard ==")
+    vocab_files = vocabulary_source_files(target)
+    if vocab_files:
+        for path in vocab_files:
+            print(f"[OK] vocabulary source: {_rel(path)}")
+        return 0
+    expected_paths = [
+        target.module_dir / "vocabulary.yaml",
+        CURRICULUM_ROOT / target.level / "vocabulary" / f"{target.slug}.yaml",
+    ]
+    print(f"[FAIL] no vocabulary source found for {target.label}; checked:")
+    for path in expected_paths:
+        print(f"  - {_rel(path)}")
+    return 1
+
+
 def build_checks(
     target: ModuleTarget,
     *,
@@ -278,6 +398,7 @@ def build_checks(
     install_site_deps: bool,
 ) -> list[CommandCheck]:
     source_files = module_source_files(target)
+    vocab_files = vocabulary_source_files(target)
     checks = [
         CommandCheck(
             "generate MDX",
@@ -300,25 +421,44 @@ def build_checks(
                 str(target.local_num),
             ),
         ),
-        CommandCheck(
-            "validate plan config",
-            (
-                str(VENV_PYTHON),
-                "scripts/validate_plan_config.py",
-                f"{target.level}/{target.slug}",
-            ),
-        ),
-        CommandCheck(
-            "check MDX generation drift",
-            (
-                str(VENV_PYTHON),
-                "scripts/audit/check_mdx_generation_drift.py",
-                "--files",
-                *(_rel(path) for path in source_files),
-            ),
-        ),
-        CommandCheck("git diff whitespace check", ("git", "diff", "--check")),
     ]
+    if vocab_files:
+        checks.append(
+            CommandCheck(
+                "validate vocabulary",
+                (
+                    str(VENV_PYTHON),
+                    "scripts/validate/validate_vocab_yaml.py",
+                    *(_rel(path) for path in vocab_files),
+                ),
+            )
+        )
+    checks.extend(
+        [
+            CommandCheck(
+                "validate plan config",
+                (
+                    str(VENV_PYTHON),
+                    "scripts/validate_plan_config.py",
+                    f"{target.level}/{target.slug}",
+                ),
+            ),
+            CommandCheck(
+                "check MDX generation drift",
+                (
+                    str(VENV_PYTHON),
+                    "scripts/audit/check_mdx_generation_drift.py",
+                    "--files",
+                    *(_rel(path) for path in source_files),
+                ),
+            ),
+            CommandCheck("git diff whitespace check", ("git", "diff", "--check")),
+            CommandCheck(
+                "agent trailer audit",
+                (str(VENV_PYTHON), "scripts/audit/lint_agent_trailer.py"),
+            ),
+        ]
+    )
 
     if site_build:
         site_dir = PROJECT_ROOT / "site"
@@ -377,6 +517,15 @@ def certify(args: argparse.Namespace) -> int:
     rc = run_qg_guard(target, clean=args.clean_qg_artifacts, dry_run=args.dry_run_qg_cleanup)
     if rc != 0:
         return rc
+    rc = run_diff_guard(max_changed_files=args.max_changed_files)
+    if rc != 0:
+        return rc
+    rc = run_plan_yaml_validation(target)
+    if rc != 0:
+        return rc
+    rc = run_vocabulary_presence_guard(target)
+    if rc != 0:
+        return rc
 
     for check in build_checks(
         target,
@@ -390,6 +539,10 @@ def certify(args: argparse.Namespace) -> int:
             rc = run_mdx_source_parity(target)
             if rc != 0:
                 return rc
+
+    rc = run_diff_guard(max_changed_files=args.max_changed_files)
+    if rc != 0:
+        return rc
 
     print(f"\n[OK] {target.label} deterministic certification passed")
     return 0
@@ -421,6 +574,15 @@ def build_parser() -> argparse.ArgumentParser:
         "--install-site-deps",
         action="store_true",
         help="Run npm ci in site/ before the production build.",
+    )
+    parser.add_argument(
+        "--max-changed-files",
+        type=int,
+        default=MAX_CHANGED_FILES_DEFAULT,
+        help=(
+            "Fail when the current diff has more changed/untracked files than this "
+            f"limit (default: {MAX_CHANGED_FILES_DEFAULT})."
+        ),
     )
     return parser
 

--- a/scripts/build/run_llm_qg_parity.py
+++ b/scripts/build/run_llm_qg_parity.py
@@ -15,6 +15,10 @@ Usage:
     .venv/bin/python scripts/build/run_llm_qg_parity.py folk koliadky-shchedrivky
     .venv/bin/python scripts/build/run_llm_qg_parity.py folk <slug> --reviewer codex-tools
 
+The shared QG runner resumes dimensions whose prompt/raw-response artifacts
+already parse cleanly, and retries a dimension when the backend returns an empty
+or malformed response.
+
 Outputs ``<module_dir>/llm_qg.json`` and prints the aggregate verdict line. Exit
 code 0 on success, 1 on missing plan/module.
 """

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -45,6 +45,7 @@ WRITER_ALIASES = {
     "agy": "agy-tools",
 }
 WRITER_CHOICES = (*linear_pipeline.WRITER_CHOICES, *WRITER_ALIASES)
+LLM_QG_DIM_MAX_ATTEMPTS = 2
 
 
 @dataclass(slots=True)
@@ -972,6 +973,52 @@ def _normalize_writer(writer: str) -> str:
     return WRITER_ALIASES.get(writer, writer)
 
 
+def _parse_llm_qg_dim_response(response: str, *, dim: str, response_path: Path) -> dict[str, Any]:
+    if not response.strip():
+        raise linear_pipeline.LinearPipelineError(
+            f"LLM QG {dim} empty backend response in {response_path}"
+        )
+    try:
+        return linear_pipeline.parse_review_response(response, dim)
+    except linear_pipeline.LinearPipelineError as exc:
+        raise linear_pipeline.LinearPipelineError(
+            f"LLM QG {dim} malformed backend response in {response_path}: {exc}"
+        ) from exc
+
+
+def _resume_llm_qg_dim_if_current(
+    *,
+    dim: str,
+    prompt: str,
+    prompt_path: Path,
+    response_path: Path,
+) -> dict[str, Any] | None:
+    if not prompt_path.exists() or not response_path.exists():
+        return None
+    try:
+        if prompt_path.read_text(encoding="utf-8") != prompt:
+            return None
+        response = response_path.read_text(encoding="utf-8")
+        parsed = _parse_llm_qg_dim_response(response, dim=dim, response_path=response_path)
+    except OSError as exc:
+        print(
+            f"[llm-qg] {dim}: could not read existing artifacts; retrying ({exc})",
+            file=sys.stderr,
+            flush=True,
+        )
+        return None
+    except linear_pipeline.LinearPipelineError as exc:
+        print(
+            f"[llm-qg] {dim}: existing response artifact is unusable; retrying ({exc})",
+            file=sys.stderr,
+            flush=True,
+        )
+        return None
+
+    print(f"[llm-qg] {dim}: resumed from {response_path.name}", flush=True)
+    return parsed
+
+
 def _run_llm_qg(
     *,
     plan: Mapping[str, Any],
@@ -1009,28 +1056,58 @@ def _run_llm_qg(
             use_generator=use_generator,
             obligation_checklist=obligation_checklist,
         )
-        (module_dir / f"llm-qg-{dim}-prompt.md").write_text(prompt, encoding="utf-8")
-        result = invoke(
-            agent_name,
-            prompt,
-            mode="read-only",
-            cwd=module_dir,
-            model=defaults["model"],
-            task_id=f"linear-v7-qg-{plan['slug']}-{dim}",
-            entrypoint="dispatch",
-            effort=defaults["effort"],
-            tool_config={"output_format": "stream-json"},
-            stdout_silence_timeout=stdout_silence_timeout,
+        prompt_path = module_dir / f"llm-qg-{dim}-prompt.md"
+        response_path = module_dir / f"llm-qg-{dim}-response.raw.md"
+        resumed = _resume_llm_qg_dim_if_current(
+            dim=dim,
+            prompt=prompt,
+            prompt_path=prompt_path,
+            response_path=response_path,
         )
-        response = str(getattr(result, "response", "") or "")
-        # Persist raw reviewer response BEFORE parse so #M-10 forensic
-        # continuity holds when the parser raises (build #10, 2026-05-21
-        # exposed prose-wrapped JSON shape with no saved artifact).
-        (module_dir / f"llm-qg-{dim}-response.raw.md").write_text(
-            response,
-            encoding="utf-8",
-        )
-        report[dim] = linear_pipeline.parse_review_response(response, dim)
+        if resumed is not None:
+            report[dim] = resumed
+            continue
+
+        prompt_path.write_text(prompt, encoding="utf-8")
+        last_error: linear_pipeline.LinearPipelineError | None = None
+        for attempt in range(1, LLM_QG_DIM_MAX_ATTEMPTS + 1):
+            result = invoke(
+                agent_name,
+                prompt,
+                mode="read-only",
+                cwd=module_dir,
+                model=defaults["model"],
+                task_id=f"linear-v7-qg-{plan['slug']}-{dim}",
+                entrypoint="dispatch",
+                effort=defaults["effort"],
+                tool_config={"output_format": "stream-json"},
+                stdout_silence_timeout=stdout_silence_timeout,
+            )
+            response = str(getattr(result, "response", "") or "")
+            # Persist raw reviewer response BEFORE parse so #M-10 forensic
+            # continuity holds when the parser raises (build #10, 2026-05-21
+            # exposed prose-wrapped JSON shape with no saved artifact).
+            response_path.write_text(response, encoding="utf-8")
+            try:
+                report[dim] = _parse_llm_qg_dim_response(
+                    response,
+                    dim=dim,
+                    response_path=response_path,
+                )
+                break
+            except linear_pipeline.LinearPipelineError as exc:
+                last_error = exc
+                if attempt < LLM_QG_DIM_MAX_ATTEMPTS:
+                    print(
+                        f"[llm-qg] {dim}: attempt {attempt}/{LLM_QG_DIM_MAX_ATTEMPTS} failed; retrying ({exc})",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                    continue
+                raise linear_pipeline.LinearPipelineError(
+                    f"LLM QG {dim} failed after {LLM_QG_DIM_MAX_ATTEMPTS} attempt(s); "
+                    f"raw response saved to {response_path}: {last_error}"
+                ) from last_error
 
     return linear_pipeline.aggregate_llm_review(
         report,

--- a/tests/audit/test_certify_module.py
+++ b/tests/audit/test_certify_module.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from scripts.audit import certify_module
 
 
@@ -116,6 +118,94 @@ def test_build_checks_use_project_venv_python() -> None:
 
     assert python_commands
     assert all(command[0] == str(certify_module.VENV_PYTHON) for command in python_commands)
+
+
+def test_build_checks_include_standard_certification_guards() -> None:
+    target = certify_module.ModuleTarget(
+        lang_pair="l2-uk-en",
+        level="a1",
+        slug="my-family",
+        local_num=6,
+    )
+
+    checks = certify_module.build_checks(target, site_build=False, install_site_deps=False)
+    names = [check.name for check in checks]
+    vocab_check = next(check for check in checks if check.name == "validate vocabulary")
+
+    assert "validate vocabulary" in names
+    assert "validate plan config" in names
+    assert "check MDX generation drift" in names
+    assert "agent trailer audit" in names
+    assert vocab_check.command[1] == "scripts/validate/validate_vocab_yaml.py"
+    assert all("vocabulary.yaml" in arg for arg in vocab_check.command[2:])
+
+
+def test_build_checks_do_not_add_vocabulary_validator_for_missing_file() -> None:
+    target = certify_module.ModuleTarget(
+        lang_pair="l2-uk-en",
+        level="a1",
+        slug="does-not-exist",
+        local_num=999,
+    )
+
+    checks = certify_module.build_checks(target, site_build=False, install_site_deps=False)
+
+    assert "validate vocabulary" not in {check.name for check in checks}
+
+
+def test_vocabulary_presence_guard_fails_clearly_for_missing_file(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    target = certify_module.ModuleTarget(
+        lang_pair="l2-uk-en",
+        level="a1",
+        slug="does-not-exist",
+        local_num=999,
+    )
+
+    rc = certify_module.run_vocabulary_presence_guard(target)
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "no vocabulary source found for a1/does-not-exist" in captured.out
+    assert "curriculum/l2-uk-en/a1/does-not-exist/vocabulary.yaml" in captured.out
+
+
+def test_forbidden_diff_reason_flags_generated_artifacts_and_protected_configs() -> None:
+    cases = {
+        ".python-version": "protected repo config",
+        ".yamllint": "protected repo config",
+        ".markdownlint.json": "protected repo config",
+        "curriculum/l2-uk-en/a2/status/greetings.json": "generated status JSON",
+        "curriculum/l2-uk-en/a2/audit/greetings-review.md": "generated audit review",
+        "curriculum/l2-uk-en/a2/review/greetings-review.md": "generated review file",
+        "curriculum/l2-uk-en/a2/greetings/vocabulary.yaml.errors.txt": "validator sidecar",
+        "docs/A2-STATUS.md": "generated level status",
+        "data/telemetry/module-builds.sqlite": "local telemetry",
+    }
+
+    for rel_path, expected in cases.items():
+        assert expected in (certify_module.forbidden_diff_reason(rel_path) or "")
+
+    assert certify_module.forbidden_diff_reason("curriculum/l2-uk-en/a2/greetings/module.md") is None
+
+
+def test_changed_or_untracked_paths_reports_tracked_and_untracked(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "codex@example.test")
+    _git(repo, "config", "user.name", "Codex")
+    tracked = repo / "tracked\tfile.txt"
+    tracked.write_text("old\n", encoding="utf-8")
+    _git(repo, "add", "tracked\tfile.txt")
+    _git(repo, "commit", "-m", "init")
+    tracked.write_text("new\n", encoding="utf-8")
+    (repo / "untracked space.txt").write_text("new\n", encoding="utf-8")
+
+    paths = certify_module.changed_or_untracked_paths(repo)
+
+    assert paths == ("tracked\tfile.txt", "untracked space.txt")
 
 
 def test_parse_target_accepts_slug_and_module_number() -> None:

--- a/tests/test_v7_build_reviewer_assert.py
+++ b/tests/test_v7_build_reviewer_assert.py
@@ -1,9 +1,12 @@
+import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
 from scripts.build import linear_pipeline, v7_build
+from scripts.common.thresholds import QG_DIMS
 
 
 def test_reviewer_override_normalizes_alias():
@@ -157,3 +160,121 @@ def test_reviewer_assert_v7_build(tmp_path: Path):
                         wiki_manifest={},
                         wiki_coverage_gate={},
                     )
+
+
+def _llm_qg_response(dim: str) -> str:
+    return json.dumps(
+        {
+            "score": 8.5,
+            "evidence": f'"{dim} evidence quote"',
+            "verdict": "PASS",
+        }
+    )
+
+
+def _patch_llm_qg_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        v7_build.linear_pipeline,
+        "render_review_prompt",
+        lambda *_args, **_kwargs: f"prompt::{_args[3]}",
+    )
+    monkeypatch.setattr(v7_build, "_generated_content", lambda _module_dir: "generated")
+
+
+def test_llm_qg_retries_empty_dimension_response(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_llm_qg_prompt(monkeypatch)
+    first_dim = QG_DIMS[0]
+    calls: list[str] = []
+
+    def invoke(_agent: str, prompt: str, **_kwargs: object) -> SimpleNamespace:
+        dim = prompt.split("::", 1)[1]
+        calls.append(dim)
+        if dim == first_dim and calls.count(dim) == 1:
+            return SimpleNamespace(response="")
+        return SimpleNamespace(response=_llm_qg_response(dim))
+
+    monkeypatch.setattr("scripts.agent_runtime.runner.invoke", invoke)
+
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    report = v7_build._run_llm_qg(
+        plan={"slug": "test-slug", "level": "a1"},
+        plan_content="plan",
+        module_dir=module_dir,
+        writer="claude-tools",
+        reviewer_override="codex-tools",
+    )
+
+    assert calls.count(first_dim) == 2
+    assert set(report["dimensions"]) == set(QG_DIMS)
+    assert (module_dir / f"llm-qg-{first_dim}-response.raw.md").read_text(
+        encoding="utf-8"
+    ).strip()
+
+
+def test_llm_qg_resumes_current_successful_dimension_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_llm_qg_prompt(monkeypatch)
+    resumed_dim = QG_DIMS[0]
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    (module_dir / f"llm-qg-{resumed_dim}-prompt.md").write_text(
+        f"prompt::{resumed_dim}",
+        encoding="utf-8",
+    )
+    (module_dir / f"llm-qg-{resumed_dim}-response.raw.md").write_text(
+        _llm_qg_response(resumed_dim),
+        encoding="utf-8",
+    )
+    calls: list[str] = []
+
+    def invoke(_agent: str, prompt: str, **_kwargs: object) -> SimpleNamespace:
+        dim = prompt.split("::", 1)[1]
+        calls.append(dim)
+        return SimpleNamespace(response=_llm_qg_response(dim))
+
+    monkeypatch.setattr("scripts.agent_runtime.runner.invoke", invoke)
+
+    report = v7_build._run_llm_qg(
+        plan={"slug": "test-slug", "level": "a1"},
+        plan_content="plan",
+        module_dir=module_dir,
+        writer="claude-tools",
+        reviewer_override="codex-tools",
+    )
+
+    assert resumed_dim not in calls
+    assert set(report["dimensions"]) == set(QG_DIMS)
+
+
+def test_llm_qg_reports_malformed_dimension_response_clearly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_llm_qg_prompt(monkeypatch)
+
+    def invoke(_agent: str, _prompt: str, **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(response="not structured output")
+
+    monkeypatch.setattr("scripts.agent_runtime.runner.invoke", invoke)
+
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    with pytest.raises(linear_pipeline.LinearPipelineError) as exc_info:
+        v7_build._run_llm_qg(
+            plan={"slug": "test-slug", "level": "a1"},
+            plan_content="plan",
+            module_dir=module_dir,
+            writer="claude-tools",
+            reviewer_override="codex-tools",
+        )
+
+    message = str(exc_info.value)
+    assert f"LLM QG {QG_DIMS[0]} failed after" in message
+    assert "malformed backend response" in message
+    assert "response.raw.md" in message


### PR DESCRIPTION
## Summary
- Extend `scripts/audit/certify_module.py` with module-scoped plan YAML validation, vocabulary presence/validation, artifact/diff guardrails, and the agent trailer audit.
- Harden the shared LLM QG runner with per-dimension retry, prompt-matched resume from successful raw-response artifacts, and explicit empty/malformed backend response errors.
- Update the standalone LLM QG parity runner help text and add focused unit tests for the new certifier/QG behavior.

## Validation
- `.venv/bin/python -m pytest tests/audit/test_certify_module.py tests/test_v7_build_reviewer_assert.py -q`
- `.venv/bin/ruff check scripts/audit/certify_module.py scripts/build/v7_build.py scripts/build/run_llm_qg_parity.py tests/audit/test_certify_module.py tests/test_v7_build_reviewer_assert.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `git diff --check origin/main..HEAD`
- `certify_module.run_diff_guard(max_changed_files=20)`
- Commit and push hooks passed.

## Review Notes
- Local review used a read-only Gemini pass plus Codex challenge adjudication.
- Added a read-only DeepSeek (`deepseek-v4-pro`) review pass per orchestration preference.
- Fixed the confirmed Gemini/Codex finding: parse git path output with `-z`/NUL splitting in the diff guard.
- Fixed the DeepSeek findings: validate vocabulary through the real validator entrypoint and fail missing vocabulary with a clear guard instead of a ghost path.
- No module content was edited by review agents.