### PR TITLE
docs(postmortem): conform atlas-3150 autopsy to required Symptom/Root cause headings

### DIFF
--- a/docs/bug-autopsies/atlas-3150-misdiagnosis.md
+++ b/docs/bug-autopsies/atlas-3150-misdiagnosis.md
@@ -11,6 +11,15 @@
 > the reviewing orchestrator (me). This file documents the mis-diagnosis itself, the real and
 > instructive failure.
 
+## Symptom
+The reviewing orchestrator broadcast a **false catastrophe**: it told the user that the
+`atlas-3150-autoexpand` dispatch had "zeroed all manifest enrichment (wiki 691→0)" and "deleted a
+certified module," then acted on that belief — wrote a (now-retracted) autopsy
+(`atlas-reenrich-enrichment-loss.md`, merged in #3466), reopened #3331, and blocked #3150. None of
+it was real: the dispatch's committed work was sound and gates-passing. The expensive, confusing
+part was that every downstream artifact (autopsy, reopened issue, block) was built on a single
+measurement taken at the wrong moment against the wrong object.
+
 ## What actually happened
 The `atlas-3150-autoexpand` dispatch (#3150) **succeeded**. Commit `4ea59f3f` (9 files, zero
 curriculum) added a manifest-vocabulary-coverage gate (`check_manifest_vocabulary_coverage.py`),
@@ -22,7 +31,9 @@ wired it into CI, updated `build_data_manifest.py` / `promote_module.py`, added 
 It was marked `status=failed` only because it **hung at the push/PR step** — the known **#2985
 finalize-zombie** (work done + locally committed, never finalized). Not a data failure.
 
-## The two forensics errors (the actual bug)
+## Root cause
+The two forensics errors below — not any defect in the dispatch — are the actual bug:
+
 1. **Measured a mid-write transient, not the committed artifact.** I read the worktree's
    *working-tree* `lexicon-manifest.json` and found `wiki_reference=0`. The codex process was
    **still live-writing the file** (it rewrites enrichment in place; I caught the gap between


### PR DESCRIPTION
## What
The `atlas-3150-misdiagnosis.md` autopsy failed the SessionStart postmortem hygiene check with two errors:

```
❌ docs/bug-autopsies/atlas-3150-misdiagnosis.md — missing required field: Symptom
❌ docs/bug-autopsies/atlas-3150-misdiagnosis.md — missing required field: Root cause
```

The content was fine — it just used `## What actually happened` and `## The two forensics errors (the actual bug)` as headings, which `scripts/audit/check_postmortems.py` does not recognize as the required `Symptom`/`Root cause` fields.

## Fix (conform faithfully, don't bolt on empties)
- **Add `## Symptom`** — the observable failure: the orchestrator broadcast a false catastrophe (retracted autopsy `atlas-reenrich-enrichment-loss.md`, reopened #3331, blocked #3150) built on one mis-timed measurement.
- **Rename** `## The two forensics errors (the actual bug)` → **`## Root cause`** (it already *is* the root-cause analysis), keeping the original framing in a one-line intro.

No content removed. `## Prevention` and the issue links were already present and recognized.

## Verify
```
$ .venv/bin/python -m scripts.audit.check_postmortems --quiet   # scans worktree
exit=0   (0 errors)
```

Docs-only (`docs/bug-autopsies/*.md`) — no pytest scope per #M-7; the relevant gate is the postmortem checker, now green.

X-Agent: claude/postmortem-atlas-3150-headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)