### PR TITLE
[codex] feat(readings): primary-text rights classifier (Phase 1a)

### DIFF
--- a/data/authors_rights.yaml
+++ b/data/authors_rights.yaml
@@ -1,0 +1,341 @@
+# Curated starter table for scripts/readings/rights_classifier.py.
+# Keys intentionally include plan-facing spellings and common aliases.
+
+"Котляревський":
+  death_year: 1838
+"Іван Котляревський":
+  death_year: 1838
+"Котляревський І.":
+  death_year: 1838
+
+"Шевченко":
+  death_year: 1861
+"Тарас Шевченко":
+  death_year: 1861
+"Шевченко Т.Г.":
+  death_year: 1861
+
+"Куліш":
+  death_year: 1897
+  note: Panteleimon Kulish
+"Пантелеймон Куліш":
+  death_year: 1897
+"Куліш П.":
+  death_year: 1897
+
+"Марко Вовчок":
+  death_year: 1907
+"Вовчок Марко":
+  death_year: 1907
+
+"Леся Українка":
+  death_year: 1913
+
+"Коцюбинський":
+  death_year: 1913
+"Михайло Коцюбинський":
+  death_year: 1913
+"Коцюбинський М.":
+  death_year: 1913
+
+"Франко":
+  death_year: 1916
+"Іван Франко":
+  death_year: 1916
+"Франко І.":
+  death_year: 1916
+"Франко І.Я.":
+  death_year: 1916
+
+"Нечуй-Левицький":
+  death_year: 1918
+"Іван Нечуй-Левицький":
+  death_year: 1918
+"Нечуй-Левицький І.":
+  death_year: 1918
+
+"Самійленко":
+  death_year: 1925
+"Володимир Самійленко":
+  death_year: 1925
+
+"Черемшина":
+  death_year: 1927
+"Марко Черемшина":
+  death_year: 1927
+
+"Грушевський":
+  death_year: 1934
+"Михайло Грушевський":
+  death_year: 1934
+"Грушевський М.":
+  death_year: 1934
+
+"Стефаник":
+  death_year: 1936
+"Василь Стефаник":
+  death_year: 1936
+"Стефаник В.":
+  death_year: 1936
+
+"Антонич":
+  death_year: 1937
+"Богдан-Ігор Антонич":
+  death_year: 1937
+"Антонич Б.-І.":
+  death_year: 1937
+
+"Кобилянська":
+  death_year: 1942
+"Ольга Кобилянська":
+  death_year: 1942
+"Кобилянська О.":
+  death_year: 1942
+
+"Олесь":
+  death_year: 1944
+"Олександр Олесь":
+  death_year: 1944
+
+"Винниченко":
+  death_year: 1951
+"Володимир Винниченко":
+  death_year: 1951
+"Винниченко В.":
+  death_year: 1951
+
+"Довженко":
+  death_year: 1956
+"Олександр Довженко":
+  death_year: 1956
+"Довженко О.":
+  death_year: 1956
+
+"Багряний":
+  death_year: 1963
+"Іван Багряний":
+  death_year: 1963
+"Багряний І.":
+  death_year: 1963
+
+"Симоненко":
+  death_year: 1963
+"Василь Симоненко":
+  death_year: 1963
+"Симоненко В.":
+  death_year: 1963
+
+"Рильський":
+  death_year: 1964
+"Максим Рильський":
+  death_year: 1964
+"Рильський М.":
+  death_year: 1964
+
+"Сосюра":
+  death_year: 1965
+"Володимир Сосюра":
+  death_year: 1965
+"Сосюра В.":
+  death_year: 1965
+
+"Тичина":
+  death_year: 1967
+"Павло Тичина":
+  death_year: 1967
+"Тичина П.":
+  death_year: 1967
+
+"Бажан":
+  death_year: 1983
+"Микола Бажан":
+  death_year: 1983
+"Бажан М.":
+  death_year: 1983
+
+"Стус":
+  death_year: 1985
+  note: dissident
+"Василь Стус":
+  death_year: 1985
+  note: dissident
+"Стус В.":
+  death_year: 1985
+  note: dissident
+
+"Гончар":
+  death_year: 1995
+"Олесь Гончар":
+  death_year: 1995
+"Гончар О.":
+  death_year: 1995
+
+"Костенко":
+  death_year: null
+  note: living
+"Ліна Костенко":
+  death_year: null
+  note: living
+"Костенко Л.":
+  death_year: null
+  note: living
+
+"Драч":
+  death_year: 2018
+"Іван Драч":
+  death_year: 2018
+"Драч І.":
+  death_year: 2018
+
+"Павличко":
+  death_year: 2023
+"Дмитро Павличко":
+  death_year: 2023
+"Павличко Д.":
+  death_year: 2023
+
+"Андрухович":
+  death_year: null
+  note: living
+"Юрій Андрухович":
+  death_year: null
+  note: living
+"Андрухович Ю.":
+  death_year: null
+  note: living
+
+"Забужко":
+  death_year: null
+  note: living
+"Оксана Забужко":
+  death_year: null
+  note: living
+"Забужко О.":
+  death_year: null
+  note: living
+
+"Жадан":
+  death_year: null
+  note: living
+"Сергій Жадан":
+  death_year: null
+  note: living
+"Жадан С.":
+  death_year: null
+  note: living
+
+"Матіос":
+  death_year: null
+  note: living
+"Марія Матіос":
+  death_year: null
+  note: living
+"Матіос М.":
+  death_year: null
+  note: living
+
+"Зеров":
+  death_year: 1937
+  repressed_rehabilitated: true
+  rehab_year: 1958
+"Микола Зеров":
+  death_year: 1937
+  repressed_rehabilitated: true
+  rehab_year: 1958
+"Зеров М.":
+  death_year: 1937
+  repressed_rehabilitated: true
+  rehab_year: 1958
+
+"Підмогильний":
+  death_year: 1937
+  repressed_rehabilitated: true
+  rehab_year: 1956
+"Валер'ян Підмогильний":
+  death_year: 1937
+  repressed_rehabilitated: true
+  rehab_year: 1956
+"Підмогильний В.":
+  death_year: 1937
+  repressed_rehabilitated: true
+  rehab_year: 1956
+
+"Микола Куліш":
+  death_year: 1937
+  repressed_rehabilitated: true
+  rehab_year: 1956
+"Куліш М.":
+  death_year: 1937
+  repressed_rehabilitated: true
+  rehab_year: 1956
+
+"Курбас":
+  death_year: 1937
+  repressed_rehabilitated: true
+  rehab_year: 1957
+"Лесь Курбас":
+  death_year: 1937
+  repressed_rehabilitated: true
+  rehab_year: 1957
+"Курбас Л.":
+  death_year: 1937
+  repressed_rehabilitated: true
+  rehab_year: 1957
+
+"Семенко":
+  death_year: 1937
+  repressed_rehabilitated: true
+  rehab_year: null
+  note: rehabilitation year uncertain
+"Михайль Семенко":
+  death_year: 1937
+  repressed_rehabilitated: true
+  rehab_year: null
+  note: rehabilitation year uncertain
+"Семенко М.":
+  death_year: 1937
+  repressed_rehabilitated: true
+  rehab_year: null
+  note: rehabilitation year uncertain
+
+"Плужник":
+  death_year: 1936
+  repressed_rehabilitated: true
+  rehab_year: 1956
+"Євген Плужник":
+  death_year: 1936
+  repressed_rehabilitated: true
+  rehab_year: 1956
+"Плужник Є.":
+  death_year: 1936
+  repressed_rehabilitated: true
+  rehab_year: 1956
+
+"Йогансен":
+  death_year: 1937
+  repressed_rehabilitated: true
+  rehab_year: 1958
+"Майк Йогансен":
+  death_year: 1937
+  repressed_rehabilitated: true
+  rehab_year: 1958
+"Йогансен М.":
+  death_year: 1937
+  repressed_rehabilitated: true
+  rehab_year: 1958
+
+"Хвильовий":
+  death_year: 1933
+  repressed_rehabilitated: true
+  rehab_year: null
+  note: banned/persecuted; conservative rehabilitation handling
+"Микола Хвильовий":
+  death_year: 1933
+  repressed_rehabilitated: true
+  rehab_year: null
+  note: banned/persecuted; conservative rehabilitation handling
+"Хвильовий М.":
+  death_year: 1933
+  repressed_rehabilitated: true
+  rehab_year: null
+  note: banned/persecuted; conservative rehabilitation handling

--- a/scripts/readings/generate_readings.py
+++ b/scripts/readings/generate_readings.py
@@ -27,6 +27,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from scripts.etymology.transliterate import transliterate
+from scripts.readings.rights_classifier import classify_rights
 
 CURRICULUM_ROOT = PROJECT_ROOT / "curriculum" / "l2-uk-en"
 FOLK_ROOT = CURRICULUM_ROOT / "folk"
@@ -248,7 +249,7 @@ def generate_for_modules(
             if corpus is None:
                 skipped.append(SkippedReading(candidate.title, slug, "no matching corpus text"))
                 continue
-            if not is_public_domain(corpus):
+            if not is_public_domain(corpus, track=candidate.track):
                 skipped.append(SkippedReading(candidate.title, slug, "corpus row is not public-domain"))
                 continue
             verdict = verifier(candidate, corpus)
@@ -410,8 +411,28 @@ def verify_candidate_against_corpus(
     )
 
 
-def is_public_domain(corpus: CorpusText) -> bool:
+def is_public_domain(
+    corpus: CorpusText,
+    *,
+    track: str | None = None,
+    current_year: int | None = None,
+) -> bool:
     """Fail closed unless the row has a conservative public-domain signal."""
+    try:
+        verdict = classify_rights(
+            corpus.author,
+            corpus.work,
+            corpus.year,
+            corpus.source_file,
+            track or corpus.language_period,
+            current_year=current_year,
+        )
+    except (FileNotFoundError, ValueError):
+        return _legacy_is_public_domain(corpus)
+    return verdict["rights_class"] == "public_domain"
+
+
+def _legacy_is_public_domain(corpus: CorpusText) -> bool:
     if corpus.author == "Народна творчість" and corpus.source_file.startswith("ukrlib-narod"):
         return True
     return corpus.year is not None and corpus.year <= 1928

--- a/scripts/readings/rights_classifier.py
+++ b/scripts/readings/rights_classifier.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Classify primary-text hosting rights for the readings pipeline."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Literal, TypedDict
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_RIGHTS_PATH = PROJECT_ROOT / "data" / "authors_rights.yaml"
+
+RightsClass = Literal["public_domain", "in_copyright"]
+
+FOLK_AUTHOR_KEYS = frozenset(
+    {
+        "народна творчість",
+        "традиційний текст",
+        "traditional",
+        "anonymous",
+        "анонім",
+    }
+)
+PREMODERN_TRACK_KEYS = frozenset(
+    {
+        "oes",
+        "old east slavic",
+        "old_east_slavic",
+        "ruthenian",
+        "baroque",
+        "middle ukrainian",
+        "middle_ukrainian",
+        "old ukrainian",
+        "old_ukrainian",
+    }
+)
+STRESS_MARKS = {"\u0300", "\u0301"}
+WHITESPACE_RE = re.compile(r"\s+")
+
+
+class RightsVerdict(TypedDict):
+    """Serializable rights verdict for one demanded primary text."""
+
+    rights_class: RightsClass
+    basis: str
+    confidence: float
+
+
+@dataclass(frozen=True)
+class AuthorRights:
+    death_year: int | None
+    repressed_rehabilitated: bool = False
+    rehab_year: int | None = None
+    note: str = ""
+
+
+def classify_rights(
+    author: str,
+    work: str = "",
+    year: int | str | None = None,
+    source_file: str = "",
+    track: str = "",
+    *,
+    current_year: int | None = None,
+    rights_path: Path = DEFAULT_RIGHTS_PATH,
+) -> RightsVerdict:
+    """Return the hosting-rights verdict for a demanded work."""
+    threshold = _pd_threshold(current_year)
+    normalized_author = normalize_author(author)
+    normalized_track = normalize_token(track)
+    normalized_source = str(source_file or "").casefold()
+    work_year = _optional_int(year, "year")
+
+    if _is_folk_or_traditional(normalized_author, normalized_source):
+        return _verdict("public_domain", "folk/traditional public-domain source", 1.0)
+
+    if _is_premodern(normalized_track, work_year):
+        return _verdict("public_domain", "pre-modern track/work before 1800", 0.95)
+
+    author_table = load_author_rights(rights_path)
+    author_rights = author_table.get(normalized_author)
+    if author_rights is not None:
+        return _classify_known_author(author_rights, threshold)
+
+    if work_year is not None and work_year <= 1928:
+        return _verdict("public_domain", f"legacy publication-year fallback ({work_year} <= 1928)", 0.7)
+
+    return _verdict("in_copyright", "conservative default (unknown)", 0.5)
+
+
+def is_public_domain_verdict(verdict: RightsVerdict) -> bool:
+    """Return whether a classifier verdict permits full-text hosting."""
+    return verdict["rights_class"] == "public_domain"
+
+
+def load_author_rights(rights_path: Path = DEFAULT_RIGHTS_PATH) -> dict[str, AuthorRights]:
+    """Load the curated author-rights table keyed by normalized author name."""
+    raw = yaml.safe_load(rights_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"{rights_path} must contain a YAML mapping")
+
+    table: dict[str, AuthorRights] = {}
+    for author_key, raw_rights in raw.items():
+        if not isinstance(raw_rights, dict):
+            raise ValueError(f"{rights_path}: {author_key!r} must map to fields")
+        normalized_key = normalize_author(str(author_key))
+        if not normalized_key:
+            raise ValueError(f"{rights_path}: author key must not be blank")
+        rights = AuthorRights(
+            death_year=_optional_int(raw_rights.get("death_year"), f"{author_key}.death_year"),
+            repressed_rehabilitated=_optional_bool(
+                raw_rights.get("repressed_rehabilitated", False),
+                f"{author_key}.repressed_rehabilitated",
+            ),
+            rehab_year=_optional_int(raw_rights.get("rehab_year"), f"{author_key}.rehab_year"),
+            note=str(raw_rights.get("note") or ""),
+        )
+        existing = table.get(normalized_key)
+        if existing is not None and existing != rights:
+            raise ValueError(f"{rights_path}: conflicting duplicate author key after normalization: {author_key!r}")
+        table[normalized_key] = rights
+    return table
+
+
+def normalize_author(author: str) -> str:
+    """Normalize an author key for table lookup."""
+    return normalize_token(author)
+
+
+def normalize_token(value: str) -> str:
+    """Case-fold, de-stress, and collapse punctuation/spacing for rights keys."""
+    decomposed = unicodedata.normalize("NFD", value or "")
+    chars: list[str] = []
+    for char in decomposed:
+        if char in STRESS_MARKS:
+            continue
+        if unicodedata.category(char).startswith("P"):
+            chars.append(" ")
+            continue
+        chars.append(char)
+    normalized = unicodedata.normalize("NFC", "".join(chars))
+    return WHITESPACE_RE.sub(" ", normalized).strip().casefold()
+
+
+def _classify_known_author(author_rights: AuthorRights, threshold: int) -> RightsVerdict:
+    if author_rights.repressed_rehabilitated:
+        if author_rights.rehab_year is None:
+            return _verdict("in_copyright", "rehabilitation+70: rehab year unknown", 0.85)
+        if author_rights.rehab_year >= threshold:
+            return _verdict(
+                "in_copyright",
+                f"rehabilitation+70: rehab_year {author_rights.rehab_year} >= {threshold}",
+                0.95,
+            )
+        return _verdict(
+            "public_domain",
+            f"rehabilitation+70: rehab_year {author_rights.rehab_year} before {threshold}",
+            0.95,
+        )
+
+    if author_rights.death_year is None:
+        return _verdict("in_copyright", "conservative default (unknown death year)", 0.8)
+
+    if author_rights.death_year >= threshold:
+        return _verdict(
+            "in_copyright",
+            f"death_year {author_rights.death_year} >= {threshold} life+70 threshold",
+            0.95,
+        )
+
+    return _verdict(
+        "public_domain",
+        f"death_year {author_rights.death_year} before {threshold} life+70 threshold",
+        0.95,
+    )
+
+
+def _is_folk_or_traditional(normalized_author: str, normalized_source: str) -> bool:
+    return normalized_author in FOLK_AUTHOR_KEYS or normalized_source.startswith("ukrlib-narod")
+
+
+def _is_premodern(normalized_track: str, work_year: int | None) -> bool:
+    return normalized_track in PREMODERN_TRACK_KEYS and (work_year is None or work_year < 1800)
+
+
+def _pd_threshold(current_year: int | None) -> int:
+    year = date.today().year if current_year is None else current_year
+    if year < 1:
+        raise ValueError("current_year must be positive")
+    return year - 70
+
+
+def _verdict(rights_class: RightsClass, basis: str, confidence: float) -> RightsVerdict:
+    return {"rights_class": rights_class, "basis": basis, "confidence": confidence}
+
+
+def _optional_int(value: object, field_name: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must be an integer or null")
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be an integer or null") from exc
+
+
+def _optional_bool(value: object, field_name: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    raise ValueError(f"{field_name} must be true or false")

--- a/tests/test_rights_classifier.py
+++ b/tests/test_rights_classifier.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.readings.generate_readings import CorpusText, is_public_domain
+from scripts.readings.rights_classifier import classify_rights
+
+CURRENT_YEAR = 2026
+
+
+@pytest.mark.parametrize(
+    "author",
+    [
+        "Франко",
+        "Шевченко",
+        "Коцюбинський",
+        "Винниченко",
+    ],
+)
+def test_public_domain_authors(author: str) -> None:
+    verdict = classify_rights(author, "Твір", None, "", "", current_year=CURRENT_YEAR)
+
+    assert verdict["rights_class"] == "public_domain"
+
+
+@pytest.mark.parametrize(
+    "author",
+    [
+        "Стус",
+        "Тичина",
+        "Рильський",
+    ],
+)
+def test_standard_life_plus_70_in_copyright(author: str) -> None:
+    verdict = classify_rights(author, "Твір", None, "", "", current_year=CURRENT_YEAR)
+
+    assert verdict["rights_class"] == "in_copyright"
+
+
+@pytest.mark.parametrize(
+    "author",
+    [
+        "Зеров",
+        "Підмогильний",
+        "Хвильовий",
+    ],
+)
+def test_repressed_rehabilitated_authors_stay_in_copyright(author: str) -> None:
+    verdict = classify_rights(author, "Твір", None, "", "", current_year=CURRENT_YEAR)
+
+    assert verdict["rights_class"] == "in_copyright"
+    assert "rehabilitation" in verdict["basis"]
+
+
+def test_folk_author_is_public_domain() -> None:
+    verdict = classify_rights("Народна творчість", "Дума", None, "", "", current_year=CURRENT_YEAR)
+
+    assert verdict["rights_class"] == "public_domain"
+
+
+def test_unknown_author_defaults_in_copyright() -> None:
+    verdict = classify_rights("Іван Невідомий", "Твір", None, "", "", current_year=CURRENT_YEAR)
+
+    assert verdict["rights_class"] == "in_copyright"
+    assert verdict["basis"] == "conservative default (unknown)"
+
+
+def test_pre_1929_year_is_public_domain_fallback() -> None:
+    verdict = classify_rights("Іван Невідомий", "Твір", 1928, "", "", current_year=CURRENT_YEAR)
+
+    assert verdict["rights_class"] == "public_domain"
+
+
+def test_boundary_death_years(tmp_path: Path) -> None:
+    rights_path = tmp_path / "authors_rights.yaml"
+    rights_path.write_text(
+        """
+"Boundary PD":
+  death_year: 1955
+"Boundary Copyright":
+  death_year: 1956
+""",
+        encoding="utf-8",
+    )
+
+    pd_verdict = classify_rights(
+        "Boundary PD",
+        "Твір",
+        None,
+        "",
+        "",
+        current_year=CURRENT_YEAR,
+        rights_path=rights_path,
+    )
+    copyright_verdict = classify_rights(
+        "Boundary Copyright",
+        "Твір",
+        None,
+        "",
+        "",
+        current_year=CURRENT_YEAR,
+        rights_path=rights_path,
+    )
+
+    assert pd_verdict["rights_class"] == "public_domain"
+    assert copyright_verdict["rights_class"] == "in_copyright"
+
+
+def test_generate_readings_gate_delegates_to_classifier() -> None:
+    corpus = CorpusText(
+        chunk_id="x",
+        author="Василь Стус",
+        work="Вірш",
+        work_id="stus",
+        year=None,
+        genre="poetry",
+        language_period="modern",
+        source_file="ukrlib-poetry",
+        source_url="",
+        text="",
+    )
+
+    assert is_public_domain(corpus, current_year=CURRENT_YEAR) is False


### PR DESCRIPTION
## Summary

Implements Phase 1a of the primary-text hosting pipeline from `docs/plans/purring-crafting-lovelace.md`.

- Adds `scripts/readings/rights_classifier.py` with life+70, rehabilitation+70, folk/traditional, pre-modern, legacy year, and conservative unknown-author handling.
- Adds `data/authors_rights.yaml` as the curated starter author table with plan-facing aliases.
- Wires `scripts/readings/generate_readings.py::is_public_domain` through the classifier while retaining the old fallback if the classifier data cannot load.
- Adds focused classifier tests plus a generator-gate regression.

Refs #2836.

## #M-4 Deterministic Preamble

| Claim | Evidence |
|---|---|
| tests pass | `.venv/bin/python -m pytest tests/test_rights_classifier.py -q` final raw line:<br>`============================== 15 passed in 0.25s ==============================` |
| lint clean | `.venv/bin/ruff check scripts/readings/rights_classifier.py tests/test_rights_classifier.py` final raw line:<br>`All checks passed!` |
| classifier works on real demand | Raw manifest classification output below. |

```text
Франко І.	Щось про 'малоруську' (українську) 'самостійність' [Поступ, 1905]	public_domain	death_year 1916 before 1956 life+70 threshold
Стус В.	Феномен доби (Сходження на Голгофу слави)	in_copyright	death_year 1985 >= 1956 life+70 threshold
Зеров М.	Українське письменство	in_copyright	rehabilitation+70: rehab_year 1958 >= 1956
Сергій Жадан	Інтернат	in_copyright	conservative default (unknown death year)
Михайло Грушевський	Історія української літератури, том V	public_domain	death_year 1934 before 1956 life+70 threshold
```

## Additional Validation

```text
.venv/bin/python -m pytest tests/test_generate_readings.py -q
============================== 3 passed in 0.13s ===============================
```

```text
.venv/bin/python scripts/audit/lint_agent_trailer.py
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```
