### PR TITLE
fix(deps): resolve idna and lockfile conflicts (#2732)

### DIFF
--- a/.dagger/uv.lock
+++ b/.dagger/uv.lock
@@ -258,11 +258,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.17"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.550Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -85,18 +85,17 @@ keyring==25.7.0
 librt==0.11.0
 lxml==6.0.4
 lz4==4.4.5
-mando==0.8.2
+mando==0.7.1
 marisa-trie==1.3.1
 markdown-it-py==4.0.0
 markdown2==2.5.5
 markdownify==1.2.2
-marker-pdf==1.10.2
 MarkupSafe==3.0.3
 mcp-memory-service==10.74.1
 mcp==1.27.2
 mdurl==0.1.2
 more-itertools==11.0.2
-mpmath==1.4.1
+mpmath==1.3.0
 multidict==6.7.1
 multiprocess==0.70.19
 mypy==2.1.0
@@ -125,7 +124,6 @@ psutil==7.2.2
 pyarrow==24.0.0
 pyasn1==0.6.3
 pyasn1_modules==0.4.2
-pycookiecheat==0.8.0
 pycparser==3.0
 pydantic-settings==2.14.1
 pydantic==2.12.5
@@ -150,7 +148,7 @@ pytest-cov==7.1.0
 pytest-xdist==3.8.0
 pytest==9.0.3
 python-dateutil==2.9.0.post0
-python-discovery==1.1.0
+python-discovery==1.4.2
 python-docx==1.2.0
 python-dotenv==1.2.2
 python-jose==3.5.0
@@ -172,7 +170,7 @@ scikit-learn==1.8.0
 scipy==1.17.0
 sentence-transformers==5.4.1
 sentencepiece==0.2.1
-setuptools==82.0.1
+setuptools==81.0.0
 shellingham==1.5.4
 six==1.17.0
 sniffio==1.3.1
@@ -182,7 +180,6 @@ sse-starlette==3.2.0
 stanza==1.11.0
 starlette==1.2.1
 stevedore==5.8.0
-surya-ocr==0.17.1
 sympy==1.14.0
 tenacity==9.1.4
 threadpoolctl==3.6.0


### PR DESCRIPTION
Resolves #2732.

- Bumped idna to 3.18 in `.dagger/uv.lock`
- Removed `marker-pdf`, `pycookiecheat` and `surya-ocr` from `requirements-lock.txt` because they conflict with newer security-bumped versions of `cryptography` and `anthropic`, and are only used in manually invoked local scripts.
- Downgraded `mando` to `0.7.1` to satisfy `radon`
- Downgraded `mpmath` to `1.3.0` to satisfy `sympy`
- Downgraded `setuptools` to `81.0.0` to satisfy `torch`
- Bumped `python-discovery` to `1.4.2` to satisfy `virtualenv`
- `requirements-lock.txt` now cleanly resolves with `pip install --dry-run`.