### PR TITLE
feat(repo): add core.bare watchdog and auto-heal PreToolUse hook (#2842)

### DIFF
--- a/agents_extensions/shared/hooks/heal-core-bare.py
+++ b/agents_extensions/shared/hooks/heal-core-bare.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""PreToolUse guard — auto-heals core.bare before git operations (#2842).
+
+Reads the Claude Code hook payload on stdin (JSON with `tool_name` +
+`tool_input.command`). If the command invokes `git`, it checks core.bare
+and resets it to false if it has drifted to true. This prevents mid-session
+git breakages from bubbling up to the agents.
+
+Always exits 0 to allow the actual tool invocation to proceed.
+"""
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _read_payload() -> dict:
+    try:
+        return json.loads(sys.stdin.read() or "{}")
+    except json.JSONDecodeError:
+        return {}
+
+
+def _bash_command(payload: dict) -> str:
+    return ((payload.get("tool_input") or {}).get("command") or "").strip()
+
+
+def _is_git_command(command: str) -> bool:
+    """True if `git` is invoked as the primary command or in a sub-segment."""
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        return False
+
+    return "git" in tokens
+
+
+def main() -> int:
+    payload = _read_payload()
+    command = _bash_command(payload)
+
+    if not command or not _is_git_command(command):
+        return 0
+
+    project_dir = Path(__file__).resolve().parents[3]
+    script = project_dir / "scripts" / "audit" / "check_core_bare.py"
+    python_bin = project_dir / ".venv" / "bin" / "python"
+
+    if script.exists() and python_bin.exists():
+        subprocess.run(
+            [str(python_bin), str(script), "--repo", str(project_dir), "--fix", "-q"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agents_extensions/shared/settings.json
+++ b/agents_extensions/shared/settings.json
@@ -646,6 +646,11 @@
           },
           {
             "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/heal-core-bare.py",
+            "timeout": 3
+          },
+          {
+            "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-branch-switch-in-main.py",
             "timeout": 3
           },

--- a/scripts/core_bare_watchdog.sh
+++ b/scripts/core_bare_watchdog.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Watchdog daemon: continuously asserts core.bare == false on this repository.
+# Auto-resets to false if it drifts to true. See #2842.
+# Runs completely independently of git work-tree ops, making it resilient
+# against the breakage it tries to heal.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "Starting core.bare watchdog for $REPO_DIR"
+
+while true; do
+    if [ "$(git -C "$REPO_DIR" config --get core.bare 2>/dev/null)" = "true" ]; then
+        git -C "$REPO_DIR" config --local core.bare false 2>/dev/null
+        echo "⚠️  watchdog: reset core.bare true→false (git work tree was broken; see #2842)" >&2
+    fi
+    sleep 5
+done


### PR DESCRIPTION
Closes #2842.

This PR implements the requested `core.bare` detection canary. It provides two layers of protection:
1. A small watchdog script (`scripts/core_bare_watchdog.sh`) that runs independently of git operations and continuously checks/heals `core.bare`.
2. A PreToolUse(Bash) hook (`agents_extensions/shared/hooks/heal-core-bare.py`) wired into the agent runtime settings that intercepts any `git` commands and runs `check_core_bare.py --fix` immediately prior to execution, preventing mid-session git breakages from propagating to tools.