### PR TITLE
fix(build): auto-commit python_qg_correction_loop.json (#M-10 forensics)

### DIFF
--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -113,6 +113,7 @@ _MODULE_ARTIFACT_NAMES = (
     "python_qg.json",
     "wiki_coverage_gate.json",
     "wiki_coverage_review.json",
+    "python_qg_correction_loop.json",
     "llm_qg_correction_loop.json",
     "llm_qg.json",
 )

--- a/tests/test_v7_build_persist_guard.py
+++ b/tests/test_v7_build_persist_guard.py
@@ -168,6 +168,40 @@ def test_persist_scoped_add_leaves_unrelated_untracked_file_out(tmp_path: Path) 
     assert "?? scratch-notes.txt" in git(child, "status", "--short")
 
 
+def test_artifact_names_cover_both_correction_loop_summaries() -> None:
+    # #M-10 forensics: BOTH correction-loop summaries must be auto-committed so
+    # `git worktree remove` cannot destroy them. python_qg_correction_loop.json was
+    # silently omitted (only its llm_qg sibling was listed), losing the loop summary
+    # — stopped_reason / best_round / per-round frontier — needed to diagnose a build.
+    names = set(v7_build._MODULE_ARTIFACT_NAMES)
+    assert "python_qg_correction_loop.json" in names
+    assert "llm_qg_correction_loop.json" in names
+
+
+def test_persist_commits_python_qg_correction_loop(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    child = add_build_worktree(repo)
+    seed_artifacts(child)
+    module_dir = child / "curriculum" / "l2-uk-en" / "a1" / "foo"
+    (module_dir / "python_qg_correction_loop.json").write_text(
+        '{"best_round": 2, "stopped_reason": "pass"}\n', encoding="utf-8"
+    )
+    worktree = build_worktree(repo, child)
+
+    assert (
+        v7_build._persist_build_artifacts(
+            worktree,
+            level="a1",
+            slug="foo",
+            result="failed",
+        )
+        is True
+    )
+
+    committed = git(child, "show", "--name-only", "--format=", "HEAD")
+    assert "curriculum/l2-uk-en/a1/foo/python_qg_correction_loop.json" in committed
+
+
 def test_main_guard_refuses_primary_checkout_but_allows_archive_child(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Small #M-10 forensics fix found while diagnosing the folk #3079 loop.

`_MODULE_ARTIFACT_NAMES` (the build-artifact auto-commit set in `v7_build.py::_persist_build_artifacts`) listed `llm_qg_correction_loop.json` but **omitted its sibling `python_qg_correction_loop.json`** — while the per-round `python_qg_correction_r*.json` ARE globbed. So the python_qg loop **summary** (best_round, stopped_reason, per-round frontier/violations) was left UNTRACKED and would be destroyed on `git worktree remove` — the exact #M-10 forensic-loss mode. It was the key evidence for diagnosing the C.3 loop blocker and had to be preserved by hand.

- 1-line addition to the name list (symmetric with `llm_qg_correction_loop.json`).
- Guard tests: behavioral (seed → persist → assert committed) + symmetric name-list assertion, so neither correction-loop summary can be silently dropped again.

6/6 persist-guard tests pass, ruff clean. Self-merge on CI green (trivial artifact-list fix, no gate/loop logic).