### PR TITLE
docs(folk): require researched ≥4 primary-text catalog in seminar orchestrator prompts (#2836)

### DIFF
--- a/docs/prompts/orchestrators/folk/preflight-readiness-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/folk/preflight-readiness-audit-orchestrator.md
@@ -1,12 +1,12 @@
 # FOLK Preflight Readiness Audit Orchestrator
 
-Prompt version: 0.1
+Prompt version: 0.2
 Last reviewed: 2026-06-21
 
 ## Source Assumptions
 
 - FOLK is the pilot seminar track. Use it to establish patterns for later seminar tracks, but verify every rule against the current repo.
-- FOLK modules require primary readings. If a reading is not yet available, record it as a blocker or reading-needed task rather than omitting it.
+- FOLK modules require a researched primary-text catalog, not a single token reading — target ≥4 distinct corpus-verified primary texts per module when the corpus supports it (`EXEMPLAR-STANDARD.md` §3), corpus-bound and never backfilled. If readings are not yet available, record blockers/reading-needed tasks rather than omitting them.
 - The current reading system includes `site/src/content/readings/`, `PrimaryReading`, `scripts/generate_mdx/reading_links.py`, and `scripts/readings/generate_readings.py`.
 - This audit is read-only for curriculum, site, plans, wiki, and source files. Its only content write is a durable report under `docs/audits/`.
 
@@ -64,7 +64,8 @@ git rev-parse --show-toplevel
 ## Audit Checks
 
 - Confirm active FOLK track shape from current source/site files; do not infer active tracks from plan-only leftovers.
-- For every selected plan, list required readings from `readings:` or create a reading-needed finding when no reading is specified.
+- For every selected plan, survey corpus/source availability and report the **primary-text catalog**: how many distinct verified primary texts the corpus holds for the topic vs how many the plan/module currently surfaces. Raise a **reading-deficit** finding when the corpus supports ≥4 distinct texts but the plan/module surfaces fewer (FOLK floor, `EXEMPLAR-STANDARD.md` §3); raise `reading-needed` when no usable text exists. The floor is corpus-bound — fewer than 4 is acceptable only when the gate-safe corpus genuinely lacks that many distinct verified texts, and is **never** met by backfilled or scholarly-quoted text.
+- Flag any `references:` entry tagged `type: primary` that is actually a secondary/scholarly work (monograph, survey, analysis, e.g. Костомаров/Чижевський/Попович); these must be `type: scholarly` and must not count toward the reading floor.
 - For every reading candidate, record copyright decision: hosted, linked-only, excerpt-only, or omit.
 - Verify that hosted readings have or need `site/src/content/readings/<slug>.mdx` with `public_domain: true`.
 - Verify that each built module has `resources.yaml` with one or more `role: reading` entries and learner tasks.

--- a/docs/prompts/orchestrators/folk/production-build-orchestrator.md
+++ b/docs/prompts/orchestrators/folk/production-build-orchestrator.md
@@ -1,12 +1,12 @@
 # FOLK Production Build Orchestrator
 
-Prompt version: 0.1
+Prompt version: 0.2
 Last reviewed: 2026-06-21
 
 ## Source Assumptions
 
 - FOLK is the seminar pilot and must model reading-first seminar production.
-- Every module needs one or more primary reading candidates. If the text is not immediately available, stop or record a blocker; do not build around an empty reading layer.
+- Every module needs a **researched primary-text catalog** — survey the corpus for every distinct verified text on the topic and surface as many as it supports (**FOLK floor: ≥4 distinct primary readings when the gate-safe corpus holds ≥4 verified fragments**, `EXEMPLAR-STANDARD.md` §3; corpus-bound, never backfilled with from-memory or scholarly-quoted text). If a text is not available, record a `reading-needed` blocker; do not build around an empty or padded reading layer.
 - Hosted readings currently live in `site/src/content/readings/` and require `public_domain: true`. Non-hostable texts need `role: reading` external links and clear copyright notes.
 - FOLK uses `verify_shippable` and `assemble_mdx`, not the core `generate_mdx.py` path.
 
@@ -75,7 +75,8 @@ git rev-parse --show-toplevel
 ## Production Rules
 
 - Work one module at a time. Finish reading discovery, source writing, reading generation, MDX assembly, and validation before moving to the next slug.
-- Start each module from the primary reading candidates. Each candidate needs a copyright decision: hosted, linked-only, excerpt-only, or omit with reason.
+- Start each module from the primary reading candidates. Build the full corpus-supported catalog (FOLK target ≥4 distinct primary texts; fewer only when the gate-safe corpus genuinely lacks them, recorded as `reading-needed`). Each candidate needs a copyright decision: hosted, linked-only, excerpt-only, or omit with reason.
+- Keep scholarly/secondary works (monographs, surveys, analyses) as `type: scholarly` references — never tag them `type: primary` and never count them toward the reading floor. A primary text reconstructed inside a scholar's prose is not a clean hostable reading; source the standalone text from a primary-text corpus.
 - Search likely teaching/source locations such as Osvita only with exact URL and rights verification; do not invent links or assume teaching-site content is hostable.
 - Use `:::primary-reading` only for verified verbatim folk-primary fragments.
 - Keep archaic or dialectal forms inside quoted primary text unless VESUM/slovnyk.me/heritage verifies the form for exposition.

--- a/docs/prompts/orchestrators/folk/quality-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/folk/quality-audit-orchestrator.md
@@ -1,6 +1,6 @@
 # FOLK Quality Audit Orchestrator
 
-Prompt version: 0.1
+Prompt version: 0.2
 Last reviewed: 2026-06-21
 
 ## Source Assumptions
@@ -58,7 +58,7 @@ git rev-parse --show-toplevel
 
 ## Audit Dimensions
 
-- Reading coverage: one or more readings per module; hosted/link-only/excerpt-only/omit decisions are explicit.
+- Reading coverage: the module surfaces the corpus-supported primary-text catalog — **FOLK floor ≥4 distinct primary readings when the gate-safe corpus holds ≥4 verified fragments** (`EXEMPLAR-STANDARD.md` §3), fewer only when the corpus genuinely lacks them and never backfilled; hosted/link-only/excerpt-only/omit decisions are explicit; scholarly works are not miscounted as readings (any `type: primary` that is actually scholarly is a finding).
 - Hosted readings: valid frontmatter, `public_domain: true`, source notes, `taught_in`, and working `/readings/<slug>/` links.
 - Quote integrity: no from-memory fragments; every boxed primary text has source provenance and verification status.
 - Source fidelity: no ghost sources, invented collectors, unsupported dates, or citation drift.

--- a/docs/prompts/orchestrators/folk/remediation-build-orchestrator.md
+++ b/docs/prompts/orchestrators/folk/remediation-build-orchestrator.md
@@ -1,6 +1,6 @@
 # FOLK Remediation Build Orchestrator
 
-Prompt version: 0.1
+Prompt version: 0.2
 Last reviewed: 2026-06-21
 
 ## Source Assumptions
@@ -65,6 +65,7 @@ git rev-parse --show-toplevel
 
 - Every audit finding selected for the batch must be fixed or explicitly deferred with reason.
 - Reading findings are first-class: fix missing `role: reading`, broken `/readings/` links, missing hosted files, bad copyright decisions, and missing learner tasks before declaring the module clean.
+- **Reading-deficit findings are first-class too:** when the gate-safe corpus holds ≥4 distinct verified primary texts but the module surfaces fewer (FOLK floor, `EXEMPLAR-STANDARD.md` §3), add the missing texts from the corpus — never backfill with from-memory, paraphrased, or scholarly-quoted content. Re-tag any `type: primary` reference that is actually a secondary/scholarly work as `type: scholarly`; it does not count toward the floor.
 - For unavailable texts, record the search and leave a visible reading-needed blocker instead of hiding the gap.
 - If hosting is not permitted, use link-only or excerpt-only treatment; do not paste full copyrighted text.
 - Regenerate readings and module MDX through current repo tooling; do not hand-edit generated output except with a documented reason. Assemble committed site MDX through `scripts.build.linear_pipeline.assemble_mdx`.

--- a/docs/prompts/orchestrators/shared/reading-section-rules.md
+++ b/docs/prompts/orchestrators/shared/reading-section-rules.md
@@ -1,15 +1,25 @@
 # Shared Reading Section Rules
 
-Prompt suite component version: 0.1
+Prompt suite component version: 0.2
 Last reviewed: 2026-06-21
 
 The global reading reference is the seminar equivalent of a lexicon: modules should connect learners to original texts, either hosted on-site when copyright allows or linked externally when hosting is not allowed.
 
 ## Required Reading Coverage
 
-- Every seminar module must identify one or more primary reading candidates.
+- A seminar module's reading layer is a **researched primary-text catalog**, not a single token reading. Before writing, survey the corpus and source registries for **every distinct, verifiable primary text** that belongs to the module's topic (each song, duma, poem, chronicle passage, or other primary artifact appropriate to the track) — then surface as many as the corpus genuinely supports.
+- **Per-track minimum (corpus-bound).** Each seminar track sets a primary-text floor. **FOLK targets ≥4 distinct primary readings per module when the gate-safe corpus holds ≥4 distinct verified fragments** (`docs/folk-epic/EXEMPLAR-STANDARD.md` §3). A module may surface fewer **only** when the corpus genuinely lacks that many distinct verified texts — e.g. `koliadky-shchedrivky`'s gate-safe corpus holds 2 distinct songs, so 2–3 is correct for it, not a deficiency.
+- **Never backfill to the floor.** Do not pad the catalog to hit a number with from-memory text, paraphrase, reconstructed fragments, or scholarly-quoted snippets. Under-coverage relative to corpus availability is recorded as a `reading-needed` finding — never hidden, never faked.
 - If no usable reading is present yet, record it as a blocker or explicit `reading-needed` task; do not silently omit readings.
 - A reading can be a full original text, an excerpt, a chronicle/source passage, a literary work, a folk text, or another primary artifact appropriate to the track.
+
+## Primary Text vs Scholarship
+
+The reading catalog holds **primary texts only** — the works learners read in the original. **Secondary/scholarly works are not readings**, even when a plan lists them under `references:`:
+
+- Scholarly monographs, surveys, and analyses (e.g. Костомаров «Слов'янська міфологія», Чижевський «Історія української літератури», Попович «Нарис історії культури України», Грушевський used as analysis) are `type: scholarly` references — **never `type: primary`, and never counted toward the reading floor**.
+- A primary text embedded inside a scholar's analytical prose (reconstructed or quoted by the author) is **not** a clean hostable reading; source the standalone text from a primary-text corpus instead.
+- When auditing or building, flag any reference tagged `type: primary` that is actually a secondary work and re-tag it `type: scholarly`. The reading floor counts only standalone primary texts.
 
 ## Current Repo Surfaces
 


### PR DESCRIPTION
## What

Strengthens the 5 FOLK orchestrator prompt files (from the merged suite #3689) to encode the **codified reading standard** instead of a weak \`≥1\` floor.

**The gap (found while shipping Щедрик, #3690):** the merged FOLK orchestrators required only "one or more primary reading candidates", but \`docs/folk-epic/EXEMPLAR-STANDARD.md\` §3 requires a **researched ≥4 primary-text catalog when the gate-safe corpus supports it** — corpus-bound, **never backfilled** with from-memory or scholarly-quoted text — and kept **separate from scholarly citations**. This is the systemic diagnosis from the session-78 handoff: 41/42 folk plans mislabel scholarly books as \`type: primary\` and never catalog the actual primary texts.

## Changes (docs-only, 5 files)

- **\`shared/reading-section-rules.md\`** — rewrite *Required Reading Coverage* as a researched, corpus-bound per-track catalog (FOLK ≥4-when-corpus-supports, no backfill); new **Primary Text vs Scholarship** section (scholarly monographs/surveys/analyses are \`type: scholarly\`, never \`type: primary\`, never counted toward the floor).
- **folk \`preflight-readiness-audit\`** — audit reports the primary-text catalog vs corpus availability; **reading-deficit** finding when corpus has ≥4 but module surfaces fewer; flag \`type: primary\` entries that are actually scholarly.
- **folk \`production-build\`** — build the full corpus-supported catalog; keep scholarship as \`type: scholarly\`.
- **folk \`remediation-build\`** — reading-deficit-vs-corpus is a first-class finding; re-tag mislabeled scholarship.
- **folk \`quality-audit\`** — reading-coverage dimension scored against the corpus-bound ≥4 floor, not "one or more".

Each edited file bumped \`0.1 → 0.2\`.

## Why this matters

Generalizes the koliadky plan fix (Костомаров/Чижевський/Попович re-tagged primary→scholarly in #3690) into the **template layer**, so all 42 folk modules get a proper reading catalog by construction — fixing the root cause, not one module at a time. It is the FOLK seminar pilot, so this also sets the pattern for HIST/BIO/LIT/ISTORIO/OES/RUTH.

## Notes

- Docs-only; the "Lint Prompts" CI job is path-filtered to \`scripts/\`/\`agents_extensions/\`/\`gemini_extensions/\` and does not gate \`docs/prompts/**\`.
- \`X-Agent: claude/folk-reading-catalog-standard\` trailer present (lint PASS).
- **No auto-merge** — track-driver PR for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)