### PR TITLE
feat(a1): certify my story

### DIFF
--- a/curriculum/l2-uk-en/a1/my-story/activities.yaml
+++ b/curriculum/l2-uk-en/a1/my-story/activities.yaml
@@ -209,3 +209,27 @@ workbook:
           - text: 'Зараз я вчив українську.'
             correct: false
         explanation: 'Use буду + infinitive for the future.'
+  - type: error-correction
+    title: Repair the timeline
+    instruction: Fix the time word and verb so the story stays clear.
+    items:
+      - sentence: 'Раніше я живу в Канаді.'
+        error: 'живу'
+        correction: 'жив / жила'
+        explanation: 'Раніше points to the past.'
+      - sentence: 'Зараз я жив у Києві.'
+        error: 'жив'
+        correction: 'живу'
+        explanation: 'Зараз points to the present.'
+      - sentence: 'Далі я працював тут.'
+        error: 'працював'
+        correction: 'буду працювати'
+        explanation: 'Далі points to a future plan.'
+      - sentence: 'Я буду працюю в офісі.'
+        error: 'працюю'
+        correction: 'працювати'
+        explanation: 'After буду, use the infinitive працювати.'
+      - sentence: 'Моє ім''я є Софія.'
+        error: 'Моє ім''я є'
+        correction: 'Мене звати'
+        explanation: 'Use the familiar A1 name chunk Мене звати.'

--- a/curriculum/l2-uk-en/a1/my-story/module.md
+++ b/curriculum/l2-uk-en/a1/my-story/module.md
@@ -1,7 +1,12 @@
 # Моя історія
 
-You can now talk about **what happened**, **what is true now**, and **what will
-happen next**. This module turns those three tools into one simple life story.
+<!-- plan_coverage_audit objectives=4 content_sections=4 dialogue_situations=1 activity_hints=4 covered=true missing=[] -->
+<!-- bad_form_audit bad_form_patterns_found=6 marked_with_bad_tags=6 remaining_unmarked=0 -->
+<!-- activity_split_audit level=A1 inline_n=4 workbook_n=6 inline_range=[4,6] workbook_range=[6,9] split_valid=true -->
+
+Привіт! You can now talk about **what happened**, **what is true now**, and
+**what will happen next**. This module turns those three tools into one simple
+life story.
 
 The safe A1 story frame is:
 
@@ -92,6 +97,36 @@ This story moves like a simple timeline:
 4. **Далі я буду...**
 
 For A1, that is enough. A good story is clear, not long.
+
+### Дідусь розповідає
+
+```text
+Онука: Дідусю, розкажи свою історію.
+Дідусь: Я народився в селі.
+Дідусь: У дитинстві я ходив у школу.
+Дідусь: Потім я переїхав у місто.
+Дідусь: Зараз я працюю в лікарні.
+Онука: А що ти будеш робити далі?
+Дідусь: Улітку я буду відпочивати на дачі.
+Онука: Чудова історія!
+```
+
+Support after the Ukrainian lines:
+
+| Українська | English support |
+| --- | --- |
+| **Онука: Дідусю, розкажи свою історію.** | Granddaughter: Grandpa, tell your story. |
+| **Дідусь: Я народився в селі.** | Grandfather: I was born in a village. |
+| **Дідусь: У дитинстві я ходив у школу.** | Grandfather: In childhood I went to school. |
+| **Дідусь: Потім я переїхав у місто.** | Grandfather: Then I moved to a city. |
+| **Дідусь: Зараз я працюю в лікарні.** | Grandfather: Now I work in a hospital. |
+| **Онука: А що ти будеш робити далі?** | Granddaughter: And what will you do next? |
+| **Дідусь: Улітку я буду відпочивати на дачі.** | Grandfather: In summer I will rest at the dacha. |
+| **Онука: Чудова історія!** | Granddaughter: A wonderful story! |
+
+The place words are useful, but the grammar stays familiar:
+**в селі**, **у школу**, **у місто**, **в лікарні**, **на дачі**. Learn them as
+whole chunks for this story.
 
 <!-- INJECT_ACTIVITY: act-2 -->
 
@@ -200,12 +235,12 @@ Keep the time word and the verb in the same time.
 
 | Learner sentence | Better A1 sentence |
 | --- | --- |
-| <del>**Раніше я живу в Канаді.**</del> | **Раніше я жив / жила в Канаді.** |
-| <del>**Зараз я жив у Києві.**</del> | **Зараз я живу в Києві.** |
-| <del>**Далі я працював тут.**</del> | **Далі я буду працювати тут.** |
-| <del>**Я буду працюю в офісі.**</del> | **Я буду працювати в офісі.** |
-| <del>**Вона буде подорожує.**</del> | **Вона буде подорожувати.** |
-| <del>**Моє ім'я є Софія.**</del> | **Мене звати Софія.** |
+| <bad>**Раніше я живу в Канаді.**</bad> | **Раніше я жив / жила в Канаді.** |
+| <bad>**Зараз я жив у Києві.**</bad> | **Зараз я живу в Києві.** |
+| <bad>**Далі я працював тут.**</bad> | **Далі я буду працювати тут.** |
+| <bad>**Я буду працюю в офісі.**</bad> | **Я буду працювати в офісі.** |
+| <bad>**Вона буде подорожує.**</bad> | **Вона буде подорожувати.** |
+| <bad>**Моє ім'я є Софія.**</bad> | **Мене звати Софія.** |
 
 The last repair is important. Ukrainian does not need the English-style
 sentence **my name is...**. Use the familiar A1 chunk **Мене звати...**.
@@ -238,3 +273,6 @@ Support after the Ukrainian lines:
 
 Stop here. If you can tell this kind of story, you can connect past, present,
 and future without leaving A1.
+
+You can now tell a short life story in three time frames: **раніше**, **зараз**,
+and **далі**.

--- a/site/src/content/docs/a1/my-story.mdx
+++ b/site/src/content/docs/a1/my-story.mdx
@@ -59,8 +59,9 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs syncKey="module-tab">
 <TabItem label="Lesson">
 
-You can now talk about **what happened**, **what is true now**, and **what will
-happen next**. This module turns those three tools into one simple life story.
+Привіт! You can now talk about **what happened**, **what is true now**, and
+**what will happen next**. This module turns those three tools into one simple
+life story.
 
 The safe A1 story frame is:
 
@@ -153,6 +154,36 @@ This story moves like a simple timeline:
 4. **Далі я буду...**
 
 For A1, that is enough. A good story is clear, not long.
+
+### Дідусь розповідає
+
+```text
+Онука: Дідусю, розкажи свою історію.
+Дідусь: Я народився в селі.
+Дідусь: У дитинстві я ходив у школу.
+Дідусь: Потім я переїхав у місто.
+Дідусь: Зараз я працюю в лікарні.
+Онука: А що ти будеш робити далі?
+Дідусь: Улітку я буду відпочивати на дачі.
+Онука: Чудова історія!
+```
+
+Support after the Ukrainian lines:
+
+| Українська | English support |
+| --- | --- |
+| **Онука: Дідусю, розкажи свою історію.** | Granddaughter: Grandpa, tell your story. |
+| **Дідусь: Я народився в селі.** | Grandfather: I was born in a village. |
+| **Дідусь: У дитинстві я ходив у школу.** | Grandfather: In childhood I went to school. |
+| **Дідусь: Потім я переїхав у місто.** | Grandfather: Then I moved to a city. |
+| **Дідусь: Зараз я працюю в лікарні.** | Grandfather: Now I work in a hospital. |
+| **Онука: А що ти будеш робити далі?** | Granddaughter: And what will you do next? |
+| **Дідусь: Улітку я буду відпочивати на дачі.** | Grandfather: In summer I will rest at the dacha. |
+| **Онука: Чудова історія!** | Granddaughter: A wonderful story! |
+
+The place words are useful, but the grammar stays familiar:
+**в селі**, **у школу**, **у місто**, **в лікарні**, **на дачі**. Learn them as
+whole chunks for this story.
 
 ### Put the life story in order
 
@@ -267,12 +298,12 @@ Keep the time word and the verb in the same time.
 
 | Learner sentence | Better A1 sentence |
 | --- | --- |
-| <del>**Раніше я живу в Канаді.**</del> | **Раніше я жив / жила в Канаді.** |
-| <del>**Зараз я жив у Києві.**</del> | **Зараз я живу в Києві.** |
-| <del>**Далі я працював тут.**</del> | **Далі я буду працювати тут.** |
-| <del>**Я буду працюю в офісі.**</del> | **Я буду працювати в офісі.** |
-| <del>**Вона буде подорожує.**</del> | **Вона буде подорожувати.** |
-| <del>**Моє ім'я є Софія.**</del> | **Мене звати Софія.** |
+| <bad>**Раніше я живу в Канаді.**</bad> | **Раніше я жив / жила в Канаді.** |
+| <bad>**Зараз я жив у Києві.**</bad> | **Зараз я живу в Києві.** |
+| <bad>**Далі я працював тут.**</bad> | **Далі я буду працювати тут.** |
+| <bad>**Я буду працюю в офісі.**</bad> | **Я буду працювати в офісі.** |
+| <bad>**Вона буде подорожує.**</bad> | **Вона буде подорожувати.** |
+| <bad>**Моє ім'я є Софія.**</bad> | **Мене звати Софія.** |
 
 The last repair is important. Ukrainian does not need the English-style
 sentence **my name is...**. Use the familiar A1 chunk **Мене звати...**.
@@ -306,10 +337,13 @@ Support after the Ukrainian lines:
 Stop here. If you can tell this kind of story, you can connect past, present,
 and future without leaving A1.
 
+You can now tell a short life story in three time frames: **раніше**, **зараз**,
+and **далі**.
+
 </TabItem>
 <TabItem label="Vocabulary">
 
-<VocabCard client:only="react" words={JSON.parse(`[{"word":"історія","translation":"story, history","pos":"noun","example":"Це моя історія.","examples":["story, history","Це моя історія."],"atlas_href":"/lexicon/історія/"},{"word":"народитися","translation":"to be born","pos":"verb","example":"Я народився в Канаді.","examples":["to be born","Я народився в Канаді."],"atlas_href":"/lexicon/народитися/"},{"word":"народилася","translation":"was born (feminine)","pos":"verb","example":"Вона народилася у Львові.","examples":["was born (feminine)","Вона народилася у Львові."],"atlas_href":"/lexicon/народилася/"},{"word":"раніше","translation":"earlier, before","pos":"adverb","example":"Раніше я жив у Торонто.","examples":["earlier, before","Раніше я жив у Торонто."],"atlas_href":"/lexicon/раніше/"},{"word":"зараз","translation":"now","pos":"adverb","example":"Зараз я живу в Києві.","examples":["now","Зараз я живу в Києві."],"atlas_href":"/lexicon/зараз/"},{"word":"далі","translation":"next, further","pos":"adverb","example":"Далі я буду вчити українську.","examples":["next, further","Далі я буду вчити українську."],"atlas_href":"/lexicon/далі/"},{"word":"у дитинстві","translation":"in childhood","pos":"phrase","example":"У дитинстві я ходила в школу.","examples":["in childhood","У дитинстві я ходила в школу."],"atlas_href":"/lexicon/у-дитинстві/"},{"word":"жити","translation":"to live","pos":"verb","example":"Я буду жити у Львові.","examples":["to live","Я буду жити у Львові."],"atlas_href":"/lexicon/жити/"},{"word":"жив","translation":"lived (masculine)","pos":"verb","example":"Раніше я жив у Варшаві.","examples":["lived (masculine)","Раніше я жив у Варшаві."],"atlas_href":"/lexicon/жив/"},{"word":"жила","translation":"lived (feminine)","pos":"verb","example":"Раніше я жила в Одесі.","examples":["lived (feminine)","Раніше я жила в Одесі."],"atlas_href":"/lexicon/жила/"},{"word":"переїхати","translation":"to move, relocate","pos":"verb","example":"Потім я переїхав у Київ.","examples":["to move, relocate","Потім я переїхав у Київ."],"atlas_href":"/lexicon/переїхати/"},{"word":"працювати","translation":"to work","pos":"verb","example":"Далі я буду працювати тут.","examples":["to work","Далі я буду працювати тут."],"atlas_href":"/lexicon/працювати/"},{"word":"вивчати","translation":"to study","pos":"verb","example":"Зараз я вивчаю українську.","examples":["to study","Зараз я вивчаю українську."],"atlas_href":"/lexicon/вивчати/"},{"word":"подорожувати","translation":"to travel","pos":"verb","example":"Ми будемо подорожувати Україною.","examples":["to travel","Ми будемо подорожувати Україною."],"atlas_href":"/lexicon/подорожувати/"},{"word":"родина","translation":"family","pos":"noun","example":"Моя родина говорить українською.","examples":["family","Моя родина говорить українською."],"atlas_href":"/lexicon/родина/"},{"word":"щодня","translation":"every day","pos":"adverb","example":"Я буду говорити українською щодня.","examples":["every day","Я буду говорити українською щодня."],"atlas_href":"/lexicon/щодня/"}]`)} title="Vocabulary" />
+<VocabCard client:only="react" words={JSON.parse(`[{"word":"історія","translation":"story, history","pos":"noun","example":"Це моя історія.","examples":["story, history","Це моя історія."],"atlas_href":"/lexicon/історія/"},{"word":"народитися","translation":"to be born","pos":"verb","example":"Я народився в Канаді.","examples":["to be born","Я народився в Канаді."],"atlas_href":"/lexicon/народитися/"},{"word":"народилася","translation":"was born (feminine)","pos":"verb","example":"Вона народилася у Львові.","examples":["was born (feminine)","Вона народилася у Львові."]},{"word":"раніше","translation":"earlier, before","pos":"adverb","example":"Раніше я жив у Торонто.","examples":["earlier, before","Раніше я жив у Торонто."],"atlas_href":"/lexicon/раніше/"},{"word":"зараз","translation":"now","pos":"adverb","example":"Зараз я живу в Києві.","examples":["now","Зараз я живу в Києві."],"atlas_href":"/lexicon/зараз/"},{"word":"далі","translation":"next, further","pos":"adverb","example":"Далі я буду вчити українську.","examples":["next, further","Далі я буду вчити українську."],"atlas_href":"/lexicon/далі/"},{"word":"у дитинстві","translation":"in childhood","pos":"phrase","example":"У дитинстві я ходила в школу.","examples":["in childhood","У дитинстві я ходила в школу."],"atlas_href":"/lexicon/у-дитинстві/"},{"word":"жити","translation":"to live","pos":"verb","example":"Я буду жити у Львові.","examples":["to live","Я буду жити у Львові."],"atlas_href":"/lexicon/жити/"},{"word":"жив","translation":"lived (masculine)","pos":"verb","example":"Раніше я жив у Варшаві.","examples":["lived (masculine)","Раніше я жив у Варшаві."]},{"word":"жила","translation":"lived (feminine)","pos":"verb","example":"Раніше я жила в Одесі.","examples":["lived (feminine)","Раніше я жила в Одесі."],"atlas_href":"/lexicon/жила/"},{"word":"переїхати","translation":"to move, relocate","pos":"verb","example":"Потім я переїхав у Київ.","examples":["to move, relocate","Потім я переїхав у Київ."],"atlas_href":"/lexicon/переїхати/"},{"word":"працювати","translation":"to work","pos":"verb","example":"Далі я буду працювати тут.","examples":["to work","Далі я буду працювати тут."],"atlas_href":"/lexicon/працювати/"},{"word":"вивчати","translation":"to study","pos":"verb","example":"Зараз я вивчаю українську.","examples":["to study","Зараз я вивчаю українську."],"atlas_href":"/lexicon/вивчати/"},{"word":"подорожувати","translation":"to travel","pos":"verb","example":"Ми будемо подорожувати Україною.","examples":["to travel","Ми будемо подорожувати Україною."],"atlas_href":"/lexicon/подорожувати/"},{"word":"родина","translation":"family","pos":"noun","example":"Моя родина говорить українською.","examples":["family","Моя родина говорить українською."],"atlas_href":"/lexicon/родина/"},{"word":"щодня","translation":"every day","pos":"adverb","example":"Я буду говорити українською щодня.","examples":["every day","Я буду говорити українською щодня."],"atlas_href":"/lexicon/щодня/"}]`)} title="Vocabulary" />
 
 <FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"історія","back":"story, history"},{"front":"народитися","back":"to be born"},{"front":"народилася","back":"was born (feminine)"},{"front":"раніше","back":"earlier, before"},{"front":"зараз","back":"now"},{"front":"далі","back":"next, further"},{"front":"у дитинстві","back":"in childhood"},{"front":"жити","back":"to live"},{"front":"жив","back":"lived (masculine)"},{"front":"жила","back":"lived (feminine)"},{"front":"переїхати","back":"to move, relocate"},{"front":"працювати","back":"to work"},{"front":"вивчати","back":"to study"},{"front":"подорожувати","back":"to travel"},{"front":"родина","back":"family"},{"front":"щодня","back":"every day"}]`)} />
 
@@ -322,7 +356,7 @@ and future without leaving A1.
 
 ### Put the life story in order
 
-*(see lesson, §Історія Марії)*
+*(see lesson, §Дідусь розповідає)*
 
 ### Match the tense
 
@@ -351,6 +385,10 @@ and future without leaving A1.
 ### Say your story
 
 <Translate client:only='react' questions={JSON.parse(`[{"source": "Earlier I lived in Toronto.", "options": [{"text": "Раніше я жив у Торонто.", "correct": true}, {"text": "Зараз я живу в Торонто.", "correct": false}, {"text": "Далі я буду жити в Торонто.", "correct": false}], "explanation": "Earlier points to the past."}, {"source": "Now I live in Kyiv.", "options": [{"text": "Зараз я живу в Києві.", "correct": true}, {"text": "Раніше я жив у Києві.", "correct": false}, {"text": "Далі я буду жити в Києві.", "correct": false}], "explanation": "Now points to the present."}, {"source": "Next I will study Ukrainian.", "options": [{"text": "Далі я буду вчити українську.", "correct": true}, {"text": "Далі я вчив українську.", "correct": false}, {"text": "Зараз я вчив українську.", "correct": false}], "explanation": "Use буду + infinitive for the future."}]`)} instruction={"Choose the Ukrainian sentence that matches the English prompt."} isUkrainian={false} />
+
+### Repair the timeline
+
+<ErrorCorrection client:only='react' instruction="Fix the time word and verb so the story stays clear." items={JSON.parse(`[{"sentence": "Раніше я живу в Канаді.", "errorWord": "живу", "correctForm": "жив / жила", "options": [], "explanation": "Раніше points to the past."}, {"sentence": "Зараз я жив у Києві.", "errorWord": "жив", "correctForm": "живу", "options": [], "explanation": "Зараз points to the present."}, {"sentence": "Далі я працював тут.", "errorWord": "працював", "correctForm": "буду працювати", "options": [], "explanation": "Далі points to a future plan."}, {"sentence": "Я буду працюю в офісі.", "errorWord": "працюю", "correctForm": "працювати", "options": [], "explanation": "After буду, use the infinitive працювати."}, {"sentence": "Моє ім'я є Софія.", "errorWord": "Моє ім'я є", "correctForm": "Мене звати", "options": [], "explanation": "Use the familiar A1 name chunk Мене звати."}]`)} isUkrainian={false} />
 
 </TabItem>
 <TabItem label="Resources">


### PR DESCRIPTION
## Summary
- certify A1 M52 `my-story` against the plan-required three-time-frame life-story objectives
- add the missing grandparent life-story scene with `село`, `школа`, `місто`, `лікарня`, `дача`
- mark repair traps with `<bad>` and add a sixth workbook repair activity; regenerate MDX

## Deterministic checks
- `.venv/bin/python scripts/generate_mdx.py l2-uk-en a1 52 --validate`
- `.venv/bin/python scripts/validate_activities.py l2-uk-en a1 52`
- `.venv/bin/python scripts/validate/validate_vocab_yaml.py curriculum/l2-uk-en/a1/my-story/vocabulary.yaml`
- `.venv/bin/python scripts/validate_plan_config.py a1/my-story`
- `.venv/bin/python scripts/lexicon/check_manifest_freshness.py`
- `.venv/bin/python scripts/lexicon/check_manifest_vocabulary_coverage.py --changed-only --base origin/main`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `.venv/bin/python scripts/audit/certify_module.py a1/my-story --clean-qg-artifacts` (post-commit; includes production build, 3115 pages)

## Independent Gemini CLI QG
Artifact: `/var/folders/pd/wvj52r1j3bd4z9y3dfc2k4180000gn/T/m52-gemini-qg-MIFPzP/llm_qg.json`

Scores:
- pedagogical: 10.0
- naturalness: 10.0
- decolonization: 10.0
- engagement: 9.5
- tone: 10.0

Tool notes:
- `gemini-3.1-pro-preview`: quota exhausted
- `gemini-2.5-pro`: quota exhausted
- `gemini-2.5-flash`: server capacity exhausted; stopped after repeated 429/backoff with no JSON
- accepted reviewer/model: `gemini-2.5-flash-lite`
- DeepSeek: not used

## Swarm / telemetry metadata
- swarm_used: false
- swarm_label: none
- swarm_note: solo run; no swarm used
- participants: codex, gemini-cli-direct

## Pre-submit hygiene
- `.python-version`, `.yamllint`, `.markdownlint.json` unchanged
- no `status/*.json`, `audit/*-review.md`, `review/*-review.md`, telemetry DB, or QG artifacts committed
- changed files are scoped to M52 source + generated MDX

X-Agent: codex/a1-m52-my-story-quality
