### PR TITLE
feat(lexicon): single-word lexical calque corrections — decolonization §6 slice 3 [#3098]

### DIFF
--- a/scripts/lexicon/calque_corrections.py
+++ b/scripts/lexicon/calque_corrections.py
@@ -269,6 +269,47 @@ CURATED_CALQUES: dict[str, dict[str, object]] = {
         "heritage_guard": "search_heritage(жовтіючий, include_live_slovnyk=false): No heritage evidence found.",
     },
     "бувший": {"corrections": ["колишній"], "note": "-вш- participle does not exist in Ukrainian (рос. бывший)", "source": ["avramenko-11"]},
+    # §6 lexical-calque slice 3 (#3098) — single-word blanket lexical calques.
+    "слідуючий": {
+        "kind": "lexical",
+        "corrections": ["наступний"],
+        "note": "рос. следующий; use наступний for 'next'",
+        "source": ["voron-9", "zabolotnyi-5"],
+        "evidence": [
+            "9-klas-ukrajinska-mova-voron-2017_s0232: следующий — тут: наступний; Як правильно перекласти ... следующий? ... наступний",
+        ],
+        "heritage_guard": "search_heritage(слідуючий, include_live_slovnyk=false): No heritage evidence found.",
+    },
+    "багаточисельний": {
+        "kind": "lexical",
+        "corrections": ["численний"],
+        "note": "рос. многочисленный; use численний for 'numerous'",
+        "source": ["antonenko-p065", "zabolotnyi-11"],
+        "evidence": [
+            "Антоненко-Давидович: Слова багаточисельний ... нема в українській мові, є прикметник численний",
+        ],
+        "heritage_guard": "search_heritage(багаточисельний, include_live_slovnyk=false): No heritage evidence found.",
+    },
+    "міроприємство": {
+        "kind": "lexical",
+        "corrections": ["захід", "заходи"],
+        "note": "рос. мероприятие; use захід / заходи",
+        "source": ["antonenko-p044", "glazova-10"],
+        "evidence": [
+            "Антоненко-Давидович: Відповідником до російських мера, мероприятие є захід, а в множині — заходи",
+        ],
+        "heritage_guard": "search_heritage(міроприємство, include_live_slovnyk=false): No heritage evidence found.",
+    },
+    "учбовий": {
+        "kind": "lexical",
+        "corrections": ["навчальний"],
+        "note": "рос. учебный; use навчальний",
+        "source": ["avramenko-5", "zabolotnyi-10"],
+        "evidence": [
+            "5-klas-ukrmova-avramenko-2022_s0038: НЕПРАВИЛЬНО учбовий заклад; ПРАВИЛЬНО навчальний заклад",
+        ],
+        "heritage_guard": "search_heritage(учбовий, include_live_slovnyk=false): ЕСУМ hits are related/noisy snippets, not safe headword attestation.",
+    },
 }
 
 # Phrasal / collocation calques (whole-phrase replacement).
@@ -466,6 +507,28 @@ SENSE_RESTRICTED_CALQUES: dict[str, dict[str, object]] = {
             "Грінченко: Рахунок ... Счет, разсчет. В рахунку помилився.",
         ],
         "heritage_guard": "search_heritage(рахунок, include_live_slovnyk=false): Грінченко authentic for account/count; therefore на рахунок is sense-restricted to the 'regarding' calque.",
+    },
+    "любий": {
+        "corrections": ["будь-який", "кожний", "усякий"],
+        "calque_sense": "any / whichever (рос. любой)",
+        "authentic_sense": "dear, beloved, pleasant (любий друже; любий мій)",
+        "note": "Грінченко attests любий as 'dear/beloved'; calque only when it means 'any' → будь-який.",
+        "source": ["ua-gec", "grinchenko", "antonenko"],
+        "evidence": [
+            "UA-GEC 1846: Error: любий; Correction: будь-який; Type: F/Calque",
+        ],
+        "heritage_guard": "search_heritage(любий, include_live_slovnyk=false): Грінченко authentic for 'dear/beloved'; therefore sense-restricted, not blanket.",
+    },
+    "неділя": {
+        "corrections": ["тиждень"],
+        "calque_sense": "week / a seven-day period (рос. неделя)",
+        "authentic_sense": "Sunday (day of the week)",
+        "note": "Грінченко attests неділя as Sunday; calque only when it means a week-long period → тиждень.",
+        "source": ["glazova-10", "grinchenko"],
+        "evidence": [
+            "10-klas-ukrmova-glazova-2018_s0075: Прем’єра ... через дві неділі ... Довідка. Тиждень",
+        ],
+        "heritage_guard": "search_heritage(неділя, include_live_slovnyk=false): Грінченко authentic for Sunday; therefore sense-restricted, not blanket.",
     },
 }
 

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -1744,7 +1744,7 @@ def _curated_calque(lemma: str, base: str) -> dict[str, Any] | None:
         if key in CURATED_CALQUES:
             row = CURATED_CALQUES[key]
             return {
-                "kind": "participle",
+                "kind": str(row.get("kind", "participle")),
                 "corrections": list(row["corrections"]),
                 "note": str(row["note"]),
                 "source": list(row["source"]),

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "cc655a7f9377ce6ccaccd0b193c4c65d2114a9c69872f9f8ebb00242fd59bb0b",
+  "fingerprint": "eccb00c2620084ceeec600a88ea0a1a0e32f529369f3195ed4e6cf2136130fb5",
   "inputs": {
     "lexicon_code": [
       {
@@ -24,7 +24,7 @@
       },
       {
         "path": "scripts/lexicon/calque_corrections.py",
-        "sha256": "d07e477961e20e0b4c73380c679b880674330b92cbd0db017275ec43f64934e7"
+        "sha256": "b5d8ec683d1d8f3f4c64bbde9e6d8bab8c1778bd8af0eb13203dc80a5a434edc"
       },
       {
         "path": "scripts/lexicon/check_manifest_freshness.py",
@@ -36,7 +36,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "bb4c0b19c10ea7fe71be29ad7137037d84723c077e0d099c7e5ac7bcc2e0234d"
+        "sha256": "030d781f1b442b42369c038901694d6a91ad174bdc88469309d3827d639fa76a"
       },
       {
         "path": "scripts/lexicon/generate_vesum_aliases.py",

--- a/tests/test_calque_corrections.py
+++ b/tests/test_calque_corrections.py
@@ -150,6 +150,36 @@ def test_collocation_slice2_sense_restricted_entries_have_guarded_senses():
         assert headword not in PHRASAL_CALQUES
 
 
+def test_single_word_lexical_slice3_entries_have_evidence():
+    """Slice 3 keeps only source-backed single-word lexical calques."""
+    expected = {
+        "слідуючий": "наступний",
+        "багаточисельний": "численний",
+        "міроприємство": "захід",
+        "учбовий": "навчальний",
+    }
+    for headword, correction in expected.items():
+        entry = CURATED_CALQUES[headword]
+        assert correction in entry["corrections"]
+        assert entry["evidence"]
+        assert "search_heritage" in entry["heritage_guard"]
+
+
+def test_single_word_lexical_slice3_polysemes_are_sense_restricted():
+    """любий and неділя are authentic words outside the calque sense."""
+    expected = {
+        "любий": ("будь-який", "dear"),
+        "неділя": ("тиждень", "Sunday"),
+    }
+    for headword, (correction, authentic_marker) in expected.items():
+        entry = SENSE_RESTRICTED_CALQUES[headword]
+        assert correction in entry["corrections"]
+        assert authentic_marker in entry["authentic_sense"]
+        assert entry["evidence"]
+        assert "search_heritage" in entry["heritage_guard"]
+        assert headword not in CURATED_CALQUES
+
+
 def test_buckets_are_disjoint():
     """A headword must not be both warn-worthy and safe, nor double-bucketed."""
     curated = set(CURATED_CALQUES)

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -959,9 +959,33 @@ def test_curated_calque_matches_collocation_slice2_sense_restricted_entries() ->
         assert "search_heritage" in card["heritage_guard"]
 
 
+def test_curated_calque_matches_single_word_lexical_slice3_entries() -> None:
+    expected = {
+        "слідуючий": ("lexical", "наступний"),
+        "багаточисельний": ("lexical", "численний"),
+        "міроприємство": ("lexical", "захід"),
+        "учбовий": ("lexical", "навчальний"),
+        "любий": ("sense_restricted", "будь-який"),
+        "неділя": ("sense_restricted", "тиждень"),
+    }
+    for headword, (kind, correction) in expected.items():
+        card = _curated_calque(headword, headword)
+        assert card is not None
+        assert card["kind"] == kind
+        assert correction in card["corrections"]
+        assert card["evidence"]
+        assert "search_heritage" in card["heritage_guard"]
+
+
 def test_collocation_slice2_authentic_phrases_are_not_exact_flagged() -> None:
     assert _curated_calque("біля школи", "біля школи") is None
     assert _curated_calque("на рахунок у банку", "на рахунок у банку") is None
+
+
+def test_single_word_lexical_slice3_authentic_phrases_are_not_exact_flagged() -> None:
+    assert _curated_calque("любий друже", "любий друже") is None
+    assert _curated_calque("у неділю", "у неділю") is None
+    assert _curated_calque("яблуко", "яблуко") is None
 
 
 def test_curated_calque_unknown_lemma_returns_none() -> None:


### PR DESCRIPTION
Third §6 decolonization-moat slice (after participles #3296 + collocations #3318). Adds 6 single-word lexical calques, each source-verified, with the manifest §6 delta applied surgically.

## Entries (all source-cited in calque_corrections.py)
**Blanket (CURATED_CALQUES):**
- слідуючий → наступний (рос. следующий) · 9-klas Voron
- багаточисельний → численний (рос. многочисленный) · Антоненко-Давидович
- міроприємство → захід/заходи (рос. мероприятие) · Антоненко-Давидович
- учбовий → навчальний (рос. учебный) · 5-klas Avramenko

**Sense-restricted (authentic in one sense, calque in another):**
- любий → будь-який/кожний/усякий — calque only as 'any' (рос. любой); **authentic = 'dear'** (любий друже). UA-GEC 1846 F/Calque + Грінченко.
- неділя → тиждень — calque only as 'week' (рос. неделя); **authentic = 'Sunday'**. 10-klas Glazova + Грінченко.

## Orchestrator verification (inline, #M-4)
- VESUM 6/6 valid corrections (наступний, численний, захід, навчальний, тиждень, будь-який).
- search_heritage confirms the sense-restrictions don't over-flag: Грінченко attests любий='dear/милий' and неділя='Sunday/Воскресенье'.
- 82 tests pass (test_calque_corrections + test_lexicon_enrich_manifest).

## Manifest
Surgical §6 patch of the 3 lemmas that are in the Atlas manifest (слідуючий, міроприємство, неділя) — computed via `_curated_calque` deterministically (network-free), NOT a full re-enrich (lossy on wiki_reference per #3331). Fingerprint regenerated → freshness green. +83/−1.

Refs #3098.

🤖 Generated with [Claude Code](https://claude.com/claude-code)