### PR TITLE
feat(atlas): gate blocks shipping a thin/un-enriched lexicon manifest (#3658)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,12 @@ jobs:
       - name: Check DB-free Atlas manifest freshness
         run: python scripts/lexicon/check_manifest_freshness.py
 
+      # Root-cause guard for the #3631 empty-atlas regression: a manifest committed
+      # without enrichment (enrichment_generated False / ~0 enriched entries) renders
+      # an empty Atlas while the fingerprint/freshness gate above stays green. Blocks it.
+      - name: Block thin/un-enriched Atlas manifest (#3658)
+        run: python scripts/audit/check_atlas_manifest_enrichment.py
+
       # Diff-scoped + advisory (#3150): only flags modules whose vocabulary.yaml changed
       # in THIS PR (no cross-PR coupling on the merge-train), and never blocks merge — a
       # full manifest regen is ~33 min and the merge-train adds vocab faster than that.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -153,6 +153,16 @@ repos:
         files: ^scripts/lexicon/.*\.py$
         stages: [pre-commit]
 
+      # Block committing a thin/un-enriched Atlas manifest (#3631 empty-atlas
+      # regression class, #3658). Fires when the manifest itself is staged.
+      - id: atlas-manifest-enrichment-depth
+        name: Atlas manifest enrichment-depth gate
+        entry: bash scripts/pre_commit/project_python.sh scripts/audit/check_atlas_manifest_enrichment.py
+        language: system
+        pass_filenames: false
+        files: ^site/src/data/lexicon-manifest\.json$
+        stages: [pre-commit]
+
       - id: lint-dispatch-brief-venv
         name: dispatch brief .venv worktree guardrail
         entry: >-

--- a/scripts/audit/check_atlas_manifest_enrichment.py
+++ b/scripts/audit/check_atlas_manifest_enrichment.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""DB-free gate: block shipping a thin/un-enriched Atlas lexicon manifest (#3658).
+
+Root-cause prevention for the #3631 empty-atlas regression class. A manifest built
+via ``build_data_manifest`` WITHOUT a subsequent ``enrich_manifest`` pass ships with
+``enrichment_generated`` False and ~0 enriched entries — which renders an empty Word
+Atlas even though every CI fingerprint/freshness check stays green (the fingerprint
+covers lexicon *code*, not manifest *content*). #3631 did exactly this: enrichment
+dropped from ~2499/4148 to 0 and the regression reached main; #3654 restored it.
+
+This gate inspects the committed ``site/src/data/lexicon-manifest.json`` and FAILS
+when it is thin, so the empty-atlas class can never reach main again. It is DB-free
+and reads only the committed JSON, so it runs in CI (unlike the DB-dependent
+``scripts/audit/validate_atlas_conformance.py``).
+
+NOTE: deliberately NOT placed under ``scripts/lexicon/`` — that dir is hashed by the
+manifest code-fingerprint (``LEXICON_CODE_GLOB``), so a check-only file there would
+spuriously force a ``make atlas`` regen on every edit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
+
+# The #3631 regression was a cliff: ~85% enriched -> 0%. Healthy manifests have
+# historically run 60-85% enriched. A 0.40 floor decisively separates a thin
+# manifest (0%) from any legitimate state while leaving wide margin against false
+# positives as the lexicon grows. Tune via --min-ratio if enrichment coverage
+# legitimately shifts.
+MIN_ENRICHED_RATIO = 0.40
+
+
+def check_enrichment(
+    *,
+    manifest_path: Path = DEFAULT_MANIFEST,
+    min_ratio: float = MIN_ENRICHED_RATIO,
+) -> int:
+    """Return 0 when the manifest is adequately enriched, non-zero otherwise."""
+    if not manifest_path.exists():
+        print(f"::error::Atlas manifest missing at {manifest_path}; run `make atlas`.")
+        return 2
+
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"::error::Atlas manifest unreadable ({exc}); run `make atlas`.")
+        return 2
+
+    entries = manifest.get("entries") or []
+    total = len(entries)
+    if total == 0:
+        print("::error::Atlas manifest has 0 entries — thin/empty manifest; run `make atlas`.")
+        return 2
+
+    enriched = sum(1 for e in entries if isinstance(e, dict) and e.get("enrichment"))
+    ratio = enriched / total
+    flag = manifest.get("enrichment_generated")
+
+    problems: list[str] = []
+    if flag is not True:
+        problems.append(f"enrichment_generated={flag!r} (expected True)")
+    if ratio < min_ratio:
+        problems.append(
+            f"enriched ratio {ratio:.1%} ({enriched}/{total}) below floor {min_ratio:.0%}"
+        )
+
+    if problems:
+        print(
+            "::error::Atlas manifest is thin/un-enriched — refusing to ship "
+            "(empty-atlas regression class #3631/#3658): " + "; ".join(problems)
+        )
+        print(
+            "Fix: re-run enrichment (`make atlas`, or enrich_manifest against the warm "
+            "slovnyk cache) and recommit site/src/data/lexicon-manifest.json."
+        )
+        return 2
+
+    print(
+        f"Atlas manifest enrichment OK: {enriched}/{total} entries enriched "
+        f"({ratio:.1%}); enrichment_generated=True."
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Block shipping a thin/un-enriched Atlas lexicon manifest (#3658)."
+    )
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST, help="Manifest JSON path.")
+    parser.add_argument(
+        "--min-ratio",
+        type=float,
+        default=MIN_ENRICHED_RATIO,
+        help="Minimum fraction of entries that must carry enrichment.",
+    )
+    args = parser.parse_args()
+    manifest = args.manifest
+    if not manifest.is_absolute():
+        manifest = ROOT / manifest
+    return check_enrichment(manifest_path=manifest, min_ratio=args.min_ratio)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_atlas_manifest_enrichment_gate.py
+++ b/tests/test_atlas_manifest_enrichment_gate.py
@@ -1,0 +1,73 @@
+"""Tests for the Atlas manifest enrichment-depth gate (#3658).
+
+Guards the #3631 empty-atlas regression class: a thin/un-enriched manifest must
+fail the gate, and the real committed manifest must always pass.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.audit.check_atlas_manifest_enrichment import (
+    DEFAULT_MANIFEST,
+    check_enrichment,
+)
+
+
+def _write(path: Path, *, enrichment_generated, n_total: int, n_enriched: int) -> Path:
+    entries = []
+    for i in range(n_total):
+        entry = {"lemma": f"w{i}", "gloss": "g"}
+        if i < n_enriched:
+            entry["enrichment"] = {"definition": "d"}
+        entries.append(entry)
+    path.write_text(
+        json.dumps({"enrichment_generated": enrichment_generated, "entries": entries}),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_healthy_manifest_passes(tmp_path: Path) -> None:
+    m = _write(tmp_path / "m.json", enrichment_generated=True, n_total=100, n_enriched=85)
+    assert check_enrichment(manifest_path=m) == 0
+
+
+def test_thin_manifest_zero_enriched_fails(tmp_path: Path) -> None:
+    # The exact #3631 shape: enrichment_generated False, 0 enriched entries.
+    m = _write(tmp_path / "m.json", enrichment_generated=False, n_total=4148, n_enriched=0)
+    assert check_enrichment(manifest_path=m) == 2
+
+
+def test_below_ratio_floor_fails(tmp_path: Path) -> None:
+    # enrichment_generated True but coverage collapsed below the floor.
+    m = _write(tmp_path / "m.json", enrichment_generated=True, n_total=100, n_enriched=30)
+    assert check_enrichment(manifest_path=m) == 2
+
+
+def test_ratio_at_floor_passes(tmp_path: Path) -> None:
+    m = _write(tmp_path / "m.json", enrichment_generated=True, n_total=100, n_enriched=40)
+    assert check_enrichment(manifest_path=m, min_ratio=0.40) == 0
+
+
+def test_enrichment_flag_false_fails_even_if_entries_enriched(tmp_path: Path) -> None:
+    m = _write(tmp_path / "m.json", enrichment_generated=False, n_total=100, n_enriched=90)
+    assert check_enrichment(manifest_path=m) == 2
+
+
+def test_empty_entries_fails(tmp_path: Path) -> None:
+    m = _write(tmp_path / "m.json", enrichment_generated=True, n_total=0, n_enriched=0)
+    assert check_enrichment(manifest_path=m) == 2
+
+
+def test_missing_manifest_fails(tmp_path: Path) -> None:
+    assert check_enrichment(manifest_path=tmp_path / "nope.json") == 2
+
+
+@pytest.mark.skipif(not DEFAULT_MANIFEST.exists(), reason="committed manifest not present")
+def test_committed_manifest_is_enriched() -> None:
+    # The real shipped manifest must always pass — this is the regression guard.
+    assert check_enrichment() == 0


### PR DESCRIPTION
Closes #3658.

## Problem
The #3631 empty-atlas regression shipped a manifest built via `build_data_manifest` **without** `enrich_manifest` → `enrichment_generated=False` and ~0 enriched entries → empty Word Atlas. Every existing CI check stayed green because the fingerprint/freshness gate covers lexicon **code**, not manifest **content**. #3654 restored enrichment manually; nothing prevented recurrence.

## Fix — deterministic root-cause guard
New DB-free gate `scripts/audit/check_atlas_manifest_enrichment.py`:
- FAILS unless `enrichment_generated is True` **and** enriched-entry ratio ≥ **0.40**.
- The #3631 cliff was ~85% → 0%; 0.40 decisively separates thin (0%) from any legitimate state (historically 60–85%) with margin. Tunable via `--min-ratio`.
- Placed under `scripts/audit/` (NOT `scripts/lexicon/`) so it stays out of the lexicon code-fingerprint (`LEXICON_CODE_GLOB`) and never forces a spurious `make atlas` regen.

## Wiring
- **CI**: new `ci.yml` step "Block thin/un-enriched Atlas manifest (#3658)" (sibling to the freshness gate). Static `run:`, no untrusted interpolation.
- **pre-commit**: `atlas-manifest-enrichment-depth` hook, fires when `site/src/data/lexicon-manifest.json` is staged.
- **tests**: `tests/test_atlas_manifest_enrichment_gate.py` — 8 tests incl. the exact #3631 shape and a guard that the real committed manifest always passes.

## Verification (raw)
- `pytest tests/test_atlas_manifest_enrichment_gate.py -q` → `8 passed`
- `ruff check` → `All checks passed!`
- gate rc=0 on real manifest (`3512/4148 entries enriched, 84.7%`); rc=2 on a synthesized thin manifest (`enrichment_generated=False; enriched ratio 0.0%`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)