### PR TITLE
fix(immersion): sync stale A2 immersion sources up to full-immersion policy

### DIFF
--- a/agents_extensions/shared/phases/calibration/a2.md
+++ b/agents_extensions/shared/phases/calibration/a2.md
@@ -4,7 +4,7 @@
 A2 teaches Ukrainian IN Ukrainian. Easy Ukrainian is the default teaching voice
 from M01; immersion is already high and converges to full by end of A2:
 - Band 1 (M01-20): 85-100% Ukrainian — easy Ukrainian explanations, English for vocab glosses only
-- Band 2 (M21-50): 90-100% Ukrainian — richer Ukrainian, glosses + rare one-line clarification
+- Band 2 (M21-50): 90-100% Ukrainian — richer Ukrainian, vocabulary glosses only
 - Band 3 (M51-70): 95-100% Ukrainian — near-B1, first-use metalanguage gloss only
 
 Explaining Ukrainian grammar in English prose is WRONG pedagogy at A2 — the

--- a/agents_extensions/shared/phases/calibration/a2.md
+++ b/agents_extensions/shared/phases/calibration/a2.md
@@ -1,16 +1,17 @@
 # Track Calibration: A2
 
-## Bilingual Scope
-A2 uses 3-band GRADUATED immersion — targets increase by module band:
-- Band 1 (M01-20): 45-65% Ukrainian — Core grammar, English for theory
-- Band 2 (M21-50): 55-75% Ukrainian — Applied grammar, English only for abstracts
-- Band 3 (M51-70): 70-90% Ukrainian — Consolidation, near-full immersion
+## Immersion Scope
+A2 teaches Ukrainian IN Ukrainian. Easy Ukrainian is the default teaching voice
+from M01; immersion is already high and converges to full by end of A2:
+- Band 1 (M01-20): 85-100% Ukrainian — easy Ukrainian explanations, English for vocab glosses only
+- Band 2 (M21-50): 90-100% Ukrainian — richer Ukrainian, glosses + rare one-line clarification
+- Band 3 (M51-70): 95-100% Ukrainian — near-B1, first-use metalanguage gloss only
 
-English explanations with Ukrainian examples and increasing Ukrainian prose
-sections is CORRECT pedagogy. Do NOT flag bilingual content as LANGUAGE_BLENDER
-when it falls within the module's immersion band.
-Flag: Sections that exceed the module's immersion maximum.
-Flag: Modules that fall below their minimum immersion target.
+Explaining Ukrainian grammar in English prose is WRONG pedagogy at A2 — the
+learner must build Ukrainian by using it, not hear about it in English.
+Flag: English support/theory paragraphs in the body (LANGUAGE_BLENDER / immersion-below-band).
+Flag: mirrored English translation paragraphs after Ukrainian prose or dialogues.
+Flag: Modules that fall below their immersion minimum.
 
 ## Russicism Lookup (A2-specific)
 All A1 Russicisms plus:

--- a/agents_extensions/shared/quick-ref/a2.md
+++ b/agents_extensions/shared/quick-ref/a2.md
@@ -18,7 +18,7 @@ voice from M01. Immersion is already high and converges to full by end of A2:
 | Band | Modules | Target | English allowed for |
 |------|---------|--------|-----------------|
 | Core A2 | M01-20 | 85-100% | Vocabulary glosses only (Tab 2 / inline em-dash) |
-| Applied | M21-50 | 90-100% | Vocabulary glosses; rare one-line clarification |
+| Applied | M21-50 | 90-100% | Vocabulary glosses only (Tab 2 / inline em-dash) |
 | Consolidation | M51-70 | 95-100% | First-use metalanguage gloss only; otherwise Ukrainian |
 
 **Critical rule:** NEVER mix languages within a sentence at A2.

--- a/agents_extensions/shared/quick-ref/a2.md
+++ b/agents_extensions/shared/quick-ref/a2.md
@@ -12,17 +12,19 @@ Max 15 words per Ukrainian sentence. Max 2 clauses per sentence.
 
 ## Immersion Strategy (A2)
 
-A2 uses graduated immersion (50-90%) across three bands:
+A2 teaches Ukrainian IN Ukrainian — easy Ukrainian is the default teaching
+voice from M01. Immersion is already high and converges to full by end of A2:
 
-| Band | Modules | Target | English used for |
+| Band | Modules | Target | English allowed for |
 |------|---------|--------|-----------------|
-| Core grammar | M01-20 | 45-65% | Grammar theory (cases, aspect) |
-| Applied grammar | M21-50 | 55-75% | Abstract concepts only |
-| Consolidation | M51-70 | 70-90% | Vocabulary tables only |
+| Core A2 | M01-20 | 85-100% | Vocabulary glosses only (Tab 2 / inline em-dash) |
+| Applied | M21-50 | 90-100% | Vocabulary glosses; rare one-line clarification |
+| Consolidation | M51-70 | 95-100% | First-use metalanguage gloss only; otherwise Ukrainian |
 
 **Critical rule:** NEVER mix languages within a sentence at A2.
 Each sentence is 100% Ukrainian OR 100% English.
-Ukrainian paragraph first, then English translation paragraph below if needed.
+FORBIDDEN: mirrored English translation paragraphs after Ukrainian prose or
+dialogues. Teach the concept in easy Ukrainian — do not explain Ukrainian in English.
 
 ## A2-Specific Writing Notes
 

--- a/agents_extensions/shared/skills/content-review/content-review-prompt.md
+++ b/agents_extensions/shared/skills/content-review/content-review-prompt.md
@@ -93,7 +93,7 @@ Read the activities YAML and check:
 
 ### CORE MODE (A1-C2)
 
-- [ ] **Immersion ratio appropriate** -- Estimate Ukrainian vs English word ratio. Compare against tier targets (A1.1: 20-40%, A2: 50-75%, B1+: 75%+).
+- [ ] **Immersion ratio appropriate** -- Estimate Ukrainian vs English word ratio. Compare against tier targets (A1 uses scaffolded immersion; A2 uses easy Ukrainian with a natural 85-100%+ ramp; B1+ is Ukrainian-only body prose).
 - [ ] **Grammar accuracy** -- Verify grammar explanations against textbooks using `mcp__sources__search_text`. Flag incorrect rules as **CRITICAL**.
 
 ### HISTORY/BIO/ISTORIO MODE

--- a/agents_extensions/shared/skills/content-review/content-review-prompt.md
+++ b/agents_extensions/shared/skills/content-review/content-review-prompt.md
@@ -93,7 +93,7 @@ Read the activities YAML and check:
 
 ### CORE MODE (A1-C2)
 
-- [ ] **Immersion ratio appropriate** -- Estimate Ukrainian vs English word ratio. Compare against tier targets (A1 uses scaffolded immersion; A2 uses easy Ukrainian with a natural 85-100%+ ramp; B1+ is Ukrainian-only body prose).
+- [ ] **Immersion ratio appropriate** -- Estimate Ukrainian vs English word ratio. Compare against tier targets (A1 uses scaffolded immersion; A2 is banded — M01-20: 85-100%, M21-50: 90-100%, M51-70: 95-100%; B1+ is Ukrainian-only body prose).
 - [ ] **Grammar accuracy** -- Verify grammar explanations against textbooks using `mcp__sources__search_text`. Flag incorrect rules as **CRITICAL**.
 
 ### HISTORY/BIO/ISTORIO MODE

--- a/agents_extensions/shared/skills/plan-review/review-tiers/tier-1-beginner.md
+++ b/agents_extensions/shared/skills/plan-review/review-tiers/tier-1-beginner.md
@@ -84,7 +84,7 @@ WELCOME → PREVIEW → PRESENT → PRACTICE → CELEBRATE
 
 | Category | Pattern | Example | Required Fix |
 |----------|---------|---------|--------------|
-| **OVERWHELMING_INTRO** | Too much complexity too fast | First paragraph uses dense Ukrainian | Rewrite in easier Ukrainian with repeated frames |
+| **OVERWHELMING_INTRO** | Too much complexity too fast | First paragraph uses dense Ukrainian | A1: add English scaffolding; A2: rewrite in easier Ukrainian with repeated frames |
 | **NO_QUICK_WIN** | Long content before any practice | 500 words before first activity | Add mini-exercise earlier |
 | **MISSING_SUPPORT** | Learner left to guess meaning | Dense Ukrainian with no frame | Add a simple Ukrainian frame or a short gloss |
 | **SCARY_GRAMMAR** | Complex terminology for beginners | "Accusative case" without explanation | Simplify or explain term |
@@ -130,10 +130,14 @@ WELCOME → PREVIEW → PRESENT → PRACTICE → CELEBRATE
 - Clear pronunciation guidance (stress marks)
 - Consistent grammar patterns (no exceptions early)
 
-**English in A2 must be minimal:**
-- vocabulary glosses
-- one-line clarification only when a concept would otherwise be opaque
-- never long English body scaffolding
+**A1 English must be:**
+- B1-level readability (accessible to non-native English speakers too)
+- encouraging and clear
+- scaffolded where the learner would otherwise struggle
+
+**English in A2 must be limited to:**
+- vocabulary glosses only (inline em-dash or Tab 2 Словник)
+- never one-line English clarifications or long English body scaffolding
 
 ### Activity Quality (Beginner Gates)
 

--- a/agents_extensions/shared/skills/plan-review/review-tiers/tier-1-beginner.md
+++ b/agents_extensions/shared/skills/plan-review/review-tiers/tier-1-beginner.md
@@ -2,7 +2,7 @@
 
 > **Target:** A1 and A2 modules
 > **Pedagogy:** PPP (Present-Practice-Produce)
-> **Immersion:** 10-90% Ukrainian (scaffolded with English, graduated by band)
+> **Immersion:** A1 is scaffolded with English; A2 uses easy Ukrainian with a natural complexity ramp
 > **Experience Goal:** Safe, encouraging tutoring — learner feels supported, not overwhelmed
 
 ---
@@ -12,8 +12,9 @@
 > **Key Question:** "Does this feel like a patient, encouraging tutor?"
 >
 > At A1/A2, learners are fragile. They need:
-> - Clear, simple explanations in English
-> - Gentle introduction of Ukrainian
+> - A1: clear, simple English support
+> - A2: clear, simple Ukrainian as the main teaching voice
+> - Gentle introduction of harder Ukrainian structures
 > - Lots of encouragement
 > - Predictable structure (safety)
 > - Quick wins (dopamine hits)
@@ -61,7 +62,7 @@ WELCOME → PREVIEW → PRESENT → PRACTICE → CELEBRATE
 |--------|-------------|------|
 | New words per section | ≤5-7 | >10 new words without practice |
 | Concepts before practice | ≤2 concepts | >3 concepts before any exercise |
-| English support | Present when needed | Missing when learner would struggle |
+| Language support | A1 English support; A2 easy Ukrainian frames | A2 body prose replaced by English scaffolding |
 | Visual aids | Tables, charts for grammar | Prose-only explanations |
 
 ### Emotional Safety Mapping
@@ -83,9 +84,9 @@ WELCOME → PREVIEW → PRESENT → PRACTICE → CELEBRATE
 
 | Category | Pattern | Example | Required Fix |
 |----------|---------|---------|--------------|
-| **OVERWHELMING_INTRO** | Too much Ukrainian too fast | First paragraph all Ukrainian | Add English scaffolding |
+| **OVERWHELMING_INTRO** | Too much complexity too fast | First paragraph uses dense Ukrainian | Rewrite in easier Ukrainian with repeated frames |
 | **NO_QUICK_WIN** | Long content before any practice | 500 words before first activity | Add mini-exercise earlier |
-| **MISSING_ENGLISH** | Learner left to guess meaning | Ukrainian without translation | Add translation/gloss |
+| **MISSING_SUPPORT** | Learner left to guess meaning | Dense Ukrainian with no frame | Add a simple Ukrainian frame or a short gloss |
 | **SCARY_GRAMMAR** | Complex terminology for beginners | "Accusative case" without explanation | Simplify or explain term |
 | **NO_ENCOURAGEMENT** | Flat, mechanical instruction | "Now do exercise 2" | Add "Great! Now let's..." |
 | **TOO_MUCH_AT_ONCE** | >3 concepts before practice | 5 verb forms in one section | Split into smaller chunks |
@@ -98,7 +99,7 @@ WELCOME → PREVIEW → PRESENT → PRACTICE → CELEBRATE
 | Criterion | A+ Standard | B Standard | C or Below |
 |-----------|-------------|------------|------------|
 | **Opening** | Warm welcome, clear preview | Basic intro | Cold start |
-| **English Support** | Present throughout, scaffolded reduction | Present but inconsistent | Missing when needed |
+| **A1 English / A2 Easy Ukrainian** | A1 has support; A2 is simple Ukrainian | Some mismatch | A2 body relies on English scaffolding |
 | **Visual Aids** | Tables, charts, clear formatting | Some visual organization | Walls of text |
 | **Pacing** | Small chunks, frequent practice | Reasonable chunks | Overwhelming sections |
 | **Quick Wins** | Multiple small successes | At least one | None until end |
@@ -117,9 +118,9 @@ WELCOME → PREVIEW → PRESENT → PRACTICE → CELEBRATE
 | A1.1 | 20-40% | Heavy English support |
 | A1.2 | 40-60% | Increasing Ukrainian |
 | A1.3 | 60-80% | Scaffolded transition |
-| A2 M01-20 | 45-65% | Core grammar — English for theory |
-| A2 M21-50 | 55-75% | Applied grammar — English only for abstract concepts |
-| A2 M51-70 | 70-90% | Consolidation — near-full Ukrainian |
+| A2 M01-20 | 85-100% | Easy Ukrainian; short repeated frames |
+| A2 M21-50 | 90-100% | Richer Ukrainian with controlled connectors |
+| A2 M51-70 | 95-100% | Near-B1 Ukrainian; transparent 2-3 clause sentences |
 
 ### Language Quality (Beginner Adaptation)
 
@@ -129,10 +130,10 @@ WELCOME → PREVIEW → PRESENT → PRACTICE → CELEBRATE
 - Clear pronunciation guidance (stress marks)
 - Consistent grammar patterns (no exceptions early)
 
-**English must be:**
-- B1-level readability (accessible to non-native English speakers too)
-- Contractions allowed ("you'll", "don't")
-- Encouraging tone
+**English in A2 must be minimal:**
+- vocabulary glosses
+- one-line clarification only when a concept would otherwise be opaque
+- never long English body scaffolding
 
 ### Activity Quality (Beginner Gates)
 

--- a/docs/best-practices/module-content-quality.md
+++ b/docs/best-practices/module-content-quality.md
@@ -139,8 +139,8 @@ HOOK → TENSION → JOURNEY → CLIMAX → RESOLUTION → CALL TO ACTION
 
 | Level | Ukrainian % |
 |-------|------------|
-| A1 | 10-40% (English scaffolded) |
-| A2 | 40-75% |
+| A1 | 10-40% (English scaffolds Ukrainian content) |
+| A2 | 85-100% (easy Ukrainian is the teaching voice; English for glosses only) |
 | B1 | 90-100% |
 | B2+ | 100% |
 | Seminar tracks | 98-100% |

--- a/docs/best-practices/module-content-quality.md
+++ b/docs/best-practices/module-content-quality.md
@@ -140,7 +140,9 @@ HOOK → TENSION → JOURNEY → CLIMAX → RESOLUTION → CALL TO ACTION
 | Level | Ukrainian % |
 |-------|------------|
 | A1 | 10-40% (English scaffolds Ukrainian content) |
-| A2 | 85-100% (easy Ukrainian is the teaching voice; English for glosses only) |
+| A2 M01-20 | 85-100% (easy Ukrainian is the teaching voice; English for glosses only) |
+| A2 M21-50 | 90-100% (richer Ukrainian; English for glosses only) |
+| A2 M51-70 | 95-100% (near-B1 Ukrainian; English for glosses only) |
 | B1 | 90-100% |
 | B2+ | 100% |
 | Seminar tracks | 98-100% |

--- a/docs/prompts/a2-certification-orchestration-prompt.md
+++ b/docs/prompts/a2-certification-orchestration-prompt.md
@@ -1,0 +1,499 @@
+# A2 Certification Orchestration Prompt
+
+Use this as a standalone handoff prompt for a fresh A2 certification thread.
+Copy from `BEGIN PROMPT` through `END PROMPT`.
+
+## BEGIN PROMPT
+
+You are continuing certification orchestration for the A2 Ukrainian course in
+`/Users/krisztiankoos/projects/learn-ukrainian`.
+
+Your goal is to make A2 learner pages certification-ready one module at a time,
+starting with the first uncertified module in curriculum order. Certification is
+stricter than "released" or "live": the page must be source-backed,
+teacher-natural, A2-appropriate, reviewed by an independent Claude/Opus pass,
+independently gate-checked, merged to `main`, CI-green, and live on the public
+site route.
+
+Definition of certified for an A2 module:
+
+- The source files and generated MDX are merged to `main`.
+- The public route returns 200 after deploy:
+  `https://learn-ukrainian.github.io/a2/<slug>/`.
+- The lesson is grounded in the plan, A2 grammar scope, Ukrainian sources, and
+  the A2 wiki/locked-review corpus.
+- Deterministic gates pass.
+- LLM QG has no dimension below 8.0; target 9.0 where practical.
+- The PR body records LLM QG scores, Claude/Opus review outcome, independent
+  final gate outcome, validation commands, route evidence, and token telemetry.
+- No generated status/review/audit artifacts are committed.
+
+## Known Baseline To Verify, Not Assume
+
+As of 2026-06-16, local `origin/main` was at `b3827f1b51` and A2 release PR
+[#3262](https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/3262)
+had already merged at `9ad2c982b73fdae267bac0d0af2ef848d952166c`.
+
+PR #3262 made A2 release-ready by:
+
+- accepting the existing `targets` alias in `mark-the-words` activities;
+- aligning the activities schema with A2 source formats already supported by
+  the parser;
+- treating `scripts/yaml_activities.py` as an MDX generator dependency in the
+  source-parity gate;
+- regenerating all 69 released A2 lesson MDX pages;
+- adding regression tests for parser aliases and parity dependencies.
+
+Do not treat #3262 as certification. It is the release-readiness baseline.
+Verify current `main`, current open PRs, current A2 route status, and any
+already-certified A2 modules before choosing the next target. If no certified
+A2 module evidence exists, start at M01 `a2-bridge`.
+
+## Non-Negotiable Repo Rules
+
+- Do all implementation in a dispatch worktree:
+  `.worktrees/dispatch/codex/a2-mXX-<slug>-certify/`.
+- Branch name:
+  `codex/a2-mXX-<slug>-certify`.
+- Commit trailer:
+  `X-Agent: codex/a2-mXX-<slug>-certify`.
+- Do not modify `.python-version`, `.yamllint`, or `.markdownlint.json`.
+- Do not use `sys.executable`; always use `.venv/bin/python`.
+- Do not use container paths such as `/app/...`.
+- Use `site/`, not `starlight/`.
+- Do not hand-edit generated MDX unless the generator itself is the scoped
+  target. Edit curriculum sources, regenerate MDX, and include both only when
+  source changes require generated MDX changes.
+- Do not commit:
+  - `curriculum/l2-uk-en/**/status/*.json`
+  - `curriculum/l2-uk-en/**/audit/*-review.md`
+  - `curriculum/l2-uk-en/**/review/*-review.md`
+  - `docs/*-STATUS.md`
+  - `data/telemetry/**`
+  - `llm_qg.json`, `python_qg.json`, raw reviewer prompts/responses, or other
+    transient QG evidence unless an existing module-build workflow explicitly
+    requires that artifact in git. Prefer summarizing scores in the PR body.
+- Keep changed files directly related to the module.
+- One PR certifies one module unless the user explicitly expands scope.
+- Never weaken tests or linter configs to pass CI.
+
+## Mandatory First Reads
+
+Before editing, read and report what you learned from:
+
+- `AGENTS.md`
+- `agents_extensions/shared/memory/MEMORY.md`
+- `docs/runbooks/module-build-token-telemetry.md`
+- `curriculum/l2-uk-en/curriculum.yaml`, A2 section
+- `agents_extensions/shared/quick-ref/a2.md`
+- `agents_extensions/shared/phases/calibration/a2.md`
+- `site/src/content/docs/a2/index.mdx`
+- PR #3262 body and files
+- any current A2 PRs:
+  `gh pr list --state open --search "a2" --json number,title,headRefName,url`
+- `docs/decisions/pending/*.md`; only block if a pending decision's `Scope`
+  covers the target module
+
+For the selected module also read:
+
+- `curriculum/l2-uk-en/plans/a2/<slug>.yaml`
+- `curriculum/l2-uk-en/a2/<slug>/module.md`
+- `curriculum/l2-uk-en/a2/<slug>/activities.yaml`
+- `curriculum/l2-uk-en/a2/<slug>/vocabulary.yaml`
+- `curriculum/l2-uk-en/a2/<slug>/resources.yaml`
+- `wiki/grammar/a2/<slug>.md`
+- `wiki/grammar/a2/<slug>.sources.yaml`
+- `wiki/.reviews/grammar/a2/<slug>-review-LOCKED.md`
+- `site/src/content/docs/a2/<slug>.mdx`
+
+## A2 Curriculum Order
+
+Use this sequence unless current source says otherwise:
+
+### A2.1 [Основи та вступ до виду дієслова]
+
+1. M01 `a2-bridge`
+2. M02 `aspect-concept`
+3. M03 `aspect-in-vocabulary`
+4. M04 `liudyna-i-stosunky`
+5. M05 `genitive-intro`
+6. M06 `genitive-dates-numbers`
+7. M07 `foundations-practice`
+8. M08 `checkpoint-foundations`
+
+### A2.2 [Родовий відмінок: завершення]
+
+1. M09 `genitive-prepositions-source`
+2. M10 `genitive-prepositions-purpose`
+3. M11 `genitive-prepositions-direction`
+4. M12 `euphony-advanced`
+5. M13 `genitive-adjectives-pronouns`
+6. M14 `genitive-plural`
+7. M15 `shopping-and-health`
+8. M16 `checkpoint-genitive`
+
+### A2.3 [Давальний відмінок]
+
+1. M17 `dative-pronouns`
+2. M18 `dative-nouns`
+3. M19 `dative-adjectives-pronouns`
+4. M20 `locative-expanded`
+5. M21 `dative-verbs`
+6. M22 `services-and-communication`
+7. M23 `checkpoint-dative`
+
+### A2.4 [Орудний відмінок і звертання]
+
+1. M24 `instrumental-accompaniment`
+2. M25 `instrumental-means`
+3. M26 `instrumental-profession`
+4. M27 `vocative-expanded`
+5. M28 `instrumental-prepositions`
+6. M29 `instrumental-adjectives-pronouns`
+7. M30 `work-and-food`
+8. M31 `checkpoint-instrumental`
+
+### A2.5 [Синтез відмінків та множина]
+
+1. M32 `plural-nominative-accusative`
+2. M33 `plural-genitive`
+3. M34 `plural-other-cases`
+4. M35 `dozvillia-i-khobi`
+5. M36 `which-case-when`
+6. M37 `all-cases-practice`
+7. M38 `home-and-daily-life`
+8. M39 `checkpoint-cases`
+
+### A2.6 [Вид, часи та рух]
+
+1. M40 `aspect-in-past`
+2. M41 `synthetic-future`
+3. M42 `aspect-mastery`
+4. M43 `motion-verbs`
+5. M44 `imperative-complete`
+6. M45 `telling-stories-and-travel`
+7. M46 `checkpoint-verbs`
+
+### A2.7 [Складні речення та умови]
+
+1. M47 `because-and-although`
+2. M48 `purpose-clauses`
+3. M49 `relative-clauses`
+4. M50 `word-order-emphasis`
+5. M51 `real-conditionals`
+6. M52 `education-and-work`
+7. M53 `checkpoint-syntax`
+
+### A2.8 [Удосконалення та випуск]
+
+1. M54 `comparison`
+2. M55 `numerals-and-cases`
+3. M56 `sviy-and-sebe`
+4. M57 `indefinite-negative-pronouns`
+5. M58 `synonyms-antonyms-style`
+6. M59 `preferences-and-choices`
+7. M60 `nature-and-traditions`
+
+### A2.9 [Метамова: місток та основи]
+
+1. M61 `metalanguage-words-and-cases`
+2. M62 `metalanguage-verbs-and-time`
+3. M63 `metalanguage-sentences-and-classroom`
+4. M64 `metalanguage-phonetics`
+5. M65 `metalanguage-morphology`
+6. M66 `metalanguage-syntax-cases`
+
+### A2.10 [Вдосконалення та випуск]
+
+1. M67 `a2-comprehensive-review`
+2. M68 `a2-practice-exam`
+3. M69 `a2-finale`
+
+## A2 Pedagogy Bar
+
+A2 is not B1. Do not deepen by making the material abstract or advanced.
+Improve by making it clearer, better scaffolded, better sourced, and more
+usable by a real A2 learner.
+
+Use these A2 constraints:
+
+- Allowed grammar: all 7 cases, simple subordinate clauses with
+  `який` / `що` / `коли`, aspect pairs introduced.
+- Forbidden grammar: participles and complex subordinate clauses.
+- Ukrainian sentences should stay short: max 15 words, max 2 clauses.
+- Do not mix languages inside one sentence. A sentence is fully Ukrainian or
+  fully English.
+- Teach Ukrainian IN Ukrainian. Easy Ukrainian is the teaching voice from M01;
+  immersion is already high and converges to full by end of A2:
+  - M01-M20: 85-100% Ukrainian
+  - M21-M50: 90-100% Ukrainian
+  - M51-M69: 95-100% Ukrainian
+- English appears ONLY as vocabulary glosses (inline em-dash or Tab 2 Словник).
+  NEVER explain Ukrainian grammar in English prose. NEVER add mirrored English
+  translation paragraphs after Ukrainian content. The learner builds Ukrainian by
+  using it, not by hearing about it in English.
+- No Latin transliteration.
+- No IPA or phonetic brackets.
+- Stress marks only where the project convention requires them.
+- Register is concrete everyday A2: real actions, real objects, real service
+  situations, real school/work/home/travel needs.
+- Avoid literary, poetic, figurative, and heavily abstract language. In M58,
+  where style is the topic, keep figures controlled, glossed, and A2-limited.
+- Grammar metalanguage is allowed where the plan requires it, but gloss it and
+  teach it as language a learner can use, not as academic taxonomy.
+
+Run explicit A2 calque/russianism checks. At minimum, reject:
+
+- `приймати участь` -> `брати участь`
+- `самий кращий` -> `найкращий`
+- `на то, що` -> `на те, що`
+- `відноситися` when the intended meaning is `стосуватися` or `ставитися`
+- `слідуючий` -> `наступний`
+- `скучати` when the intended meaning is `сумувати` / `нудьгувати`
+- `нравитися` -> `подобатися`
+- `робити рішення` -> `приймати рішення`
+- `брати місце` -> `відбуватися`
+- `робити сенс` -> `мати сенс`
+
+## Source And Evidence Rules
+
+- The plan remains the source of truth. If a plan is wrong or underspecified,
+  isolate that as a separate problem before rewriting around it.
+- Use Ukrainian sources and repo-local tools before guessing:
+  VESUM, `data/sources.db`, textbook corpus, wiki grammar source files, and
+  locked A2 grammar reviews.
+- Do not fabricate quotes, textbook references, source titles, error codes,
+  route statuses, PR states, or review outcomes.
+- Every claim in the PR body must be backed by a local command, GitHub command,
+  route check, or reviewer output.
+- If Qdrant or a search service is unavailable, use local deterministic sources
+  and say exactly which tool/source was used.
+
+## Per-Module Workflow
+
+1. Sync and select the next target.
+
+   ```bash
+   git fetch --prune origin
+   git switch main
+   git pull --ff-only
+   gh pr list --state open --search "a2" --json number,title,headRefName,url
+   ```
+
+2. Create the worktree.
+
+   ```bash
+   git worktree add -b codex/a2-mXX-<slug>-certify \
+     .worktrees/dispatch/codex/a2-mXX-<slug>-certify origin/main
+   cd .worktrees/dispatch/codex/a2-mXX-<slug>-certify
+   ```
+
+3. Read the target source set and find actual defects.
+
+   Do not churn prose for style alone. Prioritize:
+
+   - A2 grammar scope violations
+   - weak or missing scaffolding
+   - unnatural Ukrainian
+   - Russianisms, calques, or Anglicisms
+   - activity answers that do not match component schemas
+   - vocabulary entries that lack useful learner support
+   - source-plan drift
+   - MDX generation drift
+   - route/build failures
+
+4. Apply narrowly scoped fixes in source files.
+
+   Common source files:
+
+   - `curriculum/l2-uk-en/a2/<slug>/module.md`
+   - `curriculum/l2-uk-en/a2/<slug>/activities.yaml`
+   - `curriculum/l2-uk-en/a2/<slug>/vocabulary.yaml`
+   - `curriculum/l2-uk-en/a2/<slug>/resources.yaml`
+
+   Activity YAML may be a V1 bare list or a V2 object with `inline:` and
+   `workbook:` lists. Never wrap the root list in an `activities:` key.
+
+5. Regenerate MDX.
+
+   The wrapper usage is:
+
+   ```bash
+   .venv/bin/python scripts/generate_mdx.py l2-uk-en a2 <module_num> --validate
+   ```
+
+   Do not run `scripts/generate_mdx.py --help`; the wrapper interprets the
+   first positional argument as the curriculum.
+
+6. Run deterministic gates.
+
+   ```bash
+   .venv/bin/python scripts/validate_plan_config.py --quiet a2
+   .venv/bin/python scripts/validate_activities.py l2-uk-en a2 <module_num>
+   .venv/bin/python scripts/validate_activities_v2.py \
+     curriculum/l2-uk-en/a2/<slug>/activities.yaml
+   .venv/bin/python scripts/audit/check_mdx_generation_drift.py --files \
+     curriculum/l2-uk-en/plans/a2/<slug>.yaml \
+     curriculum/l2-uk-en/a2/<slug>/module.md \
+     curriculum/l2-uk-en/a2/<slug>/activities.yaml \
+     curriculum/l2-uk-en/a2/<slug>/vocabulary.yaml \
+     curriculum/l2-uk-en/a2/<slug>/resources.yaml \
+     site/src/content/docs/a2/<slug>.mdx
+   .venv/bin/python scripts/audit/check_mdx_source_parity.py --files \
+     curriculum/l2-uk-en/a2/<slug>/module.md \
+     curriculum/l2-uk-en/a2/<slug>/activities.yaml \
+     curriculum/l2-uk-en/a2/<slug>/vocabulary.yaml \
+     curriculum/l2-uk-en/a2/<slug>/resources.yaml \
+     site/src/content/docs/a2/<slug>.mdx
+   git diff --check
+   npm run build --prefix site -- --outDir /tmp/learn-ukrainian-a2-mXX-<slug>-dist
+   ```
+
+   If `validate_activities_v2.py` rejects a V1-only file shape, report that
+   and rely on the level validator plus schema-specific tests relevant to the
+   file. Do not convert V1 to V2 unless the module fix requires it.
+
+7. Run LLM QG.
+
+   Use the current project runner. For Codex-authored module edits, the reviewer
+   must be a different model family:
+
+   ```bash
+   .venv/bin/python scripts/build/run_llm_qg_parity.py a2 <slug> \
+     --writer codex-tools --reviewer claude-tools
+   ```
+
+   The script writes transient JSON evidence. Summarize the scores and verdicts
+   in the PR body. Do not commit transient QG JSON unless current project rules
+   explicitly require it.
+
+8. Ask Claude/Opus for review before committing.
+
+   Use the available Claude review bridge/dispatch path. The review request must
+   include the target module, diff, plan, A2 calibration constraints, local gate
+   outputs, and LLM QG summary. Ask for this output:
+
+   ```text
+   Review A2 MXX <slug> certification diff.
+   Return one of: BLOCKER, FIX_BEFORE_PR, PASS.
+   Focus on A2 scope, Ukrainian naturalness, Russianisms/calques,
+   activity correctness, source-plan adherence, and whether the page is
+   genuinely useful to an A2 learner.
+   Cite concrete file paths and lines for every finding.
+   ```
+
+   Fix surviving findings, regenerate, and rerun affected gates.
+
+9. Run the independent final gate.
+
+   Use Agy/Gemini-family only through the established bridge/fleet protocol if
+   available. Do not use GitHub Gemini Code Assist and do not let the same model
+   family review itself. Treat concrete findings as actionable; challenge vague
+   or unsupported findings with evidence.
+
+10. Commit, push, and open a PR.
+
+    ```bash
+    git status --short
+    git add <only-related-files>
+    git diff --cached --stat
+    git commit -m "fix(a2): certify MXX <slug>" \
+      --trailer "X-Agent: codex/a2-mXX-<slug>-certify"
+    .venv/bin/python scripts/audit/lint_agent_trailer.py
+    git push -u origin codex/a2-mXX-<slug>-certify
+    gh pr create --base main --head codex/a2-mXX-<slug>-certify \
+      --title "fix(a2): certify MXX <slug>" \
+      --body-file /tmp/a2-mXX-<slug>-pr-body.md
+    ```
+
+11. PR body requirements.
+
+    Include:
+
+    - summary of source changes;
+    - exact A2 module and public route;
+    - deterministic validation commands and outcomes;
+    - LLM QG dimension scores and verdict;
+    - Claude/Opus review outcome;
+    - independent final gate outcome;
+    - public or local route/build evidence;
+    - artifact exclusion note;
+    - token telemetry summary.
+
+    Token telemetry must follow
+    `docs/runbooks/module-build-token-telemetry.md` and explicitly state:
+
+    ```text
+    Token telemetry:
+    - swarm_used: true/false
+    - swarm_label: ...
+    - swarm_note: ...
+    - wall_clock_minutes: ...
+    - token_source: actual/estimated/unavailable
+    ```
+
+    Persist the same record through the Monitor API endpoint described in the
+    runbook. Do not commit the local SQLite telemetry store.
+
+12. CI, review, merge, and public route.
+
+    ```bash
+    gh pr checks <PR_NUMBER> --watch --interval 10
+    ```
+
+    If blocking CI fails, fix it. Do not admin-bypass blocking failures.
+
+    When CI is green and required reviews are addressed:
+
+    ```bash
+    gh pr merge <PR_NUMBER> --squash --delete-branch
+    git switch main
+    git pull --ff-only
+    ```
+
+    After deploy, verify:
+
+    ```bash
+    curl -sI https://learn-ukrainian.github.io/a2/<slug>/ | head
+    ```
+
+    Then clean the worktree:
+
+    ```bash
+    git worktree remove .worktrees/dispatch/codex/a2-mXX-<slug>-certify
+    git branch -d codex/a2-mXX-<slug>-certify
+    ```
+
+13. Move to the next module only after the previous module is merged and live.
+
+## First Response In The New Thread
+
+Do not implement immediately. First respond with:
+
+- confirmation that mandatory reads were completed;
+- current `main` and `origin/main` SHAs;
+- root dirty/clean state;
+- current A2 open PRs, if any;
+- verified A2 release baseline and whether #3262 is present in current `main`;
+- known certified A2 modules, if any, with evidence;
+- selected next target module;
+- branch name, worktree path, public route, and `X-Agent` trailer;
+- any blocker from pending decisions or current CI.
+
+Then wait for the user to say to proceed.
+
+## END PROMPT
+
+## Construction Review
+
+- Built from the B1 orchestration example but adapted to A2's actual 69-module,
+  10-phase curriculum in `curriculum/l2-uk-en/curriculum.yaml`.
+- Checked A2-specific calibration in `agents_extensions/shared/quick-ref/a2.md`
+  and `agents_extensions/shared/phases/calibration/a2.md`.
+- Anchored the release baseline to merged PR #3262 without conflating release
+  readiness with certification.
+- Used current repo commands for A2 validation, MDX drift, source parity, site
+  build, LLM QG, agent trailers, and PR checks.
+- Preserved hard project constraints: `.venv/bin/python`, `site/`, worktree
+  subtree layout, no linter config edits, no `.python-version` edits, no
+  generated status/audit/review artifacts, and no committed telemetry DB.


### PR DESCRIPTION
## What

Several source/doc/prompt files still carried the **old low-immersion** A2 model (45-75% Ukrainian, "English for theory", "English support below") even though the live policy in `scripts/config.py` sets A2 to **85-100% graduated immersion** — easy Ukrainian as the teaching voice, English for vocabulary glosses only.

On the next deploy those stale files would regress reviewers and builds back toward **more English**. This PR raises them all to the full-immersion policy. **English is removed, never added** — teach Ukrainian *in* Ukrainian, not *about* Ukrainian in English.

## Files
- `agents_extensions/shared/quick-ref/a2.md` — 85-100% bands, English = glosses only
- `agents_extensions/shared/phases/calibration/a2.md` — flag English support/theory paragraphs as wrong pedagogy
- `skills/content-review` + `skills/plan-review tier-1` — synced from the committed (correct) deploy copy
- `docs/best-practices/module-content-quality.md` — A2 table 40-75% → 85-100%
- `docs/prompts/a2-certification-orchestration-prompt.md` — immersion section corrected (was 45-65%)

## Tests
`deploy_idempotency + adaptive_immersion + ulp_immersion_calibration` = **38 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)