### PR TITLE
fix(validation): accept bare vocabulary lists

### DIFF
--- a/scripts/validate/validate_vocab_yaml.py
+++ b/scripts/validate/validate_vocab_yaml.py
@@ -26,6 +26,17 @@ VALID_GENDER = {'m', 'f', 'n', 'pl', '-', ''}
 logger = logging.getLogger("validate_vocab_yaml")
 
 
+def _items_from_data(data):
+    """Return (items, enriched_schema) for supported vocabulary shapes."""
+    if isinstance(data, list):
+        return data, False
+
+    if isinstance(data, dict) and isinstance(data.get('items'), list):
+        return data['items'], True
+
+    return None, False
+
+
 def validate_file(file_path):
     logger.info("Validating %s...", file_path.name)
     try:
@@ -37,37 +48,44 @@ def validate_file(file_path):
     errors = []
     lemmas = set()
 
-    if 'items' not in data or not isinstance(data['items'], list):
-        print("  ❌ Missing 'items' list")
+    items, enriched_schema = _items_from_data(data)
+    if items is None:
+        logger.error("  unsupported vocabulary schema: expected bare list or mapping with 'items' list")
         return False
 
-    for i, item in enumerate(data['items']):
-        lemma = item.get('lemma')
+    for i, item in enumerate(items):
+        if not isinstance(item, dict):
+            errors.append(f"Item #{i}: Expected mapping")
+            continue
+
+        lemma = item.get('lemma') if enriched_schema else item.get('word') or item.get('lemma')
         if not lemma:
-            errors.append(f"Item #{i}: Missing 'lemma'")
+            errors.append(f"Item #{i}: Missing 'lemma' or 'word'")
             continue
 
         if lemma in lemmas:
             errors.append(f"Duplicate lemma: '{lemma}'")
         lemmas.add(lemma)
 
-        # Mandatory Enrichment Check
-        if not item.get('ipa'):
-            errors.append(f"'{lemma}': Missing IPA")
         if not item.get('translation'):
             errors.append(f"'{lemma}': Missing Translation")
 
-        # Enum Checks
-        pos = item.get('pos', 'other')
-        if pos not in VALID_POS:
-            errors.append(f"'{lemma}': Invalid POS '{pos}'")
+        if enriched_schema:
+            # Mandatory Enrichment Check
+            if not item.get('ipa'):
+                errors.append(f"'{lemma}': Missing IPA")
 
-        if pos == 'noun':
-            gen = item.get('gender', '')
-            if not gen:
-                errors.append(f"'{lemma}' (noun): Missing Gender")
-            elif gen not in VALID_GENDER:
-                errors.append(f"'{lemma}': Invalid Gender '{gen}'")
+            # Enum Checks
+            pos = item.get('pos', 'other')
+            if pos not in VALID_POS:
+                errors.append(f"'{lemma}': Invalid POS '{pos}'")
+
+            if pos == 'noun':
+                gen = item.get('gender', '')
+                if not gen:
+                    errors.append(f"'{lemma}' (noun): Missing Gender")
+                elif gen not in VALID_GENDER:
+                    errors.append(f"'{lemma}': Invalid Gender '{gen}'")
 
     if errors:
         # Log count only — per-error detail goes to a side file to avoid

--- a/tests/validate/test_validate_vocab_yaml.py
+++ b/tests/validate/test_validate_vocab_yaml.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+from scripts.validate.validate_vocab_yaml import validate_file
+
+
+def _write(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_validate_vocab_yaml_accepts_bare_word_list(tmp_path: Path) -> None:
+    vocab_path = _write(
+        tmp_path / "vocabulary.yaml",
+        """
+- word: відмінок
+  translation: case
+  pos: noun
+  example: "Називний - це відмінок."
+- word: називний
+  translation: nominative
+  pos: adjective
+  example: "Студент - це називний відмінок."
+""",
+    )
+
+    assert validate_file(vocab_path) is True
+
+
+def test_validate_vocab_yaml_accepts_enriched_items_schema(tmp_path: Path) -> None:
+    vocab_path = _write(
+        tmp_path / "vocabulary.yaml",
+        """
+items:
+  - lemma: відмінок
+    ipa: "/ʋidˈminok/"
+    translation: case
+    pos: noun
+    gender: m
+""",
+    )
+
+    assert validate_file(vocab_path) is True
+
+
+def test_validate_vocab_yaml_requires_enriched_lemma(tmp_path: Path) -> None:
+    vocab_path = _write(
+        tmp_path / "vocabulary.yaml",
+        """
+items:
+  - lemma: ""
+    word: відмінок
+    ipa: "/ʋidˈminok/"
+    translation: case
+    pos: noun
+    gender: m
+""",
+    )
+
+    assert validate_file(vocab_path) is False
+
+
+def test_validate_vocab_yaml_rejects_unknown_top_level_schema(tmp_path: Path) -> None:
+    vocab_path = _write(
+        tmp_path / "vocabulary.yaml",
+        """
+terms:
+  - word: відмінок
+    translation: case
+""",
+    )
+
+    assert validate_file(vocab_path) is False


### PR DESCRIPTION
Summary:
- Teach validate_vocab_yaml.py to accept both repository vocabulary shapes: bare module lists and enriched items: mappings.
- Keep IPA/POS/gender checks strict for the enriched items: schema while validating bare lists for term + translation.
- Add focused pytest coverage for both shapes and enriched lemma strictness.

Validation:
- .venv/bin/python -m ruff check scripts/validate/validate_vocab_yaml.py tests/validate/test_validate_vocab_yaml.py
- .venv/bin/python -m py_compile scripts/validate/validate_vocab_yaml.py
- .venv/bin/python -m pytest tests/audit/test_certify_module.py tests/validate/test_validate_vocab_yaml.py
- .venv/bin/python scripts/validate/validate_vocab_yaml.py curriculum/l2-uk-en/a2/a2-bridge/vocabulary.yaml
- .venv/bin/python scripts/audit/certify_module.py a2/a2-bridge
- git diff --check
- .venv/bin/python scripts/audit/lint_agent_trailer.py

Review:
- DeepSeek/Hermes read-only review returned SHIP; minor enriched-lemma precision note was addressed before commit.