### PR TITLE
fix(vesum-gate): existence-gate accepts real active-participle calques (#3647)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -10021,6 +10021,24 @@ _HERITAGE_FALLBACK_BLOCKED_SURFACES = frozenset(
     }
 )
 
+# Existence-gate accept-set (#3647, user decision 2026-06-21): real Ukrainian
+# active-participle surfaces that the heritage classifier flags is_russianism=True
+# yet are morphologically real forms of real verbs (оточувати → оточуючий,
+# слідувати → слідуючий). The folk/seminar VESUM gate is an EXISTENCE gate: a real
+# form passes. Calque-flagging ("we suggest довколишній / наступний") is a SEPARATE
+# concern handled by the russianism layer (Антоненко / UA-GEC / check_russian_shadow),
+# NOT by rejecting the form here — one gate, one job. This is the explicit accept
+# counterpart to _HERITAGE_FALLBACK_BLOCKED_SURFACES above; it bypasses the russianism
+# guard for these specific surfaces only, so genuine russianisms (діюча, протиріччя —
+# blocked above) keep failing. бажаючий / керуючий / завідуючий already pass via the
+# classifier (classification=standard) and need no entry here.
+_FOLK_EXISTENCE_ACCEPTED_CALQUE_PARTICIPLES = frozenset(
+    {
+        "оточуючий",
+        "слідуючий",
+    }
+)
+
 
 def _engine_classifies_authentic(candidate: str) -> bool:
     """True iff the shared heritage classifier (#2912) attests ``candidate`` as
@@ -10148,6 +10166,12 @@ def _resolve_folk_heritage_attested_missing(
     attested: set[str] = set()
     for word, candidates in candidates_by_missing.items():
         if candidates & _HERITAGE_FALLBACK_BLOCKED_SURFACES:
+            continue
+        # Existence-gate accept (#3647): real active-participle calques the classifier
+        # mislabels russianism. Checked before the russianism guard so they pass; the
+        # calque suggestion is the separate russianism layer's job, not a rejection here.
+        if candidates & _FOLK_EXISTENCE_ACCEPTED_CALQUE_PARTICIPLES:
+            attested.add(word)
             continue
         if attestation_index and any(candidate in attestation_index for candidate in candidates):
             attested.add(word)

--- a/tests/test_vesum_heritage_attestation.py
+++ b/tests/test_vesum_heritage_attestation.py
@@ -116,14 +116,15 @@ def test_core_level_vesum_gate_does_not_use_folk_attestation_fallback() -> None:
 
 @requires_sources_db
 def test_folk_vesum_gate_accepts_engine_authentic_not_in_allowlist() -> None:
-    # `другоє` (poetic archaic `-оє`, verified in a 1955 Kupala song) and
-    # `Кострубонько` (ritual figure) are NOT in folk_heritage_attestations.yaml;
-    # only the classifier attests them as authentic-archaism.
-    gate = _gate("другоє Кострубонько")
+    # `Кострубонько` (ritual figure) is NOT in folk_heritage_attestations.yaml;
+    # only the classifier attests it as authentic-archaism. (#3647: `другоє` was
+    # dropped — VESUM has no such form and search_heritage returns no evidence, so
+    # the existence gate correctly does not attest it; the fixture overclaimed it.)
+    gate = _gate("Кострубонько")
 
     assert gate["passed"] is True
     assert gate["missing"] == []
-    assert gate["heritage_attested"] == 2
+    assert gate["heritage_attested"] == 1
 
 
 @requires_sources_db
@@ -179,11 +180,13 @@ def test_folk_vesum_gate_accepts_negated_participles_of_standard_bases() -> None
 
 @requires_sources_db
 def test_folk_vesum_gate_accepts_productive_derivational_bases() -> None:
-    gate = _gate("гаївковий знеособлювальними виворожувати виворожують другоє ягілки гагілку незгладжений")
+    # (#3647: `другоє` dropped — unattested in VESUM and the heritage classifier;
+    # the existence gate cannot attest it. The remaining 7 are real productive forms.)
+    gate = _gate("гаївковий знеособлювальними виворожувати виворожують ягілки гагілку незгладжений")
 
     assert gate["passed"] is True
     assert gate["missing"] == []
-    assert gate["heritage_attested"] == 8
+    assert gate["heritage_attested"] == 7
 
 
 @requires_sources_db


### PR DESCRIPTION
Closes #3647.

## Problem
3 `test_vesum_heritage_attestation` cases passed in CI but **failed against real VESUM data** (CI ships a stub `sources.db`, so `@requires_sources_db` skipped them — the stub masked a real failure). Reproduced locally against the full 1.7GB corpus.

## Root cause
The folk/seminar VESUM gate is an **existence gate**, but it rejected real Ukrainian active-participle forms inconsistently:
- `оточуючий` / `слідуючий` → the heritage classifier flags `is_russianism=True`, so the russianism guard rejected them.
- `бажаючий` / `керуючий` / `завідуючий` → classifier says `classification=standard`, so they passed.

Morphologically identical forms, opposite verdicts — a 3/2 split. (Probed the classifier directly to confirm.)

## Fix (per user decision 2026-06-21: existence-gate, not style-gate)
- Add `_FOLK_EXISTENCE_ACCEPTED_CALQUE_PARTICIPLES` — an explicit accept-set counterpart to the existing `_HERITAGE_FALLBACK_BLOCKED_SURFACES`, consulted **before** the russianism guard so these real forms pass. Calque-flagging ("suggest довколишній / наступний") stays in the **separate** russianism layer (Антоненко / UA-GEC / check_russian_shadow) — one gate, one job.
- Genuine russianisms (`діюча`, `протиріччя`, `получаючий`, …) are in the blocked set and **keep failing** — teeth preserved.
- Drop unattested `другоє` from two fixtures: `verify_word` says NOT in VESUM and `search_heritage` returns no evidence, so the existence gate correctly cannot attest it (the fixtures overclaimed a "1955 song" with no corpus backing).

## Verification (real 1.7GB corpus, local)
- `tests/test_vesum_heritage_attestation.py` — **20 passed** (the 3 prior fails now pass; the adversarial leak-tests stay green).
- Broader VESUM-gate + linear_pipeline suites — **73 passed**, no regression.
- `ruff check` clean.