### PR TITLE
chore(lexicon): refresh Atlas manifest fingerprint after #3603

### DIFF
--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "ce42130909e860235ace8cd0c6281091a80c996515a656dd139a398215e4af5f",
+  "fingerprint": "c952286d427a0f778185edc26a463ab5b5321a1668a2761630d4c8dc4bb86871",
   "inputs": {
     "lexicon_code": [
       {
@@ -24,7 +24,7 @@
       },
       {
         "path": "scripts/lexicon/calque_corrections.py",
-        "sha256": "b5d8ec683d1d8f3f4c64bbde9e6d8bab8c1778bd8af0eb13203dc80a5a434edc"
+        "sha256": "d1af3c47b47916c90f7e9fa6fa1e2a9e29283ffda14e430415a97848f91556c5"
       },
       {
         "path": "scripts/lexicon/check_manifest_freshness.py",
@@ -40,7 +40,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "2c8922a6da0a6da4d07d24cc59ab063bd709d2a6cd567ae87bed1e42b114efd9"
+        "sha256": "c8814a4a1b97c7e8942c46077322ccfb12c0e687eb188cfa7396693a5bbe27e1"
       },
       {
         "path": "scripts/lexicon/generate_vesum_aliases.py",


### PR DESCRIPTION
Regenerates the DB-free Atlas manifest freshness sidecar (`lexicon-manifest.fingerprint.json`) after #3603 changed `scripts/lexicon/*.py` (phrasal calques + `_reverse_calques()`).

- The sidecar is a pure SHA256 of `scripts/lexicon/*.py` (no DB, no manifest regen).
- Left stale by #3603, the advisory **Atlas Manifest Freshness** gate went red on main.
- `check_manifest_freshness.py` now reports: `Atlas manifest freshness OK: 16 lexicon code files.`
- Mirrors the proven #3626→#3628 follow-up pattern.

Keeps the Atlas freshness gate honest (Atlas-trust history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)