### PR TITLE
fix(security): least-privilege file modes (7x) + jinja autoescape (CodeQL)

### DIFF
--- a/scripts/agent_runtime/usage.py
+++ b/scripts/agent_runtime/usage.py
@@ -124,7 +124,7 @@ def write_record(record: dict[str, Any]) -> None:
         record = redact_value(record)
         path = _usage_file(record["agent"], record["entrypoint"])
         line = (json.dumps(record, ensure_ascii=False, default=str) + "\n").encode("utf-8")
-        fd = os.open(str(path), os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o644)
+        fd = os.open(str(path), os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o600)
         try:
             os.write(fd, line)
         finally:

--- a/scripts/batch/batch_utils.py
+++ b/scripts/batch/batch_utils.py
@@ -146,7 +146,7 @@ class BatchLock:
             fd = os.open(
                 str(self.lock_file),
                 os.O_CREAT | os.O_EXCL | os.O_WRONLY,
-                0o644,
+                0o600,
             )
             try:
                 os.write(fd, lock_data.encode("utf-8"))

--- a/scripts/batch_gemini_runner/utils.py
+++ b/scripts/batch_gemini_runner/utils.py
@@ -65,14 +65,14 @@ def _switch_gemini_account(new_account: str) -> bool:
         # Acquire lock (spin with short sleep for up to 10s)
         for _ in range(100):
             try:
-                fd = os.open(str(lock_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+                fd = os.open(str(lock_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
                 break
             except FileExistsError:
                 time.sleep(0.1)
         else:
             # Timeout -- force acquire (stale lock from crashed process)
             lock_file.unlink(missing_ok=True)
-            fd = os.open(str(lock_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+            fd = os.open(str(lock_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
 
         data = json.loads(GEMINI_ACCOUNTS_FILE.read_text(encoding="utf-8"))
         old_active = data.get("active", "")

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -252,7 +252,7 @@ def _append_dispatch_event(event: str, **fields: Any) -> None:
         fd = os.open(
             str(_TASKS_DIR / "dispatch_events.jsonl"),
             os.O_APPEND | os.O_CREAT | os.O_WRONLY,
-            0o644,
+            0o600,
         )
         try:
             os.write(fd, line)

--- a/scripts/docs/migrate_to_html.py
+++ b/scripts/docs/migrate_to_html.py
@@ -144,7 +144,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
   </header>
 
   <main>
-    {{ content }}
+    {{ content | safe }}
   </main>
 </div>
 </body>
@@ -214,7 +214,7 @@ def migrate(input_path: Path, output_path: Path, *, force: bool = False) -> bool
     md = MarkdownIt()
     content_html = md.render(md_text)
 
-    template = Template(HTML_TEMPLATE)
+    template = Template(HTML_TEMPLATE, autoescape=True)
     final_html = template.render(
         title=title,
         metadata=metadata,

--- a/scripts/rag/benchmark_embeddings.py
+++ b/scripts/rag/benchmark_embeddings.py
@@ -224,7 +224,7 @@ def load_queries() -> list[dict]:
 
 def acquire_benchmark_lock(lock_path: str, benchmark_kind: str = "embedder"):
     """Acquire a non-blocking file lock for benchmark mutual exclusion."""
-    raw_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+    raw_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
     lock_fd = os.fdopen(raw_fd, "a+", encoding="utf-8")
     try:
         fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)

--- a/scripts/telemetry/emit.py
+++ b/scripts/telemetry/emit.py
@@ -117,7 +117,7 @@ def _event_file(day: datetime | None = None) -> Path:
 
 
 def _write_line(path: Path, line: bytes) -> None:
-    fd = os.open(str(path), os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o644)
+    fd = os.open(str(path), os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o600)
     try:
         os.write(fd, line)
     finally:


### PR DESCRIPTION
Resolves **8 CodeQL alerts** (mechanical / least-privilege lane of the security sweep).

## py/overly-permissive-file (7x) — `0o644` → `0o600`
Owner-only perms on files that may contain agent/account/dispatch/telemetry data:
`scripts/agent_runtime/usage.py`, `scripts/telemetry/emit.py`, `scripts/delegate.py` (dispatch_events), `scripts/batch/batch_utils.py` (BatchLock), `scripts/batch_gemini_runner/utils.py` (2 account locks), `scripts/rag/benchmark_embeddings.py` (benchmark lock).

## py/jinja2/autoescape-false (1x)
`scripts/docs/migrate_to_html.py`: `Template(..., autoescape=True)`; markdown-rendered `{{ content | safe }}` (markdown-it `html=False` ⇒ content already escaped, no XSS reintroduced).

Authored by **agy** dispatch; reviewed + finalized by orchestrator (ruff clean, import sanity, dropped a stray out-of-scope file). Supersedes the jinja slice of #3579.

🤖 Generated with [Claude Code](https://claude.com/claude-code)