### PR TITLE
[codex] fix iterative writer tools gate aggregation

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -3341,17 +3341,19 @@ def _enforce_writer_runtime_gates(
     phase_writer_summary: Mapping[str, Any],
     tool_calls: list[Mapping[str, Any]] | None,
     event_sink: Callable[..., None] | None = None,
+    enforce_mcp_tools_never_invoked: bool = True,
 ) -> None:
     failures = [
         *classify_writer_trace(tool_calls or []),
     ]
-    mcp_failure = _mcp_tools_never_invoked_failure(
-        writer=writer,
-        module=module,
-        phase_writer_summary=phase_writer_summary,
-    )
-    if mcp_failure is not None:
-        failures.append(mcp_failure)
+    if enforce_mcp_tools_never_invoked:
+        mcp_failure = _mcp_tools_never_invoked_failure(
+            writer=writer,
+            module=module,
+            phase_writer_summary=phase_writer_summary,
+        )
+        if mcp_failure is not None:
+            failures.append(mcp_failure)
     if not failures:
         return
 
@@ -3880,6 +3882,7 @@ def invoke_writer(
     tool_trace_path: Path | None = None,
     stdout_silence_timeout: int | None = None,
     effort: str | None = None,
+    enforce_mcp_tools_never_invoked: bool = True,
 ) -> str:
     """Call the selected writer through the universal agent runtime.
 
@@ -3984,6 +3987,7 @@ def invoke_writer(
             phase_writer_summary=phase_writer_summary,
             tool_calls=tool_calls,
             event_sink=event_sink,
+            enforce_mcp_tools_never_invoked=enforce_mcp_tools_never_invoked,
         )
     return response_text
 
@@ -10154,6 +10158,58 @@ def _task_with_ledger(task: SectionTask, ledger: Ledger) -> SectionTask:
     )
 
 
+def _sum_phase_writer_summary_int(
+    summaries: Sequence[Mapping[str, Any]],
+    key: str,
+) -> int:
+    return sum(int(summary.get(key) or 0) for summary in summaries)
+
+
+def _sum_nullable_phase_writer_summary_int(
+    summaries: Sequence[Mapping[str, Any]],
+    key: str,
+) -> int | None:
+    total = 0
+    saw_unknown = False
+    for summary in summaries:
+        value = summary.get(key)
+        if value is None:
+            saw_unknown = True
+            continue
+        total += int(value)
+    if saw_unknown and total == 0:
+        return None
+    return total
+
+
+def _aggregate_iterative_phase_writer_summaries(
+    summaries: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    violations: list[Any] = []
+    for summary in summaries:
+        raw_violations = summary.get("tool_theatre_violations") or []
+        if isinstance(raw_violations, list):
+            violations.extend(raw_violations)
+
+    return {
+        "sections_total": _sum_phase_writer_summary_int(summaries, "sections_total"),
+        "sections_with_cot": _sum_phase_writer_summary_int(summaries, "sections_with_cot"),
+        "tool_calls_total": _sum_nullable_phase_writer_summary_int(summaries, "tool_calls_total"),
+        "verify_words_calls": _sum_nullable_phase_writer_summary_int(summaries, "verify_words_calls"),
+        "tool_call_telemetry_available": all(
+            summary.get("tool_call_telemetry_available") is not False for summary in summaries
+        ),
+        "end_gate_fired": any(bool(summary.get("end_gate_fired")) for summary in summaries),
+        "removed_via_gate": _sum_phase_writer_summary_int(summaries, "removed_via_gate"),
+        "tool_theatre_violations": violations[:TELEMETRY_MAX_THEATRE_VIOLATIONS],
+        "tool_theatre_violation_count": _sum_phase_writer_summary_int(
+            summaries,
+            "tool_theatre_violation_count",
+        ),
+        "iterative_invocations_total": len(summaries),
+    }
+
+
 def run_iterative_writer(
     plan: Mapping[str, Any],
     knowledge_packet: object,
@@ -10188,6 +10244,13 @@ def run_iterative_writer(
     invoke = invoke_fn or invoke_writer
     ledger = Ledger()
     artifacts: list[SectionArtifact] = []
+    phase_writer_summaries: list[dict[str, Any]] = []
+
+    def iterative_event_sink(event: str, **fields: Any) -> None:
+        if event == "phase_writer_summary":
+            phase_writer_summaries.append(dict(fields))
+        if event_sink is not None:
+            event_sink(event, **fields)
 
     for base_task in tasks:
         task = _task_with_ledger(base_task, ledger)
@@ -10202,20 +10265,34 @@ def run_iterative_writer(
             implementation_map=implementation_map,
             obligation_checklist=obligation_checklist,
         )
-        output = invoke(
-            prompt,
-            writer,
-            cwd=cwd,
-            module=module,
-            sections=[task.title],
-            event_sink=event_sink,
-            tool_trace_path=tool_trace_path,
-            stdout_silence_timeout=stdout_silence_timeout,
-            effort=effort,
-        )
+        invoke_kwargs: dict[str, Any] = {
+            "cwd": cwd,
+            "module": module,
+            "sections": [task.title],
+            "event_sink": iterative_event_sink,
+            "tool_trace_path": tool_trace_path,
+            "stdout_silence_timeout": stdout_silence_timeout,
+            "effort": effort,
+        }
+        if invoke_fn is None:
+            invoke_kwargs["enforce_mcp_tools_never_invoked"] = False
+        output = invoke(prompt, writer, **invoke_kwargs)
         artifact = _record_section_precheck(task, parse_section_writer_output(output, task))
         artifacts.append(artifact)
         ledger = update_ledger(ledger, artifact)
+
+    module_ref = module or next(
+        (str(summary.get("module")) for summary in phase_writer_summaries if summary.get("module")),
+        "",
+    )
+    if module_ref and phase_writer_summaries:
+        _enforce_writer_runtime_gates(
+            writer=writer,
+            module=module_ref,
+            phase_writer_summary=_aggregate_iterative_phase_writer_summaries(phase_writer_summaries),
+            tool_calls=[],
+            event_sink=event_sink,
+        )
 
     return assemble_iterative(artifacts, plan)
 

--- a/tests/test_iterative_writer_runtime_gate.py
+++ b/tests/test_iterative_writer_runtime_gate.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from scripts.agent_runtime import tool_config as tool_config_mod
+from scripts.build import linear_pipeline
+
+
+def _seed_sources_mcp_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    mcp_config_path = tmp_path / ".mcp.json"
+    mcp_config_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "sources": {
+                        "type": "streamable-http",
+                        "url": "http://127.0.0.1:8766/mcp",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    tool_config_mod._load_mcp_config.cache_clear()
+    monkeypatch.setattr(tool_config_mod, "_DEFAULT_MCP_CONFIG_PATH", mcp_config_path)
+
+
+def _iterative_plan() -> dict[str, Any]:
+    return {
+        "level": "b1",
+        "module": 1,
+        "slug": "iterative-tools-gate",
+        "title": "Iterative tools gate",
+        "content_outline": [
+            {"section": "Intro", "words": 1, "points": ["Open the module."]},
+            {"section": "Discussion", "words": 1, "points": ["Synthesize the module."]},
+        ],
+    }
+
+
+def _section_artifact_response(section_id: str, title: str) -> str:
+    payload = {
+        "section_id": section_id,
+        "markdown": f"## {title}\n\nGrounded sentence for {title}.",
+        "citations_used": [],
+        "primary_readings_used": [],
+        "vocab_candidates": [],
+        "activity_refs": [],
+        "self_check": {},
+    }
+    return "```section_artifact.json\n" + json.dumps(payload) + "\n```"
+
+
+def _patch_invoke_writer_with_tool_totals(
+    monkeypatch: pytest.MonkeyPatch,
+    tool_totals: list[int],
+) -> list[str]:
+    original_invoke_writer = linear_pipeline.invoke_writer
+    section_calls: list[str] = []
+
+    def fake_invoke_writer(prompt: str, writer: str, **kwargs: Any) -> str:
+        section_title = kwargs["sections"][0]
+        section_index = len(section_calls)
+        section_calls.append(section_title)
+        tool_calls_total = tool_totals[section_index]
+        tool_calls = [
+            {
+                "tool": "mcp__sources__search_text",
+                "args": {"query": section_title},
+                "result": {"matches": []},
+            }
+            for _ in range(tool_calls_total)
+        ]
+
+        def fake_runtime_invoker(_agent: str, _prompt: str, **_runtime_kwargs: Any) -> SimpleNamespace:
+            return SimpleNamespace(
+                response=_section_artifact_response(f"s{section_index + 1}", section_title),
+                tool_calls=tool_calls,
+                tool_calls_total=tool_calls_total,
+            )
+
+        return original_invoke_writer(
+            prompt,
+            writer,
+            invoker=fake_runtime_invoker,
+            **kwargs,
+        )
+
+    monkeypatch.setattr(linear_pipeline, "invoke_writer", fake_invoke_writer)
+    return section_calls
+
+
+def test_iterative_tools_writer_runtime_gate_aggregates_module_tool_calls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_sources_mcp_config(tmp_path, monkeypatch)
+    section_calls = _patch_invoke_writer_with_tool_totals(monkeypatch, [2, 0])
+
+    result = linear_pipeline.run_iterative_writer(
+        _iterative_plan(),
+        knowledge_packet="",
+        readings=[],
+        writer="gemini-tools",
+        cwd=tmp_path,
+        module="folk/iterative-tools-gate",
+    )
+
+    assert section_calls == ["Intro", "Discussion"]
+    assert "## Intro" in result["module_md"]
+    assert "## Discussion" in result["module_md"]
+
+
+def test_iterative_tools_writer_runtime_gate_fails_when_module_has_zero_tool_calls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_sources_mcp_config(tmp_path, monkeypatch)
+    section_calls = _patch_invoke_writer_with_tool_totals(monkeypatch, [0, 0])
+    events: list[dict[str, Any]] = []
+
+    with pytest.raises(linear_pipeline.LinearPipelineError, match="mcp_tools_never_invoked"):
+        linear_pipeline.run_iterative_writer(
+            _iterative_plan(),
+            knowledge_packet="",
+            readings=[],
+            writer="gemini-tools",
+            cwd=tmp_path,
+            module="folk/iterative-tools-gate",
+            event_sink=lambda event, **fields: events.append({"event": event, **fields}),
+        )
+
+    assert section_calls == ["Intro", "Discussion"]
+    assert any(
+        event["event"] == "writer_failure_class"
+        and event["failure_class"] == "mcp_tools_never_invoked"
+        and event["gate"] == "tools_writer_runtime_gate"
+        for event in events
+    )


### PR DESCRIPTION
## Changed

- Deferred only the mcp_tools_never_invoked writer-runtime gate during iterative section invocations.
- Aggregated iterative phase_writer_summary tool totals after all sections finish, then enforced tools_writer_runtime_gate once at module scope.
- Added stubbed iterative-writer tests for mixed tool/no-tool sections and the true all-zero failure case.

## Root Cause

In iterative mode, run_iterative_writer calls the writer once per section. The runtime gate was evaluating tool_calls_total for each section invocation, so a legitimate synthesis section with zero corpus lookups could hard-fail even when the module was otherwise fully tool-grounded.

## Validation

- .venv/bin/pytest -q tests/test_iterative_writer_runtime_gate.py tests/test_linear_pipeline_telemetry.py::test_mcp_tools_writer_runtime_gate_still_fires_for_empty_tool_calls tests/test_v7_writer_dispatch.py::test_positive_runtime_gate_does_not_fire_for_non_tools_writer tests/test_writer_isolation.py tests/test_agent_runtime_tool_calls.py tests/test_textbook_grounding_gate.py
  - ============================== 48 passed in 0.74s ==============================
- .venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_iterative_writer_runtime_gate.py
  - All checks passed!
- .venv/bin/python scripts/audit/lint_agent_trailer.py
  - All 3 non-skipped commit(s) carry an X-Agent trailer.
