### PR TITLE
fix(a1): polish food and drink quality

### DIFF
--- a/curriculum/l2-uk-en/a1/food-and-drink/activities.yaml
+++ b/curriculum/l2-uk-en/a1/food-and-drink/activities.yaml
@@ -51,7 +51,7 @@ inline:
         right: 'sparkling water'
   - id: act-3
     type: fill-in
-    title: Cafe chunks, not case tables
+    title: Cafe drink chunks
     instruction: Choose the whole chunk that completes the service line.
     items:
       - sentence: 'Мені каву ___, будь ласка.'
@@ -101,18 +101,18 @@ inline:
     title: Food guardrails
     instruction: Decide whether each statement fits this module.
     items:
-      - statement: 'Борщ is taught here as a Ukrainian cultural dish.'
+      - statement: 'Борщ is a Ukrainian cultural dish in this module.'
         answer: true
-        explanation: 'Borscht is framed as Ukrainian, not as generic regional soup.'
-      - statement: 'At A1, без цукру is taught as a full chunk.'
+        explanation: 'It is named as Ukrainian family and cultural food.'
+      - statement: 'Без цукру is practiced as a full chunk.'
         answer: true
-        explanation: 'The module does not teach a formal genitive lesson.'
+        explanation: 'Practice the whole phrase as a service line.'
       - statement: 'Творог is the standard course word for cheese.'
         answer: false
         explanation: 'Use сир, or кисломолочний сир when needed.'
       - statement: 'Смажена картопля is the clean Ukrainian form.'
         answer: true
-        explanation: 'Do not use жарена картопля as course language.'
+        explanation: 'Use смажена картопля for fried potatoes.'
       - statement: "Я п'ю борщ is the natural line for soup."
         answer: false
         explanation: 'Ukrainian says я їм борщ.'
@@ -198,6 +198,78 @@ workbook:
       - 'Я їм рибу з рисом.'
       - "Я п'ю чай без цукру."
     correct_order: [0, 1, 2, 3, 4, 5, 6, 7]
+  - type: match-up
+    title: Extra food-table glosses
+    instruction: Match the food word with its English support.
+    pairs:
+      - left: 'рис'
+        right: 'rice'
+      - left: 'макарони'
+        right: 'pasta'
+      - left: 'морква'
+        right: 'carrot'
+      - left: 'цибуля'
+        right: 'onion'
+      - left: 'помідор'
+        right: 'tomato'
+      - left: 'огірок'
+        right: 'cucumber'
+      - left: 'апельсин'
+        right: 'orange'
+      - left: 'йогурт'
+        right: 'yogurt'
+      - left: 'олія'
+        right: 'oil'
+      - left: 'кефір'
+        right: 'kefir'
+      - left: 'лимонад'
+        right: 'lemonade'
+  - type: fill-in
+    title: Meal verb rhythm
+    instruction: Choose the natural short line.
+    items:
+      - sentence: 'Вранці я ___.'
+        answer: 'снідаю'
+        options:
+          - 'снідаю'
+          - 'обідаю'
+          - 'вечеряю'
+        explanation: 'Morning meal: я снідаю.'
+      - sentence: 'Вдень я ___.'
+        answer: 'обідаю'
+        options:
+          - 'обідаю'
+          - 'вечеряю'
+          - "п'ю"
+        explanation: 'Lunch: я обідаю.'
+      - sentence: 'Увечері я ___.'
+        answer: 'вечеряю'
+        options:
+          - 'вечеряю'
+          - 'снідаю'
+          - 'їм чай'
+        explanation: 'Dinner: я вечеряю.'
+      - sentence: 'Я ___ борщ.'
+        answer: 'їм'
+        options:
+          - 'їм'
+          - "п'ю"
+          - 'снідаю'
+        explanation: 'Soup and borscht are eaten.'
+      - sentence: "Я ___ чай."
+        answer: "п'ю"
+        options:
+          - "п'ю"
+          - 'їм'
+          - 'вечеряю'
+        explanation: 'Tea is drunk.'
+      - sentence: 'Я хочу каву ___.'
+        answer: 'з молоком'
+        options:
+          - 'з молоком'
+          - 'без цукру'
+          - 'смачна'
+        explanation: 'Кава з молоком is a whole drink chunk.'
   - type: unjumble
     title: Build safe food lines
     instruction: Put the words in a natural A1 order.
@@ -231,8 +303,8 @@ workbook:
           - 'будь ласка'
         answer: 'Чай без цукру, будь ласка'
       - words:
-          - 'Смачного'
-        answer: 'Смачного'
+          - 'Смачного!'
+        answer: 'Смачного!'
   - type: error-correction
     title: Repair food and drink interference
     instruction: Choose the clean Ukrainian repair.
@@ -245,7 +317,7 @@ workbook:
           - 'Я хочу їсти. / Я голодний.'
           - 'Я маю голод. / Я є голодний.'
           - 'Я є хочу їсти. / Я маю голодний.'
-        explanation: 'Use Я хочу їсти or Я голодний; do not copy English have/be patterns.'
+        explanation: 'Use Я хочу їсти or Я голодний for hunger.'
       - sentence: "Кіт п'є теплий молоко."
         error: 'теплий молоко'
         answer: "Кіт п'є тепле молоко."
@@ -261,7 +333,7 @@ workbook:
           - 'Вареники із сиром.'
           - 'Вареники з творогом.'
           - 'Вареники із сир.'
-        explanation: 'Use сир for the course form.'
+        explanation: 'Use сир in this food context.'
       - sentence: 'Я люблю творог.'
         error: 'творог'
         answer: 'Я люблю сир.'
@@ -269,7 +341,7 @@ workbook:
           - 'Я люблю сир.'
           - 'Я люблю творог.'
           - 'Я люблю сиром.'
-        explanation: 'Use сир as the course form.'
+        explanation: 'Use сир as the everyday Ukrainian food word.'
       - sentence: 'На столі жарена картопля.'
         error: 'жарена'
         answer: 'На столі смажена картопля.'
@@ -296,9 +368,9 @@ workbook:
         explanation: 'Use одну воду, or ask for a glass of water.'
       - sentence: 'Суп з картофель.'
         error: 'картофель'
-        answer: 'Суп із картоплею. або Картопляний суп.'
+        answer: 'Суп із картоплею. Або картопляний суп.'
         options:
-          - 'Суп із картоплею. або Картопляний суп.'
+          - 'Суп із картоплею. Або картопляний суп.'
           - 'Суп з картофель.'
           - 'Суп із картофель.'
         explanation: 'Use картопля / картоплею or картопляний.'
@@ -334,6 +406,14 @@ workbook:
           - 'Дайте чай без цукор.'
           - 'Дайте чай з цукру.'
         explanation: 'Без цукру is memorized as a whole chunk.'
+      - sentence: 'Чай з цукор.'
+        error: 'з цукор'
+        answer: 'Чай з цукром.'
+        options:
+          - 'Чай з цукром.'
+          - 'Чай з цукор.'
+          - 'Чай без цукром.'
+        explanation: 'Чай з цукром is a whole drink chunk.'
       - sentence: 'Борщ дуже смачно.'
         error: 'дуже смачно'
         answer: 'Борщ дуже смачний.'
@@ -342,3 +422,19 @@ workbook:
           - 'Борщ дуже смачно.'
           - 'Борщ дуже смачна.'
         explanation: 'With the noun борщ, use смачний.'
+      - sentence: 'Каша дуже смачний.'
+        error: 'смачний'
+        answer: 'Каша дуже смачна.'
+        options:
+          - 'Каша дуже смачна.'
+          - 'Каша дуже смачний.'
+          - 'Каша дуже смачно.'
+        explanation: 'With the noun каша, use смачна.'
+      - sentence: 'Приємного апетиту!'
+        error: 'Приємного апетиту!'
+        answer: 'Смачного!'
+        options:
+          - 'Смачного!'
+          - 'Приємного апетиту!'
+          - 'Добрий апетит!'
+        explanation: 'Смачного! is the natural meal formula here.'

--- a/curriculum/l2-uk-en/a1/food-and-drink/module.md
+++ b/curriculum/l2-uk-en/a1/food-and-drink/module.md
@@ -1,12 +1,16 @@
 # Їжа та напої
 
-A1.6 begins with food and drink because the words are useful immediately. You
-can say what you want for breakfast, name simple ingredients, understand a few
-Ukrainian cultural dishes, and talk about what you usually eat during the day.
+<!-- <implementation_map_audit>manifest_obligations=15 covered_in_map=15 missing=[]</implementation_map_audit> -->
+<!-- <bad_form_audit>italic_bad_form_patterns_found=6 converted_to_marker=6 remaining=0</bad_form_audit> -->
+<!-- <activity_split_audit>level=A1 inline_n=4 workbook_n=6 inline_range=[4,6] workbook_range=[6,9] split_valid=true</activity_split_audit> -->
 
-This is not a formal case lesson. Phrases such as **кава з молоком**,
-**чай з цукром**, **без цукру**, and **без молока** are ready chunks. Learn the
-whole phrase, repeat it aloud, and use it before you analyze the endings.
+**Їжа. Напої. Сніданок. Обід. Вечеря.** Say the small lines first:
+**Я хочу каву з молоком. Я їм борщ. Я п'ю чай. Смачного!** Then add simple
+ingredients and a short food day.
+
+Start with whole phrases: **кава з молоком**, **чай з цукром**,
+**без цукру**, and **без молока**. Repeat the full phrase aloud and use it as
+one service line.
 
 By the end, you can:
 
@@ -19,12 +23,12 @@ By the end, you can:
 - recognize **борщ**, **вареники**, and **сало** as Ukrainian cultural forms;
 - repair common interference: **сир**, not **<!-- bad -->творог<!-- /bad -->**;
   **смажена картопля**, not **<!-- bad -->жарена картопля<!-- /bad -->**;
-  **Смачного!**, not a calqued restaurant formula.
+  natural **Смачного!** at the table.
 
-:::caution
+:::tip
 Keep **з молоком**, **з цукром**, **без цукру**, and **без молока** as whole
-food-and-drink chunks. Do not stop the A1 lesson for a formal case
-explanation.
+food-and-drink chunks. The grammar behind the endings will have its own space
+later.
 :::
 
 ## Діалоги
@@ -39,7 +43,7 @@ explanation.
 Мама: А чай?
 Леся: Чай без цукру, будь ласка.
 Мама: Добре. Є ще каша і яблуко.
-Леся: Чудово. Я снідаю вдома.
+Леся: Чудово, дякую.
 Мама: Смачного!
 ```
 
@@ -47,82 +51,76 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Мама: Доброго ранку! Що ти хочеш на сніданок?** | Mom: Good morning! What do you want for breakfast? |
-| **Леся: Я хочу каву з молоком і хліб з маслом.** | Lesia: I want coffee with milk and bread with butter. |
-| **Мама: А чай?** | Mom: And tea? |
-| **Леся: Чай без цукру, будь ласка.** | Lesia: Tea without sugar, please. |
-| **Мама: Добре. Є ще каша і яблуко.** | Mom: Good. There is also porridge and an apple. |
-| **Леся: Чудово. Я снідаю вдома.** | Lesia: Great. I have breakfast at home. |
-| **Мама: Смачного!** | Mom: Enjoy your meal! |
+| Мама: Доброго ранку! Що ти хочеш на сніданок? | Mom: Good morning! What do you want for breakfast? |
+| Леся: Я хочу каву з молоком і хліб з маслом. | Lesia: I want coffee with milk and bread with butter. |
+| Мама: А чай? | Mom: And tea? |
+| Леся: Чай без цукру, будь ласка. | Lesia: Tea without sugar, please. |
+| Мама: Добре. Є ще каша і яблуко. | Mom: Good. There is also porridge and an apple. |
+| Леся: Чудово, дякую. | Lesia: Great, thank you. |
+| Мама: Смачного! | Mom: Enjoy your meal! |
 
-The useful question is **Що ти хочеш?** You already know **хотіти** from the
-earlier modules. Here it works with food as a service phrase: **я хочу каву**,
-**я хочу чай**, **я хочу хліб**. Do not stop to build a case table from these
-forms. Treat the breakfast lines as restaurant and home chunks: **каву з
-молоком**, **чай без цукру**, **хліб з маслом**.
+**Що ти хочеш? — Я хочу...** Use the same short line with food and drinks:
+**я хочу каву**, **я хочу чай**, **я хочу хліб**. Keep the breakfast chunks
+together: **каву з молоком**, **чай без цукру**, **хліб з маслом**.
 
-The natural meal verb is also important. Ukrainian does not need an English
-style line such as "I eat breakfast." Say **я снідаю** for "I have breakfast."
-For the other meals, say **я обідаю** and **я вечеряю**. You can still say
-**я їм суп** or **я п'ю чай** when you name a food or drink directly.
+**Я снідаю. Я обідаю. Я вечеряю.** These are the compact meal lines. Add a
+food or drink when you need detail: **я їм суп**, **я їм борщ**, **я п'ю чай**,
+**я п'ю воду**.
 
 ### Готуємо борщ із бабусею
 
 ```text
 Бабуся: Сьогодні готуємо борщ.
-Онука: Що нам потрібно?
-Бабуся: Буряк, картопля, капуста, морква, цибуля і м'ясо.
+Онука: Що є для борщу?
+Бабуся: Є буряк, картопля, капуста, морква, цибуля і м'ясо.
 Онука: А сметана?
 Бабуся: Так, борщ зі сметаною дуже добрий.
 Онука: Я люблю борщ. Він дуже смачний.
-Бабуся: Так, борщ - це українська родинна страва.
+Бабуся: І я люблю. У нашій родині борщ часто на обід.
 ```
 
 Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Бабуся: Сьогодні готуємо борщ.** | Grandmother: Today we are cooking borscht. |
-| **Онука: Що нам потрібно?** | Granddaughter: What do we need? |
-| **Бабуся: Буряк, картопля, капуста, морква, цибуля і м'ясо.** | Grandmother: Beet, potato, cabbage, carrot, onion, and meat. |
-| **Онука: А сметана?** | Granddaughter: And sour cream? |
-| **Бабуся: Так, борщ зі сметаною дуже добрий.** | Grandmother: Yes, borscht with sour cream is very good. |
-| **Онука: Я люблю борщ. Він дуже смачний.** | Granddaughter: I like borscht. It is very tasty. |
-| **Бабуся: Так, борщ - це українська родинна страва.** | Grandmother: Yes, borscht is a Ukrainian family dish. |
+| Бабуся: Сьогодні готуємо борщ. | Grandmother: Today we are cooking borscht. |
+| Онука: Що є для борщу? | Granddaughter: What is there for borscht? |
+| Бабуся: Є буряк, картопля, капуста, морква, цибуля і м'ясо. | Grandmother: There are beet, potato, cabbage, carrot, onion, and meat. |
+| Онука: А сметана? | Granddaughter: And sour cream? |
+| Бабуся: Так, борщ зі сметаною дуже добрий. | Grandmother: Yes, borscht with sour cream is very good. |
+| Онука: Я люблю борщ. Він дуже смачний. | Granddaughter: I like borscht. It is very tasty. |
+| Бабуся: І я люблю. У нашій родині борщ часто на обід. | Grandmother: I like it too. In our family, borscht is often for lunch. |
 
-Borscht is taught here as a Ukrainian cultural form, not as a generic regional
-soup. Families have their own versions, but the core classroom scene is simple:
-**буряк**, **картопля**, **капуста**, **м'ясо**, and **сметана**. You do not
-need a recipe in Ukrainian yet. You need to recognize the ingredients and hear
-how they live in a family dialogue.
+Борщ має багато родинних версій. In the family dialogue, listen for the
+ingredients: **буряк**, **картопля**, **капуста**, **м'ясо**, and **сметана**.
 
 Notice the taste lines. **Борщ дуже смачний** describes a masculine noun:
 borscht is tasty. **Каша дуже смачна** describes a feminine noun: porridge is
 tasty. **Дуже смачно!** is different: it is an impersonal comment, like "very
-tasty!" after you taste something. At A1, learn the examples instead of a full
-adjective table.
+tasty!" after you taste something. For now, learn the examples and copy the
+small pairs aloud.
 
 ### Щоденні звички
 
 ```text
-Марко: Що ти зазвичай їси на сніданок?
-Олена: Кашу, яблуко і чай.
-Марко: А що ти їси на обід?
-Олена: Суп або борщ, салат і хліб.
-Марко: Що ти п'єш?
-Олена: Воду або компот. Увечері я вечеряю вдома.
+Марко: Олено, що в тебе на сніданок?
+Олена: Каша, яблуко і чай. А в тебе?
+Марко: Хліб з маслом і кава.
+Олена: А на обід?
+Марко: Суп або борщ, салат і хліб.
+Олена: Я п'ю воду або компот. Увечері вечеряю вдома.
 ```
 
 Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Марко: Що ти зазвичай їси на сніданок?** | Marko: What do you usually eat for breakfast? |
-| **Олена: Кашу, яблуко і чай.** | Olena: Porridge, an apple, and tea. |
-| **Марко: А що ти їси на обід?** | Marko: And what do you eat for lunch? |
-| **Олена: Суп або борщ, салат і хліб.** | Olena: Soup or borscht, salad, and bread. |
-| **Марко: Що ти п'єш?** | Marko: What do you drink? |
-| **Олена: Воду або компот. Увечері я вечеряю вдома.** | Olena: Water or compote. In the evening I have dinner at home. |
+| Марко: Олено, що в тебе на сніданок? | Marko: Olena, what do you have for breakfast? |
+| Олена: Каша, яблуко і чай. А в тебе? | Olena: Porridge, an apple, and tea. And you? |
+| Марко: Хліб з маслом і кава. | Marko: Bread with butter and coffee. |
+| Олена: А на обід? | Olena: And for lunch? |
+| Марко: Суп або борщ, салат і хліб. | Marko: Soup or borscht, salad, and bread. |
+| Олена: Я п'ю воду або компот. Увечері вечеряю вдома. | Olena: I drink water or compote. In the evening I have dinner at home. |
 
 Use **що ти їси?** for food and **що ти п'єш?** for drinks. Ukrainian normally
 says **я їм борщ**, not "I drink borscht." Soups are eaten. For the meal
@@ -141,31 +139,27 @@ itself, keep the three compact verbs:
 Start with everyday food words that you can use at home, in a shop, or at a
 simple cafe.
 
-| Category | Words |
-| --- | --- |
-| bread and grains | **хліб**, **каша**, **рис**, **макарони** |
-| meat and fish | **м'ясо**, **курка**, **риба** |
-| vegetables | **картопля**, **морква**, **цибуля**, **помідор**, **огірок** |
-| fruit | **яблуко**, **банан**, **апельсин**, **лимон** |
-| dairy | **молоко**, **сир**, **масло**, **сметана**, **йогурт** |
-| simple extras | **яйце**, **цукор**, **сіль**, **олія** |
+| Category | Ukrainian words | English support |
+| --- | --- | --- |
+| bread and grains | **хліб**, **каша**, **рис**, **макарони** | bread, porridge, rice, pasta |
+| meat and fish | **м'ясо**, **курка**, **риба** | meat, chicken, fish |
+| vegetables | **картопля**, **морква**, **цибуля**, **помідор**, **огірок** | potato, carrot, onion, tomato, cucumber |
+| fruit | **яблуко**, **банан**, **апельсин**, **лимон** | apple, banana, orange, lemon |
+| dairy | **молоко**, **сир**, **масло**, **сметана**, **йогурт** | milk, cheese, butter, sour cream, yogurt |
+| simple extras | **яйце**, **цукор**, **сіль**, **олія** | egg, sugar, salt, oil |
 
-The word **сир** is important. In Ukrainian classroom materials, use **сир**
-for cheese or cottage cheese context, and use **кисломолочний сир** when you
-must be more specific. Do not teach **<!-- bad -->творог<!-- /bad -->** as the
-course form. If the lesson talks about dumplings with cheese, the line is
-**вареники із сиром**.
+The word **сир** is important. Use **сир** for cheese or cottage cheese
+contexts; when you must be more specific, use **кисломолочний сир**. If the
+line talks about dumplings with cheese, say **вареники із сиром**.
 
 The word **смажений** is another safety point. Say **смажена картопля** for
-fried potatoes. Do not use **<!-- bad -->жарена картопля<!-- /bad -->** in
-course language. The same repair logic protects learners from copying
-Russianized menu language into Ukrainian.
+fried potatoes. This repair helps keep everyday menu language clean Ukrainian.
 
 Ukrainian cultural dishes are not side notes. **Борщ** is a Ukrainian national
 and family dish. **Вареники** are a Ukrainian dish made with dough and fillings
 such as potato, cabbage, meat, cherries, or **сир**. **Сало** is a Ukrainian
-cultural food with strong symbolic meaning. In this A1 module, the goal is not
-to explain food history. The goal is to name these foods on Ukrainian terms.
+cultural food with strong symbolic meaning. Name these foods on Ukrainian terms
+first; food history can come later.
 
 Use small description lines:
 
@@ -182,12 +176,12 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Борщ дуже смачний.** | Borscht is very tasty. |
-| **Чай гарячий.** | Tea is hot. |
-| **Каша гаряча.** | The porridge is hot. |
-| **Вода холодна.** | The water is cold. |
-| **Сік солодкий.** | The juice is sweet. |
-| **Сіль солона.** | Salt is salty. |
+| Борщ дуже смачний. | Borscht is very tasty. |
+| Чай гарячий. | Tea is hot. |
+| Каша гаряча. | The porridge is hot. |
+| Вода холодна. | The water is cold. |
+| Сік солодкий. | The juice is sweet. |
+| Сіль солона. | Salt is salty. |
 
 These examples help you hear gender agreement without a formal table. The
 lesson gives you pairs such as **смачний борщ**, **смачна каша**, and
@@ -200,12 +194,12 @@ become familiar.
 
 Useful drinks divide into a few practical groups:
 
-| Group | Drinks |
-| --- | --- |
-| hot | **кава**, **чай** |
-| cold | **вода**, **сік**, **компот**, **лимонад** |
-| dairy | **молоко**, **кефір** |
-| recognition only | **пиво**, **вино** |
+| Group | Ukrainian drinks | English support |
+| --- | --- | --- |
+| hot | **кава**, **чай** | coffee, tea |
+| cold | **вода**, **сік**, **компот**, **лимонад** | water, juice, compote, lemonade |
+| dairy | **молоко**, **кефір** | milk, kefir |
+| recognition only | **пиво**, **вино** | beer, wine |
 
 The most useful drink phrases are chunks:
 
@@ -216,8 +210,7 @@ The most useful drink phrases are chunks:
 - **без цукру** - without sugar;
 - **без молока** - without milk.
 
-Do not turn these into a lesson on the instrumental or genitive case. At A1,
-the task is to make the service line automatic:
+Practice them as full service lines:
 
 ```text
 Мені каву з молоком, будь ласка.
@@ -230,10 +223,10 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Мені каву з молоком, будь ласка.** | Coffee with milk for me, please. |
-| **Чай без цукру, будь ласка.** | Tea without sugar, please. |
-| **Воду з газом, будь ласка.** | Sparkling water, please. |
-| **Без молока, будь ласка.** | Without milk, please. |
+| Мені каву з молоком, будь ласка. | Coffee with milk for me, please. |
+| Чай без цукру, будь ласка. | Tea without sugar, please. |
+| Воду з газом, будь ласка. | Sparkling water, please. |
+| Без молока, будь ласка. | Without milk, please. |
 
 The polite frame **будь ласка** keeps the line useful in a cafe or at home.
 When someone gives you food, answer with **дякую**. When people begin eating,
@@ -243,10 +236,9 @@ the natural Ukrainian etiquette formula is **Смачного!**
 
 ## Меню вдома і в кафе
 
-Read this simple menu aloud. It combines recognition, service chunks, and
-Ukrainian food culture.
+Read this simple menu aloud. Each line can become a home plan or a cafe order.
 
-| Меню | Простий вибір |
+| Меню | Що є |
 | --- | --- |
 | Сніданок | каша, хліб з маслом, яблуко, кава з молоком |
 | Обід | борщ зі сметаною, салат, вода без газу |
@@ -267,16 +259,14 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Офіціантка: Добрий день! Що ви хочете?** | Server: Good afternoon! What would you like? |
-| **Клієнт: Мені борщ зі сметаною і воду без газу, будь ласка.** | Customer: Borscht with sour cream and still water for me, please. |
-| **Офіціантка: Добре. А на десерт?** | Server: Good. And for dessert? |
-| **Клієнт: Вареники із сиром.** | Customer: Varenyky with cheese. |
-| **Офіціантка: Смачного!** | Server: Enjoy your meal! |
+| Офіціантка: Добрий день! Що ви хочете? | Server: Good afternoon! What would you like? |
+| Клієнт: Мені борщ зі сметаною і воду без газу, будь ласка. | Customer: Borscht with sour cream and still water for me, please. |
+| Офіціантка: Добре. А на десерт? | Server: Good. And for dessert? |
+| Клієнт: Вареники із сиром. | Customer: Varenyky with cheese. |
+| Офіціантка: Смачного! | Server: Enjoy your meal! |
 
-The greeting is **Добрий день!** in a simple public-service scene. Keep the
-course language Ukrainian and precise. The cultural foods stay Ukrainian:
-**борщ**, **вареники**, and **сало** are not presented as anonymous "Eastern
-European" items.
+The greeting is **Добрий день!** in a simple public-service scene. The cultural
+foods stay Ukrainian and precise: **борщ**, **вареники**, and **сало**.
 
 You may also recognize simple buying measures: **літр**, **грам**, and
 **кілограм**. Keep them as recognition words for now: **літр води**,
@@ -301,19 +291,17 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Вранці я снідаю вдома.** | In the morning I have breakfast at home. |
-| **Я їм кашу і яблуко.** | I eat porridge and an apple. |
-| **Я п'ю каву з молоком.** | I drink coffee with milk. |
-| **Вдень я обідаю на роботі.** | During the day I have lunch at work. |
-| **Я їм суп або борщ.** | I eat soup or borscht. |
-| **Увечері я вечеряю вдома.** | In the evening I have dinner at home. |
-| **Я їм рибу з рисом і п'ю чай без цукру.** | I eat fish with rice and drink tea without sugar. |
+| Вранці я снідаю вдома. | In the morning I have breakfast at home. |
+| Я їм кашу і яблуко. | I eat porridge and an apple. |
+| Я п'ю каву з молоком. | I drink coffee with milk. |
+| Вдень я обідаю на роботі. | During the day I have lunch at work. |
+| Я їм суп або борщ. | I eat soup or borscht. |
+| Увечері я вечеряю вдома. | In the evening I have dinner at home. |
+| Я їм рибу з рисом і п'ю чай без цукру. | I eat fish with rice and drink tea without sugar. |
 
 This story deliberately repeats **я їм**, **я п'ю**, **я снідаю**, **я
-обідаю**, and **я вечеряю**. Repetition is useful here because meals are one of
-the first places where English transfer feels tempting. You can say **I have
-breakfast** in English, but in Ukrainian the compact verb **снідати** is the
-natural tool.
+обідаю**, and **я вечеряю**. Hear the rhythm: meal verb first, then a food or
+drink line when you want more detail.
 
 You can also talk about liking food:
 
@@ -328,19 +316,17 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Мені подобається борщ.** | I like borscht. |
-| **Я люблю вареники.** | I like varenyky. |
-| **Мені не подобається чай з цукром.** | I do not like tea with sugar. |
-| **Я люблю каву без молока.** | I like coffee without milk. |
+| Мені подобається борщ. | I like borscht. |
+| Я люблю вареники. | I like varenyky. |
+| Мені не подобається чай з цукром. | I do not like tea with sugar. |
+| Я люблю каву без молока. | I like coffee without milk. |
 
-The basic eating and drinking verbs are **їсти** and **пити**. For liking,
-keep two recognition chunks available: **Мені подобається…** and
-**Я полюбляю…**. A cultural text may say **Полюбляємо його не лише ми, а й
-наші гості** about a beloved food; for your own A1 output, shorter lines such
-as **мені подобається борщ** are enough.
+**Їсти / пити. Любити / подобатися.** Keep the lines short: **Мені
+подобається борщ**, **Я люблю вареники**, **Мені не подобається чай з
+цукром**.
 
 Again, keep the chunks whole. **Без цукру** and **без молока** are service
-phrases, not a case chart. You will meet the grammar later with more room.
+phrases you can use right away.
 
 <span id="repair-food-and-drink-interference"></span>
 
@@ -351,21 +337,20 @@ Use this short repair map. Read the right column aloud.
 | Avoid | Use |
 | --- | --- |
 | **<!-- bad -->творог<!-- /bad -->** as the course word | **сир**, or **кисломолочний сир** when needed |
-| **<!-- bad -->жарена картопля<!-- /bad -->** | **смажена картопля** |
-| **я їм сніданок** as the main pattern | **я снідаю** |
-| **я п'ю борщ** | **я їм борщ** |
-| **без цукор** | **без цукру** as a chunk |
-| **борщ дуже смачно** | **борщ дуже смачний** |
-| **приємного апетиту** as the course formula | **Смачного!** |
+| <!-- bad -->жарена картопля<!-- /bad --> | **смажена картопля** |
+| я їм сніданок** as the main pattern | **я снідаю |
+| я п'ю борщ | **я їм борщ** |
+| без цукор | **без цукру** as a chunk |
+| борщ дуже смачно | **борщ дуже смачний** |
+| приємного апетиту** as the meal formula | **Смачного! |
 
-The goal is not to shame a learner who has heard mixed forms. The goal is to
-give the learner clean, memorable Ukrainian forms early. Food vocabulary is
-high-frequency, so early repairs matter.
+Mixed forms are common in real life. Keep the clean forms in your mouth early:
+**сир**, **смажена картопля**, **я їм борщ**, **Смачного!**
 
 ## Підсумок
 
-You are ready for M36 when you can say a simple food day and keep the cultural
-and repair points clean:
+You can finish this lesson when you can say a simple food day and keep the
+Ukrainian food words clean:
 
 ```text
 Вранці я снідаю вдома.
@@ -380,12 +365,12 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Вранці я снідаю вдома.** | In the morning I have breakfast at home. |
-| **Я хочу каву з молоком і хліб з маслом.** | I want coffee with milk and bread with butter. |
-| **На обід я їм борщ зі сметаною.** | For lunch I eat borscht with sour cream. |
-| **Борщ - українська родинна страва.** | Borscht is a Ukrainian family dish. |
-| **Увечері я вечеряю: риба з рисом і чай без цукру.** | In the evening I have dinner: fish with rice and tea without sugar. |
-| **Смачного!** | Enjoy your meal! |
+| Вранці я снідаю вдома. | In the morning I have breakfast at home. |
+| Я хочу каву з молоком і хліб з маслом. | I want coffee with milk and bread with butter. |
+| На обід я їм борщ зі сметаною. | For lunch I eat borscht with sour cream. |
+| Борщ - українська родинна страва. | Borscht is a Ukrainian family dish. |
+| Увечері я вечеряю: риба з рисом і чай без цукру. | In the evening I have dinner: fish with rice and tea without sugar. |
+| Смачного! | Enjoy your meal! |
 
 Final self-check:
 

--- a/curriculum/l2-uk-en/a1/food-and-drink/resources.yaml
+++ b/curriculum/l2-uk-en/a1/food-and-drink/resources.yaml
@@ -13,16 +13,10 @@
   source_ref: "ULP Season 1, Episode 13"
   url: https://www.ukrainianlessons.com/episode13/
   notes: "Continuation of the food/cafe cluster named in the plan."
-- title: "Ukrainian Course: Nouns in the Instrumental Case"
-  role: grammar table
-  source_ref: "ukrainiancourse.com"
-  url: https://www.ukrainiancourse.com/grammar-tables/nouns-in-the-instrumental-case/
-  notes: "Reference for forms behind chunks like кава з молоком; not used as a formal A1 case lesson."
-- title: "Ukrainian Course: Nouns in the Genitive Case"
-  role: grammar table
-  source_ref: "ukrainiancourse.com"
-  url: https://www.ukrainiancourse.com/grammar-tables/nouns-in-the-genitive-case/
-  notes: "Reference for forms behind chunks like без цукру; not used as a formal A1 case lesson."
+- title: "State Standard 2024, Topic 3"
+  role: communicative standard
+  source_ref: "State Standard 2024, Topic 3 (ресторан)"
+  notes: "Plan-level communicative situation for restaurant, food, and ordering language."
 - title: "Wiki: pedagogy/a1/food-and-drink"
   role: internal wiki
   source_ref: "Wiki: pedagogy/a1/food-and-drink (LOCKED 2026-04-23)"

--- a/curriculum/l2-uk-en/a1/food-and-drink/vocabulary.yaml
+++ b/curriculum/l2-uk-en/a1/food-and-drink/vocabulary.yaml
@@ -33,7 +33,7 @@
 - word: м'ясо
   translation: meat
   pos: noun
-  example: "Для борщу потрібно м'ясо."
+  example: "У борщі є м'ясо."
 - word: риба
   translation: fish
   pos: noun
@@ -78,10 +78,30 @@
   translation: to have dinner
   pos: verb
   example: "Увечері я вечеряю."
+- word: їсти
+  translation: to eat
+  pos: verb
+  example: "Я хочу їсти."
+- word: пити
+  translation: to drink
+  pos: verb
+  example: "Я хочу пити."
+- word: голодний
+  translation: hungry
+  pos: adjective
+  example: "Я голодний."
 - word: каша
   translation: porridge
   pos: noun
   example: "Каша гаряча."
+- word: рис
+  translation: rice
+  pos: noun
+  example: "На вечерю риба з рисом."
+- word: макарони
+  translation: pasta
+  pos: noun
+  example: "Макарони на столі."
 - word: сир
   translation: cheese; cottage cheese
   pos: noun
@@ -98,14 +118,54 @@
   translation: potato
   pos: noun
   example: "Смажена картопля."
+- word: картопляний
+  translation: potato; made with potato
+  pos: adjective
+  example: "Картопляний суп."
 - word: буряк
   translation: beet
   pos: noun
-  example: "Для борщу потрібен буряк."
+  example: "У борщі є буряк."
+- word: морква
+  translation: carrot
+  pos: noun
+  example: "Для борщу є морква."
 - word: капуста
   translation: cabbage
   pos: noun
-  example: "Для борщу потрібна капуста."
+  example: "У борщі є капуста."
+- word: цибуля
+  translation: onion
+  pos: noun
+  example: "Для борщу є цибуля."
+- word: помідор
+  translation: tomato
+  pos: noun
+  example: "На столі помідор."
+- word: огірок
+  translation: cucumber
+  pos: noun
+  example: "Огірок холодний."
+- word: банан
+  translation: banana
+  pos: noun
+  example: "Банан солодкий."
+- word: апельсин
+  translation: orange
+  pos: noun
+  example: "Апельсин на столі."
+- word: лимон
+  translation: lemon
+  pos: noun
+  example: "Чай з лимоном."
+- word: полуничний
+  translation: strawberry
+  pos: adjective
+  example: "Полуничний джем."
+- word: джем
+  translation: jam
+  pos: noun
+  example: "Полуничний джем."
 - word: цукор
   translation: sugar
   pos: noun
@@ -122,6 +182,38 @@
   translation: compote
   pos: noun
   example: "Я п'ю компот."
+- word: курка
+  translation: chicken
+  pos: noun
+  example: "Курка на вечерю."
+- word: йогурт
+  translation: yogurt
+  pos: noun
+  example: "Йогурт на сніданок."
+- word: олія
+  translation: oil
+  pos: noun
+  example: "Олія на столі."
+- word: кефір
+  translation: kefir
+  pos: noun
+  example: "Я п'ю кефір."
+- word: лимонад
+  translation: lemonade
+  pos: noun
+  example: "Лимонад холодний."
+- word: пиво
+  translation: beer
+  pos: noun
+  example: "Пиво - напій."
+- word: вино
+  translation: wine
+  pos: noun
+  example: "Вино - напій."
+- word: склянка
+  translation: glass
+  pos: noun
+  example: "Склянка води."
 - word: смажений
   translation: fried
   pos: adjective
@@ -130,6 +222,26 @@
   translation: tasty
   pos: adjective
   example: "Борщ дуже смачний."
+- word: гарячий
+  translation: hot
+  pos: adjective
+  example: "Чай гарячий."
+- word: теплий
+  translation: warm
+  pos: adjective
+  example: "Тепле молоко."
+- word: холодний
+  translation: cold
+  pos: adjective
+  example: "Вода холодна."
+- word: солодкий
+  translation: sweet
+  pos: adjective
+  example: "Сік солодкий."
+- word: солоний
+  translation: salty
+  pos: adjective
+  example: "Сіль солона."
 - word: без цукру
   translation: without sugar
   pos: chunk

--- a/site/src/content/docs/a1/food-and-drink.mdx
+++ b/site/src/content/docs/a1/food-and-drink.mdx
@@ -59,13 +59,13 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs syncKey="module-tab">
 <TabItem label="Lesson">
 
-A1.6 begins with food and drink because the words are useful immediately. You
-can say what you want for breakfast, name simple ingredients, understand a few
-Ukrainian cultural dishes, and talk about what you usually eat during the day.
+**Їжа. Напої. Сніданок. Обід. Вечеря.** Say the small lines first:
+**Я хочу каву з молоком. Я їм борщ. Я п'ю чай. Смачного!** Then add simple
+ingredients and a short food day.
 
-This is not a formal case lesson. Phrases such as **кава з молоком**,
-**чай з цукром**, **без цукру**, and **без молока** are ready chunks. Learn the
-whole phrase, repeat it aloud, and use it before you analyze the endings.
+Start with whole phrases: **кава з молоком**, **чай з цукром**,
+**без цукру**, and **без молока**. Repeat the full phrase aloud and use it as
+one service line.
 
 By the end, you can:
 
@@ -78,12 +78,12 @@ By the end, you can:
 - recognize **борщ**, **вареники**, and **сало** as Ukrainian cultural forms;
 - repair common interference: **сир**, not **<del>творог</del>**;
   **смажена картопля**, not **<del>жарена картопля</del>**;
-  **Смачного!**, not a calqued restaurant formula.
+  natural **Смачного!** at the table.
 
-:::caution
+:::tip
 Keep **з молоком**, **з цукром**, **без цукру**, and **без молока** as whole
-food-and-drink chunks. Do not stop the A1 lesson for a formal case
-explanation.
+food-and-drink chunks. The grammar behind the endings will have its own space
+later.
 :::
 
 ## Діалоги
@@ -100,7 +100,7 @@ explanation.
 Мама: А чай?
 Леся: Чай без цукру, будь ласка.
 Мама: Добре. Є ще каша і яблуко.
-Леся: Чудово. Я снідаю вдома.
+Леся: Чудово, дякую.
 Мама: Смачного!
 ```
 
@@ -108,82 +108,76 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Мама: Доброго ранку! Що ти хочеш на сніданок?** | Mom: Good morning! What do you want for breakfast? |
-| **Леся: Я хочу каву з молоком і хліб з маслом.** | Lesia: I want coffee with milk and bread with butter. |
-| **Мама: А чай?** | Mom: And tea? |
-| **Леся: Чай без цукру, будь ласка.** | Lesia: Tea without sugar, please. |
-| **Мама: Добре. Є ще каша і яблуко.** | Mom: Good. There is also porridge and an apple. |
-| **Леся: Чудово. Я снідаю вдома.** | Lesia: Great. I have breakfast at home. |
-| **Мама: Смачного!** | Mom: Enjoy your meal! |
+| Мама: Доброго ранку! Що ти хочеш на сніданок? | Mom: Good morning! What do you want for breakfast? |
+| Леся: Я хочу каву з молоком і хліб з маслом. | Lesia: I want coffee with milk and bread with butter. |
+| Мама: А чай? | Mom: And tea? |
+| Леся: Чай без цукру, будь ласка. | Lesia: Tea without sugar, please. |
+| Мама: Добре. Є ще каша і яблуко. | Mom: Good. There is also porridge and an apple. |
+| Леся: Чудово, дякую. | Lesia: Great, thank you. |
+| Мама: Смачного! | Mom: Enjoy your meal! |
 
-The useful question is **Що ти хочеш?** You already know **хотіти** from the
-earlier modules. Here it works with food as a service phrase: **я хочу каву**,
-**я хочу чай**, **я хочу хліб**. Do not stop to build a case table from these
-forms. Treat the breakfast lines as restaurant and home chunks: **каву з
-молоком**, **чай без цукру**, **хліб з маслом**.
+**Що ти хочеш? — Я хочу...** Use the same short line with food and drinks:
+**я хочу каву**, **я хочу чай**, **я хочу хліб**. Keep the breakfast chunks
+together: **каву з молоком**, **чай без цукру**, **хліб з маслом**.
 
-The natural meal verb is also important. Ukrainian does not need an English
-style line such as "I eat breakfast." Say **я снідаю** for "I have breakfast."
-For the other meals, say **я обідаю** and **я вечеряю**. You can still say
-**я їм суп** or **я п'ю чай** when you name a food or drink directly.
+**Я снідаю. Я обідаю. Я вечеряю.** These are the compact meal lines. Add a
+food or drink when you need detail: **я їм суп**, **я їм борщ**, **я п'ю чай**,
+**я п'ю воду**.
 
 ### Готуємо борщ із бабусею
 
 ```text
 Бабуся: Сьогодні готуємо борщ.
-Онука: Що нам потрібно?
-Бабуся: Буряк, картопля, капуста, морква, цибуля і м'ясо.
+Онука: Що є для борщу?
+Бабуся: Є буряк, картопля, капуста, морква, цибуля і м'ясо.
 Онука: А сметана?
 Бабуся: Так, борщ зі сметаною дуже добрий.
 Онука: Я люблю борщ. Він дуже смачний.
-Бабуся: Так, борщ - це українська родинна страва.
+Бабуся: І я люблю. У нашій родині борщ часто на обід.
 ```
 
 Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Бабуся: Сьогодні готуємо борщ.** | Grandmother: Today we are cooking borscht. |
-| **Онука: Що нам потрібно?** | Granddaughter: What do we need? |
-| **Бабуся: Буряк, картопля, капуста, морква, цибуля і м'ясо.** | Grandmother: Beet, potato, cabbage, carrot, onion, and meat. |
-| **Онука: А сметана?** | Granddaughter: And sour cream? |
-| **Бабуся: Так, борщ зі сметаною дуже добрий.** | Grandmother: Yes, borscht with sour cream is very good. |
-| **Онука: Я люблю борщ. Він дуже смачний.** | Granddaughter: I like borscht. It is very tasty. |
-| **Бабуся: Так, борщ - це українська родинна страва.** | Grandmother: Yes, borscht is a Ukrainian family dish. |
+| Бабуся: Сьогодні готуємо борщ. | Grandmother: Today we are cooking borscht. |
+| Онука: Що є для борщу? | Granddaughter: What is there for borscht? |
+| Бабуся: Є буряк, картопля, капуста, морква, цибуля і м'ясо. | Grandmother: There are beet, potato, cabbage, carrot, onion, and meat. |
+| Онука: А сметана? | Granddaughter: And sour cream? |
+| Бабуся: Так, борщ зі сметаною дуже добрий. | Grandmother: Yes, borscht with sour cream is very good. |
+| Онука: Я люблю борщ. Він дуже смачний. | Granddaughter: I like borscht. It is very tasty. |
+| Бабуся: І я люблю. У нашій родині борщ часто на обід. | Grandmother: I like it too. In our family, borscht is often for lunch. |
 
-Borscht is taught here as a Ukrainian cultural form, not as a generic regional
-soup. Families have their own versions, but the core classroom scene is simple:
-**буряк**, **картопля**, **капуста**, **м'ясо**, and **сметана**. You do not
-need a recipe in Ukrainian yet. You need to recognize the ingredients and hear
-how they live in a family dialogue.
+Борщ має багато родинних версій. In the family dialogue, listen for the
+ingredients: **буряк**, **картопля**, **капуста**, **м'ясо**, and **сметана**.
 
 Notice the taste lines. **Борщ дуже смачний** describes a masculine noun:
 borscht is tasty. **Каша дуже смачна** describes a feminine noun: porridge is
 tasty. **Дуже смачно!** is different: it is an impersonal comment, like "very
-tasty!" after you taste something. At A1, learn the examples instead of a full
-adjective table.
+tasty!" after you taste something. For now, learn the examples and copy the
+small pairs aloud.
 
 ### Щоденні звички
 
 ```text
-Марко: Що ти зазвичай їси на сніданок?
-Олена: Кашу, яблуко і чай.
-Марко: А що ти їси на обід?
-Олена: Суп або борщ, салат і хліб.
-Марко: Що ти п'єш?
-Олена: Воду або компот. Увечері я вечеряю вдома.
+Марко: Олено, що в тебе на сніданок?
+Олена: Каша, яблуко і чай. А в тебе?
+Марко: Хліб з маслом і кава.
+Олена: А на обід?
+Марко: Суп або борщ, салат і хліб.
+Олена: Я п'ю воду або компот. Увечері вечеряю вдома.
 ```
 
 Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Марко: Що ти зазвичай їси на сніданок?** | Marko: What do you usually eat for breakfast? |
-| **Олена: Кашу, яблуко і чай.** | Olena: Porridge, an apple, and tea. |
-| **Марко: А що ти їси на обід?** | Marko: And what do you eat for lunch? |
-| **Олена: Суп або борщ, салат і хліб.** | Olena: Soup or borscht, salad, and bread. |
-| **Марко: Що ти п'єш?** | Marko: What do you drink? |
-| **Олена: Воду або компот. Увечері я вечеряю вдома.** | Olena: Water or compote. In the evening I have dinner at home. |
+| Марко: Олено, що в тебе на сніданок? | Marko: Olena, what do you have for breakfast? |
+| Олена: Каша, яблуко і чай. А в тебе? | Olena: Porridge, an apple, and tea. And you? |
+| Марко: Хліб з маслом і кава. | Marko: Bread with butter and coffee. |
+| Олена: А на обід? | Olena: And for lunch? |
+| Марко: Суп або борщ, салат і хліб. | Marko: Soup or borscht, salad, and bread. |
+| Олена: Я п'ю воду або компот. Увечері вечеряю вдома. | Olena: I drink water or compote. In the evening I have dinner at home. |
 
 Use **що ти їси?** for food and **що ти п'єш?** for drinks. Ukrainian normally
 says **я їм борщ**, not "I drink borscht." Soups are eaten. For the meal
@@ -204,31 +198,27 @@ itself, keep the three compact verbs:
 Start with everyday food words that you can use at home, in a shop, or at a
 simple cafe.
 
-| Category | Words |
-| --- | --- |
-| bread and grains | **хліб**, **каша**, **рис**, **макарони** |
-| meat and fish | **м'ясо**, **курка**, **риба** |
-| vegetables | **картопля**, **морква**, **цибуля**, **помідор**, **огірок** |
-| fruit | **яблуко**, **банан**, **апельсин**, **лимон** |
-| dairy | **молоко**, **сир**, **масло**, **сметана**, **йогурт** |
-| simple extras | **яйце**, **цукор**, **сіль**, **олія** |
+| Category | Ukrainian words | English support |
+| --- | --- | --- |
+| bread and grains | **хліб**, **каша**, **рис**, **макарони** | bread, porridge, rice, pasta |
+| meat and fish | **м'ясо**, **курка**, **риба** | meat, chicken, fish |
+| vegetables | **картопля**, **морква**, **цибуля**, **помідор**, **огірок** | potato, carrot, onion, tomato, cucumber |
+| fruit | **яблуко**, **банан**, **апельсин**, **лимон** | apple, banana, orange, lemon |
+| dairy | **молоко**, **сир**, **масло**, **сметана**, **йогурт** | milk, cheese, butter, sour cream, yogurt |
+| simple extras | **яйце**, **цукор**, **сіль**, **олія** | egg, sugar, salt, oil |
 
-The word **сир** is important. In Ukrainian classroom materials, use **сир**
-for cheese or cottage cheese context, and use **кисломолочний сир** when you
-must be more specific. Do not teach **<del>творог</del>** as the
-course form. If the lesson talks about dumplings with cheese, the line is
-**вареники із сиром**.
+The word **сир** is important. Use **сир** for cheese or cottage cheese
+contexts; when you must be more specific, use **кисломолочний сир**. If the
+line talks about dumplings with cheese, say **вареники із сиром**.
 
 The word **смажений** is another safety point. Say **смажена картопля** for
-fried potatoes. Do not use **<del>жарена картопля</del>** in
-course language. The same repair logic protects learners from copying
-Russianized menu language into Ukrainian.
+fried potatoes. This repair helps keep everyday menu language clean Ukrainian.
 
 Ukrainian cultural dishes are not side notes. **Борщ** is a Ukrainian national
 and family dish. **Вареники** are a Ukrainian dish made with dough and fillings
 such as potato, cabbage, meat, cherries, or **сир**. **Сало** is a Ukrainian
-cultural food with strong symbolic meaning. In this A1 module, the goal is not
-to explain food history. The goal is to name these foods on Ukrainian terms.
+cultural food with strong symbolic meaning. Name these foods on Ukrainian terms
+first; food history can come later.
 
 Use small description lines:
 
@@ -245,19 +235,19 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Борщ дуже смачний.** | Borscht is very tasty. |
-| **Чай гарячий.** | Tea is hot. |
-| **Каша гаряча.** | The porridge is hot. |
-| **Вода холодна.** | The water is cold. |
-| **Сік солодкий.** | The juice is sweet. |
-| **Сіль солона.** | Salt is salty. |
+| Борщ дуже смачний. | Borscht is very tasty. |
+| Чай гарячий. | Tea is hot. |
+| Каша гаряча. | The porridge is hot. |
+| Вода холодна. | The water is cold. |
+| Сік солодкий. | The juice is sweet. |
+| Сіль солона. | Salt is salty. |
 
 These examples help you hear gender agreement without a formal table. The
 lesson gives you pairs such as **смачний борщ**, **смачна каша**, and
 **тепле молоко** as ready models. Use them, copy them, and let the pattern
 become familiar.
 
-### Cafe chunks, not case tables
+### Cafe drink chunks
 
 <FillIn client:only='react' items={JSON.parse(`[{"sentence": "Мені каву ___, будь ласка.", "answer": "з молоком", "options": ["з молоком", "з молоко", "без молоко"]}, {"sentence": "Чай ___, будь ласка.", "answer": "без цукру", "options": ["без цукру", "без цукор", "з цукор"]}, {"sentence": "Я їм хліб ___.", "answer": "з маслом", "options": ["з маслом", "без масло", "з масло"]}, {"sentence": "Дайте, будь ласка, воду ___.", "answer": "з газом", "options": ["з газом", "з газ", "без газ"]}, {"sentence": "Я люблю каву ___.", "answer": "без молока", "options": ["без молока", "без молоко", "з молока"]}, {"sentence": "Вона п'є чай ___.", "answer": "з лимоном", "options": ["з лимоном", "з лимон", "без лимон"]}]`)} instruction={"Choose the whole chunk that completes the service line."} isUkrainian={false} />
 
@@ -265,12 +255,12 @@ become familiar.
 
 Useful drinks divide into a few practical groups:
 
-| Group | Drinks |
-| --- | --- |
-| hot | **кава**, **чай** |
-| cold | **вода**, **сік**, **компот**, **лимонад** |
-| dairy | **молоко**, **кефір** |
-| recognition only | **пиво**, **вино** |
+| Group | Ukrainian drinks | English support |
+| --- | --- | --- |
+| hot | **кава**, **чай** | coffee, tea |
+| cold | **вода**, **сік**, **компот**, **лимонад** | water, juice, compote, lemonade |
+| dairy | **молоко**, **кефір** | milk, kefir |
+| recognition only | **пиво**, **вино** | beer, wine |
 
 The most useful drink phrases are chunks:
 
@@ -281,8 +271,7 @@ The most useful drink phrases are chunks:
 - **без цукру** - without sugar;
 - **без молока** - without milk.
 
-Do not turn these into a lesson on the instrumental or genitive case. At A1,
-the task is to make the service line automatic:
+Practice them as full service lines:
 
 ```text
 Мені каву з молоком, будь ласка.
@@ -295,10 +284,10 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Мені каву з молоком, будь ласка.** | Coffee with milk for me, please. |
-| **Чай без цукру, будь ласка.** | Tea without sugar, please. |
-| **Воду з газом, будь ласка.** | Sparkling water, please. |
-| **Без молока, будь ласка.** | Without milk, please. |
+| Мені каву з молоком, будь ласка. | Coffee with milk for me, please. |
+| Чай без цукру, будь ласка. | Tea without sugar, please. |
+| Воду з газом, будь ласка. | Sparkling water, please. |
+| Без молока, будь ласка. | Without milk, please. |
 
 The polite frame **будь ласка** keeps the line useful in a cafe or at home.
 When someone gives you food, answer with **дякую**. When people begin eating,
@@ -306,14 +295,13 @@ the natural Ukrainian etiquette formula is **Смачного!**
 
 ### Food guardrails
 
-<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Борщ is taught here as a Ukrainian cultural dish.", "isTrue": true, "explanation": "Borscht is framed as Ukrainian, not as generic regional soup."}, {"statement": "At A1, без цукру is taught as a full chunk.", "isTrue": true, "explanation": "The module does not teach a formal genitive lesson."}, {"statement": "Творог is the standard course word for cheese.", "isTrue": false, "explanation": "Use сир, or кисломолочний сир when needed."}, {"statement": "Смажена картопля is the clean Ukrainian form.", "isTrue": true, "explanation": "Do not use жарена картопля as course language."}, {"statement": "Я п'ю борщ is the natural line for soup.", "isTrue": false, "explanation": "Ukrainian says я їм борщ."}, {"statement": "Смачного! is the natural meal formula.", "isTrue": true, "explanation": "Use Смачного! when people begin eating."}, {"statement": "Я снідаю means I have breakfast.", "isTrue": true, "explanation": "Use the compact meal verb."}, {"statement": "Борщ дуже смачно is the best sentence.", "isTrue": false, "explanation": "Say Борщ дуже смачний for the noun борщ."}]`)} instruction={"Decide whether each statement fits this module."} isUkrainian={false} />
+<TrueFalse client:only='react' items={JSON.parse(`[{"statement": "Борщ is a Ukrainian cultural dish in this module.", "isTrue": true, "explanation": "It is named as Ukrainian family and cultural food."}, {"statement": "Без цукру is practiced as a full chunk.", "isTrue": true, "explanation": "Practice the whole phrase as a service line."}, {"statement": "Творог is the standard course word for cheese.", "isTrue": false, "explanation": "Use сир, or кисломолочний сир when needed."}, {"statement": "Смажена картопля is the clean Ukrainian form.", "isTrue": true, "explanation": "Use смажена картопля for fried potatoes."}, {"statement": "Я п'ю борщ is the natural line for soup.", "isTrue": false, "explanation": "Ukrainian says я їм борщ."}, {"statement": "Смачного! is the natural meal formula.", "isTrue": true, "explanation": "Use Смачного! when people begin eating."}, {"statement": "Я снідаю means I have breakfast.", "isTrue": true, "explanation": "Use the compact meal verb."}, {"statement": "Борщ дуже смачно is the best sentence.", "isTrue": false, "explanation": "Say Борщ дуже смачний for the noun борщ."}]`)} instruction={"Decide whether each statement fits this module."} isUkrainian={false} />
 
 ## Меню вдома і в кафе
 
-Read this simple menu aloud. It combines recognition, service chunks, and
-Ukrainian food culture.
+Read this simple menu aloud. Each line can become a home plan or a cafe order.
 
-| Меню | Простий вибір |
+| Меню | Що є |
 | --- | --- |
 | Сніданок | каша, хліб з маслом, яблуко, кава з молоком |
 | Обід | борщ зі сметаною, салат, вода без газу |
@@ -334,16 +322,14 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Офіціантка: Добрий день! Що ви хочете?** | Server: Good afternoon! What would you like? |
-| **Клієнт: Мені борщ зі сметаною і воду без газу, будь ласка.** | Customer: Borscht with sour cream and still water for me, please. |
-| **Офіціантка: Добре. А на десерт?** | Server: Good. And for dessert? |
-| **Клієнт: Вареники із сиром.** | Customer: Varenyky with cheese. |
-| **Офіціантка: Смачного!** | Server: Enjoy your meal! |
+| Офіціантка: Добрий день! Що ви хочете? | Server: Good afternoon! What would you like? |
+| Клієнт: Мені борщ зі сметаною і воду без газу, будь ласка. | Customer: Borscht with sour cream and still water for me, please. |
+| Офіціантка: Добре. А на десерт? | Server: Good. And for dessert? |
+| Клієнт: Вареники із сиром. | Customer: Varenyky with cheese. |
+| Офіціантка: Смачного! | Server: Enjoy your meal! |
 
-The greeting is **Добрий день!** in a simple public-service scene. Keep the
-course language Ukrainian and precise. The cultural foods stay Ukrainian:
-**борщ**, **вареники**, and **сало** are not presented as anonymous "Eastern
-European" items.
+The greeting is **Добрий день!** in a simple public-service scene. The cultural
+foods stay Ukrainian and precise: **борщ**, **вареники**, and **сало**.
 
 You may also recognize simple buying measures: **літр**, **грам**, and
 **кілограм**. Keep them as recognition words for now: **літр води**,
@@ -368,19 +354,17 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Вранці я снідаю вдома.** | In the morning I have breakfast at home. |
-| **Я їм кашу і яблуко.** | I eat porridge and an apple. |
-| **Я п'ю каву з молоком.** | I drink coffee with milk. |
-| **Вдень я обідаю на роботі.** | During the day I have lunch at work. |
-| **Я їм суп або борщ.** | I eat soup or borscht. |
-| **Увечері я вечеряю вдома.** | In the evening I have dinner at home. |
-| **Я їм рибу з рисом і п'ю чай без цукру.** | I eat fish with rice and drink tea without sugar. |
+| Вранці я снідаю вдома. | In the morning I have breakfast at home. |
+| Я їм кашу і яблуко. | I eat porridge and an apple. |
+| Я п'ю каву з молоком. | I drink coffee with milk. |
+| Вдень я обідаю на роботі. | During the day I have lunch at work. |
+| Я їм суп або борщ. | I eat soup or borscht. |
+| Увечері я вечеряю вдома. | In the evening I have dinner at home. |
+| Я їм рибу з рисом і п'ю чай без цукру. | I eat fish with rice and drink tea without sugar. |
 
 This story deliberately repeats **я їм**, **я п'ю**, **я снідаю**, **я
-обідаю**, and **я вечеряю**. Repetition is useful here because meals are one of
-the first places where English transfer feels tempting. You can say **I have
-breakfast** in English, but in Ukrainian the compact verb **снідати** is the
-natural tool.
+обідаю**, and **я вечеряю**. Hear the rhythm: meal verb first, then a food or
+drink line when you want more detail.
 
 You can also talk about liking food:
 
@@ -395,19 +379,17 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Мені подобається борщ.** | I like borscht. |
-| **Я люблю вареники.** | I like varenyky. |
-| **Мені не подобається чай з цукром.** | I do not like tea with sugar. |
-| **Я люблю каву без молока.** | I like coffee without milk. |
+| Мені подобається борщ. | I like borscht. |
+| Я люблю вареники. | I like varenyky. |
+| Мені не подобається чай з цукром. | I do not like tea with sugar. |
+| Я люблю каву без молока. | I like coffee without milk. |
 
-The basic eating and drinking verbs are **їсти** and **пити**. For liking,
-keep two recognition chunks available: **Мені подобається…** and
-**Я полюбляю…**. A cultural text may say **Полюбляємо його не лише ми, а й
-наші гості** about a beloved food; for your own A1 output, shorter lines such
-as **мені подобається борщ** are enough.
+**Їсти / пити. Любити / подобатися.** Keep the lines short: **Мені
+подобається борщ**, **Я люблю вареники**, **Мені не подобається чай з
+цукром**.
 
 Again, keep the chunks whole. **Без цукру** and **без молока** are service
-phrases, not a case chart. You will meet the grammar later with more room.
+phrases you can use right away.
 
 <span id="repair-food-and-drink-interference"></span>
 
@@ -418,21 +400,20 @@ Use this short repair map. Read the right column aloud.
 | Avoid | Use |
 | --- | --- |
 | **<del>творог</del>** as the course word | **сир**, or **кисломолочний сир** when needed |
-| **<del>жарена картопля</del>** | **смажена картопля** |
-| **я їм сніданок** as the main pattern | **я снідаю** |
-| **я п'ю борщ** | **я їм борщ** |
-| **без цукор** | **без цукру** as a chunk |
-| **борщ дуже смачно** | **борщ дуже смачний** |
-| **приємного апетиту** as the course formula | **Смачного!** |
+| <del>жарена картопля</del> | **смажена картопля** |
+| я їм сніданок** as the main pattern | **я снідаю |
+| я п'ю борщ | **я їм борщ** |
+| без цукор | **без цукру** as a chunk |
+| борщ дуже смачно | **борщ дуже смачний** |
+| приємного апетиту** as the meal formula | **Смачного! |
 
-The goal is not to shame a learner who has heard mixed forms. The goal is to
-give the learner clean, memorable Ukrainian forms early. Food vocabulary is
-high-frequency, so early repairs matter.
+Mixed forms are common in real life. Keep the clean forms in your mouth early:
+**сир**, **смажена картопля**, **я їм борщ**, **Смачного!**
 
 ## 📋 Підсумок
 
-You are ready for M36 when you can say a simple food day and keep the cultural
-and repair points clean:
+You can finish this lesson when you can say a simple food day and keep the
+Ukrainian food words clean:
 
 ```text
 Вранці я снідаю вдома.
@@ -447,12 +428,12 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Вранці я снідаю вдома.** | In the morning I have breakfast at home. |
-| **Я хочу каву з молоком і хліб з маслом.** | I want coffee with milk and bread with butter. |
-| **На обід я їм борщ зі сметаною.** | For lunch I eat borscht with sour cream. |
-| **Борщ - українська родинна страва.** | Borscht is a Ukrainian family dish. |
-| **Увечері я вечеряю: риба з рисом і чай без цукру.** | In the evening I have dinner: fish with rice and tea without sugar. |
-| **Смачного!** | Enjoy your meal! |
+| Вранці я снідаю вдома. | In the morning I have breakfast at home. |
+| Я хочу каву з молоком і хліб з маслом. | I want coffee with milk and bread with butter. |
+| На обід я їм борщ зі сметаною. | For lunch I eat borscht with sour cream. |
+| Борщ - українська родинна страва. | Borscht is a Ukrainian family dish. |
+| Увечері я вечеряю: риба з рисом і чай без цукру. | In the evening I have dinner: fish with rice and tea without sugar. |
+| Смачного! | Enjoy your meal! |
 
 Final self-check:
 
@@ -471,9 +452,9 @@ Ukrainian cultural dish.
 </TabItem>
 <TabItem label="Vocabulary">
 
-<VocabCard client:only="react" words={JSON.parse(`[{"word":"їжа","translation":"food","pos":"noun","example":"Їжа дуже смачна.","examples":["food","Їжа дуже смачна."],"atlas_href":"/lexicon/їжа/"},{"word":"напій","translation":"drink","pos":"noun","example":"Кава - гарячий напій.","examples":["drink","Кава - гарячий напій."],"atlas_href":"/lexicon/напій/"},{"word":"хліб","translation":"bread","pos":"noun","example":"Я їм хліб з маслом.","examples":["bread","Я їм хліб з маслом."],"atlas_href":"/lexicon/хліб/"},{"word":"кава","translation":"coffee","pos":"noun","example":"Мені каву з молоком, будь ласка.","examples":["coffee","Мені каву з молоком, будь ласка."],"atlas_href":"/lexicon/кава/"},{"word":"чай","translation":"tea","pos":"noun","example":"Чай без цукру, будь ласка.","examples":["tea","Чай без цукру, будь ласка."],"atlas_href":"/lexicon/чай/"},{"word":"вода","translation":"water","pos":"noun","example":"Я п'ю воду.","examples":["water","Я п'ю воду."],"atlas_href":"/lexicon/вода/"},{"word":"молоко","translation":"milk","pos":"noun","example":"Кава з молоком.","examples":["milk","Кава з молоком."],"atlas_href":"/lexicon/молоко/"},{"word":"сік","translation":"juice","pos":"noun","example":"Сік солодкий.","examples":["juice","Сік солодкий."],"atlas_href":"/lexicon/сік/"},{"word":"м'ясо","translation":"meat","pos":"noun","example":"Для борщу потрібно м'ясо.","examples":["meat","Для борщу потрібно м'ясо."],"atlas_href":"/lexicon/м-ясо/"},{"word":"риба","translation":"fish","pos":"noun","example":"На вечерю риба з рисом.","examples":["fish","На вечерю риба з рисом."],"atlas_href":"/lexicon/риба/"},{"word":"суп","translation":"soup","pos":"noun","example":"Я їм суп.","examples":["soup","Я їм суп."],"atlas_href":"/lexicon/суп/"},{"word":"борщ","translation":"borscht","pos":"noun","example":"Борщ дуже смачний.","examples":["borscht","Борщ дуже смачний."],"atlas_href":"/lexicon/борщ/"},{"word":"вареники","translation":"varenyky","pos":"noun","example":"Я люблю вареники із сиром.","examples":["varenyky","Я люблю вареники із сиром."],"atlas_href":"/lexicon/вареники/"},{"word":"сало","translation":"salo","pos":"noun","example":"Сало - українська культурна їжа.","examples":["salo","Сало - українська культурна їжа."],"atlas_href":"/lexicon/сало/"},{"word":"сніданок","translation":"breakfast","pos":"noun","example":"На сніданок я їм кашу.","examples":["breakfast","На сніданок я їм кашу."],"atlas_href":"/lexicon/сніданок/"},{"word":"обід","translation":"lunch","pos":"noun","example":"На обід я їм борщ.","examples":["lunch","На обід я їм борщ."],"atlas_href":"/lexicon/обід/"},{"word":"вечеря","translation":"dinner","pos":"noun","example":"Вечеря вдома.","examples":["dinner","Вечеря вдома."],"atlas_href":"/lexicon/вечеря/"},{"word":"снідати","translation":"to have breakfast","pos":"verb","example":"Я снідаю вдома.","examples":["to have breakfast","Я снідаю вдома."],"atlas_href":"/lexicon/снідати/"},{"word":"обідати","translation":"to have lunch","pos":"verb","example":"Вдень я обідаю.","examples":["to have lunch","Вдень я обідаю."],"atlas_href":"/lexicon/обідати/"},{"word":"вечеряти","translation":"to have dinner","pos":"verb","example":"Увечері я вечеряю.","examples":["to have dinner","Увечері я вечеряю."],"atlas_href":"/lexicon/вечеряти/"},{"word":"каша","translation":"porridge","pos":"noun","example":"Каша гаряча.","examples":["porridge","Каша гаряча."],"atlas_href":"/lexicon/каша/"},{"word":"сир","translation":"cheese; cottage cheese","pos":"noun","example":"Вареники із сиром.","examples":["cheese; cottage cheese","Вареники із сиром."],"atlas_href":"/lexicon/сир/"},{"word":"масло","translation":"butter","pos":"noun","example":"Хліб з маслом.","examples":["butter","Хліб з маслом."],"atlas_href":"/lexicon/масло/"},{"word":"яйце","translation":"egg","pos":"noun","example":"На столі яйце.","examples":["egg","На столі яйце."],"atlas_href":"/lexicon/яйце/"},{"word":"картопля","translation":"potato","pos":"noun","example":"Смажена картопля.","examples":["potato","Смажена картопля."],"atlas_href":"/lexicon/картопля/"},{"word":"буряк","translation":"beet","pos":"noun","example":"Для борщу потрібен буряк.","examples":["beet","Для борщу потрібен буряк."],"atlas_href":"/lexicon/буряк/"},{"word":"капуста","translation":"cabbage","pos":"noun","example":"Для борщу потрібна капуста.","examples":["cabbage","Для борщу потрібна капуста."],"atlas_href":"/lexicon/капуста/"},{"word":"цукор","translation":"sugar","pos":"noun","example":"Чай без цукру.","examples":["sugar","Чай без цукру."],"atlas_href":"/lexicon/цукор/"},{"word":"сіль","translation":"salt","pos":"noun","example":"Сіль солона.","examples":["salt","Сіль солона."],"atlas_href":"/lexicon/сіль/"},{"word":"сметана","translation":"sour cream","pos":"noun","example":"Борщ зі сметаною.","examples":["sour cream","Борщ зі сметаною."],"atlas_href":"/lexicon/сметана/"},{"word":"компот","translation":"compote","pos":"noun","example":"Я п'ю компот.","examples":["compote","Я п'ю компот."],"atlas_href":"/lexicon/компот/"},{"word":"смажений","translation":"fried","pos":"adjective","example":"Смажена картопля.","examples":["fried","Смажена картопля."],"atlas_href":"/lexicon/смажений/"},{"word":"смачний","translation":"tasty","pos":"adjective","example":"Борщ дуже смачний.","examples":["tasty","Борщ дуже смачний."],"atlas_href":"/lexicon/смачний/"},{"word":"без цукру","translation":"without sugar","pos":"chunk","example":"Чай без цукру.","examples":["without sugar","Чай без цукру."],"atlas_href":"/lexicon/без-цукру/"},{"word":"без молока","translation":"without milk","pos":"chunk","example":"Кава без молока.","examples":["without milk","Кава без молока."],"atlas_href":"/lexicon/без-молока/"},{"word":"з молоком","translation":"with milk","pos":"chunk","example":"Кава з молоком.","examples":["with milk","Кава з молоком."],"atlas_href":"/lexicon/з-молоком/"},{"word":"Смачного!","translation":"Enjoy your meal!","pos":"phrase","example":"Смачного!","examples":["Enjoy your meal!","Смачного!"]}]`)} title="Vocabulary" />
+<VocabCard client:only="react" words={JSON.parse(`[{"word":"їжа","translation":"food","pos":"noun","example":"Їжа дуже смачна.","examples":["food","Їжа дуже смачна."],"atlas_href":"/lexicon/їжа/"},{"word":"напій","translation":"drink","pos":"noun","example":"Кава - гарячий напій.","examples":["drink","Кава - гарячий напій."],"atlas_href":"/lexicon/напій/"},{"word":"хліб","translation":"bread","pos":"noun","example":"Я їм хліб з маслом.","examples":["bread","Я їм хліб з маслом."],"atlas_href":"/lexicon/хліб/"},{"word":"кава","translation":"coffee","pos":"noun","example":"Мені каву з молоком, будь ласка.","examples":["coffee","Мені каву з молоком, будь ласка."],"atlas_href":"/lexicon/кава/"},{"word":"чай","translation":"tea","pos":"noun","example":"Чай без цукру, будь ласка.","examples":["tea","Чай без цукру, будь ласка."],"atlas_href":"/lexicon/чай/"},{"word":"вода","translation":"water","pos":"noun","example":"Я п'ю воду.","examples":["water","Я п'ю воду."],"atlas_href":"/lexicon/вода/"},{"word":"молоко","translation":"milk","pos":"noun","example":"Кава з молоком.","examples":["milk","Кава з молоком."],"atlas_href":"/lexicon/молоко/"},{"word":"сік","translation":"juice","pos":"noun","example":"Сік солодкий.","examples":["juice","Сік солодкий."],"atlas_href":"/lexicon/сік/"},{"word":"м'ясо","translation":"meat","pos":"noun","example":"У борщі є м'ясо.","examples":["meat","У борщі є м'ясо."],"atlas_href":"/lexicon/м-ясо/"},{"word":"риба","translation":"fish","pos":"noun","example":"На вечерю риба з рисом.","examples":["fish","На вечерю риба з рисом."],"atlas_href":"/lexicon/риба/"},{"word":"суп","translation":"soup","pos":"noun","example":"Я їм суп.","examples":["soup","Я їм суп."],"atlas_href":"/lexicon/суп/"},{"word":"борщ","translation":"borscht","pos":"noun","example":"Борщ дуже смачний.","examples":["borscht","Борщ дуже смачний."],"atlas_href":"/lexicon/борщ/"},{"word":"вареники","translation":"varenyky","pos":"noun","example":"Я люблю вареники із сиром.","examples":["varenyky","Я люблю вареники із сиром."]},{"word":"сало","translation":"salo","pos":"noun","example":"Сало - українська культурна їжа.","examples":["salo","Сало - українська культурна їжа."],"atlas_href":"/lexicon/сало/"},{"word":"сніданок","translation":"breakfast","pos":"noun","example":"На сніданок я їм кашу.","examples":["breakfast","На сніданок я їм кашу."],"atlas_href":"/lexicon/сніданок/"},{"word":"обід","translation":"lunch","pos":"noun","example":"На обід я їм борщ.","examples":["lunch","На обід я їм борщ."],"atlas_href":"/lexicon/обід/"},{"word":"вечеря","translation":"dinner","pos":"noun","example":"Вечеря вдома.","examples":["dinner","Вечеря вдома."],"atlas_href":"/lexicon/вечеря/"},{"word":"снідати","translation":"to have breakfast","pos":"verb","example":"Я снідаю вдома.","examples":["to have breakfast","Я снідаю вдома."],"atlas_href":"/lexicon/снідати/"},{"word":"обідати","translation":"to have lunch","pos":"verb","example":"Вдень я обідаю.","examples":["to have lunch","Вдень я обідаю."],"atlas_href":"/lexicon/обідати/"},{"word":"вечеряти","translation":"to have dinner","pos":"verb","example":"Увечері я вечеряю.","examples":["to have dinner","Увечері я вечеряю."],"atlas_href":"/lexicon/вечеряти/"},{"word":"їсти","translation":"to eat","pos":"verb","example":"Я хочу їсти.","examples":["to eat","Я хочу їсти."],"atlas_href":"/lexicon/їсти/"},{"word":"пити","translation":"to drink","pos":"verb","example":"Я хочу пити.","examples":["to drink","Я хочу пити."],"atlas_href":"/lexicon/пити/"},{"word":"голодний","translation":"hungry","pos":"adjective","example":"Я голодний.","examples":["hungry","Я голодний."]},{"word":"каша","translation":"porridge","pos":"noun","example":"Каша гаряча.","examples":["porridge","Каша гаряча."],"atlas_href":"/lexicon/каша/"},{"word":"рис","translation":"rice","pos":"noun","example":"На вечерю риба з рисом.","examples":["rice","На вечерю риба з рисом."],"atlas_href":"/lexicon/рис/"},{"word":"макарони","translation":"pasta","pos":"noun","example":"Макарони на столі.","examples":["pasta","Макарони на столі."]},{"word":"сир","translation":"cheese; cottage cheese","pos":"noun","example":"Вареники із сиром.","examples":["cheese; cottage cheese","Вареники із сиром."],"atlas_href":"/lexicon/сир/"},{"word":"масло","translation":"butter","pos":"noun","example":"Хліб з маслом.","examples":["butter","Хліб з маслом."],"atlas_href":"/lexicon/масло/"},{"word":"яйце","translation":"egg","pos":"noun","example":"На столі яйце.","examples":["egg","На столі яйце."],"atlas_href":"/lexicon/яйце/"},{"word":"картопля","translation":"potato","pos":"noun","example":"Смажена картопля.","examples":["potato","Смажена картопля."],"atlas_href":"/lexicon/картопля/"},{"word":"картопляний","translation":"potato; made with potato","pos":"adjective","example":"Картопляний суп.","examples":["potato; made with potato","Картопляний суп."]},{"word":"буряк","translation":"beet","pos":"noun","example":"У борщі є буряк.","examples":["beet","У борщі є буряк."],"atlas_href":"/lexicon/буряк/"},{"word":"морква","translation":"carrot","pos":"noun","example":"Для борщу є морква.","examples":["carrot","Для борщу є морква."]},{"word":"капуста","translation":"cabbage","pos":"noun","example":"У борщі є капуста.","examples":["cabbage","У борщі є капуста."],"atlas_href":"/lexicon/капуста/"},{"word":"цибуля","translation":"onion","pos":"noun","example":"Для борщу є цибуля.","examples":["onion","Для борщу є цибуля."],"atlas_href":"/lexicon/цибуля/"},{"word":"помідор","translation":"tomato","pos":"noun","example":"На столі помідор.","examples":["tomato","На столі помідор."],"atlas_href":"/lexicon/помідор/"},{"word":"огірок","translation":"cucumber","pos":"noun","example":"Огірок холодний.","examples":["cucumber","Огірок холодний."],"atlas_href":"/lexicon/огірок/"},{"word":"банан","translation":"banana","pos":"noun","example":"Банан солодкий.","examples":["banana","Банан солодкий."]},{"word":"апельсин","translation":"orange","pos":"noun","example":"Апельсин на столі.","examples":["orange","Апельсин на столі."]},{"word":"лимон","translation":"lemon","pos":"noun","example":"Чай з лимоном.","examples":["lemon","Чай з лимоном."],"atlas_href":"/lexicon/лимон/"},{"word":"полуничний","translation":"strawberry","pos":"adjective","example":"Полуничний джем.","examples":["strawberry","Полуничний джем."]},{"word":"джем","translation":"jam","pos":"noun","example":"Полуничний джем.","examples":["jam","Полуничний джем."]},{"word":"цукор","translation":"sugar","pos":"noun","example":"Чай без цукру.","examples":["sugar","Чай без цукру."],"atlas_href":"/lexicon/цукор/"},{"word":"сіль","translation":"salt","pos":"noun","example":"Сіль солона.","examples":["salt","Сіль солона."],"atlas_href":"/lexicon/сіль/"},{"word":"сметана","translation":"sour cream","pos":"noun","example":"Борщ зі сметаною.","examples":["sour cream","Борщ зі сметаною."],"atlas_href":"/lexicon/сметана/"},{"word":"компот","translation":"compote","pos":"noun","example":"Я п'ю компот.","examples":["compote","Я п'ю компот."],"atlas_href":"/lexicon/компот/"},{"word":"курка","translation":"chicken","pos":"noun","example":"Курка на вечерю.","examples":["chicken","Курка на вечерю."]},{"word":"йогурт","translation":"yogurt","pos":"noun","example":"Йогурт на сніданок.","examples":["yogurt","Йогурт на сніданок."]},{"word":"олія","translation":"oil","pos":"noun","example":"Олія на столі.","examples":["oil","Олія на столі."],"atlas_href":"/lexicon/олія/"},{"word":"кефір","translation":"kefir","pos":"noun","example":"Я п'ю кефір.","examples":["kefir","Я п'ю кефір."]},{"word":"лимонад","translation":"lemonade","pos":"noun","example":"Лимонад холодний.","examples":["lemonade","Лимонад холодний."]},{"word":"пиво","translation":"beer","pos":"noun","example":"Пиво - напій.","examples":["beer","Пиво - напій."]},{"word":"вино","translation":"wine","pos":"noun","example":"Вино - напій.","examples":["wine","Вино - напій."]},{"word":"склянка","translation":"glass","pos":"noun","example":"Склянка води.","examples":["glass","Склянка води."],"atlas_href":"/lexicon/склянка/"},{"word":"смажений","translation":"fried","pos":"adjective","example":"Смажена картопля.","examples":["fried","Смажена картопля."],"atlas_href":"/lexicon/смажений/"},{"word":"смачний","translation":"tasty","pos":"adjective","example":"Борщ дуже смачний.","examples":["tasty","Борщ дуже смачний."],"atlas_href":"/lexicon/смачний/"},{"word":"гарячий","translation":"hot","pos":"adjective","example":"Чай гарячий.","examples":["hot","Чай гарячий."],"atlas_href":"/lexicon/гарячий/"},{"word":"теплий","translation":"warm","pos":"adjective","example":"Тепле молоко.","examples":["warm","Тепле молоко."],"atlas_href":"/lexicon/теплий/"},{"word":"холодний","translation":"cold","pos":"adjective","example":"Вода холодна.","examples":["cold","Вода холодна."],"atlas_href":"/lexicon/холодний/"},{"word":"солодкий","translation":"sweet","pos":"adjective","example":"Сік солодкий.","examples":["sweet","Сік солодкий."],"atlas_href":"/lexicon/солодкий/"},{"word":"солоний","translation":"salty","pos":"adjective","example":"Сіль солона.","examples":["salty","Сіль солона."],"atlas_href":"/lexicon/солоний/"},{"word":"без цукру","translation":"without sugar","pos":"chunk","example":"Чай без цукру.","examples":["without sugar","Чай без цукру."],"atlas_href":"/lexicon/без-цукру/"},{"word":"без молока","translation":"without milk","pos":"chunk","example":"Кава без молока.","examples":["without milk","Кава без молока."],"atlas_href":"/lexicon/без-молока/"},{"word":"з молоком","translation":"with milk","pos":"chunk","example":"Кава з молоком.","examples":["with milk","Кава з молоком."],"atlas_href":"/lexicon/з-молоком/"},{"word":"Смачного!","translation":"Enjoy your meal!","pos":"phrase","example":"Смачного!","examples":["Enjoy your meal!","Смачного!"]}]`)} title="Vocabulary" />
 
-<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"їжа","back":"food"},{"front":"напій","back":"drink"},{"front":"хліб","back":"bread"},{"front":"кава","back":"coffee"},{"front":"чай","back":"tea"},{"front":"вода","back":"water"},{"front":"молоко","back":"milk"},{"front":"сік","back":"juice"},{"front":"м'ясо","back":"meat"},{"front":"риба","back":"fish"},{"front":"суп","back":"soup"},{"front":"борщ","back":"borscht"},{"front":"вареники","back":"varenyky"},{"front":"сало","back":"salo"},{"front":"сніданок","back":"breakfast"},{"front":"обід","back":"lunch"},{"front":"вечеря","back":"dinner"},{"front":"снідати","back":"to have breakfast"},{"front":"обідати","back":"to have lunch"},{"front":"вечеряти","back":"to have dinner"},{"front":"каша","back":"porridge"},{"front":"сир","back":"cheese; cottage cheese"},{"front":"масло","back":"butter"},{"front":"яйце","back":"egg"},{"front":"картопля","back":"potato"},{"front":"буряк","back":"beet"},{"front":"капуста","back":"cabbage"},{"front":"цукор","back":"sugar"},{"front":"сіль","back":"salt"},{"front":"сметана","back":"sour cream"},{"front":"компот","back":"compote"},{"front":"смажений","back":"fried"},{"front":"смачний","back":"tasty"},{"front":"без цукру","back":"without sugar"},{"front":"без молока","back":"without milk"},{"front":"з молоком","back":"with milk"},{"front":"Смачного!","back":"Enjoy your meal!"}]`)} />
+<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"їжа","back":"food"},{"front":"напій","back":"drink"},{"front":"хліб","back":"bread"},{"front":"кава","back":"coffee"},{"front":"чай","back":"tea"},{"front":"вода","back":"water"},{"front":"молоко","back":"milk"},{"front":"сік","back":"juice"},{"front":"м'ясо","back":"meat"},{"front":"риба","back":"fish"},{"front":"суп","back":"soup"},{"front":"борщ","back":"borscht"},{"front":"вареники","back":"varenyky"},{"front":"сало","back":"salo"},{"front":"сніданок","back":"breakfast"},{"front":"обід","back":"lunch"},{"front":"вечеря","back":"dinner"},{"front":"снідати","back":"to have breakfast"},{"front":"обідати","back":"to have lunch"},{"front":"вечеряти","back":"to have dinner"},{"front":"їсти","back":"to eat"},{"front":"пити","back":"to drink"},{"front":"голодний","back":"hungry"},{"front":"каша","back":"porridge"},{"front":"рис","back":"rice"},{"front":"макарони","back":"pasta"},{"front":"сир","back":"cheese; cottage cheese"},{"front":"масло","back":"butter"},{"front":"яйце","back":"egg"},{"front":"картопля","back":"potato"},{"front":"картопляний","back":"potato; made with potato"},{"front":"буряк","back":"beet"},{"front":"морква","back":"carrot"},{"front":"капуста","back":"cabbage"},{"front":"цибуля","back":"onion"},{"front":"помідор","back":"tomato"},{"front":"огірок","back":"cucumber"},{"front":"банан","back":"banana"},{"front":"апельсин","back":"orange"},{"front":"лимон","back":"lemon"},{"front":"полуничний","back":"strawberry"},{"front":"джем","back":"jam"},{"front":"цукор","back":"sugar"},{"front":"сіль","back":"salt"},{"front":"сметана","back":"sour cream"},{"front":"компот","back":"compote"},{"front":"курка","back":"chicken"},{"front":"йогурт","back":"yogurt"},{"front":"олія","back":"oil"},{"front":"кефір","back":"kefir"},{"front":"лимонад","back":"lemonade"},{"front":"пиво","back":"beer"},{"front":"вино","back":"wine"},{"front":"склянка","back":"glass"},{"front":"смажений","back":"fried"},{"front":"смачний","back":"tasty"},{"front":"гарячий","back":"hot"},{"front":"теплий","back":"warm"},{"front":"холодний","back":"cold"},{"front":"солодкий","back":"sweet"},{"front":"солоний","back":"salty"},{"front":"без цукру","back":"without sugar"},{"front":"без молока","back":"without milk"},{"front":"з молоком","back":"with milk"},{"front":"Смачного!","back":"Enjoy your meal!"}]`)} />
 
 </TabItem>
 <TabItem label="Activities">
@@ -486,7 +467,7 @@ Ukrainian cultural dish.
 
 *(see lesson, §Щоденні звички)*
 
-### Cafe chunks, not case tables
+### Cafe drink chunks
 
 *(see lesson, §Їжа)*
 
@@ -502,15 +483,23 @@ Ukrainian cultural dish.
 
 <Order client:only='react' items={JSON.parse(`["Вранці я снідаю вдома.", "Я їм кашу і яблуко.", "Я п'ю каву з молоком.", "Вдень я обідаю на роботі.", "На обід я їм борщ зі сметаною.", "Увечері я вечеряю вдома.", "Я їм рибу з рисом.", "Я п'ю чай без цукру."]`)} correct_order={JSON.parse(`[0, 1, 2, 3, 4, 5, 6, 7]`)} instruction={"Put the food day from morning to evening."} isUkrainian={true} />
 
+### Extra food-table glosses
+
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "рис", "right": "rice"}, {"left": "макарони", "right": "pasta"}, {"left": "морква", "right": "carrot"}, {"left": "цибуля", "right": "onion"}, {"left": "помідор", "right": "tomato"}, {"left": "огірок", "right": "cucumber"}, {"left": "апельсин", "right": "orange"}, {"left": "йогурт", "right": "yogurt"}, {"left": "олія", "right": "oil"}, {"left": "кефір", "right": "kefir"}, {"left": "лимонад", "right": "lemonade"}]`)} instruction={"Match the food word with its English support."} isUkrainian={false} />
+
+### Meal verb rhythm
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Вранці я ___.", "answer": "снідаю", "options": ["снідаю", "обідаю", "вечеряю"]}, {"sentence": "Вдень я ___.", "answer": "обідаю", "options": ["обідаю", "вечеряю", "п'ю"]}, {"sentence": "Увечері я ___.", "answer": "вечеряю", "options": ["вечеряю", "снідаю", "їм чай"]}, {"sentence": "Я ___ борщ.", "answer": "їм", "options": ["їм", "п'ю", "снідаю"]}, {"sentence": "Я ___ чай.", "answer": "п'ю", "options": ["п'ю", "їм", "вечеряю"]}, {"sentence": "Я хочу каву ___.", "answer": "з молоком", "options": ["з молоком", "без цукру", "смачна"]}]`)} instruction={"Choose the natural short line."} isUkrainian={false} />
+
 ### Build safe food lines
 
-<Unjumble client:only='react' items={JSON.parse(`[{"jumbled": "Я / снідаю / вдома", "answer": "Я снідаю вдома"}, {"jumbled": "Мені / каву / з / молоком / будь ласка", "answer": "Мені каву з молоком, будь ласка"}, {"jumbled": "Борщ / дуже / смачний", "answer": "Борщ дуже смачний"}, {"jumbled": "Я / їм / борщ", "answer": "Я їм борщ"}, {"jumbled": "Чай / без / цукру / будь ласка", "answer": "Чай без цукру, будь ласка"}, {"jumbled": "Смачного", "answer": "Смачного"}]`)} instruction={"Put the words in a natural A1 order."} />
+<Unjumble client:only='react' items={JSON.parse(`[{"jumbled": "Я / снідаю / вдома", "answer": "Я снідаю вдома"}, {"jumbled": "Мені / каву / з / молоком / будь ласка", "answer": "Мені каву з молоком, будь ласка"}, {"jumbled": "Борщ / дуже / смачний", "answer": "Борщ дуже смачний"}, {"jumbled": "Я / їм / борщ", "answer": "Я їм борщ"}, {"jumbled": "Чай / без / цукру / будь ласка", "answer": "Чай без цукру, будь ласка"}, {"jumbled": "Смачного!", "answer": "Смачного!"}]`)} instruction={"Put the words in a natural A1 order."} />
 
 <span id="repair-food-and-drink-interference"></span>
 
 ### Repair food and drink interference
 
-<ErrorCorrection client:only='react' instruction="Choose the clean Ukrainian repair." items={JSON.parse(`[{"sentence": "Я маю голод. / Я є голодний.", "errorWord": "Я маю голод. / Я є голодний.", "correctForm": "Я хочу їсти. / Я голодний.", "options": ["Я хочу їсти. / Я голодний.", "Я маю голод. / Я є голодний.", "Я є хочу їсти. / Я маю голодний."], "explanation": "Use Я хочу їсти or Я голодний; do not copy English have/be patterns."}, {"sentence": "Кіт п'є теплий молоко.", "errorWord": "теплий молоко", "correctForm": "Кіт п'є тепле молоко.", "options": ["Кіт п'є тепле молоко.", "Кіт п'є теплий молоко.", "Кіт п'є тепла молоко."], "explanation": "Молоко is neuter, so use тепле молоко."}, {"sentence": "Вареники з творогом.", "errorWord": "творогом", "correctForm": "Вареники із сиром.", "options": ["Вареники із сиром.", "Вареники з творогом.", "Вареники із сир."], "explanation": "Use сир for the course form."}, {"sentence": "Я люблю творог.", "errorWord": "творог", "correctForm": "Я люблю сир.", "options": ["Я люблю сир.", "Я люблю творог.", "Я люблю сиром."], "explanation": "Use сир as the course form."}, {"sentence": "На столі жарена картопля.", "errorWord": "жарена", "correctForm": "На столі смажена картопля.", "options": ["На столі смажена картопля.", "На столі жарена картопля.", "На столі смажений картопля."], "explanation": "Use смажена картопля."}, {"sentence": "Жарена картопля.", "errorWord": "Жарена", "correctForm": "Смажена картопля.", "options": ["Смажена картопля.", "Жарена картопля.", "Смажений картопля."], "explanation": "The clean Ukrainian phrase is смажена картопля."}, {"sentence": "Дайте мені один воду.", "errorWord": "один воду", "correctForm": "Дайте мені одну воду. (або склянку води)", "options": ["Дайте мені одну воду. (або склянку води)", "Дайте мені один воду.", "Дайте мені одне воду."], "explanation": "Use одну воду, or ask for a glass of water."}, {"sentence": "Суп з картофель.", "errorWord": "картофель", "correctForm": "Суп із картоплею. або Картопляний суп.", "options": ["Суп із картоплею. або Картопляний суп.", "Суп з картофель.", "Суп із картофель."], "explanation": "Use картопля / картоплею or картопляний."}, {"sentence": "Я їм сніданок о сьомій.", "errorWord": "їм сніданок", "correctForm": "Я снідаю о сьомій.", "options": ["Я снідаю о сьомій.", "Я їм сніданок о сьомій.", "Я сніданок о сьомій."], "explanation": "Use the meal verb снідати."}, {"sentence": "Я п'ю борщ.", "errorWord": "п'ю", "correctForm": "Я їм борщ.", "options": ["Я їм борщ.", "Я п'ю борщ.", "Я п'ю суп."], "explanation": "Soup is eaten in Ukrainian."}, {"sentence": "Клубнічний джем.", "errorWord": "Клубнічний", "correctForm": "Полуничний джем.", "options": ["Полуничний джем.", "Клубнічний джем.", "Клубніка джем."], "explanation": "Use полуниця / полуничний, not the Russian-root form."}, {"sentence": "Дайте чай без цукор.", "errorWord": "без цукор", "correctForm": "Дайте чай без цукру.", "options": ["Дайте чай без цукру.", "Дайте чай без цукор.", "Дайте чай з цукру."], "explanation": "Без цукру is memorized as a whole chunk."}, {"sentence": "Борщ дуже смачно.", "errorWord": "дуже смачно", "correctForm": "Борщ дуже смачний.", "options": ["Борщ дуже смачний.", "Борщ дуже смачно.", "Борщ дуже смачна."], "explanation": "With the noun борщ, use смачний."}]`)} isUkrainian={false} />
+<ErrorCorrection client:only='react' instruction="Choose the clean Ukrainian repair." items={JSON.parse(`[{"sentence": "Я маю голод. / Я є голодний.", "errorWord": "Я маю голод. / Я є голодний.", "correctForm": "Я хочу їсти. / Я голодний.", "options": ["Я хочу їсти. / Я голодний.", "Я маю голод. / Я є голодний.", "Я є хочу їсти. / Я маю голодний."], "explanation": "Use Я хочу їсти or Я голодний for hunger."}, {"sentence": "Кіт п'є теплий молоко.", "errorWord": "теплий молоко", "correctForm": "Кіт п'є тепле молоко.", "options": ["Кіт п'є тепле молоко.", "Кіт п'є теплий молоко.", "Кіт п'є тепла молоко."], "explanation": "Молоко is neuter, so use тепле молоко."}, {"sentence": "Вареники з творогом.", "errorWord": "творогом", "correctForm": "Вареники із сиром.", "options": ["Вареники із сиром.", "Вареники з творогом.", "Вареники із сир."], "explanation": "Use сир in this food context."}, {"sentence": "Я люблю творог.", "errorWord": "творог", "correctForm": "Я люблю сир.", "options": ["Я люблю сир.", "Я люблю творог.", "Я люблю сиром."], "explanation": "Use сир as the everyday Ukrainian food word."}, {"sentence": "На столі жарена картопля.", "errorWord": "жарена", "correctForm": "На столі смажена картопля.", "options": ["На столі смажена картопля.", "На столі жарена картопля.", "На столі смажений картопля."], "explanation": "Use смажена картопля."}, {"sentence": "Жарена картопля.", "errorWord": "Жарена", "correctForm": "Смажена картопля.", "options": ["Смажена картопля.", "Жарена картопля.", "Смажений картопля."], "explanation": "The clean Ukrainian phrase is смажена картопля."}, {"sentence": "Дайте мені один воду.", "errorWord": "один воду", "correctForm": "Дайте мені одну воду. (або склянку води)", "options": ["Дайте мені одну воду. (або склянку води)", "Дайте мені один воду.", "Дайте мені одне воду."], "explanation": "Use одну воду, or ask for a glass of water."}, {"sentence": "Суп з картофель.", "errorWord": "картофель", "correctForm": "Суп із картоплею. Або картопляний суп.", "options": ["Суп із картоплею. Або картопляний суп.", "Суп з картофель.", "Суп із картофель."], "explanation": "Use картопля / картоплею or картопляний."}, {"sentence": "Я їм сніданок о сьомій.", "errorWord": "їм сніданок", "correctForm": "Я снідаю о сьомій.", "options": ["Я снідаю о сьомій.", "Я їм сніданок о сьомій.", "Я сніданок о сьомій."], "explanation": "Use the meal verb снідати."}, {"sentence": "Я п'ю борщ.", "errorWord": "п'ю", "correctForm": "Я їм борщ.", "options": ["Я їм борщ.", "Я п'ю борщ.", "Я п'ю суп."], "explanation": "Soup is eaten in Ukrainian."}, {"sentence": "Клубнічний джем.", "errorWord": "Клубнічний", "correctForm": "Полуничний джем.", "options": ["Полуничний джем.", "Клубнічний джем.", "Клубніка джем."], "explanation": "Use полуниця / полуничний, not the Russian-root form."}, {"sentence": "Дайте чай без цукор.", "errorWord": "без цукор", "correctForm": "Дайте чай без цукру.", "options": ["Дайте чай без цукру.", "Дайте чай без цукор.", "Дайте чай з цукру."], "explanation": "Без цукру is memorized as a whole chunk."}, {"sentence": "Чай з цукор.", "errorWord": "з цукор", "correctForm": "Чай з цукром.", "options": ["Чай з цукром.", "Чай з цукор.", "Чай без цукром."], "explanation": "Чай з цукром is a whole drink chunk."}, {"sentence": "Борщ дуже смачно.", "errorWord": "дуже смачно", "correctForm": "Борщ дуже смачний.", "options": ["Борщ дуже смачний.", "Борщ дуже смачно.", "Борщ дуже смачна."], "explanation": "With the noun борщ, use смачний."}, {"sentence": "Каша дуже смачний.", "errorWord": "смачний", "correctForm": "Каша дуже смачна.", "options": ["Каша дуже смачна.", "Каша дуже смачний.", "Каша дуже смачно."], "explanation": "With the noun каша, use смачна."}, {"sentence": "Приємного апетиту!", "errorWord": "Приємного апетиту!", "correctForm": "Смачного!", "options": ["Смачного!", "Приємного апетиту!", "Добрий апетит!"], "explanation": "Смачного! is the natural meal formula here."}]`)} isUkrainian={false} />
 
 </TabItem>
 <TabItem label="Resources">
@@ -518,8 +507,7 @@ Ukrainian cultural dish.
 :::info[🎧 🔗 External Resources]
 
 **🔗 Online resources:**
-- 🔗 [Ukrainian Course: Nouns in the Genitive Case](https://www.ukrainiancourse.com/grammar-tables/nouns-in-the-genitive-case/) — Reference for forms behind chunks like без цукру; not used as a formal A1 case lesson.
-- 🔗 [Ukrainian Course: Nouns in the Instrumental Case](https://www.ukrainiancourse.com/grammar-tables/nouns-in-the-instrumental-case/) — Reference for forms behind chunks like кава з молоком; not used as a formal A1 case lesson.
+- 🔗 **State Standard 2024, Topic 3** — Plan-level communicative situation for restaurant, food, and ordering language.
 - 🔗 [Ukrainian Lessons Podcast Episode 11](https://www.ukrainianlessons.com/episode11/) — Beginner Ukrainian food and cafe language connected to the plan reference.
 - 🔗 [Ukrainian Lessons Podcast Episode 12](https://www.ukrainianlessons.com/episode12/) — Additional beginner food, drink, and ordering practice.
 - 🔗 [Ukrainian Lessons Podcast Episode 13](https://www.ukrainianlessons.com/episode13/) — Continuation of the food/cafe cluster named in the plan.


### PR DESCRIPTION
## Summary
- Polish A1 M36 food-and-drink learner tone and scaffolding.
- Add and restore required workbook repair practice, expanding the workbook set to 6 activities.
- Expand vocabulary to scaffold food/drink tables and repair items.
- Trim resources away from formal case tables and keep plan-backed sources.

## Validation
- `.venv/bin/python scripts/generate_mdx.py l2-uk-en a1 36 --validate`
- `.venv/bin/python scripts/audit/certify_module.py a1/food-and-drink --clean-qg-artifacts`
- `.venv/bin/python scripts/lexicon/check_manifest_freshness.py`
- `.venv/bin/python scripts/lexicon/check_manifest_vocabulary_coverage.py --changed-only --base origin/main`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Production build via certifier

## Gemini CLI LLM QG
- pedagogical: 9.0
- naturalness: 10.0
- decolonization: 10.0
- engagement: 9.5
- tone: 9.5
- aggregate verdict: PASS
- terminal verdict: PASS
- min score: 9.0 (pedagogical)

## Orchestration
- Swarm: not used
- Swarm note: Solo run; no helper swarm used. Required Gemini CLI QG was run as validation only.
- DeepSeek: not used

X-Agent: codex/a1-m36-food-and-drink-quality