### PR TITLE
fix(a1): polish checkpoint places quality

### DIFF
--- a/curriculum/l2-uk-en/a1/checkpoint-places/activities.yaml
+++ b/curriculum/l2-uk-en/a1/checkpoint-places/activities.yaml
@@ -172,9 +172,9 @@ workbook:
       - statement: 'Вона працює на пошті.'
         answer: true
         explanation: 'На пошті is the safe Ukrainian chunk.'
-      - statement: 'Я з Америки.'
+      - statement: 'Я з Канади.'
         answer: true
-        explanation: 'Звідки? uses the from-place form.'
+        explanation: 'Звідки? uses з/із/зі plus the learned родовий form.'
       - statement: 'Книга є на столі.'
         answer: false
         explanation: 'A natural A1 location line is Книга на столі.'
@@ -280,15 +280,15 @@ workbook:
           - text: 'Вона живе в Київ.'
             correct: false
         explanation: 'Живе answers де? and needs в/у plus locative.'
-      - prompt: 'Repair: Я з Америці.'
+      - prompt: 'Repair: Я з Канаді.'
         options:
-          - text: 'Я з Америки.'
+          - text: 'Я з Канади.'
             correct: true
-          - text: 'Я з Америці.'
+          - text: 'Я з Канаді.'
             correct: false
-          - text: 'Я в Америку.'
+          - text: 'Я в Канаду.'
             correct: false
-        explanation: 'Звідки? uses a from-place form, not the static place form.'
+        explanation: 'Звідки? uses the learned родовий form, not the static place form.'
   - type: unjumble
     title: Rebuild final city lines
     instruction: Put the words in a safe A1.5 order.
@@ -322,13 +322,75 @@ workbook:
           - 'я'
           - 'їду'
           - 'на'
-          - 'вокзал'
-          - 'на'
           - 'метро'
-        answer: 'Увечері я їду на вокзал на метро'
+          - 'на'
+          - 'вокзал'
+        answer: 'Увечері я їду на метро на вокзал'
       - words:
           - 'Вона'
           - 'йде'
           - 'зі'
           - 'школи'
         answer: 'Вона йде зі школи'
+  - type: fill-in
+    title: One city story chunks
+    instruction: Complete the checkpoint story with learned place chunks.
+    items:
+      - sentence: 'Сьогодні Анна ___ Києві.'
+        answer: 'в'
+        options:
+          - 'в'
+          - 'з'
+          - 'на'
+        explanation: 'Before the vowel in Києві, в is smooth and answers де?'
+      - sentence: 'Вона ___ Канади, із Торонто.'
+        answer: 'з'
+        options:
+          - 'з'
+          - 'в'
+          - 'на'
+        explanation: 'Origin answers звідки?: з Канади.'
+      - sentence: 'Анна йде ___ музей.'
+        answer: 'в'
+        options:
+          - 'в'
+          - 'у'
+          - 'з'
+        explanation: 'В музей is a learned destination chunk.'
+      - sentence: 'Музей ___ площі.'
+        answer: 'на'
+        options:
+          - 'на'
+          - 'в'
+          - 'з'
+        explanation: 'На площі answers де?'
+      - sentence: 'До центру вона їде ___.'
+        answer: 'на метро'
+        options:
+          - 'на метро'
+          - 'з метро'
+          - 'у метрою'
+        explanation: 'На метро is the transport chunk.'
+      - sentence: 'Після музею вона їде ___.'
+        answer: 'на вокзал'
+        options:
+          - 'на вокзал'
+          - 'на вокзалі'
+          - 'з вокзалу'
+        explanation: 'Їде asks куди?, so use на вокзал.'
+  - type: match-up
+    title: Function check
+    instruction: Match each phrase with the question it answers.
+    pairs:
+      - left: 'у центрі'
+        right: 'Де?'
+      - left: 'у музей'
+        right: 'Куди?'
+      - left: 'з Канади'
+        right: 'Звідки?'
+      - left: 'на метро'
+        right: 'Як?'
+      - left: 'прямо'
+        right: 'Куди повернути?'
+      - left: 'на площі'
+        right: 'Де?'

--- a/curriculum/l2-uk-en/a1/checkpoint-places/module.md
+++ b/curriculum/l2-uk-en/a1/checkpoint-places/module.md
@@ -1,102 +1,96 @@
 # Підсумок: Місця
 
-This checkpoint closes A1.5. It is not a new case lesson. The goal is to show
-that you can move through one Ukrainian city scene with the place tools from
-M28-M34: smooth sound links, **де?**, **куди?**, transport, directions, and
-**звідки?**
+<!-- <implementation_map_audit>manifest_obligations=15 covered_in_map=15 missing=[]</implementation_map_audit> -->
+<!-- <bad_form_audit>italic_bad_form_patterns_found=0 converted_to_marker=0 remaining=0</bad_form_audit> -->
+<!-- <activity_split_audit>level=A1 inline_n=4 workbook_n=6 inline_range=[4,6] workbook_range=[6,9] split_valid=true</activity_split_audit> -->
 
-By the end, you can:
+**Місця — places checkpoint.** Сьогодні — одна українська міська сцена:
+**де?**, **куди?**, **звідки?**, милозвучність, транспорт і напрямки.
 
-- choose smoother **у/в**, **і/й**, and **з/із/зі** forms in short place lines;
-- answer **де?** with a static place chunk such as **у центрі** or
-  **на площі**;
-- answer **куди?** with a destination such as **у музей**, **на вокзал**, or
-  **в Україну**;
-- use transport and route words: **автобусом**, **на метро**, **прямо**,
+**У місті — in the city.** Ви вже можете:
+
+- вибрати smoother **у/в**, **і/й**, and **з/із/зі** in short place lines;
+- відповісти **де?** with **у центрі**, **на площі**, **в Одесі**;
+- відповісти **куди?** with **у музей**, **на вокзал**, **в Україну**;
+- сказати route and transport chunks: **автобусом**, **на метро**, **прямо**,
   **направо**, **наліво**;
-- answer **звідки?** with **з/із/зі + from-place form**: **з України**,
-  **зі школи**, **з роботи**;
-- keep Ukrainian city names and Ukrainian grammar independent and precise.
+- відповісти **звідки?** with **з/із/зі + родовий відмінок**:
+  **з України**, **зі школи**, **з роботи**;
+- писати city names as Ukrainian names: **Київ**, **Львів**, **Харків**,
+  **Одеса**.
 
 ## Що ми знаємо?
 
 <!-- INJECT_ACTIVITY: act-1 -->
 
-A1.5 gives you a small city map. Do not begin with a full case table. Begin
-with the question you need.
+**Мапа місць — place map.** Спочатку питання -> потім коротка відповідь.
 
 | Need | Question | Safe pattern | Example |
 | --- | --- | --- | --- |
-| current place | **Де?** | **в/у/на + місцевий** | **Я в Україні. Музей на площі.** |
-| destination | **Куди?** | **в/у/на + напрямок** | **Я йду в музей. Їду на вокзал.** |
-| source or origin | **Звідки?** | **з/із/зі + from-place form** | **Я з України. Вона зі школи.** |
-| route | **Як дістатися?** | direction word | **Ідіть прямо, потім направо.** |
-| transport | **Як ти їдеш?** | vehicle chunk | **Автобусом. На метро. Пішки.** |
+| current place | Де? | **в/у/на + місцевий** | Я в Україні. Музей на площі. |
+| destination | Куди? | **в/у/на + напрямок** | Я йду в музей. Їду на вокзал. |
+| source or origin | Звідки? | **з/із/зі + родовий** | Я з України. Вона зі школи. |
+| route | Як дістатися? | direction word | Ідіть прямо, потім направо. |
+| transport | Як ти їдеш? | vehicle chunk | Автобусом. На метро. Пішки. |
 
-The first checkpoint skill is static location. **Де?** asks where a person or
-thing is. Ukrainian uses a preposition and a place form together: **у школі**,
-**на роботі**, **у парку**, **в центрі**. The preposition alone is not enough.
-Say **Я в школі**, not **я в школа**. Say **Вона живе в Києві**, not
-**вона живе Київ**. For A1, learn the most useful chunks and use them in short
-sentences.
+**Де? — місце.** Готові chunks: **у школі**, **на роботі**, **у парку**,
+**в центрі**. Keep the preposition and the place form together. Say **Я в
+школі**, not **я в школа**. Say **Вона живе в Києві**, not **вона живе Київ**.
+Practice the useful chunks in short sentences.
 
-The second skill is using state verbs in one place. **Жити**, **працювати**,
-**вчитися**, and **гуляти** can all answer **де?** when the action stays in one
-place: **я живу в Одесі**, **мама працює на пошті**, **ми гуляємо в парку**.
-Ukrainian often drops the English-style helper in present-tense identity and
-location lines. **Книга на столі** is enough. **Я студент** is enough.
+**Жити, працювати, вчитися, гуляти.** Якщо дія в одному місці, answer **де?**:
+**я живу в Одесі**, **мама працює на пошті**, **ми гуляємо в парку**.
+**Книга на столі. Я студент. Вона вдома.** Complete short lines.
 
-The third skill is direction. **Куди?** asks where motion is going. This is why
-**Я в школі** and **Я йду в школу** are different. The preposition can look the
-same, but the job is different: static place versus destination. Keep the
-question visible in your mind before choosing the chunk.
+**Куди? — рух.** Пара: **Я в школі** (**де?**) / **Я йду в школу** (**куди?**).
+Same preposition, different question. Keep the question visible before choosing
+the chunk.
 
-The fourth skill is source or origin. **Звідки?** uses **з/із/зі** and a
-from-place form: **з України**, **з Києва**, **зі Львова**, **з роботи**,
-**зі школи**. This also brings back euphony. **Зі США** and **зі Львова** are
-chosen because they are easier to pronounce than a heavy consonant cluster.
+**Звідки? — source or origin.** After **Звідки?**, say the learned **з/із/зі +
+родовий відмінок** forms: **з України**, **з Києва**, **зі Львова**,
+**з роботи**, **зі школи**. This also brings back euphony. **Зі США** and
+**зі Львова** are easier to pronounce than a heavy consonant cluster.
 
-The fifth skill is a few stable space words. **Тут**, **там**, **туди**, and
-**звідти** can carry meaning without a new ending. At A1, treat them as ready
-words. You can say **Музей там**, **я йду туди**, and **вона йде звідти**
-without explaining subordinate clauses or advanced syntax.
+**Тут, там, туди, звідти.** These stable space words carry meaning without a
+new ending. Treat them as ready words. You can say **Музей там**, **я йду
+туди**, and **вона йде звідти** without explaining bigger sentence patterns.
 
 <!-- INJECT_ACTIVITY: act-2 -->
 
 ## Читання
 
-Read the city note aloud. It combines Kyiv, transport, directions, and the
-three place questions.
+**Читання — city note.** Прочитайте текст aloud: Kyiv, transport, directions,
+and the three place questions.
 
 ```text
 Сьогодні Анна в Києві.
 Вона з Канади, із Торонто, але зараз живе в Україні.
 Анна хоче йти в музей у центрі.
+До центру Анна їде на метро.
 Біля метро вона питає: Де тут музей?
-Олег відповідає: Музей на площі. Їдьте на метро до центру.
-Потім ідіть прямо і поверніть направо.
-Анна їде на метро, виходить і йде направо.
+Олег відповідає: Музей на площі. Ідіть прямо і поверніть направо.
+Анна йде прямо, потім направо.
 На площі вона бачить музей і кафе.
 Після музею Анна йде в кафе, а потім їде на вокзал.
 На вокзалі вона каже: Я їду у Львів.
 ```
 
-Support after the Ukrainian lines:
+**Підказка — quick help.**
 
 | Українська | English support |
 | --- | --- |
-| **Сьогодні Анна в Києві.** | Today Anna is in Kyiv. |
-| **Вона з Канади, із Торонто, але зараз живе в Україні.** | She is from Canada, from Toronto, but now lives in Ukraine. |
-| **Анна хоче йти в музей у центрі.** | Anna wants to go to a museum in the center. |
-| **Біля метро вона питає: Де тут музей?** | Near the metro she asks: Where is the museum here? |
-| **Олег відповідає: Музей на площі. Їдьте на метро до центру.** | Oleh answers: The museum is on the square. Take the metro to the center. |
-| **Потім ідіть прямо і поверніть направо.** | Then go straight and turn right. |
-| **Анна їде на метро, виходить і йде направо.** | Anna takes the metro, exits, and goes right. |
-| **На площі вона бачить музей і кафе.** | On the square she sees the museum and a cafe. |
-| **Після музею Анна йде в кафе, а потім їде на вокзал.** | After the museum Anna goes to a cafe, and then goes to the station. |
-| **На вокзалі вона каже: Я їду у Львів.** | At the station she says: I am going to Lviv. |
+| Сьогодні Анна в Києві. | Today Anna is in Kyiv. |
+| Вона з Канади, із Торонто, але зараз живе в Україні. | She is from Canada, from Toronto, but now lives in Ukraine. |
+| Анна хоче йти в музей у центрі. | Anna wants to go to a museum in the center. |
+| До центру Анна їде на метро. | Anna takes the metro to the center. |
+| Біля метро вона питає: Де тут музей? | Near the metro she asks: Where is the museum here? |
+| Олег відповідає: Музей на площі. Ідіть прямо і поверніть направо. | Oleh answers: The museum is on the square. Go straight and turn right. |
+| Анна йде прямо, потім направо. | Anna goes straight, then right. |
+| На площі вона бачить музей і кафе. | On the square she sees the museum and a cafe. |
+| Після музею Анна йде в кафе, а потім їде на вокзал. | After the museum Anna goes to a cafe, and then goes to the station. |
+| На вокзалі вона каже: Я їду у Львів. | At the station she says: I am going to Lviv. |
 
-Answer in short phrases:
+**Короткі відповіді — short answers.**
 
 - **Де Анна сьогодні?**
 - **Звідки вона?**
@@ -105,20 +99,22 @@ Answer in short phrases:
 - **Як Анна їде до центру?**
 - **Куди вона їде після кафе?**
 
-Notice the checkpoint rhythm. One line says where Anna is: **в Києві**. One
-line says where she is from: **з Канади, із Торонто**. One line says where she
-is going: **у музей**, later **на вокзал** and **у Львів**. These are not three
-versions of the same answer. They are three different questions.
+**Ритм чекпойнту — checkpoint rhythm.** One line says where Anna is:
+**в Києві**. One line says where she is from: **з Канади, із Торонто**. One
+line says where she is going: **у музей**, later **на вокзал** and **у Львів**.
+These are not three versions of the same answer. They are three different
+questions.
 
 <!-- INJECT_ACTIVITY: act-3 -->
 
 ## Граматика
 
-Use this checkpoint as a repair map, not as a new declension chart.
+**Питання -> відповідь.** Start from **де?**, **куди?**, or **звідки?** and
+choose one short answer.
 
 ### 1. Де? static place
 
-For a static place, keep the whole chunk together:
+**Де? — цілий chunk.** Keep the whole chunk together:
 
 ```text
 Я в Україні.
@@ -127,29 +123,27 @@ For a static place, keep the whole chunk together:
 Книга на столі.
 ```
 
-Support after the Ukrainian lines:
+**Підказка — quick help.**
 
 | Українська | English support |
 | --- | --- |
-| **Я в Україні.** | I am in Ukraine. |
-| **Він у Києві.** | He is in Kyiv. |
-| **Мама на роботі.** | Mom is at work. |
-| **Книга на столі.** | The book is on the table. |
+| Я в Україні. | I am in Ukraine. |
+| Він у Києві. | He is in Kyiv. |
+| Мама на роботі. | Mom is at work. |
+| Книга на столі. | The book is on the table. |
 
-The most common beginner error is leaving the noun unchanged after the
-preposition. Repair it by asking **де?** first: **в школа** becomes
-**в школі**, **в Київ** becomes **в Києві**.
+**Де? -> в школі.** If your sentence sounds like **в школа** or **в Київ**, ask
+**де?** first: **в школа** becomes **в школі**, **в Київ** becomes **в Києві**.
 
-At A1, the most useful visible pattern is simple: many **перша відміна**
-nouns change final **-а** to **-і** for a place chunk, as in **школа ->
-в школі**. Keep **в/у** or **на** with the noun. You do not need the full table
-yet. You also do not need to force **бути** into every present-tense sentence:
-**Я студент**, **Вона вдома**, and **ми в школі** are natural checkpoint
-models.
+**Місцевий відмінок — locative.** Practice a small set of short pairs:
+**школа -> в школі**, **Київ -> у Києві**, **пошта -> на пошті**. Keep
+**в/у** or **на** with the noun. Short present-tense lines work naturally:
+**Я студент**, **Вона вдома**, **ми в школі**.
 
 ### 2. State verbs in one place
 
-The same place chunk can follow state or in-place action verbs:
+**Дієслово + де?** The same place chunk can follow state or in-place action
+verbs:
 
 ```text
 Я живу в Одесі.
@@ -158,27 +152,26 @@ The same place chunk can follow state or in-place action verbs:
 Друзі гуляють у парку.
 ```
 
-Support after the Ukrainian lines:
+**Підказка — quick help.**
 
 | Українська | English support |
 | --- | --- |
-| **Я живу в Одесі.** | I live in Odesa. |
-| **Вона працює на пошті.** | She works at the post office. |
-| **Ми вчимося в школі.** | We study at school. |
-| **Друзі гуляють у парку.** | Friends walk in the park. |
+| Я живу в Одесі. | I live in Odesa. |
+| Вона працює на пошті. | She works at the post office. |
+| Ми вчимося в школі. | We study at school. |
+| Друзі гуляють у парку. | Friends walk in the park. |
 
-Some places prefer **на** as a fixed Ukrainian habit: **на пошті**,
-**на вокзалі**, **на роботі**, **на площі**. Do not translate English
-prepositions one by one. Learn the city chunks.
+**На пошті, на вокзалі, на роботі.** Ready city chunks: **на пошті**,
+**на вокзалі**, **на роботі**, **на площі**.
 
-Start from the smallest line: **Я вдома**. Then add a verb when you need one:
-**жити в місті**, **вчитись у школі**, **працювати на заводі**, and
-**гуляти в парку**. All four still answer **де?** because the action stays in
-one place.
+**Я вдома.** Start from the smallest line: **Я вдома**. Then add a verb when
+you need one: **жити в місті**, **вчитись у школі**, **працювати на пошті**,
+and **гуляти в парку**. All four still answer **де?** because the action stays
+in one place.
 
 ### 3. Куди? destination
 
-Motion changes the job of the phrase:
+**Рух -> куди?** Compare the place chunk with the destination chunk:
 
 ```text
 Я в школі.
@@ -189,24 +182,25 @@ Motion changes the job of the phrase:
 Ми їдемо в Україну.
 ```
 
-Support after the Ukrainian lines:
+**Підказка — quick help.**
 
 | Українська | English support |
 | --- | --- |
-| **Я в школі.** | I am at school. |
-| **Я йду в школу.** | I am going to school. |
-| **Олена на роботі.** | Olena is at work. |
-| **Олена йде на роботу.** | Olena is going to work. |
-| **Ми в Україні.** | We are in Ukraine. |
-| **Ми їдемо в Україну.** | We are going to Ukraine. |
+| Я в школі. | I am at school. |
+| Я йду в школу. | I am going to school. |
+| Олена на роботі. | Olena is at work. |
+| Олена йде на роботу. | Olena is going to work. |
+| Ми в Україні. | We are in Ukraine. |
+| Ми їдемо в Україну. | We are going to Ukraine. |
 
-If the verb is **іти** or **їхати**, check whether the question is **куди?**
-before using a static place form. The contrast is the point: **Де?** keeps you
-inside the place, while **куди?** sends you toward the place.
+**Іти / їхати -> куди?** **Іти** and **їхати** usually send you toward a
+place. Ask **куди?** before the chunk: **Я йду в школу**, not **я йду в
+школі**.
 
 ### 4. Звідки? source and origin
 
-For source, use **з/із/зі** plus the from-place chunks:
+**Звідки? -> з/із/зі.** For source, use **з/із/зі + родовий відмінок** in
+learned forms:
 
 ```text
 Я з України.
@@ -216,23 +210,24 @@ For source, use **з/із/зі** plus the from-place chunks:
 Тато йде з роботи.
 ```
 
-Support after the Ukrainian lines:
+**Підказка — quick help.**
 
 | Українська | English support |
 | --- | --- |
-| **Я з України.** | I am from Ukraine. |
-| **Марко з Києва.** | Marko is from Kyiv. |
-| **Олена зі Львова.** | Olena is from Lviv. |
-| **Студент іде зі школи.** | The student is coming from school. |
-| **Тато йде з роботи.** | Dad is coming from work. |
+| Я з України. | I am from Ukraine. |
+| Марко з Києва. | Marko is from Kyiv. |
+| Олена зі Львова. | Olena is from Lviv. |
+| Студент іде зі школи. | The student is coming from school. |
+| Тато йде з роботи. | Dad is coming from work. |
 
-This is where euphony matters again. **Зі Львова**, **зі школи**, and
+**Милозвучність повертається.** **Зі Львова**, **зі школи**, and
 **зі США** make the sound path easier. **З України** and **з Одеси** are light
 without an extra syllable.
 
 ### 5. Тут, там, туди, звідти
 
-These words help you speak before you know many endings:
+**Готові слова — ready words.** These words help you speak before you know many
+endings:
 
 ```text
 Музей там.
@@ -240,61 +235,63 @@ These words help you speak before you know many endings:
 Вона йде звідти.
 ```
 
-Support after the Ukrainian lines:
+**Підказка — quick help.**
 
 | Українська | English support |
 | --- | --- |
-| **Музей там.** | The museum is there. |
-| **Я йду туди.** | I am going there. |
-| **Вона йде звідти.** | She is coming from there. |
+| Музей там. | The museum is there. |
+| Я йду туди. | I am going there. |
+| Вона йде звідти. | She is coming from there. |
 
-Use them as complete A1 tools. You do not need to analyze bigger sentences
-with **де**, **куди**, and **звідки** as conjunctions yet.
+**Короткі відповіді.** Use them as complete short answers. Bigger sentences
+with **де**, **куди**, and **звідки** can wait.
 
 <!-- INJECT_ACTIVITY: act-4 -->
 
 ## Діалог
 
-This video call takes place during a walk in Odesa. It reviews city names,
-location, destination, origin, route language, transport, and euphony in one
-scene.
+**Діалог в Одесі — Odesa call.** Марія гуляє Одесою на відеодзвінку з Лукою.
+
+**Слова сцени — scene words.** Recognize these Odesa words for this dialogue:
+**Дерибасівська вулиця** — Derybasivska Street, **Потьомкінські сходи** —
+Potemkin Stairs, **порт** — port, **пляж** — beach.
 
 ```text
 Марія: Привіт, Лука! Я зараз в Одесі.
 Лука: Чудово! Де саме ти?
 Марія: Я на Дерибасівській вулиці.
-Лука: Звідки ти йдеш?
-Марія: Я йду з кафе. Спочатку була в центрі.
-Лука: Куди ти йдеш тепер?
-Марія: Я йду до Потьомкінських сходів, а потім у порт.
-Лука: Як дістатися до порту?
-Марія: Іду прямо, потім направо. Можна також їхати автобусом.
-Лука: А пляж?
+Лука: Гарно! Звідки ти йдеш?
+Марія: Я йду з кафе. Спочатку була в центрі, а тепер іду до Потьомкінських сходів.
+Лука: А потім?
+Марія: Потім іду у порт. Бачиш? Тут прямо, а там направо.
+Лука: Пішки?
+Марія: Так, пішки. Увечері їду автобусом на вокзал.
+Лука: А пляж буде?
 Марія: Після порту я йду на пляж. Увечері їду на вокзал.
 Лука: Ти з Одеси?
 Марія: Ні, я з України, з Києва, але Одеса дуже гарна.
 ```
 
-Support after the Ukrainian lines:
+**Підказка — quick help.**
 
 | Українська | English support |
 | --- | --- |
-| **Марія: Привіт, Лука! Я зараз в Одесі.** | Maria: Hi, Luka! I am in Odesa now. |
-| **Лука: Чудово! Де саме ти?** | Luka: Great! Where exactly are you? |
-| **Марія: Я на Дерибасівській вулиці.** | Maria: I am on Derybasivska Street. |
-| **Лука: Звідки ти йдеш?** | Luka: Where are you coming from? |
-| **Марія: Я йду з кафе. Спочатку була в центрі.** | Maria: I am coming from a cafe. First I was in the center. |
-| **Лука: Куди ти йдеш тепер?** | Luka: Where are you going now? |
-| **Марія: Я йду до Потьомкінських сходів, а потім у порт.** | Maria: I am going to the Potemkin Stairs, and then to the port. |
-| **Лука: Як дістатися до порту?** | Luka: How do you get to the port? |
-| **Марія: Іду прямо, потім направо. Можна також їхати автобусом.** | Maria: I go straight, then right. You can also go by bus. |
-| **Лука: А пляж?** | Luka: And the beach? |
-| **Марія: Після порту я йду на пляж. Увечері їду на вокзал.** | Maria: After the port I am going to the beach. In the evening I go to the station. |
-| **Лука: Ти з Одеси?** | Luka: Are you from Odesa? |
-| **Марія: Ні, я з України, з Києва, але Одеса дуже гарна.** | Maria: No, I am from Ukraine, from Kyiv, but Odesa is very beautiful. |
+| Марія: Привіт, Лука! Я зараз в Одесі. | Maria: Hi, Luka! I am in Odesa now. |
+| Лука: Чудово! Де саме ти? | Luka: Great! Where exactly are you? |
+| Марія: Я на Дерибасівській вулиці. | Maria: I am on Derybasivska Street. |
+| Лука: Гарно! Звідки ти йдеш? | Luka: Nice! Where are you coming from? |
+| Марія: Я йду з кафе. Спочатку була в центрі, а тепер іду до Потьомкінських сходів. | Maria: I am coming from a cafe. First I was in the center, and now I am going to the Potemkin Stairs. |
+| Лука: А потім? | Luka: And then? |
+| Марія: Потім іду у порт. Бачиш? Тут прямо, а там направо. | Maria: Then I am going to the port. See? Here it is straight, and there to the right. |
+| Лука: Пішки? | Luka: On foot? |
+| Марія: Так, пішки. Увечері їду автобусом на вокзал. | Maria: Yes, on foot. In the evening I am going by bus to the station. |
+| Лука: А пляж буде? | Luka: And will there be the beach? |
+| Марія: Після порту я йду на пляж. Увечері їду на вокзал. | Maria: After the port I am going to the beach. In the evening I go to the station. |
+| Лука: Ти з Одеси? | Luka: Are you from Odesa? |
+| Марія: Ні, я з України, з Києва, але Одеса дуже гарна. | Maria: No, I am from Ukraine, from Kyiv, but Odesa is very beautiful. |
 
-The dialogue is longer than a single drill, but its pieces are small. You can
-answer it with a checklist:
+**Чеклист діалогу — dialogue checklist.** The dialogue is longer than a single
+drill, but its pieces are small. You can answer it with a checklist:
 
 - **Де?** — **в Одесі**, **на Дерибасівській вулиці**, **в центрі**;
 - **Звідки?** — **з кафе**, **з України**, **з Києва**;
@@ -303,16 +300,16 @@ answer it with a checklist:
 - **Як?** — **пішки**, **автобусом**;
 - **Куди повернути?** — **прямо**, **направо**.
 
-Keep the city names Ukrainian: **Київ**, **Львів**, **Харків**, **Одеса**.
-In English use **Kyiv**, **Lviv**, **Kharkiv**, and **Odesa**. Do not use
-Russian-imperial spellings as course forms. Keep the country phrase precise:
-**в Україні**, **в Україну**, **з України**.
+**Українські назви міст.** Keep the city names Ukrainian: **Київ**, **Львів**,
+**Харків**, **Одеса**. In English use **Kyiv**, **Lviv**, **Kharkiv**, and
+**Odesa**. Avoid older Russian-imperial spellings in your notes. Keep the
+country phrase precise: **в Україні**, **в Україну**, **з України**.
 
 <span id="підсумок"></span>
 
 ## Підсумок
 
-A1.5 is ready when you can build one connected city answer:
+**Фінальна відповідь — final answer.** Build one connected city answer:
 
 ```text
 Добрий день! Я з Канади, але зараз живу в Україні.
@@ -323,26 +320,24 @@ A1.5 is ready when you can build one connected city answer:
 Увечері їду на вокзал, а завтра їду у Львів.
 ```
 
-Support after the Ukrainian lines:
+**Підказка — quick help.**
 
 | Українська | English support |
 | --- | --- |
-| **Добрий день! Я з Канади, але зараз живу в Україні.** | Good afternoon! I am from Canada, but now I live in Ukraine. |
-| **Сьогодні я в Києві, у центрі.** | Today I am in Kyiv, in the center. |
-| **Я йду в музей, потім у кафе.** | I am going to a museum, then to a cafe. |
-| **До музею їду на метро.** | To the museum I go by metro. |
-| **Після метро йду прямо і направо.** | After the metro I go straight and right. |
-| **Увечері їду на вокзал, а завтра їду у Львів.** | In the evening I go to the station, and tomorrow I go to Lviv. |
+| Добрий день! Я з Канади, але зараз живу в Україні. | Good afternoon! I am from Canada, but now I live in Ukraine. |
+| Сьогодні я в Києві, у центрі. | Today I am in Kyiv, in the center. |
+| Я йду в музей, потім у кафе. | I am going to a museum, then to a cafe. |
+| До музею їду на метро. | To the museum I go by metro. |
+| Після метро йду прямо і направо. | After the metro I go straight and right. |
+| Увечері їду на вокзал, а завтра їду у Львів. | In the evening I go to the station, and tomorrow I go to Lviv. |
 
 :::caution
-Keep the place system Ukrainian. Do not explain **у/в**, **і/й**, or
-**з/із/зі** through another language. Do not write **на Україні** for the
-country. Do not use **Kiev**, **Lvov**, **Kharkov**, or **Odessa** as course
-forms. Use **Київ**, **Львів**, **Харків**, **Одеса**, and in English
-**Kyiv**, **Lviv**, **Kharkiv**, **Odesa**.
+**Україна — в Україні.** Say **в Україні**, **в Україну**, **з України** for
+the country. For city names, use **Київ**, **Львів**, **Харків**, **Одеса**;
+in English notes, write **Kyiv**, **Lviv**, **Kharkiv**, **Odesa**.
 :::
 
-Final self-check:
+**Фінальна самоперевірка — final self-check.**
 
 1. Say where you are: **Я в Україні. Я у Києві.**
 2. Say where you are going: **Я йду в музей. Я їду на вокзал.**
@@ -351,6 +346,6 @@ Final self-check:
 5. Repair one trap: **Я в школі**, not **я в школа**.
 6. Repair another trap: **Я йду в школу**, not **я йду в школі**.
 
-Now write your own six-line place checkpoint. Include one current place, one
-destination, one source, one transport chunk, one direction word, and one
-Ukrainian city name.
+**Ваші шість рядків — your six lines.** Напишіть маленьку міську нотатку:
+де ви, куди йдете, звідки ви, як їдете, куди повертаєте, і одне українське
+місто.

--- a/curriculum/l2-uk-en/a1/checkpoint-places/resources.yaml
+++ b/curriculum/l2-uk-en/a1/checkpoint-places/resources.yaml
@@ -1,30 +1,6 @@
-- title: "Основні випадки чергування у-в, і-й, з, із, зі"
-  role: article
-  source_ref: "МійКлас"
-  url: https://www.miyklas.com.ua/p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/osnovni-vipadki-cherguvannia-u-v-i-i-z-iz-zi-pravila-milozvuchnosti-41612
-  notes: "Ukrainian-language reference page for the full euphony set reused from M28: у/в, і/й, з, із, зі."
-- title: "Ukrainian Course: Nouns in the Prepositional Case"
-  role: grammar table
-  source_ref: "ukrainiancourse.com"
-  url: https://www.ukrainiancourse.com/grammar-tables/nouns-in-the-prepositional-case/
-  notes: "Reference table for the static-place forms behind де? chunks; this site labels the locative case as prepositional."
-- title: "Ukrainian Course: Nouns in the Accusative Case"
-  role: grammar table
-  source_ref: "ukrainiancourse.com"
-  url: https://www.ukrainiancourse.com/grammar-tables/nouns-in-the-accusative-case/
-  notes: "Reference table for the direction/destination forms behind куди? chunks."
-- title: "Ukrainian Course: Nouns in the Genitive Case"
-  role: grammar table
-  source_ref: "ukrainiancourse.com"
-  url: https://www.ukrainiancourse.com/grammar-tables/nouns-in-the-genitive-case/
-  notes: "Reference table for the from-place forms behind звідки? chunks."
-- title: "Ukrainian Language: Unit 10, Page 1"
-  role: reading unit
-  source_ref: "ukrainianlanguage.uk"
-  url: https://ukrainianlanguage.uk/read/unit10/page10-1.htm
-  notes: "Beginner reading unit connected to city and place vocabulary."
-- title: "Ukrainian Language: Unit 10, Page 2"
-  role: reading unit
-  source_ref: "ukrainianlanguage.uk"
-  url: https://ukrainianlanguage.uk/read/unit10/page10-2.htm
-  notes: "Follow-up beginner city/place reading practice."
+- title: "Synthesis of M28-M34 content"
+  role: internal synthesis
+  source_ref: "Synthesis of M28-M34 content"
+  notes: >-
+    Checkpoint source obligation: no new material, only place, euphony,
+    transport, directions, and origin integration.

--- a/site/src/content/docs/a1/checkpoint-places.mdx
+++ b/site/src/content/docs/a1/checkpoint-places.mdx
@@ -59,23 +59,20 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs syncKey="module-tab">
 <TabItem label="Lesson">
 
-This checkpoint closes A1.5. It is not a new case lesson. The goal is to show
-that you can move through one Ukrainian city scene with the place tools from
-M28-M34: smooth sound links, **де?**, **куди?**, transport, directions, and
-**звідки?**
+**Місця — places checkpoint.** Сьогодні — одна українська міська сцена:
+**де?**, **куди?**, **звідки?**, милозвучність, транспорт і напрямки.
 
-By the end, you can:
+**У місті — in the city.** Ви вже можете:
 
-- choose smoother **у/в**, **і/й**, and **з/із/зі** forms in short place lines;
-- answer **де?** with a static place chunk such as **у центрі** or
-  **на площі**;
-- answer **куди?** with a destination such as **у музей**, **на вокзал**, or
-  **в Україну**;
-- use transport and route words: **автобусом**, **на метро**, **прямо**,
+- вибрати smoother **у/в**, **і/й**, and **з/із/зі** in short place lines;
+- відповісти **де?** with **у центрі**, **на площі**, **в Одесі**;
+- відповісти **куди?** with **у музей**, **на вокзал**, **в Україну**;
+- сказати route and transport chunks: **автобусом**, **на метро**, **прямо**,
   **направо**, **наліво**;
-- answer **звідки?** with **з/із/зі + from-place form**: **з України**,
-  **зі школи**, **з роботи**;
-- keep Ukrainian city names and Ukrainian grammar independent and precise.
+- відповісти **звідки?** with **з/із/зі + родовий відмінок**:
+  **з України**, **зі школи**, **з роботи**;
+- писати city names as Ukrainian names: **Київ**, **Львів**, **Харків**,
+  **Одеса**.
 
 ## Що ми знаємо?
 
@@ -83,44 +80,37 @@ By the end, you can:
 
 <MatchUp client:only='react' pairs={JSON.parse(`[{"left": "Де Анна?", "right": "Вона в Києві."}, {"left": "Куди вона йде?", "right": "Вона йде в музей."}, {"left": "Звідки вона?", "right": "Вона з Канади."}, {"left": "Як вона їде?", "right": "Вона їде на метро."}, {"left": "Як дістатися?", "right": "Ідіть прямо і направо."}, {"left": "Де музей?", "right": "Музей на площі."}, {"left": "Куди їде автобус?", "right": "На вокзал."}, {"left": "Звідки йде студент?", "right": "Зі школи."}]`)} instruction={"Match each question with the answer that proves the right checkpoint skill."} isUkrainian={false} />
 
-A1.5 gives you a small city map. Do not begin with a full case table. Begin
-with the question you need.
+**Мапа місць — place map.** Спочатку питання -> потім коротка відповідь.
 
 | Need | Question | Safe pattern | Example |
 | --- | --- | --- | --- |
-| current place | **Де?** | **в/у/на + місцевий** | **Я в Україні. Музей на площі.** |
-| destination | **Куди?** | **в/у/на + напрямок** | **Я йду в музей. Їду на вокзал.** |
-| source or origin | **Звідки?** | **з/із/зі + from-place form** | **Я з України. Вона зі школи.** |
-| route | **Як дістатися?** | direction word | **Ідіть прямо, потім направо.** |
-| transport | **Як ти їдеш?** | vehicle chunk | **Автобусом. На метро. Пішки.** |
+| current place | Де? | **в/у/на + місцевий** | Я в Україні. Музей на площі. |
+| destination | Куди? | **в/у/на + напрямок** | Я йду в музей. Їду на вокзал. |
+| source or origin | Звідки? | **з/із/зі + родовий** | Я з України. Вона зі школи. |
+| route | Як дістатися? | direction word | Ідіть прямо, потім направо. |
+| transport | Як ти їдеш? | vehicle chunk | Автобусом. На метро. Пішки. |
 
-The first checkpoint skill is static location. **Де?** asks where a person or
-thing is. Ukrainian uses a preposition and a place form together: **у школі**,
-**на роботі**, **у парку**, **в центрі**. The preposition alone is not enough.
-Say **Я в школі**, not **я в школа**. Say **Вона живе в Києві**, not
-**вона живе Київ**. For A1, learn the most useful chunks and use them in short
-sentences.
+**Де? — місце.** Готові chunks: **у школі**, **на роботі**, **у парку**,
+**в центрі**. Keep the preposition and the place form together. Say **Я в
+школі**, not **я в школа**. Say **Вона живе в Києві**, not **вона живе Київ**.
+Practice the useful chunks in short sentences.
 
-The second skill is using state verbs in one place. **Жити**, **працювати**,
-**вчитися**, and **гуляти** can all answer **де?** when the action stays in one
-place: **я живу в Одесі**, **мама працює на пошті**, **ми гуляємо в парку**.
-Ukrainian often drops the English-style helper in present-tense identity and
-location lines. **Книга на столі** is enough. **Я студент** is enough.
+**Жити, працювати, вчитися, гуляти.** Якщо дія в одному місці, answer **де?**:
+**я живу в Одесі**, **мама працює на пошті**, **ми гуляємо в парку**.
+**Книга на столі. Я студент. Вона вдома.** Complete short lines.
 
-The third skill is direction. **Куди?** asks where motion is going. This is why
-**Я в школі** and **Я йду в школу** are different. The preposition can look the
-same, but the job is different: static place versus destination. Keep the
-question visible in your mind before choosing the chunk.
+**Куди? — рух.** Пара: **Я в школі** (**де?**) / **Я йду в школу** (**куди?**).
+Same preposition, different question. Keep the question visible before choosing
+the chunk.
 
-The fourth skill is source or origin. **Звідки?** uses **з/із/зі** and a
-from-place form: **з України**, **з Києва**, **зі Львова**, **з роботи**,
-**зі школи**. This also brings back euphony. **Зі США** and **зі Львова** are
-chosen because they are easier to pronounce than a heavy consonant cluster.
+**Звідки? — source or origin.** After **Звідки?**, say the learned **з/із/зі +
+родовий відмінок** forms: **з України**, **з Києва**, **зі Львова**,
+**з роботи**, **зі школи**. This also brings back euphony. **Зі США** and
+**зі Львова** are easier to pronounce than a heavy consonant cluster.
 
-The fifth skill is a few stable space words. **Тут**, **там**, **туди**, and
-**звідти** can carry meaning without a new ending. At A1, treat them as ready
-words. You can say **Музей там**, **я йду туди**, and **вона йде звідти**
-without explaining subordinate clauses or advanced syntax.
+**Тут, там, туди, звідти.** These stable space words carry meaning without a
+new ending. Treat them as ready words. You can say **Музей там**, **я йду
+туди**, and **вона йде звідти** without explaining bigger sentence patterns.
 
 ### Choose the city move
 
@@ -128,38 +118,38 @@ without explaining subordinate clauses or advanced syntax.
 
 ## Читання
 
-Read the city note aloud. It combines Kyiv, transport, directions, and the
-three place questions.
+**Читання — city note.** Прочитайте текст aloud: Kyiv, transport, directions,
+and the three place questions.
 
 ```text
 Сьогодні Анна в Києві.
 Вона з Канади, із Торонто, але зараз живе в Україні.
 Анна хоче йти в музей у центрі.
+До центру Анна їде на метро.
 Біля метро вона питає: Де тут музей?
-Олег відповідає: Музей на площі. Їдьте на метро до центру.
-Потім ідіть прямо і поверніть направо.
-Анна їде на метро, виходить і йде направо.
+Олег відповідає: Музей на площі. Ідіть прямо і поверніть направо.
+Анна йде прямо, потім направо.
 На площі вона бачить музей і кафе.
 Після музею Анна йде в кафе, а потім їде на вокзал.
 На вокзалі вона каже: Я їду у Львів.
 ```
 
-Support after the Ukrainian lines:
+**Підказка — quick help.**
 
 | Українська | English support |
 | --- | --- |
-| **Сьогодні Анна в Києві.** | Today Anna is in Kyiv. |
-| **Вона з Канади, із Торонто, але зараз живе в Україні.** | She is from Canada, from Toronto, but now lives in Ukraine. |
-| **Анна хоче йти в музей у центрі.** | Anna wants to go to a museum in the center. |
-| **Біля метро вона питає: Де тут музей?** | Near the metro she asks: Where is the museum here? |
-| **Олег відповідає: Музей на площі. Їдьте на метро до центру.** | Oleh answers: The museum is on the square. Take the metro to the center. |
-| **Потім ідіть прямо і поверніть направо.** | Then go straight and turn right. |
-| **Анна їде на метро, виходить і йде направо.** | Anna takes the metro, exits, and goes right. |
-| **На площі вона бачить музей і кафе.** | On the square she sees the museum and a cafe. |
-| **Після музею Анна йде в кафе, а потім їде на вокзал.** | After the museum Anna goes to a cafe, and then goes to the station. |
-| **На вокзалі вона каже: Я їду у Львів.** | At the station she says: I am going to Lviv. |
+| Сьогодні Анна в Києві. | Today Anna is in Kyiv. |
+| Вона з Канади, із Торонто, але зараз живе в Україні. | She is from Canada, from Toronto, but now lives in Ukraine. |
+| Анна хоче йти в музей у центрі. | Anna wants to go to a museum in the center. |
+| До центру Анна їде на метро. | Anna takes the metro to the center. |
+| Біля метро вона питає: Де тут музей? | Near the metro she asks: Where is the museum here? |
+| Олег відповідає: Музей на площі. Ідіть прямо і поверніть направо. | Oleh answers: The museum is on the square. Go straight and turn right. |
+| Анна йде прямо, потім направо. | Anna goes straight, then right. |
+| На площі вона бачить музей і кафе. | On the square she sees the museum and a cafe. |
+| Після музею Анна йде в кафе, а потім їде на вокзал. | After the museum Anna goes to a cafe, and then goes to the station. |
+| На вокзалі вона каже: Я їду у Львів. | At the station she says: I am going to Lviv. |
 
-Answer in short phrases:
+**Короткі відповіді — short answers.**
 
 - **Де Анна сьогодні?**
 - **Звідки вона?**
@@ -168,10 +158,11 @@ Answer in short phrases:
 - **Як Анна їде до центру?**
 - **Куди вона їде після кафе?**
 
-Notice the checkpoint rhythm. One line says where Anna is: **в Києві**. One
-line says where she is from: **з Канади, із Торонто**. One line says where she
-is going: **у музей**, later **на вокзал** and **у Львів**. These are not three
-versions of the same answer. They are three different questions.
+**Ритм чекпойнту — checkpoint rhythm.** One line says where Anna is:
+**в Києві**. One line says where she is from: **з Канади, із Торонто**. One
+line says where she is going: **у музей**, later **на вокзал** and **у Львів**.
+These are not three versions of the same answer. They are three different
+questions.
 
 ### A1.5 city shelves
 
@@ -179,11 +170,12 @@ versions of the same answer. They are three different questions.
 
 ## Граматика
 
-Use this checkpoint as a repair map, not as a new declension chart.
+**Питання -> відповідь.** Start from **де?**, **куди?**, or **звідки?** and
+choose one short answer.
 
 ### 1. Де? static place
 
-For a static place, keep the whole chunk together:
+**Де? — цілий chunk.** Keep the whole chunk together:
 
 ```text
 Я в Україні.
@@ -192,29 +184,27 @@ For a static place, keep the whole chunk together:
 Книга на столі.
 ```
 
-Support after the Ukrainian lines:
+**Підказка — quick help.**
 
 | Українська | English support |
 | --- | --- |
-| **Я в Україні.** | I am in Ukraine. |
-| **Він у Києві.** | He is in Kyiv. |
-| **Мама на роботі.** | Mom is at work. |
-| **Книга на столі.** | The book is on the table. |
+| Я в Україні. | I am in Ukraine. |
+| Він у Києві. | He is in Kyiv. |
+| Мама на роботі. | Mom is at work. |
+| Книга на столі. | The book is on the table. |
 
-The most common beginner error is leaving the noun unchanged after the
-preposition. Repair it by asking **де?** first: **в школа** becomes
-**в школі**, **в Київ** becomes **в Києві**.
+**Де? -> в школі.** If your sentence sounds like **в школа** or **в Київ**, ask
+**де?** first: **в школа** becomes **в школі**, **в Київ** becomes **в Києві**.
 
-At A1, the most useful visible pattern is simple: many **перша відміна**
-nouns change final **-а** to **-і** for a place chunk, as in **школа ->
-в школі**. Keep **в/у** or **на** with the noun. You do not need the full table
-yet. You also do not need to force **бути** into every present-tense sentence:
-**Я студент**, **Вона вдома**, and **ми в школі** are natural checkpoint
-models.
+**Місцевий відмінок — locative.** Practice a small set of short pairs:
+**школа -> в школі**, **Київ -> у Києві**, **пошта -> на пошті**. Keep
+**в/у** or **на** with the noun. Short present-tense lines work naturally:
+**Я студент**, **Вона вдома**, **ми в школі**.
 
 ### 2. State verbs in one place
 
-The same place chunk can follow state or in-place action verbs:
+**Дієслово + де?** The same place chunk can follow state or in-place action
+verbs:
 
 ```text
 Я живу в Одесі.
@@ -223,27 +213,26 @@ The same place chunk can follow state or in-place action verbs:
 Друзі гуляють у парку.
 ```
 
-Support after the Ukrainian lines:
+**Підказка — quick help.**
 
 | Українська | English support |
 | --- | --- |
-| **Я живу в Одесі.** | I live in Odesa. |
-| **Вона працює на пошті.** | She works at the post office. |
-| **Ми вчимося в школі.** | We study at school. |
-| **Друзі гуляють у парку.** | Friends walk in the park. |
+| Я живу в Одесі. | I live in Odesa. |
+| Вона працює на пошті. | She works at the post office. |
+| Ми вчимося в школі. | We study at school. |
+| Друзі гуляють у парку. | Friends walk in the park. |
 
-Some places prefer **на** as a fixed Ukrainian habit: **на пошті**,
-**на вокзалі**, **на роботі**, **на площі**. Do not translate English
-prepositions one by one. Learn the city chunks.
+**На пошті, на вокзалі, на роботі.** Ready city chunks: **на пошті**,
+**на вокзалі**, **на роботі**, **на площі**.
 
-Start from the smallest line: **Я вдома**. Then add a verb when you need one:
-**жити в місті**, **вчитись у школі**, **працювати на заводі**, and
-**гуляти в парку**. All four still answer **де?** because the action stays in
-one place.
+**Я вдома.** Start from the smallest line: **Я вдома**. Then add a verb when
+you need one: **жити в місті**, **вчитись у школі**, **працювати на пошті**,
+and **гуляти в парку**. All four still answer **де?** because the action stays
+in one place.
 
 ### 3. Куди? destination
 
-Motion changes the job of the phrase:
+**Рух -> куди?** Compare the place chunk with the destination chunk:
 
 ```text
 Я в школі.
@@ -254,24 +243,25 @@ Motion changes the job of the phrase:
 Ми їдемо в Україну.
 ```
 
-Support after the Ukrainian lines:
+**Підказка — quick help.**
 
 | Українська | English support |
 | --- | --- |
-| **Я в школі.** | I am at school. |
-| **Я йду в школу.** | I am going to school. |
-| **Олена на роботі.** | Olena is at work. |
-| **Олена йде на роботу.** | Olena is going to work. |
-| **Ми в Україні.** | We are in Ukraine. |
-| **Ми їдемо в Україну.** | We are going to Ukraine. |
+| Я в школі. | I am at school. |
+| Я йду в школу. | I am going to school. |
+| Олена на роботі. | Olena is at work. |
+| Олена йде на роботу. | Olena is going to work. |
+| Ми в Україні. | We are in Ukraine. |
+| Ми їдемо в Україну. | We are going to Ukraine. |
 
-If the verb is **іти** or **їхати**, check whether the question is **куди?**
-before using a static place form. The contrast is the point: **Де?** keeps you
-inside the place, while **куди?** sends you toward the place.
+**Іти / їхати -> куди?** **Іти** and **їхати** usually send you toward a
+place. Ask **куди?** before the chunk: **Я йду в школу**, not **я йду в
+школі**.
 
 ### 4. Звідки? source and origin
 
-For source, use **з/із/зі** plus the from-place chunks:
+**Звідки? -> з/із/зі.** For source, use **з/із/зі + родовий відмінок** in
+learned forms:
 
 ```text
 Я з України.
@@ -281,23 +271,24 @@ For source, use **з/із/зі** plus the from-place chunks:
 Тато йде з роботи.
 ```
 
-Support after the Ukrainian lines:
+**Підказка — quick help.**
 
 | Українська | English support |
 | --- | --- |
-| **Я з України.** | I am from Ukraine. |
-| **Марко з Києва.** | Marko is from Kyiv. |
-| **Олена зі Львова.** | Olena is from Lviv. |
-| **Студент іде зі школи.** | The student is coming from school. |
-| **Тато йде з роботи.** | Dad is coming from work. |
+| Я з України. | I am from Ukraine. |
+| Марко з Києва. | Marko is from Kyiv. |
+| Олена зі Львова. | Olena is from Lviv. |
+| Студент іде зі школи. | The student is coming from school. |
+| Тато йде з роботи. | Dad is coming from work. |
 
-This is where euphony matters again. **Зі Львова**, **зі школи**, and
+**Милозвучність повертається.** **Зі Львова**, **зі школи**, and
 **зі США** make the sound path easier. **З України** and **з Одеси** are light
 without an extra syllable.
 
 ### 5. Тут, там, туди, звідти
 
-These words help you speak before you know many endings:
+**Готові слова — ready words.** These words help you speak before you know many
+endings:
 
 ```text
 Музей там.
@@ -305,16 +296,16 @@ These words help you speak before you know many endings:
 Вона йде звідти.
 ```
 
-Support after the Ukrainian lines:
+**Підказка — quick help.**
 
 | Українська | English support |
 | --- | --- |
-| **Музей там.** | The museum is there. |
-| **Я йду туди.** | I am going there. |
-| **Вона йде звідти.** | She is coming from there. |
+| Музей там. | The museum is there. |
+| Я йду туди. | I am going there. |
+| Вона йде звідти. | She is coming from there. |
 
-Use them as complete A1 tools. You do not need to analyze bigger sentences
-with **де**, **куди**, and **звідки** as conjunctions yet.
+**Короткі відповіді.** Use them as complete short answers. Bigger sentences
+with **де**, **куди**, and **звідки** can wait.
 
 ### Odesa call gaps
 
@@ -322,46 +313,48 @@ with **де**, **куди**, and **звідки** as conjunctions yet.
 
 ## Діалог
 
-This video call takes place during a walk in Odesa. It reviews city names,
-location, destination, origin, route language, transport, and euphony in one
-scene.
+**Діалог в Одесі — Odesa call.** Марія гуляє Одесою на відеодзвінку з Лукою.
+
+**Слова сцени — scene words.** Recognize these Odesa words for this dialogue:
+**Дерибасівська вулиця** — Derybasivska Street, **Потьомкінські сходи** —
+Potemkin Stairs, **порт** — port, **пляж** — beach.
 
 ```text
 Марія: Привіт, Лука! Я зараз в Одесі.
 Лука: Чудово! Де саме ти?
 Марія: Я на Дерибасівській вулиці.
-Лука: Звідки ти йдеш?
-Марія: Я йду з кафе. Спочатку була в центрі.
-Лука: Куди ти йдеш тепер?
-Марія: Я йду до Потьомкінських сходів, а потім у порт.
-Лука: Як дістатися до порту?
-Марія: Іду прямо, потім направо. Можна також їхати автобусом.
-Лука: А пляж?
+Лука: Гарно! Звідки ти йдеш?
+Марія: Я йду з кафе. Спочатку була в центрі, а тепер іду до Потьомкінських сходів.
+Лука: А потім?
+Марія: Потім іду у порт. Бачиш? Тут прямо, а там направо.
+Лука: Пішки?
+Марія: Так, пішки. Увечері їду автобусом на вокзал.
+Лука: А пляж буде?
 Марія: Після порту я йду на пляж. Увечері їду на вокзал.
 Лука: Ти з Одеси?
 Марія: Ні, я з України, з Києва, але Одеса дуже гарна.
 ```
 
-Support after the Ukrainian lines:
+**Підказка — quick help.**
 
 | Українська | English support |
 | --- | --- |
-| **Марія: Привіт, Лука! Я зараз в Одесі.** | Maria: Hi, Luka! I am in Odesa now. |
-| **Лука: Чудово! Де саме ти?** | Luka: Great! Where exactly are you? |
-| **Марія: Я на Дерибасівській вулиці.** | Maria: I am on Derybasivska Street. |
-| **Лука: Звідки ти йдеш?** | Luka: Where are you coming from? |
-| **Марія: Я йду з кафе. Спочатку була в центрі.** | Maria: I am coming from a cafe. First I was in the center. |
-| **Лука: Куди ти йдеш тепер?** | Luka: Where are you going now? |
-| **Марія: Я йду до Потьомкінських сходів, а потім у порт.** | Maria: I am going to the Potemkin Stairs, and then to the port. |
-| **Лука: Як дістатися до порту?** | Luka: How do you get to the port? |
-| **Марія: Іду прямо, потім направо. Можна також їхати автобусом.** | Maria: I go straight, then right. You can also go by bus. |
-| **Лука: А пляж?** | Luka: And the beach? |
-| **Марія: Після порту я йду на пляж. Увечері їду на вокзал.** | Maria: After the port I am going to the beach. In the evening I go to the station. |
-| **Лука: Ти з Одеси?** | Luka: Are you from Odesa? |
-| **Марія: Ні, я з України, з Києва, але Одеса дуже гарна.** | Maria: No, I am from Ukraine, from Kyiv, but Odesa is very beautiful. |
+| Марія: Привіт, Лука! Я зараз в Одесі. | Maria: Hi, Luka! I am in Odesa now. |
+| Лука: Чудово! Де саме ти? | Luka: Great! Where exactly are you? |
+| Марія: Я на Дерибасівській вулиці. | Maria: I am on Derybasivska Street. |
+| Лука: Гарно! Звідки ти йдеш? | Luka: Nice! Where are you coming from? |
+| Марія: Я йду з кафе. Спочатку була в центрі, а тепер іду до Потьомкінських сходів. | Maria: I am coming from a cafe. First I was in the center, and now I am going to the Potemkin Stairs. |
+| Лука: А потім? | Luka: And then? |
+| Марія: Потім іду у порт. Бачиш? Тут прямо, а там направо. | Maria: Then I am going to the port. See? Here it is straight, and there to the right. |
+| Лука: Пішки? | Luka: On foot? |
+| Марія: Так, пішки. Увечері їду автобусом на вокзал. | Maria: Yes, on foot. In the evening I am going by bus to the station. |
+| Лука: А пляж буде? | Luka: And will there be the beach? |
+| Марія: Після порту я йду на пляж. Увечері їду на вокзал. | Maria: After the port I am going to the beach. In the evening I go to the station. |
+| Лука: Ти з Одеси? | Luka: Are you from Odesa? |
+| Марія: Ні, я з України, з Києва, але Одеса дуже гарна. | Maria: No, I am from Ukraine, from Kyiv, but Odesa is very beautiful. |
 
-The dialogue is longer than a single drill, but its pieces are small. You can
-answer it with a checklist:
+**Чеклист діалогу — dialogue checklist.** The dialogue is longer than a single
+drill, but its pieces are small. You can answer it with a checklist:
 
 - **Де?** — **в Одесі**, **на Дерибасівській вулиці**, **в центрі**;
 - **Звідки?** — **з кафе**, **з України**, **з Києва**;
@@ -370,16 +363,16 @@ answer it with a checklist:
 - **Як?** — **пішки**, **автобусом**;
 - **Куди повернути?** — **прямо**, **направо**.
 
-Keep the city names Ukrainian: **Київ**, **Львів**, **Харків**, **Одеса**.
-In English use **Kyiv**, **Lviv**, **Kharkiv**, and **Odesa**. Do not use
-Russian-imperial spellings as course forms. Keep the country phrase precise:
-**в Україні**, **в Україну**, **з України**.
+**Українські назви міст.** Keep the city names Ukrainian: **Київ**, **Львів**,
+**Харків**, **Одеса**. In English use **Kyiv**, **Lviv**, **Kharkiv**, and
+**Odesa**. Avoid older Russian-imperial spellings in your notes. Keep the
+country phrase precise: **в Україні**, **в Україну**, **з України**.
 
 <span id="підсумок"></span>
 
 ## 📋 Підсумок
 
-A1.5 is ready when you can build one connected city answer:
+**Фінальна відповідь — final answer.** Build one connected city answer:
 
 ```text
 Добрий день! Я з Канади, але зараз живу в Україні.
@@ -390,26 +383,24 @@ A1.5 is ready when you can build one connected city answer:
 Увечері їду на вокзал, а завтра їду у Львів.
 ```
 
-Support after the Ukrainian lines:
+**Підказка — quick help.**
 
 | Українська | English support |
 | --- | --- |
-| **Добрий день! Я з Канади, але зараз живу в Україні.** | Good afternoon! I am from Canada, but now I live in Ukraine. |
-| **Сьогодні я в Києві, у центрі.** | Today I am in Kyiv, in the center. |
-| **Я йду в музей, потім у кафе.** | I am going to a museum, then to a cafe. |
-| **До музею їду на метро.** | To the museum I go by metro. |
-| **Після метро йду прямо і направо.** | After the metro I go straight and right. |
-| **Увечері їду на вокзал, а завтра їду у Львів.** | In the evening I go to the station, and tomorrow I go to Lviv. |
+| Добрий день! Я з Канади, але зараз живу в Україні. | Good afternoon! I am from Canada, but now I live in Ukraine. |
+| Сьогодні я в Києві, у центрі. | Today I am in Kyiv, in the center. |
+| Я йду в музей, потім у кафе. | I am going to a museum, then to a cafe. |
+| До музею їду на метро. | To the museum I go by metro. |
+| Після метро йду прямо і направо. | After the metro I go straight and right. |
+| Увечері їду на вокзал, а завтра їду у Львів. | In the evening I go to the station, and tomorrow I go to Lviv. |
 
 :::caution
-Keep the place system Ukrainian. Do not explain **у/в**, **і/й**, or
-**з/із/зі** through another language. Do not write **на Україні** for the
-country. Do not use **Kiev**, **Lvov**, **Kharkov**, or **Odessa** as course
-forms. Use **Київ**, **Львів**, **Харків**, **Одеса**, and in English
-**Kyiv**, **Lviv**, **Kharkiv**, **Odesa**.
+**Україна — в Україні.** Say **в Україні**, **в Україну**, **з України** for
+the country. For city names, use **Київ**, **Львів**, **Харків**, **Одеса**;
+in English notes, write **Kyiv**, **Lviv**, **Kharkiv**, **Odesa**.
 :::
 
-Final self-check:
+**Фінальна самоперевірка — final self-check.**
 
 1. Say where you are: **Я в Україні. Я у Києві.**
 2. Say where you are going: **Я йду в музей. Я їду на вокзал.**
@@ -418,9 +409,9 @@ Final self-check:
 5. Repair one trap: **Я в школі**, not **я в школа**.
 6. Repair another trap: **Я йду в школу**, not **я йду в школі**.
 
-Now write your own six-line place checkpoint. Include one current place, one
-destination, one source, one transport chunk, one direction word, and one
-Ukrainian city name.
+**Ваші шість рядків — your six lines.** Напишіть маленьку міську нотатку:
+де ви, куди йдете, звідки ви, як їдете, куди повертаєте, і одне українське
+місто.
 
 </TabItem>
 <TabItem label="Vocabulary">
@@ -450,7 +441,7 @@ Ukrainian city name.
 
 ### Ready checkpoint lines
 
-<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Музей у центрі.", "isTrue": true, "explanation": "This answers де? with a static place chunk."}, {"statement": "Я йду в школу.", "isTrue": true, "explanation": "Йду asks куди?, so в школу is correct."}, {"statement": "Я в школа.", "isTrue": false, "explanation": "Static place needs в школі."}, {"statement": "Вона працює на пошті.", "isTrue": true, "explanation": "На пошті is the safe Ukrainian chunk."}, {"statement": "Я з Америки.", "isTrue": true, "explanation": "Звідки? uses the from-place form."}, {"statement": "Книга є на столі.", "isTrue": false, "explanation": "A natural A1 location line is Книга на столі."}, {"statement": "Ідіть прямо, потім направо.", "isTrue": true, "explanation": "This is a clear route instruction."}, {"statement": "Я з США.", "isTrue": false, "explanation": "Use зі США to avoid the heavy cluster."}]`)} instruction={"Decide whether each line is ready for an A1.5 place answer."} isUkrainian={false} />
+<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Музей у центрі.", "isTrue": true, "explanation": "This answers де? with a static place chunk."}, {"statement": "Я йду в школу.", "isTrue": true, "explanation": "Йду asks куди?, so в школу is correct."}, {"statement": "Я в школа.", "isTrue": false, "explanation": "Static place needs в школі."}, {"statement": "Вона працює на пошті.", "isTrue": true, "explanation": "На пошті is the safe Ukrainian chunk."}, {"statement": "Я з Канади.", "isTrue": true, "explanation": "Звідки? uses з/із/зі plus the learned родовий form."}, {"statement": "Книга є на столі.", "isTrue": false, "explanation": "A natural A1 location line is Книга на столі."}, {"statement": "Ідіть прямо, потім направо.", "isTrue": true, "explanation": "This is a clear route instruction."}, {"statement": "Я з США.", "isTrue": false, "explanation": "Use зі США to avoid the heavy cluster."}]`)} instruction={"Decide whether each line is ready for an A1.5 place answer."} isUkrainian={false} />
 
 ### Find the route mismatch
 
@@ -460,26 +451,27 @@ Ukrainian city name.
 
 ### Repair checkpoint-places interference
 
-<Quiz client:only='react' questions={JSON.parse(`[{"question": "Repair: Я в школа.", "options": [{"text": "Я в школі.", "correct": true}, {"text": "Я в школа.", "correct": false}, {"text": "Я з школи.", "correct": false}], "explanation": "Де? needs в/у plus the static place form."}, {"question": "Repair: Я іду в школі.", "options": [{"text": "Я іду в школу.", "correct": true}, {"text": "Я іду в школі.", "correct": false}, {"text": "Я іду зі школи.", "correct": false}], "explanation": "Іду asks куди?, so use the destination chunk."}, {"question": "Repair: Я працюю в пошті.", "options": [{"text": "Я працюю на пошті.", "correct": true}, {"text": "Я працюю в пошті.", "correct": false}, {"text": "Я працюю до пошти.", "correct": false}], "explanation": "The safe Ukrainian chunk is на пошті."}, {"question": "Repair: Книга є на столі.", "options": [{"text": "Книга на столі.", "correct": true}, {"text": "Книга є на столі.", "correct": false}, {"text": "Книга в стіл.", "correct": false}], "explanation": "Ukrainian normally omits the present helper in this place line."}, {"question": "Repair: Вона живе Київ.", "options": [{"text": "Вона живе в Києві.", "correct": true}, {"text": "Вона живе Київ.", "correct": false}, {"text": "Вона живе в Київ.", "correct": false}], "explanation": "Живе answers де? and needs в/у plus locative."}, {"question": "Repair: Я з Америці.", "options": [{"text": "Я з Америки.", "correct": true}, {"text": "Я з Америці.", "correct": false}, {"text": "Я в Америку.", "correct": false}], "explanation": "Звідки? uses a from-place form, not the static place form."}]`)} instruction={"Choose the natural Ukrainian repair."} isUkrainian={false} />
+<Quiz client:only='react' questions={JSON.parse(`[{"question": "Repair: Я в школа.", "options": [{"text": "Я в школі.", "correct": true}, {"text": "Я в школа.", "correct": false}, {"text": "Я з школи.", "correct": false}], "explanation": "Де? needs в/у plus the static place form."}, {"question": "Repair: Я іду в школі.", "options": [{"text": "Я іду в школу.", "correct": true}, {"text": "Я іду в школі.", "correct": false}, {"text": "Я іду зі школи.", "correct": false}], "explanation": "Іду asks куди?, so use the destination chunk."}, {"question": "Repair: Я працюю в пошті.", "options": [{"text": "Я працюю на пошті.", "correct": true}, {"text": "Я працюю в пошті.", "correct": false}, {"text": "Я працюю до пошти.", "correct": false}], "explanation": "The safe Ukrainian chunk is на пошті."}, {"question": "Repair: Книга є на столі.", "options": [{"text": "Книга на столі.", "correct": true}, {"text": "Книга є на столі.", "correct": false}, {"text": "Книга в стіл.", "correct": false}], "explanation": "Ukrainian normally omits the present helper in this place line."}, {"question": "Repair: Вона живе Київ.", "options": [{"text": "Вона живе в Києві.", "correct": true}, {"text": "Вона живе Київ.", "correct": false}, {"text": "Вона живе в Київ.", "correct": false}], "explanation": "Живе answers де? and needs в/у plus locative."}, {"question": "Repair: Я з Канаді.", "options": [{"text": "Я з Канади.", "correct": true}, {"text": "Я з Канаді.", "correct": false}, {"text": "Я в Канаду.", "correct": false}], "explanation": "Звідки? uses the learned родовий form, not the static place form."}]`)} instruction={"Choose the natural Ukrainian repair."} isUkrainian={false} />
 
 ### Rebuild final city lines
 
-<Unjumble client:only='react' items={JSON.parse(`[{"jumbled": "Я / в / Києві / у / центрі", "answer": "Я в Києві у центрі"}, {"jumbled": "Я / йду / в / музей", "answer": "Я йду в музей"}, {"jumbled": "Я / з / України", "answer": "Я з України"}, {"jumbled": "Ідіть / прямо / потім / направо", "answer": "Ідіть прямо потім направо"}, {"jumbled": "Увечері / я / їду / на / вокзал / на / метро", "answer": "Увечері я їду на вокзал на метро"}, {"jumbled": "Вона / йде / зі / школи", "answer": "Вона йде зі школи"}]`)} instruction={"Put the words in a safe A1.5 order."} />
+<Unjumble client:only='react' items={JSON.parse(`[{"jumbled": "Я / в / Києві / у / центрі", "answer": "Я в Києві у центрі"}, {"jumbled": "Я / йду / в / музей", "answer": "Я йду в музей"}, {"jumbled": "Я / з / України", "answer": "Я з України"}, {"jumbled": "Ідіть / прямо / потім / направо", "answer": "Ідіть прямо потім направо"}, {"jumbled": "Увечері / я / їду / на / метро / на / вокзал", "answer": "Увечері я їду на метро на вокзал"}, {"jumbled": "Вона / йде / зі / школи", "answer": "Вона йде зі школи"}]`)} instruction={"Put the words in a safe A1.5 order."} />
+
+### One city story chunks
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Сьогодні Анна ___ Києві.", "answer": "в", "options": ["в", "з", "на"]}, {"sentence": "Вона ___ Канади, із Торонто.", "answer": "з", "options": ["з", "в", "на"]}, {"sentence": "Анна йде ___ музей.", "answer": "в", "options": ["в", "у", "з"]}, {"sentence": "Музей ___ площі.", "answer": "на", "options": ["на", "в", "з"]}, {"sentence": "До центру вона їде ___.", "answer": "на метро", "options": ["на метро", "з метро", "у метрою"]}, {"sentence": "Після музею вона їде ___.", "answer": "на вокзал", "options": ["на вокзал", "на вокзалі", "з вокзалу"]}]`)} instruction={"Complete the checkpoint story with learned place chunks."} isUkrainian={false} />
+
+### Function check
+
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "у центрі", "right": "Де?"}, {"left": "у музей", "right": "Куди?"}, {"left": "з Канади", "right": "Звідки?"}, {"left": "на метро", "right": "Як?"}, {"left": "прямо", "right": "Куди повернути?"}, {"left": "на площі", "right": "Де?"}]`)} instruction={"Match each phrase with the question it answers."} isUkrainian={false} />
 
 </TabItem>
 <TabItem label="Resources">
 
 :::info[🎧 🔗 External Resources]
 
-**📝 Articles:**
-- 📄 [Основні випадки чергування у-в, і-й, з, із, зі](https://www.miyklas.com.ua/p/ukrainska-mova/5-klas/fonetika-grafika-orfoepiia-orfografiia-14565/osnovni-vipadki-cherguvannia-u-v-i-i-z-iz-zi-pravila-milozvuchnosti-41612) — Ukrainian-language reference page for the full euphony set reused from M28: у/в, і/й, з, із, зі.
-
 **🔗 Online resources:**
-- 🔗 [Ukrainian Course: Nouns in the Accusative Case](https://www.ukrainiancourse.com/grammar-tables/nouns-in-the-accusative-case/) — Reference table for the direction/destination forms behind куди? chunks.
-- 🔗 [Ukrainian Course: Nouns in the Genitive Case](https://www.ukrainiancourse.com/grammar-tables/nouns-in-the-genitive-case/) — Reference table for the from-place forms behind звідки? chunks.
-- 🔗 [Ukrainian Course: Nouns in the Prepositional Case](https://www.ukrainiancourse.com/grammar-tables/nouns-in-the-prepositional-case/) — Reference table for the static-place forms behind де? chunks; this site labels the locative case as prepositional.
-- 🔗 [Ukrainian Language: Unit 10, Page 1](https://ukrainianlanguage.uk/read/unit10/page10-1.htm) — Beginner reading unit connected to city and place vocabulary.
-- 🔗 [Ukrainian Language: Unit 10, Page 2](https://ukrainianlanguage.uk/read/unit10/page10-2.htm) — Follow-up beginner city/place reading practice.
+- 🔗 **Synthesis of M28-M34 content** — Checkpoint source obligation: no new material, only place, euphony, transport, directions, and origin integration.
 :::
 
 </TabItem>


### PR DESCRIPTION
## Summary
- Polish A1 M35 `checkpoint-places` as a review module for M28-M34, with no new required vocabulary.
- Add audit comments, valid A1 activity split, two workbook checkpoint activities, and regenerated MDX.
- Trim resources to the plan-aligned internal synthesis entry and improve Ukrainian-first checkpoint tone/dialogue scaffolding.

## Deterministic checks
- PASS: `.venv/bin/python scripts/generate_mdx.py l2-uk-en a1 35 --validate`
- PASS: `.venv/bin/python scripts/lexicon/check_manifest_freshness.py`
- PASS: `.venv/bin/python scripts/lexicon/check_manifest_vocabulary_coverage.py --changed-only --base origin/main`
- PASS: `.venv/bin/python scripts/audit/certify_module.py a1/checkpoint-places --clean-qg-artifacts`
- PASS: `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- PASS: `git diff --check`

## Independent Gemini CLI QG
- Reviewer: `gemini-tools`
- Writer label: `codex-tools`
- Command: `.venv/bin/python scripts/build/run_llm_qg_parity.py a1 checkpoint-places --writer codex-tools --reviewer gemini-tools`
- Terminal verdict: PASS
- Aggregate verdict: REVISE (pedagogical warning), but all rubric categories are >= 8.0
- Minimum score: 8.5
- Scores:
  - pedagogical: 8.5
  - naturalness: 10.0
  - decolonization: 10.0
  - engagement: 10.0
  - tone: 10.0

## Telemetry notes
- module: A1 M35 `checkpoint-places`
- agent: `codex/a1-m35-checkpoint-places-quality`
- swarm_used: false
- swarm_label: none
- swarm_note: Solo run; no helper swarm used. Required Gemini CLI QG was run as validation only.
- participants: `codex` main agent, `gemini-tools` independent QG reviewer
- deepseek: not used
- forbidden artifacts: not committed; QG artifacts cleaned before commit