### PR TITLE
fix(atlas): refresh stale fingerprint + kill double header + auto-sync hook (#3649)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -137,6 +137,22 @@ repos:
         files: ^(site/src/components/.*\.(tsx|astro)|scripts/pipeline/config_tables\.py|docs/lesson-contract\.md)$
         stages: [pre-commit]
 
+      # Atlas lexicon code-fingerprint must stay in sync with scripts/lexicon/*.py.
+      # Regenerate it, then diff: a drifted sidecar blocks the commit until it is
+      # staged. Root-cause fix for the recurring "Atlas Manifest Freshness" CI
+      # red (#3649) — drift can no longer reach main by someone forgetting
+      # `make atlas`.
+      - id: atlas-lexicon-fingerprint-drift
+        name: Atlas lexicon fingerprint freshness gate
+        entry: >-
+          bash -c 'bash scripts/pre_commit/project_python.sh
+          scripts/pre_commit/regen_lexicon_fingerprint.py && git diff --exit-code
+          site/src/data/lexicon-manifest.fingerprint.json'
+        language: system
+        pass_filenames: false
+        files: ^scripts/lexicon/.*\.py$
+        stages: [pre-commit]
+
       - id: lint-dispatch-brief-venv
         name: dispatch brief .venv worktree guardrail
         entry: >-

--- a/scripts/pre_commit/regen_lexicon_fingerprint.py
+++ b/scripts/pre_commit/regen_lexicon_fingerprint.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Pre-commit: regenerate the Atlas lexicon code-fingerprint.
+
+Root-cause fix for the recurring "Atlas Manifest Freshness" CI failure (#3649).
+
+The committed sidecar ``site/src/data/lexicon-manifest.fingerprint.json`` hashes
+``scripts/lexicon/*.py`` (see ``scripts/lexicon/manifest_fingerprint.py``). It
+must be regenerated whenever that code changes, but humans and agents kept
+forgetting — every such miss turns the gate red on every PR that touches the
+trigger paths (#3603 -> #3629, #3626 -> #3628, #3646 -> #3649). This hook
+regenerates the sidecar deterministically at commit time; the companion
+``.pre-commit-config.yaml`` entry then runs ``git diff --exit-code`` on the
+sidecar, so a drifted fingerprint blocks the commit until the refreshed file is
+staged. After that, drift cannot reach ``main``.
+
+Deliberately lives in ``scripts/pre_commit/`` rather than ``scripts/lexicon/``:
+the latter is the hashed glob, so a maintainer script there would churn the very
+fingerprint it maintains.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.lexicon.manifest_fingerprint import DEFAULT_FINGERPRINT, write_fingerprint
+
+
+def main() -> int:
+    payload = write_fingerprint(DEFAULT_FINGERPRINT, root=ROOT)
+    print(
+        "Atlas lexicon fingerprint written: "
+        f"{payload['fingerprint']} "
+        f"({payload['stats']['lexicon_code_files']} lexicon code files)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "7dd6f12ec95468e0066e93bbaa83ee64ed3d592c617870bda500c973f8efafd5",
+  "fingerprint": "a20087447c4c25f1c5fd6ed9b0ecb31760c94de87e66f661c343883ca4b9f41c",
   "inputs": {
     "lexicon_code": [
       {
@@ -40,11 +40,19 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "c8814a4a1b97c7e8942c46077322ccfb12c0e687eb188cfa7396693a5bbe27e1"
+        "sha256": "bd65d1778fb42df607e51fb76ef9e4188ca4d81ad87dd8b67d4252ab1ebd90b9"
+      },
+      {
+        "path": "scripts/lexicon/esum_garbled.py",
+        "sha256": "e16ea0b5e2fe0362bd2363f766549c755bf772e60c689129424f06f636893b54"
       },
       {
         "path": "scripts/lexicon/export_open_dataset.py",
         "sha256": "0ceb0d6373e301c92611c239bb8bcd616f71af8ebb938d0e48b2b85346e6d065"
+      },
+      {
+        "path": "scripts/lexicon/fix_esum_garbled_etymologies.py",
+        "sha256": "5dc115380709adf1e85755b5b8df7c17898627d5560f686662ee63b99f5d93fd"
       },
       {
         "path": "scripts/lexicon/generate_vesum_aliases.py",
@@ -75,6 +83,6 @@
   "schema_version": 1,
   "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
   "stats": {
-    "lexicon_code_files": 17
+    "lexicon_code_files": 19
   }
 }

--- a/site/src/lexicon/WordAtlasArticle.astro
+++ b/site/src/lexicon/WordAtlasArticle.astro
@@ -410,17 +410,6 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
     <span class="poc-label">Атлас слів (Лексикон)</span>
   </div>
 
-  <div class="topnav">
-    <div class="topnav-inner">
-      <span class="topnav-brand">learn-ukrainian</span>
-      <a class="topnav-link" href="/">Головна</a>
-      <a class="topnav-link" href="/a1/">A1-A2</a>
-      <a class="topnav-link" href="/b1/">B1</a>
-      <a class="topnav-link active" href="/lexicon/">Лексикон</a>
-      <a class="topnav-link" href="/lexicon/index/">А-Я</a>
-    </div>
-  </div>
-
   <div id={`word-${entry.url_slug}`}>
     {entry.form_of ? (
       <>

--- a/site/src/styles/word-atlas.css
+++ b/site/src/styles/word-atlas.css
@@ -207,43 +207,6 @@
   background: var(--lu-state-active);
 }
 
-.topnav {
-  padding: 14px 24px;
-  border-bottom: 1px solid var(--lu-border);
-  background: var(--lu-surface);
-}
-
-.topnav-inner {
-  max-width: var(--content-width);
-  margin: 0 auto;
-  display: flex;
-  align-items: center;
-  gap: 28px;
-  font-size: 14px;
-}
-
-.topnav-brand {
-  font-weight: 700;
-  color: var(--blue);
-}
-
-.topnav-link {
-  color: var(--gray-600);
-  text-decoration: none;
-}
-
-.topnav-link:hover {
-  color: var(--blue);
-}
-
-.topnav-link.active {
-  color: var(--teal);
-  font-weight: 700;
-  border-bottom: 2px solid var(--teal);
-  padding-bottom: 12px;
-  margin-bottom: -14px;
-}
-
 .word-hero {
   background: var(--lu-id-lexicon);
   color: white;
@@ -995,13 +958,11 @@
 }
 
 @media (max-width: 720px) {
-  .word-switch,
-  .topnav {
+  .word-switch {
     padding-left: 14px;
     padding-right: 14px;
   }
 
-  .topnav-inner,
   .atlas-search,
   .used-in-card {
     align-items: stretch;

--- a/tests/test_lexicon_manifest_fingerprint.py
+++ b/tests/test_lexicon_manifest_fingerprint.py
@@ -74,6 +74,36 @@ def test_manifest_fingerprint_ignores_vocab_lemma_churn(tmp_path: Path) -> None:
     assert after == before
 
 
+def test_write_fingerprint_is_idempotent(tmp_path: Path) -> None:
+    # The pre-commit hook regenerates the sidecar then `git diff --exit-code`s it.
+    # If write_fingerprint were non-deterministic, that gate would block every
+    # commit. Guarantee re-running on unchanged code yields byte-identical output.
+    root = _fixture_repo(tmp_path)
+    sidecar = root / "site" / "src" / "data" / "lexicon-manifest.fingerprint.json"
+
+    write_fingerprint(sidecar, root=root)
+    first = sidecar.read_bytes()
+    write_fingerprint(sidecar, root=root)
+    second = sidecar.read_bytes()
+
+    assert first == second
+
+
+def test_write_fingerprint_changes_after_lexicon_edit(tmp_path: Path) -> None:
+    # Conversely, editing lexicon code MUST change the regenerated sidecar — that
+    # is the drift the pre-commit `git diff --exit-code` is meant to catch.
+    root = _fixture_repo(tmp_path)
+    sidecar = root / "site" / "src" / "data" / "lexicon-manifest.fingerprint.json"
+
+    write_fingerprint(sidecar, root=root)
+    before = sidecar.read_bytes()
+    (root / "scripts" / "lexicon" / "alpha.py").write_text("VALUE = 999\n", encoding="utf-8")
+    write_fingerprint(sidecar, root=root)
+    after = sidecar.read_bytes()
+
+    assert after != before
+
+
 def test_manifest_freshness_check_passes_on_matching_sidecar(tmp_path: Path, capsys) -> None:
     root = _fixture_repo(tmp_path)
     sidecar = root / "site" / "src" / "data" / "lexicon-manifest.fingerprint.json"


### PR DESCRIPTION
## What
Makes Atlas **spotless**: green CI, single header, design-conformant body — and stops the fingerprint from going stale **again**.

### 1. CI red AGAIN — `Atlas Manifest Freshness` (the immediate error)
The committed code-fingerprint (`site/src/data/lexicon-manifest.fingerprint.json`) hashes `scripts/lexicon/*.py`. #3646 edited lexicon code without `make atlas`, so the hash drifted (`7dd6f12…` → `a200874…`). **Regenerated the sidecar via `write_fingerprint()` only** — code-hash, **no manifest-data regen, zero data drift** (the issue's canonical-DB caveat is about the data pipeline, not the fingerprint). `check_manifest_freshness.py` → rc 0.

### 2. WHY AGAIN — recurrence root cause (the real fix)
The fingerprint is a generated file kept fresh only by **human discipline**, so it drifts on every lexicon PR that forgets: #3603→#3629, #3626→#3628, #3646→#3649. Added a pre-commit hook **`atlas-lexicon-fingerprint-drift`** that regenerates the sidecar when `scripts/lexicon/*.py` is staged and `git diff --exit-code`s it — **drift can no longer reach `main`**. Mirrors the existing `lesson-schema-drift` idiom. Proven end-to-end: simulated a lexicon edit → hook produced a different fingerprint → gate blocked.

### 3. Double header
`WordAtlasArticle.astro` rendered its **own `<div class="topnav">` site-nav** on top of `CourseLayout`'s `lu-header`. Removed the duplicate nav (the site nav already exposes **Word Atlas**) + dead `.topnav*` CSS. The hero «Шапка» stays per `word-atlas-design.md` §4; the header itself is the standard site header (excepted from the design per direction).

## Verification (live dev render)
- `/lexicon/` and `/lexicon/прапор/`: **exactly 1 `<header>`, 0 `topnav`, 1 hero, 1 `word-title`** (structural grep + screenshot).
- No console errors; body follows the design (teal sections, course cross-links, provenance footer).
- `tests/test_lexicon_manifest_fingerprint.py`: **10/10 pass** (added idempotency + drift-after-edit covering the pre-commit contract); ruff clean; all pre-commit hooks pass.

## Coordination
codex has a parallel WIP branch `codex/atlas-cleanup` (phrase cards on `[lemma].astro`, no PR). **No overlap** with this PR's files — it can rebase cleanly.

Closes #3649.