### PR TITLE
fix(lexicon): calque-flag оточуючий + broaden слідуючий in russianism gate (#3688)

### DIFF
--- a/scripts/audit/checks/russicism_detection.py
+++ b/scripts/audit/checks/russicism_detection.py
@@ -59,10 +59,24 @@ _RUSSICISMS: list[dict] = [
         "note": "Russian 'относиться'",
     },
     {
-        "pattern": r"\bслідуючий\b",
+        # Active-participle calque + inflections (слідуюча/слідуюче/слідуючих…).
+        # Existence-gate accepts the real form (#3647); this layer surfaces the
+        # native suggestion (#3688). Stem-match like \bприкольн\w+ above so the
+        # flag fires on any inflected use, not just masc-nom.
+        "pattern": r"\bслідуюч\w*\b",
         "term": "слідуючий",
         "fix": "наступний",
-        "note": "Russian 'следующий'",
+        "note": "Russian 'следующий' — active-participle calque; use наступний",
+    },
+    {
+        # оточуюч* — calque active participle ('окружающий'). Curated in
+        # calque_corrections.CURATED_CALQUES (Atlas §6 reference) but missing
+        # from this gate's pattern set, so the suggestion never fired (#3688).
+        # довколишній/навколишній are VESUM-attested; оточуюче середовище → довкілля.
+        "pattern": r"\bоточуюч\w*\b",
+        "term": "оточуючий",
+        "fix": "довколишній / навколишній",
+        "note": "Russian 'окружающий' — active-participle calque; use довколишній/навколишній (оточуюче середовище → довкілля)",
     },
     # "любий" meaning "будь-який" (any) — not "любий" meaning "dear/beloved"
     # Only flag when followed by a noun that suggests "any" meaning

--- a/tests/test_russicism_detection.py
+++ b/tests/test_russicism_detection.py
@@ -72,6 +72,26 @@ class TestBasicDetection:
         violations = check_russicisms(content)
         assert len(violations) == 1
 
+    def test_detects_слідуюча_inflected(self):
+        """Broadened pattern fires on inflected слідуюч* too, not just masc-nom (#3688)."""
+        content = _wrap("Слідуюча тема — це наголос у словах.")
+        violations = check_russicisms(content)
+        assert len(violations) == 1
+        assert "наступний" in str(violations)
+
+    def test_detects_оточуюче_calque(self):
+        """оточуюч* calque surfaces with the native suggestion (#3688 — was missing from gate)."""
+        content = _wrap("Ми вивчаємо оточуюче середовище довкола села.")
+        violations = check_russicisms(content)
+        assert len(violations) == 1
+        assert "довколишній" in str(violations) or "навколишній" in str(violations)
+
+    def test_detects_оточуючих_inflected(self):
+        """Inflected оточуючих also fires (#3688)."""
+        content = _wrap("Опис оточуючих лісів, полів і річок.")
+        violations = check_russicisms(content)
+        assert len(violations) == 1
+
     def test_detects_кушати(self):
         """Detects 'кушати' (should be 'їсти')."""
         content = _wrap("Давайте кушати разом.")


### PR DESCRIPTION
Closes #3688 (follow-up to #3647 / PR #3686).

## Problem
The VESUM existence-gate now **accepts** the real active-participle calques (`оточуючий`, `слідуючий`); per the user's #3647 decision the *"suggest the proper form"* half belongs in the **separate russianism layer**. Codex's #3686 review noted that layer's teeth were weak for exactly these forms — and tracing it:

- **`оточуючий`** is richly curated in `calque_corrections.CURATED_CALQUES` (Atlas §6 *reference* data) but was **absent from `_RUSSICISMS`** — the pattern set that `_russianisms_strict_gate` (`linear_pipeline.py:14365`) actually consumes. So its suggestion **never fired**.
- **`слідуючий`**'s pattern was masc-nom-only (`\bслідуючий\b`), missing inflections (слідуюча/слідуюче/слідуючих…) — so it wouldn't reliably fire on real content.

## Fix
`scripts/audit/checks/russicism_detection.py` `_RUSSICISMS`:
| form | → suggestion |
|---|---|
| `оточуюч*` | `довколишній / навколишній` (оточуюче середовище → довкілля) |
| `слідуюч*` | `наступний` (broadened to stem-match, house style cf. `\bприкольн\w+`) |

Severity stays **count-based** (`warning` when alone — `critical` only at ≥3), which is the *correct* posture for #3647's accept-the-real-form decision: it surfaces the native suggestion to the writer-correction path + LLM dim **without hard-blocking** folk/seminar content that legitimately quotes or discusses the form.

## Linguistic verification (#M-4)
- Replacements **довколишній / навколишній / наступний** are all VESUM-attested (`verify_words`).
- The calque participles are non-normative (no heritage evidence per `CURATED_CALQUES` `heritage_guard`) — correct to flag.

## Tests
+3 (`слідуюча` inflected, `оточуюче середовище`, `оточуючих` inflected). **65** russicism_detection + **38** sibling russianism tests pass; ruff clean.