### PR TITLE
docs(folk): handoff S64 — module+site quality pivot (reading-tasks plan, site PR #3624, wave-8)

### DIFF
--- a/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
+++ b/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
@@ -63,7 +63,25 @@
 > the "don't self-merge" restriction, not the "don't push to main" one. Stage-0 PR #2759 self-merged
 > under this grant (commit `abf280f490`).
 
-## ▶▶▶ SESSION 63 HANDOFF (2026-06-19 — ✅ 6 built folk modules CORPUS-HAMMERED (quote-verification, 0 fabrications) + machine-green → **6/42 modules certified-shippable**. NEXT = build the remaining 36 modules and/or deeper pedagogy review.) — **RESUME HERE**
+## ▶▶▶ SESSION 64 HANDOFF (2026-06-19 — 🎯 USER PIVOT to MODULE+SITE QUALITY: reading-tasks plan APPROVED; site immersion+nav bugs fixed (PR #3624); wave-8 wikis compiled+preserved. Several threads OPEN.) — **RESUME HERE**
+
+**🟢 ONE-LINE STATE:** Folk: wikis **22/42** (merged), modules **6/42 certified**. This session the USER redirected to **module + site QUALITY** — reading-tasks, AI-link leakage, English UI leaks, broken nav. One site PR open + an APPROVED implementation plan for the content side + wave-8 compiled-but-not-shipped.
+
+### ⚡ OPEN / NEXT ACTIONS (priority order)
+1. **PR #3624** `claude/folk-site-immersion-nav` — Ukrainian admonition labels (#M-13) + Ukrainian sidebar labels for ALL tracks + **un-hid folk left nav** (`HIDDEN_LINK_TRACKS` emptied in `[...slug].astro` — folk was half-un-hidden: public since 2026-06-14 but nav suppressed). ⚠️ **NOT self-merged — completes the folk-nav un-hide (reverses #3027) + touches core-track nav labels → needs orchestrator sign-off.** CI was being watched (Frontend build gate validates the .astro edits). **VERIFY CI green + get orchestrator nod, then merge.**
+2. **APPROVED PLAN — reading-tasks + anti-leakage** (`docs/plans/hazy-dreaming-willow.md`). User wants learners to READ THE ORIGINALS as explicit reading tasks with FINDABLE links; current external links are **91% AI-hallucinated** (bare landings `ukrlib/narod/`, `osvita.ua/...`, `diasporiana/...` + guessed `book.php?id=N`). ROOT CAUSE: **no gate resolves URLs** (`_verify_resources_live` exists at `linear_pipeline.py:12642` but is optional). Phases: **A** review+merge gemini **PR #3599** (`:::primary-reading` embed panel, #3162 — adopt, don't duplicate; review nit: its `primary-reading-box` CSS is undefined → unstyled); **B** promote `_verify_resources_live` to a mandatory allowlist+resolve gate + add `role:reading` (resources.py icon/group + writer prompt) + `data/primary_text_sources.yaml` allowlist (Ізборник/litopys.org.ua, Вікіджерела/uk.wikisource, on-site wiki); **C** retrofit the 6 modules' resources.yaml (purge the 10 hallucinated links + add verified reading tasks). User answers: drive #3599 first; sourcing = on-site wiki + embedded + verified-external-allowlist + resolve-gate.
+3. **Wave-8 wikis** — COMPILED + gate-PASSED (sotsialno-pobutovi-kazky 9.0, striletski-povstanski-pisni 8.0, suspilno-pobutovi-pisni ~8-9, prykazky-ta-pryslivia), **preserved (NOT corpus-hammered, NOT pushed)** on LOCAL branch `claude/folk-wikis-wave8` commit `6369788b8b`. NEXT: corpus-hammer (#M-11) each + PR (no index.md) → 26/42. (striletski source_grounding 8/REVISE — hammer hardest.)
+
+### ⚠️ INFRA / coordination notes (#0.2)
+- codex MERGED #3294 (#3079 C.2c foreign-proper-noun VESUM exemption) — the `vesnianky` build's `Бельтейн/Новруз/Ханамі` stall is handled upstream; the `vesnianky-hayivky` build was STOPPED by user mid-run (worktree `.worktrees/builds/folk-vesnianky-hayivky-*` left on disk; partial). Module-building (the 36 remaining) is **paused** by user pending the reading-task + site quality work.
+- gemini has many open site/infra PRs (#3595 chtyvo-links #3175, #3599 primary-reading, #3601 bare-repo-canary [explains stray `agents_extensions/` + `core_bare_watchdog.sh` edits in main working tree], etc.). `linear_pipeline.py` + `site/` are HOT — branch from latest origin/main, rebase, coordinate.
+- `search_images` "Phase-3 blocker" was a PHANTOM (removed S62) — optional 1-of-3 multimedia tools.
+
+### ✅ MERGED THIS SESSION: #3586 (wave-7 wikis →22/42), #3587 (dumy vesum fix →6/6 modules machine-pass DoD), #3588 (S62), #3593 (S63). Issue hygiene: #2836 progress comment, #2837 (kalendarna E2E pilot) CLOSED. Git hygiene: stale `folk-wikis-wave3` worktree removed.
+
+### IN-FLIGHT: PR #3624 (CI/orchestrator). Merge grant LIVE for folk wiki/module work; site-infra + #3027 reversal = orchestrator sign-off, not self-merge. Worktree-only; never main.
+
+## ▶▶▶ SESSION 63 HANDOFF (2026-06-19 — ✅ 6 built folk modules CORPUS-HAMMERED (quote-verification, 0 fabrications) + machine-green → **6/42 modules certified-shippable**. NEXT = build the remaining 36 modules and/or deeper pedagogy review.)
 
 **🟢 ONE-LINE STATE:** Wikis **22/42**. **Modules: 6/42 BUILT and now CERTIFIED-shippable** (`verify_shippable` GREEN + corpus-hammer DONE): kalendarna-obriadovist-zvychai, koliadky-shchedrivky, narodna-kultura-yak-systema, narodni-viruvannia-mifolohiia-demonolohiia, zamovliannia-zaklynannia-prymovky, dumy-nevilnytski-lytsarski. The remaining **36 folk modules are NOT yet built** (queue in `phase-folk-queue.md`).
 


### PR DESCRIPTION
Consolidates a long session where the USER pivoted folk to **module + site quality**.

**Merged this session:** #3586 (wave-7 wikis →22/42), #3587 (dumy vesum fix →6/6 modules pass DoD), #3588/#3593 (S62/S63 handoffs).

**Open / next (in S64):**
- **PR #3624** — Ukrainian admonition + nav labels (#M-13) + un-hid folk left nav. Flagged for orchestrator (reverses #3027 + core-track labels); a frontend test fixture was updated after a caught CI failure.
- **Approved plan** `docs/plans/hazy-dreaming-willow.md` — reading-tasks + anti-leakage URL gate (91% of folk external links are AI-hallucinated; root cause = no URL-resolution gate). Phase A adopt gemini PR #3599; B gate+role:reading+allowlist; C retrofit 6.
- **Wave-8 wikis** compiled + gate-passed, preserved on local branch `folk-wikis-wave8` (`6369788b8b`), pending corpus-hammer + PR → 26/42.

Issue hygiene: #2836 progress comment, #2837 closed. Git hygiene: stale wave3 worktree removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)