### PR TITLE
fix(lexicon): fold url_slug collisions in Atlas manifest build (unblocks main)

### DIFF
--- a/scripts/lexicon/build_data_manifest.py
+++ b/scripts/lexicon/build_data_manifest.py
@@ -484,6 +484,64 @@ def _merge_heritage_seed_records(by_lemma: dict[str, dict]) -> None:
         }
 
 
+def _resolve_slug_collisions(by_lemma: dict[str, dict]) -> None:
+    """Guarantee ``url_slug`` uniqueness by folding entries that collide.
+
+    Two distinct lemmas can yield the same slug when they differ only by
+    characters ``_slug_for_url`` deliberately folds (commas, spaces, slashes,
+    apostrophes) — e.g. ``тому що`` vs ``тому, що`` and ``через те що`` vs
+    ``через те, що``, added as separate entries by the §6 calque-correction
+    layer (#3098). Astro's ``[lemma].astro`` route keys on the slug, so a
+    collision would make two lemmas resolve to one page; ``build_manifest``
+    must enforce the invariant ``test_manifest_url_slugs_are_unique`` checks.
+
+    Colliding entries are folded into one deterministic canonical
+    (no interior punctuation > highest source priority > shortest lemma >
+    alphabetical), merging ``course_usage`` (deduped by module identity) and
+    ``atlas_normalizations``, backfilling missing optional fields, and recording
+    the folded surface form(s) under ``slug_variants``.
+    """
+    by_slug: dict[str, list[str]] = {}
+    for key, entry in by_lemma.items():
+        by_slug.setdefault(entry["url_slug"], []).append(key)
+
+    for collision_keys in by_slug.values():
+        if len(collision_keys) < 2:
+            continue
+
+        def _rank(k: str) -> tuple:
+            e = by_lemma[k]
+            has_interior_punct = bool(re.search(r"[^\w\s]", e["lemma"], re.UNICODE))
+            return (
+                has_interior_punct,
+                _source_priority(e["primary_source"]),
+                len(e["lemma"]),
+                e["lemma"],
+            )
+
+        canonical_key, *folded_keys = sorted(collision_keys, key=_rank)
+        canonical = by_lemma[canonical_key]
+        for fold_key in folded_keys:
+            other = by_lemma.pop(fold_key)
+            for u in other.get("course_usage", []):
+                usage_id = (u["track"], u["module_num"], u["slug"])
+                if not any(
+                    (x["track"], x["module_num"], x["slug"]) == usage_id
+                    for x in canonical["course_usage"]
+                ):
+                    canonical["course_usage"].append(u)
+            for norm in other.get("atlas_normalizations", []):
+                _append_normalization(canonical, norm)
+            for field in ("gloss", "pos", "ipa"):
+                if not canonical.get(field) and other.get(field):
+                    canonical[field] = other[field]
+            if "seed_group" in other and "seed_group" not in canonical:
+                canonical["seed_group"] = other["seed_group"]
+            variants = canonical.setdefault("slug_variants", [])
+            if other["lemma"] != canonical["lemma"] and other["lemma"] not in variants:
+                variants.append(other["lemma"])
+
+
 def build_manifest() -> dict:
     """Build the manifest dict and return it (caller writes to disk)."""
     by_lemma: dict[str, dict] = {}
@@ -505,6 +563,7 @@ def build_manifest() -> dict:
 
     _merge_seed_records(by_lemma)
     _merge_heritage_seed_records(by_lemma)
+    _resolve_slug_collisions(by_lemma)
 
     entries = sorted(by_lemma.values(), key=lambda e: e["lemma"])
     return {

--- a/tests/test_lexicon_build_manifest.py
+++ b/tests/test_lexicon_build_manifest.py
@@ -191,3 +191,55 @@ def test_manifest_url_slugs_are_unique() -> None:
     duplicates = {slug: lemmas for slug, lemmas in slugs.items() if len(lemmas) > 1}
 
     assert duplicates == {}
+
+
+def test_resolve_slug_collisions_folds_comma_variant() -> None:
+    """Comma-variant lemmas that collide on slug fold into one canonical entry."""
+    from scripts.lexicon.build_data_manifest import (
+        _resolve_slug_collisions,
+        _slug_for_url,
+    )
+
+    # Precondition: the slug function folds commas, so these collide.
+    assert _slug_for_url("тому що") == _slug_for_url("тому, що")
+
+    by_lemma = {
+        "тому що": {
+            "lemma": "тому що",
+            "url_slug": _slug_for_url("тому що"),
+            "gloss": "because",
+            "pos": "conj",
+            "ipa": None,
+            "primary_source": "built_vocabulary",
+            "course_usage": [
+                {"track": "b1", "module_num": 1, "slug": "m1", "context": "built_vocabulary"}
+            ],
+        },
+        "тому, що": {
+            "lemma": "тому, що",
+            "url_slug": _slug_for_url("тому, що"),
+            "gloss": "because (comma form)",
+            "pos": "conj",
+            "ipa": None,
+            "primary_source": "built_vocabulary",
+            "course_usage": [
+                {"track": "b1", "module_num": 2, "slug": "m2", "context": "built_vocabulary"}
+            ],
+            "atlas_normalizations": [{"kind": "calque_correction", "source_lemma": "x"}],
+        },
+    }
+
+    _resolve_slug_collisions(by_lemma)
+
+    survivors = list(by_lemma.values())
+    assert len(survivors) == 1
+    entry = survivors[0]
+    # Canonical = the form WITHOUT interior punctuation.
+    assert entry["lemma"] == "тому що"
+    assert entry["slug_variants"] == ["тому, що"]
+    # course_usage from both folded entries is merged (deduped by module identity).
+    assert {u["module_num"] for u in entry["course_usage"]} == {1, 2}
+    # normalizations from the folded entry are carried over.
+    assert any(
+        n["kind"] == "calque_correction" for n in entry.get("atlas_normalizations", [])
+    )


### PR DESCRIPTION
## Why
`main` is RED: `test_manifest_url_slugs_are_unique` fails because `_slug_for_url` folds commas, so the §6 calque layer's comma-variant conjunctions (`тому, що`, `через те, що`) collide on slug with the base forms (`тому що`, `через те що`). This blocks the entire merge train.

## Fix (root cause)
`_resolve_slug_collisions` — a final-assembly pass in `build_data_manifest.py` that folds entries sharing a `url_slug` into one deterministic canonical (no-interior-punct > source-priority > shortest > alphabetical), merging `course_usage` + `atlas_normalizations` and recording folded forms under `slug_variants`. Isolated to assembly — does NOT touch `_lemma_key` (used across many curated maps). + focused unit test.

## Verification
`tests/test_lexicon_build_manifest.py` → **14 passed** (incl. the previously-failing slug test + new unit test). ruff clean.

## Follow-up (same PR)
Committed manifest regen (`make atlas`) to fix the 2 deployed routes + the advisory freshness gate — pushing next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)