### PR TITLE
feat(lexicon): calque cross-feed and systemic collocations (#3098)

### DIFF
--- a/scripts/lexicon/calque_corrections.py
+++ b/scripts/lexicon/calque_corrections.py
@@ -345,6 +345,11 @@ PHRASAL_CALQUES: dict[str, dict[str, object]] = {
     "ні в якому разі": {"corrections": ["аж ніяк", "у жодному разі"], "note": "рос. ни в коем случае", "source": ["ua-gec", "grok-3098"]},  # ua-gec 0717, 1844
     "прийшло в голову": {"corrections": ["спало на думку"], "note": "рос. пришло в голову (F/Collocation); в голову прийшли → спали на гадку", "source": ["ua-gec", "grok-3098"]},  # ua-gec 0834
     # §6 collocation/phrasal slice 2 (#3098) — kept only with direct correction evidence.
+    "приймати міри": {"corrections": ["вживати заходів"], "note": "рос. принимать меры", "source": ["ua-gec", "grok-3098"]},
+    "прийняти міри": {"corrections": ["вжити заходів"], "note": "рос. принять меры", "source": ["ua-gec", "grok-3098"]},
+    "мати відношення": {"corrections": ["мати стосунок"], "note": "рос. иметь отношение", "source": ["ua-gec", "grok-3098"]},
+    "більша половина": {"corrections": ["більша частина"], "note": "рос. большая половина (половини є рівними)", "source": ["antonenko-davydovych", "grok-3098"]},
+    "підводити підсумки": {"corrections": ["підбивати підсумки"], "note": "рос. подводить итоги", "source": ["antonenko-davydovych", "grok-3098"]},
     "при допомозі": {
         "corrections": ["за допомогою"],
         "note": "syntactic calque; use the instrumental phrase за допомогою",

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -1791,6 +1791,33 @@ def _curated_calque(lemma: str, base: str) -> dict[str, Any] | None:
     return None
 
 
+def _reverse_calques(lemma: str, base: str) -> list[dict[str, Any]] | None:
+    """Find calques where this lemma is the recommended correction."""
+    results: list[dict[str, Any]] = []
+
+    for calque_dict in (CURATED_CALQUES, SENSE_RESTRICTED_CALQUES, PHRASAL_CALQUES):
+        for calque, row in calque_dict.items():
+            corrections = row.get("corrections", [])
+            if lemma in corrections or base in corrections:
+                kind = row.get("kind", "participle")
+                if calque_dict is SENSE_RESTRICTED_CALQUES:
+                    kind = "sense_restricted"
+                elif calque_dict is PHRASAL_CALQUES:
+                    kind = "phrasal"
+
+                result = {
+                    "calque": calque,
+                    "kind": str(kind),
+                    "note": str(row.get("note", "")),
+                    "source": list(row.get("source", [])),
+                }
+                if "calque_sense" in row:
+                    result["calque_sense"] = str(row["calque_sense"])
+                results.append(result)
+
+    return results if results else None
+
+
 def _entry_scoped_heritage_status(status: dict[str, Any]) -> dict[str, Any]:
     clean_status = dict(status)
     clean_status.pop("sovietization_risk", None)
@@ -3110,6 +3137,11 @@ def enrich() -> tuple[int, int]:
                     "source": list(curated_calque.get("source", [])),
                     "citation": "Антоненко-Давидович «Як ми говоримо» (davydov via MCP query_slovnyk_me + p145 prose via get_chunk_context; search_heritage guard applied)",
                 }
+
+            reverse_calques = _reverse_calques(lemma, base)
+            if reverse_calques:
+                entry["heritage_status"]["reverse_calques"] = reverse_calques
+
             pronunciation = _kaikki_pronunciation(kaikki_lookup, lemma)
             if pronunciation:
                 entry["pronunciation"] = pronunciation

--- a/site/src/lexicon/WordAtlasArticle.astro
+++ b/site/src/lexicon/WordAtlasArticle.astro
@@ -88,6 +88,14 @@ interface CuratedCalque {
   authentic_sense?: string;
 }
 
+interface ReverseCalque {
+  calque: string;
+  kind: "participle" | "phrasal" | "sense_restricted";
+  note: string;
+  source: string[];
+  calque_sense?: string;
+}
+
 interface HeritageStatus {
   classification: string;
   attestations: HeritageAttestation[];
@@ -95,6 +103,7 @@ interface HeritageStatus {
   russian_shadow: boolean;
   calque_warning?: { detail?: string } | null;
   curated_calque?: CuratedCalque | null;
+  reverse_calques?: ReverseCalque[] | null;
 }
 
 interface LexiconSections {
@@ -309,6 +318,10 @@ function buildStyleNotes() {
   }
   if (heritage?.curated_calque) {
     notes.push(`${heritage.curated_calque.note} Нейтральні відповідники: ${heritage.curated_calque.corrections.join(", ")}.`);
+  }
+  if (heritage?.reverse_calques?.length) {
+    const calqueForms = heritage.reverse_calques.map((rev) => `«${rev.calque}»`);
+    notes.push(`Рекомендовано замість скалькованої форми ${calqueForms.join(" або ")} (стилістична порада §6).`);
   }
   if (maxSovietizationRisk > 0) {
     notes.push("СУМ-11 подано для прозорості, але радянські ілюстрації не слід сприймати як стилістично нейтральний сучасний приклад.");


### PR DESCRIPTION
Adds reverse link feature to calque system, ensuring recommendations show calque warnings on the recommended word page too. Also adds the remaining systematic collocations to the blocklist. Resolves #3098.