### PR TITLE
fix(lexicon): render inflected forms as canonical form-of cards

### DIFF
--- a/scripts/lexicon/build_data_manifest.py
+++ b/scripts/lexicon/build_data_manifest.py
@@ -266,6 +266,7 @@ _SOURCE_PRIORITY = {
     "built_vocabulary": 0,
     "built_vocabulary_normalized": 1,
     "built_vocabulary_canonicalized": 1,
+    "built_vocabulary_form": 1,
     "surzhyk_to_avoid": 1,
     "heritage_status_seed": 2,
 }
@@ -298,7 +299,7 @@ def _append_normalization(entry: dict, normalization: dict[str, str] | None) -> 
         normalizations.append(normalization)
 
 
-def _atlas_record_for_manifest(rec: dict, taught_lemma_keys: set[str]) -> dict | None:
+def _atlas_record_for_manifest(rec: dict, taught_lemma_keys: set[str]) -> dict | list[dict] | None:
     """Normalize course surfaces to Atlas lemma heads, or omit non-lemmas."""
     display_lemma = str(rec["lemma"])
     key = _lemma_key(display_lemma)
@@ -333,25 +334,12 @@ def _atlas_record_for_manifest(rec: dict, taught_lemma_keys: set[str]) -> dict |
         )
         return canonicalized
 
-    # Auto-generated VESUM aliasing: fold an inflected form into its lemma. The committed map
-    # is the authority — it is pre-gated by generate_vesum_aliases (unambiguous single VESUM
-    # lemma, OR homograph resolved to its sole taught candidate; form != lemma; functional
-    # interjections excluded). Folding to a lemma NOT yet taught CREATES that lemma page via
-    # _merge_lemma_records (tranche 2 "create-page" cases, e.g. вареники→вареник).
+    # Auto-generated VESUM aliasing: fold an inflected form into its lemma.
     alias_target = VESUM_INFLECTION_ALIASES_BY_KEY.get(key)
     if alias_target:
         aliased = dict(rec)
         aliased["lemma"] = alias_target
         aliased["source"] = "built_vocabulary_normalized"
-        # A create-case (target lemma taught NOWHERE else) materializes a NEW lemma page whose
-        # head IS this record. The surface form's gloss/pos describe the inflected surface —
-        # e.g. заходьте is imperative "come in, polite/plural"; восьма is the feminine ordinal /
-        # "eight o'clock" — and would mislabel the citation-form lemma head (заходити = verb
-        # infinitive; восьмий = masc. ordinal). Do NOT assert them on the new lemma: the
-        # enrichment pass supplies the lemma's own meaning and the renderer degrades gracefully
-        # on null gloss/pos. Surface values are preserved in the provenance reason. (A plain
-        # fold into an ALREADY-TAUGHT lemma keeps its fields — it merges into the taught head,
-        # whose own gloss/pos win, so the surface values are harmless there.)
         if _lemma_key(alias_target) not in taught_lemma_keys:
             surface_gloss = aliased.get("gloss")
             surface_pos = aliased.get("pos")
@@ -371,6 +359,17 @@ def _atlas_record_for_manifest(rec: dict, taught_lemma_keys: set[str]) -> dict |
             target_lemma=alias_target,
             reason=reason,
         )
+
+        # If it's a single word, yield a form_of record to preserve the URL and render a canonical card
+        if " " not in display_lemma.strip():
+            form_rec = dict(rec)
+            form_rec["form_of"] = {
+                "lemma": alias_target,
+                "url_slug": _slug_for_url(alias_target),
+            }
+            form_rec["source"] = "built_vocabulary_form"
+            return [aliased, form_rec]
+
         return aliased
 
     return rec
@@ -413,6 +412,8 @@ def _merge_lemma_records(
                 "primary_source": rec["source"],
                 "course_usage": [usage_entry],
             }
+            if "form_of" in rec:
+                by_lemma[key]["form_of"] = rec["form_of"]
             _append_normalization(by_lemma[key], rec.get("atlas_normalization"))
             continue
 
@@ -430,6 +431,8 @@ def _merge_lemma_records(
                 existing["pos"] = rec["pos"]
             if rec.get("ipa"):
                 existing["ipa"] = rec["ipa"]
+        if "form_of" in rec and "form_of" not in existing:
+            existing["form_of"] = rec["form_of"]
         _append_normalization(existing, rec.get("atlas_normalization"))
 
         # Dedupe course_usage by module identity, keeping the highest-signal
@@ -496,11 +499,14 @@ def build_manifest() -> dict:
     }
 
     for module, raw_records in raw_records_by_module:
-        built_records = [
-            record
-            for rec in raw_records
-            if (record := _atlas_record_for_manifest(rec, taught_lemma_keys)) is not None
-        ]
+        built_records = []
+        for rec in raw_records:
+            res = _atlas_record_for_manifest(rec, taught_lemma_keys)
+            if res:
+                if isinstance(res, list):
+                    built_records.extend(res)
+                else:
+                    built_records.append(res)
         _merge_lemma_records(by_lemma, module, built_records)
 
     _merge_seed_records(by_lemma)
@@ -521,6 +527,9 @@ def build_manifest() -> dict:
             ),
             "from_heritage_status_seed": sum(
                 1 for e in entries if e.get("seed_group") == "heritage-status-samples"
+            ),
+            "form_of_count": sum(
+                1 for e in entries if "form_of" in e
             ),
         },
         "modules": modules,

--- a/site/src/lexicon/WordAtlasArticle.astro
+++ b/site/src/lexicon/WordAtlasArticle.astro
@@ -111,6 +111,7 @@ interface LexiconEntry {
   lemma: string;
   url_slug: string;
   gloss: string | null;
+  form_of?: { lemma: string; url_slug: string } | null;
   pos: string | null;
   ipa: string | null;
   pronunciation?: { ipa: string; source: string } | null;
@@ -408,7 +409,37 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
   </div>
 
   <div id={`word-${entry.url_slug}`}>
-    <div class="word-hero">
+    {entry.form_of ? (
+      <>
+        <div class="word-hero">
+          <div class="word-hero-inner">
+            <span class="lexicon-badge">Лексикон · Форма слова</span>
+            <h1 class="word-title">{entry.lemma}</h1>
+            <div class="word-pos">
+              {[posLabel, headwordIpa, entry.gloss ? `«${entry.gloss}»` : null].filter(Boolean).join(" · ")}
+            </div>
+          </div>
+        </div>
+        <div class="content-area">
+          <section class="atlas-section">
+            <div class="editorial-calque info" style="margin-top: 2rem;">
+              <div class="editorial-calque-header">
+                <div class="editorial-info-icon" aria-hidden="true">→</div>
+                Форма слова
+              </div>
+              <p style="font-size: 1.1rem;">
+                <strong>{entry.lemma}</strong> — це граматична форма слова <a href={`/lexicon/${entry.form_of.url_slug}/`} style="font-weight: bold; text-decoration: underline;">{entry.form_of.lemma}</a>.
+              </p>
+              <p>
+                Перейдіть на сторінку леми <a href={`/lexicon/${entry.form_of.url_slug}/`}>«{entry.form_of.lemma}»</a> для перегляду повного значення, відмінювання та етимології.
+              </p>
+            </div>
+          </section>
+        </div>
+      </>
+    ) : (
+      <>
+        <div class="word-hero">
       <div class="word-hero-inner">
         <span class="lexicon-badge">Лексикон · A-Я · {letter}</span>
         <h1 class="word-title">
@@ -754,7 +785,11 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
           {maxSovietizationRisk > 0 && <span>СУМ-11 показано через прозорість, з обов'язковим прапорцем</span>}
         </div>
       </div>
+        </div>
+      </div>
     </div>
+      </>
+    )}
   </div>
 </div>
 

--- a/site/src/pages/lexicon/[lemma].astro
+++ b/site/src/pages/lexicon/[lemma].astro
@@ -10,6 +10,7 @@ interface LexiconEntry {
   lemma: string;
   url_slug: string;
   gloss: string | null;
+  form_of?: { lemma: string; url_slug: string } | null;
 }
 
 interface LexiconManifest {
@@ -30,7 +31,9 @@ export async function getStaticPaths() {
 const { entry } = Astro.props as { entry: LexiconEntry };
 const frontmatter = {
   title: entry.lemma,
-  description: entry.gloss ? `${entry.lemma} — ${entry.gloss}` : `${entry.lemma} — стаття Лексикону`,
+  description: entry.form_of
+    ? `${entry.lemma} — форма слова «${entry.form_of.lemma}»`
+    : entry.gloss ? `${entry.lemma} — ${entry.gloss}` : `${entry.lemma} — стаття Лексикону`,
 };
 ---
 


### PR DESCRIPTION
Resolves #3450. Tags single-word inflected forms with form_of instead of folding them away. Renders canonical form-of card instead of duplicating the article.