### PR TITLE
feat(atlas): typeahead word search — replace non-scaling dropdown + kill duplicate theme toggle

### DIFF
--- a/site/src/layouts/CourseLayout.astro
+++ b/site/src/layouts/CourseLayout.astro
@@ -63,7 +63,7 @@ const topNav = [
   { href: '/a2/', label: 'A2' },
   { href: '/b1/', label: 'B1 Preview' },
   { href: '/lexicon/', label: 'Word Atlas' },
-  { href: '/search/', label: 'Search' },
+  { href: '/lexicon/index/', label: 'Search' },
 ];
 
 const isActive = (href: string) => {

--- a/site/src/lexicon/WordAtlasArticle.astro
+++ b/site/src/lexicon/WordAtlasArticle.astro
@@ -219,8 +219,6 @@ const CONTEXT_LABELS_UK: Record<string, string> = {
   surzhyk_to_avoid: "остерігайтеся",
 };
 
-const switchEntries = buildSwitchEntries();
-
 function formatIpa(value: string | null | undefined) {
   const trimmed = value?.trim();
   if (!trimmed) return null;
@@ -365,17 +363,6 @@ function buildSourceList() {
   return Array.from(sources).sort((a, b) => a.localeCompare(b, "uk"));
 }
 
-function buildSwitchEntries() {
-  const preferred = ["князь", "прапор", "файний"];
-  const byLemma = new Map(allEntries.map((item) => [item.lemma, item]));
-  const selected = [
-    ...preferred.map((lemma) => byLemma.get(lemma)).filter((item): item is LexiconEntry => Boolean(item)),
-    entry,
-    ...allEntries.filter((item) => item.enrichment).slice(0, 12),
-  ];
-  return selected.filter((item, index, arr) => arr.findIndex((candidate) => candidate.url_slug === item.url_slug) === index).slice(0, 15);
-}
-
 function groupExternalMaterials(items: NonNullable<Enrichment["external_materials"]>) {
   const groups = new Map<string, NonNullable<Enrichment["external_materials"]>>();
   for (const item of items) {
@@ -390,23 +377,30 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
 
 <div class="word-atlas" data-word-atlas>
   <div class="word-switch">
-    <label for="word-atlas-switcher">Слово:</label>
-    <select id="word-atlas-switcher" data-word-switch>
-      {switchEntries.map((item) => (
-        <option value={item.url_slug} selected={item.url_slug === entry.url_slug}>
-          {item.lemma}{item.gloss ? ` — ${item.gloss}` : ""}
-        </option>
-      ))}
-    </select>
-    <form class="atlas-search" action="/lexicon/index/" method="get">
-      <input name="q" type="search" aria-label="Шукати" placeholder="Шукати слово або джерело" />
-      <button class="atlas-button search" type="submit">Шукати</button>
-      <a class="atlas-button filter" href="/lexicon/index/">Фільтр</a>
-    </form>
-    <div class="theme-toggle" role="group" aria-label="Тема">
-      <button type="button" data-theme-choice="light">Світла</button>
-      <button type="button" data-theme-choice="dark">Темна</button>
+    <div class="atlas-typeahead" data-atlas-typeahead>
+      <input
+        type="search"
+        class="atlas-typeahead-input"
+        placeholder="Шукати слово…"
+        aria-label="Шукати слово в Лексиконі"
+        role="combobox"
+        aria-expanded="false"
+        aria-autocomplete="list"
+        aria-controls="atlas-typeahead-list"
+        autocomplete="off"
+        spellcheck="false"
+        data-atlas-typeahead-input
+      />
+      <ul
+        id="atlas-typeahead-list"
+        class="atlas-typeahead-list"
+        role="listbox"
+        aria-label="Результати пошуку"
+        hidden
+        data-atlas-typeahead-list
+      ></ul>
     </div>
+    <a class="atlas-button filter" href="/lexicon/index/">Перегляд А–Я</a>
     <span class="poc-label">Атлас слів (Лексикон)</span>
   </div>
 
@@ -798,30 +792,81 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
 <script is:inline>
   (() => {
     const root = document.querySelector('[data-word-atlas]');
-    const switcher = root?.querySelector('[data-word-switch]');
-    switcher?.addEventListener('change', () => {
-      const value = switcher.value;
-      window.location.href = value ? `/lexicon/${encodeURIComponent(value)}/` : '/lexicon/';
-    });
+    const ta = root?.querySelector('[data-atlas-typeahead]');
+    const taInput = ta?.querySelector('[data-atlas-typeahead-input]');
+    const taList = ta?.querySelector('[data-atlas-typeahead-list]');
+    if (taInput && taList) {
+      let taIndex = null;
+      let taLoading = null;
+      let taItems = [];
+      let taActive = -1;
 
-    const syncThemeButtons = () => {
-      const theme = document.documentElement.dataset.theme || 'light';
-      root?.querySelectorAll('[data-theme-choice]').forEach((button) => {
-        button.classList.toggle('active', button.dataset.themeChoice === theme);
-      });
-    };
+      const taLoad = () => {
+        if (taIndex) return Promise.resolve(taIndex);
+        if (!taLoading) {
+          taLoading = fetch('/lexicon/search-index.json')
+            .then((r) => r.json())
+            .then((data) => { taIndex = Array.isArray(data) ? data : []; return taIndex; })
+            .catch(() => { taIndex = []; return taIndex; });
+        }
+        return taLoading;
+      };
 
-    root?.querySelectorAll('[data-theme-choice]').forEach((button) => {
-      button.addEventListener('click', () => {
-        const next = button.dataset.themeChoice;
-        document.documentElement.dataset.theme = next;
-        try {
-          window.localStorage.setItem('lu-theme', next);
-        } catch {}
-        syncThemeButtons();
+      const taNorm = (s) => (s || '').toLowerCase().normalize('NFC').replace(/['́̀ˈ]/g, '').trim();
+      const taEsc = (s) => (s || '').replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+      const taGo = (slug) => { if (slug) window.location.href = `/lexicon/${encodeURIComponent(slug)}/`; };
+
+      const taRender = () => {
+        if (!taItems.length) {
+          taList.hidden = true;
+          taList.innerHTML = '';
+          taInput.setAttribute('aria-expanded', 'false');
+          taInput.removeAttribute('aria-activedescendant');
+          return;
+        }
+        taList.innerHTML = taItems.map((it, i) =>
+          `<li role="option" id="ata-opt-${i}" class="atlas-typeahead-opt${i === taActive ? ' active' : ''}" data-slug="${taEsc(it.s)}" aria-selected="${i === taActive}">`
+          + `<span class="ata-lemma">${taEsc(it.l)}</span>`
+          + (it.g ? `<span class="ata-gloss">${taEsc(it.g)}</span>` : '')
+          + '</li>'
+        ).join('');
+        taList.hidden = false;
+        taInput.setAttribute('aria-expanded', 'true');
+        if (taActive >= 0) taInput.setAttribute('aria-activedescendant', `ata-opt-${taActive}`);
+      };
+
+      const taSearch = (q) => {
+        const nq = taNorm(q);
+        if (!nq || !taIndex) { taItems = []; taActive = -1; taRender(); return; }
+        const starts = [];
+        const contains = [];
+        for (const e of taIndex) {
+          const nl = taNorm(e.l);
+          if (nl.startsWith(nq)) { if (starts.length < 12) starts.push(e); }
+          else if (contains.length < 12 && (nl.includes(nq) || taNorm(e.g).includes(nq))) contains.push(e);
+          if (starts.length >= 12) break;
+        }
+        taItems = starts.concat(contains).slice(0, 12);
+        taActive = taItems.length ? 0 : -1;
+        taRender();
+      };
+
+      taInput.addEventListener('focus', taLoad, { once: true });
+      taInput.addEventListener('input', () => { taLoad().then(() => taSearch(taInput.value)); });
+      taInput.addEventListener('keydown', (ev) => {
+        if (ev.key === 'ArrowDown') { ev.preventDefault(); if (taItems.length) { taActive = (taActive + 1) % taItems.length; taRender(); } }
+        else if (ev.key === 'ArrowUp') { ev.preventDefault(); if (taItems.length) { taActive = (taActive - 1 + taItems.length) % taItems.length; taRender(); } }
+        else if (ev.key === 'Enter') { if (taItems[taActive]) { ev.preventDefault(); taGo(taItems[taActive].s); } }
+        else if (ev.key === 'Escape') { taItems = []; taActive = -1; taRender(); }
       });
-    });
-    syncThemeButtons();
+      taList.addEventListener('mousedown', (ev) => {
+        const li = ev.target.closest('[data-slug]');
+        if (li) { ev.preventDefault(); taGo(li.getAttribute('data-slug')); }
+      });
+      document.addEventListener('click', (ev) => {
+        if (ta && !ta.contains(ev.target)) { taItems = []; taActive = -1; taRender(); }
+      });
+    }
 
     root?.querySelectorAll('[data-ety-note]').forEach((stage) => {
       stage.addEventListener('click', () => {

--- a/site/src/pages/lexicon/search-index.json.ts
+++ b/site/src/pages/lexicon/search-index.json.ts
@@ -1,0 +1,30 @@
+import type { APIRoute } from "astro";
+import manifest from "../../data/lexicon-manifest.json";
+
+/**
+ * Static client-side search index for the Word Atlas typeahead.
+ *
+ * Emits one compact record per lemma — `l` (lemma), `s` (url_slug), `g` (gloss) —
+ * so the typeahead can find any of the ~4k+ (growing to 10k+) entries from any
+ * page without a `<select>` that cannot scale. Prerendered at build, so it stays
+ * in sync with the manifest automatically. ~251 KB at 4148 entries.
+ */
+interface ManifestEntry {
+  lemma: string;
+  url_slug: string;
+  gloss: string | null;
+}
+
+export const GET: APIRoute = () => {
+  const entries = (manifest as { entries: ManifestEntry[] }).entries.map((e) => ({
+    l: e.lemma,
+    s: e.url_slug,
+    g: e.gloss ?? null,
+  }));
+  return new Response(JSON.stringify(entries), {
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+};

--- a/site/src/styles/word-atlas.css
+++ b/site/src/styles/word-atlas.css
@@ -118,24 +118,6 @@
   font-size: 13px;
 }
 
-.word-switch label {
-  opacity: 0.7;
-}
-
-.word-switch select,
-.atlas-search input {
-  border: 1px solid var(--lu-border);
-  border-radius: 6px;
-  background: var(--lu-surface-muted);
-  color: var(--lu-text);
-  font-size: 13px;
-}
-
-.word-switch select {
-  max-width: min(100%, 320px);
-  padding: 4px 12px;
-}
-
 .word-switch .poc-label {
   margin-left: auto;
   color: var(--lu-primary);
@@ -143,23 +125,73 @@
   letter-spacing: 0.5px;
 }
 
-.atlas-search {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex: 1 1 280px;
-  min-width: 260px;
+.atlas-typeahead {
+  position: relative;
+  flex: 1 1 320px;
+  min-width: 220px;
+  max-width: 520px;
 }
 
-.atlas-search input {
+.atlas-typeahead-input {
   width: 100%;
-  min-width: 140px;
-  padding: 6px 10px;
+  padding: 7px 12px;
+  border: 1px solid var(--lu-border);
+  border-radius: 8px;
+  background: var(--lu-surface-muted);
+  color: var(--lu-text);
+  font-size: 14px;
 }
 
-.atlas-search input::placeholder {
+.atlas-typeahead-input::placeholder {
   color: var(--lu-text-muted);
   opacity: 1;
+}
+
+.atlas-typeahead-input:focus {
+  outline: none;
+  border-color: var(--lu-primary);
+  box-shadow: 0 0 0 2px var(--lu-state-active);
+}
+
+.atlas-typeahead-list {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 200;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  max-height: 340px;
+  overflow-y: auto;
+  background: var(--lu-surface);
+  border: 1px solid var(--lu-border);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+}
+
+.atlas-typeahead-opt {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 7px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.atlas-typeahead-opt.active,
+.atlas-typeahead-opt:hover {
+  background: var(--lu-state-active);
+}
+
+.ata-lemma {
+  font-weight: 700;
+  color: var(--lu-text);
+}
+
+.ata-gloss {
+  color: var(--lu-text-muted);
+  font-size: 13px;
 }
 
 .atlas-button {
@@ -169,42 +201,14 @@
   font-size: 13px;
   font-weight: 700;
   cursor: pointer;
-}
-
-.atlas-button.search {
-  background: var(--lu-state-active);
-  color: var(--lu-primary);
-  border-color: var(--lu-primary);
+  text-decoration: none;
+  white-space: nowrap;
 }
 
 .atlas-button.filter {
   background: var(--lu-accent);
   color: var(--lu-on-accent);
   border-color: var(--lu-accent);
-}
-
-.theme-toggle {
-  display: inline-flex;
-  padding: 2px;
-  border: 1px solid var(--lu-border);
-  border-radius: 8px;
-  background: var(--lu-surface-muted);
-}
-
-.theme-toggle button {
-  border: 0;
-  border-radius: 6px;
-  padding: 4px 10px;
-  color: var(--lu-text-muted);
-  background: transparent;
-  font-size: 12px;
-  font-weight: 700;
-  cursor: pointer;
-}
-
-.theme-toggle button.active {
-  color: var(--lu-text);
-  background: var(--lu-state-active);
 }
 
 .word-hero {
@@ -963,7 +967,11 @@
     padding-right: 14px;
   }
 
-  .atlas-search,
+  .atlas-typeahead {
+    flex-basis: 100%;
+    max-width: none;
+  }
+
   .used-in-card {
     align-items: stretch;
     flex-direction: column;


### PR DESCRIPTION
## Why
The per-page word chooser was a `<select>` populated with a curated **13-item** list — it can't find an arbitrary word and doesn't scale to the **4148** (→10k+) lexicon entries. As you flagged: for 10k+ words a dropdown is the wrong control; **search is.** Also fixed a **duplicate theme toggle** (the atlas bar had its own «Світла/Темна» on top of the site header's) and a **dead nav link**.

## What
- **NEW `/lexicon/search-index.json`** — compact `{l,s,g}` per lemma (~251 KB, prerendered, auto-syncs with the manifest at build).
- **Inline typeahead** replaces the `<select>` in `WordAtlasArticle`: accessible combobox, lazy-fetches the index on first focus, prefix+substring match on lemma **and** gloss, ArrowUp/Down + Enter, click/Enter → `/lexicon/{slug}`. Finds any word from any page.
- **Removed the duplicate theme toggle** — the atlas's bespoke «Світла/Темна» duplicated `CourseLayout`'s site toggle (same PoC-chrome root cause as the #3651 double header). One toggle now.
- **Fixed dead top-nav «Search»** (`/search/` → 404) → `/lexicon/index/` (the А-Я browse/filter).
- Removed the now-dead `switchEntries`/`buildSwitchEntries` + `.atlas-search`/`.theme-toggle` CSS.

## Verified live (astro dev, screenshots in thread)
- Typing «хліб» → suggestions «хліб — bread» / «шматок хліба — piece of bread» → click navigates to the rich `/lexicon/хліб/` page.
- Exactly **one** theme toggle (site header).
- No console errors.