### PR TITLE
feat(build): deterministic pre-promote quality gate for seminar/folk modules (Option A)

### DIFF
--- a/docs/folk-epic/seminar-quality-gate-design.md
+++ b/docs/folk-epic/seminar-quality-gate-design.md
@@ -7,6 +7,10 @@
 
 ## 0. Core principle — AGENTS IN TANDEM > the best solo model (user 2026-06-17)
 
+> **2026-06-23 supersession note:** §9 supersedes the model PANEL idea as the
+> gating mechanism for PR1. A panel remains a future option; the locked MVP gate
+> is one recorded cross-family reviewer bound to the exact content hash.
+
 > *"Agents working in tandem surpass the most advanced LLM model. We have to stick to this."*
 > Proven in-house this very session: Codex (a different model) found **3 real holes** in the
 > liveness gate that my own (Claude) review missed. Tandem catches what solo cannot.
@@ -87,6 +91,10 @@ decolonization) for history-leaning tracks, that's the sanctioned 7th dim — bu
 when a track's profile demands it, and keep MIN-aggregation noise in mind (§3).
 
 ## 3. The gate change (Phase A)
+
+> **2026-06-23 supersession note:** §9 supersedes this phase for the gating
+> mechanism. Do not re-arm in-build LLM-QG terminal dims; enforce quality at the
+> promote boundary through the deterministic recorded sidecar.
 
 **Make `pedagogy + engagement + beauty` gating at ≥8 — but for SEMINAR profiles ONLY.**
 
@@ -181,3 +189,45 @@ a non-word-counted primary-text reading panel).
 2. Phase C foundation: #3162 literary-corpus routing + finish 6 wikis + 6 dossiers (fleet writers, deepseek review).
 3. Phase D: rebuild 6 modules → ≥8 (fleet bake-off workflow + gate + correction loop), one at a time.
 4. Phase E: verify 6 live ≥8, regen MDX (resolve generator discrepancy), REGROUP for user judgment → then generalize to all seminar tracks.
+
+## 9. Option A — deterministic PRE-PROMOTE gate (LOCKED 2026-06-23, supersedes §3)
+
+The May-2026 demotion of subjective LLM-QG dimensions is permanent for in-build
+behavior. Do **not** re-arm `QG_DIMS`, `aggregate_review`,
+`terminal_dims_for`, or `v7_build.py` LLM-QG enforcement. The in-build reviewer
+continues to warn on subjective dimensions so the build loop does not recreate
+the 2026-05-23 "0 ships" failure.
+
+Quality is enforced separately at the promote boundary. A seminar module may
+promote only when it has a git-tracked `promote_quality.json` sidecar next to
+`llm_qg.json`, containing a recorded cross-family LLM-QG score that is bound to
+the exact lesson source content hash. The hash basis is `lesson_sources_v1`:
+the source plan plus `module.md`, `activities.yaml`, `vocabulary.yaml`, and
+`resources.yaml` when present.
+
+The mechanism components are:
+
+- `scripts/common/thresholds.py`: source of truth for per-track promote floors
+  via `SEMINAR_PROMOTE_DIMS`, `SEMINAR_PROMOTE_PROFILES`, and
+  `seminar_promote_floors_for`.
+- `scripts/build/promote_quality_gate.py`: deterministic `record` and `verify`
+  tool. `record` computes hashes from disk and stamps current floors; `verify`
+  fails closed on missing, stale, same-family, unknown-family, barred reviewer,
+  below-floor, missing-dimension, or weaker-recorded-floor sidecars.
+- `scripts/build/verify_shippable.py`: adds a `promote_quality` step after the
+  existing render/build checks. Unenrolled levels are non-blocking `n/a`; enrolled
+  tracks fail shippability when the sidecar is absent or invalid.
+- `scripts/sync/promote_module.py`: PR1 includes only the missing `json` import
+  bug fix for the folk readings promote path. The actual promote hook remains
+  PR2 scope.
+- `tests/test_promote_quality_gate.py` and
+  `tests/test_threshold_source_of_truth.py`: cover the fail-closed sidecar
+  behavior and keep the threshold floors in the SSOT.
+
+MVP reviewer policy is a single cross-family reviewer. A second review is an
+appeal or audit path, not a default blocker. For folk, DeepSeek is barred as the
+promote-quality reviewer in code. Enrollment is folk-first and per-track:
+adding another seminar track is a thresholds profile entry plus tests, not an
+in-build LLM-QG behavior change. PR1 is mechanism only; CI enforcement,
+`promote_module.py` gate wiring, sidecar bootstrap, and required-check governance
+belong to PR2.

--- a/scripts/build/promote_quality_gate.py
+++ b/scripts/build/promote_quality_gate.py
@@ -1,0 +1,523 @@
+"""Deterministic pre-promote quality gate for enrolled seminar tracks."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+from scripts.audit.wiki_completeness_gate import SEMINAR_LEVELS
+from scripts.common.thresholds import seminar_promote_floors_for
+
+ROOT = Path(__file__).resolve().parents[2]
+CURRICULUM = ROOT / "curriculum" / "l2-uk-en"
+
+KNOWN_FAMILIES = {
+    "anthropic",
+    "openai",
+    "google",
+    "deepseek",
+    "xai",
+    "cursor",
+    "mistral",
+}
+CONTENT_HASH_ALGORITHM = "sha256"
+CONTENT_HASH_BASIS = "lesson_sources_v1"
+SCHEMA_VERSION = 1
+
+
+def _level_key(level: str | None) -> str:
+    return str(level or "").strip().casefold()
+
+
+def _default_module_dir(level: str, slug: str, repo_root: Path) -> Path:
+    return repo_root / "curriculum" / "l2-uk-en" / _level_key(level) / slug
+
+
+def _plan_path(level: str, slug: str, repo_root: Path) -> Path:
+    return repo_root / "curriculum" / "l2-uk-en" / "plans" / _level_key(level) / f"{slug}.yaml"
+
+
+def _module_dir_path(
+    level: str,
+    slug: str,
+    *,
+    module_dir: Path | None,
+    repo_root: Path,
+) -> Path:
+    return Path(module_dir) if module_dir is not None else _default_module_dir(level, slug, repo_root)
+
+
+def _repo_rel(path: Path, repo_root: Path) -> str:
+    return path.resolve().relative_to(repo_root.resolve()).as_posix()
+
+
+def lesson_source_paths(
+    level: str,
+    slug: str,
+    *,
+    module_dir: Path | None = None,
+    repo_root: Path = ROOT,
+) -> tuple[Path, ...]:
+    """Return the fixed-order source list for the promote content hash."""
+    resolved_module_dir = _module_dir_path(
+        level,
+        slug,
+        module_dir=module_dir,
+        repo_root=repo_root,
+    )
+    return (
+        _plan_path(level, slug, repo_root),
+        resolved_module_dir / "module.md",
+        resolved_module_dir / "activities.yaml",
+        resolved_module_dir / "vocabulary.yaml",
+        resolved_module_dir / "resources.yaml",
+    )
+
+
+def content_digest(files: Iterable[Path], *, repo_root: Path = ROOT) -> dict[str, Any]:
+    """Compute the stable lesson_sources_v1 digest and per-file sha list."""
+    digest = hashlib.sha256()
+    file_rows: list[dict[str, str]] = []
+    for path in files:
+        if not path.exists():
+            continue
+        data = path.read_bytes()
+        file_sha = hashlib.sha256(data)
+        rel = _repo_rel(path, repo_root)
+        digest.update(rel.encode("utf-8") + b"\0" + file_sha.digest() + b"\0")
+        file_rows.append({"path": rel, "sha256": file_sha.hexdigest()})
+    return {
+        "algorithm": CONTENT_HASH_ALGORITHM,
+        "basis": CONTENT_HASH_BASIS,
+        "digest": digest.hexdigest(),
+        "files": file_rows,
+    }
+
+
+def content_hash(
+    level: str,
+    slug: str,
+    *,
+    module_dir: Path | None = None,
+    repo_root: Path = ROOT,
+) -> dict[str, Any]:
+    """Compute the content hash for a lesson module and its source plan."""
+    return content_digest(
+        lesson_source_paths(level, slug, module_dir=module_dir, repo_root=repo_root),
+        repo_root=repo_root,
+    )
+
+
+def _sidecar_path(level: str, slug: str, *, module_dir: Path | None, repo_root: Path) -> Path:
+    return _module_dir_path(level, slug, module_dir=module_dir, repo_root=repo_root) / "promote_quality.json"
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _normalized_family(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().casefold()
+    return normalized or None
+
+
+def _family_from(sidecar: Mapping[str, Any], key: str) -> str | None:
+    agent = sidecar.get(key)
+    if not isinstance(agent, Mapping):
+        return None
+    return _normalized_family(agent.get("family"))
+
+
+def _score_value(scores: Mapping[str, Any], dim: str) -> float | None:
+    try:
+        raw = scores[dim]
+    except KeyError:
+        return None
+    if isinstance(raw, bool):
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _content_staleness_failures(sidecar_hash: Mapping[str, Any], current_hash: Mapping[str, Any]) -> list[str]:
+    failures: list[str] = []
+    if sidecar_hash.get("algorithm") != CONTENT_HASH_ALGORITHM:
+        failures.append("content_hash algorithm is not sha256")
+    if sidecar_hash.get("basis") != CONTENT_HASH_BASIS:
+        failures.append("content_hash basis is not lesson_sources_v1")
+
+    sidecar_digest = sidecar_hash.get("digest")
+    if not isinstance(sidecar_digest, str):
+        failures.append("content_hash digest missing or invalid")
+        return failures
+
+    if sidecar_digest == current_hash["digest"]:
+        return failures
+
+    recorded_rows = sidecar_hash.get("files")
+    if not isinstance(recorded_rows, list):
+        failures.append("content_hash files missing or invalid")
+        return failures
+
+    recorded: dict[str, str | None] = {}
+    for row in recorded_rows:
+        if not isinstance(row, Mapping):
+            failures.append("content_hash files contain a non-object row")
+            continue
+        path = row.get("path")
+        sha = row.get("sha256")
+        if not isinstance(path, str) or not isinstance(sha, str):
+            failures.append("content_hash files contain an invalid row")
+            continue
+        recorded[path] = sha
+
+    current = {row["path"]: row["sha256"] for row in current_hash["files"]}
+    for rel_path in sorted(recorded.keys() | current.keys()):
+        if recorded.get(rel_path) != current.get(rel_path):
+            failures.append(f"stale: {rel_path} changed since scoring")
+
+    if not failures:
+        failures.append("stale: content_hash digest changed since scoring")
+    return failures
+
+
+def _family_failures(sidecar: Mapping[str, Any], level: str) -> list[str]:
+    failures: list[str] = []
+    writer_family = _family_from(sidecar, "writer")
+    reviewer_family = _family_from(sidecar, "reviewer")
+
+    if writer_family not in KNOWN_FAMILIES:
+        failures.append(f"unknown writer family: {writer_family or '<missing>'}")
+    if reviewer_family not in KNOWN_FAMILIES:
+        failures.append(f"unknown reviewer family: {reviewer_family or '<missing>'}")
+    if writer_family in KNOWN_FAMILIES and reviewer_family in KNOWN_FAMILIES:
+        if writer_family == reviewer_family:
+            failures.append(f"reviewer family must differ from writer family: {reviewer_family}")
+        if _level_key(level) == "folk" and reviewer_family == "deepseek":
+            failures.append("folk reviewer family deepseek is barred for promote quality scoring")
+    return failures
+
+
+def _floor_failures(
+    sidecar_floors: Any,
+    current_floors: Mapping[str, float],
+) -> list[str]:
+    if sidecar_floors is None:
+        return []
+    if not isinstance(sidecar_floors, Mapping):
+        return ["recorded floors are not an object"]
+
+    failures: list[str] = []
+    for dim, floor in current_floors.items():
+        recorded = sidecar_floors.get(dim)
+        if recorded is None:
+            failures.append(f"recorded floor missing: {dim}")
+            continue
+        try:
+            recorded_float = float(recorded)
+        except (TypeError, ValueError):
+            failures.append(f"recorded floor invalid: {dim}")
+            continue
+        if recorded_float != float(floor):
+            failures.append(f"recorded floor stale: {dim} recorded {recorded_float:g}, current {float(floor):g}")
+
+    extra = sorted(set(sidecar_floors) - set(current_floors))
+    for dim in extra:
+        failures.append(f"recorded floor unexpected: {dim}")
+    return failures
+
+
+def verify(
+    level: str,
+    slug: str,
+    *,
+    module_dir: Path | None = None,
+    repo_root: Path = ROOT,
+) -> dict[str, Any]:
+    """Verify that an enrolled seminar module has a fresh passing sidecar."""
+    floors = seminar_promote_floors_for(level)
+    if floors is None:
+        return {
+            "applicable": False,
+            "passed": True,
+            "reason": "level not enrolled in pre-promote gate",
+            "per_dim": [],
+            "failures": [],
+        }
+
+    sidecar_file = _sidecar_path(level, slug, module_dir=module_dir, repo_root=repo_root)
+    failures: list[str] = []
+    per_dim: list[dict[str, Any]] = []
+
+    if not sidecar_file.exists():
+        failures.append(f"missing sidecar: {_repo_rel(sidecar_file, repo_root)}")
+        return {
+            "applicable": True,
+            "passed": False,
+            "reason": "; ".join(failures),
+            "per_dim": per_dim,
+            "failures": failures,
+        }
+
+    try:
+        sidecar = json.loads(sidecar_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        failures.append(f"sidecar JSON parse failed: {exc.msg}")
+        return {
+            "applicable": True,
+            "passed": False,
+            "reason": "; ".join(failures),
+            "per_dim": per_dim,
+            "failures": failures,
+        }
+
+    if not isinstance(sidecar, Mapping):
+        failures.append("sidecar root is not an object")
+        sidecar = {}
+
+    if sidecar.get("schema_version") != SCHEMA_VERSION:
+        failures.append(f"unsupported schema_version: {sidecar.get('schema_version')!r}")
+
+    sidecar_hash = sidecar.get("content_hash")
+    if not isinstance(sidecar_hash, Mapping):
+        failures.append("content_hash missing or invalid")
+    else:
+        current_hash = content_hash(level, slug, module_dir=module_dir, repo_root=repo_root)
+        failures.extend(_content_staleness_failures(sidecar_hash, current_hash))
+
+    failures.extend(_family_failures(sidecar, level))
+
+    scores = sidecar.get("scores")
+    if not isinstance(scores, Mapping):
+        failures.append("scores missing or invalid")
+        scores = {}
+
+    for dim, floor in floors.items():
+        score = _score_value(scores, dim)
+        ok = score is not None and score >= float(floor)
+        per_dim.append({"dim": dim, "score": score, "floor": float(floor), "ok": ok})
+        if score is None:
+            failures.append(f"missing or invalid score: {dim}")
+        elif not ok:
+            failures.append(f"score below floor: {dim} {score:g} < {float(floor):g}")
+
+    failures.extend(_floor_failures(sidecar.get("floors"), floors))
+
+    passed = not failures
+    return {
+        "applicable": True,
+        "passed": passed,
+        "reason": "all promote quality floors satisfied" if passed else "; ".join(failures),
+        "per_dim": per_dim,
+        "failures": failures,
+    }
+
+
+def _validate_family(family: str, field: str) -> str:
+    normalized = _normalized_family(family)
+    if normalized not in KNOWN_FAMILIES:
+        raise ValueError(f"unknown {field} family: {family}")
+    return normalized
+
+
+def _review_artifact_record(path: Path, repo_root: Path) -> dict[str, str]:
+    return {"path": _repo_rel(path, repo_root), "sha256": _sha256_file(path)}
+
+
+def record(
+    level: str,
+    slug: str,
+    *,
+    module_dir: Path | None,
+    repo_root: Path = ROOT,
+    writer_family: str,
+    writer_agent: str,
+    writer_model: str,
+    reviewer_family: str,
+    reviewer_agent: str,
+    reviewer_model: str,
+    scores: Mapping[str, float],
+    evidence: Mapping[str, str] | None,
+    scored_at: str,
+    assembled_mdx_path: Path | None = None,
+    review_artifact: Path | None = None,
+) -> dict[str, Any]:
+    """Record a promote-quality sidecar by hashing the local source files."""
+    floors = seminar_promote_floors_for(level)
+    if floors is None:
+        track = _level_key(level)
+        scope = "seminar level" if track in SEMINAR_LEVELS else "level"
+        raise ValueError(f"{scope} not enrolled in pre-promote gate: {level}")
+
+    writer_family_key = _validate_family(writer_family, "writer")
+    reviewer_family_key = _validate_family(reviewer_family, "reviewer")
+    resolved_module_dir = _module_dir_path(
+        level,
+        slug,
+        module_dir=module_dir,
+        repo_root=repo_root,
+    )
+    resolved_module_dir.mkdir(parents=True, exist_ok=True)
+
+    score_rows = {dim: float(score) for dim, score in scores.items()}
+    per_dim = [
+        score_rows.get(dim) is not None and score_rows[dim] >= float(floor)
+        for dim, floor in floors.items()
+    ]
+    sidecar = {
+        "schema_version": SCHEMA_VERSION,
+        "track": _level_key(level),
+        "slug": slug,
+        "profile": f"{_level_key(level)}_promote_v1",
+        "content_hash": content_hash(
+            level,
+            slug,
+            module_dir=resolved_module_dir,
+            repo_root=repo_root,
+        ),
+        "assembled_mdx_sha256": _sha256_file(assembled_mdx_path) if assembled_mdx_path else None,
+        "writer": {
+            "agent": writer_agent,
+            "model": writer_model,
+            "family": writer_family_key,
+        },
+        "reviewer": {
+            "agent": reviewer_agent,
+            "model": reviewer_model,
+            "family": reviewer_family_key,
+        },
+        "scores": score_rows,
+        "floors": {dim: float(floor) for dim, floor in floors.items()},
+        "evidence": dict(evidence or {}),
+        "verdict": "PASS" if all(per_dim) else "FAIL",
+        "scored_at": scored_at,
+        "review_artifact": _review_artifact_record(review_artifact, repo_root) if review_artifact else None,
+    }
+
+    sidecar_file = resolved_module_dir / "promote_quality.json"
+    sidecar_file.write_text(json.dumps(sidecar, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return {"path": sidecar_file, "sidecar": sidecar}
+
+
+def _parse_key_value(raw: str, *, label: str) -> tuple[str, str]:
+    if "=" not in raw:
+        raise argparse.ArgumentTypeError(f"{label} must be dim=value: {raw}")
+    key, value = raw.split("=", 1)
+    key = key.strip()
+    if not key:
+        raise argparse.ArgumentTypeError(f"{label} key is empty: {raw}")
+    return key, value
+
+
+def _parse_scores(items: list[str]) -> dict[str, float]:
+    scores: dict[str, float] = {}
+    for item in items:
+        key, value = _parse_key_value(item, label="--score")
+        try:
+            scores[key] = float(value)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(f"--score value must be numeric: {item}") from exc
+    return scores
+
+
+def _parse_evidence(items: list[str] | None) -> dict[str, str]:
+    evidence: dict[str, str] = {}
+    for item in items or []:
+        key, value = _parse_key_value(item, label="--evidence")
+        evidence[key] = value
+    return evidence
+
+
+def _utc_now_iso() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _print_verify_report(report: Mapping[str, Any], level: str, slug: str) -> None:
+    if report["passed"]:
+        if report["applicable"] is False:
+            print(f"PASS promote_quality n/a for {level}/{slug}: {report['reason']}")
+        else:
+            print(f"PASS promote_quality for {level}/{slug}: {report['reason']}")
+            for row in report.get("per_dim", []):
+                print(f"- {row['dim']}: {row['score']} >= {row['floor']}")
+        return
+
+    print(f"FAIL promote_quality for {level}/{slug}: {report['reason']}")
+    for failure in report.get("failures", []):
+        print(f"- {failure}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    verify_parser = subparsers.add_parser("verify", help="verify a promote-quality sidecar")
+    verify_parser.add_argument("level")
+    verify_parser.add_argument("slug")
+    verify_parser.add_argument("--module-dir", type=Path)
+    verify_parser.add_argument("--repo-root", type=Path, default=ROOT)
+    verify_parser.add_argument("--json", action="store_true")
+
+    record_parser = subparsers.add_parser("record", help="write a promote-quality sidecar")
+    record_parser.add_argument("level")
+    record_parser.add_argument("slug")
+    record_parser.add_argument("--module-dir", type=Path)
+    record_parser.add_argument("--repo-root", type=Path, default=ROOT)
+    record_parser.add_argument("--writer-family", required=True)
+    record_parser.add_argument("--writer-agent", required=True)
+    record_parser.add_argument("--writer-model", required=True)
+    record_parser.add_argument("--reviewer-family", required=True)
+    record_parser.add_argument("--reviewer-agent", required=True)
+    record_parser.add_argument("--reviewer-model", required=True)
+    record_parser.add_argument("--score", action="append", default=[], required=True)
+    record_parser.add_argument("--evidence", action="append")
+    record_parser.add_argument("--scored-at")
+    record_parser.add_argument("--assembled-mdx", type=Path)
+    record_parser.add_argument("--review-artifact", type=Path)
+
+    args = parser.parse_args(argv)
+    if args.command == "verify":
+        report = verify(args.level, args.slug, module_dir=args.module_dir, repo_root=args.repo_root)
+        if args.json:
+            print(json.dumps(report, indent=2, sort_keys=True))
+        else:
+            _print_verify_report(report, args.level, args.slug)
+        return 0 if report["passed"] else 1
+
+    try:
+        result = record(
+            args.level,
+            args.slug,
+            module_dir=args.module_dir,
+            repo_root=args.repo_root,
+            writer_family=args.writer_family,
+            writer_agent=args.writer_agent,
+            writer_model=args.writer_model,
+            reviewer_family=args.reviewer_family,
+            reviewer_agent=args.reviewer_agent,
+            reviewer_model=args.reviewer_model,
+            scores=_parse_scores(args.score),
+            evidence=_parse_evidence(args.evidence),
+            scored_at=args.scored_at or _utc_now_iso(),
+            assembled_mdx_path=args.assembled_mdx,
+            review_artifact=args.review_artifact,
+        )
+    except (argparse.ArgumentTypeError, ValueError) as exc:
+        parser.error(str(exc))
+    print(f"wrote {result['path']}")
+    print(f"verdict: {result['sidecar']['verdict']}")
+    print(f"content_hash: {result['sidecar']['content_hash']['digest']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build/verify_shippable.py
+++ b/scripts/build/verify_shippable.py
@@ -196,6 +196,7 @@ def verify(
         run_mdx_render_gate,
         run_python_qg,
     )
+    from scripts.build.promote_quality_gate import verify as _promote_verify
 
     module_dir = module_dir or _default_module_dir(level, slug)
     plan_path = plan_path or _default_plan_path(level, slug)
@@ -272,6 +273,20 @@ def verify(
                 site_mdx.unlink(missing_ok=True)
             else:
                 site_mdx.write_text(prior, encoding="utf-8")
+
+    # --- 5. seminar pre-promote quality sidecar (Option A) ---
+    try:
+        promote_rep = _promote_verify(level, slug, module_dir=module_dir)
+        if promote_rep.get("applicable") is False:
+            add("promote_quality", None, "n/a — level not enrolled")
+        else:
+            add(
+                "promote_quality",
+                promote_rep.get("passed"),
+                promote_rep.get("reason") or "; ".join(promote_rep.get("failures", [])),
+            )
+    except Exception as exc:
+        add("promote_quality", False, f"promote_quality raised: {type(exc).__name__}: {str(exc)[:200]}")
 
     return _finalize(level, slug, steps)
 

--- a/scripts/common/thresholds.py
+++ b/scripts/common/thresholds.py
@@ -100,6 +100,44 @@ shippable."""
 STYLE_REVIEW_DIMENSION_FLOOR: float = 8.5
 """Per-dimension floor for the style reviewer."""
 
+# Seminar pre-promote quality gate (Option A, 2026-06-23). SEPARATE from
+# in-build LLM-QG (which stays warning-only — do NOT change
+# QG_DIMS/aggregate_review/terminal_dims_for). Per-track, data-driven (design
+# §2a): enrolling a track = a dict entry.
+SEMINAR_PROMOTE_DIMS: tuple[str, ...] = (
+    "pedagogical",
+    "engagement",
+    "beauty",
+    "naturalness",
+    "tone",
+    "decolonization",
+)
+SEMINAR_PROMOTE_PROFILES: Mapping[str, Mapping[str, float]] = MappingProxyType(
+    {
+        "folk": MappingProxyType(
+            {
+                "pedagogical": 8.5,
+                "engagement": 8.5,
+                "beauty": 8.5,
+                "naturalness": 8.5,
+                "tone": 8.5,
+                "decolonization": 9.0,
+            }
+        ),
+    }
+)
+
+
+def seminar_promote_floors_for(level: str | None) -> Mapping[str, float] | None:
+    """Per-dim promote floors for a seminar track enrolled in the gate.
+
+    Returns None for pass-through levels, including core levels and seminar
+    tracks not yet enrolled.
+    """
+    if not level:
+        return None
+    return SEMINAR_PROMOTE_PROFILES.get(str(level).strip().casefold())
+
 # ---------------------------------------------------------------------------
 # Per-level thresholds — families (A1..C2)
 # ---------------------------------------------------------------------------

--- a/scripts/sync/promote_module.py
+++ b/scripts/sync/promote_module.py
@@ -7,6 +7,7 @@ import argparse
 import contextlib
 import difflib
 import hashlib
+import json
 import os
 import re
 import subprocess

--- a/tests/test_promote_quality_gate.py
+++ b/tests/test_promote_quality_gate.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.build import promote_quality_gate as gate
+from scripts.common.thresholds import seminar_promote_floors_for
+
+SLUG = "koliadky-shchedrivky"
+
+
+def _write_stub_repo(tmp_path: Path, *, slug: str = SLUG) -> tuple[Path, Path]:
+    repo_root = tmp_path / "repo"
+    module_dir = repo_root / "curriculum" / "l2-uk-en" / "folk" / slug
+    plan_dir = repo_root / "curriculum" / "l2-uk-en" / "plans" / "folk"
+    module_dir.mkdir(parents=True)
+    plan_dir.mkdir(parents=True)
+    (plan_dir / f"{slug}.yaml").write_text("title: Stub plan\n", encoding="utf-8")
+    (module_dir / "module.md").write_text("# Stub module\n", encoding="utf-8")
+    (module_dir / "activities.yaml").write_text("- prompt: Stub\n", encoding="utf-8")
+    (module_dir / "vocabulary.yaml").write_text("- term: Stub\n", encoding="utf-8")
+    (module_dir / "resources.yaml").write_text("- url: https://example.com\n", encoding="utf-8")
+    return repo_root, module_dir
+
+
+def _passing_scores() -> dict[str, float]:
+    floors = seminar_promote_floors_for("folk")
+    assert floors is not None
+    return {dim: floor + 0.1 for dim, floor in floors.items()}
+
+
+def _record_passing(repo_root: Path, module_dir: Path, *, scores: dict[str, float] | None = None) -> dict:
+    result = gate.record(
+        "folk",
+        SLUG,
+        module_dir=module_dir,
+        repo_root=repo_root,
+        writer_family="anthropic",
+        writer_agent="claude",
+        writer_model="claude-opus-4.8",
+        reviewer_family="openai",
+        reviewer_agent="codex",
+        reviewer_model="gpt-5.5",
+        scores=scores or _passing_scores(),
+        evidence={"pedagogical": "stub evidence"},
+        scored_at="2026-06-23T00:00:00Z",
+    )
+    return result["sidecar"]
+
+
+def _load_sidecar(module_dir: Path) -> dict:
+    return json.loads((module_dir / "promote_quality.json").read_text(encoding="utf-8"))
+
+
+def _write_sidecar(module_dir: Path, sidecar: dict) -> None:
+    (module_dir / "promote_quality.json").write_text(
+        json.dumps(sidecar, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_content_hash_stable_and_changes_for_any_hashed_file(tmp_path: Path) -> None:
+    repo_root, module_dir = _write_stub_repo(tmp_path)
+    baseline = gate.content_hash("folk", SLUG, module_dir=module_dir, repo_root=repo_root)
+    assert gate.content_hash("folk", SLUG, module_dir=module_dir, repo_root=repo_root) == baseline
+
+    rel_paths = [
+        Path("curriculum/l2-uk-en/plans/folk") / f"{SLUG}.yaml",
+        Path("curriculum/l2-uk-en/folk") / SLUG / "module.md",
+        Path("curriculum/l2-uk-en/folk") / SLUG / "activities.yaml",
+        Path("curriculum/l2-uk-en/folk") / SLUG / "vocabulary.yaml",
+        Path("curriculum/l2-uk-en/folk") / SLUG / "resources.yaml",
+    ]
+    for rel_path in rel_paths:
+        path = repo_root / rel_path
+        original = path.read_text(encoding="utf-8")
+        path.write_text(original + "\nchanged\n", encoding="utf-8")
+        changed = gate.content_hash("folk", SLUG, module_dir=module_dir, repo_root=repo_root)
+        assert changed["digest"] != baseline["digest"], rel_path
+        path.write_text(original, encoding="utf-8")
+
+    assert gate.content_hash("folk", SLUG, module_dir=module_dir, repo_root=repo_root) == baseline
+
+
+def test_verify_passes_valid_cross_family_sidecar(tmp_path: Path) -> None:
+    repo_root, module_dir = _write_stub_repo(tmp_path)
+    _record_passing(repo_root, module_dir)
+
+    report = gate.verify("folk", SLUG, module_dir=module_dir, repo_root=repo_root)
+
+    assert report["applicable"] is True
+    assert report["passed"] is True
+    assert {row["dim"] for row in report["per_dim"]} == set(seminar_promote_floors_for("folk") or {})
+
+
+def test_verify_fails_closed_without_sidecar(tmp_path: Path) -> None:
+    repo_root, module_dir = _write_stub_repo(tmp_path)
+
+    report = gate.verify("folk", SLUG, module_dir=module_dir, repo_root=repo_root)
+
+    assert report["passed"] is False
+    assert any("missing sidecar" in failure for failure in report["failures"])
+
+
+def test_verify_fails_closed_on_stale_digest_and_reports_path(tmp_path: Path) -> None:
+    repo_root, module_dir = _write_stub_repo(tmp_path)
+    _record_passing(repo_root, module_dir)
+    (module_dir / "module.md").write_text("# Stub module\nchanged\n", encoding="utf-8")
+
+    report = gate.verify("folk", SLUG, module_dir=module_dir, repo_root=repo_root)
+
+    assert report["passed"] is False
+    assert any("module.md changed since scoring" in failure for failure in report["failures"])
+
+
+def test_verify_fails_closed_on_same_family_reviewer(tmp_path: Path) -> None:
+    repo_root, module_dir = _write_stub_repo(tmp_path)
+    sidecar = _record_passing(repo_root, module_dir)
+    sidecar["reviewer"]["family"] = "anthropic"
+    _write_sidecar(module_dir, sidecar)
+
+    report = gate.verify("folk", SLUG, module_dir=module_dir, repo_root=repo_root)
+
+    assert report["passed"] is False
+    assert any("must differ" in failure for failure in report["failures"])
+
+
+def test_verify_fails_closed_on_deepseek_reviewer_for_folk(tmp_path: Path) -> None:
+    repo_root, module_dir = _write_stub_repo(tmp_path)
+    sidecar = _record_passing(repo_root, module_dir)
+    sidecar["reviewer"]["family"] = "deepseek"
+    _write_sidecar(module_dir, sidecar)
+
+    report = gate.verify("folk", SLUG, module_dir=module_dir, repo_root=repo_root)
+
+    assert report["passed"] is False
+    assert any("deepseek" in failure for failure in report["failures"])
+
+
+def test_verify_fails_closed_on_score_below_floor(tmp_path: Path) -> None:
+    repo_root, module_dir = _write_stub_repo(tmp_path)
+    scores = _passing_scores()
+    scores["beauty"] = 8.4
+    _record_passing(repo_root, module_dir, scores=scores)
+
+    report = gate.verify("folk", SLUG, module_dir=module_dir, repo_root=repo_root)
+
+    assert report["passed"] is False
+    assert any("beauty" in failure and "below floor" in failure for failure in report["failures"])
+
+
+def test_verify_fails_closed_on_weaker_recorded_floors(tmp_path: Path) -> None:
+    repo_root, module_dir = _write_stub_repo(tmp_path)
+    sidecar = _record_passing(repo_root, module_dir)
+    sidecar["floors"]["beauty"] = 8.0
+    _write_sidecar(module_dir, sidecar)
+
+    report = gate.verify("folk", SLUG, module_dir=module_dir, repo_root=repo_root)
+
+    assert report["passed"] is False
+    assert any("recorded floor stale: beauty" in failure for failure in report["failures"])
+
+
+def test_verify_fails_closed_on_missing_score_dim(tmp_path: Path) -> None:
+    repo_root, module_dir = _write_stub_repo(tmp_path)
+    sidecar = _record_passing(repo_root, module_dir)
+    del sidecar["scores"]["beauty"]
+    _write_sidecar(module_dir, sidecar)
+
+    report = gate.verify("folk", SLUG, module_dir=module_dir, repo_root=repo_root)
+
+    assert report["passed"] is False
+    assert any("missing or invalid score: beauty" in failure for failure in report["failures"])
+
+
+def test_verify_fails_closed_on_unknown_reviewer_family(tmp_path: Path) -> None:
+    repo_root, module_dir = _write_stub_repo(tmp_path)
+    sidecar = _record_passing(repo_root, module_dir)
+    sidecar["reviewer"]["family"] = "unknown-family"
+    _write_sidecar(module_dir, sidecar)
+
+    report = gate.verify("folk", SLUG, module_dir=module_dir, repo_root=repo_root)
+
+    assert report["passed"] is False
+    assert any("unknown reviewer family" in failure for failure in report["failures"])
+
+
+@pytest.mark.parametrize("level", ["a1", "bio"])
+def test_verify_passes_through_unenrolled_levels(tmp_path: Path, level: str) -> None:
+    report = gate.verify(level, SLUG, module_dir=tmp_path / "missing", repo_root=tmp_path)
+
+    assert report == {
+        "applicable": False,
+        "passed": True,
+        "reason": "level not enrolled in pre-promote gate",
+        "per_dim": [],
+        "failures": [],
+    }
+
+
+def test_record_verify_round_trip_and_computes_digest_locally(tmp_path: Path) -> None:
+    repo_root, module_dir = _write_stub_repo(tmp_path)
+
+    assert "content_hash" not in inspect.signature(gate.record).parameters
+    sidecar = _record_passing(repo_root, module_dir)
+
+    assert sidecar["content_hash"] == gate.content_hash(
+        "folk",
+        SLUG,
+        module_dir=module_dir,
+        repo_root=repo_root,
+    )
+    assert gate.verify("folk", SLUG, module_dir=module_dir, repo_root=repo_root)["passed"] is True
+
+
+def test_gate_reads_floors_from_thresholds_ssot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo_root, module_dir = _write_stub_repo(tmp_path)
+    _record_passing(repo_root, module_dir)
+
+    monkeypatch.setattr(gate, "seminar_promote_floors_for", lambda _level: {"pedagogical": 9.9})
+
+    report = gate.verify("folk", SLUG, module_dir=module_dir, repo_root=repo_root)
+
+    assert report["passed"] is False
+    assert any("pedagogical" in failure for failure in report["failures"])

--- a/tests/test_threshold_source_of_truth.py
+++ b/tests/test_threshold_source_of_truth.py
@@ -21,6 +21,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 from common.thresholds import (
     REVIEW_PASS_FLOOR,
     REVIEW_REJECT_FLOOR,
+    SEMINAR_PROMOTE_PROFILES,
     STYLE_REVIEW_DIMENSION_FLOOR,
     STYLE_REVIEW_TARGET,
 )
@@ -37,6 +38,8 @@ _CANONICAL_NAMES: frozenset[str] = frozenset({
     "STYLE_REVIEW_TARGET",
     "STYLE_REVIEW_DIMENSION_FLOOR",
     "LEVEL_THRESHOLDS",
+    "SEMINAR_PROMOTE_DIMS",
+    "SEMINAR_PROMOTE_PROFILES",
 })
 
 # Float literals that are threshold-valued. 5.0 / 7.0 are common but not
@@ -46,7 +49,9 @@ _THRESHOLD_VALUES: frozenset[float] = frozenset({
     REVIEW_REJECT_FLOOR,
     STYLE_REVIEW_TARGET,
     STYLE_REVIEW_DIMENSION_FLOOR,
-})
+}) | frozenset(
+    value for profile in SEMINAR_PROMOTE_PROFILES.values() for value in profile.values()
+)
 
 # Words that make a nearby float literal "look like" a threshold. If none
 # of these appear within 3 lines of the literal, we don't flag — an 8.0

--- a/tests/test_verify_shippable.py
+++ b/tests/test_verify_shippable.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import scripts.build.linear_pipeline as lp
 import scripts.build.verify_shippable as vs
+from scripts.build import promote_quality_gate as pqg
 
 
 def _mk(tmp_path):
@@ -26,10 +27,21 @@ def test_shippable_when_all_green(tmp_path, monkeypatch):
     monkeypatch.setattr(
         lp, "run_mdx_render_gate", lambda t: {"passed": True, "message": "ok", "failures": []}
     )
+    monkeypatch.setattr(
+        pqg,
+        "verify",
+        lambda *args, **kwargs: {
+            "applicable": True,
+            "passed": True,
+            "reason": "ok",
+            "failures": [],
+        },
+    )
     rep = vs.verify("folk", "x", module_dir=md, plan_path=plan)
     assert rep["shippable"] is True
     steps = {s["step"]: s["passed"] for s in rep["steps"]}
     assert steps["python_qg"] and steps["assemble_mdx"] and steps["mdx_render"]
+    assert steps["promote_quality"]
     assert rep["corpus_hammer_required"] is True
 
 


### PR DESCRIPTION
## Summary

PR1 mechanism only for the seminar/folk deterministic pre-promote quality gate:

- Adds seminar promote floors to `scripts/common/thresholds.py` as the SSOT.
- Adds `scripts/build/promote_quality_gate.py` with `record` and `verify`, content-hash binding, cross-family enforcement, folk DeepSeek reviewer bar, stale-sidecar detection, and fail-closed score/floor checks.
- Wires `verify_shippable` with a separate `promote_quality` step; unenrolled levels are `n/a`, enrolled folk modules fail shippability without a fresh sidecar.
- Fixes the missing `json` import in `scripts/sync/promote_module.py` only.
- Updates the design doc with locked Option A and supersession notes.
- Adds focused gate tests and updates the existing `verify_shippable` all-green fixture to model the new step.

PR1: mechanism only; CI enforcement + promote_module.py hook + sidecar bootstrap follow in PR2.

## #M-4 Raw Evidence

### `.venv/bin/ruff check <changed files>` final line

```text
All checks passed!
```

### `.venv/bin/python -m pytest tests/test_promote_quality_gate.py tests/test_threshold_source_of_truth.py -q` final summary line

```text
============================== 22 passed in 4.45s ==============================
```

### `git -C <worktree> diff --name-status origin/main...HEAD`

```text
M	docs/folk-epic/seminar-quality-gate-design.md
A	scripts/build/promote_quality_gate.py
M	scripts/build/verify_shippable.py
M	scripts/common/thresholds.py
M	scripts/sync/promote_module.py
A	tests/test_promote_quality_gate.py
M	tests/test_threshold_source_of_truth.py
M	tests/test_verify_shippable.py
```

`tests/test_verify_shippable.py` is included because the existing affected-test hook needed its all-green fixture to account for the newly wired `promote_quality` step.

### `.venv/bin/python -m scripts.build.promote_quality_gate verify folk koliadky-shchedrivky` raw output

```text
FAIL promote_quality for folk/koliadky-shchedrivky: missing sidecar: curriculum/l2-uk-en/folk/koliadky-shchedrivky/promote_quality.json
- missing sidecar: curriculum/l2-uk-en/folk/koliadky-shchedrivky/promote_quality.json
```

Expected for PR1: no real sidecar is committed.

### Temporary round-trip demo: `record` then `verify`

```text
wrote /var/folders/pd/wvj52r1j3bd4z9y3dfc2k4180000gn/T/tmp.XXnIVxq0Dg/curriculum/l2-uk-en/folk/demo-promote-quality/promote_quality.json
verdict: PASS
content_hash: 6a3006b9fb6974dab4feb5b13f3e6c0b5bceceb049e95e12744681cbd4632f52
PASS promote_quality for folk/demo-promote-quality: all promote quality floors satisfied
- pedagogical: 8.7 >= 8.5
- engagement: 8.6 >= 8.5
- beauty: 8.8 >= 8.5
- naturalness: 9.1 >= 8.5
- tone: 8.6 >= 8.5
- decolonization: 9.2 >= 9.0
```

## Additional Local Validation

```text
.venv/bin/python -m pytest tests/test_verify_shippable.py -q
============================== 9 passed in 0.44s ===============================
```

```text
.venv/bin/python scripts/audit/lint_agent_trailer.py
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```
