### PR TITLE
fix(folk): verse renders as lines — white-space:pre-line on primary-reading blockquotes (#3661)

### DIFF
--- a/site/src/styles/lesson.css
+++ b/site/src/styles/lesson.css
@@ -245,6 +245,15 @@
   margin-bottom: 0;
 }
 
+/* Folk verse (колядки/думи/щедрівки) is authored as Markdown blockquotes, whose
+   soft line breaks the browser otherwise collapses to spaces — making verse render
+   as a run-on paragraph (#3661). Preserve the newlines as line breaks so verse reads
+   as verse. Scoped to the primary-reading container ONLY: prose/scholarly blockquotes
+   elsewhere must keep normal wrapping. */
+.primary-reading-content blockquote {
+  white-space: pre-line;
+}
+
 .myth-source {
   font-size: 0.8125rem;
   color: var(--ifm-color-emphasis-600, #757575);


### PR DESCRIPTION
## Problem (#3661)
Folk verse (колядки/думи/щедрівки) authored as Markdown blockquotes rendered as a **run-on paragraph**. Markdown preserves the soft line-breaks as literal `\n` inside the `<blockquote><p>…</p>`, but with `white-space: normal` the browser collapses them to spaces.

## Fix
One scoped rule in `site/src/styles/lesson.css`:
```css
.primary-reading-content blockquote { white-space: pre-line; }
```
Scoped to the **primary-reading container only** — prose/scholarly blockquotes elsewhere keep normal wrapping (per the issue's scope note).

## Verification (dev server, koliadky-shchedrivky)
Three independent confirmations:
1. **HTML mechanism:** rendered blockquote = `<p>Як ще не було початку світа,\nТогди не було неба, ні землі,\n…</p>` — newlines preserved.
2. **Runtime:** computed `white-space` = `pre-line` on all 3 primary-reading blockquotes; block heights (210/575/450px @ 26px line-height) consistent with multi-line verse.
3. **Visual:** the 18-line cosmogonic колядка now renders as 18 separate lines (was a single run-on paragraph).

This unblocks migrating the standalone reading pages (#3660) off their `<br />` stopgap to clean `>` blockquotes.

Closes #3661.