### PR TITLE
[codex] feat(build): median-of-N reviewer ensemble + noise-aware regression guard (#3079)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -471,6 +471,10 @@ WIKI_COVERAGE_OVERALL_VERDICTS = {"PASS", "PARTIAL", "FAIL"}
 WIKI_COVERAGE_EVIDENCE_QUOTE_MARKERS = ('"', "“", "«")
 LLM_QG_CORE_MAX_ROUNDS = 1
 LLM_QG_SEMINAR_MAX_ROUNDS = 3
+LLM_QG_REVIEWER_SAMPLES = {"seminar": 3}
+# LLM judges have measurable round-over-round noise; only stop correction on
+# min-score drops that exceed this conservative tolerance.
+LLM_QG_REGRESSION_NOISE_TOLERANCE = 0.5
 PYTHON_QG_CORE_MAX_CORRECTION_ROUNDS = 1
 PYTHON_QG_SEMINAR_MAX_CORRECTION_ROUNDS = 8
 PYTHON_QG_MIN_REGRESSION_PATIENCE = 3
@@ -4653,6 +4657,12 @@ def python_qg_max_correction_rounds_for_level(level: str | None) -> int:
     )
 
 
+def llm_qg_reviewer_samples_for_level(level: str | None) -> int:
+    """Return the per-dim LLM-QG reviewer sample count for a curriculum level."""
+    profile = "seminar" if str(level or "").strip().lower() in SEMINAR_LEVELS else "core"
+    return max(1, int(LLM_QG_REVIEWER_SAMPLES.get(profile, 1)))
+
+
 def _python_qg_level_from_plan_path(plan_path: Path) -> str | None:
     with contextlib.suppress(LinearPipelineError, OSError, yaml.YAMLError):
         return str(load_plan(plan_path).get("level") or "").strip().lower()
@@ -5249,6 +5259,101 @@ def parse_review_response(
     return entry
 
 
+def llm_qg_median_sample_index(scores: Sequence[float]) -> int:
+    """Return the source-sample index for the median score.
+
+    Even-sized ensembles choose the lower-middle score so the selected report
+    remains one real reviewer sample rather than synthesized evidence.
+    """
+    if not scores:
+        raise LinearPipelineError("LLM QG reviewer ensemble requires at least one score")
+    return sorted(range(len(scores)), key=lambda index: (float(scores[index]), index))[
+        (len(scores) - 1) // 2
+    ]
+
+
+def select_median_llm_review_sample(
+    dim_results: Sequence[Mapping[str, Any]],
+    *,
+    dim: str,
+    reviewer: str | None = None,
+    module: str | None = None,
+    writer_under_review: str | None = None,
+    event_sink: Callable[..., None] | None = None,
+) -> dict[str, Any]:
+    """Select the full per-dim result whose score is the ensemble median."""
+    if not dim_results:
+        raise LinearPipelineError(f"LLM QG reviewer ensemble for {dim} has no samples")
+    scores = [float(result["score"]) for result in dim_results]
+    chosen_index = llm_qg_median_sample_index(scores)
+    _emit(
+        event_sink,
+        "reviewer_ensemble",
+        dim=dim,
+        n=len(dim_results),
+        scores=scores,
+        median_score=scores[chosen_index],
+        chosen_sample_index=chosen_index,
+        reviewer=reviewer,
+        module=module,
+        writer_under_review=writer_under_review,
+    )
+    return dict(dim_results[chosen_index])
+
+
+def invoke_reviewer_dim_ensemble(
+    prompt: str,
+    reviewer: str,
+    *,
+    dim: str,
+    writer_under_review: str,
+    reviewer_samples: int,
+    cwd: Path = PROJECT_ROOT,
+    invoker: Callable[..., Any] | None = None,
+    module: str | None = None,
+    event_sink: Callable[..., None] | None = None,
+    stdout_silence_timeout: int | None = None,
+) -> dict[str, Any]:
+    """Invoke a per-dim reviewer once or as a median-of-N ensemble."""
+    sample_count = max(1, int(reviewer_samples))
+    if sample_count == 1:
+        response = invoke_reviewer_dim(
+            prompt,
+            reviewer,
+            dim=dim,
+            writer_under_review=writer_under_review,
+            cwd=cwd,
+            invoker=invoker,
+            module=module,
+            event_sink=event_sink,
+            stdout_silence_timeout=stdout_silence_timeout,
+        )
+        return parse_review_response(response, dim)
+
+    dim_results: list[dict[str, Any]] = []
+    for _sample_index in range(sample_count):
+        response = invoke_reviewer_dim(
+            prompt,
+            reviewer,
+            dim=dim,
+            writer_under_review=writer_under_review,
+            cwd=cwd,
+            invoker=invoker,
+            module=module,
+            event_sink=event_sink,
+            stdout_silence_timeout=stdout_silence_timeout,
+        )
+        dim_results.append(parse_review_response(response, dim))
+    return select_median_llm_review_sample(
+        dim_results,
+        dim=dim,
+        reviewer=reviewer,
+        module=module,
+        writer_under_review=writer_under_review,
+        event_sink=event_sink,
+    )
+
+
 def parse_wiki_coverage_review_response(response: str) -> dict[str, Any]:
     payload = _parse_json_or_yaml_mapping(response)
     verdicts = payload.get("verdicts")
@@ -5676,9 +5781,14 @@ def run_llm_qg_with_corrections(
     python_qg_runner: Callable[[], dict[str, Any]] | None = None,
     invoker: Callable[..., Any] | None = None,
     event_sink: Callable[..., None] | None = None,
+    reviewer_samples: int | None = None,
 ) -> dict[str, Any]:
     """Run LLM-QG with a bounded insert-only pedagogical correction loop."""
     review_rounds = max(1, int(max_rounds or llm_qg_max_rounds_for_level(plan.get("level"))))
+    llm_qg_reviewer_samples = max(
+        1,
+        int(reviewer_samples or llm_qg_reviewer_samples_for_level(plan.get("level"))),
+    )
     rounds: list[dict[str, Any]] = []
     corrections: list[dict[str, Any]] = []
     pending_python_qg: dict[str, Any] | None = None
@@ -5698,6 +5808,8 @@ def run_llm_qg_with_corrections(
             stdout_silence_timeout=stdout_silence_timeout,
             use_generator=use_generator,
             obligation_checklist=obligation_checklist,
+            event_sink=event_sink,
+            reviewer_samples=llm_qg_reviewer_samples,
         )
         round_record = {
             "round": round_num,
@@ -5721,6 +5833,7 @@ def run_llm_qg_with_corrections(
         if round_num > 1 and min_score_regressed(
             _llm_qg_dimensions(rounds[-2]["llm_qg"]),
             _llm_qg_dimensions(llm_qg),
+            tolerance=LLM_QG_REGRESSION_NOISE_TOLERANCE,
         ):
             stopped_reason = "min_score_regressed"
             break

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -1032,11 +1032,14 @@ def _run_llm_qg(
     stdout_silence_timeout: int | None = None,
     use_generator: bool = False,
     obligation_checklist: Mapping[str, Any] | None = None,
+    event_sink: Callable[..., None] | None = None,
+    reviewer_samples: int = 1,
 ) -> dict[str, Any]:
     from scripts.agent_runtime.runner import invoke
 
     reviewer = _reviewer_for_writer(writer, reviewer_override)
     defaults = linear_pipeline.REVIEWER_DEFAULTS[reviewer]
+    sample_count = max(1, int(reviewer_samples))
 
     assert linear_pipeline.WRITER_DEFAULTS[writer]["model"] != defaults["model"], \
         f"same-model self-review forbidden: writer={writer} reviewer={reviewer}"
@@ -1058,56 +1061,86 @@ def _run_llm_qg(
         )
         prompt_path = module_dir / f"llm-qg-{dim}-prompt.md"
         response_path = module_dir / f"llm-qg-{dim}-response.raw.md"
-        resumed = _resume_llm_qg_dim_if_current(
-            dim=dim,
-            prompt=prompt,
-            prompt_path=prompt_path,
-            response_path=response_path,
-        )
-        if resumed is not None:
-            report[dim] = resumed
-            continue
+        if sample_count == 1:
+            resumed = _resume_llm_qg_dim_if_current(
+                dim=dim,
+                prompt=prompt,
+                prompt_path=prompt_path,
+                response_path=response_path,
+            )
+            if resumed is not None:
+                report[dim] = resumed
+                continue
 
         prompt_path.write_text(prompt, encoding="utf-8")
-        last_error: linear_pipeline.LinearPipelineError | None = None
-        for attempt in range(1, LLM_QG_DIM_MAX_ATTEMPTS + 1):
-            result = invoke(
-                agent_name,
-                prompt,
-                mode="read-only",
-                cwd=module_dir,
-                model=defaults["model"],
-                task_id=f"linear-v7-qg-{plan['slug']}-{dim}",
-                entrypoint="dispatch",
-                effort=defaults["effort"],
-                tool_config={"output_format": "stream-json"},
-                stdout_silence_timeout=stdout_silence_timeout,
+        dim_results: list[dict[str, Any]] = []
+        raw_responses: list[str] = []
+        for sample_index in range(sample_count):
+            sample_response_path = (
+                response_path
+                if sample_count == 1
+                else module_dir / f"llm-qg-{dim}-sample-{sample_index + 1}-response.raw.md"
             )
-            response = str(getattr(result, "response", "") or "")
-            # Persist raw reviewer response BEFORE parse so #M-10 forensic
-            # continuity holds when the parser raises (build #10, 2026-05-21
-            # exposed prose-wrapped JSON shape with no saved artifact).
-            response_path.write_text(response, encoding="utf-8")
-            try:
-                report[dim] = _parse_llm_qg_dim_response(
-                    response,
-                    dim=dim,
-                    response_path=response_path,
+            task_id = f"linear-v7-qg-{plan['slug']}-{dim}"
+            if sample_count > 1:
+                task_id = f"{task_id}-s{sample_index + 1}"
+            last_error: linear_pipeline.LinearPipelineError | None = None
+            for attempt in range(1, LLM_QG_DIM_MAX_ATTEMPTS + 1):
+                result = invoke(
+                    agent_name,
+                    prompt,
+                    mode="read-only",
+                    cwd=module_dir,
+                    model=defaults["model"],
+                    task_id=task_id,
+                    entrypoint="dispatch",
+                    effort=defaults["effort"],
+                    tool_config={"output_format": "stream-json"},
+                    stdout_silence_timeout=stdout_silence_timeout,
                 )
-                break
-            except linear_pipeline.LinearPipelineError as exc:
-                last_error = exc
-                if attempt < LLM_QG_DIM_MAX_ATTEMPTS:
-                    print(
-                        f"[llm-qg] {dim}: attempt {attempt}/{LLM_QG_DIM_MAX_ATTEMPTS} failed; retrying ({exc})",
-                        file=sys.stderr,
-                        flush=True,
+                response = str(getattr(result, "response", "") or "")
+                # Persist raw reviewer response BEFORE parse so #M-10 forensic
+                # continuity holds when the parser raises (build #10, 2026-05-21
+                # exposed prose-wrapped JSON shape with no saved artifact).
+                sample_response_path.write_text(response, encoding="utf-8")
+                try:
+                    dim_results.append(
+                        _parse_llm_qg_dim_response(
+                            response,
+                            dim=dim,
+                            response_path=sample_response_path,
+                        )
                     )
-                    continue
-                raise linear_pipeline.LinearPipelineError(
-                    f"LLM QG {dim} failed after {LLM_QG_DIM_MAX_ATTEMPTS} attempt(s); "
-                    f"raw response saved to {response_path}: {last_error}"
-                ) from last_error
+                    raw_responses.append(response)
+                    break
+                except linear_pipeline.LinearPipelineError as exc:
+                    last_error = exc
+                    if attempt < LLM_QG_DIM_MAX_ATTEMPTS:
+                        print(
+                            f"[llm-qg] {dim}: attempt {attempt}/{LLM_QG_DIM_MAX_ATTEMPTS} failed; retrying ({exc})",
+                            file=sys.stderr,
+                            flush=True,
+                        )
+                        continue
+                    raise linear_pipeline.LinearPipelineError(
+                        f"LLM QG {dim} failed after {LLM_QG_DIM_MAX_ATTEMPTS} attempt(s); "
+                        f"raw response saved to {sample_response_path}: {last_error}"
+                    ) from last_error
+
+        if sample_count == 1:
+            report[dim] = dim_results[0]
+        else:
+            scores = [float(result["score"]) for result in dim_results]
+            chosen_index = linear_pipeline.llm_qg_median_sample_index(scores)
+            response_path.write_text(raw_responses[chosen_index], encoding="utf-8")
+            report[dim] = linear_pipeline.select_median_llm_review_sample(
+                dim_results,
+                dim=dim,
+                reviewer=reviewer,
+                module=f"{str(plan['level']).lower()}/{plan['slug']}",
+                writer_under_review=writer,
+                event_sink=event_sink,
+            )
 
     return linear_pipeline.aggregate_llm_review(
         report,
@@ -1912,6 +1945,7 @@ def _run(args: argparse.Namespace) -> int:
             writer=writer,
             reviewer_override=reviewer_override,
         )
+        llm_qg_reviewer_samples = linear_pipeline.llm_qg_reviewer_samples_for_level(level)
         timeout_agent = _reviewer_for_writer(writer, llm_qg_reviewer_override)
         started_at = time.monotonic()
         if (
@@ -1941,6 +1975,7 @@ def _run(args: argparse.Namespace) -> int:
                     obligation_checklist=obligation_checklist,
                     max_rounds=linear_pipeline.llm_qg_max_rounds_for_level(level),
                     event_sink=tracker.emit,
+                    reviewer_samples=llm_qg_reviewer_samples,
                 )
             else:
                 llm_qg = _run_llm_qg(
@@ -1955,6 +1990,8 @@ def _run(args: argparse.Namespace) -> int:
                     stdout_silence_timeout=args.writer_timeout,
                     use_generator=use_generator,
                     obligation_checklist=obligation_checklist,
+                    event_sink=tracker.emit,
+                    reviewer_samples=llm_qg_reviewer_samples,
                 )
             linear_pipeline.write_json(module_dir / "llm_qg.json", llm_qg)
         aggregate = llm_qg["aggregate"]

--- a/scripts/build/v7_review.py
+++ b/scripts/build/v7_review.py
@@ -266,6 +266,7 @@ def _run(args: argparse.Namespace) -> int:
         phase = "review"
         started_at = time.monotonic()
         report: dict[str, dict[str, Any]] = {}
+        reviewer_samples = linear_pipeline.llm_qg_reviewer_samples_for_level(level)
         for dim in QG_DIMS:
             prompt = linear_pipeline.render_review_prompt(
                 plan,
@@ -273,17 +274,17 @@ def _run(args: argparse.Namespace) -> int:
                 content,
                 dim,
             )
-            response = linear_pipeline.invoke_reviewer_dim(
+            report[dim] = linear_pipeline.invoke_reviewer_dim_ensemble(
                 prompt,
                 reviewer,
                 dim=dim,
                 writer_under_review=writer_under_review,
+                reviewer_samples=reviewer_samples,
                 cwd=content_path.parent,
                 module=module_ref,
                 event_sink=event_sink,
                 stdout_silence_timeout=args.writer_timeout,
             )
-            report[dim] = linear_pipeline.parse_review_response(response, dim)
 
         audit_calls_total = sum(
             1 for event in captured_events if event["event"] == "reviewer_audit_call"

--- a/scripts/common/review_loop.py
+++ b/scripts/common/review_loop.py
@@ -41,11 +41,13 @@ def aggregate_min(dim_results: Mapping[str, Any]) -> tuple[float, str | None]:
 def min_score_regressed(
     prev: Mapping[str, Any],
     curr: Mapping[str, Any],
+    *,
+    tolerance: float = 0.0,
 ) -> bool:
-    """True iff the aggregate MIN score dropped round-over-round."""
+    """True iff the aggregate MIN score dropped beyond tolerance."""
     prev_min, _ = aggregate_min(prev)
     curr_min, _ = aggregate_min(curr)
-    return curr_min < prev_min
+    return (prev_min - curr_min) > float(tolerance)
 
 
 def best_round_index(

--- a/tests/test_llm_qg_correction_loop.py
+++ b/tests/test_llm_qg_correction_loop.py
@@ -80,6 +80,76 @@ def test_llm_qg_best_round_uses_highest_aggregate_min_not_last(tmp_path: Path) -
     assert module_text.count("Self-check prompt.") == 1
 
 
+def test_llm_qg_min_score_drop_within_noise_tolerance_does_not_stop(tmp_path: Path) -> None:
+    module_dir = _module_dir(tmp_path)
+    plan_path = _plan_path(tmp_path)
+    reports = [
+        _llm_report(pedagogical=7.0),
+        _llm_report(pedagogical=6.5),
+        _llm_report(pedagogical=6.6),
+    ]
+
+    def llm_runner(**_: Any) -> dict[str, Any]:
+        return reports.pop(0)
+
+    def corrector(context: linear_pipeline.CorrectionContext) -> str:
+        round_id = len(reports)
+        return (
+            "<fixes><fix><insert_after>Anchor sentence.</insert_after>"
+            f"<text>\n\nTolerance scaffold {round_id}.</text></fix></fixes>"
+        )
+
+    linear_pipeline.run_llm_qg_with_corrections(
+        plan={"level": "folk", "sequence": 1, "slug": "sample"},
+        plan_path=plan_path,
+        plan_content="plan",
+        module_dir=module_dir,
+        writer="codex-tools",
+        llm_qg_runner=llm_runner,
+        python_qg_runner=_python_qg_pass,
+        corrector=corrector,
+        max_rounds=3,
+    )
+
+    loop = json.loads((module_dir / "llm_qg_correction_loop.json").read_text(encoding="utf-8"))
+    assert loop["stopped_reason"] == "max_rounds"
+    assert [round_summary["round"] for round_summary in loop["rounds"]] == [1, 2, 3]
+
+
+def test_llm_qg_min_score_drop_beyond_noise_tolerance_stops(tmp_path: Path) -> None:
+    module_dir = _module_dir(tmp_path)
+    plan_path = _plan_path(tmp_path)
+    reports = [
+        _llm_report(pedagogical=7.0),
+        _llm_report(pedagogical=6.4),
+    ]
+
+    def llm_runner(**_: Any) -> dict[str, Any]:
+        return reports.pop(0)
+
+    def corrector(context: linear_pipeline.CorrectionContext) -> str:
+        return (
+            "<fixes><fix><insert_after>Anchor sentence.</insert_after>"
+            "<text>\n\nRegression scaffold.</text></fix></fixes>"
+        )
+
+    linear_pipeline.run_llm_qg_with_corrections(
+        plan={"level": "folk", "sequence": 1, "slug": "sample"},
+        plan_path=plan_path,
+        plan_content="plan",
+        module_dir=module_dir,
+        writer="codex-tools",
+        llm_qg_runner=llm_runner,
+        python_qg_runner=_python_qg_pass,
+        corrector=corrector,
+        max_rounds=3,
+    )
+
+    loop = json.loads((module_dir / "llm_qg_correction_loop.json").read_text(encoding="utf-8"))
+    assert loop["stopped_reason"] == "min_score_regressed"
+    assert [round_summary["round"] for round_summary in loop["rounds"]] == [1, 2]
+
+
 def test_llm_qg_insert_after_fix_is_reviewed_on_next_round(tmp_path: Path) -> None:
     module_dir = _module_dir(tmp_path)
     plan_path = _plan_path(tmp_path)

--- a/tests/test_llm_qg_reviewer_ensemble.py
+++ b/tests/test_llm_qg_reviewer_ensemble.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from scripts.build import linear_pipeline
+
+
+def _review_response(score: float, evidence: str) -> str:
+    return json.dumps(
+        {
+            "score": score,
+            "evidence": f'"{evidence}"',
+            "verdict": "PASS" if score >= 8.0 else "REVISE",
+        }
+    )
+
+
+def _event_collector() -> tuple[list[dict[str, Any]], Any]:
+    events: list[dict[str, Any]] = []
+
+    def collect(event: str, **fields: Any) -> None:
+        events.append({"event": event, **fields})
+
+    return events, collect
+
+
+def test_reviewer_ensemble_selects_odd_median_sample(monkeypatch: pytest.MonkeyPatch) -> None:
+    scores = [6.0, 8.0, 7.0]
+    calls: list[str] = []
+    events, event_sink = _event_collector()
+
+    def reviewer(_prompt: str, _reviewer: str, *, dim: str, **_kwargs: Any) -> str:
+        sample_index = len(calls)
+        calls.append(dim)
+        return _review_response(scores[sample_index], f"sample {sample_index + 1}")
+
+    monkeypatch.setattr(linear_pipeline, "invoke_reviewer_dim", reviewer)
+
+    result = linear_pipeline.invoke_reviewer_dim_ensemble(
+        "prompt",
+        "codex-tools",
+        dim="pedagogical",
+        writer_under_review="claude-tools",
+        reviewer_samples=3,
+        event_sink=event_sink,
+    )
+
+    assert calls == ["pedagogical", "pedagogical", "pedagogical"]
+    assert result == {
+        "score": 7.0,
+        "evidence": '"sample 3"',
+        "verdict": "REVISE",
+    }
+    assert events == [
+        {
+            "event": "reviewer_ensemble",
+            "dim": "pedagogical",
+            "n": 3,
+            "scores": [6.0, 8.0, 7.0],
+            "median_score": 7.0,
+            "chosen_sample_index": 2,
+            "reviewer": "codex-tools",
+            "module": None,
+            "writer_under_review": "claude-tools",
+        }
+    ]
+
+
+def test_reviewer_ensemble_n1_passthrough_single_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    events, event_sink = _event_collector()
+
+    def reviewer(_prompt: str, _reviewer: str, *, dim: str, **_kwargs: Any) -> str:
+        calls.append(dim)
+        return _review_response(8.0, "single sample")
+
+    monkeypatch.setattr(linear_pipeline, "invoke_reviewer_dim", reviewer)
+
+    result = linear_pipeline.invoke_reviewer_dim_ensemble(
+        "prompt",
+        "codex-tools",
+        dim="tone",
+        writer_under_review="claude-tools",
+        reviewer_samples=1,
+        event_sink=event_sink,
+    )
+
+    assert calls == ["tone"]
+    assert result == {
+        "score": 8.0,
+        "evidence": '"single sample"',
+        "verdict": "PASS",
+    }
+    assert events == []
+
+
+def test_reviewer_ensemble_even_n_uses_lower_middle_real_sample(monkeypatch: pytest.MonkeyPatch) -> None:
+    scores = [6.0, 8.0, 7.0, 9.0]
+    calls: list[str] = []
+    events, event_sink = _event_collector()
+
+    def reviewer(_prompt: str, _reviewer: str, *, dim: str, **_kwargs: Any) -> str:
+        sample_index = len(calls)
+        calls.append(dim)
+        return _review_response(scores[sample_index], f"even sample {sample_index + 1}")
+
+    monkeypatch.setattr(linear_pipeline, "invoke_reviewer_dim", reviewer)
+
+    result = linear_pipeline.invoke_reviewer_dim_ensemble(
+        "prompt",
+        "codex-tools",
+        dim="engagement",
+        writer_under_review="claude-tools",
+        reviewer_samples=4,
+        event_sink=event_sink,
+    )
+
+    assert result == {
+        "score": 7.0,
+        "evidence": '"even sample 3"',
+        "verdict": "REVISE",
+    }
+    assert events[0]["median_score"] == 7.0
+    assert events[0]["chosen_sample_index"] == 2
+
+
+def test_llm_qg_reviewer_samples_profile_config() -> None:
+    assert linear_pipeline.llm_qg_reviewer_samples_for_level("folk") == 3
+    assert linear_pipeline.llm_qg_reviewer_samples_for_level("a1") == 1


### PR DESCRIPTION
## Design

- Adds seminar-only `LLM_QG_REVIEWER_SAMPLES = {"seminar": 3}` with `llm_qg_reviewer_samples_for_level(...)`; core/default remains one reviewer sample.
- Adds a median selector that chooses the full real sample at the median score. Even N uses the lower-middle sample, so evidence is never synthesized.
- Threads reviewer sample count through `v7_build._run_llm_qg`, `v7_review`, and the seminar correction loop telemetry path.
- Adds `LLM_QG_REGRESSION_NOISE_TOLERANCE = 0.5`; best-round selection is unchanged, but stop-on-regression only fires when the min-score drop exceeds tolerance.

## Raw Evidence

Requested pytest command:

```text
============================== 38 passed in 0.67s ==============================
```

Median selection correct:

```text
tests/test_llm_qg_reviewer_ensemble.py::test_reviewer_ensemble_selects_odd_median_sample PASSED [ 92%]
tests/test_llm_qg_reviewer_ensemble.py::test_reviewer_ensemble_even_n_uses_lower_middle_real_sample PASSED [ 97%]
```

N=1 unchanged passthrough:

```text
tests/test_llm_qg_reviewer_ensemble.py::test_reviewer_ensemble_n1_passthrough_single_call PASSED [ 94%]
```

Lint:

```text
All checks passed!
```

Commit:

```text
08c83fe15f feat(build): median-of-N reviewer ensemble + noise-aware regression guard (#3079)
```

Push:

```text
branch 'codex/folk-3079-reviewer-ensemble' set up to track 'origin/codex/folk-3079-reviewer-ensemble'.
```

Trailer audit:

```text
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

## Follow-up

convergence re-verification pending (re-run --enhance on #3495 rebased on this).
