### PR TITLE
fix(pipeline): #3079 C.3 — raise seminar correction budget + whitespace-normalized reviewer-fix anchor matching (vesum convergence)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -7971,7 +7971,7 @@ def _find_exact_reviewer_fix_span(
     offset = text.find(anchor)
     if offset < 0:
         return None
-    return _trim_reviewer_fix_boundary_span(text, (offset, offset + len(anchor)))
+    return offset, offset + len(anchor)
 
 
 def _find_unique_reviewer_fix_normalized_span(

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -7962,6 +7962,7 @@ def _find_unique_reviewer_fix_normalized_span(
 ) -> tuple[int, int] | None:
     normalized_text, spans = _reviewer_fix_whitespace_normalized_view(text)
     normalized_anchor, _anchor_spans = _reviewer_fix_whitespace_normalized_view(anchor)
+    normalized_anchor = normalized_anchor.strip()
     offsets = _normalized_reviewer_anchor_offsets(normalized_text, normalized_anchor)
     if len(offsets) == 1:
         return _span_from_normalized_reviewer_anchor_offset(
@@ -7979,6 +7980,7 @@ def _find_unique_reviewer_fix_normalized_span(
         variant_anchor, _variant_spans = _reviewer_fix_whitespace_normalized_view(
             variant
         )
+        variant_anchor = variant_anchor.strip()
         if not variant_anchor or variant_anchor in seen_normalized_anchors:
             continue
         seen_normalized_anchors.add(variant_anchor)

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -6864,21 +6864,15 @@ def _count_applicable_reviewer_fixes(text: str, fixes: Sequence[Mapping[str, str
     for fix in fixes:
         if "insert_after" in fix and "text" in fix:
             anchor = str(fix["insert_after"])
-            if anchor in updated:
-                updated = updated.replace(anchor, anchor + str(fix["text"]), 1)
-                count += 1
-            elif span := _find_unique_reviewer_fix_normalized_span(updated, anchor):
+            if span := _find_reviewer_fix_span(updated, anchor):
                 _, end = span
                 updated = updated[:end] + str(fix["text"]) + updated[end:]
                 count += 1
             continue
         find = str(fix.get("find") or "")
         replace = fix.get("replace")
-        if find and replace is not None and find in updated:
-            updated = updated.replace(find, str(replace), 1)
-            count += 1
-        elif find and replace is not None and (
-            span := _find_unique_reviewer_fix_normalized_span(updated, find)
+        if find and replace is not None and (
+            span := _find_reviewer_fix_span(updated, find)
         ):
             start, end = span
             updated = updated[:start] + str(replace) + updated[end:]
@@ -7956,19 +7950,45 @@ def _span_from_normalized_reviewer_anchor_offset(
     return start, end
 
 
+def _trim_reviewer_fix_boundary_span(
+    text: str,
+    span: tuple[int, int],
+) -> tuple[int, int] | None:
+    start, end = span
+    while start < end and text[start].isspace():
+        start += 1
+    while end > start and text[end - 1].isspace():
+        end -= 1
+    if start == end:
+        return None
+    return start, end
+
+
+def _find_exact_reviewer_fix_span(
+    text: str,
+    anchor: str,
+) -> tuple[int, int] | None:
+    offset = text.find(anchor)
+    if offset < 0:
+        return None
+    return _trim_reviewer_fix_boundary_span(text, (offset, offset + len(anchor)))
+
+
 def _find_unique_reviewer_fix_normalized_span(
     text: str,
     anchor: str,
 ) -> tuple[int, int] | None:
     normalized_text, spans = _reviewer_fix_whitespace_normalized_view(text)
     normalized_anchor, _anchor_spans = _reviewer_fix_whitespace_normalized_view(anchor)
-    normalized_anchor = normalized_anchor.strip()
     offsets = _normalized_reviewer_anchor_offsets(normalized_text, normalized_anchor)
     if len(offsets) == 1:
-        return _span_from_normalized_reviewer_anchor_offset(
-            spans,
-            offsets[0],
-            len(normalized_anchor),
+        return _trim_reviewer_fix_boundary_span(
+            text,
+            _span_from_normalized_reviewer_anchor_offset(
+                spans,
+                offsets[0],
+                len(normalized_anchor),
+            ),
         )
     if len(offsets) > 1:
         return None
@@ -7980,7 +8000,6 @@ def _find_unique_reviewer_fix_normalized_span(
         variant_anchor, _variant_spans = _reviewer_fix_whitespace_normalized_view(
             variant
         )
-        variant_anchor = variant_anchor.strip()
         if not variant_anchor or variant_anchor in seen_normalized_anchors:
             continue
         seen_normalized_anchors.add(variant_anchor)
@@ -7989,18 +8008,30 @@ def _find_unique_reviewer_fix_normalized_span(
             variant_anchor,
         )
         if len(variant_offsets) == 1:
-            matched_spans.add(
+            if span := _trim_reviewer_fix_boundary_span(
+                text,
                 _span_from_normalized_reviewer_anchor_offset(
                     spans,
                     variant_offsets[0],
                     len(variant_anchor),
-                )
-            )
+                ),
+            ):
+                matched_spans.add(span)
         elif len(variant_offsets) > 1:
             ambiguous = True
     if ambiguous or len(matched_spans) != 1:
         return None
     return next(iter(matched_spans))
+
+
+def _find_reviewer_fix_span(
+    text: str,
+    anchor: str,
+) -> tuple[int, int] | None:
+    return _find_exact_reviewer_fix_span(
+        text,
+        anchor,
+    ) or _find_unique_reviewer_fix_normalized_span(text, anchor)
 
 
 def _apply_reviewer_fixes(
@@ -8017,8 +8048,9 @@ def _apply_reviewer_fixes(
     for fix in fixes:
         if "insert_after" in fix and "text" in fix:
             anchor = fix["insert_after"]
-            if anchor in updated:
-                updated = updated.replace(anchor, anchor + fix["text"], 1)
+            if span := _find_exact_reviewer_fix_span(updated, anchor):
+                _, end = span
+                updated = updated[:end] + fix["text"] + updated[end:]
             elif span := _find_unique_reviewer_fix_normalized_span(updated, anchor):
                 start, end = span
                 matched = updated[start:end]
@@ -8045,8 +8077,11 @@ def _apply_reviewer_fixes(
             continue
         find = fix.get("find")
         replace = fix.get("replace")
-        if find and replace is not None and find in updated:
-            updated = updated.replace(find, replace, 1)
+        if find and replace is not None and (
+            span := _find_exact_reviewer_fix_span(updated, find)
+        ):
+            start, end = span
+            updated = updated[:start] + replace + updated[end:]
         elif find and replace is not None and (
             span := _find_unique_reviewer_fix_normalized_span(updated, find)
         ):

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -7968,6 +7968,8 @@ def _find_exact_reviewer_fix_span(
     text: str,
     anchor: str,
 ) -> tuple[int, int] | None:
+    if not anchor or all(char.isspace() for char in anchor):
+        return None
     offset = text.find(anchor)
     if offset < 0:
         return None

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -472,7 +472,7 @@ WIKI_COVERAGE_EVIDENCE_QUOTE_MARKERS = ('"', "“", "«")
 LLM_QG_CORE_MAX_ROUNDS = 1
 LLM_QG_SEMINAR_MAX_ROUNDS = 3
 PYTHON_QG_CORE_MAX_CORRECTION_ROUNDS = 1
-PYTHON_QG_SEMINAR_MAX_CORRECTION_ROUNDS = 4
+PYTHON_QG_SEMINAR_MAX_CORRECTION_ROUNDS = 8
 PYTHON_QG_MIN_REGRESSION_PATIENCE = 3
 PYTHON_QG_MALFORMED_REPORT_VIOLATIONS = 999
 PYTHON_QG_VIOLATION_COUNT_KEYS = (
@@ -6867,10 +6867,21 @@ def _count_applicable_reviewer_fixes(text: str, fixes: Sequence[Mapping[str, str
             if anchor in updated:
                 updated = updated.replace(anchor, anchor + str(fix["text"]), 1)
                 count += 1
+            elif span := _find_unique_reviewer_fix_normalized_span(updated, anchor):
+                _, end = span
+                updated = updated[:end] + str(fix["text"]) + updated[end:]
+                count += 1
             continue
         find = str(fix.get("find") or "")
-        if find and find in updated:
-            updated = updated.replace(find, str(fix.get("replace") or ""), 1)
+        replace = fix.get("replace")
+        if find and replace is not None and find in updated:
+            updated = updated.replace(find, str(replace), 1)
+            count += 1
+        elif find and replace is not None and (
+            span := _find_unique_reviewer_fix_normalized_span(updated, find)
+        ):
+            start, end = span
+            updated = updated[:start] + str(replace) + updated[end:]
             count += 1
     return count
 
@@ -7813,6 +7824,32 @@ def _emit_reviewer_fix_anchor_unmatched(
     )
 
 
+def _emit_reviewer_fix_anchor_normalized_match(
+    anchor: str,
+    matched: str,
+    replacement: str | None,
+    *,
+    operation: str,
+    gate: str | None,
+    module_dir: Path | None,
+    plan_path: Path | None,
+) -> None:
+    emit_event(
+        "reviewer_fix_anchor_normalized_match",
+        **_correction_event_fields(
+            gate=gate or "",
+            module_dir=module_dir,
+            plan_path=plan_path,
+        )
+        if module_dir is not None and plan_path is not None
+        else {"gate": gate},
+        operation=operation,
+        anchor_preview=_correction_preview(anchor),
+        matched_preview=_correction_preview(matched),
+        text_preview=_correction_preview(replacement),
+    )
+
+
 def _emit_final_reviewer_unmatched_events(
     unmatched_anchors: frozenset[str],
     fixes: list[dict[str, str]],
@@ -7840,6 +7877,130 @@ def _emit_final_reviewer_unmatched_events(
             )
 
 
+def _reviewer_fix_whitespace_normalized_view(
+    text: str,
+) -> tuple[str, tuple[tuple[int, int], ...]]:
+    chars: list[str] = []
+    spans: list[tuple[int, int]] = []
+    index = 0
+    while index < len(text):
+        if text[index].isspace():
+            start = index
+            while index < len(text) and text[index].isspace():
+                index += 1
+            chars.append(" ")
+            spans.append((start, index))
+            continue
+        chars.append(text[index])
+        spans.append((index, index + 1))
+        index += 1
+    return "".join(chars), tuple(spans)
+
+
+def _strip_reviewer_anchor_stress(anchor: str) -> str:
+    decomposed = unicodedata.normalize("NFD", anchor)
+    stripped = "".join(char for char in decomposed if char != "\u0301")
+    return unicodedata.normalize("NFC", stripped)
+
+
+def _strip_reviewer_anchor_markdown_wrapper(anchor: str) -> str:
+    wrapper_chars = "*_`~"
+    start = 0
+    end = len(anchor)
+    while start < end and anchor[start] in wrapper_chars:
+        start += 1
+    while end > start and anchor[end - 1] in wrapper_chars:
+        end -= 1
+    return anchor[start:end]
+
+
+def _reviewer_anchor_normalized_variants(anchor: str) -> tuple[str, ...]:
+    variants: list[str] = []
+    candidates = (
+        anchor,
+        _strip_reviewer_anchor_stress(anchor),
+        _strip_reviewer_anchor_markdown_wrapper(anchor),
+        _strip_reviewer_anchor_markdown_wrapper(_strip_reviewer_anchor_stress(anchor)),
+    )
+    for candidate in candidates:
+        if candidate not in variants:
+            variants.append(candidate)
+    return tuple(variants)
+
+
+def _normalized_reviewer_anchor_offsets(
+    normalized_text: str,
+    normalized_anchor: str,
+) -> list[int]:
+    if not normalized_anchor:
+        return []
+    offsets: list[int] = []
+    start = 0
+    while True:
+        offset = normalized_text.find(normalized_anchor, start)
+        if offset < 0:
+            return offsets
+        offsets.append(offset)
+        if len(offsets) > 1:
+            return offsets
+        start = offset + 1
+
+
+def _span_from_normalized_reviewer_anchor_offset(
+    spans: tuple[tuple[int, int], ...],
+    offset: int,
+    anchor_length: int,
+) -> tuple[int, int]:
+    start = spans[offset][0]
+    end = spans[offset + anchor_length - 1][1]
+    return start, end
+
+
+def _find_unique_reviewer_fix_normalized_span(
+    text: str,
+    anchor: str,
+) -> tuple[int, int] | None:
+    normalized_text, spans = _reviewer_fix_whitespace_normalized_view(text)
+    normalized_anchor, _anchor_spans = _reviewer_fix_whitespace_normalized_view(anchor)
+    offsets = _normalized_reviewer_anchor_offsets(normalized_text, normalized_anchor)
+    if len(offsets) == 1:
+        return _span_from_normalized_reviewer_anchor_offset(
+            spans,
+            offsets[0],
+            len(normalized_anchor),
+        )
+    if len(offsets) > 1:
+        return None
+
+    matched_spans: set[tuple[int, int]] = set()
+    ambiguous = False
+    seen_normalized_anchors = {normalized_anchor}
+    for variant in _reviewer_anchor_normalized_variants(anchor)[1:]:
+        variant_anchor, _variant_spans = _reviewer_fix_whitespace_normalized_view(
+            variant
+        )
+        if not variant_anchor or variant_anchor in seen_normalized_anchors:
+            continue
+        seen_normalized_anchors.add(variant_anchor)
+        variant_offsets = _normalized_reviewer_anchor_offsets(
+            normalized_text,
+            variant_anchor,
+        )
+        if len(variant_offsets) == 1:
+            matched_spans.add(
+                _span_from_normalized_reviewer_anchor_offset(
+                    spans,
+                    variant_offsets[0],
+                    len(variant_anchor),
+                )
+            )
+        elif len(variant_offsets) > 1:
+            ambiguous = True
+    if ambiguous or len(matched_spans) != 1:
+        return None
+    return next(iter(matched_spans))
+
+
 def _apply_reviewer_fixes(
     text: str,
     fixes: list[dict[str, str]],
@@ -7856,6 +8017,19 @@ def _apply_reviewer_fixes(
             anchor = fix["insert_after"]
             if anchor in updated:
                 updated = updated.replace(anchor, anchor + fix["text"], 1)
+            elif span := _find_unique_reviewer_fix_normalized_span(updated, anchor):
+                start, end = span
+                matched = updated[start:end]
+                updated = updated[:end] + fix["text"] + updated[end:]
+                _emit_reviewer_fix_anchor_normalized_match(
+                    anchor,
+                    matched,
+                    fix["text"],
+                    operation="insert_after",
+                    gate=gate,
+                    module_dir=module_dir,
+                    plan_path=plan_path,
+                )
             else:
                 unmatched_anchors.add(anchor)
                 if emit_unmatched_events:
@@ -7871,6 +8045,21 @@ def _apply_reviewer_fixes(
         replace = fix.get("replace")
         if find and replace is not None and find in updated:
             updated = updated.replace(find, replace, 1)
+        elif find and replace is not None and (
+            span := _find_unique_reviewer_fix_normalized_span(updated, find)
+        ):
+            start, end = span
+            matched = updated[start:end]
+            updated = updated[:start] + replace + updated[end:]
+            _emit_reviewer_fix_anchor_normalized_match(
+                find,
+                matched,
+                replace,
+                operation="replace",
+                gate=gate,
+                module_dir=module_dir,
+                plan_path=plan_path,
+            )
         elif find:
             unmatched_anchors.add(find)
             if emit_unmatched_events:

--- a/tests/test_python_qg_correction_loop.py
+++ b/tests/test_python_qg_correction_loop.py
@@ -436,5 +436,6 @@ def test_python_qg_core_uses_legacy_single_correction_path(tmp_path: Path) -> No
     assert report["gates"]["passed"] is True
     assert (module_dir / "module.md").read_text(encoding="utf-8") == "PASS\n"
     assert not (module_dir / "python_qg_correction_loop.json").exists()
+    assert linear_pipeline.PYTHON_QG_SEMINAR_MAX_CORRECTION_ROUNDS == 8
     assert linear_pipeline.python_qg_max_correction_rounds_for_level("a1") == 1
-    assert linear_pipeline.python_qg_max_correction_rounds_for_level("folk") == 4
+    assert linear_pipeline.python_qg_max_correction_rounds_for_level("folk") == 8

--- a/tests/test_reviewer_correction_diagnostics.py
+++ b/tests/test_reviewer_correction_diagnostics.py
@@ -71,3 +71,105 @@ def test_reviewer_correction_unmatched_anchor_emits_diagnostic(
     ]
     assert events[0]["gate"] == "russianisms_clean"
     assert events[0]["anchor_preview"] == "Missing anchor"
+
+
+def test_reviewer_fix_whitespace_normalized_anchor_match_applies_once(
+    tmp_path: Path,
+) -> None:
+    telemetry = tmp_path / "events.jsonl"
+    text = "Before\n\nAlpha\n  beta   gamma\n\nAfter\n"
+
+    with linear_pipeline.telemetry_event_sink(telemetry):
+        result = linear_pipeline._apply_reviewer_fixes(
+            text,
+            [{"find": "Alpha beta gamma", "replace": "Alpha beta delta"}],
+            gate="vesum_verified",
+            module_dir=_module_dir(tmp_path),
+            plan_path=tmp_path / "plan.yaml",
+        )
+
+    assert result.text == "Before\n\nAlpha beta delta\n\nAfter\n"
+    assert result.unmatched_anchors == frozenset()
+    events = _events(telemetry)
+    assert [event["event"] for event in events] == [
+        "reviewer_fix_anchor_normalized_match"
+    ]
+    assert events[0]["gate"] == "vesum_verified"
+    assert events[0]["operation"] == "replace"
+    assert events[0]["anchor_preview"] == "Alpha beta gamma"
+    assert events[0]["matched_preview"] == "Alpha\n  beta   gamma"
+
+
+def test_reviewer_fix_ambiguous_normalized_anchor_fails_closed(
+    tmp_path: Path,
+) -> None:
+    telemetry = tmp_path / "events.jsonl"
+    text = "One\n  two\nMiddle\nOne\t\t two\n"
+
+    with linear_pipeline.telemetry_event_sink(telemetry):
+        result = linear_pipeline._apply_reviewer_fixes(
+            text,
+            [{"find": "One two", "replace": "Changed"}],
+            gate="vesum_verified",
+            module_dir=_module_dir(tmp_path),
+            plan_path=tmp_path / "plan.yaml",
+        )
+
+    assert result.text == text
+    assert result.unmatched_anchors == frozenset({"One two"})
+    events = _events(telemetry)
+    assert [event["event"] for event in events] == [
+        "reviewer_fixes_anchor_unmatched"
+    ]
+    assert "Changed" not in result.text
+
+
+def test_reviewer_fix_genuine_no_match_stays_unmatched(
+    tmp_path: Path,
+) -> None:
+    telemetry = tmp_path / "events.jsonl"
+    text = "Alpha beta\n"
+
+    with linear_pipeline.telemetry_event_sink(telemetry):
+        result = linear_pipeline._apply_reviewer_fixes(
+            text,
+            [{"find": "Gamma delta", "replace": "Changed"}],
+            gate="vesum_verified",
+            module_dir=_module_dir(tmp_path),
+            plan_path=tmp_path / "plan.yaml",
+        )
+
+    assert result.text == text
+    assert result.unmatched_anchors == frozenset({"Gamma delta"})
+    events = _events(telemetry)
+    assert [event["event"] for event in events] == [
+        "reviewer_fixes_anchor_unmatched"
+    ]
+
+
+def test_reviewer_fix_exact_match_fast_path_stays_silent(
+    tmp_path: Path,
+) -> None:
+    telemetry = tmp_path / "events.jsonl"
+
+    with linear_pipeline.telemetry_event_sink(telemetry):
+        result = linear_pipeline._apply_reviewer_fixes(
+            "Alpha beta\n",
+            [{"find": "Alpha beta", "replace": "Changed"}],
+            gate="vesum_verified",
+            module_dir=_module_dir(tmp_path),
+            plan_path=tmp_path / "plan.yaml",
+        )
+
+    assert result.text == "Changed\n"
+    assert result.unmatched_anchors == frozenset()
+    assert _events(telemetry) == []
+
+
+def test_reviewer_fix_applicable_count_ignores_missing_replace() -> None:
+    count = linear_pipeline._count_applicable_reviewer_fixes(
+        "Alpha\n  beta\n",
+        [{"find": "Alpha beta"}],
+    )
+
+    assert count == 0

--- a/tests/test_reviewer_correction_diagnostics.py
+++ b/tests/test_reviewer_correction_diagnostics.py
@@ -120,6 +120,36 @@ def test_reviewer_fix_leading_boundary_whitespace_is_not_replaced() -> None:
     assert result.unmatched_anchors == frozenset()
 
 
+def test_reviewer_fix_trailing_boundary_does_not_match_inside_larger_word() -> None:
+    result = linear_pipeline._apply_reviewer_fixes(
+        "Intro: retargeting\n",
+        [{"find": "target ", "replace": "FIXED"}],
+    )
+
+    assert result.text == "Intro: retargeting\n"
+    assert result.unmatched_anchors == frozenset({"target "})
+
+
+def test_reviewer_insert_after_trailing_boundary_does_not_match_inside_larger_word() -> None:
+    result = linear_pipeline._apply_reviewer_fixes(
+        "retargeting\n",
+        [{"insert_after": "target ", "text": "INSERTED"}],
+    )
+
+    assert result.text == "retargeting\n"
+    assert result.unmatched_anchors == frozenset({"target "})
+
+
+def test_reviewer_fix_literal_trailing_boundary_space_preserves_space() -> None:
+    result = linear_pipeline._apply_reviewer_fixes(
+        "Intro: target retail\n",
+        [{"find": "target ", "replace": "FIXED"}],
+    )
+
+    assert result.text == "Intro: FIXED retail\n"
+    assert result.unmatched_anchors == frozenset()
+
+
 def test_reviewer_insert_after_trailing_boundary_whitespace_inserts_before_run() -> None:
     result = linear_pipeline._apply_reviewer_fixes(
         "target\n\n- item",

--- a/tests/test_reviewer_correction_diagnostics.py
+++ b/tests/test_reviewer_correction_diagnostics.py
@@ -130,6 +130,26 @@ def test_reviewer_fix_exact_delete_replaces_full_trailing_space_span() -> None:
     assert result.unmatched_anchors == frozenset()
 
 
+def test_reviewer_fix_all_whitespace_anchor_fails_closed() -> None:
+    result = linear_pipeline._apply_reviewer_fixes(
+        "a   b",
+        [{"find": "   ", "replace": "X"}],
+    )
+
+    assert result.text == "a   b"
+    assert result.unmatched_anchors == frozenset({"   "})
+
+
+def test_reviewer_fix_empty_anchor_is_noop() -> None:
+    result = linear_pipeline._apply_reviewer_fixes(
+        "a   b",
+        [{"find": "", "replace": "X"}],
+    )
+
+    assert result.text == "a   b"
+    assert result.unmatched_anchors == frozenset()
+
+
 def test_reviewer_fix_leading_boundary_whitespace_is_not_replaced() -> None:
     result = linear_pipeline._apply_reviewer_fixes(
         "Intro\n\ntarget",
@@ -178,6 +198,26 @@ def test_reviewer_insert_after_trailing_boundary_whitespace_inserts_before_run()
 
     assert result.text == "targetINSERTED\n\n- item"
     assert result.unmatched_anchors == frozenset()
+
+
+def test_reviewer_insert_after_all_whitespace_anchor_fails_closed() -> None:
+    result = linear_pipeline._apply_reviewer_fixes(
+        "a   b",
+        [{"insert_after": "   ", "text": "X"}],
+    )
+
+    assert result.text == "a   b"
+    assert result.unmatched_anchors == frozenset({"   "})
+
+
+def test_reviewer_insert_after_empty_anchor_fails_closed() -> None:
+    result = linear_pipeline._apply_reviewer_fixes(
+        "a   b",
+        [{"insert_after": "", "text": "X"}],
+    )
+
+    assert result.text == "a   b"
+    assert result.unmatched_anchors == frozenset({""})
 
 
 def test_reviewer_fix_ambiguous_normalized_anchor_fails_closed(

--- a/tests/test_reviewer_correction_diagnostics.py
+++ b/tests/test_reviewer_correction_diagnostics.py
@@ -100,6 +100,36 @@ def test_reviewer_fix_whitespace_normalized_anchor_match_applies_once(
     assert events[0]["matched_preview"] == "Alpha\n  beta   gamma"
 
 
+def test_reviewer_fix_trailing_boundary_whitespace_is_not_replaced() -> None:
+    result = linear_pipeline._apply_reviewer_fixes(
+        "Intro: target\n\n- next item\n",
+        [{"find": "target ", "replace": "FIXED"}],
+    )
+
+    assert result.text == "Intro: FIXED\n\n- next item\n"
+    assert result.unmatched_anchors == frozenset()
+
+
+def test_reviewer_fix_leading_boundary_whitespace_is_not_replaced() -> None:
+    result = linear_pipeline._apply_reviewer_fixes(
+        "Intro\n\ntarget",
+        [{"find": " target", "replace": "FIXED"}],
+    )
+
+    assert result.text == "Intro\n\nFIXED"
+    assert result.unmatched_anchors == frozenset()
+
+
+def test_reviewer_insert_after_trailing_boundary_whitespace_inserts_before_run() -> None:
+    result = linear_pipeline._apply_reviewer_fixes(
+        "target\n\n- item",
+        [{"insert_after": "target ", "text": "INSERTED"}],
+    )
+
+    assert result.text == "targetINSERTED\n\n- item"
+    assert result.unmatched_anchors == frozenset()
+
+
 def test_reviewer_fix_ambiguous_normalized_anchor_fails_closed(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_reviewer_correction_diagnostics.py
+++ b/tests/test_reviewer_correction_diagnostics.py
@@ -110,6 +110,26 @@ def test_reviewer_fix_trailing_boundary_whitespace_is_not_replaced() -> None:
     assert result.unmatched_anchors == frozenset()
 
 
+def test_reviewer_fix_exact_match_replaces_full_trailing_space_span() -> None:
+    result = linear_pipeline._apply_reviewer_fixes(
+        "foo  bar",
+        [{"find": "foo  ", "replace": "foo "}],
+    )
+
+    assert result.text == "foo bar"
+    assert result.unmatched_anchors == frozenset()
+
+
+def test_reviewer_fix_exact_delete_replaces_full_trailing_space_span() -> None:
+    result = linear_pipeline._apply_reviewer_fixes(
+        "foo bar",
+        [{"find": "foo ", "replace": ""}],
+    )
+
+    assert result.text == "bar"
+    assert result.unmatched_anchors == frozenset()
+
+
 def test_reviewer_fix_leading_boundary_whitespace_is_not_replaced() -> None:
     result = linear_pipeline._apply_reviewer_fixes(
         "Intro\n\ntarget",
@@ -143,7 +163,7 @@ def test_reviewer_insert_after_trailing_boundary_does_not_match_inside_larger_wo
 def test_reviewer_fix_literal_trailing_boundary_space_preserves_space() -> None:
     result = linear_pipeline._apply_reviewer_fixes(
         "Intro: target retail\n",
-        [{"find": "target ", "replace": "FIXED"}],
+        [{"find": "target ", "replace": "FIXED "}],
     )
 
     assert result.text == "Intro: FIXED retail\n"


### PR DESCRIPTION
## Summary

- Raise seminar Python-QG correction rounds from 4 to 8 while preserving the core single-correction path.
- Add exact-first, unique whitespace-normalized reviewer-fix anchor matching for `find` and `insert_after` anchors.
- Emit `reviewer_fix_anchor_normalized_match` telemetry when the normalized path applies, and keep ambiguous/no-match anchors fail-closed.

## Validation

```text
.venv/bin/python -m pytest tests/test_python_qg_correction_loop.py tests/test_vesum_verified_postfix.py tests/test_no_rewrite_contract.py tests/test_reviewer_correction_diagnostics.py tests/test_reviewer_fixes_parser.py -q
collected 75 items
============================== 75 passed in 1.67s ==============================
```

```text
.venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_python_qg_correction_loop.py tests/test_vesum_verified_postfix.py tests/test_no_rewrite_contract.py tests/test_reviewer_correction_diagnostics.py tests/test_reviewer_fixes_parser.py
All checks passed!
```

```text
.venv/bin/python scripts/audit/lint_agent_trailer.py
Checking 1 commit(s) in origin/main..HEAD:

  53678e39a1  PASS  X-Agent: codex/folk-3079-vesum-convergence

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

```text
Gemini follow-up review
NO FINDINGS
```
