### PR TITLE
fix(deps): complete stanza 1.12.2 RCE bump — add required udtools/udapi/termcolor to lock (supersedes #3650)

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -179,12 +179,13 @@ sniffio==1.3.1
 soupsieve==2.8.3
 sqlite-vec==0.1.9
 sse-starlette==3.2.0
-stanza==1.11.0
+stanza==1.12.2
 starlette==1.3.1
 stevedore==5.8.0
 surya-ocr==0.17.1
 sympy==1.14.0
 tenacity==9.1.4
+termcolor==3.3.0
 threadpoolctl==3.6.0
 timm==1.0.27
 tokenizers==0.22.2
@@ -198,6 +199,8 @@ typer==0.25.1
 typing-inspection==0.4.2
 typing_extensions==4.15.0
 tzlocal==5.3.1
+udapi==0.5.2
+udtools==0.2.8
 ukrainian_word_stress==1.1.1
 unlzw3==0.2.3
 urllib3==2.7.0


### PR DESCRIPTION
## Security — resolves HIGH stanza RCE
Bumps **stanza 1.11.0 → 1.12.2**, which fixes [GHSA-v5jw-96jm-7h2c](https://github.com/stanfordnlp/stanza/security/advisories/GHSA-v5jw-96jm-7h2c) — RCE via unsafe pickle deserialization (1.12.x enforces `weights_only=True` on model load). Closes the 2 open HIGH Dependabot alerts on stanza.

## Why #3650 (dependabot) failed CI — and the real root cause
Dependabot's #3650 made the same bump but pytest failed:
```
stanza/models/common/utils.py:24: from udtools import udeval
E ModuleNotFoundError: No module named 'udtools'
```
**stanza 1.12.x declares `udtools>=0.2.4` as a NEW required core dependency** (1.11.0 had none). Our `requirements-lock.txt` is installed with **`pip install --no-deps`** (`ci.yml`), so every transitive dep must be listed explicitly — and the lock-only bump never added `udtools` (→ `udapi` → `termcolor`). So `import stanza` dies for every stanza-touching test. This is the long-standing "udtools break" that also sank the earlier #2825 (1.12.1) bump.

## Fix
Complete the lock with stanza's resolved new deps (resolved via `pip install --dry-run`):
| add | reason |
|---|---|
| `udtools==0.2.8` | stanza's declared required dep (official UD eval toolkit) |
| `udapi==0.5.2` | udtools dep |
| `termcolor==3.3.0` | udapi dep |

`colorama` + `regex` were already in the lock.

## License note (flagging for awareness)
`udtools` / `udapi` are **GPL-2.0-or-later**. They are **stanza's own required dependencies** as of 1.12.x — not a gratuitous add — and we only ever do inference (uk lemmatization); the `udeval` path is never called. Acceptable under the project's non-commercial open-source posture (CLAUDE.md), but noting it explicitly.

## Verification (local, mirroring CI's `--no-deps` install)
```
pip install --no-deps stanza==1.12.2 udtools==0.2.8 udapi==0.5.2 termcolor==3.3.0
import stanza            -> OK 1.12.2
stanza.models.common.utils imports cleanly (udtools resolved)
pytest tests/test_stress_annotation.py -> 35 passed
```
stress_annotator + rebuild_vocab_simple import clean on 1.12.2.

Supersedes **#3650** (incomplete lock).