### PR TITLE
docs(rules): allow dispatched Claude for review/any task — `-p` sunset cancelled

### DIFF
--- a/agents_extensions/shared/agents/curriculum-orchestrator.md
+++ b/agents_extensions/shared/agents/curriculum-orchestrator.md
@@ -105,10 +105,11 @@ Bad pedagogy creates durable learner errors. Strong modules beat many mediocre m
   track is currently Claude/BIO-orchestrator owned; do not duplicate BIO triage
   unless the track orchestrator asks.
 - Content/code implementation lanes: Cursor and Codex via delegate worktrees.
-- Review lanes: Claude `review-deep` is the **in-session inline** seat — you (the
+- Review lanes: Claude `review-deep` — **prefer in-session inline for cost** — you (the
   interactive orchestrator) read the artifact, verify claims, and write the verdict
-  on the main quota; never `claude -p` / `--agent claude` / an `Agent`-tool review
-  subagent (defer to the next interactive session if context is heavy). DeepSeek via
+  on the main quota. Dispatching Claude (`claude -p` / `--agent claude` / `review-deep` /
+  an `Agent` review subagent) is permitted when needed (user 2026-06-22, `-p` sunset
+  cancelled); for routine reviews prefer inline or a non-Claude lane. DeepSeek via
   Hermes delegate and Codex integration review are the dispatched (non-Claude) lanes —
   route the bulk of reviews there. See `rules/model-assignment.md` § reviewer-seat
   economics. Gemini is paused for review/merge confidence until the user re-enables it.

--- a/agents_extensions/shared/agents/infra-orchestrator.md
+++ b/agents_extensions/shared/agents/infra-orchestrator.md
@@ -130,8 +130,9 @@ hash + a one-line summary, `headroom_retrieve` only the exact detail. Never run 
 
 ## Dispatch routing & caps
 - Per-task model assignment is in `agents_extensions/shared/rules/model-assignment.md` (served at
-  `/api/rules`). Inline IS yours: hard-bug reasoning, the adversarial/design/code-review seat (in-session,
-  never `claude -p`/`--agent claude`/Agent-subagent), browser/UI testing, `mcp__sources__*` verification.
+  `/api/rules`). Inline IS yours: hard-bug reasoning, the adversarial/design/code-review seat (prefer
+  in-session for cost; dispatching Claude — `claude -p`/`--agent claude`/`review-deep` — is permitted when
+  needed, user 2026-06-22, `-p` sunset cancelled), browser/UI testing, `mcp__sources__*` verification.
 - **>50 LOC non-test inline → STOP and dispatch.** Dispatch enforces worktree + commits.
 - Cap: 2 Claude + 2 Codex + 2 agy in flight; check `/api/delegate/active`, queue if hit. deepseek = off-seat
   review (use it; don't review inline). Use `/code-review` after non-trivial gate/adapter/pipeline changes.

--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -11,7 +11,7 @@ Match the EXACT command — not a principle. Memory does not enforce; the dispat
 | Code Review (PR diff) — cheap second opinion | `delegate.py dispatch --agent deepseek --model deepseek-v4-flash --mode read-only` (hermes; PR #2107 adapter). Empirical winner 2026-05-17 bakeoff (A+ at 15s) |
 | Content Review with VESUM verification (load-bearing) | `delegate.py dispatch --agent deepseek --model deepseek-v4-pro` (hermes; MCP-backed: proactively calls `sources` `verify_words`, `query_cefr_level`, `check_russian_shadow`). Validated by PR #2112 write-mode dispatch on artifacts-MD feature |
 | Wiki / content writing | `delegate.py dispatch --agent agy` (Gemini-family lane; **metered** — agy replaced gemini-cli 2026-06-08; §7/factual cleared 2026-06-13). Wiki-writer policy stays Gemini-family. |
-| Adversarial review of design / ADR / architecture / code — the **Claude reviewer seat** | **IN-SESSION INLINE** — the interactive orchestrator reads the artifact, verifies claims, writes the verdict + fix notes, on the main subscription quota. **NEVER** `claude -p` / `--agent claude` / Agent-SDK / GH-Actions-Claude, and **NEVER an `Agent`-tool review subagent**. Context heavy → **DEFER** to the next interactive session's start (top-of-handoff `Claude review PENDING: <artifact>`). See the reviewer-seat economics below. |
+| Adversarial review of design / ADR / architecture / code — the **Claude reviewer seat** | **Prefer IN-SESSION INLINE for cost** — the interactive orchestrator reads the artifact, verifies claims, writes the verdict + fix notes on the main quota (cheapest path; economics below). Dispatching Claude (`claude -p` / `--agent claude` / `review-deep` / an `Agent` review subagent) **is permitted when it adds value or inline isn't feasible** — the `-p` sunset was cancelled (user 2026-06-22). For routine reviews still prefer inline or a non-Claude lane; reserve dispatched Claude for catches that need it. Context heavy → DEFER to the next interactive session, or dispatch if it must clear now. |
 | Q&A or single-shot review without commit | `ab ask-codex` / `ab ask-gemini --model gemini-3.0-flash-preview` for routine, `--model gemini-3.1-pro-preview` only for deep |
 | Search / grep / "find me X" across files | `Agent` tool with `subagent_type: Explore`, `model: "haiku"` |
 | Status check on running dispatches | Monitor API curl, never inline file scans |
@@ -24,22 +24,23 @@ There is ONE Claude Code quota. A dispatched / headless / subagent Claude compet
 orchestrator's own seat, AND a subagent starts a fresh context that **reloads the full project (~2–3M tokens,
 ~1000:1 overhead per the global `code-editing-safety` §7 rule)** to return a verdict that inline costs
 ~15–25k. A subagent therefore *duplicates a session boot you pay for anyway* → ~50–150× the tokens for the
-identical verdict. So the Claude reviewer seat is fulfilled IN-SESSION:
+identical verdict. So **prefer** fulfilling the Claude reviewer seat IN-SESSION (dispatching Claude is
+permitted — the `-p` sunset was cancelled, user 2026-06-22 — but it costs the multiple above, so route by need):
 
 1. **Default: review INLINE, early in the session** while context is light — cheapest, full faculties, and you
    reuse the read to write the fix.
 2. **Context heavy + a Claude review is still needed: DEFER** to the next MANUAL interactive session's start
    (record a top-of-handoff `Claude review PENDING: <artifact>` so cold-start picks it up first). That
-   artifact's merge waits one session. Do NOT cram it into the depleted session and do NOT spawn a subagent.
-   "Next session" = the next manual interactive session, NOT a cron / scheduled cloud agent / `claude -p`
-   (those are the capped pool).
+   artifact's merge waits one session. Prefer this over cramming it into a depleted session or spawning a
+   subagent (cost) — though dispatch IS available when the review must clear now.
 3. **Inline-now despite heavy context** only when latency is unacceptable (the review must clear THIS session
    to unblock something).
 
 Non-Claude reviewers are UNAFFECTED — keep routing the bulk of reviews to them: DeepSeek (rows above) for PR
-diffs + VESUM content review, Codex for novel-architecture catches. Only the *Claude* seat is in-session.
-(As of mid-June 2026 the headless `--agent claude` lane is also independently off — `@anthropic-ai/claude-code`
-recent versions fail with "native binary not installed" — but the economics above stand regardless of lane health.)
+diffs + VESUM content review, Codex for novel-architecture catches. The *Claude* seat is **preferred** in-session for cost.
+(The headless `--agent claude` / `claude -p` lane is AVAILABLE again — the mid-June 2026 sunset / "native binary not
+installed" fiasco was cancelled, user 2026-06-22; Claude may be used for ANY task, incl. dispatched review, when needed.
+The cost economics above stand regardless: dispatched Claude is far pricier than inline, so route by need, not by ban.)
 
 The same table lives in `memory/MEMORY.md` rule #M0; this file is the deploy-rule mirror so it loads via `npm run agents:deploy` into `.claude/rules/`.
 

--- a/agents_extensions/shared/skills/batch-review/SKILL.md
+++ b/agents_extensions/shared/skills/batch-review/SKILL.md
@@ -46,7 +46,8 @@ List the modules to review and any skipped modules.
 > module or a small batch (≤3), review INLINE** in this session (or defer to next session if context is heavy) —
 > do NOT spawn subagents. Subagents here are justified ONLY for a **genuinely large batch** where wall-clock +
 > context-overflow outweigh the per-subagent reload. When in doubt, prefer non-Claude dispatched reviewers
-> (DeepSeek/Codex) for the bulk and keep the Claude seat in-session.
+> (DeepSeek/Codex) for the bulk and prefer the Claude seat in-session for cost — dispatching Claude is
+> permitted when needed (user 2026-06-22), but it costs the multiple above, so route by need, not by ban.
 
 Split the reviewable modules into chunks of 2-3 modules each.
 Spawn up to 4 subagents using the Agent tool, each processing its chunk.


### PR DESCRIPTION
## Why
Per your direction (2026-06-22): *"claude can be used for anything if needed since they cancelled the -p fiasco."*

The persistent rules told every cold-start session the **opposite** — that the dispatched Claude seat (`claude -p` / `--agent claude` / `review-deep` / an `Agent` review subagent) was **forbidden** ("NEVER"), inline-only. That stale ban would keep being re-applied by future sessions until the source is updated.

## What changed
Converted the **hard prohibition → a cost preference**. The ~50–150× subagent-reload overhead is a real fact, so for routine work inline is still cheapest — but dispatching Claude is now **permitted when it adds value or inline isn't feasible**.

| File | Change |
|---|---|
| `agents_extensions/shared/rules/model-assignment.md` (served at `/api/rules`) | Row 14 + reviewer-seat economics reframed from "NEVER dispatch the Claude seat" → "prefer inline for cost, dispatch by need". Removed the now-stale *"headless lane is off / native binary not installed"* note. |
| `agents_extensions/shared/agents/infra-orchestrator.md` | Review-seat bullet relaxed. |
| `agents_extensions/shared/agents/curriculum-orchestrator.md` | Review-lane bullet relaxed. |
| `agents_extensions/shared/skills/batch-review/SKILL.md` | "keep the Claude seat in-session" → "prefer in-session for cost; dispatch when needed". |

The cost economics are **retained as guidance**, not a ban.

## Verification
- No residual hard-ban phrasing in any of the 4 files (grep clean).
- Deploy orphan-path guard: ✅ all declared. `lint_prompts.py`: ✅ clean. Skill metadata lint: ✅ 9 skills OK.
- `tests/test_deploy_script_idempotency.py`: 6 passed.

## Merge ownership
**Governance / served-rule / agent-def change → leaving this for you to merge** (not self-merging). I've adopted the relaxed rule for this session already; I'll update my local MEMORY (#M0/#0) to match so my own cold-starts stop re-applying the ban.