### PR TITLE
chore(lexicon): refresh Atlas manifest fingerprint (clears advisory freshness gate)

### DIFF
--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "4429414577f027a615128e36a7dca2dcaca468588588becccfef7b39b42bd4bc",
+  "fingerprint": "ce42130909e860235ace8cd0c6281091a80c996515a656dd139a398215e4af5f",
   "inputs": {
     "lexicon_code": [
       {
@@ -12,7 +12,7 @@
       },
       {
         "path": "scripts/lexicon/build_data_manifest.py",
-        "sha256": "fb283a095391fcc6f7738476fda36f164d14b2587ef44ad8b10efce62ecd3a81"
+        "sha256": "e89cda21e8ed0ae504b239adf1c80278b81efa098d2ae9605c6d10ec514aa0d8"
       },
       {
         "path": "scripts/lexicon/build_kaikki_lookup.py",


### PR DESCRIPTION
Follow-up to #3626. That PR changed the manifest build code (added the slug-collision fold), which moved the DB-free freshness code-hash, so the committed fingerprint sidecar went stale (advisory "Atlas Manifest Freshness" red).

Verified surgically: the committed manifest is **already collision-free** (fold reported 0 changes, 2891 entries unchanged) — the slug collision only existed in the larger build output (4050 entries), which #3626 fixed. Only the fingerprint sidecar needed refreshing. `check_manifest_freshness.py` now exits 0.

No manifest content change; no deployed-route impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
