### PR TITLE
[codex] Add Headroom low-resource ops docs

### DIFF
--- a/docs/runbooks/headroom-local-ops.md
+++ b/docs/runbooks/headroom-local-ops.md
@@ -1,0 +1,237 @@
+# Headroom Local Operations
+
+This runbook records the local Headroom proxy settings used on the development
+machine and the update automation for the pipx-managed `headroom-ai` install.
+The proxy is local runtime infrastructure; do not commit files from
+`~/.headroom/`.
+
+## Current Intent
+
+Use Headroom as a CPU-sensitive background optimizer:
+
+- keep proxy compression enabled
+- keep provider cache alignment enabled
+- use explicit MCP compression for large logs, handoffs, and search output
+- disable the memory subsystem for now
+- disable Kompress ML compression until resource use is stable
+- avoid globally aggressive compression profiles for normal Codex/Claude work
+
+Recent observations before this tuning:
+
+- `headroom perf --hours 24` reported about `4.2%` token savings.
+- Cache hit rate was about `94.6%`, so cache behavior was already strong.
+- macOS process sampling caught a burst around `491%` CPU, meaning roughly five
+  cores busy during a compression spike.
+
+## Proxy Settings
+
+The managed LaunchAgent runs:
+
+```bash
+~/.headroom/deploy/default/run-headroom.sh
+```
+
+That script should normally stay as the managed wrapper around
+`headroom install agent run --profile default`. Persist CPU tuning in the
+deployment manifest instead:
+
+```bash
+~/.headroom/deploy/default/manifest.json
+```
+
+The proxy can be re-applied with memory enabled for experiments:
+
+```bash
+headroom install apply --profile default --memory
+```
+
+For the normal low-resource profile, leave memory disabled and keep these
+environment values under `base_env`:
+
+```bash
+HEADROOM_ANTHROPIC_PRE_UPSTREAM_CONCURRENCY=3
+HEADROOM_ANTHROPIC_PRE_UPSTREAM_MEMORY_CONTEXT_TIMEOUT_SECONDS=1.0
+HEADROOM_MIN_TOKENS=5000
+HEADROOM_MAX_ITEMS=25
+HEADROOM_DISABLE_KOMPRESS=1
+```
+
+The manifest also carries the supported proxy args:
+
+```bash
+--anthropic-pre-upstream-concurrency 3
+--anthropic-pre-upstream-memory-context-timeout-seconds 1.0
+--disable-kompress
+```
+
+Do not include `--memory` or `HEADROOM_MEMORY_ENABLED=1` in this low-resource
+profile. Keeping memory initialized while disabling automatic memory context
+and memory tools has little practical value and still increases resource use.
+
+Restart with launchd if `headroom install restart --profile default` fails on
+`kickstart`:
+
+```bash
+plist="$HOME/Library/LaunchAgents/com.headroom.default.plist"
+domain="gui/$(id -u)"
+launchctl bootout "$domain/com.headroom.default" 2>/dev/null || true
+launchctl bootout "$domain" "$plist" 2>/dev/null || true
+sleep 2
+launchctl bootstrap "$domain" "$plist"
+```
+
+Verify:
+
+```bash
+curl -fsS http://127.0.0.1:8787/health |
+  jq '{status, ready, version, runtime: .runtime.anthropic_pre_upstream, memory: .checks.memory, config: {disable_kompress: .config.disable_kompress, memory: .config.memory, min_tokens_to_crush: .config.min_tokens_to_crush, max_items_after_crush: .config.max_items_after_crush}}'
+```
+
+## Why These Settings
+
+`HEADROOM_ANTHROPIC_PRE_UPSTREAM_CONCURRENCY=3`
+
+Caps simultaneous Anthropic pre-upstream work. The auto default resolved to `8`
+on this machine, which allows multi-core CPU spikes when several requests need
+compression or memory-context work. Lowering this to `3` favors desktop
+responsiveness over maximum burst throughput.
+
+`HEADROOM_MIN_TOKENS=5000`
+
+Raises the compression threshold from the observed default of `500` tokens.
+This skips low- and medium-value compression work where CPU overhead can exceed
+the benefit. Very large logs, tool outputs, and handoffs still remain eligible.
+
+`HEADROOM_MAX_ITEMS=25`
+
+Keeps list and JSON compression tighter than the observed default of `50`
+retained items without going as sparse as aggressive profiles. If an answer
+needs omitted detail, CCR retrieval can recover the original content.
+
+`HEADROOM_DISABLE_KOMPRESS=1`
+
+Disables Kompress ML compression. The proxy still does structural/schema/log
+compression and cache alignment, but avoids the expensive ML path that can
+drive CPU and memory spikes.
+
+Memory disabled
+
+Memory and compression are separate systems. In low-resource mode, disabling
+memory is cleaner than keeping the memory database initialized while preventing
+memory context and memory tools from being injected. Re-enable memory only for a
+specific experiment or after a Headroom release improves resource behavior.
+
+`HEADROOM_ANTHROPIC_PRE_UPSTREAM_MEMORY_CONTEXT_TIMEOUT_SECONDS=1.0`
+
+Shortens memory-context lookup from the observed default of `2.0` seconds.
+This is fail-open: under load, Headroom should omit injected memory rather than
+hold a pre-upstream slot and worsen latency.
+
+## Settings To Avoid Globally
+
+Do not enable `agent-90` globally for routine work. It sets:
+
+```bash
+HEADROOM_COMPRESS_USER_MESSAGES=1
+HEADROOM_COMPRESS_SYSTEM_MESSAGES=1
+HEADROOM_MIN_TOKENS=120
+HEADROOM_MAX_ITEMS=8
+HEADROOM_FORCE_KOMPRESS=1
+HEADROOM_ACCURACY_GUARD=strict
+```
+
+That profile is useful for a deliberate compression experiment, but it is the
+wrong default when the primary concern is CPU usage.
+
+Do not run `headroom learn --apply` unless explicitly requested. It can rewrite
+agent instruction files such as `AGENTS.md`, `CLAUDE.md`, or `GEMINI.md`.
+
+## Update Automation
+
+The helper script is:
+
+```bash
+scripts/launchd/headroom-update.sh
+```
+
+It checks PyPI for the latest `headroom-ai` version, runs
+`pipx upgrade headroom-ai` only when a newer version exists, restarts the
+`default` persistent Headroom profile, falls back to launchd bootout/bootstrap
+if the managed restart fails, and verifies `/health`.
+
+Run it manually:
+
+```bash
+scripts/launchd/headroom-update.sh
+```
+
+For an installed crontab, copy the script to a stable local runtime path first:
+
+```bash
+mkdir -p "$HOME/.headroom/bin" "$HOME/.headroom/logs"
+install -m 755 scripts/launchd/headroom-update.sh \
+  "$HOME/.headroom/bin/headroom-update.sh"
+```
+
+### launchd
+
+Use the disabled template:
+
+```bash
+scripts/launchd/com.learn-ukrainian.headroom-update.plist.disabled
+```
+
+Install it for the current checkout:
+
+```bash
+PROJECT_ROOT="$(pwd)"
+sed "s#__PROJECT_ROOT__#${PROJECT_ROOT}#g" \
+  scripts/launchd/com.learn-ukrainian.headroom-update.plist.disabled \
+  > "$HOME/Library/LaunchAgents/com.learn-ukrainian.headroom-update.plist"
+
+launchctl bootout "gui/$(id -u)" \
+  "$HOME/Library/LaunchAgents/com.learn-ukrainian.headroom-update.plist" \
+  2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" \
+  "$HOME/Library/LaunchAgents/com.learn-ukrainian.headroom-update.plist"
+launchctl enable "gui/$(id -u)/com.learn-ukrainian.headroom-update"
+```
+
+Kick it once without waiting for the daily schedule:
+
+```bash
+launchctl kickstart -k "gui/$(id -u)/com.learn-ukrainian.headroom-update"
+```
+
+### crontab Alternative
+
+On systems where cron is preferred:
+
+```cron
+15 3 * * * $HOME/.headroom/bin/headroom-update.sh >> $HOME/.headroom/logs/headroom-update.cron.log 2>&1
+```
+
+Use `crontab -e` and add the line manually so existing entries are not
+overwritten. The active local machine currently uses this crontab form.
+
+## Validation
+
+After a restart or upgrade:
+
+```bash
+headroom --version
+headroom install status
+curl -fsS http://127.0.0.1:8787/health | jq '{status, ready, version, runtime, config}'
+headroom perf --hours 24
+```
+
+Watch these fields:
+
+- `runtime.anthropic_pre_upstream.resolved_concurrency` should be `3`.
+- `config.disable_kompress` should be `true`.
+- `config.memory` should be `false`.
+- `memory.status` should be `disabled`.
+- `config.min_tokens_to_crush` should be `5000`.
+- `config.max_items_after_crush` should be `25`.
+- `runtime.compression_executor.queued` should usually be `0`.
+- CPU bursts should be lower than the previous multi-core spikes.

--- a/docs/runbooks/headroom-local-ops.md
+++ b/docs/runbooks/headroom-local-ops.md
@@ -185,7 +185,9 @@ Install it for the current checkout:
 
 ```bash
 PROJECT_ROOT="$(pwd)"
-sed "s#__PROJECT_ROOT__#${PROJECT_ROOT}#g" \
+sed \
+  -e "s#__PROJECT_ROOT__#${PROJECT_ROOT}#g" \
+  -e "s#__HOME__#${HOME}#g" \
   scripts/launchd/com.learn-ukrainian.headroom-update.plist.disabled \
   > "$HOME/Library/LaunchAgents/com.learn-ukrainian.headroom-update.plist"
 
@@ -213,6 +215,11 @@ On systems where cron is preferred:
 
 Use `crontab -e` and add the line manually so existing entries are not
 overwritten. The active local machine currently uses this crontab form.
+
+The updater uses a lock directory under `~/.headroom/` and writes its PID into
+that lock. If the previous process is gone, or if the lock is older than
+`HEADROOM_UPDATE_LOCK_TIMEOUT_SECONDS` (`21600` seconds by default), the next
+run removes the stale lock and continues.
 
 ## Validation
 

--- a/scripts/launchd/com.learn-ukrainian.headroom-update.plist.disabled
+++ b/scripts/launchd/com.learn-ukrainian.headroom-update.plist.disabled
@@ -30,7 +30,7 @@
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/Users/krisztiankoos/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>__HOME__/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     </dict>
 </dict>
 </plist>

--- a/scripts/launchd/com.learn-ukrainian.headroom-update.plist.disabled
+++ b/scripts/launchd/com.learn-ukrainian.headroom-update.plist.disabled
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.learn-ukrainian.headroom-update</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__PROJECT_ROOT__/scripts/launchd/headroom-update.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__PROJECT_ROOT__</string>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>15</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/learn-ukrainian-headroom-update.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/learn-ukrainian-headroom-update.err.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/krisztiankoos/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/launchd/headroom-update.sh
+++ b/scripts/launchd/headroom-update.sh
@@ -8,6 +8,8 @@ PYPI_URL="${HEADROOM_PYPI_URL:-https://pypi.org/pypi/headroom-ai/json}"
 HEALTH_URL="${HEADROOM_HEALTH_URL:-http://127.0.0.1:8787/health}"
 LOG_DIR="${HEADROOM_UPDATE_LOG_DIR:-$HOME/.headroom/logs}"
 LOCK_DIR="${HEADROOM_UPDATE_LOCK_DIR:-$HOME/.headroom/headroom-update.lock}"
+LOCK_TIMEOUT_SECONDS="${HEADROOM_UPDATE_LOCK_TIMEOUT_SECONDS:-21600}"
+LOCK_PID_FILE="$LOCK_DIR/pid"
 
 mkdir -p "$LOG_DIR"
 
@@ -24,7 +26,66 @@ require_cmd() {
 }
 
 cleanup_lock() {
+  rm -f "$LOCK_PID_FILE" 2>/dev/null || true
   rmdir "$LOCK_DIR" 2>/dev/null || true
+}
+
+lock_mtime_epoch() {
+  stat -f %m "$LOCK_DIR" 2>/dev/null || stat -c %Y "$LOCK_DIR" 2>/dev/null || echo 0
+}
+
+lock_is_stale() {
+  local pid=""
+  local mtime="0"
+  local now="0"
+
+  if [[ -r "$LOCK_PID_FILE" ]]; then
+    pid="$(tr -cd '0-9' < "$LOCK_PID_FILE")"
+  fi
+
+  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+    return 1
+  fi
+
+  if [[ -n "$pid" ]]; then
+    log "removing stale headroom update lock for exited pid $pid"
+    return 0
+  fi
+
+  mtime="$(lock_mtime_epoch)"
+  now="$(date '+%s')"
+  if (( mtime > 0 && now - mtime > LOCK_TIMEOUT_SECONDS )); then
+    log "removing stale headroom update lock without pid file"
+    return 0
+  fi
+
+  return 1
+}
+
+acquire_lock() {
+  mkdir -p "$(dirname "$LOCK_DIR")"
+
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    printf '%s\n' "$$" > "$LOCK_PID_FILE"
+    trap cleanup_lock EXIT
+    return 0
+  fi
+
+  if lock_is_stale; then
+    rm -f "$LOCK_PID_FILE" 2>/dev/null || true
+    rmdir "$LOCK_DIR" 2>/dev/null || {
+      log "stale lock directory is not empty: $LOCK_DIR"
+      exit 1
+    }
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+      printf '%s\n' "$$" > "$LOCK_PID_FILE"
+      trap cleanup_lock EXIT
+      return 0
+    fi
+  fi
+
+  log "another headroom update check is already running"
+  exit 0
 }
 
 restart_headroom() {
@@ -55,11 +116,7 @@ require_cmd jq
 require_cmd launchctl
 require_cmd pipx
 
-if ! mkdir "$LOCK_DIR" 2>/dev/null; then
-  log "another headroom update check is already running"
-  exit 0
-fi
-trap cleanup_lock EXIT
+acquire_lock
 
 current="$(headroom --version | awk '{print $3}')"
 latest="$(curl -fsS --retry 2 --connect-timeout 10 "$PYPI_URL" | jq -r '.info.version')"

--- a/scripts/launchd/headroom-update.sh
+++ b/scripts/launchd/headroom-update.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+PROFILE="${HEADROOM_PROFILE:-default}"
+PYPI_URL="${HEADROOM_PYPI_URL:-https://pypi.org/pypi/headroom-ai/json}"
+HEALTH_URL="${HEADROOM_HEALTH_URL:-http://127.0.0.1:8787/health}"
+LOG_DIR="${HEADROOM_UPDATE_LOG_DIR:-$HOME/.headroom/logs}"
+LOCK_DIR="${HEADROOM_UPDATE_LOCK_DIR:-$HOME/.headroom/headroom-update.lock}"
+
+mkdir -p "$LOG_DIR"
+
+log() {
+  printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*"
+}
+
+require_cmd() {
+  local name="$1"
+  if ! command -v "$name" >/dev/null 2>&1; then
+    log "missing required command: $name"
+    exit 127
+  fi
+}
+
+cleanup_lock() {
+  rmdir "$LOCK_DIR" 2>/dev/null || true
+}
+
+restart_headroom() {
+  if headroom install restart --profile "$PROFILE"; then
+    return 0
+  fi
+
+  log "managed restart failed; using launchd bootout/bootstrap fallback"
+
+  local label="com.headroom.$PROFILE"
+  local domain="gui/$(id -u)"
+  local plist="$HOME/Library/LaunchAgents/$label.plist"
+
+  if [[ ! -f "$plist" ]]; then
+    log "missing launchd plist: $plist"
+    return 1
+  fi
+
+  launchctl bootout "$domain/$label" 2>/dev/null || true
+  launchctl bootout "$domain" "$plist" 2>/dev/null || true
+  sleep 2
+  launchctl bootstrap "$domain" "$plist"
+}
+
+require_cmd curl
+require_cmd headroom
+require_cmd jq
+require_cmd launchctl
+require_cmd pipx
+
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  log "another headroom update check is already running"
+  exit 0
+fi
+trap cleanup_lock EXIT
+
+current="$(headroom --version | awk '{print $3}')"
+latest="$(curl -fsS --retry 2 --connect-timeout 10 "$PYPI_URL" | jq -r '.info.version')"
+
+if [[ -z "$current" || -z "$latest" || "$latest" == "null" ]]; then
+  log "could not resolve current/latest version: current=$current latest=$latest"
+  exit 1
+fi
+
+if [[ "$current" == "$latest" ]]; then
+  log "headroom-ai current: $current"
+  exit 0
+fi
+
+log "upgrading headroom-ai $current -> $latest"
+pipx upgrade headroom-ai
+
+log "restarting headroom profile: $PROFILE"
+restart_headroom
+
+curl -fsS --retry 5 --retry-delay 2 --connect-timeout 5 "$HEALTH_URL" >/dev/null
+log "headroom healthy after upgrade to $latest"


### PR DESCRIPTION
## Summary

- Add a Headroom local operations runbook for the low-resource proxy profile.
- Add a pipx-based Headroom update checker with launchd restart fallback.
- Add a disabled launchd template for daily Headroom update checks.

## Local Runtime State Applied

The local Headroom proxy was switched to low-resource mode outside the repo:

- memory disabled
- Kompress disabled
- Anthropic pre-upstream concurrency set to 3
- memory-context timeout left at 1.0s for future memory experiments
- min compression threshold raised to 5000 tokens
- max retained items set to 25
- daily crontab installed against `$HOME/.headroom/bin/headroom-update.sh`

These files under `~/.headroom/` are local runtime state and are not committed.

## Validation

- `bash -n scripts/launchd/headroom-update.sh`
- `plutil -lint scripts/launchd/com.learn-ukrainian.headroom-update.plist.disabled`
- `markdownlint docs/runbooks/headroom-local-ops.md`
- `scripts/launchd/headroom-update.sh`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `git diff --cached --check`
- Live Headroom `/health` verified: memory disabled, Kompress disabled, concurrency 3, min tokens 5000, max items 25
