### PR TITLE
ci(actionlint): add workflow-structure gate (root-cause fix for #3742)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,41 @@
+name: actionlint
+
+# Structural/schema gate for GitHub Actions workflow files (root-cause fix for
+# the #3739/#3742 break: a de-indented setup-node `with:` block was valid YAML
+# but invalid Actions, slipped past yamllint + zizmor, and broke the Pages
+# deploy in production). actionlint type-checks `${{ }}` expressions, validates
+# step keys / `with:` inputs / runner labels, and lints `run:` scripts via the
+# shellcheck preinstalled on GitHub runners.
+#
+# Runs on EVERY PR (no `paths:` filter) on purpose: it lints only the handful
+# of workflow files, finishes in seconds, and — unlike the path-scoped
+# validate-yaml job — is therefore safe to add to branch protection's required
+# checks without deadlocking doc-only PRs (GitHub blocks on a *skipped* required
+# check). The pinned version + checksums live in scripts/audit/check_workflows.sh,
+# which both this job and local devs invoke (single source of truth).
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  actionlint:
+    name: actionlint (workflow files)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Lint workflows
+        env:
+          # Force the pinned, checksum-verified actionlint build for a
+          # reproducible result even if a runner image ever bundles its own.
+          ACTIONLINT_FORCE_DOWNLOAD: '1'
+        run: scripts/audit/check_workflows.sh

--- a/scripts/audit/check_workflows.sh
+++ b/scripts/audit/check_workflows.sh
@@ -43,9 +43,17 @@ checksum_for() {
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+# Remove only a binary we downloaded ourselves (stays empty for ACTIONLINT_BIN
+# or a system actionlint). The EXIT trap fires on success, error, and SIGTERM,
+# so the temp dir never leaks for a local dev across runs.
+_DOWNLOAD_DIR=""
+cleanup() { [[ -n "$_DOWNLOAD_DIR" ]] && rm -rf "$_DOWNLOAD_DIR"; return 0; }
+trap cleanup EXIT
+
 sha256_verify() {
   # sha256_verify <expected> <file>
   local expected="$1" file="$2" actual
+  [[ -f "$file" ]] || { echo "❌ download missing, cannot verify: $file" >&2; return 1; }
   if command -v sha256sum >/dev/null 2>&1; then
     actual="$(sha256sum "$file" | awk '{print $1}')"
   elif command -v shasum >/dev/null 2>&1; then
@@ -62,15 +70,23 @@ sha256_verify() {
   fi
 }
 
+# Sets RESOLVED_BIN (and, when it downloads, _DOWNLOAD_DIR). Called directly —
+# NOT in $(...) — so the globals survive into the caller and the EXIT trap.
+RESOLVED_BIN=""
 resolve_actionlint() {
-  # Explicit override wins.
+  # Explicit override wins — but validate it so a stale path fails loudly here
+  # instead of with a cryptic "No such file" when we later try to run it.
   if [[ -n "${ACTIONLINT_BIN:-}" ]]; then
-    echo "$ACTIONLINT_BIN"
+    if [[ ! -x "$ACTIONLINT_BIN" ]]; then
+      echo "❌ ACTIONLINT_BIN is not an executable file: $ACTIONLINT_BIN" >&2
+      return 1
+    fi
+    RESOLVED_BIN="$ACTIONLINT_BIN"
     return 0
   fi
   # Local convenience: use a system actionlint unless CI forces a pinned fetch.
   if [[ -z "${ACTIONLINT_FORCE_DOWNLOAD:-}" ]] && command -v actionlint >/dev/null 2>&1; then
-    command -v actionlint
+    RESOLVED_BIN="$(command -v actionlint)"
     return 0
   fi
 
@@ -90,23 +106,24 @@ resolve_actionlint() {
     return 1
   fi
 
-  local tmp tarball url
-  tmp="$(mktemp -d)"
-  tarball="${tmp}/actionlint.tar.gz"
+  # Download into a temp dir the EXIT trap will remove.
+  _DOWNLOAD_DIR="$(mktemp -d)"
+  local tarball url
+  tarball="${_DOWNLOAD_DIR}/actionlint.tar.gz"
   url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_${platform}.tar.gz"
 
   echo "→ fetching actionlint v${ACTIONLINT_VERSION} (${platform})" >&2
   curl -fsSL -o "$tarball" "$url"
   sha256_verify "$expected" "$tarball"
-  tar -xzf "$tarball" -C "$tmp" actionlint
-  echo "${tmp}/actionlint"
+  tar -xzf "$tarball" -C "$_DOWNLOAD_DIR" actionlint
+  RESOLVED_BIN="${_DOWNLOAD_DIR}/actionlint"
 }
 
 main() {
   cd "$REPO_ROOT"
 
-  local bin
-  bin="$(resolve_actionlint)"
+  resolve_actionlint
+  local bin="$RESOLVED_BIN"
 
   # Targets: explicit args, else every workflow file.
   local -a targets=()

--- a/scripts/audit/check_workflows.sh
+++ b/scripts/audit/check_workflows.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Lint .github/workflows/** with actionlint — the structural/schema gate for
+# GitHub Actions workflow files.
+#
+# WHY THIS EXISTS (root-cause fix for the #3739/#3742 deploy-yaml break):
+#   `validate-yaml.yml` runs yamllint only on curriculum/** and `zizmor.yml`
+#   does Actions *security* analysis. Nothing validated workflow *structure*,
+#   so #3739 de-indented setup-node's `with:` keys (valid YAML, invalid
+#   Actions) and the broken workflow merged — Pages deploy then failed in
+#   production. actionlint type-checks `${{ }}` expressions, validates step
+#   keys / `with:` inputs / runner labels, and (with shellcheck on PATH)
+#   lints `run:` scripts. It exits non-zero on any finding → a real gate.
+#
+# SINGLE SOURCE OF TRUTH: both CI (.github/workflows/actionlint.yml) and local
+#   devs call this script, so the pinned version + checksums never drift apart.
+#
+# USAGE:
+#   scripts/audit/check_workflows.sh                 # lint all workflow files
+#   scripts/audit/check_workflows.sh path/to/wf.yml  # lint specific file(s)
+#
+# ENV:
+#   ACTIONLINT_BIN=/path/to/actionlint   explicit binary override (skip download)
+#   ACTIONLINT_FORCE_DOWNLOAD=1          ignore any actionlint on PATH and always
+#                                        fetch the pinned, checksum-verified build
+#                                        (set in CI for reproducibility)
+set -euo pipefail
+
+# --- pinned release (bump VERSION + all checksums together) -------------------
+ACTIONLINT_VERSION="1.7.12"
+# sha256 of each release tarball, from the upstream checksums.txt for v1.7.12.
+# Verify when bumping: gh api repos/rhysd/actionlint/releases/latest \
+#   --jq '.assets[]|select(.name|endswith("checksums.txt")).url' \
+#   | xargs -I{} gh api {} -H 'Accept: application/octet-stream'
+checksum_for() {
+  case "$1" in
+    linux_amd64)  echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8" ;;
+    linux_arm64)  echo "325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6" ;;
+    darwin_amd64) echo "5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644" ;;
+    darwin_arm64) echo "aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f" ;;
+    *) return 1 ;;
+  esac
+}
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+sha256_verify() {
+  # sha256_verify <expected> <file>
+  local expected="$1" file="$2" actual
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$file" | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "$file" | awk '{print $1}')"
+  else
+    echo "❌ no sha256sum/shasum available to verify download" >&2
+    return 1
+  fi
+  if [[ "$actual" != "$expected" ]]; then
+    echo "❌ actionlint checksum mismatch" >&2
+    echo "   expected: $expected" >&2
+    echo "   actual:   $actual" >&2
+    return 1
+  fi
+}
+
+resolve_actionlint() {
+  # Explicit override wins.
+  if [[ -n "${ACTIONLINT_BIN:-}" ]]; then
+    echo "$ACTIONLINT_BIN"
+    return 0
+  fi
+  # Local convenience: use a system actionlint unless CI forces a pinned fetch.
+  if [[ -z "${ACTIONLINT_FORCE_DOWNLOAD:-}" ]] && command -v actionlint >/dev/null 2>&1; then
+    command -v actionlint
+    return 0
+  fi
+
+  # Detect platform.
+  local os arch platform
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  case "$(uname -m)" in
+    x86_64|amd64) arch="amd64" ;;
+    aarch64|arm64) arch="arm64" ;;
+    *) echo "❌ unsupported arch: $(uname -m)" >&2; return 1 ;;
+  esac
+  platform="${os}_${arch}"
+
+  local expected
+  if ! expected="$(checksum_for "$platform")"; then
+    echo "❌ no pinned actionlint checksum for platform: $platform" >&2
+    return 1
+  fi
+
+  local tmp tarball url
+  tmp="$(mktemp -d)"
+  tarball="${tmp}/actionlint.tar.gz"
+  url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_${platform}.tar.gz"
+
+  echo "→ fetching actionlint v${ACTIONLINT_VERSION} (${platform})" >&2
+  curl -fsSL -o "$tarball" "$url"
+  sha256_verify "$expected" "$tarball"
+  tar -xzf "$tarball" -C "$tmp" actionlint
+  echo "${tmp}/actionlint"
+}
+
+main() {
+  cd "$REPO_ROOT"
+
+  local bin
+  bin="$(resolve_actionlint)"
+
+  # Targets: explicit args, else every workflow file.
+  local -a targets=()
+  if (($# > 0)); then
+    targets=("$@")
+  else
+    while IFS= read -r f; do targets+=("$f"); done < <(
+      find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) | sort
+    )
+  fi
+
+  if ((${#targets[@]} == 0)); then
+    echo "✅ no workflow files to lint"
+    return 0
+  fi
+
+  echo "→ actionlint $("$bin" --version | head -1) on ${#targets[@]} workflow file(s)" >&2
+  "$bin" -color "${targets[@]}"
+  echo "✅ actionlint: all workflow files valid"
+}
+
+main "$@"

--- a/tests/test_actionlint_workflow.py
+++ b/tests/test_actionlint_workflow.py
@@ -1,0 +1,99 @@
+"""Keep the actionlint workflow-structure gate load-bearing.
+
+``.github/workflows/actionlint.yml`` is the root-cause fix for the #3739/#3742
+break, where a de-indented ``setup-node`` ``with:`` block was valid YAML but
+invalid Actions, passed yamllint + zizmor, and broke the Pages deploy. The gate
+runs ``scripts/audit/check_workflows.sh`` (a checksum-pinned actionlint).
+
+These tests assert the wiring statically — no actionlint binary or network is
+required — so the gate cannot be silently removed or gutted: the workflow must
+trigger on PRs and invoke the shared script, and the shared script must keep its
+pinned version + per-platform checksums + checksum verification.
+"""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "actionlint.yml"
+_SCRIPT = _REPO_ROOT / "scripts" / "audit" / "check_workflows.sh"
+
+# Platforms the shared script must pin a checksum for (CI + common dev machines).
+_REQUIRED_PLATFORMS = ("linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64")
+
+
+def _load_workflow() -> dict:
+    data = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), "actionlint workflow did not parse to a mapping"
+    return data
+
+
+def _triggers(workflow: dict) -> dict:
+    # PyYAML (YAML 1.1) parses the bare ``on:`` key as the boolean True.
+    raw = workflow.get("on", workflow.get(True))
+    assert raw is not None, "actionlint workflow has no `on:` triggers"
+    return raw
+
+
+def test_workflow_file_exists_and_parses() -> None:
+    assert _WORKFLOW.is_file(), f"missing workflow: {_WORKFLOW}"
+    _load_workflow()
+
+
+def test_workflow_triggers_on_pull_requests() -> None:
+    triggers = _triggers(_load_workflow())
+    assert "pull_request" in triggers, (
+        "actionlint must run on pull_request so it gates PRs that touch workflows"
+    )
+
+
+def test_workflow_invokes_shared_script() -> None:
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    assert "scripts/audit/check_workflows.sh" in text, (
+        "workflow must call the shared runner (single source of truth)"
+    )
+    # Reproducible CI: ignore any runner-bundled actionlint, fetch the pin.
+    assert "ACTIONLINT_FORCE_DOWNLOAD" in text
+
+
+def test_workflow_uses_minimal_permissions() -> None:
+    workflow = _load_workflow()
+    assert workflow.get("permissions") == {"contents": "read"}, (
+        "actionlint job needs only contents:read"
+    )
+
+
+def test_workflow_checkout_does_not_persist_credentials() -> None:
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    assert "persist-credentials: false" in text, (
+        "checkout must set persist-credentials: false (zizmor baseline)"
+    )
+
+
+def test_shared_script_exists_and_is_executable() -> None:
+    assert _SCRIPT.is_file(), f"missing runner: {_SCRIPT}"
+    mode = _SCRIPT.stat().st_mode
+    assert mode & stat.S_IXUSR, f"{_SCRIPT} must be executable"
+
+
+def test_shared_script_pins_version_and_checksums() -> None:
+    text = _SCRIPT.read_text(encoding="utf-8")
+    assert 'ACTIONLINT_VERSION="' in text, "script must pin an actionlint version"
+    # A 64-hex sha256 must be present for every required platform.
+    for platform in _REQUIRED_PLATFORMS:
+        assert platform in text, f"script missing checksum entry for {platform}"
+    # Verification must actually run on the downloaded tarball.
+    assert "sha256_verify" in text, "script must verify the download checksum"
+
+
+def test_checksum_entries_are_well_formed() -> None:
+    import re
+
+    text = _SCRIPT.read_text(encoding="utf-8")
+    for platform in _REQUIRED_PLATFORMS:
+        match = re.search(rf"{platform}\)\s+echo\s+\"([0-9a-f]{{64}})\"", text)
+        assert match, f"{platform} checksum is not a 64-char lowercase hex sha256"


### PR DESCRIPTION
## Why

`#3739` de-indented `setup-node`'s `with:` keys — **valid YAML, invalid Actions** — and it merged because nothing validates workflow *structure*:
- `validate-yaml.yml` runs `yamllint` only on `curriculum/**`.
- `zizmor.yml` does Actions **security** analysis, not structural/schema lint.
- the `check yaml syntax` pre-commit hook checks YAML syntax, not Actions semantics.

The broken workflow then **failed the Pages deploy in production** (fixed reactively in `#3742`). This is the load-bearing root-cause guard promised in that fix.

## What

[`actionlint`](https://github.com/rhysd/actionlint) — type-checks `${{ }}` expressions, validates step keys / `with:` inputs / runner labels, lints `run:` scripts via shellcheck — as a **hard gate**.

- **`scripts/audit/check_workflows.sh`** — checksum-pinned actionlint **v1.7.12**, multi-arch, runnable locally *and* by CI. Single source of truth for the pinned version + per-platform sha256, so the two never drift. `ACTIONLINT_BIN` / `ACTIONLINT_FORCE_DOWNLOAD` escape hatches.
- **`.github/workflows/actionlint.yml`** — runs on **every PR** (no `paths:` filter, on purpose: it lints only the handful of workflow files in seconds, so it is safe to add to branch-protection required checks *without* deadlocking doc-only PRs on a skipped required check). `contents: read` only; `persist-credentials: false`.
- **`tests/test_actionlint_workflow.py`** — static wiring guard (no binary/network) so the gate can't be silently removed or gutted.

## Verification (real artifact, #M-4 / #M-4a)

actionlint **v1.7.12**, checksums verified against upstream `checksums.txt`:
- current 9 workflows → **exit 0** (pass)
- `#3742`-class break (de-indented `with:` key) → **exit 1** (fail)
- bad `${{ github.evnt.* }}` expression → **exit 1** (fail)
- `scripts/audit/check_workflows.sh` exercised in all three modes (`ACTIONLINT_BIN` override, force-download w/ checksum verify, broken-file) ✅
- pre-commit (ruff + pytest 8/8 + gitleaks + yaml) green on push.

## Follow-up (maintainer's call)

To make this a *required* check: it already runs on every PR, so just add **`actionlint (workflow files)`** to branch protection — no path-filter deadlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)