### PR TITLE
fix(a1): polish i eat i drink quality

### DIFF
--- a/curriculum/l2-uk-en/a1/i-eat-i-drink/activities.yaml
+++ b/curriculum/l2-uk-en/a1/i-eat-i-drink/activities.yaml
@@ -261,6 +261,62 @@ workbook:
       - "Діти п'ють молоко."
       - 'Смачного!'
     correct_order: [0, 1, 2, 3, 4, 5, 6]
+  - type: match-up
+    title: Food-day object pairs
+    instruction: Match the starter with the clean food or drink line.
+    pairs:
+      - left: 'я п''ю + кава'
+        right: 'я п''ю каву'
+      - left: 'вона п''є + вода'
+        right: 'вона п''є воду'
+      - left: 'ти їси + риба'
+        right: 'ти їси рибу'
+      - left: 'вони їдять + каша'
+        right: 'вони їдять кашу'
+      - left: 'ми їмо + картопля'
+        right: 'ми їмо картоплю'
+      - left: 'я їм + хліб'
+        right: 'я їм хліб'
+      - left: 'діти п''ють + молоко'
+        right: 'діти п''ють молоко'
+      - left: 'він п''є + сік'
+        right: 'він п''є сік'
+  - type: unjumble
+    title: Build food and drink lines
+    instruction: Put the words in a natural A1 order.
+    items:
+      - words:
+          - 'Я'
+          - 'їм'
+          - 'кашу'
+        answer: 'Я їм кашу'
+      - words:
+          - 'Вона'
+          - "п'є"
+          - 'воду'
+        answer: "Вона п'є воду"
+      - words:
+          - 'Ми'
+          - 'їмо'
+          - 'суп'
+          - 'і'
+          - 'салат'
+        answer: 'Ми їмо суп і салат'
+      - words:
+          - 'Діти'
+          - "п'ють"
+          - 'молоко'
+        answer: "Діти п'ють молоко"
+      - words:
+          - 'Я'
+          - 'хочу'
+          - 'воду'
+        answer: 'Я хочу воду'
+      - words:
+          - 'Ти'
+          - 'їси'
+          - 'рибу'
+        answer: 'Ти їси рибу'
   - type: error-correction
     title: Repair eat and drink interference
     instruction: Choose the clean Ukrainian repair.
@@ -298,14 +354,14 @@ workbook:
           - 'Ти їсиш яблуко.'
           - 'Ти їсть яблуко.'
         explanation: 'The form is ти їси.'
-      - sentence: 'Я мию мене.'
-        error: 'Я мию мене.'
-        answer: 'Я вмиваюся.'
+      - sentence: "Я п'ю вода."
+        error: "Я п'ю вода."
+        answer: "Я п'ю воду."
         options:
-          - 'Я вмиваюся.'
-          - 'Я мию мене.'
-          - 'Я мию я.'
-        explanation: 'Use the Ukrainian reflexive verb вмиватися.'
+          - "Я п'ю воду."
+          - "Я п'ю вода."
+          - "Я п'ю воді."
+        explanation: "Вода becomes воду after п'ю."
       - sentence: "На перерві: Я п'ю кава."
         error: "Я п'ю кава."
         answer: "Я п'ю каву."

--- a/curriculum/l2-uk-en/a1/i-eat-i-drink/module.md
+++ b/curriculum/l2-uk-en/a1/i-eat-i-drink/module.md
@@ -1,17 +1,27 @@
 # Я їм, я п'ю
 
-You already know food and drink words. Now you can say what you eat and drink
-with the two everyday verbs **їсти** and **пити**. This is also the first clear
-A1 place for the direct object: the food or drink that receives the action.
+<!-- <implementation_map_audit>manifest_obligations=13 covered_in_map=13 missing=[]</implementation_map_audit> -->
+<!-- <bad_form_audit>italic_bad_form_patterns_found=11 converted_to_marker=11 remaining=0</bad_form_audit> -->
+<!-- <activity_split_audit>level=A1 inline_n=4 workbook_n=6 inline_range=[4,6] workbook_range=[6,9] split_valid=true</activity_split_audit> -->
+
+**Їм. П'ю. Каву. Воду.** You already know food and drink words. Now you can
+make a small daily line: what you eat, what you drink, and what direct-object
+form the food noun takes after the verb.
+
+This is a manageable A1 step. The two everyday verbs are **їсти** and
+**пити**. The food or drink after them is the direct object: the noun phrase
+that answers **що?** after the verb.
 
 The key question is **що?**:
 
 - **Я їм що?** - **хліб**, **суп**, **кашу**.
 - **Я п'ю що?** - **чай**, **сік**, **воду**.
 
-For inanimate food and drink words, most forms stay familiar. The main new
-change is feminine **-а/-я -> -у/-ю**: **кава -> каву**,
-**вода -> воду**, **риба -> рибу**, **картопля -> картоплю**.
+For inanimate food and drink words, most forms stay familiar. You have already
+seen the visible ending **-а/-я -> -у/-ю** in earlier **куди?** direction
+lines. Here the same small ending helps with a new question: **що я їм? що я
+п'ю?** **Кава -> каву**, **вода -> воду**, **риба -> рибу**,
+**картопля -> картоплю**.
 
 By the end, you can:
 
@@ -28,12 +38,10 @@ By the end, you can:
 :::tip
 Ask **що?** after **їсти**, **пити**, **хотіти**, **любити**, **купувати**, and
 **бачити**. If the object is a feminine food or drink word ending in **-а/-я**,
-expect **-у/-ю**.
+expect **-у/-ю**. Same visible ending, new job.
 :::
 
 ## Діалоги
-
-<!-- INJECT_ACTIVITY: act-1 -->
 
 ### Розмова за сніданком
 
@@ -51,13 +59,22 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Мама: Що ти їси на сніданок?** | Mom: What are you eating for breakfast? |
-| **Данило: Я їм кашу і п'ю каву.** | Danylo: I am eating porridge and drinking coffee. |
-| **Мама: А Олена?** | Mom: And Olena? |
-| **Данило: Вона їсть хліб з маслом і п'є чай.** | Danylo: She eats bread with butter and drinks tea. |
-| **Мама: А діти?** | Mom: And the children? |
-| **Данило: Вони їдять яйця і п'ють молоко.** | Danylo: They eat eggs and drink milk. |
-| **Мама: Добре. Смачного!** | Mom: Good. Enjoy your meal! |
+| Мама: Що ти їси на сніданок? | Mom: What are you eating for breakfast? |
+| Данило: Я їм кашу і п'ю каву. | Danylo: I am eating porridge and drinking coffee. |
+| Мама: А Олена? | Mom: And Olena? |
+| Данило: Вона їсть хліб з маслом і п'є чай. | Danylo: She eats bread with butter and drinks tea. |
+| Мама: А діти? | Mom: And the children? |
+| Данило: Вони їдять яйця і п'ють молоко. | Danylo: They eat eggs and drink milk. |
+| Мама: Добре. Смачного! | Mom: Good. Enjoy your meal! |
+
+New words in that scene:
+
+- **чай** - tea;
+- **яйця** - eggs;
+- **хліб з маслом** - bread with butter.
+
+Treat **з маслом** as one food phrase here; you do not need the full grammar of
+**з** today.
 
 The dialogue gives the full sound of both verbs without a chart first:
 **я їм**, **вона їсть**, **вони їдять**; **я п'ю**, **вона п'є**,
@@ -67,10 +84,12 @@ not **<!-- bad -->Я є їм хліб<!-- /bad -->**.
 This is the **перша особа** path first: **я їм** and **я п'ю** become complete
 when a **прямий об'єкт** answers **що?**.
 
-The food is also doing grammar work. **Каша** becomes **кашу** after
+The nouns also show the grammar pattern. **Каша** becomes **кашу** after
 **я їм** because it answers **що?** and ends in **-а**. **Кава** becomes
 **каву** after **я п'ю** for the same reason. But **хліб**, **чай**, **молоко**,
 and **яйце** stay the same in these inanimate food lines.
+
+<!-- INJECT_ACTIVITY: act-1 -->
 
 ### За обідом на роботі
 
@@ -87,12 +106,12 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Ірина: Що ви їсте на обід?** | Iryna: What are you eating for lunch? |
-| **Колеги: Ми їмо суп і салат.** | Coworkers: We are eating soup and salad. |
-| **Ірина: А що п'єте?** | Iryna: And what are you drinking? |
-| **Колеги: Ми п'ємо воду або сік.** | Coworkers: We are drinking water or juice. |
-| **Ірина: Я теж хочу суп і воду.** | Iryna: I also want soup and water. |
-| **Колега: Добре, замовляй.** | Coworker: Good, order. |
+| Ірина: Що ви їсте на обід? | Iryna: What are you eating for lunch? |
+| Колеги: Ми їмо суп і салат. | Coworkers: We are eating soup and salad. |
+| Ірина: А що п'єте? | Iryna: And what are you drinking? |
+| Колеги: Ми п'ємо воду або сік. | Coworkers: We are drinking water or juice. |
+| Ірина: Я теж хочу суп і воду. | Iryna: I also want soup and water. |
+| Колега: Добре, замовляй. | Coworker: Okay, go ahead and order. |
 
 Here **ми їмо** and **ми п'ємо** move the verbs into the plural. The direct
 objects stay simple: **суп**, **салат**, **сік** do not change; **вода** becomes
@@ -106,9 +125,8 @@ form: **Я хочу воду**, **я хочу каву**, **я хочу суп**
 
 ## Їсти і пити
 
-The verb **їсти** is irregular. Learn it as its own small system. Ukrainian
-school grammar, including a **Заболотний, 7 клас** verb table, treats **їсти**
-as a special present-tense pattern rather than a regular model.
+The verb **їсти** is irregular. Learn it as its own small system. Do not try to
+force it into a regular pattern; for today, the six useful forms are enough.
 
 | Person | Їсти | Example |
 | --- | --- | --- |
@@ -148,14 +166,20 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Я їм хліб.** | I eat bread. |
-| **Ти їси рибу?** | Do you eat fish? |
-| **Вона п'є воду.** | She drinks water. |
-| **Ми п'ємо чай.** | We drink tea. |
+| Я їм хліб. | I eat bread. |
+| Ти їси рибу? | Do you eat fish? |
+| Вона п'є воду. | She drinks water. |
+| Ми п'ємо чай. | We drink tea. |
 
-These are direct actions. The action goes straight to the food or drink. Later,
-the same tool helps with **я читаю книгу**, **я бачу прапор**, and **я купую
-каву**. For now, keep the food examples automatic.
+These verbs take direct objects. The noun after the verb answers **що?** Later,
+the same direct-object pattern helps with **я читаю книгу**, **я бачу прапор**,
+and **я купую каву**. For now, keep the food examples automatic.
+
+:::tip
+Small win: if you can say **Я їм суп** and **Я п'ю воду**, you already have the
+shape of the lesson. The table only helps you say the same thing with **ти**,
+**вона**, **ми**, **ви**, and **вони**.
+:::
 
 <!-- INJECT_ACTIVITY: act-3 -->
 
@@ -187,12 +211,12 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Це кава. Я п'ю каву.** | This is coffee. I drink coffee. |
-| **Це вода. Я п'ю воду.** | This is water. I drink water. |
-| **Це риба. Я їм рибу.** | This is fish. I eat fish. |
-| **Це картопля. Я їм картоплю.** | This is potato. I eat potato. |
+| Це кава. Я п'ю каву. | This is coffee. I drink coffee. |
+| Це вода. Я п'ю воду. | This is water. I drink water. |
+| Це риба. Я їм рибу. | This is fish. I eat fish. |
+| Це картопля. Я їм картоплю. | This is potato. I eat potato. |
 
-Masculine and neuter food words make the learner's job easier:
+Masculine and neuter inanimate nouns make your job easier:
 
 ```text
 Це суп. Я їм суп.
@@ -205,16 +229,22 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Це суп. Я їм суп.** | This is soup. I eat soup. |
-| **Це сік. Я п'ю сік.** | This is juice. I drink juice. |
-| **Це молоко. Я п'ю молоко.** | This is milk. I drink milk. |
-| **Це яблуко. Я їм яблуко.** | This is an apple. I eat an apple. |
+| Це суп. Я їм суп. | This is soup. I eat soup. |
+| Це сік. Я п'ю сік. | This is juice. I drink juice. |
+| Це молоко. Я п'ю молоко. | This is milk. I drink milk. |
+| Це яблуко. Я їм яблуко. | This is an apple. I eat an apple. |
 
 The words **любити**, **бачити**, and **купувати** also use the same direct
-object idea when they act on a thing: the action **переходить** to the object.
+object idea with inanimate nouns: the verb **переходить** to the object.
 You can already understand lines such as **Я люблю Київ**, **Я бачу
 синьо-жовтий прапор**, and **Я купую каву**. In a shop or cafe, keep the money
 word Ukrainian too: **гривня**.
+
+:::note
+Today you do not need the whole accusative case. Keep one noun rule: masculine
+and neuter inanimate words stay the same, while feminine **-а/-я** becomes
+**-у/-ю**.
+:::
 
 <!-- INJECT_ACTIVITY: act-4 -->
 
@@ -222,7 +252,7 @@ word Ukrainian too: **гривня**.
 
 The grammar name is **знахідний відмінок**. The practical A1 test is simpler:
 
-1. Is there an action like **їсти**, **пити**, **хотіти**, **любити**,
+1. Is there a verb like **їсти**, **пити**, **хотіти**, **любити**,
    **бачити**, or **купувати**?
 2. Does the object answer **що?**
 3. Is the object an inanimate feminine word ending in **-а** or **-я**?
@@ -240,10 +270,15 @@ neuter and inanimate, keep it unchanged for this path.
 | **хліб** | **Я їм хліб.** |
 | **молоко** | **Діти п'ють молоко.** |
 
-The contrast also repairs a common learner line:
+The contrast also repairs a common first line:
 **<!-- bad -->Я хочу вода<!-- /bad -->** becomes **Я хочу пити** or
 **Я хочу воду**. Both are useful. The first uses an infinitive. The second uses
 the direct object **воду**.
+
+:::caution
+Do not add English-style helper words. Ukrainian says **Я їм хліб**, not
+**<!-- bad -->Я є їм хліб<!-- /bad -->**. The verb already carries the meaning.
+:::
 
 ## Підсумок
 
@@ -261,25 +296,23 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Вранці я їм кашу і п'ю каву.** | In the morning I eat porridge and drink coffee. |
-| **На обід я їм суп, салат і хліб.** | For lunch I eat soup, salad, and bread. |
-| **Я п'ю воду або сік.** | I drink water or juice. |
-| **Увечері ми їмо рибу і картоплю.** | In the evening we eat fish and potato. |
-| **Діти п'ють молоко.** | The children drink milk. |
+| Вранці я їм кашу і п'ю каву. | In the morning I eat porridge and drink coffee. |
+| На обід я їм суп, салат і хліб. | For lunch I eat soup, salad, and bread. |
+| Я п'ю воду або сік. | I drink water or juice. |
+| Увечері ми їмо рибу і картоплю. | In the evening we eat fish and potatoes. |
+| Діти п'ють молоко. | The children drink milk. |
 
 Keep three checks in your head:
 
 - **їсти** is irregular: **їм, їси, їсть, їмо, їсте, їдять**;
 - **пити** carries the apostrophe: **п'ю, п'єш, п'є, п'ємо, п'єте, п'ють**;
-- feminine inanimate food words change in the direct object:
+- feminine inanimate food nouns change in the direct object:
   **кава -> каву**, **вода -> воду**, **риба -> рибу**,
   **картопля -> картоплю**.
 
-Use clean Ukrainian classroom language. Say **тато** in family examples, use
-**Добрий день** and **До побачення** for formal service scenes, introduce
-yourself with **Мене звати Анна**, say **Я студент** without a helper verb, and
-say **Мені 20 років** for age. These patterns keep Ukrainian grammar from
-being squeezed into English or Russian frames.
+That is enough for today. You are not trying to master every direct object in
+Ukrainian. You are making food and drink lines sound clean: **Я їм кашу**,
+**Я п'ю каву**, **Я хочу воду**.
 
 <span id="repair-i-eat-i-drink-interference"></span>
 
@@ -291,7 +324,7 @@ being squeezed into English or Russian frames.
 | **<!-- bad -->Я хочу вода.<!-- /bad -->** | **Я хочу пити.** or **Я хочу воду.** |
 | **<!-- bad -->Він їст суп.<!-- /bad -->** | **Він їсть суп.** |
 | **<!-- bad -->Ти їсиш яблуко.<!-- /bad -->** | **Ти їси яблуко.** |
-| **<!-- bad -->Я мию мене.<!-- /bad -->** | **Я вмиваюся.** |
+| **<!-- bad -->Я п'ю вода.<!-- /bad -->** | **Я п'ю воду.** |
 | **<!-- bad -->Я п'ю кава.<!-- /bad -->** | **Я п'ю каву.** |
 
 For self-check, name three things you eat today and three things you drink.

--- a/curriculum/l2-uk-en/a1/i-eat-i-drink/resources.yaml
+++ b/curriculum/l2-uk-en/a1/i-eat-i-drink/resources.yaml
@@ -3,20 +3,10 @@
   source_ref: "ULP Season 1, Episode 32"
   url: https://www.ukrainianlessons.com/episode32/
   notes: "Beginner introduction to the accusative case for inanimate objects."
-- title: "Ukrainian Course: Nouns in the Accusative Case"
-  role: grammar table
-  source_ref: "ukrainiancourse.com"
-  url: https://www.ukrainiancourse.com/grammar-tables/nouns-in-the-accusative-case/
-  notes: "Reference table for accusative noun forms; this module uses only the A1-safe inanimate pattern."
-- title: "Ukrainian Course: Grammar Tables"
-  role: grammar tables index
-  source_ref: "ukrainiancourse.com"
-  url: https://www.ukrainiancourse.com/grammar-tables/
-  notes: "General grammar-table index; the module keeps їсти and пити as A1 classroom paradigms."
-- title: "Заболотний Grade 6, p.94"
-  role: textbook grounding
-  source_ref: "Заболотний Grade 6, p.94"
-  notes: "School grammar grounding for the accusative case as the object receiving an action."
+- title: "State Standard 2024, Topic 3"
+  role: communicative standard
+  source_ref: "State Standard 2024, Topic 3"
+  notes: "A1-safe everyday eating and drinking lines inside the food and restaurant communicative domain."
 - title: "Wiki: pedagogy/a1/i-eat-i-drink"
   role: internal wiki
   source_ref: "Wiki: pedagogy/a1/i-eat-i-drink"

--- a/curriculum/l2-uk-en/a1/i-eat-i-drink/vocabulary.yaml
+++ b/curriculum/l2-uk-en/a1/i-eat-i-drink/vocabulary.yaml
@@ -110,6 +110,26 @@
   translation: bread
   pos: noun
   example: "Я їм хліб."
+- word: чай
+  translation: tea
+  pos: noun
+  example: "Вона п'є чай."
+- word: масло
+  translation: butter
+  pos: noun
+  example: "Це масло."
+- word: маслом
+  translation: butter (with butter form)
+  pos: noun form
+  example: "Хліб з маслом."
+- word: яйце
+  translation: egg
+  pos: noun
+  example: "Це яйце."
+- word: яйця
+  translation: eggs
+  pos: noun
+  example: "Вони їдять яйця."
 - word: суп
   translation: soup
   pos: noun

--- a/site/src/content/docs/a1/i-eat-i-drink.mdx
+++ b/site/src/content/docs/a1/i-eat-i-drink.mdx
@@ -59,18 +59,24 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs syncKey="module-tab">
 <TabItem label="Lesson">
 
-You already know food and drink words. Now you can say what you eat and drink
-with the two everyday verbs **їсти** and **пити**. This is also the first clear
-A1 place for the direct object: the food or drink that receives the action.
+**Їм. П'ю. Каву. Воду.** You already know food and drink words. Now you can
+make a small daily line: what you eat, what you drink, and what direct-object
+form the food noun takes after the verb.
+
+This is a manageable A1 step. The two everyday verbs are **їсти** and
+**пити**. The food or drink after them is the direct object: the noun phrase
+that answers **що?** after the verb.
 
 The key question is **що?**:
 
 - **Я їм що?** - **хліб**, **суп**, **кашу**.
 - **Я п'ю що?** - **чай**, **сік**, **воду**.
 
-For inanimate food and drink words, most forms stay familiar. The main new
-change is feminine **-а/-я -> -у/-ю**: **кава -> каву**,
-**вода -> воду**, **риба -> рибу**, **картопля -> картоплю**.
+For inanimate food and drink words, most forms stay familiar. You have already
+seen the visible ending **-а/-я -> -у/-ю** in earlier **куди?** direction
+lines. Here the same small ending helps with a new question: **що я їм? що я
+п'ю?** **Кава -> каву**, **вода -> воду**, **риба -> рибу**,
+**картопля -> картоплю**.
 
 By the end, you can:
 
@@ -87,14 +93,10 @@ By the end, you can:
 :::tip
 Ask **що?** after **їсти**, **пити**, **хотіти**, **любити**, **купувати**, and
 **бачити**. If the object is a feminine food or drink word ending in **-а/-я**,
-expect **-у/-ю**.
+expect **-у/-ю**. Same visible ending, new job.
 :::
 
 ## Діалоги
-
-### Direct object endings
-
-<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Я їм ___.", "answer": "рибу", "options": ["рибу", "риба", "рибі"]}, {"sentence": "Вона п'є ___.", "answer": "воду", "options": ["воду", "вода", "воді"]}, {"sentence": "Він їсть ___.", "answer": "хліб", "options": ["хліб", "хлібу", "хлібом"]}, {"sentence": "Ми п'ємо ___.", "answer": "молоко", "options": ["молоко", "молоку", "молоком"]}, {"sentence": "Вони їдять ___.", "answer": "кашу", "options": ["кашу", "каша", "каші"]}, {"sentence": "Ти п'єш ___.", "answer": "каву", "options": ["каву", "кава", "каві"]}, {"sentence": "Я їм ___.", "answer": "суп", "options": ["суп", "супу", "супом"]}, {"sentence": "Вона їсть ___.", "answer": "картоплю", "options": ["картоплю", "картопля", "картоплі"]}]`)} instruction={"Choose the correct direct-object form after їсти or пити."} isUkrainian={false} />
 
 ### Розмова за сніданком
 
@@ -112,13 +114,22 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Мама: Що ти їси на сніданок?** | Mom: What are you eating for breakfast? |
-| **Данило: Я їм кашу і п'ю каву.** | Danylo: I am eating porridge and drinking coffee. |
-| **Мама: А Олена?** | Mom: And Olena? |
-| **Данило: Вона їсть хліб з маслом і п'є чай.** | Danylo: She eats bread with butter and drinks tea. |
-| **Мама: А діти?** | Mom: And the children? |
-| **Данило: Вони їдять яйця і п'ють молоко.** | Danylo: They eat eggs and drink milk. |
-| **Мама: Добре. Смачного!** | Mom: Good. Enjoy your meal! |
+| Мама: Що ти їси на сніданок? | Mom: What are you eating for breakfast? |
+| Данило: Я їм кашу і п'ю каву. | Danylo: I am eating porridge and drinking coffee. |
+| Мама: А Олена? | Mom: And Olena? |
+| Данило: Вона їсть хліб з маслом і п'є чай. | Danylo: She eats bread with butter and drinks tea. |
+| Мама: А діти? | Mom: And the children? |
+| Данило: Вони їдять яйця і п'ють молоко. | Danylo: They eat eggs and drink milk. |
+| Мама: Добре. Смачного! | Mom: Good. Enjoy your meal! |
+
+New words in that scene:
+
+- **чай** - tea;
+- **яйця** - eggs;
+- **хліб з маслом** - bread with butter.
+
+Treat **з маслом** as one food phrase here; you do not need the full grammar of
+**з** today.
 
 The dialogue gives the full sound of both verbs without a chart first:
 **я їм**, **вона їсть**, **вони їдять**; **я п'ю**, **вона п'є**,
@@ -128,10 +139,14 @@ not **<del>Я є їм хліб</del>**.
 This is the **перша особа** path first: **я їм** and **я п'ю** become complete
 when a **прямий об'єкт** answers **що?**.
 
-The food is also doing grammar work. **Каша** becomes **кашу** after
+The nouns also show the grammar pattern. **Каша** becomes **кашу** after
 **я їм** because it answers **що?** and ends in **-а**. **Кава** becomes
 **каву** after **я п'ю** for the same reason. But **хліб**, **чай**, **молоко**,
 and **яйце** stay the same in these inanimate food lines.
+
+### Direct object endings
+
+<FillIn client:only='react' items={JSON.parse(`[{"sentence": "Я їм ___.", "answer": "рибу", "options": ["рибу", "риба", "рибі"]}, {"sentence": "Вона п'є ___.", "answer": "воду", "options": ["воду", "вода", "воді"]}, {"sentence": "Він їсть ___.", "answer": "хліб", "options": ["хліб", "хлібу", "хлібом"]}, {"sentence": "Ми п'ємо ___.", "answer": "молоко", "options": ["молоко", "молоку", "молоком"]}, {"sentence": "Вони їдять ___.", "answer": "кашу", "options": ["кашу", "каша", "каші"]}, {"sentence": "Ти п'єш ___.", "answer": "каву", "options": ["каву", "кава", "каві"]}, {"sentence": "Я їм ___.", "answer": "суп", "options": ["суп", "супу", "супом"]}, {"sentence": "Вона їсть ___.", "answer": "картоплю", "options": ["картоплю", "картопля", "картоплі"]}]`)} instruction={"Choose the correct direct-object form after їсти or пити."} isUkrainian={false} />
 
 ### За обідом на роботі
 
@@ -148,12 +163,12 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Ірина: Що ви їсте на обід?** | Iryna: What are you eating for lunch? |
-| **Колеги: Ми їмо суп і салат.** | Coworkers: We are eating soup and salad. |
-| **Ірина: А що п'єте?** | Iryna: And what are you drinking? |
-| **Колеги: Ми п'ємо воду або сік.** | Coworkers: We are drinking water or juice. |
-| **Ірина: Я теж хочу суп і воду.** | Iryna: I also want soup and water. |
-| **Колега: Добре, замовляй.** | Coworker: Good, order. |
+| Ірина: Що ви їсте на обід? | Iryna: What are you eating for lunch? |
+| Колеги: Ми їмо суп і салат. | Coworkers: We are eating soup and salad. |
+| Ірина: А що п'єте? | Iryna: And what are you drinking? |
+| Колеги: Ми п'ємо воду або сік. | Coworkers: We are drinking water or juice. |
+| Ірина: Я теж хочу суп і воду. | Iryna: I also want soup and water. |
+| Колега: Добре, замовляй. | Coworker: Okay, go ahead and order. |
 
 Here **ми їмо** and **ми п'ємо** move the verbs into the plural. The direct
 objects stay simple: **суп**, **салат**, **сік** do not change; **вода** becomes
@@ -169,9 +184,8 @@ form: **Я хочу воду**, **я хочу каву**, **я хочу суп**
 
 ## Їсти і пити
 
-The verb **їсти** is irregular. Learn it as its own small system. Ukrainian
-school grammar, including a **Заболотний, 7 клас** verb table, treats **їсти**
-as a special present-tense pattern rather than a regular model.
+The verb **їсти** is irregular. Learn it as its own small system. Do not try to
+force it into a regular pattern; for today, the six useful forms are enough.
 
 | Person | Їсти | Example |
 | --- | --- | --- |
@@ -211,14 +225,20 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Я їм хліб.** | I eat bread. |
-| **Ти їси рибу?** | Do you eat fish? |
-| **Вона п'є воду.** | She drinks water. |
-| **Ми п'ємо чай.** | We drink tea. |
+| Я їм хліб. | I eat bread. |
+| Ти їси рибу? | Do you eat fish? |
+| Вона п'є воду. | She drinks water. |
+| Ми п'ємо чай. | We drink tea. |
 
-These are direct actions. The action goes straight to the food or drink. Later,
-the same tool helps with **я читаю книгу**, **я бачу прапор**, and **я купую
-каву**. For now, keep the food examples automatic.
+These verbs take direct objects. The noun after the verb answers **що?** Later,
+the same direct-object pattern helps with **я читаю книгу**, **я бачу прапор**,
+and **я купую каву**. For now, keep the food examples automatic.
+
+:::tip
+Small win: if you can say **Я їм суп** and **Я п'ю воду**, you already have the
+shape of the lesson. The table only helps you say the same thing with **ти**,
+**вона**, **ми**, **ви**, and **вони**.
+:::
 
 ### Verb person pairs
 
@@ -252,12 +272,12 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Це кава. Я п'ю каву.** | This is coffee. I drink coffee. |
-| **Це вода. Я п'ю воду.** | This is water. I drink water. |
-| **Це риба. Я їм рибу.** | This is fish. I eat fish. |
-| **Це картопля. Я їм картоплю.** | This is potato. I eat potato. |
+| Це кава. Я п'ю каву. | This is coffee. I drink coffee. |
+| Це вода. Я п'ю воду. | This is water. I drink water. |
+| Це риба. Я їм рибу. | This is fish. I eat fish. |
+| Це картопля. Я їм картоплю. | This is potato. I eat potato. |
 
-Masculine and neuter food words make the learner's job easier:
+Masculine and neuter inanimate nouns make your job easier:
 
 ```text
 Це суп. Я їм суп.
@@ -270,16 +290,22 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Це суп. Я їм суп.** | This is soup. I eat soup. |
-| **Це сік. Я п'ю сік.** | This is juice. I drink juice. |
-| **Це молоко. Я п'ю молоко.** | This is milk. I drink milk. |
-| **Це яблуко. Я їм яблуко.** | This is an apple. I eat an apple. |
+| Це суп. Я їм суп. | This is soup. I eat soup. |
+| Це сік. Я п'ю сік. | This is juice. I drink juice. |
+| Це молоко. Я п'ю молоко. | This is milk. I drink milk. |
+| Це яблуко. Я їм яблуко. | This is an apple. I eat an apple. |
 
 The words **любити**, **бачити**, and **купувати** also use the same direct
-object idea when they act on a thing: the action **переходить** to the object.
+object idea with inanimate nouns: the verb **переходить** to the object.
 You can already understand lines such as **Я люблю Київ**, **Я бачу
 синьо-жовтий прапор**, and **Я купую каву**. In a shop or cafe, keep the money
 word Ukrainian too: **гривня**.
+
+:::note
+Today you do not need the whole accusative case. Keep one noun rule: masculine
+and neuter inanimate words stay the same, while feminine **-а/-я** becomes
+**-у/-ю**.
+:::
 
 ### Eat and drink forms
 
@@ -289,7 +315,7 @@ word Ukrainian too: **гривня**.
 
 The grammar name is **знахідний відмінок**. The practical A1 test is simpler:
 
-1. Is there an action like **їсти**, **пити**, **хотіти**, **любити**,
+1. Is there a verb like **їсти**, **пити**, **хотіти**, **любити**,
    **бачити**, or **купувати**?
 2. Does the object answer **що?**
 3. Is the object an inanimate feminine word ending in **-а** or **-я**?
@@ -307,10 +333,15 @@ neuter and inanimate, keep it unchanged for this path.
 | **хліб** | **Я їм хліб.** |
 | **молоко** | **Діти п'ють молоко.** |
 
-The contrast also repairs a common learner line:
+The contrast also repairs a common first line:
 **<del>Я хочу вода</del>** becomes **Я хочу пити** or
 **Я хочу воду**. Both are useful. The first uses an infinitive. The second uses
 the direct object **воду**.
+
+:::caution
+Do not add English-style helper words. Ukrainian says **Я їм хліб**, not
+**<del>Я є їм хліб</del>**. The verb already carries the meaning.
+:::
 
 ## 📋 Підсумок
 
@@ -328,25 +359,23 @@ Support after the Ukrainian lines:
 
 | Українська | English support |
 | --- | --- |
-| **Вранці я їм кашу і п'ю каву.** | In the morning I eat porridge and drink coffee. |
-| **На обід я їм суп, салат і хліб.** | For lunch I eat soup, salad, and bread. |
-| **Я п'ю воду або сік.** | I drink water or juice. |
-| **Увечері ми їмо рибу і картоплю.** | In the evening we eat fish and potato. |
-| **Діти п'ють молоко.** | The children drink milk. |
+| Вранці я їм кашу і п'ю каву. | In the morning I eat porridge and drink coffee. |
+| На обід я їм суп, салат і хліб. | For lunch I eat soup, salad, and bread. |
+| Я п'ю воду або сік. | I drink water or juice. |
+| Увечері ми їмо рибу і картоплю. | In the evening we eat fish and potatoes. |
+| Діти п'ють молоко. | The children drink milk. |
 
 Keep three checks in your head:
 
 - **їсти** is irregular: **їм, їси, їсть, їмо, їсте, їдять**;
 - **пити** carries the apostrophe: **п'ю, п'єш, п'є, п'ємо, п'єте, п'ють**;
-- feminine inanimate food words change in the direct object:
+- feminine inanimate food nouns change in the direct object:
   **кава -> каву**, **вода -> воду**, **риба -> рибу**,
   **картопля -> картоплю**.
 
-Use clean Ukrainian classroom language. Say **тато** in family examples, use
-**Добрий день** and **До побачення** for formal service scenes, introduce
-yourself with **Мене звати Анна**, say **Я студент** without a helper verb, and
-say **Мені 20 років** for age. These patterns keep Ukrainian grammar from
-being squeezed into English or Russian frames.
+That is enough for today. You are not trying to master every direct object in
+Ukrainian. You are making food and drink lines sound clean: **Я їм кашу**,
+**Я п'ю каву**, **Я хочу воду**.
 
 <span id="repair-i-eat-i-drink-interference"></span>
 
@@ -358,7 +387,7 @@ being squeezed into English or Russian frames.
 | **<del>Я хочу вода.</del>** | **Я хочу пити.** or **Я хочу воду.** |
 | **<del>Він їст суп.</del>** | **Він їсть суп.** |
 | **<del>Ти їсиш яблуко.</del>** | **Ти їси яблуко.** |
-| **<del>Я мию мене.</del>** | **Я вмиваюся.** |
+| **<del>Я п'ю вода.</del>** | **Я п'ю воду.** |
 | **<del>Я п'ю кава.</del>** | **Я п'ю каву.** |
 
 For self-check, name three things you eat today and three things you drink.
@@ -367,16 +396,16 @@ Say them aloud with **я їм** and **я п'ю**.
 </TabItem>
 <TabItem label="Vocabulary">
 
-<VocabCard client:only="react" words={JSON.parse(`[{"word":"їсти","translation":"to eat","pos":"verb","example":"Я хочу їсти.","examples":["to eat","Я хочу їсти."],"atlas_href":"/lexicon/їсти/"},{"word":"їм","translation":"I eat","pos":"verb","example":"Я їм суп.","examples":["I eat","Я їм суп."],"atlas_href":"/lexicon/їм/"},{"word":"їси","translation":"you eat","pos":"verb","example":"Ти їси рибу?","examples":["you eat","Ти їси рибу?"],"atlas_href":"/lexicon/їси/"},{"word":"їсть","translation":"he/she eats","pos":"verb","example":"Вона їсть хліб.","examples":["he/she eats","Вона їсть хліб."],"atlas_href":"/lexicon/їсть/"},{"word":"їмо","translation":"we eat","pos":"verb","example":"Ми їмо салат.","examples":["we eat","Ми їмо салат."],"atlas_href":"/lexicon/їмо/"},{"word":"їсте","translation":"you eat","pos":"verb","example":"Ви їсте кашу?","examples":["you eat","Ви їсте кашу?"],"atlas_href":"/lexicon/їсте/"},{"word":"їдять","translation":"they eat","pos":"verb","example":"Вони їдять яблука.","examples":["they eat","Вони їдять яблука."],"atlas_href":"/lexicon/їдять/"},{"word":"пити","translation":"to drink","pos":"verb","example":"Я хочу пити.","examples":["to drink","Я хочу пити."],"atlas_href":"/lexicon/пити/"},{"word":"п'ю","translation":"I drink","pos":"verb","example":"Я п'ю каву.","examples":["I drink","Я п'ю каву."],"atlas_href":"/lexicon/п-ю/"},{"word":"п'єш","translation":"you drink","pos":"verb","example":"Ти п'єш воду?","examples":["you drink","Ти п'єш воду?"],"atlas_href":"/lexicon/п-єш/"},{"word":"п'є","translation":"he/she drinks","pos":"verb","example":"Він п'є сік.","examples":["he/she drinks","Він п'є сік."],"atlas_href":"/lexicon/п-є/"},{"word":"п'ємо","translation":"we drink","pos":"verb","example":"Ми п'ємо чай.","examples":["we drink","Ми п'ємо чай."],"atlas_href":"/lexicon/п-ємо/"},{"word":"п'єте","translation":"you drink","pos":"verb","example":"Ви п'єте каву?","examples":["you drink","Ви п'єте каву?"],"atlas_href":"/lexicon/п-єте/"},{"word":"п'ють","translation":"they drink","pos":"verb","example":"Вони п'ють молоко.","examples":["they drink","Вони п'ють молоко."],"atlas_href":"/lexicon/п-ють/"},{"word":"що?","translation":"what?","pos":"question","example":"Що ти їси?","examples":["what?","Що ти їси?"]},{"word":"знахідний відмінок","translation":"accusative case","pos":"grammar term","example":"Каву is a знахідний відмінок form.","examples":["accusative case","Каву is a знахідний відмінок form."],"atlas_href":"/lexicon/знахідний-відмінок/"},{"word":"прямий додаток","translation":"direct object","pos":"grammar term","example":"У реченні Я п'ю воду, воду is the direct object.","examples":["direct object","У реченні Я п'ю воду, воду is the direct object."],"atlas_href":"/lexicon/прямий-додаток/"},{"word":"кава","translation":"coffee","pos":"noun","example":"Це кава.","examples":["coffee","Це кава."],"atlas_href":"/lexicon/кава/"},{"word":"каву","translation":"coffee (direct object)","pos":"noun","example":"Я п'ю каву.","examples":["coffee (direct object)","Я п'ю каву."],"atlas_href":"/lexicon/каву/"},{"word":"вода","translation":"water","pos":"noun","example":"Це вода.","examples":["water","Це вода."],"atlas_href":"/lexicon/вода/"},{"word":"воду","translation":"water (direct object)","pos":"noun","example":"Вона п'є воду.","examples":["water (direct object)","Вона п'є воду."],"atlas_href":"/lexicon/воду/"},{"word":"риба","translation":"fish","pos":"noun","example":"Це риба.","examples":["fish","Це риба."],"atlas_href":"/lexicon/риба/"},{"word":"рибу","translation":"fish (direct object)","pos":"noun","example":"Ти їси рибу?","examples":["fish (direct object)","Ти їси рибу?"],"atlas_href":"/lexicon/рибу/"},{"word":"каша","translation":"porridge","pos":"noun","example":"Це каша.","examples":["porridge","Це каша."],"atlas_href":"/lexicon/каша/"},{"word":"кашу","translation":"porridge (direct object)","pos":"noun","example":"Вони їдять кашу.","examples":["porridge (direct object)","Вони їдять кашу."],"atlas_href":"/lexicon/кашу/"},{"word":"картопля","translation":"potato","pos":"noun","example":"Картопля смачна.","examples":["potato","Картопля смачна."],"atlas_href":"/lexicon/картопля/"},{"word":"картоплю","translation":"potato (direct object)","pos":"noun","example":"Ми їмо картоплю.","examples":["potato (direct object)","Ми їмо картоплю."],"atlas_href":"/lexicon/картоплю/"},{"word":"хліб","translation":"bread","pos":"noun","example":"Я їм хліб.","examples":["bread","Я їм хліб."],"atlas_href":"/lexicon/хліб/"},{"word":"суп","translation":"soup","pos":"noun","example":"Він їсть суп.","examples":["soup","Він їсть суп."],"atlas_href":"/lexicon/суп/"},{"word":"сік","translation":"juice","pos":"noun","example":"Я п'ю сік.","examples":["juice","Я п'ю сік."],"atlas_href":"/lexicon/сік/"},{"word":"молоко","translation":"milk","pos":"noun","example":"Діти п'ють молоко.","examples":["milk","Діти п'ють молоко."],"atlas_href":"/lexicon/молоко/"},{"word":"яблуко","translation":"apple","pos":"noun","example":"Ти їси яблуко.","examples":["apple","Ти їси яблуко."],"atlas_href":"/lexicon/яблуко/"},{"word":"салат","translation":"salad","pos":"noun","example":"Ми їмо салат.","examples":["salad","Ми їмо салат."],"atlas_href":"/lexicon/салат/"},{"word":"м'ясо","translation":"meat","pos":"noun","example":"Вона їсть м'ясо.","examples":["meat","Вона їсть м'ясо."],"atlas_href":"/lexicon/м-ясо/"},{"word":"хотіти","translation":"to want","pos":"verb","example":"Я хочу пити.","examples":["to want","Я хочу пити."],"atlas_href":"/lexicon/хотіти/"},{"word":"купувати","translation":"to buy","pos":"verb","example":"Я купую каву.","examples":["to buy","Я купую каву."],"atlas_href":"/lexicon/купувати/"},{"word":"бачити","translation":"to see","pos":"verb","example":"Я бачу прапор.","examples":["to see","Я бачу прапор."],"atlas_href":"/lexicon/бачити/"}]`)} title="Vocabulary" />
+<VocabCard client:only="react" words={JSON.parse(`[{"word":"їсти","translation":"to eat","pos":"verb","example":"Я хочу їсти.","examples":["to eat","Я хочу їсти."],"atlas_href":"/lexicon/їсти/"},{"word":"їм","translation":"I eat","pos":"verb","example":"Я їм суп.","examples":["I eat","Я їм суп."]},{"word":"їси","translation":"you eat","pos":"verb","example":"Ти їси рибу?","examples":["you eat","Ти їси рибу?"]},{"word":"їсть","translation":"he/she eats","pos":"verb","example":"Вона їсть хліб.","examples":["he/she eats","Вона їсть хліб."]},{"word":"їмо","translation":"we eat","pos":"verb","example":"Ми їмо салат.","examples":["we eat","Ми їмо салат."]},{"word":"їсте","translation":"you eat","pos":"verb","example":"Ви їсте кашу?","examples":["you eat","Ви їсте кашу?"]},{"word":"їдять","translation":"they eat","pos":"verb","example":"Вони їдять яблука.","examples":["they eat","Вони їдять яблука."]},{"word":"пити","translation":"to drink","pos":"verb","example":"Я хочу пити.","examples":["to drink","Я хочу пити."],"atlas_href":"/lexicon/пити/"},{"word":"п'ю","translation":"I drink","pos":"verb","example":"Я п'ю каву.","examples":["I drink","Я п'ю каву."]},{"word":"п'єш","translation":"you drink","pos":"verb","example":"Ти п'єш воду?","examples":["you drink","Ти п'єш воду?"]},{"word":"п'є","translation":"he/she drinks","pos":"verb","example":"Він п'є сік.","examples":["he/she drinks","Він п'є сік."]},{"word":"п'ємо","translation":"we drink","pos":"verb","example":"Ми п'ємо чай.","examples":["we drink","Ми п'ємо чай."]},{"word":"п'єте","translation":"you drink","pos":"verb","example":"Ви п'єте каву?","examples":["you drink","Ви п'єте каву?"]},{"word":"п'ють","translation":"they drink","pos":"verb","example":"Вони п'ють молоко.","examples":["they drink","Вони п'ють молоко."]},{"word":"що?","translation":"what?","pos":"question","example":"Що ти їси?","examples":["what?","Що ти їси?"]},{"word":"знахідний відмінок","translation":"accusative case","pos":"grammar term","example":"Каву is a знахідний відмінок form.","examples":["accusative case","Каву is a знахідний відмінок form."],"atlas_href":"/lexicon/знахідний-відмінок/"},{"word":"прямий додаток","translation":"direct object","pos":"grammar term","example":"У реченні Я п'ю воду, воду is the direct object.","examples":["direct object","У реченні Я п'ю воду, воду is the direct object."],"atlas_href":"/lexicon/прямий-додаток/"},{"word":"кава","translation":"coffee","pos":"noun","example":"Це кава.","examples":["coffee","Це кава."],"atlas_href":"/lexicon/кава/"},{"word":"каву","translation":"coffee (direct object)","pos":"noun","example":"Я п'ю каву.","examples":["coffee (direct object)","Я п'ю каву."]},{"word":"вода","translation":"water","pos":"noun","example":"Це вода.","examples":["water","Це вода."],"atlas_href":"/lexicon/вода/"},{"word":"воду","translation":"water (direct object)","pos":"noun","example":"Вона п'є воду.","examples":["water (direct object)","Вона п'є воду."]},{"word":"риба","translation":"fish","pos":"noun","example":"Це риба.","examples":["fish","Це риба."],"atlas_href":"/lexicon/риба/"},{"word":"рибу","translation":"fish (direct object)","pos":"noun","example":"Ти їси рибу?","examples":["fish (direct object)","Ти їси рибу?"]},{"word":"каша","translation":"porridge","pos":"noun","example":"Це каша.","examples":["porridge","Це каша."],"atlas_href":"/lexicon/каша/"},{"word":"кашу","translation":"porridge (direct object)","pos":"noun","example":"Вони їдять кашу.","examples":["porridge (direct object)","Вони їдять кашу."]},{"word":"картопля","translation":"potato","pos":"noun","example":"Картопля смачна.","examples":["potato","Картопля смачна."],"atlas_href":"/lexicon/картопля/"},{"word":"картоплю","translation":"potato (direct object)","pos":"noun","example":"Ми їмо картоплю.","examples":["potato (direct object)","Ми їмо картоплю."]},{"word":"хліб","translation":"bread","pos":"noun","example":"Я їм хліб.","examples":["bread","Я їм хліб."],"atlas_href":"/lexicon/хліб/"},{"word":"чай","translation":"tea","pos":"noun","example":"Вона п'є чай.","examples":["tea","Вона п'є чай."],"atlas_href":"/lexicon/чай/"},{"word":"масло","translation":"butter","pos":"noun","example":"Це масло.","examples":["butter","Це масло."],"atlas_href":"/lexicon/масло/"},{"word":"маслом","translation":"butter (with butter form)","pos":"noun form","example":"Хліб з маслом.","examples":["butter (with butter form)","Хліб з маслом."]},{"word":"яйце","translation":"egg","pos":"noun","example":"Це яйце.","examples":["egg","Це яйце."],"atlas_href":"/lexicon/яйце/"},{"word":"яйця","translation":"eggs","pos":"noun","example":"Вони їдять яйця.","examples":["eggs","Вони їдять яйця."]},{"word":"суп","translation":"soup","pos":"noun","example":"Він їсть суп.","examples":["soup","Він їсть суп."],"atlas_href":"/lexicon/суп/"},{"word":"сік","translation":"juice","pos":"noun","example":"Я п'ю сік.","examples":["juice","Я п'ю сік."],"atlas_href":"/lexicon/сік/"},{"word":"молоко","translation":"milk","pos":"noun","example":"Діти п'ють молоко.","examples":["milk","Діти п'ють молоко."],"atlas_href":"/lexicon/молоко/"},{"word":"яблуко","translation":"apple","pos":"noun","example":"Ти їси яблуко.","examples":["apple","Ти їси яблуко."],"atlas_href":"/lexicon/яблуко/"},{"word":"салат","translation":"salad","pos":"noun","example":"Ми їмо салат.","examples":["salad","Ми їмо салат."],"atlas_href":"/lexicon/салат/"},{"word":"м'ясо","translation":"meat","pos":"noun","example":"Вона їсть м'ясо.","examples":["meat","Вона їсть м'ясо."],"atlas_href":"/lexicon/м-ясо/"},{"word":"хотіти","translation":"to want","pos":"verb","example":"Я хочу пити.","examples":["to want","Я хочу пити."],"atlas_href":"/lexicon/хотіти/"},{"word":"купувати","translation":"to buy","pos":"verb","example":"Я купую каву.","examples":["to buy","Я купую каву."],"atlas_href":"/lexicon/купувати/"},{"word":"бачити","translation":"to see","pos":"verb","example":"Я бачу прапор.","examples":["to see","Я бачу прапор."],"atlas_href":"/lexicon/бачити/"}]`)} title="Vocabulary" />
 
-<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"їсти","back":"to eat"},{"front":"їм","back":"I eat"},{"front":"їси","back":"you eat"},{"front":"їсть","back":"he/she eats"},{"front":"їмо","back":"we eat"},{"front":"їсте","back":"you eat"},{"front":"їдять","back":"they eat"},{"front":"пити","back":"to drink"},{"front":"п'ю","back":"I drink"},{"front":"п'єш","back":"you drink"},{"front":"п'є","back":"he/she drinks"},{"front":"п'ємо","back":"we drink"},{"front":"п'єте","back":"you drink"},{"front":"п'ють","back":"they drink"},{"front":"що?","back":"what?"},{"front":"знахідний відмінок","back":"accusative case"},{"front":"прямий додаток","back":"direct object"},{"front":"кава","back":"coffee"},{"front":"каву","back":"coffee (direct object)"},{"front":"вода","back":"water"},{"front":"воду","back":"water (direct object)"},{"front":"риба","back":"fish"},{"front":"рибу","back":"fish (direct object)"},{"front":"каша","back":"porridge"},{"front":"кашу","back":"porridge (direct object)"},{"front":"картопля","back":"potato"},{"front":"картоплю","back":"potato (direct object)"},{"front":"хліб","back":"bread"},{"front":"суп","back":"soup"},{"front":"сік","back":"juice"},{"front":"молоко","back":"milk"},{"front":"яблуко","back":"apple"},{"front":"салат","back":"salad"},{"front":"м'ясо","back":"meat"},{"front":"хотіти","back":"to want"},{"front":"купувати","back":"to buy"},{"front":"бачити","back":"to see"}]`)} />
+<FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"їсти","back":"to eat"},{"front":"їм","back":"I eat"},{"front":"їси","back":"you eat"},{"front":"їсть","back":"he/she eats"},{"front":"їмо","back":"we eat"},{"front":"їсте","back":"you eat"},{"front":"їдять","back":"they eat"},{"front":"пити","back":"to drink"},{"front":"п'ю","back":"I drink"},{"front":"п'єш","back":"you drink"},{"front":"п'є","back":"he/she drinks"},{"front":"п'ємо","back":"we drink"},{"front":"п'єте","back":"you drink"},{"front":"п'ють","back":"they drink"},{"front":"що?","back":"what?"},{"front":"знахідний відмінок","back":"accusative case"},{"front":"прямий додаток","back":"direct object"},{"front":"кава","back":"coffee"},{"front":"каву","back":"coffee (direct object)"},{"front":"вода","back":"water"},{"front":"воду","back":"water (direct object)"},{"front":"риба","back":"fish"},{"front":"рибу","back":"fish (direct object)"},{"front":"каша","back":"porridge"},{"front":"кашу","back":"porridge (direct object)"},{"front":"картопля","back":"potato"},{"front":"картоплю","back":"potato (direct object)"},{"front":"хліб","back":"bread"},{"front":"чай","back":"tea"},{"front":"масло","back":"butter"},{"front":"маслом","back":"butter (with butter form)"},{"front":"яйце","back":"egg"},{"front":"яйця","back":"eggs"},{"front":"суп","back":"soup"},{"front":"сік","back":"juice"},{"front":"молоко","back":"milk"},{"front":"яблуко","back":"apple"},{"front":"салат","back":"salad"},{"front":"м'ясо","back":"meat"},{"front":"хотіти","back":"to want"},{"front":"купувати","back":"to buy"},{"front":"бачити","back":"to see"}]`)} />
 
 </TabItem>
 <TabItem label="Activities">
 
 ### Direct object endings
 
-*(see lesson, §Діалоги)*
+*(see lesson, §Розмова за сніданком)*
 
 ### Choose the food line
 
@@ -402,11 +431,19 @@ Say them aloud with **я їм** and **я п'ю**.
 
 <Order client:only='react' items={JSON.parse(`["Що ти їси на обід?", "Я їм суп і салат.", "А що ти п'єш?", "Я п'ю воду або сік.", "Олена їсть хліб з маслом.", "Діти п'ють молоко.", "Смачного!"]`)} correct_order={JSON.parse(`[0, 1, 2, 3, 4, 5, 6]`)} instruction={"Put the conversation in a natural order."} isUkrainian={true} />
 
+### Food-day object pairs
+
+<MatchUp client:only='react' pairs={JSON.parse(`[{"left": "я п'ю + кава", "right": "я п'ю каву"}, {"left": "вона п'є + вода", "right": "вона п'є воду"}, {"left": "ти їси + риба", "right": "ти їси рибу"}, {"left": "вони їдять + каша", "right": "вони їдять кашу"}, {"left": "ми їмо + картопля", "right": "ми їмо картоплю"}, {"left": "я їм + хліб", "right": "я їм хліб"}, {"left": "діти п'ють + молоко", "right": "діти п'ють молоко"}, {"left": "він п'є + сік", "right": "він п'є сік"}]`)} instruction={"Match the starter with the clean food or drink line."} isUkrainian={false} />
+
+### Build food and drink lines
+
+<Unjumble client:only='react' items={JSON.parse(`[{"jumbled": "Я / їм / кашу", "answer": "Я їм кашу"}, {"jumbled": "Вона / п'є / воду", "answer": "Вона п'є воду"}, {"jumbled": "Ми / їмо / суп / і / салат", "answer": "Ми їмо суп і салат"}, {"jumbled": "Діти / п'ють / молоко", "answer": "Діти п'ють молоко"}, {"jumbled": "Я / хочу / воду", "answer": "Я хочу воду"}, {"jumbled": "Ти / їси / рибу", "answer": "Ти їси рибу"}]`)} instruction={"Put the words in a natural A1 order."} />
+
 <span id="repair-i-eat-i-drink-interference"></span>
 
 ### Repair eat and drink interference
 
-<ErrorCorrection client:only='react' instruction="Choose the clean Ukrainian repair." items={JSON.parse(`[{"sentence": "Я є їм хліб.", "errorWord": "Я є їм хліб.", "correctForm": "Я їм хліб.", "options": ["Я їм хліб.", "Я є їм хліб.", "Я є їсти хліб."], "explanation": "Do not use є as an English-style helper."}, {"sentence": "Я хочу вода.", "errorWord": "Я хочу вода.", "correctForm": "Я хочу пити. або Я хочу воду.", "options": ["Я хочу пити. або Я хочу воду.", "Я хочу вода.", "Я хочу воді."], "explanation": "Use an infinitive or the direct object воду."}, {"sentence": "Він їст суп.", "errorWord": "Він їст суп.", "correctForm": "Він їсть суп.", "options": ["Він їсть суп.", "Він їст суп.", "Він їси суп."], "explanation": "Write їсть with the soft sign."}, {"sentence": "Ти їсиш яблуко.", "errorWord": "Ти їсиш яблуко.", "correctForm": "Ти їси яблуко.", "options": ["Ти їси яблуко.", "Ти їсиш яблуко.", "Ти їсть яблуко."], "explanation": "The form is ти їси."}, {"sentence": "Я мию мене.", "errorWord": "Я мию мене.", "correctForm": "Я вмиваюся.", "options": ["Я вмиваюся.", "Я мию мене.", "Я мию я."], "explanation": "Use the Ukrainian reflexive verb вмиватися."}, {"sentence": "На перерві: Я п'ю кава.", "errorWord": "Я п'ю кава.", "correctForm": "Я п'ю каву.", "options": ["Я п'ю кава.", "Я п'ю каві.", "Я п'ю каву."], "explanation": "Кава becomes каву after п'ю."}]`)} isUkrainian={false} />
+<ErrorCorrection client:only='react' instruction="Choose the clean Ukrainian repair." items={JSON.parse(`[{"sentence": "Я є їм хліб.", "errorWord": "Я є їм хліб.", "correctForm": "Я їм хліб.", "options": ["Я їм хліб.", "Я є їм хліб.", "Я є їсти хліб."], "explanation": "Do not use є as an English-style helper."}, {"sentence": "Я хочу вода.", "errorWord": "Я хочу вода.", "correctForm": "Я хочу пити. або Я хочу воду.", "options": ["Я хочу пити. або Я хочу воду.", "Я хочу вода.", "Я хочу воді."], "explanation": "Use an infinitive or the direct object воду."}, {"sentence": "Він їст суп.", "errorWord": "Він їст суп.", "correctForm": "Він їсть суп.", "options": ["Він їсть суп.", "Він їст суп.", "Він їси суп."], "explanation": "Write їсть with the soft sign."}, {"sentence": "Ти їсиш яблуко.", "errorWord": "Ти їсиш яблуко.", "correctForm": "Ти їси яблуко.", "options": ["Ти їси яблуко.", "Ти їсиш яблуко.", "Ти їсть яблуко."], "explanation": "The form is ти їси."}, {"sentence": "Я п'ю вода.", "errorWord": "Я п'ю вода.", "correctForm": "Я п'ю воду.", "options": ["Я п'ю воду.", "Я п'ю вода.", "Я п'ю воді."], "explanation": "Вода becomes воду after п'ю."}, {"sentence": "На перерві: Я п'ю кава.", "errorWord": "Я п'ю кава.", "correctForm": "Я п'ю каву.", "options": ["Я п'ю кава.", "Я п'ю каві.", "Я п'ю каву."], "explanation": "Кава becomes каву after п'ю."}]`)} isUkrainian={false} />
 
 </TabItem>
 <TabItem label="Resources">
@@ -414,11 +451,9 @@ Say them aloud with **я їм** and **я п'ю**.
 :::info[🎧 🔗 External Resources]
 
 **🔗 Online resources:**
-- 🔗 [Ukrainian Course: Grammar Tables](https://www.ukrainiancourse.com/grammar-tables/) — General grammar-table index; the module keeps їсти and пити as A1 classroom paradigms.
-- 🔗 [Ukrainian Course: Nouns in the Accusative Case](https://www.ukrainiancourse.com/grammar-tables/nouns-in-the-accusative-case/) — Reference table for accusative noun forms; this module uses only the A1-safe inanimate pattern.
+- 🔗 **State Standard 2024, Topic 3** — A1-safe everyday eating and drinking lines inside the food and restaurant communicative domain.
 - 🔗 [ULP Season 1, Episode 32](https://www.ukrainianlessons.com/episode32/) — Beginner introduction to the accusative case for inanimate objects.
 - 🔗 **Wiki: pedagogy/a1/i-eat-i-drink** — Authoritative pedagogical brief for M37.
-- 🔗 **Заболотний Grade 6, p.94** — School grammar grounding for the accusative case as the object receiving an action.
 :::
 
 </TabItem>


### PR DESCRIPTION
## Summary
- Polish A1 M37 `i-eat-i-drink` tone, scaffolding, and direct-object explanation.
- Move the first inline practice after the first taught breakfast dialogue and add audit markers for implementation coverage, bad-form markup, and activity split.
- Scaffold `чай`, `яйця`, `хліб з маслом` / `маслом`; expand vocabulary to 42 entries.
- Expand workbook practice to 6 activities and replace the off-topic repair line with a food/direct-object repair.
- Trim resources to plan-appropriate A1 food/drink grounding.

## Deterministic checks
- [x] `.venv/bin/python scripts/generate_mdx.py l2-uk-en a1 37 --validate`
- [x] `.venv/bin/python scripts/validate_activities.py l2-uk-en a1 37`
- [x] `.venv/bin/python scripts/validate_vocab_yaml.py curriculum/l2-uk-en/a1/i-eat-i-drink/vocabulary.yaml` (42 items)
- [x] `.venv/bin/python scripts/validate_plan_config.py a1/i-eat-i-drink`
- [x] `.venv/bin/python scripts/audit/certify_module.py a1/i-eat-i-drink --clean-qg-artifacts` (includes production build, 3103 pages)
- [x] `.venv/bin/python scripts/lexicon/check_manifest_freshness.py`
- [x] `.venv/bin/python scripts/lexicon/check_manifest_vocabulary_coverage.py --changed-only --base origin/main`
- [x] `git diff --check`
- [x] `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Gemini CLI LLM QG
Independent Gemini CLI QG was performed with direct headless Gemini CLI using repo-rendered QG prompts. Earlier `gemini-tools` wrapper attempts returned malformed or cross-contaminated outputs and were discarded.

| Rubric | Score | Verdict |
| --- | ---: | --- |
| Pedagogical | 9.5 | PASS |
| Naturalness | 9.5 | PASS |
| Decolonization | 9.5 | PASS |
| Engagement | 9.5 | PASS |
| Tone | 9.5 | PASS |

Aggregate: PASS. Terminal: PASS. Minimum: 9.5 (pedagogical).

## Swarm / tools
- Swarm used: false
- Swarm label: solo
- Swarm note: solo run; no helper swarm used. Required independent Gemini CLI QG validation only.
- Participants: codex main agent, Gemini CLI QG reviewer
- DeepSeek: not used

## Hygiene
- Protected files unchanged: `.python-version`, `.yamllint`, `.markdownlint.json`
- No generated status/audit/review/QG artifacts committed
- Commit trailer present: `X-Agent: codex/a1-m37-i-eat-i-drink-quality`