### PR TITLE
feat(api): per-module status + LLM-QG scores endpoint (user #1 priority)

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -517,6 +517,44 @@ Each entry includes `pipeline_version`, `failed_phases`, and `blocking_issues`.
 
 ---
 
+### `GET /api/state/scores/{track}` and `GET /api/state/scores/{track}/{slug}`
+
+Per-module **status + LLM-QG quality scores** — the live view for watching the
+seminar quality-gate prototype converge to ≥8
+(`docs/folk-epic/seminar-quality-gate-design.md`). Source of truth:
+`curriculum/l2-uk-en/<track>/<slug>/llm_qg.json` (`.aggregate` + `.dimensions`)
+plus the audit status cache. Always fresh (small reads, no TTL cache) so polling
+during a build reflects the latest correction round.
+
+```bash
+curl -s http://localhost:8765/api/state/scores/folk | python3 -m json.tool
+curl -s http://localhost:8765/api/state/scores/folk/kalendarna-obriadovist-zvychai | python3 -m json.tool
+```
+
+Track response: `{track, count, scored, modules[], meta}`. Each module:
+
+```json
+{
+  "track": "folk", "num": 4, "slug": "kalendarna-obriadovist-zvychai",
+  "status": "not_run", "word_count": null, "word_target": null,
+  "scored": true,
+  "aggregate": {
+    "verdict": "REVISE", "terminal_verdict": "PASS",
+    "min_score": 7.0, "min_dim": "pedagogical",
+    "failing_dims": ["pedagogical", "engagement", "tone"], "warning_dims": [...]
+  },
+  "dimensions": {"pedagogical": 7.0, "naturalness": 10.0, "decolonization": 10.0,
+                 "engagement": 7.0, "tone": 7.5}
+}
+```
+
+- A module not yet QG-scored returns `scored: false`, `aggregate: null`, `dimensions: {}`.
+- `dimensions` is read generically, so a newly-added dim (e.g. `beauty` once the
+  seminar gate Phase A lands) appears automatically with no endpoint change.
+- Unknown track or slug → `404`.
+
+---
+
 ### `GET /api/state/research-coverage`
 
 Per-track research completeness and quality distribution.

--- a/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
+++ b/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
@@ -63,7 +63,44 @@
 > the "don't self-merge" restriction, not the "don't push to main" one. Stage-0 PR #2759 self-merged
 > under this grant (commit `abf280f490`).
 
-## ▶▶▶ SESSION 44 HANDOFF (2026-06-17 — 🎯 DESIGN LOCKED: the seminar content-quality gate is the BACKBONE for building ALL seminar tracks. Read `docs/folk-epic/seminar-quality-gate-design.md` and execute from there) — **RESUME HERE**
+## ▶▶▶ SESSION 45 HANDOFF (2026-06-17 — ✅ USER #1 JOB DONE: per-module status+scores Monitor API endpoint shipped. Phase A (`beauty` dim) DISPATCHED in parallel; Phase B de-risk is the next gate) — **RESUME HERE**
+
+> **✅ DONE this session — USER #1 PRIORITY (the API scores view, S44 line 68):** built
+> `GET /api/state/scores/{track}` + `/{track}/{slug}` in `scripts/api/state_router.py`. Returns per
+> module: `status` + `aggregate{verdict,terminal_verdict,min_score,min_dim,failing_dims,warning_dims}` +
+> `dimensions{<dim>.score}`, reading `curriculum/l2-uk-en/<track>/<slug>/llm_qg.json` + the audit status
+> cache. **`beauty` auto-surfaces once Phase A lands** (dims read generically). Always-fresh (no cache) so
+> polling during a build shows the latest round. 7 tests (`tests/test_api_state_scores.py`), documented in
+> `docs/MONITOR-API.md`. **Smoke-verified on real folk data: 42 modules, 6 scored** — pedagogical 5.8–7.0,
+> engagement 6.8–7.4 (confirms the design's "weak content ships" premise); koliadky is strong (ped 9.2/eng 9.0).
+> Shipped in THIS PR (branch `claude/folk-s45-api-scores`); self-merge when CI green (NOT blocked like Phase A).
+>
+> **▶ IN-FLIGHT (verify before assuming — `curl /api/delegate/active`):**
+> - **Dispatch `folk-phaseA-beauty-gate`** (codex gpt-5.5 xhigh) — branch `codex/folk-phaseA-beauty-gate`
+>   off origin/main. Brief: `batch_state/briefs/phaseA-beauty-gate.md` (gitignored; re-derivable from design §3).
+>   CODE ONLY: `beauty`→`QG_DIMS`; `beauty=8.0` at all 7 `_make_review_floors` sites; seminar-scoped terminal
+>   dims `{decolonization,pedagogical,engagement,beauty}` via `terminal_dims_for` (core stays `frozenset()`);
+>   `beauty` in the seminar reviewer rubric + output-format JSON; tests. **Opens a DRAFT PR, NOT merged** —
+>   design §3 forbids merging the terminal promotion until the Phase B de-risk proves convergence (else every
+>   seminar build fails with no path to pass). The `beauty` rubric (craft + soul) was authored by me in the brief.
+> - (Not mine: `atlas-3150-autoexpand` codex — lexicon lane.)
+>
+> **▶ NEXT ACTION (Phase B de-risk — design §8 step 0, THE gate):** when the Phase A branch lands, run **ONE**
+> v7 build on **kalendarna** against that branch, watching per-round subjective-dim scores:
+> 1. `git worktree add … codex/folk-phaseA-beauty-gate` (branch FROM the Phase A branch, not main).
+> 2. Symlink data into the sparse worktree (`ln -s <main>/data/vesum.db data/vesum.db; ln -s <main>/data/sources.db data/sources.db`); reuse the main `.venv`.
+> 3. `PYTHONPATH=$PWD .venv/bin/python -u scripts/build/v7_build.py folk kalendarna-obriadovist-zvychai --no-resume 2>&1 | grep --line-buffered '^{"event"'` under `Monitor`.
+> 4. **Verdict:** does the correction loop (#3079, seminar budget 8) drive pedagogical/engagement/beauty to ≥8 and SHIP, or thrash/fail? `llm_qg_correction_loop.json` + per-round `llm_qg.json` give the trace. Distinguish "loop can't move subjective dims" vs "#3162 corpus blocks beauty's soul-half" from reviewer evidence.
+>    - **converges →** finalize+merge Phase A. **single-reviewer NOISE →** build the §3 multi-model panel (deepseek+codex+agy+claude, median). **loop can't move subjective dims →** loop fix (#3079) = priority #0. (Cleanest: dispatch the de-risk to codex — self-contained worktree+symlinks+build+report.) Watch convergence live via the new `/api/state/scores/folk/kalendarna-obriadovist-zvychai`.
+>
+> **Carry-forward:** kalendarna `module.md` (Jun 17) NEWER than its `llm_qg.json` (Jun 9) — baseline is round 0.
+> #3162 (Phase C blocker, "soul" half of beauty): 3-part fix — route folk primaries to `literary_texts` (mirror
+> #2973, `_build_textbook_excerpt_context` ~L1775) + non-word-counted primary-text reading panel + extend ukrlib
+> /narod/ ingest. I OWN it (#0.2) at Phase C. Merge grant LIVE (CI-green → self-merge; Phase A held per §3).
+> Worktree-only; never commit to main. Tasks: #5 API (done, this PR), #1 Phase A in-flight, #2 de-risk
+> blocked-by #1, #3 panel/profiles cond., #4 Phase C/D/E.
+
+## ▶▶▶ SESSION 44 HANDOFF (2026-06-17 — 🎯 DESIGN LOCKED: the seminar content-quality gate is the BACKBONE for building ALL seminar tracks. Read `docs/folk-epic/seminar-quality-gate-design.md` and execute from there)
 
 > ### 🥇 #1 NEXT-SESSION JOB (user 2026-06-17, TOP PRIORITY — do this FIRST, before the gate build):
 > **Expose per-module STATUS + per-dimension SCORING from the Monitor API.** The user wants to

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -12,6 +12,8 @@ Endpoints:
   GET /api/state/module/{track}/{num}  Single module deep-dive with comms
   GET /api/state/final-reviews/{track} Phase F results aggregated per track
   GET /api/state/failing              Modules with audit/phase failures
+  GET /api/state/scores/{track}       Per-module status + LLM-QG aggregate + per-dim scores
+  GET /api/state/scores/{track}/{slug} One module's status + per-dimension scores
   GET /api/state/research-coverage    Per-track research completeness
   GET /api/state/research/{track}    Per-module research quality + dimensions + upgrade queue
   GET /api/state/review-coverage      Per-track review completeness + quality
@@ -24,6 +26,7 @@ Performance notes:
 """
 
 import asyncio
+import json
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -721,6 +724,113 @@ async def failing_modules(track: str | None = Query(None)):
         return {"count": len(failing), "modules": failing}
 
     return await asyncio.to_thread(_compute)
+
+
+def _read_llm_qg_scores(module_dir: Path) -> dict[str, Any]:
+    """Read per-module LLM-QG aggregate + per-dimension scores from llm_qg.json.
+
+    Returns ``{"aggregate": {...}|None, "dimensions": {dim: score}}``. Missing,
+    unreadable, or malformed files degrade to ``aggregate=None`` / empty dims
+    (a module may not have been QG-scored yet). The dimension map is read
+    generically, so a newly-added dim (e.g. ``beauty`` once Phase A lands) is
+    surfaced automatically with no change here.
+    """
+    path = module_dir / "llm_qg.json"
+    if not path.exists():
+        return {"aggregate": None, "dimensions": {}}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {"aggregate": None, "dimensions": {}}
+
+    raw_agg = data.get("aggregate") if isinstance(data, dict) else None
+    aggregate: dict[str, Any] | None = None
+    if isinstance(raw_agg, dict):
+        aggregate = {
+            "verdict": raw_agg.get("verdict"),
+            "terminal_verdict": raw_agg.get("terminal_verdict"),
+            "min_score": raw_agg.get("min_score"),
+            "min_dim": raw_agg.get("min_dim"),
+            "failing_dims": raw_agg.get("failing_dims", []),
+            "warning_dims": raw_agg.get("warning_dims", []),
+        }
+
+    raw_dims = data.get("dimensions") if isinstance(data, dict) else None
+    dimensions: dict[str, Any] = {}
+    if isinstance(raw_dims, dict):
+        for dim, entry in raw_dims.items():
+            if isinstance(entry, dict) and "score" in entry:
+                dimensions[dim] = entry.get("score")
+    return {"aggregate": aggregate, "dimensions": dimensions}
+
+
+def _module_score_record(track_id: str, track_dir: Path, num: int, slug: str) -> dict[str, Any]:
+    """Assemble one module's status + LLM-QG score record."""
+    audit = get_audit_status(track_dir, slug)
+    scores = _read_llm_qg_scores(safe_join(track_dir, slug))
+    return {
+        "track": track_id,
+        "num": num,
+        "slug": slug,
+        "status": audit.get("status"),
+        "word_count": audit.get("word_count"),
+        "word_target": audit.get("word_target"),
+        "scored": scores["aggregate"] is not None,
+        "aggregate": scores["aggregate"],
+        "dimensions": scores["dimensions"],
+    }
+
+
+@router.get("/scores/{track}")
+async def module_scores(track: str):
+    """Per-module status + LLM-QG aggregate + per-dimension scores for a track.
+
+    The view the user watches the seminar quality-gate prototype converge with
+    (docs/folk-epic/seminar-quality-gate-design.md). Source of truth:
+    ``curriculum/l2-uk-en/<track>/<slug>/llm_qg.json`` (``.aggregate`` +
+    ``.dimensions``) plus the audit status cache. Always fresh (small reads, no
+    cache) so polling during a build reflects the latest round.
+    """
+    def _compute() -> dict[str, Any] | None:
+        level_cfg = next((l for l in LEVELS if l["id"] == track), None)
+        if not level_cfg:
+            return None
+        track_dir = CURRICULUM_ROOT / level_cfg["path"]
+        modules = [
+            _module_score_record(track, track_dir, num, slug)
+            for num, slug in get_plan_slugs(track)
+        ]
+        scored = sum(1 for m in modules if m["scored"])
+        return {"track": track, "count": len(modules), "scored": scored, "modules": modules}
+
+    result = await asyncio.to_thread(_compute)
+    if result is None:
+        return JSONResponse(status_code=404, content={"error": f"Track '{track}' not found"})
+    return _with_state_meta(result, source="fs:llm_qg+status", stale_after_s=0.0, cache="miss", age_s=0.0)
+
+
+@router.get("/scores/{track}/{slug}")
+async def module_scores_one(track: str, slug: str):
+    """One module's status + LLM-QG aggregate + per-dimension scores."""
+    def _compute() -> dict[str, Any] | None:
+        level_cfg = next((l for l in LEVELS if l["id"] == track), None)
+        if not level_cfg:
+            return None
+        track_dir = CURRICULUM_ROOT / level_cfg["path"]
+        match = next((ns for ns in get_plan_slugs(track) if ns[1] == slug), None)
+        if match is None:
+            return {"__not_found__": "slug"}
+        num, resolved_slug = match
+        return _module_score_record(track, track_dir, num, resolved_slug)
+
+    result = await asyncio.to_thread(_compute)
+    if result is None:
+        return JSONResponse(status_code=404, content={"error": f"Track '{track}' not found"})
+    if result.get("__not_found__"):
+        return JSONResponse(
+            status_code=404, content={"error": f"Module '{slug}' not found in track '{track}'"}
+        )
+    return _with_state_meta(result, source="fs:llm_qg+status", stale_after_s=0.0, cache="miss", age_s=0.0)
 
 
 @router.get("/research-coverage")

--- a/tests/test_api_state_scores.py
+++ b/tests/test_api_state_scores.py
@@ -1,0 +1,127 @@
+"""Tests for the /api/state/scores endpoints + the llm_qg score reader.
+
+The scores view is how the user watches the seminar quality-gate prototype
+converge to >=8 (docs/folk-epic/seminar-quality-gate-design.md). It reads
+per-module ``llm_qg.json`` (``.aggregate`` + ``.dimensions``) plus the audit
+status cache, and must degrade gracefully when a module has not been scored.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import scripts.api.main as api_main
+import scripts.api.state_router as state_router
+from scripts.api.state_router import _read_llm_qg_scores
+
+client = TestClient(api_main.app, raise_server_exceptions=False)
+
+
+def _write_llm_qg(module_dir: Path, *, dims: dict[str, float], aggregate: dict) -> None:
+    module_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "dimensions": {d: {"score": s, "evidence": "「x」", "verdict": "PASS"} for d, s in dims.items()},
+        "aggregate": aggregate,
+    }
+    (module_dir / "llm_qg.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# _read_llm_qg_scores — the pure reader
+# --------------------------------------------------------------------------- #
+
+
+def test_read_scores_parses_dims_and_aggregate(tmp_path: Path) -> None:
+    _write_llm_qg(
+        tmp_path,
+        dims={"pedagogical": 7.0, "engagement": 6.8, "beauty": 8.0},
+        aggregate={
+            "verdict": "REVISE",
+            "terminal_verdict": "REVISE",
+            "min_score": 6.8,
+            "min_dim": "engagement",
+            "failing_dims": ["engagement", "pedagogical"],
+            "warning_dims": [],
+        },
+    )
+    out = _read_llm_qg_scores(tmp_path)
+    assert out["dimensions"] == {"pedagogical": 7.0, "engagement": 6.8, "beauty": 8.0}
+    assert out["aggregate"]["min_dim"] == "engagement"
+    assert out["aggregate"]["terminal_verdict"] == "REVISE"
+    # beauty surfaces generically — no code change needed when the dim lands.
+    assert "beauty" in out["dimensions"]
+
+
+def test_read_scores_missing_file_degrades(tmp_path: Path) -> None:
+    out = _read_llm_qg_scores(tmp_path / "does-not-exist")
+    assert out == {"aggregate": None, "dimensions": {}}
+
+
+def test_read_scores_malformed_json_degrades(tmp_path: Path) -> None:
+    (tmp_path / "llm_qg.json").write_text("{ not json", encoding="utf-8")
+    out = _read_llm_qg_scores(tmp_path)
+    assert out == {"aggregate": None, "dimensions": {}}
+
+
+# --------------------------------------------------------------------------- #
+# /api/state/scores/{track}[/{slug}] — the endpoints
+# --------------------------------------------------------------------------- #
+
+
+def _fake_track(tmp_path: Path, monkeypatch) -> None:
+    """Wire a one-path fake 'demo' track with a scored + an unscored module."""
+    track_dir = tmp_path / "demo"
+    _write_llm_qg(
+        track_dir / "scored-mod",
+        dims={"pedagogical": 7.0, "engagement": 6.8},
+        aggregate={
+            "verdict": "REVISE",
+            "terminal_verdict": "REVISE",
+            "min_score": 6.8,
+            "min_dim": "engagement",
+            "failing_dims": ["engagement"],
+            "warning_dims": [],
+        },
+    )
+    (track_dir / "unscored-mod").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(state_router, "LEVELS", [{"id": "demo", "name": "Demo", "path": "demo"}])
+    monkeypatch.setattr(state_router, "CURRICULUM_ROOT", tmp_path)
+    monkeypatch.setattr(
+        state_router, "get_plan_slugs", lambda _t: [(1, "scored-mod"), (2, "unscored-mod")]
+    )
+
+
+def test_scores_track_lists_modules_with_scored_flag(tmp_path: Path, monkeypatch) -> None:
+    _fake_track(tmp_path, monkeypatch)
+    body = client.get("/api/state/scores/demo").json()
+    assert body["track"] == "demo"
+    assert body["count"] == 2
+    assert body["scored"] == 1
+    by_slug = {m["slug"]: m for m in body["modules"]}
+    assert by_slug["scored-mod"]["scored"] is True
+    assert by_slug["scored-mod"]["dimensions"]["engagement"] == 6.8
+    assert by_slug["scored-mod"]["aggregate"]["min_dim"] == "engagement"
+    assert by_slug["unscored-mod"]["scored"] is False
+    assert by_slug["unscored-mod"]["aggregate"] is None
+    assert "meta" in body
+
+
+def test_scores_one_module(tmp_path: Path, monkeypatch) -> None:
+    _fake_track(tmp_path, monkeypatch)
+    body = client.get("/api/state/scores/demo/scored-mod").json()
+    assert body["slug"] == "scored-mod"
+    assert body["dimensions"]["pedagogical"] == 7.0
+    assert body["aggregate"]["terminal_verdict"] == "REVISE"
+
+
+def test_scores_unknown_track_404(tmp_path: Path, monkeypatch) -> None:
+    _fake_track(tmp_path, monkeypatch)
+    assert client.get("/api/state/scores/nope").status_code == 404
+
+
+def test_scores_unknown_slug_404(tmp_path: Path, monkeypatch) -> None:
+    _fake_track(tmp_path, monkeypatch)
+    assert client.get("/api/state/scores/demo/nope").status_code == 404


### PR DESCRIPTION
## What
Adds `GET /api/state/scores/{track}` and `GET /api/state/scores/{track}/{slug}` to the Monitor API — the **user's #1 priority** (folk-driver handoff S44): a live view of every module's **status + per-dimension LLM-QG quality scores**, so the seminar quality-gate prototype can be watched converging to ≥8 (`docs/folk-epic/seminar-quality-gate-design.md`).

## Shape
Per module: `status`, `word_count`/`word_target`, `scored`, `aggregate{verdict, terminal_verdict, min_score, min_dim, failing_dims, warning_dims}`, `dimensions{<dim>.score}`.
- Source of truth: `curriculum/l2-uk-en/<track>/<slug>/llm_qg.json` (`.aggregate` + `.dimensions`) + the audit status cache.
- **Always fresh** (no TTL cache) so polling during a build reflects the latest correction round.
- `dimensions` is read generically → **`beauty` auto-surfaces once the seminar gate Phase A lands**, no endpoint change.
- Unknown track/slug → `404`; unscored module → `scored:false`, `aggregate:null`, `dimensions:{}`.

## Verification (deterministic)
- `ruff`: clean. `pytest tests/test_api_state_scores.py tests/test_api_state.py` → **21 passed**.
- Smoke-run on real folk data: **42 modules, 6 scored** (pedagogical 5.8–7.0, engagement 6.8–7.4 — confirms the "weak content ships" premise the gate effort closes; koliadky strong at ped 9.2 / eng 9.0).
- 7 new tests in `tests/test_api_state_scores.py`; documented in `docs/MONITOR-API.md`.

## Also bundled
Session 45 folk-driver handoff (`docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md`): this endpoint is done; Phase A (`beauty` dim wiring) is dispatched in parallel (held until the Phase B de-risk per design §3/§4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)