### PR TITLE
[codex] deterministic reading_coverage gate for seminar/folk modules (#3695)

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -12078,7 +12078,7 @@ def _extract_plan_pronunciation_video_urls(plan: Mapping[str, Any]) -> list[dict
 _HOSTED_READING_VALUES = frozenset({"host", "hosted"})
 _READING_COVERAGE_FLOOR = 4
 _READING_TITLE_STRIP_CHARS = " \t\r\n«»„“”\"'‘’"
-_PRIMARY_READING_BLOCK_RE = re.compile(
+_READING_COVERAGE_BLOCK_RE = re.compile(
     r"^:::primary-reading(?P<attrs>[^\n]*)\n(?P<body>.*?)^:::\s*$",
     re.MULTILINE | re.DOTALL,
 )
@@ -12091,7 +12091,7 @@ def _normalize_reading_title(value: object) -> str:
 
 
 def _primary_reading_blocks(module_text: str) -> list[re.Match[str]]:
-    return list(_PRIMARY_READING_BLOCK_RE.finditer(module_text))
+    return list(_READING_COVERAGE_BLOCK_RE.finditer(module_text))
 
 
 def _primary_reading_attribution_lines(block_body: str) -> list[str]:

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -178,6 +178,7 @@ PYTHON_QG_GATE_ORDER = (
     "citations_resolve",
     "plan_reference_match",
     "resource_coverage",
+    "reading_coverage",
     "resources_url_resolve",
     "chunk_context_for_all_refs",
     "published_quote_for_publishable_refs",
@@ -8436,6 +8437,7 @@ def run_python_qg(
     with contextlib.suppress(LinearPipelineError, ValueError):
         wiki_manifest = build_wiki_manifest_data(plan_path, plan=plan)
     record("resource_coverage", _resource_coverage_gate(resources, plan, wiki_manifest))
+    record("reading_coverage", _reading_coverage_gate(module_text, plan))
     record(
         "resources_url_resolve",
         _resources_url_resolve_gate(
@@ -12071,6 +12073,124 @@ def _extract_plan_pronunciation_video_urls(plan: Mapping[str, Any]) -> list[dict
         for key, value in group_values.items():
             add(f"pronunciation_videos.{group}.{key}", value)
     return records
+
+
+_HOSTED_READING_VALUES = frozenset({"host", "hosted"})
+_READING_COVERAGE_FLOOR = 4
+_READING_TITLE_STRIP_CHARS = " \t\r\n«»„“”\"'‘’"
+_PRIMARY_READING_BLOCK_RE = re.compile(
+    r"^:::primary-reading(?P<attrs>[^\n]*)\n(?P<body>.*?)^:::\s*$",
+    re.MULTILINE | re.DOTALL,
+)
+_PRIMARY_READING_SLUG_ATTR_RE = re.compile(r'\breading\s*=\s*"(?P<slug>[^"]+)"')
+
+
+def _normalize_reading_title(value: object) -> str:
+    text = str(value or "").strip(_READING_TITLE_STRIP_CHARS).casefold()
+    return re.sub(r"\s+", " ", text)
+
+
+def _primary_reading_blocks(module_text: str) -> list[re.Match[str]]:
+    return list(_PRIMARY_READING_BLOCK_RE.finditer(module_text))
+
+
+def _primary_reading_attribution_lines(block_body: str) -> list[str]:
+    lines: list[str] = []
+    for line in block_body.splitlines():
+        stripped = line.strip()
+        while stripped.startswith(">"):
+            stripped = stripped[1:].strip()
+        if stripped.startswith(("—", "–", "-")):
+            lines.append(stripped)
+    return lines
+
+
+def _primary_reading_slug_attrs(blocks: Sequence[re.Match[str]]) -> set[str]:
+    return {
+        match.group("slug").strip()
+        for block in blocks
+        for match in _PRIMARY_READING_SLUG_ATTR_RE.finditer(block.group("attrs"))
+    }
+
+
+def _hosted_plan_readings(plan: Mapping[str, Any]) -> list[dict[str, str]]:
+    readings = plan.get("readings")
+    if not isinstance(readings, list):
+        return []
+    hosted_readings: list[dict[str, str]] = []
+    for entry in readings:
+        if not isinstance(entry, Mapping):
+            continue
+        hosting = str(entry.get("hosting") or "").strip().casefold()
+        if hosting not in _HOSTED_READING_VALUES:
+            continue
+        hosted_readings.append(
+            {
+                "title": str(entry.get("title") or "").strip(),
+                "reading_slug": str(entry.get("reading_slug") or "").strip(),
+            }
+        )
+    return hosted_readings
+
+
+def _reading_coverage_gate(module_text: str, plan: Mapping[str, Any]) -> dict[str, Any]:
+    level_key = str(plan.get("level") or "").strip().casefold()
+    if level_key not in SEMINAR_LEVELS:
+        return {"passed": True, "skipped": "non-seminar"}
+
+    blocks = _primary_reading_blocks(module_text)
+    hosted_readings = _hosted_plan_readings(plan)
+    normalized_attribution_lines = [
+        _normalize_reading_title(line)
+        for block in blocks
+        for line in _primary_reading_attribution_lines(block.group("body"))
+    ]
+    reading_slug_attrs = _primary_reading_slug_attrs(blocks)
+
+    missing: list[dict[str, str]] = []
+    matched: list[dict[str, str]] = []
+    for reading in hosted_readings:
+        normalized_title = _normalize_reading_title(reading["title"])
+        slug = reading["reading_slug"]
+        matched_by_title = bool(
+            normalized_title and any(normalized_title in line for line in normalized_attribution_lines)
+        )
+        matched_by_slug = bool(slug and f"/readings/{slug}/" in module_text)
+        # Source modules can surface generated hosted readings before MDX conversion
+        # as a primary-reading directive attribute rather than a rendered link.
+        matched_by_directive_attr = bool(slug and slug in reading_slug_attrs)
+        if matched_by_title or matched_by_slug or matched_by_directive_attr:
+            matched_by = "title"
+            if matched_by_slug:
+                matched_by = "reading_link"
+            elif matched_by_directive_attr:
+                matched_by = "primary_reading_attr"
+            matched.append({**reading, "matched_by": matched_by})
+        else:
+            missing.append(reading)
+
+    passed = not missing
+    report: dict[str, Any] = {
+        "passed": passed,
+        "severity": "HARD" if not passed else None,
+        "checked": len(hosted_readings),
+        "surfaced_primary_readings": len(blocks),
+        "matched_hosted_readings": matched,
+        "missing_hosted_readings": missing,
+    }
+
+    exception = str(plan.get("reading_coverage_exception") or "").strip()
+    if len(blocks) < _READING_COVERAGE_FLOOR and not exception:
+        report["warning"] = {
+            "severity": "WARNING",
+            "message": (
+                "fewer than 4 primary-reading blocks surfaced; floor is advisory "
+                "and does not affect gate pass/fail"
+            ),
+            "surfaced": len(blocks),
+            "expected_minimum": _READING_COVERAGE_FLOOR,
+        }
+    return report
 
 
 def _resource_coverage_gate(

--- a/tests/test_reading_coverage_gate.py
+++ b/tests/test_reading_coverage_gate.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from scripts.build.linear_pipeline import PYTHON_QG_GATE_ORDER, _reading_coverage_gate
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_fixture_gate(tmp_path: Path, plan: dict[str, Any], module_text: str) -> dict[str, Any]:
+    plan_path = tmp_path / "plan.yaml"
+    module_path = tmp_path / "module.md"
+    plan_path.write_text(yaml.safe_dump(plan, allow_unicode=True, sort_keys=False), encoding="utf-8")
+    module_path.write_text(module_text, encoding="utf-8")
+    loaded_plan = yaml.safe_load(plan_path.read_text(encoding="utf-8"))
+    return _reading_coverage_gate(module_path.read_text(encoding="utf-8"), loaded_plan)
+
+
+def _primary_reading_block(title: str) -> str:
+    return f""":::primary-reading
+> Рядок першоджерела.
+
+— Народна творчість, {title}
+:::
+"""
+
+
+def _module_with_four_blocks(first_title: str = "«Інший текст»") -> str:
+    return "\n".join(
+        [
+            _primary_reading_block(first_title),
+            _primary_reading_block("«Другий текст»"),
+            _primary_reading_block("«Третій текст»"),
+            _primary_reading_block("«Четвертий текст»"),
+        ]
+    )
+
+
+def test_reading_coverage_gate_registered_in_python_qg_order() -> None:
+    assert PYTHON_QG_GATE_ORDER.index("resource_coverage") < PYTHON_QG_GATE_ORDER.index("reading_coverage")
+    assert PYTHON_QG_GATE_ORDER.index("reading_coverage") < PYTHON_QG_GATE_ORDER.index("resources_url_resolve")
+
+
+def test_hard_pass_when_host_reading_title_is_in_primary_reading_attribution(tmp_path: Path) -> None:
+    plan = {
+        "level": "folk",
+        "readings": [
+            {"title": "«Ой весна»", "hosting": "host", "reading_slug": "oi-vesna"},
+        ],
+    }
+
+    result = _run_fixture_gate(tmp_path, plan, _module_with_four_blocks('"Ой весна"'))
+
+    assert result["passed"] is True
+    assert result["missing_hosted_readings"] == []
+    assert "warning" not in result
+
+
+def test_hard_pass_when_host_reading_slug_link_is_in_module(tmp_path: Path) -> None:
+    plan = {
+        "level": "folk",
+        "readings": [
+            {"title": "«Ой весна»", "hosting": "host", "reading_slug": "oi-vesna"},
+        ],
+    }
+
+    result = _run_fixture_gate(tmp_path, plan, "Read the hosted source at /readings/oi-vesna/.")
+
+    assert result["passed"] is True
+    assert result["missing_hosted_readings"] == []
+    assert result["warning"]["severity"] == "WARNING"
+
+
+def test_hard_fail_when_host_reading_is_omitted(tmp_path: Path) -> None:
+    plan = {
+        "level": "folk",
+        "readings": [
+            {"title": "«Ой весна»", "hosting": "host", "reading_slug": "oi-vesna"},
+        ],
+    }
+
+    result = _run_fixture_gate(tmp_path, plan, _module_with_four_blocks())
+
+    assert result["passed"] is False
+    assert result["severity"] == "HARD"
+    assert result["missing_hosted_readings"] == [
+        {"title": "«Ой весна»", "reading_slug": "oi-vesna"},
+    ]
+
+
+def test_title_normalization_matches_quote_glyphs_case_and_whitespace(tmp_path: Path) -> None:
+    plan = {
+        "level": "folk",
+        "readings": [
+            {
+                "title": "«  Думи   нічні  »",
+                "hosting": "hosted",
+                "reading_slug": "dumy-nichni",
+            },
+        ],
+    }
+
+    result = _run_fixture_gate(tmp_path, plan, _module_with_four_blocks("„думи нічні“"))
+
+    assert result["passed"] is True
+    assert result["missing_hosted_readings"] == []
+
+
+def test_linked_only_reading_omission_is_not_a_failure(tmp_path: Path) -> None:
+    plan = {
+        "level": "folk",
+        "readings": [
+            {"title": "«Ой весна»", "hosting": "linked-only", "reading_slug": "oi-vesna"},
+        ],
+    }
+
+    result = _run_fixture_gate(tmp_path, plan, _module_with_four_blocks())
+
+    assert result["passed"] is True
+    assert result["checked"] == 0
+    assert result["missing_hosted_readings"] == []
+
+
+def test_floor_warning_is_advisory_and_exception_suppresses_it(tmp_path: Path) -> None:
+    plan = {"level": "folk", "readings": []}
+    module_text = "\n".join([_primary_reading_block("«Один»"), _primary_reading_block("«Два»")])
+
+    warning_result = _run_fixture_gate(tmp_path, plan, module_text)
+    assert warning_result["passed"] is True
+    assert warning_result["warning"] == {
+        "severity": "WARNING",
+        "message": (
+            "fewer than 4 primary-reading blocks surfaced; floor is advisory "
+            "and does not affect gate pass/fail"
+        ),
+        "surfaced": 2,
+        "expected_minimum": 4,
+    }
+
+    exception_plan = {
+        "level": "folk",
+        "readings": [],
+        "reading_coverage_exception": "corpus acquisition blocked",
+    }
+    exception_result = _run_fixture_gate(tmp_path, exception_plan, module_text)
+    assert exception_result["passed"] is True
+    assert "warning" not in exception_result
+
+
+def test_non_seminar_level_is_skipped(tmp_path: Path) -> None:
+    plan = {
+        "level": "a1",
+        "readings": [
+            {"title": "«Ой весна»", "hosting": "host", "reading_slug": "oi-vesna"},
+        ],
+    }
+
+    result = _run_fixture_gate(tmp_path, plan, "")
+
+    assert result == {"passed": True, "skipped": "non-seminar"}
+
+
+@pytest.mark.parametrize(
+    ("slug", "expect_floor_warning"),
+    [
+        ("koliadky-shchedrivky", False),
+        ("kalendarna-obriadovist-zvychai", False),
+        ("narodna-kultura-yak-systema", False),
+        ("dumy-nevilnytski-lytsarski", False),
+        ("narodni-viruvannia-mifolohiia-demonolohiia", True),
+        ("zamovliannia-zaklynannia-prymovky", True),
+    ],
+)
+def test_real_built_folk_modules_all_pass_reading_coverage(slug: str, expect_floor_warning: bool) -> None:
+    plan_path = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "plans" / "folk" / f"{slug}.yaml"
+    module_path = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "folk" / slug / "module.md"
+    plan = yaml.safe_load(plan_path.read_text(encoding="utf-8"))
+    module_text = module_path.read_text(encoding="utf-8")
+
+    result = _reading_coverage_gate(module_text, plan)
+
+    assert result["passed"] is True
+    assert result["missing_hosted_readings"] == []
+    if expect_floor_warning:
+        assert result["warning"]["severity"] == "WARNING"
+    else:
+        assert "warning" not in result


### PR DESCRIPTION
## Summary

Fixes #3695.

- Adds a seminar-only `reading_coverage` gate to the V7 `python_qg` chain.
- Enforces hosted plan `readings:` entries are surfaced in `module.md` through primary-reading attribution, reading links, or existing source directive slug attributes before MDX conversion.
- Adds deterministic unit coverage plus the six real built folk modules as anti-wedge regression tests.

## #M-4 Deterministic Preamble

`.venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_reading_coverage_gate.py` final line:

```text
All checks passed!
```

`.venv/bin/python -m pytest tests/test_reading_coverage_gate.py -q` final summary:

```text
============================== 14 passed in 0.41s ==============================
```

`git -C /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/reading-coverage-gate-3695 diff --name-status origin/main...HEAD`:

```text
M	scripts/build/linear_pipeline.py
A	tests/test_reading_coverage_gate.py
```

Six built folk modules reading_coverage proof:

```text
koliadky-shchedrivky: passed=True severity=None checked=4 surfaced=5 missing=0 warning=none
kalendarna-obriadovist-zvychai: passed=True severity=None checked=4 surfaced=5 missing=0 warning=none
narodna-kultura-yak-systema: passed=True severity=None checked=5 surfaced=5 missing=0 warning=none
dumy-nevilnytski-lytsarski: passed=True severity=None checked=4 surfaced=7 missing=0 warning=none
narodni-viruvannia-mifolohiia-demonolohiia: passed=True severity=None checked=0 surfaced=2 missing=0 warning=WARNING
zamovliannia-zaklynannia-prymovky: passed=True severity=None checked=0 surfaced=0 missing=0 warning=WARNING
```

## Notes

The floor check is advisory only. The two acquisition-blocked folk modules still pass the hard gate and emit warning-only floor diagnostics.
