### PR TITLE
feat(api): expose per-module LLM-QG scoring

### DIFF
--- a/scripts/api/state_compute.py
+++ b/scripts/api/state_compute.py
@@ -5,6 +5,7 @@ pipeline version phase resolution, and legacy research/content checks.
 """
 
 import contextlib
+import json
 import re
 import sys
 from datetime import UTC, datetime
@@ -229,6 +230,141 @@ def _get_quick_verify(orch_dir: Path) -> dict:
         return json.loads(qv_path.read_text("utf-8"))
     except Exception:
         return {}
+
+
+def _read_json_file(path: Path) -> dict | None:
+    """Read a JSON object, returning None for absent or unusable artifacts."""
+    try:
+        if not path.exists():
+            return None
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def read_llm_qg(track_dir: Path, slug: str) -> dict | None:
+    """Read a module's LLM quality-gate artifact if present."""
+    try:
+        path = safe_join(track_dir, slug, "llm_qg.json")
+    except ValueError:
+        return None
+    return _read_json_file(path)
+
+
+def read_wiki_gate(track_dir: Path, slug: str) -> dict | None:
+    """Read a module's wiki completeness gate artifact if present."""
+    try:
+        path = safe_join(track_dir, slug, "wiki_completeness_gate.json")
+    except ValueError:
+        return None
+    return _read_json_file(path)
+
+
+def read_module_status(track_dir: Path, slug: str) -> dict | None:
+    """Read a generated module status cache opportunistically if present."""
+    try:
+        path = safe_join(track_dir, "status", f"{slug}.json")
+    except ValueError:
+        return None
+    return _read_json_file(path)
+
+
+def _project_llm_qg_dimensions(dimensions: object, *, verbose: bool) -> dict | None:
+    if not isinstance(dimensions, dict):
+        return None
+
+    projected = {}
+    for name, value in dimensions.items():
+        if verbose:
+            projected[name] = value
+            continue
+        if isinstance(value, dict):
+            projected[name] = value.get("score")
+        else:
+            projected[name] = value
+    return projected
+
+
+def summarize_llm_qg(llm_qg: dict | None) -> dict | None:
+    """Return the compact per-module LLM-QG summary used by API projections."""
+    if not isinstance(llm_qg, dict):
+        return None
+
+    aggregate = llm_qg.get("aggregate") if isinstance(llm_qg.get("aggregate"), dict) else {}
+    return {
+        "verdict": aggregate.get("verdict"),
+        "min_score": aggregate.get("min_score"),
+        "min_dim": aggregate.get("min_dim"),
+        "dimensions": _project_llm_qg_dimensions(llm_qg.get("dimensions"), verbose=False),
+    }
+
+
+def compute_llm_qg_track(track_id: str, level_cfg: dict, *, verbose: bool = False) -> dict:
+    """Compute per-module LLM quality-gate status from artifacts already on disk."""
+    track_dir = CURRICULUM_ROOT / level_cfg["path"]
+    plan_slugs = get_plan_slugs(track_id)
+    modules = []
+    min_scores = []
+    scored = 0
+    passing = 0
+    failing = 0
+
+    for num, slug in plan_slugs:
+        llm_qg = read_llm_qg(track_dir, slug)
+        wiki_gate = read_wiki_gate(track_dir, slug)
+        status = read_module_status(track_dir, slug)
+        has_llm_qg = llm_qg is not None
+
+        aggregate = (
+            llm_qg.get("aggregate")
+            if has_llm_qg and isinstance(llm_qg.get("aggregate"), dict)
+            else None
+        )
+        dimensions = _project_llm_qg_dimensions(
+            llm_qg.get("dimensions") if has_llm_qg else None,
+            verbose=verbose,
+        )
+        verdict = aggregate.get("verdict") if isinstance(aggregate, dict) else None
+
+        if has_llm_qg:
+            scored += 1
+            if verdict == "PASS":
+                passing += 1
+            else:
+                failing += 1
+            min_score = aggregate.get("min_score") if isinstance(aggregate, dict) else None
+            if isinstance(min_score, (int, float)) and not isinstance(min_score, bool):
+                min_scores.append(float(min_score))
+
+        modules.append({
+            "num": num,
+            "slug": slug,
+            "has_llm_qg": has_llm_qg,
+            "verdict": verdict,
+            "aggregate": aggregate,
+            "dimensions": dimensions if has_llm_qg else None,
+            "wiki_gate": (
+                {"verdict": wiki_gate.get("verdict")}
+                if isinstance(wiki_gate, dict) and "verdict" in wiki_gate
+                else None
+            ),
+            "status": status,
+        })
+
+    return {
+        "track": track_id,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "summary": {
+            "total": len(plan_slugs),
+            "scored": scored,
+            "passing": passing,
+            "failing": failing,
+            "unscored": len(plan_slugs) - scored,
+            "min_dim_score": min(min_scores) if min_scores else None,
+        },
+        "modules": modules,
+    }
 
 
 def compute_module_detail(track_id: str, num: int, level_cfg: dict) -> dict:

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -49,9 +49,12 @@ from .state_build import (
     compute_track_health,
 )
 from .state_compute import (
+    compute_llm_qg_track,
     compute_module_detail,
     compute_research_detail,
+    read_llm_qg,
     severity_key,
+    summarize_llm_qg,
 )
 from .state_coverage import (
     compute_pipeline_track,
@@ -834,6 +837,22 @@ async def build_status_all():
     return result
 
 
+@router.get("/llm-qg/{track_id}")
+async def llm_qg_track(
+    track_id: str,
+    verbose: bool = Query(
+        False,
+        description="True = include full dimension evidence. Default returns score-only dimensions.",
+    ),
+):
+    """Per-module LLM quality-gate scores from build artifacts on disk."""
+    level_cfg = next((l for l in LEVELS if l["id"] == track_id), None)
+    if not level_cfg:
+        return JSONResponse(status_code=404, content={"error": f"Track '{track_id}' not found"})
+
+    return await asyncio.to_thread(compute_llm_qg_track, track_id, level_cfg, verbose=verbose)
+
+
 @router.get("/build-stats")
 async def build_stats_all():
     """V6 build stats aggregated across all tracks."""
@@ -944,6 +963,8 @@ async def module_detail_by_slug(
     audit = full.get("audit") or {}
     review = full.get("review") or {}
     final_review = full.get("final_review")
+    track_dir = CURRICULUM_ROOT / level_cfg["path"]
+    llm_qg = await asyncio.to_thread(read_llm_qg, track_dir, slug)
 
     return {
         "track": track_id,
@@ -971,6 +992,7 @@ async def module_detail_by_slug(
         "blocking_issues": audit.get("blocking_issues") or [],
         "retry_count": retry_count,
         "worker": current_worker,
+        "llm_qg": summarize_llm_qg(llm_qg),
     }
 
 

--- a/tests/test_llm_qg_api.py
+++ b/tests/test_llm_qg_api.py
@@ -1,0 +1,76 @@
+"""Tests for LLM quality-gate Monitor API projections."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+import scripts.api.main as api_main
+import scripts.api.state_router as state_router
+
+client = TestClient(api_main.app, raise_server_exceptions=False)
+
+
+def _folk_scored_module(body: dict) -> dict:
+    return next(module for module in body["modules"] if module["has_llm_qg"])
+
+
+def test_folk_llm_qg_track_returns_scored_modules():
+    resp = client.get("/api/state/llm-qg/folk")
+    body = resp.json()
+
+    assert resp.status_code == 200
+    assert body["track"] == "folk"
+    assert body["summary"]["scored"] >= 6
+    assert body["summary"]["total"] == len(state_router.get_plan_slugs("folk"))
+    assert len(body["modules"]) == body["summary"]["total"]
+
+    scored = [module for module in body["modules"] if module["has_llm_qg"]]
+    assert scored
+    for module in scored:
+        assert isinstance(module["dimensions"], dict)
+        assert len(module["dimensions"]) >= 5
+        assert all(isinstance(score, (int, float)) for score in module["dimensions"].values())
+
+
+def test_track_with_no_llm_qg_artifacts_returns_unscored_modules():
+    resp = client.get("/api/state/llm-qg/a2")
+    body = resp.json()
+
+    assert resp.status_code == 200
+    assert body["track"] == "a2"
+    assert body["summary"]["scored"] == 0
+    assert body["summary"]["unscored"] == body["summary"]["total"]
+    assert all(module["has_llm_qg"] is False for module in body["modules"])
+    assert all(module["dimensions"] is None for module in body["modules"])
+
+
+def test_llm_qg_unknown_track_returns_404():
+    resp = client.get("/api/state/llm-qg/no-such-track")
+
+    assert resp.status_code == 404
+    assert resp.json() == {"error": "Track 'no-such-track' not found"}
+
+
+def test_llm_qg_verbose_includes_evidence_default_omits_it():
+    compact = _folk_scored_module(client.get("/api/state/llm-qg/folk").json())
+    verbose = _folk_scored_module(client.get("/api/state/llm-qg/folk?verbose=true").json())
+
+    compact_dim = next(iter(compact["dimensions"].values()))
+    verbose_dim = next(iter(verbose["dimensions"].values()))
+
+    assert isinstance(compact_dim, (int, float))
+    assert isinstance(verbose_dim, dict)
+    assert "evidence" in verbose_dim
+
+
+def test_module_slug_compact_projection_includes_llm_qg_block():
+    track = client.get("/api/state/llm-qg/folk").json()
+    slug = _folk_scored_module(track)["slug"]
+
+    body = client.get(f"/api/state/module/folk/slug/{slug}").json()
+
+    assert body["slug"] == slug
+    assert body["llm_qg"] is not None
+    assert body["llm_qg"]["verdict"] is not None
+    assert isinstance(body["llm_qg"]["dimensions"], dict)
+    assert all(isinstance(score, (int, float)) for score in body["llm_qg"]["dimensions"].values())


### PR DESCRIPTION
## Summary
- Adds `GET /api/state/llm-qg/{track_id}` to read per-module LLM quality-gate artifacts already on disk.
- Keeps default dimensions lean as score-only values; `?verbose=true` includes dimension evidence payloads.
- Adds nullable compact `llm_qg` data to `/api/state/module/{track_id}/slug/{slug}`.

## Raw folk sample output
```json
{"generated_at": "2026-06-17T11:55:54.280626+00:00", "modules": [{"aggregate": {"failing_dims": ["pedagogical", "decolonization", "engagement", "tone"], "min_dim": "pedagogical", "min_score": 6.8, "rejected_dims": [], "terminal_verdict": "REVISE", "verdict": "REVISE", "warning_dims": ["pedagogical", "engagement", "tone"]}, "dimensions": {"decolonization": 8.4, "engagement": 7.1, "naturalness": 8.2, "pedagogical": 6.8, "tone": 7.2}, "has_llm_qg": true, "num": 1, "slug": "narodna-kultura-yak-systema", "status": null, "verdict": "REVISE", "wiki_gate": {"verdict": "PASS"}}, {"aggregate": {"failing_dims": ["pedagogical", "engagement", "tone"], "min_dim": "pedagogical", "min_score": 5.8, "rejected_dims": ["pedagogical"], "terminal_verdict": "PASS", "verdict": "REJECT", "warning_dims": ["pedagogical", "engagement", "tone"]}, "dimensions": {"decolonization": 9.0, "engagement": 7.4, "naturalness": 8.1, "pedagogical": 5.8, "tone": 7.8}, "has_llm_qg": true, "num": 2, "slug": "narodni-viruvannia-mifolohiia-demonolohiia", "status": null, "verdict": "REJECT", "wiki_gate": {"verdict": "PASS"}}, {"aggregate": {"failing_dims": ["pedagogical", "naturalness", "decolonization", "engagement"], "min_dim": "engagement", "min_score": 6.8, "rejected_dims": [], "terminal_verdict": "REVISE", "verdict": "REVISE", "warning_dims": ["pedagogical", "naturalness", "engagement"]}, "dimensions": {"decolonization": 7.8, "engagement": 6.8, "naturalness": 7.2, "pedagogical": 7.1, "tone": 8.2}, "has_llm_qg": true, "num": 3, "slug": "zamovliannia-zaklynannia-prymovky", "status": null, "verdict": "REVISE", "wiki_gate": {"verdict": "PASS"}}, {"aggregate": {"failing_dims": ["pedagogical", "engagement", "tone"], "min_dim": "pedagogical", "min_score": 7.0, "rejected_dims": [], "terminal_verdict": "PASS", "verdict": "REVISE", "warning_dims": ["pedagogical", "engagement", "tone"]}, "dimensions": {"decolonization": 10.0, "engagement": 7.0, "naturalness": 10.0, "pedagogical": 7.0, "tone": 7.5}, "has_llm_qg": true, "num": 4, "slug": "kalendarna-obriadovist-zvychai", "status": null, "verdict": "REVISE", "wiki_gate": {"verdict": "PASS"}}, {"aggregate": {"failing_dims": [], "min_dim": "tone", "min_score": 8.5, "rejected_dims": [], "terminal_verdict": "PASS", "verdict": "PASS", "warning_dims": []}, "dimensions": {"decolonization": 9.5, "engagement": 9.0, "naturalness": 8.6, "pedagogical": 9.2, "tone": 8.5}, "has_llm_qg": true, "num": 5, "slug": "koliadky-shchedrivky", "status": null, "verdict": "PASS", "wiki_gate": {"verdict": "PASS"}}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 6, "slug": "vesnianky-hayivky", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 7, "slug": "kupalski-rusalni-pisni", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 8, "slug": "zhnyvarski-obzhynkovi-pisni", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 9, "slug": "rodynna-obriadovist-zvychai", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 10, "slug": "vesilni-pisni", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 11, "slug": "holosinnya", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": {"failing_dims": ["pedagogical", "naturalness", "engagement"], "min_dim": "pedagogical", "min_score": 5.8, "rejected_dims": ["pedagogical"], "terminal_verdict": "PASS", "verdict": "REJECT", "warning_dims": ["pedagogical", "naturalness", "engagement"]}, "dimensions": {"decolonization": 9.2, "engagement": 7.4, "naturalness": 7.2, "pedagogical": 5.8, "tone": 8.4}, "has_llm_qg": true, "num": 12, "slug": "dumy-nevilnytski-lytsarski", "status": null, "verdict": "REJECT", "wiki_gate": {"verdict": "PASS"}}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 13, "slug": "dumy-sotsialno-pobutovi", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 14, "slug": "kobzarstvo-lirnytstvo", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 15, "slug": "bylyny-kyivskoho-tsyklu", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 16, "slug": "istorychni-pisni", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 17, "slug": "striletski-povstanski-pisni", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 18, "slug": "rodynno-pobutovi-pisni", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 19, "slug": "kolomyiky", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 20, "slug": "suspilno-pobutovi-pisni", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 21, "slug": "narodni-balady", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 22, "slug": "pisni-literaturnoho-pokhodzhennia", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 23, "slug": "charivni-kazky", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 24, "slug": "kazky-pro-tvaryn", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 25, "slug": "sotsialno-pobutovi-kazky", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 26, "slug": "narodni-lehendy", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 27, "slug": "istorychni-perekazy", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 28, "slug": "narodni-opovidannia-buvalshchyny-memoraty", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 29, "slug": "prykazky-ta-pryslivia", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 30, "slug": "zahadky", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 31, "slug": "narodni-anekdoty", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 32, "slug": "dytiachyi-folklor-kolyskovi", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 33, "slug": "vertep-narodna-drama", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 34, "slug": "narodni-muzychni-instrumenty", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 35, "slug": "narodni-tantsi", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 36, "slug": "pysankarstvo", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 37, "slug": "narodna-vyshyvka-rushnyk-strii", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 38, "slug": "narodni-remesla-ta-khudozhni-promysly", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 39, "slug": "narodne-zhytlo-sadyba-hospodarstvo", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 40, "slug": "narodna-kukhnia-obriadova-yizha", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 41, "slug": "rehionalni-etnokulturni-tradytsii", "status": null, "verdict": null, "wiki_gate": null}, {"aggregate": null, "dimensions": null, "has_llm_qg": false, "num": 42, "slug": "narodna-kultura-ta-vysoka-kultura-mistky", "status": null, "verdict": null, "wiki_gate": null}], "summary": {"failing": 5, "min_dim_score": 5.8, "passing": 1, "scored": 6, "total": 42, "unscored": 36}, "track": "folk"}
```

## Verification
- `.venv/bin/pytest tests/test_llm_qg_api.py -q`
- `.venv/bin/pytest tests/test_api_state.py tests/test_module_deepdive_api.py -q`
- `.venv/bin/ruff check scripts/api/state_router.py scripts/api/state_compute.py tests/test_llm_qg_api.py`
- TestClient compact `folk` request shown above
