### PR TITLE
fix(security): resolve 4 CodeQL findings (redos, url-sanitization x2, fs-race)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -10615,9 +10615,12 @@ def _normalize_for_vesum(lemma: str) -> str:
             lambda m: _strip_morpheme_hyphen(m.group(1)),
             text,
         )
-    text = re.sub(r"^(?:\*\*|\*|_)+", "", text.strip())
-    text = re.sub(r"(?:\*\*|\*|_)+$", "", text)
+    text = _strip_markdown_edge_markers(text)
     return _canonicalize_vesum_apostrophes(text).strip()
+
+
+def _strip_markdown_edge_markers(text: str) -> str:
+    return text.strip().lstrip("*_").rstrip("*_")
 
 
 def _canonicalize_vesum_apostrophes(text: str) -> str:

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -1,6 +1,7 @@
 import json
 import sqlite3
 import typing
+from urllib.parse import urlparse
 
 import pytest
 
@@ -117,6 +118,10 @@ def _conn() -> sqlite3.Connection:
         """
     )
     return conn
+
+
+def _url_hostname(url: str) -> str | None:
+    return urlparse(url).hostname
 
 
 def test_cleanup_helpers_strip_chunk_and_decode_entities() -> None:
@@ -1799,14 +1804,15 @@ def test_wiki_reference_success(monkeypatch, tmp_path) -> None:
     assert ref["wikipedia"]["title"] == "Україна"
     assert ref["wikipedia"]["summary"] == "Україна — держава в Східній Європі."
     assert ref["wikipedia"]["url"] == "https://uk.wikipedia.org/wiki/Україна"
-    assert "uk.wiktionary.org" in ref["wiktionary_url"]
+    assert _url_hostname(ref["wiktionary_url"]) == "uk.wiktionary.org"
+    assert _url_hostname("https://uk.wiktionary.org.attacker.example/wiki/Україна") != "uk.wiktionary.org"
     assert ref["wikisource_url"] is None
 
     # test with literary attestation
     ref_with_lit = enrich_manifest_module._wiki_reference("Україна", {"text": "some excerpt"})
     assert ref_with_lit is not None
     assert ref_with_lit["wikisource_url"] is not None
-    assert "uk.wikisource.org" in ref_with_lit["wikisource_url"]
+    assert _url_hostname(ref_with_lit["wikisource_url"]) == "uk.wikisource.org"
 
 
 def test_proper_noun_wikipedia_meaning_uses_one_line_cached_gloss(monkeypatch, tmp_path) -> None:

--- a/tests/test_vesum_verified_postfix.py
+++ b/tests/test_vesum_verified_postfix.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import time
+
 import pytest
 import yaml
 
@@ -7,6 +9,7 @@ from scripts.build.linear_pipeline import (
     _iter_vesum_word_surfaces,
     _looks_like_stem_fragment,
     _normalize_for_vesum,
+    _strip_markdown_edge_markers,
     _vesum_gate,
 )
 
@@ -100,6 +103,25 @@ def test_normalize_for_vesum_canonicalizes_apostrophe_variants() -> None:
     assert _normalize_for_vesum("в‘ють") == "в'ють"
     assert _normalize_for_vesum("в`ють") == "в'ють"
     assert _normalize_for_vesum("в´ють") == "в'ють"
+
+
+def test_strip_markdown_edge_markers_preserves_intended_behavior() -> None:
+    assert _strip_markdown_edge_markers("**Дебат") == "Дебат"
+    assert _strip_markdown_edge_markers("Дебат**") == "Дебат"
+    assert _strip_markdown_edge_markers("*_слово_**") == "слово"
+    assert _strip_markdown_edge_markers(" будь-що ") == "будь-що"
+    assert _strip_markdown_edge_markers("слово***!") == "слово***!"
+
+
+def test_strip_markdown_edge_markers_handles_unmatched_star_run_quickly() -> None:
+    raw = "слово" + ("*" * 50_000) + "!"
+
+    started_at = time.perf_counter()
+    normalized = _strip_markdown_edge_markers(raw)
+    elapsed = time.perf_counter() - started_at
+
+    assert normalized == raw
+    assert elapsed < 1.0
 
 
 def test_vesum_gate_normalizes_stress_and_markdown_before_lookup() -> None:


### PR DESCRIPTION
## Summary

Fixes or resolves the 4 HARD CodeQL alerts in scope.

## Per-alert notes

1. `py/redos` in `scripts/build/linear_pipeline.py`

The vulnerable regexes used overlapping `**` / `*` alternatives under a repeated group to strip markdown edge markers. The replacement is deterministic `text.strip().lstrip("*_").rstrip("*_")`, preserving the intended marker behavior without regex backtracking. Added regression coverage for intended marker stripping and a crafted unmatched `*` run.

2. `py/incomplete-url-substring-sanitization` in `tests/test_lexicon_enrich_manifest.py` for `uk.wiktionary.org`

The test checked the host by substring. It now parses the URL with `urllib.parse.urlparse(url).hostname` and compares `== "uk.wiktionary.org"`, with a spoof-host negative assertion.

3. `py/incomplete-url-substring-sanitization` in `tests/test_lexicon_enrich_manifest.py` for `uk.wikisource.org`

The test checked the host by substring. It now parses the URL with `urllib.parse.urlparse(url).hostname` and compares `== "uk.wikisource.org"`.

4. `js/file-system-race` in `scripts/legacy/typescript/enrich-activities.ts`

Dismissed via `gh api` as `won't fix` instead of editing. The file is legacy/unused dead code; the requested usage grep only found self-references:

```text
./scripts/legacy/typescript/enrich-activities.ts:11: *   npx ts-node scripts/enrich-activities.ts l2-uk-en 1-100
./scripts/legacy/typescript/enrich-activities.ts:745:    console.log('Usage: npx ts-node scripts/enrich-activities.ts l2-uk-en [range]');
```

Dismissal evidence:

```json
{"dismissed_comment":"scripts/legacy/typescript/enrich-activities.ts is legacy/unused dead code: repository grep for enrich-activities in *.ts/*.json finds only self-references in this file, so editing it would keep dead code alive rather reduce reachable risk.","dismissed_reason":"won't fix","number":244,"path":"scripts/legacy/typescript/enrich-activities.ts","rule":"js/file-system-race","state":"dismissed"}
```

## Test evidence

Manifest URL test:

```text
============================== 69 passed in 1.37s ==============================
```

Linear pipeline regex regression test:

```text
======================= 3 passed, 31 deselected in 1.26s =======================
```

Ruff:

```text
All checks passed!
```