### PR TITLE
chore(git): gitignore agent scratch dirs — kill recurring dirty tree (#M-10a)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,3 +363,7 @@ data/processed/v2/
 # Dead-code inventory reports are regenerable (scripts/audit/find_dead_code.py); do not track (#1863)
 audit/cleanup-inventory-*.md
 docs/outreach/
+
+# Agent working-artifact scratch — recurring, never deliverables (#M-10a)
+/scratch/
+/docs/folk-epic/briefs/


### PR DESCRIPTION
## Summary
Gitignore the two recurring agent-scratch dirs that keep showing up as untracked in the main tree:
- `/scratch/` — agent working artifacts (e.g. `atlas_mojibake_out.txt`)
- `/docs/folk-epic/briefs/` — review/brief artifacts (e.g. deepseek exemplar reviews)

These are never deliverables; gitignoring them is the root-cause fix for the recurring dirty-tree reminders (#M-10a).

## Why this supersedes #3682
#3682 had the same intent but was branched off a **diverged local `main`** (a stray direct `fix(b1)` commit `61ebc5c675` that was never on origin/main), so its diff dragged in 6 unrelated B1 modules + docs/b1 mdx and went UNSTABLE. This PR is the clean version: **`.gitignore` only, 4 lines, off real `origin/main`**. B1 content flows through Codex's B1 lane, not a gitignore PR.

## Verify
- `git diff --stat` → `.gitignore | 4 ++++` (one file)
- `git check-ignore scratch/ docs/folk-epic/briefs/` → both ignored