### PR TITLE
fix(build): harden iterative assembly resume

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -9937,6 +9937,12 @@ def render_section_writer_prompt(
         f"- title: {task.title}",
         f"- word_budget: {task.word_budget}",
         "",
+        "## Section Body Rules",
+        "- Do not write the section heading. The assembler emits the exact "
+        "plan title as an H2.",
+        "- Start `markdown` with the section body. In-body subheadings are "
+        "allowed after body text when useful.",
+        "",
         "## Points To Cover",
         point_lines,
         "",
@@ -10797,6 +10803,31 @@ def _artifact_sidecar_entry(
     }
 
 
+_ITERATIVE_LEADING_SECTION_HEADING_RE = re.compile(r"^\s{0,3}#{1,3}(?:\s+|$)")
+
+
+def _strip_leading_iterative_section_headings(markdown: str) -> str:
+    lines = markdown.strip("\n").splitlines()
+    index = 0
+    while index < len(lines) and not lines[index].strip():
+        index += 1
+    while index < len(lines) and _ITERATIVE_LEADING_SECTION_HEADING_RE.match(
+        lines[index]
+    ):
+        index += 1
+        while index < len(lines) and not lines[index].strip():
+            index += 1
+    return "\n".join(lines[index:]).strip("\n")
+
+
+def _canonical_iterative_section_markdown(markdown: str, title: str) -> str:
+    body = _strip_leading_iterative_section_headings(markdown)
+    heading = f"## {title}"
+    if not body:
+        return heading
+    return f"{heading}\n\n{body}"
+
+
 def assemble_iterative(
     artifacts: Sequence[SectionArtifact],
     plan: Mapping[str, Any],
@@ -10804,12 +10835,20 @@ def assemble_iterative(
     activities: Sequence[Mapping[str, Any]] | None = None,
 ) -> dict[str, Any]:
     ordered_artifacts = _artifact_by_plan_order(artifacts, plan)
+    outline_entries = _section_outline_entries(plan)
 
     markdown_parts: list[str] = []
     sidecar: dict[str, dict[str, Any]] = {}
     next_line = 1
-    for artifact in ordered_artifacts:
-        section_markdown = artifact.markdown.strip("\n")
+    for index, (artifact, outline_entry) in enumerate(
+        zip(ordered_artifacts, outline_entries, strict=True),
+        start=1,
+    ):
+        section_title = _section_outline_title(outline_entry, index)
+        section_markdown = _canonical_iterative_section_markdown(
+            artifact.markdown,
+            section_title,
+        )
         section_lines = section_markdown.splitlines() or [""]
         line_start = next_line
         line_end = line_start + len(section_lines) - 1

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -1594,6 +1594,44 @@ def _phase_artifact_passes(module_dir: Path, phase: str) -> bool:
     return False
 
 
+def _iterative_result_from_writer_phase_artifacts(module_dir: Path) -> dict[str, Any]:
+    artifacts = {
+        name: (module_dir / name).read_text(encoding="utf-8")
+        for name in linear_pipeline.WRITER_ARTIFACTS
+    }
+    sidecar = _read_json(module_dir / "iterative_writer_sidecar.json")
+    if not isinstance(sidecar, Mapping):
+        sidecar = {}
+    return {
+        "module_md": artifacts["module.md"],
+        "activities_yaml": artifacts["activities.yaml"],
+        "vocabulary_yaml": artifacts["vocabulary.yaml"],
+        "resources_yaml": artifacts["resources.yaml"],
+        "sidecar": sidecar,
+    }
+
+
+def _writer_phase_artifacts(
+    *,
+    writer_mode: str,
+    module_dir: Path,
+    writer_output: str,
+    iterative_result: Mapping[str, Any] | None,
+) -> tuple[dict[str, str], Mapping[str, Any] | None]:
+    if iterative_result is not None:
+        return (
+            linear_pipeline.iterative_result_to_writer_artifacts(iterative_result),
+            iterative_result,
+        )
+    if writer_mode == "iterative":
+        resumed_result = _iterative_result_from_writer_phase_artifacts(module_dir)
+        return (
+            linear_pipeline.iterative_result_to_writer_artifacts(resumed_result),
+            resumed_result,
+        )
+    return linear_pipeline.parse_writer_output(writer_output), None
+
+
 def _run_stress_annotation_for_level(module_dir: Path, level: str) -> dict[str, Any]:
     if level.lower() in SEMINAR_LEVELS:
         return linear_pipeline.strip_stress_marks_for_seminar(module_dir)
@@ -1824,12 +1862,13 @@ def _run(args: argparse.Namespace) -> int:
                 wiki_manifest,
                 encoding="utf-8",
             )
-        if iterative_result is None:
-            artifacts = linear_pipeline.parse_writer_output(writer_output)
-        else:
-            artifacts = linear_pipeline.iterative_result_to_writer_artifacts(
-                iterative_result
-            )
+        artifacts, iterative_result = _writer_phase_artifacts(
+            writer_mode=writer_mode,
+            module_dir=module_dir,
+            writer_output=writer_output,
+            iterative_result=iterative_result,
+        )
+        if iterative_result is not None:
             linear_pipeline.write_json(
                 module_dir / "iterative_writer_sidecar.json",
                 iterative_result.get("sidecar", {}),

--- a/tests/test_iterative_assembly_headings.py
+++ b/tests/test_iterative_assembly_headings.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from scripts.build import linear_pipeline
+
+PLAN_SECTION_TITLES = [
+    "Розминка",
+    "Конфліктна карта: як читати походження веснянок",
+    "Читання: Як веснянка кличе весну",
+    "Аналіз: Хоровод, гаївка і великодній простір",
+    "Дискусія: Від обряду до естетики",
+    "Підсумок",
+]
+
+
+def _plan() -> dict[str, Any]:
+    return {
+        "level": "folk",
+        "sequence": 1,
+        "module": 1,
+        "slug": "vesnianky-hayivky",
+        "title": "Веснянки і гаївки",
+        "content_outline": [
+            {"section": title, "words": 1, "points": ["Cover the section."]}
+            for title in PLAN_SECTION_TITLES
+        ],
+    }
+
+
+def _artifact(section_id: str, markdown: str) -> linear_pipeline.SectionArtifact:
+    return linear_pipeline.SectionArtifact(
+        section_id=section_id,
+        markdown=markdown,
+        citations_used=[],
+        primary_readings_used=[],
+        vocab_candidates=[],
+        activity_refs=[],
+        self_check={},
+    )
+
+
+def test_assemble_iterative_emits_plan_h2_headings_once() -> None:
+    artifacts = [
+        _artifact(
+            "s1",
+            "### Warmup invented heading\n\nBody for warmup.\n\n### Kept subheading\n\nMore.",
+        ),
+        _artifact("s2", "Conflict map body without any section heading."),
+        _artifact(
+            "s3",
+            "# Invented module title\n\n## Invented reading title\n\nReading body.",
+        ),
+        _artifact("s4", "## 4. Spatial analysis\n\nAnalysis body."),
+        _artifact("s5", "### Discussion as theme\n\nDiscussion body."),
+        _artifact("s6", "Summary body.\n\n### Kept closing subheading\n\nFinal note."),
+    ]
+
+    result = linear_pipeline.assemble_iterative(artifacts, _plan())
+    module_md = result["module_md"]
+    gate = linear_pipeline._section_gate(module_md, _plan())
+
+    assert gate["passed"] is True
+    assert gate["missing_headings"] == []
+    assert gate["duplicate_headings"] == []
+    for title in PLAN_SECTION_TITLES:
+        assert len(re.findall(rf"^## {re.escape(title)}$", module_md, re.MULTILINE)) == 1
+    assert "## 4. Spatial analysis" not in module_md
+    assert "### Kept subheading" in module_md
+    assert "### Kept closing subheading" in module_md
+
+
+def test_assemble_iterative_sidecar_ranges_follow_rewritten_headings() -> None:
+    result = linear_pipeline.assemble_iterative(
+        [
+            _artifact("s1", "### Wrong opening\n\nFirst body."),
+            _artifact("s2", "Second body."),
+            _artifact("s3", "Third body."),
+            _artifact("s4", "Fourth body."),
+            _artifact("s5", "Fifth body."),
+            _artifact("s6", "Sixth body."),
+        ],
+        _plan(),
+    )
+
+    lines = result["module_md"].splitlines()
+    sidecar = result["sidecar"]
+
+    for index, title in enumerate(PLAN_SECTION_TITLES, start=1):
+        entry = sidecar[f"s{index}"]
+        assert lines[entry["line_start"] - 1] == f"## {title}"
+        assert entry["line_start"] <= entry["line_end"]

--- a/tests/test_iterative_resume.py
+++ b/tests/test_iterative_resume.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.build import linear_pipeline, v7_build
+
+
+def _artifacts_with_unnamed_module_fence() -> dict[str, str]:
+    return {
+        "module.md": "## Intro\n\n```\nunnamed fence allowed in iterative module body\n```\n",
+        "activities.yaml": "[]\n",
+        "vocabulary.yaml": "[]\n",
+        "resources.yaml": "[]\n",
+    }
+
+
+def _write_artifacts(module_dir: Path, artifacts: dict[str, str]) -> None:
+    for name, content in artifacts.items():
+        (module_dir / name).write_text(content, encoding="utf-8")
+
+
+def test_iterative_resume_reads_artifacts_without_single_shot_fence_parse(
+    tmp_path: Path,
+) -> None:
+    artifacts = _artifacts_with_unnamed_module_fence()
+    _write_artifacts(tmp_path, artifacts)
+    (tmp_path / "iterative_writer_sidecar.json").write_text(
+        '{"s1": {"line_start": 1, "line_end": 4}}\n',
+        encoding="utf-8",
+    )
+    writer_output = linear_pipeline.render_writer_artifacts_output(artifacts)
+
+    resumed_artifacts, iterative_result = v7_build._writer_phase_artifacts(
+        writer_mode="iterative",
+        module_dir=tmp_path,
+        writer_output=writer_output,
+        iterative_result=None,
+    )
+
+    assert resumed_artifacts == artifacts
+    assert iterative_result is not None
+    assert iterative_result["module_md"] == artifacts["module.md"]
+    assert iterative_result["sidecar"]["s1"]["line_start"] == 1
+
+
+def test_single_shot_resume_still_rejects_unnamed_module_fence(
+    tmp_path: Path,
+) -> None:
+    writer_output = linear_pipeline.render_writer_artifacts_output(
+        _artifacts_with_unnamed_module_fence()
+    )
+
+    with pytest.raises(
+        linear_pipeline.LinearPipelineError,
+        match="unnamed fenced block",
+    ):
+        v7_build._writer_phase_artifacts(
+            writer_mode="single_shot",
+            module_dir=tmp_path,
+            writer_output=writer_output,
+            iterative_result=None,
+        )


### PR DESCRIPTION
## Summary
- canonicalize iterative section headings during assembly so plan sections emit exact H2 titles in plan order
- route iterative writer-phase resume through written iterative artifacts instead of single-shot strict writer-output parsing
- add offline synthetic tests for heading canonicalization, sidecar ranges, and iterative resume unnamed-fence tolerance

## Validation
- .venv/bin/python -m py_compile scripts/build/linear_pipeline.py scripts/build/v7_build.py tests/test_iterative_assembly_headings.py tests/test_iterative_resume.py: py_compile exit=0
- .venv/bin/pytest -q tests/test_iterative_assembly_headings.py tests/test_iterative_resume.py tests/test_iterative_activity_generation.py tests/test_iterative_vocab_merge.py tests/test_iterative_writer_runtime_gate.py: 13 passed in 0.50s
- .venv/bin/ruff check scripts/build/linear_pipeline.py scripts/build/v7_build.py tests/test_iterative_assembly_headings.py tests/test_iterative_resume.py: All checks passed!
- .venv/bin/python scripts/audit/lint_agent_trailer.py: All 6 non-skipped commit(s) carry an X-Agent trailer

No real writer builds run; validation used offline synthetic artifacts only.