### PR TITLE
[codex] Wire agy sources MCP plumbing

### DIFF
--- a/scripts/agent_runtime/adapters/agy.py
+++ b/scripts/agent_runtime/adapters/agy.py
@@ -30,7 +30,7 @@ Known behavioral facts as of agy 1.0.0 (verified locally 2026-05-20):
   and ``import gemini`` is a no-op in a default install.
 
 MCP enablement is managed by agy's global Antigravity configuration at
-``~/.gemini/antigravity-cli/mcp_config.json`` using ``httpUrl``
+``~/.gemini/config/mcp_config.json`` using ``httpUrl``
 streamable-HTTP server entries. Verified locally on 2026-06-13:
 ``agy -p`` invoked ``mcp__sources__verify_word`` through that global config.
 The adapter still does not pass a per-invocation MCP flag because agy has

--- a/scripts/agent_runtime/tool_config.py
+++ b/scripts/agent_runtime/tool_config.py
@@ -10,7 +10,7 @@ from typing import Any
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _DEFAULT_MCP_CONFIG_PATH = _REPO_ROOT / ".mcp.json"
 _AGY_APP_DATA_ENV = "AGY_APP_DATA_DIR"
-_DEFAULT_AGY_APP_DATA_DIR = "~/.gemini/antigravity-cli"
+_DEFAULT_AGY_MCP_CONFIG_PATH = "~/.gemini/config/mcp_config.json"
 _RESOLUTION_STATUSES = {"ok", "config_missing", "config_empty", "servers_not_found"}
 _CODEX_MCP_SERVER_FIELDS = frozenset(
     {
@@ -53,8 +53,10 @@ def _resolved_mcp_config_path(mcp_config_path: Path | None) -> Path:
 
 def _resolved_agy_mcp_config_path() -> Path:
     """Return agy's global Antigravity MCP config path."""
-    app_data_dir = os.environ.get(_AGY_APP_DATA_ENV, _DEFAULT_AGY_APP_DATA_DIR)
-    return (Path(app_data_dir).expanduser() / "mcp_config.json").resolve()
+    app_data_dir = os.environ.get(_AGY_APP_DATA_ENV)
+    if app_data_dir:
+        return (Path(app_data_dir).expanduser() / "mcp_config.json").resolve()
+    return Path(_DEFAULT_AGY_MCP_CONFIG_PATH).expanduser().resolve()
 
 
 def _codex_sanitize_server_config(server_config: dict) -> dict:

--- a/scripts/build/dispatch.py
+++ b/scripts/build/dispatch.py
@@ -645,9 +645,15 @@ def _dispatch_via_runtime(
     if is_gemini:
         # Gemini in the pipeline is always -y (write-enabled) — existing behavior.
         runtime_mode = "workspace-write"
+        agy_tool_config = None
+        agy_mcp_diagnostics = {}
         if mcp_tools:
             tool_config, _diagnostics = build_mcp_tool_config(
                 "gemini",
+                mcp_servers=["sources"],
+            )
+            agy_tool_config, agy_mcp_diagnostics = build_mcp_tool_config(
+                "agy",
                 mcp_servers=["sources"],
             )
         else:
@@ -771,14 +777,13 @@ def _dispatch_via_runtime(
             call_timeout: int | None,
         ) -> AttemptOutcome:
             # Agy rung (PR #2375): separate-quota probe via Antigravity CLI.
-            # No MCP tool_config (agy doesn't share the gemini-tools MCP plumbing);
-            # caller of the dispatch path that requested MCP grounding may need
-            # to evaluate the agy response independently.
+            # agy resolves MCP from Antigravity's global config, not Gemini's
+            # per-call --allowed-mcp-server-names plumbing.
             is_agy = rung.cli == "agy-cli"
             if is_agy:
                 attempt_agent = "agy"
                 auth_mode_label = "AGY-CLI"
-                call_tool_config = None
+                call_tool_config = dict(agy_tool_config or {})
             else:
                 attempt_agent = runtime_agent_name
                 auth_mode_label = "OAuth" if rung.auth_mode == "oauth" else "API"
@@ -794,8 +799,33 @@ def _dispatch_via_runtime(
                 prompt_chars=len(prompt),
                 timeout=call_timeout_effective,
                 initial_response_timeout=initial_response_timeout,
-                mcp_tools=mcp_tools and not is_agy,
+                mcp_tools=mcp_tools,
             )
+            if is_agy and mcp_tools and not call_tool_config:
+                elapsed = time.monotonic() - t0
+                status = agy_mcp_diagnostics.get("resolution_status", "config_empty")
+                message = (
+                    "Agy MCP tool_config requested but resolver returned none "
+                    f"({status}). Refusing dispatch tool-less."
+                )
+                _save_dispatch_log(
+                    orch_dir,
+                    phase,
+                    label,
+                    model=rung.model,
+                    prompt_chars=len(prompt),
+                    response_chars=0,
+                    stderr=message,
+                    returncode=None,
+                    duration_s=elapsed,
+                    ok=False,
+                    prompt=prompt,
+                )
+                return AttemptOutcome(
+                    status="fatal",
+                    elapsed_s=elapsed,
+                    stderr_excerpt=message,
+                )
             try:
                 if not is_agy:
                     _pace_gemini_calls()

--- a/tests/agent_runtime/test_agy_tool_config.py
+++ b/tests/agent_runtime/test_agy_tool_config.py
@@ -26,6 +26,12 @@ def _write_agy_mcp_config(app_data_dir: Path, data: dict) -> Path:
     return config_path
 
 
+def _write_mcp_config(config_path: Path, data: dict) -> Path:
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(data), encoding="utf-8")
+    return config_path
+
+
 def test_agy_resolves_requested_global_mcp_server(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -42,6 +48,36 @@ def test_agy_resolves_requested_global_mcp_server(
     monkeypatch.setenv("AGY_APP_DATA_DIR", str(app_data_dir))
 
     tool_config, diagnostics = build_mcp_tool_config("agy", mcp_servers=["sources"])
+
+    assert tool_config == {"mcp_server_names": ["sources"]}
+    assert diagnostics["config_path"] == str(config_path.resolve())
+    assert diagnostics["resolution_status"] == "ok"
+    assert diagnostics["resolved_servers"] == ["sources"]
+    assert diagnostics["missing_server_names"] == []
+
+
+def test_agy_tools_resolves_requested_default_mcp_config_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = _write_mcp_config(
+        tmp_path / ".gemini" / "config" / "mcp_config.json",
+        {
+            "mcpServers": {
+                "sources": {"url": "http://127.0.0.1:8766/mcp"},
+            }
+        },
+    )
+    monkeypatch.delenv("AGY_APP_DATA_DIR", raising=False)
+    monkeypatch.setattr(
+        "agent_runtime.tool_config._DEFAULT_AGY_MCP_CONFIG_PATH",
+        str(config_path),
+    )
+
+    tool_config, diagnostics = build_mcp_tool_config(
+        "agy-tools",
+        mcp_servers=["sources"],
+    )
 
     assert tool_config == {"mcp_server_names": ["sources"]}
     assert diagnostics["config_path"] == str(config_path.resolve())

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -350,10 +350,10 @@ class TestDispatchAgent:
             "mcp_server_names": ["sources"],
             "auth_mode": "subscription",
         }
-        # Rung 2: agy-cli (the new rung) — tool_config is None, agent is "agy"
+        # Rung 2: agy-cli resolves agy's global sources MCP config.
         assert second_call["model"] == "gemini-3.5-flash-high"
         assert mock_invoke.call_args_list[1].args[0] == "agy"
-        assert second_call["tool_config"] is None
+        assert second_call["tool_config"] == {"mcp_server_names": ["sources"]}
         # Rung 3: gemini-cli flash + oauth
         assert third_call["model"] == "gemini-3-flash-preview"
         assert third_call["tool_config"] == {

--- a/tests/test_mcp_init_observability.py
+++ b/tests/test_mcp_init_observability.py
@@ -205,6 +205,42 @@ def test_runtime_tool_config_emits_resolution_event_success(
     assert events[0][1]["resolved_servers"] == ["sources"]
 
 
+def test_runtime_tool_config_agy_tools_resolves_sources(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = _valid_sources_config(tmp_path / "mcp_config.json")
+    monkeypatch.delenv("AGY_APP_DATA_DIR", raising=False)
+    monkeypatch.setattr(
+        tool_config_mod,
+        "_DEFAULT_AGY_MCP_CONFIG_PATH",
+        str(config_path),
+    )
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    config = linear_pipeline._runtime_tool_config(
+        "agy-tools",
+        workspace_dir=linear_pipeline.PROJECT_ROOT,
+        event_sink=lambda event, **fields: events.append((event, fields)),
+    )
+
+    assert config["output_format"] == "stream-json"
+    assert config["mcp_server_names"] == ["sources"]
+    assert events == [
+        (
+            "mcp_config_resolved",
+            {
+                "writer": "agy-tools",
+                "requested_servers": ["sources"],
+                "resolved_servers": ["sources"],
+                "config_path": str(config_path.resolve()),
+                "resolution_status": "ok",
+                "missing_server_names": [],
+            },
+        )
+    ]
+
+
 def test_runtime_tool_config_codex_tools_disables_writer_unsafe_features(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- Fix agy MCP resolution to use Antigravity's active default MCP config at `~/.gemini/config/mcp_config.json`, while preserving `AGY_APP_DATA_DIR` as an explicit override for custom/hermetic setups.
- Wire the Gemini fallback ladder's agy rung to receive the resolved `sources` MCP `tool_config` instead of dispatching with `None`.
- Keep the fail-closed guard: if an agy rung is requested with MCP grounding but resolution is empty, dispatch returns a fatal tool-less refusal instead of launching agy ungrounded.
- Add resolver and V7 writer-path tests for `agy-tools` resolving `sources`.

## Root Cause

`linear_pipeline._runtime_tool_config("agy-tools")` called the shared resolver, but the agy resolver looked at `~/.gemini/antigravity-cli/mcp_config.json`, which is empty/missing on the working path. The working Antigravity CLI config with `sources` is `~/.gemini/config/mcp_config.json`.

The fallback writer path also explicitly set the agy rung `tool_config` to `None` in `scripts/build/dispatch.py`, so even when MCP grounding was requested, agy could be launched without resolved tools.

## Validation

- Resolver dry-run:
  - `build_mcp_tool_config('agy-tools', mcp_servers=['sources'])` -> `{'mcp_server_names': ['sources']}`
  - diagnostics: `resolution_status='ok'`, `config_path='/Users/krisztiankoos/.gemini/config/mcp_config.json'`
  - `_runtime_tool_config('agy-tools')` -> `mcp_server_names=['sources']`
- `.venv/bin/python -m pytest tests/agent_runtime/test_agy_tool_config.py tests/test_mcp_init_observability.py` -> 39 passed
- `.venv/bin/python -m pytest tests/test_agent_runtime_tool_config.py tests/agent_runtime/test_agy_tool_config.py tests/test_mcp_init_observability.py tests/test_dispatch.py tests/test_gemini_fallback_agy.py` -> 81 passed
- Commit hook affected pytest -> 66 passed
- `.venv/bin/ruff check scripts/` -> passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` -> passed
- `git diff --check` -> passed
