### PR TITLE
fix(deps): bump pydantic-settings 2.14.1→2.14.2 (MEDIUM symlink-follow GHSA-4xgf-cpjx-pc3j)

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -127,7 +127,7 @@ pyasn1==0.6.3
 pyasn1_modules==0.4.2
 pycookiecheat==0.8.0
 pycparser==3.0
-pydantic-settings==2.14.1
+pydantic-settings==2.14.2
 pydantic==2.12.5
 pydantic_core==2.41.5
 pyee==13.0.1


### PR DESCRIPTION
Resolves the open MEDIUM Dependabot alert **GHSA-4xgf-cpjx-pc3j** — `pydantic-settings` `NestedSecretsSettingsSource` follows symlinks.

- Vulnerable range: `>= 2.12.0, < 2.14.2`; **first patched: 2.14.2**.
- Patch bump within the same minor — no new transitive deps (`pip install --dry-run` → `Would install pydantic-settings-2.14.2` only).
- `pydantic-settings` is a **transitive** dep (lock-only; not in `requirements.txt`, not imported directly in our code) → behaviorally inert for us; we don't use `NestedSecretsSettingsSource`.

Second of the two open vulnerability buckets; the HIGH stanza RCE is #3691.