### PR TITLE
feat(agents): wire Headroom pickup into curriculum orchestrator + track-orchestrator defs

### DIFF
--- a/agents_extensions/shared/agents/curriculum-orchestrator.md
+++ b/agents_extensions/shared/agents/curriculum-orchestrator.md
@@ -141,6 +141,19 @@ Bad pedagogy creates durable learner errors. Strong modules beat many mediocre m
 - V7 builds must run in worktrees because they write curriculum artifacts and telemetry.
 - Pre-submit checklist authority is `AGENTS.md:11-26`; read it directly before PR work.
 
+## Headroom — compress big context, keep handoffs tight
+Headroom (the `headroom` MCP, shared compression + memory layer) is ON across the fleet — use it:
+- **Large content** (build logs, corpus/search dumps, cross-agent review bundles, validation output —
+  roughly >200 lines / 20 KB): call `headroom_compress` FIRST, reason over the hash + a one-line
+  summary, and `headroom_retrieve` only the exact detail. Single biggest context-saver on a long
+  orchestration session — default to it.
+- **Handoffs:** `docs/session-state/current.orchestrator.md` stays the durable cross-agent SSOT. The
+  proxy memory store is local-only with no MCP write tool yet (`native_tool`/`bridge` off) — it
+  auto-injects context but cannot carry the handoff across agents, so keep git as the backstop and push
+  bulky evidence behind Headroom hashes rather than pasting it. Migrate the handoff body to Headroom
+  once the durable memory-write tool lands.
+- Full rule: `agents_extensions/shared/rules/headroom.md`. Never run `headroom learn --apply`.
+
 ## Definition of Done — render before promote (#3137/#3138)
 `python_qg`-green does NOT mean a module renders. The `mdx_render` gate is deferred and historically
 never ran, so a template-literal escape bug (#3137) shipped: on 2026-06-14 three modules went out

--- a/agents_extensions/shared/agents/curriculum-track-orchestrator.md
+++ b/agents_extensions/shared/agents/curriculum-track-orchestrator.md
@@ -114,6 +114,23 @@ initialPrompt: |
   It must always carry: current epic phase, IN-FLIGHT dispatches + their watcher ids, NEXT ACTION,
   and the role/boundary reminders above.
 
+  ### Headroom — compress big context, keep the handoff tight
+  Headroom (the `headroom` MCP, shared compression + memory layer) is ON — use it so a long driver
+  session does not burn context or git-churn:
+  - **Large content** (build logs, corpus/search dumps, review bundles, validation output — roughly
+    >200 lines / 20 KB): call `headroom_compress` FIRST, reason over the returned hash + a one-line
+    summary, and `headroom_retrieve` only the exact fragment you need (e.g. to corpus-hammer a quote).
+    This is the single biggest context-saver on a marathon track-driver session — do it by default,
+    not as an afterthought.
+  - **Handoff durability:** your git-tracked handoff stays the durable cross-agent SSOT. The proxy's
+    memory store is local-only and currently has NO MCP write tool (`native_tool`/`bridge` off), so do
+    NOT rely on it to carry the handoff across agents (codex). It DOES auto-inject relevant memory
+    context, so keep the handoff tight and push bulky evidence behind Headroom hashes rather than
+    pasting it. When the durable memory-write tool lands, migrate the handoff body to Headroom and cut
+    git to a thin pointer — until then, git is the backstop.
+  - Full rule: `agents_extensions/shared/rules/headroom.md`. Never run `headroom learn --apply`
+    (it rewrites agent instruction files).
+
   ## COMMUNICATE WITH MAIN ORCHESTRATOR
   Use this ping format when main needs to know something:
   `TRACK-UPDATE track=<track> pr=<number|none> state=<blocked|ready|in-flight>


### PR DESCRIPTION
Per user 2026-06-18 ("all claude agents should pick up Headroom, esp curriculum-track-orchestrator + curriculum-orchestrator"). Builds on codex's foundation `1237a2dc12`.

## What this does
Adds a **Headroom** section to both Claude curriculum agent defs (`agents_extensions/shared/agents/`):
- **Compress large content** (build logs, corpus/search dumps, review bundles >~200 lines / 20 KB) via `headroom_compress`, reason over hash+summary, `headroom_retrieve` only the needed fragment — the biggest context-saver on long sessions.
- **Handoff durability** guidance (see verified gap below).

`start-claude.sh` already deploys these (`npm run claude:deploy`) + ensures the proxy (`ensure_headroom.sh`), so the git config materializes on launch. **Deploy idempotency test green (6/6).**

## Verified investigation (the gap from my earlier review)
I traced the actual Headroom capability:
- ✅ **Memory store is durable + cross-agent already** — `~/.headroom/memory.db` is user-scoped, shared by all local agents; proxy `config.memory: true` with per-request context injection.
- ✅ **Compress/retrieve MCP works** — round-trip verified (compress→hash→retrieve returns exact original).
- ❌ **No durable memory-WRITE tool.** `headroom mcp serve` exposes only `compress`/`retrieve`/`stats` — there is **no `memory_save`/`recall` MCP tool** in this version (`native_tool: false`, `bridge_enabled: false`). Memory is written via the `headroom memory import` CLI, not a tool an agent can call mid-session.

**Implication:** the full "handoffs in Headroom memory instead of git" can't be flag-flipped here — it needs the native memory-write tool (a Headroom version/feature, or codex's follow-up). So the agent defs honestly say: **git handoff stays the durable cross-agent SSOT; push bulky evidence behind Headroom hashes; migrate the handoff body to memory once the write tool lands.** No over-promising.

## For codex / next step
The remaining piece for git-free handoffs is enabling a memory-write MCP tool (`native_tool`) + the cross-agent bridge. That's a Headroom-capability item, not a config flag I could flip — flagging for coordination.