### PR TITLE
fix(site): Ukrainian admonition + nav labels (#M-13) + un-hide folk left nav

### DIFF
--- a/site/plugins/remark-admonitions.mjs
+++ b/site/plugins/remark-admonitions.mjs
@@ -1,12 +1,14 @@
 const ADMONITION_TYPES = new Set(['info', 'tip', 'caution', 'note', 'danger', 'warning']);
 
+// Ukrainian labels — this is a Ukrainian-immersion curriculum; admonition
+// callouts must never surface English UI text (immersion rule #M-13).
 const DEFAULT_TITLES = {
-  info: 'Info',
-  tip: 'Tip',
-  caution: 'Caution',
-  note: 'Note',
-  danger: 'Danger',
-  warning: 'Warning',
+  info: 'Інформація',
+  tip: 'Порада',
+  caution: 'Увага',
+  note: 'Примітка',
+  danger: 'Небезпека',
+  warning: 'Застереження',
 };
 
 function visit(node, callback) {

--- a/site/src/layouts/CourseLayout.astro
+++ b/site/src/layouts/CourseLayout.astro
@@ -174,7 +174,7 @@ const isActive = (href: string) => {
             </button>
           </nav>
           <details class="lu-mobile-menu">
-            <summary aria-label="Open navigation">Menu</summary>
+            <summary aria-label="Відкрити навігацію">Меню</summary>
             <nav aria-label="Mobile primary">
               {topNav.map((item) => (
                 <a href={item.href} aria-current={isActive(item.href) ? 'page' : undefined}>
@@ -221,7 +221,7 @@ const isActive = (href: string) => {
           {sidebar && (
             <details class="lu-sidebar" open>
               <summary class="lu-sidebar-toggle">
-                {sidebar.titleLabel ?? 'Lessons'} · {sidebar.positionLabel}
+                {sidebar.titleLabel ?? 'Уроки'} · {sidebar.positionLabel}
               </summary>
               <div class="lu-sidebar-body">
                 <a class="lu-sidebar-back" href={sidebar.backHref}>← {sidebar.backLabel}</a>
@@ -231,7 +231,7 @@ const isActive = (href: string) => {
                     <div class="lu-mini-fill" style={`width:${sidebarPct}%`} />
                   </div>
                 </div>
-                <nav class="lu-sidebar-nav" aria-label={sidebar.navLabel ?? 'Lessons in this track'}>
+                <nav class="lu-sidebar-nav" aria-label={sidebar.navLabel ?? 'Уроки цього рівня'}>
                   {sidebar.links.map((link) => (
                     <a
                       class:list={['lu-sidebar-link', link.active && 'active']}

--- a/site/src/pages/[...slug].astro
+++ b/site/src/pages/[...slug].astro
@@ -275,7 +275,11 @@ const TRACKS: Record<string, TrackOverview> = {
 };
 
 const HIDDEN_DOCS = new Set(['a1/review-clears-needs-human']);
-const HIDDEN_LINK_TRACKS = new Set(['folk']);
+// Folk un-hidden 2026-06-19: 6 modules are e2e-certified and folk is already
+// public (astro.config hiddenPublicPaths=[]); this completes the nav un-hide so
+// folk module pages get their left sidebar + breadcrumbs + search (reverses #3027 —
+// coordinate with orchestrator on the launch posture).
+const HIDDEN_LINK_TRACKS = new Set<string>();
 const SEARCH_LESSON_PREFIXES = new Set(['a1', 'a2']);
 const normalizeId = (id: string) => id.replace(/\.mdx?$/, '').replace(/\/index$/, '');
 const hrefFromRoute = (route: string) => `/${route}/`;
@@ -528,15 +532,16 @@ const sidebar = props.kind === 'doc'
       });
       const currentIndex = links.findIndex((link) => link.active);
       const position = currentIndex >= 0 ? currentIndex + 1 : 0;
-      const isB1 = docTrack === 'b1';
       return {
         backHref: `/${docTrack}/`,
         backLabel: TRACKS[docTrack]?.label ?? docTrack.toUpperCase(),
+        // Ukrainian sidebar labels for ALL tracks (immersion rule #M-13) — was
+        // gated to b1 only, which leaked English nav text for folk/seminars/core.
         positionLabel: position > 0
-          ? isB1 ? `Урок ${position} з ${links.length}` : `Lesson ${position} of ${links.length}`
-          : isB1 ? `${links.length} уроки` : `${links.length} lessons`,
-        titleLabel: isB1 ? 'Уроки' : undefined,
-        navLabel: isB1 ? 'Уроки цього рівня' : undefined,
+          ? `Урок ${position} з ${links.length}`
+          : `${links.length} уроки`,
+        titleLabel: 'Уроки',
+        navLabel: 'Уроки цього рівня',
         progressDone: position,
         progressTotal: links.length,
         links,

--- a/site/tests/unit/remark-admonitions.test.ts
+++ b/site/tests/unit/remark-admonitions.test.ts
@@ -29,11 +29,11 @@ describe('remark admonitions', () => {
     expect(html).not.toContain(':::info');
   });
 
-  it('renders a plain tip directive with the default title', async () => {
+  it('renders a plain tip directive with the default Ukrainian title (#M-13)', async () => {
     const html = await renderMarkdown('::::tip\nKeep going.\n::::\n');
 
     expect(html).toContain('<aside class="admonition admonition-tip">');
-    expect(html).toContain('<p class="admonition-title">Tip</p>');
+    expect(html).toContain('<p class="admonition-title">Порада</p>');
     expect(html).toContain('<p>Keep going.</p>');
     expect(html).not.toContain('::::tip');
   });


### PR DESCRIPTION
Two user-reported site bugs (folk modules look broken on the live site).

## 1. English UI leaks — immersion (#M-13, top priority)
- Bare `:::note`/`:::caution` rendered **English** labels via `remark-admonitions.mjs` `DEFAULT_TITLES`. → localized to **Примітка / Порада / Увага / Застереження / Небезпека / Інформація** (all 6 lemmas VESUM-verified).
- The **left sidebar** showed English ("Lesson X of Y", "N lessons", "Lessons", "Menu") for **every track except b1** — the Ukrainian labels were gated to `isB1`. → sidebar `positionLabel`/`titleLabel`/`navLabel` now Ukrainian for **all tracks**; `CourseLayout` fallbacks localized (`Menu`→`Меню`, `Lessons`→`Уроки`).

## 2. Broken left nav on folk module pages
`[...slug].astro` had `HIDDEN_LINK_TRACKS = new Set(['folk'])`, which **suppressed folk's sidebar + breadcrumbs + search** — even though folk is already **public** (`astro.config hiddenPublicPaths=[]`, 2026-06-14) and `LevelLanding`'s hidden set is empty. Folk was *half*-un-hidden → reachable but no left nav. Emptied the set → folk pages get their nav.

## ⚠️ Coordination
- **#2 completes the folk-nav un-hide (reverses orchestrator #3027).** Justification: folk is already public + **6 modules are e2e-certified** (verify_shippable green + corpus-hammered this session). **Not self-merging** — orchestrator sign-off on launch posture requested.
- The sidebar-label fix also affects **core tracks** (labels were b1-gated). Please confirm the universal Ukrainian-nav change is wanted (it's the correct #M-13 fix).

Verified: no orphaned `isB1`; `node --check` on the remark plugin passes; the full astro build runs in the Frontend CI gate. **No auto-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)