### PR TITLE
docs: harden orchestrator prompt suite checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ on:
       - 'gemini_extensions/**'
       - 'scripts/build/phases/**/*.md'
       - 'scripts/build/contracts/**/*.md'
+      - 'docs/prompts/orchestrators/**'
       - 'docs/lesson-contract.md'
       - 'docs/lesson-schema.yaml'
       - 'site/**'
@@ -136,6 +137,7 @@ jobs:
               - 'agents_extensions/codex/**'
               - 'gemini_extensions/**'
               - 'scripts/build/phases/**/*.md'
+              - 'docs/prompts/orchestrators/**'
             lesson_schema:
               - '.github/workflows/ci.yml'
               - 'docs/lesson-contract.md'

--- a/docs/prompts/orchestrators/README.md
+++ b/docs/prompts/orchestrators/README.md
@@ -58,6 +58,16 @@ FOLK is the pilot seminar track. Its prompts should be treated as the model for 
 - `shared/review-output-schema.md`: durable audit report schema and issue inventory format.
 - `shared/seminar-source-rules.md`: seminar-track source, decolonization, quote, and active-track taxonomy rules.
 - `shared/reading-section-rules.md`: primary-reading and global reading-reference rules, including copyright decisions.
+- `shared/reading-catalog-template.md`: structured primary/source reading candidate template with hosting decisions and blocker fields.
+- `shared/seminar-track-checklists.md`: track-specific source families and high-risk checks for HIST, BIO, LIT, ISTORIO, OES, and RUTH.
+
+## Automated Prompt Guards
+
+`scripts/lint/lint_prompts.py` validates the suite prompt surface in CI. It
+checks active-track coverage against `curriculum/l2-uk-en/curriculum.yaml`,
+rejects stale prompt directories such as `lit-crimea` and `lit-doc`, and enforces
+required suite sections, worktree sanity commands, forbidden-write markers,
+seminar reading coverage, telemetry fields, and independent-review fields.
 
 Each level prompt references these shared files, but also restates the critical rules so it remains usable when pasted alone into Codex, Gemini, or Claude.
 

--- a/docs/prompts/orchestrators/lit-drama/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-drama/suite-orchestrator.md
@@ -55,7 +55,8 @@ git rev-parse --show-toplevel
 - `docs/prompts/orchestrators/b2/**`
 - inactive `lit-crimea` or `lit-doc` prompt/source work
 - non-hostable copyrighted full scripts or performance recordings
-- protected configs, generated status/audit/review artifacts, and `data/telemetry/**`
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- generated `status/`, curriculum `audit/`, curriculum `review/`, and `data/telemetry/**` artifacts
 
 ## Lifecycle Rules
 

--- a/docs/prompts/orchestrators/lit-essay/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-essay/suite-orchestrator.md
@@ -54,7 +54,8 @@ git rev-parse --show-toplevel
 - `docs/prompts/orchestrators/b2/**`
 - inactive `lit-crimea` or `lit-doc` work
 - non-hostable copyrighted essays or excerpts beyond compliant limits
-- protected configs, generated status/audit/review artifacts, and `data/telemetry/**`
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- generated `status/`, curriculum `audit/`, curriculum `review/`, and `data/telemetry/**` artifacts
 
 ## Lifecycle Rules
 

--- a/docs/prompts/orchestrators/lit-fantastika/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-fantastika/suite-orchestrator.md
@@ -54,7 +54,8 @@ git rev-parse --show-toplevel
 - `docs/prompts/orchestrators/b2/**`
 - inactive LIT remnants
 - non-hostable copyrighted contemporary fiction
-- protected configs, generated status/audit/review artifacts, and `data/telemetry/**`
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- generated `status/`, curriculum `audit/`, curriculum `review/`, and `data/telemetry/**` artifacts
 
 ## Lifecycle Rules
 

--- a/docs/prompts/orchestrators/lit-hist-fic/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-hist-fic/suite-orchestrator.md
@@ -54,7 +54,8 @@ git rev-parse --show-toplevel
 - `docs/prompts/orchestrators/b2/**`
 - inactive LIT remnants
 - non-hostable copyrighted novels or long excerpts
-- protected configs, generated status/audit/review artifacts, and `data/telemetry/**`
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- generated `status/`, curriculum `audit/`, curriculum `review/`, and `data/telemetry/**` artifacts
 
 ## Lifecycle Rules
 

--- a/docs/prompts/orchestrators/lit-humor/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-humor/suite-orchestrator.md
@@ -54,7 +54,8 @@ git rev-parse --show-toplevel
 - `docs/prompts/orchestrators/b2/**`
 - inactive LIT remnants
 - non-hostable copyrighted humor, scripts, or meme images
-- protected configs, generated status/audit/review artifacts, and `data/telemetry/**`
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- generated `status/`, curriculum `audit/`, curriculum `review/`, and `data/telemetry/**` artifacts
 
 ## Lifecycle Rules
 

--- a/docs/prompts/orchestrators/lit-war/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-war/suite-orchestrator.md
@@ -54,7 +54,8 @@ git rev-parse --show-toplevel
 - `docs/prompts/orchestrators/b2/**`
 - inactive LIT remnants
 - non-hostable full contemporary texts, captivity images, or propaganda-origin media
-- protected configs, generated status/audit/review artifacts, and `data/telemetry/**`
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- generated `status/`, curriculum `audit/`, curriculum `review/`, and `data/telemetry/**` artifacts
 
 ## Lifecycle Rules
 

--- a/docs/prompts/orchestrators/lit-youth/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/lit-youth/suite-orchestrator.md
@@ -54,7 +54,8 @@ git rev-parse --show-toplevel
 - `docs/prompts/orchestrators/b2/**`
 - a separate `lit-juvenile`, `lit-doc`, or `lit-crimea` prompt suite
 - non-hostable full children's/YA texts or illustrations
-- protected configs, generated status/audit/review artifacts, and `data/telemetry/**`
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- generated `status/`, curriculum `audit/`, curriculum `review/`, and `data/telemetry/**` artifacts
 
 ## Lifecycle Rules
 

--- a/docs/prompts/orchestrators/shared/reading-catalog-template.md
+++ b/docs/prompts/orchestrators/shared/reading-catalog-template.md
@@ -1,0 +1,78 @@
+# Shared Reading Catalog Template
+
+Prompt suite component version: 0.1
+Last reviewed: 2026-06-22
+
+Use this template during seminar preflight and production when a module needs a
+primary/source reading layer. The catalog is a search record and rights decision
+log; it is not limited to readings already available in the repo.
+
+## Required Candidate Fields
+
+Each candidate should carry these fields when known:
+
+```yaml
+- title: ""
+  title_en: ""
+  author: ""
+  collector: ""
+  genre: ""
+  track: ""
+  module_slug: ""
+  source_type: primary
+  source_family: ""
+  source_edition: ""
+  source_url: ""
+  source_id: ""
+  text_identity_verified: false
+  license: ""
+  copyright_status: unknown
+  hosting_decision: reading-needed
+  reading_slug: ""
+  excerpt_allowed: false
+  quote_status: do-not-quote
+  verification_notes: ""
+  learner_task: ""
+  blocker: true
+```
+
+## Hosting Decisions
+
+Use exactly one `hosting_decision` per candidate:
+
+- `hosted`: public-domain or otherwise clearly hostable; create or update the
+  hosted reading file and keep provenance in frontmatter.
+- `linked-only`: stable learner-safe source URL exists, but hosting is not
+  allowed or rights are uncertain.
+- `excerpt-only`: a short compliant excerpt may be quoted, but full hosting is
+  not allowed.
+- `omit`: source is unreliable, unsafe, duplicate, or pedagogically unsuitable;
+  keep the search note so the omission is reviewable.
+- `reading-needed`: the module needs this source, but no verified usable text or
+  rights decision exists yet. Treat unresolved `reading-needed` items as
+  blockers for production unless the stage is explicitly preflight-only.
+
+## Verification Rules
+
+- `source_type` for catalog candidates must be `primary`. Secondary scholarship
+  belongs in references, not in the reading catalog.
+- `text_identity_verified: true` means the title, author or collector, edition,
+  and text are matched to a specific source. Do not set it from memory.
+- `quote_status` should be one of `verified`, `paraphrase-only`, or
+  `do-not-quote`.
+- `reading_slug` is required only for `hosted` readings.
+- `learner_task` should describe what the student does with the text, not just
+  where the text came from.
+
+## Preflight Summary Format
+
+```text
+Reading coverage:
+- hosted: <count>
+- linked-only: <count>
+- excerpt-only: <count>
+- omit: <count>
+- reading-needed: <count>
+Primary source families checked: <list>
+Unresolved blockers: <none | source/rights/text-identity issues>
+```

--- a/docs/prompts/orchestrators/shared/reading-section-rules.md
+++ b/docs/prompts/orchestrators/shared/reading-section-rules.md
@@ -37,7 +37,9 @@ Current hosted readings require explicit `public_domain: true` in frontmatter. D
 
 ## Plan And Resource Fields
 
-When the current track plan supports a `readings:` block, include for each candidate:
+Use `docs/prompts/orchestrators/shared/reading-catalog-template.md` for the
+preflight search record and rights decision log. When the current track plan
+supports a `readings:` block, include for each candidate:
 
 - `title`
 - `title_en` when useful
@@ -57,7 +59,8 @@ Every reading candidate must carry a decision:
 - `hosted`: public-domain or otherwise clearly hostable; create/update `site/src/content/readings/<slug>.mdx`.
 - `linked-only`: not hostable or uncertain, but a stable public teaching/source URL exists; add `role: reading` link and learner task.
 - `excerpt-only`: only a short compliant excerpt may be quoted; link to the original when possible.
-- `omit`: no reliable or legally usable source found yet; record the search and leave a reading-needed blocker.
+- `omit`: no reliable, learner-safe, or pedagogically usable source exists after search; record the search and reason.
+- `reading-needed`: the module needs the source, but no verified usable text or rights decision exists yet; record it as a blocker.
 
 Start with obvious public teaching/library sources such as Osvita when relevant, but verify the exact current domain, URL, license/copyright posture, and text identity. Do not invent `osvita` links or assume that a teaching site automatically grants republication rights.
 

--- a/docs/prompts/orchestrators/shared/seminar-source-rules.md
+++ b/docs/prompts/orchestrators/shared/seminar-source-rules.md
@@ -18,6 +18,7 @@ Use these rules for seminar tracks such as FOLK, HIST, BIO, LIT, active LIT subt
 - Do not invent titles, authors, collectors, publication dates, source IDs, or citations.
 - For FOLK, inspect `docs/folk-epic/EXEMPLAR-STANDARD.md`, `docs/folk-epic/folk-review-rubric.md`, `docs/folk-epic/folk-text-layer-spec.md`, and `scripts/build/phases/linear-write-seminar-folk-rules.md`.
 - For later seminar tracks, inspect the closest track-specific audit and rubric files before adapting FOLK rules.
+- Use `docs/prompts/orchestrators/shared/seminar-track-checklists.md` for track-specific source families and high-risk checks before adapting FOLK rules.
 - For historical-linguistic tracks OES and RUTH, treat source passages, orthography, paleography, register, and terminology as factual content. Do not use "Old Russian" or "Common East Slavic" framing where the track docs require Old Rus' / Old Ukrainian / Ruthenian terminology.
 
 ## Quote And Claim Integrity

--- a/docs/prompts/orchestrators/shared/seminar-track-checklists.md
+++ b/docs/prompts/orchestrators/shared/seminar-track-checklists.md
@@ -1,0 +1,117 @@
+# Shared Seminar Track Checklists
+
+Prompt suite component version: 0.1
+Last reviewed: 2026-06-22
+
+Use this file with `seminar-source-rules.md` before adapting FOLK patterns to a
+new seminar batch. It lists source families and high-risk checks; it is not a
+substitute for reading the current plan, dossier, registry, and local sources.
+
+## All Seminar Tracks
+
+- Confirm the track is active in `curriculum/l2-uk-en/curriculum.yaml` and site
+  content, not just present in old plan directories.
+- Build the reading catalog from primary/source texts first, then add secondary
+  references separately.
+- Classify every reading candidate with
+  `hosted`, `linked-only`, `excerpt-only`, `omit`, or `reading-needed`.
+- Treat invented source titles, unverifiable quotes, broken reading links,
+  unresolved rights, and flattening colonial terminology as blockers.
+
+## HIST
+
+Source families:
+
+- Chronicles, legal acts, treaties, state documents, memoirs, letters, oral
+  histories, testimony, maps, speeches, propaganda artifacts, photographs, and
+  archival excerpts where rights allow.
+
+High-risk checks:
+
+- Separate primary evidence, textbook synthesis, historiography, and memory
+  politics.
+- Avoid neutralizing Russian imperial, Soviet, or Russian Federation violence.
+- Include regional, Crimean Tatar, Jewish, Polish, diaspora, and other
+  perspectives only when source-grounded.
+
+## BIO
+
+Source families:
+
+- Autobiographical writing, letters, diaries, interviews, speeches, court or
+  state documents, contemporaneous press, portraits or photographs, and reliable
+  biographical scholarship.
+
+High-risk checks:
+
+- Use source-tier dossiers and mark weakly sourced life claims.
+- Separate portrait/image rights from text-reading rights.
+- For politically charged figures, state contested frames directly and do not
+  launder imperial, Soviet, or collaborationist narratives.
+
+## LIT And Active LIT Subtracks
+
+Source families:
+
+- Poems, prose excerpts, drama scenes, essays, pamphlets, letters, diaries,
+  manifestos, interviews, authorial notes, and performance/source recordings
+  where rights allow.
+
+High-risk checks:
+
+- Ukrainian literature is an independent tradition, not a branch of Russian
+  letters.
+- Do not use `lit-crimea` or `lit-doc` unless they become active manifest
+  tracks again.
+- For `lit-youth`, remember that older planning docs may say `LIT-JUVENILE`.
+- Contemporary war, YA, drama, and speculative texts often require
+  `linked-only` or `excerpt-only` decisions.
+
+## ISTORIO
+
+Source families:
+
+- Historiographic essays, methodological texts, primary documents used as case
+  studies, archival excerpts, memory-policy documents, reviews, and competing
+  interpretive schools.
+
+High-risk checks:
+
+- Identify whether a reading is primary evidence, historiographic argument, or
+  memory-politics artifact.
+- Do not treat Russian imperial or Soviet historiography as neutral authority.
+- Name competing interpretations and their source base when a topic is
+  contested.
+
+## OES
+
+Source families:
+
+- St Sophia graffiti, birch bark letters, Povist vremennykh lit, Ruska Pravda,
+  sermons, hagiography, inscriptions, charters, Slovo o polku Ihorevim, and
+  edition/transcription notes.
+
+High-risk checks:
+
+- Use Old Rus' / Old Ukrainian terminology required by the track. Do not write
+  "Old Russian" or flatten the material into a uniform "Common East Slavic"
+  language.
+- Distinguish high/literary, legal, and vernacular registers.
+- Treat orthography, paleography, source spelling, and transliteration as
+  factual content.
+
+## RUTH
+
+Source families:
+
+- Lithuanian Statutes, charters, chancery records, Peresopnytsia Gospel, Ostrih
+  Bible, Smotrytsky grammar, Berynda lexicon, polemical prose, Cossack
+  chronicles, Orlyk's Constitution, Skovoroda, and edition/transcription notes.
+
+High-risk checks:
+
+- Distinguish Ruthenian, Prosta Mova, Church Slavonic, Polish, Latin, and modern
+  Ukrainian layers.
+- Treat chancery formulae, legal vocabulary, diglossia, orthography, and
+  paleography as factual content.
+- Do not modernize or silently repair source spelling inside verbatim examples.

--- a/scripts/lint/lint_prompts.py
+++ b/scripts/lint/lint_prompts.py
@@ -302,10 +302,16 @@ def extract_section(text: str, heading: str) -> str:
 
 def extract_curriculum_level_keys(manifest_path: Path = CURRICULUM_MANIFEST) -> set[str]:
     """Extract active level/track keys from curriculum.yaml without PyYAML."""
-    if not manifest_path.exists():
-        return set()
+    return set(extract_curriculum_level_types(manifest_path))
 
-    keys: set[str] = set()
+
+def extract_curriculum_level_types(manifest_path: Path = CURRICULUM_MANIFEST) -> dict[str, str]:
+    """Extract active level/track types from curriculum.yaml without PyYAML."""
+    if not manifest_path.exists():
+        return {}
+
+    level_types: dict[str, str] = {}
+    current_level: str | None = None
     in_levels = False
     for raw_line in manifest_path.read_text(encoding="utf-8").splitlines():
         if raw_line.strip() == "levels:":
@@ -313,12 +319,19 @@ def extract_curriculum_level_keys(manifest_path: Path = CURRICULUM_MANIFEST) -> 
             continue
         if not in_levels:
             continue
-        if raw_line and not raw_line.startswith(" "):
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        if not raw_line.startswith(" "):
             break
-        match = re.match(r"^  ([a-z0-9][a-z0-9-]*):\s*$", raw_line)
-        if match:
-            keys.add(match.group(1))
-    return keys
+        level_match = re.match(r"^  ([a-z0-9][a-z0-9-]*):\s*$", raw_line)
+        if level_match:
+            current_level = level_match.group(1)
+            level_types.setdefault(current_level, "")
+            continue
+        type_match = re.match(r"^    type:\s*([a-z0-9_-]+)\s*(?:#.*)?$", raw_line)
+        if current_level and type_match:
+            level_types[current_level] = type_match.group(1)
+    return level_types
 
 
 def require_markers(
@@ -344,7 +357,12 @@ def require_markers(
     ]
 
 
-def check_suite_final_response(filepath: Path, text: str, track: str) -> list[dict]:
+def check_suite_final_response(
+    filepath: Path,
+    text: str,
+    track: str,
+    seminar_tracks: set[str],
+) -> list[dict]:
     """Validate the Expected Final Response contract."""
     final_section = extract_section(text, "## Expected Final Response")
     violations = require_markers(
@@ -365,7 +383,7 @@ def check_suite_final_response(filepath: Path, text: str, track: str) -> list[di
         line_anchor="## Expected Final Response",
     )
     reading_field = "Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>"
-    if track in SEMINAR_SUITE_TRACKS and reading_field not in final_section:
+    if track in seminar_tracks and reading_field not in final_section:
         violations.append(make_violation(
             "ORCH_SUITE_READING_COVERAGE",
             f"Seminar suite final response missing field: {reading_field}",
@@ -375,9 +393,14 @@ def check_suite_final_response(filepath: Path, text: str, track: str) -> list[di
     return violations
 
 
-def check_suite_seminar_references(filepath: Path, text: str, track: str) -> list[dict]:
+def check_suite_seminar_references(
+    filepath: Path,
+    text: str,
+    track: str,
+    seminar_tracks: set[str],
+) -> list[dict]:
     """Validate seminar-only shared references."""
-    if track not in SEMINAR_SUITE_TRACKS:
+    if track not in seminar_tracks:
         return []
     return require_markers(
         text,
@@ -388,11 +411,15 @@ def check_suite_seminar_references(filepath: Path, text: str, track: str) -> lis
     )
 
 
-def check_orchestrator_suite_file(filepath: Path) -> list[dict]:
+def check_orchestrator_suite_file(
+    filepath: Path,
+    seminar_tracks: set[str] | None = None,
+) -> list[dict]:
     """Validate one suite-orchestrator prompt contract."""
     violations: list[dict] = []
     text = filepath.read_text(encoding="utf-8")
     track = filepath.parent.name
+    seminar_tracks = seminar_tracks or SEMINAR_SUITE_TRACKS
 
     violations.extend(require_markers(
         text,
@@ -428,8 +455,8 @@ def check_orchestrator_suite_file(filepath: Path) -> list[dict]:
         "Forbidden Writes missing protected marker",
         line_anchor="## Forbidden Writes",
     ))
-    violations.extend(check_suite_final_response(filepath, text, track))
-    violations.extend(check_suite_seminar_references(filepath, text, track))
+    violations.extend(check_suite_final_response(filepath, text, track, seminar_tracks))
+    violations.extend(check_suite_seminar_references(filepath, text, track, seminar_tracks))
     return violations
 
 
@@ -441,7 +468,7 @@ def check_orchestrator_track_coverage(
 ) -> list[dict]:
     """Validate prompt dirs and suites against active curriculum tracks."""
     violations: list[dict] = []
-    active_tracks = extract_curriculum_level_keys(manifest_path)
+    active_tracks = set(extract_curriculum_level_types(manifest_path))
     manifest_display = manifest_path if manifest_path.exists() else root
 
     for track in sorted(prompt_track_dirs - active_tracks):
@@ -491,6 +518,12 @@ def scan_orchestrator_suites(
     suite_tracks = {
         path.parent.name for path in root.glob("*/suite-orchestrator.md")
     }
+    seminar_tracks = {
+        track for track, track_type in extract_curriculum_level_types(manifest_path).items()
+        if track_type == "seminar"
+    }
+    if not seminar_tracks:
+        seminar_tracks = SEMINAR_SUITE_TRACKS
     violations.extend(check_orchestrator_track_coverage(
         root,
         manifest_path,
@@ -499,7 +532,7 @@ def scan_orchestrator_suites(
     ))
 
     for filepath in sorted(root.glob("*/suite-orchestrator.md")):
-        violations.extend(check_orchestrator_suite_file(filepath))
+        violations.extend(check_orchestrator_suite_file(filepath, seminar_tracks=seminar_tracks))
 
     return violations
 

--- a/scripts/lint/lint_prompts.py
+++ b/scripts/lint/lint_prompts.py
@@ -522,8 +522,7 @@ def scan_orchestrator_suites(
         track for track, track_type in extract_curriculum_level_types(manifest_path).items()
         if track_type == "seminar"
     }
-    if not seminar_tracks:
-        seminar_tracks = SEMINAR_SUITE_TRACKS
+    seminar_tracks |= SEMINAR_SUITE_TRACKS
     violations.extend(check_orchestrator_track_coverage(
         root,
         manifest_path,

--- a/scripts/lint/lint_prompts.py
+++ b/scripts/lint/lint_prompts.py
@@ -25,9 +25,72 @@ PROMPT_SCAN_DIRS = [
     PROJECT_ROOT / "agents_extensions/shared" / "phases",
 ]
 
+ORCHESTRATOR_PROMPT_ROOT = PROJECT_ROOT / "docs" / "prompts" / "orchestrators"
+CURRICULUM_MANIFEST = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "curriculum.yaml"
+
 # Directories to scan for curriculum research files (--curriculum mode)
 CURRICULUM_RESEARCH_DIRS = [
     PROJECT_ROOT / "curriculum" / "l2-uk-en",
+]
+
+LEGACY_NON_SUITE_PROMPT_TRACKS = {"a1", "a2", "b1", "b2", "folk"}
+SEMINAR_SUITE_TRACKS = {
+    "hist",
+    "bio",
+    "lit",
+    "lit-drama",
+    "lit-essay",
+    "lit-fantastika",
+    "lit-hist-fic",
+    "lit-humor",
+    "lit-war",
+    "lit-youth",
+    "istorio",
+    "oes",
+    "ruth",
+}
+
+SUITE_REQUIRED_MARKERS = [
+    "Prompt version:",
+    "## Source Assumptions",
+    "## Goal",
+    "## WORKTREE_ROOT Setup",
+    "## Read First",
+    "## Allowed Writes",
+    "## Forbidden Writes",
+    "## Helpers And Headroom",
+    "## Validation Commands",
+    "## Expected Final Response",
+]
+
+SUITE_SHARED_REFERENCES = [
+    "docs/prompts/orchestrators/shared/repo-rules.md",
+    "docs/prompts/orchestrators/shared/validation-checklist.md",
+    "docs/prompts/orchestrators/shared/telemetry-and-pr.md",
+    "docs/prompts/orchestrators/shared/review-output-schema.md",
+]
+
+SEMINAR_SHARED_REFERENCES = [
+    "docs/prompts/orchestrators/shared/seminar-source-rules.md",
+    "docs/prompts/orchestrators/shared/reading-section-rules.md",
+]
+
+WORKTREE_SANITY_MARKERS = [
+    ".worktrees/dispatch/codex/",
+    "pwd",
+    "git status --short --branch",
+    "git rev-parse --show-toplevel",
+]
+
+FORBIDDEN_WRITE_MARKERS = [
+    "docs/prompts/orchestrators/b2/**",
+    ".python-version",
+    ".yamllint",
+    ".markdownlint.json",
+    "status/",
+    "audit/",
+    "review/",
+    "data/telemetry/**",
 ]
 
 # ---------- RULES ----------
@@ -190,7 +253,255 @@ def scan_prompts() -> list[dict]:
             all_violations.extend(check_line_rules(filepath))
             all_violations.extend(check_file_level_rule(filepath))
 
+    all_violations.extend(scan_orchestrator_suites())
     return all_violations
+
+
+def make_violation(
+    rule: str,
+    message: str,
+    filepath: Path,
+    *,
+    severity: str = "error",
+    line: int = 1,
+    content: str = "",
+) -> dict:
+    """Return a linter violation in the existing prompt-lint shape."""
+    try:
+        rel_file = str(filepath.relative_to(PROJECT_ROOT))
+    except ValueError:
+        rel_file = str(filepath)
+    return {
+        "rule": rule,
+        "severity": severity,
+        "file": rel_file,
+        "line": line,
+        "message": message,
+        "content": content[:120],
+    }
+
+
+def line_number_for(text: str, needle: str) -> int:
+    """Return the 1-based line number for a substring, or 1 if absent."""
+    index = text.find(needle)
+    if index == -1:
+        return 1
+    return text[:index].count("\n") + 1
+
+
+def extract_section(text: str, heading: str) -> str:
+    """Extract a markdown H2 section body."""
+    start = text.find(heading)
+    if start == -1:
+        return ""
+    next_heading = text.find("\n## ", start + len(heading))
+    if next_heading == -1:
+        return text[start:]
+    return text[start:next_heading]
+
+
+def extract_curriculum_level_keys(manifest_path: Path = CURRICULUM_MANIFEST) -> set[str]:
+    """Extract active level/track keys from curriculum.yaml without PyYAML."""
+    if not manifest_path.exists():
+        return set()
+
+    keys: set[str] = set()
+    in_levels = False
+    for raw_line in manifest_path.read_text(encoding="utf-8").splitlines():
+        if raw_line.strip() == "levels:":
+            in_levels = True
+            continue
+        if not in_levels:
+            continue
+        if raw_line and not raw_line.startswith(" "):
+            break
+        match = re.match(r"^  ([a-z0-9][a-z0-9-]*):\s*$", raw_line)
+        if match:
+            keys.add(match.group(1))
+    return keys
+
+
+def require_markers(
+    text: str,
+    filepath: Path,
+    markers: list[str],
+    rule: str,
+    message_prefix: str,
+    *,
+    line_anchor: str | None = None,
+) -> list[dict]:
+    """Return violations for missing text markers."""
+    line = line_number_for(text, line_anchor) if line_anchor else 1
+    return [
+        make_violation(
+            rule,
+            f"{message_prefix}: {marker}",
+            filepath,
+            line=line,
+        )
+        for marker in markers
+        if marker not in text
+    ]
+
+
+def check_suite_final_response(filepath: Path, text: str, track: str) -> list[dict]:
+    """Validate the Expected Final Response contract."""
+    final_section = extract_section(text, "## Expected Final Response")
+    violations = require_markers(
+        final_section,
+        filepath,
+        [
+            "Files changed: <paths>",
+            "Validation run: <commands and outcomes>",
+            "Telemetry: <posted | not module-build | unavailable with reason>",
+            "Independent review: <status>",
+            "Forbidden artifacts included: no",
+            "swarm_used: true/false",
+            "swarm_label: <none | helper | swarm>",
+            "swarm_note: <helpers used, or solo run; no swarm used>",
+        ],
+        "ORCH_SUITE_FINAL_RESPONSE",
+        "Expected Final Response missing field",
+        line_anchor="## Expected Final Response",
+    )
+    reading_field = "Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>"
+    if track in SEMINAR_SUITE_TRACKS and reading_field not in final_section:
+        violations.append(make_violation(
+            "ORCH_SUITE_READING_COVERAGE",
+            f"Seminar suite final response missing field: {reading_field}",
+            filepath,
+            line=line_number_for(text, "## Expected Final Response"),
+        ))
+    return violations
+
+
+def check_suite_seminar_references(filepath: Path, text: str, track: str) -> list[dict]:
+    """Validate seminar-only shared references."""
+    if track not in SEMINAR_SUITE_TRACKS:
+        return []
+    return require_markers(
+        text,
+        filepath,
+        SEMINAR_SHARED_REFERENCES,
+        "ORCH_SUITE_SEMINAR_REFERENCE",
+        "Seminar suite missing shared reference",
+    )
+
+
+def check_orchestrator_suite_file(filepath: Path) -> list[dict]:
+    """Validate one suite-orchestrator prompt contract."""
+    violations: list[dict] = []
+    text = filepath.read_text(encoding="utf-8")
+    track = filepath.parent.name
+
+    violations.extend(require_markers(
+        text,
+        filepath,
+        SUITE_REQUIRED_MARKERS,
+        "ORCH_SUITE_REQUIRED_SECTION",
+        "Missing required suite marker",
+    ))
+    violations.extend(require_markers(
+        text,
+        filepath,
+        SUITE_SHARED_REFERENCES,
+        "ORCH_SUITE_SHARED_REFERENCE",
+        "Missing shared prompt reference",
+    ))
+
+    worktree_section = extract_section(text, "## WORKTREE_ROOT Setup")
+    violations.extend(require_markers(
+        worktree_section,
+        filepath,
+        WORKTREE_SANITY_MARKERS,
+        "ORCH_SUITE_WORKTREE_SANITY",
+        "WORKTREE_ROOT setup missing",
+        line_anchor="## WORKTREE_ROOT Setup",
+    ))
+
+    forbidden_section = extract_section(text, "## Forbidden Writes")
+    violations.extend(require_markers(
+        forbidden_section,
+        filepath,
+        FORBIDDEN_WRITE_MARKERS,
+        "ORCH_SUITE_FORBIDDEN_WRITE",
+        "Forbidden Writes missing protected marker",
+        line_anchor="## Forbidden Writes",
+    ))
+    violations.extend(check_suite_final_response(filepath, text, track))
+    violations.extend(check_suite_seminar_references(filepath, text, track))
+    return violations
+
+
+def check_orchestrator_track_coverage(
+    root: Path,
+    manifest_path: Path,
+    prompt_track_dirs: set[str],
+    suite_tracks: set[str],
+) -> list[dict]:
+    """Validate prompt dirs and suites against active curriculum tracks."""
+    violations: list[dict] = []
+    active_tracks = extract_curriculum_level_keys(manifest_path)
+    manifest_display = manifest_path if manifest_path.exists() else root
+
+    for track in sorted(prompt_track_dirs - active_tracks):
+        violations.append(make_violation(
+            "ORCH_TRACK_NOT_ACTIVE",
+            f"Prompt directory has no active curriculum.yaml level: {track}",
+            root / track,
+        ))
+
+    for track in sorted(active_tracks - prompt_track_dirs):
+        violations.append(make_violation(
+            "ORCH_ACTIVE_TRACK_MISSING_PROMPT",
+            f"Active curriculum.yaml level has no orchestrator prompt dir: {track}",
+            manifest_display,
+        ))
+
+    for track in sorted((active_tracks - LEGACY_NON_SUITE_PROMPT_TRACKS) - suite_tracks):
+        violations.append(make_violation(
+            "ORCH_ACTIVE_TRACK_MISSING_SUITE",
+            f"Active non-legacy track has no suite-orchestrator.md: {track}",
+            root / track,
+        ))
+
+    for stale_track in ["lit-crimea", "lit-doc"]:
+        if stale_track in prompt_track_dirs:
+            violations.append(make_violation(
+                "ORCH_STALE_LIT_TRACK",
+                f"Stale plan-only LIT track must not have prompt suite: {stale_track}",
+                root / stale_track,
+            ))
+    return violations
+
+
+def scan_orchestrator_suites(
+    root: Path = ORCHESTRATOR_PROMPT_ROOT,
+    manifest_path: Path = CURRICULUM_MANIFEST,
+) -> list[dict]:
+    """Validate orchestrator prompt suite coverage and contracts."""
+    if not root.exists():
+        return []
+
+    violations: list[dict] = []
+    prompt_track_dirs = {
+        path.name for path in root.iterdir()
+        if path.is_dir() and path.name != "shared"
+    }
+    suite_tracks = {
+        path.parent.name for path in root.glob("*/suite-orchestrator.md")
+    }
+    violations.extend(check_orchestrator_track_coverage(
+        root,
+        manifest_path,
+        prompt_track_dirs,
+        suite_tracks,
+    ))
+
+    for filepath in sorted(root.glob("*/suite-orchestrator.md")):
+        violations.extend(check_orchestrator_suite_file(filepath))
+
+    return violations
 
 
 def scan_curriculum_research() -> list[dict]:

--- a/tests/test_lint_prompts.py
+++ b/tests/test_lint_prompts.py
@@ -389,6 +389,34 @@ class TestOrchestratorSuiteContracts:
         assert "ORCH_SUITE_READING_COVERAGE" in rules
         assert "ORCH_SUITE_SEMINAR_REFERENCE" in rules
 
+    def test_manifest_seminar_type_is_additive_to_curated_set(self, tmp_path: Path):
+        root = tmp_path / "orchestrators"
+        new_suite = root / "new-seminar" / "suite-orchestrator.md"
+        lit_suite = root / "lit" / "suite-orchestrator.md"
+        new_suite.parent.mkdir(parents=True)
+        lit_suite.parent.mkdir(parents=True)
+        new_suite.write_text(_valid_suite_text("new-seminar"), encoding="utf-8")
+        lit_suite.write_text(
+            _valid_suite_text("lit", seminar=False),
+            encoding="utf-8",
+        )
+        manifest = tmp_path / "curriculum.yaml"
+        manifest.write_text(
+            "levels:\n"
+            "  new-seminar:\n"
+            "    type: seminar\n"
+            "  lit:\n"
+            "    type: track\n",
+            encoding="utf-8",
+        )
+
+        violations = scan_orchestrator_suites(root=root, manifest_path=manifest)
+        assert any(
+            v["rule"] == "ORCH_SUITE_READING_COVERAGE"
+            and v["file"].endswith("lit/suite-orchestrator.md")
+            for v in violations
+        )
+
     def test_scan_orchestrator_suites_accepts_valid_active_suite(self, tmp_path: Path):
         root = tmp_path / "orchestrators"
         suite_path = root / "lit" / "suite-orchestrator.md"

--- a/tests/test_lint_prompts.py
+++ b/tests/test_lint_prompts.py
@@ -17,6 +17,9 @@ sys.path.insert(0, str(ROOT / "scripts" / "lint"))
 from lint_prompts import (
     RESEARCH_RULES,
     check_line_rules,
+    check_orchestrator_suite_file,
+    extract_curriculum_level_keys,
+    scan_orchestrator_suites,
     scan_prompts,
 )
 
@@ -227,3 +230,146 @@ class TestScanIntegration:
         assert len(retired_files) >= 5, (
             f"Expected 5+ retired templates, found {len(retired_files)}"
         )
+
+
+# ---------- Orchestrator suite contract tests ----------
+
+def _valid_suite_text(track: str, *, seminar: bool = True) -> str:
+    """Return a minimal valid suite prompt for contract tests."""
+    seminar_refs = ""
+    reading_line = ""
+    if seminar:
+        seminar_refs = "\n".join([
+            "- `docs/prompts/orchestrators/shared/seminar-source-rules.md`",
+            "- `docs/prompts/orchestrators/shared/reading-section-rules.md`",
+        ])
+        reading_line = "Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>\n"
+    return f"""# {track.upper()} Orchestrator Suite
+
+Prompt version: 0.1
+
+## Source Assumptions
+
+Current source assumptions.
+
+## Goal
+
+Build the scoped track.
+
+## WORKTREE_ROOT Setup
+
+```bash
+git worktree add -b codex/{track}-<stage> .worktrees/dispatch/codex/{track}-<stage> origin/main
+cd .worktrees/dispatch/codex/{track}-<stage>
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+## Read First
+
+- `docs/prompts/orchestrators/shared/repo-rules.md`
+- `docs/prompts/orchestrators/shared/validation-checklist.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
+- `docs/prompts/orchestrators/shared/review-output-schema.md`
+{seminar_refs}
+
+## Allowed Writes
+
+- Scoped files only.
+
+## Forbidden Writes
+
+- `docs/prompts/orchestrators/b2/**`
+- `.python-version`, `.yamllint`, `.markdownlint.json`
+- generated `status/`, curriculum `audit/`, curriculum `review/`, and `data/telemetry/**` artifacts
+
+## Lifecycle Rules
+
+- Run the right stage.
+
+## Helpers And Headroom
+
+Use helpers sparingly.
+
+## Validation Commands
+
+```bash
+git diff --check
+```
+
+## Expected Final Response
+
+```text
+{track.upper()} stage: <preflight | production | quality-audit | remediation>
+Scope: <slugs or audit report>
+{reading_line}Files changed: <paths>
+Validation run: <commands and outcomes>
+Telemetry: <posted | not module-build | unavailable with reason>
+Independent review: <status>
+Forbidden artifacts included: no
+swarm_used: true/false
+swarm_label: <none | helper | swarm>
+swarm_note: <helpers used, or solo run; no swarm used>
+```
+"""
+
+
+class TestOrchestratorSuiteContracts:
+    """Tests for docs/prompts/orchestrators suite hardening."""
+
+    def test_extract_curriculum_level_keys(self, tmp_path: Path):
+        manifest = tmp_path / "curriculum.yaml"
+        manifest.write_text(
+            "version: '1.0'\n"
+            "levels:\n"
+            "  c1:\n"
+            "    type: core\n"
+            "  lit-humor:\n"
+            "    type: seminar\n"
+            "other: ignored\n",
+            encoding="utf-8",
+        )
+        assert extract_curriculum_level_keys(manifest) == {"c1", "lit-humor"}
+
+    def test_seminar_suite_requires_reading_coverage(self, tmp_path: Path):
+        suite_path = tmp_path / "lit" / "suite-orchestrator.md"
+        suite_path.parent.mkdir()
+        suite_path.write_text(
+            _valid_suite_text("lit").replace(
+                "Reading coverage: <hosted/link-only/excerpt-only/omit/needed counts>\n",
+                "",
+            ),
+            encoding="utf-8",
+        )
+        violations = check_orchestrator_suite_file(suite_path)
+        assert any(v["rule"] == "ORCH_SUITE_READING_COVERAGE" for v in violations)
+
+    def test_scan_orchestrator_suites_rejects_stale_lit_track(self, tmp_path: Path):
+        root = tmp_path / "orchestrators"
+        (root / "lit-doc").mkdir(parents=True)
+        manifest = tmp_path / "curriculum.yaml"
+        manifest.write_text("levels:\n  lit:\n    type: seminar\n", encoding="utf-8")
+
+        violations = scan_orchestrator_suites(root=root, manifest_path=manifest)
+        assert any(v["rule"] == "ORCH_TRACK_NOT_ACTIVE" for v in violations)
+        assert any(v["rule"] == "ORCH_STALE_LIT_TRACK" for v in violations)
+
+    def test_scan_orchestrator_suites_requires_active_suite(self, tmp_path: Path):
+        root = tmp_path / "orchestrators"
+        (root / "c1").mkdir(parents=True)
+        manifest = tmp_path / "curriculum.yaml"
+        manifest.write_text("levels:\n  c1:\n    type: core\n", encoding="utf-8")
+
+        violations = scan_orchestrator_suites(root=root, manifest_path=manifest)
+        assert any(v["rule"] == "ORCH_ACTIVE_TRACK_MISSING_SUITE" for v in violations)
+
+    def test_scan_orchestrator_suites_accepts_valid_active_suite(self, tmp_path: Path):
+        root = tmp_path / "orchestrators"
+        suite_path = root / "lit" / "suite-orchestrator.md"
+        suite_path.parent.mkdir(parents=True)
+        suite_path.write_text(_valid_suite_text("lit"), encoding="utf-8")
+        manifest = tmp_path / "curriculum.yaml"
+        manifest.write_text("levels:\n  lit:\n    type: seminar\n", encoding="utf-8")
+
+        assert scan_orchestrator_suites(root=root, manifest_path=manifest) == []

--- a/tests/test_lint_prompts.py
+++ b/tests/test_lint_prompts.py
@@ -19,6 +19,7 @@ from lint_prompts import (
     check_line_rules,
     check_orchestrator_suite_file,
     extract_curriculum_level_keys,
+    extract_curriculum_level_types,
     scan_orchestrator_suites,
     scan_prompts,
 )
@@ -325,12 +326,17 @@ class TestOrchestratorSuiteContracts:
             "levels:\n"
             "  c1:\n"
             "    type: core\n"
+            "# column-zero comments should not end levels parsing\n"
             "  lit-humor:\n"
             "    type: seminar\n"
             "other: ignored\n",
             encoding="utf-8",
         )
         assert extract_curriculum_level_keys(manifest) == {"c1", "lit-humor"}
+        assert extract_curriculum_level_types(manifest) == {
+            "c1": "core",
+            "lit-humor": "seminar",
+        }
 
     def test_seminar_suite_requires_reading_coverage(self, tmp_path: Path):
         suite_path = tmp_path / "lit" / "suite-orchestrator.md"
@@ -363,6 +369,25 @@ class TestOrchestratorSuiteContracts:
 
         violations = scan_orchestrator_suites(root=root, manifest_path=manifest)
         assert any(v["rule"] == "ORCH_ACTIVE_TRACK_MISSING_SUITE" for v in violations)
+
+    def test_scan_orchestrator_suites_derives_seminar_type(self, tmp_path: Path):
+        root = tmp_path / "orchestrators"
+        suite_path = root / "new-seminar" / "suite-orchestrator.md"
+        suite_path.parent.mkdir(parents=True)
+        suite_path.write_text(
+            _valid_suite_text("new-seminar", seminar=False),
+            encoding="utf-8",
+        )
+        manifest = tmp_path / "curriculum.yaml"
+        manifest.write_text(
+            "levels:\n  new-seminar:\n    type: seminar\n",
+            encoding="utf-8",
+        )
+
+        violations = scan_orchestrator_suites(root=root, manifest_path=manifest)
+        rules = {v["rule"] for v in violations}
+        assert "ORCH_SUITE_READING_COVERAGE" in rules
+        assert "ORCH_SUITE_SEMINAR_REFERENCE" in rules
 
     def test_scan_orchestrator_suites_accepts_valid_active_suite(self, tmp_path: Path):
         root = tmp_path / "orchestrators"


### PR DESCRIPTION
## Summary

Implements the prompt hardening follow-ups from the orchestrator suite work:

- Extends `scripts/lint/lint_prompts.py` to validate `docs/prompts/orchestrators/**/suite-orchestrator.md` contracts.
- Checks active prompt coverage against `curriculum/l2-uk-en/curriculum.yaml` and rejects stale prompt dirs such as `lit-crimea` / `lit-doc`.
- Enforces required suite sections, shared references, worktree sanity commands, forbidden-write markers, seminar reading coverage, telemetry, independent review, and swarm fields.
- Adds focused tests for active-track parsing, stale-track rejection, missing-suite rejection, and reading coverage enforcement.
- Adds shared seminar docs: reading catalog template and per-track source/checklist guidance.
- Wires `docs/prompts/orchestrators/**` into CI path filters so prompt-doc changes run the prompt lint job.

## Scope guard

- B2 content untouched.
- No `lit-crimea` / `lit-doc` prompt suites added.
- 15 files changed, below the 20-file artifact guard.
- No protected config changes, generated curriculum `status/`, `audit/`, `review/`, or `data/telemetry/**` artifacts.

## Validation

- `.venv/bin/ruff check scripts/lint/lint_prompts.py tests/test_lint_prompts.py`
- `.venv/bin/python scripts/lint/lint_prompts.py`
- `.venv/bin/pytest tests/test_lint_prompts.py -q`
- `/Users/krisztiankoos/projects/learn-ukrainian/node_modules/.bin/markdownlint-cli2 "docs/prompts/orchestrators/README.md" "docs/prompts/orchestrators/shared/*.md" "docs/prompts/orchestrators/*/suite-orchestrator.md"`
- `.venv/bin/python` workflow YAML parse check
- `git diff --check` / cached diff check
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Local review

Local-code-review checklist applied. Ruff/tests/project checks passed; function-size simplification was applied. Gemini bridge review was attempted but unavailable because local Gemini CLI returned `IneligibleTierError` requiring migration to Antigravity; no Gemini findings were produced.

## Telemetry

Not a module-build PR. `swarm_used: false`; `swarm_note: solo prompt hardening run; no swarm used`.