### PR TITLE
fix(infra): stop orphan-guard aborting deploy on in-flight dispatch briefs (#3456)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,8 @@ temp/
 *.yml.orig
 .venv/
 .agent/
-.agents/  # deploy target (rsync'd from agents_extensions/shared/skills); like .claude/.codex/.agent
+# deploy target (rsync'd from agents_extensions/shared/skills); like .claude/.codex/.agent
+.agents/
 # Temporary/sample images in docs (textbook screenshots, vision test outputs)
 docs/temp_*.png
 docs/bolshakova_*.png

--- a/scripts/deploy_prompts.sh
+++ b/scripts/deploy_prompts.sh
@@ -57,7 +57,13 @@ ORPHAN_PATHS_CLAUDE="scheduled_tasks.lock worktrees"
 # tmp/ — runtime scratch (issue/PR draft bodies, transient tarballs) written into
 #          .agent/ by orchestration tooling. Runtime-only, NOT source-tracked.
 #          Same rationale as prompts/: declare so rsync --delete preserves it.
-ORPHAN_PATHS_AGENT="wake cache prompts tmp *-thread-bootstrap.md *-thread-handoff.md *-thread-lease.json"
+# *-brief.md / dispatch-*.md — transient dispatch briefs (.agent/atlas-3150-brief.md,
+#          .agent/dispatch-3098-slice3.md) hand-authored by orchestrators when firing a
+#          dispatch. Same category as prompts/ and tmp/: runtime-only scratch, NOT
+#          source-tracked. Without these patterns a single in-flight brief aborts the
+#          ENTIRE deploy (every target), so committed source prompt fixes silently never
+#          reach .claude/ + .codex/ + .agent/ runtime — agents keep running stale prompts (#3456).
+ORPHAN_PATHS_AGENT="wake cache prompts tmp *-thread-bootstrap.md *-thread-handoff.md *-thread-lease.json *-brief.md dispatch-*.md"
 ORPHAN_PATHS_AGENTS=""
 # agents/curriculum-orchestrator.toml and agents/curriculum-writer.toml —
 # Codex agent definitions with no shared equivalent.

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -163,6 +163,32 @@ def test_codex_orphan_is_caught(tmp_path: Path) -> None:
     assert "undeclared orphan 'stale-only.txt'" in combined_output
 
 
+def test_agent_transient_briefs_are_preserved(tmp_path: Path) -> None:
+    """In-flight dispatch briefs in .agent/ must neither abort the deploy nor be wiped.
+
+    Regression for #3456: a single undeclared brief aborted the whole deploy, so
+    committed source prompt fixes silently never reached the runtime targets. The
+    *-brief.md / dispatch-*.md patterns are declared in ORPHAN_PATHS_AGENT, so the
+    preflight guard ignores them and rsync --delete preserves them.
+    """
+    repo = _init_checkout(tmp_path)
+    agent_dir = repo / ".agent"
+    agent_dir.mkdir(parents=True)
+    brief = agent_dir / "atlas-3150-brief.md"
+    brief.write_text("transient dispatch brief\n", encoding="utf-8")
+    dispatch = agent_dir / "dispatch-3098-slice3.md"
+    dispatch.write_text("transient dispatch prompt\n", encoding="utf-8")
+
+    deploy_result = _run(repo, DEPLOY_SCRIPT)
+    assert deploy_result.returncode == 0, (
+        "deploy aborted with an in-flight brief present:\n"
+        f"stdout: {deploy_result.stdout}\nstderr: {deploy_result.stderr}"
+    )
+    # rsync --delete must preserve the declared transient scratch.
+    assert brief.exists(), "atlas-3150-brief.md was wiped by rsync --delete"
+    assert dispatch.exists(), "dispatch-3098-slice3.md was wiped by rsync --delete"
+
+
 def test_drift_is_caught(tmp_path: Path) -> None:
     """Post-deploy edits to a target tree must be reported as drift."""
     repo = _init_checkout(tmp_path)


### PR DESCRIPTION
## Problem (#3456)
The deploy preflight orphan-guard aborts the **entire** `scripts/deploy_prompts.sh` run whenever a transient dispatch brief (`.agent/atlas-3150-brief.md`, `.agent/dispatch-*.md`) sits in the `.agent/` deploy target. Because the abort is all-or-nothing, committed **source** prompt fixes silently never propagate to the `.claude/` + `.codex/` + `.agent/` runtimes — agents keep running stale prompts (concrete damage: the #M-13 A2-immersion landmine drift caught 2026-06-17).

## Root cause
Briefs are hand-authored runtime scratch in `.agent/` — the same category as the already-declared `prompts/`, `tmp/`, `wake/`, and `*-thread-*` files. They were simply never declared in `ORPHAN_PATHS_AGENT`. No tooling writes them by a fixed path, so declaring-in-place is consistent with how the analogous thread-handoff files already live at `.agent/` top-level.

## Changes
- **`deploy_prompts.sh`**: declare `*-brief.md` + `dispatch-*.md` in `ORPHAN_PATHS_AGENT`. One mechanism handles both halves — it glob-matches the preflight guard (no abort) **and** becomes an `rsync --exclude` so `--delete` preserves the in-flight briefs. The hard abort is **retained** for genuinely-undeclared orphans (weakening it to per-target skip would introduce silent partial deploys).
- **`tests/test_deploy_script_idempotency.py`**: new `test_agent_transient_briefs_are_preserved` — deploy succeeds with a brief/dispatch file present and rsync `--delete` preserves both. The existing `test_codex_orphan_is_caught` stays green (data-loss guard still fires for unexpected files).
- **`.gitignore`**: fix a broken inline-comment on the `.agents/` line — git honors `#` only at line start, so the pattern was the literal `.agents/  # ...` and matched nothing, leaking the `.agents/` skills deploy target as untracked. Comment moved to its own line. (Sibling bug surfaced while verifying the fix.)

## Verification
- `bash -n` clean · `ruff` clean · `pytest tests/test_deploy_script_idempotency.py` → **6 passed**
- Live dry-run: `✅ All orphan paths are declared`
- Live deploy: **exit 0**, all 8 in-flight brief/dispatch files preserved, previously-blocked skills propagated
- `.agents/skills/*` now correctly `git check-ignore`-matched

Closes #3456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)