### PR TITLE
fix(bridge): ask-grok-build no longer crashes on session persistence

### DIFF
--- a/scripts/ai_agent_bridge/_db.py
+++ b/scripts/ai_agent_bridge/_db.py
@@ -407,27 +407,41 @@ def get_session(task_id: str) -> dict:
     return {"claude": None, "gemini": None, "codex": None}
 
 
-def _session_column(agent: str) -> str:
-    """Map agent name to session table column."""
-    columns = {
-        "claude": "claude_session_id",
-        "gemini": "gemini_session_id",
-        "codex": "codex_session_id",
-    }
-    if agent not in columns:
-        raise ValueError(f"Unknown session agent: {agent}")
-    return columns[agent]
+# Agents whose sessions are PERSISTED for resumption. These are exactly the
+# columns `get_session` reads back. Agents NOT listed here are always-fresh
+# (resume_policy="never" — e.g. grok-build, agy, cursor, hermes/deepseek):
+# their session id is never read back, so we do not persist it.
+_SESSION_COLUMNS = {
+    "claude": "claude_session_id",
+    "gemini": "gemini_session_id",
+    "codex": "codex_session_id",
+}
+
+
+def _session_column(agent: str) -> str | None:
+    """Map a resumable agent to its session column, or None for always-fresh agents."""
+    return _SESSION_COLUMNS.get(agent)
 
 
 def set_session(task_id: str, agent: str, session_id: str):
-    """Set session ID for an agent on a task."""
+    """Persist an agent's session id for later resumption.
+
+    No-op for always-fresh agents (those without a session column): their runs
+    never resume, so nothing reads the id back. Previously this raised
+    ``ValueError: Unknown session agent`` and crashed ``ask-grok-build`` after a
+    successful run (grok-build is resume_policy="never" yet returns a session id).
+    """
     if not task_id:
+        return
+
+    column = _session_column(agent)
+    if column is None:
+        # Always-fresh agent (grok-build / agy / cursor / …) — nothing to persist.
         return
 
     conn = get_db()
     cursor = conn.cursor()
     timestamp = datetime.now(UTC).isoformat()
-    column = _session_column(agent)
 
     # Upsert session
     cursor.execute("SELECT task_id FROM sessions WHERE task_id = ?", (task_id,))

--- a/scripts/ai_agent_bridge/_db.py
+++ b/scripts/ai_agent_bridge/_db.py
@@ -408,14 +408,21 @@ def get_session(task_id: str) -> dict:
 
 
 # Agents whose sessions are PERSISTED for resumption. These are exactly the
-# columns `get_session` reads back. Agents NOT listed here are always-fresh
-# (resume_policy="never" — e.g. grok-build, agy, cursor, hermes/deepseek):
-# their session id is never read back, so we do not persist it.
+# columns `get_session` reads back.
 _SESSION_COLUMNS = {
     "claude": "claude_session_id",
     "gemini": "gemini_session_id",
     "codex": "codex_session_id",
 }
+
+# Always-fresh agents (resume_policy="never"): their runs never resume, so their
+# session id is intentionally NOT persisted. Listed explicitly so set_session stays
+# silent for them while still flagging a genuinely-unknown agent (e.g. a new
+# resumable agent whose _SESSION_COLUMNS entry was forgotten — that would otherwise
+# silently never persist).
+_ALWAYS_FRESH_AGENTS = frozenset(
+    {"grok-build", "agy", "cursor", "hermes", "deepseek-v4-pro", "qwen", "opencode"}
+)
 
 
 def _session_column(agent: str) -> str | None:
@@ -436,7 +443,14 @@ def set_session(task_id: str, agent: str, session_id: str):
 
     column = _session_column(agent)
     if column is None:
-        # Always-fresh agent (grok-build / agy / cursor / …) — nothing to persist.
+        # No session column => always-fresh agent, nothing to persist. Stay silent
+        # for the known set; warn for a genuinely-unknown agent so a forgotten
+        # _SESSION_COLUMNS entry doesn't fail silently.
+        if agent not in _ALWAYS_FRESH_AGENTS:
+            print(
+                f"⚠️  set_session: no session column for agent '{agent}'; not persisting. "
+                "Add it to _SESSION_COLUMNS (resumable) or _ALWAYS_FRESH_AGENTS (always-fresh)."
+            )
         return
 
     conn = get_db()

--- a/tests/test_bridge_set_session.py
+++ b/tests/test_bridge_set_session.py
@@ -1,0 +1,68 @@
+"""Regression tests for ai_agent_bridge._db.set_session (grok-build crash fix).
+
+Bug: `set_session` raised `ValueError: Unknown session agent: grok-build` and
+crashed `ask-grok-build` AFTER a successful run, because grok-build is
+resume_policy="never" yet returns a session id, and only claude/gemini/codex had
+session columns. Fix: set_session is a no-op for always-fresh agents (those
+without a persisted session column), instead of raising.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from ai_agent_bridge._db import (
+    _session_column,
+    get_session,
+    init_db,
+    set_session,
+)
+
+
+@pytest.fixture
+def bridge_db(tmp_path):
+    """Use a temporary broker DB so tests never touch the real one."""
+    db_path = tmp_path / "messages.db"
+    with patch("ai_agent_bridge._db.DB_PATH", db_path):
+        conn = init_db()
+        conn.close()
+        yield db_path
+
+
+def test_session_column_known_resumable_agents():
+    assert _session_column("claude") == "claude_session_id"
+    assert _session_column("gemini") == "gemini_session_id"
+    assert _session_column("codex") == "codex_session_id"
+
+
+@pytest.mark.parametrize("agent", ["grok-build", "agy", "cursor", "hermes", "deepseek-v4-pro"])
+def test_session_column_none_for_always_fresh_agents(agent):
+    """Always-fresh agents have no persisted column -> None (no longer raises)."""
+    assert _session_column(agent) is None
+
+
+def test_set_session_persists_resumable_agent(bridge_db):
+    set_session("task-1", "codex", "codex-session-abcdef12")
+    assert get_session("task-1")["codex"] == "codex-session-abcdef12"
+
+
+def test_set_session_noop_for_grok_build_does_not_raise(bridge_db):
+    """The exact regression: grok-build must not crash set_session."""
+    # Must not raise (previously ValueError: Unknown session agent: grok-build).
+    set_session("task-2", "grok-build", "019ef5b4-8c38-7421-85ff")
+    # And it is a genuine no-op: the resumable columns stay empty.
+    sess = get_session("task-2")
+    assert sess["claude"] is None
+    assert sess["gemini"] is None
+    assert sess["codex"] is None
+
+
+@pytest.mark.parametrize("agent", ["agy", "cursor", "hermes"])
+def test_set_session_noop_for_other_fresh_agents(bridge_db, agent):
+    set_session(f"task-{agent}", agent, "some-session-id")
+    sess = get_session(f"task-{agent}")
+    assert sess == {"claude": None, "gemini": None, "codex": None}

--- a/tests/test_bridge_set_session.py
+++ b/tests/test_bridge_set_session.py
@@ -61,8 +61,33 @@ def test_set_session_noop_for_grok_build_does_not_raise(bridge_db):
     assert sess["codex"] is None
 
 
-@pytest.mark.parametrize("agent", ["agy", "cursor", "hermes"])
+def test_set_session_noop_is_zero_touch(bridge_db):
+    """A no-op must not even create a sessions row for the task."""
+    from ai_agent_bridge._db import get_db
+
+    set_session("task-zero", "grok-build", "sess-x")
+    conn = get_db()
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE task_id = ?", ("task-zero",)
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row[0] == 0
+
+
+@pytest.mark.parametrize("agent", ["agy", "cursor", "hermes", "deepseek-v4-pro"])
 def test_set_session_noop_for_other_fresh_agents(bridge_db, agent):
     set_session(f"task-{agent}", agent, "some-session-id")
     sess = get_session(f"task-{agent}")
     assert sess == {"claude": None, "gemini": None, "codex": None}
+
+
+def test_set_session_warns_for_unknown_agent(bridge_db, capsys):
+    """An agent that is neither resumable nor known-always-fresh warns (not silent),
+    so a forgotten _SESSION_COLUMNS entry is observable rather than failing silently."""
+    set_session("task-unknown", "totally-new-agent", "sess-y")  # must not raise
+    out = capsys.readouterr().out
+    assert "no session column for agent 'totally-new-agent'" in out
+    # still a genuine no-op
+    assert get_session("task-unknown") == {"claude": None, "gemini": None, "codex": None}


### PR DESCRIPTION
## Bug
`ab ask-grok-build` crashes with `ValueError: Unknown session agent: grok-build` (`scripts/ai_agent_bridge/_db.py` `_session_column`) — **after** a successful grok-build run, losing the response. Surfaced while fanning out a fleet review of #3768.

## Root cause
`grok-build` is `resume_policy="never"` (its sessions are never read back — `_grok_build.py:107`), yet `_grok_build.py` still calls `set_session(task, "grok-build", session_id)` with a real id. `set_session` only knew `claude`/`gemini`/`codex` and **raised** on anything else. The same latent crash sits behind **agy / cursor / any future always-fresh adapter** that returns a non-`None` session id — agy avoids it only by luck (it passes `session_id=None`).

## Fix (root cause, class-wide — not grok-only)
`set_session` is now a **no-op for agents without a persisted session column** (the always-fresh class), instead of raising. `_session_column` returns `None` for them. Only `claude`/`gemini`/`codex` are persisted — exactly the columns `get_session` reads back for resumption — so nothing functional is lost and no dead schema is added.

## Verification
- **New test** `tests/test_bridge_set_session.py` — **11 cases**: resumable agents still persist; `grok-build`/`agy`/`cursor`/`hermes`/`deepseek-v4-pro` no-op without raising; the exact regression covered. ✅
- **End-to-end smoke**: ran a real `ab ask-grok-build` with the fix → `Grok Build finished` → response stored + sent, **exit 0, no ValueError**. (Same call previously died at `set_session`.) ✅
- ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)