### PR TITLE
feat(a1): certify what happened

### DIFF
--- a/curriculum/l2-uk-en/a1/what-happened/module.md
+++ b/curriculum/l2-uk-en/a1/what-happened/module.md
@@ -1,5 +1,13 @@
 # Що сталося?
 
+<!-- plan_coverage_audit objectives=4 content_sections=4 dialogue_situations=1 activity_hints=3 covered=true missing=[] -->
+<!-- bad_form_audit bad_form_patterns_found=8 marked_with_bad_tags=8 remaining_unmarked=0 -->
+<!-- activity_split_audit level=A1 inline_n=4 workbook_n=6 inline_range=[4,6] workbook_range=[6,9] split_valid=true -->
+
+Привіт! Today you make one small time jump: from **зараз** to **учора**.
+You will learn how to say what happened, ask **Що ти робив/робила?**, and keep
+the past ending matched to the person or thing you are talking about.
+
 You already know how present-tense verbs change for the person:
 **я читаю**, **ти читаєш**, **він читає**. Past tense is different. In the
 simple A1 pattern here, the past verb shows **gender in the singular**, not
@@ -19,6 +27,12 @@ The useful question is:
 **Що ти робив?** - What were you doing? (to a male speaker)
 
 **Що ти робила?** - What were you doing? (to a female speaker)
+
+:::note[A1 boundary]
+Stay with the regular visible endings today: **-в**, **-ла**, **-ло**, **-ли**.
+Use the familiar verbs in this lesson first. Your win is simple: match the past
+ending to the subject.
+:::
 
 :::tip[Gender, not person]
 In the past tense, **я читав**, **ти читав**, and **він читав** can share the
@@ -67,10 +81,10 @@ The grammar work is small but important:
 
 ```text
 Марія: Як ти провів вихідні?
-Іван: Добре. У суботу я гуляв.
+Іван: Добре. У суботу я ходив на концерт.
 Іван: У неділю я дивився фільм.
 Іван: А ти що робила?
-Марія: Я ходила в кафе.
+Марія: Я читала роман і ходила в кафе.
 Марія: Ми їли торт.
 Іван: Ви пили каву?
 Марія: Так, ми пили каву.
@@ -81,16 +95,19 @@ Support after the Ukrainian lines:
 | Українська | English support |
 | --- | --- |
 | **Марія: Як ти провів вихідні?** | Mariia: How did you spend the weekend? |
-| **Іван: Добре. У суботу я гуляв.** | Ivan: Good. On Saturday I walked. |
+| **Іван: Добре. У суботу я ходив на концерт.** | Ivan: Good. On Saturday I went to a concert. |
 | **Іван: У неділю я дивився фільм.** | Ivan: On Sunday I watched a film. |
 | **Іван: А ти що робила?** | Ivan: And what were you doing? |
-| **Марія: Я ходила в кафе.** | Mariia: I went to a cafe. |
+| **Марія: Я читала роман і ходила в кафе.** | Mariia: I read a novel and went to a cafe. |
 | **Марія: Ми їли торт.** | Mariia: We ate cake. |
 | **Іван: Ви пили каву?** | Ivan: Did you drink coffee? |
 | **Марія: Так, ми пили каву.** | Mariia: Yes, we drank coffee. |
 
 Notice the plural forms: **ми їли**, **ми пили**, **ви пили**. In the plural,
 use **-ли**. Do not add present-tense person endings after it.
+
+For now, just understand **концерт** - concert and **роман** - novel when you
+see them in the dialogue. You do not need to use them yet.
 
 <!-- INJECT_ACTIVITY: act-2 -->
 
@@ -137,24 +154,21 @@ Good A1 questions:
 
 Short details help the past sentence sound real:
 
-**Розширення речення другорядними членами** means a past sentence can grow by
-one small detail at a time.
+A past sentence can grow by one small detail at a time.
 
 - **що?** - **Я їв сніданок.** / **Я їла сніданок.**
 - **куди?** - **Я йшов до школи.** / **Я йшла до школи.**
 - **яку?** - **Я читав цікаву книжку.** / **Я читала цікаву книжку.**
 
-The time marker **вчора** tells you the action is before now. The beginner
+The time marker **учора** tells you the action is before now. The beginner
 formation is still the same: use **-в** for masculine, **-ла для жіночого**
 forms, **-ло** for neuter, and **-ли** for plural.
 
-School Ukrainian often asks **що зробив?** or **що зробила?** to notice gender:
-**Місяць згубив намистинки. Ніч згубила намистинки.** You only need the idea:
-masculine subject, masculine past form; feminine subject, feminine past form.
+A quick check with names you know is enough:
+**Іван читав. Марія читала.** Same action, different subject gender.
 
-Keep the grammar here narrow. Later Ukrainian will give you more verb choices.
-For this A1 step, practice only the endings **-в**, **-ла**, **-ло**, and
-**-ли** with familiar verbs.
+Keep the grammar here narrow. Practice only the endings **-в**, **-ла**,
+**-ло**, and **-ли** with familiar verbs.
 
 <!-- INJECT_ACTIVITY: act-3 -->
 
@@ -200,30 +214,31 @@ Use the repair list to keep English habits from taking over:
 
 | Learner sentence | Better Ukrainian |
 | --- | --- |
-| <del>**Чоловік: Я читала.**</del> | **Чоловік: Я читав.** |
-| <del>**Жінка: Я читав.**</del> | **Жінка: Я читала.** |
-| <del>**Сонце встав.**</del> | **Сонце встало.** |
-| <del>**Я буду читав завтра.**</del> | **Я буду читати завтра.** |
+| <bad>**Чоловік: Я читала.**</bad> | **Чоловік: Я читав.** |
+| <bad>**Жінка: Я читав.**</bad> | **Жінка: Я читала.** |
+| <bad>**Ми читалимо текст.**</bad> | **Ми читали текст.** |
+| <bad>**Вони читалить текст.**</bad> | **Вони читали текст.** |
+| <bad>**Сонце встав.**</bad> | **Сонце встало.** |
+| <bad>**Я буду читав завтра.**</bad> | **Я буду читати завтра.** |
+| <bad>**Він принісв книгу.**</bad> | Recognition only: **Він приніс книгу.** |
+| <bad>**Він везв сумку.**</bad> | Recognition only: **Він віз сумку.** |
 
 The last line looks ahead to future tense. The repair is simple for now:
 after **буду**, use the infinitive **читати**, not a past form.
 
-Some verb pairs will later show more meaning differences, for example
-**читав** and **прочитав**, or **летіли** and **полетіли**. Do not study that
-system here. For this A1 lesson, your job is only to match the past ending to
-the subject.
+You may see other past forms such as **прочитав**, **полетіли**, **ніс**,
+**віз**, or **мерз**. Just recognize that they are past forms. For speaking
+today, stay with regular forms like **читав**, **читала**, **читало**,
+**читали**.
 
-Later grammar will use words like **процес**, **незавершена дія**, and
-**результат**. That is not your task now. Later grammar will also show
-consonant-stem forms.
+:::caution[Do not build every past form today]
+Forms like **приніс** and **віз** are useful to recognize later, but they are
+not built by adding **-в**. For this lesson, produce the regular forms in the
+tables and treat these harder forms as repairs you can understand.
+:::
 
-**Знайомство з основами на приголосний** comes later. Forms such as **ніс**,
-**віз**, and **мерз** are not the active A1 pattern. For today, stay with regular
-forms like **читав**, **читала**, **читало**, **читали**.
-
-The next grammar step is **майбутнього часу і наказового способу**, future
-time and requests. For now, one future repair is enough: after **буду**, use an
-infinitive, as in **Я буду читати завтра.**
+The next time step is future tense. For now, one future repair is enough: after
+**буду**, use an infinitive, as in **Я буду читати завтра.**
 
 ### Mini story practice
 
@@ -270,6 +285,11 @@ Self-check:
 1. Can you say **я читав** or **я читала** for yourself?
 2. Can you change **він працював** to **вона працювала**?
 3. Can you change **вона говорила** to **вони говорили**?
+
+:::tip[Progress marker]
+If you can answer **Що ти робив/робила учора?** with one correct sentence, you
+have your first past-tense answer. A longer story comes next.
+:::
 
 Stop here when the endings feel visible. The next module uses the same forms
 to tell a simple story about yesterday.

--- a/site/src/content/docs/a1/what-happened.mdx
+++ b/site/src/content/docs/a1/what-happened.mdx
@@ -59,6 +59,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs syncKey="module-tab">
 <TabItem label="Lesson">
 
+Привіт! Today you make one small time jump: from **зараз** to **учора**.
+You will learn how to say what happened, ask **Що ти робив/робила?**, and keep
+the past ending matched to the person or thing you are talking about.
+
 You already know how present-tense verbs change for the person:
 **я читаю**, **ти читаєш**, **він читає**. Past tense is different. In the
 simple A1 pattern here, the past verb shows **gender in the singular**, not
@@ -78,6 +82,12 @@ The useful question is:
 **Що ти робив?** - What were you doing? (to a male speaker)
 
 **Що ти робила?** - What were you doing? (to a female speaker)
+
+:::note[A1 boundary]
+Stay with the regular visible endings today: **-в**, **-ла**, **-ло**, **-ли**.
+Use the familiar verbs in this lesson first. Your win is simple: match the past
+ending to the subject.
+:::
 
 :::tip[Gender, not person]
 In the past tense, **я читав**, **ти читав**, and **він читав** can share the
@@ -128,10 +138,10 @@ The grammar work is small but important:
 
 ```text
 Марія: Як ти провів вихідні?
-Іван: Добре. У суботу я гуляв.
+Іван: Добре. У суботу я ходив на концерт.
 Іван: У неділю я дивився фільм.
 Іван: А ти що робила?
-Марія: Я ходила в кафе.
+Марія: Я читала роман і ходила в кафе.
 Марія: Ми їли торт.
 Іван: Ви пили каву?
 Марія: Так, ми пили каву.
@@ -142,16 +152,19 @@ Support after the Ukrainian lines:
 | Українська | English support |
 | --- | --- |
 | **Марія: Як ти провів вихідні?** | Mariia: How did you spend the weekend? |
-| **Іван: Добре. У суботу я гуляв.** | Ivan: Good. On Saturday I walked. |
+| **Іван: Добре. У суботу я ходив на концерт.** | Ivan: Good. On Saturday I went to a concert. |
 | **Іван: У неділю я дивився фільм.** | Ivan: On Sunday I watched a film. |
 | **Іван: А ти що робила?** | Ivan: And what were you doing? |
-| **Марія: Я ходила в кафе.** | Mariia: I went to a cafe. |
+| **Марія: Я читала роман і ходила в кафе.** | Mariia: I read a novel and went to a cafe. |
 | **Марія: Ми їли торт.** | Mariia: We ate cake. |
 | **Іван: Ви пили каву?** | Ivan: Did you drink coffee? |
 | **Марія: Так, ми пили каву.** | Mariia: Yes, we drank coffee. |
 
 Notice the plural forms: **ми їли**, **ми пили**, **ви пили**. In the plural,
 use **-ли**. Do not add present-tense person endings after it.
+
+For now, just understand **концерт** - concert and **роман** - novel when you
+see them in the dialogue. You do not need to use them yet.
 
 ### Choose the past form
 
@@ -200,24 +213,21 @@ Good A1 questions:
 
 Short details help the past sentence sound real:
 
-**Розширення речення другорядними членами** means a past sentence can grow by
-one small detail at a time.
+A past sentence can grow by one small detail at a time.
 
 - **що?** - **Я їв сніданок.** / **Я їла сніданок.**
 - **куди?** - **Я йшов до школи.** / **Я йшла до школи.**
 - **яку?** - **Я читав цікаву книжку.** / **Я читала цікаву книжку.**
 
-The time marker **вчора** tells you the action is before now. The beginner
+The time marker **учора** tells you the action is before now. The beginner
 formation is still the same: use **-в** for masculine, **-ла для жіночого**
 forms, **-ло** for neuter, and **-ли** for plural.
 
-School Ukrainian often asks **що зробив?** or **що зробила?** to notice gender:
-**Місяць згубив намистинки. Ніч згубила намистинки.** You only need the idea:
-masculine subject, masculine past form; feminine subject, feminine past form.
+A quick check with names you know is enough:
+**Іван читав. Марія читала.** Same action, different subject gender.
 
-Keep the grammar here narrow. Later Ukrainian will give you more verb choices.
-For this A1 step, practice only the endings **-в**, **-ла**, **-ло**, and
-**-ли** with familiar verbs.
+Keep the grammar here narrow. Practice only the endings **-в**, **-ла**,
+**-ло**, and **-ли** with familiar verbs.
 
 ### Gender, not person
 
@@ -267,30 +277,31 @@ Use the repair list to keep English habits from taking over:
 
 | Learner sentence | Better Ukrainian |
 | --- | --- |
-| <del>**Чоловік: Я читала.**</del> | **Чоловік: Я читав.** |
-| <del>**Жінка: Я читав.**</del> | **Жінка: Я читала.** |
-| <del>**Сонце встав.**</del> | **Сонце встало.** |
-| <del>**Я буду читав завтра.**</del> | **Я буду читати завтра.** |
+| <bad>**Чоловік: Я читала.**</bad> | **Чоловік: Я читав.** |
+| <bad>**Жінка: Я читав.**</bad> | **Жінка: Я читала.** |
+| <bad>**Ми читалимо текст.**</bad> | **Ми читали текст.** |
+| <bad>**Вони читалить текст.**</bad> | **Вони читали текст.** |
+| <bad>**Сонце встав.**</bad> | **Сонце встало.** |
+| <bad>**Я буду читав завтра.**</bad> | **Я буду читати завтра.** |
+| <bad>**Він принісв книгу.**</bad> | Recognition only: **Він приніс книгу.** |
+| <bad>**Він везв сумку.**</bad> | Recognition only: **Він віз сумку.** |
 
 The last line looks ahead to future tense. The repair is simple for now:
 after **буду**, use the infinitive **читати**, not a past form.
 
-Some verb pairs will later show more meaning differences, for example
-**читав** and **прочитав**, or **летіли** and **полетіли**. Do not study that
-system here. For this A1 lesson, your job is only to match the past ending to
-the subject.
+You may see other past forms such as **прочитав**, **полетіли**, **ніс**,
+**віз**, or **мерз**. Just recognize that they are past forms. For speaking
+today, stay with regular forms like **читав**, **читала**, **читало**,
+**читали**.
 
-Later grammar will use words like **процес**, **незавершена дія**, and
-**результат**. That is not your task now. Later grammar will also show
-consonant-stem forms.
+:::caution[Do not build every past form today]
+Forms like **приніс** and **віз** are useful to recognize later, but they are
+not built by adding **-в**. For this lesson, produce the regular forms in the
+tables and treat these harder forms as repairs you can understand.
+:::
 
-**Знайомство з основами на приголосний** comes later. Forms such as **ніс**,
-**віз**, and **мерз** are not the active A1 pattern. For today, stay with regular
-forms like **читав**, **читала**, **читало**, **читали**.
-
-The next grammar step is **майбутнього часу і наказового способу**, future
-time and requests. For now, one future repair is enough: after **буду**, use an
-infinitive, as in **Я буду читати завтра.**
+The next time step is future tense. For now, one future repair is enough: after
+**буду**, use an infinitive, as in **Я буду читати завтра.**
 
 ### Mini story practice
 
@@ -338,6 +349,11 @@ Self-check:
 2. Can you change **він працював** to **вона працювала**?
 3. Can you change **вона говорила** to **вони говорили**?
 
+:::tip[Progress marker]
+If you can answer **Що ти робив/робила учора?** with one correct sentence, you
+have your first past-tense answer. A longer story comes next.
+:::
+
 Stop here when the endings feel visible. The next module uses the same forms
 to tell a simple story about yesterday.
 
@@ -356,7 +372,7 @@ to tell a simple story about yesterday.
 </TabItem>
 <TabItem label="Vocabulary">
 
-<VocabCard client:only="react" words={JSON.parse(`[{"word":"учора","translation":"yesterday","pos":"adverb","example":"Учора я читав.","examples":["yesterday","Учора я читав."],"atlas_href":"/lexicon/учора/"},{"word":"робити","translation":"to do","pos":"verb","example":"Що ти робив?","examples":["to do","Що ти робив?"],"atlas_href":"/lexicon/робити/"},{"word":"читати","translation":"to read","pos":"verb","example":"Вона читала книжку.","examples":["to read","Вона читала книжку."],"atlas_href":"/lexicon/читати/"},{"word":"працювати","translation":"to work","pos":"verb","example":"Ми працювали разом.","examples":["to work","Ми працювали разом."],"atlas_href":"/lexicon/працювати/"},{"word":"гуляти","translation":"to walk","pos":"verb","example":"Він гуляв у парку.","examples":["to walk","Він гуляв у парку."],"atlas_href":"/lexicon/гуляти/"},{"word":"готувати","translation":"to cook","pos":"verb","example":"Олена готувала вечерю.","examples":["to cook","Олена готувала вечерю."],"atlas_href":"/lexicon/готувати/"},{"word":"дивитися","translation":"to watch","pos":"verb","example":"Тарас дивився фільм.","examples":["to watch","Тарас дивився фільм."],"atlas_href":"/lexicon/дивитися/"},{"word":"говорити","translation":"to speak","pos":"verb","example":"Марія говорила телефоном.","examples":["to speak","Марія говорила телефоном."],"atlas_href":"/lexicon/говорити/"},{"word":"минулий","translation":"past","pos":"adjective","example":"Це минулий час.","examples":["past","Це минулий час."],"atlas_href":"/lexicon/минулий/"},{"word":"вихідні","translation":"weekend","pos":"noun plural","example":"Як ти провів вихідні?","examples":["weekend","Як ти провів вихідні?"],"atlas_href":"/lexicon/вихідні/"},{"word":"субота","translation":"Saturday","pos":"noun","example":"У суботу ми гуляли.","examples":["Saturday","У суботу ми гуляли."],"atlas_href":"/lexicon/субота/"},{"word":"неділя","translation":"Sunday","pos":"noun","example":"У неділю він читав.","examples":["Sunday","У неділю він читав."],"atlas_href":"/lexicon/неділя/"},{"word":"разом","translation":"together","pos":"adverb","example":"Вони працювали разом.","examples":["together","Вони працювали разом."],"atlas_href":"/lexicon/разом/"},{"word":"фільм","translation":"film","pos":"noun","example":"Ми дивилися фільм.","examples":["film","Ми дивилися фільм."],"atlas_href":"/lexicon/фільм/"},{"word":"книжка","translation":"book","pos":"noun","example":"Я читала книжку.","examples":["book","Я читала книжку."],"atlas_href":"/lexicon/книжка/"},{"word":"вечеря","translation":"dinner","pos":"noun","example":"Вона готувала вечерю.","examples":["dinner","Вона готувала вечерю."],"atlas_href":"/lexicon/вечеря/"},{"word":"парк","translation":"park","pos":"noun","example":"Він гуляв у парку.","examples":["park","Він гуляв у парку."],"atlas_href":"/lexicon/парк/"},{"word":"рід","translation":"gender","pos":"noun","example":"Минулий час показує рід.","examples":["gender","Минулий час показує рід."],"atlas_href":"/lexicon/рід/"},{"word":"особа","translation":"person","pos":"noun","example":"Це не особа.","examples":["person","Це не особа."],"atlas_href":"/lexicon/особа/"},{"word":"закінчення","translation":"ending","pos":"noun","example":"Закінчення -ла жіноче.","examples":["ending","Закінчення -ла жіноче."],"atlas_href":"/lexicon/закінчення/"}]`)} title="Vocabulary" />
+<VocabCard client:only="react" words={JSON.parse(`[{"word":"учора","translation":"yesterday","pos":"adverb","example":"Учора я читав.","examples":["yesterday","Учора я читав."],"atlas_href":"/lexicon/учора/"},{"word":"робити","translation":"to do","pos":"verb","example":"Що ти робив?","examples":["to do","Що ти робив?"],"atlas_href":"/lexicon/робити/"},{"word":"читати","translation":"to read","pos":"verb","example":"Вона читала книжку.","examples":["to read","Вона читала книжку."],"atlas_href":"/lexicon/читати/"},{"word":"працювати","translation":"to work","pos":"verb","example":"Ми працювали разом.","examples":["to work","Ми працювали разом."],"atlas_href":"/lexicon/працювати/"},{"word":"гуляти","translation":"to walk","pos":"verb","example":"Він гуляв у парку.","examples":["to walk","Він гуляв у парку."],"atlas_href":"/lexicon/гуляти/"},{"word":"готувати","translation":"to cook","pos":"verb","example":"Олена готувала вечерю.","examples":["to cook","Олена готувала вечерю."],"atlas_href":"/lexicon/готувати/"},{"word":"дивитися","translation":"to watch","pos":"verb","example":"Тарас дивився фільм.","examples":["to watch","Тарас дивився фільм."],"atlas_href":"/lexicon/дивитися/"},{"word":"говорити","translation":"to speak","pos":"verb","example":"Марія говорила телефоном.","examples":["to speak","Марія говорила телефоном."],"atlas_href":"/lexicon/говорити/"},{"word":"минулий","translation":"past","pos":"adjective","example":"Це минулий час.","examples":["past","Це минулий час."],"atlas_href":"/lexicon/минулий/"},{"word":"вихідні","translation":"weekend","pos":"noun plural","example":"Як ти провів вихідні?","examples":["weekend","Як ти провів вихідні?"]},{"word":"субота","translation":"Saturday","pos":"noun","example":"У суботу ми гуляли.","examples":["Saturday","У суботу ми гуляли."],"atlas_href":"/lexicon/субота/"},{"word":"неділя","translation":"Sunday","pos":"noun","example":"У неділю він читав.","examples":["Sunday","У неділю він читав."],"atlas_href":"/lexicon/неділя/"},{"word":"разом","translation":"together","pos":"adverb","example":"Вони працювали разом.","examples":["together","Вони працювали разом."],"atlas_href":"/lexicon/разом/"},{"word":"фільм","translation":"film","pos":"noun","example":"Ми дивилися фільм.","examples":["film","Ми дивилися фільм."],"atlas_href":"/lexicon/фільм/"},{"word":"книжка","translation":"book","pos":"noun","example":"Я читала книжку.","examples":["book","Я читала книжку."],"atlas_href":"/lexicon/книжка/"},{"word":"вечеря","translation":"dinner","pos":"noun","example":"Вона готувала вечерю.","examples":["dinner","Вона готувала вечерю."],"atlas_href":"/lexicon/вечеря/"},{"word":"парк","translation":"park","pos":"noun","example":"Він гуляв у парку.","examples":["park","Він гуляв у парку."],"atlas_href":"/lexicon/парк/"},{"word":"рід","translation":"gender","pos":"noun","example":"Минулий час показує рід.","examples":["gender","Минулий час показує рід."],"atlas_href":"/lexicon/рід/"},{"word":"особа","translation":"person","pos":"noun","example":"Це не особа.","examples":["person","Це не особа."],"atlas_href":"/lexicon/особа/"},{"word":"закінчення","translation":"ending","pos":"noun","example":"Закінчення -ла жіноче.","examples":["ending","Закінчення -ла жіноче."],"atlas_href":"/lexicon/закінчення/"}]`)} title="Vocabulary" />
 
 <FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"учора","back":"yesterday"},{"front":"робити","back":"to do"},{"front":"читати","back":"to read"},{"front":"працювати","back":"to work"},{"front":"гуляти","back":"to walk"},{"front":"готувати","back":"to cook"},{"front":"дивитися","back":"to watch"},{"front":"говорити","back":"to speak"},{"front":"минулий","back":"past"},{"front":"вихідні","back":"weekend"},{"front":"субота","back":"Saturday"},{"front":"неділя","back":"Sunday"},{"front":"разом","back":"together"},{"front":"фільм","back":"film"},{"front":"книжка","back":"book"},{"front":"вечеря","back":"dinner"},{"front":"парк","back":"park"},{"front":"рід","back":"gender"},{"front":"особа","back":"person"},{"front":"закінчення","back":"ending"}]`)} />
 


### PR DESCRIPTION
## Summary
- Certifies A1 M48 `what-happened` live-content quality against the immutable plan.
- Tightens A1 past-tense boundaries around regular visible endings, learner-facing repair traps, and the plan's concert/novel details.
- Regenerates the public MDX for the updated module source.

## Deterministic Checks
- `.venv/bin/python scripts/generate_mdx.py l2-uk-en a1 48 --validate`
- `.venv/bin/python scripts/validate_activities.py l2-uk-en a1 48`
- `.venv/bin/python scripts/validate/validate_vocab_yaml.py curriculum/l2-uk-en/a1/what-happened/vocabulary.yaml`
- `.venv/bin/python scripts/validate_plan_config.py a1/what-happened`
- `.venv/bin/python scripts/lexicon/check_manifest_freshness.py`
- `.venv/bin/python scripts/lexicon/check_manifest_vocabulary_coverage.py --changed-only --base origin/main`
- `git diff --check` / `git diff --check origin/main..HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `.venv/bin/python scripts/audit/certify_module.py a1/what-happened --clean-qg-artifacts` (production build passed, 3114 pages)

## Independent LLM QG
Reviewer: Gemini CLI direct, final accepted fallback `gemini-2.5-flash`.

Scores:
- pedagogical: 9.0
- naturalness: 9.5
- decolonization: 9.5
- engagement: 9.0
- tone: 9.5

Tool notes:
- `gemini-3.1-pro-preview` was capacity-blocked.
- `gemini-2.5-pro` was quota-exhausted.
- Final accepted QG pass was source-backed; noisy or malformed Gemini outputs were rejected.
- DeepSeek was not used.

## Swarm / Telemetry Notes
- `swarm_used`: false
- `swarm_label`: none
- `swarm_note`: solo run; no swarm used
- `participants`: codex main agent; gemini-cli-direct
