### PR TITLE
feat(pipeline): Implement intentional_error opt-out flag for VESUM distractors checking

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -10173,9 +10173,12 @@ def _vesum_gate(
     2. **Intentional misspellings in `error-correction` activities** —
        `error:`, `errorWord:`, and `error_word:` fields contain the typo the
        student must fix (e.g. `прокидаєштся`). Verifying them would always fail.
-    3. **Wrong multiple-choice options** — `options: [{text, correct}]` values
-       with `correct: false` are author-labeled distractors. They may include
-       intentionally non-standard forms that test overgeneralization.
+    3. **Intentional-error multiple-choice options** — `options: [{text, correct, intentional_error}]`
+       values with `intentional_error: true` are deliberately incorrect/nonstandard forms
+       (e.g. overgeneralized morphology like "п'юся") used as distractors to test common
+       learner errors. They are excluded from VESUM verification (the opt-out). Regular
+       distractors (`correct: false` without `intentional_error`) are real Ukrainian words
+       placed in pedagogically wrong context and must be verified.
     4. **Sentence-initial capitalization** — VESUM is case-sensitive, so
        `Спочатку` (capitalized first word) returns no matches even though
        `спочатку` does. Lookup is performed in lowercase; the report keeps

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -11247,15 +11247,12 @@ def _activity_vesum_text(
     future nested shape like `error: { text: "...", note: "..." }` would be
     entirely excluded.
 
-    For multiple-choice-style `options: [{text, correct}]` lists, `text` on
-    options with falsy `correct` is an intentional wrong answer. Skip only that
-    option's text leaf so correct options and surrounding prompts are still
-    verified.
+    For multiple-choice-style `options: [{text, correct}]` lists, verify distractors
+    by default. Only skip the `text` leaf of options explicitly marked with
+    `intentional_error: true`.
 
     For fill-in activities, bare-list `options:` values are suffix fragments,
-    not VESUM lemmas. For quiz-like item dicts with `options:` plus `answer:`,
-    only the option equal to the answer is verified; sibling distractors can be
-    fabricated wrong forms.
+    not VESUM lemmas, and are unconditionally skipped.
 
     For true-false activities, false statements are intentional wrong claims
     and may contain fabricated Ukrainian forms. Only true statements are
@@ -11279,30 +11276,6 @@ def _activity_vesum_text(
         skip_subtree.update(_HIGHLIGHT_MORPHEMES_ANSWER_KEY_FIELDS)
 
     out: list[str] = []
-
-    def answer_values(*answers: Any) -> set[str]:
-        values: set[str] = set()
-        for answer in answers:
-            if isinstance(answer, str):
-                values.add(answer)
-            elif isinstance(answer, list):
-                values.update(item for item in answer if isinstance(item, str))
-        return values
-
-    def walk_answer_options(options: Any, answers: set[str]) -> None:
-        if not answers:
-            return
-        if isinstance(options, list):
-            for option in options:
-                if isinstance(option, str):
-                    if option in answers:
-                        walk(option, "options")
-                elif isinstance(option, dict):
-                    text = option.get("text")
-                    if isinstance(text, str) and text in answers:
-                        walk(option, "options", in_options_list=True)
-        elif isinstance(options, str) and options in answers:
-            walk(options, "options")
 
     def walk_truefalse_statement(
         statement: Any,
@@ -11335,11 +11308,10 @@ def _activity_vesum_text(
         item_idx: int | None = None,
     ) -> None:
         if isinstance(node, dict):
-            wrong_option = (
+            intentional_error_option = (
                 in_options_list
                 and isinstance(node.get("text"), str)
-                and "correct" in node
-                and not node.get("correct", False)
+                and node.get("intentional_error") is True
             )
             for key, child in node.items():
                 if key in skip_subtree:
@@ -11358,12 +11330,6 @@ def _activity_vesum_text(
                     # is always a suffix fragment.  Skip unconditionally.
                     # See #1967.
                     continue
-                if key == "options" and ("answer" in node or "correctAnswer" in node):
-                    walk_answer_options(
-                        child,
-                        answer_values(node.get("answer"), node.get("correctAnswer")),
-                    )
-                    continue
                 if activity_type == "true-false" and key == "statement":
                     walk_truefalse_statement(
                         child,
@@ -11371,7 +11337,7 @@ def _activity_vesum_text(
                         item_idx=item_idx,
                     )
                     continue
-                if wrong_option and key == "text":
+                if intentional_error_option and key == "text":
                     continue
                 walk(child, key, item_idx=item_idx)
         elif isinstance(node, list):

--- a/scripts/yaml_activities.py
+++ b/scripts/yaml_activities.py
@@ -29,6 +29,7 @@ except ImportError:
 class QuizOption:
     text: str
     correct: bool
+    intentional_error: bool = False
 
 
 @dataclass
@@ -785,7 +786,11 @@ class ActivityParser:
                     is_correct = i == correct_index if type(correct_index) is int else opt == correct_answer
                     options.append(QuizOption(text=opt, correct=is_correct))
                 else:
-                    options.append(QuizOption(text=opt['text'], correct=opt.get('correct', False)))
+                    options.append(QuizOption(
+                        text=opt['text'],
+                        correct=opt.get('correct', False),
+                        intentional_error=opt.get('intentional_error', False)
+                    ))
             question = item_data.get('question') or item_data.get('prompt', '')
             items.append(QuizItem(question=question, options=options, explanation=item_data.get('explanation')))
         return QuizActivity(
@@ -806,7 +811,11 @@ class ActivityParser:
                     is_correct = (opt in correct_answer) if isinstance(correct_answer, list) else (opt == correct_answer)
                     options.append(QuizOption(text=opt, correct=is_correct))
                 else:
-                    options.append(QuizOption(text=opt['text'], correct=opt.get('correct', False)))
+                    options.append(QuizOption(
+                        text=opt['text'],
+                        correct=opt.get('correct', False),
+                        intentional_error=opt.get('intentional_error', False)
+                    ))
             question = item_data.get('question') or item_data.get('prompt', '')
             items.append(SelectItem(question=question, options=options, min_correct=item_data.get('min_correct'), explanation=item_data.get('explanation')))
         return SelectActivity(title=data.get('title', ''), instruction=data.get('instruction', ''), items=items)

--- a/tests/build/test_linear_pipeline.py
+++ b/tests/build/test_linear_pipeline.py
@@ -2134,10 +2134,7 @@ def test_vesum_gate_skips_error_field_of_error_correction_items_shape(
     assert "одягаєшся" in forwarded
 
 
-@pytest.mark.parametrize("answer_key", ["correctAnswer", "answer"])
-def test_activity_vesum_text_filters_quiz_distractors_by_answer_spelling(
-    answer_key: str,
-) -> None:
+def test_activity_vesum_text_verifies_distractors_unless_opted_out() -> None:
     activity = {
         "id": "act-1",
         "type": "quiz",
@@ -2145,8 +2142,12 @@ def test_activity_vesum_text_filters_quiz_distractors_by_answer_spelling(
         "items": [
             {
                 "question": "Яка форма правильна для «я»?",
-                "options": ["користуювася", "користуюся"],
-                answer_key: "користуюся",
+                "options": [
+                    {"text": "користуювася", "intentional_error": True},
+                    {"text": "користуюся", "correct": True},
+                    {"text": "звичайний_дистрактор", "correct": False},
+                    "простий_дистрактор_рядок",
+                ],
             }
         ],
     }
@@ -2155,6 +2156,8 @@ def test_activity_vesum_text_filters_quiz_distractors_by_answer_spelling(
 
     assert "користуювася" not in vesum_text
     assert "користуюся" in vesum_text
+    assert "звичайний_дистрактор" in vesum_text
+    assert "простий_дистрактор_рядок" in vesum_text
 
 
 def test_activity_vesum_text_skips_false_true_false_statements() -> None:
@@ -2557,8 +2560,8 @@ def test_vesum_gate_skips_fillin_options_bare_list() -> None:
     assert report["passed"] is True
 
 
-def test_vesum_gate_skips_quiz_options_distractors() -> None:
-    """Regression for #1962 gate 1 leak 2. quiz non-answer options are distractors."""
+def test_vesum_gate_skips_quiz_options_distractors_with_opt_out() -> None:
+    """Regression for #1962 gate 1 leak 2, updated for #2738. quiz distractors are verified unless opted out."""
     activities = [
         {
             "id": "act-1",
@@ -2566,8 +2569,10 @@ def test_vesum_gate_skips_quiz_options_distractors() -> None:
             "items": [
                 {
                     "question": "Я ___ каву.",
-                    "options": ["п'юся", "п'ю"],
-                    "answer": "п'ю",
+                    "options": [
+                        {"text": "п'юся", "intentional_error": True},
+                        {"text": "п'ю", "correct": True},
+                    ],
                 }
             ],
         }
@@ -2665,7 +2670,7 @@ def test_vesum_gate_passes_m20_build_3_artifacts() -> None:
                 "items": [
                     {
                         "question": "Я ___ каву о восьмій.",
-                        "options": ["п'юся", "п'ю"],
+                        "options": [{"text": "п'юся", "intentional_error": True}, {"text": "п'ю", "correct": True}],
                         "answer": "п'ю",
                     }
                 ],

--- a/tests/replay/fixtures/activities/mc_with_correct_false.yaml
+++ b/tests/replay/fixtures/activities/mc_with_correct_false.yaml
@@ -5,3 +5,4 @@ options:
     correct: true
   - text: "олівець"
     correct: false
+    intentional_error: true

--- a/tests/test_vesum_gate_distractor_and_phonetic.py
+++ b/tests/test_vesum_gate_distractor_and_phonetic.py
@@ -6,7 +6,7 @@ from scripts.build.linear_pipeline import _build_vesum_text, _vesum_gate
 
 
 def test_mc_distractor_text_not_verified() -> None:
-    """correct: false option text must not be checked against VESUM."""
+    """options marked intentional_error: true (deliberate wrong distractors) must not be checked against VESUM."""
     activity = {
         "type": "multiple-choice",
         "questions": [
@@ -14,8 +14,8 @@ def test_mc_distractor_text_not_verified() -> None:
                 "question": "Я ___ каву.",
                 "options": [
                     {"text": "п'ю", "correct": True},
-                    {"text": "п'юся", "correct": False},
-                    {"text": "п'єшся", "correct": False},
+                    {"text": "п'юся", "correct": False, "intentional_error": True},
+                    {"text": "п'єшся", "correct": False, "intentional_error": True},
                 ],
             }
         ],


### PR DESCRIPTION
Fixes #2738. Updates linear_pipeline.py to verify distractors by default for quiz-like MC activities, removing the walk_answer_options exclusion. Authors can now opt-out specific distractors from linguistic validation by passing `intentional_error: true` on the option object. Updates QuizOption parsing to support this flag. Re-written test fixtures conform to the new opt-out schema behavior.