### PR TITLE
fix(ci): repair deploy-pages.yml indentation broken by #3739 (deploy is failing)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -38,9 +38,9 @@ jobs:
         with:
           # Astro 6 requires Node >=22.12.0; matches ci.yml. Node 20 broke the
           # deploy build ("Node.js v20.x is not supported by Astro").
-        node-version: '22'
-        cache: 'npm'
-        cache-dependency-path: site/package-lock.json
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: site/package-lock.json
 
       - name: Cache Atlas lexicon manifest
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4


### PR DESCRIPTION
**Urgent:** the #3659 merge (#3739) de-indented the setup-node `with:` keys in `deploy-pages.yml`, which is valid YAML but structurally invalid for Actions — the post-merge Pages deploy **failed** (`This run likely failed because of a workflow file issue`). Live site is safe (Pages didn't publish a failed build). This re-indents the keys under `with:`. Merging re-triggers the deploy, which should now succeed. A follow-up adds an **actionlint** CI guard so a malformed workflow can't merge unvalidated again (root cause: deploy workflows don't run in PR CI).