### PR TITLE
fix(a2): certify genitive purpose prepositions

### DIFF
--- a/curriculum/l2-uk-en/a2/genitive-prepositions-purpose/resources.yaml
+++ b/curriculum/l2-uk-en/a2/genitive-prepositions-purpose/resources.yaml
@@ -12,9 +12,9 @@
   role: article
   source_ref: "docs/resources/dobraforma/dobraforma_db.json: df-024"
   url: "https://opentext.ku.edu/dobraforma/chapter/7-2/"
-  notes: "Practice page directly aligned to для, без, біля, and після."
+  notes: "Practice page aligned to the core для, без, and біля pattern; this module extends the spatial set with навпроти and коло."
 - title: "Talk Ukrainian: Ukrainian prepositions"
   role: article
   source_ref: "docs/resources/talkukrainian/talkukrainian_db.json: tu-034"
   url: "https://talkukrainian.com/prepositions/"
-  notes: "Short learner-facing guide to common Ukrainian prepositions."
+  notes: "Short learner-facing guide for broader review of common Ukrainian prepositions."

--- a/site/src/content/docs/a2/genitive-prepositions-purpose.mdx
+++ b/site/src/content/docs/a2/genitive-prepositions-purpose.mdx
@@ -132,7 +132,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 ### Для, без чи біля?
 
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "___ Олени ця ковдра?", "options": [{"text": "Для", "correct": true}, {"text": "Без", "correct": false}, {"text": "Біля", "correct": false}], "explanation": "Ковдра призначена для Олени."}, {"question": "Ми не поїдемо ___ ліхтарика.", "options": [{"text": "без", "correct": true}, {"text": "для", "correct": false}, {"text": "навпроти", "correct": false}], "explanation": "Без показує відсутність потрібної речі."}, {"question": "Намет стоїть ___ річки.", "options": [{"text": "біля", "correct": true}, {"text": "для", "correct": false}, {"text": "без", "correct": false}], "explanation": "Біля показує місце поруч."}, {"question": "Кафе ___ бібліотеки.", "options": [{"text": "навпроти", "correct": true}, {"text": "без", "correct": false}, {"text": "для", "correct": false}], "explanation": "Навпроти означає на іншому боці."}, {"question": "Чай ___ цукру.", "options": [{"text": "без", "correct": true}, {"text": "для", "correct": false}, {"text": "коло", "correct": false}], "explanation": "Без цукру означає, що цукру немає."}, {"question": "Час ___ відпочинку.", "options": [{"text": "для", "correct": true}, {"text": "без", "correct": false}, {"text": "біля", "correct": false}], "explanation": "Для відпочинку показує мету."}, {"question": "Автобус стоїть ___ дороги.", "options": [{"text": "коло", "correct": true}, {"text": "без", "correct": false}, {"text": "для", "correct": false}], "explanation": "Коло дороги означає біля дороги."}, {"question": "Аптека ___ лікарні.", "options": [{"text": "біля", "correct": true}, {"text": "для", "correct": false}, {"text": "без", "correct": false}], "explanation": "Біля лікарні показує місце."}]`)} isUkrainian={true} />
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "___ Олени ця ковдра?", "options": [{"text": "Для", "correct": true}, {"text": "Без", "correct": false}, {"text": "Біля", "correct": false}], "explanation": "Ковдра призначена для Олени."}, {"question": "Ми не поїдемо ___ ліхтарика.", "options": [{"text": "без", "correct": true}, {"text": "для", "correct": false}, {"text": "навпроти", "correct": false}], "explanation": "Без показує відсутність потрібної речі."}, {"question": "Намет стоїть ___ річки.", "options": [{"text": "біля", "correct": true}, {"text": "для", "correct": false}, {"text": "без", "correct": false}], "explanation": "Біля показує місце поруч."}, {"question": "Кафе ___ бібліотеки.", "options": [{"text": "навпроти", "correct": true}, {"text": "без", "correct": false}, {"text": "для", "correct": false}], "explanation": "Навпроти означає на іншому боці."}, {"question": "Чай ___ цукру.", "options": [{"text": "без", "correct": true}, {"text": "для", "correct": false}, {"text": "коло", "correct": false}], "explanation": "Без цукру означає, що цукру немає."}, {"question": "Час ___ відпочинку.", "options": [{"text": "для", "correct": true}, {"text": "без", "correct": false}, {"text": "біля", "correct": false}], "explanation": "Для відпочинку показує мету."}, {"question": "Автобус стоїть ___ дороги.", "options": [{"text": "коло", "correct": true}, {"text": "без", "correct": false}, {"text": "для", "correct": false}], "explanation": "Коло дороги означає біля дороги."}, {"question": "Аптека ___ лікарні.", "options": [{"text": "біля", "correct": true}, {"text": "для", "correct": false}, {"text": "без", "correct": false}], "explanation": "Біля лікарні показує місце."}]`)} instruction={"Оберіть прийменник за значенням."} isUkrainian={true} />
 
 ## Для кого? Для чого?
 
@@ -260,7 +260,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 ### Родовий після прийменника
 
-<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Це подарунок для ___.", "answer": "мами", "options": ["мами", "мама", "маму"]}, {"sentence": "Кава без ___.", "answer": "цукру", "options": ["цукру", "цукор", "цукром"]}, {"sentence": "Зупинка біля ___.", "answer": "школи", "options": ["школи", "школа", "школу"]}, {"sentence": "Банк навпроти ___.", "answer": "вокзалу", "options": ["вокзалу", "вокзал", "вокзалом"]}, {"sentence": "Ми без ___.", "answer": "карти", "options": ["карти", "карта", "карту"]}, {"sentence": "Місце для ___.", "answer": "намету", "options": ["намету", "намет", "наметом"]}, {"sentence": "Коло ___ росте дерево.", "answer": "хати", "options": ["хати", "хата", "хату"]}, {"sentence": "Аптека біля ___.", "answer": "лікарні", "options": ["лікарні", "лікарня", "лікарню"]}]`)} isUkrainian={true} />
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Це подарунок для ___.", "answer": "мами", "options": ["мами", "мама", "маму"]}, {"sentence": "Кава без ___.", "answer": "цукру", "options": ["цукру", "цукор", "цукром"]}, {"sentence": "Зупинка біля ___.", "answer": "школи", "options": ["школи", "школа", "школу"]}, {"sentence": "Банк навпроти ___.", "answer": "вокзалу", "options": ["вокзалу", "вокзал", "вокзалом"]}, {"sentence": "Ми без ___.", "answer": "карти", "options": ["карти", "карта", "карту"]}, {"sentence": "Місце для ___.", "answer": "намету", "options": ["намету", "намет", "наметом"]}, {"sentence": "Коло ___ росте дерево.", "answer": "хати", "options": ["хати", "хата", "хату"]}, {"sentence": "Аптека біля ___.", "answer": "лікарні", "options": ["лікарні", "лікарня", "лікарню"]}]`)} instruction={"Оберіть правильну форму."} isUkrainian={true} />
 
 ## Біля, навпроти, коло
 
@@ -383,7 +383,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 ### Ситуація і фраза
 
-<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "подарунок, одержувач мама", "right": "подарунок для мами"}, {"left": "кава, цукру немає", "right": "кава без цукру"}, {"left": "місце поруч зі школою", "right": "біля школи"}, {"left": "місце на іншому боці від бібліотеки", "right": "навпроти бібліотеки"}, {"left": "місце поруч із хатою", "right": "коло хати"}, {"left": "час, призначення відпочинок", "right": "час для відпочинку"}, {"left": "допомоги немає", "right": "без допомоги"}, {"left": "місце поруч зі станцією", "right": "біля станції"}]`)} isUkrainian={true} />
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "подарунок, одержувач мама", "right": "подарунок для мами"}, {"left": "кава, цукру немає", "right": "кава без цукру"}, {"left": "місце поруч зі школою", "right": "біля школи"}, {"left": "місце на іншому боці від бібліотеки", "right": "навпроти бібліотеки"}, {"left": "місце поруч із хатою", "right": "коло хати"}, {"left": "час, призначення відпочинок", "right": "час для відпочинку"}, {"left": "допомоги немає", "right": "без допомоги"}, {"left": "місце поруч зі станцією", "right": "біля станції"}]`)} instruction={"Зіставте ситуацію з природною фразою."} isUkrainian={true} />
 
 ## Типові помилки
 
@@ -547,7 +547,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 ### Значення прийменників
 
-<GroupSort client:only='react' groups={JSON.parse(`{"призначення": ["для мами", "для навчання", "для відпочинку", "для групи"], "відсутність": ["без цукру", "без молока", "без карти", "без допомоги"], "місце": ["біля школи", "навпроти бібліотеки", "коло хати", "біля станції"]}`)} isUkrainian={true} />
+<GroupSort client:only='react' groups={JSON.parse(`{"призначення": ["для мами", "для навчання", "для відпочинку", "для групи"], "відсутність": ["без цукру", "без молока", "без карти", "без допомоги"], "місце": ["біля школи", "навпроти бібліотеки", "коло хати", "біля станції"]}`)} instruction={"Розсортуйте фрази за значенням."} isUkrainian={true} />
 
 </TabItem>
 <TabItem label="Словник">
@@ -577,11 +577,11 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 ### Правильно чи ні?
 
-<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "для мами", "isTrue": true, "explanation": "Мами - родовий відмінок."}, {"statement": "без молоко", "isTrue": false, "explanation": "Потрібно: без молока."}, {"statement": "біля школи", "isTrue": true, "explanation": "Школи - родовий відмінок."}, {"statement": "навпроти вокзал", "isTrue": false, "explanation": "Потрібно: навпроти вокзалу."}, {"statement": "коло дороги", "isTrue": true, "explanation": "Дороги - родовий відмінок."}, {"statement": "для навчання", "isTrue": true, "explanation": "Навчання вже має форму родового/називного, але фраза правильна."}, {"statement": "без парасолька", "isTrue": false, "explanation": "Потрібно: без парасольки."}, {"statement": "біля площі", "isTrue": true, "explanation": "Площі - правильна форма."}]`)} isUkrainian={true} />
+<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "для мами", "isTrue": true, "explanation": "Мами - родовий відмінок."}, {"statement": "без молоко", "isTrue": false, "explanation": "Потрібно: без молока."}, {"statement": "біля школи", "isTrue": true, "explanation": "Школи - родовий відмінок."}, {"statement": "навпроти вокзал", "isTrue": false, "explanation": "Потрібно: навпроти вокзалу."}, {"statement": "коло дороги", "isTrue": true, "explanation": "Дороги - родовий відмінок."}, {"statement": "для навчання", "isTrue": true, "explanation": "Навчання вже має форму родового/називного, але фраза правильна."}, {"statement": "без парасолька", "isTrue": false, "explanation": "Потрібно: без парасольки."}, {"statement": "біля площі", "isTrue": true, "explanation": "Площі - правильна форма."}]`)} instruction={"Перевірте форму після прийменника."} isUkrainian={true} />
 
 ### Моя карта
 
-<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Я живу ___ школи.", "answer": "біля", "options": ["біля", "без", "для"]}, {"sentence": "Це зошит ___ навчання.", "answer": "для", "options": ["для", "без", "навпроти"]}, {"sentence": "Я п'ю чай ___ цукру.", "answer": "без", "options": ["без", "біля", "для"]}, {"sentence": "Кафе ___ ринку.", "answer": "навпроти", "options": ["навпроти", "без", "для"]}, {"sentence": "Ми сидимо ___ вогню.", "answer": "коло", "options": ["коло", "без", "для"]}, {"sentence": "Це важливо ___ мене.", "answer": "для", "options": ["для", "біля", "без"]}, {"sentence": "Я прийшов ___ карти.", "answer": "без", "options": ["без", "навпроти", "коло"]}, {"sentence": "Зупинка ___ лікарні.", "answer": "біля", "options": ["біля", "без", "для"]}]`)} isUkrainian={true} />
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Я живу ___ школи.", "answer": "біля", "options": ["біля", "без", "для"]}, {"sentence": "Це зошит ___ навчання.", "answer": "для", "options": ["для", "без", "навпроти"]}, {"sentence": "Я п'ю чай ___ цукру.", "answer": "без", "options": ["без", "біля", "для"]}, {"sentence": "Кафе ___ ринку.", "answer": "навпроти", "options": ["навпроти", "без", "для"]}, {"sentence": "Ми сидимо ___ вогню.", "answer": "коло", "options": ["коло", "без", "для"]}, {"sentence": "Це важливо ___ мене.", "answer": "для", "options": ["для", "біля", "без"]}, {"sentence": "Я прийшов ___ карти.", "answer": "без", "options": ["без", "навпроти", "коло"]}, {"sentence": "Зупинка ___ лікарні.", "answer": "біля", "options": ["біля", "без", "для"]}]`)} instruction={"Доповніть короткі речення."} isUkrainian={true} />
 
 ### Виправте форму після прийменника
 
@@ -589,7 +589,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 ### Повідомлення для групи
 
-<Unjumble client:only='react' items={JSON.parse(`[{"jumbled": "Це / ковдра / для / Олени", "answer": "Це ковдра для Олени."}, {"jumbled": "Ми / не / поїдемо / без / ліхтарика", "answer": "Ми не поїдемо без ліхтарика."}, {"jumbled": "Намет / стоїть / біля / річки", "answer": "Намет стоїть біля річки."}, {"jumbled": "Кафе / навпроти / бібліотеки", "answer": "Кафе навпроти бібліотеки."}, {"jumbled": "Я / стою / біля / станції / метро", "answer": "Я стою біля станції метро."}, {"jumbled": "Це / важливо / для / нашої / групи", "answer": "Це важливо для нашої групи."}]`)} />
+<Unjumble client:only='react' items={JSON.parse(`[{"jumbled": "Це / ковдра / для / Олени", "answer": "Це ковдра для Олени."}, {"jumbled": "Ми / не / поїдемо / без / ліхтарика", "answer": "Ми не поїдемо без ліхтарика."}, {"jumbled": "Намет / стоїть / біля / річки", "answer": "Намет стоїть біля річки."}, {"jumbled": "Кафе / навпроти / бібліотеки", "answer": "Кафе навпроти бібліотеки."}, {"jumbled": "Я / стою / біля / станції / метро", "answer": "Я стою біля станції метро."}, {"jumbled": "Це / важливо / для / нашої / групи", "answer": "Це важливо для нашої групи."}]`)} instruction={"Поставте слова в природний порядок."} />
 
 </TabItem>
 <TabItem label="Ресурси">
@@ -597,8 +597,8 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 :::info[🎧 🔗 Зовнішні ресурси]
 
 **📝 Статті:**
-- 📄 [Dobra Forma: Genitive Case after Prepositions біля, після, для and без](https://opentext.ku.edu/dobraforma/chapter/7-2/) — Practice page directly aligned to для, без, біля, and після.
-- 📄 [Talk Ukrainian: Ukrainian prepositions](https://talkukrainian.com/prepositions/) — Short learner-facing guide to common Ukrainian prepositions.
+- 📄 [Dobra Forma: Genitive Case after Prepositions біля, після, для and без](https://opentext.ku.edu/dobraforma/chapter/7-2/) — Practice page aligned to the core для, без, and біля pattern; this module extends the spatial set with навпроти and коло.
+- 📄 [Talk Ukrainian: Ukrainian prepositions](https://talkukrainian.com/prepositions/) — Short learner-facing guide for broader review of common Ukrainian prepositions.
 - 📄 [ULP: Genitive Case (Родовий відмінок)](https://www.ukrainianlessons.com/genitive-case/) — Reference for genitive forms and common genitive contexts.
 - 📄 [ULP: Prepositions and Cases](https://www.ukrainianlessons.com/prepositions-cases/) — Learner-facing overview of Ukrainian prepositions and the cases they require.
 :::


### PR DESCRIPTION
## Summary
- Certifies A2 M10 `genitive-prepositions-purpose` with a narrow resource-note polish.
- Clarifies that the Dobra Forma resource covers the core `для` / `без` / `біля` pattern while the module extends spatial practice with `навпроти` and `коло`.
- Regenerates only the M10 MDX output, restoring source activity `instruction` props and updating the resource notes.

## Validation
- `.venv/bin/python scripts/audit/certify_module.py a2/genitive-prepositions-purpose --install-site-deps`
- `.venv/bin/python scripts/audit/certify_module.py a2/genitive-prepositions-purpose`

## Review / telemetry
- `run_id: a2-m10-certify-9ed80022`
- `module: a2/genitive-prepositions-purpose`
- `status: ready`
- `swarm_used: true`
- `swarm_label: thin`
- `swarm_note: Codex explorer read-only prescan flagged the resource/title scope advisory; DeepSeek/Hermes read-only final diff review returned SHIP; Gemini read-only PR gate returned SHIP. No external agent edited files, ran gh, pushed, merged, or modified module content.`
- `token_source: unavailable`
- Participants: main Codex implementation/integration; Codex explorer `gpt-5.4-mini` read-only prescan; Hermes/DeepSeek `deepseek-v4-pro` read-only reviewer; Gemini `gemini-3.1-pro-preview` read-only PR gate.

## Guardrails
- No `.python-version`, `.yamllint`, or `.markdownlint.json` changes.
- No `status/*.json`, `audit/*-review.md`, `review/*-review.md`, telemetry DB, or scratch artifacts included.
