### PR TITLE
fix(infra): give infra Claude its own cold-start handoff identity (claude-infra)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
       - 'scripts/deploy_prompts.sh'
       - 'scripts/ensure_headroom.sh'
       - 'start-claude.sh'
+      - 'start-claude-infra.sh'
       - 'start-codex.sh'
       - 'tests/**/*.py'
       - 'pyproject.toml'
@@ -84,6 +85,7 @@ jobs:
               - 'scripts/deploy_prompts.sh'
               - 'scripts/ensure_headroom.sh'
               - 'start-claude.sh'
+              - 'start-claude-infra.sh'
               - 'start-codex.sh'
               - 'tests/**/*.py'
               - 'package.json'
@@ -123,6 +125,7 @@ jobs:
               - 'package.json'
               - 'package-lock.json'
               - 'start-claude.sh'
+              - 'start-claude-infra.sh'
               - 'start-codex.sh'
               - 'scripts/check_rules_deployment.sh'
               - 'scripts/deploy_prompts.sh'
@@ -340,6 +343,7 @@ jobs:
         run: |
           bash -n \
             start-claude.sh \
+            start-claude-infra.sh \
             start-codex.sh \
             scripts/ensure_headroom.sh \
             scripts/deploy_prompts.sh \

--- a/docs/session-state/current.claude-infra.md
+++ b/docs/session-state/current.claude-infra.md
@@ -1,0 +1,31 @@
+# Current — Claude INFRA / CODE lane role handoff
+
+> **Lane:** infrastructure + our code — pipeline, gates, tooling, build, CI, schemas,
+> harness, Atlas/lexicon. SEPARATE from the folk/seminar Claude (agent `claude`) and from
+> the curriculum track-orchestrators.
+>
+> **Handoff identity:** `claude-infra`. Launch with **`./start-claude-infra.sh`** so the
+> SessionStart hook routes cold-start to this lane's own slot
+> (`.agent/claude-infra-thread-handoff.md`) instead of the shared `claude` slot. Plain
+> `claude` / `start-claude.sh` (no `SESSION_HANDOFF_AGENT`) defaults to agent `claude`,
+> which the folk driver and track-orchestrators also use — that shared slot is the
+> cold-start collision this file's lane was created to avoid.
+
+## Cold-start
+1. `git fetch origin`
+2. `gh pr list --search 'author:@me' --state open`
+3. `curl -sS http://127.0.0.1:8765/api/orient`
+4. Read the live queue: `.agent/claude-infra-thread-handoff.md` (gitignored, machine-local — START HERE).
+
+## Lane boundaries
+- Infra/code only. Do NOT touch the folk/seminar content lane
+  (`.agent/claude-thread-handoff.md`, `docs/folk-epic/`) or any track's content.
+- Keep the main checkout read-only for committed work; use dispatch worktrees.
+- Shared git identity across agents is expected — judge work by content + lane, never flag
+  identity collisions (it is noise the user does not want).
+- Self-merge grant: green + off-seat-reviewed infra PRs may be self-merged; honor blocking CI.
+
+> The live, session-by-session infra queue is hand-maintained in the gitignored
+> `.agent/claude-infra-thread-handoff.md` (machine-local runtime state, never committed).
+> This committed file is the durable pointer so a fresh clone knows the lane exists and how
+> to enter it.

--- a/scripts/audit/test_session_setup_hook.sh
+++ b/scripts/audit/test_session_setup_hook.sh
@@ -50,11 +50,12 @@ setup_fixture() {
 run_hook() {
   local root="$1"
   local allow_git_router="${2:-0}"
+  local handoff_agent="${3:-claude}"
 
   HOME="$TMP_ROOT/home" \
     CLAUDE_PROJECT_DIR="$root" \
     CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS=32000 \
-    SESSION_HANDOFF_AGENT=claude \
+    SESSION_HANDOFF_AGENT="$handoff_agent" \
     SESSION_HANDOFF_ALLOW_GIT_ROUTER="$allow_git_router" \
     "$HOOK"
 }
@@ -171,6 +172,19 @@ assert_contains "$output" "WARN: Could not locate latest brief in current.md und
 assert_contains "$output" "thread_handoff.py prepare --agent claude" "no table"
 assert_not_contains "$output" "NO TABLE FALLBACK BODY" "no table"
 fallback_warn_count=$((fallback_warn_count + $(count_warns "$output")))
+
+# 8. SESSION_HANDOFF_AGENT routes each lane to its OWN thread handoff slot.
+#    Regression guard for the infra/folk cold-start collision: with both handoff files
+#    present, agent=claude-infra must select the infra slot, never the folk `claude` slot.
+setup_fixture "$fixture_root"
+mkdir -p "$fixture_root/.agent"
+printf '# infra handoff\n' > "$fixture_root/.agent/claude-infra-thread-handoff.md"
+printf '# folk handoff\n' > "$fixture_root/.agent/claude-thread-handoff.md"
+output="$(run_hook "$fixture_root" 0 claude-infra)"
+assert_contains "$output" "Thread handoff: .agent/claude-infra-thread-handoff.md" "infra lane isolation"
+assert_contains "$output" "Bootstrap prompt: .agent/claude-infra-thread-bootstrap.md" "infra lane isolation"
+assert_not_contains "$output" "Thread handoff: .agent/claude-thread-handoff.md" "infra lane isolation"
+assert_not_contains "$output" "WARN:" "infra lane isolation"
 
 printf 'marker_hit_stdout_bytes=%s\n' "$marker_bytes"
 printf 'fallback_warn_count=%s\n' "$fallback_warn_count"

--- a/start-claude-infra.sh
+++ b/start-claude-infra.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Launch a Claude session as the INFRA / CODE driver — NOT the folk/seminar Claude and
+# NOT a curriculum track-orchestrator.
+#
+# Handoff identity: `claude-infra` (exported as SESSION_HANDOFF_AGENT). The SessionStart
+# hook (agents_extensions/shared/hooks/session-setup.sh) keys the cold-start thread handoff
+# off this variable, so the infra lane reads/writes its OWN slot
+# (.agent/claude-infra-thread-handoff.md) instead of the shared `claude` slot that the folk
+# driver and the track-orchestrators (start-bio-driver.sh etc.) also land on. Without this,
+# every Claude session defaults to agent `claude` and they clobber each other's handoff.
+#
+# Everything else (skills deploy, native-install launch, --chrome, bypassPermissions,
+# Headroom routing, autocompact window) is inherited from start-claude.sh.
+#
+# See docs/session-state/current.claude-infra.md for the lane's role + cold-start.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export SESSION_HANDOFF_AGENT=claude-infra
+exec "$ROOT/start-claude.sh" "$@"

--- a/tests/test_session_setup_hook.py
+++ b/tests/test_session_setup_hook.py
@@ -1,0 +1,37 @@
+"""Run the SessionStart-hook handoff-routing fixtures under the required pytest gate.
+
+``scripts/audit/test_session_setup_hook.sh`` exercises the cold-start handoff
+selection logic in ``agents_extensions/shared/hooks/session-setup.sh`` — including
+the regression guard that ``SESSION_HANDOFF_AGENT`` routes each lane (e.g.
+``claude`` vs ``claude-infra``) to its OWN ``.agent/<agent>-thread-handoff.md``
+slot. The shell script was previously not wired into CI, so this thin wrapper
+makes the guard load-bearing: it runs in the required ``Test (pytest)`` job.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_HOOK_TEST = _REPO_ROOT / "scripts" / "audit" / "test_session_setup_hook.sh"
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_session_setup_hook_handoff_fixtures() -> None:
+    assert _HOOK_TEST.is_file(), f"missing hook test: {_HOOK_TEST}"
+    result = subprocess.run(
+        ["bash", str(_HOOK_TEST)],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, (
+        f"hook fixtures failed (rc={result.returncode})\n"
+        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )
+    assert "ok - session setup hook handoff fixtures passed" in result.stdout


### PR DESCRIPTION
## Problem
The infra/code Claude and the folk/seminar track-orchestrator both launch as agent `claude`, so the SessionStart hook (`agents_extensions/shared/hooks/session-setup.sh`) routes **every** cold-start to the single `.agent/claude-thread-handoff.md` slot — whichever lane wrote it last wins. The infra handoff lived in a **sidecar** `.agent/claude-infra-handoff.md` that nothing in cold-start ever reads (`thread_handoff.py` only produces `<agent>-thread-handoff.md`). Net effect: infra sessions bootstrap into the **folk** handoff. (A third file, `docs/session-state/current.claude.md`, even claims "main orchestrator" — three roles, one slot.)

This is the same class of collision for **every** track driver: `start-bio-driver.sh` → `start-claude.sh --agent curriculum-track-orchestrator`, but `--agent` selects the agent *definition* and never reaches the hook, so it also lands on `claude`.

## Root cause
The hook already honors a `SESSION_HANDOFF_AGENT` env override — but **no launcher ever sets it**, so all Claude sessions fall through to the default `claude`.

## Fix (uses the existing switch; no hook change)
- **`start-claude-infra.sh`** exports `SESSION_HANDOFF_AGENT=claude-infra` then execs `start-claude.sh` (mirrors `scripts/start-bio-driver.sh`). The infra lane now reads/writes its own slot `.agent/claude-infra-thread-handoff.md`; folk/track drivers stay on `claude`.
- **`docs/session-state/current.claude-infra.md`** — committed role pointer so a fresh clone knows the lane + how to enter it.
- Wire the new launcher into the three CI path-filters + the `Validate agent shell entrypoints` shellcheck step.
- Make the previously-**orphaned** `scripts/audit/test_session_setup_hook.sh` load-bearing: a pytest wrapper (`tests/test_session_setup_hook.py`) runs it in the required `Test (pytest)` gate, plus a new `claude-infra` lane-isolation regression case.

## Verification
- End-to-end: real hook with `SESSION_HANDOFF_AGENT=claude-infra` emits `Agent: claude-infra` → `Thread handoff: .agent/claude-infra-thread-handoff.md` (no folk leakage).
- `tests/test_session_setup_hook.py` ✅ (runs all 8 hook fixtures incl. the new case) · `tests/orchestration/test_thread_handoff.py` 17/17 ✅ · ruff clean · `bash -n` on the launcher ✅ · ci.yml parses.

The local sidecar→canonical handoff migration (`.agent/claude-infra-thread-handoff.md` + bootstrap) is gitignored machine state, done out-of-band.

> Out of scope (follow-up): give the other track drivers their own `claude-<track>` identities too — same root cause, separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)