### PR TITLE
[codex] feat(readings): primary-text demand manifest (Phase 0)

### DIFF
--- a/scripts/readings/primary_text_demand.py
+++ b/scripts/readings/primary_text_demand.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Build the primary-text demand manifest from curriculum plan references."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+import unicodedata
+from collections import Counter
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.generate_mdx.reading_links import normalize_work_title
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_PLANS_DIR = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "plans"
+DEFAULT_OUT = PROJECT_ROOT / "data" / "primary_text_demand.json"
+STRESS_MARKS = {"\u0300", "\u0301"}
+WHITESPACE_RE = re.compile(r"\s+")
+
+
+@dataclass(frozen=True)
+class PrimaryReference:
+    """One primary reference selected from one plan."""
+
+    work: str
+    author: str
+    note: str
+    path: str
+    slug: str
+    track: str
+    grade: Any
+
+
+@dataclass
+class RegistryAccumulator:
+    """Mutable aggregation bucket for one normalized work/author key."""
+
+    work: str
+    author: str
+    normalized_key: str
+    taught_by: dict[tuple[str, str, str], dict[str, Any]] = field(default_factory=dict)
+    note_samples: set[str] = field(default_factory=set)
+    paths: set[str] = field(default_factory=set)
+
+    def add(self, ref: PrimaryReference) -> None:
+        module_key = (ref.track, ref.slug, _grade_key(ref.grade))
+        self.taught_by.setdefault(
+            module_key,
+            {
+                "slug": ref.slug,
+                "track": ref.track,
+                "grade": ref.grade,
+            },
+        )
+        if ref.note:
+            self.note_samples.add(ref.note)
+        if ref.path:
+            self.paths.add(ref.path)
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "work": self.work,
+            "author": self.author,
+            "normalized_key": self.normalized_key,
+            "taught_by": sorted(
+                self.taught_by.values(),
+                key=lambda item: (item["track"], item["slug"], _grade_key(item["grade"])),
+            ),
+            "note_samples": sorted(self.note_samples),
+            "paths": sorted(self.paths),
+        }
+
+
+def normalize_author(author: str) -> str:
+    """Normalize an author name for registry dedupe."""
+    if not author:
+        return ""
+
+    decomposed = unicodedata.normalize("NFD", author)
+    chars: list[str] = []
+    for char in decomposed:
+        if char in STRESS_MARKS:
+            continue
+        if unicodedata.category(char).startswith("P"):
+            chars.append(" ")
+            continue
+        chars.append(char)
+
+    normalized = unicodedata.normalize("NFC", "".join(chars))
+    return WHITESPACE_RE.sub(" ", normalized).strip().casefold()
+
+
+def normalized_key(work: str, author: str) -> str:
+    """Return the stable manifest key for a work/author pair."""
+    return f"{normalize_work_title(work)}::{normalize_author(author)}"
+
+
+def build_manifest(plans_dir: Path = DEFAULT_PLANS_DIR, *, track: str | None = None) -> dict[str, Any]:
+    """Scan plan YAML files and return the demand manifest payload."""
+    refs = collect_primary_references(plans_dir, track=track)
+    buckets: dict[str, RegistryAccumulator] = {}
+    per_track_counts: Counter[str] = Counter()
+
+    for ref in refs:
+        key = normalized_key(ref.work, ref.author)
+        if not key.startswith("::"):
+            buckets.setdefault(key, RegistryAccumulator(ref.work, ref.author, key)).add(ref)
+            per_track_counts[ref.track] += 1
+
+    entries = [bucket.to_json() for _, bucket in sorted(buckets.items())]
+    summary = {
+        "total_distinct_works": len(entries),
+        "total_primary_refs": sum(per_track_counts.values()),
+        "per_track_counts": dict(sorted(per_track_counts.items())),
+        "works_taught_by_multiple_modules": sum(1 for entry in entries if len(entry["taught_by"]) > 1),
+    }
+    return {"summary": summary, "entries": entries}
+
+
+def collect_primary_references(plans_dir: Path, *, track: str | None = None) -> list[PrimaryReference]:
+    """Collect valid ``type: primary`` references from plan files."""
+    refs: list[PrimaryReference] = []
+    for plan_path in _plan_paths(plans_dir, track=track):
+        plan = _load_plan(plan_path)
+        if plan is None:
+            continue
+        references = plan.get("references")
+        if references is None:
+            LOGGER.warning("Skipping %s: no references list", _display_path(plan_path))
+            continue
+        if not isinstance(references, list):
+            LOGGER.warning("Skipping %s: references is not a list", _display_path(plan_path))
+            continue
+
+        grade = _grade_hint(plan)
+        plan_track = plan_path.parent.name
+        slug = plan_path.stem
+        for index, item in enumerate(references):
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") != "primary":
+                continue
+            work = _text_field(item.get("work")) or _text_field(item.get("title"))
+            if not work:
+                LOGGER.warning("Skipping %s reference %s: primary reference has no work/title", plan_path, index)
+                continue
+            refs.append(
+                PrimaryReference(
+                    work=work,
+                    author=_text_field(item.get("author")),
+                    note=_text_field(item.get("note")),
+                    path=_text_field(item.get("path")),
+                    slug=slug,
+                    track=plan_track,
+                    grade=grade,
+                )
+            )
+    return refs
+
+
+def write_manifest(manifest: dict[str, Any], out_path: Path) -> None:
+    """Write the manifest JSON with stable formatting."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def format_summary(summary: dict[str, Any]) -> str:
+    """Render the summary block for CLI output."""
+    lines = [
+        "Primary text demand summary",
+        f"total_distinct_works: {summary['total_distinct_works']}",
+        f"total_primary_refs: {summary['total_primary_refs']}",
+        f"works_taught_by_multiple_modules: {summary['works_taught_by_multiple_modules']}",
+        "per_track_counts:",
+    ]
+    for track, count in summary["per_track_counts"].items():
+        lines.append(f"  {track}: {count}")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT, help="Manifest JSON output path")
+    parser.add_argument("--track", help="Only scan plans whose parent directory matches this track")
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Print summary to stdout and skip writing the manifest file",
+    )
+    parser.add_argument("--plans-dir", type=Path, default=DEFAULT_PLANS_DIR, help="Plan YAML root to scan")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    logging.basicConfig(level=logging.WARNING, format="warning: %(message)s")
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    manifest = build_manifest(args.plans_dir, track=args.track)
+
+    if args.summary:
+        print(format_summary(manifest["summary"]))
+        return 0
+
+    write_manifest(manifest, args.out)
+    return 0
+
+
+def _plan_paths(plans_dir: Path, *, track: str | None) -> list[Path]:
+    if not plans_dir.is_dir():
+        LOGGER.warning("Skipping %s: plans directory does not exist", _display_path(plans_dir))
+        return []
+    paths = [
+        path
+        for path in sorted(plans_dir.rglob("*.yaml"))
+        if len(path.relative_to(plans_dir).parts) == 2
+    ]
+    if track is None:
+        return paths
+    return [path for path in paths if path.parent.name == track]
+
+
+def _load_plan(plan_path: Path) -> dict[str, Any] | None:
+    try:
+        raw = yaml.safe_load(plan_path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        LOGGER.warning("Skipping %s: malformed YAML: %s", _display_path(plan_path), exc)
+        return None
+    except OSError as exc:
+        LOGGER.warning("Skipping %s: cannot read file: %s", _display_path(plan_path), exc)
+        return None
+    if not isinstance(raw, dict):
+        LOGGER.warning("Skipping %s: YAML document is not a mapping", _display_path(plan_path))
+        return None
+    return raw
+
+
+def _text_field(value: Any) -> str:
+    if value is None or isinstance(value, bool | list | dict):
+        return ""
+    return str(value).strip()
+
+
+def _grade_hint(plan: dict[str, Any]) -> Any:
+    for key in ("grade", "level"):
+        if key in plan and plan[key] is not None:
+            return plan[key]
+    return None
+
+
+def _grade_key(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return path.relative_to(PROJECT_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_primary_text_demand.py
+++ b/tests/test_primary_text_demand.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from scripts.readings.primary_text_demand import build_manifest, main
+
+
+def test_primary_text_manifest_dedupes_primary_refs(tmp_path: Path) -> None:
+    plans_dir = _write_plan_fixture(tmp_path)
+
+    manifest = build_manifest(plans_dir)
+
+    assert manifest["summary"] == {
+        "total_distinct_works": 2,
+        "total_primary_refs": 3,
+        "per_track_counts": {"folk": 1, "hist": 1, "lit": 1},
+        "works_taught_by_multiple_modules": 1,
+    }
+    works = {entry["work"]: entry for entry in manifest["entries"]}
+    assert "Академічна стаття" not in works
+    assert sorted(works) == ["Лісова пісня", "Руська Правда"]
+
+    forest_song = works["Лісова пісня"]
+    assert forest_song["author"] == "Ле́ся Українка"
+    assert forest_song["normalized_key"] == "лісова пісня::леся українка"
+    assert forest_song["note_samples"] == ["драма-феєрія", "спільний семінарний текст"]
+    assert forest_song["paths"] == ["https://example.test/lisova-pisnia"]
+    assert forest_song["taught_by"] == [
+        {"slug": "ritual-forest", "track": "folk", "grade": "FOLK"},
+        {"slug": "forest-song", "track": "lit", "grade": "LIT"},
+    ]
+
+    assert works["Руська Правда"]["author"] == "Ярославове коло"
+    assert works["Руська Правда"]["taught_by"] == [
+        {"slug": "ruska-pravda", "track": "hist", "grade": None}
+    ]
+
+    folk_only = build_manifest(plans_dir, track="folk")
+    assert folk_only["summary"] == {
+        "total_distinct_works": 1,
+        "total_primary_refs": 1,
+        "per_track_counts": {"folk": 1},
+        "works_taught_by_multiple_modules": 0,
+    }
+
+
+def test_primary_text_manifest_cli_writes_json(tmp_path: Path) -> None:
+    plans_dir = _write_plan_fixture(tmp_path)
+    out_path = tmp_path / "demand.json"
+
+    assert main(["--plans-dir", str(plans_dir), "--out", str(out_path)]) == 0
+
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload["summary"]["total_primary_refs"] == 3
+    assert len(payload["entries"]) == 2
+
+
+def test_primary_text_manifest_summary_skips_file_write(tmp_path: Path, capsys) -> None:
+    plans_dir = _write_plan_fixture(tmp_path)
+    out_path = tmp_path / "should-not-exist.json"
+
+    assert main(["--plans-dir", str(plans_dir), "--out", str(out_path), "--summary"]) == 0
+
+    assert not out_path.exists()
+    assert capsys.readouterr().out == (
+        "Primary text demand summary\n"
+        "total_distinct_works: 2\n"
+        "total_primary_refs: 3\n"
+        "works_taught_by_multiple_modules: 1\n"
+        "per_track_counts:\n"
+        "  folk: 1\n"
+        "  hist: 1\n"
+        "  lit: 1\n"
+    )
+
+
+def test_primary_text_manifest_skips_malformed_yaml(tmp_path: Path, caplog) -> None:
+    plans_dir = _write_plan_fixture(tmp_path)
+    (plans_dir / "lit" / "broken.yaml").write_text("references: [", encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING):
+        manifest = build_manifest(plans_dir)
+
+    assert manifest["summary"]["total_primary_refs"] == 3
+    assert "malformed YAML" in caplog.text
+
+
+def _write_plan_fixture(tmp_path: Path) -> Path:
+    plans_dir = tmp_path / "plans"
+    (plans_dir / "lit").mkdir(parents=True)
+    (plans_dir / "folk").mkdir()
+    (plans_dir / "hist").mkdir()
+    (plans_dir / "lit" / "forest-song.yaml").write_text(
+        """
+level: LIT
+references:
+  - title: Лісова пісня
+    author: Леся Українка
+    type: primary
+    work: Лісова пісня
+    note: драма-феєрія
+    path: https://example.test/lisova-pisnia
+  - title: Академічна стаття
+    author: Дослідник
+    type: academic
+    work: Академічна стаття
+""",
+        encoding="utf-8",
+    )
+    (plans_dir / "folk" / "ritual-forest.yaml").write_text(
+        """
+level: FOLK
+references:
+  - title: "«Лісова пісня»"
+    author: "Ле́ся Українка"
+    type: primary
+    work: Лісова пісня
+    note: спільний семінарний текст
+""",
+        encoding="utf-8",
+    )
+    (plans_dir / "hist" / "ruska-pravda.yaml").write_text(
+        """
+references:
+  - title: Руська Правда
+    author: Ярославове коло
+    type: primary
+    note: title-only fallback
+""",
+        encoding="utf-8",
+    )
+    return plans_dir


### PR DESCRIPTION
## #M-4 deterministic preamble

| Claim | Evidence |
|---|---|
| tests pass | `.venv/bin/python -m pytest tests/test_primary_text_demand.py -q` |
| lint clean | `.venv/bin/ruff check scripts/readings/primary_text_demand.py tests/test_primary_text_demand.py` |
| manifest runs on real data | `.venv/bin/python scripts/readings/primary_text_demand.py --summary` |

### Tests pass

```text
============================== 4 passed in 0.34s ===============================
```

### Lint clean

```text
All checks passed!
```

### Manifest runs on real data

```text
Primary text demand summary
total_distinct_works: 1882
total_primary_refs: 2493
works_taught_by_multiple_modules: 224
per_track_counts:
  bio: 482
  folk: 58
  hist: 289
  istorio: 330
  lit: 516
  lit-crimea: 25
  lit-doc: 20
  lit-drama: 35
  lit-essay: 117
  lit-fantastika: 37
  lit-hist-fic: 36
  lit-humor: 26
  lit-war: 48
  lit-youth: 42
  oes: 232
  ruth: 200
```

## Summary

Implements Phase 0 of the approved primary-text demand inventory plan for #2836.

- Adds `scripts/readings/primary_text_demand.py` to scan active `curriculum/l2-uk-en/plans/<track>/<slug>.yaml` plans, select `type: primary` references, dedupe by normalized `(work, author)`, and emit `summary` plus sorted `entries` JSON.
- Reuses `normalize_work_title` from `scripts/generate_mdx/reading_links.py` for work keys and applies matching stress/punctuation normalization for authors.
- Adds targeted tests for primary-only selection, cross-track dedupe, `title` fallback, `--track`, `--summary`, JSON writing, and malformed-YAML skip behavior.

## Notes

The dispatch referenced `docs/plans/purring-crafting-lovelace.md`; that file is not present in this worktree or `origin/main`, so the implementation follows the approved Phase 0/component 1 contract from the dispatch brief. No generated `data/primary_text_demand.json` file is committed; the script writes it by default unless `--summary` is used.

Refs #2836.