### PR TITLE
feat(site): link all existing tracks in homepage course map + enable path-scoped Pages auto-deploy

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,11 +1,14 @@
 name: Deploy to GitHub Pages
 
 on:
-  # Auto-deploy disabled — push to main no longer triggers deploy.
-  # To deploy: run manually via Actions tab (workflow_dispatch),
-  # or re-enable the push trigger below when ready.
-  # push:
-  #   branches: [main]
+  # Auto-deploy on content/site changes to main, path-scoped so pure-infra,
+  # test, script, and docs merges don't trigger a full prod rebuild. Manual
+  # deploy via workflow_dispatch (Actions tab) stays available as a gate.
+  push:
+    branches: [main]
+    paths:
+      - 'site/**'
+      - '.github/workflows/deploy-pages.yml'
   workflow_dispatch:
 
 permissions:

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -20,17 +20,27 @@ const moduleCount = (id: string) => {
   return typeof entry === 'object' && entry ? entry.modules ?? 0 : 0;
 };
 
-const coreTracks: TrackRow[] = [
+// Tracks that have a generated `/{id}/` landing route — keep in sync with
+// `configuredTracks` in `[...slug].astro`. A course-map row links to its landing
+// only when its id is here, so a listed track without a landing (e.g. the lit-*
+// subgenres) stays plain text instead of linking to a 404.
+const LANDING_TRACKS = new Set([
+  'a1', 'a2', 'b1', 'b2', 'c1', 'c2',
+  'folk', 'bio', 'hist', 'istorio', 'lit', 'oes', 'ruth',
+]);
+const trackHref = (id: string) => (LANDING_TRACKS.has(id) ? `/${id}/` : undefined);
+
+const coreTracks: TrackRow[] = ([
   { id: 'a1', label: 'A1', titleKey: 'home.track.beginner', statusKey: 'status.released' },
   { id: 'a2', label: 'A2', titleKey: 'home.track.preIntermediate', statusKey: 'status.released' },
   { id: 'b1', label: 'B1', titleKey: 'home.track.intermediate', statusKey: 'status.released' },
-  { id: 'b2', label: 'B2', titleKey: 'home.track.upperIntermediate', statusKey: 'status.preview', href: '/b2/' },
+  { id: 'b2', label: 'B2', titleKey: 'home.track.upperIntermediate', statusKey: 'status.preview' },
   { id: 'c1', label: 'C1', titleKey: 'home.track.advanced', statusKey: 'status.planned' },
   { id: 'c2', label: 'C2', titleKey: 'home.track.mastery', statusKey: 'status.longRange' },
-];
+] as TrackRow[]).map((track) => ({ ...track, href: trackHref(track.id) }));
 
-const seminarTracks: TrackRow[] = [
-  { id: 'folk', label: 'FOLK', titleKey: 'home.seminar.folk', statusKey: 'status.previewLive', href: '/folk/' },
+const seminarTracks: TrackRow[] = ([
+  { id: 'folk', label: 'FOLK', titleKey: 'home.seminar.folk', statusKey: 'status.previewLive' },
   { id: 'bio', label: 'BIO', titleKey: 'level.bio.name', statusKey: 'status.plannedSeminar' },
   { id: 'hist', label: 'HIST', titleKey: 'home.seminar.hist', statusKey: 'status.plannedSeminar' },
   { id: 'istorio', label: 'ISTORIO', titleKey: 'level.istorio.name', statusKey: 'status.plannedSeminar' },
@@ -44,7 +54,9 @@ const seminarTracks: TrackRow[] = [
   { id: 'lit-drama', label: 'LIT-DRAMA', titleKey: 'home.seminar.litDrama', statusKey: 'status.plannedSeminar' },
   { id: 'oes', label: 'OES', titleKey: 'level.oes.name', statusKey: 'status.plannedSeminar' },
   { id: 'ruth', label: 'RUTH', titleKey: 'home.seminar.ruth', statusKey: 'status.plannedSeminar' },
-].filter((track) => moduleCount(track.id) > 0);
+] as TrackRow[])
+  .filter((track) => moduleCount(track.id) > 0)
+  .map((track) => ({ ...track, href: trackHref(track.id) }));
 ---
 
 <CourseLayout


### PR DESCRIPTION
## Two changes (both homepage shipping)

### 1. Course map — link every existing track (was: only Folklore)
You flagged that in the course-map section only Folk was clickable. Now each row links to its `/{id}/` landing, derived from a `LANDING_TRACKS` set that mirrors `configuredTracks` in `[...slug].astro`:
- **Linked** (have a real landing): a1, a2, b1, b2, c1, c2, folk, bio, hist, istorio, lit, oes, ruth.
- **Not linked**: the 7 lit-* subgenres (lit-essay, lit-hist-fic, lit-fantastika, lit-war, lit-humor, lit-youth, lit-drama) — they have **no landing route**, so linking them would 404. They stay plain text.
- `as TrackRow[]` keeps `ChromeKey` typing intact through `.map` (avoids literal widening).

> Note: c1/c2 link to their "future track" roadmap landings (reachable). If you'd rather not link the planned tracks, that's a one-line tweak to `LANDING_TRACKS`.

### 2. Enable path-scoped Pages auto-deploy
Re-enables push-to-main deploy (was manual-only), **path-scoped to `site/**`** so infra/test/docs merges don't trigger a full prod rebuild. `workflow_dispatch` retained. This fixes the root reason today's homepage updates weren't visible — the live site was silently lagging `main`.

**Merging this PR will itself trigger the first deploy** (the workflow file is in the trigger paths), publishing the current homepage (all-track links + B2 link + the already-correct B1/B2 copy).

## Verification
- index.astro reuses the proven `track-link` render pattern; YAML validated; pre-commit clean.
- Relying on CI `Frontend (build + vitest)` for the real build.