### PR TITLE
certify A2 M03 aspect vocabulary

### DIFF
--- a/curriculum/l2-uk-en/a2/aspect-in-vocabulary/module.md
+++ b/curriculum/l2-uk-en/a2/aspect-in-vocabulary/module.md
@@ -20,14 +20,9 @@
 У наступних модулях ця звичка допоможе ще більше. До дієслів додадуться
 описи людей, родовий відмінок і кількість.
 
-**English support.** This module is about vocabulary habits, not about
-creating every verb form from a rule. Ukrainian aspect often lives in pairs.
-One verb helps you talk about the process, and the other helps you talk about
-the completed result.
-
-Write the pair as one vocabulary item. Do not keep `читати` on one card and
-`прочитати` far away on another card. A2 speaking becomes easier when the two
-forms are stored together from the start.
+**English support.** This module is about vocabulary habits, not rules for
+creating every form. Store each pair together: one verb for process, one verb
+for completed result.
 
 ## Діалог 1 — нотатки до рецепта
 
@@ -49,13 +44,9 @@ forms are stored together from the start.
 Коли зустрічаєте нове дієслово, відразу питайте себе: де його пара?
 :::
 
-**English support.** The recipe situation gives you a concrete image. The
-grandmother is not asking for a grammar lecture. She is teaching a notebook
-habit: when one verb appears, look for the partner that belongs with it.
-
-This is why the module title says that verbs "go in pairs." The phrase is a
-memory tool. It reminds you to connect forms before you try to use them in
-longer stories.
+Цей рецепт дає простий образ для пам'яті. Бабуся не просить онуку
+пояснити всю граматику. Вона показує робочу звичку: коли з'являється
+одне дієслово, шукай його партнера.
 
 ## Чому дієслова краще вчити парами?
 
@@ -64,8 +55,7 @@ longer stories.
 
 > Я писав лист.
 
-Але як сказати `I wrote and finished the letter`? Для цього потрібен
-партнер:
+Але як сказати, що лист уже готовий? Для цього потрібен партнер:
 
 > Я написав лист.
 
@@ -93,14 +83,10 @@ longer stories.
 
 Коли пара лежить поруч, ви бачите систему, а не випадковий список.
 
-**English support.** A single English translation can hide the difference.
-Both `писати` and `написати` can be translated as "to write." The useful
-question is not only "what does it mean?" It is also "does this form show the
-process or the completed result?"
-
-Your notes should therefore keep three things together: the imperfective
-form, the perfective form, and one short example sentence. That is enough for
-this stage.
+Один англійський переклад може приховати різницю. `Писати` і `написати`
+обидва можуть стояти біля слова `to write`, але в українській вони не
+працюють однаково. У нотатках тримайте разом три речі: недоконану форму,
+доконану форму й одне коротке речення.
 
 ## Спосіб 1 — додати префікс
 
@@ -131,19 +117,13 @@ this stage.
 кожний префікс автоматично дає просту видову пару. Іноді з'являється
 новий відтінок. На A2 достатньо знати центральні високочастотні пари.
 
-**English support.** Prefixes are helpful, but they are not a machine where
-you can attach any prefix and get the correct pair. In many common pairs, the
-prefix is almost neutral for an A2 learner: `писати / написати`, `читати /
-прочитати`, `робити / зробити`.
+Префікс — це підказка, а не автомат. Не можна додати будь-який префікс
+і завжди отримати правильну пару. Тому на A2 краще вчити готові часті
+пари: `писати / написати`, `читати / прочитати`, `робити / зробити`.
 
-Still, prefixes can also create a new meaning. Learn the high-frequency pairs
-as ready-made vocabulary. Later, you will study the meanings of prefixes in
-more detail.
-
-For now, treat the prefix as a recognition signal. When you hear `написав`,
-do not stop and analyze every historical meaning of `на-`. First ask the A2
-question: is the speaker pointing to a finished written result? In the common
-pair `писати / написати`, the answer is usually yes.
+Коли чуєте `написав`, не зупиняйтеся на історії префікса `на-`.
+Спершу ставте A2-питання: мовець показує готовий написаний результат?
+У частій парі `писати / написати` відповідь зазвичай так.
 
 ### Міні-список для щоденного вживання
 
@@ -153,7 +133,7 @@ pair `писати / написати`, the answer is usually yes.
 | дім | `робити / зробити` |
 | кухня | `готувати / приготувати` |
 | навчання | `читати / прочитати` |
-| зустріч | `казати / сказати` |
+| зустріч | `говорити / сказати` |
 
 <!-- INJECT_ACTIVITY: act-1 -->
 
@@ -176,6 +156,9 @@ pair `писати / написати`, the answer is usually yes.
 
 Якщо ви бачите `допомагати` і `допомогти`, не думайте: це два випадкові
 слова. Думайте: це пара, яку треба вчити як єдине ціле.
+
+Тут ми не розбираємо слово на всі частини. Достатньо бачити: у парі може
+змінитися суфікс або частина основи, де живе корінь.
 
 ### Чому це важливо для словника
 
@@ -209,22 +192,17 @@ pair `писати / написати`, the answer is usually yes.
 Не хвилюйтеся, якщо словник дає більше однієї форми. Для A2 спершу
 вибирайте найчастішу пару. Пишіть один короткий приклад.
 
-**English support.** A dictionary is not just for translation. It can help
-you check aspect. When you see one member of a pair, search for the other
-member and write both forms together.
+Словник потрібен не тільки для перекладу. Він допомагає перевірити вид.
+Коли бачите один член пари, шукайте другого й записуйте обидві форми
+разом.
 
-If several forms appear, choose the one that matches your A2 need. You do not
-need every prefix family yet. You need a small reliable set that helps you
-speak about everyday process and result.
+Практичний формат картки простий:
 
-One practical card format is:
+`недоконаний / доконаний — короткий переклад — речення з процесом —
+речення з результатом`
 
-`imperfective / perfective — English meaning — one process sentence — one
-result sentence`
-
-That format keeps you from memorizing only labels. It also keeps you from
-using the perfective form whenever English uses a simple past verb. The
-example sentences do the real teaching.
+Такий формат не дає вчити лише етикетки. Приклади роблять головну
+роботу.
 
 ## Спосіб 3 — інше слово
 
@@ -254,22 +232,17 @@ example sentences do the real teaching.
 Такі пари швидко входять у живе мовлення. Вони часті й працюють у
 побуті, роботі та навчанні.
 
-**English support.** Some pairs look irregular from an English point of view.
-Do not try to force them into a prefix rule. `брати / взяти` and `говорити /
-сказати` are common enough that you should memorize them as complete pairs.
+Не намагайтеся силою зробити з них префіксальне правило. `Брати / взяти`
+і `говорити / сказати` настільки часті, що їх краще запам'ятати як
+готові пари.
 
-This is normal in Ukrainian. A very frequent verb often has an older or less
-transparent partner. Treat the pair like one vocabulary unit with two useful
-doors: process and result.
-
-These pairs are also useful because they appear in ordinary conversations.
-You will hear `говорив` when someone describes a conversation as an activity.
-You will hear `сказав` when the important point is one completed statement.
-That is why the pair belongs in your active vocabulary early.
+Це нормально для української. Дуже часте дієслово може мати старшого або
+менш прозорого партнера. Ставтеся до пари як до однієї словникової
+одиниці з двома дверима: процес і результат.
 
 <!-- INJECT_ACTIVITY: act-2 -->
 
-## Не кожні близькі слова є видовою парою
+## Не всі близькі слова утворюють видову пару
 
 Тут легко заплутатися. Якщо два дієслова пов'язані за змістом, це ще
 не гарантує, що вони є видовою парою.
@@ -283,6 +256,11 @@ That is why the pair belongs in your active vocabulary early.
 - `шукати` = бути в процесі пошуку;
 - `знайти` = досягти результату й натрапити на потрібне.
 
+Є окрема видова пара `знаходити / знайти`, коли йдеться про дію
+знаходження: `Я часто знаходжу цікаві слова`, `Я знайшов потрібне слово`.
+Але `шукати` означає сам процес пошуку, тому `шукати / знайти` краще
+позначати як пов'язані дії в одній історії, а не як механічну пару.
+
 У навчанні це корисно пам'ятати, щоб не робити помилку типу
 `кожен результат = автоматично видова пара`.
 
@@ -291,19 +269,9 @@ That is why the pair belongs in your active vocabulary early.
 1. Спершу вчіть найчастіші готові пари.
 2. Якщо сумніваєтеся, перевірте в словнику або в надійному ресурсі.
 
-**English support.** This warning prevents overgeneralization. `Шукати` and
-`знайти` belong to the same life situation, but they are not a neat mechanical
-pair like `читати / прочитати`. You can learn them together, but mark them as
-related actions.
-
-That note matters because it stops a common mistake: assuming every result
-verb is automatically the perfective partner of the process verb. Ukrainian
-does not work that mechanically.
-
-This is also why the module tells you to check a dictionary. A2 learners do
-not need to solve every morphological puzzle. They need to know when a pair is
-safe, when a pair is only related by meaning, and when a form should simply be
-memorized.
+**English support.** Prefixes and story links are clues, not guarantees.
+Learn common pairs as vocabulary, and mark `шукати / знайти` as related
+actions. For the true "find" pair, use `знаходити / знайти`.
 
 ## Двадцять пар, які варто мати під рукою
 
@@ -349,13 +317,10 @@ memorized.
 
 Так список стає не таблицею для зубріння, а набором готових фраз.
 
-**English support.** The list of twenty pairs is a working shelf, not a test
-of memory. Choose the pairs that fit your real life first. If you write
-emails, start with `писати / написати` and `відповідати / відповісти`. If you
-cook, start with `готувати / приготувати` and `варити / зварити`.
-
-When a pair is personally useful, it becomes easier to remember. The grammar
-then supports communication instead of feeling like a separate chart.
+Цей список — робоча полиця, а не тест пам'яті. Оберіть пари, які справді
+потрібні вам. Якщо ви часто пишете листи, почніть із `писати / написати`
+і `відповідати / відповісти`. Якщо ви готуєте, почніть із
+`готувати / приготувати` і `варити / зварити`.
 
 ## Як тренувати пари без перевантаження
 
@@ -379,17 +344,20 @@ then supports communication instead of feeling like a separate chart.
 
 Так ви вчите не таблицю, а живий контраст.
 
-**English support.** Keep the practice small. Three pairs a day are better
-than twenty pairs that you only read once. Say one process sentence and one
-result sentence. Then close the book and try again later.
+Ще одна корисна звичка — повертатися до старих пар через день або два.
+Не треба щоразу брати новий список. Краще взяти вчорашні три пари й
+швидко сказати нові речення. Наприклад, учора ви записали
+`писати / написати`, а сьогодні можете сказати про повідомлення, заяву
+або короткий коментар.
 
-This module is successful when you start asking one automatic question: "What
-is the partner?" That question prepares you for the next aspect modules.
+Так пара переходить із пасивного словника в активний. Ви не просто
+впізнаєте форму в тексті, а можете самі вибрати потрібний погляд:
+процес чи результат. Для A2 це вже дуже сильна навичка.
 
-If you cannot make a sentence yet, use a frame. For process, try "I was doing
-X for a while." For result, try "I did X and now it is finished." Then replace
-the English frame with the Ukrainian pair. The frame is temporary, but it
-helps you choose the right member of the pair.
+Тримайте тренування малим. Три пари на день краще, ніж двадцять пар,
+які ви прочитали один раз. Якщо речення не йде одразу, використайте
+опору: спершу скажіть процес, потім результат. Опора тимчасова, а звичка
+залишається.
 
 <!-- INJECT_ACTIVITY: act-3 -->
 
@@ -409,13 +377,8 @@ helps you choose the right member of the pair.
 У наступних модулях ми будемо використовувати ці пари в минулому часі.
 Потім вони з'являться в майбутньому та в довших історіях.
 
-**English support.** Summary: do not learn aspect as an isolated grammar box.
-Learn it as vocabulary plus meaning. The pair tells you what action you are
-talking about. The context tells you whether the speaker sees the process or
-the result.
-
-That is the whole practical goal here. You are building a small internal
-dictionary where verbs arrive in pairs. Later modules will use these pairs in
-past stories, future plans, instructions, and longer conversations.
+**English support.** Summary: learn aspect as vocabulary plus meaning. The
+pair names the action; the context tells you whether the speaker sees process
+or result.
 
 <!-- INJECT_ACTIVITY: act-4 -->

--- a/curriculum/l2-uk-en/a2/aspect-in-vocabulary/vocabulary.yaml
+++ b/curriculum/l2-uk-en/a2/aspect-in-vocabulary/vocabulary.yaml
@@ -62,6 +62,22 @@
   translation: to prepare, to cook
   pos: verb pair
   example: "Вони готували вечерю і приготували салат."
+- word: бачити / побачити
+  translation: to see
+  pos: verb pair
+  example: "Я бачив вивіску і потім побачив потрібний номер."
+- word: вчити / вивчити
+  translation: to learn, to study
+  pos: verb pair
+  example: "Ми вчили нові слова і вивчили три пари."
+- word: слухати / послухати
+  translation: to listen
+  pos: verb pair
+  example: "Я слухав подкаст і послухав короткий випуск до кінця."
+- word: дзвонити / подзвонити
+  translation: to call
+  pos: verb pair
+  example: "Вона дзвонила мамі і потім подзвонила колезі."
 - word: брати / взяти
   translation: to take
   pos: verb pair
@@ -82,6 +98,10 @@
   translation: to help
   pos: verb pair
   example: "Я допомагав другу і потім допоміг сестрі."
+- word: повертати / повернути
+  translation: to return
+  pos: verb pair
+  example: "Я повертав книгу і нарешті повернув її до бібліотеки."
 - word: варити / зварити
   translation: to cook, to boil
   pos: verb pair
@@ -90,6 +110,22 @@
   translation: to shape, to make by hand
   pos: verb pair
   example: "Діти ліпили вареники і зліпили останню партію."
+- word: ловити / піймати
+  translation: to catch
+  pos: verb pair
+  example: "Діти ловили м'яч і піймали його."
+- word: класти / покласти
+  translation: to put
+  pos: verb pair
+  example: "Він клав ключі на стіл і поклав їх у сумку."
+- word: їсти / з'їсти
+  translation: to eat
+  pos: verb pair
+  example: "Ми їли суп і з'їли його до кінця."
+- word: знаходити / знайти
+  translation: to find
+  pos: verb pair
+  example: "Я часто знаходжу цікаві слова і знайшов потрібний приклад."
 - word: шукати / знайти
   translation: to look for / to find
   pos: related verbs

--- a/site/src/content/docs/a2/aspect-in-vocabulary.mdx
+++ b/site/src/content/docs/a2/aspect-in-vocabulary.mdx
@@ -79,14 +79,9 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 У наступних модулях ця звичка допоможе ще більше. До дієслів додадуться
 описи людей, родовий відмінок і кількість.
 
-**English support.** This module is about vocabulary habits, not about
-creating every verb form from a rule. Ukrainian aspect often lives in pairs.
-One verb helps you talk about the process, and the other helps you talk about
-the completed result.
-
-Write the pair as one vocabulary item. Do not keep `читати` on one card and
-`прочитати` far away on another card. A2 speaking becomes easier when the two
-forms are stored together from the start.
+**English support.** This module is about vocabulary habits, not rules for
+creating every form. Store each pair together: one verb for process, one verb
+for completed result.
 
 ## Діалог 1 — нотатки до рецепта
 
@@ -109,13 +104,9 @@ forms are stored together from the start.
 Коли зустрічаєте нове дієслово, відразу питайте себе: де його пара?
 :::
 
-**English support.** The recipe situation gives you a concrete image. The
-grandmother is not asking for a grammar lecture. She is teaching a notebook
-habit: when one verb appears, look for the partner that belongs with it.
-
-This is why the module title says that verbs "go in pairs." The phrase is a
-memory tool. It reminds you to connect forms before you try to use them in
-longer stories.
+Цей рецепт дає простий образ для пам'яті. Бабуся не просить онуку
+пояснити всю граматику. Вона показує робочу звичку: коли з'являється
+одне дієслово, шукай його партнера.
 
 ## Чому дієслова краще вчити парами?
 
@@ -124,8 +115,7 @@ longer stories.
 
 > Я писав лист.
 
-Але як сказати `I wrote and finished the letter`? Для цього потрібен
-партнер:
+Але як сказати, що лист уже готовий? Для цього потрібен партнер:
 
 > Я написав лист.
 
@@ -153,14 +143,10 @@ longer stories.
 
 Коли пара лежить поруч, ви бачите систему, а не випадковий список.
 
-**English support.** A single English translation can hide the difference.
-Both `писати` and `написати` can be translated as "to write." The useful
-question is not only "what does it mean?" It is also "does this form show the
-process or the completed result?"
-
-Your notes should therefore keep three things together: the imperfective
-form, the perfective form, and one short example sentence. That is enough for
-this stage.
+Один англійський переклад може приховати різницю. `Писати` і `написати`
+обидва можуть стояти біля слова `to write`, але в українській вони не
+працюють однаково. У нотатках тримайте разом три речі: недоконану форму,
+доконану форму й одне коротке речення.
 
 ## Спосіб 1 — додати префікс
 
@@ -191,19 +177,13 @@ this stage.
 кожний префікс автоматично дає просту видову пару. Іноді з'являється
 новий відтінок. На A2 достатньо знати центральні високочастотні пари.
 
-**English support.** Prefixes are helpful, but they are not a machine where
-you can attach any prefix and get the correct pair. In many common pairs, the
-prefix is almost neutral for an A2 learner: `писати / написати`, `читати /
-прочитати`, `робити / зробити`.
+Префікс — це підказка, а не автомат. Не можна додати будь-який префікс
+і завжди отримати правильну пару. Тому на A2 краще вчити готові часті
+пари: `писати / написати`, `читати / прочитати`, `робити / зробити`.
 
-Still, prefixes can also create a new meaning. Learn the high-frequency pairs
-as ready-made vocabulary. Later, you will study the meanings of prefixes in
-more detail.
-
-For now, treat the prefix as a recognition signal. When you hear `написав`,
-do not stop and analyze every historical meaning of `на-`. First ask the A2
-question: is the speaker pointing to a finished written result? In the common
-pair `писати / написати`, the answer is usually yes.
+Коли чуєте `написав`, не зупиняйтеся на історії префікса `на-`.
+Спершу ставте A2-питання: мовець показує готовий написаний результат?
+У частій парі `писати / написати` відповідь зазвичай так.
 
 ### Міні-список для щоденного вживання
 
@@ -213,7 +193,7 @@ pair `писати / написати`, the answer is usually yes.
 | дім | `робити / зробити` |
 | кухня | `готувати / приготувати` |
 | навчання | `читати / прочитати` |
-| зустріч | `казати / сказати` |
+| зустріч | `говорити / сказати` |
 
 ### Знайди партнера
 
@@ -238,6 +218,9 @@ pair `писати / написати`, the answer is usually yes.
 
 Якщо ви бачите `допомагати` і `допомогти`, не думайте: це два випадкові
 слова. Думайте: це пара, яку треба вчити як єдине ціле.
+
+Тут ми не розбираємо слово на всі частини. Достатньо бачити: у парі може
+змінитися суфікс або частина основи, де живе корінь.
 
 ### Чому це важливо для словника
 
@@ -271,22 +254,17 @@ pair `писати / написати`, the answer is usually yes.
 Не хвилюйтеся, якщо словник дає більше однієї форми. Для A2 спершу
 вибирайте найчастішу пару. Пишіть один короткий приклад.
 
-**English support.** A dictionary is not just for translation. It can help
-you check aspect. When you see one member of a pair, search for the other
-member and write both forms together.
+Словник потрібен не тільки для перекладу. Він допомагає перевірити вид.
+Коли бачите один член пари, шукайте другого й записуйте обидві форми
+разом.
 
-If several forms appear, choose the one that matches your A2 need. You do not
-need every prefix family yet. You need a small reliable set that helps you
-speak about everyday process and result.
+Практичний формат картки простий:
 
-One practical card format is:
+`недоконаний / доконаний — короткий переклад — речення з процесом —
+речення з результатом`
 
-`imperfective / perfective — English meaning — one process sentence — one
-result sentence`
-
-That format keeps you from memorizing only labels. It also keeps you from
-using the perfective form whenever English uses a simple past verb. The
-example sentences do the real teaching.
+Такий формат не дає вчити лише етикетки. Приклади роблять головну
+роботу.
 
 ## Спосіб 3 — інше слово
 
@@ -317,24 +295,19 @@ example sentences do the real teaching.
 Такі пари швидко входять у живе мовлення. Вони часті й працюють у
 побуті, роботі та навчанні.
 
-**English support.** Some pairs look irregular from an English point of view.
-Do not try to force them into a prefix rule. `брати / взяти` and `говорити /
-сказати` are common enough that you should memorize them as complete pairs.
+Не намагайтеся силою зробити з них префіксальне правило. `Брати / взяти`
+і `говорити / сказати` настільки часті, що їх краще запам'ятати як
+готові пари.
 
-This is normal in Ukrainian. A very frequent verb often has an older or less
-transparent partner. Treat the pair like one vocabulary unit with two useful
-doors: process and result.
-
-These pairs are also useful because they appear in ordinary conversations.
-You will hear `говорив` when someone describes a conversation as an activity.
-You will hear `сказав` when the important point is one completed statement.
-That is why the pair belongs in your active vocabulary early.
+Це нормально для української. Дуже часте дієслово може мати старшого або
+менш прозорого партнера. Ставтеся до пари як до однієї словникової
+одиниці з двома дверима: процес і результат.
 
 ### Як утворилася пара?
 
 <GroupSort client:only='react' groups={JSON.parse(`{"переважно префікс": ["писати / написати", "читати / прочитати", "готувати / приготувати", "варити / зварити", "класти / покласти"], "зміна основи або суфікса": ["відповідати / відповісти", "вирішувати / вирішити", "запитувати / запитати", "допомагати / допомогти"], "інше слово": ["брати / взяти", "говорити / сказати", "ловити / піймати"]}`)} instruction={"Розподіліть пари за головною моделлю, яку ви помічаєте."} isUkrainian={false} />
 
-## Не кожні близькі слова є видовою парою
+## Не всі близькі слова утворюють видову пару
 
 Тут легко заплутатися. Якщо два дієслова пов'язані за змістом, це ще
 не гарантує, що вони є видовою парою.
@@ -348,6 +321,11 @@ That is why the pair belongs in your active vocabulary early.
 - `шукати` = бути в процесі пошуку;
 - `знайти` = досягти результату й натрапити на потрібне.
 
+Є окрема видова пара `знаходити / знайти`, коли йдеться про дію
+знаходження: `Я часто знаходжу цікаві слова`, `Я знайшов потрібне слово`.
+Але `шукати` означає сам процес пошуку, тому `шукати / знайти` краще
+позначати як пов'язані дії в одній історії, а не як механічну пару.
+
 У навчанні це корисно пам'ятати, щоб не робити помилку типу
 `кожен результат = автоматично видова пара`.
 
@@ -356,19 +334,9 @@ That is why the pair belongs in your active vocabulary early.
 1. Спершу вчіть найчастіші готові пари.
 2. Якщо сумніваєтеся, перевірте в словнику або в надійному ресурсі.
 
-**English support.** This warning prevents overgeneralization. `Шукати` and
-`знайти` belong to the same life situation, but they are not a neat mechanical
-pair like `читати / прочитати`. You can learn them together, but mark them as
-related actions.
-
-That note matters because it stops a common mistake: assuming every result
-verb is automatically the perfective partner of the process verb. Ukrainian
-does not work that mechanically.
-
-This is also why the module tells you to check a dictionary. A2 learners do
-not need to solve every morphological puzzle. They need to know when a pair is
-safe, when a pair is only related by meaning, and when a form should simply be
-memorized.
+**English support.** Prefixes and story links are clues, not guarantees.
+Learn common pairs as vocabulary, and mark `шукати / знайти` as related
+actions. For the true "find" pair, use `знаходити / знайти`.
 
 ## Двадцять пар, які варто мати під рукою
 
@@ -414,13 +382,10 @@ memorized.
 
 Так список стає не таблицею для зубріння, а набором готових фраз.
 
-**English support.** The list of twenty pairs is a working shelf, not a test
-of memory. Choose the pairs that fit your real life first. If you write
-emails, start with `писати / написати` and `відповідати / відповісти`. If you
-cook, start with `готувати / приготувати` and `варити / зварити`.
-
-When a pair is personally useful, it becomes easier to remember. The grammar
-then supports communication instead of feeling like a separate chart.
+Цей список — робоча полиця, а не тест пам'яті. Оберіть пари, які справді
+потрібні вам. Якщо ви часто пишете листи, почніть із `писати / написати`
+і `відповідати / відповісти`. Якщо ви готуєте, почніть із
+`готувати / приготувати` і `варити / зварити`.
 
 ## Як тренувати пари без перевантаження
 
@@ -444,17 +409,20 @@ then supports communication instead of feeling like a separate chart.
 
 Так ви вчите не таблицю, а живий контраст.
 
-**English support.** Keep the practice small. Three pairs a day are better
-than twenty pairs that you only read once. Say one process sentence and one
-result sentence. Then close the book and try again later.
+Ще одна корисна звичка — повертатися до старих пар через день або два.
+Не треба щоразу брати новий список. Краще взяти вчорашні три пари й
+швидко сказати нові речення. Наприклад, учора ви записали
+`писати / написати`, а сьогодні можете сказати про повідомлення, заяву
+або короткий коментар.
 
-This module is successful when you start asking one automatic question: "What
-is the partner?" That question prepares you for the next aspect modules.
+Так пара переходить із пасивного словника в активний. Ви не просто
+впізнаєте форму в тексті, а можете самі вибрати потрібний погляд:
+процес чи результат. Для A2 це вже дуже сильна навичка.
 
-If you cannot make a sentence yet, use a frame. For process, try "I was doing
-X for a while." For result, try "I did X and now it is finished." Then replace
-the English frame with the Ukrainian pair. The frame is temporary, but it
-helps you choose the right member of the pair.
+Тримайте тренування малим. Три пари на день краще, ніж двадцять пар,
+які ви прочитали один раз. Якщо речення не йде одразу, використайте
+опору: спершу скажіть процес, потім результат. Опора тимчасова, а звичка
+залишається.
 
 ### Запиши пару правильно
 
@@ -476,14 +444,9 @@ helps you choose the right member of the pair.
 У наступних модулях ми будемо використовувати ці пари в минулому часі.
 Потім вони з'являться в майбутньому та в довших історіях.
 
-**English support.** Summary: do not learn aspect as an isolated grammar box.
-Learn it as vocabulary plus meaning. The pair tells you what action you are
-talking about. The context tells you whether the speaker sees the process or
-the result.
-
-That is the whole practical goal here. You are building a small internal
-dictionary where verbs arrive in pairs. Later modules will use these pairs in
-past stories, future plans, instructions, and longer conversations.
+**English support.** Summary: learn aspect as vocabulary plus meaning. The
+pair names the action; the context tells you whether the speaker sees process
+or result.
 
 ### Яка нотатка краща?
 
@@ -492,9 +455,9 @@ past stories, future plans, instructions, and longer conversations.
 </TabItem>
 <TabItem label="Vocabulary">
 
-<VocabCard client:only="react" words={JSON.parse(`[{"word":"видова пара","translation":"aspectual pair","pos":"noun","example":"Писати / написати - це видова пара.","examples":["aspectual pair","Писати / написати - це видова пара."],"atlas_href":"/lexicon/видова-пара/"},{"word":"пара","translation":"pair","pos":"noun","example":"Я записую нове дієслово разом з парою.","examples":["pair","Я записую нове дієслово разом з парою."],"atlas_href":"/lexicon/пара/"},{"word":"префікс","translation":"prefix","pos":"noun","example":"Префікс часто допомагає утворити доконаний вид.","examples":["prefix","Префікс часто допомагає утворити доконаний вид."],"atlas_href":"/lexicon/префікс/"},{"word":"суфікс","translation":"suffix","pos":"noun","example":"У цій парі змінюється суфікс.","examples":["suffix","У цій парі змінюється суфікс."],"atlas_href":"/lexicon/суфікс/"},{"word":"корінь","translation":"root","pos":"noun","example":"Іноді в парі змінюється корінь слова.","examples":["root","Іноді в парі змінюється корінь слова."],"atlas_href":"/lexicon/корінь/"},{"word":"утворювати","translation":"to form","pos":"verb","example":"Так ми утворюємо нову пару.","examples":["to form","Так ми утворюємо нову пару."],"atlas_href":"/lexicon/утворювати/"},{"word":"записувати","translation":"to write down","pos":"verb","example":"Я люблю записувати дієслова в зошит.","examples":["to write down","Я люблю записувати дієслова в зошит."],"atlas_href":"/lexicon/записувати/"},{"word":"словник","translation":"dictionary","pos":"noun","example":"Перевір цю пару в словнику.","examples":["dictionary","Перевір цю пару в словнику."],"atlas_href":"/lexicon/словник/"},{"word":"запам'ятовувати","translation":"to memorize","pos":"verb","example":"Такі пари треба запам'ятовувати разом.","examples":["to memorize","Такі пари треба запам'ятовувати разом."],"atlas_href":"/lexicon/запам-ятовувати/"},{"word":"модель","translation":"pattern, model","pos":"noun","example":"Це найчастіша модель для A2.","examples":["pattern, model","Це найчастіша модель для A2."],"atlas_href":"/lexicon/модель/"},{"word":"базовий","translation":"basic","pos":"adjective","example":"Це базовий список видових пар.","examples":["basic","Це базовий список видових пар."],"atlas_href":"/lexicon/базовий/"},{"word":"видовий партнер","translation":"aspectual partner","pos":"noun phrase","example":"Записуй дієслово разом із видовим партнером.","examples":["aspectual partner","Записуй дієслово разом із видовим партнером."]},{"word":"читати / прочитати","translation":"to read","pos":"verb pair","example":"Я читаю статтю, а ввечері прочитаю її.","examples":["to read","Я читаю статтю, а ввечері прочитаю її."],"atlas_href":"/lexicon/читати-прочитати/"},{"word":"писати / написати","translation":"to write","pos":"verb pair","example":"Вона писала нотатку і швидко написала лист.","examples":["to write","Вона писала нотатку і швидко написала лист."],"atlas_href":"/lexicon/писати-написати/"},{"word":"робити / зробити","translation":"to do, to make","pos":"verb pair","example":"Ми робили завдання і зробили його до вечора.","examples":["to do, to make","Ми робили завдання і зробили його до вечора."],"atlas_href":"/lexicon/робити-зробити/"},{"word":"готувати / приготувати","translation":"to prepare, to cook","pos":"verb pair","example":"Вони готували вечерю і приготували салат.","examples":["to prepare, to cook","Вони готували вечерю і приготували салат."],"atlas_href":"/lexicon/готувати-приготувати/"},{"word":"брати / взяти","translation":"to take","pos":"verb pair","example":"Я брав чашку і потім узяв ложку.","examples":["to take","Я брав чашку і потім узяв ложку."],"atlas_href":"/lexicon/брати-взяти/"},{"word":"говорити / сказати","translation":"to speak / to say","pos":"verb pair","example":"Ми довго говорили, а потім я сказав головне.","examples":["to speak / to say","Ми довго говорили, а потім я сказав головне."],"atlas_href":"/lexicon/говорити-сказати/"},{"word":"відповідати / відповісти","translation":"to answer","pos":"verb pair","example":"Він відповідав спокійно і нарешті відповів точно.","examples":["to answer","Він відповідав спокійно і нарешті відповів точно."],"atlas_href":"/lexicon/відповідати-відповісти/"},{"word":"вирішувати / вирішити","translation":"to decide, to solve","pos":"verb pair","example":"Ми довго вирішували і зрештою вирішили.","examples":["to decide, to solve","Ми довго вирішували і зрештою вирішили."],"atlas_href":"/lexicon/вирішувати-вирішити/"},{"word":"допомагати / допомогти","translation":"to help","pos":"verb pair","example":"Я допомагав другу і потім допоміг сестрі.","examples":["to help","Я допомагав другу і потім допоміг сестрі."],"atlas_href":"/lexicon/допомагати-допомогти/"},{"word":"варити / зварити","translation":"to cook, to boil","pos":"verb pair","example":"Бабуся варила суп і швидко зварила борщ.","examples":["to cook, to boil","Бабуся варила суп і швидко зварила борщ."],"atlas_href":"/lexicon/варити-зварити/"},{"word":"ліпити / зліпити","translation":"to shape, to make by hand","pos":"verb pair","example":"Діти ліпили вареники і зліпили останню партію.","examples":["to shape, to make by hand","Діти ліпили вареники і зліпили останню партію."],"atlas_href":"/lexicon/ліпити-зліпити/"},{"word":"шукати / знайти","translation":"to look for / to find","pos":"related verbs","example":"Я шукав ключі й нарешті знайшов їх.","examples":["to look for / to find","Я шукав ключі й нарешті знайшов їх."]}]`)} title="Vocabulary" />
+<VocabCard client:only="react" words={JSON.parse(`[{"word":"видова пара","translation":"aspectual pair","pos":"noun","example":"Писати / написати - це видова пара.","examples":["aspectual pair","Писати / написати - це видова пара."],"atlas_href":"/lexicon/видова-пара/"},{"word":"пара","translation":"pair","pos":"noun","example":"Я записую нове дієслово разом з парою.","examples":["pair","Я записую нове дієслово разом з парою."],"atlas_href":"/lexicon/пара/"},{"word":"префікс","translation":"prefix","pos":"noun","example":"Префікс часто допомагає утворити доконаний вид.","examples":["prefix","Префікс часто допомагає утворити доконаний вид."],"atlas_href":"/lexicon/префікс/"},{"word":"суфікс","translation":"suffix","pos":"noun","example":"У цій парі змінюється суфікс.","examples":["suffix","У цій парі змінюється суфікс."],"atlas_href":"/lexicon/суфікс/"},{"word":"корінь","translation":"root","pos":"noun","example":"Іноді в парі змінюється корінь слова.","examples":["root","Іноді в парі змінюється корінь слова."],"atlas_href":"/lexicon/корінь/"},{"word":"утворювати","translation":"to form","pos":"verb","example":"Так ми утворюємо нову пару.","examples":["to form","Так ми утворюємо нову пару."],"atlas_href":"/lexicon/утворювати/"},{"word":"записувати","translation":"to write down","pos":"verb","example":"Я люблю записувати дієслова в зошит.","examples":["to write down","Я люблю записувати дієслова в зошит."],"atlas_href":"/lexicon/записувати/"},{"word":"словник","translation":"dictionary","pos":"noun","example":"Перевір цю пару в словнику.","examples":["dictionary","Перевір цю пару в словнику."],"atlas_href":"/lexicon/словник/"},{"word":"запам'ятовувати","translation":"to memorize","pos":"verb","example":"Такі пари треба запам'ятовувати разом.","examples":["to memorize","Такі пари треба запам'ятовувати разом."],"atlas_href":"/lexicon/запам-ятовувати/"},{"word":"модель","translation":"pattern, model","pos":"noun","example":"Це найчастіша модель для A2.","examples":["pattern, model","Це найчастіша модель для A2."],"atlas_href":"/lexicon/модель/"},{"word":"базовий","translation":"basic","pos":"adjective","example":"Це базовий список видових пар.","examples":["basic","Це базовий список видових пар."],"atlas_href":"/lexicon/базовий/"},{"word":"видовий партнер","translation":"aspectual partner","pos":"noun phrase","example":"Записуй дієслово разом із видовим партнером.","examples":["aspectual partner","Записуй дієслово разом із видовим партнером."]},{"word":"читати / прочитати","translation":"to read","pos":"verb pair","example":"Я читаю статтю, а ввечері прочитаю її.","examples":["to read","Я читаю статтю, а ввечері прочитаю її."],"atlas_href":"/lexicon/читати-прочитати/"},{"word":"писати / написати","translation":"to write","pos":"verb pair","example":"Вона писала нотатку і швидко написала лист.","examples":["to write","Вона писала нотатку і швидко написала лист."],"atlas_href":"/lexicon/писати-написати/"},{"word":"робити / зробити","translation":"to do, to make","pos":"verb pair","example":"Ми робили завдання і зробили його до вечора.","examples":["to do, to make","Ми робили завдання і зробили його до вечора."],"atlas_href":"/lexicon/робити-зробити/"},{"word":"готувати / приготувати","translation":"to prepare, to cook","pos":"verb pair","example":"Вони готували вечерю і приготували салат.","examples":["to prepare, to cook","Вони готували вечерю і приготували салат."],"atlas_href":"/lexicon/готувати-приготувати/"},{"word":"бачити / побачити","translation":"to see","pos":"verb pair","example":"Я бачив вивіску і потім побачив потрібний номер.","examples":["to see","Я бачив вивіску і потім побачив потрібний номер."],"atlas_href":"/lexicon/бачити-побачити/"},{"word":"вчити / вивчити","translation":"to learn, to study","pos":"verb pair","example":"Ми вчили нові слова і вивчили три пари.","examples":["to learn, to study","Ми вчили нові слова і вивчили три пари."],"atlas_href":"/lexicon/вчити-вивчити/"},{"word":"слухати / послухати","translation":"to listen","pos":"verb pair","example":"Я слухав подкаст і послухав короткий випуск до кінця.","examples":["to listen","Я слухав подкаст і послухав короткий випуск до кінця."]},{"word":"дзвонити / подзвонити","translation":"to call","pos":"verb pair","example":"Вона дзвонила мамі і потім подзвонила колезі.","examples":["to call","Вона дзвонила мамі і потім подзвонила колезі."],"atlas_href":"/lexicon/дзвонити-подзвонити/"},{"word":"брати / взяти","translation":"to take","pos":"verb pair","example":"Я брав чашку і потім узяв ложку.","examples":["to take","Я брав чашку і потім узяв ложку."],"atlas_href":"/lexicon/брати-взяти/"},{"word":"говорити / сказати","translation":"to speak / to say","pos":"verb pair","example":"Ми довго говорили, а потім я сказав головне.","examples":["to speak / to say","Ми довго говорили, а потім я сказав головне."],"atlas_href":"/lexicon/говорити-сказати/"},{"word":"відповідати / відповісти","translation":"to answer","pos":"verb pair","example":"Він відповідав спокійно і нарешті відповів точно.","examples":["to answer","Він відповідав спокійно і нарешті відповів точно."],"atlas_href":"/lexicon/відповідати-відповісти/"},{"word":"вирішувати / вирішити","translation":"to decide, to solve","pos":"verb pair","example":"Ми довго вирішували і зрештою вирішили.","examples":["to decide, to solve","Ми довго вирішували і зрештою вирішили."],"atlas_href":"/lexicon/вирішувати-вирішити/"},{"word":"допомагати / допомогти","translation":"to help","pos":"verb pair","example":"Я допомагав другу і потім допоміг сестрі.","examples":["to help","Я допомагав другу і потім допоміг сестрі."],"atlas_href":"/lexicon/допомагати-допомогти/"},{"word":"повертати / повернути","translation":"to return","pos":"verb pair","example":"Я повертав книгу і нарешті повернув її до бібліотеки.","examples":["to return","Я повертав книгу і нарешті повернув її до бібліотеки."]},{"word":"варити / зварити","translation":"to cook, to boil","pos":"verb pair","example":"Бабуся варила суп і швидко зварила борщ.","examples":["to cook, to boil","Бабуся варила суп і швидко зварила борщ."],"atlas_href":"/lexicon/варити-зварити/"},{"word":"ліпити / зліпити","translation":"to shape, to make by hand","pos":"verb pair","example":"Діти ліпили вареники і зліпили останню партію.","examples":["to shape, to make by hand","Діти ліпили вареники і зліпили останню партію."],"atlas_href":"/lexicon/ліпити-зліпити/"},{"word":"ловити / піймати","translation":"to catch","pos":"verb pair","example":"Діти ловили м'яч і піймали його.","examples":["to catch","Діти ловили м'яч і піймали його."]},{"word":"класти / покласти","translation":"to put","pos":"verb pair","example":"Він клав ключі на стіл і поклав їх у сумку.","examples":["to put","Він клав ключі на стіл і поклав їх у сумку."],"atlas_href":"/lexicon/класти-покласти/"},{"word":"їсти / з'їсти","translation":"to eat","pos":"verb pair","example":"Ми їли суп і з'їли його до кінця.","examples":["to eat","Ми їли суп і з'їли його до кінця."],"atlas_href":"/lexicon/їсти-з-їсти/"},{"word":"знаходити / знайти","translation":"to find","pos":"verb pair","example":"Я часто знаходжу цікаві слова і знайшов потрібний приклад.","examples":["to find","Я часто знаходжу цікаві слова і знайшов потрібний приклад."]},{"word":"шукати / знайти","translation":"to look for / to find","pos":"related verbs","example":"Я шукав ключі й нарешті знайшов їх.","examples":["to look for / to find","Я шукав ключі й нарешті знайшов їх."]}]`)} title="Vocabulary" />
 
-<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"видова пара","back":"aspectual pair"},{"front":"пара","back":"pair"},{"front":"префікс","back":"prefix"},{"front":"суфікс","back":"suffix"},{"front":"корінь","back":"root"},{"front":"утворювати","back":"to form"},{"front":"записувати","back":"to write down"},{"front":"словник","back":"dictionary"},{"front":"запам'ятовувати","back":"to memorize"},{"front":"модель","back":"pattern, model"},{"front":"базовий","back":"basic"},{"front":"видовий партнер","back":"aspectual partner"},{"front":"читати / прочитати","back":"to read"},{"front":"писати / написати","back":"to write"},{"front":"робити / зробити","back":"to do, to make"},{"front":"готувати / приготувати","back":"to prepare, to cook"},{"front":"брати / взяти","back":"to take"},{"front":"говорити / сказати","back":"to speak / to say"},{"front":"відповідати / відповісти","back":"to answer"},{"front":"вирішувати / вирішити","back":"to decide, to solve"},{"front":"допомагати / допомогти","back":"to help"},{"front":"варити / зварити","back":"to cook, to boil"},{"front":"ліпити / зліпити","back":"to shape, to make by hand"},{"front":"шукати / знайти","back":"to look for / to find"}]`)} />
+<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"видова пара","back":"aspectual pair"},{"front":"пара","back":"pair"},{"front":"префікс","back":"prefix"},{"front":"суфікс","back":"suffix"},{"front":"корінь","back":"root"},{"front":"утворювати","back":"to form"},{"front":"записувати","back":"to write down"},{"front":"словник","back":"dictionary"},{"front":"запам'ятовувати","back":"to memorize"},{"front":"модель","back":"pattern, model"},{"front":"базовий","back":"basic"},{"front":"видовий партнер","back":"aspectual partner"},{"front":"читати / прочитати","back":"to read"},{"front":"писати / написати","back":"to write"},{"front":"робити / зробити","back":"to do, to make"},{"front":"готувати / приготувати","back":"to prepare, to cook"},{"front":"бачити / побачити","back":"to see"},{"front":"вчити / вивчити","back":"to learn, to study"},{"front":"слухати / послухати","back":"to listen"},{"front":"дзвонити / подзвонити","back":"to call"},{"front":"брати / взяти","back":"to take"},{"front":"говорити / сказати","back":"to speak / to say"},{"front":"відповідати / відповісти","back":"to answer"},{"front":"вирішувати / вирішити","back":"to decide, to solve"},{"front":"допомагати / допомогти","back":"to help"},{"front":"повертати / повернути","back":"to return"},{"front":"варити / зварити","back":"to cook, to boil"},{"front":"ліпити / зліпити","back":"to shape, to make by hand"},{"front":"ловити / піймати","back":"to catch"},{"front":"класти / покласти","back":"to put"},{"front":"їсти / з'їсти","back":"to eat"},{"front":"знаходити / знайти","back":"to find"},{"front":"шукати / знайти","back":"to look for / to find"}]`)} />
 
 </TabItem>
 <TabItem label="Activities">


### PR DESCRIPTION
## Summary
- Certifies A2 M03 (`aspect-in-vocabulary`) for the A2 language policy.
- Reduces English support from 10 repeated blocks to 3 concise rescue notes (~78 English words) while keeping the source above the 2,000-word plan target.
- Fixes the `говорити / сказати` consistency issue, clarifies `шукати / знайти` versus `знаходити / знайти`, adds missing vocabulary entries for the 20-pair table, and regenerates only the M03 MDX.

## Validation
- `.venv/bin/python scripts/generate_mdx.py l2-uk-en a2 3 --validate`
- `.venv/bin/python scripts/audit/certify_module.py a2/aspect-in-vocabulary`
- DeepSeek/Hermes read-only pre-edit review: BLOCK, fixed required findings.
- DeepSeek/Hermes read-only post-edit gate: SHIP.

## Token Telemetry
- run_id: `a2-m03-pr3385`
- swarm_used: true
- swarm_label: thin
- swarm_note: DeepSeek/Hermes read-only language-balance prescan and post-edit certification gate only; one post-edit invocation hung and was interrupted, then rerun narrowly; no external edits, gh, push, merge, or file modifications.
- wall_clock_minutes: 26.0
- token_source: unavailable
- main: codex gpt-5-codex high, integration and certification, calls 1, tokens unavailable
- reviewers: hermes deepseek-v4-pro, read-only language-balance and post-edit certification review, calls 3, tokens unavailable
- total_tokens: unavailable
