### PR TITLE
fix(atlas): calm Sovietization note + real /lexicon/ landing

### DIFF
--- a/site/src/lexicon/AtlasTypeahead.astro
+++ b/site/src/lexicon/AtlasTypeahead.astro
@@ -1,0 +1,185 @@
+---
+interface Props {
+  id: string;
+  label: string;
+  placeholder?: string;
+  containerClass?: string;
+  labelClass?: string;
+}
+
+const {
+  id,
+  label,
+  placeholder = "Шукати слово…",
+  containerClass = "",
+  labelClass = "atlas-typeahead-label sr-only",
+} = Astro.props as Props;
+
+const inputId = `${id}-input`;
+const listId = `${id}-list`;
+---
+
+<div class:list={["atlas-typeahead", containerClass]} data-atlas-typeahead>
+  <label for={inputId} class={labelClass}>{label}</label>
+  <input
+    id={inputId}
+    type="search"
+    class="atlas-typeahead-input"
+    placeholder={placeholder}
+    role="combobox"
+    aria-expanded="false"
+    aria-autocomplete="list"
+    aria-haspopup="listbox"
+    aria-controls={listId}
+    autocomplete="off"
+    spellcheck="false"
+    data-atlas-typeahead-input
+  />
+  <ul
+    id={listId}
+    class="atlas-typeahead-list"
+    role="listbox"
+    aria-label="Результати пошуку"
+    hidden
+    data-atlas-typeahead-list
+  ></ul>
+</div>
+
+<script is:inline>
+  (() => {
+    const initAtlasTypeahead = (ta) => {
+      if (ta.dataset.atlasTypeaheadReady === "true") return;
+
+      const taInput = ta.querySelector("[data-atlas-typeahead-input]");
+      const taList = ta.querySelector("[data-atlas-typeahead-list]");
+      if (!taInput || !taList) return;
+
+      ta.dataset.atlasTypeaheadReady = "true";
+
+      let taIndex = null;
+      let taLoading = null;
+      let taItems = [];
+      let taActive = -1;
+
+      const taLoad = () => {
+        if (taIndex) return Promise.resolve(taIndex);
+        if (!taLoading) {
+          taLoading = fetch("/lexicon/search-index.json")
+            .then((r) => r.json())
+            .then((data) => {
+              taIndex = Array.isArray(data) ? data : [];
+              return taIndex;
+            })
+            .catch(() => {
+              taIndex = [];
+              return taIndex;
+            });
+        }
+        return taLoading;
+      };
+
+      const taNorm = (s) => (s || "").toLowerCase().normalize("NFC").replace(/['́̀ˈ]/g, "").trim();
+      const taEsc = (s) =>
+        (s || "").replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c]);
+      const taGo = (slug) => {
+        if (slug) window.location.href = `/lexicon/${encodeURIComponent(slug)}/`;
+      };
+      const taOptionId = (i) => `${taInput.id || "atlas-typeahead"}-opt-${i}`;
+
+      const taRender = () => {
+        if (!taItems.length) {
+          taList.hidden = true;
+          taList.innerHTML = "";
+          taInput.setAttribute("aria-expanded", "false");
+          taInput.removeAttribute("aria-activedescendant");
+          return;
+        }
+
+        taList.innerHTML = taItems
+          .map(
+            (it, i) =>
+              `<li role="option" id="${taEsc(taOptionId(i))}" class="atlas-typeahead-opt${
+                i === taActive ? " active" : ""
+              }" data-slug="${taEsc(it.s)}" aria-selected="${i === taActive}">` +
+              `<span class="ata-lemma">${taEsc(it.l)}</span>` +
+              (it.g ? `<span class="ata-gloss">${taEsc(it.g)}</span>` : "") +
+              "</li>",
+          )
+          .join("");
+        taList.hidden = false;
+        taInput.setAttribute("aria-expanded", "true");
+        if (taActive >= 0) taInput.setAttribute("aria-activedescendant", taOptionId(taActive));
+      };
+
+      const taSearch = (q) => {
+        const nq = taNorm(q);
+        if (!nq || !taIndex) {
+          taItems = [];
+          taActive = -1;
+          taRender();
+          return;
+        }
+
+        const starts = [];
+        const contains = [];
+        for (const e of taIndex) {
+          const nl = taNorm(e.l);
+          if (nl.startsWith(nq)) {
+            if (starts.length < 12) starts.push(e);
+          } else if (contains.length < 12 && (nl.includes(nq) || taNorm(e.g).includes(nq))) {
+            contains.push(e);
+          }
+          if (starts.length >= 12) break;
+        }
+        taItems = starts.concat(contains).slice(0, 12);
+        taActive = taItems.length ? 0 : -1;
+        taRender();
+      };
+
+      taInput.addEventListener("focus", taLoad, { once: true });
+      taInput.addEventListener("input", () => {
+        taLoad().then(() => taSearch(taInput.value));
+      });
+      taInput.addEventListener("keydown", (ev) => {
+        if (ev.key === "ArrowDown") {
+          ev.preventDefault();
+          if (taItems.length) {
+            taActive = (taActive + 1) % taItems.length;
+            taRender();
+          }
+        } else if (ev.key === "ArrowUp") {
+          ev.preventDefault();
+          if (taItems.length) {
+            taActive = (taActive - 1 + taItems.length) % taItems.length;
+            taRender();
+          }
+        } else if (ev.key === "Enter") {
+          if (taItems[taActive]) {
+            ev.preventDefault();
+            taGo(taItems[taActive].s);
+          }
+        } else if (ev.key === "Escape") {
+          taItems = [];
+          taActive = -1;
+          taRender();
+        }
+      });
+      taList.addEventListener("mousedown", (ev) => {
+        const li = ev.target.closest("[data-slug]");
+        if (li) {
+          ev.preventDefault();
+          taGo(li.getAttribute("data-slug"));
+        }
+      });
+      document.addEventListener("click", (ev) => {
+        if (ta && !ta.contains(ev.target)) {
+          taItems = [];
+          taActive = -1;
+          taRender();
+        }
+      });
+    };
+
+    document.querySelectorAll("[data-atlas-typeahead]").forEach(initAtlasTypeahead);
+  })();
+</script>

--- a/site/src/lexicon/LexiconBrowse.astro
+++ b/site/src/lexicon/LexiconBrowse.astro
@@ -1,0 +1,201 @@
+---
+interface CourseUsage {
+  track: string;
+  module_num: number;
+  slug: string;
+  context: string;
+}
+
+interface LexiconEntry {
+  lemma: string;
+  url_slug: string;
+  gloss: string | null;
+  primary_source: string;
+  course_usage: CourseUsage[];
+}
+
+interface Props {
+  entries: LexiconEntry[];
+}
+
+const { entries } = Astro.props as Props;
+
+const ukCollator = new Intl.Collator("uk", { sensitivity: "base" });
+
+const SOURCE_LABELS_UK: Record<string, string> = {
+  built_vocabulary: "вивчається",
+  plan_required: "обов’язкова",
+  plan_recommended: "рекомендована",
+  surzhyk_to_avoid: "остерігайтеся",
+};
+
+const groups = new Map<string, LexiconEntry[]>();
+for (const entry of entries) {
+  const letter = entry.lemma.charAt(0).toLocaleUpperCase("uk");
+  const bucket = groups.get(letter) ?? [];
+  bucket.push(entry);
+  groups.set(letter, bucket);
+}
+
+const sortedGroups = Array.from(groups.entries())
+  .sort(([a], [b]) => ukCollator.compare(a, b))
+  .map(([letter, groupEntries]) => ({
+    letter,
+    entries: groupEntries.slice().sort((a, b) => ukCollator.compare(a.lemma, b.lemma)),
+  }));
+---
+
+<nav class="atlas-letter-nav" aria-label="Український алфавіт">
+  {
+    sortedGroups.map(({ letter }) => (
+      <a href={`#letter-${letter}`}>{letter}</a>
+    ))
+  }
+</nav>
+
+<div class="atlas-letter-groups">
+  {
+    sortedGroups.map(({ letter, entries }) => (
+      <section class="atlas-letter-section" data-lex-section>
+        <h2 id={`letter-${letter}`}>{letter}</h2>
+        <ul class="atlas-entry-list">
+          {entries.map((entry) => {
+            const usageLabel = entry.course_usage.length === 1 ? "модуль" : "модулів";
+            const searchText = [
+              entry.lemma,
+              entry.gloss ?? "",
+              entry.primary_source,
+              ...entry.course_usage.map((usage) => `${usage.track} ${usage.slug}`),
+            ].join(" ");
+
+            return (
+              <li data-lex-entry data-source={entry.primary_source} data-search={searchText}>
+                <a class="atlas-entry-lemma" href={`/lexicon/${entry.url_slug}/`}>
+                  {entry.lemma}
+                </a>
+                {entry.gloss && <span class="atlas-entry-gloss">«{entry.gloss}»</span>}
+                <span class="atlas-entry-source">{SOURCE_LABELS_UK[entry.primary_source] ?? entry.primary_source}</span>
+                <span class="atlas-entry-usage">
+                  {entry.course_usage.length} {usageLabel}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+    ))
+  }
+</div>
+
+<style>
+  .atlas-letter-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    padding: 0.75rem;
+    border: 1px solid var(--lu-border);
+    border-radius: 8px;
+    background: var(--lu-surface);
+    box-shadow: 0 10px 24px color-mix(in srgb, var(--lu-text) 8%, transparent);
+  }
+
+  .atlas-letter-nav a {
+    min-width: 2rem;
+    min-height: 2rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 6px;
+    color: var(--lu-primary);
+    font-weight: 900;
+    text-decoration: none;
+  }
+
+  .atlas-letter-nav a:hover,
+  .atlas-letter-nav a:focus-visible {
+    background: var(--lu-state-active);
+  }
+
+  .atlas-letter-groups {
+    display: flex;
+    flex-direction: column;
+    gap: 1.4rem;
+  }
+
+  .atlas-letter-section h2 {
+    margin: 0 0 0.7rem;
+    padding-bottom: 0.35rem;
+    border-bottom: 2px solid var(--lu-accent);
+    color: var(--lu-primary);
+    font-size: 1.3rem;
+  }
+
+  .atlas-letter-section[hidden],
+  .atlas-entry-list li[hidden] {
+    display: none;
+  }
+
+  .atlas-entry-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+    gap: 0.7rem;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  .atlas-entry-list li {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.28rem 0.65rem;
+    align-items: start;
+    min-height: 7.6rem;
+    padding: 0.85rem;
+    border: 1px solid var(--lu-border);
+    border-left: 4px solid var(--lu-primary);
+    border-radius: 8px;
+    background: var(--lu-surface);
+    box-shadow: 0 10px 24px color-mix(in srgb, var(--lu-text) 8%, transparent);
+  }
+
+  .atlas-entry-lemma {
+    grid-column: 1 / -1;
+    color: var(--lu-text);
+    font-size: 1.05rem;
+    font-weight: 900;
+    text-decoration: none;
+  }
+
+  .atlas-entry-lemma:hover,
+  .atlas-entry-lemma:focus-visible {
+    color: var(--lu-primary);
+  }
+
+  .atlas-entry-gloss {
+    min-width: 0;
+    color: var(--lu-text-muted);
+    font-style: italic;
+  }
+
+  .atlas-entry-source,
+  .atlas-entry-usage {
+    align-self: end;
+    padding: 0.1rem 0.5rem;
+    border: 1px solid var(--lu-border);
+    border-radius: 4px;
+    background: var(--lu-surface-muted);
+    color: var(--lu-text-muted);
+    font-size: 0.78rem;
+    font-weight: 800;
+  }
+
+  .atlas-entry-usage {
+    white-space: nowrap;
+  }
+
+  @media (max-width: 680px) {
+    .atlas-entry-list li {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/site/src/lexicon/WordAtlasArticle.astro
+++ b/site/src/lexicon/WordAtlasArticle.astro
@@ -1,4 +1,6 @@
 ---
+import AtlasTypeahead from "./AtlasTypeahead.astro";
+
 interface CourseUsage {
   track: string;
   module_num: number;
@@ -171,7 +173,7 @@ const externalGroups = groupExternalMaterials(enrichment?.external_materials ?? 
 const componentLinks = buildComponentLinks(entry, allEntries);
 const sourceList = buildSourceList();
 const phraseHasGloss = Boolean(entry.gloss && (!enrichment?.meaning || enrichment.meaning.definitions.length === 0));
-const shouldShowEditorialWarning = maxSovietizationRisk > 0 || Boolean(heritage?.is_russianism);
+const shouldShowEditorialWarning = Boolean(heritage?.is_russianism);
 const shouldShowHeritageDefense = Boolean(
   heritage &&
     !heritage.is_russianism &&
@@ -377,29 +379,7 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
 
 <div class="word-atlas" data-word-atlas>
   <div class="word-switch">
-    <div class="atlas-typeahead" data-atlas-typeahead>
-      <input
-        type="search"
-        class="atlas-typeahead-input"
-        placeholder="Шукати слово…"
-        aria-label="Шукати слово в Лексиконі"
-        role="combobox"
-        aria-expanded="false"
-        aria-autocomplete="list"
-        aria-controls="atlas-typeahead-list"
-        autocomplete="off"
-        spellcheck="false"
-        data-atlas-typeahead-input
-      />
-      <ul
-        id="atlas-typeahead-list"
-        class="atlas-typeahead-list"
-        role="listbox"
-        aria-label="Результати пошуку"
-        hidden
-        data-atlas-typeahead-list
-      ></ul>
-    </div>
+    <AtlasTypeahead id="atlas-article-search" label="Шукати слово в Лексиконі" />
     <a class="atlas-button filter" href="/lexicon/index/">Перегляд А–Я</a>
     <span class="poc-label">Атлас слів (Лексикон)</span>
   </div>
@@ -453,31 +433,37 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
       </div>
     </div>
 
-    <div class="content-area">
-      {shouldShowEditorialWarning && (
-        <section class="atlas-section">
-          <div class="editorial-warn">
-            <div class="editorial-warn-header">
-              <div class="editorial-warn-icon" aria-hidden="true">⚠</div>
-              {maxSovietizationRisk > 0 ? "Радянські ідеологічні формулювання у СУМ-11" : "Редакційне попередження"}
-            </div>
-            {maxSovietizationRisk > 0 ? (
-              <>
-                <p>
-                  СУМ-11 показано для прозорості, але ця картка має ознаки радянської редакторської політики.
-                  Це не означає, що саме слово негативне: перевагу слід надавати сучасним або дорадянським джерелам.
-                </p>
-                <p class="atlas-muted">
-                  Тригер: <code>sovietization_risk={maxSovietizationRisk}</code>
-                  {sovietizationKeywords.length > 0 && <> · keywords: <code>{sovietizationKeywords.join(", ")}</code></>}
-                </p>
-              </>
-            ) : (
-              <p>Класифікатор позначає цю форму як проблемну для стандартної української. Перевіряйте рекомендовані відповідники в джерелах.</p>
-            )}
+  <div class="content-area">
+    {maxSovietizationRisk > 0 && (
+      <section class="atlas-section">
+        <div class="editorial-calque info">
+          <div class="editorial-calque-header">
+            <div class="editorial-info-icon" aria-hidden="true">→</div>
+            Радянські формулювання в СУМ-11 (стосується означення, не слова)
           </div>
-        </section>
-      )}
+          <p>
+            СУМ-11 показано для прозорості, але ця картка має ознаки радянської редакторської політики.
+            Це не означає, що саме слово негативне: перевагу слід надавати сучасним або дорадянським джерелам.
+          </p>
+          <p class="atlas-muted">
+            Тригер: <code>sovietization_risk={maxSovietizationRisk}</code>
+            {sovietizationKeywords.length > 0 && <> · keywords: <code>{sovietizationKeywords.join(", ")}</code></>}
+          </p>
+        </div>
+      </section>
+    )}
+
+    {shouldShowEditorialWarning && (
+      <section class="atlas-section">
+        <div class="editorial-warn" data-editorial-warn="is_russianism">
+          <div class="editorial-warn-header">
+            <div class="editorial-warn-icon" aria-hidden="true">⚠</div>
+            Редакційне попередження
+          </div>
+          <p>Класифікатор позначає цю форму як проблемну для стандартної української. Перевіряйте рекомендовані відповідники в джерелах.</p>
+        </div>
+      </section>
+    )}
 
       {shouldShowHeritageDefense && (
         <section class="atlas-section">
@@ -792,81 +778,6 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
 <script is:inline>
   (() => {
     const root = document.querySelector('[data-word-atlas]');
-    const ta = root?.querySelector('[data-atlas-typeahead]');
-    const taInput = ta?.querySelector('[data-atlas-typeahead-input]');
-    const taList = ta?.querySelector('[data-atlas-typeahead-list]');
-    if (taInput && taList) {
-      let taIndex = null;
-      let taLoading = null;
-      let taItems = [];
-      let taActive = -1;
-
-      const taLoad = () => {
-        if (taIndex) return Promise.resolve(taIndex);
-        if (!taLoading) {
-          taLoading = fetch('/lexicon/search-index.json')
-            .then((r) => r.json())
-            .then((data) => { taIndex = Array.isArray(data) ? data : []; return taIndex; })
-            .catch(() => { taIndex = []; return taIndex; });
-        }
-        return taLoading;
-      };
-
-      const taNorm = (s) => (s || '').toLowerCase().normalize('NFC').replace(/['́̀ˈ]/g, '').trim();
-      const taEsc = (s) => (s || '').replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
-      const taGo = (slug) => { if (slug) window.location.href = `/lexicon/${encodeURIComponent(slug)}/`; };
-
-      const taRender = () => {
-        if (!taItems.length) {
-          taList.hidden = true;
-          taList.innerHTML = '';
-          taInput.setAttribute('aria-expanded', 'false');
-          taInput.removeAttribute('aria-activedescendant');
-          return;
-        }
-        taList.innerHTML = taItems.map((it, i) =>
-          `<li role="option" id="ata-opt-${i}" class="atlas-typeahead-opt${i === taActive ? ' active' : ''}" data-slug="${taEsc(it.s)}" aria-selected="${i === taActive}">`
-          + `<span class="ata-lemma">${taEsc(it.l)}</span>`
-          + (it.g ? `<span class="ata-gloss">${taEsc(it.g)}</span>` : '')
-          + '</li>'
-        ).join('');
-        taList.hidden = false;
-        taInput.setAttribute('aria-expanded', 'true');
-        if (taActive >= 0) taInput.setAttribute('aria-activedescendant', `ata-opt-${taActive}`);
-      };
-
-      const taSearch = (q) => {
-        const nq = taNorm(q);
-        if (!nq || !taIndex) { taItems = []; taActive = -1; taRender(); return; }
-        const starts = [];
-        const contains = [];
-        for (const e of taIndex) {
-          const nl = taNorm(e.l);
-          if (nl.startsWith(nq)) { if (starts.length < 12) starts.push(e); }
-          else if (contains.length < 12 && (nl.includes(nq) || taNorm(e.g).includes(nq))) contains.push(e);
-          if (starts.length >= 12) break;
-        }
-        taItems = starts.concat(contains).slice(0, 12);
-        taActive = taItems.length ? 0 : -1;
-        taRender();
-      };
-
-      taInput.addEventListener('focus', taLoad, { once: true });
-      taInput.addEventListener('input', () => { taLoad().then(() => taSearch(taInput.value)); });
-      taInput.addEventListener('keydown', (ev) => {
-        if (ev.key === 'ArrowDown') { ev.preventDefault(); if (taItems.length) { taActive = (taActive + 1) % taItems.length; taRender(); } }
-        else if (ev.key === 'ArrowUp') { ev.preventDefault(); if (taItems.length) { taActive = (taActive - 1 + taItems.length) % taItems.length; taRender(); } }
-        else if (ev.key === 'Enter') { if (taItems[taActive]) { ev.preventDefault(); taGo(taItems[taActive].s); } }
-        else if (ev.key === 'Escape') { taItems = []; taActive = -1; taRender(); }
-      });
-      taList.addEventListener('mousedown', (ev) => {
-        const li = ev.target.closest('[data-slug]');
-        if (li) { ev.preventDefault(); taGo(li.getAttribute('data-slug')); }
-      });
-      document.addEventListener('click', (ev) => {
-        if (ta && !ta.contains(ev.target)) { taItems = []; taActive = -1; taRender(); }
-      });
-    }
 
     root?.querySelectorAll('[data-ety-note]').forEach((stage) => {
       stage.addEventListener('click', () => {

--- a/site/src/pages/lexicon/index.astro
+++ b/site/src/pages/lexicon/index.astro
@@ -1,34 +1,39 @@
 ---
 /**
- * Атлас слів (Лексикон) — default Word Atlas surface.
+ * Атлас слів (Лексикон) landing page.
  */
 import CourseLayout from "../../layouts/CourseLayout.astro";
-import WordAtlasArticle from "../../lexicon/WordAtlasArticle.astro";
+import AtlasTypeahead from "../../lexicon/AtlasTypeahead.astro";
+import LexiconBrowse from "../../lexicon/LexiconBrowse.astro";
 import manifest from "../../data/lexicon-manifest.json";
+
+interface CourseUsage {
+  track: string;
+  module_num: number;
+  slug: string;
+  context: string;
+}
 
 interface LexiconEntry {
   lemma: string;
   url_slug: string;
   gloss: string | null;
+  primary_source: string;
+  course_usage: CourseUsage[];
 }
 
 interface LexiconManifest {
   version: string;
   generated_at: string;
+  stats: Record<string, number>;
   entries: LexiconEntry[];
 }
 
 const data = manifest as LexiconManifest;
-const defaultEntry =
-  data.entries.find((entry) => entry.lemma === "князь") ??
-  data.entries.find((entry) => entry.lemma === "прапор") ??
-  data.entries[0];
 
 const frontmatter = {
-  title: defaultEntry?.lemma ?? "Лексикон",
-  description: defaultEntry?.gloss
-    ? `${defaultEntry.lemma} — ${defaultEntry.gloss}`
-    : "Український атлас курсових слів із джерелами, морфологією та курсом.",
+  title: "Атлас слів",
+  description: "Пошук і А-Я перегляд українських слів курсу з джерелами, морфологією та місцями появи.",
 };
 ---
 
@@ -40,12 +45,102 @@ const frontmatter = {
   wide
   showHero={false}
 >
-  {defaultEntry && (
-    <WordAtlasArticle
-      entry={defaultEntry}
-      allEntries={data.entries}
-      generatedAt={data.generated_at}
-      manifestVersion={data.version}
-    />
-  )}
+  <div class="word-atlas lexicon-landing" data-word-atlas>
+    <section class="lexicon-landing-hero" aria-labelledby="lexicon-landing-title">
+      <span class="lexicon-badge">Лексикон</span>
+      <h1 id="lexicon-landing-title">Атлас слів</h1>
+      <p>
+        Шукайте курсові слова з джерелами, морфологією та місцями появи в модулях.
+        Або перегляньте всі {data.stats.lemmas_total ?? data.entries.length} лем за українським алфавітом.
+      </p>
+      <AtlasTypeahead
+        id="lexicon-landing-search"
+        label="Шукати слово в Атласі"
+        placeholder="Введіть українське слово…"
+        containerClass="atlas-typeahead-landing"
+        labelClass="atlas-typeahead-label"
+      />
+    </section>
+
+    <section class="atlas-section lexicon-browse-section" aria-labelledby="lexicon-browse-title">
+      <div class="lexicon-browse-heading">
+        <h2 id="lexicon-browse-title">Перегляд А–Я</h2>
+        <p>Усі статті згруповано за першою літерою; кожна картка веде до повної словникової статті.</p>
+      </div>
+      <LexiconBrowse entries={data.entries} />
+    </section>
+  </div>
 </CourseLayout>
+
+<style>
+  .lexicon-landing {
+    padding-bottom: 4rem;
+  }
+
+  .lexicon-landing-hero {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 3.5rem 1.5rem 2.75rem;
+    text-align: center;
+  }
+
+  .lexicon-badge {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.75rem;
+    padding: 0 0.65rem;
+    border-radius: 4px;
+    background: var(--lu-state-active);
+    color: var(--lu-primary);
+    font-size: 0.78rem;
+    font-weight: 900;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .lexicon-landing-hero h1 {
+    margin: 0.7rem 0 0;
+    color: var(--lu-text);
+    font-size: clamp(2.4rem, 4vw, 4.25rem);
+    line-height: 1;
+  }
+
+  .lexicon-landing-hero p {
+    max-width: 720px;
+    margin: 1rem auto 0;
+    color: var(--lu-text-muted);
+    font-size: 1.1rem;
+    line-height: 1.65;
+  }
+
+  .lexicon-browse-section {
+    max-width: var(--content-width);
+    margin: 0 auto;
+    padding: 0 1.5rem;
+  }
+
+  .lexicon-browse-heading {
+    margin-bottom: 1rem;
+  }
+
+  .lexicon-browse-heading p {
+    max-width: 680px;
+    margin: 0;
+    color: var(--lu-text-muted);
+    line-height: 1.55;
+  }
+
+  @media (max-width: 680px) {
+    .lexicon-landing-hero {
+      padding: 2.5rem 1rem 2rem;
+    }
+
+    .lexicon-landing-hero h1 {
+      font-size: 2.4rem;
+    }
+
+    .lexicon-browse-section {
+      padding: 0 1rem;
+    }
+  }
+</style>

--- a/site/src/pages/lexicon/index/index.astro
+++ b/site/src/pages/lexicon/index/index.astro
@@ -3,6 +3,7 @@
  * Атлас слів (Лексикон) — full А-Я index view.
  */
 import CourseLayout from "../../../layouts/CourseLayout.astro";
+import LexiconBrowse from "../../../lexicon/LexiconBrowse.astro";
 import manifest from "../../../data/lexicon-manifest.json";
 
 interface CourseUsage {
@@ -37,21 +38,6 @@ const SOURCE_LABELS_UK: Record<string, string> = {
   plan_recommended: "рекомендована",
   surzhyk_to_avoid: "остерігайтеся",
 };
-
-const groups = new Map<string, LexiconEntry[]>();
-for (const entry of data.entries) {
-  const letter = entry.lemma.charAt(0).toLocaleUpperCase("uk");
-  const bucket = groups.get(letter) ?? [];
-  bucket.push(entry);
-  groups.set(letter, bucket);
-}
-
-const sortedGroups = Array.from(groups.entries())
-  .sort(([a], [b]) => ukCollator.compare(a, b))
-  .map(([letter, entries]) => ({
-    letter,
-    entries: entries.slice().sort((a, b) => ukCollator.compare(a.lemma, b.lemma)),
-  }));
 
 const sourceOptions = Array.from(
   new Set(data.entries.map((entry) => entry.primary_source).filter(Boolean)),
@@ -122,49 +108,7 @@ const frontmatter = {
       <p>Спробуйте коротший запит або приберіть обмеження за типом появи.</p>
     </div>
 
-    <nav class="atlas-letter-nav" aria-label="Український алфавіт">
-      {sortedGroups.map(({ letter }) => (
-        <a href={`#letter-${letter}`}>{letter}</a>
-      ))}
-    </nav>
-
-    <div class="atlas-letter-groups">
-      {sortedGroups.map(({ letter, entries }) => (
-        <section class="atlas-letter-section" data-lex-section>
-          <h2 id={`letter-${letter}`}>{letter}</h2>
-          <ul class="atlas-entry-list">
-            {entries.map((entry) => {
-              const usageLabel = entry.course_usage.length === 1 ? "модуль" : "модулів";
-              const searchText = [
-                entry.lemma,
-                entry.gloss ?? "",
-                entry.primary_source,
-                ...entry.course_usage.map((usage) => `${usage.track} ${usage.slug}`),
-              ].join(" ");
-
-              return (
-                <li
-                  data-lex-entry
-                  data-source={entry.primary_source}
-                  data-search={searchText}
-                >
-                  <a class="atlas-entry-lemma" href={`/lexicon/${entry.url_slug}/`}>
-                    {entry.lemma}
-                  </a>
-                  {entry.gloss && <span class="atlas-entry-gloss">«{entry.gloss}»</span>}
-                  <span class="atlas-entry-source">
-                    {SOURCE_LABELS_UK[entry.primary_source] ?? entry.primary_source}
-                  </span>
-                  <span class="atlas-entry-usage">
-                    {entry.course_usage.length} {usageLabel}
-                  </span>
-                </li>
-              );
-            })}
-          </ul>
-        </section>
-      ))}
-    </div>
+    <LexiconBrowse entries={data.entries} />
   </div>
 
   <script is:inline>
@@ -352,12 +296,10 @@ const frontmatter = {
     background: var(--lu-surface-muted);
   }
 
-  .atlas-filter-panel[hidden],
-  .atlas-empty-state[hidden],
-  .atlas-letter-section[hidden],
-  .atlas-entry-list li[hidden] {
-    display: none;
-  }
+.atlas-filter-panel[hidden],
+.atlas-empty-state[hidden] {
+  display: none;
+}
 
   .atlas-empty-state {
     padding: 1rem;
@@ -386,102 +328,11 @@ const frontmatter = {
     color: var(--lu-text-muted);
   }
 
-  .atlas-letter-nav {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.35rem;
-    padding: 0.75rem;
+@media (max-width: 680px) {
+  .atlas-filter-row,
+  .atlas-filter-panel {
+    grid-template-columns: 1fr;
   }
-
-  .atlas-letter-nav a {
-    min-width: 2rem;
-    min-height: 2rem;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 6px;
-    color: var(--lu-primary);
-    font-weight: 900;
-    text-decoration: none;
-  }
-
-  .atlas-letter-nav a:hover {
-    background: var(--lu-state-active);
-  }
-
-  .atlas-letter-groups {
-    display: flex;
-    flex-direction: column;
-    gap: 1.4rem;
-  }
-
-  .atlas-letter-section h2 {
-    margin: 0 0 0.7rem;
-    padding-bottom: 0.35rem;
-    border-bottom: 2px solid var(--lu-accent);
-    color: var(--lu-primary);
-    font-size: 1.3rem;
-  }
-
-  .atlas-entry-list {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
-    gap: 0.7rem;
-    padding: 0;
-    margin: 0;
-    list-style: none;
-  }
-
-  .atlas-entry-list li {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    gap: 0.28rem 0.65rem;
-    align-items: start;
-    min-height: 7.6rem;
-    padding: 0.85rem;
-    border-left: 4px solid var(--lu-primary);
-  }
-
-  .atlas-entry-lemma {
-    grid-column: 1 / -1;
-    color: var(--lu-text);
-    font-size: 1.05rem;
-    font-weight: 900;
-    text-decoration: none;
-  }
-
-  .atlas-entry-lemma:hover {
-    color: var(--lu-primary);
-  }
-
-  .atlas-entry-gloss {
-    min-width: 0;
-    color: var(--lu-text-muted);
-    font-style: italic;
-  }
-
-  .atlas-entry-source,
-  .atlas-entry-usage {
-    align-self: end;
-    padding: 0.1rem 0.5rem;
-    border: 1px solid var(--lu-border);
-    border-radius: 4px;
-    background: var(--lu-surface-muted);
-    color: var(--lu-text-muted);
-    font-size: 0.78rem;
-    font-weight: 800;
-  }
-
-  .atlas-entry-usage {
-    white-space: nowrap;
-  }
-
-  @media (max-width: 680px) {
-    .atlas-filter-row,
-    .atlas-filter-panel,
-    .atlas-entry-list li {
-      grid-template-columns: 1fr;
-    }
 
     .atlas-view-nav {
       width: 100%;

--- a/site/src/styles/word-atlas.css
+++ b/site/src/styles/word-atlas.css
@@ -132,6 +132,34 @@
   max-width: 520px;
 }
 
+.atlas-typeahead-label {
+  display: block;
+  margin-bottom: 0.55rem;
+  color: var(--lu-text);
+  font-size: 0.95rem;
+  font-weight: 900;
+  text-align: left;
+}
+
+.atlas-typeahead-label.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.atlas-typeahead-landing {
+  width: 100%;
+  max-width: 620px;
+  margin: 2rem auto 0;
+  padding: 0 1rem;
+}
+
 .atlas-typeahead-input {
   width: 100%;
   padding: 7px 12px;
@@ -140,6 +168,14 @@
   background: var(--lu-surface-muted);
   color: var(--lu-text);
   font-size: 14px;
+}
+
+.atlas-typeahead-landing .atlas-typeahead-input {
+  min-height: 3.25rem;
+  padding: 0.85rem 1rem;
+  border-width: 2px;
+  background: var(--lu-surface);
+  font-size: 1rem;
 }
 
 .atlas-typeahead-input::placeholder {


### PR DESCRIPTION
## Summary
- Demotes СУМ-11 Soviet-framing notices to the calm `editorial-calque info` style and scopes the copy to the definition, not the word.
- Keeps the red `editorial-warn` warning for word-level russianism cases only.
- Replaces `/lexicon/` default-word rendering with a Ukrainian Atlas landing: centered reusable typeahead search plus the shared A-Я browse list.

## Why
A normal word such as `прапор` should not look condemned because a legacy source definition has Soviet framing. The landing page also needed to be an entry point instead of an arbitrary article dump.

## Evidence

```text
$ cd site && npm run build > /tmp/atlas-ux-pass-2-build.log 2>&1
$ grep -E "\[build\] Complete|/lexicon/(index.html|index/index.html|прапор/index.html|явище-природи/index.html)" /tmp/atlas-ux-pass-2-build.log
02:25:52   ├─ /lexicon/index/index.html (+28ms) 
02:25:54   ├─ /lexicon/прапор/index.html (+0ms) 
02:25:55   ├─ /lexicon/явище-природи/index.html (+3ms) 
02:25:55   ├─ /lexicon/index.html (+19ms) 
02:25:57 [build] Complete!
```

```text
$ cd site && grep -n "editorial-warn" src/lexicon/WordAtlasArticle.astro
458:        <div class="editorial-warn" data-editorial-warn="is_russianism">
459:          <div class="editorial-warn-header">
460:            <div class="editorial-warn-icon" aria-hidden="true">⚠</div>
```

```text
$ cd site && grep -nE "князь|прапор" src/pages/lexicon/index.astro
# stdout: <empty>; exit 1 (no matches)
```

```text
$ cd site && npm test > /tmp/atlas-ux-pass-2-vitest.log 2>&1
$ grep -E "Test Files|Tests|Duration" /tmp/atlas-ux-pass-2-vitest.log
 Test Files  21 passed (21)
      Tests  345 passed (345)
   Duration  32.00s (transform 818ms, setup 1.12s, import 3.21s, tests 33.98s, environment 5.60s)
```

```text
$ .venv/bin/python scripts/audit/lint_agent_trailer.py
Checking 1 commit(s) in origin/main..HEAD:

  662ad2e2d2  PASS  X-Agent: codex/atlas-ux-pass-2

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```
