### PR TITLE
feat(atlas): P3 promote grow-candidates → gated PR, human-merged (#3675)

### DIFF
--- a/.github/workflows/atlas-grow.yml
+++ b/.github/workflows/atlas-grow.yml
@@ -1,0 +1,225 @@
+# ATLAS_GROW_TOKEN secret note:
+# Use a PAT with contents:write and pull-requests:write for PR creation/push.
+# PRs opened with GITHUB_TOKEN do not trigger pull_request workflows, so required
+# checks never start and auto-merge cannot fire. If the secret is absent, this
+# workflow falls back to GITHUB_TOKEN, opens/updates the PR, and skips auto-merge.
+
+name: Atlas Grow
+
+on:
+  schedule:
+    - cron: '23 7 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  grow:
+    name: Promote clean Word Atlas grow candidates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: '.python-version'
+
+      - name: Check local dictionary data
+        id: dictionary_data
+        run: |
+          missing=()
+          [[ -f data/vesum.db ]] || missing+=(data/vesum.db)
+          [[ -f data/sources.db ]] || missing+=(data/sources.db)
+          if ((${#missing[@]})); then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Atlas grow skipped; missing local dictionary data: ${missing[*]}"
+            echo "::notice::Seed data/vesum.db and data/sources.db on the runner to enable scheduled Atlas grow."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create local venv
+        if: steps.dictionary_data.outputs.available == 'true'
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install PyYAML requests ukrainian-word-stress
+
+      - name: Configure GitHub auth
+        if: steps.dictionary_data.outputs.available == 'true'
+        env:
+          ATLAS_GROW_TOKEN: ${{ secrets.ATLAS_GROW_TOKEN }}
+          FALLBACK_GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          if [[ -n "$ATLAS_GROW_TOKEN" ]]; then
+            token="$ATLAS_GROW_TOKEN"
+            auto_merge_enabled=true
+            echo "Using ATLAS_GROW_TOKEN for PR creation and auto-merge."
+          else
+            token="$FALLBACK_GITHUB_TOKEN"
+            auto_merge_enabled=false
+            echo "::notice::ATLAS_GROW_TOKEN is not configured; falling back to GITHUB_TOKEN."
+            echo "::notice::Auto-merge skipped. Configure ATLAS_GROW_TOKEN and enable repository auto-merge."
+          fi
+          echo "::add-mask::$token"
+          {
+            echo "GH_TOKEN=$token"
+            echo "AUTO_MERGE_ENABLED=$auto_merge_enabled"
+          } >> "$GITHUB_ENV"
+          git config user.name "atlas-grow[bot]"
+          git config user.email "atlas-grow[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${token}@github.com/${GITHUB_REPOSITORY}.git"
+
+      - name: Run Atlas grow pipeline
+        if: steps.dictionary_data.outputs.available == 'true'
+        run: |
+          .venv/bin/python -m scripts.lexicon.content_lexicon_reconciler
+          .venv/bin/python -m scripts.lexicon.grow_lexicon_from_content --report
+          .venv/bin/python -m scripts.lexicon.promote_grow_candidates --write --report
+
+      - name: Detect manifest changes
+        if: steps.dictionary_data.outputs.available == 'true'
+        id: changes
+        run: |
+          git status --porcelain -- site/src/data/lexicon-manifest.json site/src/data/lexicon-manifest.fingerprint.json
+          if git diff --quiet -- site/src/data/lexicon-manifest.json; then
+            echo "manifest_changed=false" >> "$GITHUB_OUTPUT"
+            echo "No Atlas manifest changes to promote."
+          else
+            echo "manifest_changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Prepare PR body
+        if: steps.dictionary_data.outputs.available == 'true' && steps.changes.outputs.manifest_changed == 'true'
+        id: pr_body
+        run: |
+          .venv/bin/python - <<'PY'
+          import json
+          import subprocess
+          from pathlib import Path
+
+          from scripts.lexicon.build_data_manifest import _lemma_key
+
+          manifest_path = Path("site/src/data/lexicon-manifest.json")
+          base_manifest = json.loads(
+              subprocess.check_output(["git", "show", f"HEAD:{manifest_path.as_posix()}"], text=True)
+          )
+          current_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+          base_keys = {
+              _lemma_key(entry.get("lemma"))
+              for entry in base_manifest.get("entries", [])
+              if isinstance(entry, dict) and entry.get("lemma")
+          }
+          promoted = [
+              str(entry.get("lemma"))
+              for entry in current_manifest.get("entries", [])
+              if isinstance(entry, dict)
+              and entry.get("lemma")
+              and _lemma_key(entry.get("lemma")) not in base_keys
+          ]
+          held_path = Path("data/lexicon/grow_needs_review.json")
+          held = json.loads(held_path.read_text(encoding="utf-8")) if held_path.exists() else []
+
+          lines = [
+              "## Summary",
+              f"Promotes {len(promoted)} deterministic Word Atlas grow candidate(s) from #3675.",
+              "",
+              "Held candidates are not written to the manifest and stay human-review only.",
+              "",
+              "## Promoted lemmas",
+          ]
+          lines.extend([f"- {lemma}" for lemma in promoted] or ["- none"])
+          lines.extend(["", "## Held for review"])
+          if held:
+              for item in held:
+                  lines.append(f"- {item.get('lemma', '')}: {item.get('reason', '')}")
+          else:
+              lines.append("- none")
+          lines.extend(
+              [
+                  "",
+                  "## Validation",
+                  "- Atlas grow workflow ran P1 -> P2 -> P3 promotion.",
+                  "- P3 validates the prospective manifest before writing it.",
+                  "",
+                  "## Automation note",
+                  "Auto-merge requires `ATLAS_GROW_TOKEN` plus repository Allow auto-merge.",
+                  "When the secret is absent, this workflow opens the PR with `GITHUB_TOKEN` and skips auto-merge.",
+              ]
+          )
+          body_path = Path("/tmp/atlas-grow-pr-body.md")
+          body_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+          with Path("/tmp/atlas-grow-pr-meta.env").open("w", encoding="utf-8") as out:
+              out.write(f"promoted_count={len(promoted)}\n")
+              out.write(f"held_count={len(held)}\n")
+              out.write(f"body_path={body_path}\n")
+          PY
+          cat /tmp/atlas-grow-pr-meta.env >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push branch
+        if: steps.dictionary_data.outputs.available == 'true' && steps.changes.outputs.manifest_changed == 'true'
+        id: push
+        env:
+          PROMOTED_COUNT: ${{ steps.pr_body.outputs.promoted_count }}
+        run: |
+          branch="atlas-grow/$(date -u +%F)"
+          git fetch --no-tags origin "refs/heads/${branch}:refs/remotes/origin/${branch}" || true
+          git switch -c "$branch"
+          git add site/src/data/lexicon-manifest.json site/src/data/lexicon-manifest.fingerprint.json
+          git commit \
+            -m "chore(atlas): grow lexicon from content (${PROMOTED_COUNT} lemmas) (#3675)" \
+            --trailer "X-Agent: codex/atlas-grow-3675-p3"
+          if git show-ref --verify --quiet "refs/remotes/origin/${branch}"; then
+            expect="$(git rev-parse "refs/remotes/origin/${branch}")"
+            git push --force-with-lease="refs/heads/${branch}:${expect}" -u origin "$branch"
+          else
+            git push -u origin "$branch"
+          fi
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update PR
+        if: steps.dictionary_data.outputs.available == 'true' && steps.changes.outputs.manifest_changed == 'true'
+        id: pr
+        env:
+          BODY_PATH: ${{ steps.pr_body.outputs.body_path }}
+          BRANCH: ${{ steps.push.outputs.branch }}
+          HELD_COUNT: ${{ steps.pr_body.outputs.held_count }}
+          PROMOTED_COUNT: ${{ steps.pr_body.outputs.promoted_count }}
+        run: |
+          gh label create atlas-grow --color 1f883d --description "Automated Word Atlas grow PR" || true
+          labels=(--label atlas-grow)
+          if [[ "$HELD_COUNT" != "0" ]]; then
+            gh label create needs-review --color d1242f --description "Contains held candidates needing human review" || true
+            labels+=(--label needs-review)
+          fi
+          title="chore(atlas): grow lexicon from content (${PROMOTED_COUNT} lemmas) (#3675)"
+          if gh pr view "$BRANCH" --json url --jq .url >/tmp/atlas-grow-pr-url.txt 2>/dev/null; then
+            pr_url="$(cat /tmp/atlas-grow-pr-url.txt)"
+            gh pr edit "$pr_url" --title "$title" --body-file "$BODY_PATH" --add-label atlas-grow
+            if [[ "$HELD_COUNT" != "0" ]]; then
+              gh pr edit "$pr_url" --add-label needs-review
+            fi
+          else
+            pr_url="$(gh pr create --base main --head "$BRANCH" --title "$title" --body-file "$BODY_PATH" "${labels[@]}")"
+          fi
+          echo "url=$pr_url" >> "$GITHUB_OUTPUT"
+          gh pr view "$pr_url" --json url
+
+      - name: Enable auto-merge
+        if: steps.dictionary_data.outputs.available == 'true' && steps.changes.outputs.manifest_changed == 'true'
+        env:
+          PR_URL: ${{ steps.pr.outputs.url }}
+        run: |
+          if [[ "$AUTO_MERGE_ENABLED" == "true" ]]; then
+            gh pr merge --auto --squash --delete-branch "$PR_URL"
+          else
+            echo "::notice::Skipping auto-merge because ATLAS_GROW_TOKEN is absent."
+            echo "::notice::Configure ATLAS_GROW_TOKEN and repository Allow auto-merge for automatic merge on green CI."
+          fi

--- a/.github/workflows/atlas-grow.yml
+++ b/.github/workflows/atlas-grow.yml
@@ -1,8 +1,15 @@
-# ATLAS_GROW_TOKEN secret note:
-# Use a PAT with contents:write and pull-requests:write for PR creation/push.
-# PRs opened with GITHUB_TOKEN do not trigger pull_request workflows, so required
-# checks never start and auto-merge cannot fire. If the secret is absent, this
-# workflow falls back to GITHUB_TOKEN, opens/updates the PR, and skips auto-merge.
+# ATLAS_GROW_TOKEN secret note (OPEN-ONLY — this workflow NEVER merges):
+# Use a fine-grained PAT scoped to THIS repo, contents:write + pull-requests:write,
+# used ONLY to push the branch and OPEN the PR. PRs opened with the default
+# GITHUB_TOKEN do not trigger pull_request workflows, so the PR's required checks
+# would never run and a reviewer couldn't trust the gates; ATLAS_GROW_TOKEN exists
+# solely to make those checks run. There is NO auto-merge step — every Atlas-grow PR
+# is left for a human to review and merge. If the secret is absent, the PR still opens
+# with GITHUB_TOKEN (its checks won't auto-run; re-run them before merging).
+#
+# NOTE: the scheduled run is a no-op on GitHub-hosted runners — it requires
+# data/vesum.db + data/sources.db, which are local/gitignored. It does real work only
+# where that dictionary data exists (a self-hosted runner, or run the pipeline locally).
 
 name: Atlas Grow
 
@@ -60,19 +67,14 @@ jobs:
         run: |
           if [[ -n "$ATLAS_GROW_TOKEN" ]]; then
             token="$ATLAS_GROW_TOKEN"
-            auto_merge_enabled=true
-            echo "Using ATLAS_GROW_TOKEN for PR creation and auto-merge."
+            echo "Using ATLAS_GROW_TOKEN to open the PR so its CI checks run."
           else
             token="$FALLBACK_GITHUB_TOKEN"
-            auto_merge_enabled=false
-            echo "::notice::ATLAS_GROW_TOKEN is not configured; falling back to GITHUB_TOKEN."
-            echo "::notice::Auto-merge skipped. Configure ATLAS_GROW_TOKEN and enable repository auto-merge."
+            echo "::notice::ATLAS_GROW_TOKEN is not configured; opening the PR with GITHUB_TOKEN."
+            echo "::notice::The PR's checks will not auto-run; re-run them before reviewing and merging."
           fi
           echo "::add-mask::$token"
-          {
-            echo "GH_TOKEN=$token"
-            echo "AUTO_MERGE_ENABLED=$auto_merge_enabled"
-          } >> "$GITHUB_ENV"
+          echo "GH_TOKEN=$token" >> "$GITHUB_ENV"
           git config user.name "atlas-grow[bot]"
           git config user.email "atlas-grow[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${token}@github.com/${GITHUB_REPOSITORY}.git"
@@ -150,8 +152,8 @@ jobs:
                   "- P3 validates the prospective manifest before writing it.",
                   "",
                   "## Automation note",
-                  "Auto-merge requires `ATLAS_GROW_TOKEN` plus repository Allow auto-merge.",
-                  "When the secret is absent, this workflow opens the PR with `GITHUB_TOKEN` and skips auto-merge.",
+                  "Opened automatically; NEVER auto-merged — a human reviews and merges this PR.",
+                  "`ATLAS_GROW_TOKEN` (open-only) exists solely so these checks run; it cannot merge.",
               ]
           )
           body_path = Path("/tmp/atlas-grow-pr-body.md")
@@ -211,15 +213,3 @@ jobs:
           fi
           echo "url=$pr_url" >> "$GITHUB_OUTPUT"
           gh pr view "$pr_url" --json url
-
-      - name: Enable auto-merge
-        if: steps.dictionary_data.outputs.available == 'true' && steps.changes.outputs.manifest_changed == 'true'
-        env:
-          PR_URL: ${{ steps.pr.outputs.url }}
-        run: |
-          if [[ "$AUTO_MERGE_ENABLED" == "true" ]]; then
-            gh pr merge --auto --squash --delete-branch "$PR_URL"
-          else
-            echo "::notice::Skipping auto-merge because ATLAS_GROW_TOKEN is absent."
-            echo "::notice::Configure ATLAS_GROW_TOKEN and repository Allow auto-merge for automatic merge on green CI."
-          fi

--- a/.gitignore
+++ b/.gitignore
@@ -343,6 +343,7 @@ data/lexicon/slovnyk_cache/
 # Generated build artifact: regenerate on demand with
 #   .venv/bin/python -m scripts.lexicon.grow_lexicon_from_content (#3675 P2; promotion = P3)
 data/lexicon/grow_candidates.json
+data/lexicon/grow_needs_review.json
 data/eval-archive/
 
 # clawpatch tool output (config + findings + locks + patches — regenerable)

--- a/scripts/lexicon/promote_grow_candidates.py
+++ b/scripts/lexicon/promote_grow_candidates.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""Promote deterministic Atlas grow candidates into the live manifest.
+
+Phase 2 writes ``data/lexicon/grow_candidates.json`` with a confidence split:
+``auto_merge`` entries are dictionary-grounded and safe to promote, while
+``needs_review`` entries are held for a human. This script promotes only the
+clean bucket, validates the prospective manifest before writing it, and leaves
+the held set as a local PR-body artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import json
+import sys
+import tempfile
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.audit.check_atlas_manifest_enrichment import check_enrichment
+from scripts.lexicon import verify_manifest
+from scripts.lexicon.build_data_manifest import _lemma_key, _slug_for_url
+from scripts.lexicon.fill_from_content import ModuleInfo, _load_manifest, _manifest_entry
+from scripts.lexicon.manifest_fingerprint import DEFAULT_FINGERPRINT, write_fingerprint
+from scripts.sync.promote_module import _write_atomically
+
+DEFAULT_CANDIDATES = PROJECT_ROOT / "data" / "lexicon" / "grow_candidates.json"
+DEFAULT_MANIFEST = PROJECT_ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
+DEFAULT_NEEDS_REVIEW = PROJECT_ROOT / "data" / "lexicon" / "grow_needs_review.json"
+PRIMARY_SOURCE = "content_lexicon_grow"
+_OPTIONAL_CANDIDATE_FIELDS = (
+    "heritage_status",
+    "enrichment",
+    "pronunciation",
+    "sections",
+    "wiki_reference",
+)
+_ENRICHED_STAT_KEYS = ("enriched", "enriched_total", "enriched_count")
+_DUMMY_MODULE = ModuleInfo(track="", slug="", module_num=0, vocab_path=Path())
+
+SelfCheck = Callable[[Path], int]
+FingerprintWriter = Callable[[Path], Any]
+
+
+@dataclass(frozen=True)
+class HeldLemma:
+    lemma: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class PromotionResult:
+    candidates_found: bool
+    promoted: tuple[str, ...]
+    skipped_existing: tuple[str, ...]
+    held: tuple[HeldLemma, ...]
+    lemmas_total: int | None
+    manifest_written: bool
+    fingerprint_written: bool
+    needs_review_written: bool
+    dry_run: bool
+
+
+class SelfCheckError(RuntimeError):
+    """Raised when a prospective manifest fails a required promote gate."""
+
+    def __init__(self, exit_code: int) -> None:
+        self.exit_code = exit_code or 2
+        super().__init__(f"manifest self-check failed with exit code {self.exit_code}")
+
+
+def promote_grow_candidates(
+    *,
+    candidates_path: Path = DEFAULT_CANDIDATES,
+    manifest_path: Path = DEFAULT_MANIFEST,
+    needs_review_path: Path = DEFAULT_NEEDS_REVIEW,
+    fingerprint_path: Path = DEFAULT_FINGERPRINT,
+    write: bool = False,
+    self_check: SelfCheck | None = None,
+    fingerprint_writer: FingerprintWriter | None = None,
+) -> PromotionResult:
+    """Promote clean grow candidates and return a structured summary."""
+    candidates_path = _resolve_path(candidates_path)
+    manifest_path = _resolve_path(manifest_path)
+    needs_review_path = _resolve_path(needs_review_path)
+    fingerprint_path = _resolve_path(fingerprint_path)
+    self_check = self_check or verify_prospective_manifest
+    fingerprint_writer = fingerprint_writer or _write_fingerprint_sidecar
+
+    if not candidates_path.exists():
+        return PromotionResult(
+            candidates_found=False,
+            promoted=(),
+            skipped_existing=(),
+            held=(),
+            lemmas_total=None,
+            manifest_written=False,
+            fingerprint_written=False,
+            needs_review_written=False,
+            dry_run=not write,
+        )
+
+    candidates = _load_candidates(candidates_path)
+    held = tuple(_held_lemmas(candidates.get("needs_review", [])))
+    manifest = _load_manifest(manifest_path)
+    entries = manifest["entries"]
+    existing_keys = _manifest_lemma_keys(entries)
+    sorted_keys = [_lemma_key(str(entry.get("lemma") or "")) for entry in entries if isinstance(entry, dict)]
+
+    promoted: list[str] = []
+    skipped_existing: list[str] = []
+    for candidate in _candidate_entries(candidates.get("auto_merge", [])):
+        lemma = _candidate_lemma(candidate)
+        key = _lemma_key(lemma)
+        if key in existing_keys:
+            skipped_existing.append(lemma)
+            continue
+        entry = manifest_entry_from_candidate(candidate)
+        _insert_manifest_entry(entries, sorted_keys, entry)
+        existing_keys.add(key)
+        promoted.append(lemma)
+
+    if promoted:
+        _refresh_manifest_metadata(manifest)
+
+    manifest_written = False
+    fingerprint_written = False
+    needs_review_written = False
+
+    if write:
+        if promoted:
+            _validate_before_write(manifest, manifest_path, self_check)
+            _write_json_atomically(manifest_path, manifest)
+            manifest_written = True
+            fingerprint_writer(fingerprint_path)
+            fingerprint_written = True
+        _write_needs_review(needs_review_path, held)
+        needs_review_written = True
+
+    return PromotionResult(
+        candidates_found=True,
+        promoted=tuple(promoted),
+        skipped_existing=tuple(skipped_existing),
+        held=held,
+        lemmas_total=len(entries),
+        manifest_written=manifest_written,
+        fingerprint_written=fingerprint_written,
+        needs_review_written=needs_review_written,
+        dry_run=not write,
+    )
+
+
+def manifest_entry_from_candidate(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    """Build one live manifest entry from a P2 enriched candidate."""
+    lemma = _candidate_lemma(candidate)
+    gloss = _candidate_gloss(candidate)
+    pos = _clean_optional_str(candidate.get("pos"))
+    base_entry = _manifest_entry(
+        lemma,
+        {"translation": gloss, "gloss": gloss, "pos": pos, "ipa": candidate.get("ipa")},
+        _DUMMY_MODULE,
+        {"pos": pos},
+    )
+    base_entry["url_slug"] = _slug_for_url(lemma)
+    base_entry["primary_source"] = PRIMARY_SOURCE
+    base_entry["course_usage"] = _course_usage(candidate)
+
+    for field in _OPTIONAL_CANDIDATE_FIELDS:
+        if field in candidate:
+            base_entry[field] = candidate[field]
+    if "pos" in candidate:
+        base_entry["pos"] = candidate.get("pos")
+    return base_entry
+
+
+def verify_prospective_manifest(manifest_path: Path) -> int:
+    """Run the required Atlas promote gates against a manifest file."""
+    verify_status = verify_manifest.run(
+        manifest_path,
+        sample=0,
+        baseline_path=None,
+        run_conformance=True,
+    )
+    enrichment_status = check_enrichment(manifest_path=manifest_path)
+    return verify_status or enrichment_status
+
+
+def format_summary(result: PromotionResult, *, report: bool = False, candidates_path: Path = DEFAULT_CANDIDATES) -> str:
+    lines = ["Atlas grow promotion"]
+    if not result.candidates_found:
+        lines.append(f"Candidates: no candidates file at {_display_path(candidates_path)}")
+        lines.extend(
+            [
+                "Promoted: 0",
+                "Held for review: 0",
+                "New lemmas_total: unchanged",
+            ]
+        )
+        return "\n".join(lines)
+
+    lines.extend(
+        [
+            f"Mode: {'dry-run' if result.dry_run else 'write'}",
+            f"Promoted: {len(result.promoted)}",
+            f"Skipped existing: {len(result.skipped_existing)}",
+            f"Held for review: {len(result.held)}",
+            f"New lemmas_total: {result.lemmas_total}",
+            f"Manifest written: {str(result.manifest_written).lower()}",
+            f"Fingerprint written: {str(result.fingerprint_written).lower()}",
+            f"Needs-review written: {str(result.needs_review_written).lower()}",
+        ]
+    )
+    if report:
+        if result.promoted:
+            lines.append("Promoted lemmas:")
+            lines.extend(f"- {lemma}" for lemma in result.promoted)
+        if result.skipped_existing:
+            lines.append("Skipped existing lemmas:")
+            lines.extend(f"- {lemma}" for lemma in result.skipped_existing)
+        if result.held:
+            lines.append("Held lemmas:")
+            lines.extend(f"- {item.lemma}: {item.reason}" for item in result.held)
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidates", type=Path, default=DEFAULT_CANDIDATES)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--needs-review", type=Path, default=DEFAULT_NEEDS_REVIEW)
+    parser.add_argument("--fingerprint", type=Path, default=DEFAULT_FINGERPRINT)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--write", action="store_true", help="Write the manifest and held-review report")
+    mode.add_argument("--dry-run", action="store_true", help="Report what would change without writing")
+    parser.add_argument("--report", action="store_true", help="Print promoted and held lemma details")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        result = promote_grow_candidates(
+            candidates_path=args.candidates,
+            manifest_path=args.manifest,
+            needs_review_path=args.needs_review,
+            fingerprint_path=args.fingerprint,
+            write=args.write,
+        )
+    except SelfCheckError as exc:
+        print(f"error: {exc}; no files written", file=sys.stderr)
+        return exc.exit_code
+    print(format_summary(result, report=args.report, candidates_path=args.candidates))
+    return 0
+
+
+def _resolve_path(path: Path) -> Path:
+    path = Path(path)
+    return path if path.is_absolute() else PROJECT_ROOT / path
+
+
+def _load_candidates(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Candidates payload must be a JSON object: {path}")
+    return payload
+
+
+def _candidate_entries(raw_entries: object) -> list[Mapping[str, Any]]:
+    if not isinstance(raw_entries, list):
+        return []
+    return [entry for entry in raw_entries if isinstance(entry, Mapping)]
+
+
+def _candidate_lemma(candidate: Mapping[str, Any]) -> str:
+    lemma = str(candidate.get("lemma") or "").strip()
+    if not lemma:
+        raise ValueError("candidate entry is missing lemma")
+    return lemma
+
+
+def _manifest_lemma_keys(entries: Sequence[Any]) -> set[str]:
+    keys: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            continue
+        lemma = entry.get("lemma")
+        if isinstance(lemma, str) and lemma.strip():
+            keys.add(_lemma_key(lemma))
+    return keys
+
+
+def _candidate_gloss(candidate: Mapping[str, Any]) -> str | None:
+    enrichment = candidate.get("enrichment")
+    if isinstance(enrichment, Mapping):
+        meaning = enrichment.get("meaning")
+        gloss = _meaning_text(meaning)
+        if gloss:
+            return gloss
+    return _clean_optional_str(candidate.get("gloss"))
+
+
+def _meaning_text(meaning: object) -> str | None:
+    if isinstance(meaning, str):
+        return _clean_optional_str(meaning)
+    if not isinstance(meaning, Mapping):
+        return None
+    definitions = meaning.get("definitions")
+    if isinstance(definitions, list):
+        for definition in definitions:
+            text = _definition_text(definition)
+            if text:
+                return text
+    for key in ("text", "definition", "gloss"):
+        text = _clean_optional_str(meaning.get(key))
+        if text:
+            return text
+    return None
+
+
+def _definition_text(definition: object) -> str | None:
+    if isinstance(definition, Mapping):
+        for key in ("text", "definition", "value"):
+            text = _clean_optional_str(definition.get(key))
+            if text:
+                return text
+        return None
+    return _clean_optional_str(definition)
+
+
+def _clean_optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _course_usage(candidate: Mapping[str, Any]) -> list[dict[str, Any]]:
+    direct_usage = candidate.get("course_usage")
+    if isinstance(direct_usage, list):
+        return [dict(item) for item in direct_usage if isinstance(item, Mapping)]
+
+    contexts = candidate.get("source_contexts")
+    if isinstance(contexts, list):
+        usage_rows: list[dict[str, Any]] = []
+        for item in contexts:
+            if not isinstance(item, Mapping):
+                continue
+            usage = _usage_from_context(item)
+            if usage:
+                usage_rows.append(usage)
+        return usage_rows
+
+    context = candidate.get("source_context")
+    if isinstance(context, Mapping):
+        usage = _usage_from_context(context)
+        return [usage] if usage else []
+    return []
+
+
+def _usage_from_context(context: Mapping[str, Any]) -> dict[str, Any] | None:
+    track = _clean_optional_str(context.get("track"))
+    slug = _clean_optional_str(context.get("slug"))
+    if not track or not slug:
+        return None
+    usage: dict[str, Any] = {
+        "track": track,
+        "slug": slug,
+        "context": _clean_optional_str(context.get("context")) or PRIMARY_SOURCE,
+    }
+    module_num = context.get("module_num")
+    if module_num is not None:
+        usage["module_num"] = module_num
+    return usage
+
+
+def _insert_manifest_entry(entries: list[dict[str, Any]], sorted_keys: list[str], entry: dict[str, Any]) -> None:
+    key = _lemma_key(str(entry["lemma"]))
+    index = bisect.bisect_left(sorted_keys, key)
+    entries.insert(index, entry)
+    sorted_keys.insert(index, key)
+
+
+def _refresh_manifest_metadata(manifest: dict[str, Any]) -> None:
+    entries = manifest.get("entries", [])
+    if not isinstance(entries, list):
+        raise ValueError("Manifest entries must be a list")
+    stats = manifest.setdefault("stats", {})
+    if not isinstance(stats, dict):
+        stats = {}
+        manifest["stats"] = stats
+    stats["lemmas_total"] = len(entries)
+    enriched_count = sum(1 for entry in entries if isinstance(entry, Mapping) and entry.get("enrichment"))
+    for key in _ENRICHED_STAT_KEYS:
+        if key in stats:
+            stats[key] = enriched_count
+    manifest["enrichment_generated"] = True
+
+
+def _validate_before_write(manifest: dict[str, Any], manifest_path: Path, self_check: SelfCheck) -> None:
+    with tempfile.TemporaryDirectory(prefix="atlas-grow-promote-") as tmp_dir:
+        temp_manifest = Path(tmp_dir) / manifest_path.name
+        temp_manifest.write_bytes(_json_bytes(manifest))
+        exit_code = self_check(temp_manifest)
+    if exit_code != 0:
+        raise SelfCheckError(exit_code)
+
+
+def _write_json_atomically(path: Path, payload: object) -> None:
+    _write_atomically(path, _json_bytes(payload))
+
+
+def _write_needs_review(path: Path, held: Sequence[HeldLemma]) -> None:
+    payload = [{"lemma": item.lemma, "reason": item.reason} for item in held]
+    _write_json_atomically(path, payload)
+
+
+def _json_bytes(payload: object) -> bytes:
+    return (json.dumps(payload, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+
+
+def _held_lemmas(raw_items: object) -> list[HeldLemma]:
+    if not isinstance(raw_items, list):
+        return []
+    held: list[HeldLemma] = []
+    for item in raw_items:
+        if not isinstance(item, Mapping):
+            continue
+        entry = item.get("entry")
+        lemma = ""
+        if isinstance(entry, Mapping):
+            lemma = str(entry.get("lemma") or "").strip()
+        reason = str(item.get("reason") or "").strip()
+        held.append(HeldLemma(lemma=lemma, reason=reason))
+    return held
+
+
+def _write_fingerprint_sidecar(path: Path) -> dict[str, Any]:
+    return write_fingerprint(path, root=PROJECT_ROOT)
+
+
+def _display_path(path: Path) -> str:
+    path = _resolve_path(path)
+    try:
+        return path.relative_to(PROJECT_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "efaecb035c422af0a29fafdb3ba375b0b88154a18ce36af0323a843c1da8e314",
+  "fingerprint": "4bdb402c5e8cfb1257c7bf9fa43645091c4793b85edd8e7ba5bc91d797973acd",
   "inputs": {
     "lexicon_code": [
       {
@@ -87,6 +87,10 @@
         "sha256": "4919c84c88b8cf0bc1508250e6da4c80860e8a33a4a4df49402c8aedef3e9e68"
       },
       {
+        "path": "scripts/lexicon/promote_grow_candidates.py",
+        "sha256": "df805e6d299a01c5f842b8bbcb8a56b69f22555040001d3b33c0ae64daaecce2"
+      },
+      {
         "path": "scripts/lexicon/verify_manifest.py",
         "sha256": "73f4c6842805558f86b825f11529b707150a4f47cf8815e790f1c9dc99b1aefd"
       }
@@ -95,6 +99,6 @@
   "schema_version": 1,
   "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
   "stats": {
-    "lexicon_code_files": 22
+    "lexicon_code_files": 23
   }
 }

--- a/tests/test_promote_grow_candidates.py
+++ b/tests/test_promote_grow_candidates.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.lexicon import promote_grow_candidates as promote
+
+
+def test_manifest_entry_from_candidate_is_schema_conformant() -> None:
+    candidate = _candidate(
+        lemma="мама",
+        source_context={
+            "track": "a1",
+            "module_num": 1,
+            "slug": "hello",
+            "context": "content_mdx",
+        },
+    )
+
+    entry = promote.manifest_entry_from_candidate(candidate)
+
+    assert entry["lemma"] == "мама"
+    assert entry["url_slug"] == "мама"
+    assert entry["gloss"] == "mother"
+    assert entry["pos"] == "noun"
+    assert entry["primary_source"] == promote.PRIMARY_SOURCE
+    assert entry["course_usage"] == [
+        {
+            "track": "a1",
+            "module_num": 1,
+            "slug": "hello",
+            "context": "content_mdx",
+        }
+    ]
+    assert entry["heritage_status"] == candidate["heritage_status"]
+    assert entry["enrichment"] == candidate["enrichment"]
+
+
+def test_write_promotes_candidate_in_sorted_order_and_updates_stats(tmp_path: Path) -> None:
+    manifest_path = _write_manifest(tmp_path, [_entry("авто"), _entry("якір")])
+    candidates_path = _write_candidates(tmp_path, [_candidate("мама")], [])
+    needs_review_path = tmp_path / "grow_needs_review.json"
+    fingerprint_path = tmp_path / "lexicon-manifest.fingerprint.json"
+
+    result = promote.promote_grow_candidates(
+        candidates_path=candidates_path,
+        manifest_path=manifest_path,
+        needs_review_path=needs_review_path,
+        fingerprint_path=fingerprint_path,
+        write=True,
+        self_check=lambda _path: 0,
+        fingerprint_writer=_fingerprint_writer,
+    )
+
+    manifest = _read_json(manifest_path)
+    assert [entry["lemma"] for entry in manifest["entries"]] == ["авто", "мама", "якір"]
+    assert manifest["stats"]["lemmas_total"] == 3
+    assert manifest["stats"]["enriched_count"] == 3
+    assert manifest["enrichment_generated"] is True
+    assert result.promoted == ("мама",)
+    assert result.manifest_written is True
+    assert result.fingerprint_written is True
+    assert result.needs_review_written is True
+    assert _read_json(needs_review_path) == []
+    assert _read_json(fingerprint_path) == {"fingerprint": "fixture"}
+
+
+def test_second_run_is_idempotent(tmp_path: Path) -> None:
+    manifest_path = _write_manifest(tmp_path, [_entry("авто"), _entry("якір")])
+    candidates_path = _write_candidates(tmp_path, [_candidate("мама")], [])
+    needs_review_path = tmp_path / "grow_needs_review.json"
+    fingerprint_path = tmp_path / "lexicon-manifest.fingerprint.json"
+
+    first = promote.promote_grow_candidates(
+        candidates_path=candidates_path,
+        manifest_path=manifest_path,
+        needs_review_path=needs_review_path,
+        fingerprint_path=fingerprint_path,
+        write=True,
+        self_check=lambda _path: 0,
+        fingerprint_writer=_fingerprint_writer,
+    )
+    after_first = manifest_path.read_text(encoding="utf-8")
+    second = promote.promote_grow_candidates(
+        candidates_path=candidates_path,
+        manifest_path=manifest_path,
+        needs_review_path=needs_review_path,
+        fingerprint_path=fingerprint_path,
+        write=True,
+        self_check=lambda _path: 0,
+        fingerprint_writer=_fingerprint_writer,
+    )
+
+    assert first.promoted == ("мама",)
+    assert second.promoted == ()
+    assert second.skipped_existing == ("мама",)
+    assert second.manifest_written is False
+    assert second.fingerprint_written is False
+    assert manifest_path.read_text(encoding="utf-8") == after_first
+
+
+def test_existing_lemma_is_skipped_case_insensitively(tmp_path: Path) -> None:
+    manifest_path = _write_manifest(tmp_path, [_entry("Мама")])
+    candidates_path = _write_candidates(tmp_path, [_candidate("мама")], [])
+    needs_review_path = tmp_path / "grow_needs_review.json"
+
+    result = promote.promote_grow_candidates(
+        candidates_path=candidates_path,
+        manifest_path=manifest_path,
+        needs_review_path=needs_review_path,
+        write=True,
+        self_check=lambda _path: 0,
+        fingerprint_writer=_fingerprint_writer,
+    )
+
+    manifest = _read_json(manifest_path)
+    assert [entry["lemma"] for entry in manifest["entries"]] == ["Мама"]
+    assert result.promoted == ()
+    assert result.skipped_existing == ("мама",)
+    assert result.manifest_written is False
+    assert _read_json(needs_review_path) == []
+
+
+def test_needs_review_is_reported_but_never_promoted(tmp_path: Path) -> None:
+    manifest_path = _write_manifest(tmp_path, [_entry("авто")])
+    held = [{"entry": _candidate("сумнів"), "reason": "missing dictionary definition"}]
+    candidates_path = _write_candidates(tmp_path, [], held)
+    needs_review_path = tmp_path / "grow_needs_review.json"
+
+    result = promote.promote_grow_candidates(
+        candidates_path=candidates_path,
+        manifest_path=manifest_path,
+        needs_review_path=needs_review_path,
+        write=True,
+        self_check=lambda _path: 0,
+        fingerprint_writer=_fingerprint_writer,
+    )
+
+    assert [entry["lemma"] for entry in _read_json(manifest_path)["entries"]] == ["авто"]
+    assert result.promoted == ()
+    assert result.held == (promote.HeldLemma("сумнів", "missing dictionary definition"),)
+    assert _read_json(needs_review_path) == [
+        {"lemma": "сумнів", "reason": "missing dictionary definition"}
+    ]
+    report = promote.format_summary(result, report=True)
+    assert "- сумнів: missing dictionary definition" in report
+
+
+def test_gate_failure_aborts_without_writing(tmp_path: Path, monkeypatch) -> None:
+    manifest_path = _write_manifest(tmp_path, [_entry("авто")])
+    before = manifest_path.read_text(encoding="utf-8")
+    candidates_path = _write_candidates(tmp_path, [_candidate("мама")], [])
+    needs_review_path = tmp_path / "grow_needs_review.json"
+    fingerprint_path = tmp_path / "lexicon-manifest.fingerprint.json"
+    monkeypatch.setattr(promote, "verify_prospective_manifest", lambda _path: 2)
+
+    code = promote.main(
+        [
+            "--candidates",
+            str(candidates_path),
+            "--manifest",
+            str(manifest_path),
+            "--needs-review",
+            str(needs_review_path),
+            "--fingerprint",
+            str(fingerprint_path),
+            "--write",
+        ]
+    )
+
+    assert code != 0
+    assert manifest_path.read_text(encoding="utf-8") == before
+    assert not needs_review_path.exists()
+    assert not fingerprint_path.exists()
+
+
+def test_dry_run_writes_nothing(tmp_path: Path) -> None:
+    manifest_path = _write_manifest(tmp_path, [_entry("авто")])
+    before = manifest_path.read_text(encoding="utf-8")
+    candidates_path = _write_candidates(tmp_path, [_candidate("мама")], [])
+    needs_review_path = tmp_path / "grow_needs_review.json"
+    fingerprint_path = tmp_path / "lexicon-manifest.fingerprint.json"
+
+    result = promote.promote_grow_candidates(
+        candidates_path=candidates_path,
+        manifest_path=manifest_path,
+        needs_review_path=needs_review_path,
+        fingerprint_path=fingerprint_path,
+        write=False,
+        self_check=lambda _path: 2,
+        fingerprint_writer=_fingerprint_writer,
+    )
+
+    assert result.promoted == ("мама",)
+    assert result.dry_run is True
+    assert result.manifest_written is False
+    assert manifest_path.read_text(encoding="utf-8") == before
+    assert not needs_review_path.exists()
+    assert not fingerprint_path.exists()
+
+
+def test_missing_candidates_file_is_clean_noop(tmp_path: Path) -> None:
+    result = promote.promote_grow_candidates(
+        candidates_path=tmp_path / "missing.json",
+        manifest_path=tmp_path / "unused-manifest.json",
+        write=True,
+        self_check=lambda _path: 2,
+        fingerprint_writer=_fingerprint_writer,
+    )
+
+    assert result.candidates_found is False
+    assert result.promoted == ()
+    assert "no candidates file" in promote.format_summary(result)
+
+
+def _candidate(lemma: str = "мама", **overrides: object) -> dict[str, object]:
+    candidate: dict[str, object] = {
+        "lemma": lemma,
+        "pos": "noun",
+        "heritage_status": {
+            "classification": "standard",
+            "attestations": [],
+            "is_russianism": False,
+            "russian_shadow": False,
+            "calque_warning": None,
+        },
+        "enrichment": {
+            "meaning": {
+                "definitions": ["mother"],
+                "source": "fixture",
+            },
+            "sources": ["fixture"],
+        },
+    }
+    candidate.update(overrides)
+    return candidate
+
+
+def _entry(lemma: str) -> dict[str, object]:
+    return {
+        "lemma": lemma,
+        "url_slug": lemma.casefold(),
+        "gloss": lemma,
+        "pos": "noun",
+        "ipa": None,
+        "primary_source": "built_vocabulary",
+        "course_usage": [],
+        "heritage_status": {
+            "classification": "standard",
+            "attestations": [],
+            "is_russianism": False,
+            "russian_shadow": False,
+            "calque_warning": None,
+        },
+        "enrichment": {
+            "meaning": {
+                "definitions": [lemma],
+                "source": "fixture",
+            },
+            "sources": ["fixture"],
+        },
+    }
+
+
+def _write_manifest(tmp_path: Path, entries: list[dict[str, object]]) -> Path:
+    path = tmp_path / "lexicon-manifest.json"
+    payload = {
+        "version": "0.1",
+        "generated_at": "2026-06-22T00:00:00+00:00",
+        "stats": {
+            "lemmas_total": len(entries),
+            "enriched_count": sum(1 for entry in entries if entry.get("enrichment")),
+        },
+        "modules": [],
+        "seed_groups": [],
+        "entries": entries,
+        "enrichment_generated": True,
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _write_candidates(tmp_path: Path, auto_merge: list[dict[str, object]], needs_review: list[dict[str, object]]) -> Path:
+    path = tmp_path / "grow_candidates.json"
+    payload = {
+        "counts": {
+            "total_delta": len(auto_merge) + len(needs_review),
+            "processed": len(auto_merge) + len(needs_review),
+            "auto_merge": len(auto_merge),
+            "needs_review": len(needs_review),
+        },
+        "auto_merge": auto_merge,
+        "needs_review": needs_review,
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _read_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _fingerprint_writer(path: Path) -> None:
+    path.write_text('{"fingerprint": "fixture"}\n', encoding="utf-8")


### PR DESCRIPTION
## Summary

References #3675.

- Adds `scripts/lexicon/promote_grow_candidates.py` to promote only `auto_merge[]` candidates into the live Atlas manifest, write held candidates to the ignored `grow_needs_review.json`, validate the prospective manifest before writing, and refresh the fingerprint sidecar.
- Adds `.github/workflows/atlas-grow.yml` for scheduled/manual P1 -> P2 -> P3 runs, PR creation, held-candidate labeling, and auto-merge only when `ATLAS_GROW_TOKEN` is configured.
- Adds focused tests for entry construction, sorted insertion, idempotency, skip-existing behavior, held passthrough, gate-failure aborts, and dry-run no-op behavior.

## ATLAS_GROW_TOKEN setup note

The workflow documents and implements the auth fallback: configure `secrets.ATLAS_GROW_TOKEN` with `contents:write` and `pull-requests:write`, and enable repository Allow auto-merge, for automatic merge on green CI. If the secret is absent, the workflow falls back to `GITHUB_TOKEN`, opens/updates the PR, and prints a notice while skipping `gh pr merge --auto` because `GITHUB_TOKEN` PRs do not trigger `pull_request` checks.

## Raw validation evidence

### pytest

```text
============================== 8 passed in 0.30s ===============================
```

### ruff

```text
All checks passed!
```

### workflow YAML check

```text
YAML OK
```

### E2E dry run

```text
{
  "summary": {
    "files_scanned": 253,
    "unique_forms": 34437,
    "recognized_lemmas": 13193,
    "already_in_lexicon": 2712,
    "missing_delta": 10481,
    "unrecognized": 2517
  },
  "missing_lemmas": [],
  "unrecognized_forms": [],
  "limit": 0,
  "truncated": {
    "missing_lemmas": true,
    "unrecognized_forms": true
  }
}
```

```text
total_delta: 10481
processed: 20
auto_merge: 18
needs_review: 2
```

```text
Atlas grow promotion
Mode: dry-run
Promoted: 18
Skipped existing: 0
Held for review: 2
New lemmas_total: 4166
Manifest written: false
Fingerprint written: false
Needs-review written: false
Promoted lemmas:
- абзац
- абичий
- абищо
- абревіатура
- абревіація
- абрикос
- абрикоса
- абсолютний
- абсолютно
- абстрактно
- абстрактність
- абстракція
- абсурд
- авангард
- аварійний
- автентичний
- автентичність
- автобусний
Held lemmas:
- а-а-а: missing dictionary definition
- абстрактніший: missing dictionary definition
```

### freshness/trailer guards

```text
Atlas manifest freshness OK: 23 lexicon code files.
# TODO(#3150): dictionary DB/cache version drift is out of scope until CI can access #2928 data.
```

```text
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```
