### PR TITLE
[codex] enforce pre-promote quality gate for enrolled seminar tracks (folk)

### DIFF
--- a/.github/workflows/content-ci.yml
+++ b/.github/workflows/content-ci.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       content: ${{ steps.filter.outputs.content }}
+      promote: ${{ steps.filter.outputs.promote }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -27,6 +28,11 @@ jobs:
               - 'curriculum/**/*.md'
               - 'curriculum/l2-uk-en/plans/**/*.yaml'
               - 'plans/**/*.yaml'
+            promote:
+              - 'site/src/content/docs/**/*.mdx'
+              - 'curriculum/l2-uk-en/**/module.md'
+              - 'curriculum/l2-uk-en/**/*.yaml'
+              - 'curriculum/l2-uk-en/**/promote_quality.json'
 
   section7-xref:
     name: Content Gate (Section 7 xref)
@@ -77,3 +83,23 @@ jobs:
         run: |
           git fetch --no-tags --prune origin '+refs/heads/main:refs/remotes/origin/main'
           python scripts/audit/check_dossier_wordcount.py --changed
+
+  promote-quality:
+    name: Content Gate (promote quality)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.promote == 'true'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+      - name: Install promote gate dependencies
+        run: python -m pip install PyYAML
+      - name: Check changed promote-quality sidecars
+        run: |
+          git fetch --no-tags --prune origin '+refs/heads/main:refs/remotes/origin/main'
+          python scripts/audit/check_promote_quality_changed.py --changed

--- a/scripts/audit/check_promote_quality_changed.py
+++ b/scripts/audit/check_promote_quality_changed.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Check changed seminar modules against the pre-promote quality gate."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.common.thresholds import seminar_promote_floors_for
+from scripts.pipeline.module_archetypes import SEMINAR_TRACKS
+
+
+def _load_wiki_completeness_gate() -> None:
+    module_name = "scripts.audit.wiki_completeness_gate"
+    if module_name in sys.modules:
+        return
+    if "scripts.audit" not in sys.modules:
+        audit_package = types.ModuleType("scripts.audit")
+        audit_package.__path__ = [str(PROJECT_ROOT / "scripts" / "audit")]
+        sys.modules["scripts.audit"] = audit_package
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        PROJECT_ROOT / "scripts" / "audit" / "wiki_completeness_gate.py",
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load wiki completeness gate")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+
+
+_load_wiki_completeness_gate()
+from scripts.build.promote_quality_gate import verify
+
+LESSON_SOURCE_FILES = frozenset(
+    {
+        "module.md",
+        "activities.yaml",
+        "vocabulary.yaml",
+        "resources.yaml",
+    }
+)
+PROMOTE_QUALITY_FILE = "promote_quality.json"
+
+
+@dataclass(frozen=True, order=True)
+class ModuleTarget:
+    track: str
+    slug: str
+
+
+def _is_seminar_track(track: str) -> bool:
+    return track in SEMINAR_TRACKS or seminar_promote_floors_for(track) is not None
+
+
+def _is_deployed_lesson(repo_root: Path, track: str, slug: str) -> bool:
+    return (
+        repo_root
+        / "site"
+        / "src"
+        / "content"
+        / "docs"
+        / track
+        / f"{slug}.mdx"
+    ).exists()
+
+
+def _repo_relative_path(raw_path: str, repo_root: Path) -> PurePosixPath | None:
+    path = Path(raw_path)
+    if path.is_absolute():
+        try:
+            path = path.resolve().relative_to(repo_root.resolve())
+        except ValueError:
+            return None
+    return PurePosixPath(path.as_posix())
+
+
+def target_from_changed_path(raw_path: str, repo_root: Path) -> ModuleTarget | None:
+    rel = _repo_relative_path(raw_path, repo_root)
+    if rel is None:
+        return None
+
+    parts = rel.parts
+    if (
+        len(parts) == 6
+        and parts[:4] == ("site", "src", "content", "docs")
+        and parts[5].endswith(".mdx")
+    ):
+        track = parts[4].casefold()
+        slug = PurePosixPath(parts[5]).stem
+        if slug != "index" and _is_seminar_track(track):
+            return ModuleTarget(track, slug)
+        return None
+
+    if len(parts) == 5 and parts[:2] == ("curriculum", "l2-uk-en"):
+        track = parts[2].casefold()
+        slug = parts[3]
+        filename = parts[4]
+        if (
+            _is_seminar_track(track)
+            and filename in (LESSON_SOURCE_FILES | {PROMOTE_QUALITY_FILE})
+            and _is_deployed_lesson(repo_root, track, slug)
+        ):
+            return ModuleTarget(track, slug)
+
+    return None
+
+
+def changed_paths_from_git(repo_root: Path, base: str) -> list[str]:
+    proc = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--diff-filter=AMR",
+            "--name-only",
+            f"{base}...HEAD",
+        ],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        if proc.stderr:
+            print(proc.stderr.strip(), file=sys.stderr)
+        raise SystemExit(proc.returncode)
+    return [line for line in proc.stdout.splitlines() if line]
+
+
+def collect_targets(changed_paths: list[str], repo_root: Path) -> list[ModuleTarget]:
+    targets = {
+        target
+        for path in changed_paths
+        if (target := target_from_changed_path(path, repo_root)) is not None
+    }
+    return sorted(targets)
+
+
+def _format_score(value: Any) -> str:
+    if value is None:
+        return "missing"
+    try:
+        return f"{float(value):g}"
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _print_report(target: ModuleTarget, report: dict[str, Any]) -> None:
+    if not report["applicable"]:
+        print(f"NOTICE: {target.track}/{target.slug} not enrolled -- advisory only")
+        return
+
+    status = "PASS" if report["passed"] else "FAIL"
+    print(f"{status}: {target.track}/{target.slug}: {report['reason']}")
+    for row in report.get("per_dim", []):
+        outcome = "ok" if row.get("ok") else "fail"
+        print(
+            f"  - {row['dim']}: {_format_score(row.get('score'))} >= "
+            f"{float(row['floor']):g} ({outcome})"
+        )
+    if not report["passed"]:
+        for failure in report.get("failures", []):
+            print(f"  - {failure}")
+
+
+def run(changed_paths: list[str], *, repo_root: Path, emit_json: bool) -> int:
+    targets = collect_targets(changed_paths, repo_root)
+    results: list[dict[str, Any]] = []
+    enrolled_failures: list[ModuleTarget] = []
+
+    for target in targets:
+        floors = seminar_promote_floors_for(target.track)
+        report = verify(target.track, target.slug, repo_root=repo_root)
+        if floors is None and report["applicable"]:
+            report = {
+                **report,
+                "applicable": False,
+                "passed": True,
+                "reason": "track not enrolled in pre-promote gate",
+                "failures": [],
+            }
+        if report["applicable"] and not report["passed"]:
+            enrolled_failures.append(target)
+        if not emit_json:
+            _print_report(target, report)
+        results.append(
+            {
+                "track": target.track,
+                "slug": target.slug,
+                "applicable": report["applicable"],
+                "passed": report["passed"],
+                "reason": report["reason"],
+                "failures": report.get("failures", []),
+                "per_dim": report.get("per_dim", []),
+            }
+        )
+
+    summary = {
+        "checked": len(targets),
+        "enrolled_failures": len(enrolled_failures),
+        "passed": not enrolled_failures,
+        "results": results,
+    }
+    if emit_json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(
+            "SUMMARY: promote-quality checked "
+            f"{len(targets)} gated seminar module(s); "
+            f"enrolled_failures={len(enrolled_failures)}"
+        )
+    return 1 if enrolled_failures else 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base",
+        default="origin/main",
+        help="Base ref for changed-file detection",
+    )
+    parser.add_argument(
+        "--changed",
+        action="store_true",
+        help="Check files changed against --base...HEAD",
+    )
+    parser.add_argument(
+        "--changed-file",
+        action="append",
+        default=[],
+        help="Changed path to check; repeatable for tests",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=PROJECT_ROOT,
+        help="Repository root",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON report")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    changed_paths = list(args.changed_file)
+    if args.changed or not changed_paths:
+        changed_paths.extend(changed_paths_from_git(repo_root, args.base))
+    return run(changed_paths, repo_root=repo_root, emit_json=args.json)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync/promote_module.py
+++ b/scripts/sync/promote_module.py
@@ -7,16 +7,43 @@ import argparse
 import contextlib
 import difflib
 import hashlib
+import importlib.util
 import json
 import os
 import re
 import subprocess
 import sys
 import tempfile
+import types
 from dataclasses import dataclass
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+def _load_wiki_completeness_gate() -> None:
+    module_name = "scripts.audit.wiki_completeness_gate"
+    if module_name in sys.modules:
+        return
+    if "scripts.audit" not in sys.modules:
+        audit_package = types.ModuleType("scripts.audit")
+        audit_package.__path__ = [str(ROOT / "scripts" / "audit")]
+        sys.modules["scripts.audit"] = audit_package
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        ROOT / "scripts" / "audit" / "wiki_completeness_gate.py",
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load wiki completeness gate")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+
+
+_load_wiki_completeness_gate()
+from scripts.build import promote_quality_gate
+
 CURRICULUM_ROOT = Path("curriculum") / "l2-uk-en"
 DOCS_ROOT = Path("site") / "src" / "content" / "docs"
 ATLAS_OUTPUT_FILES = (
@@ -24,6 +51,7 @@ ATLAS_OUTPUT_FILES = (
     Path("site") / "src" / "data" / "lexicon-manifest.fingerprint.json",
 )
 READINGS_GENERATOR = "scripts.readings.generate_readings"
+PROMOTE_QUALITY_FILE = "promote_quality.json"
 
 LESSON_SOURCE_FILES = frozenset(
     {
@@ -248,6 +276,17 @@ def _collect_source_files(repo_root: Path, source: SourceSpec) -> tuple[list[Sou
         else:
             files.append(SourceFile(source_rel=source_rel, dest_rel=source_rel, content=content))
 
+    quality_rel = _source_rel_for_lesson(source.level, source.slug, PROMOTE_QUALITY_FILE)
+    quality_content = _read_build_file(repo_root, source, quality_rel)
+    if quality_content is not None:
+        files.append(
+            SourceFile(
+                source_rel=quality_rel,
+                dest_rel=quality_rel,
+                content=quality_content,
+            )
+        )
+
     return files, missing_required, missing_optional
 
 
@@ -292,6 +331,16 @@ def _classify_destination(repo_root: Path, source: SourceSpec, files: list[Sourc
             mismatches.append(_diff_summary(dest_rel, current, item.content))
 
     return any_required_exists, mismatches
+
+
+def _has_pending_quality_sidecar(repo_root: Path, files: list[SourceFile]) -> bool:
+    for item in files:
+        if item.dest_rel.name != PROMOTE_QUALITY_FILE:
+            continue
+        dest = repo_root / item.dest_rel
+        if not dest.exists() or dest.read_bytes() != item.content:
+            return True
+    return False
 
 
 def _dry_run(repo_root: Path, files: list[SourceFile], missing_optional: list[Path]) -> None:
@@ -383,6 +432,36 @@ def _run_generate_readings(repo_root: Path, source: SourceSpec) -> tuple[int, li
     return 0, written
 
 
+def _promote_module_dir(repo_root: Path, source: SourceSpec) -> Path:
+    return repo_root / CURRICULUM_ROOT / source.level / source.slug
+
+
+def _check_promote_quality(repo_root: Path, source: SourceSpec, *, dry_run: bool) -> int:
+    report = promote_quality_gate.verify(
+        source.level,
+        source.slug,
+        module_dir=_promote_module_dir(repo_root, source),
+        repo_root=repo_root,
+    )
+    if not report["applicable"]:
+        return 0
+    if report["passed"]:
+        print(
+            f"PASS promote_quality {source.level}/{source.slug}: {report['reason']}"
+        )
+        return 0
+
+    prefix = "WARNING" if dry_run else "ERROR"
+    print(
+        f"{prefix} promote_quality failed for {source.level}/{source.slug}: "
+        f"{report['reason']}",
+        file=sys.stderr,
+    )
+    for failure in report.get("failures", []):
+        print(f"- {failure}", file=sys.stderr)
+    return 0 if dry_run else 1
+
+
 def promote(args: argparse.Namespace, *, repo_root: Path = ROOT) -> int:
     repo_root = repo_root.resolve()
     try:
@@ -403,6 +482,7 @@ def promote(args: argparse.Namespace, *, repo_root: Path = ROOT) -> int:
 
     if args.dry_run:
         _dry_run(repo_root, files, missing_optional)
+        _check_promote_quality(repo_root, source, dry_run=True)
         return 0
 
     any_required_exists, mismatches = _classify_destination(repo_root, source, files)
@@ -412,7 +492,11 @@ def promote(args: argparse.Namespace, *, repo_root: Path = ROOT) -> int:
             print(mismatch, file=sys.stderr, end="" if mismatch.endswith("\n") else "\n")
         return 1
 
-    if any_required_exists and not mismatches:
+    if any_required_exists and not mismatches and not _has_pending_quality_sidecar(
+        repo_root, files
+    ):
+        if _check_promote_quality(repo_root, source, dry_run=False) != 0:
+            return 1
         print("OK already-promoted")
         return 0
 
@@ -442,6 +526,10 @@ def promote(args: argparse.Namespace, *, repo_root: Path = ROOT) -> int:
         written.extend(rel for rel in ATLAS_OUTPUT_FILES if (repo_root / rel).exists())
     elif args.refresh_atlas:
         print("OK atlas refresh skipped; promoted files did not change vocabulary.yaml")
+
+    promote_quality_status = _check_promote_quality(repo_root, source, dry_run=False)
+    if promote_quality_status != 0:
+        return promote_quality_status
 
     if not written:
         print("OK no changes")

--- a/tests/test_check_promote_quality_changed.py
+++ b/tests/test_check_promote_quality_changed.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.audit import check_promote_quality_changed as check_changed
+from scripts.build import promote_quality_gate
+from scripts.common.thresholds import seminar_promote_floors_for
+
+SLUG = "koliadky-shchedrivky"
+
+
+def _write_module(repo_root: Path, *, track: str = "folk", slug: str = SLUG) -> Path:
+    module_dir = repo_root / "curriculum" / "l2-uk-en" / track / slug
+    plan_dir = repo_root / "curriculum" / "l2-uk-en" / "plans" / track
+    mdx_dir = repo_root / "site" / "src" / "content" / "docs" / track
+    module_dir.mkdir(parents=True)
+    plan_dir.mkdir(parents=True)
+    mdx_dir.mkdir(parents=True)
+    (plan_dir / f"{slug}.yaml").write_text("title: Stub plan\n", encoding="utf-8")
+    (module_dir / "module.md").write_text("# Stub module\n", encoding="utf-8")
+    (module_dir / "activities.yaml").write_text("- prompt: Stub\n", encoding="utf-8")
+    (module_dir / "vocabulary.yaml").write_text("- term: Stub\n", encoding="utf-8")
+    (module_dir / "resources.yaml").write_text(
+        "- url: https://example.com\n",
+        encoding="utf-8",
+    )
+    (mdx_dir / f"{slug}.mdx").write_text("lesson\n", encoding="utf-8")
+    return module_dir
+
+
+def _passing_scores(track: str = "folk") -> dict[str, float]:
+    floors = seminar_promote_floors_for(track)
+    assert floors is not None
+    return {dim: floor + 0.1 for dim, floor in floors.items()}
+
+
+def _record_sidecar(
+    repo_root: Path,
+    module_dir: Path,
+    *,
+    scores: dict[str, float] | None = None,
+) -> None:
+    promote_quality_gate.record(
+        "folk",
+        SLUG,
+        module_dir=module_dir,
+        repo_root=repo_root,
+        writer_family="anthropic",
+        writer_agent="claude",
+        writer_model="claude-opus-4.8",
+        reviewer_family="openai",
+        reviewer_agent="codex",
+        reviewer_model="gpt-5",
+        scores=scores or _passing_scores(),
+        evidence={"summary": "synthetic test fixture"},
+        scored_at="2026-06-23T00:00:00Z",
+    )
+
+
+def test_enrolled_below_floor_sidecar_exits_nonzero(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo_root = tmp_path / "repo"
+    module_dir = _write_module(repo_root)
+    scores = _passing_scores()
+    scores["beauty"] = 8.4
+    _record_sidecar(repo_root, module_dir, scores=scores)
+
+    rc = check_changed.main(
+        [
+            "--repo-root",
+            str(repo_root),
+            "--changed-file",
+            f"curriculum/l2-uk-en/folk/{SLUG}/module.md",
+        ]
+    )
+
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert f"FAIL: folk/{SLUG}" in out
+    assert "score below floor: beauty" in out
+    assert "enrolled_failures=1" in out
+
+
+@pytest.mark.parametrize(
+    "changed_path",
+    [
+        f"site/src/content/docs/folk/{SLUG}.mdx",
+        f"curriculum/l2-uk-en/folk/{SLUG}/module.md",
+        f"curriculum/l2-uk-en/folk/{SLUG}/promote_quality.json",
+    ],
+)
+def test_enrolled_passing_sidecar_exits_zero_from_each_trigger_shape(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    changed_path: str,
+) -> None:
+    repo_root = tmp_path / "repo"
+    module_dir = _write_module(repo_root)
+    _record_sidecar(repo_root, module_dir)
+
+    rc = check_changed.main(
+        ["--repo-root", str(repo_root), "--changed-file", changed_path]
+    )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert f"PASS: folk/{SLUG}" in out
+    assert "enrolled_failures=0" in out
+
+
+def test_unenrolled_seminar_deployed_mdx_changed_is_notice_only(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo_root = tmp_path / "repo"
+
+    rc = check_changed.main(
+        [
+            "--repo-root",
+            str(repo_root),
+            "--changed-file",
+            "site/src/content/docs/bio/lesia-ukrainka.mdx",
+        ]
+    )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "NOTICE: bio/lesia-ukrainka not enrolled" in out
+    assert "enrolled_failures=0" in out
+
+
+def test_no_seminar_change_exits_zero(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo_root = tmp_path / "repo"
+
+    rc = check_changed.main(
+        [
+            "--repo-root",
+            str(repo_root),
+            "--changed-file",
+            "README.md",
+            "--changed-file",
+            "curriculum/l2-uk-en/a1/hello/module.md",
+        ]
+    )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "checked 0 gated seminar module(s)" in out
+
+
+def test_enrolled_source_without_deployed_mdx_is_not_gated(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo_root = tmp_path / "repo"
+    _write_module(repo_root, slug="unbuilt-folk")
+    (repo_root / "site" / "src" / "content" / "docs" / "folk" / "unbuilt-folk.mdx").unlink()
+
+    rc = check_changed.main(
+        [
+            "--repo-root",
+            str(repo_root),
+            "--changed-file",
+            "curriculum/l2-uk-en/folk/unbuilt-folk/module.md",
+        ]
+    )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "checked 0 gated seminar module(s)" in out

--- a/tests/test_promote_module.py
+++ b/tests/test_promote_module.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.build import promote_quality_gate
+from scripts.common.thresholds import seminar_promote_floors_for
+from scripts.sync import promote_module
+
+
+def _git(
+    repo: Path,
+    *args: str,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    merged_env = {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith(("GIT_", "PRE_COMMIT"))
+    }
+    if env:
+        merged_env.update(env)
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=merged_env,
+    )
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "user.email", "test@example.com")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "base")
+    return repo
+
+
+def _rel_module(level: str, slug: str, filename: str) -> Path:
+    return Path("curriculum") / "l2-uk-en" / level / slug / filename
+
+
+def _rel_plan(level: str, slug: str) -> Path:
+    return Path("curriculum") / "l2-uk-en" / "plans" / level / f"{slug}.yaml"
+
+
+def _rel_mdx_build(level: str, slug: str) -> Path:
+    return Path("curriculum") / "l2-uk-en" / level / slug / f"{slug}.mdx"
+
+
+def _rel_mdx(level: str, slug: str) -> Path:
+    return Path("site") / "src" / "content" / "docs" / level / f"{slug}.mdx"
+
+
+def _write_plan_on_main(repo: Path, *, level: str, slug: str) -> None:
+    plan = repo / _rel_plan(level, slug)
+    plan.parent.mkdir(parents=True, exist_ok=True)
+    plan.write_text("title: Promote fixture\n", encoding="utf-8")
+    _git(repo, "add", plan.relative_to(repo).as_posix())
+    _git(repo, "commit", "-m", f"plan {level}/{slug}")
+
+
+def _passing_scores(level: str) -> dict[str, float]:
+    floors = seminar_promote_floors_for(level)
+    assert floors is not None
+    return {dim: floor + 0.1 for dim, floor in floors.items()}
+
+
+def _seed_build_branch(
+    repo: Path,
+    branch: str,
+    *,
+    level: str,
+    slug: str,
+    scores: dict[str, float] | None = None,
+) -> None:
+    _git(repo, "switch", "-c", branch)
+    files = {
+        "module.md": "# Module\n",
+        "activities.yaml": "- kind: quiz\n",
+        "vocabulary.yaml": "- word: test\n",
+        "resources.yaml": "resources: []\n",
+    }
+    for filename, content in files.items():
+        path = repo / _rel_module(level, slug, filename)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    mdx = repo / _rel_mdx_build(level, slug)
+    mdx.parent.mkdir(parents=True, exist_ok=True)
+    mdx.write_text("mdx content\n", encoding="utf-8")
+    if scores is not None:
+        promote_quality_gate.record(
+            level,
+            slug,
+            module_dir=repo / _rel_module(level, slug, ""),
+            repo_root=repo,
+            writer_family="anthropic",
+            writer_agent="claude",
+            writer_model="claude-opus-4.8",
+            reviewer_family="openai",
+            reviewer_agent="codex",
+            reviewer_model="gpt-5",
+            scores=scores,
+            evidence={"summary": "synthetic promote fixture"},
+            scored_at="2026-06-23T00:00:00Z",
+        )
+    _git(repo, "add", ".")
+    _git(
+        repo,
+        "commit",
+        "-m",
+        f"build {branch}",
+        env={
+            "GIT_AUTHOR_DATE": "2026-06-23T00:00:00 +0000",
+            "GIT_COMMITTER_DATE": "2026-06-23T00:00:00 +0000",
+        },
+    )
+    _git(repo, "switch", "main")
+
+
+def _stub_folk_readings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        promote_module,
+        "_run_generate_readings",
+        lambda _repo_root, _source: (0, []),
+    )
+
+
+def test_promote_fails_closed_for_failing_enrolled_sidecar(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    level = "folk"
+    slug = "quality-fixture"
+    branch = f"build/{level}/{slug}-20260623-000000"
+    _write_plan_on_main(repo, level=level, slug=slug)
+    scores = _passing_scores(level)
+    scores["beauty"] = 8.4
+    _seed_build_branch(repo, branch, level=level, slug=slug, scores=scores)
+    _stub_folk_readings(monkeypatch)
+
+    rc = promote_module.main(["--build-branch", branch, "--no-commit"], repo_root=repo)
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert f"ERROR promote_quality failed for {level}/{slug}" in captured.err
+    assert "score below floor: beauty" in captured.err
+
+
+def test_promote_proceeds_for_passing_enrolled_sidecar(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    level = "folk"
+    slug = "quality-fixture"
+    branch = f"build/{level}/{slug}-20260623-000000"
+    _write_plan_on_main(repo, level=level, slug=slug)
+    _seed_build_branch(repo, branch, level=level, slug=slug, scores=_passing_scores(level))
+    _stub_folk_readings(monkeypatch)
+
+    rc = promote_module.main(["--build-branch", branch, "--no-commit"], repo_root=repo)
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert f"PASS promote_quality {level}/{slug}" in captured.out
+    assert (repo / _rel_module(level, slug, "promote_quality.json")).exists()
+    assert (repo / _rel_mdx(level, slug)).read_text(encoding="utf-8") == "mdx content\n"
+
+
+def test_promote_proceeds_for_unenrolled_seminar_without_sidecar(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    level = "bio"
+    slug = "quality-fixture"
+    branch = f"build/{level}/{slug}-20260623-000000"
+    _seed_build_branch(repo, branch, level=level, slug=slug)
+
+    rc = promote_module.main(["--build-branch", branch, "--no-commit"], repo_root=repo)
+
+    assert rc == 0
+    assert not (repo / _rel_module(level, slug, "promote_quality.json")).exists()
+    assert (repo / _rel_mdx(level, slug)).exists()


### PR DESCRIPTION
## Summary

- Add `scripts/audit/check_promote_quality_changed.py`, a changed-file wrapper around the existing `promote_quality_gate.verify` logic.
- Add an advisory `promote-quality` job to `content-ci.yml`, scoped by paths-filter output.
- Add a fail-closed `promote_module.py` hook for enrolled seminar tracks and tests for wrapper and promote behavior.

## Scope / Governance

The CI job is advisory by default. Making `promote-quality` a required check is a governance follow-up for the user/orchestrator to flip after review.

The wrapper only gates deployed seminar lessons. Unenrolled seminar tracks print NOTICE and remain advisory; source/sidecar changes for unbuilt lessons without deployed MDX are skipped.

## #M-4 Evidence

### Ruff

```text
All checks passed!
```

### Pytest

```text
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/promote-quality-gate-pr2b
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 10 items

tests/test_check_promote_quality_changed.py .......                     [ 70%]
tests/test_promote_module.py ...                                        [100%]

============================== 10 passed in 0.99s ==============================
```

### Diff Name-Status

```text
M	.github/workflows/content-ci.yml
A	scripts/audit/check_promote_quality_changed.py
M	scripts/sync/promote_module.py
A	tests/test_check_promote_quality_changed.py
A	tests/test_promote_module.py
```

### Wrapper Demo: Synthetic Failing Enrolled Module

```text
FAIL: folk/synthetic-failing-quality: score below floor: beauty 8.4 < 8.5
  - pedagogical: 8.6 >= 8.5 (ok)
  - engagement: 8.6 >= 8.5 (ok)
  - beauty: 8.4 >= 8.5 (fail)
  - naturalness: 8.6 >= 8.5 (ok)
  - tone: 8.6 >= 8.5 (ok)
  - decolonization: 9.1 >= 9 (ok)
  - score below floor: beauty 8.4 < 8.5
SUMMARY: promote-quality checked 1 gated seminar module(s); enrolled_failures=1
exit=1
```

### Wrapper Demo: Real Passing Folk Module

```text
PASS: folk/koliadky-shchedrivky: all promote quality floors satisfied
  - pedagogical: 9.4 >= 8.5 (ok)
  - engagement: 9.2 >= 8.5 (ok)
  - beauty: 9.3 >= 8.5 (ok)
  - naturalness: 9 >= 8.5 (ok)
  - tone: 9.2 >= 8.5 (ok)
  - decolonization: 9.4 >= 9 (ok)
SUMMARY: promote-quality checked 1 gated seminar module(s); enrolled_failures=0
exit=0
```
