### PR TITLE
[codex] Tolerate iterative activity artifact fences

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -10135,50 +10135,106 @@ def render_iterative_activity_prompt(
     return "\n".join(lines).rstrip() + "\n"
 
 
-_ITERATIVE_ACTIVITY_FENCE_RE = re.compile(
-    r"^[ \t]*(?P<run>`{3,})(?P<info>[^\n]*)\n"
-    r"(?P<body>.*?)"
-    r"^[ \t]*(?P=run)[ \t]*$",
-    re.DOTALL | re.MULTILINE,
-)
+_ACTIVITY_ARTIFACT_FENCE_LANGUAGES = {"json", "yaml", "yml"}
 
 
 def _artifact_name_from_fence_info(info: str) -> str | None:
-    for token in info.strip().split()[1:]:
+    for token in info.strip().split():
         value = token.removeprefix("file=")
         if value in WRITER_JSON_ARTIFACTS:
             return value
     return None
 
 
+def _activity_fence_language(info: str) -> str | None:
+    language = _fence_language(info)
+    if language in _ACTIVITY_ARTIFACT_FENCE_LANGUAGES:
+        return language
+    if _artifact_name_from_fence_info(info) == "activities.yaml":
+        return "yaml"
+    return None
+
+
+def _load_iterative_activities_data(raw: str, *, source: str) -> Any:
+    stripped = raw.strip()
+    if not stripped:
+        raise LinearPipelineError(f"Iterative activity writer output {source} is empty")
+    try:
+        return json.loads(stripped, parse_constant=_reject_non_strict_json_constant)
+    except (json.JSONDecodeError, ValueError) as json_exc:
+        try:
+            return yaml.safe_load(stripped)
+        except yaml.YAMLError as yaml_exc:
+            raise LinearPipelineError(
+                f"Iterative activity writer output {source} is unrecoverable: {json_exc}"
+            ) from yaml_exc
+
+
+def _validate_iterative_activities_data(
+    activities: Any, *, source: str
+) -> list[dict[str, Any]]:
+    if activities is None:
+        raise LinearPipelineError(f"Iterative activity writer output {source} is empty")
+    _normalize_writer_json_artifact("activities.yaml", activities)
+    return _validate_activities_artifact(activities)
+
+
+def _parse_iterative_activities_artifact(raw: str, *, source: str) -> list[dict[str, Any]]:
+    return _validate_iterative_activities_data(
+        _load_iterative_activities_data(raw, source=source),
+        source=source,
+    )
+
+
 def parse_iterative_activities_output(output: str) -> list[dict[str, Any]]:
     """Parse and validate the activity-only iterative writer response."""
-    matches = [
-        match
-        for match in _ITERATIVE_ACTIVITY_FENCE_RE.finditer(output)
-        if _artifact_name_from_fence_info(match.group("info")) == "activities.yaml"
+    fenced_blocks = _iter_section_fenced_blocks(output)
+    exact_blocks = [
+        (info, body)
+        for info, body in fenced_blocks
+        if _artifact_name_from_fence_info(info) == "activities.yaml"
+        and _activity_fence_language(info) is not None
     ]
-    if not matches:
-        raise LinearPipelineError(
-            "Iterative activity writer output must contain `json file=activities.yaml`"
-        )
-    if len(matches) > 1:
+    if len(exact_blocks) > 1:
         raise LinearPipelineError(
             "Iterative activity writer output contains duplicate activities.yaml blocks"
         )
-    match = matches[0]
-    info = match.group("info")
-    if _fence_language(info) != "json":
-        got = _fence_language(info) or "<none>"
-        raise LinearPipelineError(f"activities.yaml must be fenced json, got {got}")
-    content_start_line = output[: match.start("body")].count("\n") + 1
-    activities_yaml = _parse_and_dump_writer_json_artifact(
-        "activities.yaml",
-        match.group("body"),
-        content_start_line,
+    if exact_blocks:
+        _info, body = exact_blocks[0]
+        return _parse_iterative_activities_artifact(
+            body,
+            source="activities.yaml fence",
+        )
+
+    language_blocks = [
+        (info, body)
+        for info, body in fenced_blocks
+        if _fence_language(info) in _ACTIVITY_ARTIFACT_FENCE_LANGUAGES
+    ]
+    if language_blocks:
+        info, body = language_blocks[0]
+        return _parse_iterative_activities_artifact(
+            body,
+            source=f"{_fence_language(info)} fence",
+        )
+
+    try:
+        activities = _load_iterative_activities_data(
+            output,
+            source="bare top-level document",
+        )
+    except LinearPipelineError as exc:
+        raise LinearPipelineError(
+            "Iterative activity writer output contains no recoverable activities.yaml artifact"
+        ) from exc
+    if not isinstance(activities, (list, Mapping)):
+        raise LinearPipelineError(
+            "Iterative activity writer output contains no recoverable activities.yaml artifact"
+        )
+    return _validate_iterative_activities_data(
+        activities,
+        source="bare top-level document",
     )
-    activities = yaml.safe_load(activities_yaml)
-    return _validate_activities_artifact(activities)
 
 
 def _section_parse_label(section_id: str | None) -> str:

--- a/tests/test_iterative_activity_generation.py
+++ b/tests/test_iterative_activity_generation.py
@@ -40,18 +40,20 @@ def _plan_with_activity_hints() -> dict[str, Any]:
 def _section_response(section_id: str, title: str) -> str:
     payload = {
         "section_id": section_id,
-        "markdown": f"## {title}\n\nGrounded sentence for {title}.",
         "citations_used": [],
         "primary_readings_used": [],
         "vocab_candidates": [],
         "activity_refs": [],
         "self_check": {},
     }
-    return "```section_artifact.json\n" + json.dumps(payload) + "\n```"
+    return (
+        f"````markdown section.md\nGrounded sentence for {title}.\n````\n"
+        f"```json section_artifact.json\n{json.dumps(payload)}\n```"
+    )
 
 
-def _activities_response() -> str:
-    payload = [
+def _activities_payload() -> list[dict[str, Any]]:
+    return [
         {
             "type": "quiz",
             "title": "Opening Check",
@@ -73,7 +75,58 @@ def _activities_response() -> str:
             "self_check": ["I used one idea from each section."],
         },
     ]
-    return "```json file=activities.yaml\n" + json.dumps(payload) + "\n```"
+def _activities_response(fence: str = "```json file=activities.yaml") -> str:
+    return f"{fence}\n" + json.dumps(_activities_payload()) + "\n```"
+
+
+def test_iterative_activity_parser_accepts_bare_json_fence() -> None:
+    output = _activities_response("```json")
+
+    activities = linear_pipeline.parse_iterative_activities_output(output)
+
+    assert activities[0]["title"] == "Opening Check"
+    assert activities[1]["type"] == "performance"
+
+
+def test_iterative_activity_parser_accepts_yaml_differently_labeled_fence() -> None:
+    output = (
+        "```yaml file=practice.yaml\n"
+        + yaml.safe_dump(_activities_payload(), allow_unicode=True, sort_keys=False)
+        + "```"
+    )
+
+    activities = linear_pipeline.parse_iterative_activities_output(output)
+
+    assert activities[0]["type"] == "quiz"
+    assert activities[1]["self_check"] == ["I used one idea from each section."]
+
+
+def test_iterative_activity_parser_prefers_exact_activities_fence() -> None:
+    output = '```json\n{"note": "not activities"}\n```\n' + _activities_response()
+
+    activities = linear_pipeline.parse_iterative_activities_output(output)
+
+    assert activities[0]["title"] == "Opening Check"
+    assert activities[1]["type"] == "performance"
+
+
+def test_iterative_activity_parser_accepts_bare_top_level_list() -> None:
+    activities = linear_pipeline.parse_iterative_activities_output(
+        json.dumps(_activities_payload())
+    )
+
+    assert activities[0]["title"] == "Opening Check"
+    assert activities[1]["type"] == "performance"
+
+
+def test_iterative_activity_parser_rejects_no_recoverable_artifact() -> None:
+    with pytest.raises(
+        linear_pipeline.LinearPipelineError,
+        match=r"Iterative activity writer output.*activities\.yaml",
+    ):
+        linear_pipeline.parse_iterative_activities_output(
+            "I cannot create activities for this module."
+        )
 
 
 def test_iterative_writer_generates_schema_valid_activities(tmp_path: Path) -> None:
@@ -84,7 +137,7 @@ def test_iterative_writer_generates_schema_valid_activities(tmp_path: Path) -> N
         section = kwargs["sections"][0]
         calls.append(section)
         if section == linear_pipeline.ITERATIVE_ACTIVITY_WRITER_SECTION:
-            return _activities_response()
+            return _activities_response("```json")
         return _section_response(f"s{len(calls)}", section)
 
     result = linear_pipeline.run_iterative_writer(


### PR DESCRIPTION
## Changed
- Reused the iterative section fenced-block scanner for activity-writer output parsing.
- Activity output now prefers an activities.yaml-labeled fence, then falls back to the first json/yaml fence, then a bare top-level document.
- Added offline tests for bare json, yaml/differently-labeled fences, exact-label preference, no-artifact errors, and end-to-end iterative writer stubs without file= labels.

## Why
Agy sometimes omits or varies the exact `json file=activities.yaml` fence label even when the activity artifact is otherwise valid, causing the writer phase to fail after section parsing had already succeeded.

## Checks
- `.venv/bin/python -m py_compile scripts/build/linear_pipeline.py tests/test_iterative_activity_generation.py`
- `.venv/bin/pytest tests/test_iterative_activity_generation.py tests/test_iterative_section_parse.py tests/test_iterative_vocab_merge.py tests/test_iterative_assembly_headings.py`
- `.venv/bin/pytest -q tests/test_iterative_activity_generation.py tests/test_iterative_section_parse.py tests/test_iterative_vocab_merge.py tests/test_iterative_assembly_headings.py`
- `.venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_iterative_activity_generation.py`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

No agy/Claude builds run; offline tests only.