### PR TITLE
feat(seminar): add gated beauty QG dim (Phase A — BLOCKED on Phase B de-risk)

### DIFF
--- a/agents_extensions/shared/phases/gemini/_shared-quality-dimensions-seminar.md
+++ b/agents_extensions/shared/phases/gemini/_shared-quality-dimensions-seminar.md
@@ -16,51 +16,84 @@
 - Use `[!decolonization]` and `[!myth-buster]` callouts naturally (not forced)
 - Prefer Ukrainian-language academic sources (uk.wikipedia.org, history.org.ua, litopys.org.ua)
 
-### 3. Engagement — Would You Keep Reading?
+### 3. Engagement — Would You Keep Reading and Care?
 - Opening hook in first 50 words
 - {ENGAGEMENT_MIN}+ callout boxes using 4+ different types
 - Narrative arc: HOOK → TENSION → JOURNEY → CLIMAX → RESOLUTION → CALL TO ACTION
-- 2+ surprising/counterintuitive facts, 2+ "why this matters now" statements
-- Direct address to reader (Уявіть..., Чому це важливо?)
+- 2+ surprising/counterintuitive facts, 2+ "why this matters now" statements that help the learner fall in love with the heritage, not just pass an audit
+- Direct address to reader (Уявіть..., Чому це важливо?) anchored in the source's identity-bearing power
 - No formulaic openers, no generic conclusions — end with resonance
 
-### 4. Word Count — Targets Are Minimums
+### 4. Beauty — Does the Lesson Convey the Beauty of the Source AND Read Beautifully Itself?
+Two halves, **both required** (this dimension is gated ≥8 for seminar tracks):
+
+1. **Craft (the lesson's own prose):** vivid, elegant, memorable Ukrainian a learner wants to re-read.
+   Imagery and rhythm where the subject invites it — never flat encyclopedic exposition. No purple prose,
+   no cliché, no mechanical scaffolding ("Далі розглянемо…") dressed up as style.
+2. **Soul (the source conveyed):** authentic folk texts — пісні, думи, голосіння, заклинання, колядки —
+   are **quoted** (verbatim, cited, verified — never fabricated) and **framed** so their beauty and
+   identity-bearing power *resonate*. The learner should feel WHY this text mattered enough to carry a
+   people's identity through centuries of oppression. Lean toward letting the source speak; the lesson
+   opens a window onto it rather than summarizing it dry.
+
+**Score anchors:**
+- **9–10:** Genuine literary quality in the lesson prose AND ≥1 primary folk text quoted and framed so its
+  beauty lands emotionally — a reader is moved, not merely informed. The source's voice is present, not paraphrased away.
+- **8 (floor):** Solid, clean, engaging craft with no flat stretches AND the source present via ≥1 well-chosen,
+  well-framed authentic quote that conveys its character. Memorable in places.
+- **6:** Competent but flat. Correct and orderly, but the prose doesn't sing; folk texts are described/summarized
+  rather than quoted and made to resonate. Beauty asserted, not conveyed.
+- **≤4:** Dry, generic, textbook-encyclopedic. No primary-text presence, or quotes dumped without framing. Reads like a summary.
+
+**Evidence (required):** cite a verbatim excerpt from the lesson exemplifying (or failing) craft, AND name the
+primary folk text quoted (or note its absence). A PASS with no quoted excerpt is invalid.
+
+**Corpus note (design §6 / #3162):** the folk *literary* corpus is not yet fully routed, so "soul" is currently
+limited to authentic quotes the writer can reach (textbook-sourced cited excerpts count). Score honestly against
+what is *present and authentic*; do not penalize for corpus depth that is not yet available — that gap is Phase C's job.
+
+### 5. Pedagogical Quality — Advanced Seminar Immersion
+- Teach an advanced near-full-immersion seminar learner through Ukrainian-first prose; do not flatten the lesson into dry scholarship or beginner drills
+- Concepts should build through source, context, and guided interpretation, with academic depth woven in only when it deepens interest
+- Scaffolding should open the source for the learner, not replace the source with summary
+
+### 6. Word Count — Targets Are Minimums
 - Minimum: {WORD_TARGET} words. Below = FAIL.
 - Maximum: ~150% of target.
 - Section budgets are guidance (±30% OK), but no section starved (<50% of budget)
 
-### 5. Writing Quality — No Robotic Prose
+### 7. Writing Quality — No Robotic Prose
 - Every paragraph: ONE clear point, logical flow
 - No word salad, no purple prose, no mechanical transitions
 - Vary sentence openers and section structures
 - "Це не просто X, а Y" — max ONE in entire module
 - Repetitive filler flagged at 2+ occurrences
 
-### 6. Immersion
+### 8. Immersion
 - Follow the immersion target: {IMMERSION_RULE}
 - No English inside Ukrainian sentences
 
-### 7. Research & Primary Sources
+### 9. Research & Primary Sources
 - 3+ cited Ukrainian-language academic sources
 - 5+ dated chronological events
 - 2+ primary source quotes (verified, not fabricated)
 - No fabricated dates or facts — mark uncertain info
 - Soften absolute claims unless verified
 
-### 8. Patriotic Content
+### 10. Patriotic Content
 - Pride in Ukrainian cultural, scientific, and artistic achievement
 - Recognize historical Ukrainian figures as Ukrainian (not Soviet/Russian/Polish)
 - Resistance framing: Ukrainians who resisted domination
 - This is restoring systematically erased context, not propaganda
 
-### 9. Activity Boundary
+### 11. Activity Boundary
 - Do NOT generate activities, exercises, or vocabulary tables (separate phase)
 
-### 10. Plan Compliance — Every Detail Matters
+### 12. Plan Compliance — Every Detail Matters
 - **Visual Forcing Function**: If a plan point uses words like "chart", "table", "list all", "list of all", "map", "display", "show" → you MUST output a Markdown table or bulleted list. Prose summaries of structural elements are FORBIDDEN.
 - **Anti-Compression Directive**: If the plan specifies a count (e.g., "10 vowels", "33 letters", "6 cases") → every single element must be visibly listed in your output. Never compress into a summary sentence.
 - **Activity hints are HARD constraints**: item counts and focus descriptions in `activity_hints` are minimums, not suggestions.
 
-### 11. Pacing — No Exposition Deserts
+### 13. Pacing — No Exposition Deserts
 - Maximum 200 words of continuous exposition without a structural element (table, example list, callout box, or primary source quote).
 - Alternate between analysis and evidence within each H2 section.

--- a/docs/decisions/2026-04-26-llm-qg-per-dim-thresholds.md
+++ b/docs/decisions/2026-04-26-llm-qg-per-dim-thresholds.md
@@ -8,7 +8,7 @@
 
 ## Binding constraint (North Star §7, paraphrased)
 
-> LLM QG passes only when **Pedagogical, Naturalness, Decolonization, Engagement, Tone** each ≥ the per-level floor in `LEVEL_THRESHOLDS`. **No weighted average. One failing dim fails the module.**
+> LLM QG passes only when **Pedagogical, Naturalness, Decolonization, Engagement, Tone, Beauty** each ≥ the per-level floor in `LEVEL_THRESHOLDS`. **No weighted average. One failing dim fails the module.**
 
 This document specifies the schema + aggregator semantics that satisfy this constraint and supplies the per-level per-dim default floors.
 
@@ -22,7 +22,7 @@ This document specifies the schema + aggregator semantics that satisfy this cons
 | `REVIEW_REJECT_FLOOR` | global, level-agnostic | 6.0 |
 | `LevelThresholds.naturalness_min` | per-level, single dim | A1/A2/B1=9.0, B2+=8.0 |
 
-The Phase 4 LLM QG contract requires per-level floors for **all 5 dims**, not just naturalness. The current schema can't express that without ad-hoc parallel constants. `scripts/build/v6_build.py:1854-1858` already enforces a single global `REVIEW_TARGET_SCORE` per-dim floor (`dim_floor_fail` predicate); the aggregator is already MIN (`min(raw_scores)`, line 1844). The change is in the **floor lookup**, not the aggregator shape.
+The Phase 4 LLM QG contract requires per-level floors for **all 6 dims**, not just naturalness. The current schema can't express that without ad-hoc parallel constants. `scripts/build/v6_build.py:1854-1858` already enforces a single global `REVIEW_TARGET_SCORE` per-dim floor (`dim_floor_fail` predicate); the aggregator is already MIN (`min(raw_scores)`, line 1844). The change is in the **floor lookup**, not the aggregator shape.
 
 ## Schema (proposed)
 
@@ -35,8 +35,9 @@ QG_DIMS: tuple[str, ...] = (
     "decolonization",
     "engagement",
     "tone",
+    "beauty",
 )
-"""The 5 LLM QG dimensions per North Star §7. Tests assert this tuple
+"""The 6 LLM QG dimensions per North Star §7. Tests assert this tuple
 matches the per-dim reviewer prompt set under
 ``scripts/build/phases/v6-review/`` (post-retirement of legacy 9-dim)."""
 
@@ -78,16 +79,16 @@ class LevelThresholds:
 
 ## Per-level per-dim default floors
 
-Rationale: A1/A2/B1 are stricter than B2+ because thin source material at lower CEFR levels makes awkwardness easier to miss; this matches the existing `naturalness_min` pattern. **Decolonization is held high regardless of level** — it's identity-critical and not a complexity-tradeoff. **Pedagogical and Naturalness track Decolonization at lower levels** because a beginner module that fails either of those is unshippable. **Engagement and Tone hold steady at 8.0** — these are quality-stretch dims that tolerate B-grade and still ship.
+Rationale: A1/A2/B1 are stricter than B2+ because thin source material at lower CEFR levels makes awkwardness easier to miss; this matches the existing `naturalness_min` pattern. **Decolonization is held high regardless of level** — it's identity-critical and not a complexity-tradeoff. **Pedagogical and Naturalness track Decolonization at lower levels** because a beginner module that fails either of those is unshippable. **Engagement, Tone, and Beauty hold steady at 8.0** — these are quality-stretch dims that tolerate B-grade and still ship.
 
-| Level | pedagogical | naturalness | decolonization | engagement | tone |
-|---|---|---|---|---|---|
-| A1   | 9.0 | 9.0 | 9.0 | 8.0 | 8.0 |
-| A2   | 9.0 | 9.0 | 9.0 | 8.0 | 8.0 |
-| B1   | 9.0 | 9.0 | 9.0 | 8.0 | 8.0 |
-| B2   | 8.0 | 8.0 | 9.0 | 8.0 | 8.0 |
-| C1   | 8.0 | 8.0 | 9.0 | 8.0 | 8.0 |
-| C2   | 8.0 | 8.0 | 9.0 | 8.0 | 8.0 |
+| Level | pedagogical | naturalness | decolonization | engagement | tone | beauty |
+|---|---|---|---|---|---|---|
+| A1   | 9.0 | 9.0 | 9.0 | 8.0 | 8.0 | 8.0 |
+| A2   | 9.0 | 9.0 | 9.0 | 8.0 | 8.0 | 8.0 |
+| B1   | 9.0 | 9.0 | 9.0 | 8.0 | 8.0 | 8.0 |
+| B2   | 8.0 | 8.0 | 9.0 | 8.0 | 8.0 | 8.0 |
+| C1   | 8.0 | 8.0 | 9.0 | 8.0 | 8.0 | 8.0 |
+| C2   | 8.0 | 8.0 | 9.0 | 8.0 | 8.0 | 8.0 |
 
 REJECT floor: **6.0 across all (level, dim)** — matches the current `REVIEW_REJECT_FLOOR` global. Below 6 means the module is structurally broken and needs a re-plan, not a fix-loop. (User policy 2026-04-23 in strict-reviewer-persona.md.)
 

--- a/scripts/build/phases/linear-review-dim.generated.md
+++ b/scripts/build/phases/linear-review-dim.generated.md
@@ -30,11 +30,16 @@ judgment regex cannot make. For `{DIM}`:
 
 - `engagement`: does the prose *hold attention*? Assess whether callouts carry
   real pedagogy vs filler, whether tone is warm vs bureaucratic, whether
-  direct-address is content-anchored, whether dialogue feels human. Score the
-  *quality* of engagement, not its presence.
+  direct-address is content-anchored, whether dialogue feels human. For seminar
+  tracks, assess whether the lesson helps the learner care about the heritage
+  and want to keep reading. Score the *quality* of engagement, not its
+  presence.
 - `pedagogical`: does the sequencing actually teach? Are examples illuminating?
   Does each concept earn the next? Respect the learner's prior knowledge
-  (BUILD, don't REPEAT). Source-pedagogy failures are in scope even when the
+  (BUILD, don't REPEAT). For seminar tracks, the learner is advanced and
+  near-full-immersion: academic depth should be woven through source-guided
+  Ukrainian teaching, not flattened into dry scholarship or beginner drills.
+  Source-pedagogy failures are in scope even when the
   plan/wiki asked for them: REVISE or REJECT any grammar module that promotes a
   metaphor, discourse heuristic, activity label, or writer-created grouping into
   a grammar taxonomy unless Ukrainian textbook/corpus evidence explicitly
@@ -80,6 +85,28 @@ judgment regex cannot make. For `{DIM}`:
   apply the matching anchor.
 - `tone`: is the teacher's voice consistent and warm? Assess register beyond the
   META_NARRATION the gate caught.
+- `beauty`: does the lesson convey the beauty of the source AND read
+  beautifully itself? This dimension has two required halves:
+  (1) **Craft**: vivid, elegant, memorable Ukrainian a learner wants to
+  re-read; imagery and rhythm where the subject invites it; no flat
+  encyclopedic exposition, cliché, purple prose, or mechanical scaffolding
+  dressed up as style. (2) **Soul**: authentic folk texts (пісні, думи,
+  голосіння, заклинання, колядки) are quoted verbatim, cited, verified, and
+  framed so their beauty and identity-bearing power resonate. Let the source
+  speak rather than summarizing it dry.
+
+  Score anchors: 9-10 = genuine literary quality in the lesson prose AND at
+  least one primary folk text quoted and framed so its beauty lands
+  emotionally; 8 = solid craft with no flat stretches AND at least one
+  well-framed authentic quote; 6 = competent but flat, with folk texts
+  described or summarized rather than made to resonate; <=4 = dry, generic, no
+  primary-text presence, or quotes dumped without framing.
+
+  Evidence required: cite a verbatim excerpt from the lesson exemplifying (or
+  failing) craft, and name the primary folk text quoted or note its absence. A
+  PASS with no quoted excerpt is invalid. Corpus note: the folk literary corpus
+  is not yet fully routed, so score honestly against authentic quotes present
+  and do not penalize for corpus depth that Phase C has not delivered.
 
 A dim score that re-states what a deterministic gate already enforced is a
 reviewer-protocol failure. Cite something the gate cannot see.
@@ -162,7 +189,9 @@ Unverified items become FLAG strings in your evidence and weigh the score down.
 - **H. Corpus-access (all dims).** Verify no out-of-level citations
   (a1/a2: Grades 1-4/1-5 only; no adult literary; external limited to ULP /
   Pohribnyi). FLAG `out_of_level_textbook` / `out_of_level_literary` /
-  `out_of_level_external`. Score as PEDAGOGICAL evidence-against.
+  `out_of_level_external`. Score as PEDAGOGICAL evidence-against, and as
+  BEAUTY evidence-against where source choice weakens source-centered seminar
+  craft.
 - **I. Student-aware (pedagogical, engagement, naturalness).** Verify the writer
   did not re-explain already-taught grammar (`re_explained_known_grammar`) and
   did not introduce unknown vocab without inline gloss

--- a/scripts/build/phases/linear-review-dim.md
+++ b/scripts/build/phases/linear-review-dim.md
@@ -33,11 +33,16 @@ For `{DIM}` specifically:
   callouts carry real pedagogy vs filler, whether the tone is warm vs
   bureaucratic, whether direct-address phrases (e.g. `Notice the soft sign
   in **писатися**`) are content-anchored vs generic, whether dialogue feels
-  human vs robotic. Score the *quality* of engagement, not its presence —
+  human vs robotic. For seminar tracks, assess whether the lesson helps the
+  learner care about the heritage and want to keep reading, not merely whether
+  it includes hooks. Score the *quality* of engagement, not its presence —
   presence is the gate's job.
 - `pedagogical`: does the sequencing actually teach? Are examples
   illuminating? Does each concept earn the next? The gate confirmed word
   budgets and section presence; you assess whether the pedagogy *works*.
+  For seminar tracks, the learner is advanced and near-full-immersion:
+  academic depth should be woven through source-guided Ukrainian teaching, not
+  flattened into dry scholarship or beginner drills.
   Source-pedagogy failures are in scope even when the plan/wiki asked for
   them: REVISE or REJECT any grammar module that promotes a metaphor,
   discourse heuristic, activity label, or writer-created grouping into a
@@ -156,6 +161,33 @@ For `{DIM}` specifically:
     named persona or named characters, and no foreigner-textbook anti-patterns
     such as transliteration tables, "X sounds like Y in English", "the student
     must learn", or English topic-sentence openers.
+- `beauty`: does the lesson convey the beauty of the source AND read
+  beautifully itself? This dimension has two required halves:
+  (1) **Craft**: vivid, elegant, memorable Ukrainian a learner wants to
+  re-read; imagery and rhythm where the subject invites it; no flat
+  encyclopedic exposition, cliché, purple prose, or mechanical scaffolding
+  dressed up as style. (2) **Soul**: authentic folk texts (пісні, думи,
+  голосіння, заклинання, колядки) are quoted verbatim, cited, verified, and
+  framed so their beauty and identity-bearing power resonate. Let the source
+  speak rather than summarizing it dry.
+
+  Score anchors:
+  - 9-10: genuine literary quality in the lesson prose AND at least one
+    primary folk text quoted and framed so its beauty lands emotionally; the
+    source's voice is present, not paraphrased away.
+  - 8: solid, clean, engaging craft with no flat stretches AND the source
+    present via at least one well-chosen, well-framed authentic quote that
+    conveys its character.
+  - 6: competent but flat; folk texts are described or summarized rather than
+    quoted and made to resonate.
+  - <=4: dry, generic, textbook-encyclopedic; no primary-text presence, or
+    quotes dumped without framing.
+
+  Evidence required: cite a verbatim excerpt from the lesson exemplifying (or
+  failing) craft, and name the primary folk text quoted or note its absence. A
+  PASS with no quoted excerpt is invalid. Corpus note: the folk literary corpus
+  is not yet fully routed, so score honestly against authentic quotes present
+  and do not penalize for corpus depth that Phase C has not delivered.
 
 A dim score that re-states what a deterministic gate already enforced is a
 reviewer-protocol failure. Cite something the gate cannot see.
@@ -182,7 +214,8 @@ teach while applying the existing `{DIM}` rubric.
 The Tier-1 audits below (A through I, expanded in this rebuild) feed evidence
 into specific dims as labeled. Audit F (activity split) → pedagogical +
 engagement. Audit G (corpus access) → all dims, weighted strongest for
-pedagogical (out-of-level citations are mostly a pedagogical problem). Audit H
+pedagogical and beauty on source-centered seminar modules (out-of-level
+citations are mostly a pedagogical problem). Audit H
 (student-aware) → pedagogical + engagement + naturalness. Audit I (audit-line
 integrity) → all dims, as a meta-signal that the writer was honest with itself.
 

--- a/scripts/common/thresholds.py
+++ b/scripts/common/thresholds.py
@@ -52,19 +52,24 @@ QG_DIMS: tuple[str, ...] = (
     "decolonization",
     "engagement",
     "tone",
+    "beauty",
 )
-"""The 5 LLM QG dimensions per North Star §7."""
+"""The 6 LLM QG dimensions per North Star §7."""
 
 LLM_QG_TERMINAL_DIMS: frozenset[str] = frozenset({"decolonization"})
-"""LLM QG dims whose REJECT verdict terminates the build.
+"""Back-compat LLM QG dims whose REJECT verdict terminates the build.
 
 Per architectural reset 2026-05-23
 (docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md
 decision #2): subjective dims (pedagogical, naturalness, engagement, tone)
 were stochastic and produced zero shipped modules across 6 builds
-2026-05-22 to 2026-05-23. They're demoted to warning. Decolonization stays
-terminal because political safety is not subjective: Russian framing leaking
-in is a hard rule, not a judgment call.
+2026-05-22 to 2026-05-23. The profile resolver below wires the seminar-only
+re-promotion of pedagogical, engagement, and beauty per
+docs/folk-epic/seminar-quality-gate-design.md §3. Merge remains blocked until
+the Phase B de-risk proves the correction loop closes the gap; the blast
+radius is seminar-scoped, and core profiles remain untouched. Decolonization
+stays terminal for seminars because political safety is not subjective:
+Russian framing leaking in is a hard rule, not a judgment call.
 
 Adding a dim here means: a REJECT in that dim raises LinearPipelineError and
 kills the build. Removing a dim means: a REJECT in that dim emits
@@ -75,8 +80,18 @@ shipped modules with captured human decisions; see PR-G placeholder), dims can
 be re-added to this set with the agreement-rate justification logged.
 """
 
+SEMINAR_TERMINAL_DIMS: frozenset[str] = frozenset(
+    {"decolonization", "pedagogical", "engagement", "beauty"}
+)
+"""Default terminal LLM QG dims for seminar/track profiles."""
+
+# Per-track override hook (design §2a): folk leans beauty; hist will lean rigor.
+# Empty today: all seminar tracks use SEMINAR_TERMINAL_DIMS. Add entries as
+# tracks are tuned.
+TRACK_DIM_PROFILES: dict[str, frozenset[str]] = {}
+
 LLM_QG_WARNING_DIMS: frozenset[str] = frozenset(QG_DIMS) - LLM_QG_TERMINAL_DIMS
-"""Derived: LLM QG dims whose REJECT verdict is logged but does not terminate."""
+"""Derived legacy warning dims for callers still using LLM_QG_TERMINAL_DIMS."""
 
 
 def terminal_dims_for(profile: str | None) -> frozenset[str]:
@@ -88,7 +103,8 @@ def terminal_dims_for(profile: str | None) -> frozenset[str]:
     """
     if profile is not None and str(profile).strip().casefold() == "core":
         return frozenset()
-    return LLM_QG_TERMINAL_DIMS
+    profile_key = str(profile).strip().casefold() if profile is not None else ""
+    return TRACK_DIM_PROFILES.get(profile_key, SEMINAR_TERMINAL_DIMS)
 
 
 STYLE_REVIEW_TARGET: float = 9.0
@@ -185,6 +201,7 @@ def _make_review_floors(
     decolonization: float,
     engagement: float,
     tone: float,
+    beauty: float,
 ) -> Mapping[str, DimensionFloor]:
     pass_floors = {
         "pedagogical": pedagogical,
@@ -192,6 +209,7 @@ def _make_review_floors(
         "decolonization": decolonization,
         "engagement": engagement,
         "tone": tone,
+        "beauty": beauty,
     }
     return MappingProxyType({
         dim: DimensionFloor(pass_floor=pass_floor, reject_floor=REVIEW_REJECT_FLOOR)
@@ -208,6 +226,7 @@ _LEVEL_THRESHOLDS: dict[str, LevelThresholds] = {
             decolonization=9.0,
             engagement=8.0,
             tone=8.0,
+            beauty=8.0,
         ),
     ),
     "A2": LevelThresholds(
@@ -218,6 +237,7 @@ _LEVEL_THRESHOLDS: dict[str, LevelThresholds] = {
             decolonization=9.0,
             engagement=8.0,
             tone=8.0,
+            beauty=8.0,
         ),
     ),
     "B1": LevelThresholds(
@@ -228,6 +248,7 @@ _LEVEL_THRESHOLDS: dict[str, LevelThresholds] = {
             decolonization=9.0,
             engagement=8.0,
             tone=8.0,
+            beauty=8.0,
         ),
     ),
     "B2": LevelThresholds(
@@ -238,6 +259,7 @@ _LEVEL_THRESHOLDS: dict[str, LevelThresholds] = {
             decolonization=9.0,
             engagement=8.0,
             tone=8.0,
+            beauty=8.0,
         ),
     ),
     "C1": LevelThresholds(
@@ -248,6 +270,7 @@ _LEVEL_THRESHOLDS: dict[str, LevelThresholds] = {
             decolonization=9.0,
             engagement=8.0,
             tone=8.0,
+            beauty=8.0,
         ),
     ),
     "C2": LevelThresholds(
@@ -258,6 +281,7 @@ _LEVEL_THRESHOLDS: dict[str, LevelThresholds] = {
             decolonization=9.0,
             engagement=8.0,
             tone=8.0,
+            beauty=8.0,
         ),
     ),
 }
@@ -273,6 +297,7 @@ _DEFAULT_THRESHOLDS = LevelThresholds(
         decolonization=9.0,
         engagement=8.0,
         tone=8.0,
+        beauty=8.0,
     ),
 )
 """Fallback for unknown level codes. Matches the audit-side ``default``

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -1406,6 +1406,34 @@ def test_aggregate_llm_review_requires_exact_qg_dims() -> None:
         linear_pipeline.aggregate_llm_review(report, "A1")
 
 
+def test_validate_llm_review_report_accepts_beauty_dim() -> None:
+    report = {
+        dim: {
+            "score": 9.0,
+            "evidence": f'"Specific quoted evidence for {dim}."',
+            "verdict": "PASS",
+        }
+        for dim in QG_DIMS
+    }
+
+    linear_pipeline.validate_llm_review_report(report)
+
+
+def test_validate_llm_review_report_rejects_missing_beauty_dim() -> None:
+    report = {
+        dim: {
+            "score": 9.0,
+            "evidence": f'"Specific quoted evidence for {dim}."',
+            "verdict": "PASS",
+        }
+        for dim in QG_DIMS
+    }
+    del report["beauty"]
+
+    with pytest.raises(linear_pipeline.LinearPipelineError, match=r"missing=.*beauty"):
+        linear_pipeline.validate_llm_review_report(report)
+
+
 def test_aggregate_llm_review_requires_quoted_evidence() -> None:
     report = {
         dim: {

--- a/tests/build/test_linear_pipeline_wiki_packet.py
+++ b/tests/build/test_linear_pipeline_wiki_packet.py
@@ -37,11 +37,11 @@ def test_build_knowledge_packet_reads_wiki_and_sources(monkeypatch) -> None:
         plan=plan,
     )
 
-    assert "Подача теми «Мій ранок»" in packet
-    assert "засвоєнням зворотних дієслів" in packet
-    assert "wiki/pedagogy/a1/my-morning.md" in packet
-    assert "S1=4-klas-ukrmova-zaharijchuk_s1922" in packet
-    assert "S9=ukrainian_wiki/reflexive-verbs-nuances" in packet
+    assert "Введення теми має відбуватися покроково" in packet
+    assert "зворотних дієслів" in packet
+    assert "pedagogy/a1/my-morning.md" in packet
+    assert "Source: Сторінка 25 (zaharijchuk, Grade 1, p.24" in packet
+    assert "Source: Сторінка 53 (zaharijchuk, Grade 1, p.52" in packet
     assert "mcp__sources__verify_lemma" in packet
     assert "mcp__sources__search_style_guide" in packet
     assert "mcp__sources__search_definitions" in packet

--- a/tests/test_linear_pipeline_telemetry.py
+++ b/tests/test_linear_pipeline_telemetry.py
@@ -131,6 +131,7 @@ def _reviewer_response(dim: str) -> str:
         "decolonization": 7.5,
         "engagement": 9.0,
         "tone": 8.0,
+        "beauty": 8.0,
     }
     quote_a = f"{dim} quote one"
     quote_b = f"{dim} quote two"
@@ -160,6 +161,7 @@ def _reviewer_audit_calls(dim: str) -> list[dict[str, Any]]:
         ],
         "engagement": [("query_wikipedia", "quote_verification", 1)],
         "tone": [("search_idioms", "sovietization_check", 1)],
+        "beauty": [("search_literary", "quote_verification", 1)],
     }
     return [
         {
@@ -272,14 +274,14 @@ def test_reviewer_telemetry_events_and_rollup_fire_from_dim_wrappers() -> None:
     )
 
     dim_events = _events_named(events, "reviewer_dim_evidence")
-    assert len(dim_events) == 5
+    assert len(dim_events) == len(QG_DIMS)
     assert {event["dim"] for event in dim_events} == set(QG_DIMS)
     assert all(len(event["evidence_quotes"]) == 3 for event in dim_events)
     assert all(len(event["rubric_mapping"]) <= 500 for event in dim_events)
     assert all(event["writer_under_review"] == "claude-tools" for event in dim_events)
 
     audit_events = _events_named(events, "reviewer_audit_call")
-    assert len(audit_events) == 8
+    assert len(audit_events) == 9
     assert {event["audit_type"] for event in audit_events} == {
         "source_attribution",
         "quote_verification",
@@ -291,12 +293,12 @@ def test_reviewer_telemetry_events_and_rollup_fire_from_dim_wrappers() -> None:
     assert all(event["flags_raised"] == [] for event in audit_events)
 
     summary = _events_named(events, "phase_review_summary")[0]
-    assert summary["dims_scored"] == 5
-    assert summary["dims_with_evidence"] == 5
-    assert summary["audit_calls_total"] == 8
+    assert summary["dims_scored"] == len(QG_DIMS)
+    assert summary["dims_with_evidence"] == len(QG_DIMS)
+    assert summary["audit_calls_total"] == 9
     assert summary["flags_raised_total"] == 0
     assert summary["min_dim_score"] == 7.5
-    assert summary["weighted_score"] == 8.2
+    assert summary["weighted_score"] == 8.17
 
 
 def test_telemetry_event_schema_is_bounded_and_flat() -> None:

--- a/tests/test_linear_pipeline_wiki_coverage.py
+++ b/tests/test_linear_pipeline_wiki_coverage.py
@@ -12,13 +12,14 @@ ROOT = Path(__file__).resolve().parents[1]
 WRITER_TEMPLATE = ROOT / "scripts/build/phases/linear-write.md"
 
 
-def test_qg_dims_remain_five_standard_dimensions() -> None:
+def test_qg_dims_remain_six_standard_dimensions() -> None:
     assert QG_DIMS == (
         "pedagogical",
         "naturalness",
         "decolonization",
         "engagement",
         "tone",
+        "beauty",
     )
 
 

--- a/tests/test_llm_qg_demote.py
+++ b/tests/test_llm_qg_demote.py
@@ -16,31 +16,42 @@ def test_terminal_and_warning_dims_partition_qg_dims() -> None:
     assert frozenset() == LLM_QG_TERMINAL_DIMS & LLM_QG_WARNING_DIMS
 
 
-def test_decolonization_is_only_terminal_dim_in_2026_05_23_baseline() -> None:
-    """Per architectural reset 2026-05-23 decision #3."""
+def test_legacy_terminal_dim_set_preserves_2026_05_23_baseline() -> None:
+    """Back-compat constant preserves architectural reset 2026-05-23 decision #3."""
     assert frozenset({"decolonization"}) == LLM_QG_TERMINAL_DIMS
 
 
 def test_terminal_dims_for_profiles() -> None:
     assert terminal_dims_for("core") == frozenset()
-    assert terminal_dims_for("seminar") == frozenset({"decolonization"})
-    assert terminal_dims_for(None) == frozenset({"decolonization"})
+    assert terminal_dims_for("seminar") == frozenset(
+        {"decolonization", "pedagogical", "engagement", "beauty"}
+    )
+    assert terminal_dims_for("track") == frozenset(
+        {"decolonization", "pedagogical", "engagement", "beauty"}
+    )
+    assert terminal_dims_for("folk") == frozenset(
+        {"decolonization", "pedagogical", "engagement", "beauty"}
+    )
+    assert terminal_dims_for(None) == frozenset(
+        {"decolonization", "pedagogical", "engagement", "beauty"}
+    )
 
 
 def test_warning_dim_reject_does_not_drive_terminal_verdict() -> None:
     """A REJECT in a warning dim leaves terminal_verdict == PASS."""
     scores = {
-        "pedagogical": 4.0,  # REJECT (below 6.0 reject floor)
-        "naturalness": 9.0,
+        "pedagogical": 9.0,
+        "naturalness": 4.0,  # REJECT (below 6.0 reject floor)
         "decolonization": 9.5,  # PASS
         "engagement": 8.5,
         "tone": 8.5,
+        "beauty": 8.5,
     }
-    verdict = aggregate_review(scores, "A1")
+    verdict = aggregate_review(scores, "A1", profile="seminar")
     assert verdict.verdict == "REJECT"
     assert verdict.terminal_verdict == "PASS"
-    assert "pedagogical" in verdict.rejected_dims
-    assert "pedagogical" in verdict.warning_dims
+    assert "naturalness" in verdict.rejected_dims
+    assert "naturalness" in verdict.warning_dims
 
 
 def test_core_decolonization_revise_is_warning_not_terminal() -> None:
@@ -51,6 +62,7 @@ def test_core_decolonization_revise_is_warning_not_terminal() -> None:
         "decolonization": 7.0,  # REVISE
         "engagement": 8.5,
         "tone": 8.5,
+        "beauty": 8.5,
     }
     verdict = aggregate_review(scores, "A1", profile="core")
     assert verdict.verdict == "REVISE"
@@ -67,6 +79,7 @@ def test_seminar_decolonization_revise_stays_terminal() -> None:
         "decolonization": 7.0,  # REVISE
         "engagement": 9.0,
         "tone": 9.0,
+        "beauty": 9.0,
     }
     verdict = aggregate_review(scores, "bio", profile="seminar")
     assert verdict.verdict == "REVISE"
@@ -82,6 +95,7 @@ def test_all_pass_yields_pass_on_both() -> None:
         "decolonization": 9.0,
         "engagement": 8.5,
         "tone": 8.5,
+        "beauty": 8.5,
     }
     verdict = aggregate_review(scores, "A1")
     assert verdict.verdict == "PASS"
@@ -97,8 +111,9 @@ def test_warning_revise_does_not_drive_terminal_revise() -> None:
         "decolonization": 9.0,
         "engagement": 8.5,
         "tone": 8.5,
+        "beauty": 8.5,
     }
-    verdict = aggregate_review(scores, "A1")
+    verdict = aggregate_review(scores, "A1", profile="core")
     assert verdict.verdict == "REVISE"
     assert verdict.terminal_verdict == "PASS"
 
@@ -114,7 +129,11 @@ def test_aggregate_llm_review_json_shape_includes_terminal_warning_fields() -> N
         for dim in QG_DIMS
     }
 
-    aggregate = linear_pipeline.aggregate_llm_review(report, "A1")["aggregate"]
+    aggregate = linear_pipeline.aggregate_llm_review(
+        report,
+        "A1",
+        profile="core",
+    )["aggregate"]
 
     assert aggregate["verdict"] == "REJECT"
     assert aggregate["terminal_verdict"] == "PASS"

--- a/tests/test_review_floors_table_sync.py
+++ b/tests/test_review_floors_table_sync.py
@@ -26,6 +26,7 @@ def _parse_doc_floor_table() -> dict[str, dict[str, float]]:
         r"\|\s*(\d+\.\d)\s*"
         r"\|\s*(\d+\.\d)\s*"
         r"\|\s*(\d+\.\d)\s*"
+        r"\|\s*(\d+\.\d)\s*"
         r"\|\s*(\d+\.\d)\s*\|$",
         re.MULTILINE,
     )

--- a/tests/test_threshold_source_of_truth.py
+++ b/tests/test_threshold_source_of_truth.py
@@ -19,6 +19,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from common.thresholds import (
+    LEVEL_THRESHOLDS,
+    QG_DIMS,
     REVIEW_PASS_FLOOR,
     REVIEW_REJECT_FLOOR,
     STYLE_REVIEW_DIMENSION_FLOOR,
@@ -172,6 +174,23 @@ def test_no_canonical_name_redeclared_outside_thresholds() -> None:
         "Canonical threshold names must live only in scripts/common/thresholds.py.\n"
         + "\n".join(offenders)
     )
+
+
+def test_qg_dims_include_beauty_as_sixth_dimension() -> None:
+    assert QG_DIMS == (
+        "pedagogical",
+        "naturalness",
+        "decolonization",
+        "engagement",
+        "tone",
+        "beauty",
+    )
+
+
+def test_every_level_has_beauty_review_floor() -> None:
+    for level, thresholds in LEVEL_THRESHOLDS.items():
+        assert "beauty" in thresholds.review_floors, level
+        assert set(thresholds.review_floors) == set(QG_DIMS)
 
 
 def test_review_pass_floor_imports_are_legacy_allowlisted() -> None:

--- a/tests/test_thresholds_per_dim.py
+++ b/tests/test_thresholds_per_dim.py
@@ -26,6 +26,7 @@ EXPECTED_PASS_FLOORS = {
         "decolonization": 9.0,
         "engagement": 8.0,
         "tone": 8.0,
+        "beauty": 8.0,
     },
     "A2": {
         "pedagogical": 9.0,
@@ -33,6 +34,7 @@ EXPECTED_PASS_FLOORS = {
         "decolonization": 9.0,
         "engagement": 8.0,
         "tone": 8.0,
+        "beauty": 8.0,
     },
     "B1": {
         "pedagogical": 9.0,
@@ -40,6 +42,7 @@ EXPECTED_PASS_FLOORS = {
         "decolonization": 9.0,
         "engagement": 8.0,
         "tone": 8.0,
+        "beauty": 8.0,
     },
     "B2": {
         "pedagogical": 8.0,
@@ -47,6 +50,7 @@ EXPECTED_PASS_FLOORS = {
         "decolonization": 9.0,
         "engagement": 8.0,
         "tone": 8.0,
+        "beauty": 8.0,
     },
     "C1": {
         "pedagogical": 8.0,
@@ -54,6 +58,7 @@ EXPECTED_PASS_FLOORS = {
         "decolonization": 9.0,
         "engagement": 8.0,
         "tone": 8.0,
+        "beauty": 8.0,
     },
     "C2": {
         "pedagogical": 8.0,
@@ -61,6 +66,7 @@ EXPECTED_PASS_FLOORS = {
         "decolonization": 9.0,
         "engagement": 8.0,
         "tone": 8.0,
+        "beauty": 8.0,
     },
 }
 
@@ -101,6 +107,7 @@ def test_aggregate_review_passes_when_all_dims_clear_pass_floors() -> None:
             "decolonization": 9.0,
             "engagement": 8.0,
             "tone": 8.0,
+            "beauty": 8.0,
         },
         "A1",
     )
@@ -120,6 +127,7 @@ def test_aggregate_review_revises_when_one_dim_between_reject_and_pass() -> None
             "decolonization": 9.0,
             "engagement": 8.0,
             "tone": 8.0,
+            "beauty": 8.0,
         },
         "A1",
     )
@@ -139,6 +147,7 @@ def test_aggregate_review_rejects_when_any_dim_below_reject_floor() -> None:
             "decolonization": 5.9,
             "engagement": 10.0,
             "tone": 10.0,
+            "beauty": 10.0,
         },
         "B2",
     )
@@ -158,6 +167,7 @@ def test_aggregate_review_core_profile_keeps_full_reject_terminal_pass() -> None
             "decolonization": 5.9,
             "engagement": 10.0,
             "tone": 10.0,
+            "beauty": 10.0,
         },
         "A1",
         profile="core",
@@ -172,8 +182,39 @@ def test_aggregate_review_core_profile_keeps_full_reject_terminal_pass() -> None
 
 def test_terminal_dims_for_defaults_to_strict_terminal_set() -> None:
     assert terminal_dims_for("core") == frozenset()
-    assert terminal_dims_for("seminar") == frozenset({"decolonization"})
-    assert terminal_dims_for(None) == frozenset({"decolonization"})
+    assert terminal_dims_for("seminar") == frozenset(
+        {"decolonization", "pedagogical", "engagement", "beauty"}
+    )
+    assert terminal_dims_for("track") == frozenset(
+        {"decolonization", "pedagogical", "engagement", "beauty"}
+    )
+    assert terminal_dims_for("folk") == frozenset(
+        {"decolonization", "pedagogical", "engagement", "beauty"}
+    )
+    assert terminal_dims_for(None) == frozenset(
+        {"decolonization", "pedagogical", "engagement", "beauty"}
+    )
+
+
+def test_aggregate_review_seminar_gates_beauty_but_core_does_not() -> None:
+    scores = {
+        "pedagogical": 8.0,
+        "naturalness": 8.0,
+        "decolonization": 9.0,
+        "engagement": 8.0,
+        "tone": 8.0,
+        "beauty": 7.0,
+    }
+
+    seminar_verdict = aggregate_review(scores, "B2", profile="folk")
+    core_verdict = aggregate_review(scores, "B2", profile="core")
+
+    assert seminar_verdict.verdict == "REVISE"
+    assert seminar_verdict.terminal_verdict == "REVISE"
+    assert seminar_verdict.failing_dims == ("beauty",)
+    assert core_verdict.verdict == "REVISE"
+    assert core_verdict.terminal_verdict == "PASS"
+    assert core_verdict.warning_dims == ("beauty",)
 
 
 def test_aggregate_review_tolerates_extra_legacy_dims() -> None:
@@ -184,6 +225,7 @@ def test_aggregate_review_tolerates_extra_legacy_dims() -> None:
             "decolonization": 9.0,
             "engagement": 8.0,
             "tone": 8.0,
+            "beauty": 8.0,
             "language": 0.0,
         },
         "B2",


### PR DESCRIPTION
## Summary

- Adds `beauty` as the sixth LLM QG dimension and gives every level/default threshold a `beauty=8.0` review floor.
- Wires seminar-scoped terminal gating through `terminal_dims_for(...)`: non-core seminar/track profiles gate on `decolonization`, `pedagogical`, `engagement`, and `beauty`; `core` still returns `frozenset()`.
- Updates seminar reviewer rubrics and active per-dim reviewer prompts so `beauty` is scored with `score`, quoted evidence/evidence_quotes, and verdict.
- Updates threshold, linear-pipeline, telemetry, and floor-table tests for six dimensions.

## BLOCKED on Phase B de-risk

DO NOT MERGE until the Phase B de-risk build proves the correction loop converges a folk module to >=8 on beauty/engagement/pedagogy (design §4). This Phase A PR deliberately wires the gate but must remain blocked until that proof exists; otherwise seminar builds could fail with no path to pass.

Core (a1-c2) gating is untouched: `terminal_dims_for("core")` remains `frozenset()`.

## Evidence

`ruff check scripts/common/thresholds.py scripts/build/linear_pipeline.py tests/test_threshold_source_of_truth.py tests/test_thresholds_per_dim.py tests/test_llm_qg_demote.py tests/build/test_linear_pipeline.py tests/build/test_linear_pipeline_wiki_packet.py tests/test_linear_pipeline_wiki_coverage.py tests/test_review_floors_table_sync.py tests/test_linear_pipeline_telemetry.py`

```text
All checks passed!
```

`.venv/bin/python -m pytest tests/test_threshold_source_of_truth.py tests/test_thresholds_per_dim.py tests/test_llm_qg_demote.py tests/test_review_floors_table_sync.py tests/test_linear_pipeline_telemetry.py tests/test_linear_pipeline_wiki_coverage.py tests/test_linear_pipeline_vesum_heritage_attestation.py tests/test_llm_qg_correction_loop.py tests/build/test_linear_pipeline.py tests/build/test_linear_pipeline_wiki_packet.py tests/build/test_llm_qg_evidence_quotes.py -q`

```text
======================= 215 passed, 1 skipped in 10.95s ========================
```

`.venv/bin/python -c "import scripts.build.linear_pipeline"; printf 'exit=%s\n' "$?"`

```text
exit=0
```
