### PR TITLE
feat(audit): content spell gate — flag unrecognized words vs VESUM (#3675)

### DIFF
--- a/scripts/audit/check_content_spelling.py
+++ b/scripts/audit/check_content_spelling.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Advisory content spell gate backed by local VESUM forms.
+
+This gate reports Ukrainian surface forms in built MDX content that are not
+present in ``data/vesum.db``. An unrecognized form is only a spelling warning:
+it may be a typo, a proper name, or a valid form absent from VESUM.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = Path(__file__).resolve().parent
+SCRIPTS_DIR = PROJECT_ROOT / "scripts"
+if str(SCRIPT_DIR) in sys.path:
+    sys.path.remove(str(SCRIPT_DIR))
+for import_root in (SCRIPTS_DIR, PROJECT_ROOT):
+    if str(import_root) not in sys.path:
+        sys.path.insert(0, str(import_root))
+
+from scripts.lexicon import content_lexicon_reconciler as reconciler
+
+
+@dataclass(frozen=True)
+class SpellingExample:
+    """One unrecognized surface form plus the first deterministic source line."""
+
+    form: str
+    example_source: Path
+    example_line: str
+
+
+@dataclass(frozen=True)
+class SpellingResult:
+    """Spell-gate result data with count helpers for output formats."""
+
+    files_scanned: int
+    unique_forms: tuple[str, ...]
+    unrecognized_forms: tuple[SpellingExample, ...]
+
+    @property
+    def summary(self) -> dict[str, int]:
+        return {
+            "files_scanned": self.files_scanned,
+            "unique_forms": len(self.unique_forms),
+            "unrecognized": len(self.unrecognized_forms),
+        }
+
+
+def check_content_spelling(
+    paths: Sequence[Path],
+    *,
+    vesum_lookup: reconciler.VesumLookup = reconciler.verify_words,
+) -> SpellingResult:
+    """Return unique Ukrainian forms not found in the VESUM ``forms`` table."""
+    source_by_form = reconciler.collect_forms(paths)
+    forms = tuple(sorted(source_by_form))
+    matches_by_form = reconciler.lemmatize_forms(forms, vesum_lookup=vesum_lookup)
+    example_lines = _collect_first_example_lines(paths)
+
+    unrecognized = tuple(
+        SpellingExample(
+            form=form,
+            example_source=source_by_form[form],
+            example_line=example_lines.get((form, source_by_form[form]), ""),
+        )
+        for form in forms
+        if not matches_by_form.get(form)
+    )
+
+    return SpellingResult(
+        files_scanned=len(paths),
+        unique_forms=forms,
+        unrecognized_forms=tuple(
+            sorted(
+                unrecognized,
+                key=lambda item: (_display_path(item.example_source, PROJECT_ROOT), item.form),
+            )
+        ),
+    )
+
+
+def result_to_json_payload(
+    result: SpellingResult,
+    *,
+    limit: int | None = None,
+    project_root: Path = PROJECT_ROOT,
+) -> dict[str, Any]:
+    """Return a machine-readable spelling report payload."""
+    unrecognized = _limit_sequence(result.unrecognized_forms, limit)
+    return {
+        "summary": result.summary,
+        "unrecognized_forms": [
+            {
+                "form": item.form,
+                "example_source": _display_path(item.example_source, project_root),
+                "example_line": item.example_line,
+            }
+            for item in unrecognized
+        ],
+        "grouped_by_file": [
+            {
+                "source": source,
+                "forms": [
+                    {
+                        "form": item.form,
+                        "example_line": item.example_line,
+                    }
+                    for item in items
+                ],
+            }
+            for source, items in _group_by_file(unrecognized, project_root).items()
+        ],
+        "limit": limit,
+        "truncated": {
+            "unrecognized_forms": limit is not None
+            and len(result.unrecognized_forms) > len(unrecognized),
+        },
+    }
+
+
+def format_human_summary(
+    result: SpellingResult,
+    *,
+    limit: int | None = None,
+    project_root: Path = PROJECT_ROOT,
+) -> str:
+    """Format an advisory spelling report grouped by source file."""
+    summary = result.summary
+    lines = [
+        "Content spelling gate",
+        f"Files scanned: {summary['files_scanned']}",
+        f"Unique Ukrainian forms: {summary['unique_forms']}",
+        f"Unrecognized forms: {summary['unrecognized']}",
+        "",
+        "Potential misspellings:",
+    ]
+
+    unrecognized = _limit_sequence(result.unrecognized_forms, limit)
+    if unrecognized:
+        for source, items in _group_by_file(unrecognized, project_root).items():
+            lines.append(f"- {source}")
+            for item in items:
+                lines.append(f"  - {item.form}: {item.example_line}")
+        lines.extend(
+            _truncation_lines(
+                len(result.unrecognized_forms),
+                len(unrecognized),
+                "unrecognized forms",
+            )
+        )
+    else:
+        lines.append("- none")
+
+    lines.extend(
+        [
+            "",
+            "Advisory mode: unrecognized forms are warnings, not definitive typos.",
+            "Use --strict to return non-zero when unrecognized forms are present.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Report Ukrainian content forms not recognized by local VESUM."
+    )
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON output")
+    parser.add_argument("--limit", type=int, help="Limit listed unrecognized examples")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero when any unrecognized forms are found",
+    )
+    parser.add_argument(
+        "--changed-vs-base",
+        metavar="BASE",
+        help="Only scan content MDX changed against BASE, including local edits",
+    )
+    return parser
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    vesum_lookup: reconciler.VesumLookup = reconciler.verify_words,
+    paths: Sequence[Path] | None = None,
+    project_root: Path = PROJECT_ROOT,
+) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.limit is not None and args.limit < 0:
+        parser.error("--limit must be non-negative")
+
+    resolved_paths = list(paths) if paths is not None else _resolve_content_paths(args.changed_vs_base)
+
+    try:
+        result = check_content_spelling(resolved_paths, vesum_lookup=vesum_lookup)
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(
+            json.dumps(
+                result_to_json_payload(result, limit=args.limit, project_root=project_root),
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+    else:
+        print(format_human_summary(result, limit=args.limit, project_root=project_root))
+
+    return 1 if args.strict and result.unrecognized_forms else 0
+
+
+def _resolve_content_paths(base: str | None) -> list[Path]:
+    if base:
+        return reconciler.changed_content_mdx_paths(base)
+    return reconciler.discover_content_mdx_paths()
+
+
+def _collect_first_example_lines(paths: Sequence[Path]) -> dict[tuple[str, Path], str]:
+    examples: dict[tuple[str, Path], str] = {}
+    for path in sorted(paths):
+        prose = reconciler.strip_mdx_to_prose(path.read_text(encoding="utf-8"))
+        for line in prose.splitlines():
+            example_line = " ".join(line.strip().split())
+            if not example_line:
+                continue
+            for token in reconciler.extract_ukrainian_tokens(line):
+                examples.setdefault((token, path), example_line)
+    return examples
+
+
+def _group_by_file(
+    items: Sequence[SpellingExample],
+    project_root: Path,
+) -> dict[str, list[SpellingExample]]:
+    grouped: dict[str, list[SpellingExample]] = defaultdict(list)
+    for item in items:
+        grouped[_display_path(item.example_source, project_root)].append(item)
+    return dict(grouped)
+
+
+def _display_path(path: Path, project_root: Path) -> str:
+    try:
+        return path.resolve().relative_to(project_root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _limit_sequence[T](items: Sequence[T], limit: int | None) -> Sequence[T]:
+    if limit is None:
+        return items
+    return items[:limit]
+
+
+def _truncation_lines(total: int, shown: int, label: str) -> list[str]:
+    if shown >= total:
+        return []
+    return [f"... {total - shown} more {label} not shown"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_content_spelling_gate.py
+++ b/tests/test_content_spelling_gate.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.audit import check_content_spelling as gate
+
+requires_vesum_db = pytest.mark.skipif(
+    not Path("data/vesum.db").exists()
+    or Path("data/vesum.db").stat().st_size < 1_000_000,
+    reason=(
+        "requires the full VESUM data/vesum.db; CI may omit or stub it; "
+        "run .venv/bin/python scripts/rag/import_vesum.py"
+    ),
+)
+
+
+def test_fixture_reports_typo_and_suppresses_valid_form(tmp_path: Path) -> None:
+    mdx_path = _write_mdx(tmp_path, "Мами хибаа слово.")
+
+    result = gate.check_content_spelling([mdx_path], vesum_lookup=_fake_vesum)
+
+    assert [item.form for item in result.unrecognized_forms] == ["хибаа"]
+    assert result.summary == {
+        "files_scanned": 1,
+        "unique_forms": 3,
+        "unrecognized": 1,
+    }
+    assert result.unrecognized_forms[0].example_line == "Мами хибаа слово."
+
+
+def test_human_report_groups_unrecognized_forms_by_file(tmp_path: Path) -> None:
+    first_path = _write_mdx(tmp_path, "Перший рядок з хибаа.", name="first.mdx")
+    second_path = _write_mdx(tmp_path, "Другий рядок з хибб.", name="second.mdx")
+    result = gate.check_content_spelling([second_path, first_path], vesum_lookup=_fake_vesum)
+
+    report = gate.format_human_summary(result, project_root=tmp_path)
+
+    assert "- first.mdx" in report
+    assert "  - хибаа: Перший рядок з хибаа." in report
+    assert "- second.mdx" in report
+    assert "  - хибб: Другий рядок з хибб." in report
+
+
+def test_advisory_cli_exits_zero_when_unrecognized_present(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mdx_path = _write_mdx(tmp_path, "Мами хибаа.")
+
+    assert gate.main([], vesum_lookup=_fake_vesum, paths=[mdx_path], project_root=tmp_path) == 0
+    output = capsys.readouterr().out
+
+    assert "Content spelling gate" in output
+    assert "Unrecognized forms: 1" in output
+    assert "хибаа" in output
+
+
+def test_strict_cli_exits_nonzero_when_unrecognized_present(tmp_path: Path) -> None:
+    mdx_path = _write_mdx(tmp_path, "Мами хибаа.")
+
+    assert (
+        gate.main(
+            ["--strict"],
+            vesum_lookup=_fake_vesum,
+            paths=[mdx_path],
+            project_root=tmp_path,
+        )
+        == 1
+    )
+
+
+def test_json_cli_reports_unrecognized_forms(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mdx_path = _write_mdx(tmp_path, "Мами хибаа.")
+
+    assert (
+        gate.main(
+            ["--json"],
+            vesum_lookup=_fake_vesum,
+            paths=[mdx_path],
+            project_root=tmp_path,
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["summary"]["unrecognized"] == 1
+    assert payload["unrecognized_forms"] == [
+        {
+            "form": "хибаа",
+            "example_source": "sample.mdx",
+            "example_line": "Мами хибаа.",
+        }
+    ]
+    assert payload["grouped_by_file"] == [
+        {
+            "source": "sample.mdx",
+            "forms": [
+                {
+                    "form": "хибаа",
+                    "example_line": "Мами хибаа.",
+                }
+            ],
+        }
+    ]
+
+
+@requires_vesum_db
+def test_real_vesum_db_recognizes_valid_form_and_flags_typo(tmp_path: Path) -> None:
+    mdx_path = _write_mdx(tmp_path, "Мами маммммм.")
+
+    result = gate.check_content_spelling([mdx_path])
+
+    assert [item.form for item in result.unrecognized_forms] == ["маммммм"]
+    assert "мами" in result.unique_forms
+
+
+def _write_mdx(tmp_path: Path, text: str, *, name: str = "sample.mdx") -> Path:
+    mdx_path = tmp_path / name
+    mdx_path.write_text(text, encoding="utf-8")
+    return mdx_path
+
+
+def _fake_vesum(words: list[str]) -> dict[str, list[dict[str, Any]]]:
+    matches = {
+        "другий": [{"lemma": "другий", "pos": "adj", "tags": "m:v_naz"}],
+        "з": [{"lemma": "з", "pos": "prep", "tags": ""}],
+        "мами": [{"lemma": "мама", "pos": "noun", "tags": "f:p:v_naz"}],
+        "перший": [{"lemma": "перший", "pos": "adj", "tags": "m:v_naz"}],
+        "рядок": [{"lemma": "рядок", "pos": "noun", "tags": "m:v_naz"}],
+        "слово": [{"lemma": "слово", "pos": "noun", "tags": "n:v_naz"}],
+    }
+    return {word: matches.get(word, []) for word in words}


### PR DESCRIPTION
## Summary

Builds on #3675 P1 and adopts the advisory content spell gate.

- Adds `scripts/audit/check_content_spelling.py`, a VESUM-backed advisory gate for unrecognized Ukrainian surface forms in built MDX content.
- Reuses `scripts.lexicon.content_lexicon_reconciler` for MDX discovery/diff scope, stripping, tokenization, and VESUM batch lookup.
- Adds fixture tests plus a real-DB-guarded smoke test.

## Evidence

```text
$ .venv/bin/python -m pytest tests/test_content_spelling_gate.py -q
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/feat-spell-gate
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 6 items

tests/test_content_spelling_gate.py ......                               [100%]

============================== 6 passed in 0.28s ===============================
```

```text
$ .venv/bin/ruff check scripts/audit/check_content_spelling.py tests/test_content_spelling_gate.py
All checks passed!
```

```text
$ .venv/bin/python scripts/audit/check_content_spelling.py --limit 20
Content spelling gate
Files scanned: 247
Unique Ukrainian forms: 33609
Unrecognized forms: 2351

Potential misspellings:
- site/src/content/docs/a1/a1-finale.mdx
  - адам: | <bad>Моє ім'я є Адам.</bad> | **Мене звати Адам.** |
  - канада: | <bad>Я маю Канада.</bad> | **Я з Канади.** |
  - канади: | **Учень: Я з Канади. Я вивчаю українську.** | Learner: I am from Canada. I am learning Ukrainian. |
  - карпати: | **Учень: Я хочу побачити Карпати. Потім я хочу побачити Лавру в Києві.** | Learner: I want to see the Carpathians. Then I want to see the Lavra in Kyiv. |
  - олена: Later you meet a new friend, Олена.
  - олену: центр. Вдень я купив сувенір і зустрів Олену. Ми обідали разом. Ввечері ми
  - хрещатик: | **Їдьте на метро. Станція Хрещатик.** | Go by metro. Khreshchatyk station. |
  - хрещатика: | **Вибачте, як дістатися до Хрещатика?** | Excuse me, how do I get to Khreshchatyk? |
- site/src/content/docs/a1/around-the-city.mdx
  - львів: - keep a route Ukrainian: **Київ / Kyiv**, **Львів / Lviv**, **зупинка**, not
  - одеса: Keep the city Ukrainian. Use **Київ / Kyiv**, **Львів / Lviv**, **Одеса /
  - одесі: | Я живу у Одесі. | **Я живу в Одесі.** |
  - остановка: <del>остановка</del>. Say **квиток** ("ticket"), not
  - харків: Odesa**, and **Харків / Kharkiv**. Say **зупинка**, not
- site/src/content/docs/a1/at-the-cafe.mdx
  - вкусна: | **<del>вкусна кава</del>** | **смачна кава** |
  - кофе: | **<del>чашку кофе</del>** | **чашку кави** |
  - кулечок: | **<del>кулечок</del>** | **пакетик** |
  - пірожене: **<del>пірожене</del>**.
  - счет: - choose the course cafe forms instead of repair forms such as **<del>счет</del>**,
- site/src/content/docs/a1/checkpoint-actions.mdx
  - ать: Group Two uses endings like **-ю/-у, -иш, -ить, -имо, -ите, -ать/-ять**:
  - имо: Group Two uses endings like **-ю/-у, -иш, -ить, -имо, -ите, -ать/-ять**:
... 2331 more unrecognized forms not shown

Advisory mode: unrecognized forms are warnings, not definitive typos.
Use --strict to return non-zero when unrecognized forms are present.
```
