### PR TITLE
[codex] Harden iterative section-output parsing

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -9879,6 +9879,7 @@ _SECTION_MARKDOWN_FENCE_RE = re.compile(
     r"```[^\n`]*section\.md[^\n`]*\n(?P<body>.*?)\n```",
     re.DOTALL,
 )
+_SECTION_FENCE_OPEN_RE = re.compile(r"^(?P<fence>`{3,}|~{3,})(?P<info>[^\n]*)$")
 
 
 def _prompt_dump(value: object) -> str:
@@ -9994,11 +9995,26 @@ def render_section_writer_prompt(
         [
             "",
             "## Output Contract",
-            "Return one `json file=section_artifact.json` fenced block with keys: "
-            "`section_id`, `markdown`, `citations_used`, `primary_readings_used`, "
-            "`vocab_candidates`, `activity_refs`, and `self_check`. For tests and "
-            "diagnostics, plain section markdown is also accepted; missing metadata "
-            "will be inferred conservatively.",
+            "Return exactly two fenced blocks, in this order:",
+            "````markdown file=section.md",
+            "<raw section body only; no section heading>",
+            "````",
+            "```json file=section_artifact.json",
+            "{",
+            f'  "section_id": "{task.section_id}",',
+            '  "citations_used": [],',
+            '  "primary_readings_used": [],',
+            '  "vocab_candidates": [',
+            '    {"word": "", "ipa": "", "pos": "", "definition": "", "translation": "", "usage": ""}',
+            "  ],",
+            '  "activity_refs": [],',
+            '  "self_check": {}',
+            "}",
+            "```",
+            "Do NOT put the section prose inside the JSON. The JSON block is only "
+            "small structured metadata: `section_id`, `citations_used`, "
+            "`primary_readings_used`, `vocab_candidates`, `activity_refs`, and "
+            "`self_check`.",
             "",
             "## SELF-CHECK",
             ITERATIVE_SECTION_SELF_CHECK_INSTRUCTION.strip(),
@@ -10165,25 +10181,137 @@ def parse_iterative_activities_output(output: str) -> list[dict[str, Any]]:
     return _validate_activities_artifact(activities)
 
 
-def _load_section_artifact_metadata(raw: str) -> dict[str, Any]:
-    parsed = yaml.safe_load(raw)
+def _section_parse_label(section_id: str | None) -> str:
+    return section_id or "<unknown section>"
+
+
+def _load_section_artifact_metadata(
+    raw: str,
+    *,
+    section_id: str | None = None,
+) -> dict[str, Any]:
+    label = _section_parse_label(section_id)
+    stripped = raw.strip()
+    if not stripped:
+        raise LinearPipelineError(
+            f"Section writer metadata for {label} in section_artifact.json is empty"
+        )
+    try:
+        parsed = json.loads(stripped, parse_constant=_reject_non_strict_json_constant)
+    except (json.JSONDecodeError, ValueError) as json_exc:
+        try:
+            parsed = yaml.safe_load(stripped)
+        except yaml.YAMLError as yaml_exc:
+            raise LinearPipelineError(
+                "Section writer metadata for "
+                f"{label} in section_artifact.json is unrecoverable: {json_exc}"
+            ) from yaml_exc
     if not isinstance(parsed, Mapping):
-        raise LinearPipelineError("section_artifact metadata must be a mapping")
+        raise LinearPipelineError(
+            f"Section writer metadata for {label} in section_artifact.json must be a mapping"
+        )
     return dict(parsed)
 
 
-def _extract_section_metadata(output: str) -> tuple[str, dict[str, Any]]:
-    json_match = _SECTION_ARTIFACT_JSON_FENCE_RE.search(output)
-    if json_match:
-        metadata = _load_section_artifact_metadata(json_match.group("body"))
+def _section_fence_body(body: str) -> str:
+    if body.endswith("\r\n"):
+        return body[:-2]
+    if body.endswith("\n"):
+        return body[:-1]
+    return body
+
+
+def _iter_section_fenced_blocks(output: str) -> list[tuple[str, str]]:
+    blocks: list[tuple[str, str]] = []
+    lines = output.splitlines(keepends=True)
+    index = 0
+    while index < len(lines):
+        line = lines[index].rstrip("\r\n")
+        match = _SECTION_FENCE_OPEN_RE.match(line)
+        if not match:
+            index += 1
+            continue
+
+        fence = match.group("fence")
+        info = match.group("info").strip()
+        marker = re.escape(fence[0])
+        min_length = len(fence)
+        close_re = re.compile(rf"^{marker}{{{min_length},}}\s*$")
+        body_lines: list[str] = []
+        index += 1
+        while index < len(lines):
+            close_candidate = lines[index].rstrip("\r\n")
+            if close_re.match(close_candidate):
+                blocks.append((info, _section_fence_body("".join(body_lines))))
+                break
+            body_lines.append(lines[index])
+            index += 1
+        index += 1
+    return blocks
+
+
+def _section_markdown_fence(info: str) -> bool:
+    lowered = info.lower()
+    return "section.md" in lowered or _fence_language(info) == "markdown"
+
+
+def _section_metadata_fence(info: str) -> bool:
+    return "section_artifact.json" in info.lower()
+
+
+def _extract_section_metadata(
+    output: str,
+    *,
+    section_id: str | None = None,
+) -> tuple[str, dict[str, Any]]:
+    label = _section_parse_label(section_id)
+    fenced_blocks = _iter_section_fenced_blocks(output)
+    markdown_blocks = [body for info, body in fenced_blocks if _section_markdown_fence(info)]
+    metadata_blocks = [body for info, body in fenced_blocks if _section_metadata_fence(info)]
+
+    if len(markdown_blocks) > 1:
+        raise LinearPipelineError(f"Section writer output for {label} has duplicate markdown fences")
+    if len(metadata_blocks) > 1:
+        raise LinearPipelineError(
+            f"Section writer output for {label} has duplicate section_artifact.json fences"
+        )
+
+    if markdown_blocks:
+        if not metadata_blocks:
+            raise LinearPipelineError(
+                f"Section writer output for {label} missing section_artifact.json metadata fence"
+            )
+        metadata = _load_section_artifact_metadata(metadata_blocks[0], section_id=section_id)
+        return markdown_blocks[0], metadata
+
+    if metadata_blocks:
+        metadata = _load_section_artifact_metadata(metadata_blocks[0], section_id=section_id)
         markdown = str(metadata.get("markdown") or "").strip()
         if not markdown:
-            raise LinearPipelineError("section_artifact.json missing markdown")
+            raise LinearPipelineError(
+                f"section_artifact.json for {label} missing markdown or section.md fence"
+            )
+        return markdown, metadata
+
+    json_match = _SECTION_ARTIFACT_JSON_FENCE_RE.search(output)
+    if json_match:
+        metadata = _load_section_artifact_metadata(
+            json_match.group("body"),
+            section_id=section_id,
+        )
+        markdown = str(metadata.get("markdown") or "").strip()
+        if not markdown:
+            raise LinearPipelineError(
+                f"section_artifact.json for {label} missing markdown or section.md fence"
+            )
         return markdown, metadata
 
     comment_match = _SECTION_ARTIFACT_COMMENT_RE.search(output)
     if comment_match:
-        metadata = _load_section_artifact_metadata(comment_match.group("body"))
+        metadata = _load_section_artifact_metadata(
+            comment_match.group("body"),
+            section_id=section_id,
+        )
         markdown = (
             output[: comment_match.start()] + output[comment_match.end() :]
         ).strip()
@@ -10236,7 +10364,7 @@ def _infer_primary_readings_used(task: SectionTask, markdown: str) -> list[str]:
 
 
 def parse_section_writer_output(output: str, task: SectionTask) -> SectionArtifact:
-    markdown, metadata = _extract_section_metadata(output)
+    markdown, metadata = _extract_section_metadata(output, section_id=task.section_id)
     if not markdown:
         raise LinearPipelineError(f"Writer returned empty section for {task.section_id}")
 

--- a/tests/test_iterative_section_parse.py
+++ b/tests/test_iterative_section_parse.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from scripts.build import linear_pipeline
+
+
+def _task(section_id: str = "s1", title: str = "Opening") -> linear_pipeline.SectionTask:
+    return linear_pipeline.SectionTask(
+        section_id=section_id,
+        title=title,
+        word_budget=1,
+        points=["Cover the section."],
+        assigned_readings=[],
+        knowledge_slice="",
+        framing_rules="",
+        ledger=linear_pipeline.Ledger(),
+    )
+
+
+def _metadata(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "section_id": "s1",
+        "citations_used": ["cite-1"],
+        "primary_readings_used": ["reading-1"],
+        "vocab_candidates": [
+            {
+                "word": "гаївка",
+                "ipa": "ha-yiv-ka",
+                "pos": "noun",
+                "definition": "Обрядова весняна пісня або хоровод.",
+                "translation": "Easter round dance song",
+                "usage": "Гаївка звучить у колі біля церкви.",
+            }
+        ],
+        "activity_refs": ["act-1"],
+        "self_check": {"grounded": True},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _section_output(markdown: str, metadata_body: str | None = None) -> str:
+    body = metadata_body
+    if body is None:
+        body = json.dumps(_metadata(), ensure_ascii=False, indent=2)
+    return (
+        f"````markdown file=section.md\n{markdown}\n````\n"
+        f"```json file=section_artifact.json\n{body}\n```"
+    )
+
+
+ADVERSARIAL_MARKDOWN = (
+    'Перший абзац містить слова "гай", {обряд}, C:\\спів і «весняний хід».\n'
+    "\n"
+    'Другий абзац не структурований як JSON: {"не": "метадані"}.\n'
+    "\n"
+    "```text\n"
+    'literal { brace } and "quote" plus \\ backslash\n'
+    "```\n"
+    "\n"
+    "> Ой весна, весна, днем красна,\n"
+    "> Що ти нам принесла?"
+)
+
+
+def test_parse_section_writer_output_preserves_adversarial_markdown_verbatim() -> None:
+    artifact = linear_pipeline.parse_section_writer_output(
+        _section_output(ADVERSARIAL_MARKDOWN),
+        _task(),
+    )
+
+    assert artifact.markdown == ADVERSARIAL_MARKDOWN
+    assert artifact.section_id == "s1"
+    assert artifact.citations_used == ["cite-1"]
+    assert artifact.primary_readings_used == ["reading-1"]
+    assert artifact.activity_refs == ["act-1"]
+    assert artifact.self_check == {"grounded": True}
+    assert artifact.vocab_candidates[0]["translation"] == "Easter round dance song"
+    assert artifact.vocab_candidates[0]["usage"] == "Гаївка звучить у колі біля церкви."
+
+
+def test_parse_section_writer_output_handles_hay_quote_pattern() -> None:
+    markdown = (
+        'Назва гаївки походить від слова "гай" — сакрального місця, '
+        "де громада співає весняний приспів."
+    )
+
+    artifact = linear_pipeline.parse_section_writer_output(
+        _section_output(markdown),
+        _task(),
+    )
+
+    assert artifact.markdown == markdown
+    assert 'слова "гай"' in artifact.markdown
+
+
+def test_parse_section_writer_output_recovers_metadata_with_trailing_commas() -> None:
+    metadata_body = """
+{
+  "section_id": "s1",
+  "citations_used": ["cite-1",],
+  "primary_readings_used": [],
+  "vocab_candidates": [],
+  "activity_refs": [],
+  "self_check": {"repair": true},
+}
+""".strip()
+
+    artifact = linear_pipeline.parse_section_writer_output(
+        _section_output("Body with clean markdown.", metadata_body),
+        _task(),
+    )
+
+    assert artifact.markdown == "Body with clean markdown."
+    assert artifact.citations_used == ["cite-1"]
+    assert artifact.self_check == {"repair": True}
+
+
+def test_parse_section_writer_output_rejects_unrecoverable_metadata_with_section() -> None:
+    metadata_body = '{"section_id": "s1", "citations_used": [}'
+
+    with pytest.raises(
+        linear_pipeline.LinearPipelineError,
+        match=r"s1.*section_artifact\.json.*unrecoverable",
+    ):
+        linear_pipeline.parse_section_writer_output(
+            _section_output("Body still must not be dropped.", metadata_body),
+            _task(),
+        )
+
+
+def test_render_section_writer_prompt_requires_separate_markdown_and_json_blocks() -> None:
+    task = _task()
+    prompt = linear_pipeline.render_section_writer_prompt(
+        plan={"content_outline": [{"section": "Opening", "words": 1, "points": []}]},
+        task=task,
+        knowledge_packet="",
+        readings=[],
+    )
+
+    assert "````markdown file=section.md" in prompt
+    assert "```json file=section_artifact.json" in prompt
+    assert "Do NOT put the section prose inside the JSON" in prompt
+    assert '"markdown":' not in prompt


### PR DESCRIPTION
## Summary
- Make the iterative section writer contract emit raw `markdown file=section.md` plus separate `json file=section_artifact.json` metadata.
- Parse markdown as raw fenced text and parse only the small metadata block, with strict JSON first and bounded YAML-compatible repair fallback.
- Add offline adversarial parser tests for quotes, braces, backslashes, guillemets, nested code fences, verse, vocab metadata, recoverable metadata, and unrecoverable metadata errors.

## Root Cause
The previous parser expected markdown prose inside a flow-mapping-style metadata artifact. Unescaped prose characters such as `"`, `{`, `}`, or `\` could break metadata parsing before the section could be assembled.

## Checks
- `.venv/bin/python -m py_compile scripts/build/linear_pipeline.py tests/test_iterative_section_parse.py`
- `.venv/bin/pytest tests/test_iterative_section_parse.py tests/test_iterative_assembly_headings.py tests/test_iterative_vocab_merge.py tests/test_iterative_activity_generation.py -q`
- `.venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_iterative_section_parse.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

No `v7_build.py --writer` or other agy/Claude writer build was run.