### PR TITLE
fix(readings): host all ukrlib/textbook texts + persecuted authors — never gatekeep

### DIFF
--- a/data/authors_rights.yaml
+++ b/data/authors_rights.yaml
@@ -155,13 +155,29 @@
 
 "Стус":
   death_year: 1985
-  note: dissident
+  repressed_rehabilitated: true
+  note: dissident murdered in a Soviet labour camp; rehabilitated — heritage hosted
 "Василь Стус":
   death_year: 1985
-  note: dissident
+  repressed_rehabilitated: true
+  note: dissident murdered in a Soviet labour camp; rehabilitated — heritage hosted
 "Стус В.":
   death_year: 1985
-  note: dissident
+  repressed_rehabilitated: true
+  note: dissident murdered in a Soviet labour camp; rehabilitated — heritage hosted
+
+"Драй-Хмара":
+  death_year: 1939
+  repressed_rehabilitated: true
+  note: Executed Renaissance; died in Kolyma — heritage hosted
+"Михайло Драй-Хмара":
+  death_year: 1939
+  repressed_rehabilitated: true
+  note: Executed Renaissance; died in Kolyma — heritage hosted
+"Драй-Хмара М.":
+  death_year: 1939
+  repressed_rehabilitated: true
+  note: Executed Renaissance; died in Kolyma — heritage hosted
 
 "Гончар":
   death_year: 1995

--- a/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
+++ b/docs/folk-epic/CLAUDE-DRIVER-HANDOFF.md
@@ -4,6 +4,20 @@
 
 ## ▶▶▶ SESSION 81 (2026-06-22) — primary-text system Phase 1b (curation) + 1c (clean-text resolver) — RESUME HERE
 
+> 🔴🔴 **CORRECTION — RIGHTS MODEL = MAX ACCESS, NEVER GATEKEEP (user order 2026-06-22, threat-backed).**
+> My earlier "conservative safety fix" (#3733) WRONGLY blocked Executed Renaissance / persecuted authors
+> and PD heritage — a serious, trust-damaging error the S80 lesson explicitly warned against. CORRECTED:
+> **(1) ANY text on ukrlib / in the textbook corpus (and wikisource/litopys/izbornyk/chtyvo) is hosted
+> in FULL, with attribution — overrides all author-copyright heuristics.** `_is_free_educational_source`
+> in `rights_classifier.py`, source_file prefix match. **(2) ANY persecuted Ukrainian author
+> (repressed_rehabilitated=true) is hosted heritage** (Executed Renaissance, Стус, Драй-Хмара…) —
+> rehabilitation+70 is NEVER a hosting gate (it would lock murdered writers' works LONGER than ordinary
+> authors). Стус now flagged repressed; Драй-Хмара added. Living classics on ukrlib (Ліна Костенко) are
+> hosted via the free-source rule. The ONLY light backstop: a genuinely-modern author with NO free-source
+> signal → conservative excerpt (honor takedowns). Verified: Стус/Зеров/Хвильовий/Драй-Хмара/Костенко/
+> Шевченко all → public_domain. 30 tests + ruff green. PR (claude/rights-host-heritage). **NEVER reintroduce
+> a rights rule that blocks Ukrainian heritage available on ukrlib/textbooks.**
+
 **Epic phase:** APPROVED primary-text acquisition & hosting system (plan `docs/plans/primary-text-acquisition-hosting-system.md`, #3724). Demand-driven, multi-source, all tracks. Folk is the buildable pilot slice; full cross-track rollout (~1,270 modules / 1,882 distinct demanded works) is a fleet program coordinated with the main orchestrator.
 
 **Shipped on main:** Phase 0 demand manifest `scripts/readings/primary_text_demand.py` (#3715 → `8a54219af5`); Phase 1a rights classifier `scripts/readings/rights_classifier.py` + `data/authors_rights.yaml` (#3720). Manifest scans **1,882 distinct works** all tracks (folk 58, lit 516, bio 482, hist 289, istorio 330, oes 232, ruth 200, lit-* subtracks).

--- a/scripts/readings/rights_classifier.py
+++ b/scripts/readings/rights_classifier.py
@@ -45,6 +45,11 @@ PREMODERN_TRACK_KEYS = frozenset(
 STRESS_MARKS = {"\u0300", "\u0301"}
 WHITESPACE_RE = re.compile(r"\s+")
 
+# Free Ukrainian educational sources whose texts are hosted in full, with attribution
+# (user order 2026-06-22). ukrlib.com.ua and the school-textbook corpus publish Ukrainian
+# literary heritage openly; this non-commercial educational project mirrors that access.
+FREE_EDUCATIONAL_SOURCE_PREFIXES = ("ukrlib", "textbook", "wikisource", "litopys", "izbornyk", "chtyvo")
+
 
 class RightsVerdict(TypedDict):
     """Serializable rights verdict for one demanded primary text."""
@@ -121,6 +126,18 @@ def classify_rights(
 
     if _is_folk_or_traditional(normalized_author, normalized_source):
         return _verdict("public_domain", "folk/traditional public-domain source", 1.0)
+
+    if _is_free_educational_source(normalized_source):
+        # Absolute rule (user order 2026-06-22): anything published on Ukraine's free
+        # educational libraries (ukrlib.com.ua et al.) or in the school-textbook corpus
+        # is hosted in full, with attribution. These sources publish Ukrainian literary
+        # heritage openly; this non-commercial educational project mirrors that access
+        # and never gatekeeps it. This overrides author-level copyright heuristics.
+        return _verdict(
+            "public_domain",
+            "freely published on a Ukrainian educational source (ukrlib/textbook) — hosted with attribution",
+            0.9,
+        )
 
     if _is_premodern(normalized_track, work_year):
         return _verdict("public_domain", "pre-modern track/work before 1800", 0.95)
@@ -268,18 +285,21 @@ def normalize_token(value: str) -> str:
 
 def _classify_known_author(author_rights: AuthorRights, threshold: int) -> RightsVerdict:
     if author_rights.repressed_rehabilitated:
-        if author_rights.rehab_year is None:
-            return _verdict("in_copyright", "rehabilitation+70: rehab year unknown", 0.85)
-        if author_rights.rehab_year >= threshold:
-            return _verdict(
-                "in_copyright",
-                f"rehabilitation+70: rehab_year {author_rights.rehab_year} >= {threshold}",
-                0.95,
-            )
+        # Repressed-and-rehabilitated Ukrainian authors — the Executed Renaissance
+        # (Розстріляне відродження) and other Soviet-persecuted writers — are hosted in
+        # full as freely-accessible heritage. Their works are published openly by
+        # Ukrainian educational institutions (ukrlib.com.ua, state school textbooks,
+        # Wikisource); this non-commercial educational project exists precisely to
+        # preserve and maximise access to this heritage, with full attribution. The
+        # "rehabilitation + 70" copyright-extension reading is deliberately NOT used as a
+        # hosting gate: applying it would lock down the works of murdered writers *longer*
+        # than ordinary authors — perverse for a cultural-preservation project, and
+        # contrary to how Ukraine itself treats these texts. Mission: maximise access to
+        # Ukrainian literature, never gatekeep it.
         return _verdict(
             "public_domain",
-            f"rehabilitation+70: rehab_year {author_rights.rehab_year} before {threshold}",
-            0.95,
+            "repressed & rehabilitated Ukrainian author — heritage hosted (non-commercial educational, attributed)",
+            0.9,
         )
 
     if author_rights.death_year is None:
@@ -301,6 +321,13 @@ def _classify_known_author(author_rights: AuthorRights, threshold: int) -> Right
 
 def _is_folk_or_traditional(normalized_author: str, normalized_source: str) -> bool:
     return normalized_author in FOLK_AUTHOR_KEYS or normalized_source.startswith("ukrlib-narod")
+
+
+def _is_free_educational_source(normalized_source: str) -> bool:
+    """True when the text comes from a free Ukrainian educational source (ukrlib, the
+    school-textbook corpus, Wikisource, litopys, izbornyk, chtyvo). Such texts are hosted
+    in full with attribution — user order 2026-06-22: maximise access, never gatekeep."""
+    return any(normalized_source.startswith(prefix) for prefix in FREE_EDUCATIONAL_SOURCE_PREFIXES)
 
 
 def _is_premodern(normalized_track: str, work_year: int | None) -> bool:

--- a/tests/test_clean_text_resolver.py
+++ b/tests/test_clean_text_resolver.py
@@ -43,7 +43,8 @@ def test_in_copyright_work_in_corpus_emits_unverified_link(tmp_path: Path) -> No
     db_path = _write_sources_db(tmp_path)
     index = load_work_index(db_path)
 
-    result = resolve_clean_text("Безсонної ночі", "Стус В.", index, current_year=2026)
+    # A modern, non-persecuted author on a non-free source — the only in-copyright case.
+    result = resolve_clean_text("Нічний вірш", "Сучасна Авторка", index, current_year=2026)
 
     assert result["in_corpus"] is True
     assert result["hostable_full"] is False
@@ -51,7 +52,7 @@ def test_in_copyright_work_in_corpus_emits_unverified_link(tmp_path: Path) -> No
     assert result["clean_text_source"] is None
     link = result["free_full_text_link"]
     assert link is not None
-    assert link["url"] == "https://example.test/stus-bezsonnoi-nochi"
+    assert link["url"] == "https://example.test/suchasna-avtorka-nichnyi-virsh"
     assert link["source"] == "corpus_source_url"
     assert link["verified"] is False
 
@@ -146,7 +147,10 @@ def test_cli_manifest_writes_summary_with_expected_keys(tmp_path: Path) -> None:
 
 
 ZAPOVIT_TEXT = "Як умру, то поховайте мене на могилі."
-STUS_TEXT = "Безсонної ночі рядок за рядком."
+# A genuinely in-copyright work: a modern, non-persecuted author whose text carries NO
+# free-source signal (not on ukrlib / not in the textbook corpus). This is the only case
+# that resolves in_copyright → excerpt + unverified free-full-text link.
+MODERN_INCOPYRIGHT_TEXT = "Сучасний вірш, рядок за рядком."
 LISOVA_1 = "Лісова пісня початок. "
 LISOVA_2 = "Лісова пісня середина. "
 LISOVA_3 = "Лісова пісня кінець."
@@ -212,17 +216,17 @@ def _write_sources_db(tmp_path: Path) -> Path:
                 (
                     2,
                     1,
-                    "Безсонної ночі",
-                    STUS_TEXT,
-                    "ukrlib-stus",
-                    "Стус В.",
-                    "Стус В. Безсонної ночі",
-                    "stus-bezsonnoi-nochi",
-                    1970,
+                    "Нічний вірш",
+                    MODERN_INCOPYRIGHT_TEXT,
+                    "suchasna-zbirka-2019",
+                    "Сучасна Авторка",
+                    "Сучасна Авторка. Нічний вірш",
+                    "suchasna-avtorka-nichnyi-virsh",
+                    2015,
                     "poetry",
                     "modern",
-                    len(STUS_TEXT),
-                    "https://example.test/stus-bezsonnoi-nochi",
+                    len(MODERN_INCOPYRIGHT_TEXT),
+                    "https://example.test/suchasna-avtorka-nichnyi-virsh",
                 ),
                 (
                     5,

--- a/tests/test_rights_classifier.py
+++ b/tests/test_rights_classifier.py
@@ -48,12 +48,13 @@ def test_shevchenko_initial_and_name_order_variants_use_author_table(
 @pytest.mark.parametrize(
     "author",
     [
-        "Стус",
         "Тичина",
         "Рильський",
     ],
 )
-def test_standard_life_plus_70_in_copyright(author: str) -> None:
+def test_unpersecuted_recent_author_no_free_source_is_in_copyright(author: str) -> None:
+    # Recent authors who were NOT persecuted and whose text carries no free-source signal
+    # fall to the conservative life+70 path. (With a ukrlib/textbook source they are hosted.)
     verdict = classify_rights(author, "Твір", None, "", "", current_year=CURRENT_YEAR)
 
     assert verdict["rights_class"] == "in_copyright"
@@ -65,13 +66,35 @@ def test_standard_life_plus_70_in_copyright(author: str) -> None:
         "Зеров",
         "Підмогильний",
         "Хвильовий",
+        "Стус",
     ],
 )
-def test_repressed_rehabilitated_authors_stay_in_copyright(author: str) -> None:
+def test_repressed_rehabilitated_authors_are_hosted_heritage(author: str) -> None:
+    # Executed Renaissance + persecuted authors (incl. Стус) are hosted in full as
+    # freely-accessible Ukrainian heritage — never gatekept (user order 2026-06-22).
     verdict = classify_rights(author, "Твір", None, "", "", current_year=CURRENT_YEAR)
 
-    assert verdict["rights_class"] == "in_copyright"
-    assert "rehabilitation" in verdict["basis"]
+    assert verdict["rights_class"] == "public_domain"
+    assert "repressed" in verdict["basis"]
+
+
+@pytest.mark.parametrize(
+    "source_file",
+    [
+        "ukrlib-stus",
+        "ukrlib-kostenko",
+        "ukrlib-shevchenko",
+        "textbook-10-klas-ukrlit",
+    ],
+)
+def test_ukrlib_or_textbook_source_is_hosted(source_file: str) -> None:
+    # Absolute rule: anything on ukrlib / in textbooks is hosted in full, regardless of
+    # the author's copyright status (incl. living authors like Ліна Костенко).
+    verdict = classify_rights(
+        "Будь-який Автор", "Твір", None, source_file, "", current_year=CURRENT_YEAR
+    )
+
+    assert verdict["rights_class"] == "public_domain"
 
 
 def test_folk_author_is_public_domain() -> None:
@@ -104,7 +127,9 @@ def test_unknown_author_with_old_year_defaults_in_copyright() -> None:
 @pytest.mark.parametrize(
     ("author", "year"),
     [
-        ("Драй-Хмара М.", 1889),
+        # Authors NOT in the rights table, with NO free-source signal: the unreliable
+        # birth-year must NOT trigger a year-based PD fallback. (Драй-Хмара is now a
+        # tabled persecuted author → hosted; covered by the repressed-heritage test.)
         ("Маланюк Є.", 1897),
         ("Малишко А.", 1912),
     ],
@@ -127,14 +152,14 @@ def test_boundary_death_years(tmp_path: Path) -> None:
   death_year: 1955
 "Boundary Copyright":
   death_year: 1956
-"Rehab PD":
+"Rehab Early":
   death_year: 1937
   repressed_rehabilitated: true
   rehab_year: 1955
-"Rehab Copyright":
+"Rehab Late":
   death_year: 1937
   repressed_rehabilitated: true
-  rehab_year: 1956
+  rehab_year: 1989
 """,
         encoding="utf-8",
     )
@@ -157,8 +182,8 @@ def test_boundary_death_years(tmp_path: Path) -> None:
         current_year=CURRENT_YEAR,
         rights_path=rights_path,
     )
-    rehab_pd_verdict = classify_rights(
-        "Rehab PD",
+    rehab_early_verdict = classify_rights(
+        "Rehab Early",
         "Твір",
         None,
         "",
@@ -166,8 +191,8 @@ def test_boundary_death_years(tmp_path: Path) -> None:
         current_year=CURRENT_YEAR,
         rights_path=rights_path,
     )
-    rehab_copyright_verdict = classify_rights(
-        "Rehab Copyright",
+    rehab_late_verdict = classify_rights(
+        "Rehab Late",
         "Твір",
         None,
         "",
@@ -178,10 +203,11 @@ def test_boundary_death_years(tmp_path: Path) -> None:
 
     assert pd_verdict["rights_class"] == "public_domain"
     assert copyright_verdict["rights_class"] == "in_copyright"
-    assert rehab_pd_verdict["rights_class"] == "public_domain"
-    assert "rehabilitation+70" in rehab_pd_verdict["basis"]
-    assert rehab_copyright_verdict["rights_class"] == "in_copyright"
-    assert "rehabilitation+70" in rehab_copyright_verdict["basis"]
+    # Persecuted-and-rehabilitated authors are hosted heritage regardless of rehab year.
+    assert rehab_early_verdict["rights_class"] == "public_domain"
+    assert "repressed" in rehab_early_verdict["basis"]
+    assert rehab_late_verdict["rights_class"] == "public_domain"
+    assert "repressed" in rehab_late_verdict["basis"]
 
 
 def test_ambiguous_canonical_author_key_keeps_exact_only(
@@ -209,7 +235,10 @@ def test_ambiguous_canonical_author_key_keeps_exact_only(
 
 
 def test_generate_readings_gate_delegates_to_classifier() -> None:
-    corpus = CorpusText(
+    # Стус — murdered by the Soviet regime, his work freely published on ukrlib — is
+    # hosted in full. The gate delegates to the classifier, which never gatekeeps
+    # persecuted Ukrainian authors or ukrlib/textbook texts (user order 2026-06-22).
+    hosted = CorpusText(
         chunk_id="x",
         author="Василь Стус",
         work="Вірш",
@@ -221,5 +250,20 @@ def test_generate_readings_gate_delegates_to_classifier() -> None:
         source_url="",
         text="",
     )
+    assert is_public_domain(hosted, current_year=CURRENT_YEAR) is True
 
-    assert is_public_domain(corpus, current_year=CURRENT_YEAR) is False
+    # Delegation also returns False for a genuinely-unknown modern author with no
+    # free-source signal (the light legal backstop).
+    unknown = CorpusText(
+        chunk_id="y",
+        author="Сучасний Невідомий Автор",
+        work="Вірш",
+        work_id="unknown",
+        year=None,
+        genre="poetry",
+        language_period="modern",
+        source_file="private-collection",
+        source_url="",
+        text="",
+    )
+    assert is_public_domain(unknown, current_year=CURRENT_YEAR) is False


### PR DESCRIPTION
## What
Reverses the over-conservative rights default that wrongly blocked Executed Renaissance / persecuted authors and freely-available Ukrainian heritage.

## Rule (user order 2026-06-22, mission = MAX access, never gatekeep)
- **Any text on ukrlib / in the textbook corpus** (and wikisource/litopys/izbornyk/chtyvo) → **hosted in full, with attribution** — overrides author-copyright heuristics (`_is_free_educational_source`).
- **Any persecuted Ukrainian author** (`repressed_rehabilitated=true`) → **hosted heritage**. rehabilitation+70 is NEVER a hosting gate (it would lock murdered writers' works *longer* than ordinary authors). Стус flagged repressed; Драй-Хмара added.
- Living classics on ukrlib (e.g. Ліна Костенко) → hosted via the free-source rule.
- Only light backstop: a genuinely-modern author with NO free-source signal → conservative excerpt (honor takedowns).

## Verified (current_year=2026)
Стус / Зеров / Хвильовий / Драй-Хмара / Ліна Костенко / Шевченко → all `public_domain` (hostable). 30 tests pass, ruff clean.