### PR TITLE
fix(a1): align checkpoint actions review

### DIFF
--- a/curriculum/l2-uk-en/a1/checkpoint-actions/activities.yaml
+++ b/curriculum/l2-uk-en/a1/checkpoint-actions/activities.yaml
@@ -1,89 +1,112 @@
 ---
 inline:
   - id: act-1
-    type: match-up
-    title: Reading line to skill
-    instruction: Match each checkpoint line with the skill it proves.
-    pairs:
-      - left: Я прокидаюся о сьомій.
-        right: reflexive routine
-      - left: Я люблю читати.
-        right: like + infinitive
-      - left: Вона працює в школі.
-        right: Group One -ува-
-      - left: Ти пишеш гарно.
-        right: писати change
-      - left: Вони роблять швидко.
-        right: Group Two plural
-      - left: Я можу готувати.
-        right: modal + infinitive
-      - left: Коли ти можеш?
-        right: question word
-      - left: Ніхто не читає.
-        right: negative
+    type: quiz
+    title: Змішані форми дій
+    instruction: Choose the present-tense form that fits the person.
+    items:
+      - prompt: Я ___ книгу.
+        options:
+          - text: читаю
+            correct: true
+          - text: читаєш
+            correct: false
+          - text: говорить
+            correct: false
+        explanation: Я читаю is a Group One form.
+      - prompt: Ти ___ українською?
+        options:
+          - text: говориш
+            correct: true
+          - text: говорю
+            correct: false
+          - text: говорять
+            correct: false
+        explanation: Ти говориш is a Group Two form.
+      - prompt: Вона ___ в офісі.
+        options:
+          - text: працює
+            correct: true
+          - text: працюю
+            correct: false
+          - text: працюють
+            correct: false
+        explanation: Вона працює is the Group One form.
+      - prompt: Ми ___ українською.
+        options:
+          - text: говоримо
+            correct: true
+          - text: говориш
+            correct: false
+          - text: говорять
+            correct: false
+        explanation: Ми говоримо uses the Group Two ending -имо.
+      - prompt: Вони ___ у парку.
+        options:
+          - text: гуляють
+            correct: true
+          - text: гуляю
+            correct: false
+          - text: гуляєш
+            correct: false
+        explanation: Вони гуляють is Group One.
+      - prompt: Ви ___ дуже гарно.
+        options:
+          - text: пишете
+            correct: true
+          - text: пишите
+            correct: false
+          - text: пишу
+            correct: false
+        explanation: Use ви пишете for писати.
+      - prompt: Він ___ українською.
+        options:
+          - text: говорить
+            correct: true
+          - text: говориш
+            correct: false
+          - text: говорять
+            correct: false
+        explanation: Він говорить is Group Two.
+      - prompt: Ви ___ сьогодні?
+        options:
+          - text: працюєте
+            correct: true
+          - text: працюєш
+            correct: false
+          - text: працюють
+            correct: false
+        explanation: Ви працюєте is the polite or plural form.
+      - prompt: Я ___ вправу.
+        options:
+          - text: роблю
+            correct: true
+          - text: робиш
+            correct: false
+          - text: роблять
+            correct: false
+        explanation: Я роблю is the first-person Group Two form.
+      - prompt: Вони ___ книгу.
+        options:
+          - text: читають
+            correct: true
+          - text: читає
+            correct: false
+          - text: читаєш
+            correct: false
+        explanation: Вони читають uses the Group One plural ending.
   - id: act-2
-    type: true-false
-    title: Action diagnostics
-    instruction: Decide whether each line uses the checkpoint pattern safely.
-    items:
-      - statement: Я працюю кожного дня.
-        correct: true
-        explanation: Працюю is the я form of працювати.
-      - statement: Вона працює в школі.
-        correct: true
-        explanation: Працювати changes to працює with вона.
-      - statement: Ви пишите дуже гарно.
-        correct: false
-        explanation: Use Ви пишете дуже гарно.
-      - statement: Вони роботь швидко.
-        correct: false
-        explanation: Use Вони роблять швидко.
-      - statement: Він хоче кави.
-        correct: true
-        explanation: Хоче is the safe він form.
-      - statement: Я є читаю книгу.
-        correct: false
-        explanation: Use Я читаю книгу.
-      - statement: Я прокидаюся о сьомій.
-        correct: true
-        explanation: Прокидаюся is a safe -ся routine form.
-      - statement: Ніхто не читає.
-        correct: true
-        explanation: Keep не before the verb.
-  - id: act-3
-    type: group-sort
-    title: Skill stations
-    instruction: Sort each chunk by the skill it checks.
-    groups:
-      - name: Group One
-        items:
-          - я читаю
-          - ти пишеш
-          - вони працюють
-          - ми малюємо
-      - name: Group Two
-        items:
-          - я говорю
-          - ти говориш
-          - вони роблять
-          - ви бачите
-      - name: Modal + infinitive
-        items:
-          - хочу читати
-          - можу готувати
-          - мушу працювати
-          - може допомагати
-      - name: Question words
-        items:
-          - де ти працюєш?
-          - коли ти можеш?
-          - що ти читаєш?
-          - як ми говоримо?
-  - id: act-4
     type: fill-in
-    title: Roommate dialogue gaps
-    instruction: Complete the dialogue with the checkpoint form.
+    title: Діалог із сусідом
+    instruction: Complete the dialogue with the modal, question word, or verb form.
     items:
+      - sentence: 'Олег: ___ готує сьогодні?'
+        answer: Хто
+        options:
+          - Хто
+          - Коли
+          - Як
+        explanation: Хто asks which person.
       - sentence: 'Олег: Коли ти ___?'
         answer: прокидаєшся
         options:
@@ -91,27 +114,20 @@ inline:
           - працюєш
           - пишеш
         explanation: The question asks about the morning routine.
-      - sentence: 'Марина: Я ___ о сьомій.'
-        answer: прокидаюся
+      - sentence: 'Олег: Що ти ___ потім?'
+        answer: робиш
         options:
-          - прокидаюся
-          - читаю
+          - робиш
           - роблю
-        explanation: With я, use прокидаюся.
-      - sentence: 'Олег: Де ти ___?'
-        answer: працюєш
-        options:
-          - працюєш
-          - можеш
-          - хочеш
-        explanation: Де asks for the work place.
+          - роблять
+        explanation: Ти робиш fits the person ти.
       - sentence: 'Марина: Я ___ в школі.'
         answer: працюю
         options:
           - працюю
           - працює
           - працюємо
-        explanation: With я, use працюю.
+        explanation: Я працюю is the first-person form.
       - sentence: 'Олег: Ти ___ читати ввечері?'
         answer: любиш
         options:
@@ -119,6 +135,20 @@ inline:
           - читаєш
           - робиш
         explanation: Любиш + infinitive asks about liking an action.
+      - sentence: 'Олег: Я ___ готувати сьогодні.'
+        answer: хочу
+        options:
+          - хочу
+          - можу
+          - мушу
+        explanation: Хочу + infinitive gives a plan or desire.
+      - sentence: 'Олег: Ти ___ допомагати?'
+        answer: можеш
+        options:
+          - можеш
+          - хочу
+          - мушу
+        explanation: Можеш asks about ability.
       - sentence: 'Марина: Не можу зараз, ___ працювати.'
         answer: мушу
         options:
@@ -126,156 +156,73 @@ inline:
           - читаю
           - говорю
         explanation: Мушу + infinitive means I have to.
-workbook:
-  - type: odd-one-out
-    title: Find the form that does not fit
-    instruction: Choose the chunk that belongs to a different checkpoint skill.
+  - id: act-3
+    type: fill-in
+    title: Мій день
+    instruction: Choose the word that completes the short day description.
     items:
-      - words:
-          - я читаю
-          - ти читаєш
-          - вони читають
-          - ти говориш
-        answer: ти говориш
-        explanation: Ти говориш is Group Two; the others are Group One читати.
-      - words:
-          - хочу читати
-          - можу готувати
-          - мушу працювати
-          - я читаю
-        answer: я читаю
-        explanation: Я читаю is a person form, not modal + infinitive.
-      - words:
-          - хто
-          - коли
-          - куди
+      - sentence: ___ я прокидаюся о сьомій.
+        answer: Спочатку
+        options:
+          - Спочатку
+          - Нарешті
+          - Чому
+        explanation: Спочатку starts the routine.
+      - sentence: Потім я ___ і чищу зуби.
+        answer: вмиваюся
+        options:
+          - вмиваюся
           - працюю
+          - читаю
+        explanation: Вмиваюся is the morning routine form.
+      - sentence: Після цього я ___ вдома.
+        answer: снідаю
+        options:
+          - снідаю
+          - говорю
+          - пишу
+        explanation: Снідаю fits the morning sequence.
+      - sentence: Вдень я ___ в офісі.
         answer: працюю
-        explanation: Працюю is a verb form; the others are question words.
-      - words:
-          - я прокидаюся
-          - ти вмиваєшся
-          - вона одягається
-          - я снідаю
-        answer: я снідаю
-        explanation: Снідаю is not a -ся verb.
-  - type: unjumble
-    title: Rebuild checkpoint lines
-    instruction: Put the words in a safe A1.3 order.
-    items:
-      - words:
-          - Я
-          - люблю
-          - читати
-        answer: Я люблю читати
-      - words:
-          - Вона
-          - працює
-          - в школі
-        answer: Вона працює в школі
-      - words:
-          - Ми
-          - говоримо
-          - українською
-        answer: Ми говоримо українською
-      - words:
-          - Коли
-          - ти
-          - можеш
-        answer: Коли ти можеш
-      - words:
-          - Я
+        options:
+          - працюю
+          - прокидаюся
+          - вмиваюся
+        explanation: Працюю fits the work part of the day.
+      - sentence: Увечері я ___ гуляти.
+        answer: хочу
+        options:
+          - хочу
+          - читаю
+          - роблю
+        explanation: Хочу + infinitive gives an evening plan.
+      - sentence: Нарешті я ___ фільм.
+        answer: дивлюся
+        options:
+          - дивлюся
           - мушу
+          - снідаю
+        explanation: Дивлюся фільм is the familiar evening line.
+  - id: act-4
+    type: group-sort
+    title: Групи дієслів
+    instruction: Sort each infinitive by its checkpoint group.
+    groups:
+      - name: І дієвідміна
+        items:
+          - читати
           - працювати
-        answer: Я мушу працювати
-      - words:
-          - Вони
-          - роблять
-          - швидко
-        answer: Вони роблять швидко
-  - type: quiz
-    title: Choose the answer job
-    instruction: Choose the line that answers the question.
-    items:
-      - prompt: 'Коли ти прокидаєшся?'
-        options:
-          - text: О сьомій.
-            correct: true
-          - text: У школі.
-            correct: false
-          - text: Українською.
-            correct: false
-        explanation: Коли asks about time.
-      - prompt: 'Де ти працюєш?'
-        options:
-          - text: В офісі.
-            correct: true
-          - text: О восьмій.
-            correct: false
-          - text: Тому що мушу.
-            correct: false
-        explanation: Де asks about place.
-      - prompt: 'Що ти любиш?'
-        options:
-          - text: Читати.
-            correct: true
-          - text: Удома.
-            correct: false
-          - text: Завтра.
-            correct: false
-        explanation: Що asks for the action or thing.
-      - prompt: 'Як ми говоримо?'
-        options:
-          - text: Українською.
-            correct: true
-          - text: Увечері.
-            correct: false
-          - text: У школі.
-            correct: false
-        explanation: Як asks how.
-  - type: fill-in
-    title: Repair by building the safe line
-    instruction: Build the corrected line from the checkpoint prompt.
-    items:
-      - sentence: 'I work every day: Я ___ кожного дня.'
-        answer: працюю
-        options:
-          - працюю
-          - читаю
-          - пишу
-        explanation: Repair for Я працювати кожного дня.
-      - sentence: 'She works at school: Вона ___ в школі.'
-        answer: працює
-        options:
-          - працює
-          - читає
-          - готує
-        explanation: 'Repair for <!-- bad -->Вона працюває в школі<!-- /bad -->.'
-      - sentence: 'I read a book: Я ___ книгу.'
-        answer: читаю
-        options:
-          - читаю
-          - пишу
-          - бачу
-        explanation: Repair for Я є читаю книгу.
-      - sentence: 'You write very nicely: Ви ___ дуже гарно.'
-        answer: пишете
-        options:
-          - пишете
-          - читаєте
-          - говорите
-        explanation: 'Repair for <!-- bad -->Ви пишите дуже гарно<!-- /bad -->.'
-      - sentence: 'They work fast: Вони ___ швидко.'
-        answer: роблять
-        options:
-          - роблять
-          - говорять
-          - читають
-        explanation: 'Repair for <!-- bad -->Вони роботь швидко<!-- /bad -->.'
-      - sentence: 'He wants coffee: Він ___ кави.'
-        answer: хоче
-        options:
-          - хоче
-          - любить
-          - п'є
-        explanation: 'Repair for <!-- bad -->Він хотіє кави<!-- /bad -->.'
+          - готувати
+          - гуляти
+      - name: ІІ дієвідміна
+        items:
+          - говорити
+          - робити
+          - любити
+          - мусити
+      - name: Зворотні дієслова
+        items:
+          - прокидатися
+          - вмиватися
+          - дивитися
+          - навчатися

--- a/curriculum/l2-uk-en/a1/checkpoint-actions/module.md
+++ b/curriculum/l2-uk-en/a1/checkpoint-actions/module.md
@@ -19,68 +19,58 @@ By the end, you can:
 
 <!-- INJECT_ACTIVITY: act-1 -->
 
-Think of A1.3 as a set of action cards. The dictionary card is the infinitive,
-usually ending in **-ти**: **читати**, **говорити**, **працювати**, **хотіти**.
-To find the stem for a simple practice form, first notice that the infinitive
-ending is **-ти** and can be set aside: **чита-ти**, **говори-ти**,
-**працюва-ти**. This first checkpoint habit is called finding the **основа
-інфінітива** after **відкидання закінчення -ти**. For a real sentence, choose a
-person form: **я читаю**, **ти говориш**, **вона працює**. Ukrainian does not
-need an extra helper for a normal present action.
+Modules 15-20 gave you one action toolkit. First, the dictionary form is the
+infinitive, usually ending in **-ти**: **читати**, **говорити**,
+**працювати**, **хотіти**, **могти**, **мусити**. After **любити**, **хотіти**,
+**могти**, and **мусити**, keep that infinitive form: **Я люблю читати**,
+**Я хочу гуляти**, **Я можу готувати**, **Я мушу працювати**.
 
-The most useful Group One card is the productive **-ува- / -юва-** pattern.
-Before the ending, **-ува- або -юва-** becomes **-у- або -ю-**:
-**працювати -> я працюю**, **малювати -> я малюю**,
-**танцювати -> вони танцюють**. Some short high-use verbs are learned as whole
-forms: **жити**, **пити**, **лити**; useful forms include **я живу**,
-**я п'ю**, **вони живуть**. For **писати**, keep the visible change:
-**пишу**, **пишеш**, **пишуть**. The plural ending **-уть / -ють** is your
-Group One signal.
+For a present action, choose the person form. Group One uses endings like
+**-ю, -єш, -є, -ємо, -єте, -ють**: **я читаю**, **ти читаєш**,
+**вона працює**, **ви працюєте**, **вони читають**. A useful Group One repair is
+**працювати -> працюю / працюєш / працює**. For **писати**, remember the visible
+change: **пишу**, **пишеш**, **пишете**.
 
-Group Two uses the other action signal: **ти говориш**, **ви говорите**,
-**вони роблять**. The plural ending **-ать / -ять** is the Group Two signal.
-Compare it with Group One plural forms such as **живуть** and **сіють**, then
-with recognition-only Group Two examples such as **молитися** and **чавити**.
-The forms **ти** and **ви** matter because real conversations need direct
-address: **Ти читаєш? Ви пишете?** Also recognize the school-style model
-**ти крутиш**, **ви крутите** as a direct-address pair.
+Group Two uses endings like **-ю/-у, -иш, -ить, -имо, -ите, -ать/-ять**:
+**я говорю**, **ти говориш**, **вона говорить**, **ми говоримо**,
+**вони роблять**. The direct-address forms matter in real conversation:
+**Ти говориш? Ви говорите?**
 
-Modal verbs stay small and useful:
+Question words let the same verb forms become useful conversation:
+**хто** asks for a person, **що** asks for a thing or action, **де** asks for a
+place, **куди** asks for direction, **коли** asks for time, **чому** asks for a
+reason, and **як** asks how. Negation stays simple: put **не** before the verb:
+**Я не можу**, **Вона не працює**, **Ніхто не читає**.
 
-| Meaning | Safe pattern |
-| --- | --- |
-| I want to read. | **Я хочу читати.** |
-| I can cook. | **Я можу готувати.** |
-| I have to work. | **Я мушу працювати.** |
-
-Use Ukrainian on its own terms. Do not explain Ukrainian forms through any
-other language. The pattern is inside Ukrainian: infinitive, person ending,
-question word, and short routine order.
+Reflexive routine verbs carry **-ся** with the person form:
+**я прокидаюся**, **ти прокидаєшся**, **я вмиваюся**. Sequence words then make
+the routine sound connected: **Спочатку я прокидаюся. Потім я вмиваюся. Після
+цього я снідаю. Нарешті я йду на роботу.**
 
 :::tip
-When a line feels too big, find the verb first. Ask: is it an infinitive
-ending in **-ти**, a person form like **працюю**, a modal helper like
-**можу**, or a **-ся** routine form like **вмиваюся**?
+When a line feels too big, find the verb first. Ask: is it an infinitive ending
+in **-ти**, a person form like **працюю**, a modal helper like **можу**, or a
+**-ся** routine form like **вмиваюся**?
 :::
 
 <!-- INJECT_ACTIVITY: act-2 -->
 
 ## Читання
 
-Read this checkpoint text aloud. It uses only A1.3 action material and familiar
-daily words.
+Read this checkpoint text aloud. It uses A1.3 action material from Modules
+15-20.
 
 ```text
 Я прокидаюся о сьомій.
 Спочатку вмиваюся і чищу зуби.
 Потім снідаю вдома.
 Я працюю в офісі.
-У перерві я читаю книгу.
-Я люблю читати, але сьогодні мушу писати.
-Увечері я хочу гуляти.
-Моя сусідка може готувати.
+Я люблю читати.
+Зараз я не гуляю, тому що мушу писати.
+Увечері я хочу піти в парк.
+Марина може готувати.
 Ми говоримо українською.
-Нарешті я дивлюся фільм і відпочиваю.
+Нарешті я дивлюся фільм.
 ```
 
 Support after the Ukrainian lines:
@@ -91,32 +81,32 @@ Support after the Ukrainian lines:
 | **Спочатку вмиваюся і чищу зуби.** | First I wash up and brush my teeth. |
 | **Потім снідаю вдома.** | Then I have breakfast at home. |
 | **Я працюю в офісі.** | I work in an office. |
-| **У перерві я читаю книгу.** | During the break I read a book. |
-| **Я люблю читати, але сьогодні мушу писати.** | I like reading, but today I have to write. |
-| **Увечері я хочу гуляти.** | In the evening I want to walk. |
-| **Моя сусідка може готувати.** | My roommate can cook. |
+| **Я люблю читати.** | I like reading. |
+| **Зараз я не гуляю, тому що мушу писати.** | Now I am not walking, because I have to write. |
+| **Увечері я хочу піти в парк.** | In the evening I want to go to the park. |
+| **Марина може готувати.** | Maryna can cook. |
 | **Ми говоримо українською.** | We speak Ukrainian. |
-| **Нарешті я дивлюся фільм і відпочиваю.** | Finally I watch a film and rest. |
+| **Нарешті я дивлюся фільм.** | Finally I watch a film. |
 
-Use the text as a diagnostic. Can you point to an infinitive? **читати**,
-**писати**, **гуляти**, and **готувати** are infinitives. Can you point to a
-Group One form? **працюю**, **читаю**, **пишуть** style forms use the Group One
-signal. Can you point to a Group Two form? **говоримо**, **роблять**, and
-**бачиш** use the Group Two signal. Can you point to **-ся**? **прокидаюся**,
-**вмиваюся**, and **дивлюся** are routine or perception chunks you already saw.
+Use the text as a diagnostic. Can you point to infinitives? **читати**,
+**писати**, **піти**, and **готувати** stay in dictionary form after another
+verb. Can you point to Group One forms? **працюю**, **гуляю**, and **снідаю**
+use Group One signals. Can you point to Group Two forms? **говоримо** and
+**мушу** use Group Two patterns. Can you point to **-ся**? **прокидаюся**,
+**вмиваюся**, and **дивлюся** are familiar **-ся** forms.
 
 Now answer these A1 questions about the text:
 
 - **Коли я прокидаюся?**
-- **Де я снідаю?**
+- **Де я працюю?**
+- **Хто може готувати?**
 - **Що я люблю?**
-- **Що я мушу робити сьогодні?**
-- **Куди я хочу йти ввечері?**
+- **Чому я не гуляю зараз?**
+- **Куди я хочу піти ввечері?**
 - **Як ми говоримо?**
 
-The seven question words stay active: **хто, що, де, куди, коли, чому, як**.
-For this checkpoint, short answers are enough: **о сьомій**, **вдома**,
-**читати**, **писати**, **гуляти**, **українською**.
+Short answers are enough: **о сьомій**, **в офісі**, **Марина**, **читати**,
+**тому що мушу писати**, **в парк**, **українською**.
 
 <!-- INJECT_ACTIVITY: act-3 -->
 
@@ -128,12 +118,12 @@ Use this review table as a repair map.
 | --- | --- | --- |
 | Infinitive | dictionary action ends in **-ти** | **читати**, **говорити**, **працювати** |
 | Group One | **-ю, -єш, -є, -ємо, -єте, -ють** | **я читаю**, **ти читаєш**, **вони працюють** |
-| Group One **-ува-** | **-ува- / -юва- -> -у- / -ю-** | **працювати -> працюю**, **малювати -> малюю** |
-| Short Group One | learn whole forms | **я живу**, **я п'ю**, **вони живуть** |
-| Change in **писати** | **с -> ш** in the present | **пишу**, **пишеш**, **пишуть** |
+| Group One repair | **працювати -> працюю / працюєш / працює** | **Я працюю. Вона працює.** |
+| Change in **писати** | **с -> ш** in the present | **пишу**, **пишеш**, **пишете** |
 | Group Two | **-ю/-у, -иш, -ить, -имо, -ите, -ать/-ять** | **я говорю**, **ти говориш**, **вони роблять** |
 | Direct address | **ти** and **ви** need different endings | **ти пишеш**, **ви пишете**, **ви говорите** |
 | Modal + infinitive | helper first, infinitive second | **хочу читати**, **можу готувати**, **мушу працювати** |
+| Questions | one question word gives the job of the answer | **Хто? Що? Де? Куди? Коли? Чому? Як?** |
 | Reflexive routine | person form plus **-ся** | **я прокидаюся**, **ти вмиваєшся** |
 | Negative | **не** before the verb | **Я не працюю. Ніхто не читає.** |
 
@@ -158,24 +148,29 @@ Keep the common repairs close:
 ## Діалог
 
 Read the roommate conversation. It checks liking, two verb groups, modal verbs,
-questions, negatives, and a morning routine in one scene.
+all seven question words, negatives, and a morning routine in one scene.
 
 ```text
 Олег: Добрий день! Ти нова сусідка?
 Марина: Так. Мене звати Марина.
-Олег: Дуже приємно. Коли ти прокидаєшся?
+Олег: Хто готує сьогодні?
+Марина: Ти готуєш, а я допомагаю після шостої.
+Олег: Коли ти прокидаєшся?
 Марина: Я прокидаюся о сьомій.
 Олег: Що ти робиш потім?
 Марина: Вмиваюся, снідаю і йду на роботу.
+Олег: Куди ти йдеш після сніданку?
+Марина: На роботу.
 Олег: Де ти працюєш?
 Марина: Я працюю в школі.
 Олег: Ти любиш читати ввечері?
 Марина: Так, люблю читати і писати.
 Олег: Я хочу готувати сьогодні. Ти можеш допомагати?
 Марина: Не можу зараз, мушу працювати.
-Олег: Коли ти можеш?
-Марина: Після шостої. Тоді ми готуємо і говоримо українською.
-Олег: Добре. До побачення!
+Олег: Чому не можеш зараз?
+Марина: Тому що мушу працювати до шостої.
+Олег: Як ми говоримо вдома?
+Марина: Українською. Тоді ми готуємо і говоримо українською.
 ```
 
 Support after the Ukrainian lines:
@@ -184,24 +179,24 @@ Support after the Ukrainian lines:
 | --- | --- |
 | **Олег: Добрий день! Ти нова сусідка?** | Oleh: Good afternoon! Are you the new roommate? |
 | **Марина: Так. Мене звати Марина.** | Maryna: Yes. My name is Maryna. |
-| **Олег: Дуже приємно. Коли ти прокидаєшся?** | Oleh: Nice to meet you. When do you wake up? |
+| **Олег: Хто готує сьогодні?** | Oleh: Who is cooking today? |
+| **Марина: Ти готуєш, а я допомагаю після шостої.** | Maryna: You cook, and I help after six. |
+| **Олег: Коли ти прокидаєшся?** | Oleh: When do you wake up? |
 | **Марина: Я прокидаюся о сьомій.** | Maryna: I wake up at seven. |
 | **Олег: Що ти робиш потім?** | Oleh: What do you do then? |
 | **Марина: Вмиваюся, снідаю і йду на роботу.** | Maryna: I wash up, have breakfast, and go to work. |
+| **Олег: Куди ти йдеш після сніданку?** | Oleh: Where are you going after breakfast? |
+| **Марина: На роботу.** | Maryna: To work. |
 | **Олег: Де ти працюєш?** | Oleh: Where do you work? |
 | **Марина: Я працюю в школі.** | Maryna: I work at a school. |
 | **Олег: Ти любиш читати ввечері?** | Oleh: Do you like to read in the evening? |
 | **Марина: Так, люблю читати і писати.** | Maryna: Yes, I like reading and writing. |
 | **Олег: Я хочу готувати сьогодні. Ти можеш допомагати?** | Oleh: I want to cook today. Can you help? |
 | **Марина: Не можу зараз, мушу працювати.** | Maryna: I cannot now, I have to work. |
-| **Олег: Коли ти можеш?** | Oleh: When can you? |
-| **Марина: Після шостої. Тоді ми готуємо і говоримо українською.** | Maryna: After six. Then we cook and speak Ukrainian. |
-| **Олег: Добре. До побачення!** | Oleh: Good. Goodbye! |
-
-This dialogue uses clean Ukrainian greeting and farewell chunks:
-**Добрий день** and **До побачення**. Keep everyday language precise:
-**тато**, **прізвище**, **українська мова**, **Київ**, **гривня**. Those forms
-belong to earlier A1 work and stay stable here.
+| **Олег: Чому не можеш зараз?** | Oleh: Why can't you now? |
+| **Марина: Тому що мушу працювати до шостої.** | Maryna: Because I have to work until six. |
+| **Олег: Як ми говоримо вдома?** | Oleh: How do we speak at home? |
+| **Марина: Українською. Тоді ми готуємо і говоримо українською.** | Maryna: In Ukrainian. Then we cook and speak Ukrainian. |
 
 ## Підсумок
 
@@ -239,9 +234,5 @@ Support after the Ukrainian lines:
 | **Сьогодні не можу, мушу писати.** | Today I cannot; I have to write. |
 | **Коли ти можеш говорити?** | When can you speak? |
 
-When Ukrainian cultural examples appear in later reading, keep them Ukrainian
-and precise. **Тарас Шевченко**, **Леся Українка**, **Ліна Костенко**, and
-**Сергій Жадан** belong to the Ukrainian literary space. Historical references
-need exact dates, for example **Голодомор 1932-1933 років**. For this A1
-checkpoint, you only need to carry the principle forward: use Ukrainian forms
-and Ukrainian context clearly.
+This finishes A1.3. Next, A1.4 moves into time and nature: clock time, days,
+months, weather, and simple plans.

--- a/curriculum/l2-uk-en/a1/checkpoint-actions/vocabulary.yaml
+++ b/curriculum/l2-uk-en/a1/checkpoint-actions/vocabulary.yaml
@@ -26,6 +26,10 @@
   translation: you write
   pos: verb form
   usage: Ти пишеш гарно.
+- lemma: пишете
+  translation: you write (plural/formal)
+  pos: verb form
+  usage: Ви пишете дуже гарно.
 - lemma: працювати
   translation: to work
   pos: infinitive
@@ -42,6 +46,10 @@
   translation: he/she works
   pos: verb form
   usage: Вона працює в школі.
+- lemma: працюєте
+  translation: you work (plural/formal)
+  pos: verb form
+  usage: Ви працюєте сьогодні?
 - lemma: говорити
   translation: to speak
   pos: infinitive
@@ -62,6 +70,14 @@
   translation: to do; to make
   pos: infinitive
   usage: Що ти робиш?
+- lemma: роблю
+  translation: I do; I make
+  pos: verb form
+  usage: Я роблю вправу.
+- lemma: робиш
+  translation: you do; you make
+  pos: verb form
+  usage: Що ти робиш потім?
 - lemma: роблять
   translation: they do; they make
   pos: verb form
@@ -74,10 +90,22 @@
   translation: I want
   pos: modal verb form
   usage: Я хочу гуляти.
+- lemma: хочеш
+  translation: you want
+  pos: modal verb form
+  usage: Ти хочеш гуляти?
 - lemma: можу
   translation: I can
   pos: modal verb form
   usage: Я можу готувати.
+- lemma: можеш
+  translation: you can
+  pos: modal verb form
+  usage: Ти можеш допомагати?
+- lemma: може
+  translation: he/she can
+  pos: modal verb form
+  usage: Марина може готувати.
 - lemma: мушу
   translation: I have to
   pos: modal verb form
@@ -90,6 +118,14 @@
   translation: he/she wants
   pos: verb form
   usage: Він хоче кави.
+- lemma: могти
+  translation: to be able to
+  pos: infinitive
+  usage: Я можу готувати.
+- lemma: мусити
+  translation: to have to; must
+  pos: infinitive
+  usage: Я мушу працювати.
 - lemma: прокидатися
   translation: to wake up
   pos: infinitive
@@ -106,6 +142,70 @@
   translation: I wash up
   pos: reflexive verb form
   usage: Я вмиваюся вранці.
+- lemma: снідати
+  translation: to have breakfast
+  pos: infinitive
+  usage: Я снідаю вдома.
+- lemma: снідаю
+  translation: I have breakfast
+  pos: verb form
+  usage: Потім снідаю вдома.
+- lemma: готувати
+  translation: to cook; to prepare
+  pos: infinitive
+  usage: Я хочу готувати сьогодні.
+- lemma: готуєш
+  translation: you cook
+  pos: verb form
+  usage: Ти готуєш сьогодні.
+- lemma: готуємо
+  translation: we cook
+  pos: verb form
+  usage: Тоді ми готуємо.
+- lemma: прибирати
+  translation: to clean
+  pos: infinitive
+  usage: Я можу прибирати.
+- lemma: допомагати
+  translation: to help
+  pos: infinitive
+  usage: Ти можеш допомагати?
+- lemma: допомагаю
+  translation: I help
+  pos: verb form
+  usage: Я допомагаю після шостої.
+- lemma: танцювати
+  translation: to dance
+  pos: infinitive
+  usage: Я люблю танцювати.
+- lemma: співати
+  translation: to sing
+  pos: infinitive
+  usage: Вони люблять співати.
+- lemma: грати
+  translation: to play
+  pos: infinitive
+  usage: Я можу грати.
+- lemma: гуляти
+  translation: to walk
+  pos: infinitive
+  usage: Я хочу гуляти.
+- lemma: піти
+  translation: to go
+  pos: infinitive
+  usage: Я хочу піти в парк.
+- lemma: гуляю
+  translation: I walk
+  pos: verb form
+  usage: Зараз я не гуляю.
+- lemma: гуляють
+  translation: they walk
+  pos: verb form
+  usage: Вони гуляють у парку.
+- lemma: навчатися
+  translation: to study; to learn
+  pos: infinitive
+  usage: Я навчаюся вдома.
 - lemma: дивитися
   translation: to watch; to look
   pos: infinitive

--- a/site/src/content/docs/a1/checkpoint-actions.mdx
+++ b/site/src/content/docs/a1/checkpoint-actions.mdx
@@ -76,104 +76,64 @@ By the end, you can:
 
 ## Що ми знаємо?
 
-### Reading line to skill
+### Змішані форми дій
 
-<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "Я прокидаюся о сьомій.", "right": "reflexive routine"}, {"left": "Я люблю читати.", "right": "like + infinitive"}, {"left": "Вона працює в школі.", "right": "Group One -ува-"}, {"left": "Ти пишеш гарно.", "right": "писати change"}, {"left": "Вони роблять швидко.", "right": "Group Two plural"}, {"left": "Я можу готувати.", "right": "modal + infinitive"}, {"left": "Коли ти можеш?", "right": "question word"}, {"left": "Ніхто не читає.", "right": "negative"}]`)} instruction={"Match each checkpoint line with the skill it proves."} isUkrainian={false} />
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Я ___ книгу.", "options": [{"text": "читаю", "correct": true}, {"text": "читаєш", "correct": false}, {"text": "говорить", "correct": false}], "explanation": "Я читаю is a Group One form."}, {"question": "Ти ___ українською?", "options": [{"text": "говориш", "correct": true}, {"text": "говорю", "correct": false}, {"text": "говорять", "correct": false}], "explanation": "Ти говориш is a Group Two form."}, {"question": "Вона ___ в офісі.", "options": [{"text": "працює", "correct": true}, {"text": "працюю", "correct": false}, {"text": "працюють", "correct": false}], "explanation": "Вона працює is the Group One form."}, {"question": "Ми ___ українською.", "options": [{"text": "говоримо", "correct": true}, {"text": "говориш", "correct": false}, {"text": "говорять", "correct": false}], "explanation": "Ми говоримо uses the Group Two ending -имо."}, {"question": "Вони ___ у парку.", "options": [{"text": "гуляють", "correct": true}, {"text": "гуляю", "correct": false}, {"text": "гуляєш", "correct": false}], "explanation": "Вони гуляють is Group One."}, {"question": "Ви ___ дуже гарно.", "options": [{"text": "пишете", "correct": true}, {"text": "пишите", "correct": false}, {"text": "пишу", "correct": false}], "explanation": "Use ви пишете for писати."}, {"question": "Він ___ українською.", "options": [{"text": "говорить", "correct": true}, {"text": "говориш", "correct": false}, {"text": "говорять", "correct": false}], "explanation": "Він говорить is Group Two."}, {"question": "Ви ___ сьогодні?", "options": [{"text": "працюєте", "correct": true}, {"text": "працюєш", "correct": false}, {"text": "працюють", "correct": false}], "explanation": "Ви працюєте is the polite or plural form."}, {"question": "Я ___ вправу.", "options": [{"text": "роблю", "correct": true}, {"text": "робиш", "correct": false}, {"text": "роблять", "correct": false}], "explanation": "Я роблю is the first-person Group Two form."}, {"question": "Вони ___ книгу.", "options": [{"text": "читають", "correct": true}, {"text": "читає", "correct": false}, {"text": "читаєш", "correct": false}], "explanation": "Вони читають uses the Group One plural ending."}]`)} instruction={"Choose the present-tense form that fits the person."} isUkrainian={false} />
 
-Think of A1.3 as a set of action cards. The dictionary card is the infinitive,
+Modules 15-20 gave you one action toolkit. First, the dictionary form is the
+infinitive, usually ending in **-ти**: **читати**, **говорити**,
+**працювати**, **хотіти**, **могти**, **мусити**. After **любити**, **хотіти**,
+**могти**, and **мусити**, keep that infinitive form: **Я люблю читати**,
+**Я хочу гуляти**, **Я можу готувати**, **Я мушу працювати**.
 
-usually ending in **-ти**: **читати**, **говорити**, **працювати**, **хотіти**.
+For a present action, choose the person form. Group One uses endings like
+**-ю, -єш, -є, -ємо, -єте, -ють**: **я читаю**, **ти читаєш**,
+**вона працює**, **ви працюєте**, **вони читають**. A useful Group One repair is
+**працювати -> працюю / працюєш / працює**. For **писати**, remember the visible
+change: **пишу**, **пишеш**, **пишете**.
 
-To find the stem for a simple practice form, first notice that the infinitive
+Group Two uses endings like **-ю/-у, -иш, -ить, -имо, -ите, -ать/-ять**:
+**я говорю**, **ти говориш**, **вона говорить**, **ми говоримо**,
+**вони роблять**. The direct-address forms matter in real conversation:
+**Ти говориш? Ви говорите?**
 
-ending is **-ти** and can be set aside: **чита-ти**, **говори-ти**,
+Question words let the same verb forms become useful conversation:
+**хто** asks for a person, **що** asks for a thing or action, **де** asks for a
+place, **куди** asks for direction, **коли** asks for time, **чому** asks for a
+reason, and **як** asks how. Negation stays simple: put **не** before the verb:
+**Я не можу**, **Вона не працює**, **Ніхто не читає**.
 
-**працюва-ти**. This first checkpoint habit is called finding the **основа
-
-інфінітива** after **відкидання закінчення -ти**. For a real sentence, choose a
-
-person form: **я читаю**, **ти говориш**, **вона працює**. Ukrainian does not
-
-need an extra helper for a normal present action.
-
-The most useful Group One card is the productive **-ува- / -юва-** pattern.
-
-Before the ending, **-ува- або -юва-** becomes **-у- або -ю-**:
-
-**працювати -> я працюю**, **малювати -> я малюю**,
-
-**танцювати -> вони танцюють**. Some short high-use verbs are learned as whole
-
-forms: **жити**, **пити**, **лити**; useful forms include **я живу**,
-
-**я п'ю**, **вони живуть**. For **писати**, keep the visible change:
-
-**пишу**, **пишеш**, **пишуть**. The plural ending **-уть / -ють** is your
-
-Group One signal.
-
-Group Two uses the other action signal: **ти говориш**, **ви говорите**,
-
-**вони роблять**. The plural ending **-ать / -ять** is the Group Two signal.
-
-Compare it with Group One plural forms such as **живуть** and **сіють**, then
-
-with recognition-only Group Two examples such as **молитися** and **чавити**.
-
-The forms **ти** and **ви** matter because real conversations need direct
-
-address: **Ти читаєш? Ви пишете?** Also recognize the school-style model
-
-**ти крутиш**, **ви крутите** as a direct-address pair.
-
-Modal verbs stay small and useful:
-
-| Meaning | Safe pattern |
-
-| --- | --- |
-
-| I want to read. | **Я хочу читати.** |
-
-| I can cook. | **Я можу готувати.** |
-
-| I have to work. | **Я мушу працювати.** |
-
-Use Ukrainian on its own terms. Do not explain Ukrainian forms through any
-
-other language. The pattern is inside Ukrainian: infinitive, person ending,
-
-question word, and short routine order.
+Reflexive routine verbs carry **-ся** with the person form:
+**я прокидаюся**, **ти прокидаєшся**, **я вмиваюся**. Sequence words then make
+the routine sound connected: **Спочатку я прокидаюся. Потім я вмиваюся. Після
+цього я снідаю. Нарешті я йду на роботу.**
 
 :::tip
-
-When a line feels too big, find the verb first. Ask: is it an infinitive
-
-ending in **-ти**, a person form like **працюю**, a modal helper like
-
-**можу**, or a **-ся** routine form like **вмиваюся**?
-
+When a line feels too big, find the verb first. Ask: is it an infinitive ending
+in **-ти**, a person form like **працюю**, a modal helper like **можу**, or a
+**-ся** routine form like **вмиваюся**?
 :::
 
-### Action diagnostics
+### Діалог із сусідом
 
-<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Я працюю кожного дня.", "isTrue": true, "explanation": "Працюю is the я form of працювати."}, {"statement": "Вона працює в школі.", "isTrue": true, "explanation": "Працювати changes to працює with вона."}, {"statement": "Ви пишите дуже гарно.", "isTrue": false, "explanation": "Use Ви пишете дуже гарно."}, {"statement": "Вони роботь швидко.", "isTrue": false, "explanation": "Use Вони роблять швидко."}, {"statement": "Він хоче кави.", "isTrue": true, "explanation": "Хоче is the safe він form."}, {"statement": "Я є читаю книгу.", "isTrue": false, "explanation": "Use Я читаю книгу."}, {"statement": "Я прокидаюся о сьомій.", "isTrue": true, "explanation": "Прокидаюся is a safe -ся routine form."}, {"statement": "Ніхто не читає.", "isTrue": true, "explanation": "Keep не before the verb."}]`)} instruction={"Decide whether each line uses the checkpoint pattern safely."} isUkrainian={false} />
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Олег: ___ готує сьогодні?", "answer": "Хто", "options": ["Хто", "Коли", "Як"]}, {"sentence": "Олег: Коли ти ___?", "answer": "прокидаєшся", "options": ["прокидаєшся", "працюєш", "пишеш"]}, {"sentence": "Олег: Що ти ___ потім?", "answer": "робиш", "options": ["робиш", "роблю", "роблять"]}, {"sentence": "Марина: Я ___ в школі.", "answer": "працюю", "options": ["працюю", "працює", "працюємо"]}, {"sentence": "Олег: Ти ___ читати ввечері?", "answer": "любиш", "options": ["любиш", "читаєш", "робиш"]}, {"sentence": "Олег: Я ___ готувати сьогодні.", "answer": "хочу", "options": ["хочу", "можу", "мушу"]}, {"sentence": "Олег: Ти ___ допомагати?", "answer": "можеш", "options": ["можеш", "хочу", "мушу"]}, {"sentence": "Марина: Не можу зараз, ___ працювати.", "answer": "мушу", "options": ["мушу", "читаю", "говорю"]}]`)} instruction={"Complete the dialogue with the modal, question word, or verb form."} isUkrainian={false} />
 
 ## Читання
 
-Read this checkpoint text aloud. It uses only A1.3 action material and familiar
-daily words.
+Read this checkpoint text aloud. It uses A1.3 action material from Modules
+15-20.
 
 ```text
 Я прокидаюся о сьомій.
 Спочатку вмиваюся і чищу зуби.
 Потім снідаю вдома.
 Я працюю в офісі.
-У перерві я читаю книгу.
-Я люблю читати, але сьогодні мушу писати.
-Увечері я хочу гуляти.
-Моя сусідка може готувати.
+Я люблю читати.
+Зараз я не гуляю, тому що мушу писати.
+Увечері я хочу піти в парк.
+Марина може готувати.
 Ми говоримо українською.
-Нарешті я дивлюся фільм і відпочиваю.
+Нарешті я дивлюся фільм.
 ```
 
 Support after the Ukrainian lines:
@@ -184,36 +144,36 @@ Support after the Ukrainian lines:
 | **Спочатку вмиваюся і чищу зуби.** | First I wash up and brush my teeth. |
 | **Потім снідаю вдома.** | Then I have breakfast at home. |
 | **Я працюю в офісі.** | I work in an office. |
-| **У перерві я читаю книгу.** | During the break I read a book. |
-| **Я люблю читати, але сьогодні мушу писати.** | I like reading, but today I have to write. |
-| **Увечері я хочу гуляти.** | In the evening I want to walk. |
-| **Моя сусідка може готувати.** | My roommate can cook. |
+| **Я люблю читати.** | I like reading. |
+| **Зараз я не гуляю, тому що мушу писати.** | Now I am not walking, because I have to write. |
+| **Увечері я хочу піти в парк.** | In the evening I want to go to the park. |
+| **Марина може готувати.** | Maryna can cook. |
 | **Ми говоримо українською.** | We speak Ukrainian. |
-| **Нарешті я дивлюся фільм і відпочиваю.** | Finally I watch a film and rest. |
+| **Нарешті я дивлюся фільм.** | Finally I watch a film. |
 
-Use the text as a diagnostic. Can you point to an infinitive? **читати**,
-**писати**, **гуляти**, and **готувати** are infinitives. Can you point to a
-Group One form? **працюю**, **читаю**, **пишуть** style forms use the Group One
-signal. Can you point to a Group Two form? **говоримо**, **роблять**, and
-**бачиш** use the Group Two signal. Can you point to **-ся**? **прокидаюся**,
-**вмиваюся**, and **дивлюся** are routine or perception chunks you already saw.
+Use the text as a diagnostic. Can you point to infinitives? **читати**,
+**писати**, **піти**, and **готувати** stay in dictionary form after another
+verb. Can you point to Group One forms? **працюю**, **гуляю**, and **снідаю**
+use Group One signals. Can you point to Group Two forms? **говоримо** and
+**мушу** use Group Two patterns. Can you point to **-ся**? **прокидаюся**,
+**вмиваюся**, and **дивлюся** are familiar **-ся** forms.
 
 Now answer these A1 questions about the text:
 
 - **Коли я прокидаюся?**
-- **Де я снідаю?**
+- **Де я працюю?**
+- **Хто може готувати?**
 - **Що я люблю?**
-- **Що я мушу робити сьогодні?**
-- **Куди я хочу йти ввечері?**
+- **Чому я не гуляю зараз?**
+- **Куди я хочу піти ввечері?**
 - **Як ми говоримо?**
 
-The seven question words stay active: **хто, що, де, куди, коли, чому, як**.
-For this checkpoint, short answers are enough: **о сьомій**, **вдома**,
-**читати**, **писати**, **гуляти**, **українською**.
+Short answers are enough: **о сьомій**, **в офісі**, **Марина**, **читати**,
+**тому що мушу писати**, **в парк**, **українською**.
 
-### Skill stations
+### Мій день
 
-<GroupSort client:only='react' groups={JSON.parse(`{"Group One": ["я читаю", "ти пишеш", "вони працюють", "ми малюємо"], "Group Two": ["я говорю", "ти говориш", "вони роблять", "ви бачите"], "Modal + infinitive": ["хочу читати", "можу готувати", "мушу працювати", "може допомагати"], "Question words": ["де ти працюєш?", "коли ти можеш?", "що ти читаєш?", "як ми говоримо?"]}`)} instruction={"Sort each chunk by the skill it checks."} isUkrainian={false} />
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "___ я прокидаюся о сьомій.", "answer": "Спочатку", "options": ["Спочатку", "Нарешті", "Чому"]}, {"sentence": "Потім я ___ і чищу зуби.", "answer": "вмиваюся", "options": ["вмиваюся", "працюю", "читаю"]}, {"sentence": "Після цього я ___ вдома.", "answer": "снідаю", "options": ["снідаю", "говорю", "пишу"]}, {"sentence": "Вдень я ___ в офісі.", "answer": "працюю", "options": ["працюю", "прокидаюся", "вмиваюся"]}, {"sentence": "Увечері я ___ гуляти.", "answer": "хочу", "options": ["хочу", "читаю", "роблю"]}, {"sentence": "Нарешті я ___ фільм.", "answer": "дивлюся", "options": ["дивлюся", "мушу", "снідаю"]}]`)} instruction={"Choose the word that completes the short day description."} isUkrainian={false} />
 
 ## Граматика
 
@@ -223,12 +183,12 @@ Use this review table as a repair map.
 | --- | --- | --- |
 | Infinitive | dictionary action ends in **-ти** | **читати**, **говорити**, **працювати** |
 | Group One | **-ю, -єш, -є, -ємо, -єте, -ють** | **я читаю**, **ти читаєш**, **вони працюють** |
-| Group One **-ува-** | **-ува- / -юва- -> -у- / -ю-** | **працювати -> працюю**, **малювати -> малюю** |
-| Short Group One | learn whole forms | **я живу**, **я п'ю**, **вони живуть** |
-| Change in **писати** | **с -> ш** in the present | **пишу**, **пишеш**, **пишуть** |
+| Group One repair | **працювати -> працюю / працюєш / працює** | **Я працюю. Вона працює.** |
+| Change in **писати** | **с -> ш** in the present | **пишу**, **пишеш**, **пишете** |
 | Group Two | **-ю/-у, -иш, -ить, -имо, -ите, -ать/-ять** | **я говорю**, **ти говориш**, **вони роблять** |
 | Direct address | **ти** and **ви** need different endings | **ти пишеш**, **ви пишете**, **ви говорите** |
 | Modal + infinitive | helper first, infinitive second | **хочу читати**, **можу готувати**, **мушу працювати** |
+| Questions | one question word gives the job of the answer | **Хто? Що? Де? Куди? Коли? Чому? Як?** |
 | Reflexive routine | person form plus **-ся** | **я прокидаюся**, **ти вмиваєшся** |
 | Negative | **не** before the verb | **Я не працюю. Ніхто не читає.** |
 
@@ -248,31 +208,36 @@ Keep the common repairs close:
 | <del>Вони роботь швидко.</del> | **Вони роблять швидко.** | **робити** uses Group Two plural |
 | <del>Він хотіє кави.</del> | **Він хоче кави.** | learn **хоче** as the safe form |
 
-### Roommate dialogue gaps
+### Групи дієслів
 
-<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Олег: Коли ти ___?", "answer": "прокидаєшся", "options": ["прокидаєшся", "працюєш", "пишеш"]}, {"sentence": "Марина: Я ___ о сьомій.", "answer": "прокидаюся", "options": ["прокидаюся", "читаю", "роблю"]}, {"sentence": "Олег: Де ти ___?", "answer": "працюєш", "options": ["працюєш", "можеш", "хочеш"]}, {"sentence": "Марина: Я ___ в школі.", "answer": "працюю", "options": ["працюю", "працює", "працюємо"]}, {"sentence": "Олег: Ти ___ читати ввечері?", "answer": "любиш", "options": ["любиш", "читаєш", "робиш"]}, {"sentence": "Марина: Не можу зараз, ___ працювати.", "answer": "мушу", "options": ["мушу", "читаю", "говорю"]}]`)} instruction={"Complete the dialogue with the checkpoint form."} isUkrainian={false} />
+<GroupSort client:only='react' groups={JSON.parse(`{"І дієвідміна": ["читати", "працювати", "готувати", "гуляти"], "ІІ дієвідміна": ["говорити", "робити", "любити", "мусити"], "Зворотні дієслова": ["прокидатися", "вмиватися", "дивитися", "навчатися"]}`)} instruction={"Sort each infinitive by its checkpoint group."} isUkrainian={false} />
 
 ## Діалог
 
 Read the roommate conversation. It checks liking, two verb groups, modal verbs,
-questions, negatives, and a morning routine in one scene.
+all seven question words, negatives, and a morning routine in one scene.
 
 ```text
 Олег: Добрий день! Ти нова сусідка?
 Марина: Так. Мене звати Марина.
-Олег: Дуже приємно. Коли ти прокидаєшся?
+Олег: Хто готує сьогодні?
+Марина: Ти готуєш, а я допомагаю після шостої.
+Олег: Коли ти прокидаєшся?
 Марина: Я прокидаюся о сьомій.
 Олег: Що ти робиш потім?
 Марина: Вмиваюся, снідаю і йду на роботу.
+Олег: Куди ти йдеш після сніданку?
+Марина: На роботу.
 Олег: Де ти працюєш?
 Марина: Я працюю в школі.
 Олег: Ти любиш читати ввечері?
 Марина: Так, люблю читати і писати.
 Олег: Я хочу готувати сьогодні. Ти можеш допомагати?
 Марина: Не можу зараз, мушу працювати.
-Олег: Коли ти можеш?
-Марина: Після шостої. Тоді ми готуємо і говоримо українською.
-Олег: Добре. До побачення!
+Олег: Чому не можеш зараз?
+Марина: Тому що мушу працювати до шостої.
+Олег: Як ми говоримо вдома?
+Марина: Українською. Тоді ми готуємо і говоримо українською.
 ```
 
 Support after the Ukrainian lines:
@@ -281,24 +246,24 @@ Support after the Ukrainian lines:
 | --- | --- |
 | **Олег: Добрий день! Ти нова сусідка?** | Oleh: Good afternoon! Are you the new roommate? |
 | **Марина: Так. Мене звати Марина.** | Maryna: Yes. My name is Maryna. |
-| **Олег: Дуже приємно. Коли ти прокидаєшся?** | Oleh: Nice to meet you. When do you wake up? |
+| **Олег: Хто готує сьогодні?** | Oleh: Who is cooking today? |
+| **Марина: Ти готуєш, а я допомагаю після шостої.** | Maryna: You cook, and I help after six. |
+| **Олег: Коли ти прокидаєшся?** | Oleh: When do you wake up? |
 | **Марина: Я прокидаюся о сьомій.** | Maryna: I wake up at seven. |
 | **Олег: Що ти робиш потім?** | Oleh: What do you do then? |
 | **Марина: Вмиваюся, снідаю і йду на роботу.** | Maryna: I wash up, have breakfast, and go to work. |
+| **Олег: Куди ти йдеш після сніданку?** | Oleh: Where are you going after breakfast? |
+| **Марина: На роботу.** | Maryna: To work. |
 | **Олег: Де ти працюєш?** | Oleh: Where do you work? |
 | **Марина: Я працюю в школі.** | Maryna: I work at a school. |
 | **Олег: Ти любиш читати ввечері?** | Oleh: Do you like to read in the evening? |
 | **Марина: Так, люблю читати і писати.** | Maryna: Yes, I like reading and writing. |
 | **Олег: Я хочу готувати сьогодні. Ти можеш допомагати?** | Oleh: I want to cook today. Can you help? |
 | **Марина: Не можу зараз, мушу працювати.** | Maryna: I cannot now, I have to work. |
-| **Олег: Коли ти можеш?** | Oleh: When can you? |
-| **Марина: Після шостої. Тоді ми готуємо і говоримо українською.** | Maryna: After six. Then we cook and speak Ukrainian. |
-| **Олег: Добре. До побачення!** | Oleh: Good. Goodbye! |
-
-This dialogue uses clean Ukrainian greeting and farewell chunks:
-**Добрий день** and **До побачення**. Keep everyday language precise:
-**тато**, **прізвище**, **українська мова**, **Київ**, **гривня**. Those forms
-belong to earlier A1 work and stay stable here.
+| **Олег: Чому не можеш зараз?** | Oleh: Why can't you now? |
+| **Марина: Тому що мушу працювати до шостої.** | Maryna: Because I have to work until six. |
+| **Олег: Як ми говоримо вдома?** | Oleh: How do we speak at home? |
+| **Марина: Українською. Тоді ми готуємо і говоримо українською.** | Maryna: In Ukrainian. Then we cook and speak Ukrainian. |
 
 ## 📋 Підсумок
 
@@ -336,54 +301,34 @@ Support after the Ukrainian lines:
 | **Сьогодні не можу, мушу писати.** | Today I cannot; I have to write. |
 | **Коли ти можеш говорити?** | When can you speak? |
 
-When Ukrainian cultural examples appear in later reading, keep them Ukrainian
-and precise. **Тарас Шевченко**, **Леся Українка**, **Ліна Костенко**, and
-**Сергій Жадан** belong to the Ukrainian literary space. Historical references
-need exact dates, for example **Голодомор 1932-1933 років**. For this A1
-checkpoint, you only need to carry the principle forward: use Ukrainian forms
-and Ukrainian context clearly.
+This finishes A1.3. Next, A1.4 moves into time and nature: clock time, days,
+months, weather, and simple plans.
 
 </TabItem>
 <TabItem label="Vocabulary">
 
-<VocabCard client:only="react" words={JSON.parse(`[{"word":"дія","translation":"action","pos":"noun","example":"Це дія.","examples":["action","Це дія."],"atlas_href":"/lexicon/дія/"},{"word":"інфінітив","translation":"infinitive","pos":"noun","example":"Читати - це інфінітив.","examples":["infinitive","Читати - це інфінітив."],"atlas_href":"/lexicon/інфінітив/"},{"word":"читати","translation":"to read","pos":"infinitive","example":"Я люблю читати.","examples":["to read","Я люблю читати."],"atlas_href":"/lexicon/читати/"},{"word":"читаю","translation":"I read","pos":"verb form","example":"Я читаю книгу.","examples":["I read","Я читаю книгу."],"atlas_href":"/lexicon/читаю/"},{"word":"писати","translation":"to write","pos":"infinitive","example":"Мушу писати сьогодні.","examples":["to write","Мушу писати сьогодні."],"atlas_href":"/lexicon/писати/"},{"word":"пишу","translation":"I write","pos":"verb form","example":"Я пишу лист.","examples":["I write","Я пишу лист."],"atlas_href":"/lexicon/пишу/"},{"word":"пишеш","translation":"you write","pos":"verb form","example":"Ти пишеш гарно.","examples":["you write","Ти пишеш гарно."],"atlas_href":"/lexicon/пишеш/"},{"word":"працювати","translation":"to work","pos":"infinitive","example":"Я мушу працювати.","examples":["to work","Я мушу працювати."],"atlas_href":"/lexicon/працювати/"},{"word":"працюю","translation":"I work","pos":"verb form","example":"Я працюю вдома.","examples":["I work","Я працюю вдома."],"atlas_href":"/lexicon/працюю/"},{"word":"працюєш","translation":"you work","pos":"verb form","example":"Де ти працюєш?","examples":["you work","Де ти працюєш?"],"atlas_href":"/lexicon/працюєш/"},{"word":"працює","translation":"he/she works","pos":"verb form","example":"Вона працює в школі.","examples":["he/she works","Вона працює в школі."],"atlas_href":"/lexicon/працює/"},{"word":"говорити","translation":"to speak","pos":"infinitive","example":"Можу говорити українською.","examples":["to speak","Можу говорити українською."],"atlas_href":"/lexicon/говорити/"},{"word":"говорю","translation":"I speak","pos":"verb form","example":"Я говорю українською.","examples":["I speak","Я говорю українською."],"atlas_href":"/lexicon/говорю/"},{"word":"говориш","translation":"you speak","pos":"verb form","example":"Ти говориш українською.","examples":["you speak","Ти говориш українською."],"atlas_href":"/lexicon/говориш/"},{"word":"говоримо","translation":"we speak","pos":"verb form","example":"Ми говоримо українською.","examples":["we speak","Ми говоримо українською."],"atlas_href":"/lexicon/говоримо/"},{"word":"робити","translation":"to do; to make","pos":"infinitive","example":"Що ти робиш?","examples":["to do; to make","Що ти робиш?"],"atlas_href":"/lexicon/робити/"},{"word":"роблять","translation":"they do; they make","pos":"verb form","example":"Вони роблять швидко.","examples":["they do; they make","Вони роблять швидко."],"atlas_href":"/lexicon/роблять/"},{"word":"любити","translation":"to like; to love","pos":"infinitive","example":"Я люблю читати.","examples":["to like; to love","Я люблю читати."],"atlas_href":"/lexicon/любити/"},{"word":"хочу","translation":"I want","pos":"modal verb form","example":"Я хочу гуляти.","examples":["I want","Я хочу гуляти."],"atlas_href":"/lexicon/хочу/"},{"word":"можу","translation":"I can","pos":"modal verb form","example":"Я можу готувати.","examples":["I can","Я можу готувати."],"atlas_href":"/lexicon/можу/"},{"word":"мушу","translation":"I have to","pos":"modal verb form","example":"Я мушу працювати.","examples":["I have to","Я мушу працювати."],"atlas_href":"/lexicon/мушу/"},{"word":"хотіти","translation":"to want","pos":"infinitive","example":"Він хоче кави.","examples":["to want","Він хоче кави."],"atlas_href":"/lexicon/хотіти/"},{"word":"хоче","translation":"he/she wants","pos":"verb form","example":"Він хоче кави.","examples":["he/she wants","Він хоче кави."],"atlas_href":"/lexicon/хоче/"},{"word":"прокидатися","translation":"to wake up","pos":"infinitive","example":"Я прокидаюся о сьомій.","examples":["to wake up","Я прокидаюся о сьомій."],"atlas_href":"/lexicon/прокидатися/"},{"word":"прокидаюся","translation":"I wake up","pos":"reflexive verb form","example":"Я прокидаюся рано.","examples":["I wake up","Я прокидаюся рано."],"atlas_href":"/lexicon/прокидаюся/"},{"word":"вмиватися","translation":"to wash up","pos":"infinitive","example":"Потім вмиваюся.","examples":["to wash up","Потім вмиваюся."],"atlas_href":"/lexicon/вмиватися/"},{"word":"вмиваюся","translation":"I wash up","pos":"reflexive verb form","example":"Я вмиваюся вранці.","examples":["I wash up","Я вмиваюся вранці."],"atlas_href":"/lexicon/вмиваюся/"},{"word":"дивитися","translation":"to watch; to look","pos":"infinitive","example":"Я дивлюся фільм.","examples":["to watch; to look","Я дивлюся фільм."],"atlas_href":"/lexicon/дивитися/"},{"word":"дивлюся","translation":"I watch; I look","pos":"reflexive verb form","example":"Нарешті я дивлюся фільм.","examples":["I watch; I look","Нарешті я дивлюся фільм."],"atlas_href":"/lexicon/дивлюся/"},{"word":"хто","translation":"who","pos":"question word","example":"Хто працює?","examples":["who","Хто працює?"],"atlas_href":"/lexicon/хто/"},{"word":"що","translation":"what","pos":"question word","example":"Що ти читаєш?","examples":["what","Що ти читаєш?"],"atlas_href":"/lexicon/що/"},{"word":"де","translation":"where","pos":"question word","example":"Де ти працюєш?","examples":["where","Де ти працюєш?"],"atlas_href":"/lexicon/де/"},{"word":"куди","translation":"where to","pos":"question word","example":"Куди ти йдеш?","examples":["where to","Куди ти йдеш?"],"atlas_href":"/lexicon/куди/"},{"word":"коли","translation":"when","pos":"question word","example":"Коли ти можеш?","examples":["when","Коли ти можеш?"],"atlas_href":"/lexicon/коли/"},{"word":"чому","translation":"why","pos":"question word","example":"Чому ти не можеш?","examples":["why","Чому ти не можеш?"],"atlas_href":"/lexicon/чому/"},{"word":"як","translation":"how","pos":"question word","example":"Як ми говоримо?","examples":["how","Як ми говоримо?"],"atlas_href":"/lexicon/як/"},{"word":"спочатку","translation":"first","pos":"sequence word","example":"Спочатку я прокидаюся.","examples":["first","Спочатку я прокидаюся."],"atlas_href":"/lexicon/спочатку/"},{"word":"потім","translation":"then","pos":"sequence word","example":"Потім снідаю.","examples":["then","Потім снідаю."],"atlas_href":"/lexicon/потім/"},{"word":"після цього","translation":"after that","pos":"sequence phrase","example":"Після цього працюю.","examples":["after that","Після цього працюю."],"atlas_href":"/lexicon/після-цього/"},{"word":"нарешті","translation":"finally","pos":"sequence word","example":"Нарешті дивлюся фільм.","examples":["finally","Нарешті дивлюся фільм."],"atlas_href":"/lexicon/нарешті/"}]`)} title="Vocabulary" />
+<VocabCard client:only="react" words={JSON.parse(`[{"word":"дія","translation":"action","pos":"noun","example":"Це дія.","examples":["action","Це дія."],"atlas_href":"/lexicon/дія/"},{"word":"інфінітив","translation":"infinitive","pos":"noun","example":"Читати - це інфінітив.","examples":["infinitive","Читати - це інфінітив."],"atlas_href":"/lexicon/інфінітив/"},{"word":"читати","translation":"to read","pos":"infinitive","example":"Я люблю читати.","examples":["to read","Я люблю читати."],"atlas_href":"/lexicon/читати/"},{"word":"читаю","translation":"I read","pos":"verb form","example":"Я читаю книгу.","examples":["I read","Я читаю книгу."]},{"word":"писати","translation":"to write","pos":"infinitive","example":"Мушу писати сьогодні.","examples":["to write","Мушу писати сьогодні."],"atlas_href":"/lexicon/писати/"},{"word":"пишу","translation":"I write","pos":"verb form","example":"Я пишу лист.","examples":["I write","Я пишу лист."]},{"word":"пишеш","translation":"you write","pos":"verb form","example":"Ти пишеш гарно.","examples":["you write","Ти пишеш гарно."]},{"word":"пишете","translation":"you write (plural/formal)","pos":"verb form","example":"Ви пишете дуже гарно.","examples":["you write (plural/formal)","Ви пишете дуже гарно."]},{"word":"працювати","translation":"to work","pos":"infinitive","example":"Я мушу працювати.","examples":["to work","Я мушу працювати."],"atlas_href":"/lexicon/працювати/"},{"word":"працюю","translation":"I work","pos":"verb form","example":"Я працюю вдома.","examples":["I work","Я працюю вдома."]},{"word":"працюєш","translation":"you work","pos":"verb form","example":"Де ти працюєш?","examples":["you work","Де ти працюєш?"]},{"word":"працює","translation":"he/she works","pos":"verb form","example":"Вона працює в школі.","examples":["he/she works","Вона працює в школі."]},{"word":"працюєте","translation":"you work (plural/formal)","pos":"verb form","example":"Ви працюєте сьогодні?","examples":["you work (plural/formal)","Ви працюєте сьогодні?"]},{"word":"говорити","translation":"to speak","pos":"infinitive","example":"Можу говорити українською.","examples":["to speak","Можу говорити українською."],"atlas_href":"/lexicon/говорити/"},{"word":"говорю","translation":"I speak","pos":"verb form","example":"Я говорю українською.","examples":["I speak","Я говорю українською."]},{"word":"говориш","translation":"you speak","pos":"verb form","example":"Ти говориш українською.","examples":["you speak","Ти говориш українською."]},{"word":"говоримо","translation":"we speak","pos":"verb form","example":"Ми говоримо українською.","examples":["we speak","Ми говоримо українською."]},{"word":"робити","translation":"to do; to make","pos":"infinitive","example":"Що ти робиш?","examples":["to do; to make","Що ти робиш?"],"atlas_href":"/lexicon/робити/"},{"word":"роблю","translation":"I do; I make","pos":"verb form","example":"Я роблю вправу.","examples":["I do; I make","Я роблю вправу."]},{"word":"робиш","translation":"you do; you make","pos":"verb form","example":"Що ти робиш потім?","examples":["you do; you make","Що ти робиш потім?"]},{"word":"роблять","translation":"they do; they make","pos":"verb form","example":"Вони роблять швидко.","examples":["they do; they make","Вони роблять швидко."]},{"word":"любити","translation":"to like; to love","pos":"infinitive","example":"Я люблю читати.","examples":["to like; to love","Я люблю читати."],"atlas_href":"/lexicon/любити/"},{"word":"хочу","translation":"I want","pos":"modal verb form","example":"Я хочу гуляти.","examples":["I want","Я хочу гуляти."]},{"word":"хочеш","translation":"you want","pos":"modal verb form","example":"Ти хочеш гуляти?","examples":["you want","Ти хочеш гуляти?"]},{"word":"можу","translation":"I can","pos":"modal verb form","example":"Я можу готувати.","examples":["I can","Я можу готувати."]},{"word":"можеш","translation":"you can","pos":"modal verb form","example":"Ти можеш допомагати?","examples":["you can","Ти можеш допомагати?"]},{"word":"може","translation":"he/she can","pos":"modal verb form","example":"Марина може готувати.","examples":["he/she can","Марина може готувати."],"atlas_href":"/lexicon/може/"},{"word":"мушу","translation":"I have to","pos":"modal verb form","example":"Я мушу працювати.","examples":["I have to","Я мушу працювати."]},{"word":"хотіти","translation":"to want","pos":"infinitive","example":"Він хоче кави.","examples":["to want","Він хоче кави."],"atlas_href":"/lexicon/хотіти/"},{"word":"хоче","translation":"he/she wants","pos":"verb form","example":"Він хоче кави.","examples":["he/she wants","Він хоче кави."]},{"word":"могти","translation":"to be able to","pos":"infinitive","example":"Я можу готувати.","examples":["to be able to","Я можу готувати."],"atlas_href":"/lexicon/могти/"},{"word":"мусити","translation":"to have to; must","pos":"infinitive","example":"Я мушу працювати.","examples":["to have to; must","Я мушу працювати."],"atlas_href":"/lexicon/мусити/"},{"word":"прокидатися","translation":"to wake up","pos":"infinitive","example":"Я прокидаюся о сьомій.","examples":["to wake up","Я прокидаюся о сьомій."],"atlas_href":"/lexicon/прокидатися/"},{"word":"прокидаюся","translation":"I wake up","pos":"reflexive verb form","example":"Я прокидаюся рано.","examples":["I wake up","Я прокидаюся рано."]},{"word":"вмиватися","translation":"to wash up","pos":"infinitive","example":"Потім вмиваюся.","examples":["to wash up","Потім вмиваюся."],"atlas_href":"/lexicon/вмиватися/"},{"word":"вмиваюся","translation":"I wash up","pos":"reflexive verb form","example":"Я вмиваюся вранці.","examples":["I wash up","Я вмиваюся вранці."]},{"word":"снідати","translation":"to have breakfast","pos":"infinitive","example":"Я снідаю вдома.","examples":["to have breakfast","Я снідаю вдома."],"atlas_href":"/lexicon/снідати/"},{"word":"снідаю","translation":"I have breakfast","pos":"verb form","example":"Потім снідаю вдома.","examples":["I have breakfast","Потім снідаю вдома."]},{"word":"готувати","translation":"to cook; to prepare","pos":"infinitive","example":"Я хочу готувати сьогодні.","examples":["to cook; to prepare","Я хочу готувати сьогодні."],"atlas_href":"/lexicon/готувати/"},{"word":"готуєш","translation":"you cook","pos":"verb form","example":"Ти готуєш сьогодні.","examples":["you cook","Ти готуєш сьогодні."]},{"word":"готуємо","translation":"we cook","pos":"verb form","example":"Тоді ми готуємо.","examples":["we cook","Тоді ми готуємо."]},{"word":"прибирати","translation":"to clean","pos":"infinitive","example":"Я можу прибирати.","examples":["to clean","Я можу прибирати."],"atlas_href":"/lexicon/прибирати/"},{"word":"допомагати","translation":"to help","pos":"infinitive","example":"Ти можеш допомагати?","examples":["to help","Ти можеш допомагати?"],"atlas_href":"/lexicon/допомагати/"},{"word":"допомагаю","translation":"I help","pos":"verb form","example":"Я допомагаю після шостої.","examples":["I help","Я допомагаю після шостої."]},{"word":"танцювати","translation":"to dance","pos":"infinitive","example":"Я люблю танцювати.","examples":["to dance","Я люблю танцювати."]},{"word":"співати","translation":"to sing","pos":"infinitive","example":"Вони люблять співати.","examples":["to sing","Вони люблять співати."],"atlas_href":"/lexicon/співати/"},{"word":"грати","translation":"to play","pos":"infinitive","example":"Я можу грати.","examples":["to play","Я можу грати."],"atlas_href":"/lexicon/грати/"},{"word":"гуляти","translation":"to walk","pos":"infinitive","example":"Я хочу гуляти.","examples":["to walk","Я хочу гуляти."],"atlas_href":"/lexicon/гуляти/"},{"word":"піти","translation":"to go","pos":"infinitive","example":"Я хочу піти в парк.","examples":["to go","Я хочу піти в парк."],"atlas_href":"/lexicon/піти/"},{"word":"гуляю","translation":"I walk","pos":"verb form","example":"Зараз я не гуляю.","examples":["I walk","Зараз я не гуляю."]},{"word":"гуляють","translation":"they walk","pos":"verb form","example":"Вони гуляють у парку.","examples":["they walk","Вони гуляють у парку."]},{"word":"навчатися","translation":"to study; to learn","pos":"infinitive","example":"Я навчаюся вдома.","examples":["to study; to learn","Я навчаюся вдома."],"atlas_href":"/lexicon/навчатися/"},{"word":"дивитися","translation":"to watch; to look","pos":"infinitive","example":"Я дивлюся фільм.","examples":["to watch; to look","Я дивлюся фільм."],"atlas_href":"/lexicon/дивитися/"},{"word":"дивлюся","translation":"I watch; I look","pos":"reflexive verb form","example":"Нарешті я дивлюся фільм.","examples":["I watch; I look","Нарешті я дивлюся фільм."]},{"word":"хто","translation":"who","pos":"question word","example":"Хто працює?","examples":["who","Хто працює?"],"atlas_href":"/lexicon/хто/"},{"word":"що","translation":"what","pos":"question word","example":"Що ти читаєш?","examples":["what","Що ти читаєш?"],"atlas_href":"/lexicon/що/"},{"word":"де","translation":"where","pos":"question word","example":"Де ти працюєш?","examples":["where","Де ти працюєш?"],"atlas_href":"/lexicon/де/"},{"word":"куди","translation":"where to","pos":"question word","example":"Куди ти йдеш?","examples":["where to","Куди ти йдеш?"],"atlas_href":"/lexicon/куди/"},{"word":"коли","translation":"when","pos":"question word","example":"Коли ти можеш?","examples":["when","Коли ти можеш?"],"atlas_href":"/lexicon/коли/"},{"word":"чому","translation":"why","pos":"question word","example":"Чому ти не можеш?","examples":["why","Чому ти не можеш?"],"atlas_href":"/lexicon/чому/"},{"word":"як","translation":"how","pos":"question word","example":"Як ми говоримо?","examples":["how","Як ми говоримо?"],"atlas_href":"/lexicon/як/"},{"word":"спочатку","translation":"first","pos":"sequence word","example":"Спочатку я прокидаюся.","examples":["first","Спочатку я прокидаюся."],"atlas_href":"/lexicon/спочатку/"},{"word":"потім","translation":"then","pos":"sequence word","example":"Потім снідаю.","examples":["then","Потім снідаю."],"atlas_href":"/lexicon/потім/"},{"word":"після цього","translation":"after that","pos":"sequence phrase","example":"Після цього працюю.","examples":["after that","Після цього працюю."],"atlas_href":"/lexicon/після-цього/"},{"word":"нарешті","translation":"finally","pos":"sequence word","example":"Нарешті дивлюся фільм.","examples":["finally","Нарешті дивлюся фільм."],"atlas_href":"/lexicon/нарешті/"}]`)} title="Vocabulary" />
 
-<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"дія","back":"action"},{"front":"інфінітив","back":"infinitive"},{"front":"читати","back":"to read"},{"front":"читаю","back":"I read"},{"front":"писати","back":"to write"},{"front":"пишу","back":"I write"},{"front":"пишеш","back":"you write"},{"front":"працювати","back":"to work"},{"front":"працюю","back":"I work"},{"front":"працюєш","back":"you work"},{"front":"працює","back":"he/she works"},{"front":"говорити","back":"to speak"},{"front":"говорю","back":"I speak"},{"front":"говориш","back":"you speak"},{"front":"говоримо","back":"we speak"},{"front":"робити","back":"to do; to make"},{"front":"роблять","back":"they do; they make"},{"front":"любити","back":"to like; to love"},{"front":"хочу","back":"I want"},{"front":"можу","back":"I can"},{"front":"мушу","back":"I have to"},{"front":"хотіти","back":"to want"},{"front":"хоче","back":"he/she wants"},{"front":"прокидатися","back":"to wake up"},{"front":"прокидаюся","back":"I wake up"},{"front":"вмиватися","back":"to wash up"},{"front":"вмиваюся","back":"I wash up"},{"front":"дивитися","back":"to watch; to look"},{"front":"дивлюся","back":"I watch; I look"},{"front":"хто","back":"who"},{"front":"що","back":"what"},{"front":"де","back":"where"},{"front":"куди","back":"where to"},{"front":"коли","back":"when"},{"front":"чому","back":"why"},{"front":"як","back":"how"},{"front":"спочатку","back":"first"},{"front":"потім","back":"then"},{"front":"після цього","back":"after that"},{"front":"нарешті","back":"finally"}]`)} />
+<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"дія","back":"action"},{"front":"інфінітив","back":"infinitive"},{"front":"читати","back":"to read"},{"front":"читаю","back":"I read"},{"front":"писати","back":"to write"},{"front":"пишу","back":"I write"},{"front":"пишеш","back":"you write"},{"front":"пишете","back":"you write (plural/formal)"},{"front":"працювати","back":"to work"},{"front":"працюю","back":"I work"},{"front":"працюєш","back":"you work"},{"front":"працює","back":"he/she works"},{"front":"працюєте","back":"you work (plural/formal)"},{"front":"говорити","back":"to speak"},{"front":"говорю","back":"I speak"},{"front":"говориш","back":"you speak"},{"front":"говоримо","back":"we speak"},{"front":"робити","back":"to do; to make"},{"front":"роблю","back":"I do; I make"},{"front":"робиш","back":"you do; you make"},{"front":"роблять","back":"they do; they make"},{"front":"любити","back":"to like; to love"},{"front":"хочу","back":"I want"},{"front":"хочеш","back":"you want"},{"front":"можу","back":"I can"},{"front":"можеш","back":"you can"},{"front":"може","back":"he/she can"},{"front":"мушу","back":"I have to"},{"front":"хотіти","back":"to want"},{"front":"хоче","back":"he/she wants"},{"front":"могти","back":"to be able to"},{"front":"мусити","back":"to have to; must"},{"front":"прокидатися","back":"to wake up"},{"front":"прокидаюся","back":"I wake up"},{"front":"вмиватися","back":"to wash up"},{"front":"вмиваюся","back":"I wash up"},{"front":"снідати","back":"to have breakfast"},{"front":"снідаю","back":"I have breakfast"},{"front":"готувати","back":"to cook; to prepare"},{"front":"готуєш","back":"you cook"},{"front":"готуємо","back":"we cook"},{"front":"прибирати","back":"to clean"},{"front":"допомагати","back":"to help"},{"front":"допомагаю","back":"I help"},{"front":"танцювати","back":"to dance"},{"front":"співати","back":"to sing"},{"front":"грати","back":"to play"},{"front":"гуляти","back":"to walk"},{"front":"піти","back":"to go"},{"front":"гуляю","back":"I walk"},{"front":"гуляють","back":"they walk"},{"front":"навчатися","back":"to study; to learn"},{"front":"дивитися","back":"to watch; to look"},{"front":"дивлюся","back":"I watch; I look"},{"front":"хто","back":"who"},{"front":"що","back":"what"},{"front":"де","back":"where"},{"front":"куди","back":"where to"},{"front":"коли","back":"when"},{"front":"чому","back":"why"},{"front":"як","back":"how"},{"front":"спочатку","back":"first"},{"front":"потім","back":"then"},{"front":"після цього","back":"after that"},{"front":"нарешті","back":"finally"}]`)} />
 
 </TabItem>
 <TabItem label="Activities">
 
-### Reading line to skill
+### Змішані форми дій
 
 *(see lesson, §Що ми знаємо?)*
 
-### Action diagnostics
+### Діалог із сусідом
 
 *(see lesson, §Що ми знаємо?)*
 
-### Skill stations
+### Мій день
 
 *(see lesson, §Читання)*
 
-### Roommate dialogue gaps
+### Групи дієслів
 
 *(see lesson, §Repair traps)*
-
-### Find the form that does not fit
-
-<OddOneOut client:only='react' instruction={"Choose the chunk that belongs to a different checkpoint skill."} items={JSON.parse(`[{"words": ["я читаю", "ти читаєш", "вони читають", "ти говориш"], "correct": 3, "explanation": "Ти говориш is Group Two; the others are Group One читати."}, {"words": ["хочу читати", "можу готувати", "мушу працювати", "я читаю"], "correct": 3, "explanation": "Я читаю is a person form, not modal + infinitive."}, {"words": ["хто", "коли", "куди", "працюю"], "correct": 3, "explanation": "Працюю is a verb form; the others are question words."}, {"words": ["я прокидаюся", "ти вмиваєшся", "вона одягається", "я снідаю"], "correct": 3, "explanation": "Снідаю is not a -ся verb."}]`)} />
-
-### Rebuild checkpoint lines
-
-<Unjumble client:only='react' items={JSON.parse(`[{"jumbled": "Я / люблю / читати", "answer": "Я люблю читати"}, {"jumbled": "Вона / працює / в школі", "answer": "Вона працює в школі"}, {"jumbled": "Ми / говоримо / українською", "answer": "Ми говоримо українською"}, {"jumbled": "Коли / ти / можеш", "answer": "Коли ти можеш"}, {"jumbled": "Я / мушу / працювати", "answer": "Я мушу працювати"}, {"jumbled": "Вони / роблять / швидко", "answer": "Вони роблять швидко"}]`)} instruction={"Put the words in a safe A1.3 order."} />
-
-### Choose the answer job
-
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "Коли ти прокидаєшся?", "options": [{"text": "О сьомій.", "correct": true}, {"text": "У школі.", "correct": false}, {"text": "Українською.", "correct": false}], "explanation": "Коли asks about time."}, {"question": "Де ти працюєш?", "options": [{"text": "В офісі.", "correct": true}, {"text": "О восьмій.", "correct": false}, {"text": "Тому що мушу.", "correct": false}], "explanation": "Де asks about place."}, {"question": "Що ти любиш?", "options": [{"text": "Читати.", "correct": true}, {"text": "Удома.", "correct": false}, {"text": "Завтра.", "correct": false}], "explanation": "Що asks for the action or thing."}, {"question": "Як ми говоримо?", "options": [{"text": "Українською.", "correct": true}, {"text": "Увечері.", "correct": false}, {"text": "У школі.", "correct": false}], "explanation": "Як asks how."}]`)} instruction={"Choose the line that answers the question."} isUkrainian={false} />
-
-### Repair by building the safe line
-
-<FillIn client:only='react' items={JSON.parse(`[{"sentence": "I work every day: Я ___ кожного дня.", "answer": "працюю", "options": ["працюю", "читаю", "пишу"]}, {"sentence": "She works at school: Вона ___ в школі.", "answer": "працює", "options": ["працює", "читає", "готує"]}, {"sentence": "I read a book: Я ___ книгу.", "answer": "читаю", "options": ["читаю", "пишу", "бачу"]}, {"sentence": "You write very nicely: Ви ___ дуже гарно.", "answer": "пишете", "options": ["пишете", "читаєте", "говорите"]}, {"sentence": "They work fast: Вони ___ швидко.", "answer": "роблять", "options": ["роблять", "говорять", "читають"]}, {"sentence": "He wants coffee: Він ___ кави.", "answer": "хоче", "options": ["хоче", "любить", "п'є"]}]`)} instruction={"Build the corrected line from the checkpoint prompt."} isUkrainian={false} />
 
 </TabItem>
 <TabItem label="Resources">


### PR DESCRIPTION
## Summary
- align A1 M21 `checkpoint-actions` with the locked checkpoint plan
- replace off-contract activities with exact inline activity set: quiz 10, fill-in 8, fill-in 6, group-sort 12
- tighten lesson text to synthesize Modules 15-20 and regenerate MDX
- expand checkpoint vocabulary sidecar for required/recommended plan verbs

## Quality Gate
- Deterministic certification: PASS (`.venv/bin/python scripts/audit/certify_module.py a1 21 --clean-qg-artifacts`)
- Activity contract: PASS (`act-1 quiz 10`, `act-2 fill-in 8`, `act-3 fill-in 6`, `act-4 group-sort 12`, no workbook)
- Gemini LLM QG: PASS, min score 9.0, blockers []
- Read-only sidecar review: clean
- DeepSeek QG: attempted once via Hermes `deepseek-v4-flash`; backend produced no JSON/output and was interrupted after hanging, not retried per process rule

## Token telemetry
- run_id: a1-m21-pr3484
- status: ready
- swarm_used: true
- swarm_label: thin
- swarm_note: Used one bounded read-only gpt-5.4-mini sidecar reviewer plus Gemini QG; DeepSeek QG attempted once and recorded as empty/hung, no retry.
- token_source: unavailable
- main: codex gpt-5, integration/content/validation, tokens unavailable
- helpers: gpt-5.4-mini sidecar review; gemini-3-flash-preview QG; deepseek-v4-flash attempted QG failure