### PR TITLE
fix(build): harvest iterative vocabulary candidates

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -9971,6 +9971,22 @@ def render_section_writer_prompt(
     lines.extend(
         [
             "",
+            "## Vocabulary Candidates",
+            "- Include 6-10 `vocab_candidates` entries for useful learner "
+            "vocabulary introduced in this section.",
+            "- Each candidate must include `word`, `ipa`, `pos`, `definition`, "
+            "`translation`, and `usage`.",
+            "- `translation` is a concise English gloss; `usage` is one short "
+            "Ukrainian example sentence that uses the lemma and matches the "
+            "section's register.",
+            "- Do not emit a candidate unless `word`, `translation`, `pos`, "
+            "and `usage` are all known.",
+        ]
+    )
+
+    lines.extend(
+        [
+            "",
             "## Output Contract",
             "Return one `json file=section_artifact.json` fenced block with keys: "
             "`section_id`, `markdown`, `citations_used`, `primary_readings_used`, "
@@ -10521,7 +10537,7 @@ def _artifact_claims(artifact: SectionArtifact) -> list[str]:
 
 def _vocab_candidate_surfaces(candidates: Sequence[Mapping[str, Any]]) -> list[str]:
     return _dedupe_preserve_order(
-        candidate.get("surface") or candidate.get("lemma") or ""
+        candidate.get("word") or candidate.get("surface") or candidate.get("lemma") or ""
         for candidate in candidates
         if isinstance(candidate, Mapping)
     )
@@ -10570,25 +10586,24 @@ def _artifact_by_plan_order(
 
 
 def _normalize_vocab_candidate(candidate: Mapping[str, Any]) -> dict[str, Any] | None:
-    surface = str(candidate.get("surface") or candidate.get("lemma") or "").strip()
-    if not surface:
+    lemma = str(candidate.get("word") or "").strip()
+    translation = str(candidate.get("translation") or "").strip()
+    pos = str(candidate.get("pos") or "").strip()
+    usage = str(candidate.get("usage") or "").strip()
+    if not all((lemma, translation, pos, usage)):
         return None
-    gloss = str(candidate.get("gloss") or candidate.get("translation") or "").strip()
-    note = str(candidate.get("note") or candidate.get("notes") or "").strip()
-    item: dict[str, Any] = {
-        "lemma": surface,
-        "translation": gloss,
-        "pos": str(candidate.get("pos") or "phrase").strip(),
-        "usage": str(candidate.get("usage") or note or surface).strip(),
+    return {
+        "lemma": lemma,
+        "translation": translation,
+        "pos": pos,
+        "usage": usage,
     }
-    if note:
-        item["notes"] = note
-    return item
 
 
-def _merge_vocab_candidates(artifacts: Sequence[SectionArtifact]) -> list[dict[str, Any]]:
+def _merge_vocab(plan: Mapping[str, Any], artifacts: Sequence[SectionArtifact]) -> list[dict[str, Any]]:
+    del plan
     vocab_items: list[dict[str, Any]] = []
-    seen_surfaces: set[str] = set()
+    seen_lemmas: set[str] = set()
     for artifact in artifacts:
         for candidate in artifact.vocab_candidates:
             if not isinstance(candidate, Mapping):
@@ -10596,11 +10611,11 @@ def _merge_vocab_candidates(artifacts: Sequence[SectionArtifact]) -> list[dict[s
             item = _normalize_vocab_candidate(candidate)
             if item is None:
                 continue
-            surface_key = item["lemma"].casefold()
-            if surface_key in seen_surfaces:
+            lemma_key = item["lemma"].casefold()
+            if lemma_key in seen_lemmas:
                 continue
             vocab_items.append(item)
-            seen_surfaces.add(surface_key)
+            seen_lemmas.add(lemma_key)
     _validate_writer_json_artifact("vocabulary.yaml", vocab_items)
     return vocab_items
 
@@ -10810,7 +10825,7 @@ def assemble_iterative(
     if module_md:
         module_md += "\n"
 
-    vocabulary = _merge_vocab_candidates(ordered_artifacts)
+    vocabulary = _merge_vocab(plan, ordered_artifacts)
     activity_items = (
         _merge_activities(ordered_artifacts, plan)
         if activities is None

--- a/tests/test_iterative_vocab_merge.py
+++ b/tests/test_iterative_vocab_merge.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from scripts.build import linear_pipeline
+
+
+def _plan() -> dict[str, Any]:
+    return {
+        "content_outline": [
+            {"section": "Opening", "words": 1, "points": ["Introduce the topic."]},
+            {"section": "Practice", "words": 1, "points": ["Extend the topic."]},
+        ]
+    }
+
+
+def _artifact(section_id: str, candidates: list[dict[str, Any]]) -> linear_pipeline.SectionArtifact:
+    return linear_pipeline.SectionArtifact(
+        section_id=section_id,
+        markdown=f"## Section {section_id}\n\nText.",
+        citations_used=[],
+        primary_readings_used=[],
+        vocab_candidates=candidates,
+        activity_refs=[],
+        self_check={},
+    )
+
+
+def _candidate(
+    word: str,
+    translation: str,
+    *,
+    pos: str = "noun",
+    usage: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "word": word,
+        "ipa": "test-ipa",
+        "pos": pos,
+        "definition": f"Definition for {word}.",
+        "translation": translation,
+        "usage": f"{word} з'являється в уривку." if usage is None else usage,
+    }
+
+
+def test_merge_vocab_harvests_section_candidates_as_valid_schema_entries() -> None:
+    artifacts = [
+        _artifact(
+            "s1",
+            [
+                _candidate("веснянка", "spring ritual song"),
+                _candidate("гаївка", "Easter round dance song"),
+            ],
+        ),
+        _artifact("s2", [_candidate("приспів", "refrain")]),
+    ]
+
+    vocab = linear_pipeline._merge_vocab(_plan(), artifacts)
+
+    assert vocab == [
+        {
+            "lemma": "веснянка",
+            "translation": "spring ritual song",
+            "pos": "noun",
+            "usage": "веснянка з'являється в уривку.",
+        },
+        {
+            "lemma": "гаївка",
+            "translation": "Easter round dance song",
+            "pos": "noun",
+            "usage": "гаївка з'являється в уривку.",
+        },
+        {
+            "lemma": "приспів",
+            "translation": "refrain",
+            "pos": "noun",
+            "usage": "приспів з'являється в уривку.",
+        },
+    ]
+    linear_pipeline._validate_writer_json_artifact("vocabulary.yaml", vocab)
+
+
+def test_merge_vocab_dedupes_by_casefolded_lemma_preserving_first_order() -> None:
+    artifacts = [
+        _artifact(
+            "s1",
+            [
+                _candidate("Веснянка", "spring ritual song"),
+                _candidate("веснянка", "duplicate gloss"),
+            ],
+        ),
+        _artifact("s2", [_candidate("гаївка", "Easter round dance song")]),
+    ]
+
+    vocab = linear_pipeline._merge_vocab(_plan(), artifacts)
+
+    assert [item["lemma"] for item in vocab] == ["Веснянка", "гаївка"]
+    assert vocab[0]["translation"] == "spring ritual song"
+
+
+def test_merge_vocab_drops_candidates_missing_required_fields() -> None:
+    missing_word = _candidate("", "missing word")
+    missing_translation = _candidate("спів", "")
+    missing_pos = _candidate("коло", "circle song", pos="")
+    missing_usage = _candidate("лад", "order", usage="")
+    valid = _candidate("обряд", "rite")
+
+    vocab = linear_pipeline._merge_vocab(
+        _plan(),
+        [_artifact("s1", [missing_word, missing_translation, missing_pos, missing_usage, valid])],
+    )
+
+    assert vocab == [
+        {
+            "lemma": "обряд",
+            "translation": "rite",
+            "pos": "noun",
+            "usage": "обряд з'являється в уривку.",
+        }
+    ]
+
+
+def test_merge_vocab_empty_input_returns_empty_list() -> None:
+    assert linear_pipeline._merge_vocab(_plan(), []) == []
+    assert linear_pipeline._merge_vocab(_plan(), [_artifact("s1", [])]) == []
+
+
+def test_parse_section_writer_output_preserves_translation_and_usage() -> None:
+    task = linear_pipeline.SectionTask(
+        section_id="s1",
+        title="Opening",
+        word_budget=1,
+        points=[],
+        assigned_readings=[],
+        knowledge_slice="",
+        framing_rules="",
+        ledger=linear_pipeline.Ledger(),
+    )
+    payload = {
+        "section_id": "s1",
+        "markdown": "## Opening\n\nText.",
+        "citations_used": [],
+        "primary_readings_used": [],
+        "vocab_candidates": [
+            {
+                "word": "веснянка",
+                "ipa": "test-ipa",
+                "pos": "noun",
+                "definition": "A spring ritual song.",
+                "translation": "spring ritual song",
+                "usage": "Веснянка звучить у весняному колі.",
+            }
+        ],
+        "activity_refs": [],
+        "self_check": {},
+    }
+    output = "```json file=section_artifact.json\n" + json.dumps(payload) + "\n```"
+
+    artifact = linear_pipeline.parse_section_writer_output(output, task)
+
+    assert artifact.vocab_candidates[0]["translation"] == "spring ritual song"
+    assert artifact.vocab_candidates[0]["usage"] == "Веснянка звучить у весняному колі."


### PR DESCRIPTION
## Summary
- Enrich the iterative section-writer prompt so `vocab_candidates` carry `translation` and `usage` alongside `word`, `ipa`, `pos`, and `definition`.
- Add deterministic `_merge_vocab(plan, artifacts)` assembly that maps `word` to `lemma`, drops incomplete candidates, dedupes by casefolded lemma, and validates with the existing `vocabulary.yaml` schema.
- Add focused tests for harvest, dedupe/order, required-field dropping, empty input, and parser preservation of `translation`/`usage`.

## Approach
Harvest approach. No dedicated vocab-writer call was added; sections now own complete vocab metadata and assembly merges it deterministically.

## Checks
- `.venv/bin/python -m py_compile scripts/build/linear_pipeline.py` -> `exit_code=0`
- `.venv/bin/python -m pytest -q tests/test_iterative_vocab_merge.py tests/test_iterative_activity_generation.py tests/test_iterative_writer_runtime_gate.py` -> `9 passed in 0.41s`
- `.venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_iterative_vocab_merge.py` -> `All checks passed!`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` -> `All 5 non-skipped commit(s) carry an X-Agent trailer.`
