### PR TITLE
fix(b2): publish preview module routes

### DIFF
--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -6,8 +6,8 @@ export const collections = {
 		loader: glob({
 			pattern: [
 				'{a1,a2,folk}/**/*.{md,mdx}',
-				'b1/**/*.{md,mdx}',
-				'{b2,bio,c1,c2,hist,istorio,lit,lit-drama,lit-essay,lit-fantastika,lit-hist-fic,lit-humor,lit-war,lit-youth,oes,ruth}/index.{md,mdx}',
+				'{b1,b2}/**/*.{md,mdx}',
+				'{bio,c1,c2,hist,istorio,lit,lit-drama,lit-essay,lit-fantastika,lit-hist-fic,lit-humor,lit-war,lit-youth,oes,ruth}/index.{md,mdx}',
 			],
 			base: './src/content/docs',
 		}),

--- a/site/src/content/docs/b2/index.mdx
+++ b/site/src/content/docs/b2/index.mdx
@@ -10,9 +10,9 @@ import LevelLanding from '@site/src/components/LevelLanding';
   client:load
   level="B2"
   title="Впевнено"
-  subtitle="Upper-intermediate Ukrainian preview map — 93 planned modules"
+  subtitle="Upper-intermediate Ukrainian preview map — 2 learner pages available · 91 planned"
   progressTitle="B2 Preview Status"
-  progressDescription="0 available · 0 reviewed · 93 planned"
+  progressDescription="2 available · 0 reviewed · 91 planned"
   moduleCount={93}
   wordTarget={4000}
   color="var(--lu-id-b2)"
@@ -20,8 +20,8 @@ import LevelLanding from '@site/src/components/LevelLanding';
     {
       unit: "B2.0 [Passive Voice System]",
       items: [
-        { num: 1, slug: "passive-voice-system", title: "Система пасивного стану в українській мові", sub: "Система пасивного стану в українській мові", status: "locked" },
-        { num: 2, slug: "past-passive-participles", title: "Пасивні дієприкметники минулого часу", sub: "Пасивні дієприкметники минулого часу", status: "locked" },
+        { num: 1, slug: "passive-voice-system", title: "Система пасивного стану в українській мові", sub: "Система пасивного стану в українській мові", status: "active" },
+        { num: 2, slug: "past-passive-participles", title: "Пасивні дієприкметники минулого часу", sub: "Пасивні дієприкметники минулого часу", status: "active" },
         { num: 3, slug: "b2-impersonal-passive", title: "Безособові пасивні конструкції на -но, -то", sub: "Безособові пасивні форми на -но, -то", status: "locked" },
         { num: 4, slug: "dim-zhytlo", title: "Дім і житло: оренда, ремонт, сусідство", sub: "Дім і житло: оренда, ремонт, сусідство", status: "locked" },
         { num: 5, slug: "reflexive-passive", title: "Зворотні дієслова у пасивному значенні", sub: "Зворотно-пасивні конструкції на -ся", status: "locked" },

--- a/site/src/pages/[...slug].astro
+++ b/site/src/pages/[...slug].astro
@@ -370,7 +370,7 @@ const searchItems: SearchItem[] = [
 
 export async function getStaticPaths() {
   const normalizeDocId = (id: string) => id.replace(/\.mdx?$/, '').replace(/\/index$/, '');
-  const publicLessonPrefixes = new Set(['a1', 'a2', 'b1', 'folk']);
+  const publicLessonPrefixes = new Set(['a1', 'a2', 'b1', 'b2', 'folk']);
   const hiddenDocs = new Set(['a1/review-clears-needs-human']);
   const configuredTracks = ['a1', 'a2', 'b1', 'b2', 'c1', 'c2', 'folk', 'bio', 'hist', 'istorio', 'lit', 'oes', 'ruth'];
   const pathDocs = await getCollection('docs');


### PR DESCRIPTION
## What changed

- Include B2 lesson MDX files in the Astro `docs` collection instead of loading only `b2/index.mdx`.
- Add `b2` to the public lesson route allow-list in `site/src/pages/[...slug].astro`.
- Mark B2 M01 `passive-voice-system` and B2 M02 `past-passive-participles` as `active` on the B2 landing page.
- Update B2 landing subtitle/progress to show `2 available` and `91 planned`.

## Why

B2 is in preview rollout and the first two built/audited modules should be accessible for human review. The landing cards were locked, and direct routes like `/b2/passive-voice-system/` returned the project 404 because B2 lesson pages were excluded from both the content collection and route allow-list.

## Validation

- `git diff --check` — PASS
- `npm run build` from `site/` — PASS (`4845 page(s) built`)
- Built route evidence:
  - `site/dist/b2/passive-voice-system/index.html` exists
  - `site/dist/b2/past-passive-participles/index.html` exists
  - M01 page contains sidebar/link evidence for M02
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — PASS

## Hygiene

- Changed files: 3
- Protected configs changed: no
- Generated `status/`, curriculum `audit/`, curriculum `review/`, telemetry DB artifacts included: no
- Worktree-local ignored validation outputs only: `.venv`, `site/node_modules`, `site/.astro`, `site/dist`, hydrated lexicon manifest cache

## Independent Review

- Reviewer: Claude, independent blocker review
- Model: `claude-opus-4-8`
- Scope: final diff for B2 preview unlock (`content.config.ts` glob, `[...slug].astro` allow-list, `b2/index.mdx` landing cards + progress text)
- Disposition: APPROVE — no blockers
- Unresolved blocker findings: 0
- Blocker findings: none

Reviewer also verified that only three B2 docs files exist on disk (`index.mdx`, M01, M02), so the broadened B2 glob and route allow-list expose exactly M01/M02 and do not over-expose locked modules 3–93.