### PR TITLE
docs(handoff): 2026-06-17 session — Atlas data+design done; 3 follow-ups in-flight

### DIFF
--- a/docs/session-state/2026-06-17-claude-atlas-poc-plus-three-followups.md
+++ b/docs/session-state/2026-06-17-claude-atlas-poc-plus-three-followups.md
@@ -1,0 +1,27 @@
+# Claude session handoff — Atlas finished (data+design) + 3 follow-ups dispatched (2026-06-17)
+
+> **ROLE:** main orchestrator. User wants the Atlas FULLY done; defines "done" as the 3
+> follow-ups below ALSO implemented. Drive them to merge; recover codex stalls yourself.
+
+## ✅ SHIPPED + MERGED this session
+- **#3393** immersion source sync (A2 full-immersion 85-100%; English never raised — user HARD rule, see MEMORY #M-13).
+- **#3405** Atlas core data fills (kaikki direct: stress 98.2%, meaning 97.0%, etymology 81.7%) + **#3331 fixed** (deterministic wiki cache).
+- **#3416** CEFR 65→99.9% (PULS preserved 0-overwrite + labelled GRAC estimates) + 29/29 proper-noun glosses.
+- **#3437** **Word Atlas POC design implemented** (docs/poc/word-atlas/*) — word-atlas.css adopted, all 15 sections, WordAtlasArticle.astro (in `src/lexicon/`, NOT src/components — lesson-schema scan), 0 stubs. Browser-verified light+dark vs POC. **Already deployed** (deploy-pages.yml run on current main).
+- Hygiene: closed #3367 (stanza/udtools broken), #3331 (fixed); cleaned merged worktrees.
+
+## 🔧 OPEN — drive to merge (sequence: manifest-touching work ONE AT A TIME, #M-9)
+1. **#3150 auto-expansion — DISPATCHED `atlas-3150-autoexpand` (codex, in-flight).** Vocab-aware CI freshness gate (current fingerprint is CODE-ONLY) + make-atlas recipe/hook so a released module's words auto-appear. Verify+merge when PR lands.
+2. **#3450 inflected-form dedupe** — fold single-word forms → canonical `form_of:<lemma>` cards (URLs preserved, no dup enrichment, no stubs). A prior attempt ballooned 2447→2800; confirm forms TAGGED not duplicated. Touches build_data_manifest + manifest + astro.
+3. **#3449 open dictionary dataset** — publish lexicon JSONs in git for community. **Owner decision 2026-06-17 (RECORDED in #3449): publish ALL + attribute every source ("tell it's theirs, won't claim it") + takedown-on-request; NO license-gating.** Build sharded JSON/JSONL + README + ATTRIBUTION.md + NOTICE.md(takedown contact). (Also fixes the 25MB single-manifest diff problem.)
+
+## ⚠️ CODEX STALL PATTERN (hit 4× this session) — recovery recipe
+Codex goes stdout-SILENT mid `make atlas` / `npm run build` and stalls before commit (esp. with --silence-timeout 0). Detect: worktree mtimes idle >12-15min + no commit. Recover: `delegate.py cancel <task>`, then run the build step yourself in the worktree (`make atlas PYTHON=<repo .venv>` or `npm run build --prefix site`), verify, commit, PR. Worked every time. Dispatch these with build pre-run if possible.
+
+## VERIFY CHECKLISTS
+- Data PRs: §8 conformance 0 violations (`verify_manifest.py`), idempotent re-enrich (hash match modulo generated_at), lexicon pytest, ruff, spot-check fills for garbage.
+- Design/frontend PRs: `npm run build --prefix site` green; serve dist + browser-compare to POC (light+dark); 0 "Стаття-заготовка" stubs.
+- Deploy: MANUAL (`gh workflow run deploy-pages.yml`); push-auto-deploy intentionally disabled. After merging atlas data/design changes, trigger a deploy.
+
+## Atlas architecture (confirmed)
+words in `site/src/data/lexicon-manifest.json` (25MB, 2447 entries) → `[lemma].astro` getStaticPaths → 1 static page/word (POC design). build:full = `astro build` (does NOT run make atlas — uses committed manifest). New vocab needs `make atlas` + commit + deploy.

--- a/docs/session-state/current.claude.md
+++ b/docs/session-state/current.claude.md
@@ -1,8 +1,14 @@
-# Current — Claude Session Handoff (2026-06-16 evening — §6 moat slice 3 SHIPPED; full merge-train + 3 dependabot rounds cleared)
+# Current — Claude Session Handoff (2026-06-17 — ATLAS finished data+design; 3 follow-ups in-flight)
 
 > **ROLE:** main orchestrator. User: grind the queue, results-focused, use the FLEET (#M-12), self-merge after review + CI-green, don't manufacture obstacles, don't idle. Quality non-negotiable.
 
-> **State:** main moving fast (merge-train). HEAD past `748332e7fd`. Atlas §6 decolonization moat now spans participles + collocations + lexical calques (5 manifest lemmas: біля, виглядати, міроприємство, неділя, слідуючий + many live-MCP-only). Live blocking CI: freshness gate, validate_plan_ordering, pytest/ruff/frontend/CodeQL.
+> **🔱 ACTIVE FOCUS → full detail in `docs/session-state/2026-06-17-claude-atlas-poc-plus-three-followups.md`.**
+> **Atlas DONE (merged):** data #3405/#3416 (CEFR 99.9%, all sections at ceiling), determinism #3331, **POC design #3437** (browser-verified light+dark, 0 stubs, deployed). Also immersion #3393.
+> **Atlas NOT "done" per user until 3 follow-ups land:** **#3150** auto-expansion (DISPATCHED `atlas-3150-autoexpand`, verify+merge), **#3450** inflected-form dedupe, **#3449** open dictionary dataset (owner decision: publish-all + attribute + takedown, NO gating). Sequence manifest-touching work one-at-a-time (#M-9). Codex stalls silent mid build/`make atlas` — cancel+recover the build yourself (recipe in the dated doc). Deploy is MANUAL (`gh workflow run deploy-pages.yml`).
+> **HARD: never raise English (MEMORY #M-13).** Awareness-only: A2-cert merge-train PRs (e.g. #3451) are track work, not the Atlas follow-ups.
+
+---
+## (prior session) 2026-06-16 evening — §6 moat slice 3 SHIPPED; full merge-train + 3 dependabot rounds cleared
 
 ## ✅ SHIPPED + MERGED this session (~22 PRs)
 - **§6 decolonization moat slice 3 (#3366, advances #3098):** 6 single-word lexical calques — слідуючий→наступний, багаточисельний→численний, міроприємство→захід, учбовий→навчальний + sense-restricted любий ("any" vs authentic "dear") / неділя ("week" vs authentic "Sunday"). VESUM-verified 6/6 + heritage-confirmed no over-flagging. Surgical 3-lemma manifest patch.


### PR DESCRIPTION
Session handoff. Atlas data (#3405/#3416, CEFR 99.9%) + POC design (#3437, browser-verified) merged + deployed. Records the 3 remaining follow-ups (#3150 dispatched, #3450 dedupe, #3449 open dataset w/ owner publish-all+attribute+takedown decision), the codex-stall recovery recipe, verify checklists, and the manual-deploy fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)