### PR TITLE
chore(deps): dependabot ignore pypdfium2 (exact-pinned by pdftext + surya-ocr)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,6 +62,10 @@ updates:
       # 2.41.5`. It must move only via a pydantic bump (which recomputes the
       # lock and brings a matching pydantic-core). Closed PR: #2540.
       - dependency-name: "pydantic-core"
+      # pypdfium2 is exact-pinned by pdftext AND surya-ocr (both require
+      # pypdfium2==4.30.0). A standalone bump (e.g. 4.30.0->5.9.0, #3359) breaks
+      # the OCR/PDF stack; it moves only via a pdftext/surya-ocr bump. Full block.
+      - dependency-name: "pypdfium2"
       # starlette is capped by fastapi (fastapi==0.136.1 requires
       # starlette<0.51.0); starlette 1.x makes the lock unresolvable by pip.
       # Allow 0.50.x patches but block >=0.51 until a fastapi bump loosens the


### PR DESCRIPTION
Stops Dependabot re-proposing `pypdfium2 4.30.0->5.x`. Both `pdftext` and `surya-ocr` require `pypdfium2==4.30.0` (exact); the major bump breaks the OCR/PDF stack at runtime (pypdfium2 is transitive-only — 0 direct imports — so flat-lock CI stays green). Closed the instance as #3359. Full block, mirrors `pydantic-core` (moves only via a pdftext/surya-ocr bump).

**6th transitive-cap ignore — root cause is #2716** (flat fully-pinned lock lets Dependabot propose past parents' caps). Worth a constraints-aware fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)