### PR TITLE
fix(atlas): daily-word cards show one clear CEFR badge, not "a1A1"

### DIFF
--- a/site/src/lexicon/DailyWords.astro
+++ b/site/src/lexicon/DailyWords.astro
@@ -26,11 +26,11 @@
   };
 
   const renderChips = (word: DailyWord): string => {
-    const chips = [word.lessonTag, word.cefr].filter(Boolean);
-    if (!chips.length) return "";
-    return `<span class="lexicon-daily-chips">${chips
-      .map((chip) => `<span class="lexicon-daily-chip">${dwEsc(chip)}</span>`)
-      .join("")}</span>`;
+    // Show only the CEFR level (A1/A2/B1) — a single, meaningful "how hard is this word"
+    // badge. The course-track tag (a1/a2/b1) was redundant and rendered mashed next to it
+    // ("a1A1"); it lives on the word's full page instead.
+    if (!word.cefr) return "";
+    return `<span class="lexicon-daily-chips"><span class="lexicon-daily-chip">${dwEsc(word.cefr)}</span></span>`;
   };
 
   const renderCard = (word: DailyWord): string => {


### PR DESCRIPTION
The daily-word cards rendered two adjacent chips — course-track tag (`a1`) + CEFR level (`A1`) — which mashed into a confusing "a1A1". Now shows only the CEFR level (the meaningful difficulty signal). Verified in browser: cards read "офіс office A1", "ходіння walking as process B1", etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)