### PR TITLE
feat(atlas): warning-severity gradient + manifest publish tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,6 +223,7 @@ site/dist
 site/node_modules
 site/.astro
 site/src/data/lexicon-manifest.json
+site/src/data/lexicon-manifest.json.gz
 /testbed/*
 !/testbed/reference/
 data/sum11/

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 PYTHON ?= .venv/bin/python
 
-.PHONY: atlas
+.PHONY: atlas atlas-publish
 atlas:
 	$(PYTHON) -m scripts.lexicon.build_data_manifest
 	$(PYTHON) scripts/lexicon/enrich_manifest.py
 	$(PYTHON) scripts/lexicon/export_open_dataset.py
 	$(PYTHON) scripts/lexicon/verify_manifest.py
+
+atlas-publish: atlas
+	$(PYTHON) scripts/lexicon/publish_manifest.py

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -72,7 +72,7 @@ from scripts.lexicon.esum_garbled import (
     strip_garbled_tail,
     trim_curated_goroh_text,
 )
-from scripts.lexicon.heritage_classifier import classify_lemma
+from scripts.lexicon.heritage_classifier import classify_lemma, compute_warning_severity
 from scripts.lexicon.manifest_fingerprint import DEFAULT_FINGERPRINT, write_fingerprint
 from scripts.verification.vesum import verify_lemma, verify_word
 from scripts.wiki.slovnyk_me import primary_synonym_sense_text
@@ -1829,6 +1829,40 @@ def _entry_scoped_heritage_status(status: dict[str, Any]) -> dict[str, Any]:
     return clean_status
 
 
+def _vesum_attested_from_morphology(morphology: dict[str, Any] | None) -> bool:
+    if not isinstance(morphology, dict):
+        return False
+    return (
+        str(morphology.get("source") or "").upper() == "VESUM"
+        and int(morphology.get("form_count") or 0) > 0
+    )
+
+
+def _max_definition_sovietization_risk(cards: list[dict[str, Any]]) -> int:
+    risks = [int(card.get("sovietization_risk") or 0) for card in cards if isinstance(card, dict)]
+    return max(risks, default=0)
+
+
+def _finalize_heritage_status(
+    status: dict[str, Any],
+    *,
+    morphology: dict[str, Any] | None,
+    definition_cards: list[dict[str, Any]],
+) -> dict[str, Any]:
+    finalized = dict(status)
+    vesum_attested = bool(finalized.get("vesum_attested")) or _vesum_attested_from_morphology(
+        morphology
+    )
+    max_sovietization_risk = _max_definition_sovietization_risk(definition_cards)
+    finalized["vesum_attested"] = vesum_attested
+    finalized["warning_severity"] = compute_warning_severity(
+        finalized,
+        vesum_attested=vesum_attested,
+        max_sovietization_risk=max_sovietization_risk,
+    )
+    return finalized
+
+
 def _is_slovnyk_warning_candidate(entry: dict[str, Any], status: dict[str, Any]) -> bool:
     return bool(
         entry.get("primary_source") == "surzhyk_to_avoid"
@@ -3181,6 +3215,11 @@ def enrich_entry(entry, conn, kaikki_lookup, *, has_sum11_flags) -> bool:
     morph = _morphology(base)
     if morph:
         block["morphology"] = morph
+    entry["heritage_status"] = _finalize_heritage_status(
+        entry["heritage_status"],
+        morphology=morph,
+        definition_cards=definition_cards,
+    )
     meaning = _meaning(conn, lemma, has_sum11_flags=has_sum11_flags, kaikki_lookup=kaikki_lookup)
     if _is_proper_noun_entry(entry):
         meaning = _proper_noun_wikipedia_meaning(lemma) or meaning
@@ -3232,10 +3271,14 @@ def enrich() -> tuple[int, int]:
                 enriched += 1
     finally:
         conn.close()
+    fingerprint_payload = write_fingerprint(DEFAULT_FINGERPRINT, root=ROOT)
     manifest["enrichment_generated"] = True
+    manifest["manifest_fingerprint"] = {
+        "schema_version": fingerprint_payload["schema_version"],
+        "fingerprint": fingerprint_payload["fingerprint"],
+    }
     manifest = _clean_html_entities_in_obj(manifest)
     MANIFEST.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-    write_fingerprint(DEFAULT_FINGERPRINT, root=ROOT)
     return enriched, len(manifest["entries"])
 
 

--- a/scripts/lexicon/heritage_classifier.py
+++ b/scripts/lexicon/heritage_classifier.py
@@ -348,6 +348,12 @@ def _has_calque_alternative(heritage_status: dict[str, Any]) -> bool:
     return isinstance(section_six, dict) and bool(section_six.get("corrections"))
 
 
+def _has_reverse_calque(heritage_status: dict[str, Any]) -> bool:
+    """A word that is the recommended replacement for a calque (§6 reverse note)."""
+    reverse = heritage_status.get("reverse_calques")
+    return isinstance(reverse, list) and bool(reverse)
+
+
 def compute_warning_severity(
     heritage_status: dict[str, Any] | None,
     *,
@@ -370,7 +376,7 @@ def compute_warning_severity(
     ):
         return "russianism_red"
 
-    if _has_calque_alternative(status):
+    if _has_calque_alternative(status) or _has_reverse_calque(status):
         return "calque_yellow"
 
     if classification in _TREASURED_CLASSIFICATIONS or (

--- a/scripts/lexicon/heritage_classifier.py
+++ b/scripts/lexicon/heritage_classifier.py
@@ -39,6 +39,14 @@ _AUTHENTIC_CLASSIFICATIONS = {
     "borrowing",
     "standard",
 }
+_TREASURED_CLASSIFICATIONS = {
+    "authentic-archaism",
+    "dialect",
+    "historism",
+    "borrowing",
+}
+_POSITIVE_ATTESTATION_PREFIXES = ("grinchenko", "literary")
+_POSITIVE_ATTESTATION_SOURCES = {"vesum", "esum", "гринченко", "есум"}
 
 _KNOWN_STANDARD_ALTERNATIVES: dict[str, tuple[str, ...]] = {
     "аранжировка": ("аранжування",),
@@ -174,7 +182,13 @@ def _classify(
     vesum_db_path: str | Path | None = None,
 ) -> dict[str, Any]:
     if not term:
-        return _status("unknown", [], is_russianism=False, russian_shadow=False)
+        return _status(
+            "unknown",
+            [],
+            is_russianism=False,
+            russian_shadow=False,
+            vesum_attested=False,
+        )
 
     russian_shadow, russian_shadow_detail = _check_russian_shadow(
         term,
@@ -192,7 +206,11 @@ def _classify(
         vesum_archaism and not vesum_archaism["has_modern"]
     )
 
-    russianism = _russianism_status(term, russian_shadow=russian_shadow)
+    russianism = _russianism_status(
+        term,
+        russian_shadow=russian_shadow,
+        vesum_attested=bool(vesum),
+    )
 
     attestations: list[dict[str, Any]] = []
     classification = "unknown"
@@ -247,6 +265,7 @@ def _classify(
             attestations,
             is_russianism=False,
             russian_shadow=russian_shadow,
+            vesum_attested=bool(vesum),
             sovietization_risk=sovietization_risk,
         )
 
@@ -259,6 +278,7 @@ def _classify(
             [vesum],
             is_russianism=False,
             russian_shadow=russian_shadow,
+            vesum_attested=True,
             sovietization_risk=sovietization_risk,
         )
 
@@ -268,6 +288,7 @@ def _classify(
         [],
         is_russianism=False,
         russian_shadow=russian_shadow,
+        vesum_attested=False,
         calque_warning=calque_warning,
     )
 
@@ -278,17 +299,89 @@ def _status(
     *,
     is_russianism: bool,
     russian_shadow: bool,
+    vesum_attested: bool = False,
     sovietization_risk: int = 0,
     calque_warning: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    return {
+    status = {
         "classification": classification,
         "attestations": _dedupe_attestations(attestations),
         "is_russianism": is_russianism,
         "russian_shadow": russian_shadow,
+        "vesum_attested": vesum_attested,
         "sovietization_risk": sovietization_risk,
         "calque_warning": calque_warning,
     }
+    status["warning_severity"] = compute_warning_severity(
+        status,
+        vesum_attested=vesum_attested,
+        max_sovietization_risk=sovietization_risk,
+    )
+    return status
+
+
+def has_positive_attestation(heritage_status: dict[str, Any]) -> bool:
+    """Return True for source-backed positive lexical attestation only."""
+    for attestation in heritage_status.get("attestations") or []:
+        if not isinstance(attestation, dict):
+            continue
+        source = str(attestation.get("source") or "").strip().casefold()
+        if not source:
+            continue
+        if source in _POSITIVE_ATTESTATION_SOURCES:
+            return True
+        if any(source.startswith(prefix) for prefix in _POSITIVE_ATTESTATION_PREFIXES):
+            return True
+    return False
+
+
+def _has_calque_alternative(heritage_status: dict[str, Any]) -> bool:
+    curated = heritage_status.get("curated_calque")
+    if isinstance(curated, dict) and curated.get("corrections"):
+        return True
+
+    calque_warning = heritage_status.get("calque_warning")
+    if isinstance(calque_warning, dict) and calque_warning.get("standard_alternatives"):
+        return True
+
+    section_six = heritage_status.get("§6_note")
+    return isinstance(section_six, dict) and bool(section_six.get("corrections"))
+
+
+def compute_warning_severity(
+    heritage_status: dict[str, Any] | None,
+    *,
+    vesum_attested: bool,
+    max_sovietization_risk: int = 0,
+) -> str:
+    """Compute the Word Atlas warning severity from status data only."""
+    status = heritage_status or {}
+    classification = str(status.get("classification") or "unknown")
+    positive_attestation = has_positive_attestation(status)
+
+    if bool(status.get("is_russianism")) and classification not in _AUTHENTIC_CLASSIFICATIONS:
+        return "russianism_red"
+
+    if (
+        bool(status.get("russian_shadow"))
+        and not vesum_attested
+        and classification == "unknown"
+        and not positive_attestation
+    ):
+        return "russianism_red"
+
+    if _has_calque_alternative(status):
+        return "calque_yellow"
+
+    if classification in _TREASURED_CLASSIFICATIONS or (
+        classification == "standard" and positive_attestation
+    ):
+        return "treasured"
+
+    if max_sovietization_risk > 0:
+        return "soviet_def_blue"
+
+    return "none"
 
 
 def _source_db_path(db_path: str | Path | None = None) -> Path:
@@ -1143,7 +1236,12 @@ def _form_default_classification(term: str) -> str:
     return "standard"
 
 
-def _russianism_status(term: str, *, russian_shadow: bool) -> dict[str, Any] | None:
+def _russianism_status(
+    term: str,
+    *,
+    russian_shadow: bool,
+    vesum_attested: bool = False,
+) -> dict[str, Any] | None:
     alternatives = _standard_alternatives(term)
     if not alternatives:
         return None
@@ -1170,6 +1268,7 @@ def _russianism_status(term: str, *, russian_shadow: bool) -> dict[str, Any] | N
         attestations,
         is_russianism=True,
         russian_shadow=russian_shadow,
+        vesum_attested=vesum_attested,
         calque_warning={"standard_alternatives": alternatives},
     )
 
@@ -1240,6 +1339,7 @@ def _merge_variant_statuses(statuses: list[dict[str, Any]]) -> dict[str, Any]:
         attestations,
         is_russianism=is_russianism,
         russian_shadow=any(bool(status.get("russian_shadow")) for status in statuses),
+        vesum_attested=any(bool(status.get("vesum_attested")) for status in statuses),
         sovietization_risk=max(int(status.get("sovietization_risk") or 0) for status in statuses),
         calque_warning=calque_warning if classification == "russianism" else None,
     )

--- a/scripts/lexicon/publish_manifest.py
+++ b/scripts/lexicon/publish_manifest.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Publish the hydrated Word Atlas manifest release asset.
+
+This is intentionally separate from ``make atlas``: the atlas target builds and
+verifies the DB-backed manifest, then this script packages that exact output,
+uploads it to the GitHub Release asset, and rewrites the small pointer committed
+to git.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+from scripts.lexicon.manifest_fingerprint import DEFAULT_FINGERPRINT
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
+DEFAULT_POINTER = ROOT / "site" / "src" / "data" / "lexicon-manifest.pointer.json"
+DEFAULT_GZIP = ROOT / "site" / "src" / "data" / "lexicon-manifest.json.gz"
+DEFAULT_RELEASE_TAG = "atlas-manifest"
+DEFAULT_REPO = "learn-ukrainian/learn-ukrainian.github.io"
+ASSET_NAME = "lexicon-manifest.json.gz"
+REQUIRED_POINTER_KEYS = (
+    "asset_url",
+    "release_tag",
+    "manifest_version",
+    "manifest_fingerprint",
+    "fingerprint_schema_version",
+    "gz_sha256",
+    "json_sha256",
+    "gz_bytes",
+    "json_bytes",
+)
+
+
+class ManifestPublishError(RuntimeError):
+    """Raised when the manifest and pointer metadata cannot be made consistent."""
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ManifestPublishError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _asset_url(repo: str, release_tag: str, asset_name: str = ASSET_NAME) -> str:
+    return f"https://github.com/{repo}/releases/download/{release_tag}/{quote(asset_name)}"
+
+
+def validate_manifest_fingerprint(
+    manifest: dict[str, Any],
+    fingerprint: dict[str, Any],
+    *,
+    manifest_path: Path = DEFAULT_MANIFEST,
+) -> None:
+    """Require the built manifest to embed the sidecar fingerprint."""
+    embedded = manifest.get("manifest_fingerprint")
+    if not isinstance(embedded, dict):
+        raise ManifestPublishError(
+            f"{manifest_path} lacks manifest_fingerprint; run `make atlas` before publishing."
+        )
+
+    expected_schema = fingerprint.get("schema_version")
+    expected_fingerprint = fingerprint.get("fingerprint")
+    if embedded.get("schema_version") != expected_schema:
+        raise ManifestPublishError(
+            "manifest_fingerprint.schema_version does not match "
+            "site/src/data/lexicon-manifest.fingerprint.json"
+        )
+    if embedded.get("fingerprint") != expected_fingerprint:
+        raise ManifestPublishError(
+            "manifest_fingerprint.fingerprint does not match "
+            "site/src/data/lexicon-manifest.fingerprint.json"
+        )
+
+
+def validate_pointer_freshness(
+    pointer: dict[str, Any],
+    fingerprint: dict[str, Any],
+    *,
+    manifest: dict[str, Any] | None = None,
+) -> None:
+    """Mirror the build-time guard for DB-free pytest coverage."""
+    missing = [key for key in REQUIRED_POINTER_KEYS if pointer.get(key) in (None, "")]
+    if missing:
+        raise ManifestPublishError(f"Atlas manifest pointer missing freshness keys: {', '.join(missing)}")
+
+    if pointer.get("fingerprint_schema_version") != fingerprint.get("schema_version"):
+        raise ManifestPublishError("Atlas manifest pointer fingerprint schema is stale")
+    if pointer.get("manifest_fingerprint") != fingerprint.get("fingerprint"):
+        raise ManifestPublishError("Atlas manifest pointer fingerprint is stale")
+
+    if manifest is None:
+        return
+
+    if manifest.get("version") != pointer.get("manifest_version"):
+        raise ManifestPublishError("Atlas manifest pointer version is stale")
+    embedded = manifest.get("manifest_fingerprint")
+    if not isinstance(embedded, dict):
+        raise ManifestPublishError("Atlas manifest lacks manifest_fingerprint")
+    if embedded.get("schema_version") != pointer.get("fingerprint_schema_version"):
+        raise ManifestPublishError("Atlas manifest fingerprint schema does not match pointer")
+    if embedded.get("fingerprint") != pointer.get("manifest_fingerprint"):
+        raise ManifestPublishError("Atlas manifest fingerprint does not match pointer")
+
+
+def gzip_manifest(manifest_path: Path = DEFAULT_MANIFEST, gzip_path: Path = DEFAULT_GZIP) -> bytes:
+    """Write a deterministic gzip for the manifest and return its bytes."""
+    manifest_bytes = manifest_path.read_bytes()
+    gzip_bytes = gzip.compress(manifest_bytes, compresslevel=9, mtime=0)
+    gzip_path.write_bytes(gzip_bytes)
+    return gzip_bytes
+
+
+def build_pointer_payload(
+    *,
+    manifest_path: Path = DEFAULT_MANIFEST,
+    gzip_path: Path = DEFAULT_GZIP,
+    fingerprint_path: Path = DEFAULT_FINGERPRINT,
+    release_tag: str = DEFAULT_RELEASE_TAG,
+    repo: str = DEFAULT_REPO,
+) -> dict[str, Any]:
+    manifest_bytes = manifest_path.read_bytes()
+    gzip_bytes = gzip_path.read_bytes()
+    manifest = json.loads(manifest_bytes.decode("utf-8"))
+    if not isinstance(manifest, dict):
+        raise ManifestPublishError(f"{manifest_path} must contain a JSON object")
+    fingerprint = _read_json(fingerprint_path)
+    validate_manifest_fingerprint(manifest, fingerprint, manifest_path=manifest_path)
+
+    manifest_version = manifest.get("version")
+    if not isinstance(manifest_version, str) or not manifest_version:
+        raise ManifestPublishError(f"{manifest_path} must contain a non-empty version")
+
+    pointer = {
+        "asset_url": _asset_url(repo, release_tag),
+        "release_tag": release_tag,
+        "manifest_version": manifest_version,
+        "manifest_fingerprint": fingerprint["fingerprint"],
+        "fingerprint_schema_version": fingerprint["schema_version"],
+        "generated_at": manifest.get("generated_at"),
+        "gz_sha256": _sha256(gzip_bytes),
+        "json_sha256": _sha256(manifest_bytes),
+        "gz_bytes": len(gzip_bytes),
+        "json_bytes": len(manifest_bytes),
+        "note": "Pins GitHub Release asset manifest for #3659; hydrate it build time instead committing raw JSON.",
+    }
+    validate_pointer_freshness(pointer, fingerprint, manifest=manifest)
+    return pointer
+
+
+def write_pointer(pointer_path: Path, payload: dict[str, Any]) -> None:
+    pointer_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = pointer_path.with_suffix(f"{pointer_path.suffix}.tmp")
+    temp_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    temp_path.replace(pointer_path)
+
+
+def upload_release_asset(
+    gzip_path: Path = DEFAULT_GZIP,
+    *,
+    release_tag: str = DEFAULT_RELEASE_TAG,
+    repo: str = DEFAULT_REPO,
+) -> None:
+    subprocess.run(
+        [
+            "gh",
+            "release",
+            "upload",
+            release_tag,
+            str(gzip_path),
+            "--repo",
+            repo,
+            "--clobber",
+        ],
+        check=True,
+    )
+
+
+def publish_manifest(
+    *,
+    manifest_path: Path = DEFAULT_MANIFEST,
+    gzip_path: Path = DEFAULT_GZIP,
+    pointer_path: Path = DEFAULT_POINTER,
+    fingerprint_path: Path = DEFAULT_FINGERPRINT,
+    release_tag: str = DEFAULT_RELEASE_TAG,
+    repo: str = DEFAULT_REPO,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    gzip_manifest(manifest_path, gzip_path)
+    pointer = build_pointer_payload(
+        manifest_path=manifest_path,
+        gzip_path=gzip_path,
+        fingerprint_path=fingerprint_path,
+        release_tag=release_tag,
+        repo=repo,
+    )
+
+    if dry_run:
+        return pointer
+
+    upload_release_asset(gzip_path, release_tag=release_tag, repo=repo)
+    write_pointer(pointer_path, pointer)
+    return pointer
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Publish the Word Atlas manifest release asset.")
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--gzip", type=Path, default=DEFAULT_GZIP)
+    parser.add_argument("--pointer", type=Path, default=DEFAULT_POINTER)
+    parser.add_argument("--fingerprint", type=Path, default=DEFAULT_FINGERPRINT)
+    parser.add_argument("--release-tag", default=DEFAULT_RELEASE_TAG)
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--dry-run", action="store_true", help="Build metadata without uploading or writing pointer")
+    args = parser.parse_args()
+
+    pointer = publish_manifest(
+        manifest_path=args.manifest,
+        gzip_path=args.gzip,
+        pointer_path=args.pointer,
+        fingerprint_path=args.fingerprint,
+        release_tag=args.release_tag,
+        repo=args.repo,
+        dry_run=args.dry_run,
+    )
+    print(
+        "Atlas manifest pointer "
+        f"{'would publish' if args.dry_run else 'published'}: "
+        f"{pointer['manifest_version']} {pointer['manifest_fingerprint']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/scripts/hydrate-manifest.mjs
+++ b/site/scripts/hydrate-manifest.mjs
@@ -2,16 +2,31 @@ import { existsSync } from "node:fs";
 import { readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { gunzipSync } from "node:zlib";
 
 const RECOVERY_COMMAND =
   "gh release download atlas-manifest -p lexicon-manifest.json.gz -O - | gunzip -c > site/src/data/lexicon-manifest.json";
 
-const scriptDir = dirname(decodeURIComponent(new URL(import.meta.url).pathname));
+const REQUIRED_POINTER_KEYS = [
+  "asset_url",
+  "release_tag",
+  "manifest_version",
+  "manifest_fingerprint",
+  "fingerprint_schema_version",
+  "gz_sha256",
+  "json_sha256",
+  "gz_bytes",
+  "json_bytes",
+];
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "../..");
 const pointerPath = resolve(repoRoot, "site/src/data/lexicon-manifest.pointer.json");
+const fingerprintPath = resolve(repoRoot, "site/src/data/lexicon-manifest.fingerprint.json");
 const manifestPath = resolve(repoRoot, "site/src/data/lexicon-manifest.json");
 const tempPath = `${manifestPath}.tmp`;
+const allowStalePointer = process.env.ATLAS_MANIFEST_ALLOW_STALE_POINTER === "1";
 
 function sha256(data) {
   return createHash("sha256").update(data).digest("hex");
@@ -25,21 +40,79 @@ function recoveryMessage() {
   return `Manual recovery command:\n${RECOVERY_COMMAND}`;
 }
 
-async function readPointer() {
-  return JSON.parse(await readFile(pointerPath, "utf8"));
+async function readJson(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+function assertPointerFresh(pointer, fingerprint) {
+  if (allowStalePointer) return;
+
+  const missing = REQUIRED_POINTER_KEYS.filter((key) => pointer[key] === undefined || pointer[key] === null || pointer[key] === "");
+  if (missing.length > 0) {
+    throw new Error(
+      `Atlas manifest pointer missing freshness keys: ${missing.join(", ")}. Run make atlas-publish.`,
+    );
+  }
+
+  if (pointer.fingerprint_schema_version !== fingerprint.schema_version) {
+    throw new Error(
+      `Atlas manifest pointer schema ${pointer.fingerprint_schema_version} is stale; expected ${fingerprint.schema_version}. Run make atlas-publish.`,
+    );
+  }
+
+  if (pointer.manifest_fingerprint !== fingerprint.fingerprint) {
+    throw new Error(
+      `Atlas manifest pointer fingerprint ${pointer.manifest_fingerprint} is stale; expected ${fingerprint.fingerprint}. Run make atlas-publish.`,
+    );
+  }
+}
+
+function assertManifestFresh(manifest, pointer, sourceLabel) {
+  if (allowStalePointer) return;
+
+  if (manifest.version !== pointer.manifest_version) {
+    throw new Error(
+      `${sourceLabel} manifest version ${manifest.version ?? "<missing>"} does not match pointer ${pointer.manifest_version}. Run make atlas-publish.`,
+    );
+  }
+
+  const embedded = manifest.manifest_fingerprint;
+  if (!embedded || typeof embedded !== "object") {
+    throw new Error(`${sourceLabel} lacks manifest_fingerprint. Run make atlas-publish.`);
+  }
+
+  if (embedded.schema_version !== pointer.fingerprint_schema_version) {
+    throw new Error(
+      `${sourceLabel} fingerprint schema ${embedded.schema_version ?? "<missing>"} does not match pointer ${pointer.fingerprint_schema_version}. Run make atlas-publish.`,
+    );
+  }
+
+  if (embedded.fingerprint !== pointer.manifest_fingerprint) {
+    throw new Error(
+      `${sourceLabel} fingerprint ${embedded.fingerprint ?? "<missing>"} does not match pointer ${pointer.manifest_fingerprint}. Run make atlas-publish.`,
+    );
+  }
+}
+
+function parseManifest(jsonBytes, pointer, sourceLabel) {
+  const manifest = JSON.parse(jsonBytes.toString("utf8"));
+  assertManifestFresh(manifest, pointer, sourceLabel);
+  return manifest;
 }
 
 async function alreadyHydrated(pointer) {
-  if (!existsSync(manifestPath)) {
-    return false;
-  }
+  if (!existsSync(manifestPath)) return false;
 
   const data = await readFile(manifestPath);
-  return sha256(data) === pointer.json_sha256;
+  if (sha256(data) !== pointer.json_sha256) return false;
+
+  parseManifest(data, pointer, manifestPath);
+  return true;
 }
 
 async function hydrate() {
-  const pointer = await readPointer();
+  const [pointer, fingerprint] = await Promise.all([readJson(pointerPath), readJson(fingerprintPath)]);
+  assertPointerFresh(pointer, fingerprint);
 
   if (await alreadyHydrated(pointer)) {
     console.log("✓ manifest already hydrated");
@@ -54,32 +127,29 @@ async function hydrate() {
   const gzBytes = Buffer.from(await response.arrayBuffer());
   const actualGzSha = sha256(gzBytes);
   if (actualGzSha !== pointer.gz_sha256) {
-    throw new Error(
-      `gz sha256 mismatch: expected ${pointer.gz_sha256}, got ${actualGzSha}\n${recoveryMessage()}`,
-    );
+    throw new Error(`gz sha mismatch: expected ${pointer.gz_sha256}, got ${actualGzSha}`);
+  }
+  if (gzBytes.length !== pointer.gz_bytes) {
+    throw new Error(`gz size mismatch: expected ${pointer.gz_bytes}, got ${gzBytes.length}`);
   }
 
   const jsonBytes = gunzipSync(gzBytes);
   const actualJsonSha = sha256(jsonBytes);
   if (actualJsonSha !== pointer.json_sha256) {
-    throw new Error(
-      `json sha256 mismatch after gunzip: expected ${pointer.json_sha256}, got ${actualJsonSha}\n${recoveryMessage()}`,
-    );
+    throw new Error(`json sha mismatch: expected ${pointer.json_sha256}, got ${actualJsonSha}`);
+  }
+  if (jsonBytes.length !== pointer.json_bytes) {
+    throw new Error(`json size mismatch: expected ${pointer.json_bytes}, got ${jsonBytes.length}`);
   }
 
+  parseManifest(jsonBytes, pointer, pointer.asset_url);
   await writeFile(tempPath, jsonBytes);
   await rename(tempPath, manifestPath);
-  console.log(`hydrated ${mb(gzBytes.length)} gz -> ${mb(jsonBytes.length)} json`);
+  console.log(`✓ hydrated manifest ${mb(jsonBytes.length)} from ${mb(gzBytes.length)} release asset`);
 }
 
 hydrate().catch(async (error) => {
-  try {
-    await unlink(tempPath);
-  } catch {
-    // Best effort cleanup; the failure above is the actionable error.
-  }
-
-  console.error(error instanceof Error ? error.message : String(error));
-  console.error(recoveryMessage());
+  await unlink(tempPath).catch(() => {});
+  console.error(`Failed to hydrate lexicon manifest: ${error.message}`);
   process.exit(1);
 });

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "a49dded39dedb0af68004832a5746a5cea64fbd0f7b2585052c6b8403229be34",
+  "fingerprint": "88e1b10578ad9a9099c4b7667758622f70a8e7017216f0671a053519f45acbc4",
   "inputs": {
     "lexicon_code": [
       {
@@ -44,7 +44,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "4761771249593ae575830ba967a92d7e2246099283d6c75a5d977ab34cd707f3"
+        "sha256": "fe801552bed63205de178a75eba175921b090a8f278426d92d3bdb8a2589ec86"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",
@@ -72,7 +72,7 @@
       },
       {
         "path": "scripts/lexicon/heritage_classifier.py",
-        "sha256": "ddb4f8e7bd52f17267e2c7e6bcdf57a64878e4e3ae0eca64ce42f8d2a43f16e5"
+        "sha256": "e51d9d2f66cadbfbf27b12c04f9734497e6eeeaa969087ea562b2e9662acab6c"
       },
       {
         "path": "scripts/lexicon/manifest_fingerprint.py",
@@ -91,6 +91,10 @@
         "sha256": "df805e6d299a01c5f842b8bbcb8a56b69f22555040001d3b33c0ae64daaecce2"
       },
       {
+        "path": "scripts/lexicon/publish_manifest.py",
+        "sha256": "3aac9e0942366c3a6d50ed2590a6b92c600f7064d458f2fe92bae1f3d42814f7"
+      },
+      {
         "path": "scripts/lexicon/verify_manifest.py",
         "sha256": "e128d60f2c72ca44fdc550fb99436adc27481d59b9877f22480f67a988ae3059"
       }
@@ -99,6 +103,6 @@
   "schema_version": 1,
   "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
   "stats": {
-    "lexicon_code_files": 23
+    "lexicon_code_files": 24
   }
 }

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "88e1b10578ad9a9099c4b7667758622f70a8e7017216f0671a053519f45acbc4",
+  "fingerprint": "f5986436945edfca90769d25893e022c7fe58edbb42180437799402980d4488e",
   "inputs": {
     "lexicon_code": [
       {
@@ -72,7 +72,7 @@
       },
       {
         "path": "scripts/lexicon/heritage_classifier.py",
-        "sha256": "e51d9d2f66cadbfbf27b12c04f9734497e6eeeaa969087ea562b2e9662acab6c"
+        "sha256": "fde3fb8e0fc380719aa1e11763f584b85e2b0ee0a48f45bc09bca0cdab2392ac"
       },
       {
         "path": "scripts/lexicon/manifest_fingerprint.py",

--- a/site/src/data/lexicon-manifest.pointer.json
+++ b/site/src/data/lexicon-manifest.pointer.json
@@ -1,9 +1,13 @@
 {
   "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest.json.gz",
   "release_tag": "atlas-manifest",
-  "gz_sha256": "b3faac5e15c39b11b8c6bb8069b135a4a9d6ee4aae27d5b3f82490c7973bf7f6",
-  "json_sha256": "e9ede4a153b8c47c0fa2dfb20da76e51966b6e678904ab0a40825ab14a1bbbb6",
-  "gz_bytes": 5634439,
-  "json_bytes": 38649293,
-  "note": "Pins the GitHub Release asset manifest for #3659; hydrate it at build time instead of committing the raw JSON."
+  "manifest_version": "0.1",
+  "manifest_fingerprint": "f5986436945edfca90769d25893e022c7fe58edbb42180437799402980d4488e",
+  "fingerprint_schema_version": 1,
+  "generated_at": "2026-06-23T11:01:00+00:00",
+  "gz_sha256": "f0a0709f886315857c6d9d6947b732939316bc020945428997288a707bd568d9",
+  "json_sha256": "2b4ad091ae376a03eef0e283c8ebe58764574ff9ea5f4a29d517dd775b20a965",
+  "gz_bytes": 5848772,
+  "json_bytes": 41505554,
+  "note": "Pins GitHub Release asset manifest for #3659; hydrate it build time instead committing raw JSON."
 }

--- a/site/src/lexicon/WordAtlasArticle.astro
+++ b/site/src/lexicon/WordAtlasArticle.astro
@@ -1,5 +1,9 @@
 ---
 import AtlasTypeahead from "./AtlasTypeahead.astro";
+import {
+  resolveHeritageBoxes,
+  type WarningSeverity,
+} from "../lib/lexicon/heritage-severity";
 
 interface CourseUsage {
   track: string;
@@ -103,8 +107,16 @@ interface HeritageStatus {
   attestations: HeritageAttestation[];
   is_russianism: boolean;
   russian_shadow: boolean;
-  calque_warning?: { detail?: string } | null;
+  warning_severity?: WarningSeverity;
+  vesum_attested?: boolean;
+  calque_warning?: { detail?: string; standard_alternatives?: string[] } | null;
   curated_calque?: CuratedCalque | null;
+  "§6_note"?: {
+    corrections: string[];
+    note: string;
+    source: string[];
+    citation?: string;
+  } | null;
   reverse_calques?: ReverseCalque[] | null;
 }
 
@@ -162,6 +174,7 @@ const nounParadigm = paradigm?.kind === "noun" ? paradigm : null;
 const verbParadigm = paradigm?.kind === "verb" ? paradigm : null;
 const posLabel = formatPos(entry.pos, enrichment?.morphology?.pos);
 const headwordIpa = formatIpa(entry.pronunciation?.ipa ?? entry.ipa);
+const heritageBoxes = resolveHeritageBoxes(entry);
 const statusBadges = buildStatusBadges();
 const etymologyStages = buildEtymologyStages(enrichment?.etymology);
 const courseUsage = entry.course_usage.slice().sort((a, b) => {
@@ -173,14 +186,8 @@ const externalGroups = groupExternalMaterials(enrichment?.external_materials ?? 
 const componentLinks = buildComponentLinks(entry, allEntries);
 const sourceList = buildSourceList();
 const phraseHasGloss = Boolean(entry.gloss && (!enrichment?.meaning || enrichment.meaning.definitions.length === 0));
-const shouldShowEditorialWarning = Boolean(heritage?.is_russianism);
-const shouldShowHeritageDefense = Boolean(
-  heritage &&
-    !heritage.is_russianism &&
-    heritage.classification &&
-    heritage.classification !== "unknown" &&
-    (heritage.classification !== "standard" || heritage.attestations.length > 0 || maxSovietizationRisk > 0),
-);
+const shouldShowEditorialWarning = Boolean(heritageBoxes.red);
+const shouldShowHeritageDefense = Boolean(heritageBoxes.green);
 const styleNotes = buildStyleNotes();
 
 const CASE_ROWS = [
@@ -262,17 +269,20 @@ function stressDisplay(form: string | undefined | null) {
 
 function buildStatusBadges() {
   const badges: Array<{ className: string; label: string; title?: string }> = [];
-  if (heritage?.is_russianism) {
-    badges.push({ className: "heritage-warn", label: "⚠ Потребує українського відповідника" });
-  } else if (heritage?.classification && heritage.classification !== "unknown") {
-    const heritageLabel = heritage.classification === "dialect"
-      ? "✓ Питома українська (діалектизм)"
-      : heritage.classification === "borrowing"
-        ? "✓ Засвоєне українське запозичення"
-        : heritage.classification === "historism"
-          ? "✓ Питома українська лексика"
-          : "✓ Питома українська лексика";
-    badges.push({ className: "heritage-ok", label: heritageLabel });
+  if (heritageBoxes.red) {
+    badges.push({
+      className: "heritage-warn",
+      label: heritageBoxes.inline?.label ?? "⚠ Потребує українського відповідника",
+    });
+  } else if (heritageBoxes.yellow) {
+    badges.push({ className: "heritage-warn", label: "Калькове застереження" });
+  } else if (heritageBoxes.green) {
+    badges.push({
+      className: "heritage-ok",
+      label: heritageBoxes.inline?.label ?? "✓ Питома українська лексика",
+    });
+  } else if (heritageBoxes.blue) {
+    badges.push({ className: "heritage-warn", label: "СУМ-11: редакторський прапорець" });
   }
   if (cefrLevel) {
     badges.push({ className: "cefr", label: `CEFR ${cefrLevel}${enrichment?.cefr?.source?.includes("estimated") ? " · орієнтовно" : ""}` });
@@ -282,9 +292,6 @@ function buildStatusBadges() {
   }
   if (heritage?.classification === "dialect") {
     badges.push({ className: "dialect", label: "Регіонально-літературне" });
-  }
-  if (maxSovietizationRisk > 0) {
-    badges.push({ className: "heritage-warn", label: "⚠ Радянські формулювання в СУМ-11" });
   }
   return badges;
 }
@@ -319,13 +326,6 @@ function buildStyleNotes() {
   }
   if (heritage?.curated_calque) {
     notes.push(`${heritage.curated_calque.note} Нейтральні відповідники: ${heritage.curated_calque.corrections.join(", ")}.`);
-  }
-  if (heritage?.reverse_calques?.length) {
-    const calqueForms = heritage.reverse_calques.map((rev) => `«${rev.calque}»`);
-    notes.push(`Рекомендовано замість скалькованої форми ${calqueForms.join(" або ")} (стилістична порада §6).`);
-  }
-  if (maxSovietizationRisk > 0) {
-    notes.push("СУМ-11 подано для прозорості, але радянські ілюстрації не слід сприймати як стилістично нейтральний сучасний приклад.");
   }
   return notes;
 }
@@ -398,7 +398,7 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
         </div>
         <div class="content-area">
           <section class="atlas-section">
-            <div class="editorial-calque info" style="margin-top: 2rem;">
+            <div class="editorial-calque info" data-severity="blue" style="margin-top: 2rem;">
               <div class="editorial-calque-header">
                 <div class="editorial-info-icon" aria-hidden="true">→</div>
                 Форма слова
@@ -434,51 +434,56 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
     </div>
 
   <div class="content-area">
-    {maxSovietizationRisk > 0 && (
-      <section class="atlas-section">
-        <div class="editorial-calque info">
-          <div class="editorial-calque-header">
-            <div class="editorial-info-icon" aria-hidden="true">→</div>
-            Радянські формулювання в СУМ-11 (стосується означення, не слова)
-          </div>
-          <p>
-            СУМ-11 показано для прозорості, але ця картка має ознаки радянської редакторської політики.
-            Це не означає, що саме слово негативне: перевагу слід надавати сучасним або дорадянським джерелам.
-          </p>
-          <p class="atlas-muted">
-            Тригер: <code>sovietization_risk={maxSovietizationRisk}</code>
-            {sovietizationKeywords.length > 0 && <> · keywords: <code>{sovietizationKeywords.join(", ")}</code></>}
-          </p>
-        </div>
-      </section>
-    )}
-
-    {shouldShowEditorialWarning && (
-      <section class="atlas-section">
-        <div class="editorial-warn" data-editorial-warn="is_russianism">
-          <div class="editorial-warn-header">
-            <div class="editorial-warn-icon" aria-hidden="true">⚠</div>
-            Редакційне попередження
-          </div>
-          <p>Класифікатор позначає цю форму як проблемну для стандартної української. Перевіряйте рекомендовані відповідники в джерелах.</p>
-        </div>
-      </section>
-    )}
-
-      {shouldShowHeritageDefense && (
+      {shouldShowEditorialWarning && (
         <section class="atlas-section">
-          <div class="editorial-success">
+          <div class="editorial-warn" data-editorial-warn="russianism_red" data-severity="red">
+            <div class="editorial-warn-header">
+              <div class="editorial-warn-icon" aria-hidden="true">⚠</div>
+              {heritageBoxes.red?.title}
+            </div>
+            <p>{heritageBoxes.red?.body}</p>
+          </div>
+        </section>
+      )}
+
+      {heritageBoxes.yellow && (
+        <section class="atlas-section">
+          <div class="editorial-calque" data-severity="yellow">
+            <div class="editorial-calque-header">
+              <div class="editorial-calque-icon" aria-hidden="true">→</div>
+              {heritageBoxes.yellow.title}
+            </div>
+            <p>{heritageBoxes.yellow.body}</p>
+            {heritageBoxes.yellow.detail && <p class="atlas-muted">{heritageBoxes.yellow.detail}</p>}
+          </div>
+        </section>
+      )}
+
+      {shouldShowHeritageDefense && heritageBoxes.green && (
+        <section class="atlas-section">
+          <div class="editorial-success" data-severity="green">
             <div class="editorial-success-header">
               <div class="editorial-success-icon" aria-hidden="true">✓</div>
-              {heritage?.classification === "dialect"
-                ? "Питома українська — регіональна форма, не русизм"
-                : "Питома українська лексика"}
+              {heritageBoxes.green.title}
+            </div>
+            <p>{heritageBoxes.green.body}</p>
+          </div>
+        </section>
+      )}
+
+      {heritageBoxes.blue && (
+        <section class="atlas-section">
+          <div class="editorial-calque info" data-severity="blue">
+            <div class="editorial-calque-header">
+              <div class="editorial-info-icon" aria-hidden="true">→</div>
+              {heritageBoxes.blue.title} (стосується означення, не слова)
             </div>
             <p>
-              Статус за класифікатором: <strong>{heritage?.classification}</strong>.
-              {heritage?.attestations?.length
-                ? ` Засвідчення: ${heritage.attestations.map((item) => `${item.source} ${item.ref}`).join("; ")}.`
-                : " Форма не позначена як русизм."}
+              {heritageBoxes.blue.body}
+            </p>
+            <p class="atlas-muted">
+              Тригер: <code>{heritageBoxes.blue.detail}</code>
+              {sovietizationKeywords.length > 0 && <> · keywords: <code>{sovietizationKeywords.join(", ")}</code></>}
             </p>
           </div>
         </section>
@@ -606,7 +611,7 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
       {styleNotes.length > 0 && (
         <section class="atlas-section">
           <h2>Стилістичні нотатки</h2>
-          <div class="editorial-calque info">
+          <div class="editorial-calque info" data-severity="blue">
             <div class="editorial-calque-header">
               <div class="editorial-info-icon" aria-hidden="true">ℹ</div>
               Редакційна нотатка

--- a/site/src/lib/lexicon/heritage-severity.ts
+++ b/site/src/lib/lexicon/heritage-severity.ts
@@ -228,7 +228,9 @@ export function resolveHeritageBoxes(entry: LexiconEntryForSeverity): HeritageBo
       severity,
       dataSeverity: "green",
       title: greenTitle(status),
-      body: "Ця форма має українське джерельне підтвердження; російська морфологічна тінь сама по собі не є підставою для попередження.",
+      body: status?.russian_shadow
+        ? "Ця форма має українське джерельне підтвердження; російська морфологічна тінь сама по собі не є підставою для попередження."
+        : "Ця форма має українське джерельне підтвердження.",
     };
   }
 

--- a/site/src/lib/lexicon/heritage-severity.ts
+++ b/site/src/lib/lexicon/heritage-severity.ts
@@ -1,0 +1,256 @@
+export type WarningSeverity =
+  | "none"
+  | "treasured"
+  | "calque_yellow"
+  | "russianism_red"
+  | "soviet_def_blue";
+
+export interface HeritageAttestation {
+  source?: string;
+  ref?: string;
+  detail?: string;
+}
+
+export interface HeritageStatus {
+  classification?: string;
+  attestations?: HeritageAttestation[];
+  is_russianism?: boolean;
+  russian_shadow?: boolean;
+  vesum_attested?: boolean;
+  warning_severity?: WarningSeverity;
+  calque_warning?: { detail?: string; standard_alternatives?: string[] } | null;
+  curated_calque?: {
+    corrections?: string[];
+    note?: string;
+    source?: string[];
+  } | null;
+  "§6_note"?: {
+    corrections?: string[];
+    note?: string;
+    source?: string[];
+  } | null;
+  reverse_calques?: Array<{
+    calque: string;
+    note?: string;
+    source?: string[];
+  }> | null;
+}
+
+export interface DefinitionCard {
+  id?: string;
+  sovietization_risk?: number;
+  sovietization_keywords?: string[];
+}
+
+export interface LexiconEntryForSeverity {
+  gloss?: string | null;
+  form_of?: unknown;
+  heritage_status?: HeritageStatus | null;
+  enrichment?: { definition_cards?: DefinitionCard[] | null } | null;
+}
+
+export interface HeritageBox {
+  severity: Exclude<WarningSeverity, "none">;
+  title: string;
+  body: string;
+  alternatives?: string[];
+  detail?: string;
+  dataSeverity: "red" | "yellow" | "green" | "blue";
+}
+
+export interface HeritageBoxes {
+  red?: HeritageBox;
+  yellow?: HeritageBox;
+  green?: HeritageBox;
+  blue?: HeritageBox;
+  inline?: {
+    severity: HeritageBox["dataSeverity"];
+    label: string;
+  };
+}
+
+const AUTHENTIC_CLASSIFICATIONS = new Set([
+  "authentic-archaism",
+  "dialect",
+  "historism",
+  "borrowing",
+  "standard",
+]);
+
+const TREASURED_CLASSIFICATIONS = new Set([
+  "authentic-archaism",
+  "dialect",
+  "historism",
+  "borrowing",
+]);
+
+const POSITIVE_ATTESTATION_SOURCES = new Set(["vesum", "esum", "гринченко", "есум"]);
+const POSITIVE_ATTESTATION_PREFIXES = ["grinchenko", "literary"];
+
+function nonEmptyStrings(values: unknown): string[] {
+  if (!Array.isArray(values)) return [];
+  return values.map((value) => String(value).trim()).filter(Boolean);
+}
+
+function unique(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+function hasPositiveAttestation(status: HeritageStatus | null | undefined): boolean {
+  return Boolean(
+    status?.attestations?.some((attestation) => {
+      const source = String(attestation.source ?? "").trim().toLocaleLowerCase("uk");
+      return (
+        POSITIVE_ATTESTATION_SOURCES.has(source) ||
+        POSITIVE_ATTESTATION_PREFIXES.some((prefix) => source.startsWith(prefix))
+      );
+    }),
+  );
+}
+
+function standardAlternatives(status: HeritageStatus | null | undefined, gloss: string | null): string[] {
+  const calqueWarning = nonEmptyStrings(status?.calque_warning?.standard_alternatives);
+  if (calqueWarning.length > 0) return unique(calqueWarning);
+
+  const curated = nonEmptyStrings(status?.curated_calque?.corrections);
+  if (curated.length > 0) return unique(curated);
+
+  const sectionSix = nonEmptyStrings(status?.["§6_note"]?.corrections);
+  if (sectionSix.length > 0) return unique(sectionSix);
+
+  const avoidMatch = String(gloss ?? "").match(/\bavoid:\s*([^.;]+)/i);
+  if (!avoidMatch) return [];
+
+  return unique(
+    avoidMatch[1]
+      .split(/\s*\/\s*|\s*,\s*/)
+      .map((value) => value.trim())
+      .filter(Boolean),
+  );
+}
+
+function hasCalqueAlternative(status: HeritageStatus | null | undefined): boolean {
+  return (
+    nonEmptyStrings(status?.curated_calque?.corrections).length > 0 ||
+    nonEmptyStrings(status?.calque_warning?.standard_alternatives).length > 0 ||
+    nonEmptyStrings(status?.["§6_note"]?.corrections).length > 0
+  );
+}
+
+function hasReverseCalque(status: HeritageStatus | null | undefined): boolean {
+  return (status?.reverse_calques?.length ?? 0) > 0;
+}
+
+function maxSovietizationRisk(entry: LexiconEntryForSeverity): number {
+  const cards = entry.enrichment?.definition_cards ?? [];
+  return cards.reduce((risk, card) => Math.max(risk, Number(card.sovietization_risk ?? 0)), 0);
+}
+
+function fallbackSeverity(status: HeritageStatus | null | undefined): WarningSeverity {
+  if (!status) return "none";
+
+  const classification = status.classification ?? "unknown";
+  const positiveAttestation = hasPositiveAttestation(status);
+
+  if (status.is_russianism && !AUTHENTIC_CLASSIFICATIONS.has(classification)) {
+    return "russianism_red";
+  }
+
+  if (
+    status.russian_shadow &&
+    status.vesum_attested === false &&
+    classification === "unknown" &&
+    !positiveAttestation
+  ) {
+    return "russianism_red";
+  }
+
+  if (hasCalqueAlternative(status) || hasReverseCalque(status)) return "calque_yellow";
+
+  if (
+    TREASURED_CLASSIFICATIONS.has(classification) ||
+    (classification === "standard" && positiveAttestation)
+  ) {
+    return "treasured";
+  }
+
+  return "none";
+}
+
+function greenTitle(status: HeritageStatus | null | undefined): string {
+  if (status?.classification === "dialect") return "Питома українська регіональна форма";
+  if (status?.classification === "borrowing") return "Засвоєне українське запозичення";
+  if (status?.classification === "historism") return "Історизм у сучасному вжитку";
+  if (status?.classification === "authentic-archaism") return "Питома українська архаїчна форма";
+  return "Питома українська лексика";
+}
+
+export function resolveHeritageBoxes(entry: LexiconEntryForSeverity): HeritageBoxes {
+  if (entry.form_of) return {};
+
+  const status = entry.heritage_status ?? null;
+  const sovietizationRisk = maxSovietizationRisk(entry);
+  const severity = status?.warning_severity ?? fallbackSeverity(status);
+  const boxes: HeritageBoxes = {};
+
+  if (severity === "russianism_red") {
+    const alternatives = standardAlternatives(status, entry.gloss ?? null);
+    boxes.red = {
+      severity,
+      dataSeverity: "red",
+      title: "Редакційне попередження",
+      body:
+        alternatives.length > 0
+          ? `Класифікатор позначає цю форму як проблемну для стандартної української. Рекомендовані відповідники: ${alternatives.join(", ")}.`
+          : "Класифікатор позначає цю форму як проблемну для стандартної української. Перевіряйте рекомендовані відповідники в джерелах.",
+      alternatives,
+    };
+  } else if (severity === "calque_yellow" || hasReverseCalque(status) || hasCalqueAlternative(status)) {
+    const alternatives = standardAlternatives(status, entry.gloss ?? null);
+    const reverseCalques = status?.reverse_calques?.map((item) => `«${item.calque}»`) ?? [];
+    boxes.yellow = {
+      severity: "calque_yellow",
+      dataSeverity: "yellow",
+      title: "Калькове застереження",
+      body:
+        alternatives.length > 0
+          ? `Нейтральні відповідники: ${alternatives.join(", ")}.`
+          : `Уникайте скалькованої форми ${reverseCalques.join(" або ")}.`,
+      alternatives,
+      detail:
+        status?.curated_calque?.note ??
+        status?.["§6_note"]?.note ??
+        status?.calque_warning?.detail ??
+        status?.reverse_calques?.[0]?.note,
+    };
+  } else if (severity === "treasured") {
+    boxes.green = {
+      severity,
+      dataSeverity: "green",
+      title: greenTitle(status),
+      body: "Ця форма має українське джерельне підтвердження; російська морфологічна тінь сама по собі не є підставою для попередження.",
+    };
+  }
+
+  if (sovietizationRisk > 0 || severity === "soviet_def_blue") {
+    boxes.blue = {
+      severity: "soviet_def_blue",
+      dataSeverity: "blue",
+      title: "Редакторський прапорець у СУМ-11",
+      body: "СУМ-11 показано для прозорості, але ця картка має ознаки радянської редакторської політики. Це не означає, що саме слово негативне.",
+      detail: `sovietization_risk=${sovietizationRisk}`,
+    };
+  }
+
+  if (boxes.red) {
+    boxes.inline = { severity: "red", label: "⚠ Потребує українського відповідника" };
+  } else if (boxes.yellow) {
+    boxes.inline = { severity: "yellow", label: "Калькове застереження" };
+  } else if (boxes.green) {
+    boxes.inline = { severity: "green", label: "✓ Питома українська лексика" };
+  } else if (boxes.blue) {
+    boxes.inline = { severity: "blue", label: "СУМ-11: редакторський прапорець" };
+  }
+
+  return boxes;
+}

--- a/site/src/styles/word-atlas.css
+++ b/site/src/styles/word-atlas.css
@@ -403,14 +403,14 @@
   border: 2px solid var(--green);
 }
 
-.editorial-calque {
+.editorial-calque:not(.info) {
   background: var(--yellow-light);
   border: 2px solid var(--yellow);
 }
 
 .editorial-calque.info {
   background: var(--blue-light);
-  border-color: var(--blue);
+  border: 2px solid var(--blue);
 }
 
 .editorial-warn-header,

--- a/site/tests/unit/build-renders.test.ts
+++ b/site/tests/unit/build-renders.test.ts
@@ -56,6 +56,7 @@ describe('Astro build renders all pages', () => {
     try {
       buildOutput = execSync('npm run build 2>&1', {
         cwd: STARLIGHT_DIR,
+        env: { ...process.env, ATLAS_MANIFEST_ALLOW_STALE_POINTER: '1' },
         timeout: 240000,
         encoding: 'utf-8',
         maxBuffer: 50 * 1024 * 1024, // 50MB: full build output for 31k pages exceeds default 1MB

--- a/site/tests/unit/heritage-severity.test.ts
+++ b/site/tests/unit/heritage-severity.test.ts
@@ -102,4 +102,20 @@ describe('resolveHeritageBoxes', () => {
       expect((boxes.red ?? boxes.yellow)?.alternatives).toEqual(alternatives);
     }
   });
+
+  // agy off-seat review #3759: the green-box body must not assert a russian
+  // morphological shadow when the word has none.
+  test('green body omits the russian-shadow clause when russian_shadow is false', () => {
+    const noShadow = resolveHeritageBoxes({
+      heritage_status: {
+        classification: 'dialect',
+        is_russianism: false,
+        russian_shadow: false,
+        vesum_attested: true,
+        attestations: [{ source: 'grinchenko_1907', ref: 'x' }],
+      },
+    } as LexiconEntryForSeverity);
+    expect(noShadow.green?.body).toContain('підтвердження');
+    expect(noShadow.green?.body).not.toContain('тінь');
+  });
 });

--- a/site/tests/unit/heritage-severity.test.ts
+++ b/site/tests/unit/heritage-severity.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'vitest';
+import { resolveHeritageBoxes, type LexiconEntryForSeverity } from '@site/src/lib/lexicon/heritage-severity';
+
+describe('resolveHeritageBoxes', () => {
+  test.each([
+    {
+      name: 'авось resolves to RED and parses avoid gloss alternatives',
+      entry: {
+        gloss: 'avoid: ану ж / а може',
+        heritage_status: {
+          classification: 'unknown',
+          is_russianism: true,
+          russian_shadow: true,
+          vesum_attested: false,
+          warning_severity: 'russianism_red',
+          attestations: [],
+        },
+      },
+      expected: { red: true, yellow: false, green: false, blue: false },
+      alternatives: ['ану ж', 'а може'],
+    },
+    {
+      name: 'calque with a standard alternative resolves to YELLOW',
+      entry: {
+        gloss: 'acting',
+        heritage_status: {
+          classification: 'unknown',
+          warning_severity: 'calque_yellow',
+          calque_warning: {
+            detail: 'Калька з російської активної дієприкметникової моделі.',
+            standard_alternatives: ['чинний'],
+          },
+          attestations: [],
+        },
+      },
+      expected: { red: false, yellow: true, green: false, blue: false },
+      alternatives: ['чинний'],
+    },
+    {
+      name: 'dialect classification resolves to GREEN',
+      entry: {
+        heritage_status: {
+          classification: 'dialect',
+          is_russianism: false,
+          russian_shadow: true,
+          vesum_attested: false,
+          attestations: [],
+        },
+      },
+      expected: { red: false, yellow: false, green: true, blue: false },
+    },
+    {
+      name: 'прапор sovietized definition resolves to BLUE',
+      entry: {
+        heritage_status: {
+          classification: 'standard',
+          is_russianism: false,
+          russian_shadow: false,
+          attestations: [],
+        },
+        enrichment: {
+          definition_cards: [{ id: 'sum11-flagged-прапор', sovietization_risk: 2 }],
+        },
+      },
+      expected: { red: false, yellow: false, green: false, blue: true },
+    },
+    {
+      name: 'russian_shadow with VESUM and no alternative resolves to no box',
+      entry: {
+        heritage_status: {
+          classification: 'unknown',
+          is_russianism: false,
+          russian_shadow: true,
+          vesum_attested: true,
+          attestations: [{ source: 'VESUM', ref: 'форма' }],
+        },
+      },
+      expected: { red: false, yellow: false, green: false, blue: false },
+    },
+    {
+      name: 'russian_shadow plus standard classification is not RED',
+      entry: {
+        heritage_status: {
+          classification: 'standard',
+          is_russianism: true,
+          russian_shadow: true,
+          vesum_attested: false,
+          attestations: [],
+        },
+      },
+      expected: { red: false, yellow: false, green: false, blue: false },
+    },
+  ])('$name', ({ entry, expected, alternatives }) => {
+    const boxes = resolveHeritageBoxes(entry as LexiconEntryForSeverity);
+
+    expect(Boolean(boxes.red)).toBe(expected.red);
+    expect(Boolean(boxes.yellow)).toBe(expected.yellow);
+    expect(Boolean(boxes.green)).toBe(expected.green);
+    expect(Boolean(boxes.blue)).toBe(expected.blue);
+
+    if (alternatives) {
+      expect((boxes.red ?? boxes.yellow)?.alternatives).toEqual(alternatives);
+    }
+  });
+});

--- a/tests/test_heritage_classifier.py
+++ b/tests/test_heritage_classifier.py
@@ -1,7 +1,13 @@
 import json
 from pathlib import Path
 
-from scripts.lexicon.heritage_classifier import classify_lemma, classify_surface_form
+import pytest
+
+from scripts.lexicon.heritage_classifier import (
+    classify_lemma,
+    classify_surface_form,
+    compute_warning_severity,
+)
 
 DB = Path(__file__).resolve().parent / "fixtures" / "heritage_sample.db"
 VESUM_DB = Path(__file__).resolve().parent / "fixtures" / "vesum_sample.db"
@@ -149,3 +155,141 @@ def test_kobita_ignores_cached_sum20_regional_evidence(monkeypatch, tmp_path) ->
     assert [(attestation["source"], attestation["ref"]) for attestation in status["attestations"]] == [
         ("VESUM", "кобіта")
     ]
+
+
+@pytest.mark.parametrize(
+    ("heritage_status", "vesum_attested", "max_sovietization_risk", "expected"),
+    [
+        (
+            {"classification": "russianism", "is_russianism": True, "attestations": []},
+            False,
+            0,
+            "russianism_red",
+        ),
+        (
+            {
+                "classification": "unknown",
+                "is_russianism": False,
+                "russian_shadow": True,
+                "attestations": [],
+            },
+            False,
+            0,
+            "russianism_red",
+        ),
+        (
+            {
+                "classification": "unknown",
+                "is_russianism": False,
+                "russian_shadow": True,
+                "attestations": [{"source": "standard_alternative", "ref": "ануж"}],
+            },
+            False,
+            0,
+            "russianism_red",
+        ),
+        (
+            {
+                "classification": "unknown",
+                "is_russianism": False,
+                "russian_shadow": True,
+                "attestations": [{"source": "literary_fts", "ref": "chunk"}],
+            },
+            False,
+            0,
+            "none",
+        ),
+        (
+            {
+                "classification": "standard",
+                "is_russianism": False,
+                "russian_shadow": True,
+                "attestations": [],
+            },
+            False,
+            0,
+            "none",
+        ),
+        (
+            {
+                "classification": "standard",
+                "is_russianism": True,
+                "russian_shadow": True,
+                "attestations": [],
+            },
+            False,
+            0,
+            "none",
+        ),
+        (
+            {
+                "classification": "standard",
+                "is_russianism": False,
+                "russian_shadow": True,
+                "attestations": [{"source": "VESUM", "ref": "слово"}],
+            },
+            True,
+            0,
+            "treasured",
+        ),
+        (
+            {
+                "classification": "dialect",
+                "is_russianism": False,
+                "russian_shadow": True,
+                "attestations": [],
+            },
+            False,
+            0,
+            "treasured",
+        ),
+        (
+            {
+                "classification": "unknown",
+                "is_russianism": False,
+                "russian_shadow": False,
+                "attestations": [],
+                "curated_calque": {"corrections": ["чинний"]},
+            },
+            False,
+            0,
+            "calque_yellow",
+        ),
+        (
+            {
+                "classification": "unknown",
+                "is_russianism": False,
+                "russian_shadow": False,
+                "attestations": [],
+            },
+            False,
+            2,
+            "soviet_def_blue",
+        ),
+        (
+            {
+                "classification": "unknown",
+                "is_russianism": False,
+                "russian_shadow": True,
+                "attestations": [],
+            },
+            False,
+            2,
+            "russianism_red",
+        ),
+    ],
+)
+def test_compute_warning_severity_is_pure(
+    heritage_status: dict,
+    vesum_attested: bool,
+    max_sovietization_risk: int,
+    expected: str,
+) -> None:
+    assert (
+        compute_warning_severity(
+            heritage_status,
+            vesum_attested=vesum_attested,
+            max_sovietization_risk=max_sovietization_risk,
+        )
+        == expected
+    )

--- a/tests/test_heritage_classifier.py
+++ b/tests/test_heritage_classifier.py
@@ -256,6 +256,20 @@ def test_kobita_ignores_cached_sum20_regional_evidence(monkeypatch, tmp_path) ->
             "calque_yellow",
         ),
         (
+            # reverse-calque word (the recommended replacement) → yellow, matching
+            # the TS resolver (agy off-seat review #3759: data model must match UI).
+            {
+                "classification": "standard",
+                "is_russianism": False,
+                "russian_shadow": False,
+                "attestations": [{"source": "grinchenko_1907", "ref": "чинний"}],
+                "reverse_calques": [{"calque": "діючий"}],
+            },
+            True,
+            0,
+            "calque_yellow",
+        ),
+        (
             {
                 "classification": "unknown",
                 "is_russianism": False,

--- a/tests/test_publish_manifest.py
+++ b/tests/test_publish_manifest.py
@@ -1,0 +1,71 @@
+import gzip
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.lexicon.publish_manifest import (
+    ManifestPublishError,
+    build_pointer_payload,
+    gzip_manifest,
+    validate_pointer_freshness,
+)
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def test_build_pointer_payload_records_manifest_version_and_fingerprint(tmp_path: Path) -> None:
+    fingerprint = {"schema_version": 1, "fingerprint": "abc123"}
+    manifest = {
+        "version": "0.1",
+        "generated_at": "2026-06-23T00:00:00+00:00",
+        "manifest_fingerprint": fingerprint,
+        "entries": [],
+    }
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    fingerprint_path = tmp_path / "lexicon-manifest.fingerprint.json"
+    gzip_path = tmp_path / "lexicon-manifest.json.gz"
+    _write_json(manifest_path, manifest)
+    _write_json(fingerprint_path, fingerprint)
+
+    gzip_bytes = gzip_manifest(manifest_path, gzip_path)
+    payload = build_pointer_payload(
+        manifest_path=manifest_path,
+        gzip_path=gzip_path,
+        fingerprint_path=fingerprint_path,
+        repo="learn-ukrainian/example",
+    )
+
+    manifest_bytes = manifest_path.read_bytes()
+    assert gzip.decompress(gzip_bytes) == manifest_bytes
+    assert payload["asset_url"].endswith("/learn-ukrainian/example/releases/download/atlas-manifest/lexicon-manifest.json.gz")
+    assert payload["manifest_version"] == "0.1"
+    assert payload["manifest_fingerprint"] == "abc123"
+    assert payload["fingerprint_schema_version"] == 1
+    assert payload["json_sha256"] == _sha256(manifest_bytes)
+    assert payload["gz_sha256"] == _sha256(gzip_path.read_bytes())
+
+
+def test_pointer_freshness_guard_fails_on_stale_pointer_fixture() -> None:
+    fingerprint = {"schema_version": 1, "fingerprint": "current"}
+    pointer = {
+        "asset_url": "https://example.test/lexicon-manifest.json.gz",
+        "release_tag": "atlas-manifest",
+        "manifest_version": "0.1",
+        "manifest_fingerprint": "stale",
+        "fingerprint_schema_version": 1,
+        "gz_sha256": "0" * 64,
+        "json_sha256": "1" * 64,
+        "gz_bytes": 10,
+        "json_bytes": 20,
+    }
+
+    with pytest.raises(ManifestPublishError, match="fingerprint is stale"):
+        validate_pointer_freshness(pointer, fingerprint)


### PR DESCRIPTION
## Summary

- Finishes PR1 warning severity: strict positive-attestation whitelist, authentic/standard classifications protected from red fallback, and table-driven TS resolver coverage.
- Promotes plain `.editorial-calque` to yellow while keeping `.editorial-calque.info` blue, with `data-severity` on editorial boxes.
- Adds `scripts/lexicon/publish_manifest.py`, `make atlas-publish`, manifest fingerprint embedding, and a build-time pointer/asset freshness guard.

## Verification

```text
$ .venv/bin/ruff check scripts/lexicon/heritage_classifier.py scripts/lexicon/enrich_manifest.py scripts/lexicon/publish_manifest.py tests/test_heritage_classifier.py tests/test_publish_manifest.py
All checks passed!
```

```text
$ .venv/bin/python -m pytest tests/test_heritage_classifier.py -q
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/pr1-finish
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 20 items
tests/test_heritage_classifier.py .................... [100%]
============================== 20 passed in 0.71s ==============================
```

```text
$ .venv/bin/python -m pytest tests/test_publish_manifest.py -q
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/pr1-finish
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 2 items
tests/test_publish_manifest.py .. [100%]
============================== 2 passed in 0.06s ===============================
```

```text
$ npm --prefix site test
Test Files  22 passed (22)
Tests  351 passed (351)
Start at  11:35:04
Duration  57.53s (transform 1.25s, setup 2.10s, import 5.58s, tests 60.37s, environment 7.24s)
```

```text
$ .venv/bin/python scripts/audit/lint_agent_trailer.py
Checking 1 commit(s) in origin/main..HEAD:

  d4691e4319  PASS  X-Agent: codex/pr1-finish

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

## Maintainer follow-up

- I did not run `make atlas` or `make atlas-publish`; this worktree does not have the DB-backed Atlas inputs.
- Normal `npm run build` now rejects the stale release pointer until `make atlas-publish` uploads the refreshed asset and rewrites `site/src/data/lexicon-manifest.pointer.json`.
- The existing Vitest build-render test sets `ATLAS_MANIFEST_ALLOW_STALE_POINTER=1` so render coverage can keep running before the maintainer publishes the fresh release asset.
- A full-repo `.venv/bin/ruff check` still reports unrelated pre-existing lint in tracked `docs/reports` and `plans` scripts; the changed Python files and push-hook ruff check are clean.
