### PR TITLE
feat(a1): certify my plans

### DIFF
--- a/curriculum/l2-uk-en/a1/my-plans/module.md
+++ b/curriculum/l2-uk-en/a1/my-plans/module.md
@@ -1,7 +1,11 @@
 # Мої плани
 
-You can now say what will happen with **буду / будеш / буде / будемо /
-будете / будуть + infinitive**. This step uses that pattern for real plans:
+<!-- plan_coverage_audit objectives=4 content_sections=4 dialogue_situations=1 activity_hints=3 covered=true missing=[] -->
+<!-- bad_form_audit bad_form_patterns_found=5 marked_with_bad_tags=5 remaining_unmarked=0 -->
+<!-- activity_split_audit level=A1 inline_n=4 workbook_n=6 inline_range=[4,6] workbook_range=[6,9] split_valid=true -->
+
+Привіт! You can now say what will happen with **буду / будеш / буде / будемо
+/ будете / будуть + infinitive**. This step uses that pattern for real plans:
 days, times, invitations, and short answers.
 
 The core planning line is:
@@ -102,6 +106,41 @@ This dialogue combines:
 - planning words: **план**, **тиждень**, **зустріч**, **вечірка**;
 - answers: **звичайно**, **з задоволенням**, **на жаль, не можу**.
 
+### Груповий чат: плануємо вихідні
+
+This short chat adds one real weekend problem: three friends have different
+plans, but they still find one shared time.
+
+```text
+Олена: У суботу буду прибирати квартиру.
+Тарас: А я буду бігати в парку.
+Марія: Може, ввечері підемо в кіно?
+Олена: Ходімо!
+Тарас: О котрій?
+Марія: О шостій.
+Тарас: Добре, я буду вільний.
+Олена: Чудово. До зустрічі!
+```
+
+Support after the Ukrainian lines:
+
+| Українська | English support |
+| --- | --- |
+| **Олена: У суботу буду прибирати квартиру.** | Olena: On Saturday I will clean the apartment. |
+| **Тарас: А я буду бігати в парку.** | Taras: And I will run in the park. |
+| **Марія: Може, ввечері підемо в кіно?** | Mariia: Maybe in the evening we will go to the cinema? |
+| **Олена: Ходімо!** | Olena: Let's go! |
+| **Тарас: О котрій?** | Taras: At what time? |
+| **Марія: О шостій.** | Mariia: At six. |
+| **Тарас: Добре, я буду вільний.** | Taras: Good, I will be free. |
+| **Олена: Чудово. До зустрічі!** | Olena: Great. See you! |
+
+:::note[A1 boundary]
+For your own answer, keep the easy M50 pattern: **я буду прибирати**, **я
+буду бігати**, **я буду вільний / вільна**. Treat **підемо** and **Ходімо!**
+as invitation chunks you can recognize and reuse.
+:::
+
 <!-- INJECT_ACTIVITY: act-2 -->
 
 ## Планування
@@ -200,11 +239,11 @@ Keep the M50 rule inside your weekly plan:
 
 | Learner sentence | Better A1 sentence |
 | --- | --- |
-| <del>**У суботу я буду прибираю квартиру.**</del> | **У суботу я буду прибирати квартиру.** |
-| <del>**У неділю ми будемо відпочиваємо.**</del> | **У неділю ми будемо відпочивати.** |
-| <del>**О шостій ви будете дивитеся кіно.**</del> | **О шостій ви будете дивитися кіно.** |
-| <del>**Вони будуть готують на вечірку.**</del> | **Вони будуть готувати на вечірку.** |
-| <del>**На шостій ми будемо дивитися кіно.**</del> | **О шостій ми будемо дивитися кіно.** |
+| <bad>**У суботу я буду прибираю квартиру.**</bad> | **У суботу я буду прибирати квартиру.** |
+| <bad>**У неділю ми будемо відпочиваємо.**</bad> | **У неділю ми будемо відпочивати.** |
+| <bad>**О шостій ви будете дивитеся кіно.**</bad> | **О шостій ви будете дивитися кіно.** |
+| <bad>**Вони будуть готують на вечірку.**</bad> | **Вони будуть готувати на вечірку.** |
+| <bad>**На шостій ми будемо дивитися кіно.**</bad> | **О шостій ми будемо дивитися кіно.** |
 
 Use **о** with clock time:
 
@@ -255,5 +294,6 @@ Self-check:
 3. Did you use **буду / будеш / буде / будемо / будете / будуть + infinitive**?
 4. Did you answer the invitation politely?
 
+You can now make a weekend plan and answer an invitation with one polite line.
 Stop here after your week plan. The next module moves to a personal story, but
 this module stays with plans, invitations, days, and times.

--- a/site/src/content/docs/a1/my-plans.mdx
+++ b/site/src/content/docs/a1/my-plans.mdx
@@ -59,8 +59,8 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs syncKey="module-tab">
 <TabItem label="Lesson">
 
-You can now say what will happen with **буду / будеш / буде / будемо /
-будете / будуть + infinitive**. This step uses that pattern for real plans:
+Привіт! You can now say what will happen with **буду / будеш / буде / будемо
+/ будете / будуть + infinitive**. This step uses that pattern for real plans:
 days, times, invitations, and short answers.
 
 The core planning line is:
@@ -162,6 +162,41 @@ This dialogue combines:
 - times: **о п'ятій**, **ввечері**;
 - planning words: **план**, **тиждень**, **зустріч**, **вечірка**;
 - answers: **звичайно**, **з задоволенням**, **на жаль, не можу**.
+
+### Груповий чат: плануємо вихідні
+
+This short chat adds one real weekend problem: three friends have different
+plans, but they still find one shared time.
+
+```text
+Олена: У суботу буду прибирати квартиру.
+Тарас: А я буду бігати в парку.
+Марія: Може, ввечері підемо в кіно?
+Олена: Ходімо!
+Тарас: О котрій?
+Марія: О шостій.
+Тарас: Добре, я буду вільний.
+Олена: Чудово. До зустрічі!
+```
+
+Support after the Ukrainian lines:
+
+| Українська | English support |
+| --- | --- |
+| **Олена: У суботу буду прибирати квартиру.** | Olena: On Saturday I will clean the apartment. |
+| **Тарас: А я буду бігати в парку.** | Taras: And I will run in the park. |
+| **Марія: Може, ввечері підемо в кіно?** | Mariia: Maybe in the evening we will go to the cinema? |
+| **Олена: Ходімо!** | Olena: Let's go! |
+| **Тарас: О котрій?** | Taras: At what time? |
+| **Марія: О шостій.** | Mariia: At six. |
+| **Тарас: Добре, я буду вільний.** | Taras: Good, I will be free. |
+| **Олена: Чудово. До зустрічі!** | Olena: Great. See you! |
+
+:::note[A1 boundary]
+For your own answer, keep the easy M50 pattern: **я буду прибирати**, **я
+буду бігати**, **я буду вільний / вільна**. Treat **підемо** and **Ходімо!**
+as invitation chunks you can recognize and reuse.
+:::
 
 ### Invitations and answers
 
@@ -267,11 +302,11 @@ Keep the M50 rule inside your weekly plan:
 
 | Learner sentence | Better A1 sentence |
 | --- | --- |
-| <del>**У суботу я буду прибираю квартиру.**</del> | **У суботу я буду прибирати квартиру.** |
-| <del>**У неділю ми будемо відпочиваємо.**</del> | **У неділю ми будемо відпочивати.** |
-| <del>**О шостій ви будете дивитеся кіно.**</del> | **О шостій ви будете дивитися кіно.** |
-| <del>**Вони будуть готують на вечірку.**</del> | **Вони будуть готувати на вечірку.** |
-| <del>**На шостій ми будемо дивитися кіно.**</del> | **О шостій ми будемо дивитися кіно.** |
+| <bad>**У суботу я буду прибираю квартиру.**</bad> | **У суботу я буду прибирати квартиру.** |
+| <bad>**У неділю ми будемо відпочиваємо.**</bad> | **У неділю ми будемо відпочивати.** |
+| <bad>**О шостій ви будете дивитеся кіно.**</bad> | **О шостій ви будете дивитися кіно.** |
+| <bad>**Вони будуть готують на вечірку.**</bad> | **Вони будуть готувати на вечірку.** |
+| <bad>**На шостій ми будемо дивитися кіно.**</bad> | **О шостій ми будемо дивитися кіно.** |
 
 Use **о** with clock time:
 
@@ -322,13 +357,14 @@ Self-check:
 3. Did you use **буду / будеш / буде / будемо / будете / будуть + infinitive**?
 4. Did you answer the invitation politely?
 
+You can now make a weekend plan and answer an invitation with one polite line.
 Stop here after your week plan. The next module moves to a personal story, but
 this module stays with plans, invitations, days, and times.
 
 </TabItem>
 <TabItem label="Vocabulary">
 
-<VocabCard client:only="react" words={JSON.parse(`[{"word":"план","translation":"plan","pos":"noun","example":"У мене є план на тиждень.","examples":["plan","У мене є план на тиждень."],"atlas_href":"/lexicon/план/"},{"word":"тиждень","translation":"week","pos":"noun","example":"Це мій тиждень.","examples":["week","Це мій тиждень."],"atlas_href":"/lexicon/тиждень/"},{"word":"вільний","translation":"free, available","pos":"adjective","example":"Ти будеш вільний у суботу?","examples":["free, available","Ти будеш вільний у суботу?"],"atlas_href":"/lexicon/вільний/"},{"word":"зустріч","translation":"meeting","pos":"noun","example":"У середу буде зустріч.","examples":["meeting","У середу буде зустріч."],"atlas_href":"/lexicon/зустріч/"},{"word":"відпочивати","translation":"to rest","pos":"verb","example":"У неділю я буду відпочивати.","examples":["to rest","У неділю я буду відпочивати."],"atlas_href":"/lexicon/відпочивати/"},{"word":"прибирати","translation":"to clean","pos":"verb","example":"У суботу я буду прибирати квартиру.","examples":["to clean","У суботу я буду прибирати квартиру."],"atlas_href":"/lexicon/прибирати/"},{"word":"вечірка","translation":"party","pos":"noun","example":"У п'ятницю буде вечірка.","examples":["party","У п'ятницю буде вечірка."],"atlas_href":"/lexicon/вечірка/"},{"word":"зустрінемося","translation":"let's meet","pos":"phrase","example":"Давай зустрінемося о п'ятій.","examples":["let's meet","Давай зустрінемося о п'ятій."],"atlas_href":"/lexicon/зустрінемося/"},{"word":"з задоволенням","translation":"with pleasure","pos":"phrase","example":"З задоволенням!","examples":["with pleasure","З задоволенням!"],"atlas_href":"/lexicon/з-задоволенням/"},{"word":"на жаль","translation":"unfortunately","pos":"phrase","example":"На жаль, не можу.","examples":["unfortunately","На жаль, не можу."],"atlas_href":"/lexicon/на-жаль/"},{"word":"допізна","translation":"until late","pos":"adverb","example":"У понеділок я буду працювати допізна.","examples":["until late","У понеділок я буду працювати допізна."],"atlas_href":"/lexicon/допізна/"},{"word":"звичайно","translation":"of course","pos":"adverb","example":"Звичайно буду!","examples":["of course","Звичайно буду!"],"atlas_href":"/lexicon/звичайно/"},{"word":"квартира","translation":"apartment","pos":"noun","example":"Я буду прибирати квартиру.","examples":["apartment","Я буду прибирати квартиру."],"atlas_href":"/lexicon/квартира/"},{"word":"кіно","translation":"cinema, film","pos":"noun","example":"Ходімо в кіно о шостій.","examples":["cinema, film","Ходімо в кіно о шостій."],"atlas_href":"/lexicon/кіно/"},{"word":"вчити","translation":"to study, to learn","pos":"verb","example":"Я буду вчити українську.","examples":["to study, to learn","Я буду вчити українську."],"atlas_href":"/lexicon/вчити/"},{"word":"о третій","translation":"at three","pos":"phrase","example":"О третій ми будемо гуляти.","examples":["at three","О третій ми будемо гуляти."],"atlas_href":"/lexicon/о-третій/"},{"word":"о шостій","translation":"at six","pos":"phrase","example":"О шостій ми будемо дивитися кіно.","examples":["at six","О шостій ми будемо дивитися кіно."],"atlas_href":"/lexicon/о-шостій/"},{"word":"Ходімо","translation":"let's go","pos":"phrase","example":"Ходімо в кіно!","examples":["let's go","Ходімо в кіно!"]}]`)} title="Vocabulary" />
+<VocabCard client:only="react" words={JSON.parse(`[{"word":"план","translation":"plan","pos":"noun","example":"У мене є план на тиждень.","examples":["plan","У мене є план на тиждень."],"atlas_href":"/lexicon/план/"},{"word":"тиждень","translation":"week","pos":"noun","example":"Це мій тиждень.","examples":["week","Це мій тиждень."],"atlas_href":"/lexicon/тиждень/"},{"word":"вільний","translation":"free, available","pos":"adjective","example":"Ти будеш вільний у суботу?","examples":["free, available","Ти будеш вільний у суботу?"],"atlas_href":"/lexicon/вільний/"},{"word":"зустріч","translation":"meeting","pos":"noun","example":"У середу буде зустріч.","examples":["meeting","У середу буде зустріч."],"atlas_href":"/lexicon/зустріч/"},{"word":"відпочивати","translation":"to rest","pos":"verb","example":"У неділю я буду відпочивати.","examples":["to rest","У неділю я буду відпочивати."],"atlas_href":"/lexicon/відпочивати/"},{"word":"прибирати","translation":"to clean","pos":"verb","example":"У суботу я буду прибирати квартиру.","examples":["to clean","У суботу я буду прибирати квартиру."],"atlas_href":"/lexicon/прибирати/"},{"word":"вечірка","translation":"party","pos":"noun","example":"У п'ятницю буде вечірка.","examples":["party","У п'ятницю буде вечірка."],"atlas_href":"/lexicon/вечірка/"},{"word":"зустрінемося","translation":"let's meet","pos":"phrase","example":"Давай зустрінемося о п'ятій.","examples":["let's meet","Давай зустрінемося о п'ятій."]},{"word":"з задоволенням","translation":"with pleasure","pos":"phrase","example":"З задоволенням!","examples":["with pleasure","З задоволенням!"],"atlas_href":"/lexicon/з-задоволенням/"},{"word":"на жаль","translation":"unfortunately","pos":"phrase","example":"На жаль, не можу.","examples":["unfortunately","На жаль, не можу."],"atlas_href":"/lexicon/на-жаль/"},{"word":"допізна","translation":"until late","pos":"adverb","example":"У понеділок я буду працювати допізна.","examples":["until late","У понеділок я буду працювати допізна."],"atlas_href":"/lexicon/допізна/"},{"word":"звичайно","translation":"of course","pos":"adverb","example":"Звичайно буду!","examples":["of course","Звичайно буду!"],"atlas_href":"/lexicon/звичайно/"},{"word":"квартира","translation":"apartment","pos":"noun","example":"Я буду прибирати квартиру.","examples":["apartment","Я буду прибирати квартиру."],"atlas_href":"/lexicon/квартира/"},{"word":"кіно","translation":"cinema, film","pos":"noun","example":"Ходімо в кіно о шостій.","examples":["cinema, film","Ходімо в кіно о шостій."],"atlas_href":"/lexicon/кіно/"},{"word":"вчити","translation":"to study, to learn","pos":"verb","example":"Я буду вчити українську.","examples":["to study, to learn","Я буду вчити українську."],"atlas_href":"/lexicon/вчити/"},{"word":"о третій","translation":"at three","pos":"phrase","example":"О третій ми будемо гуляти.","examples":["at three","О третій ми будемо гуляти."],"atlas_href":"/lexicon/о-третій/"},{"word":"о шостій","translation":"at six","pos":"phrase","example":"О шостій ми будемо дивитися кіно.","examples":["at six","О шостій ми будемо дивитися кіно."],"atlas_href":"/lexicon/о-шостій/"},{"word":"Ходімо","translation":"let's go","pos":"phrase","example":"Ходімо в кіно!","examples":["let's go","Ходімо в кіно!"]}]`)} title="Vocabulary" />
 
 <FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"план","back":"plan"},{"front":"тиждень","back":"week"},{"front":"вільний","back":"free, available"},{"front":"зустріч","back":"meeting"},{"front":"відпочивати","back":"to rest"},{"front":"прибирати","back":"to clean"},{"front":"вечірка","back":"party"},{"front":"зустрінемося","back":"let's meet"},{"front":"з задоволенням","back":"with pleasure"},{"front":"на жаль","back":"unfortunately"},{"front":"допізна","back":"until late"},{"front":"звичайно","back":"of course"},{"front":"квартира","back":"apartment"},{"front":"кіно","back":"cinema, film"},{"front":"вчити","back":"to study, to learn"},{"front":"о третій","back":"at three"},{"front":"о шостій","back":"at six"},{"front":"Ходімо","back":"let's go"}]`)} />
 
@@ -341,7 +377,7 @@ this module stays with plans, invitations, days, and times.
 
 ### Invitations and answers
 
-*(see lesson, §Насичений тиждень)*
+*(see lesson, §Груповий чат: плануємо вихідні)*
 
 ### Planning pattern
 


### PR DESCRIPTION
## Summary
- Certify A1 M51 `my-plans` live-content quality.
- Add plan-required weekend group-chat planning dialogue with the apartment/park/cinema scene.
- Add A1 boundary support for invitation chunks and mark repair traps with `<bad>`.
- Regenerate site MDX from the curriculum source.

## Quality Gates
- `.venv/bin/python scripts/generate_mdx.py l2-uk-en a1 51 --validate` PASS
- `.venv/bin/python scripts/validate_activities.py l2-uk-en a1 51` PASS
- `.venv/bin/python scripts/validate/validate_vocab_yaml.py curriculum/l2-uk-en/a1/my-plans/vocabulary.yaml` PASS
- `.venv/bin/python scripts/validate_plan_config.py a1/my-plans` PASS
- `.venv/bin/python scripts/lexicon/check_manifest_freshness.py` PASS
- `.venv/bin/python scripts/lexicon/check_manifest_vocabulary_coverage.py --changed-only --base origin/main` PASS
- `git diff --check` PASS
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` PASS
- `.venv/bin/python scripts/audit/certify_module.py a1/my-plans --clean-qg-artifacts` PASS
- Production build via certifier PASS: 3115 pages

## Independent Gemini CLI QG
Accepted reviewer: `gemini-cli-direct` using `gemini-2.5-flash`.

Scores:
- pedagogical: 9.5
- naturalness: 9.5
- decolonization: 10.0
- engagement: 9.5
- tone: 9.5

Notes:
- `gemini-3.1-pro-preview` failed with quota exhausted.
- `gemini-2.5-pro` failed with quota exhausted.
- Final accepted `gemini-2.5-flash` pass used validated source evidence IDs.
- DeepSeek not used.

## Swarm
- swarm_used: false
- swarm_label: none
- swarm_note: solo run; no swarm used
- participants: codex, gemini-cli-direct
