### PR TITLE
fix(site): make the B2 preview reachable from the homepage course ladder

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -24,7 +24,7 @@ const coreTracks: TrackRow[] = [
   { id: 'a1', label: 'A1', titleKey: 'home.track.beginner', statusKey: 'status.released' },
   { id: 'a2', label: 'A2', titleKey: 'home.track.preIntermediate', statusKey: 'status.released' },
   { id: 'b1', label: 'B1', titleKey: 'home.track.intermediate', statusKey: 'status.released' },
-  { id: 'b2', label: 'B2', titleKey: 'home.track.upperIntermediate', statusKey: 'status.preview' },
+  { id: 'b2', label: 'B2', titleKey: 'home.track.upperIntermediate', statusKey: 'status.preview', href: '/b2/' },
   { id: 'c1', label: 'C1', titleKey: 'home.track.advanced', statusKey: 'status.planned' },
   { id: 'c2', label: 'C2', titleKey: 'home.track.mastery', statusKey: 'status.longRange' },
 ];
@@ -121,9 +121,19 @@ const seminarTracks: TrackRow[] = [
         <ul>
           {coreTracks.map((track) => (
             <li>
-              <span class="track-code">{track.label}</span>
-              <span class="track-title"><ChromeText k={track.titleKey} /></span>
-              <span class="track-meta">{moduleCount(track.id)} <ChromeText k="stats.modules" /> · <ChromeText k={track.statusKey} /></span>
+              {track.href ? (
+                <a class="track-link" href={track.href}>
+                  <span class="track-code">{track.label}</span>
+                  <span class="track-title"><ChromeText k={track.titleKey} /></span>
+                  <span class="track-meta">{moduleCount(track.id)} <ChromeText k="stats.modules" /> · <ChromeText k={track.statusKey} /></span>
+                </a>
+              ) : (
+                <Fragment>
+                  <span class="track-code">{track.label}</span>
+                  <span class="track-title"><ChromeText k={track.titleKey} /></span>
+                  <span class="track-meta">{moduleCount(track.id)} <ChromeText k="stats.modules" /> · <ChromeText k={track.statusKey} /></span>
+                </Fragment>
+              )}
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Context
You asked to update the homepage for **B1 released / B2 in preview**. The *copy* is already correct and live — shipped ~2h ago by PR #3718 (`ef0a7a8a0e`), deployed in `d0974b4a27`. Verified against the live site: A1/A2/B1 = **Released**, B2 = **Preview**.

## The gap this fixes
On the live homepage, **B2 is labeled "Preview" but is not clickable** — there's no way to reach the B2 preview from the homepage, even though `/b2/` exists as a built landing route with its own "Open B2 Preview" action (`[...slug].astro`).

## Change
- Add `href: '/b2/'` to the B2 core-track row.
- Render core-track rows with the **same `track-link` conditional already used for the Folklore seminar preview** — so a "Preview" track links through to its landing. No copy, schema, or styling change; reuses a proven pattern.

## Verification
- Diff is a verbatim mirror of the working seminar `track-link` pattern (the live Folklore row proves it renders).
- Pre-commit clean. Relying on CI `Frontend (build + vitest)` for the real build (worktree is sparse, no local node_modules).

## ⚠️ Note on going live
`deploy-pages.yml`'s `push` trigger is **commented out** — deploys are manual (`workflow_dispatch`). So merging this won't update the live site until a Pages deploy is triggered. Same applies to any homepage change.