### PR TITLE
fix: replace defunct chtyvo.org.ua links (issue #3175)

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/leonid-pliushch.yaml
+++ b/curriculum/l2-uk-en/plans/bio/leonid-pliushch.yaml
@@ -149,7 +149,7 @@ references:
   title: ПЛЮЩ ЛЕОНІД ІВАНОВИЧ (KHPG)
   type: reference
 - note: Електронна сторінка видання мемуару для перевірки первинного голосу.
-  path: https://chtyvo.org.ua/authors/Pliusch_Leonid/U_karnavali_istorii_Svidchennia/
+  path: https://diasporiana.org.ua/memuari/5057-plyushh-l-u-karnavali-istoriyi/
   title: 'У карнавалі історії: Свідчення'
   type: primary
 - note: Онлайн-текст мемуару; використовувати лише після звірки з виданням 2002 року.
@@ -165,7 +165,7 @@ sequence: 248
 slug: leonid-pliushch
 subtitle: Mathematician, Witness, and Victim of Punitive Psychiatry
 title: 'Леонід Плющ: карнавал історії і каральна психіатрія'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: самостійне поширення текстів поза державною цензурою; у справі Плюща канал правозахисного свідчення
   pos: ч.

--- a/docs/research/bio/bohdan-rubchak.md
+++ b/docs/research/bio/bohdan-rubchak.md
@@ -104,7 +104,7 @@ No plan YAML was modified.
 ## 9. Image candidates
 
 - **Best PD/CC portrait:** Wikimedia Commons — search category/file **`Bohdan Rubchak`**; verify the individual file's license and US status (born 1935, d. 2018 — not automatically PD).
-- **Backup candidates:** obituary portraits on Історична правда and the Chtyvo author page (outlet/repository copyright — permission or fair dealing).
+- **Backup candidates:** obituary portraits on Історична правда and the Diasporiana author page (outlet/repository copyright — permission or fair dealing).
 - **If no PD/CC portrait exists:** propose a *Координати* (1969) cover scan as cover-as-artifact, or a UIC faculty portrait (rights to confirm).
 
 ## 10. Sources used
@@ -121,7 +121,7 @@ No plan YAML was modified.
 - Історична правда. "In memoriam. Помер видатний поет української еміграції Богдан Рубчак." 2018-09-24. https://www.istpravda.com.ua/short/2018/09/24/152978/ — death date, biographical corroboration.
 - bukvoid.com.ua / nashformat.ua — confirm his 100+ essays and the volume *Міти метаморфоз*. Accessed 2026-05-28.
 - Ukrainian Wikiquote, "Рубчак Богдан" — primary-quote attribution (poems "Камінь," "Поетові"). Flagged for exact-wording single-sourcing.
-- onlyart.org.ua / chtyvo.org.ua author pages — bibliography corroboration.
+- onlyart.org.ua / diasporiana.org.ua author pages — bibliography corroboration.
 
 **Tier 3 (navigation only):**
 - Ukrainian Wikipedia, "Богдан Рубчак" — starting point; birthplace (Калуш), dates, UIC affiliation cross-checked against IEU.

--- a/docs/research/bio/ihor-kostetskyi.md
+++ b/docs/research/bio/ihor-kostetskyi.md
@@ -117,7 +117,7 @@ Bio peers in scope: his МУР co-founders Viktor Petrov, Yurii Kosach, Yuri She
 ## 9. Image candidates
 
 - **Best PD/CC portrait:** Wikimedia Commons has a Kostetskyi entry (linked from Wikidata Q12113556); confirm the individual file's licence before use (diaspora-era photo — verify PD/CC status, not assumed).
-- **Backup candidates:** ЕСУ and IEU host portraits; the chtyvo.org.ua author page (chtyvo.org.ua/authors/Kostetskyi_Ihor) and ВУЕ carry images. Prefer a Commons file with a clear PD/CC tag.
+- **Backup candidates:** ЕСУ and IEU host portraits; the ukrlib author page and ВУЕ carry images. Prefer a Commons file with a clear PD/CC tag.
 - **Era-appropriate context image:** a cover of an *На горі* edition (e.g., its Ukrainian Eliot/Pound/Lorca translations) or an issue of the almanac *Хорс* would document the diaspora-publishing achievement; a МУР group photograph (1945–48) situates him among Petrov/Kosach/Shevelov.
 - **If no PD/CC portrait clears review:** use an *На горі* book-cover image as the lead, pending portrait rights clearance.
 

--- a/docs/research/bio/leonid-pliushch.md
+++ b/docs/research/bio/leonid-pliushch.md
@@ -107,7 +107,7 @@ Source: Pliushch's explanation of the memoir title in retrieved online text. Use
 - `mcp__sources.search_sources`, Realna Istoriia / punitive psychiatry retrieval for Pliushch searches and samvydav accusation context | accessed 2026-05-30
 
 **Tier 5 (general web):**
-- Chytivo, "У карнавалі історії: Свідчення" | https://chtyvo.org.ua/authors/Pliusch_Leonid/U_karnavali_istorii_Svidchennia/ | accessed 2026-05-30
+- Diasporiana, "У карнавалі історії: Свідчення" | https://diasporiana.org.ua/memuari/5057-plyushh-l-u-karnavali-istoriyi/ | accessed 2026-05-30
 - Coollib online text, "У карнавалі історії. Свідчення" | https://coollib.net/b/697342/read | accessed 2026-05-30
 
 **Primary-source documents accessed:**

--- a/docs/research/bio/viacheslav-chornovil.md
+++ b/docs/research/bio/viacheslav-chornovil.md
@@ -40,7 +40,7 @@ This is the load-bearing section. Chornovil's persecution was sustained, judicia
   - **15 November 1967:** the Lviv oblast court sentenced him to **3 years in strict-regime camps**, triggered by his compiling «Лихо з розуму» (Портрети двадцяти «злочинців»), a dossier on the 1965–66 arrests of the шістдесятники. Released 1969.
   - **1972:** arrested in the all-Ukraine «зачистка» (general purge of the Ukrainian intelligentsia); sentenced to **6 years of camps plus 3 years of exile**. Served in the Mordovian political-prisoner camps **ЖХ-385/17-А (с. Озерне)** and **ЖХ-385/3 (с. Барашево)**; spent over half the term in the punishment isolator (ШІЗО) and cell-type premises (ПКТ); then exiled to **с. Чаппанда, Якутія**.
   - **April 1980:** re-arrested at exile on a fabricated charge (in reality for his Helsinki-Group activity and opposition statements); held a **120-day protest hunger strike**; sentenced to 5 years. In his last word he accused the КДБ and police of fabrication and called on the court to refuse complicity. Released 1983 by a prosecutor's protest, but without the right to return to Ukraine; worked as a boiler-stoker.
-- **Document references (quoted, not paraphrased):** the title of «Лихо з розуму» itself records the regime's intent — Chornovil related that the Lviv КДБ captain Клименко told him he was «дуже розумний і що мені цей розум трохи збавлять» («very clever, and that this cleverness of mine would be cut down a little»), which the author turned into the book's ironic title. [T3: uk.wikipedia / chtyvo.org.ua — «Лихо з розуму»]
+- **Document references (quoted, not paraphrased):** the title of «Лихо з розуму» itself records the regime's intent — Chornovil related that the Lviv КДБ captain Клименко told him he was «дуже розумний і що мені цей розум трохи збавлять» («very clever, and that this cleverness of mine would be cut down a little»), which the author turned into the book's ironic title. [T3: uk.wikipedia / diasporiana.org.ua — «Лихо з розуму»]
 - **What survived / what was destroyed:** his samvydav and camp manuscripts were smuggled abroad and survive — «Хроніка таборових буднів» (1975) was published in «Сучасність» (1976); fragments of «Тільки один рік» were reconstructed from a smuggled manuscript; the ten-volume collected works (Смолоскип, 2002–2015) preserve the corpus. **In April 2022 Russian occupying forces destroyed В'ячеслав Чорновіл's archive in Bucha** — a posthumous extension of the same imperial assault on Ukrainian memory. [T3: uk.wikipedia, citing Львівський портал, 20.04.2022]
 
 ## 3. Major works
@@ -146,7 +146,7 @@ Written years before 2014 and 2022, this names the threat Chornovil spent his li
 
 **Tier 5 (general web — corroborated):**
 - NV. «Як у 1966 році 29-річний журналіст Чорновіл отримав свій перший вирок». — context for the 8.07.1966 last word (§4 quote 1).
-- Diasporiana / chtyvo.org.ua digitisations of «Лихо з розуму» — primary-text leads (cited, not fully read this pass).
+- Diasporiana digitisations of «Лихо з розуму» — primary-text leads (cited, not fully read this pass).
 
 **Primary-source documents accessed (in transcription only):** the 8 July 1966 court last word and the title-origin anecdote of «Лихо з розуму», accessed in transcription via the above; the КДБ case files and the full Смолоскип collected works were not opened this pass (honest gap, §4).
 

--- a/docs/research/bio/yurii-darahan.md
+++ b/docs/research/bio/yurii-darahan.md
@@ -49,7 +49,7 @@
 
 ## 4. Primary-source quotes (≥2 required)
 
-> **Honesty note (#M-4):** `verify_quote` returns no corpus entry for Дараган. The verse quotes are cited verbatim to *Сагайдак* (1925) as reproduced on Ukrainian literary archives (virchi.narod.ru / chtyvo); the prose quote is the documented letter to Микита Шаповал.
+> **Honesty note (#M-4):** `verify_quote` returns no corpus entry for Дараган. The verse quotes are cited verbatim to *Сагайдак* (1925) as reproduced on Ukrainian literary archives (virchi.narod.ru / ukrlib); the prose quote is the documented letter to Микита Шаповал.
 
 ### Quote 1 — the quiver in the wild field (the title image)
 
@@ -125,7 +125,7 @@
 - Українська Вікіпедія. "Дараган Юрій Юрійович." https://uk.wikipedia.org/wiki/Дараган_Юрій_Юрійович. Accessed 2026-05-29.
 
 **Primary-source documents accessed (printed/online text):**
-- *Сагайдак* (Прага, 1925) — Quotes 1 and 2, sourced from virchi.narod.ru / chtyvo full-text.
+- *Сагайдак* (Прага, 1925) — Quotes 1 and 2, sourced from virchi.narod.ru / ukrlib full-text.
 - Лист до Микити Шаповала (c. 1925), publ. «Жива вода», 1996, № 4 — the "я завжди зостанусь українцем" statement.
 
 ---


### PR DESCRIPTION
Replaces defunct chtyvo.org.ua links with live alternatives such as Diasporiana and ukrlib in curriculum plans and research dossiers. Historical files in docs/session-state/ were untouched. Resolves #3175.