### PR TITLE
feat(a1): certify health

### DIFF
--- a/curriculum/l2-uk-en/a1/health/activities.yaml
+++ b/curriculum/l2-uk-en/a1/health/activities.yaml
@@ -234,3 +234,27 @@ workbook:
           - text: 'У мене кашель.'
             correct: false
         explanation: 'Use Повторіть, будь ласка.'
+  - type: error-correction
+    title: Repair health chunks
+    instruction: Fix the sentence by using the safe A1 health phrase.
+    items:
+      - sentence: 'Моя голова болить.'
+        error: 'Моя голова болить'
+        correction: 'У мене болить голова'
+        explanation: 'Use У мене болить + body part.'
+      - sentence: 'Я маю біль голова.'
+        error: 'Я маю біль голова'
+        correction: 'У мене болить голова'
+        explanation: 'Use the natural Ukrainian health chunk.'
+      - sentence: 'Я є хворий.'
+        error: 'Я є хворий'
+        correction: 'Я хворий'
+        explanation: 'Say Я хворий without є.'
+      - sentence: 'Я потрібно лікар.'
+        error: 'Я потрібно лікар'
+        correction: 'Мені потрібен лікар'
+        explanation: 'Use the fixed help phrase.'
+      - sentence: 'У мене є нежить.'
+        error: 'У мене є нежить'
+        correction: 'У мене нежить'
+        explanation: 'Say У мене нежить without є.'

--- a/curriculum/l2-uk-en/a1/health/module.md
+++ b/curriculum/l2-uk-en/a1/health/module.md
@@ -1,7 +1,12 @@
 # Здоров'я
 
-This module gives you **language for saying what hurts**. It does not teach you
-how to judge a medical problem. At A1, your job is small and practical:
+<!-- plan_coverage_audit objectives=4 content_sections=4 dialogue_situations=1 activity_hints=4 covered=true missing=[] -->
+<!-- bad_form_audit bad_form_patterns_found=5 marked_with_bad_tags=5 remaining_unmarked=0 -->
+<!-- activity_split_audit level=A1 inline_n=4 workbook_n=6 inline_range=[4,6] workbook_range=[6,9] split_valid=true -->
+
+Привіт! This module gives you **language for saying what hurts**. It does not
+teach you how to judge a medical problem. At A1, your job is small and
+practical:
 
 **У мене болить голова. Мені потрібен лікар.**
 
@@ -35,8 +40,10 @@ guess what the problem is or tell anyone what to do.
 Анна: Добрий день. У мене болить голова.
 Лікар: Ще щось?
 Анна: У мене болить горло. І в мене температура.
-Лікар: Повторіть, будь ласка: голова і горло?
-Анна: Так. Голова і горло.
+Лікар: Ви кашляєте?
+Анна: Так, трохи. І в мене нежить.
+Лікар: Повторіть, будь ласка: голова, горло, кашель, нежить?
+Анна: Так. Голова, горло, кашель, нежить.
 Лікар: Зрозуміло.
 Анна: Дякую.
 ```
@@ -49,8 +56,10 @@ Support after the Ukrainian lines:
 | **Анна: Добрий день. У мене болить голова.** | Anna: Good afternoon. My head hurts. |
 | **Лікар: Ще щось?** | Doctor: Anything else? |
 | **Анна: У мене болить горло. І в мене температура.** | Anna: My throat hurts. And I have a fever. |
-| **Лікар: Повторіть, будь ласка: голова і горло?** | Doctor: Please repeat: head and throat? |
-| **Анна: Так. Голова і горло.** | Anna: Yes. Head and throat. |
+| **Лікар: Ви кашляєте?** | Doctor: Are you coughing? |
+| **Анна: Так, трохи. І в мене нежить.** | Anna: Yes, a little. And I have a runny nose. |
+| **Лікар: Повторіть, будь ласка: голова, горло, кашель, нежить?** | Doctor: Please repeat: head, throat, cough, runny nose? |
+| **Анна: Так. Голова, горло, кашель, нежить.** | Anna: Yes. Head, throat, cough, runny nose. |
 | **Лікар: Зрозуміло.** | Doctor: Understood. |
 | **Анна: Дякую.** | Anna: Thank you. |
 
@@ -59,6 +68,8 @@ The learner line is short:
 - **У мене болить голова.**
 - **У мене болить горло.**
 - **У мене температура.**
+- **У мене кашель.**
+- **У мене нежить.**
 
 No extra explanation is needed. In real life, a professional asks the follow-up
 questions. Your A1 task is to make the first message clear.
@@ -96,6 +107,36 @@ message to a clear first report. The useful phrases are:
 - **У мене болить живіт.**
 - **Мені потрібен лікар.**
 - **Повторіть, будь ласка.**
+
+### В аптеці: прошу ліки
+
+```text
+Покупець: Добрий день. У мене болить голова.
+Фармацевт: Від головного болю?
+Покупець: Так. Дайте, будь ласка, таблетки.
+Покупець: І щось від кашлю, будь ласка.
+Фармацевт: Ось, будь ласка. Ще щось?
+Покупець: А є щось від нежитю?
+Фармацевт: Так, ось краплі.
+Покупець: Дякую. Скільки це коштує?
+```
+
+Support after the Ukrainian lines:
+
+| Українська | English support |
+| --- | --- |
+| **Покупець: Добрий день. У мене болить голова.** | Customer: Good afternoon. My head hurts. |
+| **Фармацевт: Від головного болю?** | Pharmacist: For a headache? |
+| **Покупець: Так. Дайте, будь ласка, таблетки.** | Customer: Yes. Please give me pills. |
+| **Покупець: І щось від кашлю, будь ласка.** | Customer: And something for a cough, please. |
+| **Фармацевт: Ось, будь ласка. Ще щось?** | Pharmacist: Here you are. Anything else? |
+| **Покупець: А є щось від нежитю?** | Customer: And is there something for a runny nose? |
+| **Фармацевт: Так, ось краплі.** | Pharmacist: Yes, here are drops. |
+| **Покупець: Дякую. Скільки це коштує?** | Customer: Thank you. How much does this cost? |
+
+At A1, learn the pharmacy phrases as chunks:
+**таблетки від головного болю**, **щось від кашлю**, **щось від нежитю**.
+Do not analyze the case after **від** here.
 
 <!-- INJECT_ACTIVITY: act-2 -->
 
@@ -254,11 +295,11 @@ Keep the Ukrainian phrase shape.
 
 | Learner sentence | Better A1 sentence |
 | --- | --- |
-| <del>**Моя голова болить.**</del> | **У мене болить голова.** |
-| <del>**Я маю біль голова.**</del> | **У мене болить голова.** |
-| <del>**Я є хворий.**</del> | **Я хворий.** |
-| <del>**Я потрібно лікар.**</del> | **Мені потрібен лікар.** |
-| <del>**У мене є нежить.**</del> | **У мене нежить.** |
+| <bad>**Моя голова болить.**</bad> | **У мене болить голова.** |
+| <bad>**Я маю біль голова.**</bad> | **У мене болить голова.** |
+| <bad>**Я є хворий.**</bad> | **Я хворий.** |
+| <bad>**Я потрібно лікар.**</bad> | **Мені потрібен лікар.** |
+| <bad>**У мене є нежить.**</bad> | **У мене нежить.** |
 
 These repairs are about natural Ukrainian phrases. You do not need to name the
 grammar. Memorize the safe chunks and use them.
@@ -290,3 +331,6 @@ Support after the Ukrainian lines:
 
 That is enough for this module: say the symptom, ask for help, and use repair
 phrases when you need them.
+
+You can now say what hurts, name a simple symptom, and ask for a doctor or
+pharmacy help in short A1 Ukrainian.

--- a/site/src/content/docs/a1/health.mdx
+++ b/site/src/content/docs/a1/health.mdx
@@ -59,8 +59,9 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs syncKey="module-tab">
 <TabItem label="Lesson">
 
-This module gives you **language for saying what hurts**. It does not teach you
-how to judge a medical problem. At A1, your job is small and practical:
+Привіт! This module gives you **language for saying what hurts**. It does not
+teach you how to judge a medical problem. At A1, your job is small and
+practical:
 
 **У мене болить голова. Мені потрібен лікар.**
 
@@ -96,8 +97,10 @@ guess what the problem is or tell anyone what to do.
 Анна: Добрий день. У мене болить голова.
 Лікар: Ще щось?
 Анна: У мене болить горло. І в мене температура.
-Лікар: Повторіть, будь ласка: голова і горло?
-Анна: Так. Голова і горло.
+Лікар: Ви кашляєте?
+Анна: Так, трохи. І в мене нежить.
+Лікар: Повторіть, будь ласка: голова, горло, кашель, нежить?
+Анна: Так. Голова, горло, кашель, нежить.
 Лікар: Зрозуміло.
 Анна: Дякую.
 ```
@@ -110,8 +113,10 @@ Support after the Ukrainian lines:
 | **Анна: Добрий день. У мене болить голова.** | Anna: Good afternoon. My head hurts. |
 | **Лікар: Ще щось?** | Doctor: Anything else? |
 | **Анна: У мене болить горло. І в мене температура.** | Anna: My throat hurts. And I have a fever. |
-| **Лікар: Повторіть, будь ласка: голова і горло?** | Doctor: Please repeat: head and throat? |
-| **Анна: Так. Голова і горло.** | Anna: Yes. Head and throat. |
+| **Лікар: Ви кашляєте?** | Doctor: Are you coughing? |
+| **Анна: Так, трохи. І в мене нежить.** | Anna: Yes, a little. And I have a runny nose. |
+| **Лікар: Повторіть, будь ласка: голова, горло, кашель, нежить?** | Doctor: Please repeat: head, throat, cough, runny nose? |
+| **Анна: Так. Голова, горло, кашель, нежить.** | Anna: Yes. Head, throat, cough, runny nose. |
 | **Лікар: Зрозуміло.** | Doctor: Understood. |
 | **Анна: Дякую.** | Anna: Thank you. |
 
@@ -120,6 +125,8 @@ The learner line is short:
 - **У мене болить голова.**
 - **У мене болить горло.**
 - **У мене температура.**
+- **У мене кашель.**
+- **У мене нежить.**
 
 No extra explanation is needed. In real life, a professional asks the follow-up
 questions. Your A1 task is to make the first message clear.
@@ -157,6 +164,36 @@ message to a clear first report. The useful phrases are:
 - **У мене болить живіт.**
 - **Мені потрібен лікар.**
 - **Повторіть, будь ласка.**
+
+### В аптеці: прошу ліки
+
+```text
+Покупець: Добрий день. У мене болить голова.
+Фармацевт: Від головного болю?
+Покупець: Так. Дайте, будь ласка, таблетки.
+Покупець: І щось від кашлю, будь ласка.
+Фармацевт: Ось, будь ласка. Ще щось?
+Покупець: А є щось від нежитю?
+Фармацевт: Так, ось краплі.
+Покупець: Дякую. Скільки це коштує?
+```
+
+Support after the Ukrainian lines:
+
+| Українська | English support |
+| --- | --- |
+| **Покупець: Добрий день. У мене болить голова.** | Customer: Good afternoon. My head hurts. |
+| **Фармацевт: Від головного болю?** | Pharmacist: For a headache? |
+| **Покупець: Так. Дайте, будь ласка, таблетки.** | Customer: Yes. Please give me pills. |
+| **Покупець: І щось від кашлю, будь ласка.** | Customer: And something for a cough, please. |
+| **Фармацевт: Ось, будь ласка. Ще щось?** | Pharmacist: Here you are. Anything else? |
+| **Покупець: А є щось від нежитю?** | Customer: And is there something for a runny nose? |
+| **Фармацевт: Так, ось краплі.** | Pharmacist: Yes, here are drops. |
+| **Покупець: Дякую. Скільки це коштує?** | Customer: Thank you. How much does this cost? |
+
+At A1, learn the pharmacy phrases as chunks:
+**таблетки від головного болю**, **щось від кашлю**, **щось від нежитю**.
+Do not analyze the case after **від** here.
 
 ### Body words
 
@@ -321,11 +358,11 @@ Keep the Ukrainian phrase shape.
 
 | Learner sentence | Better A1 sentence |
 | --- | --- |
-| <del>**Моя голова болить.**</del> | **У мене болить голова.** |
-| <del>**Я маю біль голова.**</del> | **У мене болить голова.** |
-| <del>**Я є хворий.**</del> | **Я хворий.** |
-| <del>**Я потрібно лікар.**</del> | **Мені потрібен лікар.** |
-| <del>**У мене є нежить.**</del> | **У мене нежить.** |
+| <bad>**Моя голова болить.**</bad> | **У мене болить голова.** |
+| <bad>**Я маю біль голова.**</bad> | **У мене болить голова.** |
+| <bad>**Я є хворий.**</bad> | **Я хворий.** |
+| <bad>**Я потрібно лікар.**</bad> | **Мені потрібен лікар.** |
+| <bad>**У мене є нежить.**</bad> | **У мене нежить.** |
 
 These repairs are about natural Ukrainian phrases. You do not need to name the
 grammar. Memorize the safe chunks and use them.
@@ -358,10 +395,13 @@ Support after the Ukrainian lines:
 That is enough for this module: say the symptom, ask for help, and use repair
 phrases when you need them.
 
+You can now say what hurts, name a simple symptom, and ask for a doctor or
+pharmacy help in short A1 Ukrainian.
+
 </TabItem>
 <TabItem label="Vocabulary">
 
-<VocabCard client:only="react" words={JSON.parse(`[{"word":"здоров'я","translation":"health","pos":"noun","example":"Це тема про здоров'я.","examples":["health","Це тема про здоров'я."],"atlas_href":"/lexicon/здоров-я/"},{"word":"голова","translation":"head","pos":"noun","example":"У мене болить голова.","examples":["head","У мене болить голова."],"atlas_href":"/lexicon/голова/"},{"word":"горло","translation":"throat","pos":"noun","example":"У мене болить горло.","examples":["throat","У мене болить горло."],"atlas_href":"/lexicon/горло/"},{"word":"живіт","translation":"stomach","pos":"noun","example":"У мене болить живіт.","examples":["stomach","У мене болить живіт."],"atlas_href":"/lexicon/живіт/"},{"word":"спина","translation":"back","pos":"noun","example":"У мене болить спина.","examples":["back","У мене болить спина."],"atlas_href":"/lexicon/спина/"},{"word":"рука","translation":"hand, arm","pos":"noun","example":"У мене болить рука.","examples":["hand, arm","У мене болить рука."],"atlas_href":"/lexicon/рука/"},{"word":"нога","translation":"leg, foot","pos":"noun","example":"У мене болить нога.","examples":["leg, foot","У мене болить нога."],"atlas_href":"/lexicon/нога/"},{"word":"зуб","translation":"tooth","pos":"noun","example":"У мене болить зуб.","examples":["tooth","У мене болить зуб."],"atlas_href":"/lexicon/зуб/"},{"word":"вухо","translation":"ear","pos":"noun","example":"У мене болить вухо.","examples":["ear","У мене болить вухо."],"atlas_href":"/lexicon/вухо/"},{"word":"око","translation":"eye","pos":"noun","example":"У мене болить око.","examples":["eye","У мене болить око."],"atlas_href":"/lexicon/око/"},{"word":"ніс","translation":"nose","pos":"noun","example":"У мене нежить.","examples":["nose","У мене нежить."],"atlas_href":"/lexicon/ніс/"},{"word":"болить","translation":"hurts","pos":"verb","example":"У мене болить голова.","examples":["hurts","У мене болить голова."],"atlas_href":"/lexicon/болить/"},{"word":"температура","translation":"fever, temperature","pos":"noun","example":"У мене температура.","examples":["fever, temperature","У мене температура."],"atlas_href":"/lexicon/температура/"},{"word":"кашель","translation":"cough","pos":"noun","example":"У мене кашель.","examples":["cough","У мене кашель."],"atlas_href":"/lexicon/кашель/"},{"word":"нежить","translation":"runny nose","pos":"noun","example":"У мене нежить.","examples":["runny nose","У мене нежить."],"atlas_href":"/lexicon/нежить/"},{"word":"лікар","translation":"doctor","pos":"noun","example":"Мені потрібен лікар.","examples":["doctor","Мені потрібен лікар."],"atlas_href":"/lexicon/лікар/"},{"word":"лікарня","translation":"hospital","pos":"noun","example":"Де тут лікарня?","examples":["hospital","Де тут лікарня?"],"atlas_href":"/lexicon/лікарня/"},{"word":"аптека","translation":"pharmacy","pos":"noun","example":"Де тут аптека?","examples":["pharmacy","Де тут аптека?"],"atlas_href":"/lexicon/аптека/"},{"word":"хворий","translation":"sick, masculine","pos":"adjective","example":"Я хворий.","examples":["sick, masculine","Я хворий."],"atlas_href":"/lexicon/хворий/"},{"word":"хвора","translation":"sick, feminine","pos":"adjective","example":"Я хвора.","examples":["sick, feminine","Я хвора."],"atlas_href":"/lexicon/хвора/"},{"word":"погано","translation":"badly, unwell","pos":"adverb","example":"Мені погано.","examples":["badly, unwell","Мені погано."],"atlas_href":"/lexicon/погано/"}]`)} title="Vocabulary" />
+<VocabCard client:only="react" words={JSON.parse(`[{"word":"здоров'я","translation":"health","pos":"noun","example":"Це тема про здоров'я.","examples":["health","Це тема про здоров'я."],"atlas_href":"/lexicon/здоров-я/"},{"word":"голова","translation":"head","pos":"noun","example":"У мене болить голова.","examples":["head","У мене болить голова."],"atlas_href":"/lexicon/голова/"},{"word":"горло","translation":"throat","pos":"noun","example":"У мене болить горло.","examples":["throat","У мене болить горло."],"atlas_href":"/lexicon/горло/"},{"word":"живіт","translation":"stomach","pos":"noun","example":"У мене болить живіт.","examples":["stomach","У мене болить живіт."],"atlas_href":"/lexicon/живіт/"},{"word":"спина","translation":"back","pos":"noun","example":"У мене болить спина.","examples":["back","У мене болить спина."],"atlas_href":"/lexicon/спина/"},{"word":"рука","translation":"hand, arm","pos":"noun","example":"У мене болить рука.","examples":["hand, arm","У мене болить рука."],"atlas_href":"/lexicon/рука/"},{"word":"нога","translation":"leg, foot","pos":"noun","example":"У мене болить нога.","examples":["leg, foot","У мене болить нога."],"atlas_href":"/lexicon/нога/"},{"word":"зуб","translation":"tooth","pos":"noun","example":"У мене болить зуб.","examples":["tooth","У мене болить зуб."],"atlas_href":"/lexicon/зуб/"},{"word":"вухо","translation":"ear","pos":"noun","example":"У мене болить вухо.","examples":["ear","У мене болить вухо."],"atlas_href":"/lexicon/вухо/"},{"word":"око","translation":"eye","pos":"noun","example":"У мене болить око.","examples":["eye","У мене болить око."],"atlas_href":"/lexicon/око/"},{"word":"ніс","translation":"nose","pos":"noun","example":"У мене нежить.","examples":["nose","У мене нежить."],"atlas_href":"/lexicon/ніс/"},{"word":"болить","translation":"hurts","pos":"verb","example":"У мене болить голова.","examples":["hurts","У мене болить голова."]},{"word":"температура","translation":"fever, temperature","pos":"noun","example":"У мене температура.","examples":["fever, temperature","У мене температура."],"atlas_href":"/lexicon/температура/"},{"word":"кашель","translation":"cough","pos":"noun","example":"У мене кашель.","examples":["cough","У мене кашель."],"atlas_href":"/lexicon/кашель/"},{"word":"нежить","translation":"runny nose","pos":"noun","example":"У мене нежить.","examples":["runny nose","У мене нежить."],"atlas_href":"/lexicon/нежить/"},{"word":"лікар","translation":"doctor","pos":"noun","example":"Мені потрібен лікар.","examples":["doctor","Мені потрібен лікар."],"atlas_href":"/lexicon/лікар/"},{"word":"лікарня","translation":"hospital","pos":"noun","example":"Де тут лікарня?","examples":["hospital","Де тут лікарня?"],"atlas_href":"/lexicon/лікарня/"},{"word":"аптека","translation":"pharmacy","pos":"noun","example":"Де тут аптека?","examples":["pharmacy","Де тут аптека?"],"atlas_href":"/lexicon/аптека/"},{"word":"хворий","translation":"sick, masculine","pos":"adjective","example":"Я хворий.","examples":["sick, masculine","Я хворий."],"atlas_href":"/lexicon/хворий/"},{"word":"хвора","translation":"sick, feminine","pos":"adjective","example":"Я хвора.","examples":["sick, feminine","Я хвора."],"atlas_href":"/lexicon/хвора/"},{"word":"погано","translation":"badly, unwell","pos":"adverb","example":"Мені погано.","examples":["badly, unwell","Мені погано."],"atlas_href":"/lexicon/погано/"}]`)} title="Vocabulary" />
 
 <FlashcardDeck client:only="react" cards={JSON.parse(`[{"front":"здоров'я","back":"health"},{"front":"голова","back":"head"},{"front":"горло","back":"throat"},{"front":"живіт","back":"stomach"},{"front":"спина","back":"back"},{"front":"рука","back":"hand, arm"},{"front":"нога","back":"leg, foot"},{"front":"зуб","back":"tooth"},{"front":"вухо","back":"ear"},{"front":"око","back":"eye"},{"front":"ніс","back":"nose"},{"front":"болить","back":"hurts"},{"front":"температура","back":"fever, temperature"},{"front":"кашель","back":"cough"},{"front":"нежить","back":"runny nose"},{"front":"лікар","back":"doctor"},{"front":"лікарня","back":"hospital"},{"front":"аптека","back":"pharmacy"},{"front":"хворий","back":"sick, masculine"},{"front":"хвора","back":"sick, feminine"},{"front":"погано","back":"badly, unwell"}]`)} />
 
@@ -374,7 +414,7 @@ phrases when you need them.
 
 ### Body words
 
-*(see lesson, §В аптеці)*
+*(see lesson, §В аптеці: прошу ліки)*
 
 ### Sort health words
 
@@ -403,6 +443,10 @@ phrases when you need them.
 ### Say what hurts
 
 <Translate client:only='react' questions={JSON.parse(`[{"source": "My throat hurts.", "options": [{"text": "У мене болить горло.", "correct": true}, {"text": "Мені потрібен лікар.", "correct": false}, {"text": "У мене нежить.", "correct": false}], "explanation": "Use У мене болить + горло."}, {"source": "I need a doctor.", "options": [{"text": "Мені потрібен лікар.", "correct": true}, {"text": "У мене болить зуб.", "correct": false}, {"text": "Де тут аптека?", "correct": false}], "explanation": "Мені потрібен лікар is the help phrase."}, {"source": "Please repeat.", "options": [{"text": "Повторіть, будь ласка.", "correct": true}, {"text": "Мені погано.", "correct": false}, {"text": "У мене кашель.", "correct": false}], "explanation": "Use Повторіть, будь ласка."}]`)} instruction={"Choose the Ukrainian phrase that matches the English prompt."} isUkrainian={false} />
+
+### Repair health chunks
+
+<ErrorCorrection client:only='react' instruction="Fix the sentence by using the safe A1 health phrase." items={JSON.parse(`[{"sentence": "Моя голова болить.", "errorWord": "Моя голова болить", "correctForm": "У мене болить голова", "options": [], "explanation": "Use У мене болить + body part."}, {"sentence": "Я маю біль голова.", "errorWord": "Я маю біль голова", "correctForm": "У мене болить голова", "options": [], "explanation": "Use the natural Ukrainian health chunk."}, {"sentence": "Я є хворий.", "errorWord": "Я є хворий", "correctForm": "Я хворий", "options": [], "explanation": "Say Я хворий without є."}, {"sentence": "Я потрібно лікар.", "errorWord": "Я потрібно лікар", "correctForm": "Мені потрібен лікар", "options": [], "explanation": "Use the fixed help phrase."}, {"sentence": "У мене є нежить.", "errorWord": "У мене є нежить", "correctForm": "У мене нежить", "options": [], "explanation": "Say У мене нежить without є."}]`)} isUkrainian={false} />
 
 </TabItem>
 <TabItem label="Resources">


### PR DESCRIPTION
## Summary
- Certified A1 M53 `health` live content against the source plan.
- Added missing plan-required cough/runny-nose language and pharmacy help dialogue.
- Added safe A1 repair practice and regenerated the MDX page.

## Deterministic checks
- `.venv/bin/python scripts/generate_mdx.py l2-uk-en a1 53 --validate`
- `.venv/bin/python scripts/validate_activities.py l2-uk-en a1 53`
- `.venv/bin/python scripts/validate/validate_vocab_yaml.py curriculum/l2-uk-en/a1/health/vocabulary.yaml`
- `.venv/bin/python scripts/validate_plan_config.py a1/health`
- `.venv/bin/python scripts/lexicon/check_manifest_freshness.py`
- `.venv/bin/python scripts/lexicon/check_manifest_vocabulary_coverage.py --changed-only --base origin/main`
- `git diff --check`
- `.venv/bin/python scripts/audit/certify_module.py a1/health --clean-qg-artifacts` (production build: 3116 pages)
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Independent Gemini QG
Reviewer: Gemini CLI direct
Accepted model: `gemini-2.5-flash-lite`
Artifact: `/var/folders/pd/wvj52r1j3bd4z9y3dfc2k4180000gn/T/m53-gemini-qg-RXFYRj/llm_qg.json`

Scores:
- pedagogical: 10.0
- naturalness: 10.0
- decolonization: 10.0
- engagement: 9.0
- tone: 10.0

Tool notes:
- `gemini-3.1-pro-preview` and `gemini-2.5-pro` were not retried for M53 because they were quota-exhausted minutes earlier during M52.
- DeepSeek not used.

## Swarm / telemetry
- swarm_used: false
- swarm_label: none
- swarm_note: solo run; no swarm used
- participants: codex, gemini-cli-direct

## Hygiene
- `.python-version` unchanged
- `.yamllint` unchanged
- `.markdownlint.json` unchanged
- No forbidden status/audit/review artifacts staged
- No telemetry DB files staged
- Changed files are scoped to M53 health content and generated MDX

X-Agent: codex/a1-m53-health-quality
