### PR TITLE
[codex] add core orchestrator prompt suite

### DIFF
--- a/docs/prompts/orchestrators/README.md
+++ b/docs/prompts/orchestrators/README.md
@@ -1,0 +1,50 @@
+# Core Track Orchestrator Prompt Suite
+
+Prompt suite version: 0.1
+Last reviewed: 2026-06-21
+
+This directory contains reusable prompts for future A1, A2, B1, and B2 orchestration threads. They are templates, not source-of-truth curriculum policy. Every production thread that uses them must inspect the current local repository before acting, especially `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `curriculum/l2-uk-en/curriculum.yaml`, `scripts/config.py`, `scripts/audit/config.py`, and the target level files.
+
+## Lifecycle
+
+1. Preflight where needed: B2 uses a readiness audit before production because its plans, discovery files, and wiki coverage must be checked before module writing starts.
+2. Build: create or update only the scoped modules, in small sequential batches, with module-tailored instructions.
+3. Quality audit: read-only review that records every issue, writes a durable report under `docs/audits/`, and proposes remediation batches.
+4. Remediation: consume the audit report and fix every finding in PR-sized batches without changing unrelated modules.
+5. Final review and merge: run deterministic validation, include token telemetry for module-build PRs, get independent review before merge, and keep generated runtime artifacts out of the PR.
+
+## Prompt Index
+
+- `a1/quality-audit-orchestrator.md`: beginner-specific read-only audit for emotional safety, scaffolding, decodability, Cyrillic/pronunciation support, activities, vocabulary, and source/wiki coverage.
+- `a1/remediation-build-orchestrator.md`: small-batch remediation from an A1 audit report while preserving beginner tone, decodability, and scaffolded progression.
+- `a2/quality-audit-orchestrator.md`: transition-track audit for immersion ramp, grammar complexity, B1 readiness, activity variety, vocabulary, and source/wiki coverage.
+- `a2/remediation-build-orchestrator.md`: small-batch remediation from an A2 audit report without flattening A2 into B1-style immersion too early.
+- `b1/quality-audit-orchestrator.md`: read-only normalization audit for B1 M1-M82 using the M83-M94 quality bar where those modules exist.
+- `b1/remediation-build-orchestrator.md`: B1 normalization remediation that separates targeted patches from rebuilds and avoids finale contamination.
+- `b1/finale-build-orchestrator.md`: build prompt for final B1 synthesis/checkpoint/exam modules such as M93-M94, kept separate from M1-M82 normalization.
+- `b2/preflight-readiness-audit-orchestrator.md`: read-only readiness audit before B2 production.
+- `b2/production-build-orchestrator.md`: small sequential B2 production batches after preflight passes.
+- `b2/quality-audit-orchestrator.md`: post-build B2 audit for advanced syntax, register control, argumentation, and professional/academic readiness.
+
+## Shared Files
+
+- `shared/repo-rules.md`: non-negotiable repo rules to paste into future orchestration prompts.
+- `shared/validation-checklist.md`: validation commands and scope checks future agents should adapt to the target batch.
+- `shared/telemetry-and-pr.md`: commit, PR, independent review, and module-build telemetry requirements.
+- `shared/review-output-schema.md`: durable audit report schema and issue inventory format.
+
+Each level prompt references these shared files, but also restates the critical rules so it remains usable when pasted alone into Codex, Gemini, or Claude.
+
+## Helper And Swarm Policy
+
+Helpers are optional. Use one to three read-only explorers only when they materially save time, such as surveying module shapes, checking doc references, or validating prompt consistency. Use worker helpers only for mechanical edits with a clearly owned file set. The main orchestrator remains responsible for design, integration, final review, PR creation, and merge decisions.
+
+Every module-build PR must state `swarm_used` and `swarm_note` in token telemetry. Solo runs still need `swarm_used: false` and a note such as `solo run; no swarm used`.
+
+## Headroom Policy
+
+Use Headroom compression for helper summaries, logs, searches, or handoffs over roughly 200 lines or 20 KB. Pass the compressed hash plus a short summary, and retrieve the full content only when exact details are needed. Do not treat Headroom memory as the source of truth for curriculum facts, and do not run `headroom learn --apply`.
+
+## Adding C1, C2, Or Seminar Orchestrators
+
+Add a sibling directory such as `c1/`, `c2/`, `hist/`, `bio/`, `lit/`, `oes/`, or `ruth/`. Reuse the shared files rather than duplicating policy. The new prompt must still be standalone, level-specific, and grounded in local repo files. For seminar or sensitive tracks, add the track-specific decolonization and source-bias checks instead of copying core-track assumptions.

--- a/docs/prompts/orchestrators/README.md
+++ b/docs/prompts/orchestrators/README.md
@@ -39,7 +39,7 @@ Each level prompt references these shared files, but also restates the critical 
 
 Helpers are optional. Use one to three read-only explorers only when they materially save time, such as surveying module shapes, checking doc references, or validating prompt consistency. Use worker helpers only for mechanical edits with a clearly owned file set. The main orchestrator remains responsible for design, integration, final review, PR creation, and merge decisions.
 
-Every module-build PR must state `swarm_used` and `swarm_note` in token telemetry. Solo runs still need `swarm_used: false` and a note such as `solo run; no swarm used`.
+Every module-build PR must state `swarm_used`, `swarm_label`, and `swarm_note` in token telemetry. Solo runs still need `swarm_used: false`, `swarm_label: none`, and a note such as `solo run; no swarm used`.
 
 ## Headroom Policy
 

--- a/docs/prompts/orchestrators/README.md
+++ b/docs/prompts/orchestrators/README.md
@@ -1,6 +1,6 @@
 # Core Track Orchestrator Prompt Suite
 
-Prompt suite version: 0.1
+Prompt suite version: 0.2
 Last reviewed: 2026-06-21
 
 This directory contains reusable prompts for future A1, A2, B1, and B2 orchestration threads. They are templates, not source-of-truth curriculum policy. Every production thread that uses them must inspect the current local repository before acting, especially `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `curriculum/l2-uk-en/curriculum.yaml`, `scripts/config.py`, `scripts/audit/config.py`, and the target level files.
@@ -9,7 +9,7 @@ This directory contains reusable prompts for future A1, A2, B1, and B2 orchestra
 
 1. Preflight where needed: B2 uses a readiness audit before production because its plans, discovery files, and wiki coverage must be checked before module writing starts.
 2. Build: create or update only the scoped modules, in small sequential batches, with module-tailored instructions.
-3. Quality audit: read-only review that records every issue, writes a durable report under `docs/audits/`, and proposes remediation batches.
+3. Quality audit: review that does not modify curriculum or site sources, records every issue, writes a durable report under `docs/audits/`, and proposes remediation batches. The report is durable only when committed and reviewed in its own PR.
 4. Remediation: consume the audit report and fix every finding in PR-sized batches without changing unrelated modules.
 5. Final review and merge: run deterministic validation, include token telemetry for module-build PRs, get independent review before merge, and keep generated runtime artifacts out of the PR.
 
@@ -19,9 +19,9 @@ This directory contains reusable prompts for future A1, A2, B1, and B2 orchestra
 - `a1/remediation-build-orchestrator.md`: small-batch remediation from an A1 audit report while preserving beginner tone, decodability, and scaffolded progression.
 - `a2/quality-audit-orchestrator.md`: transition-track audit for immersion ramp, grammar complexity, B1 readiness, activity variety, vocabulary, and source/wiki coverage.
 - `a2/remediation-build-orchestrator.md`: small-batch remediation from an A2 audit report without flattening A2 into B1-style immersion too early.
-- `b1/quality-audit-orchestrator.md`: read-only normalization audit for B1 M1-M82 using the M83-M94 quality bar where those modules exist.
+- `b1/quality-audit-orchestrator.md`: read-only normalization audit for B1 M1-M82 using the current M83-M94 quality bar after verifying those modules in the checkout.
 - `b1/remediation-build-orchestrator.md`: B1 normalization remediation that separates targeted patches from rebuilds and avoids finale contamination.
-- `b1/finale-build-orchestrator.md`: build prompt for final B1 synthesis/checkpoint/exam modules such as M93-M94, kept separate from M1-M82 normalization.
+- `b1/finale-build-orchestrator.md`: build or remediation prompt for final B1 synthesis/checkpoint/exam modules such as M93-M94, kept separate from M1-M82 normalization.
 - `b2/preflight-readiness-audit-orchestrator.md`: read-only readiness audit before B2 production.
 - `b2/production-build-orchestrator.md`: small sequential B2 production batches after preflight passes.
 - `b2/quality-audit-orchestrator.md`: post-build B2 audit for advanced syntax, register control, argumentation, and professional/academic readiness.
@@ -47,4 +47,4 @@ Use Headroom compression for helper summaries, logs, searches, or handoffs over 
 
 ## Adding C1, C2, Or Seminar Orchestrators
 
-Add a sibling directory such as `c1/`, `c2/`, `hist/`, `bio/`, `lit/`, `oes/`, or `ruth/`. Reuse the shared files rather than duplicating policy. The new prompt must still be standalone, level-specific, and grounded in local repo files. For seminar or sensitive tracks, add the track-specific decolonization and source-bias checks instead of copying core-track assumptions.
+Add a sibling directory such as `c1/`, `c2/`, `hist/`, `bio/`, `lit/`, `oes/`, or `ruth/`. Reuse only the track-agnostic shared scaffolding: repo hygiene, worktree discipline, PR rules, and report structure. Seminar tracks must not inherit CEFR immersion, decodability, beginner-safety, or grammar-sequencing assumptions by default. Before writing seminar prompts, inspect existing seminar precedents such as `docs/audits/bio-decolonization-checklist.md` and `docs/audits/bio-track-gap-audit-2026-05-26.md` when present, then add track-specific source attribution, factuality, decolonization, Russian-shadow, and bias checks.

--- a/docs/prompts/orchestrators/a1/quality-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/a1/quality-audit-orchestrator.md
@@ -139,5 +139,6 @@ Validation run: <commands and outcomes>
 Report delivery: <draft PR URL or blocked reason>
 Curriculum files modified: no
 swarm_used: true/false
+swarm_label: <none | solo | helper | swarm>
 swarm_note: <helpers used, or solo run; no swarm used>
 ```

--- a/docs/prompts/orchestrators/a1/quality-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/a1/quality-audit-orchestrator.md
@@ -1,6 +1,6 @@
 # A1 Quality Audit Orchestrator
 
-Prompt version: 0.1
+Prompt version: 0.2
 Last reviewed: 2026-06-21
 
 ## Source Assumptions
@@ -8,7 +8,7 @@ Last reviewed: 2026-06-21
 - A1 is the beginner track. Do not judge it by B1 or B2 immersion habits.
 - Current repo examples show A1 uses English support, short Ukrainian chunks, stress marks, letter/sound work, and warm repair language.
 - Thresholds and stress/pronunciation rules must be verified from `scripts/config.py`, `scripts/audit/config.py`, and current docs before judging.
-- This audit is read-only except for the durable report under `docs/audits/`.
+- This audit must not modify curriculum or site sources. Its only content write is the durable report under `docs/audits/`, plus PR text needed to deliver that report.
 
 ## Goal
 
@@ -17,12 +17,13 @@ Audit A1 modules for beginner-safe pedagogy, emotional safety, scaffolding, Cyri
 ## WORKTREE_ROOT Setup
 
 ```bash
-cd /Users/krisztiankoos/projects/learn-ukrainian
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
 git fetch origin main
 git worktree add -b codex/a1-quality-audit .worktrees/dispatch/codex/a1-quality-audit origin/main
 cd .worktrees/dispatch/codex/a1-quality-audit
-test -e .venv || ln -s /Users/krisztiankoos/projects/learn-ukrainian/.venv .venv
-export WORKTREE_ROOT="/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/a1-quality-audit"
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
 pwd
 git status --short --branch
 git rev-parse --show-toplevel
@@ -53,6 +54,7 @@ All commands must run from `WORKTREE_ROOT`.
 ## Allowed Writes
 
 - `docs/audits/a1-quality-audit-YYYY-MM-DD.md`
+- PR body or final orchestration note text for delivering the report
 
 ## Forbidden Writes
 
@@ -76,6 +78,7 @@ All commands must run from `WORKTREE_ROOT`.
 - Check vocabulary: beginner-useful words, examples with stress where current policy requires it, no unexplained overload.
 - Check engagement: warm examples, micro-dialogues, real A1 situations, and Ukrainian-first moments where safe.
 - Check plan/wiki/source coverage against the A1 plan and `wiki/pedagogy/a1/<slug>.md` plus sources files when present.
+- Run deterministic module audits without `--fix` for built modules in scope where feasible, and record any failures alongside subjective findings.
 
 ## Helpers And Headroom
 
@@ -85,17 +88,40 @@ Read-only helper explorers are allowed for module-shape summaries or consistency
 
 Write the report to `docs/audits/a1-quality-audit-YYYY-MM-DD.md`.
 
+## Report Delivery
+
+After validation, commit and open a draft PR that contains only the report:
+
+```bash
+git add docs/audits/a1-quality-audit-YYYY-MM-DD.md
+git commit -m "docs: add A1 quality audit" --trailer "X-Agent: codex/a1-quality-audit"
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+git push -u origin codex/a1-quality-audit
+gh pr create --draft --fill --head codex/a1-quality-audit --base main
+```
+
 ## Validation Commands
 
 ```bash
 git status --short --branch
+.venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/a1/<slug>/module.md
 git diff --check
 git diff --name-only
-git diff --name-only | rg -v '^docs/audits/a1-quality-audit-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$' || true
-rg -n 'sys\.executable' docs/audits/a1-quality-audit-*.md
+if git diff --name-only | rg -v '^docs/audits/a1-quality-audit-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$'; then
+  echo "Unexpected file outside the durable audit report" >&2
+  exit 1
+fi
+if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
+  echo "Forbidden generated artifact in diff" >&2
+  exit 1
+fi
+if rg -n 'sys\.executable' docs/audits/a1-quality-audit-YYYY-MM-DD.md; then
+  echo "Audit report mentions forbidden sys.executable" >&2
+  exit 1
+fi
 ```
 
-Do not run module builds. Do not run commands that write generated curriculum audit/status/review artifacts.
+Adapt the `audit_module.py` path for each built module audited. Do not pass `--fix`. Do not run module builds. Do not run commands that write generated curriculum audit/status/review artifacts.
 
 ## Expected Final Response
 
@@ -106,6 +132,7 @@ Blockers: <n>
 Issues recorded: <n>
 Recommended remediation batches: <summary>
 Validation run: <commands and outcomes>
+Report delivery: <draft PR URL or blocked reason>
 Curriculum files modified: no
 swarm_used: true/false
 swarm_note: <helpers used, or solo run; no swarm used>

--- a/docs/prompts/orchestrators/a1/quality-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/a1/quality-audit-orchestrator.md
@@ -17,7 +17,7 @@ Audit A1 modules for beginner-safe pedagogy, emotional safety, scaffolding, Cyri
 ## WORKTREE_ROOT Setup
 
 ```bash
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
 cd "$REPO_ROOT"
 git fetch origin main
 git worktree add -b codex/a1-quality-audit .worktrees/dispatch/codex/a1-quality-audit origin/main
@@ -88,40 +88,44 @@ Read-only helper explorers are allowed for module-shape summaries or consistency
 
 Write the report to `docs/audits/a1-quality-audit-YYYY-MM-DD.md`.
 
-## Report Delivery
-
-After validation, commit and open a draft PR that contains only the report:
-
-```bash
-git add docs/audits/a1-quality-audit-YYYY-MM-DD.md
-git commit -m "docs: add A1 quality audit" --trailer "X-Agent: codex/a1-quality-audit"
-.venv/bin/python scripts/audit/lint_agent_trailer.py
-git push -u origin codex/a1-quality-audit
-gh pr create --draft --fill --head codex/a1-quality-audit --base main
-```
-
 ## Validation Commands
 
 ```bash
+REPORT="docs/audits/a1-quality-audit-$(date +%F).md"
 git status --short --branch
 .venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/a1/<slug>/module.md
 git diff --check
-git diff --name-only
-if git diff --name-only | rg -v '^docs/audits/a1-quality-audit-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$'; then
+test -f "$REPORT"
+CHANGED_FILES="$( { git diff --name-only; git diff --cached --name-only; git ls-files --others --exclude-standard; } | sort -u )"
+printf '%s\n' "$CHANGED_FILES"
+if [ -n "$CHANGED_FILES" ] && printf '%s\n' "$CHANGED_FILES" | rg -v '^docs/audits/a1-quality-audit-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$'; then
   echo "Unexpected file outside the durable audit report" >&2
   exit 1
 fi
-if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
+if [ -n "$CHANGED_FILES" ] && printf '%s\n' "$CHANGED_FILES" | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
   echo "Forbidden generated artifact in diff" >&2
   exit 1
 fi
-if rg -n 'sys\.executable' docs/audits/a1-quality-audit-YYYY-MM-DD.md; then
+if rg -n 'sys\.executable' "$REPORT"; then
   echo "Audit report mentions forbidden sys.executable" >&2
   exit 1
 fi
 ```
 
 Adapt the `audit_module.py` path for each built module audited. Do not pass `--fix`. Do not run module builds. Do not run commands that write generated curriculum audit/status/review artifacts.
+
+## Report Delivery
+
+After validation, commit and open a draft PR that contains only the report:
+
+```bash
+REPORT="docs/audits/a1-quality-audit-$(date +%F).md"
+git add "$REPORT"
+git commit -m "docs: add A1 quality audit" --trailer "X-Agent: codex/a1-quality-audit"
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+git push -u origin codex/a1-quality-audit
+gh pr create --draft --fill --head codex/a1-quality-audit --base main
+```
 
 ## Expected Final Response
 

--- a/docs/prompts/orchestrators/a1/quality-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/a1/quality-audit-orchestrator.md
@@ -1,0 +1,112 @@
+# A1 Quality Audit Orchestrator
+
+Prompt version: 0.1
+Last reviewed: 2026-06-21
+
+## Source Assumptions
+
+- A1 is the beginner track. Do not judge it by B1 or B2 immersion habits.
+- Current repo examples show A1 uses English support, short Ukrainian chunks, stress marks, letter/sound work, and warm repair language.
+- Thresholds and stress/pronunciation rules must be verified from `scripts/config.py`, `scripts/audit/config.py`, and current docs before judging.
+- This audit is read-only except for the durable report under `docs/audits/`.
+
+## Goal
+
+Audit A1 modules for beginner-safe pedagogy, emotional safety, scaffolding, Cyrillic/decodability, pronunciation support, activity quality, vocabulary usefulness, and source/wiki coverage. Record every issue found and propose remediation batches. Do not fix modules.
+
+## WORKTREE_ROOT Setup
+
+```bash
+cd /Users/krisztiankoos/projects/learn-ukrainian
+git fetch origin main
+git worktree add -b codex/a1-quality-audit .worktrees/dispatch/codex/a1-quality-audit origin/main
+cd .worktrees/dispatch/codex/a1-quality-audit
+test -e .venv || ln -s /Users/krisztiankoos/projects/learn-ukrainian/.venv .venv
+export WORKTREE_ROOT="/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/a1-quality-audit"
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+All commands must run from `WORKTREE_ROOT`.
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `curriculum/l2-uk-en/curriculum.yaml`, A1 section
+- `docs/l2-uk-en/MODULE-RICHNESS-GUIDELINES-v2.md`
+- `docs/runbooks/module-build-token-telemetry.md`
+- `scripts/config.py`
+- `scripts/audit/config.py`
+- `docs/best-practices/ulp-presentation-pattern.md` if present
+- representative A1 files before expanding scope:
+  - `curriculum/l2-uk-en/a1/sounds-letters-and-hello/module.md`
+  - `curriculum/l2-uk-en/a1/reading-ukrainian/module.md`
+  - `curriculum/l2-uk-en/a1/special-signs/module.md`
+  - `curriculum/l2-uk-en/a1/my-morning/module.md`
+  - `curriculum/l2-uk-en/a1/a1-finale/module.md`
+  - matching `activities.yaml`, `vocabulary.yaml`, `resources.yaml`, plans, wiki files under `wiki/pedagogy/a1/`, and site MDX under `site/src/content/docs/a1/`
+
+## Allowed Writes
+
+- `docs/audits/a1-quality-audit-YYYY-MM-DD.md`
+
+## Forbidden Writes
+
+- `curriculum/l2-uk-en/**`
+- `site/src/content/docs/**`
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- `data/telemetry/**`
+- any `status/`, curriculum `audit/`, or curriculum `review/` artifact
+
+## Audit Checks
+
+- Verify A1 module order, module numbers, and groups from `curriculum.yaml`.
+- Verify current A1 word targets, immersion bands, grammar constraints, activity thresholds, and stress/pronunciation policy from code and current docs before judging.
+- Check beginner emotional safety: no shaming, no "you should already know", repair language is calm, and failure states are framed as orientation.
+- Check scaffolding: each new idea moves from sound/word/chunk to sentence; tables and examples do not assume unseen grammar.
+- Check Cyrillic and decodability: early modules explain sound vs letter, syllable counting, `ь`, apostrophe, `я/ю/є/ї`, and avoid transliteration except where current repo policy allows it.
+- Check stress and pronunciation support: stress marks follow current repo policy; pronunciation traps are handled with simple, actionable routines.
+- Check cognitive load: sentence length, number of new concepts per section, and activity item complexity fit A1.
+- Check English/Ukrainian balance against the current A1 immersion bands, not a flat percentage.
+- Check activities: enough practice variety, inline/workbook split where present, no content trivia masquerading as language practice.
+- Check vocabulary: beginner-useful words, examples with stress where current policy requires it, no unexplained overload.
+- Check engagement: warm examples, micro-dialogues, real A1 situations, and Ukrainian-first moments where safe.
+- Check plan/wiki/source coverage against the A1 plan and `wiki/pedagogy/a1/<slug>.md` plus sources files when present.
+
+## Helpers And Headroom
+
+Read-only helper explorers are allowed for module-shape summaries or consistency checks. Do not delegate final judgments. Use Headroom compression for helper summaries, logs, or search output over 200 lines or 20 KB. Do not use Headroom memory as curriculum authority.
+
+## Durable Report Path
+
+Write the report to `docs/audits/a1-quality-audit-YYYY-MM-DD.md`.
+
+## Validation Commands
+
+```bash
+git status --short --branch
+git diff --check
+git diff --name-only
+git diff --name-only | rg -v '^docs/audits/a1-quality-audit-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$' || true
+rg -n 'sys\.executable' docs/audits/a1-quality-audit-*.md
+```
+
+Do not run module builds. Do not run commands that write generated curriculum audit/status/review artifacts.
+
+## Expected Final Response
+
+```text
+Report written: docs/audits/a1-quality-audit-YYYY-MM-DD.md
+Scope inspected: <modules>
+Blockers: <n>
+Issues recorded: <n>
+Recommended remediation batches: <summary>
+Validation run: <commands and outcomes>
+Curriculum files modified: no
+swarm_used: true/false
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/a1/remediation-build-orchestrator.md
+++ b/docs/prompts/orchestrators/a1/remediation-build-orchestrator.md
@@ -107,7 +107,7 @@ Run additional targeted checks required by the audit report. Run `scripts/audit/
 - Commit trailer: `X-Agent: codex/a1-remediation-<batch>`
 - Run `.venv/bin/python scripts/audit/lint_agent_trailer.py` before pushing.
 - Persist module-build telemetry using `docs/prompts/orchestrators/shared/telemetry-and-pr.md`.
-- Include `swarm_used` and `swarm_note` in telemetry and PR text.
+- Include `swarm_used`, `swarm_label`, and `swarm_note` in telemetry and PR text.
 - Require independent review before merge.
 
 ## Expected Final Response
@@ -122,5 +122,6 @@ Telemetry: <posted or unavailable with reason>
 Independent review: <status>
 Forbidden artifacts included: no
 swarm_used: true/false
+swarm_label: <none | solo | helper | swarm>
 swarm_note: <helpers used, or solo run; no swarm used>
 ```

--- a/docs/prompts/orchestrators/a1/remediation-build-orchestrator.md
+++ b/docs/prompts/orchestrators/a1/remediation-build-orchestrator.md
@@ -1,0 +1,121 @@
+# A1 Remediation Build Orchestrator
+
+Prompt version: 0.1
+Last reviewed: 2026-06-21
+
+## Source Assumptions
+
+- This prompt consumes a durable A1 audit report under `docs/audits/`.
+- A1 remediation fixes learner-facing module sources in small PR-sized batches.
+- A1 is not a place for premature immersion. Preserve beginner tone, decodability, stress/pronunciation support, and scaffolded progression.
+- Plans are source of truth. Do not edit plans unless the user explicitly scopes a plan fix.
+
+## Goal
+
+Fix all findings from the selected A1 audit batch without changing unrelated modules. Regenerate generated site MDX for changed modules, validate the result, prepare PR-ready notes, and record token telemetry for module-build work.
+
+## WORKTREE_ROOT Setup
+
+```bash
+cd /Users/krisztiankoos/projects/learn-ukrainian
+git fetch origin main
+git worktree add -b codex/a1-remediation-<batch> .worktrees/dispatch/codex/a1-remediation-<batch> origin/main
+cd .worktrees/dispatch/codex/a1-remediation-<batch>
+test -e .venv || ln -s /Users/krisztiankoos/projects/learn-ukrainian/.venv .venv
+export WORKTREE_ROOT="/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/a1-remediation-<batch>"
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
+- the A1 audit report being remediated
+- `curriculum/l2-uk-en/curriculum.yaml`
+- `docs/l2-uk-en/MODULE-RICHNESS-GUIDELINES-v2.md`
+- `scripts/config.py`, especially A1 immersion policies
+- `scripts/audit/config.py`
+- for each target slug:
+  - `curriculum/l2-uk-en/plans/a1/<slug>.yaml`
+  - `curriculum/l2-uk-en/a1/<slug>/module.md`
+  - `curriculum/l2-uk-en/a1/<slug>/activities.yaml`
+  - `curriculum/l2-uk-en/a1/<slug>/vocabulary.yaml`
+  - `curriculum/l2-uk-en/a1/<slug>/resources.yaml` if present
+  - `wiki/pedagogy/a1/<slug>.md`
+  - `wiki/pedagogy/a1/<slug>.sources.yaml`
+  - `site/src/content/docs/a1/<slug>.mdx`
+
+## Allowed Writes
+
+- For scoped target slugs only:
+  - `curriculum/l2-uk-en/a1/<slug>/module.md`
+  - `curriculum/l2-uk-en/a1/<slug>/activities.yaml`
+  - `curriculum/l2-uk-en/a1/<slug>/vocabulary.yaml`
+  - `curriculum/l2-uk-en/a1/<slug>/resources.yaml`
+  - `site/src/content/docs/a1/<slug>.mdx`
+- PR body or final orchestration note text
+
+## Forbidden Writes
+
+- A1 plans unless explicitly authorized
+- modules outside the selected audit batch
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- `data/telemetry/**`
+- generated `status/`, curriculum `audit/`, or curriculum `review/` artifacts
+
+## Remediation Rules
+
+- Fix every finding in the selected batch; do not pick only the top issues.
+- Preserve A1 learner safety: short steps, supportive tone, and visible repair language.
+- Preserve decodability: do not add unexplained Cyrillic clusters, long unglossed Ukrainian prose, or advanced grammar as "enrichment".
+- Preserve current stress/pronunciation policy. Verify it locally before changing stress marks.
+- Keep activities as language practice, not trivia. Use the existing V1 bare-list or V2 `inline:`/`workbook:` shape already present in the target file.
+- Keep vocabulary useful, concrete, and level-appropriate; verify suspicious words against local tools before adding.
+- Separate targeted patches from rebuilds. Rebuild only when the audit finding cannot be fixed safely with local edits.
+
+## Helpers And Headroom
+
+Helpers are allowed for bounded validation or mechanical YAML/MDX checks, with disjoint file ownership. Do not delegate final pedagogy decisions. Use Headroom compression for helper output or logs over 200 lines or 20 KB.
+
+## Validation Commands
+
+Adapt module numbers from `curriculum.yaml`:
+
+```bash
+.venv/bin/python scripts/validate_activities.py l2-uk-en a1 <module_num>
+.venv/bin/python scripts/validate_vocab_yaml.py curriculum/l2-uk-en/a1/<slug>/vocabulary.yaml
+.venv/bin/python scripts/generate_mdx.py l2-uk-en a1 <module_num> --validate
+.venv/bin/python scripts/audit/check_mdx_generation_drift.py --files curriculum/l2-uk-en/a1/<slug>/module.md curriculum/l2-uk-en/a1/<slug>/activities.yaml curriculum/l2-uk-en/a1/<slug>/vocabulary.yaml
+git diff --check
+git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/' || true
+```
+
+Run additional targeted checks required by the audit report. Do not include generated forbidden artifacts in the PR.
+
+## PR, Commit, And Telemetry Requirements
+
+- Branch: `codex/a1-remediation-<batch>`
+- Commit trailer: `X-Agent: codex/a1-remediation-<batch>`
+- Run `.venv/bin/python scripts/audit/lint_agent_trailer.py` before pushing.
+- Persist module-build telemetry through `POST /api/telemetry/module-builds`.
+- Include `swarm_used` and `swarm_note` in telemetry and PR text.
+- Require independent review before merge.
+
+## Expected Final Response
+
+```text
+Audit report consumed: <path>
+Batch fixed: <batch id>
+Modules changed: <slugs>
+Files changed: <paths>
+Validation run: <commands and outcomes>
+Telemetry: <posted or unavailable with reason>
+Independent review: <status>
+Forbidden artifacts included: no
+swarm_used: true/false
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/a1/remediation-build-orchestrator.md
+++ b/docs/prompts/orchestrators/a1/remediation-build-orchestrator.md
@@ -17,7 +17,7 @@ Fix all findings from the selected A1 audit batch without changing unrelated mod
 ## WORKTREE_ROOT Setup
 
 ```bash
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
 cd "$REPO_ROOT"
 git fetch origin main
 git worktree add -b codex/a1-remediation-<batch> .worktrees/dispatch/codex/a1-remediation-<batch> origin/main
@@ -92,7 +92,8 @@ Adapt module numbers from `curriculum.yaml`:
 .venv/bin/python scripts/generate_mdx.py l2-uk-en a1 <module_num> --validate
 .venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/a1/<slug>/module.md
 git diff --check
-if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
+CHANGED_FILES="$( { git diff --name-only; git diff --cached --name-only; git ls-files --others --exclude-standard; } | sort -u )"
+if [ -n "$CHANGED_FILES" ] && printf '%s\n' "$CHANGED_FILES" | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
   echo "Forbidden generated artifact in diff" >&2
   exit 1
 fi

--- a/docs/prompts/orchestrators/a1/remediation-build-orchestrator.md
+++ b/docs/prompts/orchestrators/a1/remediation-build-orchestrator.md
@@ -1,6 +1,6 @@
 # A1 Remediation Build Orchestrator
 
-Prompt version: 0.1
+Prompt version: 0.2
 Last reviewed: 2026-06-21
 
 ## Source Assumptions
@@ -17,12 +17,13 @@ Fix all findings from the selected A1 audit batch without changing unrelated mod
 ## WORKTREE_ROOT Setup
 
 ```bash
-cd /Users/krisztiankoos/projects/learn-ukrainian
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
 git fetch origin main
 git worktree add -b codex/a1-remediation-<batch> .worktrees/dispatch/codex/a1-remediation-<batch> origin/main
 cd .worktrees/dispatch/codex/a1-remediation-<batch>
-test -e .venv || ln -s /Users/krisztiankoos/projects/learn-ukrainian/.venv .venv
-export WORKTREE_ROOT="/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/a1-remediation-<batch>"
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
 pwd
 git status --short --branch
 git rev-parse --show-toplevel
@@ -89,19 +90,22 @@ Adapt module numbers from `curriculum.yaml`:
 .venv/bin/python scripts/validate_activities.py l2-uk-en a1 <module_num>
 .venv/bin/python scripts/validate_vocab_yaml.py curriculum/l2-uk-en/a1/<slug>/vocabulary.yaml
 .venv/bin/python scripts/generate_mdx.py l2-uk-en a1 <module_num> --validate
-.venv/bin/python scripts/audit/check_mdx_generation_drift.py --files curriculum/l2-uk-en/a1/<slug>/module.md curriculum/l2-uk-en/a1/<slug>/activities.yaml curriculum/l2-uk-en/a1/<slug>/vocabulary.yaml
+.venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/a1/<slug>/module.md
 git diff --check
-git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/' || true
+if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
+  echo "Forbidden generated artifact in diff" >&2
+  exit 1
+fi
 ```
 
-Run additional targeted checks required by the audit report. Do not include generated forbidden artifacts in the PR.
+Run additional targeted checks required by the audit report. Run `scripts/audit/check_mdx_generation_drift.py` only when a drift-only check is needed after generation. Do not include generated forbidden artifacts in the PR.
 
 ## PR, Commit, And Telemetry Requirements
 
 - Branch: `codex/a1-remediation-<batch>`
 - Commit trailer: `X-Agent: codex/a1-remediation-<batch>`
 - Run `.venv/bin/python scripts/audit/lint_agent_trailer.py` before pushing.
-- Persist module-build telemetry through `POST /api/telemetry/module-builds`.
+- Persist module-build telemetry using `docs/prompts/orchestrators/shared/telemetry-and-pr.md`.
 - Include `swarm_used` and `swarm_note` in telemetry and PR text.
 - Require independent review before merge.
 

--- a/docs/prompts/orchestrators/a2/quality-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/a2/quality-audit-orchestrator.md
@@ -1,6 +1,6 @@
 # A2 Quality Audit Orchestrator
 
-Prompt version: 0.1
+Prompt version: 0.2
 Last reviewed: 2026-06-21
 
 ## Source Assumptions
@@ -8,7 +8,7 @@ Last reviewed: 2026-06-21
 - A2 is a transition track, not A1 with more words and not early B1.
 - Current repo policy gives A2 a steep Ukrainian immersion ramp. Verify exact bands from `scripts/config.py` before judging.
 - A2 must prepare learners for B1 grammar-in-Ukrainian while preserving controlled register, concrete examples, and support.
-- This audit is read-only except for the durable report under `docs/audits/`.
+- This audit must not modify curriculum or site sources. Its only content write is the durable report under `docs/audits/`, plus PR text needed to deliver that report.
 
 ## Goal
 
@@ -17,12 +17,13 @@ Audit A2 modules for transition-track pedagogy: immersion ramp, grammar complexi
 ## WORKTREE_ROOT Setup
 
 ```bash
-cd /Users/krisztiankoos/projects/learn-ukrainian
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
 git fetch origin main
 git worktree add -b codex/a2-quality-audit .worktrees/dispatch/codex/a2-quality-audit origin/main
 cd .worktrees/dispatch/codex/a2-quality-audit
-test -e .venv || ln -s /Users/krisztiankoos/projects/learn-ukrainian/.venv .venv
-export WORKTREE_ROOT="/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/a2-quality-audit"
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
 pwd
 git status --short --branch
 git rev-parse --show-toplevel
@@ -50,6 +51,7 @@ git rev-parse --show-toplevel
 ## Allowed Writes
 
 - `docs/audits/a2-quality-audit-YYYY-MM-DD.md`
+- PR body or final orchestration note text for delivering the report
 
 ## Forbidden Writes
 
@@ -71,6 +73,7 @@ git rev-parse --show-toplevel
 - Check activities: variety, item quality, inline/workbook split where present, and language-practice focus.
 - Check vocabulary: terms are useful, examples are natural, and coverage matches the plan.
 - Check source/wiki coverage: each module should align with `curriculum/l2-uk-en/plans/a2/<slug>.yaml` and `wiki/grammar/a2/<slug>.md` plus sources.
+- Run deterministic module audits without `--fix` for built modules in scope where feasible, and record any failures alongside subjective findings.
 
 ## Helpers And Headroom
 
@@ -80,17 +83,40 @@ Read-only explorers are allowed for phase summaries, module-shape surveys, or co
 
 Write the report to `docs/audits/a2-quality-audit-YYYY-MM-DD.md`.
 
+## Report Delivery
+
+After validation, commit and open a draft PR that contains only the report:
+
+```bash
+git add docs/audits/a2-quality-audit-YYYY-MM-DD.md
+git commit -m "docs: add A2 quality audit" --trailer "X-Agent: codex/a2-quality-audit"
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+git push -u origin codex/a2-quality-audit
+gh pr create --draft --fill --head codex/a2-quality-audit --base main
+```
+
 ## Validation Commands
 
 ```bash
 git status --short --branch
+.venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/a2/<slug>/module.md
 git diff --check
 git diff --name-only
-git diff --name-only | rg -v '^docs/audits/a2-quality-audit-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$' || true
-rg -n 'sys\.executable' docs/audits/a2-quality-audit-*.md
+if git diff --name-only | rg -v '^docs/audits/a2-quality-audit-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$'; then
+  echo "Unexpected file outside the durable audit report" >&2
+  exit 1
+fi
+if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
+  echo "Forbidden generated artifact in diff" >&2
+  exit 1
+fi
+if rg -n 'sys\.executable' docs/audits/a2-quality-audit-YYYY-MM-DD.md; then
+  echo "Audit report mentions forbidden sys.executable" >&2
+  exit 1
+fi
 ```
 
-Do not run module builds. Do not run commands that write generated curriculum audit/status/review artifacts.
+Adapt the `audit_module.py` path for each built module audited. Do not pass `--fix`. Do not run module builds. Do not run commands that write generated curriculum audit/status/review artifacts.
 
 ## Expected Final Response
 
@@ -101,6 +127,7 @@ Blockers: <n>
 Issues recorded: <n>
 Recommended remediation batches: <summary>
 Validation run: <commands and outcomes>
+Report delivery: <draft PR URL or blocked reason>
 Curriculum files modified: no
 swarm_used: true/false
 swarm_note: <helpers used, or solo run; no swarm used>

--- a/docs/prompts/orchestrators/a2/quality-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/a2/quality-audit-orchestrator.md
@@ -17,7 +17,7 @@ Audit A2 modules for transition-track pedagogy: immersion ramp, grammar complexi
 ## WORKTREE_ROOT Setup
 
 ```bash
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
 cd "$REPO_ROOT"
 git fetch origin main
 git worktree add -b codex/a2-quality-audit .worktrees/dispatch/codex/a2-quality-audit origin/main
@@ -83,40 +83,44 @@ Read-only explorers are allowed for phase summaries, module-shape surveys, or co
 
 Write the report to `docs/audits/a2-quality-audit-YYYY-MM-DD.md`.
 
-## Report Delivery
-
-After validation, commit and open a draft PR that contains only the report:
-
-```bash
-git add docs/audits/a2-quality-audit-YYYY-MM-DD.md
-git commit -m "docs: add A2 quality audit" --trailer "X-Agent: codex/a2-quality-audit"
-.venv/bin/python scripts/audit/lint_agent_trailer.py
-git push -u origin codex/a2-quality-audit
-gh pr create --draft --fill --head codex/a2-quality-audit --base main
-```
-
 ## Validation Commands
 
 ```bash
+REPORT="docs/audits/a2-quality-audit-$(date +%F).md"
 git status --short --branch
 .venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/a2/<slug>/module.md
 git diff --check
-git diff --name-only
-if git diff --name-only | rg -v '^docs/audits/a2-quality-audit-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$'; then
+test -f "$REPORT"
+CHANGED_FILES="$( { git diff --name-only; git diff --cached --name-only; git ls-files --others --exclude-standard; } | sort -u )"
+printf '%s\n' "$CHANGED_FILES"
+if [ -n "$CHANGED_FILES" ] && printf '%s\n' "$CHANGED_FILES" | rg -v '^docs/audits/a2-quality-audit-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$'; then
   echo "Unexpected file outside the durable audit report" >&2
   exit 1
 fi
-if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
+if [ -n "$CHANGED_FILES" ] && printf '%s\n' "$CHANGED_FILES" | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
   echo "Forbidden generated artifact in diff" >&2
   exit 1
 fi
-if rg -n 'sys\.executable' docs/audits/a2-quality-audit-YYYY-MM-DD.md; then
+if rg -n 'sys\.executable' "$REPORT"; then
   echo "Audit report mentions forbidden sys.executable" >&2
   exit 1
 fi
 ```
 
 Adapt the `audit_module.py` path for each built module audited. Do not pass `--fix`. Do not run module builds. Do not run commands that write generated curriculum audit/status/review artifacts.
+
+## Report Delivery
+
+After validation, commit and open a draft PR that contains only the report:
+
+```bash
+REPORT="docs/audits/a2-quality-audit-$(date +%F).md"
+git add "$REPORT"
+git commit -m "docs: add A2 quality audit" --trailer "X-Agent: codex/a2-quality-audit"
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+git push -u origin codex/a2-quality-audit
+gh pr create --draft --fill --head codex/a2-quality-audit --base main
+```
 
 ## Expected Final Response
 

--- a/docs/prompts/orchestrators/a2/quality-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/a2/quality-audit-orchestrator.md
@@ -1,0 +1,107 @@
+# A2 Quality Audit Orchestrator
+
+Prompt version: 0.1
+Last reviewed: 2026-06-21
+
+## Source Assumptions
+
+- A2 is a transition track, not A1 with more words and not early B1.
+- Current repo policy gives A2 a steep Ukrainian immersion ramp. Verify exact bands from `scripts/config.py` before judging.
+- A2 must prepare learners for B1 grammar-in-Ukrainian while preserving controlled register, concrete examples, and support.
+- This audit is read-only except for the durable report under `docs/audits/`.
+
+## Goal
+
+Audit A2 modules for transition-track pedagogy: immersion ramp, grammar complexity, B1 readiness, wall-of-text risk, engagement, activity variety, vocabulary completeness, stress/pronunciation policy, and source/wiki coverage. Record every issue and propose remediation batches. Do not fix modules.
+
+## WORKTREE_ROOT Setup
+
+```bash
+cd /Users/krisztiankoos/projects/learn-ukrainian
+git fetch origin main
+git worktree add -b codex/a2-quality-audit .worktrees/dispatch/codex/a2-quality-audit origin/main
+cd .worktrees/dispatch/codex/a2-quality-audit
+test -e .venv || ln -s /Users/krisztiankoos/projects/learn-ukrainian/.venv .venv
+export WORKTREE_ROOT="/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/a2-quality-audit"
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `curriculum/l2-uk-en/curriculum.yaml`, A2 section
+- `docs/l2-uk-en/MODULE-RICHNESS-GUIDELINES-v2.md`
+- `docs/runbooks/module-build-token-telemetry.md`
+- `scripts/config.py`
+- `scripts/audit/config.py`
+- representative A2 files before expanding scope:
+  - `curriculum/l2-uk-en/a2/a2-bridge/module.md`
+  - `curriculum/l2-uk-en/a2/aspect-concept/module.md`
+  - `curriculum/l2-uk-en/a2/aspect-in-vocabulary/module.md`
+  - `curriculum/l2-uk-en/a2/locative-expanded/module.md`
+  - `curriculum/l2-uk-en/a2/a2-finale/module.md`
+  - matching activities, vocabulary, resources, plans, `wiki/grammar/a2/`, and `site/src/content/docs/a2/`
+
+## Allowed Writes
+
+- `docs/audits/a2-quality-audit-YYYY-MM-DD.md`
+
+## Forbidden Writes
+
+- `curriculum/l2-uk-en/**`
+- `site/src/content/docs/**`
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- `data/telemetry/**`
+- generated `status/`, curriculum `audit/`, or curriculum `review/` artifacts
+
+## Audit Checks
+
+- Verify A2 sequence and module numbers from `curriculum.yaml`.
+- Verify live A2 thresholds, immersion policies, grammar constraints, activity types, and stress/pronunciation policy from code before judging.
+- Check the immersion ramp by phase: early A2 should be easy Ukrainian with controlled scaffolding; late A2 should prepare for B1 without becoming dense B1 prose.
+- Check grammar complexity: all cases are in play, aspect pairs are introduced, simple subordinate clauses appear, participles stay out unless current policy allows fixed forms.
+- Check wall-of-text risk: long Ukrainian explanations need tables, pattern boxes, dialogues, examples, and review loops.
+- Check B1 readiness: late A2 should increase Ukrainian metalanguage, independent reading practice, and controlled multi-clause sentences.
+- Check engagement and examples: concrete everyday situations, not abstract grammar walls.
+- Check activities: variety, item quality, inline/workbook split where present, and language-practice focus.
+- Check vocabulary: terms are useful, examples are natural, and coverage matches the plan.
+- Check source/wiki coverage: each module should align with `curriculum/l2-uk-en/plans/a2/<slug>.yaml` and `wiki/grammar/a2/<slug>.md` plus sources.
+
+## Helpers And Headroom
+
+Read-only explorers are allowed for phase summaries, module-shape surveys, or consistency checks. The main auditor owns final issue severity. Use Headroom compression for helper output or long search results over 200 lines or 20 KB.
+
+## Durable Report Path
+
+Write the report to `docs/audits/a2-quality-audit-YYYY-MM-DD.md`.
+
+## Validation Commands
+
+```bash
+git status --short --branch
+git diff --check
+git diff --name-only
+git diff --name-only | rg -v '^docs/audits/a2-quality-audit-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$' || true
+rg -n 'sys\.executable' docs/audits/a2-quality-audit-*.md
+```
+
+Do not run module builds. Do not run commands that write generated curriculum audit/status/review artifacts.
+
+## Expected Final Response
+
+```text
+Report written: docs/audits/a2-quality-audit-YYYY-MM-DD.md
+Scope inspected: <modules>
+Blockers: <n>
+Issues recorded: <n>
+Recommended remediation batches: <summary>
+Validation run: <commands and outcomes>
+Curriculum files modified: no
+swarm_used: true/false
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/a2/quality-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/a2/quality-audit-orchestrator.md
@@ -134,5 +134,6 @@ Validation run: <commands and outcomes>
 Report delivery: <draft PR URL or blocked reason>
 Curriculum files modified: no
 swarm_used: true/false
+swarm_label: <none | solo | helper | swarm>
 swarm_note: <helpers used, or solo run; no swarm used>
 ```

--- a/docs/prompts/orchestrators/a2/remediation-build-orchestrator.md
+++ b/docs/prompts/orchestrators/a2/remediation-build-orchestrator.md
@@ -1,6 +1,6 @@
 # A2 Remediation Build Orchestrator
 
-Prompt version: 0.1
+Prompt version: 0.2
 Last reviewed: 2026-06-21
 
 ## Source Assumptions
@@ -17,12 +17,13 @@ Fix all findings from the selected A2 audit batch in small PR-sized batches. Reg
 ## WORKTREE_ROOT Setup
 
 ```bash
-cd /Users/krisztiankoos/projects/learn-ukrainian
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
 git fetch origin main
 git worktree add -b codex/a2-remediation-<batch> .worktrees/dispatch/codex/a2-remediation-<batch> origin/main
 cd .worktrees/dispatch/codex/a2-remediation-<batch>
-test -e .venv || ln -s /Users/krisztiankoos/projects/learn-ukrainian/.venv .venv
-export WORKTREE_ROOT="/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/a2-remediation-<batch>"
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
 pwd
 git status --short --branch
 git rev-parse --show-toplevel
@@ -90,17 +91,22 @@ Adapt module numbers from `curriculum.yaml`:
 .venv/bin/python scripts/validate_activities.py l2-uk-en a2 <module_num>
 .venv/bin/python scripts/validate_vocab_yaml.py curriculum/l2-uk-en/a2/<slug>/vocabulary.yaml
 .venv/bin/python scripts/generate_mdx.py l2-uk-en a2 <module_num> --validate
-.venv/bin/python scripts/audit/check_mdx_generation_drift.py --files curriculum/l2-uk-en/a2/<slug>/module.md curriculum/l2-uk-en/a2/<slug>/activities.yaml curriculum/l2-uk-en/a2/<slug>/vocabulary.yaml
+.venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/a2/<slug>/module.md
 git diff --check
-git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/' || true
+if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
+  echo "Forbidden generated artifact in diff" >&2
+  exit 1
+fi
 ```
+
+Run `scripts/audit/check_mdx_generation_drift.py` only when a drift-only check is needed after generation.
 
 ## PR, Commit, And Telemetry Requirements
 
 - Branch: `codex/a2-remediation-<batch>`
 - Commit trailer: `X-Agent: codex/a2-remediation-<batch>`
 - Run `.venv/bin/python scripts/audit/lint_agent_trailer.py` before pushing.
-- Persist module-build telemetry through `POST /api/telemetry/module-builds`.
+- Persist module-build telemetry using `docs/prompts/orchestrators/shared/telemetry-and-pr.md`.
 - Include `swarm_used` and `swarm_note` in telemetry and PR text.
 - Require independent review before merge.
 

--- a/docs/prompts/orchestrators/a2/remediation-build-orchestrator.md
+++ b/docs/prompts/orchestrators/a2/remediation-build-orchestrator.md
@@ -17,7 +17,7 @@ Fix all findings from the selected A2 audit batch in small PR-sized batches. Reg
 ## WORKTREE_ROOT Setup
 
 ```bash
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
 cd "$REPO_ROOT"
 git fetch origin main
 git worktree add -b codex/a2-remediation-<batch> .worktrees/dispatch/codex/a2-remediation-<batch> origin/main
@@ -93,7 +93,8 @@ Adapt module numbers from `curriculum.yaml`:
 .venv/bin/python scripts/generate_mdx.py l2-uk-en a2 <module_num> --validate
 .venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/a2/<slug>/module.md
 git diff --check
-if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
+CHANGED_FILES="$( { git diff --name-only; git diff --cached --name-only; git ls-files --others --exclude-standard; } | sort -u )"
+if [ -n "$CHANGED_FILES" ] && printf '%s\n' "$CHANGED_FILES" | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
   echo "Forbidden generated artifact in diff" >&2
   exit 1
 fi

--- a/docs/prompts/orchestrators/a2/remediation-build-orchestrator.md
+++ b/docs/prompts/orchestrators/a2/remediation-build-orchestrator.md
@@ -1,0 +1,120 @@
+# A2 Remediation Build Orchestrator
+
+Prompt version: 0.1
+Last reviewed: 2026-06-21
+
+## Source Assumptions
+
+- This prompt consumes a durable A2 audit report under `docs/audits/`.
+- A2 remediation must preserve transition-track pedagogy: easy Ukrainian first, concrete examples, controlled grammar, and a deliberate path toward B1.
+- Do not flatten early A2 into full B1-style immersion. Do not retreat late A2 into A1-style English explanation unless current repo policy and the audit finding justify it.
+- Plans are source of truth. Do not edit plans unless the user explicitly scopes a plan fix.
+
+## Goal
+
+Fix all findings from the selected A2 audit batch in small PR-sized batches. Regenerate generated site MDX for changed modules, validate the result, prepare PR-ready notes, and record module-build telemetry.
+
+## WORKTREE_ROOT Setup
+
+```bash
+cd /Users/krisztiankoos/projects/learn-ukrainian
+git fetch origin main
+git worktree add -b codex/a2-remediation-<batch> .worktrees/dispatch/codex/a2-remediation-<batch> origin/main
+cd .worktrees/dispatch/codex/a2-remediation-<batch>
+test -e .venv || ln -s /Users/krisztiankoos/projects/learn-ukrainian/.venv .venv
+export WORKTREE_ROOT="/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/a2-remediation-<batch>"
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
+- the A2 audit report being remediated
+- `curriculum/l2-uk-en/curriculum.yaml`
+- `docs/l2-uk-en/MODULE-RICHNESS-GUIDELINES-v2.md`
+- `scripts/config.py`, especially A2 immersion policies
+- `scripts/audit/config.py`
+- for each target slug:
+  - `curriculum/l2-uk-en/plans/a2/<slug>.yaml`
+  - `curriculum/l2-uk-en/a2/<slug>/module.md`
+  - `curriculum/l2-uk-en/a2/<slug>/activities.yaml`
+  - `curriculum/l2-uk-en/a2/<slug>/vocabulary.yaml`
+  - `curriculum/l2-uk-en/a2/<slug>/resources.yaml` if present
+  - `wiki/grammar/a2/<slug>.md`
+  - `wiki/grammar/a2/<slug>.sources.yaml`
+  - `site/src/content/docs/a2/<slug>.mdx`
+
+## Allowed Writes
+
+- For scoped target slugs only:
+  - `curriculum/l2-uk-en/a2/<slug>/module.md`
+  - `curriculum/l2-uk-en/a2/<slug>/activities.yaml`
+  - `curriculum/l2-uk-en/a2/<slug>/vocabulary.yaml`
+  - `curriculum/l2-uk-en/a2/<slug>/resources.yaml`
+  - `site/src/content/docs/a2/<slug>.mdx`
+- PR body or final orchestration note text
+
+## Forbidden Writes
+
+- A2 plans unless explicitly authorized
+- modules outside the selected audit batch
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- `data/telemetry/**`
+- generated `status/`, curriculum `audit/`, or curriculum `review/` artifacts
+
+## Remediation Rules
+
+- Fix every selected finding; do not truncate.
+- Preserve phase-appropriate immersion from `scripts/config.py`.
+- Use simple Ukrainian, repeated frames, concrete examples, dialogues, pattern boxes, and tables to solve clarity issues.
+- Keep grammar within A2 limits: no participle-heavy enrichment, no literary register, no unscaffolded B1 syntax.
+- Strengthen late-A2 B1 readiness through controlled Ukrainian metalanguage and short independent reading blocks.
+- Keep activities as language practice using module content as context.
+- Use the activity YAML shape already present in the module.
+- Separate targeted patches from full rebuilds.
+
+## Helpers And Headroom
+
+Helpers are allowed for bounded validation, YAML checks, or source coverage checks with clear file ownership. The main orchestrator owns final pedagogy. Use Headroom compression for helper output or logs over 200 lines or 20 KB.
+
+## Validation Commands
+
+Adapt module numbers from `curriculum.yaml`:
+
+```bash
+.venv/bin/python scripts/validate_activities.py l2-uk-en a2 <module_num>
+.venv/bin/python scripts/validate_vocab_yaml.py curriculum/l2-uk-en/a2/<slug>/vocabulary.yaml
+.venv/bin/python scripts/generate_mdx.py l2-uk-en a2 <module_num> --validate
+.venv/bin/python scripts/audit/check_mdx_generation_drift.py --files curriculum/l2-uk-en/a2/<slug>/module.md curriculum/l2-uk-en/a2/<slug>/activities.yaml curriculum/l2-uk-en/a2/<slug>/vocabulary.yaml
+git diff --check
+git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/' || true
+```
+
+## PR, Commit, And Telemetry Requirements
+
+- Branch: `codex/a2-remediation-<batch>`
+- Commit trailer: `X-Agent: codex/a2-remediation-<batch>`
+- Run `.venv/bin/python scripts/audit/lint_agent_trailer.py` before pushing.
+- Persist module-build telemetry through `POST /api/telemetry/module-builds`.
+- Include `swarm_used` and `swarm_note` in telemetry and PR text.
+- Require independent review before merge.
+
+## Expected Final Response
+
+```text
+Audit report consumed: <path>
+Batch fixed: <batch id>
+Modules changed: <slugs>
+Files changed: <paths>
+Validation run: <commands and outcomes>
+Telemetry: <posted or unavailable with reason>
+Independent review: <status>
+Forbidden artifacts included: no
+swarm_used: true/false
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/a2/remediation-build-orchestrator.md
+++ b/docs/prompts/orchestrators/a2/remediation-build-orchestrator.md
@@ -108,7 +108,7 @@ Run `scripts/audit/check_mdx_generation_drift.py` only when a drift-only check i
 - Commit trailer: `X-Agent: codex/a2-remediation-<batch>`
 - Run `.venv/bin/python scripts/audit/lint_agent_trailer.py` before pushing.
 - Persist module-build telemetry using `docs/prompts/orchestrators/shared/telemetry-and-pr.md`.
-- Include `swarm_used` and `swarm_note` in telemetry and PR text.
+- Include `swarm_used`, `swarm_label`, and `swarm_note` in telemetry and PR text.
 - Require independent review before merge.
 
 ## Expected Final Response
@@ -123,5 +123,6 @@ Telemetry: <posted or unavailable with reason>
 Independent review: <status>
 Forbidden artifacts included: no
 swarm_used: true/false
+swarm_label: <none | solo | helper | swarm>
 swarm_note: <helpers used, or solo run; no swarm used>
 ```

--- a/docs/prompts/orchestrators/b1/finale-build-orchestrator.md
+++ b/docs/prompts/orchestrators/b1/finale-build-orchestrator.md
@@ -1,28 +1,29 @@
 # B1 Finale Build Orchestrator
 
-Prompt version: 0.1
+Prompt version: 0.2
 Last reviewed: 2026-06-21
 
 ## Source Assumptions
 
 - This prompt is for final B1 synthesis, checkpoint, review, or exam modules such as M93 `comprehensive-b1-review` and M94 `practice-exam`.
-- Current local repo may have finale plans and wiki files before source module directories. Verify before writing.
+- Recent main has built source directories for M93-M94. Verify current checkout state before writing, and treat existing finale modules as remediation or hardening work rather than fresh creation.
 - Finale work is separate from M1-M82 normalization.
 - Earlier B1 modules are context and prerequisites unless explicitly unlocked for fixes.
 
 ## Goal
 
-Build or finish final B1 synthesis/checkpoint/exam modules in a small sequential batch. Respect locked/unlocked module rules, update generated site MDX and indexes only where current repo workflows require it, validate, record telemetry, and require independent review before merge.
+Build, finish, or remediate final B1 synthesis/checkpoint/exam modules in a small sequential batch. Respect locked/unlocked module rules, update generated site MDX and indexes only where current repo workflows require it, validate, record telemetry, and require independent review before merge.
 
 ## WORKTREE_ROOT Setup
 
 ```bash
-cd /Users/krisztiankoos/projects/learn-ukrainian
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
 git fetch origin main
 git worktree add -b codex/b1-finale-<batch> .worktrees/dispatch/codex/b1-finale-<batch> origin/main
 cd .worktrees/dispatch/codex/b1-finale-<batch>
-test -e .venv || ln -s /Users/krisztiankoos/projects/learn-ukrainian/.venv .venv
-export WORKTREE_ROOT="/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/b1-finale-<batch>"
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
 pwd
 git status --short --branch
 git rev-parse --show-toplevel
@@ -85,17 +86,22 @@ Adapt module numbers from `curriculum.yaml`:
 .venv/bin/python scripts/validate_activities.py l2-uk-en b1 <module_num>
 .venv/bin/python scripts/validate_vocab_yaml.py curriculum/l2-uk-en/b1/<slug>/vocabulary.yaml
 .venv/bin/python scripts/generate_mdx.py l2-uk-en b1 <module_num> --validate
-.venv/bin/python scripts/audit/check_mdx_generation_drift.py --files curriculum/l2-uk-en/b1/<slug>/module.md curriculum/l2-uk-en/b1/<slug>/activities.yaml curriculum/l2-uk-en/b1/<slug>/vocabulary.yaml
+.venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/b1/<slug>/module.md
 git diff --check
-git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/' || true
+if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
+  echo "Forbidden generated artifact in diff" >&2
+  exit 1
+fi
 ```
+
+Run `scripts/audit/check_mdx_generation_drift.py` only when a drift-only check is needed after generation.
 
 ## PR, Commit, And Telemetry Requirements
 
 - Branch: `codex/b1-finale-<batch>`
 - Commit trailer: `X-Agent: codex/b1-finale-<batch>`
 - Run `.venv/bin/python scripts/audit/lint_agent_trailer.py` before pushing.
-- Persist module-build telemetry through `POST /api/telemetry/module-builds`.
+- Persist module-build telemetry using `docs/prompts/orchestrators/shared/telemetry-and-pr.md`.
 - Include `swarm_used` and `swarm_note` in telemetry and PR text.
 - Require independent review before merge.
 

--- a/docs/prompts/orchestrators/b1/finale-build-orchestrator.md
+++ b/docs/prompts/orchestrators/b1/finale-build-orchestrator.md
@@ -1,0 +1,114 @@
+# B1 Finale Build Orchestrator
+
+Prompt version: 0.1
+Last reviewed: 2026-06-21
+
+## Source Assumptions
+
+- This prompt is for final B1 synthesis, checkpoint, review, or exam modules such as M93 `comprehensive-b1-review` and M94 `practice-exam`.
+- Current local repo may have finale plans and wiki files before source module directories. Verify before writing.
+- Finale work is separate from M1-M82 normalization.
+- Earlier B1 modules are context and prerequisites unless explicitly unlocked for fixes.
+
+## Goal
+
+Build or finish final B1 synthesis/checkpoint/exam modules in a small sequential batch. Respect locked/unlocked module rules, update generated site MDX and indexes only where current repo workflows require it, validate, record telemetry, and require independent review before merge.
+
+## WORKTREE_ROOT Setup
+
+```bash
+cd /Users/krisztiankoos/projects/learn-ukrainian
+git fetch origin main
+git worktree add -b codex/b1-finale-<batch> .worktrees/dispatch/codex/b1-finale-<batch> origin/main
+cd .worktrees/dispatch/codex/b1-finale-<batch>
+test -e .venv || ln -s /Users/krisztiankoos/projects/learn-ukrainian/.venv .venv
+export WORKTREE_ROOT="/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/b1-finale-<batch>"
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
+- `curriculum/l2-uk-en/curriculum.yaml`, B1 M83-M94
+- `scripts/config.py`, `scripts/audit/config.py`
+- `docs/l2-uk-en/MODULE-RICHNESS-GUIDELINES-v2.md`
+- target finale plans:
+  - `curriculum/l2-uk-en/plans/b1/comprehensive-b1-review.yaml`
+  - `curriculum/l2-uk-en/plans/b1/practice-exam.yaml`
+- target finale wiki:
+  - `wiki/grammar/b1/comprehensive-b1-review.md`
+  - `wiki/grammar/b1/practice-exam.md`
+- recent B1 quality bar modules M83-M92 where present, especially `reported-speech`, `checkpoint-syntax`, `text-register-formal`, `checkpoint-text-register`, `narrative-mastery`, and `debate-and-opinion`
+- current generated site structure under `site/src/content/docs/b1/`, including `index.mdx` if present
+
+## Allowed Writes
+
+- For explicitly selected finale slugs only:
+  - `curriculum/l2-uk-en/b1/<slug>/module.md`
+  - `curriculum/l2-uk-en/b1/<slug>/activities.yaml`
+  - `curriculum/l2-uk-en/b1/<slug>/vocabulary.yaml`
+  - `curriculum/l2-uk-en/b1/<slug>/resources.yaml`
+  - `site/src/content/docs/b1/<slug>.mdx`
+  - `site/src/content/docs/b1/index.mdx` only if current repo generation or navigation requires it
+- PR body or final orchestration note text
+
+## Forbidden Writes
+
+- M1-M82 normalization files unless explicitly authorized
+- plans unless explicitly authorized
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- `data/telemetry/**`
+- generated `status/`, curriculum `audit/`, or curriculum `review/` artifacts
+
+## Locked And Unlocked Rules
+
+- Treat M1-M92 as locked context by default. Read them for prerequisite coverage, but do not edit them.
+- The selected finale modules are unlocked for creation or remediation.
+- If a finale build reveals an upstream blocker in M1-M92, document it and stop or ask for scope expansion; do not silently edit upstream modules.
+- Finale modules should synthesize B1 skills rather than introduce new grammar.
+- Checkpoint/exam activities should diagnose and practice Ukrainian language skills, not test trivia.
+
+## Helpers And Headroom
+
+Helpers are allowed for prerequisite inventory, validation, or independent pre-review. The main orchestrator owns final build decisions. Use Headroom compression for helper output or logs over 200 lines or 20 KB.
+
+## Validation Commands
+
+Adapt module numbers from `curriculum.yaml`:
+
+```bash
+.venv/bin/python scripts/validate_activities.py l2-uk-en b1 <module_num>
+.venv/bin/python scripts/validate_vocab_yaml.py curriculum/l2-uk-en/b1/<slug>/vocabulary.yaml
+.venv/bin/python scripts/generate_mdx.py l2-uk-en b1 <module_num> --validate
+.venv/bin/python scripts/audit/check_mdx_generation_drift.py --files curriculum/l2-uk-en/b1/<slug>/module.md curriculum/l2-uk-en/b1/<slug>/activities.yaml curriculum/l2-uk-en/b1/<slug>/vocabulary.yaml
+git diff --check
+git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/' || true
+```
+
+## PR, Commit, And Telemetry Requirements
+
+- Branch: `codex/b1-finale-<batch>`
+- Commit trailer: `X-Agent: codex/b1-finale-<batch>`
+- Run `.venv/bin/python scripts/audit/lint_agent_trailer.py` before pushing.
+- Persist module-build telemetry through `POST /api/telemetry/module-builds`.
+- Include `swarm_used` and `swarm_note` in telemetry and PR text.
+- Require independent review before merge.
+
+## Expected Final Response
+
+```text
+Finale modules built: <slugs>
+Locked modules edited: none, or explicit list with authorization
+Files changed: <paths>
+Validation run: <commands and outcomes>
+Telemetry: <posted or unavailable with reason>
+Independent review: <status>
+Forbidden artifacts included: no
+swarm_used: true/false
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/b1/finale-build-orchestrator.md
+++ b/docs/prompts/orchestrators/b1/finale-build-orchestrator.md
@@ -103,7 +103,7 @@ Run `scripts/audit/check_mdx_generation_drift.py` only when a drift-only check i
 - Commit trailer: `X-Agent: codex/b1-finale-<batch>`
 - Run `.venv/bin/python scripts/audit/lint_agent_trailer.py` before pushing.
 - Persist module-build telemetry using `docs/prompts/orchestrators/shared/telemetry-and-pr.md`.
-- Include `swarm_used` and `swarm_note` in telemetry and PR text.
+- Include `swarm_used`, `swarm_label`, and `swarm_note` in telemetry and PR text.
 - Require independent review before merge.
 
 ## Expected Final Response
@@ -117,5 +117,6 @@ Telemetry: <posted or unavailable with reason>
 Independent review: <status>
 Forbidden artifacts included: no
 swarm_used: true/false
+swarm_label: <none | solo | helper | swarm>
 swarm_note: <helpers used, or solo run; no swarm used>
 ```

--- a/docs/prompts/orchestrators/b1/finale-build-orchestrator.md
+++ b/docs/prompts/orchestrators/b1/finale-build-orchestrator.md
@@ -17,7 +17,7 @@ Build, finish, or remediate final B1 synthesis/checkpoint/exam modules in a smal
 ## WORKTREE_ROOT Setup
 
 ```bash
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
 cd "$REPO_ROOT"
 git fetch origin main
 git worktree add -b codex/b1-finale-<batch> .worktrees/dispatch/codex/b1-finale-<batch> origin/main
@@ -88,7 +88,8 @@ Adapt module numbers from `curriculum.yaml`:
 .venv/bin/python scripts/generate_mdx.py l2-uk-en b1 <module_num> --validate
 .venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/b1/<slug>/module.md
 git diff --check
-if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
+CHANGED_FILES="$( { git diff --name-only; git diff --cached --name-only; git ls-files --others --exclude-standard; } | sort -u )"
+if [ -n "$CHANGED_FILES" ] && printf '%s\n' "$CHANGED_FILES" | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
   echo "Forbidden generated artifact in diff" >&2
   exit 1
 fi

--- a/docs/prompts/orchestrators/b1/quality-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/b1/quality-audit-orchestrator.md
@@ -1,28 +1,29 @@
 # B1 Quality Audit Orchestrator
 
-Prompt version: 0.1
+Prompt version: 0.2
 Last reviewed: 2026-06-21
 
 ## Source Assumptions
 
 - B1 is full Ukrainian immersion in module body, with English only where current repo policy permits vocabulary glosses.
-- The current B1 manifest has 94 modules. M83-M92 have built module sources in this checkout; M93-M94 may be plan/wiki-only and must not be assumed built.
-- This audit is for B1 M1-M82 normalization using the M83-M94 quality bar where those files exist.
-- This audit is read-only except for the durable report under `docs/audits/`.
+- The current B1 manifest has 94 modules. Recent main has built sources for M83-M94, including M93 `comprehensive-b1-review` and M94 `practice-exam`; verify current checkout state before judging.
+- This audit is for B1 M1-M82 normalization using the verified M83-M94 quality bar.
+- This audit must not modify curriculum or site sources. Its only content write is the durable report under `docs/audits/`, plus PR text needed to deliver that report.
 
 ## Goal
 
-Run a complete B1 normalization quality audit for M1-M82, using recent B1 quality expectations from M83-M94 when present. Record every issue without top-10 truncation, including plan/wiki/research coverage, engagement boxes, stress marks, wall-of-text risks, activities, vocabulary, and M82 quality. Include a full remediation batching plan but do not fix modules.
+Run a complete B1 normalization quality audit for M1-M82, using recent B1 quality expectations from the verified M83-M94 modules. Record every issue without top-10 truncation, including plan/wiki/research coverage, engagement boxes, stress marks, wall-of-text risks, activities, vocabulary, and M82 quality. Include a full remediation batching plan but do not fix modules.
 
 ## WORKTREE_ROOT Setup
 
 ```bash
-cd /Users/krisztiankoos/projects/learn-ukrainian
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
 git fetch origin main
 git worktree add -b codex/b1-quality-audit .worktrees/dispatch/codex/b1-quality-audit origin/main
 cd .worktrees/dispatch/codex/b1-quality-audit
-test -e .venv || ln -s /Users/krisztiankoos/projects/learn-ukrainian/.venv .venv
-export WORKTREE_ROOT="/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/b1-quality-audit"
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
 pwd
 git status --short --branch
 git rev-parse --show-toplevel
@@ -50,6 +51,7 @@ git rev-parse --show-toplevel
 ## Allowed Writes
 
 - `docs/audits/b1-normalization-quality-audit-YYYY-MM-DD.md`
+- PR body or final orchestration note text for delivering the report
 
 ## Forbidden Writes
 
@@ -72,6 +74,7 @@ git rev-parse --show-toplevel
 - Check wall-of-text risk: long grammar prose should be broken by tables, examples, comparison boxes, and activities.
 - Check activities and vocabulary against the target module focus and current `scripts/audit/config.py`.
 - Check M82 specifically as the final pre-M83 normalization boundary; note any quality discontinuity before `reported-speech`.
+- Run deterministic module audits without `--fix` for built modules in scope where feasible, and record any failures alongside subjective findings.
 - Record all findings and group them into targeted patch batches, full rebuild candidates, source/wiki gaps, and validation/tooling issues.
 
 ## Helpers And Headroom
@@ -82,17 +85,40 @@ Read-only helpers are allowed for module inventories or coverage matrices. Do no
 
 Write the report to `docs/audits/b1-normalization-quality-audit-YYYY-MM-DD.md`.
 
+## Report Delivery
+
+After validation, commit and open a draft PR that contains only the report:
+
+```bash
+git add docs/audits/b1-normalization-quality-audit-YYYY-MM-DD.md
+git commit -m "docs: add B1 normalization quality audit" --trailer "X-Agent: codex/b1-quality-audit"
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+git push -u origin codex/b1-quality-audit
+gh pr create --draft --fill --head codex/b1-quality-audit --base main
+```
+
 ## Validation Commands
 
 ```bash
 git status --short --branch
+.venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/b1/<slug>/module.md
 git diff --check
 git diff --name-only
-git diff --name-only | rg -v '^docs/audits/b1-normalization-quality-audit-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$' || true
-rg -n 'sys\.executable' docs/audits/b1-normalization-quality-audit-*.md
+if git diff --name-only | rg -v '^docs/audits/b1-normalization-quality-audit-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$'; then
+  echo "Unexpected file outside the durable audit report" >&2
+  exit 1
+fi
+if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
+  echo "Forbidden generated artifact in diff" >&2
+  exit 1
+fi
+if rg -n 'sys\.executable' docs/audits/b1-normalization-quality-audit-YYYY-MM-DD.md; then
+  echo "Audit report mentions forbidden sys.executable" >&2
+  exit 1
+fi
 ```
 
-Do not run builds. Do not write generated curriculum audit/status/review artifacts.
+Adapt the `audit_module.py` path for each built module audited. Do not pass `--fix`. Do not run builds. Do not write generated curriculum audit/status/review artifacts.
 
 ## Expected Final Response
 
@@ -103,6 +129,7 @@ Blockers: <n>
 Issues recorded: <n>
 Recommended remediation batches: <summary>
 Validation run: <commands and outcomes>
+Report delivery: <draft PR URL or blocked reason>
 Curriculum files modified: no
 swarm_used: true/false
 swarm_note: <helpers used, or solo run; no swarm used>

--- a/docs/prompts/orchestrators/b1/quality-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/b1/quality-audit-orchestrator.md
@@ -1,0 +1,109 @@
+# B1 Quality Audit Orchestrator
+
+Prompt version: 0.1
+Last reviewed: 2026-06-21
+
+## Source Assumptions
+
+- B1 is full Ukrainian immersion in module body, with English only where current repo policy permits vocabulary glosses.
+- The current B1 manifest has 94 modules. M83-M92 have built module sources in this checkout; M93-M94 may be plan/wiki-only and must not be assumed built.
+- This audit is for B1 M1-M82 normalization using the M83-M94 quality bar where those files exist.
+- This audit is read-only except for the durable report under `docs/audits/`.
+
+## Goal
+
+Run a complete B1 normalization quality audit for M1-M82, using recent B1 quality expectations from M83-M94 when present. Record every issue without top-10 truncation, including plan/wiki/research coverage, engagement boxes, stress marks, wall-of-text risks, activities, vocabulary, and M82 quality. Include a full remediation batching plan but do not fix modules.
+
+## WORKTREE_ROOT Setup
+
+```bash
+cd /Users/krisztiankoos/projects/learn-ukrainian
+git fetch origin main
+git worktree add -b codex/b1-quality-audit .worktrees/dispatch/codex/b1-quality-audit origin/main
+cd .worktrees/dispatch/codex/b1-quality-audit
+test -e .venv || ln -s /Users/krisztiankoos/projects/learn-ukrainian/.venv .venv
+export WORKTREE_ROOT="/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/b1-quality-audit"
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `curriculum/l2-uk-en/curriculum.yaml`, B1 section
+- `docs/l2-uk-en/MODULE-RICHNESS-GUIDELINES-v2.md`
+- `docs/runbooks/module-build-token-telemetry.md`
+- `scripts/config.py`
+- `scripts/audit/config.py`
+- B1 M83-M94 inventory from `curriculum.yaml`; for each present source directory, read module, activities, vocabulary, plan, wiki, and site MDX
+- Older B1 samples across M1-M82, including:
+  - `curriculum/l2-uk-en/b1/b1-baseline-past-present/module.md`
+  - `curriculum/l2-uk-en/b1/pluralia-tantum/module.md`
+  - `curriculum/l2-uk-en/b1/complex-subordinate-condition/module.md`
+  - `curriculum/l2-uk-en/b1/complex-subordinate-concess/module.md`
+  - matching plans, wiki files under `wiki/grammar/b1/`, activities, vocabulary, resources, and site MDX
+
+## Allowed Writes
+
+- `docs/audits/b1-normalization-quality-audit-YYYY-MM-DD.md`
+
+## Forbidden Writes
+
+- `curriculum/l2-uk-en/**`
+- `site/src/content/docs/**`
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- `data/telemetry/**`
+- generated `status/`, curriculum `audit/`, or curriculum `review/` artifacts
+
+## Audit Checks
+
+- Verify B1 sequence and M1-M82 scope from `curriculum.yaml`.
+- Inventory M83-M94 and explicitly record which are built, plan-only, or missing.
+- Verify current B1 thresholds, immersion, grammar constraints, activity types, and stress policy from code before judging.
+- Check plan coverage: objectives, content outline, dialogue situations, activity hints, vocabulary hints, and references.
+- Check wiki/source coverage: `wiki/grammar/b1/<slug>.md`, `.sources.yaml`, and plan references.
+- Check full Ukrainian immersion in body text; flag English body prose unless current repo policy permits it.
+- Check engagement: enough callouts, dialogues, examples, and learner-relevant contexts, without decorative filler.
+- Check stress marks and vocabulary stress policy from current docs/config before flagging.
+- Check wall-of-text risk: long grammar prose should be broken by tables, examples, comparison boxes, and activities.
+- Check activities and vocabulary against the target module focus and current `scripts/audit/config.py`.
+- Check M82 specifically as the final pre-M83 normalization boundary; note any quality discontinuity before `reported-speech`.
+- Record all findings and group them into targeted patch batches, full rebuild candidates, source/wiki gaps, and validation/tooling issues.
+
+## Helpers And Headroom
+
+Read-only helpers are allowed for module inventories or coverage matrices. Do not delegate final severity calls. Use Headroom compression for helper output or searches over 200 lines or 20 KB.
+
+## Durable Report Path
+
+Write the report to `docs/audits/b1-normalization-quality-audit-YYYY-MM-DD.md`.
+
+## Validation Commands
+
+```bash
+git status --short --branch
+git diff --check
+git diff --name-only
+git diff --name-only | rg -v '^docs/audits/b1-normalization-quality-audit-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$' || true
+rg -n 'sys\.executable' docs/audits/b1-normalization-quality-audit-*.md
+```
+
+Do not run builds. Do not write generated curriculum audit/status/review artifacts.
+
+## Expected Final Response
+
+```text
+Report written: docs/audits/b1-normalization-quality-audit-YYYY-MM-DD.md
+Scope inspected: M1-M82 plus M83-M94 bar inventory
+Blockers: <n>
+Issues recorded: <n>
+Recommended remediation batches: <summary>
+Validation run: <commands and outcomes>
+Curriculum files modified: no
+swarm_used: true/false
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/b1/quality-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/b1/quality-audit-orchestrator.md
@@ -17,7 +17,7 @@ Run a complete B1 normalization quality audit for M1-M82, using recent B1 qualit
 ## WORKTREE_ROOT Setup
 
 ```bash
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
 cd "$REPO_ROOT"
 git fetch origin main
 git worktree add -b codex/b1-quality-audit .worktrees/dispatch/codex/b1-quality-audit origin/main
@@ -85,40 +85,44 @@ Read-only helpers are allowed for module inventories or coverage matrices. Do no
 
 Write the report to `docs/audits/b1-normalization-quality-audit-YYYY-MM-DD.md`.
 
-## Report Delivery
-
-After validation, commit and open a draft PR that contains only the report:
-
-```bash
-git add docs/audits/b1-normalization-quality-audit-YYYY-MM-DD.md
-git commit -m "docs: add B1 normalization quality audit" --trailer "X-Agent: codex/b1-quality-audit"
-.venv/bin/python scripts/audit/lint_agent_trailer.py
-git push -u origin codex/b1-quality-audit
-gh pr create --draft --fill --head codex/b1-quality-audit --base main
-```
-
 ## Validation Commands
 
 ```bash
+REPORT="docs/audits/b1-normalization-quality-audit-$(date +%F).md"
 git status --short --branch
 .venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/b1/<slug>/module.md
 git diff --check
-git diff --name-only
-if git diff --name-only | rg -v '^docs/audits/b1-normalization-quality-audit-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$'; then
+test -f "$REPORT"
+CHANGED_FILES="$( { git diff --name-only; git diff --cached --name-only; git ls-files --others --exclude-standard; } | sort -u )"
+printf '%s\n' "$CHANGED_FILES"
+if [ -n "$CHANGED_FILES" ] && printf '%s\n' "$CHANGED_FILES" | rg -v '^docs/audits/b1-normalization-quality-audit-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$'; then
   echo "Unexpected file outside the durable audit report" >&2
   exit 1
 fi
-if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
+if [ -n "$CHANGED_FILES" ] && printf '%s\n' "$CHANGED_FILES" | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
   echo "Forbidden generated artifact in diff" >&2
   exit 1
 fi
-if rg -n 'sys\.executable' docs/audits/b1-normalization-quality-audit-YYYY-MM-DD.md; then
+if rg -n 'sys\.executable' "$REPORT"; then
   echo "Audit report mentions forbidden sys.executable" >&2
   exit 1
 fi
 ```
 
 Adapt the `audit_module.py` path for each built module audited. Do not pass `--fix`. Do not run builds. Do not write generated curriculum audit/status/review artifacts.
+
+## Report Delivery
+
+After validation, commit and open a draft PR that contains only the report:
+
+```bash
+REPORT="docs/audits/b1-normalization-quality-audit-$(date +%F).md"
+git add "$REPORT"
+git commit -m "docs: add B1 normalization quality audit" --trailer "X-Agent: codex/b1-quality-audit"
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+git push -u origin codex/b1-quality-audit
+gh pr create --draft --fill --head codex/b1-quality-audit --base main
+```
 
 ## Expected Final Response
 

--- a/docs/prompts/orchestrators/b1/quality-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/b1/quality-audit-orchestrator.md
@@ -136,5 +136,6 @@ Validation run: <commands and outcomes>
 Report delivery: <draft PR URL or blocked reason>
 Curriculum files modified: no
 swarm_used: true/false
+swarm_label: <none | solo | helper | swarm>
 swarm_note: <helpers used, or solo run; no swarm used>
 ```

--- a/docs/prompts/orchestrators/b1/remediation-build-orchestrator.md
+++ b/docs/prompts/orchestrators/b1/remediation-build-orchestrator.md
@@ -1,0 +1,121 @@
+# B1 Remediation Build Orchestrator
+
+Prompt version: 0.1
+Last reviewed: 2026-06-21
+
+## Source Assumptions
+
+- This prompt consumes a durable B1 normalization audit report under `docs/audits/`.
+- B1 remediation fixes M1-M82 issues in PR-sized batches.
+- M93-M94 finale work is out of scope unless the user explicitly selects a finale batch.
+- B1 module body should remain full Ukrainian immersion according to current repo policy.
+
+## Goal
+
+Fix all findings from the selected B1 normalization batch. Separate targeted patches from full rebuilds, keep changes scoped to selected modules, regenerate MDX, validate, prepare PR-ready notes, and record module-build telemetry.
+
+## WORKTREE_ROOT Setup
+
+```bash
+cd /Users/krisztiankoos/projects/learn-ukrainian
+git fetch origin main
+git worktree add -b codex/b1-remediation-<batch> .worktrees/dispatch/codex/b1-remediation-<batch> origin/main
+cd .worktrees/dispatch/codex/b1-remediation-<batch>
+test -e .venv || ln -s /Users/krisztiankoos/projects/learn-ukrainian/.venv .venv
+export WORKTREE_ROOT="/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/b1-remediation-<batch>"
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
+- the B1 audit report being remediated
+- `curriculum/l2-uk-en/curriculum.yaml`
+- `docs/l2-uk-en/MODULE-RICHNESS-GUIDELINES-v2.md`
+- `scripts/config.py`, especially B1 immersion policy
+- `scripts/audit/config.py`
+- for each target slug:
+  - `curriculum/l2-uk-en/plans/b1/<slug>.yaml`
+  - `curriculum/l2-uk-en/b1/<slug>/module.md`
+  - `curriculum/l2-uk-en/b1/<slug>/activities.yaml`
+  - `curriculum/l2-uk-en/b1/<slug>/vocabulary.yaml`
+  - `curriculum/l2-uk-en/b1/<slug>/resources.yaml` if present
+  - `wiki/grammar/b1/<slug>.md`
+  - `wiki/grammar/b1/<slug>.sources.yaml`
+  - `site/src/content/docs/b1/<slug>.mdx`
+
+## Allowed Writes
+
+- For scoped target slugs only:
+  - `curriculum/l2-uk-en/b1/<slug>/module.md`
+  - `curriculum/l2-uk-en/b1/<slug>/activities.yaml`
+  - `curriculum/l2-uk-en/b1/<slug>/vocabulary.yaml`
+  - `curriculum/l2-uk-en/b1/<slug>/resources.yaml`
+  - `site/src/content/docs/b1/<slug>.mdx`
+- PR body or final orchestration note text
+
+## Forbidden Writes
+
+- B1 plans unless explicitly authorized
+- M93-M94 or other finale files unless explicitly in scope
+- modules outside the selected batch
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- `data/telemetry/**`
+- generated `status/`, curriculum `audit/`, or curriculum `review/` artifacts
+
+## Remediation Rules
+
+- Fix every selected finding; no top-10 truncation.
+- Keep M1-M82 normalization separate from finale building.
+- Prefer targeted patches for localized issues: missing examples, weak activity item, vocabulary gap, stress policy mismatch, or source citation repair.
+- Use full rebuilds only when the module structure is fundamentally below bar or the audit report recommends a rebuild.
+- Preserve B1 Ukrainian-only body text and grammar metalanguage.
+- Do not contaminate older modules with M93-M94 finale synthesis unless the audit explicitly requests a local cross-reference.
+- Keep activities as language practice and preserve the YAML shape already present.
+
+## Helpers And Headroom
+
+Helpers are allowed for mechanical validation or bounded source checks with clear file ownership. The main orchestrator owns integration and final pedagogy. Use Headroom compression for helper output or logs over 200 lines or 20 KB.
+
+## Validation Commands
+
+Adapt module numbers from `curriculum.yaml`:
+
+```bash
+.venv/bin/python scripts/validate_activities.py l2-uk-en b1 <module_num>
+.venv/bin/python scripts/validate_vocab_yaml.py curriculum/l2-uk-en/b1/<slug>/vocabulary.yaml
+.venv/bin/python scripts/generate_mdx.py l2-uk-en b1 <module_num> --validate
+.venv/bin/python scripts/audit/check_mdx_generation_drift.py --files curriculum/l2-uk-en/b1/<slug>/module.md curriculum/l2-uk-en/b1/<slug>/activities.yaml curriculum/l2-uk-en/b1/<slug>/vocabulary.yaml
+git diff --check
+git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/' || true
+```
+
+## PR, Commit, And Telemetry Requirements
+
+- Branch: `codex/b1-remediation-<batch>`
+- Commit trailer: `X-Agent: codex/b1-remediation-<batch>`
+- Run `.venv/bin/python scripts/audit/lint_agent_trailer.py` before pushing.
+- Persist module-build telemetry through `POST /api/telemetry/module-builds`.
+- Include `swarm_used` and `swarm_note` in telemetry and PR text.
+- Require independent review before merge.
+
+## Expected Final Response
+
+```text
+Audit report consumed: <path>
+Batch fixed: <batch id>
+Modules changed: <slugs>
+Targeted patches: <n>
+Full rebuilds: <n>
+Validation run: <commands and outcomes>
+Telemetry: <posted or unavailable with reason>
+Independent review: <status>
+Forbidden artifacts included: no
+swarm_used: true/false
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/b1/remediation-build-orchestrator.md
+++ b/docs/prompts/orchestrators/b1/remediation-build-orchestrator.md
@@ -1,6 +1,6 @@
 # B1 Remediation Build Orchestrator
 
-Prompt version: 0.1
+Prompt version: 0.2
 Last reviewed: 2026-06-21
 
 ## Source Assumptions
@@ -17,12 +17,13 @@ Fix all findings from the selected B1 normalization batch. Separate targeted pat
 ## WORKTREE_ROOT Setup
 
 ```bash
-cd /Users/krisztiankoos/projects/learn-ukrainian
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
 git fetch origin main
 git worktree add -b codex/b1-remediation-<batch> .worktrees/dispatch/codex/b1-remediation-<batch> origin/main
 cd .worktrees/dispatch/codex/b1-remediation-<batch>
-test -e .venv || ln -s /Users/krisztiankoos/projects/learn-ukrainian/.venv .venv
-export WORKTREE_ROOT="/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/b1-remediation-<batch>"
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
 pwd
 git status --short --branch
 git rev-parse --show-toplevel
@@ -90,17 +91,22 @@ Adapt module numbers from `curriculum.yaml`:
 .venv/bin/python scripts/validate_activities.py l2-uk-en b1 <module_num>
 .venv/bin/python scripts/validate_vocab_yaml.py curriculum/l2-uk-en/b1/<slug>/vocabulary.yaml
 .venv/bin/python scripts/generate_mdx.py l2-uk-en b1 <module_num> --validate
-.venv/bin/python scripts/audit/check_mdx_generation_drift.py --files curriculum/l2-uk-en/b1/<slug>/module.md curriculum/l2-uk-en/b1/<slug>/activities.yaml curriculum/l2-uk-en/b1/<slug>/vocabulary.yaml
+.venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/b1/<slug>/module.md
 git diff --check
-git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/' || true
+if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
+  echo "Forbidden generated artifact in diff" >&2
+  exit 1
+fi
 ```
+
+Run `scripts/audit/check_mdx_generation_drift.py` only when a drift-only check is needed after generation.
 
 ## PR, Commit, And Telemetry Requirements
 
 - Branch: `codex/b1-remediation-<batch>`
 - Commit trailer: `X-Agent: codex/b1-remediation-<batch>`
 - Run `.venv/bin/python scripts/audit/lint_agent_trailer.py` before pushing.
-- Persist module-build telemetry through `POST /api/telemetry/module-builds`.
+- Persist module-build telemetry using `docs/prompts/orchestrators/shared/telemetry-and-pr.md`.
 - Include `swarm_used` and `swarm_note` in telemetry and PR text.
 - Require independent review before merge.
 

--- a/docs/prompts/orchestrators/b1/remediation-build-orchestrator.md
+++ b/docs/prompts/orchestrators/b1/remediation-build-orchestrator.md
@@ -108,7 +108,7 @@ Run `scripts/audit/check_mdx_generation_drift.py` only when a drift-only check i
 - Commit trailer: `X-Agent: codex/b1-remediation-<batch>`
 - Run `.venv/bin/python scripts/audit/lint_agent_trailer.py` before pushing.
 - Persist module-build telemetry using `docs/prompts/orchestrators/shared/telemetry-and-pr.md`.
-- Include `swarm_used` and `swarm_note` in telemetry and PR text.
+- Include `swarm_used`, `swarm_label`, and `swarm_note` in telemetry and PR text.
 - Require independent review before merge.
 
 ## Expected Final Response
@@ -124,5 +124,6 @@ Telemetry: <posted or unavailable with reason>
 Independent review: <status>
 Forbidden artifacts included: no
 swarm_used: true/false
+swarm_label: <none | solo | helper | swarm>
 swarm_note: <helpers used, or solo run; no swarm used>
 ```

--- a/docs/prompts/orchestrators/b1/remediation-build-orchestrator.md
+++ b/docs/prompts/orchestrators/b1/remediation-build-orchestrator.md
@@ -17,7 +17,7 @@ Fix all findings from the selected B1 normalization batch. Separate targeted pat
 ## WORKTREE_ROOT Setup
 
 ```bash
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
 cd "$REPO_ROOT"
 git fetch origin main
 git worktree add -b codex/b1-remediation-<batch> .worktrees/dispatch/codex/b1-remediation-<batch> origin/main
@@ -93,7 +93,8 @@ Adapt module numbers from `curriculum.yaml`:
 .venv/bin/python scripts/generate_mdx.py l2-uk-en b1 <module_num> --validate
 .venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/b1/<slug>/module.md
 git diff --check
-if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
+CHANGED_FILES="$( { git diff --name-only; git diff --cached --name-only; git ls-files --others --exclude-standard; } | sort -u )"
+if [ -n "$CHANGED_FILES" ] && printf '%s\n' "$CHANGED_FILES" | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
   echo "Forbidden generated artifact in diff" >&2
   exit 1
 fi

--- a/docs/prompts/orchestrators/b2/preflight-readiness-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/b2/preflight-readiness-audit-orchestrator.md
@@ -130,5 +130,6 @@ Report delivery: <draft PR URL or blocked reason>
 B2 production allowed now: yes/no
 Curriculum files modified: no
 swarm_used: true/false
+swarm_label: <none | solo | helper | swarm>
 swarm_note: <helpers used, or solo run; no swarm used>
 ```

--- a/docs/prompts/orchestrators/b2/preflight-readiness-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/b2/preflight-readiness-audit-orchestrator.md
@@ -1,6 +1,6 @@
 # B2 Preflight Readiness Audit Orchestrator
 
-Prompt version: 0.1
+Prompt version: 0.2
 Last reviewed: 2026-06-21
 
 ## Source Assumptions
@@ -8,7 +8,7 @@ Last reviewed: 2026-06-21
 - B2 is the upcoming production track. Do not build modules until readiness passes.
 - Current local repo contains B2 plans, discovery YAML, and wiki grammar/source files; built `curriculum/l2-uk-en/b2/<slug>/module.md` directories may not exist.
 - Check Ukrainian State Standard 2024 alignment only through repo-supported sources, plan references, source YAML, and local docs. Do not invent external standards or unsupported claims.
-- This audit is read-only except for the durable report under `docs/audits/`.
+- This audit must not modify plans, wiki, curriculum, discovery, or site sources. Its only content write is the durable report under `docs/audits/`, plus PR text needed to deliver that report.
 
 ## Goal
 
@@ -17,12 +17,13 @@ Determine whether B2 is ready for module production. Validate plans, sequence, `
 ## WORKTREE_ROOT Setup
 
 ```bash
-cd /Users/krisztiankoos/projects/learn-ukrainian
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
 git fetch origin main
 git worktree add -b codex/b2-preflight-readiness .worktrees/dispatch/codex/b2-preflight-readiness origin/main
 cd .worktrees/dispatch/codex/b2-preflight-readiness
-test -e .venv || ln -s /Users/krisztiankoos/projects/learn-ukrainian/.venv .venv
-export WORKTREE_ROOT="/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/b2-preflight-readiness"
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
 pwd
 git status --short --branch
 git rev-parse --show-toplevel
@@ -46,6 +47,7 @@ git rev-parse --show-toplevel
 ## Allowed Writes
 
 - `docs/audits/b2-preflight-readiness-YYYY-MM-DD.md`
+- PR body or final orchestration note text for delivering the report
 
 ## Forbidden Writes
 
@@ -77,6 +79,18 @@ Read-only helpers are allowed for inventories or slug-matrix checks. The main au
 
 Write the report to `docs/audits/b2-preflight-readiness-YYYY-MM-DD.md`.
 
+## Report Delivery
+
+After validation, commit and open a draft PR that contains only the report:
+
+```bash
+git add docs/audits/b2-preflight-readiness-YYYY-MM-DD.md
+git commit -m "docs: add B2 preflight readiness audit" --trailer "X-Agent: codex/b2-preflight-readiness"
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+git push -u origin codex/b2-preflight-readiness
+gh pr create --draft --fill --head codex/b2-preflight-readiness --base main
+```
+
 ## Validation Commands
 
 ```bash
@@ -84,8 +98,18 @@ Write the report to `docs/audits/b2-preflight-readiness-YYYY-MM-DD.md`.
 git status --short --branch
 git diff --check
 git diff --name-only
-git diff --name-only | rg -v '^docs/audits/b2-preflight-readiness-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$' || true
-rg -n 'sys\.executable' docs/audits/b2-preflight-readiness-*.md
+if git diff --name-only | rg -v '^docs/audits/b2-preflight-readiness-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$'; then
+  echo "Unexpected file outside the durable audit report" >&2
+  exit 1
+fi
+if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
+  echo "Forbidden generated artifact in diff" >&2
+  exit 1
+fi
+if rg -n 'sys\.executable' docs/audits/b2-preflight-readiness-YYYY-MM-DD.md; then
+  echo "Audit report mentions forbidden sys.executable" >&2
+  exit 1
+fi
 ```
 
 Do not run builds. Do not modify B2 plans, wiki files, discovery files, or modules.
@@ -98,6 +122,7 @@ Readiness status: pass | conditional pass | do not build
 Blockers: <n>
 Source/wiki/plan gaps: <summary>
 Validation run: <commands and outcomes>
+Report delivery: <draft PR URL or blocked reason>
 B2 production allowed now: yes/no
 Curriculum files modified: no
 swarm_used: true/false

--- a/docs/prompts/orchestrators/b2/preflight-readiness-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/b2/preflight-readiness-audit-orchestrator.md
@@ -17,7 +17,7 @@ Determine whether B2 is ready for module production. Validate plans, sequence, `
 ## WORKTREE_ROOT Setup
 
 ```bash
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
 cd "$REPO_ROOT"
 git fetch origin main
 git worktree add -b codex/b2-preflight-readiness .worktrees/dispatch/codex/b2-preflight-readiness origin/main
@@ -79,40 +79,44 @@ Read-only helpers are allowed for inventories or slug-matrix checks. The main au
 
 Write the report to `docs/audits/b2-preflight-readiness-YYYY-MM-DD.md`.
 
-## Report Delivery
-
-After validation, commit and open a draft PR that contains only the report:
-
-```bash
-git add docs/audits/b2-preflight-readiness-YYYY-MM-DD.md
-git commit -m "docs: add B2 preflight readiness audit" --trailer "X-Agent: codex/b2-preflight-readiness"
-.venv/bin/python scripts/audit/lint_agent_trailer.py
-git push -u origin codex/b2-preflight-readiness
-gh pr create --draft --fill --head codex/b2-preflight-readiness --base main
-```
-
 ## Validation Commands
 
 ```bash
+REPORT="docs/audits/b2-preflight-readiness-$(date +%F).md"
 .venv/bin/python scripts/validate_plans.py b2
 git status --short --branch
 git diff --check
-git diff --name-only
-if git diff --name-only | rg -v '^docs/audits/b2-preflight-readiness-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$'; then
+test -f "$REPORT"
+CHANGED_FILES="$( { git diff --name-only; git diff --cached --name-only; git ls-files --others --exclude-standard; } | sort -u )"
+printf '%s\n' "$CHANGED_FILES"
+if [ -n "$CHANGED_FILES" ] && printf '%s\n' "$CHANGED_FILES" | rg -v '^docs/audits/b2-preflight-readiness-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$'; then
   echo "Unexpected file outside the durable audit report" >&2
   exit 1
 fi
-if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
+if [ -n "$CHANGED_FILES" ] && printf '%s\n' "$CHANGED_FILES" | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
   echo "Forbidden generated artifact in diff" >&2
   exit 1
 fi
-if rg -n 'sys\.executable' docs/audits/b2-preflight-readiness-YYYY-MM-DD.md; then
+if rg -n 'sys\.executable' "$REPORT"; then
   echo "Audit report mentions forbidden sys.executable" >&2
   exit 1
 fi
 ```
 
 Do not run builds. Do not modify B2 plans, wiki files, discovery files, or modules.
+
+## Report Delivery
+
+After validation, commit and open a draft PR that contains only the report:
+
+```bash
+REPORT="docs/audits/b2-preflight-readiness-$(date +%F).md"
+git add "$REPORT"
+git commit -m "docs: add B2 preflight readiness audit" --trailer "X-Agent: codex/b2-preflight-readiness"
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+git push -u origin codex/b2-preflight-readiness
+gh pr create --draft --fill --head codex/b2-preflight-readiness --base main
+```
 
 ## Expected Final Response
 

--- a/docs/prompts/orchestrators/b2/preflight-readiness-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/b2/preflight-readiness-audit-orchestrator.md
@@ -1,0 +1,105 @@
+# B2 Preflight Readiness Audit Orchestrator
+
+Prompt version: 0.1
+Last reviewed: 2026-06-21
+
+## Source Assumptions
+
+- B2 is the upcoming production track. Do not build modules until readiness passes.
+- Current local repo contains B2 plans, discovery YAML, and wiki grammar/source files; built `curriculum/l2-uk-en/b2/<slug>/module.md` directories may not exist.
+- Check Ukrainian State Standard 2024 alignment only through repo-supported sources, plan references, source YAML, and local docs. Do not invent external standards or unsupported claims.
+- This audit is read-only except for the durable report under `docs/audits/`.
+
+## Goal
+
+Determine whether B2 is ready for module production. Validate plans, sequence, `curriculum.yaml` alignment, wiki/grammar articles, source YAML coverage, research/source coverage, stale slugs, sequencing, and standard-alignment blockers. Output a readiness report with explicit "do not build until fixed" blockers. Do not fix plans or build modules.
+
+## WORKTREE_ROOT Setup
+
+```bash
+cd /Users/krisztiankoos/projects/learn-ukrainian
+git fetch origin main
+git worktree add -b codex/b2-preflight-readiness .worktrees/dispatch/codex/b2-preflight-readiness origin/main
+cd .worktrees/dispatch/codex/b2-preflight-readiness
+test -e .venv || ln -s /Users/krisztiankoos/projects/learn-ukrainian/.venv .venv
+export WORKTREE_ROOT="/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/b2-preflight-readiness"
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `curriculum/l2-uk-en/curriculum.yaml`, B2 section
+- `docs/l2-uk-en/MODULE-RICHNESS-GUIDELINES-v2.md`
+- `scripts/config.py`
+- `scripts/audit/config.py`
+- all B2 plans under `curriculum/l2-uk-en/plans/b2/`
+- all B2 discovery files under `curriculum/l2-uk-en/b2/discovery/`
+- all B2 wiki and source files under `wiki/grammar/b2/`
+- relevant local docs or plan references that mention Ukrainian State Standard 2024
+
+## Allowed Writes
+
+- `docs/audits/b2-preflight-readiness-YYYY-MM-DD.md`
+
+## Forbidden Writes
+
+- `curriculum/l2-uk-en/**`
+- `wiki/**`
+- `site/src/content/docs/**`
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- `data/telemetry/**`
+- generated `status/`, curriculum `audit/`, or curriculum `review/` artifacts
+
+## Readiness Checks
+
+- Confirm every B2 slug in `curriculum.yaml` has exactly one plan file.
+- Confirm every plan slug and sequence matches the manifest.
+- Confirm discovery YAML coverage for every planned B2 slug.
+- Confirm `wiki/grammar/b2/<slug>.md` and `<slug>.sources.yaml` coverage for every planned B2 slug.
+- Identify stale plan files, `.bak` files, orphan wiki files, missing discovery files, missing source YAML, and naming mismatches.
+- Check plan quality: objectives, content outline, vocabulary hints, activity hints, references, phase labels, and B2-appropriate register.
+- Check sequencing: prerequisites appear before dependent modules; checkpoints and domain vocabulary are positioned coherently.
+- Check source coverage against repo-supported Ukrainian State Standard 2024 references. If support is absent, record a source gap instead of inventing alignment.
+- Identify blockers that require plan/wiki/source work before production.
+- Mark readiness as `pass`, `conditional pass`, or `do not build`.
+
+## Helpers And Headroom
+
+Read-only helpers are allowed for inventories or slug-matrix checks. The main auditor owns readiness judgment. Use Headroom compression for helper output or search results over 200 lines or 20 KB.
+
+## Durable Report Path
+
+Write the report to `docs/audits/b2-preflight-readiness-YYYY-MM-DD.md`.
+
+## Validation Commands
+
+```bash
+.venv/bin/python scripts/validate_plans.py b2
+git status --short --branch
+git diff --check
+git diff --name-only
+git diff --name-only | rg -v '^docs/audits/b2-preflight-readiness-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$' || true
+rg -n 'sys\.executable' docs/audits/b2-preflight-readiness-*.md
+```
+
+Do not run builds. Do not modify B2 plans, wiki files, discovery files, or modules.
+
+## Expected Final Response
+
+```text
+Report written: docs/audits/b2-preflight-readiness-YYYY-MM-DD.md
+Readiness status: pass | conditional pass | do not build
+Blockers: <n>
+Source/wiki/plan gaps: <summary>
+Validation run: <commands and outcomes>
+B2 production allowed now: yes/no
+Curriculum files modified: no
+swarm_used: true/false
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/b2/production-build-orchestrator.md
+++ b/docs/prompts/orchestrators/b2/production-build-orchestrator.md
@@ -1,0 +1,116 @@
+# B2 Production Build Orchestrator
+
+Prompt version: 0.1
+Last reviewed: 2026-06-21
+
+## Source Assumptions
+
+- Use this prompt only after `docs/audits/b2-preflight-readiness-*.md` says production may proceed.
+- B2 modules require advanced Ukrainian immersion, register control, argumentation, professional/academic readiness, and richer syntax.
+- B2 production should run in small sequential batches with module-tailored prompts, not generic batch instructions.
+- Plans are source of truth. Do not edit plans unless a preflight remediation PR explicitly scopes that work.
+
+## Goal
+
+Build the selected B2 module batch from local plans, discovery files, and wiki/source coverage. Create source modules, activities, vocabulary, resources where needed, generate site MDX, validate, record telemetry, and require independent review before merge.
+
+## WORKTREE_ROOT Setup
+
+```bash
+cd /Users/krisztiankoos/projects/learn-ukrainian
+git fetch origin main
+git worktree add -b codex/b2-production-<batch> .worktrees/dispatch/codex/b2-production-<batch> origin/main
+cd .worktrees/dispatch/codex/b2-production-<batch>
+test -e .venv || ln -s /Users/krisztiankoos/projects/learn-ukrainian/.venv .venv
+export WORKTREE_ROOT="/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/b2-production-<batch>"
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
+- passing or conditionally passing `docs/audits/b2-preflight-readiness-*.md`
+- `curriculum/l2-uk-en/curriculum.yaml`, target B2 modules
+- `docs/l2-uk-en/MODULE-RICHNESS-GUIDELINES-v2.md`
+- `scripts/config.py`, especially B2/default immersion policy
+- `scripts/audit/config.py`, especially B2 thresholds and activity types
+- for each target slug:
+  - `curriculum/l2-uk-en/plans/b2/<slug>.yaml`
+  - `curriculum/l2-uk-en/b2/discovery/<slug>.yaml`
+  - `wiki/grammar/b2/<slug>.md`
+  - `wiki/grammar/b2/<slug>.sources.yaml`
+  - existing `curriculum/l2-uk-en/b2/<slug>/` source directory if present
+  - existing `site/src/content/docs/b2/<slug>.mdx` if present
+
+## Allowed Writes
+
+- For scoped target slugs only:
+  - `curriculum/l2-uk-en/b2/<slug>/module.md`
+  - `curriculum/l2-uk-en/b2/<slug>/activities.yaml`
+  - `curriculum/l2-uk-en/b2/<slug>/vocabulary.yaml`
+  - `curriculum/l2-uk-en/b2/<slug>/resources.yaml`
+  - `site/src/content/docs/b2/<slug>.mdx`
+  - `site/src/content/docs/b2/index.mdx` only if current repo generation or navigation requires it
+- PR body or final orchestration note text
+
+## Forbidden Writes
+
+- B2 plans, discovery, or wiki files unless explicitly authorized by a preflight remediation scope
+- modules outside the selected batch
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- `data/telemetry/**`
+- generated `status/`, curriculum `audit/`, or curriculum `review/` artifacts
+
+## Production Rules
+
+- Work in small sequential batches. Finish and validate each module before moving to the next.
+- Write a module-tailored mini-prompt for each slug using that module's plan, discovery, wiki, and source YAML.
+- B2 content should be advanced but teachable: richer syntax, register and style awareness, argumentation, professional or academic tasks, and precise vocabulary.
+- Avoid generic filler, decorative complexity, and content trivia. Activities must practice Ukrainian language skills through the module topic.
+- Maintain B2 immersion according to current config; English should be limited to vocabulary glosses or current repo-permitted contexts.
+- If preflight blockers reappear, stop and record them rather than building around missing sources.
+
+## Helpers And Headroom
+
+Helpers are allowed for source extraction, validation, or independent review preparation. Assign clear file ownership for any worker. Use Headroom compression for helper output or logs over 200 lines or 20 KB.
+
+## Validation Commands
+
+Adapt module numbers from `curriculum.yaml`:
+
+```bash
+.venv/bin/python scripts/validate_activities.py l2-uk-en b2 <module_num>
+.venv/bin/python scripts/validate_vocab_yaml.py curriculum/l2-uk-en/b2/<slug>/vocabulary.yaml
+.venv/bin/python scripts/generate_mdx.py l2-uk-en b2 <module_num> --validate
+.venv/bin/python scripts/audit/check_mdx_generation_drift.py --files curriculum/l2-uk-en/b2/<slug>/module.md curriculum/l2-uk-en/b2/<slug>/activities.yaml curriculum/l2-uk-en/b2/<slug>/vocabulary.yaml
+git diff --check
+git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/' || true
+```
+
+## PR, Commit, And Telemetry Requirements
+
+- Branch: `codex/b2-production-<batch>`
+- Commit trailer: `X-Agent: codex/b2-production-<batch>`
+- Run `.venv/bin/python scripts/audit/lint_agent_trailer.py` before pushing.
+- Persist module-build telemetry through `POST /api/telemetry/module-builds`.
+- Include `swarm_used` and `swarm_note` in telemetry and PR text.
+- Require independent review before merge.
+
+## Expected Final Response
+
+```text
+B2 preflight report used: <path>
+Modules built: <slugs>
+Files changed: <paths>
+Validation run: <commands and outcomes>
+Telemetry: <posted or unavailable with reason>
+Independent review: <status>
+Forbidden artifacts included: no
+swarm_used: true/false
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/b2/production-build-orchestrator.md
+++ b/docs/prompts/orchestrators/b2/production-build-orchestrator.md
@@ -1,6 +1,6 @@
 # B2 Production Build Orchestrator
 
-Prompt version: 0.1
+Prompt version: 0.2
 Last reviewed: 2026-06-21
 
 ## Source Assumptions
@@ -17,12 +17,13 @@ Build the selected B2 module batch from local plans, discovery files, and wiki/s
 ## WORKTREE_ROOT Setup
 
 ```bash
-cd /Users/krisztiankoos/projects/learn-ukrainian
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
 git fetch origin main
 git worktree add -b codex/b2-production-<batch> .worktrees/dispatch/codex/b2-production-<batch> origin/main
 cd .worktrees/dispatch/codex/b2-production-<batch>
-test -e .venv || ln -s /Users/krisztiankoos/projects/learn-ukrainian/.venv .venv
-export WORKTREE_ROOT="/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/b2-production-<batch>"
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
 pwd
 git status --short --branch
 git rev-parse --show-toplevel
@@ -87,17 +88,22 @@ Adapt module numbers from `curriculum.yaml`:
 .venv/bin/python scripts/validate_activities.py l2-uk-en b2 <module_num>
 .venv/bin/python scripts/validate_vocab_yaml.py curriculum/l2-uk-en/b2/<slug>/vocabulary.yaml
 .venv/bin/python scripts/generate_mdx.py l2-uk-en b2 <module_num> --validate
-.venv/bin/python scripts/audit/check_mdx_generation_drift.py --files curriculum/l2-uk-en/b2/<slug>/module.md curriculum/l2-uk-en/b2/<slug>/activities.yaml curriculum/l2-uk-en/b2/<slug>/vocabulary.yaml
+.venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/b2/<slug>/module.md
 git diff --check
-git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/' || true
+if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
+  echo "Forbidden generated artifact in diff" >&2
+  exit 1
+fi
 ```
+
+Run `scripts/audit/check_mdx_generation_drift.py` only when a drift-only check is needed after generation.
 
 ## PR, Commit, And Telemetry Requirements
 
 - Branch: `codex/b2-production-<batch>`
 - Commit trailer: `X-Agent: codex/b2-production-<batch>`
 - Run `.venv/bin/python scripts/audit/lint_agent_trailer.py` before pushing.
-- Persist module-build telemetry through `POST /api/telemetry/module-builds`.
+- Persist module-build telemetry using `docs/prompts/orchestrators/shared/telemetry-and-pr.md`.
 - Include `swarm_used` and `swarm_note` in telemetry and PR text.
 - Require independent review before merge.
 

--- a/docs/prompts/orchestrators/b2/production-build-orchestrator.md
+++ b/docs/prompts/orchestrators/b2/production-build-orchestrator.md
@@ -17,7 +17,7 @@ Build the selected B2 module batch from local plans, discovery files, and wiki/s
 ## WORKTREE_ROOT Setup
 
 ```bash
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
 cd "$REPO_ROOT"
 git fetch origin main
 git worktree add -b codex/b2-production-<batch> .worktrees/dispatch/codex/b2-production-<batch> origin/main
@@ -90,7 +90,8 @@ Adapt module numbers from `curriculum.yaml`:
 .venv/bin/python scripts/generate_mdx.py l2-uk-en b2 <module_num> --validate
 .venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/b2/<slug>/module.md
 git diff --check
-if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
+CHANGED_FILES="$( { git diff --name-only; git diff --cached --name-only; git ls-files --others --exclude-standard; } | sort -u )"
+if [ -n "$CHANGED_FILES" ] && printf '%s\n' "$CHANGED_FILES" | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
   echo "Forbidden generated artifact in diff" >&2
   exit 1
 fi

--- a/docs/prompts/orchestrators/b2/production-build-orchestrator.md
+++ b/docs/prompts/orchestrators/b2/production-build-orchestrator.md
@@ -105,7 +105,7 @@ Run `scripts/audit/check_mdx_generation_drift.py` only when a drift-only check i
 - Commit trailer: `X-Agent: codex/b2-production-<batch>`
 - Run `.venv/bin/python scripts/audit/lint_agent_trailer.py` before pushing.
 - Persist module-build telemetry using `docs/prompts/orchestrators/shared/telemetry-and-pr.md`.
-- Include `swarm_used` and `swarm_note` in telemetry and PR text.
+- Include `swarm_used`, `swarm_label`, and `swarm_note` in telemetry and PR text.
 - Require independent review before merge.
 
 ## Expected Final Response
@@ -119,5 +119,6 @@ Telemetry: <posted or unavailable with reason>
 Independent review: <status>
 Forbidden artifacts included: no
 swarm_used: true/false
+swarm_label: <none | solo | helper | swarm>
 swarm_note: <helpers used, or solo run; no swarm used>
 ```

--- a/docs/prompts/orchestrators/b2/quality-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/b2/quality-audit-orchestrator.md
@@ -1,0 +1,112 @@
+# B2 Quality Audit Orchestrator
+
+Prompt version: 0.1
+Last reviewed: 2026-06-21
+
+## Source Assumptions
+
+- This is a post-build audit for B2 modules, not a preflight plan audit.
+- B2 should show higher abstraction, richer syntax, stylistic/register control, argumentation, and professional/academic readiness.
+- The audit is read-only except for the durable report under `docs/audits/`.
+- Do not assume every planned B2 module is built; audit only built modules in scope and record missing source directories separately.
+
+## Goal
+
+Review built B2 modules for B2-specific quality after production. Record a complete issue inventory without top-10 truncation, write a durable report, and propose remediation batches. Do not fix modules.
+
+## WORKTREE_ROOT Setup
+
+```bash
+cd /Users/krisztiankoos/projects/learn-ukrainian
+git fetch origin main
+git worktree add -b codex/b2-quality-audit .worktrees/dispatch/codex/b2-quality-audit origin/main
+cd .worktrees/dispatch/codex/b2-quality-audit
+test -e .venv || ln -s /Users/krisztiankoos/projects/learn-ukrainian/.venv .venv
+export WORKTREE_ROOT="/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/b2-quality-audit"
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `curriculum/l2-uk-en/curriculum.yaml`, B2 section
+- `docs/l2-uk-en/MODULE-RICHNESS-GUIDELINES-v2.md`
+- `scripts/config.py`
+- `scripts/audit/config.py`
+- target B2 production PR notes or build report if available
+- for each built target slug:
+  - `curriculum/l2-uk-en/plans/b2/<slug>.yaml`
+  - `curriculum/l2-uk-en/b2/discovery/<slug>.yaml`
+  - `curriculum/l2-uk-en/b2/<slug>/module.md`
+  - `curriculum/l2-uk-en/b2/<slug>/activities.yaml`
+  - `curriculum/l2-uk-en/b2/<slug>/vocabulary.yaml`
+  - `curriculum/l2-uk-en/b2/<slug>/resources.yaml` if present
+  - `wiki/grammar/b2/<slug>.md`
+  - `wiki/grammar/b2/<slug>.sources.yaml`
+  - `site/src/content/docs/b2/<slug>.mdx`
+
+## Allowed Writes
+
+- `docs/audits/b2-quality-audit-YYYY-MM-DD.md`
+
+## Forbidden Writes
+
+- `curriculum/l2-uk-en/**`
+- `wiki/**`
+- `site/src/content/docs/**`
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- `data/telemetry/**`
+- generated `status/`, curriculum `audit/`, or curriculum `review/` artifacts
+
+## Audit Checks
+
+- Verify built-module scope against `curriculum.yaml`; record planned but unbuilt modules separately.
+- Verify live B2 thresholds, immersion policy, activity types, and grammar constraints from code.
+- Check plan fidelity: objectives, content outline, vocabulary hints, activity hints, phase goals, and references.
+- Check source/wiki coverage and whether the module teaches from the local wiki rather than inventing source claims.
+- Check B2 abstraction: advanced concepts are explained in Ukrainian without becoming opaque.
+- Check richer syntax: multi-clause sentences are natural, controlled, and teachable; complexity is not decorative.
+- Check register and style: formal/informal, business, academic, public discourse, literary, and cross-register tasks match the module goal.
+- Check argumentation and professional/academic readiness: learners practice claims, evidence, counterargument, synthesis, reports, presentations, or analysis where appropriate.
+- Check activities: they practice language skills, not trivia about the topic.
+- Check vocabulary: enough B2 terms, register labels where useful, natural examples, and source-backed usage.
+- Check engagement and wall-of-text risk: examples, tables, callouts, and tasks make dense material usable.
+
+## Helpers And Headroom
+
+Read-only helpers are allowed for coverage matrices or validation summaries. Do not delegate final severity calls. Use Headroom compression for helper output or logs over 200 lines or 20 KB.
+
+## Durable Report Path
+
+Write the report to `docs/audits/b2-quality-audit-YYYY-MM-DD.md`.
+
+## Validation Commands
+
+```bash
+git status --short --branch
+git diff --check
+git diff --name-only
+git diff --name-only | rg -v '^docs/audits/b2-quality-audit-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$' || true
+rg -n 'sys\.executable' docs/audits/b2-quality-audit-*.md
+```
+
+Do not run builds. Do not write generated curriculum audit/status/review artifacts.
+
+## Expected Final Response
+
+```text
+Report written: docs/audits/b2-quality-audit-YYYY-MM-DD.md
+Scope inspected: <modules>
+Blockers: <n>
+Issues recorded: <n>
+Recommended remediation batches: <summary>
+Validation run: <commands and outcomes>
+Curriculum files modified: no
+swarm_used: true/false
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/b2/quality-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/b2/quality-audit-orchestrator.md
@@ -139,5 +139,6 @@ Validation run: <commands and outcomes>
 Report delivery: <draft PR URL or blocked reason>
 Curriculum files modified: no
 swarm_used: true/false
+swarm_label: <none | solo | helper | swarm>
 swarm_note: <helpers used, or solo run; no swarm used>
 ```

--- a/docs/prompts/orchestrators/b2/quality-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/b2/quality-audit-orchestrator.md
@@ -1,13 +1,13 @@
 # B2 Quality Audit Orchestrator
 
-Prompt version: 0.1
+Prompt version: 0.2
 Last reviewed: 2026-06-21
 
 ## Source Assumptions
 
 - This is a post-build audit for B2 modules, not a preflight plan audit.
 - B2 should show higher abstraction, richer syntax, stylistic/register control, argumentation, and professional/academic readiness.
-- The audit is read-only except for the durable report under `docs/audits/`.
+- This audit must not modify curriculum, wiki, discovery, or site sources. Its only content write is the durable report under `docs/audits/`, plus PR text needed to deliver that report.
 - Do not assume every planned B2 module is built; audit only built modules in scope and record missing source directories separately.
 
 ## Goal
@@ -17,12 +17,13 @@ Review built B2 modules for B2-specific quality after production. Record a compl
 ## WORKTREE_ROOT Setup
 
 ```bash
-cd /Users/krisztiankoos/projects/learn-ukrainian
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
 git fetch origin main
 git worktree add -b codex/b2-quality-audit .worktrees/dispatch/codex/b2-quality-audit origin/main
 cd .worktrees/dispatch/codex/b2-quality-audit
-test -e .venv || ln -s /Users/krisztiankoos/projects/learn-ukrainian/.venv .venv
-export WORKTREE_ROOT="/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/b2-quality-audit"
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
 pwd
 git status --short --branch
 git rev-parse --show-toplevel
@@ -53,6 +54,7 @@ git rev-parse --show-toplevel
 ## Allowed Writes
 
 - `docs/audits/b2-quality-audit-YYYY-MM-DD.md`
+- PR body or final orchestration note text for delivering the report
 
 ## Forbidden Writes
 
@@ -76,6 +78,7 @@ git rev-parse --show-toplevel
 - Check activities: they practice language skills, not trivia about the topic.
 - Check vocabulary: enough B2 terms, register labels where useful, natural examples, and source-backed usage.
 - Check engagement and wall-of-text risk: examples, tables, callouts, and tasks make dense material usable.
+- Run deterministic module audits without `--fix` for built modules in scope where feasible, and record any failures alongside subjective findings.
 
 ## Helpers And Headroom
 
@@ -85,17 +88,40 @@ Read-only helpers are allowed for coverage matrices or validation summaries. Do 
 
 Write the report to `docs/audits/b2-quality-audit-YYYY-MM-DD.md`.
 
+## Report Delivery
+
+After validation, commit and open a draft PR that contains only the report:
+
+```bash
+git add docs/audits/b2-quality-audit-YYYY-MM-DD.md
+git commit -m "docs: add B2 quality audit" --trailer "X-Agent: codex/b2-quality-audit"
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+git push -u origin codex/b2-quality-audit
+gh pr create --draft --fill --head codex/b2-quality-audit --base main
+```
+
 ## Validation Commands
 
 ```bash
 git status --short --branch
+.venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/b2/<slug>/module.md
 git diff --check
 git diff --name-only
-git diff --name-only | rg -v '^docs/audits/b2-quality-audit-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$' || true
-rg -n 'sys\.executable' docs/audits/b2-quality-audit-*.md
+if git diff --name-only | rg -v '^docs/audits/b2-quality-audit-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$'; then
+  echo "Unexpected file outside the durable audit report" >&2
+  exit 1
+fi
+if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
+  echo "Forbidden generated artifact in diff" >&2
+  exit 1
+fi
+if rg -n 'sys\.executable' docs/audits/b2-quality-audit-YYYY-MM-DD.md; then
+  echo "Audit report mentions forbidden sys.executable" >&2
+  exit 1
+fi
 ```
 
-Do not run builds. Do not write generated curriculum audit/status/review artifacts.
+Adapt the `audit_module.py` path for each built module audited. Do not pass `--fix`. Do not run builds. Do not write generated curriculum audit/status/review artifacts.
 
 ## Expected Final Response
 
@@ -106,6 +132,7 @@ Blockers: <n>
 Issues recorded: <n>
 Recommended remediation batches: <summary>
 Validation run: <commands and outcomes>
+Report delivery: <draft PR URL or blocked reason>
 Curriculum files modified: no
 swarm_used: true/false
 swarm_note: <helpers used, or solo run; no swarm used>

--- a/docs/prompts/orchestrators/b2/quality-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/b2/quality-audit-orchestrator.md
@@ -17,7 +17,7 @@ Review built B2 modules for B2-specific quality after production. Record a compl
 ## WORKTREE_ROOT Setup
 
 ```bash
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
 cd "$REPO_ROOT"
 git fetch origin main
 git worktree add -b codex/b2-quality-audit .worktrees/dispatch/codex/b2-quality-audit origin/main
@@ -88,40 +88,44 @@ Read-only helpers are allowed for coverage matrices or validation summaries. Do 
 
 Write the report to `docs/audits/b2-quality-audit-YYYY-MM-DD.md`.
 
-## Report Delivery
-
-After validation, commit and open a draft PR that contains only the report:
-
-```bash
-git add docs/audits/b2-quality-audit-YYYY-MM-DD.md
-git commit -m "docs: add B2 quality audit" --trailer "X-Agent: codex/b2-quality-audit"
-.venv/bin/python scripts/audit/lint_agent_trailer.py
-git push -u origin codex/b2-quality-audit
-gh pr create --draft --fill --head codex/b2-quality-audit --base main
-```
-
 ## Validation Commands
 
 ```bash
+REPORT="docs/audits/b2-quality-audit-$(date +%F).md"
 git status --short --branch
 .venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/b2/<slug>/module.md
 git diff --check
-git diff --name-only
-if git diff --name-only | rg -v '^docs/audits/b2-quality-audit-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$'; then
+test -f "$REPORT"
+CHANGED_FILES="$( { git diff --name-only; git diff --cached --name-only; git ls-files --others --exclude-standard; } | sort -u )"
+printf '%s\n' "$CHANGED_FILES"
+if [ -n "$CHANGED_FILES" ] && printf '%s\n' "$CHANGED_FILES" | rg -v '^docs/audits/b2-quality-audit-[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$'; then
   echo "Unexpected file outside the durable audit report" >&2
   exit 1
 fi
-if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
+if [ -n "$CHANGED_FILES" ] && printf '%s\n' "$CHANGED_FILES" | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
   echo "Forbidden generated artifact in diff" >&2
   exit 1
 fi
-if rg -n 'sys\.executable' docs/audits/b2-quality-audit-YYYY-MM-DD.md; then
+if rg -n 'sys\.executable' "$REPORT"; then
   echo "Audit report mentions forbidden sys.executable" >&2
   exit 1
 fi
 ```
 
 Adapt the `audit_module.py` path for each built module audited. Do not pass `--fix`. Do not run builds. Do not write generated curriculum audit/status/review artifacts.
+
+## Report Delivery
+
+After validation, commit and open a draft PR that contains only the report:
+
+```bash
+REPORT="docs/audits/b2-quality-audit-$(date +%F).md"
+git add "$REPORT"
+git commit -m "docs: add B2 quality audit" --trailer "X-Agent: codex/b2-quality-audit"
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+git push -u origin codex/b2-quality-audit
+gh pr create --draft --fill --head codex/b2-quality-audit --base main
+```
 
 ## Expected Final Response
 

--- a/docs/prompts/orchestrators/shared/repo-rules.md
+++ b/docs/prompts/orchestrators/shared/repo-rules.md
@@ -23,6 +23,7 @@ Paste these rules into future orchestration prompts and then verify them against
 ## Worktree Layout
 
 - Work in a dispatch worktree, not the main checkout.
+- Run worktree setup from the main checkout, or set `REPO_ROOT` to the intended source checkout before pasting a setup block. This avoids nesting dispatch worktrees inside another worktree.
 - Use `.worktrees/dispatch/codex/<task>/` for Codex work.
 - Align the branch name with the path, for example `codex/<task>`.
 - Verify the worktree before editing:

--- a/docs/prompts/orchestrators/shared/repo-rules.md
+++ b/docs/prompts/orchestrators/shared/repo-rules.md
@@ -1,6 +1,6 @@
 # Shared Repo Rules For Orchestrator Prompts
 
-Prompt version: 0.1
+Prompt suite component version: 0.2
 Last reviewed: 2026-06-21
 
 Paste these rules into future orchestration prompts and then verify them against the current local `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`.
@@ -55,5 +55,5 @@ git rev-parse --show-toplevel
 - Every commit must include an `X-Agent` trailer.
 - Format: `X-Agent: codex/<task-id>` or the correct agent/task for the thread.
 - Run `.venv/bin/python scripts/audit/lint_agent_trailer.py` before pushing.
-- Module-build PRs must include token telemetry with `swarm_used` and `swarm_note`.
+- Module-build PRs must include token telemetry with `swarm_used`, `swarm_label`, and `swarm_note`.
 - Do not commit, push, or open a PR unless the user explicitly asks or the orchestrator prompt says that is part of the task.

--- a/docs/prompts/orchestrators/shared/repo-rules.md
+++ b/docs/prompts/orchestrators/shared/repo-rules.md
@@ -1,0 +1,59 @@
+# Shared Repo Rules For Orchestrator Prompts
+
+Prompt version: 0.1
+Last reviewed: 2026-06-21
+
+Paste these rules into future orchestration prompts and then verify them against the current local `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`.
+
+## Non-Negotiable Files
+
+- Do not edit `.python-version`; it must remain `3.12.8`.
+- Do not edit `.yamllint`.
+- Do not edit `.markdownlint.json`.
+- Do not weaken tests, skip tests with empty bodies, or change assertions to weaker checks.
+- Do not delete existing scripts or utilities unless the user explicitly asks.
+
+## Interpreter And Paths
+
+- Never use `sys.executable` in project code or subprocess examples.
+- Use `.venv/bin/python` explicitly in shell commands and subprocess calls.
+- Do not use container-root absolute paths.
+- Use real local paths or repo-relative paths from the worktree root.
+
+## Worktree Layout
+
+- Work in a dispatch worktree, not the main checkout.
+- Use `.worktrees/dispatch/codex/<task>/` for Codex work.
+- Align the branch name with the path, for example `codex/<task>`.
+- Verify the worktree before editing:
+
+```bash
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+## Generated Artifacts
+
+- Do not commit `curriculum/l2-uk-en/**/status/*.json`.
+- Do not commit `curriculum/l2-uk-en/**/audit/*-review.md`.
+- Do not commit `curriculum/l2-uk-en/**/review/*-review.md`.
+- Do not commit `docs/*-STATUS.md`.
+- Do not commit telemetry SQLite files under `data/telemetry/`.
+- Durable human audit reports for these orchestrators belong under `docs/audits/`, not curriculum `audit/`, `review/`, or `status/` directories.
+
+## Scope
+
+- One PR equals one concern.
+- Changed files should stay under 20 where practical. If a PR exceeds that, recheck for generated artifacts or scope creep.
+- Every changed file must be directly related to the task.
+- Inspect local repo files before acting. Do not rely on stale prompt text.
+- Do not invent undocumented workflows, files, commands, standards, or policies.
+
+## Commits And PRs
+
+- Every commit must include an `X-Agent` trailer.
+- Format: `X-Agent: codex/<task-id>` or the correct agent/task for the thread.
+- Run `.venv/bin/python scripts/audit/lint_agent_trailer.py` before pushing.
+- Module-build PRs must include token telemetry with `swarm_used` and `swarm_note`.
+- Do not commit, push, or open a PR unless the user explicitly asks or the orchestrator prompt says that is part of the task.

--- a/docs/prompts/orchestrators/shared/review-output-schema.md
+++ b/docs/prompts/orchestrators/shared/review-output-schema.md
@@ -93,5 +93,6 @@ Recommended next batch: <batch id>
 Validation run: <commands>
 Files changed: <only docs/audits report, or none>
 swarm_used: true/false
+swarm_label: <none | solo | helper | swarm>
 swarm_note: <what helpers did, or solo run; no swarm used>
 ```

--- a/docs/prompts/orchestrators/shared/review-output-schema.md
+++ b/docs/prompts/orchestrators/shared/review-output-schema.md
@@ -1,0 +1,96 @@
+# Shared Review Output Schema
+
+Prompt version: 0.1
+Last reviewed: 2026-06-21
+
+Use this schema for durable audit reports under `docs/audits/`.
+
+## Report Header
+
+```markdown
+# <LEVEL> <SCOPE> Quality Audit
+
+Report version: 0.1
+Date: YYYY-MM-DD
+Auditor: <agent/model>
+Worktree: <absolute worktree path>
+Scope: <levels/modules inspected>
+Read-only: true
+Durable report path: docs/audits/<file>.md
+Source files inspected:
+- <path>
+
+Repo assumptions verified:
+- <fact and source path>
+```
+
+## Executive Summary
+
+Include:
+
+- pass/fail or readiness status
+- blocker count
+- non-blocking issue count
+- modules with no findings
+- modules not inspected and why
+- whether any local command was unavailable
+
+## Complete Issue Inventory
+
+Do not truncate to a top 10. Record every issue found.
+
+```markdown
+## Issues
+
+### <ISSUE-ID> <short title>
+
+Severity: blocker | high | medium | low
+Level: A1 | A2 | B1 | B2
+Module: <M## slug>
+Files:
+- <path>
+Evidence:
+- <short quote or paraphrase with section>
+Why it matters:
+- <learner, linguistic, source, or pipeline risk>
+Expected fix:
+- <specific remediation>
+Batch recommendation:
+- <batch id or "single-module patch">
+```
+
+## Coverage Matrices
+
+Use compact tables for:
+
+- plan objectives covered
+- wiki/source coverage
+- activity coverage and type variety
+- vocabulary completeness
+- immersion and language-balance observations
+- stress/pronunciation policy observations
+- module-specific blocker summary
+
+## Remediation Batching Plan
+
+Group findings into PR-sized batches. Separate:
+
+- targeted patches
+- full module rebuilds
+- source/wiki gaps that need pre-build work
+- generator or validation issues
+- deferred decisions that need user input
+
+## Final Auditor Response Schema
+
+```text
+Report written: <path>
+Scope inspected: <modules>
+Blockers: <n>
+Issues recorded: <n>
+Recommended next batch: <batch id>
+Validation run: <commands>
+Files changed: <only docs/audits report, or none>
+swarm_used: true/false
+swarm_note: <what helpers did, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/shared/review-output-schema.md
+++ b/docs/prompts/orchestrators/shared/review-output-schema.md
@@ -1,9 +1,9 @@
 # Shared Review Output Schema
 
-Prompt version: 0.1
+Prompt suite component version: 0.2
 Last reviewed: 2026-06-21
 
-Use this schema for durable audit reports under `docs/audits/`.
+Use this schema for durable audit reports under `docs/audits/`. Adapt the track fields and coverage matrices to the target. Do not import CEFR language-learning assumptions into seminar tracks unless the target prompt explicitly justifies them.
 
 ## Report Header
 
@@ -45,7 +45,7 @@ Do not truncate to a top 10. Record every issue found.
 ### <ISSUE-ID> <short title>
 
 Severity: blocker | high | medium | low
-Level: A1 | A2 | B1 | B2
+Track or level: <A1 | A2 | B1 | B2 | HIST | BIO | ISTORIO | LIT | OES | RUTH | other>
 Module: <M## slug>
 Files:
 - <path>
@@ -69,6 +69,7 @@ Use compact tables for:
 - vocabulary completeness
 - immersion and language-balance observations
 - stress/pronunciation policy observations
+- factuality, source-attribution, decolonization, and bias checks for seminar or sensitive tracks
 - module-specific blocker summary
 
 ## Remediation Batching Plan

--- a/docs/prompts/orchestrators/shared/telemetry-and-pr.md
+++ b/docs/prompts/orchestrators/shared/telemetry-and-pr.md
@@ -1,0 +1,84 @@
+# Shared Telemetry And PR Requirements
+
+Prompt version: 0.1
+Last reviewed: 2026-06-21
+
+Module-build and remediation prompts must encode this policy.
+
+## Commit Trailer
+
+Every commit must include an `X-Agent` trailer:
+
+```bash
+git commit -m "scope: summary" --trailer "X-Agent: codex/<task-id>"
+```
+
+Run the trailer linter before push:
+
+```bash
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+```
+
+## Module-Build Telemetry
+
+Persist telemetry through the local Monitor API and include the same summary in the PR body or final orchestration note. The SQLite database under `data/telemetry/` is local runtime state and must not be committed.
+
+Required fields include:
+
+- `level`
+- `slug`
+- `run_id`
+- `branch`
+- `commit_sha` when known
+- `pr_number` and `pr_url` when known
+- `status`
+- `swarm_used`
+- `swarm_note`
+- `participants`
+- `token_source`
+
+Solo runs still require `swarm_used: false` and a `swarm_note`.
+
+Example API shape. Use the local Monitor API route `/api/telemetry/module-builds`; add the host only when the local runbook or shell context requires it:
+
+```bash
+curl -s -X POST /api/telemetry/module-builds \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "run_id": "<level>-<slug>-<task>",
+    "level": "<level>",
+    "slug": "<slug>",
+    "branch": "codex/<task>",
+    "status": "ready",
+    "swarm_used": false,
+    "swarm_label": "none",
+    "swarm_note": "solo run; no swarm used",
+    "source": "codex-final",
+    "participants": [
+      {
+        "role": "main",
+        "agent": "codex",
+        "model": "<model>",
+        "label": "integration",
+        "token_source": "unavailable"
+      }
+    ]
+  }'
+```
+
+## PR Body Requirements
+
+Module-build and remediation PR bodies should include:
+
+- scope and target modules
+- source files changed
+- generated MDX files changed
+- validation commands and outcomes
+- audit findings addressed, if this is remediation
+- independent review outcome before merge
+- token telemetry summary, including `swarm_used` and `swarm_note`
+- statement that no generated `status/`, curriculum `audit/`, curriculum `review/`, or telemetry DB artifacts are included
+
+## Independent Review
+
+Before merge, require an independent-family review. The builder should not be the sole reviewer of its own module work. Record reviewer identity, review scope, and final disposition in the PR body or orchestration note.

--- a/docs/prompts/orchestrators/shared/telemetry-and-pr.md
+++ b/docs/prompts/orchestrators/shared/telemetry-and-pr.md
@@ -1,6 +1,6 @@
 # Shared Telemetry And PR Requirements
 
-Prompt version: 0.1
+Prompt suite component version: 0.2
 Last reviewed: 2026-06-21
 
 Module-build and remediation prompts must encode this policy.
@@ -33,16 +33,18 @@ Required fields include:
 - `pr_number` and `pr_url` when known
 - `status`
 - `swarm_used`
+- `swarm_label`
 - `swarm_note`
 - `participants`
 - `token_source`
 
 Solo runs still require `swarm_used: false` and a `swarm_note`.
 
-Example API shape. Use the local Monitor API route `/api/telemetry/module-builds`; add the host only when the local runbook or shell context requires it:
+Example API shape. `curl` requires a scheme and host, so set `MONITOR_API_BASE` from the current local runbook or shell context before posting. Do not commit telemetry database files.
 
 ```bash
-curl -s -X POST /api/telemetry/module-builds \
+MONITOR_API_BASE="${MONITOR_API_BASE:?set Monitor API base URL from docs/runbooks/module-build-token-telemetry.md}"
+curl -s -X POST "${MONITOR_API_BASE%/}/api/telemetry/module-builds" \
   -H 'Content-Type: application/json' \
   -d '{
     "run_id": "<level>-<slug>-<task>",
@@ -54,6 +56,7 @@ curl -s -X POST /api/telemetry/module-builds \
     "swarm_label": "none",
     "swarm_note": "solo run; no swarm used",
     "source": "codex-final",
+    "token_source": "unavailable",
     "participants": [
       {
         "role": "main",

--- a/docs/prompts/orchestrators/shared/telemetry-and-pr.md
+++ b/docs/prompts/orchestrators/shared/telemetry-and-pr.md
@@ -35,8 +35,7 @@ Required fields include:
 - `swarm_used`
 - `swarm_label`
 - `swarm_note`
-- `participants`
-- `token_source`
+- `participants`, each with `token_source`
 
 Solo runs still require `swarm_used: false` and a `swarm_note`.
 
@@ -56,7 +55,6 @@ curl -s -X POST "${MONITOR_API_BASE%/}/api/telemetry/module-builds" \
     "swarm_label": "none",
     "swarm_note": "solo run; no swarm used",
     "source": "codex-final",
-    "token_source": "unavailable",
     "participants": [
       {
         "role": "main",

--- a/docs/prompts/orchestrators/shared/validation-checklist.md
+++ b/docs/prompts/orchestrators/shared/validation-checklist.md
@@ -10,25 +10,35 @@ Use this as a menu, not a blind script. First inspect the current local repo to 
 ```bash
 git status --short --branch
 git diff --check
-git diff --name-only
-git diff -- .python-version .yamllint .markdownlint.json
-if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^docs/.*-STATUS\.md$|^data/telemetry/'; then
+CHANGED_FILES="$( { git diff --name-only; git diff --cached --name-only; git ls-files --others --exclude-standard; } | sort -u )"
+printf '%s\n' "$CHANGED_FILES"
+if ! git diff --quiet -- .python-version .yamllint .markdownlint.json || ! git diff --cached --quiet -- .python-version .yamllint .markdownlint.json; then
+  echo "Protected config changed" >&2
+  exit 1
+fi
+if [ -n "$CHANGED_FILES" ] && printf '%s\n' "$CHANGED_FILES" | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^docs/.*-STATUS\.md$|^data/telemetry/'; then
   echo "Forbidden generated artifact in diff" >&2
   exit 1
 fi
-CHANGED_CODE_FILES="$(git diff --name-only -- scripts site curriculum tests)"
+CHANGED_CODE_FILES="$(printf '%s\n' "$CHANGED_FILES" | awk '/^(scripts|site|curriculum|tests)\\// {print}')"
 if [ -n "$CHANGED_CODE_FILES" ]; then
-  if printf '%s\n' "$CHANGED_CODE_FILES" | xargs rg -n 'sys\.executable'; then
-    echo "New or modified code path contains sys.executable" >&2
-    exit 1
-  fi
+  while IFS= read -r file; do
+    [ -f "$file" ] || continue
+    if rg -n 'sys\.executable' "$file"; then
+      echo "New or modified code path contains sys.executable" >&2
+      exit 1
+    fi
+  done <<EOF
+$CHANGED_CODE_FILES
+EOF
 fi
 ```
 
 For docs-only prompt infrastructure, add a scoped path gate:
 
 ```bash
-if git diff --name-only | rg -v '^docs/prompts/orchestrators/'; then
+CHANGED_FILES="$( { git diff --name-only; git diff --cached --name-only; git ls-files --others --exclude-standard; } | sort -u )"
+if [ -n "$CHANGED_FILES" ] && printf '%s\n' "$CHANGED_FILES" | rg -v '^docs/prompts/orchestrators/'; then
   echo "Unexpected file outside docs/prompts/orchestrators/" >&2
   exit 1
 fi

--- a/docs/prompts/orchestrators/shared/validation-checklist.md
+++ b/docs/prompts/orchestrators/shared/validation-checklist.md
@@ -20,7 +20,7 @@ if [ -n "$CHANGED_FILES" ] && printf '%s\n' "$CHANGED_FILES" | rg '(^|/)status/.
   echo "Forbidden generated artifact in diff" >&2
   exit 1
 fi
-CHANGED_CODE_FILES="$(printf '%s\n' "$CHANGED_FILES" | awk '/^(scripts|site|curriculum|tests)\\// {print}')"
+CHANGED_CODE_FILES="$(printf '%s\n' "$CHANGED_FILES" | awk '/^(scripts|site|curriculum|tests)\// {print}')"
 if [ -n "$CHANGED_CODE_FILES" ]; then
   while IFS= read -r file; do
     [ -f "$file" ] || continue

--- a/docs/prompts/orchestrators/shared/validation-checklist.md
+++ b/docs/prompts/orchestrators/shared/validation-checklist.md
@@ -1,6 +1,6 @@
 # Shared Validation Checklist
 
-Prompt version: 0.1
+Prompt suite component version: 0.2
 Last reviewed: 2026-06-21
 
 Use this as a menu, not a blind script. First inspect the current local repo to confirm each command still applies.
@@ -12,12 +12,27 @@ git status --short --branch
 git diff --check
 git diff --name-only
 git diff -- .python-version .yamllint .markdownlint.json
-git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^docs/.*-STATUS\.md$|^data/telemetry/' || true
-git diff --name-only | rg -v '^docs/prompts/orchestrators/' || true
-rg -n 'sys\.executable' scripts site curriculum tests || true
+if git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^docs/.*-STATUS\.md$|^data/telemetry/'; then
+  echo "Forbidden generated artifact in diff" >&2
+  exit 1
+fi
+CHANGED_CODE_FILES="$(git diff --name-only -- scripts site curriculum tests)"
+if [ -n "$CHANGED_CODE_FILES" ]; then
+  if printf '%s\n' "$CHANGED_CODE_FILES" | xargs rg -n 'sys\.executable'; then
+    echo "New or modified code path contains sys.executable" >&2
+    exit 1
+  fi
+fi
 ```
 
-For docs-only prompt infrastructure, the expected result is that only `docs/prompts/orchestrators/**` appears in `git diff --name-only`.
+For docs-only prompt infrastructure, add a scoped path gate:
+
+```bash
+if git diff --name-only | rg -v '^docs/prompts/orchestrators/'; then
+  echo "Unexpected file outside docs/prompts/orchestrators/" >&2
+  exit 1
+fi
+```
 
 ## Markdown Sanity
 
@@ -31,26 +46,96 @@ If the command is unavailable, do not edit `.markdownlint.json`; report that mar
 
 ## Module Source Validation
 
-Adapt these commands for the target level and module number. Use `.venv/bin/python`, not `python3`:
+Adapt these commands for the target level or track and module number. Use `.venv/bin/python`, not `python3`:
 
 ```bash
-.venv/bin/python scripts/validate_activities.py l2-uk-en <level> <module_num>
-.venv/bin/python scripts/validate_vocab_yaml.py curriculum/l2-uk-en/<level>/<slug>/vocabulary.yaml
-.venv/bin/python scripts/generate_mdx.py l2-uk-en <level> <module_num> --validate
-.venv/bin/python scripts/audit/check_mdx_generation_drift.py --files curriculum/l2-uk-en/<level>/<slug>/module.md curriculum/l2-uk-en/<level>/<slug>/activities.yaml curriculum/l2-uk-en/<level>/<slug>/vocabulary.yaml
+.venv/bin/python scripts/validate_activities.py l2-uk-en <track-or-level> <module_num>
+.venv/bin/python scripts/validate_vocab_yaml.py curriculum/l2-uk-en/<track-or-level>/<slug>/vocabulary.yaml
+.venv/bin/python scripts/generate_mdx.py l2-uk-en <track-or-level> <module_num> --validate
 ```
 
 For folder-layout modules, the source files are normally:
 
-- `curriculum/l2-uk-en/<level>/<slug>/module.md`
-- `curriculum/l2-uk-en/<level>/<slug>/activities.yaml`
-- `curriculum/l2-uk-en/<level>/<slug>/vocabulary.yaml`
-- `curriculum/l2-uk-en/<level>/<slug>/resources.yaml` when present
-- generated site MDX at `site/src/content/docs/<level>/<slug>.mdx`
+- `curriculum/l2-uk-en/<track-or-level>/<slug>/module.md`
+- `curriculum/l2-uk-en/<track-or-level>/<slug>/activities.yaml`
+- `curriculum/l2-uk-en/<track-or-level>/<slug>/vocabulary.yaml`
+- `curriculum/l2-uk-en/<track-or-level>/<slug>/resources.yaml` when present
+- generated site MDX at `site/src/content/docs/<track-or-level>/<slug>.mdx`
+
+Use `scripts/audit/check_mdx_generation_drift.py` when you need a drift-only check after generation, not as a default duplicate regeneration after `generate_mdx.py --validate`.
+
+## Deterministic Audit Validation
+
+For built module sources, run the deterministic audit without `--fix` before relying on subjective review:
+
+```bash
+.venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/<track-or-level>/<slug>/module.md
+```
+
+Do not run `scripts/audit_module.py` on raw plans or wiki articles. For pre-production tracks with no built `module.md`, run plan/wiki/source coverage checks instead and record that the deterministic module audit was not applicable.
+
+## Seminar And Sensitive Track Validation
+
+For seminar or sensitive tracks such as HIST, BIO, ISTORIO, LIT, OES, RUTH, or folk/epic work, add track-specific checks before reuse:
+
+- verify source attribution and quote provenance with the repo-supported source tools or scripts available in the current checkout
+- check factual claims against the track's approved source, reading, dossier, wiki, or bibliography files
+- check decolonization, Russian-shadow, imperial framing, and inherited-bias risks using the current track rubric
+- verify that wiki/source paths match the track, such as historiography, literature, periods, figures, dossiers, readings, or other non-CEFR layouts
+- consult existing seminar audit precedents under `docs/audits/` before choosing report naming and scope
 
 ## Audit Or Review Validation
 
 Read-only audit prompts should not run full builds. They may run deterministic listing, parsing, lint, and diff checks that do not write generated artifacts. If an audit command writes `status/`, `audit/`, `review/`, or telemetry artifacts, remove those from the worktree before finalizing unless the prompt explicitly scoped a durable `docs/audits/` report.
+
+## Prompt Suite Structural Validation
+
+For this prompt suite, rerun a structural check before PR updates:
+
+```bash
+.venv/bin/python - <<'PY'
+from pathlib import Path
+
+root = Path("docs/prompts/orchestrators")
+prompts = sorted(p for p in root.glob("*/*-orchestrator.md") if "shared" not in p.parts)
+required = [
+    "Prompt version:",
+    "## Source Assumptions",
+    "## Goal",
+    "## WORKTREE_ROOT Setup",
+    "## Read First",
+    "## Allowed Writes",
+    "## Forbidden Writes",
+    "## Helpers And Headroom",
+    "## Validation Commands",
+    "## Expected Final Response",
+]
+shared = [
+    "docs/prompts/orchestrators/shared/repo-rules.md",
+    "docs/prompts/orchestrators/shared/validation-checklist.md",
+]
+errors = []
+for path in prompts:
+    text = path.read_text(encoding="utf-8")
+    for marker in required + shared:
+        if marker not in text:
+            errors.append(f"{path}: missing {marker}")
+    if not text.endswith("\n"):
+        errors.append(f"{path}: missing final newline")
+    if "\t" in text:
+        errors.append(f"{path}: contains tab")
+for path in sorted(root.rglob("*.md")):
+    text = path.read_text(encoding="utf-8")
+    if not text.endswith("\n"):
+        errors.append(f"{path}: missing final newline")
+    if "\t" in text:
+        errors.append(f"{path}: contains tab")
+print(f"checked {len(prompts)} orchestrator prompts")
+if errors:
+    print("\n".join(errors))
+    raise SystemExit(1)
+PY
+```
 
 ## Commit Validation
 

--- a/docs/prompts/orchestrators/shared/validation-checklist.md
+++ b/docs/prompts/orchestrators/shared/validation-checklist.md
@@ -1,0 +1,62 @@
+# Shared Validation Checklist
+
+Prompt version: 0.1
+Last reviewed: 2026-06-21
+
+Use this as a menu, not a blind script. First inspect the current local repo to confirm each command still applies.
+
+## Always Run For Any PR
+
+```bash
+git status --short --branch
+git diff --check
+git diff --name-only
+git diff -- .python-version .yamllint .markdownlint.json
+git diff --name-only | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^docs/.*-STATUS\.md$|^data/telemetry/' || true
+git diff --name-only | rg -v '^docs/prompts/orchestrators/' || true
+rg -n 'sys\.executable' scripts site curriculum tests || true
+```
+
+For docs-only prompt infrastructure, the expected result is that only `docs/prompts/orchestrators/**` appears in `git diff --name-only`.
+
+## Markdown Sanity
+
+If markdownlint is available locally, run it without changing configuration:
+
+```bash
+npx markdownlint-cli2 "docs/prompts/orchestrators/**/*.md"
+```
+
+If the command is unavailable, do not edit `.markdownlint.json`; report that markdownlint was not available and rely on manual Markdown inspection plus `git diff --check`.
+
+## Module Source Validation
+
+Adapt these commands for the target level and module number. Use `.venv/bin/python`, not `python3`:
+
+```bash
+.venv/bin/python scripts/validate_activities.py l2-uk-en <level> <module_num>
+.venv/bin/python scripts/validate_vocab_yaml.py curriculum/l2-uk-en/<level>/<slug>/vocabulary.yaml
+.venv/bin/python scripts/generate_mdx.py l2-uk-en <level> <module_num> --validate
+.venv/bin/python scripts/audit/check_mdx_generation_drift.py --files curriculum/l2-uk-en/<level>/<slug>/module.md curriculum/l2-uk-en/<level>/<slug>/activities.yaml curriculum/l2-uk-en/<level>/<slug>/vocabulary.yaml
+```
+
+For folder-layout modules, the source files are normally:
+
+- `curriculum/l2-uk-en/<level>/<slug>/module.md`
+- `curriculum/l2-uk-en/<level>/<slug>/activities.yaml`
+- `curriculum/l2-uk-en/<level>/<slug>/vocabulary.yaml`
+- `curriculum/l2-uk-en/<level>/<slug>/resources.yaml` when present
+- generated site MDX at `site/src/content/docs/<level>/<slug>.mdx`
+
+## Audit Or Review Validation
+
+Read-only audit prompts should not run full builds. They may run deterministic listing, parsing, lint, and diff checks that do not write generated artifacts. If an audit command writes `status/`, `audit/`, `review/`, or telemetry artifacts, remove those from the worktree before finalizing unless the prompt explicitly scoped a durable `docs/audits/` report.
+
+## Commit Validation
+
+Before pushing a module-build or remediation PR:
+
+```bash
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+git status --short
+```


### PR DESCRIPTION
## Summary

Adds a versioned core-track orchestrator prompt suite under `docs/prompts/orchestrators/` for future A1, A2, B1, and B2 work.

- Adds shared prompt rules for repo hygiene, validation, telemetry/PR expectations, and review output shape.
- Adds level-specific quality-audit and remediation/build orchestrators for A1, A2, B1, and B2.
- Keeps this docs-only: no curriculum modules, site output, status JSON, generated audit/review artifacts, or telemetry DB files are included.

## Review Fixes Applied

Addressed Claude's initial read-only review findings in `af9cd78943`:

- replaced advisory `rg ... || true` checks with fail-fast validation gates
- fixed the telemetry `curl` example by requiring a configured `MONITOR_API_BASE`
- added `swarm_label` to required telemetry fields
- removed hardcoded local user paths from worktree setup blocks
- made durable audit reports explicitly commit/push/open draft PRs
- added deterministic `scripts/audit_module.py` guidance for built module audits
- refreshed stale B1 finale/M93-M94 assumptions
- removed duplicate default MDX drift regeneration from build/remediation validation
- de-CEFRed shared review schema fields and added seminar-sensitive validation guidance

Claude re-review then caught that the new gates still missed untracked files and that audit delivery appeared before validation. Fixed in `3097855e62`:

- gates now inspect unstaged, staged, and untracked paths through a `CHANGED_FILES` set
- protected config checks now use `git diff --quiet` and fail on changes
- audit prompts validate before report delivery
- audit report checks use a concrete `REPORT="...$(date +%F).md"` variable instead of literal placeholders
- setup blocks allow explicit `REPO_ROOT` override to avoid nested worktree setup
- top-level telemetry `token_source` was removed; it remains only on participants

## Seminar-Track Reuse Intent

This is intended as a reusable pattern for future seminar-track orchestrators, but not a one-to-one copy. Seminar tracks such as HIST, BIO, ISTORIO, LIT, OES, and RUTH should reuse only the track-agnostic scaffolding: repo hygiene, worktree discipline, PR rules, and report structure. Seminar prompts still need track-specific source attribution, factuality, decolonization, Russian-shadow, bias, and pedagogy checks rather than inheriting core-track assumptions blindly.

## Validation

- commit hooks passed for all three commits
- `git diff --check`
- `git diff --check origin/main...HEAD`
- structural prompt-suite validator: checked 10 orchestrator prompts and 15 Markdown files
- forbidden artifact scan for `status/*.json`, curriculum `audit/*-review.md`, curriculum `review/*-review.md`, `docs/*-STATUS.md`, and `data/telemetry/**`
- protected config diff check for `.python-version`, `.yamllint`, `.markdownlint.json`
- review-regression scan for hardcoded local paths, `localhost:8765`, `requirements.txt`, `|| true`, stale M93-M94 wording, CEFR-only schema fields, and bare advisory artifact gates
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Claude read-only review: `review-3674-core-orchestrator-seminar`
- Claude read-only re-review: `review-3674-core-orchestrator-rereview`; findings fixed in `3097855e62`

`markdownlint-cli2` is not installed locally, so markdownlint was not run. The PR changes only prompt-suite Markdown files under `docs/prompts/orchestrators/`.
