### PR TITLE
docs(b2): harden prompt review gates

### DIFF
--- a/docs/prompts/orchestrators/b2/preflight-readiness-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/b2/preflight-readiness-audit-orchestrator.md
@@ -1,6 +1,6 @@
 # B2 Preflight Readiness Audit Orchestrator
 
-Prompt version: 0.2
+Prompt version: 0.3
 Last reviewed: 2026-06-21
 
 ## Source Assumptions
@@ -35,6 +35,7 @@ git rev-parse --show-toplevel
 - `docs/prompts/orchestrators/shared/repo-rules.md`
 - `docs/prompts/orchestrators/shared/validation-checklist.md`
 - `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
 - `curriculum/l2-uk-en/curriculum.yaml`, B2 section
 - `docs/l2-uk-en/MODULE-RICHNESS-GUIDELINES-v2.md`
 - `scripts/config.py`
@@ -71,9 +72,16 @@ git rev-parse --show-toplevel
 - Identify blockers that require plan/wiki/source work before production.
 - Mark readiness as `pass`, `conditional pass`, or `do not build`.
 
-## Helpers And Headroom
+## Helper Swarm Policy
 
-Read-only helpers are allowed for inventories or slug-matrix checks. The main auditor owns readiness judgment. Use Headroom compression for helper output or search results over 200 lines or 20 KB.
+Default to a solo preflight audit unless a helper will materially improve coverage or validation confidence. When helpers are useful, keep routine delegation to one to three helpers total.
+
+- Use `gpt-5.4-mini` explorer helpers for read-only source/wiki coverage matrices, stale-file sweeps, plan/discovery comparisons, and validation summaries.
+- Use `gpt-5.3-codex-spark` helpers only for narrow code-heavy validation such as parser, schema, or command-output triage.
+- The main auditor owns final readiness verdict, blocker inventory, remediation batching, PR creation, independent-family review routing, merge decisions, and git hygiene.
+- Do not let helpers read secrets, source `.envrc`, call `gh`, request reviews, open PRs, merge PRs, or edit plans/wiki/discovery/curriculum/site files.
+- Record helper roles in the durable report and PR body; set `swarm_used: true` when any helper or reviewer thread did bounded preflight audit work. Solo audits still require `swarm_used: false`, `swarm_label: none`, and `swarm_note`.
+- Use Headroom compression for helper output or logs over 200 lines or 20 KB; pass the hash plus a short summary.
 
 ## Durable Report Path
 
@@ -97,17 +105,28 @@ if [ -n "$CHANGED_FILES" ] && printf '%s\n' "$CHANGED_FILES" | rg '(^|/)status/.
   echo "Forbidden generated artifact in diff" >&2
   exit 1
 fi
-if rg -n 'sys\.executable' "$REPORT"; then
-  echo "Audit report mentions forbidden sys.executable" >&2
+FORBIDDEN_INTERPRETER_TOKEN='sys[.]executable'
+if rg -n "$FORBIDDEN_INTERPRETER_TOKEN" "$REPORT"; then
+  echo "Audit report mentions forbidden interpreter token" >&2
   exit 1
 fi
 ```
 
 Do not run builds. Do not modify B2 plans, wiki files, discovery files, or modules.
 
+## Independent-Family Review Gate
+
+Before merge, request a read-only independent-family review of the preflight audit-report PR. Prefer Claude Opus 4.8. If Claude Opus 4.8 is unavailable, use Agy with Gemini 3.1 Pro High, for example `agy --model gemini-3.1-pro-high --print-timeout 10m -p "<review prompt>"`.
+
+The review prompt must include the PR diff, preflight scope, validation summary, artifact-clean statement, helper/swarm note, and an explicit request for blocker-only findings. Record reviewer identity, review model, review scope, unresolved findings, and final disposition in the durable audit report or PR body. The merge rule is explicit: unresolved findings are blockers.
+
+## PR Body Requirements
+
+PR body must include: preflight scope, report path, readiness status, blocker count, source/wiki/plan gap summary, validation commands and outcomes, `swarm_used`, `swarm_label`, `swarm_note`, reviewer identity, review scope, final disposition, unresolved review findings count, and a statement that no plans, wiki, discovery, curriculum/site source files, generated curriculum artifacts, or telemetry database files are included.
+
 ## Report Delivery
 
-After validation, commit and open a draft PR that contains only the report:
+After validation, commit and open a draft PR that contains only the report plus PR body delivery text:
 
 ```bash
 REPORT="docs/audits/b2-preflight-readiness-$(date +%F).md"
@@ -127,8 +146,12 @@ Blockers: <n>
 Source/wiki/plan gaps: <summary>
 Validation run: <commands and outcomes>
 Report delivery: <draft PR URL or blocked reason>
+Review PR: <url, ready/merged/blocked>
+Independent review: <reviewer identity, model, scope, final disposition>
+Unresolved review findings: <n>
 B2 production allowed now: yes/no
 Curriculum files modified: no
+Forbidden artifacts included: no
 swarm_used: true/false
 swarm_label: <none | solo | helper | swarm>
 swarm_note: <helpers used, or solo run; no swarm used>

--- a/docs/prompts/orchestrators/b2/production-build-orchestrator.md
+++ b/docs/prompts/orchestrators/b2/production-build-orchestrator.md
@@ -1,6 +1,6 @@
 # B2 Production Build Orchestrator
 
-Prompt version: 0.4
+Prompt version: 0.5
 Last reviewed: 2026-06-22
 
 ## Source Assumptions
@@ -87,9 +87,17 @@ git rev-parse --show-toplevel
 - Maintain B2 immersion according to current config; English should be limited to vocabulary glosses or current repo-permitted contexts.
 - If preflight blockers reappear, stop and record them rather than building around missing sources.
 
-## Helpers And Headroom
+## Helper Swarm Policy
 
-Helpers are allowed for source extraction, validation, or independent review preparation. Assign clear file ownership for any worker. Use Headroom compression for helper output or logs over 200 lines or 20 KB.
+Default to a solo run for one-module patches unless a helper will materially reduce risk or wall-clock time. When helpers are useful, keep routine delegation to one to three helpers total.
+
+- Use `gpt-5.4-mini` explorer helpers for bounded source lookup, plan/wiki/source coverage summaries, prompt consistency checks, and simple validation summaries.
+- Use `gpt-5.3-codex-spark` worker helpers only for narrow mechanical edits with a clearly owned file set.
+- The main orchestrator owns planning, integration, final review, PR creation, independent-family review routing, merge decisions, and git hygiene.
+- Do not let helpers read secrets, source `.envrc`, call `gh`, request reviews, open PRs, merge PRs, or revert unrelated changes.
+- Assign clear file ownership to every worker and tell helpers they are not alone in the codebase.
+- Record helper roles in telemetry `participants`; set `swarm_used: true` when any helper or reviewer thread did bounded module-build work. Solo runs still require `swarm_used: false`, `swarm_label: none`, and `swarm_note`.
+- Use Headroom compression for helper output or logs over 200 lines or 20 KB; pass the hash plus a short summary.
 
 ## Validation Commands
 
@@ -112,6 +120,22 @@ fi
 
 Run `scripts/audit/check_mdx_generation_drift.py` only when a drift-only check is needed after generation. The `audit_module.py --skip-review` command intentionally validates deterministic module gates while leaving the review gate to the independent-review requirement below. It still writes local generated cache/status/audit outputs, so remove those known outputs before the diff gate; do not commit curriculum `review/`, `audit/`, or `status/` artifacts to satisfy the review gate.
 
+## Telemetry Workflow
+
+For every module-build PR, persist a record through `POST /api/telemetry/module-builds` and include the same summary in the PR body. Use `docs/runbooks/module-build-token-telemetry.md` and `docs/prompts/orchestrators/shared/telemetry-and-pr.md`.
+
+Required PR/telemetry fields: `run_id`, `level`, `slug`, `branch`, `commit_sha`, `pr_number`, `pr_url`, `status`, `swarm_used`, `swarm_label`, `swarm_note`, `participants`, and each participant `token_source`. Use `token_source: unavailable` rather than inventing counts when provider usage is unavailable. Do not commit `data/telemetry/**`.
+
+## Independent-Family Review Gate
+
+Before merge, request a read-only independent-family review. Prefer Claude Opus 4.8. If Claude Opus 4.8 is unavailable, use Agy with Gemini 3.1 Pro High, for example `agy --model gemini-3.1-pro-high --print-timeout 10m -p "<review prompt>"` when that is the available local route.
+
+The review prompt must include the PR diff, validation summary, telemetry summary, artifact-clean statement, and explicit request for blocker-only findings. Record reviewer identity, review model, review scope, unresolved findings, and final disposition in the PR body or final orchestration note. The merge rule is explicit: unresolved findings are blockers.
+
+## PR Body Requirements
+
+PR body must include: changed modules, source/preflight report used, validation commands and outcomes, telemetry `run_id`, `swarm_used`, `swarm_label`, `swarm_note`, reviewer identity, review scope, final disposition, unresolved findings count, and a statement that no generated `status/`, curriculum `audit/`, curriculum `review/`, or telemetry DB artifacts are included.
+
 ## PR, Commit, And Telemetry Requirements
 
 - Branch: `codex/b2-production-<batch>`
@@ -119,7 +143,7 @@ Run `scripts/audit/check_mdx_generation_drift.py` only when a drift-only check i
 - Run `.venv/bin/python scripts/audit/lint_agent_trailer.py` before pushing.
 - Persist module-build telemetry using `docs/prompts/orchestrators/shared/telemetry-and-pr.md`.
 - Include `swarm_used`, `swarm_label`, and `swarm_note` in telemetry and PR text.
-- Require independent review before merge.
+- Require independent-family review before merge; unresolved findings are blockers.
 
 ## Expected Final Response
 
@@ -128,8 +152,10 @@ B2 preflight report used: <path>
 Modules built: <slugs>
 Files changed: <paths>
 Validation run: <commands and outcomes>
-Telemetry: <posted or unavailable with reason>
-Independent review: <status>
+Telemetry: <run_id, POST status, unavailable reason if any>
+PR: <url, ready/merged/blocked>
+Independent review: <reviewer identity, model, scope, final disposition>
+Unresolved review findings: <n>
 Forbidden artifacts included: no
 swarm_used: true/false
 swarm_label: <none | solo | helper | swarm>

--- a/docs/prompts/orchestrators/b2/quality-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/b2/quality-audit-orchestrator.md
@@ -1,6 +1,6 @@
 # B2 Quality Audit Orchestrator
 
-Prompt version: 0.3
+Prompt version: 0.4
 Last reviewed: 2026-06-22
 
 ## Source Assumptions
@@ -35,6 +35,7 @@ git rev-parse --show-toplevel
 - `docs/prompts/orchestrators/shared/repo-rules.md`
 - `docs/prompts/orchestrators/shared/validation-checklist.md`
 - `docs/prompts/orchestrators/shared/review-output-schema.md`
+- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
 - `curriculum/l2-uk-en/curriculum.yaml`, B2 section
 - `docs/l2-uk-en/MODULE-RICHNESS-GUIDELINES-v2.md`
 - `scripts/config.py`
@@ -80,15 +81,24 @@ git rev-parse --show-toplevel
 - Check engagement and wall-of-text risk: examples, tables, callouts, and tasks make dense material usable.
 - Run deterministic module audits without `--fix` for built modules in scope where feasible, and record any failures alongside subjective findings.
 
-## Helpers And Headroom
+## Helper Swarm Policy
 
-Read-only helpers are allowed for coverage matrices or validation summaries. Do not delegate final severity calls. Use Headroom compression for helper output or logs over 200 lines or 20 KB.
+Default to a solo audit for a narrow one-module report unless a helper will materially improve coverage or validation confidence. When helpers are useful, keep routine delegation to one to three helpers total.
+
+- Use `gpt-5.4-mini` explorer helpers for read-only coverage matrices, source/wiki/plan comparisons, and validation summaries.
+- Use `gpt-5.3-codex-spark` helpers only for narrow code-heavy validation such as parser, schema, or command-output triage.
+- The main auditor owns final severity calls, issue inventory, remediation batching, PR creation, independent-family review routing, merge decisions, and git hygiene.
+- Do not let helpers read secrets, source `.envrc`, call `gh`, request reviews, open PRs, merge PRs, or edit curriculum/site files.
+- Record helper roles in the durable report and PR body; set `swarm_used: true` when any helper or reviewer thread did bounded audit work. Solo audits still require `swarm_used: false`, `swarm_label: none`, and `swarm_note`.
+- Use Headroom compression for helper output or logs over 200 lines or 20 KB; pass the hash plus a short summary.
 
 ## Durable Report Path
 
 Write the report to `docs/audits/b2-quality-audit-YYYY-MM-DD.md`.
 
 ## Validation Commands
+
+For multi-module audits, repeat the module audit and cleanup commands for every audited `<slug>`/`<module_num>` pair and record each command outcome in the durable report.
 
 ```bash
 REPORT="docs/audits/b2-quality-audit-$(date +%F).md"
@@ -108,17 +118,28 @@ if [ -n "$CHANGED_FILES" ] && printf '%s\n' "$CHANGED_FILES" | rg '(^|/)status/.
   echo "Forbidden generated artifact in diff" >&2
   exit 1
 fi
-if rg -n 'sys\.executable' "$REPORT"; then
-  echo "Audit report mentions forbidden sys.executable" >&2
+FORBIDDEN_INTERPRETER_TOKEN='sys[.]executable'
+if rg -n "$FORBIDDEN_INTERPRETER_TOKEN" "$REPORT"; then
+  echo "Audit report mentions forbidden interpreter token" >&2
   exit 1
 fi
 ```
 
 Adapt the `audit_module.py --skip-review` path and cleanup paths for each built module audited. Keep the review gate separate: cite the independent review source in the durable audit report or PR body. The audit command still writes local generated cache/status/audit outputs, so remove those known outputs before the diff gate; do not commit curriculum `review/`, `audit/`, or `status/` artifacts. Do not pass `--fix`. Do not run builds.
 
+## Independent-Family Review Gate
+
+Before merge, request a read-only independent-family review of the audit-report PR. Prefer Claude Opus 4.8. If Claude Opus 4.8 is unavailable, use Agy with Gemini 3.1 Pro High, for example `agy --model gemini-3.1-pro-high --print-timeout 10m -p "<review prompt>"`.
+
+The review prompt must include the PR diff, audited-module scope, validation summary, artifact-clean statement, helper/swarm note, and an explicit request for blocker-only findings. Record reviewer identity, review model, review scope, unresolved findings, and final disposition in the durable audit report or PR body. The merge rule is explicit: unresolved findings are blockers.
+
+## PR Body Requirements
+
+PR body must include: audited modules, report path, blocker count, issue count, recommended remediation batches, validation commands and outcomes, `swarm_used`, `swarm_label`, `swarm_note`, reviewer identity, review scope, final disposition, unresolved review findings count, and a statement that no curriculum/site source files, generated curriculum artifacts, or telemetry database files are included.
+
 ## Report Delivery
 
-After validation, commit and open a draft PR that contains only the report:
+After validation, commit and open a draft PR that contains only the report plus PR body delivery text:
 
 ```bash
 REPORT="docs/audits/b2-quality-audit-$(date +%F).md"
@@ -139,7 +160,11 @@ Issues recorded: <n>
 Recommended remediation batches: <summary>
 Validation run: <commands and outcomes>
 Report delivery: <draft PR URL or blocked reason>
+Review PR: <url, ready/merged/blocked>
+Independent review: <reviewer identity, model, scope, final disposition>
+Unresolved review findings: <n>
 Curriculum files modified: no
+Forbidden artifacts included: no
 swarm_used: true/false
 swarm_label: <none | solo | helper | swarm>
 swarm_note: <helpers used, or solo run; no swarm used>

--- a/scripts/lint/lint_prompts.py
+++ b/scripts/lint/lint_prompts.py
@@ -460,6 +460,68 @@ def check_orchestrator_suite_file(
     return violations
 
 
+def check_b2_prompt_contracts(root: Path) -> list[dict]:
+    """Validate B2 legacy prompts still carry executable review/swarm gates."""
+    marker_sets = {
+        root / "b2" / "preflight-readiness-audit-orchestrator.md": [
+            "## Helper Swarm Policy",
+            "gpt-5.4-mini",
+            "gpt-5.3-codex-spark",
+            "Do not let helpers read secrets",
+            "## Independent-Family Review Gate",
+            "Claude Opus 4.8",
+            "Gemini 3.1 Pro High",
+            "unresolved findings are blockers",
+            "## PR Body Requirements",
+            "reviewer identity",
+            "review scope",
+            "final disposition",
+        ],
+        root / "b2" / "production-build-orchestrator.md": [
+            "## Helper Swarm Policy",
+            "gpt-5.4-mini",
+            "gpt-5.3-codex-spark",
+            "Do not let helpers read secrets",
+            "## Independent-Family Review Gate",
+            "Claude Opus 4.8",
+            "Gemini 3.1 Pro High",
+            "unresolved findings are blockers",
+            "POST /api/telemetry/module-builds",
+            "pr_number",
+            "pr_url",
+            "reviewer identity",
+        ],
+        root / "b2" / "quality-audit-orchestrator.md": [
+            "## Helper Swarm Policy",
+            "gpt-5.4-mini",
+            "gpt-5.3-codex-spark",
+            "Do not let helpers read secrets",
+            "## Independent-Family Review Gate",
+            "Claude Opus 4.8",
+            "Gemini 3.1 Pro High",
+            "unresolved findings are blockers",
+            "## PR Body Requirements",
+            "reviewer identity",
+            "review scope",
+            "final disposition",
+        ],
+    }
+
+    violations: list[dict] = []
+    for filepath, markers in marker_sets.items():
+        if not filepath.exists():
+            continue
+        text = filepath.read_text(encoding="utf-8")
+        violations.extend(require_markers(
+            text,
+            filepath,
+            markers,
+            "ORCH_B2_REVIEW_SWARM_CONTRACT",
+            "B2 prompt missing executable review/swarm marker",
+        ))
+    return violations
+
+
 def check_orchestrator_track_coverage(
     root: Path,
     manifest_path: Path,
@@ -533,6 +595,7 @@ def scan_orchestrator_suites(
     for filepath in sorted(root.glob("*/suite-orchestrator.md")):
         violations.extend(check_orchestrator_suite_file(filepath, seminar_tracks=seminar_tracks))
 
+    violations.extend(check_b2_prompt_contracts(root))
     return violations
 
 


### PR DESCRIPTION
## Summary
- Add explicit helper swarm policy, PR-body evidence, artifact hygiene, and independent-family review gates to the B2 preflight, production build, and quality audit orchestrator prompts.
- Add B2 production module-build telemetry requirements to the build prompt.
- Remove the literal forbidden interpreter token from B2 audit/preflight report guards while preserving guard behavior.
- Add prompt-linter coverage so the B2 preflight/build/audit prompts cannot silently lose the review/swarm contract.

## Validation
- `.venv/bin/python -m py_compile scripts/lint/lint_prompts.py`
- `.venv/bin/python scripts/lint/lint_prompts.py`
- `git diff --check origin/main..HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- pre-commit on commit/amend: `tests/test_lint_prompts.py` (70 passed, 14 skipped)

## Artifact Hygiene
- Changed files: 4
- No `.python-version`, `.yamllint`, or `.markdownlint.json` changes.
- No status JSON, curriculum audit/review artifacts, or telemetry DB files included.
- No forbidden interpreter literal remains in B2 orchestrator prompts or the changed linter file.

## Independent Review
- Reviewer: Agy with Gemini 3.1 Pro High (Claude Opus 4.8 unavailable locally)
- Scope: read-only blocker-only review of B2 preflight/build/audit orchestrator prompt and linter changes
- Prior findings: preflight prompt missing the new gates; linter missing preflight enforcement
- Final disposition: NO BLOCKERS after fixes
- Unresolved review findings: 0

X-Agent: codex/b2-prompt-review-gates
