### PR TITLE
docs: add remaining orchestrator prompt suites

### DIFF
--- a/docs/prompts/orchestrators/README.md
+++ b/docs/prompts/orchestrators/README.md
@@ -1,7 +1,7 @@
 # Orchestrator Prompt Suite
 
-Prompt suite version: 0.3
-Last reviewed: 2026-06-21
+Prompt suite version: 0.4
+Last reviewed: 2026-06-22
 
 This directory contains reusable prompts for future core-track and seminar-track orchestration threads. They are templates, not source-of-truth curriculum policy. Every production thread that uses them must inspect the current local repository before acting, especially `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `curriculum/l2-uk-en/curriculum.yaml`, `scripts/config.py`, `scripts/audit/config.py`, and the target level files.
 
@@ -25,8 +25,10 @@ This directory contains reusable prompts for future core-track and seminar-track
 - `b2/preflight-readiness-audit-orchestrator.md`: read-only readiness audit before B2 production.
 - `b2/production-build-orchestrator.md`: small sequential B2 production batches after preflight passes.
 - `b2/quality-audit-orchestrator.md`: post-build B2 audit for advanced syntax, register control, argumentation, and professional/academic readiness.
+- `c1/suite-orchestrator.md`: combined preflight, production, audit, and remediation suite for C1 academic/professional/stylistic core.
+- `c2/suite-orchestrator.md`: combined preflight, production, audit, and remediation suite for C2 native-level style, professional, literary, and capstone work.
 
-## Seminar Pilot Index
+## Seminar Track Index
 
 FOLK is the pilot seminar track. Its prompts should be treated as the model for later HIST, BIO, LIT, active `lit-*`, ISTORIO, OES, and RUTH suites, adjusted to each track's source base.
 
@@ -34,6 +36,19 @@ FOLK is the pilot seminar track. Its prompts should be treated as the model for 
 - `folk/production-build-orchestrator.md`: FOLK module production with mandatory primary readings, `:::primary-reading` blocks, reading-reference wiring, folk text-layer components, and `verify_shippable`.
 - `folk/quality-audit-orchestrator.md`: post-build audit for FOLK modules against the exemplar standard, source fidelity, readings, decolonization, and rendered-site behavior.
 - `folk/remediation-build-orchestrator.md`: remediation prompt for FOLK findings, including reading-link/copyright fixes and source-grounded content repair.
+- `hist/suite-orchestrator.md`: combined suite for Ukrainian history seminar modules, primary historical documents, source criticism, and decolonized framing.
+- `bio/suite-orchestrator.md`: combined suite for biography modules, source-tier dossiers, portrait rights, primary voice readings, and politically charged framing.
+- `lit/suite-orchestrator.md`: combined suite for the main Ukrainian literature canon track.
+- `lit-drama/suite-orchestrator.md`: combined suite for drama and performance texts.
+- `lit-essay/suite-orchestrator.md`: combined suite for intellectual essay, pamphlet, and decolonization thought.
+- `lit-fantastika/suite-orchestrator.md`: combined suite for speculative fiction, Gothic, fantasy, and science-fiction texts.
+- `lit-hist-fic/suite-orchestrator.md`: combined suite for historical fiction and national-memory novels.
+- `lit-humor/suite-orchestrator.md`: combined suite for humor, satire, burlesque, parody, and meme-era continuity.
+- `lit-war/suite-orchestrator.md`: combined suite for contemporary war literature, testimony, and trauma-aware pedagogy.
+- `lit-youth/suite-orchestrator.md`: combined suite for children's and young-adult literature; this active track maps to the older `LIT-JUVENILE` planning docs.
+- `istorio/suite-orchestrator.md`: combined suite for historiography, source methodology, and competing interpretive schools.
+- `oes/suite-orchestrator.md`: combined suite for Old Rus' historical-linguistic source work.
+- `ruth/suite-orchestrator.md`: combined suite for Ruthenian / Middle Ukrainian historical-linguistic source work.
 
 ## Shared Files
 
@@ -74,4 +89,4 @@ Do not infer active tracks from stale plan-only directories. Verify active track
 
 ## Adding C1, C2, Or Seminar Orchestrators
 
-Add a sibling directory such as `c1/`, `c2/`, `hist/`, `bio/`, `lit/`, `oes/`, or `ruth/`. Reuse only the track-agnostic shared scaffolding: repo hygiene, worktree discipline, PR rules, and report structure. Seminar tracks must not inherit CEFR immersion, decodability, beginner-safety, or grammar-sequencing assumptions by default. Before writing seminar prompts, inspect existing seminar precedents such as `docs/audits/bio-decolonization-checklist.md` and `docs/audits/bio-track-gap-audit-2026-05-26.md` when present, then add track-specific source attribution, factuality, decolonization, Russian-shadow, and bias checks.
+Add a sibling directory such as `c1/`, `c2/`, `hist/`, `bio/`, `lit/`, an active `lit-*` directory, `istorio/`, `oes/`, or `ruth/`. Reuse only the track-agnostic shared scaffolding: repo hygiene, worktree discipline, PR rules, and report structure. Seminar tracks must not inherit CEFR immersion, decodability, beginner-safety, or grammar-sequencing assumptions by default. Before writing seminar prompts, inspect existing seminar precedents such as `docs/audits/bio-decolonization-checklist.md` and `docs/audits/bio-track-gap-audit-2026-05-26.md` when present, then add track-specific source attribution, factuality, decolonization, Russian-shadow, and bias checks.

--- a/docs/prompts/orchestrators/bio/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/bio/suite-orchestrator.md
@@ -1,0 +1,116 @@
+# BIO Orchestrator Suite
+
+Prompt version: 0.1
+Last reviewed: 2026-06-22
+
+## Source Assumptions
+
+- BIO is a seminar biography track, not C1 core. It uses source-tier dossiers, decolonization review, portrait/image-rights rules, and politically charged biography framing.
+- Current source surfaces include `curriculum/l2-uk-en/plans/bio/*.yaml`, `curriculum/l2-uk-en/bio/`, `docs/audits/bio-track-gap-audit-2026-05-26.md`, `docs/best-practices/bio-research-source-tiers.md`, `docs/best-practices/bio-image-rights.md`, and `docs/best-practices/politically-charged-bios.md`.
+- Every module needs primary voice readings when available: letters, poems, speeches, memoir passages, court statements, diaries, interviews, or archival documents by/about the figure.
+- This suite covers preflight, production, quality audit, and remediation. Use only the stage that matches the task.
+
+## Goal
+
+Orchestrate BIO work in small batches without touching B2. Verify source-tier coverage, build biographies with primary readings and careful rights/framing, audit decolonization and factuality, and remediate blockers.
+
+## WORKTREE_ROOT Setup
+
+```bash
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+cd "$REPO_ROOT"
+git fetch origin main
+git worktree add -b codex/bio-<stage>-<batch> .worktrees/dispatch/codex/bio-<stage>-<batch> origin/main
+cd .worktrees/dispatch/codex/bio-<stage>-<batch>
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
+- `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `docs/prompts/orchestrators/shared/seminar-source-rules.md`
+- `docs/prompts/orchestrators/shared/reading-section-rules.md`
+- `docs/audits/bio-track-gap-audit-2026-05-26.md`
+- `docs/audits/bio-decolonization-checklist.md`
+- `docs/best-practices/bio-research-source-tiers.md`
+- `docs/best-practices/bio-image-rights.md`
+- `docs/best-practices/bio-naming-canonical.md`
+- `docs/best-practices/politically-charged-bios.md`
+- `docs/templates/bio-research-dossier-template.md`
+- target `curriculum/l2-uk-en/plans/bio/<slug>.yaml`
+
+## Allowed Writes
+
+- Preflight or quality audit: `docs/audits/bio-<scope>-<date>.md`
+- For scoped BIO target slugs only:
+  - current-layout source files under `curriculum/l2-uk-en/bio/`
+  - `site/src/content/docs/bio/<slug>.mdx`
+  - hostable readings under `site/src/content/readings/`
+- PR body or final orchestration note text
+
+## Forbidden Writes
+
+- `docs/prompts/orchestrators/b2/**`
+- unrelated BIO plans, dossiers, modules, or image assets
+- non-hostable copyrighted full text or images
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- generated `status/`, curriculum `audit/`, curriculum `review/`, and `data/telemetry/**` artifacts
+
+## Lifecycle Rules
+
+- Preflight: verify Tier 1/Tier 2 source packs, primary voice readings, portrait rights or fallback, and content-warning fields for politically charged figures.
+- Production: foreground Ukrainian agency and the specific oppression mechanism; cite narrow, not broad; include primary voice when legally usable.
+- Quality audit: run the decolonization checklist, source-tier audit, naming/transliteration check, portrait-rights check, and reading-link/copyright review.
+- Remediation: fix source authority and framing blockers before prose polish.
+
+## Track-Specific Checks
+
+- Russian/Soviet sources are historical evidence, not authority over Ukrainian identity or motives.
+- Do not write hagiography. Name documented contested ideology, civilian harm, collaboration allegations, or memory disputes with sourced precision.
+- For recent war-killed or captivity figures, avoid re-victimizing images or propaganda-origin material.
+
+## Helpers And Headroom
+
+Use read-only helpers for source-tier packets, image-rights checks, and politically charged framing review. Compress long findings with Headroom.
+
+## Validation Commands
+
+Adapt to current target layout:
+
+```bash
+.venv/bin/python - <<'PY'
+from pathlib import Path
+import yaml
+for path in sorted(Path("curriculum/l2-uk-en/plans/bio").glob("*.yaml")):
+    yaml.safe_load(path.read_text(encoding="utf-8"))
+print("bio plans parse")
+PY
+git diff --check
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+```
+
+For built modules, add activity, vocabulary, generated MDX, liveness, and site checks from `shared/validation-checklist.md`.
+
+## Expected Final Response
+
+```text
+BIO stage: <preflight | production | quality-audit | remediation>
+Scope: <slugs or audit report>
+Source-tier coverage: <summary>
+Reading/portrait decisions: <summary>
+Files changed: <paths>
+Validation run: <commands and outcomes>
+Independent review: <status>
+Forbidden artifacts included: no
+swarm_used: true/false
+swarm_label: <none | helper | swarm>
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/bio/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/bio/suite-orchestrator.md
@@ -105,9 +105,11 @@ For built modules, add activity, vocabulary, generated MDX, liveness, and site c
 BIO stage: <preflight | production | quality-audit | remediation>
 Scope: <slugs or audit report>
 Source-tier coverage: <summary>
-Reading/portrait decisions: <summary>
+Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>
+Portrait rights: <hosted/link-only/omit/needed counts>
 Files changed: <paths>
 Validation run: <commands and outcomes>
+Telemetry: <posted | not module-build | unavailable with reason>
 Independent review: <status>
 Forbidden artifacts included: no
 swarm_used: true/false

--- a/docs/prompts/orchestrators/c1/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/c1/suite-orchestrator.md
@@ -1,0 +1,112 @@
+# C1 Orchestrator Suite
+
+Prompt version: 0.1
+Last reviewed: 2026-06-22
+
+## Source Assumptions
+
+- C1 is an advanced core track for academic, professional, stylistic, cultural, and linguistic mastery; it is not BIO and must not absorb BIO-specific biography work.
+- The current C1 source base includes `curriculum/l2-uk-en/plans/c1/*.yaml`, `curriculum/l2-uk-en/c1/discovery/*.yaml`, `docs/l2-uk-en/C1-PLAN-GENERATED.md`, and `docs/l2-uk-en/templates/c1-module-template.md`.
+- Plans and current config are source of truth. If old templates and plans disagree on word targets or structure, record a preflight finding before production.
+- This suite covers preflight, production, quality audit, and remediation. Use only the stage that matches the task.
+
+## Goal
+
+Run C1 work in scoped batches without touching B2 or seminar tracks. Verify plan/discovery readiness, build or remediate modules with university-level Ukrainian, audit for C1 quality, and keep generated artifacts out of the PR.
+
+## WORKTREE_ROOT Setup
+
+```bash
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+cd "$REPO_ROOT"
+git fetch origin main
+git worktree add -b codex/c1-<stage>-<batch> .worktrees/dispatch/codex/c1-<stage>-<batch> origin/main
+cd .worktrees/dispatch/codex/c1-<stage>-<batch>
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
+- `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `docs/l2-uk-en/C1-PLAN-GENERATED.md`
+- `docs/l2-uk-en/templates/c1-module-template.md`
+- `docs/l2-uk-en/templates/c1-academic-module-template.md`
+- `docs/l2-uk-en/templates/c1-checkpoint-module-template.md`
+- `docs/plans/c1-state-standard-gap-analysis.md`
+- target `curriculum/l2-uk-en/plans/c1/<slug>.yaml`
+- target `curriculum/l2-uk-en/c1/discovery/<slug>.yaml` when present
+- existing target source and `site/src/content/docs/c1/<slug>.mdx` when present
+
+## Allowed Writes
+
+- Preflight or quality audit: `docs/audits/c1-<scope>-<date>.md`
+- For scoped C1 target slugs only:
+  - `curriculum/l2-uk-en/c1/<slug>/module.md`
+  - `curriculum/l2-uk-en/c1/<slug>/activities.yaml`
+  - `curriculum/l2-uk-en/c1/<slug>/vocabulary.yaml`
+  - `curriculum/l2-uk-en/c1/<slug>/resources.yaml`
+  - `site/src/content/docs/c1/<slug>.mdx`
+- PR body or final orchestration note text
+
+## Forbidden Writes
+
+- `docs/prompts/orchestrators/b2/**`
+- plans, discovery, or wiki files unless the stage explicitly scopes a readiness remediation
+- modules outside the selected C1 batch
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- generated `status/`, curriculum `audit/`, curriculum `review/`, and `data/telemetry/**` artifacts
+
+## Lifecycle Rules
+
+- Preflight: compare plans, discovery files, generated plan docs, current config thresholds, and available source/wiki coverage. Block production on unresolved plan/discovery contradictions.
+- Production: build one module at a time with C1 academic depth, 100% Ukrainian immersion except permitted vocabulary glosses, precise register control, and serious writing support.
+- Quality audit: verify C1 content against academic/professional/stylistic expectations, not B1/B2 simplification.
+- Remediation: fix every selected audit finding in PR-sized batches and regenerate MDX through current tooling.
+
+## Track-Specific Checks
+
+- Preserve the C1 shift from language practice to studying in Ukrainian: comparative analysis, academic argument, source handling, register mastery, and complex syntax.
+- Do not backfill content with generic cultural trivia; each module needs a defensible advanced-language purpose.
+- Check that C1 cultural modules do not duplicate FOLK seminar reading rules unless the plan explicitly asks for primary-source seminar work.
+
+## Helpers And Headroom
+
+Use one to three helpers only for plan/discovery inventory, targeted validation, or source lookup. Compress long outputs with Headroom. The main orchestrator owns scope, edits, review routing, and merge readiness.
+
+## Validation Commands
+
+Adapt module numbers from `curriculum/l2-uk-en/curriculum.yaml`:
+
+```bash
+.venv/bin/python scripts/validate_activities.py l2-uk-en c1 <module_num>
+.venv/bin/python scripts/validate_vocab_yaml.py curriculum/l2-uk-en/c1/<slug>/vocabulary.yaml
+.venv/bin/python scripts/generate_mdx.py l2-uk-en c1 <module_num> --validate
+.venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/c1/<slug>/module.md
+git diff --check
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+```
+
+Run the forbidden-artifact guard from `shared/validation-checklist.md` before staging.
+
+## Expected Final Response
+
+```text
+C1 stage: <preflight | production | quality-audit | remediation>
+Scope: <slugs or audit report>
+Files changed: <paths>
+Validation run: <commands and outcomes>
+Telemetry: <posted | not module-build | unavailable with reason>
+Independent review: <status>
+Forbidden artifacts included: no
+swarm_used: true/false
+swarm_label: <none | helper | swarm>
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/c2/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/c2/suite-orchestrator.md
@@ -1,0 +1,112 @@
+# C2 Orchestrator Suite
+
+Prompt version: 0.1
+Last reviewed: 2026-06-22
+
+## Source Assumptions
+
+- C2 is the final core track: native-level style, literary mastery, professional specialization, teaching, translation, and capstone work.
+- Current sources include `curriculum/l2-uk-en/plans/c2/*.yaml`, `curriculum/l2-uk-en/c2/discovery/*.yaml`, `docs/l2-uk-en/C2-PLAN-GENERATED.md`, and `docs/l2-uk-en/templates/c2-module-template.md`.
+- Older C2 templates and generated plan docs can disagree on word targets. Treat plans/config as source of truth and record mismatches in preflight before production.
+- C2 may use authentic literary or professional texts, but it is still a core CEFR track; do not import seminar reading-floor requirements unless a plan explicitly needs source-text work.
+
+## Goal
+
+Run C2 preflight, production, quality audit, or remediation without touching B2. Build native-level Ukrainian modules with verified authentic sources, no invented quotes, and full validation.
+
+## WORKTREE_ROOT Setup
+
+```bash
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+cd "$REPO_ROOT"
+git fetch origin main
+git worktree add -b codex/c2-<stage>-<batch> .worktrees/dispatch/codex/c2-<stage>-<batch> origin/main
+cd .worktrees/dispatch/codex/c2-<stage>-<batch>
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
+- `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `docs/l2-uk-en/C2-PLAN-GENERATED.md`
+- `docs/l2-uk-en/templates/c2-module-template.md`
+- `docs/l2-uk-en/templates/c2-literary-module-template.md`
+- `docs/l2-uk-en/templates/c2-professional-module-template.md`
+- `docs/l2-uk-en/templates/c2-style-module-template.md`
+- target `curriculum/l2-uk-en/plans/c2/<slug>.yaml`
+- target `curriculum/l2-uk-en/c2/discovery/<slug>.yaml` when present
+- existing target source and `site/src/content/docs/c2/<slug>.mdx` when present
+
+## Allowed Writes
+
+- Preflight or quality audit: `docs/audits/c2-<scope>-<date>.md`
+- For scoped C2 target slugs only:
+  - `curriculum/l2-uk-en/c2/<slug>/module.md`
+  - `curriculum/l2-uk-en/c2/<slug>/activities.yaml`
+  - `curriculum/l2-uk-en/c2/<slug>/vocabulary.yaml`
+  - `curriculum/l2-uk-en/c2/<slug>/resources.yaml`
+  - `site/src/content/docs/c2/<slug>.mdx`
+- PR body or final orchestration note text
+
+## Forbidden Writes
+
+- `docs/prompts/orchestrators/b2/**`
+- unrelated C2 modules or lower-level core tracks
+- plans or discovery files unless the task explicitly scopes readiness remediation
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- generated `status/`, curriculum `audit/`, curriculum `review/`, and `data/telemetry/**` artifacts
+
+## Lifecycle Rules
+
+- Preflight: resolve plan/config/template mismatches, source availability, and whether target modules need authentic text or professional-domain evidence before writing.
+- Production: write one module at a time. C2 work must show expert register, stylistic transformation, professional precision, or creative control; no simplified filler.
+- Quality audit: check native-level quality, authentic-source fidelity, task/model-answer completeness, and whether production tasks actually test C2 control.
+- Remediation: fix selected findings, regenerate MDX, and rerun validation without broad refactors.
+
+## Track-Specific Checks
+
+- Never invent literary quotes, professional terminology, legal/medical forms, or stylistic analyses. Verify against authentic Ukrainian sources when the plan depends on them.
+- Preserve the C2 shift from understanding Ukrainian to creating, transforming, teaching, translating, and polishing with Ukrainian.
+- Keep learner tasks production-focused: transformations, critiques, portfolios, oral defense, professional documents, translation, and capstone artifacts.
+
+## Helpers And Headroom
+
+Use helpers for source verification, domain terminology checks, and validation only when they materially reduce risk. Compress long helper output with Headroom.
+
+## Validation Commands
+
+Adapt module numbers from `curriculum/l2-uk-en/curriculum.yaml`:
+
+```bash
+.venv/bin/python scripts/validate_activities.py l2-uk-en c2 <module_num>
+.venv/bin/python scripts/validate_vocab_yaml.py curriculum/l2-uk-en/c2/<slug>/vocabulary.yaml
+.venv/bin/python scripts/generate_mdx.py l2-uk-en c2 <module_num> --validate
+.venv/bin/python scripts/audit_module.py curriculum/l2-uk-en/c2/<slug>/module.md
+git diff --check
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+```
+
+Run the forbidden-artifact guard from `shared/validation-checklist.md` before staging.
+
+## Expected Final Response
+
+```text
+C2 stage: <preflight | production | quality-audit | remediation>
+Scope: <slugs or audit report>
+Files changed: <paths>
+Validation run: <commands and outcomes>
+Telemetry: <posted | not module-build | unavailable with reason>
+Independent review: <status>
+Forbidden artifacts included: no
+swarm_used: true/false
+swarm_label: <none | helper | swarm>
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/hist/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/hist/suite-orchestrator.md
@@ -1,0 +1,112 @@
+# HIST Orchestrator Suite
+
+Prompt version: 0.1
+Last reviewed: 2026-06-22
+
+## Source Assumptions
+
+- HIST is a seminar history track. It needs primary historical readings, source criticism, decolonized framing, and careful treatment of contested memory.
+- Current source surfaces include `curriculum/l2-uk-en/plans/hist/*.yaml`, `curriculum/l2-uk-en/hist/`, `docs/l2-uk-en/C1-HIST-PLAN-GENERATED.md`, `docs/l2-uk-en/C1-HIST-10-10-IMPROVEMENT-PLAN.md`, and history textbook references under `docs/references/textbooks-txt/`.
+- Every module must identify a researched catalog of primary/source readings. If a text is unavailable or rights are unclear, record `reading-needed`; do not omit the reading layer.
+- This suite covers preflight, production, quality audit, and remediation. Use only the stage that matches the task.
+
+## Goal
+
+Orchestrate HIST batches without touching B2. Verify source/readings readiness, build history seminar modules, audit factuality and framing, and remediate findings in small PRs.
+
+## WORKTREE_ROOT Setup
+
+```bash
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+cd "$REPO_ROOT"
+git fetch origin main
+git worktree add -b codex/hist-<stage>-<batch> .worktrees/dispatch/codex/hist-<stage>-<batch> origin/main
+cd .worktrees/dispatch/codex/hist-<stage>-<batch>
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
+- `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `docs/prompts/orchestrators/shared/seminar-source-rules.md`
+- `docs/prompts/orchestrators/shared/reading-section-rules.md`
+- `docs/l2-uk-en/C1-HIST-PLAN-GENERATED.md`
+- `docs/l2-uk-en/C1-HIST-10-10-IMPROVEMENT-PLAN.md`
+- relevant `docs/references/textbooks-txt/*history*.txt`
+- target `curriculum/l2-uk-en/plans/hist/<slug>.yaml`
+- existing target source, resources, readings, and `site/src/content/docs/hist/<slug>.mdx` when present
+
+## Allowed Writes
+
+- Preflight or quality audit: `docs/audits/hist-<scope>-<date>.md`
+- For scoped HIST target slugs only:
+  - current-layout source files under `curriculum/l2-uk-en/hist/`
+  - `site/src/content/docs/hist/<slug>.mdx`
+  - hostable readings under `site/src/content/readings/`
+- PR body or final orchestration note text
+
+## Forbidden Writes
+
+- `docs/prompts/orchestrators/b2/**`
+- plans, textbook references, wiki/source registries, or unrelated tracks unless explicitly scoped
+- non-hostable copyrighted full texts under `site/src/content/readings/`
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- generated `status/`, curriculum `audit/`, curriculum `review/`, and `data/telemetry/**` artifacts
+
+## Lifecycle Rules
+
+- Preflight: enumerate primary documents per target module, classify hosting rights, and block on ghost sources or missing source packs.
+- Production: build around source work first: document excerpt, provenance, context, competing interpretations, then seminar tasks.
+- Quality audit: verify date/person/place claims, source provenance, Russian-imperial/Soviet framing, and reading-link behavior.
+- Remediation: fix factuality, reading, and framing findings before style polish.
+
+## Track-Specific Checks
+
+- Historical claims need explicit support from textbook, primary, scholarly, or source-registry evidence.
+- Avoid "both sides" flattening for Russian imperial, Soviet, and Russian Federation violence.
+- Name contested memory and historiography honestly, including Polish, Jewish, Crimean Tatar, regional, and diaspora perspectives when relevant.
+
+## Helpers And Headroom
+
+Use read-only helpers for primary-document discovery, source verification, and decolonization review. Compress long outputs with Headroom.
+
+## Validation Commands
+
+Adapt to current target layout:
+
+```bash
+.venv/bin/python - <<'PY'
+from pathlib import Path
+import yaml
+for path in sorted(Path("curriculum/l2-uk-en/plans/hist").glob("*.yaml")):
+    yaml.safe_load(path.read_text(encoding="utf-8"))
+print("hist plans parse")
+PY
+git diff --check
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+```
+
+For built modules, add the relevant activity, vocabulary, MDX generation, audit, and site checks from `shared/validation-checklist.md`.
+
+## Expected Final Response
+
+```text
+HIST stage: <preflight | production | quality-audit | remediation>
+Scope: <slugs or audit report>
+Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>
+Files changed: <paths>
+Validation run: <commands and outcomes>
+Independent review: <status>
+Forbidden artifacts included: no
+swarm_used: true/false
+swarm_label: <none | helper | swarm>
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/hist/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/hist/suite-orchestrator.md
@@ -104,6 +104,7 @@ Scope: <slugs or audit report>
 Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>
 Files changed: <paths>
 Validation run: <commands and outcomes>
+Telemetry: <posted | not module-build | unavailable with reason>
 Independent review: <status>
 Forbidden artifacts included: no
 swarm_used: true/false

--- a/docs/prompts/orchestrators/istorio/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/istorio/suite-orchestrator.md
@@ -1,0 +1,140 @@
+# ISTORIO Orchestrator Suite
+
+Prompt version: 0.1
+Last reviewed: 2026-06-22
+
+## Source Assumptions
+
+- ISTORIO is an advanced historiography seminar track after HIST, not a
+  replacement for HIST modules or C1 core work.
+- Current sources include `curriculum/l2-uk-en/plans/istorio/*.yaml`,
+  `curriculum/l2-uk-en/istorio/`,
+  `site/src/content/docs/istorio/`, `docs/l2-uk-en/C1-HIST-PLAN-GENERATED.md`,
+  and history textbook/source references under `docs/references/`.
+- Every module needs a reading catalog with primary documents, historiographic
+  excerpts, or source-methodology readings. If a text is unavailable or rights
+  are unclear, record `reading-needed`; do not omit the reading layer.
+- This suite covers preflight, production, quality audit, and remediation. Use
+  only the stage that matches the task.
+
+## Goal
+
+Orchestrate ISTORIO batches without touching B2. Build historiography modules
+around primary sources, competing interpretations, decolonized methodology, and
+explicit source criticism.
+
+## WORKTREE_ROOT Setup
+
+```bash
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+cd "$REPO_ROOT"
+git fetch origin main
+git worktree add -b codex/istorio-<stage>-<batch> .worktrees/dispatch/codex/istorio-<stage>-<batch> origin/main
+cd .worktrees/dispatch/codex/istorio-<stage>-<batch>
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
+- `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `docs/prompts/orchestrators/shared/seminar-source-rules.md`
+- `docs/prompts/orchestrators/shared/reading-section-rules.md`
+- `docs/l2-uk-en/C1-HIST-PLAN-GENERATED.md`
+- relevant history references under `docs/references/`
+- target `curriculum/l2-uk-en/plans/istorio/<slug>.yaml`
+- existing target source, sidecars, readings, and
+  `site/src/content/docs/istorio/<slug>.mdx` when present
+
+## Allowed Writes
+
+- Preflight or quality audit: `docs/audits/istorio-<scope>-<date>.md`
+- For scoped ISTORIO target slugs only:
+  - current-layout source files under `curriculum/l2-uk-en/istorio/`
+  - sidecars under `curriculum/l2-uk-en/istorio/{meta,activities,vocabulary}/`
+    when the current layout uses them
+  - `site/src/content/docs/istorio/<slug>.mdx`
+  - hostable readings under `site/src/content/readings/`
+- PR body or final orchestration note text
+
+## Forbidden Writes
+
+- `docs/prompts/orchestrators/b2/**`
+- HIST, C1, or C2 modules unless the task explicitly scopes cross-track
+  remediation
+- plans, textbook references, wiki/source registries, or unrelated tracks unless
+  explicitly scoped
+- non-hostable copyrighted full texts under `site/src/content/readings/`
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- generated `status/`, curriculum `audit/`, curriculum `review/`, and
+  `data/telemetry/**` artifacts
+
+## Lifecycle Rules
+
+- Preflight: inventory primary documents, historiographic schools, source
+  availability, copyright status, and any plan/source contradictions before
+  production.
+- Production: begin from source work and historiographic method, then build
+  lecture prose, readings, vocabulary, and seminar tasks around a defensible
+  argument.
+- Quality audit: verify factual claims, source provenance, historiographic
+  attribution, decolonization framing, and reading-link behavior.
+- Remediation: fix ghost sources, factuality, and framing blockers before
+  language polish.
+
+## Track-Specific Checks
+
+- Distinguish primary evidence, historiographic interpretation, and memory
+  politics in every module.
+- Do not treat Russian imperial or Soviet historiography as neutral authority.
+- When a topic is contested, name the competing interpretations and the source
+  basis for each one.
+- Regional, Crimean Tatar, Jewish, Polish, diaspora, and other perspectives must
+  be source-grounded, not token additions.
+
+## Helpers And Headroom
+
+Use helpers for source inventory, rights classification, and historiographic
+cross-checks. Compress long source surveys with Headroom before passing them
+between agents.
+
+## Validation Commands
+
+Adapt to current target layout:
+
+```bash
+.venv/bin/python - <<'PY'
+from pathlib import Path
+import yaml
+for path in sorted(Path("curriculum/l2-uk-en/plans/istorio").glob("*.yaml")):
+    yaml.safe_load(path.read_text(encoding="utf-8"))
+print("istorio plans parse")
+PY
+git diff --check
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+```
+
+For built modules, add the current sidecar, MDX, reading, and site validation
+commands from `shared/validation-checklist.md`.
+
+## Expected Final Response
+
+```text
+ISTORIO stage: <preflight | production | quality-audit | remediation>
+Scope: <slugs or audit report>
+Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>
+Files changed: <paths>
+Validation run: <commands and outcomes>
+Independent review: <status>
+Forbidden artifacts included: no
+swarm_used: true/false
+swarm_label: <none | helper | swarm>
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/istorio/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/istorio/suite-orchestrator.md
@@ -132,6 +132,7 @@ Scope: <slugs or audit report>
 Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>
 Files changed: <paths>
 Validation run: <commands and outcomes>
+Telemetry: <posted | not module-build | unavailable with reason>
 Independent review: <status>
 Forbidden artifacts included: no
 swarm_used: true/false

--- a/docs/prompts/orchestrators/lit-drama/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-drama/suite-orchestrator.md
@@ -1,0 +1,102 @@
+# LIT-DRAMA Orchestrator Suite
+
+Prompt version: 0.1
+Last reviewed: 2026-06-22
+
+## Source Assumptions
+
+- `lit-drama` is an active LIT specialization track for drama, performance, dialogue, staging, and theatre history.
+- Treat plays, scenes, stage directions, performance manifestos, reviews, and theatre documents as reading candidates when rights allow.
+- Record unavailable or copyrighted drama texts as linked-only, excerpt-only, or `reading-needed`; do not paste full copyrighted plays.
+
+## Goal
+
+Run preflight, production, quality audit, or remediation for scoped `lit-drama` modules without touching B2 or inactive LIT remnants.
+
+## WORKTREE_ROOT Setup
+
+```bash
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+cd "$REPO_ROOT"
+git fetch origin main
+git worktree add -b codex/lit-drama-<stage>-<batch> .worktrees/dispatch/codex/lit-drama-<stage>-<batch> origin/main
+cd .worktrees/dispatch/codex/lit-drama-<stage>-<batch>
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
+- `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `docs/prompts/orchestrators/shared/seminar-source-rules.md`
+- `docs/prompts/orchestrators/shared/reading-section-rules.md`
+- `docs/l2-uk-en/templates/lit-module-template.md`
+- `docs/status/LIT-DRAMA-STATUS.md`
+- target `curriculum/l2-uk-en/plans/lit-drama/<slug>.yaml`
+- existing target source, sidecars, readings, and `site/src/content/docs/lit-drama/<slug>.mdx` when present
+
+## Allowed Writes
+
+- `docs/audits/lit-drama-<scope>-<date>.md`
+- scoped current-layout files under `curriculum/l2-uk-en/lit-drama/`
+- `site/src/content/docs/lit-drama/<slug>.mdx`
+- hostable readings under `site/src/content/readings/`
+- PR body or final orchestration note text
+
+## Forbidden Writes
+
+- `docs/prompts/orchestrators/b2/**`
+- inactive `lit-crimea` or `lit-doc` prompt/source work
+- non-hostable copyrighted full scripts or performance recordings
+- protected configs, generated status/audit/review artifacts, and `data/telemetry/**`
+
+## Lifecycle Rules
+
+- Preflight: verify active plans, drama text availability, performance/source context, and reading rights.
+- Production: center close reading of dialogue, staging, conflict, performance context, and theatre history.
+- Quality audit: check quote fidelity, scene attribution, rights, Ukrainian theatre framing, and activity quality.
+- Remediation: fix reading/copyright/source blockers before prose polish.
+
+## Track-Specific Checks
+
+- Distinguish literary text from performance adaptation; cite the edition or production being discussed.
+- Do not treat video recordings, theatre photos, or posters as hostable without separate rights verification.
+
+## Helpers And Headroom
+
+Use helpers for text/source discovery and rights classification. Compress long results with Headroom.
+
+## Validation Commands
+
+```bash
+.venv/bin/python - <<'PY'
+from pathlib import Path
+import yaml
+for path in sorted(Path("curriculum/l2-uk-en/plans/lit-drama").glob("*.yaml")):
+    yaml.safe_load(path.read_text(encoding="utf-8"))
+print("lit-drama plans parse")
+PY
+git diff --check
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+```
+
+Add current module, sidecar, MDX, and site checks when production/remediation writes content.
+
+## Expected Final Response
+
+```text
+LIT-DRAMA stage: <preflight | production | quality-audit | remediation>
+Scope: <slugs or audit report>
+Reading decisions: <summary>
+Validation run: <commands and outcomes>
+Forbidden artifacts included: no
+swarm_used: true/false
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/lit-drama/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-drama/suite-orchestrator.md
@@ -94,9 +94,13 @@ Add current module, sidecar, MDX, and site checks when production/remediation wr
 ```text
 LIT-DRAMA stage: <preflight | production | quality-audit | remediation>
 Scope: <slugs or audit report>
-Reading decisions: <summary>
+Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>
+Files changed: <paths>
 Validation run: <commands and outcomes>
+Telemetry: <posted | not module-build | unavailable with reason>
+Independent review: <status>
 Forbidden artifacts included: no
 swarm_used: true/false
+swarm_label: <none | helper | swarm>
 swarm_note: <helpers used, or solo run; no swarm used>
 ```

--- a/docs/prompts/orchestrators/lit-essay/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-essay/suite-orchestrator.md
@@ -1,0 +1,99 @@
+# LIT-ESSAY Orchestrator Suite
+
+Prompt version: 0.1
+Last reviewed: 2026-06-22
+
+## Source Assumptions
+
+- `lit-essay` is an active intellectual essay and Ukrainian thought track: essays, pamphlets, polemics, criticism, decolonization arguments, and war-era public thought.
+- Current planning docs include `docs/l2-uk-en/LIT-ESSAY-PLAN-GENERATED.md` and active plans under `curriculum/l2-uk-en/plans/lit-essay/`.
+- Every module needs primary argument readings: the essay/pamphlet/publicistic text under study, or a rights-safe excerpt/link.
+
+## Goal
+
+Run preflight, production, quality audit, or remediation for scoped `lit-essay` modules with argument-centered seminar pedagogy and explicit reading/copyright decisions.
+
+## WORKTREE_ROOT Setup
+
+```bash
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+cd "$REPO_ROOT"
+git fetch origin main
+git worktree add -b codex/lit-essay-<stage>-<batch> .worktrees/dispatch/codex/lit-essay-<stage>-<batch> origin/main
+cd .worktrees/dispatch/codex/lit-essay-<stage>-<batch>
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
+git status --short --branch
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
+- `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `docs/prompts/orchestrators/shared/seminar-source-rules.md`
+- `docs/prompts/orchestrators/shared/reading-section-rules.md`
+- `docs/l2-uk-en/LIT-ESSAY-PLAN-GENERATED.md`
+- `docs/l2-uk-en/templates/lit-module-template.md`
+- target `curriculum/l2-uk-en/plans/lit-essay/<slug>.yaml`
+
+## Allowed Writes
+
+- `docs/audits/lit-essay-<scope>-<date>.md`
+- scoped current-layout files under `curriculum/l2-uk-en/lit-essay/`
+- `site/src/content/docs/lit-essay/<slug>.mdx`
+- hostable readings under `site/src/content/readings/`
+- PR body or final orchestration note text
+
+## Forbidden Writes
+
+- `docs/prompts/orchestrators/b2/**`
+- inactive `lit-crimea` or `lit-doc` work
+- non-hostable copyrighted essays or excerpts beyond compliant limits
+- protected configs, generated status/audit/review artifacts, and `data/telemetry/**`
+
+## Lifecycle Rules
+
+- Preflight: verify the essay text, edition, date, rights, intellectual context, and counterargument sources.
+- Production: teach the argument's structure, assumptions, rhetoric, historical stakes, and contemporary relevance.
+- Quality audit: reject vague "idea history" summaries; require source-grounded claims and argument analysis.
+- Remediation: repair reading/citation/copyright blockers before style polish.
+
+## Track-Specific Checks
+
+- Analyze all ideologies critically, including Ukrainian nationalism; decolonization does not mean hagiography.
+- Keep secondary scholarship separate from the primary essay text unless the scholar's essay is itself the object of study.
+
+## Helpers And Headroom
+
+Use helpers for text location, rights, and argument-map verification. Compress long outputs with Headroom.
+
+## Validation Commands
+
+```bash
+.venv/bin/python - <<'PY'
+from pathlib import Path
+import yaml
+for path in sorted(Path("curriculum/l2-uk-en/plans/lit-essay").glob("*.yaml")):
+    yaml.safe_load(path.read_text(encoding="utf-8"))
+print("lit-essay plans parse")
+PY
+git diff --check
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+```
+
+Add module, sidecar, MDX, and site checks for content-writing stages.
+
+## Expected Final Response
+
+```text
+LIT-ESSAY stage: <preflight | production | quality-audit | remediation>
+Scope: <slugs or audit report>
+Reading decisions: <summary>
+Validation run: <commands and outcomes>
+Forbidden artifacts included: no
+swarm_used: true/false
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/lit-essay/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-essay/suite-orchestrator.md
@@ -23,7 +23,9 @@ git worktree add -b codex/lit-essay-<stage>-<batch> .worktrees/dispatch/codex/li
 cd .worktrees/dispatch/codex/lit-essay-<stage>-<batch>
 test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
 export WORKTREE_ROOT="$(pwd)"
+pwd
 git status --short --branch
+git rev-parse --show-toplevel
 ```
 
 ## Read First
@@ -91,9 +93,13 @@ Add module, sidecar, MDX, and site checks for content-writing stages.
 ```text
 LIT-ESSAY stage: <preflight | production | quality-audit | remediation>
 Scope: <slugs or audit report>
-Reading decisions: <summary>
+Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>
+Files changed: <paths>
 Validation run: <commands and outcomes>
+Telemetry: <posted | not module-build | unavailable with reason>
+Independent review: <status>
 Forbidden artifacts included: no
 swarm_used: true/false
+swarm_label: <none | helper | swarm>
 swarm_note: <helpers used, or solo run; no swarm used>
 ```

--- a/docs/prompts/orchestrators/lit-fantastika/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-fantastika/suite-orchestrator.md
@@ -23,7 +23,9 @@ git worktree add -b codex/lit-fantastika-<stage>-<batch> .worktrees/dispatch/cod
 cd .worktrees/dispatch/codex/lit-fantastika-<stage>-<batch>
 test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
 export WORKTREE_ROOT="$(pwd)"
+pwd
 git status --short --branch
+git rev-parse --show-toplevel
 ```
 
 ## Read First

--- a/docs/prompts/orchestrators/lit-fantastika/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-fantastika/suite-orchestrator.md
@@ -1,0 +1,99 @@
+# LIT-FANTASTIKA Orchestrator Suite
+
+Prompt version: 0.1
+Last reviewed: 2026-06-22
+
+## Source Assumptions
+
+- `lit-fantastika` is an active speculative fiction track covering Gothic, fantasy, science fiction, magical realism, cyberpunk, and mythic fiction.
+- Current planning docs include `docs/l2-uk-en/LIT-FANTASTIKA-PLAN-GENERATED.md` and active plans under `curriculum/l2-uk-en/plans/lit-fantastika/`.
+- Many texts are modern and copyrighted; default to linked-only or excerpt-only unless public-domain/hostable status is verified.
+
+## Goal
+
+Run preflight, production, audit, or remediation for scoped `lit-fantastika` modules, with primary readings and genre analysis that frames Ukrainian speculative fiction as its own tradition.
+
+## WORKTREE_ROOT Setup
+
+```bash
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+cd "$REPO_ROOT"
+git fetch origin main
+git worktree add -b codex/lit-fantastika-<stage>-<batch> .worktrees/dispatch/codex/lit-fantastika-<stage>-<batch> origin/main
+cd .worktrees/dispatch/codex/lit-fantastika-<stage>-<batch>
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
+git status --short --branch
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
+- `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `docs/prompts/orchestrators/shared/seminar-source-rules.md`
+- `docs/prompts/orchestrators/shared/reading-section-rules.md`
+- `docs/l2-uk-en/LIT-FANTASTIKA-PLAN-GENERATED.md`
+- `docs/l2-uk-en/templates/lit-module-template.md`
+- target `curriculum/l2-uk-en/plans/lit-fantastika/<slug>.yaml`
+
+## Allowed Writes
+
+- `docs/audits/lit-fantastika-<scope>-<date>.md`
+- scoped files under `curriculum/l2-uk-en/lit-fantastika/`
+- `site/src/content/docs/lit-fantastika/<slug>.mdx`
+- hostable readings under `site/src/content/readings/`
+- PR body or final orchestration note text
+
+## Forbidden Writes
+
+- `docs/prompts/orchestrators/b2/**`
+- inactive LIT remnants
+- non-hostable copyrighted contemporary fiction
+- protected configs, generated status/audit/review artifacts, and `data/telemetry/**`
+
+## Lifecycle Rules
+
+- Preflight: verify text availability, rights, genre context, and whether the work is public-domain, linked-only, or excerpt-only.
+- Production: analyze genre devices, Ukrainian mythic/cultural context, and anti-imperial stakes without reducing the work to plot summary.
+- Quality audit: check genre claims, source identity, rights, and avoidance of "derivative of Russian sci-fi" framing.
+- Remediation: repair source, reading, and copyright findings first.
+
+## Track-Specific Checks
+
+- Berdnyk/dissident or Soviet-era texts need political context and source verification.
+- Contemporary genre fiction must be handled with careful copyright limits.
+
+## Helpers And Headroom
+
+Use helpers for rights and text-location checks. Compress long source surveys with Headroom.
+
+## Validation Commands
+
+```bash
+.venv/bin/python - <<'PY'
+from pathlib import Path
+import yaml
+for path in sorted(Path("curriculum/l2-uk-en/plans/lit-fantastika").glob("*.yaml")):
+    yaml.safe_load(path.read_text(encoding="utf-8"))
+print("lit-fantastika plans parse")
+PY
+git diff --check
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+```
+
+Add content-generation validation for production/remediation.
+
+## Expected Final Response
+
+```text
+LIT-FANTASTIKA stage: <preflight | production | quality-audit | remediation>
+Scope: <slugs or audit report>
+Reading decisions: <summary>
+Validation run: <commands and outcomes>
+Forbidden artifacts included: no
+swarm_used: true/false
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/lit-fantastika/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-fantastika/suite-orchestrator.md
@@ -91,9 +91,13 @@ Add content-generation validation for production/remediation.
 ```text
 LIT-FANTASTIKA stage: <preflight | production | quality-audit | remediation>
 Scope: <slugs or audit report>
-Reading decisions: <summary>
+Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>
+Files changed: <paths>
 Validation run: <commands and outcomes>
+Telemetry: <posted | not module-build | unavailable with reason>
+Independent review: <status>
 Forbidden artifacts included: no
 swarm_used: true/false
+swarm_label: <none | helper | swarm>
 swarm_note: <helpers used, or solo run; no swarm used>
 ```

--- a/docs/prompts/orchestrators/lit-hist-fic/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-hist-fic/suite-orchestrator.md
@@ -23,7 +23,9 @@ git worktree add -b codex/lit-hist-fic-<stage>-<batch> .worktrees/dispatch/codex
 cd .worktrees/dispatch/codex/lit-hist-fic-<stage>-<batch>
 test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
 export WORKTREE_ROOT="$(pwd)"
+pwd
 git status --short --branch
+git rev-parse --show-toplevel
 ```
 
 ## Read First

--- a/docs/prompts/orchestrators/lit-hist-fic/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-hist-fic/suite-orchestrator.md
@@ -1,0 +1,99 @@
+# LIT-HIST-FIC Orchestrator Suite
+
+Prompt version: 0.1
+Last reviewed: 2026-06-22
+
+## Source Assumptions
+
+- `lit-hist-fic` is an active historical fiction track. It studies novels and stories that shape Ukrainian historical memory.
+- Current planning docs include `docs/l2-uk-en/LIT-HIST-FIC-PLAN-GENERATED.md` and active plans under `curriculum/l2-uk-en/plans/lit-hist-fic/`.
+- Each module needs primary literary readings plus a source-aware comparison to the historical event or memory problem being fictionalized.
+
+## Goal
+
+Run preflight, production, quality audit, or remediation for scoped `lit-hist-fic` modules while preserving literary analysis and historical-source discipline.
+
+## WORKTREE_ROOT Setup
+
+```bash
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+cd "$REPO_ROOT"
+git fetch origin main
+git worktree add -b codex/lit-hist-fic-<stage>-<batch> .worktrees/dispatch/codex/lit-hist-fic-<stage>-<batch> origin/main
+cd .worktrees/dispatch/codex/lit-hist-fic-<stage>-<batch>
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
+git status --short --branch
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
+- `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `docs/prompts/orchestrators/shared/seminar-source-rules.md`
+- `docs/prompts/orchestrators/shared/reading-section-rules.md`
+- `docs/l2-uk-en/LIT-HIST-FIC-PLAN-GENERATED.md`
+- `docs/l2-uk-en/templates/lit-module-template.md`
+- target `curriculum/l2-uk-en/plans/lit-hist-fic/<slug>.yaml`
+
+## Allowed Writes
+
+- `docs/audits/lit-hist-fic-<scope>-<date>.md`
+- scoped files under `curriculum/l2-uk-en/lit-hist-fic/`
+- `site/src/content/docs/lit-hist-fic/<slug>.mdx`
+- hostable readings under `site/src/content/readings/`
+- PR body or final orchestration note text
+
+## Forbidden Writes
+
+- `docs/prompts/orchestrators/b2/**`
+- inactive LIT remnants
+- non-hostable copyrighted novels or long excerpts
+- protected configs, generated status/audit/review artifacts, and `data/telemetry/**`
+
+## Lifecycle Rules
+
+- Preflight: verify text availability, rights, historical event/source anchors, and whether the novel's claims need HIST cross-checks.
+- Production: teach how fiction constructs memory; compare with documented history without turning the module into a history lecture.
+- Quality audit: check literary quote fidelity, historical framing, rights, and no romantic-nationalist overclaiming.
+- Remediation: repair reading, historical-source, and copyright findings first.
+
+## Track-Specific Checks
+
+- Distinguish the novel's imagined scene from the historical record.
+- Identify which imperial myth or memory distortion the work challenges, but do not let that become unsourced praise.
+
+## Helpers And Headroom
+
+Use helpers for historical cross-checks and text rights. Compress long outputs with Headroom.
+
+## Validation Commands
+
+```bash
+.venv/bin/python - <<'PY'
+from pathlib import Path
+import yaml
+for path in sorted(Path("curriculum/l2-uk-en/plans/lit-hist-fic").glob("*.yaml")):
+    yaml.safe_load(path.read_text(encoding="utf-8"))
+print("lit-hist-fic plans parse")
+PY
+git diff --check
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+```
+
+Add content-generation validation for production/remediation.
+
+## Expected Final Response
+
+```text
+LIT-HIST-FIC stage: <preflight | production | quality-audit | remediation>
+Scope: <slugs or audit report>
+Reading decisions: <summary>
+Validation run: <commands and outcomes>
+Forbidden artifacts included: no
+swarm_used: true/false
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/lit-hist-fic/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-hist-fic/suite-orchestrator.md
@@ -91,9 +91,13 @@ Add content-generation validation for production/remediation.
 ```text
 LIT-HIST-FIC stage: <preflight | production | quality-audit | remediation>
 Scope: <slugs or audit report>
-Reading decisions: <summary>
+Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>
+Files changed: <paths>
 Validation run: <commands and outcomes>
+Telemetry: <posted | not module-build | unavailable with reason>
+Independent review: <status>
 Forbidden artifacts included: no
 swarm_used: true/false
+swarm_label: <none | helper | swarm>
 swarm_note: <helpers used, or solo run; no swarm used>
 ```

--- a/docs/prompts/orchestrators/lit-humor/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-humor/suite-orchestrator.md
@@ -91,9 +91,13 @@ Add content-generation validation for production/remediation.
 ```text
 LIT-HUMOR stage: <preflight | production | quality-audit | remediation>
 Scope: <slugs or audit report>
-Reading decisions: <summary>
+Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>
+Files changed: <paths>
 Validation run: <commands and outcomes>
+Telemetry: <posted | not module-build | unavailable with reason>
+Independent review: <status>
 Forbidden artifacts included: no
 swarm_used: true/false
+swarm_label: <none | helper | swarm>
 swarm_note: <helpers used, or solo run; no swarm used>
 ```

--- a/docs/prompts/orchestrators/lit-humor/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-humor/suite-orchestrator.md
@@ -23,7 +23,9 @@ git worktree add -b codex/lit-humor-<stage>-<batch> .worktrees/dispatch/codex/li
 cd .worktrees/dispatch/codex/lit-humor-<stage>-<batch>
 test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
 export WORKTREE_ROOT="$(pwd)"
+pwd
 git status --short --branch
+git rev-parse --show-toplevel
 ```
 
 ## Read First

--- a/docs/prompts/orchestrators/lit-humor/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-humor/suite-orchestrator.md
@@ -1,0 +1,99 @@
+# LIT-HUMOR Orchestrator Suite
+
+Prompt version: 0.1
+Last reviewed: 2026-06-22
+
+## Source Assumptions
+
+- `lit-humor` is an active humor and satire track from burlesque and satire to postmodern parody and meme-era continuity.
+- Current planning docs include `docs/l2-uk-en/LIT-HUMOR-PLAN-GENERATED.md` and active plans under `curriculum/l2-uk-en/plans/lit-humor/`.
+- Primary readings can be humorous texts, satirical excerpts, parody scenes, poems, prose sketches, or documented meme/public-culture artifacts when rights allow.
+
+## Goal
+
+Run preflight, production, audit, or remediation for scoped `lit-humor` modules with close attention to register, satire targets, cultural context, and rights.
+
+## WORKTREE_ROOT Setup
+
+```bash
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+cd "$REPO_ROOT"
+git fetch origin main
+git worktree add -b codex/lit-humor-<stage>-<batch> .worktrees/dispatch/codex/lit-humor-<stage>-<batch> origin/main
+cd .worktrees/dispatch/codex/lit-humor-<stage>-<batch>
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
+git status --short --branch
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
+- `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `docs/prompts/orchestrators/shared/seminar-source-rules.md`
+- `docs/prompts/orchestrators/shared/reading-section-rules.md`
+- `docs/l2-uk-en/LIT-HUMOR-PLAN-GENERATED.md`
+- `docs/l2-uk-en/templates/lit-module-template.md`
+- target `curriculum/l2-uk-en/plans/lit-humor/<slug>.yaml`
+
+## Allowed Writes
+
+- `docs/audits/lit-humor-<scope>-<date>.md`
+- scoped files under `curriculum/l2-uk-en/lit-humor/`
+- `site/src/content/docs/lit-humor/<slug>.mdx`
+- hostable readings under `site/src/content/readings/`
+- PR body or final orchestration note text
+
+## Forbidden Writes
+
+- `docs/prompts/orchestrators/b2/**`
+- inactive LIT remnants
+- non-hostable copyrighted humor, scripts, or meme images
+- protected configs, generated status/audit/review artifacts, and `data/telemetry/**`
+
+## Lifecycle Rules
+
+- Preflight: verify text availability, humor target, cultural context, rights, and whether a meme/public artifact can be cited or only described.
+- Production: explain how humor works linguistically and politically; avoid translating the joke into dead exposition.
+- Quality audit: check register, satire target, rights, and whether the module punches up rather than normalizing imperial mockery.
+- Remediation: repair reading/copyright/context findings before prose polish.
+
+## Track-Specific Checks
+
+- Ukrainian humor should be framed as identity-preserving and power-challenging, not as provincial comic relief.
+- Be careful with slurs, dialect comedy, and Soviet/Russian caricatures; quote only when pedagogically necessary and framed.
+
+## Helpers And Headroom
+
+Use helpers for rights checks and cultural-context verification. Compress long outputs with Headroom.
+
+## Validation Commands
+
+```bash
+.venv/bin/python - <<'PY'
+from pathlib import Path
+import yaml
+for path in sorted(Path("curriculum/l2-uk-en/plans/lit-humor").glob("*.yaml")):
+    yaml.safe_load(path.read_text(encoding="utf-8"))
+print("lit-humor plans parse")
+PY
+git diff --check
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+```
+
+Add content-generation validation for production/remediation.
+
+## Expected Final Response
+
+```text
+LIT-HUMOR stage: <preflight | production | quality-audit | remediation>
+Scope: <slugs or audit report>
+Reading decisions: <summary>
+Validation run: <commands and outcomes>
+Forbidden artifacts included: no
+swarm_used: true/false
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/lit-war/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-war/suite-orchestrator.md
@@ -23,7 +23,9 @@ git worktree add -b codex/lit-war-<stage>-<batch> .worktrees/dispatch/codex/lit-
 cd .worktrees/dispatch/codex/lit-war-<stage>-<batch>
 test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
 export WORKTREE_ROOT="$(pwd)"
+pwd
 git status --short --branch
+git rev-parse --show-toplevel
 ```
 
 ## Read First
@@ -91,9 +93,13 @@ Add content-generation validation for production/remediation.
 ```text
 LIT-WAR stage: <preflight | production | quality-audit | remediation>
 Scope: <slugs or audit report>
-Reading decisions: <summary>
+Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>
+Files changed: <paths>
 Validation run: <commands and outcomes>
+Telemetry: <posted | not module-build | unavailable with reason>
+Independent review: <status>
 Forbidden artifacts included: no
 swarm_used: true/false
+swarm_label: <none | helper | swarm>
 swarm_note: <helpers used, or solo run; no swarm used>
 ```

--- a/docs/prompts/orchestrators/lit-war/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-war/suite-orchestrator.md
@@ -1,0 +1,99 @@
+# LIT-WAR Orchestrator Suite
+
+Prompt version: 0.1
+Last reviewed: 2026-06-22
+
+## Source Assumptions
+
+- `lit-war` is an active contemporary war literature track. It is time-sensitive and requires trauma-aware, source-grounded handling.
+- Current planning docs include `docs/l2-uk-en/LIT-WAR-PLAN-GENERATED.md` and active plans under `curriculum/l2-uk-en/plans/lit-war/`.
+- Most texts are recent and copyrighted. Default to linked-only or excerpt-only unless explicit hostable rights are verified.
+
+## Goal
+
+Run preflight, production, audit, or remediation for scoped `lit-war` modules, preserving Ukrainian agency, testimony, rights, and learner-safe framing.
+
+## WORKTREE_ROOT Setup
+
+```bash
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+cd "$REPO_ROOT"
+git fetch origin main
+git worktree add -b codex/lit-war-<stage>-<batch> .worktrees/dispatch/codex/lit-war-<stage>-<batch> origin/main
+cd .worktrees/dispatch/codex/lit-war-<stage>-<batch>
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
+git status --short --branch
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
+- `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `docs/prompts/orchestrators/shared/seminar-source-rules.md`
+- `docs/prompts/orchestrators/shared/reading-section-rules.md`
+- `docs/l2-uk-en/LIT-WAR-PLAN-GENERATED.md`
+- `docs/l2-uk-en/templates/lit-module-template.md`
+- target `curriculum/l2-uk-en/plans/lit-war/<slug>.yaml`
+
+## Allowed Writes
+
+- `docs/audits/lit-war-<scope>-<date>.md`
+- scoped files under `curriculum/l2-uk-en/lit-war/`
+- `site/src/content/docs/lit-war/<slug>.mdx`
+- hostable readings under `site/src/content/readings/`
+- PR body or final orchestration note text
+
+## Forbidden Writes
+
+- `docs/prompts/orchestrators/b2/**`
+- inactive LIT remnants
+- non-hostable full contemporary texts, captivity images, or propaganda-origin media
+- protected configs, generated status/audit/review artifacts, and `data/telemetry/**`
+
+## Lifecycle Rules
+
+- Preflight: verify text identity, author context, rights, sensitivity risks, and current-event claims.
+- Production: frame as literature of resistance and testimony, not neutral "conflict literature" or tragedy-on-both-sides prose.
+- Quality audit: check trauma-aware framing, agency, rights, source dates, and no Russian propaganda laundering.
+- Remediation: fix safety, source, reading, and copyright blockers before style polish.
+
+## Track-Specific Checks
+
+- Treat fallen authors and captivity testimony with dignity, not sentimentality.
+- Use absolute dates for recent events and verify them against current reliable sources.
+
+## Helpers And Headroom
+
+Use helpers for current-source verification, rights checks, and trauma/safety review. Compress long outputs with Headroom.
+
+## Validation Commands
+
+```bash
+.venv/bin/python - <<'PY'
+from pathlib import Path
+import yaml
+for path in sorted(Path("curriculum/l2-uk-en/plans/lit-war").glob("*.yaml")):
+    yaml.safe_load(path.read_text(encoding="utf-8"))
+print("lit-war plans parse")
+PY
+git diff --check
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+```
+
+Add content-generation validation for production/remediation.
+
+## Expected Final Response
+
+```text
+LIT-WAR stage: <preflight | production | quality-audit | remediation>
+Scope: <slugs or audit report>
+Reading decisions: <summary>
+Validation run: <commands and outcomes>
+Forbidden artifacts included: no
+swarm_used: true/false
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/lit-youth/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-youth/suite-orchestrator.md
@@ -1,0 +1,99 @@
+# LIT-YOUTH Orchestrator Suite
+
+Prompt version: 0.1
+Last reviewed: 2026-06-22
+
+## Source Assumptions
+
+- `lit-youth` is the active children's and young-adult literature track. Older planning docs may call this area `LIT-JUVENILE`; do not create a separate stale track from that name.
+- Current planning docs include `docs/l2-uk-en/LIT-JUVENILE-PLAN-GENERATED.md` and active plans under `curriculum/l2-uk-en/plans/lit-youth/`.
+- Most modern children's/YA texts are copyrighted. Use linked-only or excerpt-only unless hostable rights are verified.
+
+## Goal
+
+Run preflight, production, quality audit, or remediation for scoped `lit-youth` modules with age-aware text selection, rights discipline, and seminar-level literary analysis.
+
+## WORKTREE_ROOT Setup
+
+```bash
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+cd "$REPO_ROOT"
+git fetch origin main
+git worktree add -b codex/lit-youth-<stage>-<batch> .worktrees/dispatch/codex/lit-youth-<stage>-<batch> origin/main
+cd .worktrees/dispatch/codex/lit-youth-<stage>-<batch>
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
+git status --short --branch
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
+- `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `docs/prompts/orchestrators/shared/seminar-source-rules.md`
+- `docs/prompts/orchestrators/shared/reading-section-rules.md`
+- `docs/l2-uk-en/LIT-JUVENILE-PLAN-GENERATED.md`
+- `docs/l2-uk-en/templates/lit-module-template.md`
+- target `curriculum/l2-uk-en/plans/lit-youth/<slug>.yaml`
+
+## Allowed Writes
+
+- `docs/audits/lit-youth-<scope>-<date>.md`
+- scoped files under `curriculum/l2-uk-en/lit-youth/`
+- `site/src/content/docs/lit-youth/<slug>.mdx`
+- hostable readings under `site/src/content/readings/`
+- PR body or final orchestration note text
+
+## Forbidden Writes
+
+- `docs/prompts/orchestrators/b2/**`
+- a separate `lit-juvenile`, `lit-doc`, or `lit-crimea` prompt suite
+- non-hostable full children's/YA texts or illustrations
+- protected configs, generated status/audit/review artifacts, and `data/telemetry/**`
+
+## Lifecycle Rules
+
+- Preflight: verify text availability, rights, active naming (`lit-youth`), age/register suitability, and reading links.
+- Production: analyze how children's/YA literature builds Ukrainian language, imagination, and identity without flattening it into simple reading practice.
+- Quality audit: check rights, age-aware framing, literary depth, and no patronizing tone.
+- Remediation: repair rights and reading blockers before prose polish.
+
+## Track-Specific Checks
+
+- Do not host illustrations or full modern books without explicit rights.
+- Keep practical value for bilingual families visible when the plan supports it, but preserve seminar analysis.
+
+## Helpers And Headroom
+
+Use helpers for rights checks and text availability. Compress long outputs with Headroom.
+
+## Validation Commands
+
+```bash
+.venv/bin/python - <<'PY'
+from pathlib import Path
+import yaml
+for path in sorted(Path("curriculum/l2-uk-en/plans/lit-youth").glob("*.yaml")):
+    yaml.safe_load(path.read_text(encoding="utf-8"))
+print("lit-youth plans parse")
+PY
+git diff --check
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+```
+
+Add content-generation validation for production/remediation.
+
+## Expected Final Response
+
+```text
+LIT-YOUTH stage: <preflight | production | quality-audit | remediation>
+Scope: <slugs or audit report>
+Reading decisions: <summary>
+Validation run: <commands and outcomes>
+Forbidden artifacts included: no
+swarm_used: true/false
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/lit-youth/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-youth/suite-orchestrator.md
@@ -23,7 +23,9 @@ git worktree add -b codex/lit-youth-<stage>-<batch> .worktrees/dispatch/codex/li
 cd .worktrees/dispatch/codex/lit-youth-<stage>-<batch>
 test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
 export WORKTREE_ROOT="$(pwd)"
+pwd
 git status --short --branch
+git rev-parse --show-toplevel
 ```
 
 ## Read First
@@ -91,9 +93,13 @@ Add content-generation validation for production/remediation.
 ```text
 LIT-YOUTH stage: <preflight | production | quality-audit | remediation>
 Scope: <slugs or audit report>
-Reading decisions: <summary>
+Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>
+Files changed: <paths>
 Validation run: <commands and outcomes>
+Telemetry: <posted | not module-build | unavailable with reason>
+Independent review: <status>
 Forbidden artifacts included: no
 swarm_used: true/false
+swarm_label: <none | helper | swarm>
 swarm_note: <helpers used, or solo run; no swarm used>
 ```

--- a/docs/prompts/orchestrators/lit/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit/suite-orchestrator.md
@@ -107,6 +107,7 @@ Scope: <slugs or audit report>
 Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>
 Files changed: <paths>
 Validation run: <commands and outcomes>
+Telemetry: <posted | not module-build | unavailable with reason>
 Independent review: <status>
 Forbidden artifacts included: no
 swarm_used: true/false

--- a/docs/prompts/orchestrators/lit/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit/suite-orchestrator.md
@@ -1,0 +1,115 @@
+# LIT Orchestrator Suite
+
+Prompt version: 0.1
+Last reviewed: 2026-06-22
+
+## Source Assumptions
+
+- LIT is the main Ukrainian literature seminar track. It is distinct from C1/C2 literature modules and from active `lit-*` specialization tracks.
+- Current sources include `curriculum/l2-uk-en/plans/lit/*.yaml`, `curriculum/l2-uk-en/lit/`, `docs/l2-uk-en/LIT-PLAN-GENERATED.md`, `docs/l2-uk-en/templates/lit-module-template.md`, `docs/audits/bio-lit-cross-reference-exclusions.md`, and literary textbook references.
+- Every module needs a primary literary reading catalog: works, excerpts, poems, letters, diaries, or authorial texts, classified by hosting rights.
+- This suite covers preflight, production, quality audit, and remediation. Use only the stage that matches the task.
+
+## Goal
+
+Orchestrate LIT work without touching B2 or stale `lit-crimea` / `lit-doc` plan-only remnants. Build literary seminar modules around verified Ukrainian-language primary texts, decolonized literary history, and source-grounded analysis.
+
+## WORKTREE_ROOT Setup
+
+```bash
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+cd "$REPO_ROOT"
+git fetch origin main
+git worktree add -b codex/lit-<stage>-<batch> .worktrees/dispatch/codex/lit-<stage>-<batch> origin/main
+cd .worktrees/dispatch/codex/lit-<stage>-<batch>
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
+- `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `docs/prompts/orchestrators/shared/seminar-source-rules.md`
+- `docs/prompts/orchestrators/shared/reading-section-rules.md`
+- `docs/l2-uk-en/LIT-PLAN-GENERATED.md`
+- `docs/l2-uk-en/templates/lit-module-template.md`
+- `docs/audits/bio-lit-cross-reference-exclusions.md`
+- `docs/audits/bio-lit-cross-reference-gaps.md`
+- target `curriculum/l2-uk-en/plans/lit/<slug>.yaml`
+- existing target source, sidecars, readings, and `site/src/content/docs/lit/<slug>.mdx` when present
+
+## Allowed Writes
+
+- Preflight or quality audit: `docs/audits/lit-<scope>-<date>.md`
+- For scoped LIT target slugs only:
+  - current-layout source files under `curriculum/l2-uk-en/lit/`
+  - sidecars under `curriculum/l2-uk-en/lit/{meta,activities,vocabulary}/` when the current layout uses them
+  - `site/src/content/docs/lit/<slug>.mdx`
+  - hostable readings under `site/src/content/readings/`
+- PR body or final orchestration note text
+
+## Forbidden Writes
+
+- `docs/prompts/orchestrators/b2/**`
+- `docs/prompts/orchestrators/lit-crimea/**` or `docs/prompts/orchestrators/lit-doc/**`
+- plan-only stale `lit-crimea` / `lit-doc` work unless current manifests restore them
+- non-hostable copyrighted full literary texts
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- generated `status/`, curriculum `audit/`, curriculum `review/`, and `data/telemetry/**` artifacts
+
+## Lifecycle Rules
+
+- Preflight: verify active LIT taxonomy, primary text availability, copyright, sidecar layout, and LIT/BIO cross-reference implications.
+- Production: start from primary texts and the literary question; lecture prose, vocabulary, and activities must support close reading and argument.
+- Quality audit: check quote fidelity, Ukrainian literary independence, no Russian/Soviet critical framing as authority, no invented publication facts.
+- Remediation: repair reading/copyright/source issues before style or activity polish.
+
+## Track-Specific Checks
+
+- Ukrainian literature is an independent European tradition, not a branch of Russian letters.
+- Ukrainian-language authors only unless the plan explicitly frames translation, multilingual context, or imperial language politics.
+- Do not copy reference modules verbatim; use them as research scaffolding only.
+
+## Helpers And Headroom
+
+Use helpers for text availability, copyright classification, and quote verification. Compress long source surveys with Headroom.
+
+## Validation Commands
+
+Adapt to current target layout:
+
+```bash
+.venv/bin/python - <<'PY'
+from pathlib import Path
+import yaml
+for path in sorted(Path("curriculum/l2-uk-en/plans/lit").glob("*.yaml")):
+    yaml.safe_load(path.read_text(encoding="utf-8"))
+print("lit plans parse")
+PY
+git diff --check
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+```
+
+For built modules, add the current LIT sidecar, MDX, and site validation commands from `shared/validation-checklist.md`.
+
+## Expected Final Response
+
+```text
+LIT stage: <preflight | production | quality-audit | remediation>
+Scope: <slugs or audit report>
+Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>
+Files changed: <paths>
+Validation run: <commands and outcomes>
+Independent review: <status>
+Forbidden artifacts included: no
+swarm_used: true/false
+swarm_label: <none | helper | swarm>
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/oes/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/oes/suite-orchestrator.md
@@ -133,6 +133,7 @@ Scope: <slugs or audit report>
 Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>
 Files changed: <paths>
 Validation run: <commands and outcomes>
+Telemetry: <posted | not module-build | unavailable with reason>
 Independent review: <status>
 Forbidden artifacts included: no
 swarm_used: true/false

--- a/docs/prompts/orchestrators/oes/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/oes/suite-orchestrator.md
@@ -1,0 +1,141 @@
+# OES Orchestrator Suite
+
+Prompt version: 0.1
+Last reviewed: 2026-06-22
+
+## Source Assumptions
+
+- OES is the Old Rus' / early Ukrainian historical-linguistic seminar track for
+  the X-XIII century. It is not B2, not HIST, and not a generic medieval culture
+  track.
+- Current sources include `curriculum/l2-uk-en/plans/oes/*.yaml`,
+  `curriculum/l2-uk-en/oes/`, `site/src/content/docs/oes/`,
+  `docs/archive/OES-CURRICULUM.md`, and relevant linguistic/source references.
+- Every module needs a source-reading catalog: inscriptions, graffiti, birch
+  bark letters, chronicle passages, legal texts, sermons, or literary excerpts,
+  classified by hosting rights. If a text is unavailable or rights are unclear,
+  record `reading-needed`; do not omit the reading layer.
+- This suite covers preflight, production, quality audit, and remediation. Use
+  only the stage that matches the task.
+
+## Goal
+
+Orchestrate OES batches without touching B2. Build modules around verified
+source passages, historical phonology, orthography, paleography, register, and
+decolonized terminology.
+
+## WORKTREE_ROOT Setup
+
+```bash
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+cd "$REPO_ROOT"
+git fetch origin main
+git worktree add -b codex/oes-<stage>-<batch> .worktrees/dispatch/codex/oes-<stage>-<batch> origin/main
+cd .worktrees/dispatch/codex/oes-<stage>-<batch>
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
+- `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `docs/prompts/orchestrators/shared/seminar-source-rules.md`
+- `docs/prompts/orchestrators/shared/reading-section-rules.md`
+- `docs/archive/OES-CURRICULUM.md`
+- target `curriculum/l2-uk-en/plans/oes/<slug>.yaml`
+- existing target source, sidecars, readings, and
+  `site/src/content/docs/oes/<slug>.mdx` when present
+
+## Allowed Writes
+
+- Preflight or quality audit: `docs/audits/oes-<scope>-<date>.md`
+- For scoped OES target slugs only:
+  - current-layout source files under `curriculum/l2-uk-en/oes/`
+  - sidecars under `curriculum/l2-uk-en/oes/{meta,activities,vocabulary}/`
+    when the current layout uses them
+  - `site/src/content/docs/oes/<slug>.mdx`
+  - hostable readings under `site/src/content/readings/`
+- PR body or final orchestration note text
+
+## Forbidden Writes
+
+- `docs/prompts/orchestrators/b2/**`
+- HIST, ISTORIO, or RUTH modules unless the task explicitly scopes cross-track
+  remediation
+- plans, textbook references, wiki/source registries, or unrelated tracks unless
+  explicitly scoped
+- non-hostable copyrighted full texts under `site/src/content/readings/`
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- generated `status/`, curriculum `audit/`, curriculum `review/`, and
+  `data/telemetry/**` artifacts
+
+## Lifecycle Rules
+
+- Preflight: identify the exact source passage, edition/transcription status,
+  register, paleographic notes, rights status, and linguistic feature focus
+  before production.
+- Production: anchor prose and tasks in primary-source analysis before
+  historical explanation; every archaic form needs a source-backed reading and a
+  modern-Ukrainian learning purpose.
+- Quality audit: verify quoted forms, orthography, transliteration,
+  phonological claims, register labels, and decolonized terminology.
+- Remediation: fix source passage, terminology, and quote/orthography findings
+  before style or activity polish.
+
+## Track-Specific Checks
+
+- Use the track's Old Rus' / Old Ukrainian terminology and avoid imperial or
+  uniform-language framing.
+- Distinguish high/literary, legal, and vernacular registers instead of
+  flattening them into one medieval language.
+- Typical source families include St Sophia graffiti, birch bark letters,
+  Povist vremennykh lit, Ruska Pravda, sermons, hagiography, and Slovo o polku
+  Ihorevim.
+- Do not modernize, normalize, or silently repair source spelling inside
+  verbatim examples.
+
+## Helpers And Headroom
+
+Use helpers for source passage discovery, edition comparison, and terminology
+review. Compress long source tables or transcription comparisons with Headroom.
+
+## Validation Commands
+
+Adapt to current target layout:
+
+```bash
+.venv/bin/python - <<'PY'
+from pathlib import Path
+import yaml
+for path in sorted(Path("curriculum/l2-uk-en/plans/oes").glob("*.yaml")):
+    yaml.safe_load(path.read_text(encoding="utf-8"))
+print("oes plans parse")
+PY
+git diff --check
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+```
+
+For built modules, add the current sidecar, MDX, reading, and site validation
+commands from `shared/validation-checklist.md`.
+
+## Expected Final Response
+
+```text
+OES stage: <preflight | production | quality-audit | remediation>
+Scope: <slugs or audit report>
+Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>
+Files changed: <paths>
+Validation run: <commands and outcomes>
+Independent review: <status>
+Forbidden artifacts included: no
+swarm_used: true/false
+swarm_label: <none | helper | swarm>
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/ruth/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/ruth/suite-orchestrator.md
@@ -1,0 +1,142 @@
+# RUTH Orchestrator Suite
+
+Prompt version: 0.1
+Last reviewed: 2026-06-22
+
+## Source Assumptions
+
+- RUTH is the Ruthenian / Middle Ukrainian historical-linguistic seminar track
+  for the XIV-XVIII century. It follows OES conceptually but must stand on its
+  own source evidence.
+- Current sources include `curriculum/l2-uk-en/plans/ruth/*.yaml`,
+  `curriculum/l2-uk-en/ruth/`, `site/src/content/docs/ruth/`,
+  `docs/archive/RUTH-CURRICULUM.md`, and relevant linguistic/source references.
+- Every module needs a source-reading catalog: legal, chancery, scriptural,
+  grammatical, lexicographic, polemical, chronicle, constitutional, or
+  philosophical texts, classified by hosting rights. If a text is unavailable or
+  rights are unclear, record `reading-needed`; do not omit the reading layer.
+- This suite covers preflight, production, quality audit, and remediation. Use
+  only the stage that matches the task.
+
+## Goal
+
+Orchestrate RUTH batches without touching B2. Build modules around verified
+Ruthenian and Prosta Mova source passages, diglossia, chancery style, baroque
+registers, and decolonized historical-linguistic framing.
+
+## WORKTREE_ROOT Setup
+
+```bash
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+cd "$REPO_ROOT"
+git fetch origin main
+git worktree add -b codex/ruth-<stage>-<batch> .worktrees/dispatch/codex/ruth-<stage>-<batch> origin/main
+cd .worktrees/dispatch/codex/ruth-<stage>-<batch>
+test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
+export WORKTREE_ROOT="$(pwd)"
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+## Read First
+
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
+- `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `docs/prompts/orchestrators/shared/seminar-source-rules.md`
+- `docs/prompts/orchestrators/shared/reading-section-rules.md`
+- `docs/archive/RUTH-CURRICULUM.md`
+- target `curriculum/l2-uk-en/plans/ruth/<slug>.yaml`
+- existing target source, sidecars, readings, and
+  `site/src/content/docs/ruth/<slug>.mdx` when present
+
+## Allowed Writes
+
+- Preflight or quality audit: `docs/audits/ruth-<scope>-<date>.md`
+- For scoped RUTH target slugs only:
+  - current-layout source files under `curriculum/l2-uk-en/ruth/`
+  - sidecars under `curriculum/l2-uk-en/ruth/{meta,activities,vocabulary}/`
+    when the current layout uses them
+  - `site/src/content/docs/ruth/<slug>.mdx`
+  - hostable readings under `site/src/content/readings/`
+- PR body or final orchestration note text
+
+## Forbidden Writes
+
+- `docs/prompts/orchestrators/b2/**`
+- OES, HIST, or ISTORIO modules unless the task explicitly scopes cross-track
+  remediation
+- plans, textbook references, wiki/source registries, or unrelated tracks unless
+  explicitly scoped
+- non-hostable copyrighted full texts under `site/src/content/readings/`
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- generated `status/`, curriculum `audit/`, curriculum `review/`, and
+  `data/telemetry/**` artifacts
+
+## Lifecycle Rules
+
+- Preflight: identify the exact source passage, edition/transcription status,
+  register, rights status, historical context, and linguistic feature focus
+  before production.
+- Production: anchor prose and tasks in primary-source reading before broader
+  historical explanation; every archaic or mixed-register form needs a
+  source-backed reading and a modern-Ukrainian learning purpose.
+- Quality audit: verify quoted forms, orthography, translation/gloss choices,
+  register labels, historical claims, and decolonized terminology.
+- Remediation: fix source passage, terminology, and quote/orthography findings
+  before style or activity polish.
+
+## Track-Specific Checks
+
+- Distinguish Ruthenian, Prosta Mova, Church Slavonic, Polish, Latin, and modern
+  Ukrainian layers instead of flattening them.
+- Typical source families include Lithuanian Statutes, Peresopnytsia Gospel,
+  Ostrih Bible, Smotrytsky grammar, Berynda lexicon, polemical prose, Cossack
+  chronicles, Orlyk's Constitution, and Skovoroda.
+- Treat chancery formulae, legal vocabulary, diglossia, orthography, and
+  paleography as factual content requiring source support.
+- Do not modernize, normalize, or silently repair source spelling inside
+  verbatim examples.
+
+## Helpers And Headroom
+
+Use helpers for source passage discovery, edition comparison, rights
+classification, and terminology review. Compress long source tables or
+transcription comparisons with Headroom.
+
+## Validation Commands
+
+Adapt to current target layout:
+
+```bash
+.venv/bin/python - <<'PY'
+from pathlib import Path
+import yaml
+for path in sorted(Path("curriculum/l2-uk-en/plans/ruth").glob("*.yaml")):
+    yaml.safe_load(path.read_text(encoding="utf-8"))
+print("ruth plans parse")
+PY
+git diff --check
+.venv/bin/python scripts/audit/lint_agent_trailer.py
+```
+
+For built modules, add the current sidecar, MDX, reading, and site validation
+commands from `shared/validation-checklist.md`.
+
+## Expected Final Response
+
+```text
+RUTH stage: <preflight | production | quality-audit | remediation>
+Scope: <slugs or audit report>
+Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>
+Files changed: <paths>
+Validation run: <commands and outcomes>
+Independent review: <status>
+Forbidden artifacts included: no
+swarm_used: true/false
+swarm_label: <none | helper | swarm>
+swarm_note: <helpers used, or solo run; no swarm used>
+```

--- a/docs/prompts/orchestrators/ruth/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/ruth/suite-orchestrator.md
@@ -134,6 +134,7 @@ Scope: <slugs or audit report>
 Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>
 Files changed: <paths>
 Validation run: <commands and outcomes>
+Telemetry: <posted | not module-build | unavailable with reason>
 Independent review: <status>
 Forbidden artifacts included: no
 swarm_used: true/false

--- a/docs/prompts/orchestrators/shared/seminar-source-rules.md
+++ b/docs/prompts/orchestrators/shared/seminar-source-rules.md
@@ -1,16 +1,16 @@
 # Shared Seminar Source Rules
 
-Prompt suite component version: 0.1
-Last reviewed: 2026-06-21
+Prompt suite component version: 0.2
+Last reviewed: 2026-06-22
 
-Use these rules for seminar tracks such as FOLK, HIST, BIO, LIT, ISTORIO, OES, and RUTH. Adapt them to the target track; do not copy core CEFR assumptions into seminar work.
+Use these rules for seminar tracks such as FOLK, HIST, BIO, LIT, active LIT subtracks, ISTORIO, OES, and RUTH. Adapt them to the target track; do not copy core CEFR assumptions into seminar work.
 
 ## Active Track Taxonomy
 
 - Verify active track names from the current repo before writing prompts or modules.
 - Prefer active source/site directories and `curriculum.yaml` over stale plan-only leftovers.
 - Do not create prompt suites for plan-only remnants such as `lit-crimea` or `lit-doc` unless the current curriculum and site manifest say they are active tracks.
-- For LIT work, create separate prompt suites for the active `lit` and active `lit-*` tracks that exist in the current manifest.
+- For LIT work, create separate prompt suites for the active `lit` and active `lit-*` tracks that exist in the current manifest. In the current taxonomy, `lit-youth` is the active children's/YA track; older docs may call the same planning area `LIT-JUVENILE`.
 
 ## Source Universe
 
@@ -18,6 +18,7 @@ Use these rules for seminar tracks such as FOLK, HIST, BIO, LIT, ISTORIO, OES, a
 - Do not invent titles, authors, collectors, publication dates, source IDs, or citations.
 - For FOLK, inspect `docs/folk-epic/EXEMPLAR-STANDARD.md`, `docs/folk-epic/folk-review-rubric.md`, `docs/folk-epic/folk-text-layer-spec.md`, and `scripts/build/phases/linear-write-seminar-folk-rules.md`.
 - For later seminar tracks, inspect the closest track-specific audit and rubric files before adapting FOLK rules.
+- For historical-linguistic tracks OES and RUTH, treat source passages, orthography, paleography, register, and terminology as factual content. Do not use "Old Russian" or "Common East Slavic" framing where the track docs require Old Rus' / Old Ukrainian / Ruthenian terminology.
 
 ## Quote And Claim Integrity
 


### PR DESCRIPTION
## Summary

Adds combined `suite-orchestrator.md` prompts for the remaining non-B2 tracks: C1, C2, HIST, BIO, active LIT tracks, ISTORIO, OES, and RUTH. Updates the orchestrator README index and shared seminar source rules so future seminar suites reuse the reading/copyright/source pattern while staying track-specific.

## Scope guard

- B2 untouched: no `docs/prompts/orchestrators/b2/**` files changed.
- No prompt suites added for stale `lit-crimea` or `lit-doc`.
- 17 files changed, all under `docs/prompts/orchestrators/**`.
- No generated `status/`, `audit/`, `review/`, or `data/telemetry/**` artifacts.
- No protected config changes.

## Validation

- `/Users/krisztiankoos/projects/learn-ukrainian/node_modules/.bin/markdownlint-cli2 "docs/prompts/orchestrators/README.md" "docs/prompts/orchestrators/shared/*.md" "docs/prompts/orchestrators/*/suite-orchestrator.md"`
- `.venv/bin/python` required-section/shared-reference check for all suite files
- `.venv/bin/python` YAML parse check for all remaining track plan dirs
- `git diff --check` and `git diff --cached --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Telemetry

Not a module-build PR. `swarm_used: false`; `swarm_note: solo orchestrator prompt docs run; no swarm used`.

## Review focus

Please review that the suite pattern transfers cleanly to seminar tracks, that B2 remains untouched, that `lit-crimea`/`lit-doc` stay excluded, and that ISTORIO/OES/RUTH source terminology and reading/copyright requirements are strict enough.