### PR TITLE
feat(ci): forward source→site-MDX parity gate for folk/seminar (#3643)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,13 +442,19 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install PyYAML
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install PyYAML jsonschema
 
       - name: Check MDX source parity
         env:
           MDX_PARITY_BULK_REGEN: ${{ contains(github.event.pull_request.title, '[regen-mdx]') || contains(github.event.pull_request.title, '[bulk-regen]') || contains(github.event.pull_request.body, '[regen-mdx]') || contains(github.event.pull_request.body, '[bulk-regen]') && '1' || '0' }}
         run: |
-          python scripts/audit/check_mdx_source_parity.py --changed-vs-base origin/main
+          .venv/bin/python scripts/audit/check_mdx_source_parity.py --changed-vs-base origin/main
+
+      - name: Check source-to-site MDX forward parity
+        run: |
+          .venv/bin/python scripts/audit/check_mdx_forward_parity.py --changed-vs-base origin/main
 
   mdx-generation-drift:
     name: MDX Generation Drift

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -126,6 +126,17 @@ repos:
         files: ^site/src/content/docs/.*\.mdx$
         stages: [pre-commit]
 
+      - id: check-mdx-forward-parity
+        name: check forward MDX parity
+        entry: bash scripts/pre_commit/project_python.sh scripts/audit/check_mdx_forward_parity.py --files
+        language: system
+        files: >-
+          (?x)^curriculum/l2-uk-en/(plans/)?
+          (folk|hist|istorio|bio|lit|lit-essay|lit-hist-fic|lit-fantastika|
+          lit-war|lit-humor|lit-youth|lit-doc|lit-drama|lit-crimea|oes|ruth)
+          /.*\.(md|ya?ml)$
+        stages: [pre-commit]
+
       - id: lesson-schema-drift
         name: lesson schema drift gate
         entry: >-

--- a/scripts/audit/check_mdx_forward_parity.py
+++ b/scripts/audit/check_mdx_forward_parity.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Check changed folk/seminar sources have current committed site MDX."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.build import linear_pipeline
+
+
+def _load_reverse_parity() -> ModuleType:
+    helper_path = PROJECT_ROOT / "scripts" / "audit" / "check_mdx_source_parity.py"
+    spec = importlib.util.spec_from_file_location("check_mdx_source_parity_for_forward", helper_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load reverse parity helper: {helper_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+reverse_parity = _load_reverse_parity()
+SEMINAR_LEVELS = linear_pipeline.SEMINAR_LEVELS
+MDX_DIR = reverse_parity.MDX_DIR
+SOURCE_DIR = reverse_parity.SOURCE_DIR
+
+SOURCE_FILENAMES = {
+    "activities.yaml",
+    "activities.yml",
+    "module.md",
+    "resources.yaml",
+    "resources.yml",
+    "vocabulary.yaml",
+    "vocabulary.yml",
+}
+NAV_FRONTMATTER_RE = re.compile(r"^(prev|next):(?:\s|$)")
+
+
+@dataclass(frozen=True, order=True)
+class ModuleTarget:
+    level: str
+    slug: str
+
+    @property
+    def module_dir(self) -> Path:
+        return SOURCE_DIR / self.level / self.slug
+
+    @property
+    def mdx_path(self) -> Path:
+        return MDX_DIR / self.level / f"{self.slug}.mdx"
+
+
+def plan_path_for(level: str, slug: str) -> Path:
+    """Mirror the v7 build caller's plan path derivation."""
+    return linear_pipeline.plan_path_for(level, slug)
+
+
+def _as_repo_path(path: Path) -> Path:
+    if path.is_absolute():
+        return path
+    return PROJECT_ROOT / path
+
+
+def _target_for_source(path: Path) -> ModuleTarget | None:
+    path = _as_repo_path(path)
+    try:
+        rel_path = path.resolve().relative_to(SOURCE_DIR)
+    except ValueError:
+        return None
+
+    parts = rel_path.parts
+    if len(parts) < 2:
+        return None
+
+    if parts[0] == "plans":
+        if len(parts) == 3 and rel_path.suffix in {".yaml", ".yml"}:
+            level = parts[1].lower()
+            if level in SEMINAR_LEVELS:
+                return ModuleTarget(level, Path(parts[2]).stem)
+        return None
+
+    level = parts[0].lower()
+    if level not in SEMINAR_LEVELS:
+        return None
+
+    if len(parts) == 3 and parts[2] in SOURCE_FILENAMES:
+        return ModuleTarget(level, parts[1])
+
+    return None
+
+
+def affected_source_targets(paths: list[Path]) -> set[ModuleTarget]:
+    """Return folk/seminar modules whose assembled MDX may have changed."""
+    targets: set[ModuleTarget] = set()
+    for path in paths:
+        target = _target_for_source(path)
+        if target is not None:
+            targets.add(target)
+    return targets
+
+
+def _get_local_changed_files(*, cached: bool = False) -> list[Path]:
+    cmd = ["git", "diff", "--name-only"]
+    if cached:
+        cmd.append("--cached")
+    try:
+        output = subprocess.check_output(cmd, cwd=PROJECT_ROOT, text=True)
+    except subprocess.CalledProcessError:
+        return []
+    return [PROJECT_ROOT / line for line in output.splitlines() if line]
+
+
+def normalize_mdx_for_parity(text: str) -> str:
+    """Remove generated nav frontmatter and trailing whitespace before compare."""
+    lines = [line.rstrip() for line in text.splitlines()]
+
+    if lines and lines[0].strip() == "---":
+        for closing_index in range(1, len(lines)):
+            if lines[closing_index].strip() != "---":
+                continue
+            frontmatter = [
+                line for line in lines[1:closing_index] if not NAV_FRONTMATTER_RE.match(line)
+            ]
+            lines = ["---", *frontmatter, *lines[closing_index:]]
+            break
+
+    normalized = "\n".join(lines).rstrip()
+    return f"{normalized}\n" if normalized else ""
+
+
+def _assemble_target(target: ModuleTarget, output_path: Path) -> str:
+    linear_pipeline.assemble_mdx(
+        target.module_dir,
+        output_path,
+        plan_path_for(target.level, target.slug),
+    )
+    return output_path.read_text(encoding="utf-8")
+
+
+def check_targets(targets: set[ModuleTarget]) -> list[str]:
+    violations: list[str] = []
+
+    with tempfile.TemporaryDirectory(prefix="mdx-forward-parity-") as tmp_dir_raw:
+        tmp_dir = Path(tmp_dir_raw)
+        for target in sorted(targets):
+            mdx_rel = Path("site/src/content/docs") / target.level / f"{target.slug}.mdx"
+            stale_message = (
+                f"source changed but site MDX stale for {target.level}/{target.slug} — "
+                f"regenerate (assemble_mdx / `make` path) and commit {mdx_rel}"
+            )
+
+            if not target.module_dir.exists() and not target.mdx_path.exists():
+                continue
+
+            if not target.mdx_path.exists():
+                violations.append(stale_message)
+                continue
+
+            try:
+                generated = _assemble_target(target, tmp_dir / f"{target.level}-{target.slug}.mdx")
+            except Exception as exc:
+                violations.append(f"failed to assemble MDX for {target.level}/{target.slug}: {exc}")
+                continue
+
+            committed = target.mdx_path.read_text(encoding="utf-8")
+            if normalize_mdx_for_parity(generated) != normalize_mdx_for_parity(committed):
+                violations.append(stale_message)
+
+    return violations
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Check changed folk/seminar sources have current committed site MDX."
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--changed-vs-base", metavar="BASE", help="Compare base branch, e.g. origin/main")
+    group.add_argument("--files", nargs="+", type=Path, help="Scan explicit files (for pre-commit)")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.changed_vs_base:
+        changed_files = [
+            *reverse_parity.get_changed_files(base=args.changed_vs_base),
+            *_get_local_changed_files(),
+            *_get_local_changed_files(cached=True),
+        ]
+    else:
+        changed_files = reverse_parity.get_changed_files(cached=True)
+        explicit_files = [_as_repo_path(path) for path in args.files]
+        changed_files = [*changed_files, *explicit_files]
+
+    targets = affected_source_targets(changed_files)
+    if not targets:
+        print("0 findings: no changed folk/seminar sources require site MDX parity check.")
+        return 0
+
+    violations = check_targets(targets)
+    if not violations:
+        print(f"0 findings: forward MDX parity OK for {len(targets)} changed folk/seminar module(s).")
+        return 0
+
+    for violation in violations:
+        print(violation)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_mdx_forward_parity.py
+++ b/tests/test_mdx_forward_parity.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.audit import check_mdx_forward_parity as forward_parity
+
+
+def test_detects_folk_module_source() -> None:
+    path = forward_parity.SOURCE_DIR / "folk/narodna-kultura-yak-systema/module.md"
+
+    assert forward_parity.affected_source_targets([path]) == {
+        forward_parity.ModuleTarget("folk", "narodna-kultura-yak-systema")
+    }
+
+
+def test_detects_seminar_plan_source() -> None:
+    path = forward_parity.SOURCE_DIR / "plans/folk/narodna-kultura-yak-systema.yaml"
+
+    assert forward_parity.affected_source_targets([path]) == {
+        forward_parity.ModuleTarget("folk", "narodna-kultura-yak-systema")
+    }
+
+
+def test_ignores_core_track_source() -> None:
+    path = forward_parity.SOURCE_DIR / "a1/things-have-gender/module.md"
+
+    assert forward_parity.affected_source_targets([path]) == set()
+
+
+def test_normalize_strips_nav_frontmatter_and_trailing_whitespace() -> None:
+    generated = (
+        "---\n"
+        'title: "Demo"\n'
+        "prev: false\n"
+        "next: after\n"
+        "---\n"
+        "Body   \n"
+    )
+    committed = """---
+title: "Demo"
+prev: before
+next: false
+---
+Body
+"""
+
+    assert forward_parity.normalize_mdx_for_parity(generated) == forward_parity.normalize_mdx_for_parity(committed)
+
+
+def test_check_targets_flags_stale_committed_mdx(tmp_path: Path, monkeypatch) -> None:
+    source_dir = tmp_path / "curriculum/l2-uk-en"
+    mdx_dir = tmp_path / "site/src/content/docs"
+    module_dir = source_dir / "folk/demo"
+    module_dir.mkdir(parents=True)
+    mdx_path = mdx_dir / "folk/demo.mdx"
+    mdx_path.parent.mkdir(parents=True)
+    mdx_path.write_text("---\ntitle: Demo\n---\nCommitted\n", encoding="utf-8")
+
+    monkeypatch.setattr(forward_parity, "SOURCE_DIR", source_dir)
+    monkeypatch.setattr(forward_parity, "MDX_DIR", mdx_dir)
+
+    def fake_assemble(target: forward_parity.ModuleTarget, output_path: Path) -> str:
+        return "---\ntitle: Demo\n---\nGenerated\n"
+
+    monkeypatch.setattr(forward_parity, "_assemble_target", fake_assemble)
+
+    assert forward_parity.check_targets({forward_parity.ModuleTarget("folk", "demo")}) == [
+        "source changed but site MDX stale for folk/demo — regenerate "
+        "(assemble_mdx / `make` path) and commit site/src/content/docs/folk/demo.mdx"
+    ]
+
+
+def test_check_targets_accepts_nav_only_drift(tmp_path: Path, monkeypatch) -> None:
+    source_dir = tmp_path / "curriculum/l2-uk-en"
+    mdx_dir = tmp_path / "site/src/content/docs"
+    module_dir = source_dir / "folk/demo"
+    module_dir.mkdir(parents=True)
+    mdx_path = mdx_dir / "folk/demo.mdx"
+    mdx_path.parent.mkdir(parents=True)
+    mdx_path.write_text(
+        "---\ntitle: Demo\nprev: before\nnext: after\n---\nSame body  \n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(forward_parity, "SOURCE_DIR", source_dir)
+    monkeypatch.setattr(forward_parity, "MDX_DIR", mdx_dir)
+
+    def fake_assemble(target: forward_parity.ModuleTarget, output_path: Path) -> str:
+        return "---\ntitle: Demo\nprev: false\nnext: false\n---\nSame body\n"
+
+    monkeypatch.setattr(forward_parity, "_assemble_target", fake_assemble)
+
+    assert forward_parity.check_targets({forward_parity.ModuleTarget("folk", "demo")}) == []


### PR DESCRIPTION
## Summary

- Add `scripts/audit/check_mdx_forward_parity.py` to diff-scope changed folk/seminar source inputs and compare fresh `linear_pipeline.assemble_mdx(...)` output with committed site MDX.
- Normalize generated `prev`/`next` frontmatter and trailing whitespace on both sides before comparing, so navigation-only frontmatter does not false-positive.
- Wire the gate into CI and pre-commit, with pytest coverage for source targeting, core-track exclusion, stale detection, and nav-only normalization.

Fixes #3643.

## Verification

Clean/no source changes:

```console
$ .venv/bin/python scripts/audit/check_mdx_forward_parity.py --changed-vs-base origin/main
0 findings: no changed folk/seminar sources require site MDX parity check.
```

Source-only stale simulation using a temporary edit to `curriculum/l2-uk-en/folk/dumy-nevilnytski-lytsarski/vocabulary.yaml`:

```console
$ .venv/bin/python scripts/audit/check_mdx_forward_parity.py --changed-vs-base origin/main
source changed but site MDX stale for folk/dumy-nevilnytski-lytsarski — regenerate (assemble_mdx / `make` path) and commit site/src/content/docs/folk/dumy-nevilnytski-lytsarski.mdx
```

After regenerating that MDX with `linear_pipeline.assemble_mdx(...)`:

```console
$ .venv/bin/python - <<'PY'
from pathlib import Path
from scripts.build import linear_pipeline
level = 'folk'
slug = 'dumy-nevilnytski-lytsarski'
module_dir = Path('curriculum/l2-uk-en') / level / slug
mdx_path = Path('site/src/content/docs') / level / f'{slug}.mdx'
plan_path = linear_pipeline.plan_path_for(level, slug)
linear_pipeline.assemble_mdx(module_dir, mdx_path, plan_path)
print(mdx_path)
PY
site/src/content/docs/folk/dumy-nevilnytski-lytsarski.mdx

$ .venv/bin/python scripts/audit/check_mdx_forward_parity.py --changed-vs-base origin/main
0 findings: forward MDX parity OK for 1 changed folk/seminar module(s).
```

Targeted tests and lint:

```console
$ .venv/bin/python -m pytest tests/test_mdx_forward_parity*.py -q
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/fix-3643-forward-parity
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 6 items

tests/test_mdx_forward_parity.py ......                                   [100%]

============================== 6 passed in 0.38s ===============================
```

```console
$ .venv/bin/ruff check scripts tests
All checks passed!
```

```console
$ git diff --check
```

Commit trailer audit:

```console
$ .venv/bin/python scripts/audit/lint_agent_trailer.py
Checking 1 commit(s) in origin/main..HEAD:

  1f4ebe9bf0  PASS  X-Agent: codex/fix-3643-forward-parity

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

Note: literal full-repo `.venv/bin/ruff check` is not clean on current base due pre-existing unrelated files under `docs/reports/` and `plans/`; this PR leaves those untouched. The changed script/test scope and `scripts tests` scope are clean.