### PR TITLE
feat(lexicon): single-word lexical calque corrections — decolonization §6 slice 3 [#3098]

### DIFF
--- a/scripts/lexicon/calque_corrections.py
+++ b/scripts/lexicon/calque_corrections.py
@@ -269,6 +269,47 @@ CURATED_CALQUES: dict[str, dict[str, object]] = {
         "heritage_guard": "search_heritage(жовтіючий, include_live_slovnyk=false): No heritage evidence found.",
     },
     "бувший": {"corrections": ["колишній"], "note": "-вш- participle does not exist in Ukrainian (рос. бывший)", "source": ["avramenko-11"]},
+    # §6 lexical-calque slice 3 (#3098) — single-word blanket lexical calques.
+    "слідуючий": {
+        "kind": "lexical",
+        "corrections": ["наступний"],
+        "note": "рос. следующий; use наступний for 'next'",
+        "source": ["voron-9", "zabolotnyi-5"],
+        "evidence": [
+            "9-klas-ukrajinska-mova-voron-2017_s0232: следующий — тут: наступний; Як правильно перекласти ... следующий? ... наступний",
+        ],
+        "heritage_guard": "search_heritage(слідуючий, include_live_slovnyk=false): No heritage evidence found.",
+    },
+    "багаточисельний": {
+        "kind": "lexical",
+        "corrections": ["численний"],
+        "note": "рос. многочисленный; use численний for 'numerous'",
+        "source": ["antonenko-p065", "zabolotnyi-11"],
+        "evidence": [
+            "Антоненко-Давидович: Слова багаточисельний ... нема в українській мові, є прикметник численний",
+        ],
+        "heritage_guard": "search_heritage(багаточисельний, include_live_slovnyk=false): No heritage evidence found.",
+    },
+    "міроприємство": {
+        "kind": "lexical",
+        "corrections": ["захід", "заходи"],
+        "note": "рос. мероприятие; use захід / заходи",
+        "source": ["antonenko-p044", "glazova-10"],
+        "evidence": [
+            "Антоненко-Давидович: Відповідником до російських мера, мероприятие є захід, а в множині — заходи",
+        ],
+        "heritage_guard": "search_heritage(міроприємство, include_live_slovnyk=false): No heritage evidence found.",
+    },
+    "учбовий": {
+        "kind": "lexical",
+        "corrections": ["навчальний"],
+        "note": "рос. учебный; use навчальний",
+        "source": ["avramenko-5", "zabolotnyi-10"],
+        "evidence": [
+            "5-klas-ukrmova-avramenko-2022_s0038: НЕПРАВИЛЬНО учбовий заклад; ПРАВИЛЬНО навчальний заклад",
+        ],
+        "heritage_guard": "search_heritage(учбовий, include_live_slovnyk=false): ЕСУМ hits are related/noisy snippets, not safe headword attestation.",
+    },
 }
 
 # Phrasal / collocation calques (whole-phrase replacement).
@@ -466,6 +507,28 @@ SENSE_RESTRICTED_CALQUES: dict[str, dict[str, object]] = {
             "Грінченко: Рахунок ... Счет, разсчет. В рахунку помилився.",
         ],
         "heritage_guard": "search_heritage(рахунок, include_live_slovnyk=false): Грінченко authentic for account/count; therefore на рахунок is sense-restricted to the 'regarding' calque.",
+    },
+    "любий": {
+        "corrections": ["будь-який", "кожний", "усякий"],
+        "calque_sense": "any / whichever (рос. любой)",
+        "authentic_sense": "dear, beloved, pleasant (любий друже; любий мій)",
+        "note": "Грінченко attests любий as 'dear/beloved'; calque only when it means 'any' → будь-який.",
+        "source": ["ua-gec", "grinchenko", "antonenko"],
+        "evidence": [
+            "UA-GEC 1846: Error: любий; Correction: будь-який; Type: F/Calque",
+        ],
+        "heritage_guard": "search_heritage(любий, include_live_slovnyk=false): Грінченко authentic for 'dear/beloved'; therefore sense-restricted, not blanket.",
+    },
+    "неділя": {
+        "corrections": ["тиждень"],
+        "calque_sense": "week / a seven-day period (рос. неделя)",
+        "authentic_sense": "Sunday (day of the week)",
+        "note": "Грінченко attests неділя as Sunday; calque only when it means a week-long period → тиждень.",
+        "source": ["glazova-10", "grinchenko"],
+        "evidence": [
+            "10-klas-ukrmova-glazova-2018_s0075: Прем’єра ... через дві неділі ... Довідка. Тиждень",
+        ],
+        "heritage_guard": "search_heritage(неділя, include_live_slovnyk=false): Грінченко authentic for Sunday; therefore sense-restricted, not blanket.",
     },
 }
 

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -1744,7 +1744,7 @@ def _curated_calque(lemma: str, base: str) -> dict[str, Any] | None:
         if key in CURATED_CALQUES:
             row = CURATED_CALQUES[key]
             return {
-                "kind": "participle",
+                "kind": str(row.get("kind", "participle")),
                 "corrections": list(row["corrections"]),
                 "note": str(row["note"]),
                 "source": list(row["source"]),

--- a/tests/test_calque_corrections.py
+++ b/tests/test_calque_corrections.py
@@ -150,6 +150,36 @@ def test_collocation_slice2_sense_restricted_entries_have_guarded_senses():
         assert headword not in PHRASAL_CALQUES
 
 
+def test_single_word_lexical_slice3_entries_have_evidence():
+    """Slice 3 keeps only source-backed single-word lexical calques."""
+    expected = {
+        "слідуючий": "наступний",
+        "багаточисельний": "численний",
+        "міроприємство": "захід",
+        "учбовий": "навчальний",
+    }
+    for headword, correction in expected.items():
+        entry = CURATED_CALQUES[headword]
+        assert correction in entry["corrections"]
+        assert entry["evidence"]
+        assert "search_heritage" in entry["heritage_guard"]
+
+
+def test_single_word_lexical_slice3_polysemes_are_sense_restricted():
+    """любий and неділя are authentic words outside the calque sense."""
+    expected = {
+        "любий": ("будь-який", "dear"),
+        "неділя": ("тиждень", "Sunday"),
+    }
+    for headword, (correction, authentic_marker) in expected.items():
+        entry = SENSE_RESTRICTED_CALQUES[headword]
+        assert correction in entry["corrections"]
+        assert authentic_marker in entry["authentic_sense"]
+        assert entry["evidence"]
+        assert "search_heritage" in entry["heritage_guard"]
+        assert headword not in CURATED_CALQUES
+
+
 def test_buckets_are_disjoint():
     """A headword must not be both warn-worthy and safe, nor double-bucketed."""
     curated = set(CURATED_CALQUES)

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -959,9 +959,33 @@ def test_curated_calque_matches_collocation_slice2_sense_restricted_entries() ->
         assert "search_heritage" in card["heritage_guard"]
 
 
+def test_curated_calque_matches_single_word_lexical_slice3_entries() -> None:
+    expected = {
+        "слідуючий": ("lexical", "наступний"),
+        "багаточисельний": ("lexical", "численний"),
+        "міроприємство": ("lexical", "захід"),
+        "учбовий": ("lexical", "навчальний"),
+        "любий": ("sense_restricted", "будь-який"),
+        "неділя": ("sense_restricted", "тиждень"),
+    }
+    for headword, (kind, correction) in expected.items():
+        card = _curated_calque(headword, headword)
+        assert card is not None
+        assert card["kind"] == kind
+        assert correction in card["corrections"]
+        assert card["evidence"]
+        assert "search_heritage" in card["heritage_guard"]
+
+
 def test_collocation_slice2_authentic_phrases_are_not_exact_flagged() -> None:
     assert _curated_calque("біля школи", "біля школи") is None
     assert _curated_calque("на рахунок у банку", "на рахунок у банку") is None
+
+
+def test_single_word_lexical_slice3_authentic_phrases_are_not_exact_flagged() -> None:
+    assert _curated_calque("любий друже", "любий друже") is None
+    assert _curated_calque("у неділю", "у неділю") is None
+    assert _curated_calque("яблуко", "яблуко") is None
 
 
 def test_curated_calque_unknown_lemma_returns_none() -> None:


### PR DESCRIPTION
## Summary

Adds §6 slice-3 single-word lexical calques, capped to the requested six candidates:

- blanket lexical rows in `CURATED_CALQUES`: `слідуючий`, `багаточисельний`, `міроприємство`, `учбовий`
- sense-restricted polysemes in `SENSE_RESTRICTED_CALQUES`: `любий`, `неділя`
- `_curated_calque` now lets curated rows override `kind`, so these blanket rows emit `lexical` instead of being mislabeled as `participle`
- tests cover each headword card, authentic-sense exact phrase controls for `любий`/`неділя`, and the existing unknown-word control

No manifest JSON or re-enrichment artifacts are included.

## Evidence rows

- `слідуючий` → `наступний`: `9-klas-ukrajinska-mova-voron-2017_s0232: следующий — тут: наступний; Як правильно перекласти ... следующий? ... наступний`
- `багаточисельний` → `численний`: `Антоненко-Давидович: Слова багаточисельний ... нема в українській мові, є прикметник численний`
- `міроприємство` → `захід/заходи`: `Антоненко-Давидович: Відповідником до російських мера, мероприятие є захід, а в множині — заходи`
- `учбовий` → `навчальний`: `5-klas-ukrmova-avramenko-2022_s0038: НЕПРАВИЛЬНО учбовий заклад; ПРАВИЛЬНО навчальний заклад`
- `любий` → `будь-який` only for “any”: `UA-GEC 1846: Error: любий; Correction: будь-який; Type: F/Calque`
- `неділя` → `тиждень` only for “week”: `10-klas-ukrmova-glazova-2018_s0075: Прем’єра ... через дві неділі ... Довідка. Тиждень`

## Sense restriction

- `любий` is authentic for “dear/beloved” (`любий друже`) and is not blanket-flagged.
- `неділя` is authentic for Sunday (`у неділю`) and is not blanket-flagged.

## Validation

- `.venv/bin/python -m pytest tests/test_calque_corrections.py tests/test_lexicon_enrich_manifest.py -q` → 82 passed
- `.venv/bin/ruff check scripts/lexicon/calque_corrections.py scripts/lexicon/enrich_manifest.py tests/test_calque_corrections.py tests/test_lexicon_enrich_manifest.py` → All checks passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` → passed

Refs #3098