### PR TITLE
fix(a1): align verbs group two review

### DIFF
--- a/curriculum/l2-uk-en/a1/verbs-group-two/activities.yaml
+++ b/curriculum/l2-uk-en/a1/verbs-group-two/activities.yaml
@@ -1,280 +1,220 @@
 ---
 inline:
   - id: act-1
-    type: quiz
-    title: Розігрів другої групи
-    instruction: Choose the safe Group Two line.
-    items:
-      - prompt: I speak Ukrainian.
-        options:
-          - text: Я говорю українською.
-            correct: true
-          - text: Я говориш українською.
-            correct: false
-          - text: Я говорити українською.
-            correct: false
-        explanation: Я uses говорю.
-      - prompt: You see the word.
-        options:
-          - text: Ти бачиш слово.
-            correct: true
-          - text: Ти бачу слово.
-            correct: false
-          - text: Ти бачити слово.
-            correct: false
-        explanation: Ти uses бачиш.
-      - prompt: They are doing an exercise.
-        options:
-          - text: Вони роблять вправу.
-            correct: true
-          - text: Вони роблять вправа.
-            correct: false
-          - text: Вони робити вправу.
-            correct: false
-        explanation: Вони роблять is the Group Two form.
-  - id: act-2
-    type: match-up
-    title: Таблиця говорити
-    instruction: Match the person with the present-tense form.
-    pairs:
-      - left: я
-        right: говорю
-      - left: ти
-        right: говориш
-      - left: він / вона
-        right: говорить
-      - left: ми
-        right: говоримо
-      - left: ви
-        right: говорите
-      - left: вони
-        right: говорять
-  - id: act-3
     type: fill-in
-    title: Говорити, робити, бачити
-    instruction: Choose the form that fits the person.
+    title: Провідміняй говорити
+    instruction: Choose the ending that completes the Group Two form.
     items:
-      - sentence: Я ___ українською.
-        answer: говорю
+      - sentence: Я говор__ українською.
+        answer: ю
         options:
-          - говорю
-          - говориш
-          - говорить
+          - ю
+          - иш
+          - ить
         explanation: Я говорю.
-      - sentence: Ти ___ українською?
-        answer: говориш
+      - sentence: Ти говор__ українською?
+        answer: иш
         options:
-          - говориш
-          - говорю
-          - говоримо
+          - иш
+          - ю
+          - ять
         explanation: Ти говориш.
-      - sentence: Він ___.
+      - sentence: Він говор__ добре.
+        answer: ить
+        options:
+          - ить
+          - иш
+          - имо
+        explanation: Він говорить.
+      - sentence: Вона говор__ повільно.
+        answer: ить
+        options:
+          - ить
+          - ите
+          - ю
+        explanation: Вона говорить.
+      - sentence: Ми говор__ українською.
+        answer: имо
+        options:
+          - имо
+          - ите
+          - иш
+        explanation: Ми говоримо.
+      - sentence: Ви говор__ українською?
+        answer: ите
+        options:
+          - ите
+          - имо
+          - ить
+        explanation: Ви говорите.
+      - sentence: Вони говор__ українською.
+        answer: ять
+        options:
+          - ять
+          - иш
+          - ю
+        explanation: Вони говорять.
+      - sentence: Я робл__ вправу.
+        answer: ю
+        options:
+          - ю
+          - иш
+          - ять
+        explanation: Я роблю is a ready first-person chunk.
+      - sentence: Ти бач__ слово?
+        answer: иш
+        options:
+          - иш
+          - у
+          - ать
+        explanation: Ти бачиш.
+      - sentence: Вони бач__ слово.
+        answer: ать
+        options:
+          - ать
+          - иш
+          - у
+        explanation: Вони бачать.
+  - id: act-2
+    type: group-sort
+    title: І чи ІІ дієвідміна
+    instruction: Sort the infinitives by the present-tense group.
+    groups:
+      - name: І дієвідміна / Group One
+        items:
+          - читати
+          - слухати
+          - гуляти
+          - працювати
+      - name: ІІ дієвідміна / Group Two
+        items:
+          - говорити
+          - бачити
+          - робити
+          - вчити
+          - просити
+          - ходити
+  - id: act-3
+    type: quiz
+    title: Обери правильну форму
+    instruction: Choose the form that fits the sentence.
+    items:
+      - prompt: Ти ___ українською?
+        options:
+          - text: говориш
+            correct: true
+          - text: говорю
+            correct: false
+          - text: говорить
+            correct: false
+        explanation: Ти говориш.
+      - prompt: Вона ___ добре.
+        options:
+          - text: говорить
+            correct: true
+          - text: говориш
+            correct: false
+          - text: говорять
+            correct: false
+        explanation: Вона говорить.
+      - prompt: Ми ___ українську.
+        options:
+          - text: вчимо
+            correct: true
+          - text: вчиш
+            correct: false
+          - text: вчить
+            correct: false
+        explanation: Ми вчимо.
+      - prompt: Я ___ це слово.
+        options:
+          - text: бачу
+            correct: true
+          - text: бачиш
+            correct: false
+          - text: бачить
+            correct: false
+        explanation: Я бачу.
+      - prompt: Ти ___ це слово?
+        options:
+          - text: бачиш
+            correct: true
+          - text: бачу
+            correct: false
+          - text: бачать
+            correct: false
+        explanation: Ти бачиш.
+      - prompt: Вони ___ до школи.
+        options:
+          - text: ходять
+            correct: true
+          - text: ходиш
+            correct: false
+          - text: ходжу
+            correct: false
+        explanation: Вони ходять.
+      - prompt: Я ___ каву.
+        options:
+          - text: прошу
+            correct: true
+          - text: просиш
+            correct: false
+          - text: просить
+            correct: false
+        explanation: Я прошу is the ready first-person chunk.
+      - prompt: Вони ___ слово.
+        options:
+          - text: бачать
+            correct: true
+          - text: бачиш
+            correct: false
+          - text: бачу
+            correct: false
+        explanation: Вони бачать uses -ать after ч.
+  - id: act-4
+    type: fill-in
+    title: Доповни речення
+    instruction: Choose the correct present-tense form.
+    items:
+      - sentence: Вона ___ українською. (говорити)
         answer: говорить
         options:
           - говорить
-          - говорите
-          - говорять
-        explanation: Він говорить.
-      - sentence: Я ___ вправу.
+          - говориш
+          - говорю
+        explanation: Вона говорить.
+      - sentence: Я ___ вправу. (робити)
         answer: роблю
         options:
           - роблю
           - робиш
           - робить
         explanation: Я роблю is a ready chunk.
-      - sentence: Ти ___ слово?
+      - sentence: Ти ___ слово? (бачити)
         answer: бачиш
         options:
           - бачиш
           - бачу
-          - бачить
+          - бачать
         explanation: Ти бачиш.
-      - sentence: Вони ___ слово.
-        answer: бачать
+      - sentence: Ми ___ нові слова. (вчити)
+        answer: вчимо
         options:
-          - бачать
-          - бачиш
-          - бачу
-        explanation: Вони бачать.
-  - id: act-4
-    type: group-sort
-    title: Перша чи друга група
-    instruction: Sort the they-forms by group.
-    groups:
-      - name: І дієвідміна / Group One
-        items:
-          - читають
-          - слухають
-          - гуляють
-      - name: ІІ дієвідміна / Group Two
-        items:
-          - говорять
-          - роблять
-          - бачать
-          - ходять
-          - стоять
-          - сидять
-workbook:
-  - type: fill-in
-    title: Готові фрази з «я»
-    instruction: Choose the ready first-person chunk.
-    items:
-      - sentence: Я ___ вправу.
-        answer: роблю
-        options:
-          - роблю
-          - робиш
-          - робить
-        explanation: Learn я роблю as a chunk.
-      - sentence: Я ___ до школи.
-        answer: ходжу
-        options:
-          - ходжу
-          - ходиш
-          - ходить
-        explanation: Learn я ходжу as a chunk.
-      - sentence: Я ___ каву.
+          - вчимо
+          - вчиш
+          - вчать
+        explanation: Ми вчимо.
+      - sentence: Я ___ каву. (просити)
         answer: прошу
         options:
           - прошу
           - просиш
           - просить
-        explanation: Learn я прошу as a chunk.
-      - sentence: Я ___ тут.
-        answer: сиджу
+        explanation: Я прошу is the first-person chunk.
+      - sentence: Вони ___ до школи. (ходити)
+        answer: ходять
         options:
-          - сиджу
-          - сидиш
-          - сидить
-        explanation: Learn я сиджу as a chunk.
-  - type: quiz
-    title: Форми лише для впізнавання
-    instruction: Choose the form you should recognize, not overbuild.
-    items:
-      - prompt: They sleep.
-        options:
-          - text: Вони сплять.
-            correct: true
-          - text: Вони спати.
-            correct: false
-          - text: Вони спить.
-            correct: false
-        explanation: Recognize вони сплять.
-      - prompt: You eat.
-        options:
-          - text: Ти їси.
-            correct: true
-          - text: Ти їсть.
-            correct: false
-          - text: Ти їдять.
-            correct: false
-        explanation: Recognize ти їси.
-      - prompt: They eat.
-        options:
-          - text: Вони їдять.
-            correct: true
-          - text: Вони їси.
-            correct: false
-          - text: Вони їсть.
-            correct: false
-        explanation: Recognize вони їдять.
-  - type: error-correction
-    title: Виправ пастки другої групи
-    instruction: Choose the standard Ukrainian repair.
-    anchor_id: group-two-repairs
-    items:
-      - sentence: Вони робуть
-        error: Вони робуть
-        answer: Вони роблять
-        options:
-          - Вони роблять
-          - Вони працюють
-          - Вони читають
-        explanation: Робити uses вони роблять.
-      - sentence: Ти бачеш
-        error: Ти бачеш
-        answer: Ти бачиш
-        options:
-          - Ти бачиш
-          - Ти говориш
-          - Ти робиш
-        explanation: Group Two uses бачиш.
-      - sentence: Я сидю
-        error: Я сидю
-        answer: Я сиджу
-        options:
-          - Я сиджу
-          - Я ходжу
-          - Я бачу
-        explanation: Learn я сиджу as a ready chunk.
-      - sentence: Він стоє
-        error: Він стоє
-        answer: Він стоїть
-        options:
-          - Він стоїть
-          - Він сидить
-          - Він говорить
-        explanation: Стояти gives він стоїть.
-      - sentence: Я сплю, ти сплєш
-        error: Я сплю, ти сплєш
-        answer: Я сплю, ти спиш
-        options:
-          - Я сплю, ти спиш
-          - Я сплю, ти їси
-          - Я сплю, ти сидиш
-        explanation: Recognize ти спиш; do not invent the form.
-      - sentence: Я є студент
-        error: Я є студент
-        answer: Я студент
-        options:
-          - Я студент
-          - Я вчитель
-          - Я Томас
-        explanation: Ukrainian can use Я студент without є.
-      - sentence: Моє ім'я є Томас
-        error: Моє ім'я є Томас
-        answer: Мене звати Томас
-        options:
-          - Мене звати Томас
-          - Я студент Томас
-          - Це Томас
-        explanation: Use Мене звати for names.
-      - sentence: Я маю 20 років
-        error: Я маю 20 років
-        answer: Мені 20 років
-        options:
-          - Мені 20 років
-          - Я студент 20 років
-          - Це 20 років
-        explanation: Use Мені plus age.
-  - type: quiz
-    title: Мінідіалог
-    instruction: Choose the best next line.
-    items:
-      - prompt: Ти говориш українською?
-        options:
-          - text: Так, я говорю українською.
-            correct: true
-          - text: Так, я говориш українською.
-            correct: false
-          - text: Так, я говорити українською.
-            correct: false
-        explanation: Я говорю.
-      - prompt: Що ти робиш?
-        options:
-          - text: Я роблю вправу.
-            correct: true
-          - text: Я робиш вправу.
-            correct: false
-          - text: Я робити вправу.
-            correct: false
-        explanation: Я роблю is the safe answer.
-      - prompt: Ти бачиш це слово?
-        options:
-          - text: Так, я бачу це слово.
-            correct: true
-          - text: Так, я бачиш це слово.
-            correct: false
-          - text: Так, я бачити це слово.
-            correct: false
-        explanation: Я бачу.
+          - ходять
+          - ходиш
+          - ходжу
+        explanation: Вони ходять.

--- a/curriculum/l2-uk-en/a1/verbs-group-two/module.md
+++ b/curriculum/l2-uk-en/a1/verbs-group-two/module.md
@@ -1,273 +1,266 @@
 # Дієслова другої групи
 
-Group Two is your second present-tense verb pattern. The clearest beginner
-signal is the **вони** form: Group One often ends in **-ють** or **-уть**,
-while Group Two often ends in **-ять** or **-ать**. Today you will use a few
-safe Group Two verbs, then compare them with the Group One forms from the last
-lesson.
+In M16, you learned one present-tense verb pattern: **читати -> читаю,
+читаєш, читає, читаємо, читаєте, читають**. Today you add the second pattern:
+**говорити -> говорю, говориш, говорить, говоримо, говорите, говорять**.
+
+The big beginner signal is small:
+
+- Group One often has **ти ... -єш** and **вони ... -ють**: **ти читаєш**,
+  **вони читають**.
+- Group Two often has **ти ... -иш** and **вони ... -ять/-ать**:
+  **ти говориш**, **вони говорять**, **вони бачать**.
 
 By the end, you can:
 
-- say **Я говорю**, **Ти говориш**, and **Він говорить**;
-- use **робити**, **бачити**, **вчити**, **просити**, and **ходити** in short chunks;
-- recognize **вони говорять**, **вони роблять**, **вони бачать**, and **вони ходять**;
-- compare **І дієвідміна** and **ІІ дієвідміна** by the **вони** ending;
-- keep tricky first-person forms such as **роблю** and **ходжу** as ready chunks;
-- recognize exceptions such as **спати**, **дати**, and **їсти** without making them active grammar yet.
+- conjugate **говорити** in the present tense;
+- use **говорити**, **бачити**, **робити**, **вчити**, **просити**, and
+  **ходити** in short sentences;
+- compare **І дієвідміна** and **ІІ дієвідміна** by the **ти** and **вони**
+  forms;
+- keep first-person chunks such as **роблю**, **ходжу**, and **прошу** ready;
+- recognize **дивлюся** and **вчуся** as useful preview forms with **-ся**.
 
 ## Діалоги
 
 <!-- INJECT_ACTIVITY: act-1 -->
 
-Marta and Oleh are still studying. This time they talk about speaking,
-seeing, doing, asking, and walking.
+Тарас and Микола are at the gym. They do simple exercises, rest, and talk
+about what they can say in Ukrainian.
 
 ```text
-Марта: Олеже, ти говориш українською?
-Олег: Так, я говорю українською.
-Марта: Анна говорить англійською?
-Олег: Так, вона говорить англійською.
-Марта: Що ти робиш?
-Олег: Я роблю вправу.
-Марта: Ти бачиш це слово?
-Олег: Так, я бачу це слово.
-Марта: Ми вчимо нові форми?
-Олег: Так, ми вчимо нові форми.
-Марта: Вони ходять до школи?
-Олег: Так, вони ходять до школи.
+Тарас: Ти говориш українською?
+Микола: Так, я говорю трохи. А ти?
+Тарас: Я бачу, що ти добре говориш!
+Микола: Дякую, я вчуся.
 ```
-
-Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Марта: Олеже, ти говориш українською?** | Marta: Oleh, do you speak Ukrainian? |
-| **Олег: Так, я говорю українською.** | Oleh: Yes, I speak Ukrainian. |
-| **Марта: Анна говорить англійською?** | Marta: Does Anna speak English? |
-| **Олег: Так, вона говорить англійською.** | Oleh: Yes, she speaks English. |
-| **Марта: Що ти робиш?** | Marta: What are you doing? |
-| **Олег: Я роблю вправу.** | Oleh: I am doing an exercise. |
-| **Марта: Ти бачиш це слово?** | Marta: Do you see this word? |
-| **Олег: Так, я бачу це слово.** | Oleh: Yes, I see this word. |
-| **Марта: Ми вчимо нові форми?** | Marta: Are we learning new forms? |
-| **Олег: Так, ми вчимо нові форми.** | Oleh: Yes, we are learning new forms. |
-| **Марта: Вони ходять до школи?** | Marta: Do they go to school? |
-| **Олег: Так, вони ходять до школи.** | Oleh: Yes, they go to school. |
+| **Ти говориш українською?** | Do you speak Ukrainian? |
+| **Так, я говорю трохи. А ти?** | Yes, I speak a little. And you? |
+| **Я бачу, що ти добре говориш!** | I see that you speak well! |
+| **Дякую, я вчуся.** | Thanks, I am learning. |
+
+Look at the useful forms:
+
+- **ти говориш** - you speak;
+- **я говорю** - I speak;
+- **я бачу** - I see;
+- **ти добре говориш** - you speak well;
+- **я вчуся** - I am learning.
+
+**Вчуся** has **-ся** at the end. That ending often points to a reflexive
+verb. You do not need the full reflexive system yet. For now, keep **я вчуся**
+as one ready phrase.
+
+Later, at home, Тарас and Микола use two more Group Two chunks.
+
+```text
+Микола: Що ти робиш увечері?
+Тарас: Я дивлюся фільм. А ти?
+Микола: Я вчу нові слова.
+Тарас: Молодець!
+```
+
+| Українська | English support |
+| --- | --- |
+| **Що ти робиш увечері?** | What are you doing in the evening? |
+| **Я дивлюся фільм. А ти?** | I am watching a film. And you? |
+| **Я вчу нові слова.** | I am learning new words. |
+| **Молодець!** | Well done! |
+
+**Дивлюся** also has **-ся**. This module only asks you to recognize it.
+You will work with reflexive verbs more directly later.
+
+The preview infinitives are **вчитися** and **дивитися**. Keep them as
+recognition words today. Your active sentences are only **я вчуся** and
+**я дивлюся фільм**.
 
 :::tip
-Use the **вони** form as your quick check: **читають** points to Group One,
-while **говорять** points to Group Two.
+Your quick check today is the **ти** form: **читаєш** points to Group One,
+while **говориш**, **робиш**, and **бачиш** point to Group Two.
 :::
-
-<!-- INJECT_ACTIVITY: act-2 -->
 
 ## Друга дієвідміна
 
-The textbook label for this pattern is **друга дієвідміна**, or **ІІ
-дієвідміна**. The Group One label from the previous lesson is **І
-дієвідміна**. At A1, do not memorize every rule behind those labels. Use the
-visible forms.
+The Ukrainian term is **друга дієвідміна**, or **ІІ дієвідміна**. The
+infinitive often ends in **-ити**: **говорити**, **бачити**, **робити**,
+**вчити**, **просити**, **ходити**.
 
-| Quick test | Group One | Group Two |
-| --- | --- | --- |
-| they read / speak | **вони читають** | **вони говорять** |
-| they listen / do | **вони слухають** | **вони роблять** |
-| they walk / see | **вони гуляють** | **вони бачать** |
+Use **говорити** as the clean anchor.
 
-Group Two often has **и** in **ти** and **ми** forms: **говориш**,
-**говоримо**, **робиш**, **робимо**. This Ukrainian vowel **[и]** belongs to
-the Ukrainian sound map. For the **українського голосного звука [и]**, listen
-inside the **закінченнях -иш, -имо**: **говориш**, **говоримо**, **робиш**,
-**робимо**. Build the sound from Ukrainian examples, then connect it to the
-written ending.
+| Person | Ending | Form | Safe sentence |
+| --- | --- | --- | --- |
+| я | **-ю** | **говорю** | **Я говорю українською.** |
+| ти | **-иш** | **говориш** | **Ти говориш українською?** |
+| він/вона | **-ить** | **говорить** | **Вона говорить добре.** |
+| ми | **-имо** | **говоримо** | **Ми говоримо повільно.** |
+| ви | **-ите** | **говорите** | **Ви говорите українською?** |
+| вони | **-ять** | **говорять** | **Вони говорять українською.** |
 
-Here is the anchor verb **говорити**:
+Read the table once, then say only three forms aloud:
 
-| Person | Form | Safe sentence |
-| --- | --- | --- |
-| я | **говорю** | **Я говорю українською.** |
-| ти | **говориш** | **Ти говориш українською?** |
-| він/вона | **говорить** | **Вона говорить.** |
-| ми | **говоримо** | **Ми говоримо повільно.** |
-| ви | **говорите** | **Ви говорите?** |
-| вони | **говорять** | **Вони говорять українською.** |
+```text
+Я говорю.
+Ти говориш.
+Вона говорить.
+```
 
-The most important active contrast today is small:
+That is already enough for real conversation.
 
-- **читати** -> **ти читаєш**, **вони читають**;
-- **говорити** -> **ти говориш**, **вони говорять**;
-- **робити** -> **ти робиш**, **вони роблять**.
+### Шість дієслів другої групи
 
-<!-- NO_VERIFY: verified with mcp__sources get_chunk_context chunk 10-klas-ukrmova-karaman-2018_s0319; local quote-fidelity helper cannot import its sources DB search path in this worktree. -->
-> II дієвідміна.
-> Особові закінчення: -у (-ю), -иш (-їш), -ить, -іть (-їть), -имо, -імо (їмо), -ите (-їте), -ать (-ять): спішу, спішиш, спішить, спішимо, спішите, спішать. В основі наявні суфікси -а-, -и-, -і-(-ї-) (що випадають в особових формах).
+Here are the six active verbs from the plan. The full table is for recognition
+and reuse; your speaking can stay with short chunks.
 
-*— Караман Grade 10, p.179*
+| Infinitive | я | ти | він/вона | ми | ви | вони |
+| --- | --- | --- | --- | --- | --- | --- |
+| **говорити** | **говорю** | **говориш** | **говорить** | **говоримо** | **говорите** | **говорять** |
+| **бачити** | **бачу** | **бачиш** | **бачить** | **бачимо** | **бачите** | **бачать** |
+| **робити** | **роблю** | **робиш** | **робить** | **робимо** | **робите** | **роблять** |
+| **вчити** | **вчу** | **вчиш** | **вчить** | **вчимо** | **вчите** | **вчать** |
+| **просити** | **прошу** | **просиш** | **просить** | **просимо** | **просите** | **просять** |
+| **ходити** | **ходжу** | **ходиш** | **ходить** | **ходимо** | **ходите** | **ходять** |
 
-That source note is for orientation only. Your active verbs are **говорити**,
-**робити**, **бачити**, **вчити**, **просити**, and **ходити**.
+The **я** column has a few ready chunks:
 
-<!-- INJECT_ACTIVITY: act-3 -->
+- **я роблю** - I do / I make;
+- **я ходжу** - I go regularly / I walk;
+- **я прошу** - I ask for;
+- **я бачу** - I see;
+- **я вчу** - I learn / I study.
 
-### Використовуй говорити, робити, бачити
-
-Use these three verbs first.
-
-| Infinitive | I | you | he/she | they |
-| --- | --- | --- | --- | --- |
-| **говорити** | **говорю** | **говориш** | **говорить** | **говорять** |
-| **робити** | **роблю** | **робиш** | **робить** | **роблять** |
-| **бачити** | **бачу** | **бачиш** | **бачить** | **бачать** |
-
-The **я** form can change inside the word. Do not calculate it today. Learn a
-`готовий чанк`: **я роблю**, **я ходжу**, **я прошу**, **я сиджу**, **я бачу**.
-Then use the simple **ти** and **він/вона** forms:
+Do not calculate those forms during speech. Learn them as chunks.
 
 ```text
 Я роблю вправу.
-Ти робиш вправу?
-Він робить вправу.
 Я бачу слово.
-Ти бачиш слово?
+Я прошу каву.
+Я ходжу до школи.
+Я вчу українську.
 ```
-
-Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
 | **Я роблю вправу.** | I am doing an exercise. |
-| **Ти робиш вправу?** | Are you doing an exercise? |
-| **Він робить вправу.** | He is doing an exercise. |
 | **Я бачу слово.** | I see a word. |
-| **Ти бачиш слово?** | Do you see a word? |
+| **Я прошу каву.** | I ask for coffee. |
+| **Я ходжу до школи.** | I go to school regularly. |
+| **Я вчу українську.** | I study Ukrainian. |
 
-When you write your own line, choose one verb and one useful object. Keep the
-object familiar:
+You also know **любити** from M15. It is a Group Two verb too: **ти любиш**,
+**вони люблять**. Keep it as review, not as a new table.
 
-| Verb chunk | Add this | Sentence |
-| --- | --- | --- |
-| **я роблю** | **вправу** | **Я роблю вправу.** |
-| **я бачу** | **слово** | **Я бачу слово.** |
-| **я прошу** | **каву** | **Я прошу каву.** |
-| **я ходжу** | **до школи** | **Я ходжу до школи.** |
+### -ять чи -ать?
 
-This is enough for real speech. You do not need to explain why **робити**
-gives **роблю** before you can use **Я роблю вправу**.
+Most Group Two **вони** forms in this module end in **-ять**:
 
-<!-- INJECT_ACTIVITY: act-4 -->
+| Infinitive | They form |
+| --- | --- |
+| **говорити** | **вони говорять** |
+| **робити** | **вони роблять** |
+| **просити** | **вони просять** |
+| **ходити** | **вони ходять** |
+
+After **ч**, **ш**, **ж**, or **щ**, you often see **-ать**:
+
+| Infinitive | They form |
+| --- | --- |
+| **бачити** | **вони бачать** |
+| **вчити** | **вони вчать** |
+
+This is a spelling and sound pattern, not a new grammar task. If you know
+**вони бачать** and **вони вчать**, you are fine.
 
 ## Група I чи II?
 
-Use the **вони** ending when you need a fast comparison.
+<!-- INJECT_ACTIVITY: act-2 -->
 
-| Infinitive | They form | Group |
+Put the two patterns side by side.
+
+| Person | І дієвідміна: **читати** | ІІ дієвідміна: **говорити** |
 | --- | --- | --- |
-| **читати** | **вони читають** | Group One |
-| **слухати** | **вони слухають** | Group One |
-| **говорити** | **вони говорять** | Group Two |
-| **робити** | **вони роблять** | Group Two |
-| **бачити** | **вони бачать** | Group Two |
-| **ходити** | **вони ходять** | Group Two |
-| **стояти** | **вони стоять** | Group Two |
-| **сидіти** | **вони сидять** | Group Two |
+| я | **читаю** | **говорю** |
+| ти | **читаєш** | **говориш** |
+| він/вона | **читає** | **говорить** |
+| ми | **читаємо** | **говоримо** |
+| ви | **читаєте** | **говорите** |
+| вони | **читають** | **говорять** |
 
-**Стояти** and **сидіти** are useful but slightly tricky, so keep them in
-short present-tense chunks:
+For A1, compare only the visible endings:
 
-```text
-Він стоїть.
-Вона сидить.
-Вони стоять.
-Вони сидять.
-```
+| Quick question | Group One | Group Two |
+| --- | --- | --- |
+| What does **ти** end with? | **-єш**: **читаєш** | **-иш**: **говориш** |
+| What does **він/вона** end with? | **-є**: **читає** | **-ить**: **говорить** |
+| What does **вони** end with? | **-ють**: **читають** | **-ять/-ать**: **говорять**, **бачать** |
 
-Support after the Ukrainian lines:
+Try a quick sort:
 
-| Українська | English support |
-| --- | --- |
-| **Він стоїть.** | He is standing. |
-| **Вона сидить.** | She is sitting. |
-| **Вони стоять.** | They are standing. |
-| **Вони сидять.** | They are sitting. |
+- **читати**, **слухати**, **гуляти**, **працювати** -> Group One;
+- **говорити**, **бачити**, **робити**, **вчити**, **просити**, **ходити** ->
+  Group Two.
 
-### Ще корисні фрази другої групи
+:::tip
+If you forget the group name, ask yourself: **ти читаєш** or **ти говориш**?
+That one sound often gives you the answer.
+:::
 
-Use these in small sentences:
+### Форма на я
 
-| Infinitive | I | you | he/she | we | they |
-| --- | --- | --- | --- | --- | --- |
-| **вчити** | **вчу** | **вчиш** | **вчить** | **вчимо** | **вчать** |
-| **просити** | **прошу** | **просиш** | **просить** | **просимо** | **просять** |
-| **ходити** | **ходжу** | **ходиш** | **ходить** | **ходимо** | **ходять** |
-| **любити** | **люблю** | **любиш** | **любить** | **любимо** | **люблять** |
+Only the **я** form has the most visible consonant changes today.
 
-You already know **любити** from preferences. Now you can recognize why
-**ти любиш** and **вони люблять** fit the Group Two pattern.
+| Infinitive | я form | Keep it as |
+| --- | --- | --- |
+| **робити** | **роблю** | **я роблю** |
+| **ходити** | **ходжу** | **я ходжу** |
+| **просити** | **прошу** | **я прошу** |
+| **бачити** | **бачу** | **я бачу** |
+| **вчити** | **вчу** | **я вчу** |
+
+The rest of each verb is more regular:
 
 ```text
-Я ходжу до школи.
-Ти просиш каву?
-Ми вчимо українську.
-Вони люблять музику.
+ти робиш, він робить, вони роблять
+ти ходиш, він ходить, вони ходять
+ти просиш, він просить, вони просять
 ```
 
-Support after the Ukrainian lines:
+Do not memorize a sound-change rule yet. Memorize the **я** chunk beside the
+infinitive.
 
-| Українська | English support |
-| --- | --- |
-| **Я ходжу до школи.** | I go to school. |
-| **Ти просиш каву?** | Are you asking for coffee? |
-| **Ми вчимо українську.** | We are learning Ukrainian. |
-| **Вони люблять музику.** | They like music. |
-
-### Винятки лише для впізнавання
-
-Some verbs are common but irregular enough to wait. Recognize these, but do
-not build full tables today:
-
-| Infinitive | Recognition form |
-| --- | --- |
-| **спати** | **вони сплять** |
-| **бігти** | later verb |
-| **боятися** | later verb |
-| **дати** | **я дам** |
-| **їсти** | **ти їси**, **вони їдять** |
-
-If you see **я сплю**, answer only the one line you know. Do not invent the
-whole table yet.
-
-The recognition-only list protects your active practice. You can understand
-**вони сплять** or **ти їси** when you meet them, but your speaking task stays
-with the regular Group Two chunks above. This keeps the lesson useful without
-turning every exception into a table.
+<!-- INJECT_ACTIVITY: act-3 -->
 
 ## Підсумок
 
-Keep three ideas separate.
+You now have two present-tense verb groups.
 
-| Job | Tool | Example |
-| --- | --- | --- |
-| speak or ask about language | **говорити** | **Я говорю українською.** |
-| do an exercise | **робити** | **Я роблю вправу.** |
-| see a word | **бачити** | **Я бачу слово.** |
-| compare groups | **вони** ending | **читають** vs **говорять** |
+| Group | Anchor | ти | він/вона | вони |
+| --- | --- | --- | --- | --- |
+| І дієвідміна | **читати** | **читаєш** | **читає** | **читають** |
+| ІІ дієвідміна | **говорити** | **говориш** | **говорить** | **говорять** |
 
-Build a short answer:
+Use these model sentences:
 
-1. **Я говорю українською.**
-2. **Я роблю вправу.**
-3. **Я бачу це слово.**
-4. **Ти бачиш це слово?**
-5. **Ми вчимо українську.**
-6. **Вони ходять до школи.**
+```text
+Я говорю українською.
+Ти бачиш це слово?
+Вона говорить добре.
+Ми вчимо українську.
+Ви просите каву?
+Вони ходять до школи.
+```
 
-Repair the common traps by choosing the ready Ukrainian form:
+Self-check:
 
-| Watch for | Use |
-| --- | --- |
-| Group One ending on **робити** | **Вони роблять.** |
-| **е** where Group Two needs **и** | **Ти бачиш.** |
-| invented **я** form | **Я сиджу.** |
-| old identity pattern | **Я студент.** |
-| English-style name phrase | **Мене звати Томас.** |
-| English-style age phrase | **Мені 20 років.** |
+1. Провідміняйте **бачити** для **я**, **ти**, **він/вона**.
+2. **Слухати** належить до І чи ІІ дієвідміни?
+3. **Говорити** належить до І чи ІІ дієвідміни?
+4. Which form sounds right: **ти говориш** or **ти говорєш**?
+
+<!-- INJECT_ACTIVITY: act-4 -->
+
+You do not need every Ukrainian verb today. You only need a strong second
+pattern: **говорю, говориш, говорить, говоримо, говорите, говорять**. That
+pattern will make the next modules much easier.

--- a/curriculum/l2-uk-en/a1/verbs-group-two/vocabulary.yaml
+++ b/curriculum/l2-uk-en/a1/verbs-group-two/vocabulary.yaml
@@ -5,7 +5,7 @@
 - lemma: говорю
   translation: I speak
   pos: verb form
-  usage: Я говорю українською.
+  usage: Я говорю трохи.
 - lemma: говориш
   translation: you speak
   pos: verb form
@@ -13,27 +13,19 @@
 - lemma: говорить
   translation: he/she speaks
   pos: verb form
-  usage: Вона говорить.
+  usage: Вона говорить добре.
+- lemma: говоримо
+  translation: we speak
+  pos: verb form
+  usage: Ми говоримо повільно.
+- lemma: говорите
+  translation: you speak (plural/formal)
+  pos: verb form
+  usage: Ви говорите українською?
 - lemma: говорять
   translation: they speak
   pos: verb form
   usage: Вони говорять українською.
-- lemma: робити
-  translation: to do; to make
-  pos: infinitive
-  usage: Я роблю вправу.
-- lemma: роблю
-  translation: I do; I make
-  pos: verb form
-  usage: Я роблю вправу.
-- lemma: робиш
-  translation: you do
-  pos: verb form
-  usage: Ти робиш вправу?
-- lemma: роблять
-  translation: they do
-  pos: verb form
-  usage: Вони роблять вправу.
 - lemma: бачити
   translation: to see
   pos: infinitive
@@ -46,70 +38,166 @@
   translation: you see
   pos: verb form
   usage: Ти бачиш це слово?
+- lemma: бачить
+  translation: he/she sees
+  pos: verb form
+  usage: Він бачить слово.
+- lemma: бачимо
+  translation: we see
+  pos: verb form
+  usage: Ми бачимо слово.
+- lemma: бачите
+  translation: you see (plural/formal)
+  pos: verb form
+  usage: Ви бачите слово?
 - lemma: бачать
   translation: they see
   pos: verb form
   usage: Вони бачать слово.
-- lemma: вчити
-  translation: to learn; to teach
+- lemma: робити
+  translation: to do; to make
   pos: infinitive
-  usage: Ми вчимо українську.
-- lemma: вчу
-  translation: I learn
+  usage: Я роблю вправу.
+- lemma: роблю
+  translation: I do; I make
   pos: verb form
-  usage: Я вчу українську.
-- lemma: просити
-  translation: to ask for
+  usage: Я роблю вправу.
+- lemma: робиш
+  translation: you do
+  pos: verb form
+  usage: Ти робиш вправу?
+- lemma: робить
+  translation: he/she does
+  pos: verb form
+  usage: Він робить вправу.
+- lemma: робимо
+  translation: we do
+  pos: verb form
+  usage: Ми робимо вправу.
+- lemma: робите
+  translation: you do (plural/formal)
+  pos: verb form
+  usage: Ви робите вправу?
+- lemma: роблять
+  translation: they do
+  pos: verb form
+  usage: Вони роблять вправу.
+- lemma: вчити
+  translation: to learn; to study; to teach
   pos: infinitive
-  usage: Ти просиш каву?
+  usage: Я вчу українську.
+- lemma: вчу
+  translation: I learn; I study
+  pos: verb form
+  usage: Я вчу нові слова.
+- lemma: вчиш
+  translation: you learn; you study
+  pos: verb form
+  usage: Ти вчиш українську?
+- lemma: вчить
+  translation: he/she learns; he/she studies
+  pos: verb form
+  usage: Вона вчить нові слова.
+- lemma: вчимо
+  translation: we learn; we study
+  pos: verb form
+  usage: Ми вчимо українську.
+- lemma: вчите
+  translation: you learn; you study (plural/formal)
+  pos: verb form
+  usage: Ви вчите нові слова?
+- lemma: вчать
+  translation: they learn; they study
+  pos: verb form
+  usage: Вони вчать нові слова.
+- lemma: просити
+  translation: to ask for; to request
+  pos: infinitive
+  usage: Я прошу каву.
 - lemma: прошу
   translation: I ask for
   pos: verb form
   usage: Я прошу каву.
+- lemma: просиш
+  translation: you ask for
+  pos: verb form
+  usage: Ти просиш каву?
+- lemma: просить
+  translation: he/she asks for
+  pos: verb form
+  usage: Він просить каву.
+- lemma: просимо
+  translation: we ask for
+  pos: verb form
+  usage: Ми просимо каву.
+- lemma: просите
+  translation: you ask for (plural/formal)
+  pos: verb form
+  usage: Ви просите каву?
+- lemma: просять
+  translation: they ask for
+  pos: verb form
+  usage: Вони просять каву.
 - lemma: ходити
   translation: to go regularly; to walk
   pos: infinitive
   usage: Я ходжу до школи.
 - lemma: ходжу
-  translation: I go
+  translation: I go regularly; I walk
   pos: verb form
   usage: Я ходжу до школи.
+- lemma: ходиш
+  translation: you go regularly; you walk
+  pos: verb form
+  usage: Ти ходиш до школи?
+- lemma: ходить
+  translation: he/she goes regularly; he/she walks
+  pos: verb form
+  usage: Вона ходить до школи.
+- lemma: ходимо
+  translation: we go regularly; we walk
+  pos: verb form
+  usage: Ми ходимо до школи.
+- lemma: ходите
+  translation: you go regularly; you walk (plural/formal)
+  pos: verb form
+  usage: Ви ходите до школи?
 - lemma: ходять
-  translation: they go
+  translation: they go regularly; they walk
   pos: verb form
   usage: Вони ходять до школи.
-- lemma: стояти
-  translation: to stand
+- lemma: дивитися
+  translation: to watch; to look (reflexive preview)
   pos: infinitive
-  usage: Він стоїть.
-- lemma: стоїть
-  translation: he/she stands
+  usage: Я дивлюся фільм.
+- lemma: дивлюся
+  translation: I watch; I look (preview)
   pos: verb form
-  usage: Він стоїть.
-- lemma: сидіти
-  translation: to sit
+  usage: Я дивлюся фільм.
+- lemma: вчитися
+  translation: to learn; to study (reflexive preview)
   pos: infinitive
-  usage: Я сиджу.
-- lemma: сиджу
-  translation: I sit
+  usage: Я вчуся.
+- lemma: вчуся
+  translation: I am learning; I study (preview)
   pos: verb form
-  usage: Я сиджу тут.
-- lemma: спати
-  translation: to sleep
+  usage: Дякую, я вчуся.
+- lemma: любити
+  translation: to love; to like
   pos: infinitive
-  usage: Вони сплять.
-- lemma: їсти
-  translation: to eat
-  pos: infinitive
-  usage: Ти їси.
-- lemma: дати
-  translation: to give
-  pos: infinitive
-  usage: Я дам.
+  usage: Ти любиш музику?
+- lemma: любиш
+  translation: you like; you love
+  pos: verb form
+  usage: Ти любиш музику?
+- lemma: люблять
+  translation: they like; they love
+  pos: verb form
+  usage: Вони люблять музику.
 - lemma: трохи
   translation: a little
   pos: adverb
-  usage: Я трохи говорю.
+  usage: Я говорю трохи.
 - lemma: добре
   translation: well
   pos: adverb
@@ -117,4 +205,4 @@
 - lemma: увечері
   translation: in the evening
   pos: adverb
-  usage: Увечері вони ходять до школи.
+  usage: Що ти робиш увечері?

--- a/site/src/content/docs/a1/verbs-group-two.mdx
+++ b/site/src/content/docs/a1/verbs-group-two.mdx
@@ -59,328 +59,304 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs syncKey="module-tab">
 <TabItem label="Lesson">
 
-Group Two is your second present-tense verb pattern. The clearest beginner
-signal is the **вони** form: Group One often ends in **-ють** or **-уть**,
-while Group Two often ends in **-ять** or **-ать**. Today you will use a few
-safe Group Two verbs, then compare them with the Group One forms from the last
-lesson.
+In M16, you learned one present-tense verb pattern: **читати -> читаю,
+читаєш, читає, читаємо, читаєте, читають**. Today you add the second pattern:
+**говорити -> говорю, говориш, говорить, говоримо, говорите, говорять**.
+
+The big beginner signal is small:
+
+- Group One often has **ти ... -єш** and **вони ... -ють**: **ти читаєш**,
+  **вони читають**.
+- Group Two often has **ти ... -иш** and **вони ... -ять/-ать**:
+  **ти говориш**, **вони говорять**, **вони бачать**.
 
 By the end, you can:
 
-- say **Я говорю**, **Ти говориш**, and **Він говорить**;
-- use **робити**, **бачити**, **вчити**, **просити**, and **ходити** in short chunks;
-- recognize **вони говорять**, **вони роблять**, **вони бачать**, and **вони ходять**;
-- compare **І дієвідміна** and **ІІ дієвідміна** by the **вони** ending;
-- keep tricky first-person forms such as **роблю** and **ходжу** as ready chunks;
-- recognize exceptions such as **спати**, **дати**, and **їсти** without making them active grammar yet.
+- conjugate **говорити** in the present tense;
+- use **говорити**, **бачити**, **робити**, **вчити**, **просити**, and
+  **ходити** in short sentences;
+- compare **І дієвідміна** and **ІІ дієвідміна** by the **ти** and **вони**
+  forms;
+- keep first-person chunks such as **роблю**, **ходжу**, and **прошу** ready;
+- recognize **дивлюся** and **вчуся** as useful preview forms with **-ся**.
 
 ## Діалоги
 
-### Розігрів другої групи
+### Провідміняй говорити
 
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "I speak Ukrainian.", "options": [{"text": "Я говорю українською.", "correct": true}, {"text": "Я говориш українською.", "correct": false}, {"text": "Я говорити українською.", "correct": false}], "explanation": "Я uses говорю."}, {"question": "You see the word.", "options": [{"text": "Ти бачиш слово.", "correct": true}, {"text": "Ти бачу слово.", "correct": false}, {"text": "Ти бачити слово.", "correct": false}], "explanation": "Ти uses бачиш."}, {"question": "They are doing an exercise.", "options": [{"text": "Вони роблять вправу.", "correct": true}, {"text": "Вони роблять вправа.", "correct": false}, {"text": "Вони робити вправу.", "correct": false}], "explanation": "Вони роблять is the Group Two form."}]`)} instruction={"Choose the safe Group Two line."} isUkrainian={false} />
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Я говор__ українською.", "answer": "ю", "options": ["ю", "иш", "ить"]}, {"sentence": "Ти говор__ українською?", "answer": "иш", "options": ["иш", "ю", "ять"]}, {"sentence": "Він говор__ добре.", "answer": "ить", "options": ["ить", "иш", "имо"]}, {"sentence": "Вона говор__ повільно.", "answer": "ить", "options": ["ить", "ите", "ю"]}, {"sentence": "Ми говор__ українською.", "answer": "имо", "options": ["имо", "ите", "иш"]}, {"sentence": "Ви говор__ українською?", "answer": "ите", "options": ["ите", "имо", "ить"]}, {"sentence": "Вони говор__ українською.", "answer": "ять", "options": ["ять", "иш", "ю"]}, {"sentence": "Я робл__ вправу.", "answer": "ю", "options": ["ю", "иш", "ять"]}, {"sentence": "Ти бач__ слово?", "answer": "иш", "options": ["иш", "у", "ать"]}, {"sentence": "Вони бач__ слово.", "answer": "ать", "options": ["ать", "иш", "у"]}]`)} instruction={"Choose the ending that completes the Group Two form."} isUkrainian={false} />
 
-Marta and Oleh are still studying. This time they talk about speaking,
-seeing, doing, asking, and walking.
+Тарас and Микола are at the gym. They do simple exercises, rest, and talk
+about what they can say in Ukrainian.
 
 ```text
-Марта: Олеже, ти говориш українською?
-Олег: Так, я говорю українською.
-Марта: Анна говорить англійською?
-Олег: Так, вона говорить англійською.
-Марта: Що ти робиш?
-Олег: Я роблю вправу.
-Марта: Ти бачиш це слово?
-Олег: Так, я бачу це слово.
-Марта: Ми вчимо нові форми?
-Олег: Так, ми вчимо нові форми.
-Марта: Вони ходять до школи?
-Олег: Так, вони ходять до школи.
+Тарас: Ти говориш українською?
+Микола: Так, я говорю трохи. А ти?
+Тарас: Я бачу, що ти добре говориш!
+Микола: Дякую, я вчуся.
 ```
-
-Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Марта: Олеже, ти говориш українською?** | Marta: Oleh, do you speak Ukrainian? |
-| **Олег: Так, я говорю українською.** | Oleh: Yes, I speak Ukrainian. |
-| **Марта: Анна говорить англійською?** | Marta: Does Anna speak English? |
-| **Олег: Так, вона говорить англійською.** | Oleh: Yes, she speaks English. |
-| **Марта: Що ти робиш?** | Marta: What are you doing? |
-| **Олег: Я роблю вправу.** | Oleh: I am doing an exercise. |
-| **Марта: Ти бачиш це слово?** | Marta: Do you see this word? |
-| **Олег: Так, я бачу це слово.** | Oleh: Yes, I see this word. |
-| **Марта: Ми вчимо нові форми?** | Marta: Are we learning new forms? |
-| **Олег: Так, ми вчимо нові форми.** | Oleh: Yes, we are learning new forms. |
-| **Марта: Вони ходять до школи?** | Marta: Do they go to school? |
-| **Олег: Так, вони ходять до школи.** | Oleh: Yes, they go to school. |
+| **Ти говориш українською?** | Do you speak Ukrainian? |
+| **Так, я говорю трохи. А ти?** | Yes, I speak a little. And you? |
+| **Я бачу, що ти добре говориш!** | I see that you speak well! |
+| **Дякую, я вчуся.** | Thanks, I am learning. |
+
+Look at the useful forms:
+
+- **ти говориш** - you speak;
+- **я говорю** - I speak;
+- **я бачу** - I see;
+- **ти добре говориш** - you speak well;
+- **я вчуся** - I am learning.
+
+**Вчуся** has **-ся** at the end. That ending often points to a reflexive
+verb. You do not need the full reflexive system yet. For now, keep **я вчуся**
+as one ready phrase.
+
+Later, at home, Тарас and Микола use two more Group Two chunks.
+
+```text
+Микола: Що ти робиш увечері?
+Тарас: Я дивлюся фільм. А ти?
+Микола: Я вчу нові слова.
+Тарас: Молодець!
+```
+
+| Українська | English support |
+| --- | --- |
+| **Що ти робиш увечері?** | What are you doing in the evening? |
+| **Я дивлюся фільм. А ти?** | I am watching a film. And you? |
+| **Я вчу нові слова.** | I am learning new words. |
+| **Молодець!** | Well done! |
+
+**Дивлюся** also has **-ся**. This module only asks you to recognize it.
+You will work with reflexive verbs more directly later.
+
+The preview infinitives are **вчитися** and **дивитися**. Keep them as
+recognition words today. Your active sentences are only **я вчуся** and
+**я дивлюся фільм**.
 
 :::tip
-Use the **вони** form as your quick check: **читають** points to Group One,
-while **говорять** points to Group Two.
+Your quick check today is the **ти** form: **читаєш** points to Group One,
+while **говориш**, **робиш**, and **бачиш** point to Group Two.
 :::
-
-### Таблиця говорити
-
-<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "я", "right": "говорю"}, {"left": "ти", "right": "говориш"}, {"left": "він / вона", "right": "говорить"}, {"left": "ми", "right": "говоримо"}, {"left": "ви", "right": "говорите"}, {"left": "вони", "right": "говорять"}]`)} instruction={"Match the person with the present-tense form."} isUkrainian={false} />
 
 ## Друга дієвідміна
 
-The textbook label for this pattern is **друга дієвідміна**, or **ІІ
-дієвідміна**. The Group One label from the previous lesson is **І
-дієвідміна**. At A1, do not memorize every rule behind those labels. Use the
-visible forms.
+The Ukrainian term is **друга дієвідміна**, or **ІІ дієвідміна**. The
+infinitive often ends in **-ити**: **говорити**, **бачити**, **робити**,
+**вчити**, **просити**, **ходити**.
 
-| Quick test | Group One | Group Two |
-| --- | --- | --- |
-| they read / speak | **вони читають** | **вони говорять** |
-| they listen / do | **вони слухають** | **вони роблять** |
-| they walk / see | **вони гуляють** | **вони бачать** |
+Use **говорити** as the clean anchor.
 
-Group Two often has **и** in **ти** and **ми** forms: **говориш**,
-**говоримо**, **робиш**, **робимо**. This Ukrainian vowel **[и]** belongs to
-the Ukrainian sound map. For the **українського голосного звука [и]**, listen
-inside the **закінченнях -иш, -имо**: **говориш**, **говоримо**, **робиш**,
-**робимо**. Build the sound from Ukrainian examples, then connect it to the
-written ending.
+| Person | Ending | Form | Safe sentence |
+| --- | --- | --- | --- |
+| я | **-ю** | **говорю** | **Я говорю українською.** |
+| ти | **-иш** | **говориш** | **Ти говориш українською?** |
+| він/вона | **-ить** | **говорить** | **Вона говорить добре.** |
+| ми | **-имо** | **говоримо** | **Ми говоримо повільно.** |
+| ви | **-ите** | **говорите** | **Ви говорите українською?** |
+| вони | **-ять** | **говорять** | **Вони говорять українською.** |
 
-Here is the anchor verb **говорити**:
+Read the table once, then say only three forms aloud:
 
-| Person | Form | Safe sentence |
-| --- | --- | --- |
-| я | **говорю** | **Я говорю українською.** |
-| ти | **говориш** | **Ти говориш українською?** |
-| він/вона | **говорить** | **Вона говорить.** |
-| ми | **говоримо** | **Ми говоримо повільно.** |
-| ви | **говорите** | **Ви говорите?** |
-| вони | **говорять** | **Вони говорять українською.** |
+```text
+Я говорю.
+Ти говориш.
+Вона говорить.
+```
 
-The most important active contrast today is small:
+That is already enough for real conversation.
 
-- **читати** -> **ти читаєш**, **вони читають**;
-- **говорити** -> **ти говориш**, **вони говорять**;
-- **робити** -> **ти робиш**, **вони роблять**.
+### Шість дієслів другої групи
 
-> II дієвідміна.
-> Особові закінчення: -у (-ю), -иш (-їш), -ить, -іть (-їть), -имо, -імо (їмо), -ите (-їте), -ать (-ять): спішу, спішиш, спішить, спішимо, спішите, спішать. В основі наявні суфікси -а-, -и-, -і-(-ї-) (що випадають в особових формах).
+Here are the six active verbs from the plan. The full table is for recognition
+and reuse; your speaking can stay with short chunks.
 
-*— Караман Grade 10, p.179*
+| Infinitive | я | ти | він/вона | ми | ви | вони |
+| --- | --- | --- | --- | --- | --- | --- |
+| **говорити** | **говорю** | **говориш** | **говорить** | **говоримо** | **говорите** | **говорять** |
+| **бачити** | **бачу** | **бачиш** | **бачить** | **бачимо** | **бачите** | **бачать** |
+| **робити** | **роблю** | **робиш** | **робить** | **робимо** | **робите** | **роблять** |
+| **вчити** | **вчу** | **вчиш** | **вчить** | **вчимо** | **вчите** | **вчать** |
+| **просити** | **прошу** | **просиш** | **просить** | **просимо** | **просите** | **просять** |
+| **ходити** | **ходжу** | **ходиш** | **ходить** | **ходимо** | **ходите** | **ходять** |
 
-That source note is for orientation only. Your active verbs are **говорити**,
-**робити**, **бачити**, **вчити**, **просити**, and **ходити**.
+The **я** column has a few ready chunks:
 
-### Говорити, робити, бачити
+- **я роблю** - I do / I make;
+- **я ходжу** - I go regularly / I walk;
+- **я прошу** - I ask for;
+- **я бачу** - I see;
+- **я вчу** - I learn / I study.
 
-<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Я ___ українською.", "answer": "говорю", "options": ["говорю", "говориш", "говорить"]}, {"sentence": "Ти ___ українською?", "answer": "говориш", "options": ["говориш", "говорю", "говоримо"]}, {"sentence": "Він ___.", "answer": "говорить", "options": ["говорить", "говорите", "говорять"]}, {"sentence": "Я ___ вправу.", "answer": "роблю", "options": ["роблю", "робиш", "робить"]}, {"sentence": "Ти ___ слово?", "answer": "бачиш", "options": ["бачиш", "бачу", "бачить"]}, {"sentence": "Вони ___ слово.", "answer": "бачать", "options": ["бачать", "бачиш", "бачу"]}]`)} instruction={"Choose the form that fits the person."} isUkrainian={false} />
-
-### Використовуй говорити, робити, бачити
-
-Use these three verbs first.
-
-| Infinitive | I | you | he/she | they |
-| --- | --- | --- | --- | --- |
-| **говорити** | **говорю** | **говориш** | **говорить** | **говорять** |
-| **робити** | **роблю** | **робиш** | **робить** | **роблять** |
-| **бачити** | **бачу** | **бачиш** | **бачить** | **бачать** |
-
-The **я** form can change inside the word. Do not calculate it today. Learn a
-`готовий чанк`: **я роблю**, **я ходжу**, **я прошу**, **я сиджу**, **я бачу**.
-Then use the simple **ти** and **він/вона** forms:
+Do not calculate those forms during speech. Learn them as chunks.
 
 ```text
 Я роблю вправу.
-Ти робиш вправу?
-Він робить вправу.
 Я бачу слово.
-Ти бачиш слово?
+Я прошу каву.
+Я ходжу до школи.
+Я вчу українську.
 ```
-
-Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
 | **Я роблю вправу.** | I am doing an exercise. |
-| **Ти робиш вправу?** | Are you doing an exercise? |
-| **Він робить вправу.** | He is doing an exercise. |
 | **Я бачу слово.** | I see a word. |
-| **Ти бачиш слово?** | Do you see a word? |
+| **Я прошу каву.** | I ask for coffee. |
+| **Я ходжу до школи.** | I go to school regularly. |
+| **Я вчу українську.** | I study Ukrainian. |
 
-When you write your own line, choose one verb and one useful object. Keep the
-object familiar:
+You also know **любити** from M15. It is a Group Two verb too: **ти любиш**,
+**вони люблять**. Keep it as review, not as a new table.
 
-| Verb chunk | Add this | Sentence |
-| --- | --- | --- |
-| **я роблю** | **вправу** | **Я роблю вправу.** |
-| **я бачу** | **слово** | **Я бачу слово.** |
-| **я прошу** | **каву** | **Я прошу каву.** |
-| **я ходжу** | **до школи** | **Я ходжу до школи.** |
+### -ять чи -ать?
 
-This is enough for real speech. You do not need to explain why **робити**
-gives **роблю** before you can use **Я роблю вправу**.
+Most Group Two **вони** forms in this module end in **-ять**:
 
-### Перша чи друга група
+| Infinitive | They form |
+| --- | --- |
+| **говорити** | **вони говорять** |
+| **робити** | **вони роблять** |
+| **просити** | **вони просять** |
+| **ходити** | **вони ходять** |
 
-<GroupSort client:only='react' groups={JSON.parse(`{"І дієвідміна / Group One": ["читають", "слухають", "гуляють"], "ІІ дієвідміна / Group Two": ["говорять", "роблять", "бачать", "ходять", "стоять", "сидять"]}`)} instruction={"Sort the they-forms by group."} isUkrainian={false} />
+After **ч**, **ш**, **ж**, or **щ**, you often see **-ать**:
+
+| Infinitive | They form |
+| --- | --- |
+| **бачити** | **вони бачать** |
+| **вчити** | **вони вчать** |
+
+This is a spelling and sound pattern, not a new grammar task. If you know
+**вони бачать** and **вони вчать**, you are fine.
 
 ## Група I чи II?
 
-Use the **вони** ending when you need a fast comparison.
+### І чи ІІ дієвідміна
 
-| Infinitive | They form | Group |
+<GroupSort client:only='react' groups={JSON.parse(`{"І дієвідміна / Group One": ["читати", "слухати", "гуляти", "працювати"], "ІІ дієвідміна / Group Two": ["говорити", "бачити", "робити", "вчити", "просити", "ходити"]}`)} instruction={"Sort the infinitives by the present-tense group."} isUkrainian={false} />
+
+Put the two patterns side by side.
+
+| Person | І дієвідміна: **читати** | ІІ дієвідміна: **говорити** |
 | --- | --- | --- |
-| **читати** | **вони читають** | Group One |
-| **слухати** | **вони слухають** | Group One |
-| **говорити** | **вони говорять** | Group Two |
-| **робити** | **вони роблять** | Group Two |
-| **бачити** | **вони бачать** | Group Two |
-| **ходити** | **вони ходять** | Group Two |
-| **стояти** | **вони стоять** | Group Two |
-| **сидіти** | **вони сидять** | Group Two |
+| я | **читаю** | **говорю** |
+| ти | **читаєш** | **говориш** |
+| він/вона | **читає** | **говорить** |
+| ми | **читаємо** | **говоримо** |
+| ви | **читаєте** | **говорите** |
+| вони | **читають** | **говорять** |
 
-**Стояти** and **сидіти** are useful but slightly tricky, so keep them in
-short present-tense chunks:
+For A1, compare only the visible endings:
 
-```text
-Він стоїть.
-Вона сидить.
-Вони стоять.
-Вони сидять.
-```
+| Quick question | Group One | Group Two |
+| --- | --- | --- |
+| What does **ти** end with? | **-єш**: **читаєш** | **-иш**: **говориш** |
+| What does **він/вона** end with? | **-є**: **читає** | **-ить**: **говорить** |
+| What does **вони** end with? | **-ють**: **читають** | **-ять/-ать**: **говорять**, **бачать** |
 
-Support after the Ukrainian lines:
+Try a quick sort:
 
-| Українська | English support |
-| --- | --- |
-| **Він стоїть.** | He is standing. |
-| **Вона сидить.** | She is sitting. |
-| **Вони стоять.** | They are standing. |
-| **Вони сидять.** | They are sitting. |
+- **читати**, **слухати**, **гуляти**, **працювати** -> Group One;
+- **говорити**, **бачити**, **робити**, **вчити**, **просити**, **ходити** ->
+  Group Two.
 
-### Ще корисні фрази другої групи
+:::tip
+If you forget the group name, ask yourself: **ти читаєш** or **ти говориш**?
+That one sound often gives you the answer.
+:::
 
-Use these in small sentences:
+### Форма на я
 
-| Infinitive | I | you | he/she | we | they |
-| --- | --- | --- | --- | --- | --- |
-| **вчити** | **вчу** | **вчиш** | **вчить** | **вчимо** | **вчать** |
-| **просити** | **прошу** | **просиш** | **просить** | **просимо** | **просять** |
-| **ходити** | **ходжу** | **ходиш** | **ходить** | **ходимо** | **ходять** |
-| **любити** | **люблю** | **любиш** | **любить** | **любимо** | **люблять** |
+Only the **я** form has the most visible consonant changes today.
 
-You already know **любити** from preferences. Now you can recognize why
-**ти любиш** and **вони люблять** fit the Group Two pattern.
+| Infinitive | я form | Keep it as |
+| --- | --- | --- |
+| **робити** | **роблю** | **я роблю** |
+| **ходити** | **ходжу** | **я ходжу** |
+| **просити** | **прошу** | **я прошу** |
+| **бачити** | **бачу** | **я бачу** |
+| **вчити** | **вчу** | **я вчу** |
+
+The rest of each verb is more regular:
 
 ```text
-Я ходжу до школи.
-Ти просиш каву?
-Ми вчимо українську.
-Вони люблять музику.
+ти робиш, він робить, вони роблять
+ти ходиш, він ходить, вони ходять
+ти просиш, він просить, вони просять
 ```
 
-Support after the Ukrainian lines:
+Do not memorize a sound-change rule yet. Memorize the **я** chunk beside the
+infinitive.
 
-| Українська | English support |
-| --- | --- |
-| **Я ходжу до школи.** | I go to school. |
-| **Ти просиш каву?** | Are you asking for coffee? |
-| **Ми вчимо українську.** | We are learning Ukrainian. |
-| **Вони люблять музику.** | They like music. |
+### Обери правильну форму
 
-### Винятки лише для впізнавання
-
-Some verbs are common but irregular enough to wait. Recognize these, but do
-not build full tables today:
-
-| Infinitive | Recognition form |
-| --- | --- |
-| **спати** | **вони сплять** |
-| **бігти** | later verb |
-| **боятися** | later verb |
-| **дати** | **я дам** |
-| **їсти** | **ти їси**, **вони їдять** |
-
-If you see **я сплю**, answer only the one line you know. Do not invent the
-whole table yet.
-
-The recognition-only list protects your active practice. You can understand
-**вони сплять** or **ти їси** when you meet them, but your speaking task stays
-with the regular Group Two chunks above. This keeps the lesson useful without
-turning every exception into a table.
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Ти ___ українською?", "options": [{"text": "говориш", "correct": true}, {"text": "говорю", "correct": false}, {"text": "говорить", "correct": false}], "explanation": "Ти говориш."}, {"question": "Вона ___ добре.", "options": [{"text": "говорить", "correct": true}, {"text": "говориш", "correct": false}, {"text": "говорять", "correct": false}], "explanation": "Вона говорить."}, {"question": "Ми ___ українську.", "options": [{"text": "вчимо", "correct": true}, {"text": "вчиш", "correct": false}, {"text": "вчить", "correct": false}], "explanation": "Ми вчимо."}, {"question": "Я ___ це слово.", "options": [{"text": "бачу", "correct": true}, {"text": "бачиш", "correct": false}, {"text": "бачить", "correct": false}], "explanation": "Я бачу."}, {"question": "Ти ___ це слово?", "options": [{"text": "бачиш", "correct": true}, {"text": "бачу", "correct": false}, {"text": "бачать", "correct": false}], "explanation": "Ти бачиш."}, {"question": "Вони ___ до школи.", "options": [{"text": "ходять", "correct": true}, {"text": "ходиш", "correct": false}, {"text": "ходжу", "correct": false}], "explanation": "Вони ходять."}, {"question": "Я ___ каву.", "options": [{"text": "прошу", "correct": true}, {"text": "просиш", "correct": false}, {"text": "просить", "correct": false}], "explanation": "Я прошу is the ready first-person chunk."}, {"question": "Вони ___ слово.", "options": [{"text": "бачать", "correct": true}, {"text": "бачиш", "correct": false}, {"text": "бачу", "correct": false}], "explanation": "Вони бачать uses -ать after ч."}]`)} instruction={"Choose the form that fits the sentence."} isUkrainian={false} />
 
 ## 📋 Підсумок
 
-Keep three ideas separate.
+You now have two present-tense verb groups.
 
-| Job | Tool | Example |
-| --- | --- | --- |
-| speak or ask about language | **говорити** | **Я говорю українською.** |
-| do an exercise | **робити** | **Я роблю вправу.** |
-| see a word | **бачити** | **Я бачу слово.** |
-| compare groups | **вони** ending | **читають** vs **говорять** |
+| Group | Anchor | ти | він/вона | вони |
+| --- | --- | --- | --- | --- |
+| І дієвідміна | **читати** | **читаєш** | **читає** | **читають** |
+| ІІ дієвідміна | **говорити** | **говориш** | **говорить** | **говорять** |
 
-Build a short answer:
+Use these model sentences:
 
-1. **Я говорю українською.**
-2. **Я роблю вправу.**
-3. **Я бачу це слово.**
-4. **Ти бачиш це слово?**
-5. **Ми вчимо українську.**
-6. **Вони ходять до школи.**
+```text
+Я говорю українською.
+Ти бачиш це слово?
+Вона говорить добре.
+Ми вчимо українську.
+Ви просите каву?
+Вони ходять до школи.
+```
 
-Repair the common traps by choosing the ready Ukrainian form:
+Self-check:
 
-| Watch for | Use |
-| --- | --- |
-| Group One ending on **робити** | **Вони роблять.** |
-| **е** where Group Two needs **и** | **Ти бачиш.** |
-| invented **я** form | **Я сиджу.** |
-| old identity pattern | **Я студент.** |
-| English-style name phrase | **Мене звати Томас.** |
-| English-style age phrase | **Мені 20 років.** |
+1. Провідміняйте **бачити** для **я**, **ти**, **він/вона**.
+2. **Слухати** належить до І чи ІІ дієвідміни?
+3. **Говорити** належить до І чи ІІ дієвідміни?
+4. Which form sounds right: **ти говориш** or **ти говорєш**?
+
+### Доповни речення
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Вона ___ українською. (говорити)", "answer": "говорить", "options": ["говорить", "говориш", "говорю"]}, {"sentence": "Я ___ вправу. (робити)", "answer": "роблю", "options": ["роблю", "робиш", "робить"]}, {"sentence": "Ти ___ слово? (бачити)", "answer": "бачиш", "options": ["бачиш", "бачу", "бачать"]}, {"sentence": "Ми ___ нові слова. (вчити)", "answer": "вчимо", "options": ["вчимо", "вчиш", "вчать"]}, {"sentence": "Я ___ каву. (просити)", "answer": "прошу", "options": ["прошу", "просиш", "просить"]}, {"sentence": "Вони ___ до школи. (ходити)", "answer": "ходять", "options": ["ходять", "ходиш", "ходжу"]}]`)} instruction={"Choose the correct present-tense form."} isUkrainian={false} />
+
+You do not need every Ukrainian verb today. You only need a strong second
+pattern: **говорю, говориш, говорить, говоримо, говорите, говорять**. That
+pattern will make the next modules much easier.
 
 </TabItem>
 <TabItem label="Vocabulary">
 
-<VocabCard client:only="react" words={JSON.parse(`[{"word":"говорити","translation":"to speak; to talk","pos":"infinitive","example":"Я говорю українською.","examples":["to speak; to talk","Я говорю українською."],"atlas_href":"/lexicon/говорити/"},{"word":"говорю","translation":"I speak","pos":"verb form","example":"Я говорю українською.","examples":["I speak","Я говорю українською."],"atlas_href":"/lexicon/говорю/"},{"word":"говориш","translation":"you speak","pos":"verb form","example":"Ти говориш українською?","examples":["you speak","Ти говориш українською?"],"atlas_href":"/lexicon/говориш/"},{"word":"говорить","translation":"he/she speaks","pos":"verb form","example":"Вона говорить.","examples":["he/she speaks","Вона говорить."],"atlas_href":"/lexicon/говорить/"},{"word":"говорять","translation":"they speak","pos":"verb form","example":"Вони говорять українською.","examples":["they speak","Вони говорять українською."],"atlas_href":"/lexicon/говорять/"},{"word":"робити","translation":"to do; to make","pos":"infinitive","example":"Я роблю вправу.","examples":["to do; to make","Я роблю вправу."],"atlas_href":"/lexicon/робити/"},{"word":"роблю","translation":"I do; I make","pos":"verb form","example":"Я роблю вправу.","examples":["I do; I make","Я роблю вправу."],"atlas_href":"/lexicon/роблю/"},{"word":"робиш","translation":"you do","pos":"verb form","example":"Ти робиш вправу?","examples":["you do","Ти робиш вправу?"],"atlas_href":"/lexicon/робиш/"},{"word":"роблять","translation":"they do","pos":"verb form","example":"Вони роблять вправу.","examples":["they do","Вони роблять вправу."],"atlas_href":"/lexicon/роблять/"},{"word":"бачити","translation":"to see","pos":"infinitive","example":"Я бачу слово.","examples":["to see","Я бачу слово."],"atlas_href":"/lexicon/бачити/"},{"word":"бачу","translation":"I see","pos":"verb form","example":"Я бачу це слово.","examples":["I see","Я бачу це слово."],"atlas_href":"/lexicon/бачу/"},{"word":"бачиш","translation":"you see","pos":"verb form","example":"Ти бачиш це слово?","examples":["you see","Ти бачиш це слово?"],"atlas_href":"/lexicon/бачиш/"},{"word":"бачать","translation":"they see","pos":"verb form","example":"Вони бачать слово.","examples":["they see","Вони бачать слово."],"atlas_href":"/lexicon/бачать/"},{"word":"вчити","translation":"to learn; to teach","pos":"infinitive","example":"Ми вчимо українську.","examples":["to learn; to teach","Ми вчимо українську."],"atlas_href":"/lexicon/вчити/"},{"word":"вчу","translation":"I learn","pos":"verb form","example":"Я вчу українську.","examples":["I learn","Я вчу українську."],"atlas_href":"/lexicon/вчу/"},{"word":"просити","translation":"to ask for","pos":"infinitive","example":"Ти просиш каву?","examples":["to ask for","Ти просиш каву?"],"atlas_href":"/lexicon/просити/"},{"word":"прошу","translation":"I ask for","pos":"verb form","example":"Я прошу каву.","examples":["I ask for","Я прошу каву."],"atlas_href":"/lexicon/прошу/"},{"word":"ходити","translation":"to go regularly; to walk","pos":"infinitive","example":"Я ходжу до школи.","examples":["to go regularly; to walk","Я ходжу до школи."],"atlas_href":"/lexicon/ходити/"},{"word":"ходжу","translation":"I go","pos":"verb form","example":"Я ходжу до школи.","examples":["I go","Я ходжу до школи."],"atlas_href":"/lexicon/ходжу/"},{"word":"ходять","translation":"they go","pos":"verb form","example":"Вони ходять до школи.","examples":["they go","Вони ходять до школи."],"atlas_href":"/lexicon/ходять/"},{"word":"стояти","translation":"to stand","pos":"infinitive","example":"Він стоїть.","examples":["to stand","Він стоїть."],"atlas_href":"/lexicon/стояти/"},{"word":"стоїть","translation":"he/she stands","pos":"verb form","example":"Він стоїть.","examples":["he/she stands","Він стоїть."],"atlas_href":"/lexicon/стоїть/"},{"word":"сидіти","translation":"to sit","pos":"infinitive","example":"Я сиджу.","examples":["to sit","Я сиджу."],"atlas_href":"/lexicon/сидіти/"},{"word":"сиджу","translation":"I sit","pos":"verb form","example":"Я сиджу тут.","examples":["I sit","Я сиджу тут."],"atlas_href":"/lexicon/сиджу/"},{"word":"спати","translation":"to sleep","pos":"infinitive","example":"Вони сплять.","examples":["to sleep","Вони сплять."],"atlas_href":"/lexicon/спати/"},{"word":"їсти","translation":"to eat","pos":"infinitive","example":"Ти їси.","examples":["to eat","Ти їси."],"atlas_href":"/lexicon/їсти/"},{"word":"дати","translation":"to give","pos":"infinitive","example":"Я дам.","examples":["to give","Я дам."],"atlas_href":"/lexicon/дати/"},{"word":"трохи","translation":"a little","pos":"adverb","example":"Я трохи говорю.","examples":["a little","Я трохи говорю."],"atlas_href":"/lexicon/трохи/"},{"word":"добре","translation":"well","pos":"adverb","example":"Ти добре говориш.","examples":["well","Ти добре говориш."],"atlas_href":"/lexicon/до-бре/"},{"word":"увечері","translation":"in the evening","pos":"adverb","example":"Увечері вони ходять до школи.","examples":["in the evening","Увечері вони ходять до школи."],"atlas_href":"/lexicon/увечері/"}]`)} title="Vocabulary" />
+<VocabCard client:only="react" words={JSON.parse(`[{"word":"говорити","translation":"to speak; to talk","pos":"infinitive","example":"Я говорю українською.","examples":["to speak; to talk","Я говорю українською."],"atlas_href":"/lexicon/говорити/"},{"word":"говорю","translation":"I speak","pos":"verb form","example":"Я говорю трохи.","examples":["I speak","Я говорю трохи."]},{"word":"говориш","translation":"you speak","pos":"verb form","example":"Ти говориш українською?","examples":["you speak","Ти говориш українською?"]},{"word":"говорить","translation":"he/she speaks","pos":"verb form","example":"Вона говорить добре.","examples":["he/she speaks","Вона говорить добре."]},{"word":"говоримо","translation":"we speak","pos":"verb form","example":"Ми говоримо повільно.","examples":["we speak","Ми говоримо повільно."]},{"word":"говорите","translation":"you speak (plural/formal)","pos":"verb form","example":"Ви говорите українською?","examples":["you speak (plural/formal)","Ви говорите українською?"]},{"word":"говорять","translation":"they speak","pos":"verb form","example":"Вони говорять українською.","examples":["they speak","Вони говорять українською."]},{"word":"бачити","translation":"to see","pos":"infinitive","example":"Я бачу слово.","examples":["to see","Я бачу слово."],"atlas_href":"/lexicon/бачити/"},{"word":"бачу","translation":"I see","pos":"verb form","example":"Я бачу це слово.","examples":["I see","Я бачу це слово."]},{"word":"бачиш","translation":"you see","pos":"verb form","example":"Ти бачиш це слово?","examples":["you see","Ти бачиш це слово?"]},{"word":"бачить","translation":"he/she sees","pos":"verb form","example":"Він бачить слово.","examples":["he/she sees","Він бачить слово."]},{"word":"бачимо","translation":"we see","pos":"verb form","example":"Ми бачимо слово.","examples":["we see","Ми бачимо слово."]},{"word":"бачите","translation":"you see (plural/formal)","pos":"verb form","example":"Ви бачите слово?","examples":["you see (plural/formal)","Ви бачите слово?"]},{"word":"бачать","translation":"they see","pos":"verb form","example":"Вони бачать слово.","examples":["they see","Вони бачать слово."]},{"word":"робити","translation":"to do; to make","pos":"infinitive","example":"Я роблю вправу.","examples":["to do; to make","Я роблю вправу."],"atlas_href":"/lexicon/робити/"},{"word":"роблю","translation":"I do; I make","pos":"verb form","example":"Я роблю вправу.","examples":["I do; I make","Я роблю вправу."]},{"word":"робиш","translation":"you do","pos":"verb form","example":"Ти робиш вправу?","examples":["you do","Ти робиш вправу?"]},{"word":"робить","translation":"he/she does","pos":"verb form","example":"Він робить вправу.","examples":["he/she does","Він робить вправу."]},{"word":"робимо","translation":"we do","pos":"verb form","example":"Ми робимо вправу.","examples":["we do","Ми робимо вправу."]},{"word":"робите","translation":"you do (plural/formal)","pos":"verb form","example":"Ви робите вправу?","examples":["you do (plural/formal)","Ви робите вправу?"]},{"word":"роблять","translation":"they do","pos":"verb form","example":"Вони роблять вправу.","examples":["they do","Вони роблять вправу."]},{"word":"вчити","translation":"to learn; to study; to teach","pos":"infinitive","example":"Я вчу українську.","examples":["to learn; to study; to teach","Я вчу українську."],"atlas_href":"/lexicon/вчити/"},{"word":"вчу","translation":"I learn; I study","pos":"verb form","example":"Я вчу нові слова.","examples":["I learn; I study","Я вчу нові слова."]},{"word":"вчиш","translation":"you learn; you study","pos":"verb form","example":"Ти вчиш українську?","examples":["you learn; you study","Ти вчиш українську?"]},{"word":"вчить","translation":"he/she learns; he/she studies","pos":"verb form","example":"Вона вчить нові слова.","examples":["he/she learns; he/she studies","Вона вчить нові слова."]},{"word":"вчимо","translation":"we learn; we study","pos":"verb form","example":"Ми вчимо українську.","examples":["we learn; we study","Ми вчимо українську."]},{"word":"вчите","translation":"you learn; you study (plural/formal)","pos":"verb form","example":"Ви вчите нові слова?","examples":["you learn; you study (plural/formal)","Ви вчите нові слова?"]},{"word":"вчать","translation":"they learn; they study","pos":"verb form","example":"Вони вчать нові слова.","examples":["they learn; they study","Вони вчать нові слова."]},{"word":"просити","translation":"to ask for; to request","pos":"infinitive","example":"Я прошу каву.","examples":["to ask for; to request","Я прошу каву."],"atlas_href":"/lexicon/просити/"},{"word":"прошу","translation":"I ask for","pos":"verb form","example":"Я прошу каву.","examples":["I ask for","Я прошу каву."],"atlas_href":"/lexicon/прошу/"},{"word":"просиш","translation":"you ask for","pos":"verb form","example":"Ти просиш каву?","examples":["you ask for","Ти просиш каву?"]},{"word":"просить","translation":"he/she asks for","pos":"verb form","example":"Він просить каву.","examples":["he/she asks for","Він просить каву."]},{"word":"просимо","translation":"we ask for","pos":"verb form","example":"Ми просимо каву.","examples":["we ask for","Ми просимо каву."]},{"word":"просите","translation":"you ask for (plural/formal)","pos":"verb form","example":"Ви просите каву?","examples":["you ask for (plural/formal)","Ви просите каву?"]},{"word":"просять","translation":"they ask for","pos":"verb form","example":"Вони просять каву.","examples":["they ask for","Вони просять каву."]},{"word":"ходити","translation":"to go regularly; to walk","pos":"infinitive","example":"Я ходжу до школи.","examples":["to go regularly; to walk","Я ходжу до школи."],"atlas_href":"/lexicon/ходити/"},{"word":"ходжу","translation":"I go regularly; I walk","pos":"verb form","example":"Я ходжу до школи.","examples":["I go regularly; I walk","Я ходжу до школи."]},{"word":"ходиш","translation":"you go regularly; you walk","pos":"verb form","example":"Ти ходиш до школи?","examples":["you go regularly; you walk","Ти ходиш до школи?"]},{"word":"ходить","translation":"he/she goes regularly; he/she walks","pos":"verb form","example":"Вона ходить до школи.","examples":["he/she goes regularly; he/she walks","Вона ходить до школи."]},{"word":"ходимо","translation":"we go regularly; we walk","pos":"verb form","example":"Ми ходимо до школи.","examples":["we go regularly; we walk","Ми ходимо до школи."]},{"word":"ходите","translation":"you go regularly; you walk (plural/formal)","pos":"verb form","example":"Ви ходите до школи?","examples":["you go regularly; you walk (plural/formal)","Ви ходите до школи?"]},{"word":"ходять","translation":"they go regularly; they walk","pos":"verb form","example":"Вони ходять до школи.","examples":["they go regularly; they walk","Вони ходять до школи."]},{"word":"дивитися","translation":"to watch; to look (reflexive preview)","pos":"infinitive","example":"Я дивлюся фільм.","examples":["to watch; to look (reflexive preview)","Я дивлюся фільм."],"atlas_href":"/lexicon/дивитися/"},{"word":"дивлюся","translation":"I watch; I look (preview)","pos":"verb form","example":"Я дивлюся фільм.","examples":["I watch; I look (preview)","Я дивлюся фільм."]},{"word":"вчитися","translation":"to learn; to study (reflexive preview)","pos":"infinitive","example":"Я вчуся.","examples":["to learn; to study (reflexive preview)","Я вчуся."],"atlas_href":"/lexicon/вчитися/"},{"word":"вчуся","translation":"I am learning; I study (preview)","pos":"verb form","example":"Дякую, я вчуся.","examples":["I am learning; I study (preview)","Дякую, я вчуся."]},{"word":"любити","translation":"to love; to like","pos":"infinitive","example":"Ти любиш музику?","examples":["to love; to like","Ти любиш музику?"],"atlas_href":"/lexicon/любити/"},{"word":"любиш","translation":"you like; you love","pos":"verb form","example":"Ти любиш музику?","examples":["you like; you love","Ти любиш музику?"]},{"word":"люблять","translation":"they like; they love","pos":"verb form","example":"Вони люблять музику.","examples":["they like; they love","Вони люблять музику."]},{"word":"трохи","translation":"a little","pos":"adverb","example":"Я говорю трохи.","examples":["a little","Я говорю трохи."],"atlas_href":"/lexicon/трохи/"},{"word":"добре","translation":"well","pos":"adverb","example":"Ти добре говориш.","examples":["well","Ти добре говориш."],"atlas_href":"/lexicon/до-бре/"},{"word":"увечері","translation":"in the evening","pos":"adverb","example":"Що ти робиш увечері?","examples":["in the evening","Що ти робиш увечері?"],"atlas_href":"/lexicon/увечері/"}]`)} title="Vocabulary" />
 
-<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"говорити","back":"to speak; to talk"},{"front":"говорю","back":"I speak"},{"front":"говориш","back":"you speak"},{"front":"говорить","back":"he/she speaks"},{"front":"говорять","back":"they speak"},{"front":"робити","back":"to do; to make"},{"front":"роблю","back":"I do; I make"},{"front":"робиш","back":"you do"},{"front":"роблять","back":"they do"},{"front":"бачити","back":"to see"},{"front":"бачу","back":"I see"},{"front":"бачиш","back":"you see"},{"front":"бачать","back":"they see"},{"front":"вчити","back":"to learn; to teach"},{"front":"вчу","back":"I learn"},{"front":"просити","back":"to ask for"},{"front":"прошу","back":"I ask for"},{"front":"ходити","back":"to go regularly; to walk"},{"front":"ходжу","back":"I go"},{"front":"ходять","back":"they go"},{"front":"стояти","back":"to stand"},{"front":"стоїть","back":"he/she stands"},{"front":"сидіти","back":"to sit"},{"front":"сиджу","back":"I sit"},{"front":"спати","back":"to sleep"},{"front":"їсти","back":"to eat"},{"front":"дати","back":"to give"},{"front":"трохи","back":"a little"},{"front":"добре","back":"well"},{"front":"увечері","back":"in the evening"}]`)} />
+<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"говорити","back":"to speak; to talk"},{"front":"говорю","back":"I speak"},{"front":"говориш","back":"you speak"},{"front":"говорить","back":"he/she speaks"},{"front":"говоримо","back":"we speak"},{"front":"говорите","back":"you speak (plural/formal)"},{"front":"говорять","back":"they speak"},{"front":"бачити","back":"to see"},{"front":"бачу","back":"I see"},{"front":"бачиш","back":"you see"},{"front":"бачить","back":"he/she sees"},{"front":"бачимо","back":"we see"},{"front":"бачите","back":"you see (plural/formal)"},{"front":"бачать","back":"they see"},{"front":"робити","back":"to do; to make"},{"front":"роблю","back":"I do; I make"},{"front":"робиш","back":"you do"},{"front":"робить","back":"he/she does"},{"front":"робимо","back":"we do"},{"front":"робите","back":"you do (plural/formal)"},{"front":"роблять","back":"they do"},{"front":"вчити","back":"to learn; to study; to teach"},{"front":"вчу","back":"I learn; I study"},{"front":"вчиш","back":"you learn; you study"},{"front":"вчить","back":"he/she learns; he/she studies"},{"front":"вчимо","back":"we learn; we study"},{"front":"вчите","back":"you learn; you study (plural/formal)"},{"front":"вчать","back":"they learn; they study"},{"front":"просити","back":"to ask for; to request"},{"front":"прошу","back":"I ask for"},{"front":"просиш","back":"you ask for"},{"front":"просить","back":"he/she asks for"},{"front":"просимо","back":"we ask for"},{"front":"просите","back":"you ask for (plural/formal)"},{"front":"просять","back":"they ask for"},{"front":"ходити","back":"to go regularly; to walk"},{"front":"ходжу","back":"I go regularly; I walk"},{"front":"ходиш","back":"you go regularly; you walk"},{"front":"ходить","back":"he/she goes regularly; he/she walks"},{"front":"ходимо","back":"we go regularly; we walk"},{"front":"ходите","back":"you go regularly; you walk (plural/formal)"},{"front":"ходять","back":"they go regularly; they walk"},{"front":"дивитися","back":"to watch; to look (reflexive preview)"},{"front":"дивлюся","back":"I watch; I look (preview)"},{"front":"вчитися","back":"to learn; to study (reflexive preview)"},{"front":"вчуся","back":"I am learning; I study (preview)"},{"front":"любити","back":"to love; to like"},{"front":"любиш","back":"you like; you love"},{"front":"люблять","back":"they like; they love"},{"front":"трохи","back":"a little"},{"front":"добре","back":"well"},{"front":"увечері","back":"in the evening"}]`)} />
 
 </TabItem>
 <TabItem label="Activities">
 
-### Розігрів другої групи
+### Провідміняй говорити
 
 *(see lesson, §Діалоги)*
 
-### Таблиця говорити
+### І чи ІІ дієвідміна
 
-*(see lesson, §Діалоги)*
+*(see lesson, §Група I чи II?)*
 
-### Говорити, робити, бачити
+### Обери правильну форму
 
-*(see lesson, §Друга дієвідміна)*
+*(see lesson, §Форма на я)*
 
-### Перша чи друга група
+### Доповни речення
 
-*(see lesson, §Використовуй говорити, робити, бачити)*
-
-### Готові фрази з «я»
-
-<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Я ___ вправу.", "answer": "роблю", "options": ["роблю", "робиш", "робить"]}, {"sentence": "Я ___ до школи.", "answer": "ходжу", "options": ["ходжу", "ходиш", "ходить"]}, {"sentence": "Я ___ каву.", "answer": "прошу", "options": ["прошу", "просиш", "просить"]}, {"sentence": "Я ___ тут.", "answer": "сиджу", "options": ["сиджу", "сидиш", "сидить"]}]`)} instruction={"Choose the ready first-person chunk."} isUkrainian={false} />
-
-### Форми лише для впізнавання
-
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "They sleep.", "options": [{"text": "Вони сплять.", "correct": true}, {"text": "Вони спати.", "correct": false}, {"text": "Вони спить.", "correct": false}], "explanation": "Recognize вони сплять."}, {"question": "You eat.", "options": [{"text": "Ти їси.", "correct": true}, {"text": "Ти їсть.", "correct": false}, {"text": "Ти їдять.", "correct": false}], "explanation": "Recognize ти їси."}, {"question": "They eat.", "options": [{"text": "Вони їдять.", "correct": true}, {"text": "Вони їси.", "correct": false}, {"text": "Вони їсть.", "correct": false}], "explanation": "Recognize вони їдять."}]`)} instruction={"Choose the form you should recognize, not overbuild."} isUkrainian={false} />
-
-<span id="group-two-repairs"></span>
-
-### Виправ пастки другої групи
-
-<ErrorCorrection client:only='react' instruction="Choose the standard Ukrainian repair." items={JSON.parse(`[{"sentence": "Вони робуть", "errorWord": "Вони робуть", "correctForm": "Вони роблять", "options": ["Вони роблять", "Вони працюють", "Вони читають"], "explanation": "Робити uses вони роблять."}, {"sentence": "Ти бачеш", "errorWord": "Ти бачеш", "correctForm": "Ти бачиш", "options": ["Ти бачиш", "Ти говориш", "Ти робиш"], "explanation": "Group Two uses бачиш."}, {"sentence": "Я сидю", "errorWord": "Я сидю", "correctForm": "Я сиджу", "options": ["Я сиджу", "Я ходжу", "Я бачу"], "explanation": "Learn я сиджу as a ready chunk."}, {"sentence": "Він стоє", "errorWord": "Він стоє", "correctForm": "Він стоїть", "options": ["Він стоїть", "Він сидить", "Він говорить"], "explanation": "Стояти gives він стоїть."}, {"sentence": "Я сплю, ти сплєш", "errorWord": "Я сплю, ти сплєш", "correctForm": "Я сплю, ти спиш", "options": ["Я сплю, ти спиш", "Я сплю, ти їси", "Я сплю, ти сидиш"], "explanation": "Recognize ти спиш; do not invent the form."}, {"sentence": "Я є студент", "errorWord": "Я є студент", "correctForm": "Я студент", "options": ["Я студент", "Я вчитель", "Я Томас"], "explanation": "Ukrainian can use Я студент without є."}, {"sentence": "Моє ім'я є Томас", "errorWord": "Моє ім'я є Томас", "correctForm": "Мене звати Томас", "options": ["Мене звати Томас", "Я студент Томас", "Це Томас"], "explanation": "Use Мене звати for names."}, {"sentence": "Я маю 20 років", "errorWord": "Я маю 20 років", "correctForm": "Мені 20 років", "options": ["Мені 20 років", "Я студент 20 років", "Це 20 років"], "explanation": "Use Мені plus age."}]`)} isUkrainian={false} />
-
-### Мінідіалог
-
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "Ти говориш українською?", "options": [{"text": "Так, я говорю українською.", "correct": true}, {"text": "Так, я говориш українською.", "correct": false}, {"text": "Так, я говорити українською.", "correct": false}], "explanation": "Я говорю."}, {"question": "Що ти робиш?", "options": [{"text": "Я роблю вправу.", "correct": true}, {"text": "Я робиш вправу.", "correct": false}, {"text": "Я робити вправу.", "correct": false}], "explanation": "Я роблю is the safe answer."}, {"question": "Ти бачиш це слово?", "options": [{"text": "Так, я бачу це слово.", "correct": true}, {"text": "Так, я бачиш це слово.", "correct": false}, {"text": "Так, я бачити це слово.", "correct": false}], "explanation": "Я бачу."}]`)} instruction={"Choose the best next line."} isUkrainian={false} />
+*(see lesson, §Підсумок)*
 
 </TabItem>
 <TabItem label="Resources">


### PR DESCRIPTION
## Summary
- Rebuilt A1 M17 `verbs-group-two` around the locked Group Two plan: Тарас/Микола dialogues, `говорити` as the anchor table, six active Group Two verbs, and side-by-side Group One vs Group Two comparison.
- Removed stale verification/comment artifacts, old Marta/Oleh dialogue drift, workbook spillover, and off-plan exception/repair material.
- Reshaped activities to the planned inline sequence and counts: 10 ending fill-ins, 10 group-sort items, 8 form-choice quiz items, and 6 sentence fill-ins.
- Regenerated the MDX page.

## Quality Gates
- PASS: `.venv/bin/python scripts/audit/certify_module.py a1 17 --skip-site-build`
- PASS: `.venv/bin/python scripts/audit/certify_module.py a1 17`
- PASS: production site build through the certification wrapper
- PASS: `git diff --check`
- PASS: protected config/artifact hygiene checks; only four module files changed
- PASS: VESUM spot-check, 62/62 forms found
- PASS: thin swarm sidecar found two real pre-patch issues; both were fixed before certification
- PASS: LLM QG minimum upheld. Required gate is `min_score >= 8`; DeepSeek Flash QG returned `min_score: 8.5`, no blockers.
- PASS: Gemini CLI independent review returned `min_score: 9`, no blockers.

## QG Backend Notes
- DeepSeek Flash (`deepseek-v4-flash`) completed successfully and returned valid numeric QG JSON.
- Gemini CLI completed successfully and returned valid independent-review JSON.
- No Claude/Opus/claude-tools or canonical claude-tools QG was used.

## Token Telemetry
- run_id: `a1-m17-pr3468`
- swarm_used: `true`
- swarm_label: `thin`
- swarm_note: Used one read-only mini sidecar reviewer for stale artifact/reflexive-preview validation; main agent retained implementation, QG, PR, and merge decisions. DeepSeek Flash supplied numeric QG; Gemini CLI supplied independent review.
- wall_clock_minutes: unavailable
- token_source: unavailable
- main: Codex GPT-5.5 xhigh, unavailable
- helpers: gpt-5.4-mini read-only sidecar; DeepSeek Flash numeric QG; Gemini CLI independent review
- commit_sha: `17cf01a23459f3b4e4aa01f545d5631032424d84`

X-Agent: codex/a1-m17-verbs-group-two-quality