### PR TITLE
fix(atlas): practice hub clean meaning-MC glosses

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 89c1a90989f11ee09ab71765e97ecedeca85533df6d3d61a942cde650826fd3e
+  components_sha256: 0d2057e2e2178041be8169d227c777c22f5f0a4ff9ab1c41d489279088aefacb
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 394516346369d2677b6d485bda663d5d2a7c43d12b4358554023733605fbbb84
+  components_sha256: 89c1a90989f11ee09ab71765e97ecedeca85533df6d3d61a942cde650826fd3e
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -321,12 +321,10 @@ def _is_transliteration_only_gloss(gloss_clean: str, lemma_plain: str) -> bool:
     return bool(romanized) and _ascii_key(gloss_clean) == romanized
 
 
-def _meaning_mc_eligible(gloss: str, gloss_clean: str, lemma_plain: str, pos: str | None) -> bool:
+def _meaning_mc_eligible(gloss_clean: str, lemma_plain: str, pos: str | None) -> bool:
     if not gloss_clean or len(gloss_clean) > MEANING_MC_MAX_CHARS:
         return False
     if _meaning_label_is_phrase(gloss_clean):
-        return False
-    if ";" in gloss or "?" in gloss or "(" in gloss or ")" in gloss:
         return False
     if re.search(r"[.!:]$", gloss_clean):
         return False
@@ -846,7 +844,7 @@ def _build_lexeme(entry: dict[str, Any], verifier: VesumVerifier) -> dict[str, A
     lemma_plain = _plain(lemma)
     pos = _clean_text(entry.get("pos"))
     gloss_clean = _gloss_clean(gloss)
-    meaning_mc_eligible = _meaning_mc_eligible(gloss, gloss_clean, lemma_plain, pos)
+    meaning_mc_eligible = _meaning_mc_eligible(gloss_clean, lemma_plain, pos)
     # Recognition (matching/choice/flashcard) needs only lemma+gloss+level, so the word is
     # ALWAYS kept. Attach the paradigm for flashcard declensions ONLY when every form
     # VESUM-verifies; otherwise blank it so the UI never displays an unverified declension.

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -41,6 +41,8 @@ DEFAULT_GZIP_LIMIT = 140_000
 SCHEMA_VERSION = 1
 CEFR_ORDER = ("A1", "A2", "B1", "B2", "C1", "C2")
 CEFR_RANK = {level: index for index, level in enumerate(CEFR_ORDER)}
+MEANING_MC_MAX_WORDS = 4
+MEANING_MC_MAX_CHARS = 32
 NUMBER_KEYS = ("singular", "plural")
 NO_PAIR_PROBABILITY = {
     "A1": 0.70,
@@ -209,6 +211,130 @@ def _plain(value: str) -> str:
 def _headword(gloss: str) -> str:
     head = gloss.split(";")[0].split(",")[0].strip().casefold()
     return head.split()[0] if head.split() else head
+
+
+_FUNCTION_POS = frozenset(
+    {
+        "adp",
+        "conj",
+        "conjunction",
+        "det",
+        "determiner",
+        "interj",
+        "interjection",
+        "particle",
+        "prep",
+        "preposition",
+        "pron",
+        "pronoun",
+        "sconj",
+    }
+)
+_FUNCTION_GLOSS_HEADWORDS = frozenset(
+    {
+        "and",
+        "because",
+        "but",
+        "if",
+        "nor",
+        "or",
+        "than",
+        "that",
+        "though",
+        "unless",
+        "until",
+        "when",
+        "where",
+        "whether",
+        "while",
+        "yet",
+    }
+)
+_UKRAINIAN_ROMANIZATION = {
+    "а": "a",
+    "б": "b",
+    "в": "v",
+    "г": "h",
+    "ґ": "g",
+    "д": "d",
+    "е": "e",
+    "є": "ie",
+    "ж": "zh",
+    "з": "z",
+    "и": "y",
+    "і": "i",
+    "ї": "i",
+    "й": "i",
+    "к": "k",
+    "л": "l",
+    "м": "m",
+    "н": "n",
+    "о": "o",
+    "п": "p",
+    "р": "r",
+    "с": "s",
+    "т": "t",
+    "у": "u",
+    "ф": "f",
+    "х": "kh",
+    "ц": "ts",
+    "ч": "ch",
+    "ш": "sh",
+    "щ": "shch",
+    "ь": "",
+    "ю": "iu",
+    "я": "ia",
+    "'": "",
+}
+
+
+def _gloss_clean(gloss: str) -> str:
+    first_sense = re.split(r"[;,]", gloss, maxsplit=1)[0]
+    return re.sub(r"\s+", " ", first_sense).strip()
+
+
+def _meaning_label_word_count(label: str) -> int:
+    return len(re.findall(r"[^\W_]+(?:[-'][^\W_]+)?", label, flags=re.UNICODE))
+
+
+def _meaning_label_is_phrase(label: str) -> bool:
+    clean = re.sub(r"\s+", " ", label).strip()
+    return (
+        not clean
+        or "?" in clean
+        or "(" in clean
+        or ")" in clean
+        or _meaning_label_word_count(clean) > MEANING_MC_MAX_WORDS
+    )
+
+
+def _romanize_ukrainian_plain(value: str) -> str:
+    return "".join(_UKRAINIAN_ROMANIZATION.get(char, char) for char in value.casefold())
+
+
+def _ascii_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.casefold())
+
+
+def _is_transliteration_only_gloss(gloss_clean: str, lemma_plain: str) -> bool:
+    romanized = _ascii_key(_romanize_ukrainian_plain(lemma_plain))
+    return bool(romanized) and _ascii_key(gloss_clean) == romanized
+
+
+def _meaning_mc_eligible(gloss: str, gloss_clean: str, lemma_plain: str, pos: str | None) -> bool:
+    if not gloss_clean or len(gloss_clean) > MEANING_MC_MAX_CHARS:
+        return False
+    if _meaning_label_is_phrase(gloss_clean):
+        return False
+    if ";" in gloss or "?" in gloss or "(" in gloss or ")" in gloss:
+        return False
+    if re.search(r"[.!:]$", gloss_clean):
+        return False
+    if _headword(gloss_clean) in _FUNCTION_GLOSS_HEADWORDS:
+        return False
+    if pos and pos.casefold() in _FUNCTION_POS:
+        return False
+    return not _is_transliteration_only_gloss(gloss_clean, lemma_plain)
 
 
 def _stable_lemma_id(entry: dict[str, Any]) -> str:
@@ -643,6 +769,8 @@ def validate_option_set(cloze: dict[str, Any]) -> list[str]:
     if not isinstance(options, list) or len(options) < 4:
         return ["option set must contain at least four options"]
     labels = [str(option.get("label") or "") for option in options if isinstance(option, dict)]
+    if any(_meaning_label_is_phrase(label) for label in labels):
+        errors.append("option labels must not be phrase glosses")
     normalized = [_plain(label) for label in labels]
     if len(set(normalized)) != len(normalized):
         errors.append("option labels must be unique after normalization")
@@ -717,6 +845,8 @@ def _build_lexeme(entry: dict[str, Any], verifier: VesumVerifier) -> dict[str, A
         return None
     lemma_plain = _plain(lemma)
     pos = _clean_text(entry.get("pos"))
+    gloss_clean = _gloss_clean(gloss)
+    meaning_mc_eligible = _meaning_mc_eligible(gloss, gloss_clean, lemma_plain, pos)
     # Recognition (matching/choice/flashcard) needs only lemma+gloss+level, so the word is
     # ALWAYS kept. Attach the paradigm for flashcard declensions ONLY when every form
     # VESUM-verifies; otherwise blank it so the UI never displays an unverified declension.
@@ -729,6 +859,8 @@ def _build_lexeme(entry: dict[str, Any], verifier: VesumVerifier) -> dict[str, A
         "lemmaPlain": lemma_plain,
         "ipa": _ipa(entry),
         "gloss": gloss,
+        "glossClean": gloss_clean,
+        "meaningMcEligible": meaning_mc_eligible,
         "pos": pos,
         "cefr": level,
         "heritage": _heritage(entry),
@@ -951,7 +1083,9 @@ def build_practice_shards(
         index_items = []
         for order, lexeme in enumerate(level_lexemes):
             cloze_ids = cloze_ids_by_lemma.get(lexeme["lemmaId"], [])
-            modes = ["flashcards", "matching", "choice"]
+            modes = ["flashcards"]
+            if lexeme.get("meaningMcEligible"):
+                modes.extend(["matching", "choice"])
             if cloze_ids:
                 modes.append("cloze")
             index_items.append(

--- a/site/public/lexicon/practice-index.A1.json
+++ b/site/public/lexicon/practice-index.A1.json
@@ -14,9 +14,7 @@
       "lemma": "борщ",
       "lemmaId": "борщ",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 0
     },
@@ -27,9 +25,7 @@
       "lemma": "готель",
       "lemmaId": "готель",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 1
     },
@@ -144,9 +140,7 @@
       "lemma": "фільм",
       "lemmaId": "фільм",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 10
     },
@@ -209,9 +203,7 @@
       "lemma": "банк",
       "lemmaId": "банк",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 15
     },
@@ -352,9 +344,7 @@
       "lemma": "метро",
       "lemmaId": "метро",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 26
     },
@@ -430,9 +420,7 @@
       "lemma": "парк",
       "lemmaId": "парк",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 32
     },
@@ -547,9 +535,7 @@
       "lemma": "супермаркет",
       "lemmaId": "супермаркет",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 41
     },
@@ -677,9 +663,7 @@
       "lemma": "гривня",
       "lemmaId": "гривня",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 51
     },
@@ -690,9 +674,7 @@
       "lemma": "До побачення!",
       "lemmaId": "до-побачення",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 52
     },
@@ -872,9 +854,7 @@
       "lemma": "де",
       "lemmaId": "де",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 66
     },
@@ -911,9 +891,7 @@
       "lemma": "коли",
       "lemmaId": "коли",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 69
     },
@@ -924,9 +902,7 @@
       "lemma": "куди",
       "lemmaId": "куди",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 70
     },
@@ -1236,9 +1212,7 @@
       "lemma": "З Днем Незалежності України",
       "lemmaId": "з-днем-незалежності-україни",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 94
     },
@@ -1275,9 +1249,7 @@
       "lemma": "маркер",
       "lemmaId": "маркер",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 97
     },
@@ -1288,9 +1260,7 @@
       "lemma": "Марія",
       "lemmaId": "марія",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 98
     },
@@ -1327,9 +1297,7 @@
       "lemma": "Олена",
       "lemmaId": "олена",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 101
     },
@@ -1366,9 +1334,7 @@
       "lemma": "Тарас",
       "lemmaId": "тарас",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 104
     },
@@ -1392,9 +1358,7 @@
       "lemma": "Дуже приємно",
       "lemmaId": "дуже-приємно",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 106
     },
@@ -1405,9 +1369,7 @@
       "lemma": "Звідки ти?",
       "lemmaId": "звідки-ти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 107
     },
@@ -1418,9 +1380,7 @@
       "lemma": "його",
       "lemmaId": "його",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 108
     },
@@ -1457,9 +1417,7 @@
       "lemma": "Мені 20 років",
       "lemmaId": "мені-20-років",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 111
     },
@@ -1483,9 +1441,7 @@
       "lemma": "мій",
       "lemmaId": "мій",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 113
     },
@@ -1613,9 +1569,7 @@
       "lemma": "У тебе є",
       "lemmaId": "у-тебе-є",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 123
     },
@@ -1639,9 +1593,7 @@
       "lemma": "Як тебе звати?",
       "lemmaId": "як-тебе-звати",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 125
     },
@@ -1678,9 +1630,7 @@
       "lemma": "її",
       "lemmaId": "її",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 128
     },
@@ -1847,9 +1797,7 @@
       "lemma": "Можна карткою?",
       "lemmaId": "можна-карткою",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 141
     },
@@ -1990,9 +1938,7 @@
       "lemma": "скільки коштують",
       "lemmaId": "скільки-коштують",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 152
     },
@@ -2003,9 +1949,7 @@
       "lemma": "скільки коштує",
       "lemmaId": "скільки-коштує",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 153
     },
@@ -2367,9 +2311,7 @@
       "lemma": "вишиванка",
       "lemmaId": "вишиванка",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 181
     },
@@ -2588,9 +2530,7 @@
       "lemma": "те",
       "lemmaId": "те",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 198
     },
@@ -2601,9 +2541,7 @@
       "lemma": "той",
       "lemmaId": "той",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 199
     },
@@ -2627,9 +2565,7 @@
       "lemma": "це",
       "lemmaId": "це",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 201
     },
@@ -2640,9 +2576,7 @@
       "lemma": "цей",
       "lemmaId": "цей",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 202
     },
@@ -2692,9 +2626,7 @@
       "lemma": "в",
       "lemmaId": "в",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 206
     },
@@ -2718,9 +2650,7 @@
       "lemma": "з",
       "lemmaId": "з",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 208
     },
@@ -2731,9 +2661,7 @@
       "lemma": "звідки",
       "lemmaId": "звідки",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 209
     },
@@ -2744,9 +2672,7 @@
       "lemma": "зі",
       "lemmaId": "зі",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 210
     },
@@ -2757,9 +2683,7 @@
       "lemma": "Київ",
       "lemmaId": "київ",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 211
     },
@@ -2770,9 +2694,7 @@
       "lemma": "Львів",
       "lemmaId": "львів",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 212
     },
@@ -2783,9 +2705,7 @@
       "lemma": "на",
       "lemmaId": "на",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 213
     },
@@ -2796,9 +2716,7 @@
       "lemma": "Одеса",
       "lemmaId": "одеса",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 214
     },
@@ -2848,9 +2766,7 @@
       "lemma": "у",
       "lemmaId": "у",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 218
     },
@@ -2874,9 +2790,7 @@
       "lemma": "Харків",
       "lemmaId": "харків",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 220
     },
@@ -2887,9 +2801,7 @@
       "lemma": "із",
       "lemmaId": "із",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 221
     },
@@ -2991,9 +2903,7 @@
       "lemma": "Котра година?",
       "lemmaId": "котра-година",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 229
     },
@@ -3043,9 +2953,7 @@
       "lemma": "О котрій?",
       "lemmaId": "о-котрій",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 233
     },
@@ -3186,9 +3094,7 @@
       "lemma": "ходити в кіно",
       "lemmaId": "ходити-в-кіно",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 244
     },
@@ -3199,9 +3105,7 @@
       "lemma": "ходити в музей",
       "lemmaId": "ходити-в-музей",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 245
     },
@@ -3264,9 +3168,7 @@
       "lemma": "якщо буде дощ",
       "lemmaId": "якщо-буде-дощ",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 250
     },
@@ -3407,9 +3309,7 @@
       "lemma": "якого кольору?",
       "lemmaId": "якого-кольору",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 261
     },
@@ -4096,9 +3996,7 @@
       "lemma": "якого числа?",
       "lemmaId": "якого-числа",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 314
     },
@@ -4148,9 +4046,7 @@
       "lemma": "біля",
       "lemmaId": "біля",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 318
     },
@@ -4252,9 +4148,7 @@
       "lemma": "Максим",
       "lemmaId": "максим",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 326
     },
@@ -4291,9 +4185,7 @@
       "lemma": "я",
       "lemmaId": "я",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 329
     },
@@ -4304,9 +4196,7 @@
       "lemma": "Іван",
       "lemmaId": "іван",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 330
     },
@@ -4889,9 +4779,7 @@
       "lemma": "спорт",
       "lemmaId": "спорт",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 375
     },
@@ -4980,9 +4868,7 @@
       "lemma": "ходити в театр",
       "lemmaId": "ходити-в-театр",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 382
     },
@@ -4993,9 +4879,7 @@
       "lemma": "ходити на концерт",
       "lemmaId": "ходити-на-концерт",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 383
     },
@@ -5006,9 +4890,7 @@
       "lemma": "як часто?",
       "lemmaId": "як-часто",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 384
     },
@@ -5227,9 +5109,7 @@
       "lemma": "Андрій",
       "lemmaId": "андрій",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 401
     },
@@ -5279,9 +5159,7 @@
       "lemma": "Надія",
       "lemmaId": "надія",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 405
     },
@@ -5292,9 +5170,7 @@
       "lemma": "пан",
       "lemmaId": "пан",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 406
     },
@@ -5305,9 +5181,7 @@
       "lemma": "пані",
       "lemmaId": "пані",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 407
     },
@@ -5331,9 +5205,7 @@
       "lemma": "Сергій",
       "lemmaId": "сергій",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 409
     },
@@ -5539,9 +5411,7 @@
       "lemma": "Щедрий вечір",
       "lemmaId": "щедрий-вечір",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 425
     },
@@ -5552,9 +5422,7 @@
       "lemma": "ви",
       "lemmaId": "ви",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 426
     },
@@ -5565,9 +5433,7 @@
       "lemma": "вона",
       "lemmaId": "вона",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 427
     },
@@ -5825,9 +5691,7 @@
       "lemma": "ти",
       "lemmaId": "ти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 447
     },
@@ -6046,9 +5910,7 @@
       "lemma": "а",
       "lemmaId": "а",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 464
     },
@@ -6059,9 +5921,7 @@
       "lemma": "або",
       "lemmaId": "або",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 465
     },
@@ -6137,9 +5997,7 @@
       "lemma": "зате",
       "lemmaId": "зате",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 471
     },
@@ -6150,9 +6008,7 @@
       "lemma": "й",
       "lemmaId": "й",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 472
     },
@@ -6254,9 +6110,7 @@
       "lemma": "тому що",
       "lemmaId": "тому-що",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 480
     },
@@ -6267,9 +6121,7 @@
       "lemma": "чи",
       "lemmaId": "чи",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 481
     },
@@ -6280,9 +6132,7 @@
       "lemma": "якщо",
       "lemmaId": "якщо",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 482
     },
@@ -6293,9 +6143,7 @@
       "lemma": "і",
       "lemmaId": "і",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 483
     },
@@ -6319,9 +6167,7 @@
       "lemma": "який",
       "lemmaId": "який",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 485
     },
@@ -6358,9 +6204,7 @@
       "lemma": "поруч із",
       "lemmaId": "поруч-із",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 488
     },
@@ -6514,9 +6358,7 @@
       "lemma": "О котрій годині?",
       "lemmaId": "о-котрій-годині",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 500
     },
@@ -6774,9 +6616,7 @@
       "lemma": "твій",
       "lemmaId": "твій",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 520
     },
@@ -6995,9 +6835,7 @@
       "lemma": "план",
       "lemmaId": "план",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 537
     },
@@ -7008,9 +6846,7 @@
       "lemma": "жила",
       "lemmaId": "жила",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 538
     },
@@ -7073,9 +6909,7 @@
       "lemma": "вони",
       "lemmaId": "вони",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 543
     },
@@ -7112,9 +6946,7 @@
       "lemma": "ми",
       "lemmaId": "ми",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 546
     },
@@ -7229,9 +7061,7 @@
       "lemma": "не",
       "lemmaId": "не",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 555
     },
@@ -7242,9 +7072,7 @@
       "lemma": "ні",
       "lemmaId": "ні",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 556
     },
@@ -7450,9 +7278,7 @@
       "lemma": "А тебе́?",
       "lemmaId": "а-тебе",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 572
     },
@@ -7463,9 +7289,7 @@
       "lemma": "А у тебе́?",
       "lemmaId": "а-у-тебе",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 573
     },
@@ -7541,9 +7365,7 @@
       "lemma": "Ра́да тебе́ ба́чити",
       "lemmaId": "ра-да-тебе-ба-чити",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 579
     },
@@ -7554,9 +7376,7 @@
       "lemma": "Ра́дий тебе́ ба́чити",
       "lemmaId": "ра-дий-тебе-ба-чити",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 580
     },
@@ -7580,9 +7400,7 @@
       "lemma": "Як спра́ви?",
       "lemmaId": "як-спра-ви",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 582
     },
@@ -7723,9 +7541,7 @@
       "lemma": "воно",
       "lemmaId": "воно",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 593
     },
@@ -7736,9 +7552,7 @@
       "lemma": "він",
       "lemmaId": "він",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 594
     },
@@ -7775,9 +7589,7 @@
       "lemma": "Микола",
       "lemmaId": "микола",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 597
     },
@@ -7788,9 +7600,7 @@
       "lemma": "Павло",
       "lemmaId": "павло",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 598
     },
@@ -7879,9 +7689,7 @@
       "lemma": "хто це?",
       "lemmaId": "хто-це",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 605
     },
@@ -7892,9 +7700,7 @@
       "lemma": "що це?",
       "lemmaId": "що-це",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 606
     },
@@ -7905,9 +7711,7 @@
       "lemma": "ось",
       "lemmaId": "ось",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 607
     },
@@ -7918,9 +7722,7 @@
       "lemma": "ото",
       "lemmaId": "ото",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 608
     },
@@ -7931,9 +7733,7 @@
       "lemma": "оце",
       "lemmaId": "оце",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 609
     },
@@ -8048,9 +7848,7 @@
       "lemma": "транспорт",
       "lemmaId": "транспорт",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 618
     },
@@ -8152,9 +7950,7 @@
       "lemma": "бачите",
       "lemmaId": "бачите",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 626
     },
@@ -8386,9 +8182,7 @@
       "lemma": "Мені подобається...",
       "lemmaId": "мені-подобається",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 644
     },
@@ -8399,9 +8193,7 @@
       "lemma": "Мені холодно.",
       "lemmaId": "мені-холодно",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 645
     },
@@ -8412,9 +8204,7 @@
       "lemma": "мінус",
       "lemmaId": "мінус",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 646
     },
@@ -8672,9 +8462,7 @@
       "lemma": "котрий",
       "lemmaId": "котрий",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 666
     },
@@ -8984,9 +8772,7 @@
       "lemma": "Дніпро",
       "lemmaId": "дніпро",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 690
     },
@@ -9153,9 +8939,7 @@
       "lemma": "а вас?",
       "lemmaId": "а-вас",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 703
     },
@@ -9166,9 +8950,7 @@
       "lemma": "дякую",
       "lemmaId": "дякую",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 704
     },
@@ -9218,9 +9000,7 @@
       "lemma": "як вас звати?",
       "lemmaId": "як-вас-звати",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 708
     },
@@ -9855,9 +9635,7 @@
       "lemma": "подарувати",
       "lemmaId": "подарувати",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 757
     },
@@ -9972,9 +9750,7 @@
       "lemma": "за",
       "lemmaId": "за",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 766
     },
@@ -9998,9 +9774,7 @@
       "lemma": "ніж",
       "lemmaId": "ніж",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 768
     },
@@ -10011,9 +9785,7 @@
       "lemma": "наш",
       "lemmaId": "наш",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 769
     },
@@ -10024,9 +9796,7 @@
       "lemma": "цьому",
       "lemmaId": "цьому",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 770
     },
@@ -10726,9 +10496,7 @@
       "lemma": "ваш",
       "lemmaId": "ваш",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 824
     },
@@ -10908,9 +10676,7 @@
       "lemma": "радіо",
       "lemmaId": "радіо",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 838
     },
@@ -11506,9 +11272,7 @@
       "lemma": "від",
       "lemmaId": "від",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 884
     },
@@ -12013,9 +11777,7 @@
       "lemma": "б",
       "lemmaId": "б",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 923
     },
@@ -12026,9 +11788,7 @@
       "lemma": "би",
       "lemmaId": "би",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 924
     },
@@ -12117,9 +11877,7 @@
       "lemma": "попри",
       "lemmaId": "попри",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 931
     },
@@ -12130,9 +11888,7 @@
       "lemma": "задля",
       "lemmaId": "задля",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 932
     },
@@ -12143,9 +11899,7 @@
       "lemma": "оскільки",
       "lemmaId": "оскільки",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 933
     },
@@ -12299,9 +12053,7 @@
       "lemma": "дарувати",
       "lemmaId": "дарувати",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 945
     },
@@ -12390,9 +12142,7 @@
       "lemma": "внаслідок",
       "lemmaId": "внаслідок",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 952
     },
@@ -12559,9 +12309,7 @@
       "lemma": "інтернет",
       "lemmaId": "інтернет",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 965
     },
@@ -12702,9 +12450,7 @@
       "lemma": "плавати",
       "lemmaId": "плавати",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 976
     },
@@ -12780,9 +12526,7 @@
       "lemma": "вивести",
       "lemmaId": "вивести",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 982
     },
@@ -12858,9 +12602,7 @@
       "lemma": "через",
       "lemmaId": "через",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 988
     },
@@ -13183,9 +12925,7 @@
       "lemma": "Суми",
       "lemmaId": "суми",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 1013
     },
@@ -13235,9 +12975,7 @@
       "lemma": "для",
       "lemmaId": "для",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 1017
     },
@@ -13261,9 +12999,7 @@
       "lemma": "поміж",
       "lemmaId": "поміж",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 1019
     },
@@ -13274,9 +13010,7 @@
       "lemma": "посеред",
       "lemmaId": "посеред",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 1020
     },
@@ -13287,9 +13021,7 @@
       "lemma": "впродовж",
       "lemmaId": "впродовж",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 1021
     },
@@ -13313,9 +13045,7 @@
       "lemma": "до",
       "lemmaId": "до",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 1023
     },
@@ -13326,9 +13056,7 @@
       "lemma": "о",
       "lemmaId": "о",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 1024
     },
@@ -13339,9 +13067,7 @@
       "lemma": "об",
       "lemmaId": "об",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 1025
     },
@@ -13365,9 +13091,7 @@
       "lemma": "упродовж",
       "lemmaId": "упродовж",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 1027
     },
@@ -13950,9 +13674,7 @@
       "lemma": "Закарпаття",
       "lemmaId": "закарпаття",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 1072
     },
@@ -13963,9 +13685,7 @@
       "lemma": "Прикарпаття",
       "lemmaId": "прикарпаття",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 1073
     },
@@ -14039,10 +13759,10 @@
   "schema": "atlas-practice-index",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 16386,
+    "gzipBytes": 16619,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 277812,
+    "rawBytes": 272492,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/public/lexicon/practice-index.A2.json
+++ b/site/public/lexicon/practice-index.A2.json
@@ -482,9 +482,7 @@
       "lemma": "сало",
       "lemmaId": "сало",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 36
     },
@@ -495,9 +493,7 @@
       "lemma": "сусіда",
       "lemmaId": "сусіда",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 37
     },
@@ -534,9 +530,7 @@
       "lemma": "намисто",
       "lemmaId": "намисто",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 40
     },
@@ -898,9 +892,7 @@
       "lemma": "кефір",
       "lemmaId": "кефір",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 68
     },
@@ -1119,9 +1111,7 @@
       "lemma": "тату",
       "lemmaId": "тату",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 85
     },
@@ -1301,9 +1291,7 @@
       "lemma": "щоб",
       "lemmaId": "щоб",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 99
     },
@@ -1379,9 +1367,7 @@
       "lemma": "після",
       "lemmaId": "після",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 105
     },
@@ -1496,9 +1482,7 @@
       "lemma": "зустрітися",
       "lemmaId": "зустрітися",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 114
     },
@@ -1821,9 +1805,7 @@
       "lemma": "Мар'я́на",
       "lemmaId": "мар-я-на",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 139
     },
@@ -1886,9 +1868,7 @@
       "lemma": "Ілля",
       "lemmaId": "ілля",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 144
     },
@@ -1912,9 +1892,7 @@
       "lemma": "отой",
       "lemmaId": "отой",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 146
     },
@@ -1925,9 +1903,7 @@
       "lemma": "оцей",
       "lemmaId": "оцей",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 147
     },
@@ -2029,9 +2005,7 @@
       "lemma": "говорите",
       "lemmaId": "говорите",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 155
     },
@@ -2055,9 +2029,7 @@
       "lemma": "робите",
       "lemmaId": "робите",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 157
     },
@@ -2380,9 +2352,7 @@
       "lemma": "Хрещатик",
       "lemmaId": "хрещатик",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 182
     },
@@ -2406,9 +2376,7 @@
       "lemma": "спасибі",
       "lemmaId": "спасибі",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 184
     },
@@ -3004,9 +2972,7 @@
       "lemma": "адміністратор",
       "lemmaId": "адміністратор",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 230
     },
@@ -4369,9 +4335,7 @@
       "lemma": "матеріал",
       "lemmaId": "матеріал",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 335
     },
@@ -4538,9 +4502,7 @@
       "lemma": "хай",
       "lemmaId": "хай",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 348
     },
@@ -4564,9 +4526,7 @@
       "lemma": "будь-хто",
       "lemmaId": "будь-хто",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 350
     },
@@ -4577,9 +4537,7 @@
       "lemma": "будь-що",
       "lemmaId": "будь-що",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 351
     },
@@ -4655,9 +4613,7 @@
       "lemma": "хтось",
       "lemmaId": "хтось",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 357
     },
@@ -4668,9 +4624,7 @@
       "lemma": "щось",
       "lemmaId": "щось",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 358
     },
@@ -4798,9 +4752,7 @@
       "lemma": "між",
       "lemmaId": "між",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 368
     },
@@ -4811,9 +4763,7 @@
       "lemma": "над",
       "lemmaId": "над",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 369
     },
@@ -4824,9 +4774,7 @@
       "lemma": "під",
       "lemmaId": "під",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 370
     },
@@ -6020,9 +5968,7 @@
       "lemma": "то",
       "lemmaId": "то",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 462
     },
@@ -6267,9 +6213,7 @@
       "lemma": "себе",
       "lemmaId": "себе",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 481
     },
@@ -6384,9 +6328,7 @@
       "lemma": "складати / скласти іспит",
       "lemmaId": "складати-скласти-іспит",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 490
     },
@@ -6423,9 +6365,7 @@
       "lemma": "поїхати / їздити",
       "lemmaId": "поїхати-їздити",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 493
     },
@@ -6449,9 +6389,7 @@
       "lemma": "ходити по місту",
       "lemmaId": "ходити-по-місту",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 495
     },
@@ -6514,9 +6452,7 @@
       "lemma": "винести наперед",
       "lemmaId": "винести-наперед",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 500
     },
@@ -6540,9 +6476,7 @@
       "lemma": "не..., а...",
       "lemmaId": "не-а",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 502
     },
@@ -6865,9 +6799,7 @@
       "lemma": "дочекатися",
       "lemmaId": "дочекатися",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 527
     },
@@ -6904,9 +6836,7 @@
       "lemma": "попрацювати",
       "lemmaId": "попрацювати",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 530
     },
@@ -7034,9 +6964,7 @@
       "lemma": "відкривати",
       "lemmaId": "відкривати",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 540
     },
@@ -7047,9 +6975,7 @@
       "lemma": "відчинити",
       "lemmaId": "відчинити",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 541
     },
@@ -7957,9 +7883,7 @@
       "lemma": "всупереч",
       "lemmaId": "всупереч",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 611
     },
@@ -7970,9 +7894,7 @@
       "lemma": "дебати",
       "lemmaId": "дебати",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 612
     },
@@ -8282,9 +8204,7 @@
       "lemma": "семінар",
       "lemmaId": "семінар",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 636
     },
@@ -8321,9 +8241,7 @@
       "lemma": "з-поміж",
       "lemmaId": "з-поміж",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 639
     },
@@ -8373,9 +8291,7 @@
       "lemma": "говорячи",
       "lemmaId": "говорячи",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 643
     },
@@ -8386,9 +8302,7 @@
       "lemma": "працюючи",
       "lemmaId": "працюючи",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 644
     },
@@ -8399,9 +8313,7 @@
       "lemma": "слухаючи",
       "lemmaId": "слухаючи",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 645
     },
@@ -8529,9 +8441,7 @@
       "lemma": "симптом",
       "lemmaId": "симптом",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 655
     },
@@ -8932,9 +8842,7 @@
       "lemma": "бігти",
       "lemmaId": "бігти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 686
     },
@@ -8945,9 +8853,7 @@
       "lemma": "нести",
       "lemmaId": "нести",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 687
     },
@@ -8958,9 +8864,7 @@
       "lemma": "пливти",
       "lemmaId": "пливти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 688
     },
@@ -8984,9 +8888,7 @@
       "lemma": "їздити",
       "lemmaId": "їздити",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 690
     },
@@ -9049,9 +8951,7 @@
       "lemma": "термінал",
       "lemmaId": "термінал",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 695
     },
@@ -9075,9 +8975,7 @@
       "lemma": "донести",
       "lemmaId": "донести",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 697
     },
@@ -9101,9 +8999,7 @@
       "lemma": "приходити",
       "lemmaId": "приходити",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 699
     },
@@ -9114,9 +9010,7 @@
       "lemma": "приїжджати",
       "lemmaId": "приїжджати",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 700
     },
@@ -9179,9 +9073,7 @@
       "lemma": "поїду",
       "lemmaId": "поїду",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 705
     },
@@ -9231,9 +9123,7 @@
       "lemma": "виносити",
       "lemmaId": "виносити",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 709
     },
@@ -9244,9 +9134,7 @@
       "lemma": "завести",
       "lemmaId": "завести",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 710
     },
@@ -9374,9 +9262,7 @@
       "lemma": "по",
       "lemmaId": "по",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 720
     },
@@ -10180,9 +10066,7 @@
       "lemma": "Черкаси",
       "lemmaId": "черкаси",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 782
     },
@@ -10193,9 +10077,7 @@
       "lemma": "Чернівці",
       "lemmaId": "чернівці",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 783
     },
@@ -10245,9 +10127,7 @@
       "lemma": "унаслідок",
       "lemmaId": "унаслідок",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 787
     },
@@ -10258,9 +10138,7 @@
       "lemma": "коло",
       "lemmaId": "коло",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 788
     },
@@ -10297,9 +10175,7 @@
       "lemma": "попід",
       "lemmaId": "попід",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 791
     },
@@ -11350,9 +11226,7 @@
       "lemma": "привласнення",
       "lemmaId": "привласнення",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 872
     },
@@ -11363,9 +11237,7 @@
       "lemma": "реконструкція",
       "lemmaId": "реконструкція",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 873
     },
@@ -11389,9 +11261,7 @@
       "lemma": "ідентичність",
       "lemmaId": "ідентичність",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 875
     },
@@ -11402,9 +11272,7 @@
       "lemma": "бандура",
       "lemmaId": "бандура",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 876
     },
@@ -11480,9 +11348,7 @@
       "lemma": "перенесення",
       "lemmaId": "перенесення",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 882
     }
@@ -11491,10 +11357,10 @@
   "schema": "atlas-practice-index",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 13641,
+    "gzipBytes": 13780,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 230571,
+    "rawBytes": 228025,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/public/lexicon/practice-index.B1.json
+++ b/site/public/lexicon/practice-index.B1.json
@@ -3,7 +3,7 @@
     "cloze": 0,
     "clozeCoverage": 0.0,
     "clozeEligibleLexemes": 0,
-    "lexemes": 1315
+    "lexemes": 1119
   },
   "deckVersion": "atlas-practice-v1-622fc3d93d1ad580",
   "items": [
@@ -14,9 +14,7 @@
       "lemma": "Лавра",
       "lemmaId": "лавра",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 0
     },
@@ -131,9 +129,7 @@
       "lemma": "пишете",
       "lemmaId": "пишете",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 9
     },
@@ -144,9 +140,7 @@
       "lemma": "працюєте",
       "lemmaId": "працюєте",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 10
     },
@@ -261,9 +255,7 @@
       "lemma": "глечик",
       "lemmaId": "глечик",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 19
     },
@@ -274,9 +266,7 @@
       "lemma": "писанки",
       "lemmaId": "писанки",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 20
     },
@@ -287,9 +277,7 @@
       "lemma": "та",
       "lemmaId": "та",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 21
     },
@@ -326,9 +314,7 @@
       "lemma": "навпроти",
       "lemmaId": "навпроти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 24
     },
@@ -365,9 +351,7 @@
       "lemma": "гей",
       "lemmaId": "гей",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 27
     },
@@ -469,9 +453,7 @@
       "lemma": "маслом",
       "lemmaId": "маслом",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 35
     },
@@ -508,9 +490,7 @@
       "lemma": "але",
       "lemmaId": "але",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 38
     },
@@ -534,9 +514,7 @@
       "lemma": "поки",
       "lemmaId": "поки",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 40
     },
@@ -560,9 +538,7 @@
       "lemma": "проте",
       "lemmaId": "проте",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 42
     },
@@ -638,9 +614,7 @@
       "lemma": "допізна",
       "lemmaId": "допізна",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 48
     },
@@ -1132,9 +1106,7 @@
       "lemma": "пробачте",
       "lemmaId": "пробачте",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 86
     },
@@ -1210,9 +1182,7 @@
       "lemma": "вітаємо",
       "lemmaId": "вітаємо",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 92
     },
@@ -2276,9 +2246,7 @@
       "lemma": "нехай",
       "lemmaId": "нехай",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 174
     },
@@ -2328,9 +2296,7 @@
       "lemma": "дехто",
       "lemmaId": "дехто",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 178
     },
@@ -2341,9 +2307,7 @@
       "lemma": "дещо",
       "lemmaId": "дещо",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 179
     },
@@ -2354,9 +2318,7 @@
       "lemma": "деякий",
       "lemmaId": "деякий",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 180
     },
@@ -2367,9 +2329,7 @@
       "lemma": "ніякий",
       "lemmaId": "ніякий",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 181
     },
@@ -2380,9 +2340,7 @@
       "lemma": "хто-небудь",
       "lemmaId": "хто-небудь",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 182
     },
@@ -2393,9 +2351,7 @@
       "lemma": "чийсь",
       "lemmaId": "чийсь",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 183
     },
@@ -2406,9 +2362,7 @@
       "lemma": "що-небудь",
       "lemmaId": "що-небудь",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 184
     },
@@ -2445,9 +2399,7 @@
       "lemma": "перед",
       "lemmaId": "перед",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 187
     },
@@ -2822,9 +2774,7 @@
       "lemma": "кутя",
       "lemmaId": "кутя",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 216
     },
@@ -2900,9 +2850,7 @@
       "lemma": "чим",
       "lemmaId": "чим",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 222
     },
@@ -2913,9 +2861,7 @@
       "lemma": "адже",
       "lemmaId": "адже",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 223
     },
@@ -3121,9 +3067,7 @@
       "lemma": "якби",
       "lemmaId": "якби",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 239
     },
@@ -3277,9 +3221,7 @@
       "lemma": "свій",
       "lemmaId": "свій",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 251
     },
@@ -3290,9 +3232,7 @@
       "lemma": "собі",
       "lemmaId": "собі",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 252
     },
@@ -3810,9 +3750,7 @@
       "lemma": "чим... тим...",
       "lemmaId": "чим-тим",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 292
     },
@@ -4551,9 +4489,7 @@
       "lemma": "суфікс -м",
       "lemmaId": "суфікс-м",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 349
     },
@@ -4733,9 +4669,7 @@
       "lemma": "відчиняти",
       "lemmaId": "відчиняти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 363
     },
@@ -5383,9 +5317,7 @@
       "lemma": "читаючи",
       "lemmaId": "читаючи",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 413
     },
@@ -5630,9 +5562,7 @@
       "lemma": "понад",
       "lemmaId": "понад",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 432
     },
@@ -6904,9 +6834,7 @@
       "lemma": "складнопідрядне речення",
       "lemmaId": "складнопідрядне-речення",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 530
     },
@@ -6956,9 +6884,7 @@
       "lemma": "єднальний сполучник",
       "lemmaId": "єднальний-сполучник",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 534
     },
@@ -7190,9 +7116,7 @@
       "lemma": "могли б",
       "lemmaId": "могли-б",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 552
     },
@@ -7632,9 +7556,7 @@
       "lemma": "дарма що",
       "lemmaId": "дарма-що",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 586
     },
@@ -7658,9 +7580,7 @@
       "lemma": "незважаючи на",
       "lemmaId": "незважаючи-на",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 588
     },
@@ -7671,9 +7591,7 @@
       "lemma": "незважаючи на те що",
       "lemmaId": "незважаючи-на-те-що",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 589
     },
@@ -7710,9 +7628,7 @@
       "lemma": "підрядне обставинне допусту",
       "lemmaId": "підрядне-обставинне-допусту",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 592
     },
@@ -7736,9 +7652,7 @@
       "lemma": "усупереч",
       "lemmaId": "усупереч",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 594
     },
@@ -7749,9 +7663,7 @@
       "lemma": "хоч",
       "lemmaId": "хоч",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 595
     },
@@ -7775,9 +7687,7 @@
       "lemma": "коли б",
       "lemmaId": "коли-б",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 597
     },
@@ -7788,9 +7698,7 @@
       "lemma": "підрядна обставинна частина умови",
       "lemmaId": "підрядна-обставинна-частина-умови",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 598
     },
@@ -7866,9 +7774,7 @@
       "lemma": "якщо тільки",
       "lemmaId": "якщо-тільки",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 604
     },
@@ -7957,9 +7863,7 @@
       "lemma": "кома перед підрядною частиною",
       "lemmaId": "кома-перед-підрядною-частиною",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 611
     },
@@ -8048,9 +7952,7 @@
       "lemma": "аби",
       "lemmaId": "аби",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 618
     },
@@ -8178,9 +8080,7 @@
       "lemma": "підрядна обставинна частина мети",
       "lemmaId": "підрядна-обставинна-частина-мети",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 628
     },
@@ -8269,9 +8169,7 @@
       "lemma": "завдяки тому що",
       "lemmaId": "завдяки-тому-що",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 635
     },
@@ -8334,9 +8232,7 @@
       "lemma": "підрядна обставинна частина причини",
       "lemmaId": "підрядна-обставинна-частина-причини",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 640
     },
@@ -8360,9 +8256,7 @@
       "lemma": "у зв'язку з тим що",
       "lemmaId": "у-зв-язку-з-тим-що",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 642
     },
@@ -8373,9 +8267,7 @@
       "lemma": "через те що",
       "lemmaId": "через-те-що",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 643
     },
@@ -8425,9 +8317,7 @@
       "lemma": "роль у підрядній частині",
       "lemmaId": "роль-у-підрядній-частині",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 647
     },
@@ -8464,9 +8354,7 @@
       "lemma": "доти...доки",
       "lemmaId": "доти-доки",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 650
     },
@@ -8529,9 +8417,7 @@
       "lemma": "поки не",
       "lemmaId": "поки-не",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 655
     },
@@ -8542,9 +8428,7 @@
       "lemma": "підрядна обставинна частина часу",
       "lemmaId": "підрядна-обставинна-частина-часу",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 656
     },
@@ -8737,9 +8621,7 @@
       "lemma": "якщо б",
       "lemmaId": "якщо-б",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 671
     },
@@ -8750,9 +8632,7 @@
       "lemma": "виносити сміття",
       "lemmaId": "виносити-сміття",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 672
     },
@@ -8945,9 +8825,7 @@
       "lemma": "завдяки",
       "lemmaId": "завдяки",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 687
     },
@@ -8971,9 +8849,7 @@
       "lemma": "назустріч",
       "lemmaId": "назустріч",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 689
     },
@@ -9647,9 +9523,7 @@
       "lemma": "не вийшло",
       "lemmaId": "не-вийшло",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 741
     },
@@ -9751,9 +9625,7 @@
       "lemma": "урок іде",
       "lemmaId": "урок-іде",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 749
     },
@@ -9842,9 +9714,7 @@
       "lemma": "з-за",
       "lemmaId": "з-за",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 756
     },
@@ -9855,9 +9725,7 @@
       "lemma": "замість",
       "lemmaId": "замість",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 757
     },
@@ -9868,9 +9736,7 @@
       "lemma": "крім",
       "lemmaId": "крім",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 758
     },
@@ -9920,9 +9786,7 @@
       "lemma": "щодо",
       "lemmaId": "щодо",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 762
     },
@@ -10050,9 +9914,7 @@
       "lemma": "не чуючи ніг",
       "lemmaId": "не-чуючи-ніг",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 772
     },
@@ -10180,9 +10042,7 @@
       "lemma": "пишучи",
       "lemmaId": "пишучи",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 782
     },
@@ -10193,9 +10053,7 @@
       "lemma": "усміхаючись",
       "lemmaId": "усміхаючись",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 783
     },
@@ -10921,9 +10779,7 @@
       "lemma": "хочу уточнити",
       "lemmaId": "хочу-уточнити",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 839
     },
@@ -10947,9 +10803,7 @@
       "lemma": "Шановний пане",
       "lemmaId": "шановний-пане",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 841
     },
@@ -11129,9 +10983,7 @@
       "lemma": "згідно з",
       "lemmaId": "згідно-з",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 855
     },
@@ -11155,9 +11007,7 @@
       "lemma": "порівняно з",
       "lemmaId": "порівняно-з",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 857
     },
@@ -11194,9 +11044,7 @@
       "lemma": "у зв'язку з",
       "lemmaId": "у-зв-язку-з",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 860
     },
@@ -11350,9 +11198,7 @@
       "lemma": "живопис",
       "lemmaId": "живопис",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 872
     },
@@ -11467,9 +11313,7 @@
       "lemma": "везти",
       "lemmaId": "везти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 881
     },
@@ -11480,9 +11324,7 @@
       "lemma": "вести",
       "lemmaId": "вести",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 882
     },
@@ -11584,9 +11426,7 @@
       "lemma": "пливуть",
       "lemmaId": "пливуть",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 890
     },
@@ -11597,9 +11437,7 @@
       "lemma": "порт",
       "lemmaId": "порт",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 891
     },
@@ -11662,9 +11500,7 @@
       "lemma": "прилітати",
       "lemmaId": "прилітати",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 896
     },
@@ -11714,9 +11550,7 @@
       "lemma": "доїжджати",
       "lemmaId": "доїжджати",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 900
     },
@@ -11805,9 +11639,7 @@
       "lemma": "привезти",
       "lemmaId": "привезти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 907
     },
@@ -11818,9 +11650,7 @@
       "lemma": "привести",
       "lemmaId": "привести",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 908
     },
@@ -11831,9 +11661,7 @@
       "lemma": "привозити",
       "lemmaId": "привозити",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 909
     },
@@ -11844,9 +11672,7 @@
       "lemma": "приносити",
       "lemmaId": "приносити",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 910
     },
@@ -12026,9 +11852,7 @@
       "lemma": "повести",
       "lemmaId": "повести",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 924
     },
@@ -12117,9 +11941,7 @@
       "lemma": "завезти",
       "lemmaId": "завезти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 931
     },
@@ -12169,9 +11991,7 @@
       "lemma": "повз",
       "lemmaId": "повз",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 935
     },
@@ -12780,9 +12600,7 @@
       "lemma": "ознака за дією",
       "lemmaId": "ознака-за-дією",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 982
     },
@@ -12832,9 +12650,7 @@
       "lemma": "дія над предметом",
       "lemmaId": "дія-над-предметом",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 986
     },
@@ -12923,9 +12739,7 @@
       "lemma": "форма на -но/-то",
       "lemmaId": "форма-на-но-то",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 993
     },
@@ -14184,9 +13998,7 @@
       "lemma": "заради того щоб",
       "lemmaId": "заради-того-щоб",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 1090
     },
@@ -14301,9 +14113,7 @@
       "lemma": "кіоск",
       "lemmaId": "кіоск",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 1099
     },
@@ -14327,9 +14137,7 @@
       "lemma": "обабіч",
       "lemmaId": "обабіч",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 1101
     },
@@ -14366,9 +14174,7 @@
       "lemma": "серед",
       "lemmaId": "серед",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 1104
     },
@@ -14431,9 +14237,7 @@
       "lemma": "координаторка",
       "lemmaId": "координаторка",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 1109
     },
@@ -14522,9 +14326,7 @@
       "lemma": "протягом",
       "lemmaId": "протягом",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 1116
     },
@@ -14553,2564 +14355,16 @@
         "choice"
       ],
       "newOrder": 1118
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "цього року",
-      "lemmaId": "цього-року",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1119
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "часовий",
-      "lemmaId": "часовий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1120
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "щопонеділка",
-      "lemmaId": "щопонеділка",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1121
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "щосереди",
-      "lemmaId": "щосереди",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1122
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "ліричний герой",
-      "lemmaId": "ліричний-герой",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1123
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "персонаж",
-      "lemmaId": "персонаж",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1124
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "проза",
-      "lemmaId": "проза",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1125
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "уривок",
-      "lemmaId": "уривок",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1126
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "бачитися",
-      "lemmaId": "бачитися",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1127
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "взаємний",
-      "lemmaId": "взаємний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1128
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "власне зворотний",
-      "lemmaId": "власне-зворотний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1129
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "відкриватися",
-      "lemmaId": "відкриватися",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1130
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "відчинятися",
-      "lemmaId": "відчинятися",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1131
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вітатися",
-      "lemmaId": "вітатися",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1132
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "емоція",
-      "lemmaId": "емоція",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1133
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "зачинятися",
-      "lemmaId": "зачинятися",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1134
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "знайомити",
-      "lemmaId": "знайомити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1135
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "знайомитися",
-      "lemmaId": "знайомитися",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1136
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "подаватися",
-      "lemmaId": "подаватися",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1137
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "прошу вибачення",
-      "lemmaId": "прошу-вибачення",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1138
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "радіти",
-      "lemmaId": "радіти",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1139
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "сердитися",
-      "lemmaId": "сердитися",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1140
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "спілкуватися",
-      "lemmaId": "спілкуватися",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1141
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "сумувати",
-      "lemmaId": "сумувати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1142
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "цілуватися",
-      "lemmaId": "цілуватися",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1143
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "авторська ремарка",
-      "lemmaId": "авторська-ремарка",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1144
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "дослівно",
-      "lemmaId": "дослівно",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1145
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "наступного дня",
-      "lemmaId": "наступного-дня",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1146
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "питальне слово",
-      "lemmaId": "питальне-слово",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1147
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "того дня",
-      "lemmaId": "того-дня",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1148
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "частка чи",
-      "lemmaId": "частка-чи",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1149
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "друга страва",
-      "lemmaId": "друга-страва",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1150
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "куштувати",
-      "lemmaId": "куштувати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1151
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "перша страва",
-      "lemmaId": "перша-страва",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1152
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "юшка",
-      "lemmaId": "юшка",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1153
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "ательє",
-      "lemmaId": "ательє",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1154
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "здача",
-      "lemmaId": "здача",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1155
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "майстерня",
-      "lemmaId": "майстерня",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1156
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "обмін валют",
-      "lemmaId": "обмін-валют",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1157
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "обслуговування",
-      "lemmaId": "обслуговування",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1158
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "перукарня",
-      "lemmaId": "перукарня",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1159
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "повільніший",
-      "lemmaId": "повільніший",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1160
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "тканина",
-      "lemmaId": "тканина",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1161
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "якісний",
-      "lemmaId": "якісний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1162
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "якість",
-      "lemmaId": "якість",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1163
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "варт",
-      "lemmaId": "варт",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1164
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "годен",
-      "lemmaId": "годен",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1165
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "ладна",
-      "lemmaId": "ладна",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1166
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "нестягнена форма",
-      "lemmaId": "нестягнена-форма",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1167
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "неузгоджуваний",
-      "lemmaId": "неузгоджуваний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1168
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "повен",
-      "lemmaId": "повен",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1169
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "повний прикметник",
-      "lemmaId": "повний-прикметник",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1170
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "стягнена форма",
-      "lemmaId": "стягнена-форма",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1171
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "ясен",
-      "lemmaId": "ясен",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1172
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "група приголосних",
-      "lemmaId": "група-приголосних",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1173
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "закріплений",
-      "lemmaId": "закріплений",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1174
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "зникати",
-      "lemmaId": "зникати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1175
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "радісний",
-      "lemmaId": "радісний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1176
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "тиснути",
-      "lemmaId": "тиснути",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1177
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "чесний",
-      "lemmaId": "чесний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1178
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "благодійність",
-      "lemmaId": "благодійність",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1179
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "громадянське суспільство",
-      "lemmaId": "громадянське-суспільство",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1180
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "допис",
-      "lemmaId": "допис",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1181
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "електорат",
-      "lemmaId": "електорат",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1182
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "засоби масової інформації",
-      "lemmaId": "засоби-масової-інформації",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1183
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "коментар",
-      "lemmaId": "коментар",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1184
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "кореспондент",
-      "lemmaId": "кореспондент",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1185
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "кореспондентка",
-      "lemmaId": "кореспондентка",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1186
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "маніпулювання",
-      "lemmaId": "маніпулювання",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1187
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "медіаманіпулювання",
-      "lemmaId": "медіаманіпулювання",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1188
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "петиція",
-      "lemmaId": "петиція",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1189
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "прес-конференція",
-      "lemmaId": "прес-конференція",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1190
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "публіцистичний стиль",
-      "lemmaId": "публіцистичний-стиль",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1191
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "фейк",
-      "lemmaId": "фейк",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1192
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "Верховна Рада",
-      "lemmaId": "верховна-рада",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1193
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "звукова абревіатура",
-      "lemmaId": "звукова-абревіатура",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1194
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "крапка",
-      "lemmaId": "крапка",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1195
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "літерна абревіатура",
-      "lemmaId": "літерна-абревіатура",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1196
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "одиниці виміру",
-      "lemmaId": "одиниці-виміру",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1197
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "складноскорочене слово",
-      "lemmaId": "складноскорочене-слово",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1198
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "ЦНАП",
-      "lemmaId": "цнап",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1199
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "автобіографія",
-      "lemmaId": "автобіографія",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1200
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "відповідно до",
-      "lemmaId": "відповідно-до",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1201
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "доводжу до вашого відома",
-      "lemmaId": "доводжу-до-вашого-відома",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1202
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "ділове листування",
-      "lemmaId": "ділове-листування",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1203
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "реквізити",
-      "lemmaId": "реквізити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1204
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "формула ввічливості",
-      "lemmaId": "формула-ввічливості",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1205
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "шановний",
-      "lemmaId": "шановний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1206
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "штамп",
-      "lemmaId": "штамп",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1207
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "емоційно забарвлена лексика",
-      "lemmaId": "емоційно-забарвлена-лексика",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1208
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "зменшувально-пестлива форма",
-      "lemmaId": "зменшувально-пестлива-форма",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1209
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "коротше кажучи",
-      "lemmaId": "коротше-кажучи",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1210
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "невже",
-      "lemmaId": "невже",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1211
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "неповне речення",
-      "lemmaId": "неповне-речення",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1212
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "овва",
-      "lemmaId": "овва",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1213
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "отож",
-      "lemmaId": "отож",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1214
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "побутова тема",
-      "lemmaId": "побутова-тема",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1215
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "побутовий",
-      "lemmaId": "побутовий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1216
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "файний",
-      "lemmaId": "файний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1217
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "хіба",
-      "lemmaId": "хіба",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1218
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "багаж",
-      "lemmaId": "багаж",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1219
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вирушати",
-      "lemmaId": "вирушати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1220
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "закордонний паспорт",
-      "lemmaId": "закордонний-паспорт",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1221
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "зал очікування",
-      "lemmaId": "зал-очікування",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1222
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "затримка",
-      "lemmaId": "затримка",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1223
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "зворотний квиток",
-      "lemmaId": "зворотний-квиток",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1224
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "мандрівка",
-      "lemmaId": "мандрівка",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1225
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "посадка",
-      "lemmaId": "посадка",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1226
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "прикордонний контроль",
-      "lemmaId": "прикордонний-контроль",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1227
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "провідник",
-      "lemmaId": "провідник",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1228
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "розклад руху",
-      "lemmaId": "розклад-руху",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1229
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "сидячий вагон",
-      "lemmaId": "сидячий-вагон",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1230
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "хостел",
-      "lemmaId": "хостел",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1231
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вимкнути",
-      "lemmaId": "вимкнути",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1232
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "встановити",
-      "lemmaId": "встановити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1233
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "відключити",
-      "lemmaId": "відключити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1234
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "відрізати",
-      "lemmaId": "відрізати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1235
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "завершення дії",
-      "lemmaId": "завершення-дії",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1236
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "заплакати",
-      "lemmaId": "заплакати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1237
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "значення",
-      "lemmaId": "значення",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1238
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "копіювати",
-      "lemmaId": "копіювати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1239
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "механічний",
-      "lemmaId": "механічний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1240
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "одноразова дія",
-      "lemmaId": "одноразова-дія",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1241
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "початок дії",
-      "lemmaId": "початок-дії",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1242
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "пришвидшити",
-      "lemmaId": "пришвидшити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1243
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "приєднати",
-      "lemmaId": "приєднати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1244
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "програмувати",
-      "lemmaId": "програмувати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1245
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "підсилити",
-      "lemmaId": "підсилити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1246
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "розбір",
-      "lemmaId": "розбір",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1247
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "розкласти",
-      "lemmaId": "розкласти",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1248
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "словотвірна основа",
-      "lemmaId": "словотвірна-основа",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1249
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "спосіб творення",
-      "lemmaId": "спосіб-творення",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1250
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "творення дієслів",
-      "lemmaId": "творення-дієслів",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1251
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "увімкнути",
-      "lemmaId": "увімкнути",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1252
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "бачення",
-      "lemmaId": "бачення",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1253
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "біг",
-      "lemmaId": "біг",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1254
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вивчення",
-      "lemmaId": "вивчення",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1255
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "виробляти",
-      "lemmaId": "виробляти",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1256
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "документація",
-      "lemmaId": "документація",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1257
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "здобути",
-      "lemmaId": "здобути",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1258
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "знання",
-      "lemmaId": "знання",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1259
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "копіювання",
-      "lemmaId": "копіювання",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1260
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "лет",
-      "lemmaId": "лет",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1261
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "навчальний центр",
-      "lemmaId": "навчальний-центр",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1262
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "навчати",
-      "lemmaId": "навчати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1263
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "надсилання",
-      "lemmaId": "надсилання",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1264
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "обмін",
-      "lemmaId": "обмін",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1265
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "оплатити",
-      "lemmaId": "оплатити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1266
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "розвивати",
-      "lemmaId": "розвивати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1267
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "розвиток",
-      "lemmaId": "розвиток",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1268
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "сканування",
-      "lemmaId": "сканування",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1269
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "спів",
-      "lemmaId": "спів",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1270
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "створити",
-      "lemmaId": "створити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1271
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "тестувати",
-      "lemmaId": "тестувати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1272
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "ходіння",
-      "lemmaId": "ходіння",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1273
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "цифрові навички",
-      "lemmaId": "цифрові-навички",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1274
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "голово",
-      "lemmaId": "голово",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1275
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "державний службовець",
-      "lemmaId": "державний-службовець",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1276
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "добродій",
-      "lemmaId": "добродій",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1277
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "добродію",
-      "lemmaId": "добродію",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1278
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "діловий",
-      "lemmaId": "діловий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1279
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "електронний лист",
-      "lemmaId": "електронний-лист",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1280
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "знак оклику",
-      "lemmaId": "знак-оклику",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1281
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "колего",
-      "lemmaId": "колего",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1282
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "конференція",
-      "lemmaId": "конференція",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1283
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "лікарю",
-      "lemmaId": "лікарю",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1284
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "пані та панове",
-      "lemmaId": "пані-та-панове",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1285
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "професоре",
-      "lemmaId": "професоре",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1286
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "редакторка",
-      "lemmaId": "редакторка",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1287
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "урочистий",
-      "lemmaId": "урочистий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1288
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "учасниця",
-      "lemmaId": "учасниця",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1289
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "формальний",
-      "lemmaId": "формальний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1290
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "формула звертання",
-      "lemmaId": "формула-звертання",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1291
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "церемонія",
-      "lemmaId": "церемонія",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1292
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "шановна",
-      "lemmaId": "шановна",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1293
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "козацький",
-      "lemmaId": "козацький",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1294
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "мотивувальне слово",
-      "lemmaId": "мотивувальне-слово",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1295
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "похідне слово",
-      "lemmaId": "похідне-слово",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1296
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "післявоєнний",
-      "lemmaId": "післявоєнний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1297
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "складний прикметник",
-      "lemmaId": "складний-прикметник",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1298
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "сполучна голосна",
-      "lemmaId": "сполучна-голосна",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1299
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "суфікс -зьк-",
-      "lemmaId": "суфікс-зьк",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1300
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "суфікс -ськ-",
-      "lemmaId": "суфікс-ськ",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1301
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "суфікс -цьк-",
-      "lemmaId": "суфікс-цьк",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1302
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "твірна основа",
-      "lemmaId": "твірна-основа",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1303
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "доброта",
-      "lemmaId": "доброта",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1304
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "збірний іменник",
-      "lemmaId": "збірний-іменник",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1305
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "козацтво",
-      "lemmaId": "козацтво",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1306
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "назва особи",
-      "lemmaId": "назва-особи",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1307
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "назва приміщення",
-      "lemmaId": "назва-приміщення",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1308
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "непродуктивний суфікс",
-      "lemmaId": "непродуктивний-суфікс",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1309
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "пекарня",
-      "lemmaId": "пекарня",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1310
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "перехід",
-      "lemmaId": "перехід",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1311
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "похідний іменник",
-      "lemmaId": "похідний-іменник",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1312
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "префіксально-суфіксальний спосіб",
-      "lemmaId": "префіксально-суфіксальний-спосіб",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1313
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "продуктивний суфікс",
-      "lemmaId": "продуктивний-суфікс",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1314
     }
   ],
   "level": "B1",
   "schema": "atlas-practice-index",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 23155,
+    "gzipBytes": 19999,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 356494,
+    "rawBytes": 299684,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/public/lexicon/practice-index.B2.json
+++ b/site/public/lexicon/practice-index.B2.json
@@ -157,9 +157,7 @@
       "lemma": "бо",
       "lemmaId": "бо",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 11
     },
@@ -170,9 +168,7 @@
       "lemma": "відколи",
       "lemmaId": "відколи",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 12
     },
@@ -183,9 +179,7 @@
       "lemma": "однак",
       "lemmaId": "однак",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 13
     },
@@ -287,9 +281,7 @@
       "lemma": "просите",
       "lemmaId": "просите",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 21
     },
@@ -794,9 +786,7 @@
       "lemma": "пригощатися",
       "lemmaId": "пригощатися",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 60
     },
@@ -807,9 +797,7 @@
       "lemma": "нічий",
       "lemmaId": "нічий",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 61
     },
@@ -2263,9 +2251,7 @@
       "lemma": "поступка",
       "lemmaId": "поступка",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 173
     },
@@ -2289,9 +2275,7 @@
       "lemma": "заради",
       "lemmaId": "заради",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 175
     },
@@ -2302,9 +2286,7 @@
       "lemma": "доки",
       "lemmaId": "доки",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 176
     },
@@ -2523,9 +2505,7 @@
       "lemma": "з-під",
       "lemmaId": "з-під",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 193
     },
@@ -2536,9 +2516,7 @@
       "lemma": "біжучи",
       "lemmaId": "біжучи",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 194
     },
@@ -2549,9 +2527,7 @@
       "lemma": "дивлячись",
       "lemmaId": "дивлячись",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 195
     },
@@ -2562,9 +2538,7 @@
       "lemma": "навчаючись",
       "lemmaId": "навчаючись",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 196
     },
@@ -2588,9 +2562,7 @@
       "lemma": "сидячи",
       "lemmaId": "сидячи",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 198
     },
@@ -2601,9 +2573,7 @@
       "lemma": "стоячи",
       "lemmaId": "стоячи",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 199
     },
@@ -2614,9 +2584,7 @@
       "lemma": "хвилюючись",
       "lemmaId": "хвилюючись",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 200
     },
@@ -2978,9 +2946,7 @@
       "lemma": "мовляв",
       "lemmaId": "мовляв",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 228
     },
@@ -3004,9 +2970,7 @@
       "lemma": "гаївки",
       "lemmaId": "гаївки",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 230
     },
@@ -3017,9 +2981,7 @@
       "lemma": "виплисти",
       "lemmaId": "виплисти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 231
     },
@@ -3043,9 +3005,7 @@
       "lemma": "долетіти",
       "lemmaId": "долетіти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 233
     },
@@ -3108,9 +3068,7 @@
       "lemma": "переплисти",
       "lemmaId": "переплисти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 238
     },
@@ -3121,9 +3079,7 @@
       "lemma": "пливу",
       "lemmaId": "пливу",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 239
     },
@@ -3160,9 +3116,7 @@
       "lemma": "добігти",
       "lemmaId": "добігти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 242
     },
@@ -3173,9 +3127,7 @@
       "lemma": "довезти",
       "lemmaId": "довезти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 243
     },
@@ -3186,9 +3138,7 @@
       "lemma": "довести",
       "lemmaId": "довести",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 244
     },
@@ -3212,9 +3162,7 @@
       "lemma": "приїздити",
       "lemmaId": "приїздити",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 246
     },
@@ -3225,9 +3173,7 @@
       "lemma": "від'їжджати",
       "lemmaId": "від-їжджати",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 247
     },
@@ -3238,9 +3184,7 @@
       "lemma": "від'їхати",
       "lemmaId": "від-їхати",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 248
     },
@@ -3277,9 +3221,7 @@
       "lemma": "вибігати",
       "lemmaId": "вибігати",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 251
     },
@@ -3355,9 +3297,7 @@
       "lemma": "заносити",
       "lemmaId": "заносити",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 257
     },
@@ -3394,9 +3334,7 @@
       "lemma": "перебігати",
       "lemmaId": "перебігати",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 260
     },
@@ -3420,9 +3358,7 @@
       "lemma": "перейду",
       "lemmaId": "перейду",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 262
     },
@@ -3433,9 +3369,7 @@
       "lemma": "пробігти",
       "lemmaId": "пробігти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 263
     },
@@ -3446,9 +3380,7 @@
       "lemma": "провезти",
       "lemmaId": "провезти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 264
     },
@@ -3472,9 +3404,7 @@
       "lemma": "пронести",
       "lemmaId": "пронести",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 266
     },
@@ -3485,9 +3415,7 @@
       "lemma": "проїжджати",
       "lemmaId": "проїжджати",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 267
     },
@@ -4980,9 +4908,7 @@
       "lemma": "бувай",
       "lemmaId": "бувай",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 382
     },
@@ -5006,9 +4932,7 @@
       "lemma": "суржик",
       "lemmaId": "суржик",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 384
     },
@@ -5344,9 +5268,7 @@
       "lemma": "директоре",
       "lemmaId": "директоре",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 410
     },
@@ -5357,9 +5279,7 @@
       "lemma": "добродійко",
       "lemmaId": "добродійко",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 411
     },
@@ -5682,9 +5602,7 @@
       "lemma": "іменна частина присудка",
       "lemmaId": "іменна-частина-присудка",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 436
     },
@@ -5721,9 +5639,7 @@
       "lemma": "галера",
       "lemmaId": "галера",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 439
     },
@@ -5734,9 +5650,7 @@
       "lemma": "епос",
       "lemmaId": "епос",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 440
     },
@@ -5851,9 +5765,7 @@
       "lemma": "яничар",
       "lemmaId": "яничар",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 449
     },
@@ -5864,9 +5776,7 @@
       "lemma": "ясир",
       "lemmaId": "ясир",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 450
     },
@@ -5877,9 +5787,7 @@
       "lemma": "дідух",
       "lemmaId": "дідух",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 451
     },
@@ -5890,9 +5798,7 @@
       "lemma": "колядування",
       "lemmaId": "колядування",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 452
     },
@@ -5916,9 +5822,7 @@
       "lemma": "родючість",
       "lemmaId": "родючість",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 454
     },
@@ -5942,9 +5846,7 @@
       "lemma": "синкретизм",
       "lemmaId": "синкретизм",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 456
     },
@@ -6072,9 +5974,7 @@
       "lemma": "кобза",
       "lemmaId": "кобза",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 466
     },
@@ -6098,9 +5998,7 @@
       "lemma": "ліра",
       "lemmaId": "ліра",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 468
     },
@@ -6215,9 +6113,7 @@
       "lemma": "мавка",
       "lemmaId": "мавка",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 477
     },
@@ -6306,9 +6202,7 @@
       "lemma": "русалка",
       "lemmaId": "русалка",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 484
     },
@@ -6319,9 +6213,7 @@
       "lemma": "упир",
       "lemmaId": "упир",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 485
     },
@@ -6332,9 +6224,7 @@
       "lemma": "градація",
       "lemmaId": "градація",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 486
     },
@@ -6358,9 +6248,7 @@
       "lemma": "етнонім",
       "lemmaId": "етнонім",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 488
     },
@@ -6371,9 +6259,7 @@
       "lemma": "замовний",
       "lemmaId": "замовний",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 489
     },
@@ -6384,9 +6270,7 @@
       "lemma": "збирач",
       "lemmaId": "збирач",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 490
     },
@@ -6423,9 +6307,7 @@
       "lemma": "словесний",
       "lemmaId": "словесний",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 493
     },
@@ -6449,9 +6331,7 @@
       "lemma": "гетьман",
       "lemmaId": "гетьман",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 495
     },
@@ -6475,9 +6355,7 @@
       "lemma": "опришок",
       "lemmaId": "опришок",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 497
     }
@@ -6486,10 +6364,10 @@
   "schema": "atlas-practice-index",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 7790,
+    "gzipBytes": 7867,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 130232,
+    "rawBytes": 127914,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/public/lexicon/practice-index.C1.json
+++ b/site/public/lexicon/practice-index.C1.json
@@ -326,9 +326,7 @@
       "lemma": "хоча",
       "lemmaId": "хоча",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 24
     },
@@ -456,9 +454,7 @@
       "lemma": "абикому",
       "lemmaId": "абикому",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 34
     },
@@ -469,9 +465,7 @@
       "lemma": "абихто",
       "lemmaId": "абихто",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 35
     },
@@ -1782,9 +1776,7 @@
       "lemma": "асиндетон",
       "lemmaId": "асиндетон",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 136
     },
@@ -2068,9 +2060,7 @@
       "lemma": "банош",
       "lemmaId": "банош",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 158
     },
@@ -2094,9 +2084,7 @@
       "lemma": "відпливти",
       "lemmaId": "відпливти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 160
     },
@@ -2107,9 +2095,7 @@
       "lemma": "допливати",
       "lemmaId": "допливати",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 161
     },
@@ -2120,9 +2106,7 @@
       "lemma": "доплисти",
       "lemmaId": "доплисти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 162
     },
@@ -2146,9 +2130,7 @@
       "lemma": "заплисти",
       "lemmaId": "заплисти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 164
     },
@@ -2172,9 +2154,7 @@
       "lemma": "обплисти",
       "lemmaId": "обплисти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 166
     },
@@ -2185,9 +2165,7 @@
       "lemma": "пливеш",
       "lemmaId": "пливеш",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 167
     },
@@ -2198,9 +2176,7 @@
       "lemma": "припливати",
       "lemmaId": "припливати",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 168
     },
@@ -2224,9 +2200,7 @@
       "lemma": "проплисти",
       "lemmaId": "проплисти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 170
     },
@@ -2250,9 +2224,7 @@
       "lemma": "підплисти",
       "lemmaId": "підплисти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 172
     },
@@ -2341,9 +2313,7 @@
       "lemma": "переїду",
       "lemmaId": "переїду",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 179
     },
@@ -2354,9 +2324,7 @@
       "lemma": "пробігати",
       "lemmaId": "пробігати",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 180
     },
@@ -2367,9 +2335,7 @@
       "lemma": "проїду",
       "lemmaId": "проїду",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 181
     },
@@ -3134,9 +3100,7 @@
       "lemma": "бануш",
       "lemmaId": "бануш",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 240
     },
@@ -3550,9 +3514,7 @@
       "lemma": "приставка",
       "lemmaId": "приставка",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 272
     },
@@ -3693,9 +3655,7 @@
       "lemma": "координаторе",
       "lemmaId": "координаторе",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 283
     },
@@ -3706,9 +3666,7 @@
       "lemma": "редакторко",
       "lemmaId": "редакторко",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 284
     },
@@ -4057,9 +4015,7 @@
       "lemma": "веснянка",
       "lemmaId": "веснянка",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 311
     },
@@ -4070,9 +4026,7 @@
       "lemma": "гагілки",
       "lemmaId": "гагілки",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 312
     },
@@ -4083,9 +4037,7 @@
       "lemma": "гільце",
       "lemmaId": "гільце",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 313
     },
@@ -4109,9 +4061,7 @@
       "lemma": "зажинки",
       "lemmaId": "зажинки",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 315
     },
@@ -4148,9 +4098,7 @@
       "lemma": "обрядовий",
       "lemmaId": "обрядовий",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 318
     },
@@ -4174,9 +4122,7 @@
       "lemma": "перформативність",
       "lemmaId": "перформативність",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 320
     },
@@ -4187,9 +4133,7 @@
       "lemma": "посівання",
       "lemmaId": "посівання",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 321
     },
@@ -4200,9 +4144,7 @@
       "lemma": "ряджений",
       "lemmaId": "ряджений",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 322
     },
@@ -4291,9 +4233,7 @@
       "lemma": "засівання",
       "lemmaId": "засівання",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 329
     },
@@ -4421,9 +4361,7 @@
       "lemma": "демонологія",
       "lemmaId": "демонологія",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 339
     },
@@ -4447,9 +4385,7 @@
       "lemma": "нявка",
       "lemmaId": "нявка",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 341
     },
@@ -4460,9 +4396,7 @@
       "lemma": "перелесник",
       "lemmaId": "перелесник",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 342
     },
@@ -4486,9 +4420,7 @@
       "lemma": "потерча",
       "lemmaId": "потерча",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 344
     },
@@ -4499,9 +4431,7 @@
       "lemma": "хованець",
       "lemmaId": "хованець",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 345
     },
@@ -4512,9 +4442,7 @@
       "lemma": "чугайстер",
       "lemmaId": "чугайстер",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 346
     },
@@ -4538,9 +4466,7 @@
       "lemma": "примовка",
       "lemmaId": "примовка",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 348
     },
@@ -4577,9 +4503,7 @@
       "lemma": "шептуха",
       "lemmaId": "шептуха",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 351
     },
@@ -4614,10 +4538,10 @@
   "schema": "atlas-practice-index",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 5872,
+    "gzipBytes": 5919,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 93792,
+    "rawBytes": 92348,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/public/lexicon/practice-lexemes.A1.json
+++ b/site/public/lexicon/practice-lexemes.A1.json
@@ -5,11 +5,13 @@
     {
       "cefr": "A1",
       "gloss": "borshch",
+      "glossClean": "borshch",
       "heritage": "standard",
       "ipa": null,
       "lemma": "борщ",
       "lemmaId": "борщ",
       "lemmaPlain": "борщ",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -20,11 +22,13 @@
     {
       "cefr": "A1",
       "gloss": "hotel",
+      "glossClean": "hotel",
       "heritage": "standard",
       "ipa": null,
       "lemma": "готель",
       "lemmaId": "готель",
       "lemmaPlain": "готель",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -35,11 +39,13 @@
     {
       "cefr": "A1",
       "gloss": "ready",
+      "glossClean": "ready",
       "heritage": "standard",
       "ipa": null,
       "lemma": "готовий",
       "lemmaId": "готовий",
       "lemmaPlain": "готовий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -50,11 +56,13 @@
     {
       "cefr": "A1",
       "gloss": "to meet",
+      "glossClean": "to meet",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зустріти",
       "lemmaId": "зустріти",
       "lemmaPlain": "зустріти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -65,11 +73,13 @@
     {
       "cefr": "A1",
       "gloss": "map",
+      "glossClean": "map",
       "heritage": "standard",
       "ipa": null,
       "lemma": "карта",
       "lemmaId": "карта",
       "lemmaPlain": "карта",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -109,11 +119,13 @@
     {
       "cefr": "A1",
       "gloss": "card",
+      "glossClean": "card",
       "heritage": "standard",
       "ipa": null,
       "lemma": "картка",
       "lemmaId": "картка",
       "lemmaPlain": "картка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -153,11 +165,13 @@
     {
       "cefr": "A1",
       "gloss": "ticket",
+      "glossClean": "ticket",
       "heritage": "standard",
       "ipa": null,
       "lemma": "квиток",
       "lemmaId": "квиток",
       "lemmaPlain": "квиток",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -168,11 +182,13 @@
     {
       "cefr": "A1",
       "gloss": "postcard",
+      "glossClean": "postcard",
       "heritage": "standard",
       "ipa": null,
       "lemma": "листівка",
       "lemmaId": "листівка",
       "lemmaPlain": "листівка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -212,11 +228,13 @@
     {
       "cefr": "A1",
       "gloss": "to travel",
+      "glossClean": "to travel",
       "heritage": "standard",
       "ipa": null,
       "lemma": "подорожувати",
       "lemmaId": "подорожувати",
       "lemmaPlain": "подорожувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -227,11 +245,13 @@
     {
       "cefr": "A1",
       "gloss": "beginning",
+      "glossClean": "beginning",
       "heritage": "standard",
       "ipa": null,
       "lemma": "початок",
       "lemmaId": "початок",
       "lemmaPlain": "початок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -242,11 +262,13 @@
     {
       "cefr": "A1",
       "gloss": "film",
+      "glossClean": "film",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фільм",
       "lemmaId": "фільм",
       "lemmaPlain": "фільм",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -257,11 +279,13 @@
     {
       "cefr": "A1",
       "gloss": "center",
+      "glossClean": "center",
       "heritage": "standard",
       "ipa": null,
       "lemma": "центр",
       "lemmaId": "центр",
       "lemmaPlain": "центр",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -272,11 +296,13 @@
     {
       "cefr": "A1",
       "gloss": "wonderful",
+      "glossClean": "wonderful",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чудовий",
       "lemmaId": "чудовий",
       "lemmaPlain": "чудовий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -287,11 +313,13 @@
     {
       "cefr": "A1",
       "gloss": "bus",
+      "glossClean": "bus",
       "heritage": "standard",
       "ipa": null,
       "lemma": "автобус",
       "lemmaId": "автобус",
       "lemmaPlain": "автобус",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -302,11 +330,13 @@
     {
       "cefr": "A1",
       "gloss": "pharmacy",
+      "glossClean": "pharmacy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "аптека",
       "lemmaId": "аптека",
       "lemmaPlain": "аптека",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -346,11 +376,13 @@
     {
       "cefr": "A1",
       "gloss": "bank",
+      "glossClean": "bank",
       "heritage": "standard",
       "ipa": null,
       "lemma": "банк",
       "lemmaId": "банк",
       "lemmaPlain": "банк",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -361,11 +393,13 @@
     {
       "cefr": "A1",
       "gloss": "library",
+      "glossClean": "library",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бібліотека",
       "lemmaId": "бібліотека",
       "lemmaPlain": "бібліотека",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -405,11 +439,13 @@
     {
       "cefr": "A1",
       "gloss": "station",
+      "glossClean": "station",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вокзал",
       "lemmaId": "вокзал",
       "lemmaPlain": "вокзал",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -420,11 +456,13 @@
     {
       "cefr": "A1",
       "gloss": "street",
+      "glossClean": "street",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вулиця",
       "lemmaId": "вулиця",
       "lemmaPlain": "вулиця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -464,11 +502,13 @@
     {
       "cefr": "A1",
       "gloss": "far",
+      "glossClean": "far",
       "heritage": "standard",
       "ipa": null,
       "lemma": "далеко",
       "lemmaId": "далеко",
       "lemmaPlain": "далеко",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -479,11 +519,13 @@
     {
       "cefr": "A1",
       "gloss": "home; toward home",
+      "glossClean": "home",
       "heritage": "standard",
       "ipa": null,
       "lemma": "додому",
       "lemmaId": "додому",
       "lemmaPlain": "додому",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -494,11 +536,13 @@
     {
       "cefr": "A1",
       "gloss": "stop",
+      "glossClean": "stop",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зупинка",
       "lemmaId": "зупинка",
       "lemmaPlain": "зупинка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -538,11 +582,13 @@
     {
       "cefr": "A1",
       "gloss": "cafe",
+      "glossClean": "cafe",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кафе",
       "lemmaId": "кафе",
       "lemmaPlain": "кафе",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -582,11 +628,13 @@
     {
       "cefr": "A1",
       "gloss": "movie theater",
+      "glossClean": "movie theater",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кінотеатр",
       "lemmaId": "кінотеатр",
       "lemmaPlain": "кінотеатр",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -597,11 +645,13 @@
     {
       "cefr": "A1",
       "gloss": "hospital",
+      "glossClean": "hospital",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лікарня",
       "lemmaId": "лікарня",
       "lemmaPlain": "лікарня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -641,11 +691,13 @@
     {
       "cefr": "A1",
       "gloss": "shop; store",
+      "glossClean": "shop",
       "heritage": "standard",
       "ipa": null,
       "lemma": "магазин",
       "lemmaId": "магазин",
       "lemmaPlain": "магазин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -656,11 +708,13 @@
     {
       "cefr": "A1",
       "gloss": "metro",
+      "glossClean": "metro",
       "heritage": "standard",
       "ipa": null,
       "lemma": "метро",
       "lemmaId": "метро",
       "lemmaPlain": "метро",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -700,11 +754,13 @@
     {
       "cefr": "A1",
       "gloss": "museum",
+      "glossClean": "museum",
       "heritage": "standard",
       "ipa": null,
       "lemma": "музей",
       "lemmaId": "музей",
       "lemmaPlain": "музей",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -715,11 +771,13 @@
     {
       "cefr": "A1",
       "gloss": "city; town",
+      "glossClean": "city",
       "heritage": "standard",
       "ipa": null,
       "lemma": "місто",
       "lemmaId": "місто",
       "lemmaPlain": "місто",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -730,11 +788,13 @@
     {
       "cefr": "A1",
       "gloss": "on the corner",
+      "glossClean": "on the corner",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "на розі",
       "lemmaId": "на-розі",
       "lemmaPlain": "на розі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -745,11 +805,13 @@
     {
       "cefr": "A1",
       "gloss": "to the left",
+      "glossClean": "to the left",
       "heritage": "standard",
       "ipa": null,
       "lemma": "наліво",
       "lemmaId": "наліво",
       "lemmaPlain": "наліво",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -760,11 +822,13 @@
     {
       "cefr": "A1",
       "gloss": "to the right",
+      "glossClean": "to the right",
       "heritage": "standard",
       "ipa": null,
       "lemma": "направо",
       "lemmaId": "направо",
       "lemmaPlain": "направо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -775,11 +839,13 @@
     {
       "cefr": "A1",
       "gloss": "park",
+      "glossClean": "park",
       "heritage": "standard",
       "ipa": null,
       "lemma": "парк",
       "lemmaId": "парк",
       "lemmaPlain": "парк",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -790,11 +856,13 @@
     {
       "cefr": "A1",
       "gloss": "square",
+      "glossClean": "square",
       "heritage": "standard",
       "ipa": null,
       "lemma": "площа",
       "lemmaId": "площа",
       "lemmaPlain": "площа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -805,11 +873,13 @@
     {
       "cefr": "A1",
       "gloss": "post office",
+      "glossClean": "post office",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пошта",
       "lemmaId": "пошта",
       "lemmaPlain": "пошта",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -849,11 +919,13 @@
     {
       "cefr": "A1",
       "gloss": "straight ahead",
+      "glossClean": "straight ahead",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прямо",
       "lemmaId": "прямо",
       "lemmaPlain": "прямо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -864,11 +936,13 @@
     {
       "cefr": "A1",
       "gloss": "on foot",
+      "glossClean": "on foot",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пішки",
       "lemmaId": "пішки",
       "lemmaPlain": "пішки",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -879,11 +953,13 @@
     {
       "cefr": "A1",
       "gloss": "neighborhood; district",
+      "glossClean": "neighborhood",
       "heritage": "standard",
       "ipa": null,
       "lemma": "район",
       "lemmaId": "район",
       "lemmaPlain": "район",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -894,11 +970,13 @@
     {
       "cefr": "A1",
       "gloss": "restaurant",
+      "glossClean": "restaurant",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ресторан",
       "lemmaId": "ресторан",
       "lemmaPlain": "ресторан",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -909,11 +987,13 @@
     {
       "cefr": "A1",
       "gloss": "stadium",
+      "glossClean": "stadium",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стадіон",
       "lemmaId": "стадіон",
       "lemmaPlain": "стадіон",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -924,11 +1004,13 @@
     {
       "cefr": "A1",
       "gloss": "station",
+      "glossClean": "station",
       "heritage": "standard",
       "ipa": null,
       "lemma": "станція",
       "lemmaId": "станція",
       "lemmaPlain": "станція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -968,11 +1050,13 @@
     {
       "cefr": "A1",
       "gloss": "supermarket",
+      "glossClean": "supermarket",
       "heritage": "standard",
       "ipa": null,
       "lemma": "супермаркет",
       "lemmaId": "супермаркет",
       "lemmaPlain": "супермаркет",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -983,11 +1067,13 @@
     {
       "cefr": "A1",
       "gloss": "theater",
+      "glossClean": "theater",
       "heritage": "standard",
       "ipa": null,
       "lemma": "театр",
       "lemmaId": "театр",
       "lemmaPlain": "театр",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -998,11 +1084,13 @@
     {
       "cefr": "A1",
       "gloss": "tram",
+      "glossClean": "tram",
       "heritage": "standard",
       "ipa": null,
       "lemma": "трамвай",
       "lemmaId": "трамвай",
       "lemmaPlain": "трамвай",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1013,11 +1101,13 @@
     {
       "cefr": "A1",
       "gloss": "minute",
+      "glossClean": "minute",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хвилина",
       "lemmaId": "хвилина",
       "lemmaPlain": "хвилина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1057,11 +1147,13 @@
     {
       "cefr": "A1",
       "gloss": "school",
+      "glossClean": "school",
       "heritage": "authentic-archaism",
       "ipa": null,
       "lemma": "школа",
       "lemmaId": "школа",
       "lemmaPlain": "школа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1101,11 +1193,13 @@
     {
       "cefr": "A1",
       "gloss": "to go on foot",
+      "glossClean": "to go on foot",
       "heritage": "standard",
       "ipa": null,
       "lemma": "іти",
       "lemmaId": "іти",
       "lemmaPlain": "іти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1116,11 +1210,13 @@
     {
       "cefr": "A1",
       "gloss": "to go by vehicle",
+      "glossClean": "to go by vehicle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "їхати",
       "lemmaId": "їхати",
       "lemmaPlain": "їхати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1131,11 +1227,13 @@
     {
       "cefr": "A1",
       "gloss": "please",
+      "glossClean": "please",
       "heritage": "standard",
       "ipa": null,
       "lemma": "будь ласка",
       "lemmaId": "будь-ласка",
       "lemmaPlain": "будь ласка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1146,11 +1244,13 @@
     {
       "cefr": "A1",
       "gloss": "vegetarian menu",
+      "glossClean": "vegetarian menu",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "вегетаріанське меню",
       "lemmaId": "вегетаріанське-меню",
       "lemmaPlain": "вегетаріанське меню",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1161,11 +1261,13 @@
     {
       "cefr": "A1",
       "gloss": "a large coffee",
+      "glossClean": "a large coffee",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "велику каву",
       "lemmaId": "велику-каву",
       "lemmaPlain": "велику каву",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1176,11 +1278,13 @@
     {
       "cefr": "A1",
       "gloss": "hryvnia",
+      "glossClean": "hryvnia",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гривня",
       "lemmaId": "гривня",
       "lemmaPlain": "гривня",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -1191,11 +1295,13 @@
     {
       "cefr": "A1",
       "gloss": "Goodbye!",
+      "glossClean": "Goodbye!",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "До побачення!",
       "lemmaId": "до-побачення",
       "lemmaPlain": "до побачення!",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -1206,11 +1312,13 @@
     {
       "cefr": "A1",
       "gloss": "to order",
+      "glossClean": "to order",
       "heritage": "standard",
       "ipa": null,
       "lemma": "замовляти",
       "lemmaId": "замовляти",
       "lemmaPlain": "замовляти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1221,11 +1329,13 @@
     {
       "cefr": "A1",
       "gloss": "a small coffee",
+      "glossClean": "a small coffee",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "маленьку каву",
       "lemmaId": "маленьку-каву",
       "lemmaPlain": "маленьку каву",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1236,11 +1346,13 @@
     {
       "cefr": "A1",
       "gloss": "menu",
+      "glossClean": "menu",
       "heritage": "standard",
       "ipa": null,
       "lemma": "меню",
       "lemmaId": "меню",
       "lemmaPlain": "меню",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1280,11 +1392,13 @@
     {
       "cefr": "A1",
       "gloss": "waiter",
+      "glossClean": "waiter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "офіціант",
       "lemmaId": "офіціант",
       "lemmaPlain": "офіціант",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1295,11 +1409,13 @@
     {
       "cefr": "A1",
       "gloss": "waitress",
+      "glossClean": "waitress",
       "heritage": "standard",
       "ipa": null,
       "lemma": "офіціантка",
       "lemmaId": "офіціантка",
       "lemmaPlain": "офіціантка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1310,11 +1426,13 @@
     {
       "cefr": "A1",
       "gloss": "bill",
+      "glossClean": "bill",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рахунок",
       "lemmaId": "рахунок",
       "lemmaPlain": "рахунок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1325,11 +1443,13 @@
     {
       "cefr": "A1",
       "gloss": "tasty; deliciously",
+      "glossClean": "tasty",
       "heritage": "standard",
       "ipa": null,
       "lemma": "смачно",
       "lemmaId": "смачно",
       "lemmaPlain": "смачно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1340,11 +1460,13 @@
     {
       "cefr": "A1",
       "gloss": "here",
+      "glossClean": "here",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тут",
       "lemmaId": "тут",
       "lemmaPlain": "тут",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1355,11 +1477,13 @@
     {
       "cefr": "A1",
       "gloss": "to go; with me",
+      "glossClean": "to go",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "із собою",
       "lemmaId": "із-собою",
       "lemmaPlain": "із собою",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1370,11 +1494,13 @@
     {
       "cefr": "A1",
       "gloss": "to speak",
+      "glossClean": "to speak",
       "heritage": "standard",
       "ipa": null,
       "lemma": "говорити",
       "lemmaId": "говорити",
       "lemmaPlain": "говорити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1385,11 +1511,13 @@
     {
       "cefr": "A1",
       "gloss": "to cook; to prepare",
+      "glossClean": "to cook",
       "heritage": "standard",
       "ipa": null,
       "lemma": "готувати",
       "lemmaId": "готувати",
       "lemmaPlain": "готувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1400,11 +1528,13 @@
     {
       "cefr": "A1",
       "gloss": "to play",
+      "glossClean": "to play",
       "heritage": "standard",
       "ipa": null,
       "lemma": "грати",
       "lemmaId": "грати",
       "lemmaPlain": "грати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1415,11 +1545,13 @@
     {
       "cefr": "A1",
       "gloss": "to walk",
+      "glossClean": "to walk",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гуляти",
       "lemmaId": "гуляти",
       "lemmaPlain": "гуляти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1430,11 +1562,13 @@
     {
       "cefr": "A1",
       "gloss": "where",
+      "glossClean": "where",
       "heritage": "standard",
       "ipa": null,
       "lemma": "де",
       "lemmaId": "де",
       "lemmaPlain": "де",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -1445,11 +1579,13 @@
     {
       "cefr": "A1",
       "gloss": "to watch; to look",
+      "glossClean": "to watch",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дивитися",
       "lemmaId": "дивитися",
       "lemmaPlain": "дивитися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1460,11 +1596,13 @@
     {
       "cefr": "A1",
       "gloss": "to help",
+      "glossClean": "to help",
       "heritage": "standard",
       "ipa": null,
       "lemma": "допомагати",
       "lemmaId": "допомагати",
       "lemmaPlain": "допомагати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1475,11 +1613,13 @@
     {
       "cefr": "A1",
       "gloss": "when",
+      "glossClean": "when",
       "heritage": "standard",
       "ipa": null,
       "lemma": "коли",
       "lemmaId": "коли",
       "lemmaPlain": "коли",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -1490,11 +1630,13 @@
     {
       "cefr": "A1",
       "gloss": "where to",
+      "glossClean": "where to",
       "heritage": "standard",
       "ipa": null,
       "lemma": "куди",
       "lemmaId": "куди",
       "lemmaPlain": "куди",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -1505,11 +1647,13 @@
     {
       "cefr": "A1",
       "gloss": "to like; to love",
+      "glossClean": "to like",
       "heritage": "standard",
       "ipa": null,
       "lemma": "любити",
       "lemmaId": "любити",
       "lemmaPlain": "любити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1520,11 +1664,13 @@
     {
       "cefr": "A1",
       "gloss": "to be able to",
+      "glossClean": "to be able to",
       "heritage": "standard",
       "ipa": null,
       "lemma": "могти",
       "lemmaId": "могти",
       "lemmaPlain": "могти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1535,11 +1681,13 @@
     {
       "cefr": "A1",
       "gloss": "he/she can",
+      "glossClean": "he/she can",
       "heritage": "standard",
       "ipa": null,
       "lemma": "може",
       "lemmaId": "може",
       "lemmaPlain": "може",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1550,11 +1698,13 @@
     {
       "cefr": "A1",
       "gloss": "to write",
+      "glossClean": "to write",
       "heritage": "standard",
       "ipa": null,
       "lemma": "писати",
       "lemmaId": "писати",
       "lemmaPlain": "писати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1565,11 +1715,13 @@
     {
       "cefr": "A1",
       "gloss": "then",
+      "glossClean": "then",
       "heritage": "standard",
       "ipa": null,
       "lemma": "потім",
       "lemmaId": "потім",
       "lemmaPlain": "потім",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1580,11 +1732,13 @@
     {
       "cefr": "A1",
       "gloss": "to work",
+      "glossClean": "to work",
       "heritage": "standard",
       "ipa": null,
       "lemma": "працювати",
       "lemmaId": "працювати",
       "lemmaPlain": "працювати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1595,11 +1749,13 @@
     {
       "cefr": "A1",
       "gloss": "after that",
+      "glossClean": "after that",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "після цього",
       "lemmaId": "після-цього",
       "lemmaPlain": "після цього",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1610,11 +1766,13 @@
     {
       "cefr": "A1",
       "gloss": "to go",
+      "glossClean": "to go",
       "heritage": "standard",
       "ipa": null,
       "lemma": "піти",
       "lemmaId": "піти",
       "lemmaPlain": "піти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1625,11 +1783,13 @@
     {
       "cefr": "A1",
       "gloss": "to do; to make",
+      "glossClean": "to do",
       "heritage": "standard",
       "ipa": null,
       "lemma": "робити",
       "lemmaId": "робити",
       "lemmaPlain": "робити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1640,11 +1800,13 @@
     {
       "cefr": "A1",
       "gloss": "to have breakfast",
+      "glossClean": "to have breakfast",
       "heritage": "standard",
       "ipa": null,
       "lemma": "снідати",
       "lemmaId": "снідати",
       "lemmaPlain": "снідати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1655,11 +1817,13 @@
     {
       "cefr": "A1",
       "gloss": "first",
+      "glossClean": "first",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спочатку",
       "lemmaId": "спочатку",
       "lemmaPlain": "спочатку",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1670,11 +1834,13 @@
     {
       "cefr": "A1",
       "gloss": "to sing",
+      "glossClean": "to sing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "співати",
       "lemmaId": "співати",
       "lemmaPlain": "співати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1685,11 +1851,13 @@
     {
       "cefr": "A1",
       "gloss": "to dance",
+      "glossClean": "to dance",
       "heritage": "standard",
       "ipa": null,
       "lemma": "танцювати",
       "lemmaId": "танцювати",
       "lemmaPlain": "танцювати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1700,11 +1868,13 @@
     {
       "cefr": "A1",
       "gloss": "to want",
+      "glossClean": "to want",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хотіти",
       "lemmaId": "хотіти",
       "lemmaPlain": "хотіти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1715,11 +1885,13 @@
     {
       "cefr": "A1",
       "gloss": "who",
+      "glossClean": "who",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хто",
       "lemmaId": "хто",
       "lemmaPlain": "хто",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1730,11 +1902,13 @@
     {
       "cefr": "A1",
       "gloss": "to read",
+      "glossClean": "to read",
       "heritage": "standard",
       "ipa": null,
       "lemma": "читати",
       "lemmaId": "читати",
       "lemmaPlain": "читати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1745,11 +1919,13 @@
     {
       "cefr": "A1",
       "gloss": "why",
+      "glossClean": "why",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чому",
       "lemmaId": "чому",
       "lemmaPlain": "чому",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1760,11 +1936,13 @@
     {
       "cefr": "A1",
       "gloss": "what",
+      "glossClean": "what",
       "heritage": "standard",
       "ipa": null,
       "lemma": "що",
       "lemmaId": "що",
       "lemmaPlain": "що",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1775,11 +1953,13 @@
     {
       "cefr": "A1",
       "gloss": "infinitive",
+      "glossClean": "infinitive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "інфінітив",
       "lemmaId": "інфінітив",
       "lemmaPlain": "інфінітив",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1790,11 +1970,13 @@
     {
       "cefr": "A1",
       "gloss": "to give",
+      "glossClean": "to give",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дати",
       "lemmaId": "дати",
       "lemmaPlain": "дати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1805,11 +1987,13 @@
     {
       "cefr": "A1",
       "gloss": "to help",
+      "glossClean": "to help",
       "heritage": "standard",
       "ipa": null,
       "lemma": "допомогти",
       "lemmaId": "допомогти",
       "lemmaPlain": "допомогти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1820,11 +2004,13 @@
     {
       "cefr": "A1",
       "gloss": "male friend",
+      "glossClean": "male friend",
       "heritage": "standard",
       "ipa": null,
       "lemma": "друг",
       "lemmaId": "друг",
       "lemmaPlain": "друг",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1835,11 +2021,13 @@
     {
       "cefr": "A1",
       "gloss": "Happy Easter",
+      "glossClean": "Happy Easter",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "З Великоднем",
       "lemmaId": "з-великоднем",
       "lemmaPlain": "з великоднем",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1850,11 +2038,13 @@
     {
       "cefr": "A1",
       "gloss": "Happy Independence Day of Ukraine",
+      "glossClean": "Happy Independence Day of Ukraine",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "З Днем Незалежності України",
       "lemmaId": "з-днем-незалежності-україни",
       "lemmaPlain": "з днем незалежності україни",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -1865,11 +2055,13 @@
     {
       "cefr": "A1",
       "gloss": "Happy New Year",
+      "glossClean": "Happy New Year",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "З Новим роком",
       "lemmaId": "з-новим-роком",
       "lemmaPlain": "з новим роком",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1880,11 +2072,13 @@
     {
       "cefr": "A1",
       "gloss": "Merry Christmas",
+      "glossClean": "Merry Christmas",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "З Різдвом Христовим",
       "lemmaId": "з-різдвом-христовим",
       "lemmaPlain": "з різдвом христовим",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1895,11 +2089,13 @@
     {
       "cefr": "A1",
       "gloss": "marker",
+      "glossClean": "marker",
       "heritage": "standard",
       "ipa": null,
       "lemma": "маркер",
       "lemmaId": "маркер",
       "lemmaPlain": "маркер",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -1910,11 +2106,13 @@
     {
       "cefr": "A1",
       "gloss": "Mariia",
+      "glossClean": "Mariia",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Марія",
       "lemmaId": "марія",
       "lemmaPlain": "марія",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -1925,11 +2123,13 @@
     {
       "cefr": "A1",
       "gloss": "to write",
+      "glossClean": "to write",
       "heritage": "standard",
       "ipa": null,
       "lemma": "написати",
       "lemmaId": "написати",
       "lemmaPlain": "написати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1940,11 +2140,13 @@
     {
       "cefr": "A1",
       "gloss": "drink",
+      "glossClean": "drink",
       "heritage": "standard",
       "ipa": null,
       "lemma": "напій",
       "lemmaId": "напій",
       "lemmaPlain": "напій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1955,11 +2157,13 @@
     {
       "cefr": "A1",
       "gloss": "Olena",
+      "glossClean": "Olena",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Олена",
       "lemmaId": "олена",
       "lemmaPlain": "олена",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -1970,11 +2174,13 @@
     {
       "cefr": "A1",
       "gloss": "table",
+      "glossClean": "table",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стіл",
       "lemmaId": "стіл",
       "lemmaPlain": "стіл",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1985,11 +2191,13 @@
     {
       "cefr": "A1",
       "gloss": "chair",
+      "glossClean": "chair",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стілець",
       "lemmaId": "стілець",
       "lemmaPlain": "стілець",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2000,11 +2208,13 @@
     {
       "cefr": "A1",
       "gloss": "Taras",
+      "glossClean": "Taras",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Тарас",
       "lemmaId": "тарас",
       "lemmaPlain": "тарас",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -2015,11 +2225,13 @@
     {
       "cefr": "A1",
       "gloss": "brother",
+      "glossClean": "brother",
       "heritage": "standard",
       "ipa": null,
       "lemma": "брат",
       "lemmaId": "брат",
       "lemmaPlain": "брат",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2030,11 +2242,13 @@
     {
       "cefr": "A1",
       "gloss": "very nice to meet you",
+      "glossClean": "very nice to meet you",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Дуже приємно",
       "lemmaId": "дуже-приємно",
       "lemmaPlain": "дуже приємно",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -2045,11 +2259,13 @@
     {
       "cefr": "A1",
       "gloss": "where are you from? informal",
+      "glossClean": "where are you from? informal",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Звідки ти?",
       "lemmaId": "звідки-ти",
       "lemmaPlain": "звідки ти?",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -2060,11 +2276,13 @@
     {
       "cefr": "A1",
       "gloss": "his / him",
+      "glossClean": "his / him",
       "heritage": "standard",
       "ipa": null,
       "lemma": "його",
       "lemmaId": "його",
       "lemmaPlain": "його",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -2075,11 +2293,13 @@
     {
       "cefr": "A1",
       "gloss": "mom",
+      "glossClean": "mom",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мама",
       "lemmaId": "мама",
       "lemmaPlain": "мама",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2090,11 +2310,13 @@
     {
       "cefr": "A1",
       "gloss": "my name is",
+      "glossClean": "my name is",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Мене звати",
       "lemmaId": "мене-звати",
       "lemmaPlain": "мене звати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2105,11 +2327,13 @@
     {
       "cefr": "A1",
       "gloss": "I am 20 years old",
+      "glossClean": "I am 20 years old",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Мені 20 років",
       "lemmaId": "мені-20-років",
       "lemmaPlain": "мені 20 років",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -2120,11 +2344,13 @@
     {
       "cefr": "A1",
       "gloss": "me too",
+      "glossClean": "me too",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Мені теж",
       "lemmaId": "мені-теж",
       "lemmaPlain": "мені теж",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2135,11 +2361,13 @@
     {
       "cefr": "A1",
       "gloss": "my, masculine",
+      "glossClean": "my",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мій",
       "lemmaId": "мій",
       "lemmaPlain": "мій",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -2150,11 +2378,13 @@
     {
       "cefr": "A1",
       "gloss": "nationality",
+      "glossClean": "nationality",
       "heritage": "standard",
       "ipa": null,
       "lemma": "національність",
       "lemmaId": "національність",
       "lemmaPlain": "національність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2165,11 +2395,13 @@
     {
       "cefr": "A1",
       "gloss": "profession",
+      "glossClean": "profession",
       "heritage": "standard",
       "ipa": null,
       "lemma": "професія",
       "lemmaId": "професія",
       "lemmaPlain": "професія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2209,11 +2441,13 @@
     {
       "cefr": "A1",
       "gloss": "surname",
+      "glossClean": "surname",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прізвище",
       "lemmaId": "прізвище",
       "lemmaPlain": "прізвище",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2224,11 +2458,13 @@
     {
       "cefr": "A1",
       "gloss": "sister",
+      "glossClean": "sister",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сестра",
       "lemmaId": "сестра",
       "lemmaPlain": "сестра",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2239,11 +2475,13 @@
     {
       "cefr": "A1",
       "gloss": "male student",
+      "glossClean": "male student",
       "heritage": "standard",
       "ipa": null,
       "lemma": "студент",
       "lemmaId": "студент",
       "lemmaPlain": "студент",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2254,11 +2492,13 @@
     {
       "cefr": "A1",
       "gloss": "female student",
+      "glossClean": "female student",
       "heritage": "standard",
       "ipa": null,
       "lemma": "студентка",
       "lemmaId": "студентка",
       "lemmaPlain": "студентка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2269,11 +2509,13 @@
     {
       "cefr": "A1",
       "gloss": "family, close household",
+      "glossClean": "family",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сім'я",
       "lemmaId": "сім-я",
       "lemmaPlain": "сім'я",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2284,11 +2526,13 @@
     {
       "cefr": "A1",
       "gloss": "dad",
+      "glossClean": "dad",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тато",
       "lemmaId": "тато",
       "lemmaPlain": "тато",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2299,11 +2543,13 @@
     {
       "cefr": "A1",
       "gloss": "I have",
+      "glossClean": "I have",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "У мене є",
       "lemmaId": "у-мене-є",
       "lemmaPlain": "у мене є",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2314,11 +2560,13 @@
     {
       "cefr": "A1",
       "gloss": "do you have / you have",
+      "glossClean": "do you have / you have",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "У тебе є",
       "lemmaId": "у-тебе-є",
       "lemmaPlain": "у тебе є",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -2329,11 +2577,13 @@
     {
       "cefr": "A1",
       "gloss": "I am from",
+      "glossClean": "I am from",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Я з",
       "lemmaId": "я-з",
       "lemmaPlain": "я з",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2344,11 +2594,13 @@
     {
       "cefr": "A1",
       "gloss": "what is your name? informal",
+      "glossClean": "what is your name? informal",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Як тебе звати?",
       "lemmaId": "як-тебе-звати",
       "lemmaPlain": "як тебе звати?",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -2359,11 +2611,13 @@
     {
       "cefr": "A1",
       "gloss": "first name",
+      "glossClean": "first name",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ім'я",
       "lemmaId": "ім-я",
       "lemmaPlain": "ім'я",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2374,11 +2628,13 @@
     {
       "cefr": "A1",
       "gloss": "engineer",
+      "glossClean": "engineer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "інженер",
       "lemmaId": "інженер",
       "lemmaPlain": "інженер",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2389,11 +2645,13 @@
     {
       "cefr": "A1",
       "gloss": "her",
+      "glossClean": "her",
       "heritage": "standard",
       "ipa": null,
       "lemma": "її",
       "lemmaId": "її",
       "lemmaPlain": "її",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -2404,11 +2662,13 @@
     {
       "cefr": "A1",
       "gloss": "to see",
+      "glossClean": "to see",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бачити",
       "lemmaId": "бачити",
       "lemmaPlain": "бачити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2419,11 +2679,13 @@
     {
       "cefr": "A1",
       "gloss": "water",
+      "glossClean": "water",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вода",
       "lemmaId": "вода",
       "lemmaPlain": "вода",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2463,11 +2725,13 @@
     {
       "cefr": "A1",
       "gloss": "hot",
+      "glossClean": "hot",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гарячий",
       "lemmaId": "гарячий",
       "lemmaPlain": "гарячий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2478,11 +2742,13 @@
     {
       "cefr": "A1",
       "gloss": "Please give",
+      "glossClean": "Please give",
       "heritage": "standard",
       "ipa": null,
       "lemma": "Дайте, будь ласка",
       "lemmaId": "дайте-будь-ласка",
       "lemmaPlain": "дайте, будь ласка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2493,11 +2759,13 @@
     {
       "cefr": "A1",
       "gloss": "to know",
+      "glossClean": "to know",
       "heritage": "standard",
       "ipa": null,
       "lemma": "знати",
       "lemmaId": "знати",
       "lemmaPlain": "знати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2508,11 +2776,13 @@
     {
       "cefr": "A1",
       "gloss": "coffee",
+      "glossClean": "coffee",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кава",
       "lemmaId": "кава",
       "lemmaPlain": "кава",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2552,11 +2822,13 @@
     {
       "cefr": "A1",
       "gloss": "to cost",
+      "glossClean": "to cost",
       "heritage": "standard",
       "ipa": null,
       "lemma": "коштувати",
       "lemmaId": "коштувати",
       "lemmaPlain": "коштувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2567,11 +2839,13 @@
     {
       "cefr": "A1",
       "gloss": "to buy",
+      "glossClean": "to buy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "купити",
       "lemmaId": "купити",
       "lemmaPlain": "купити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2582,11 +2856,13 @@
     {
       "cefr": "A1",
       "gloss": "to buy; to be buying",
+      "glossClean": "to buy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "купувати",
       "lemmaId": "купувати",
       "lemmaPlain": "купувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2597,11 +2873,13 @@
     {
       "cefr": "A1",
       "gloss": "kilogram",
+      "glossClean": "kilogram",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кілограм",
       "lemmaId": "кілограм",
       "lemmaPlain": "кілограм",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2612,11 +2890,13 @@
     {
       "cefr": "A1",
       "gloss": "doctor",
+      "glossClean": "doctor",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лікар",
       "lemmaId": "лікар",
       "lemmaPlain": "лікар",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2627,11 +2907,13 @@
     {
       "cefr": "A1",
       "gloss": "Coffee for me, please",
+      "glossClean": "Coffee for me",
       "heritage": "standard",
       "ipa": null,
       "lemma": "Мені каву, будь ласка",
       "lemmaId": "мені-каву-будь-ласка",
       "lemmaPlain": "мені каву, будь ласка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2642,11 +2924,13 @@
     {
       "cefr": "A1",
       "gloss": "Can I pay by card?",
+      "glossClean": "Can I pay by card?",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Можна карткою?",
       "lemmaId": "можна-карткою",
       "lemmaPlain": "можна карткою?",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -2657,11 +2941,13 @@
     {
       "cefr": "A1",
       "gloss": "milk",
+      "glossClean": "milk",
       "heritage": "standard",
       "ipa": null,
       "lemma": "молоко",
       "lemmaId": "молоко",
       "lemmaPlain": "молоко",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2672,11 +2958,13 @@
     {
       "cefr": "A1",
       "gloss": "pack of tea",
+      "glossClean": "pack of tea",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пачка чаю",
       "lemmaId": "пачка-чаю",
       "lemmaPlain": "пачка чаю",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2687,11 +2975,13 @@
     {
       "cefr": "A1",
       "gloss": "to drink",
+      "glossClean": "to drink",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пити",
       "lemmaId": "пити",
       "lemmaPlain": "пити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2702,11 +2992,13 @@
     {
       "cefr": "A1",
       "gloss": "to pay",
+      "glossClean": "to pay",
       "heritage": "standard",
       "ipa": null,
       "lemma": "платити",
       "lemmaId": "платити",
       "lemmaPlain": "платити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2717,11 +3009,13 @@
     {
       "cefr": "A1",
       "gloss": "bottle of water",
+      "glossClean": "bottle of water",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пляшка води",
       "lemmaId": "пляшка-води",
       "lemmaPlain": "пляшка води",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2732,11 +3026,13 @@
     {
       "cefr": "A1",
       "gloss": "tomato",
+      "glossClean": "tomato",
       "heritage": "standard",
       "ipa": null,
       "lemma": "помідор",
       "lemmaId": "помідор",
       "lemmaPlain": "помідор",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2747,11 +3043,13 @@
     {
       "cefr": "A1",
       "gloss": "salad",
+      "glossClean": "salad",
       "heritage": "standard",
       "ipa": null,
       "lemma": "салат",
       "lemmaId": "салат",
       "lemmaPlain": "салат",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2762,11 +3060,13 @@
     {
       "cefr": "A1",
       "gloss": "fresh",
+      "glossClean": "fresh",
       "heritage": "standard",
       "ipa": null,
       "lemma": "свіжий",
       "lemmaId": "свіжий",
       "lemmaPlain": "свіжий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2777,11 +3077,13 @@
     {
       "cefr": "A1",
       "gloss": "cheese",
+      "glossClean": "cheese",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сир",
       "lemmaId": "сир",
       "lemmaPlain": "сир",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2792,11 +3094,13 @@
     {
       "cefr": "A1",
       "gloss": "glass",
+      "glossClean": "glass",
       "heritage": "standard",
       "ipa": null,
       "lemma": "склянка",
       "lemmaId": "склянка",
       "lemmaPlain": "склянка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2836,11 +3140,13 @@
     {
       "cefr": "A1",
       "gloss": "how much do they cost",
+      "glossClean": "how much do they cost",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "скільки коштують",
       "lemmaId": "скільки-коштують",
       "lemmaPlain": "скільки коштують",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -2851,11 +3157,13 @@
     {
       "cefr": "A1",
       "gloss": "how much does it cost",
+      "glossClean": "how much does it cost",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "скільки коштує",
       "lemmaId": "скільки-коштує",
       "lemmaPlain": "скільки коштує",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -2866,11 +3174,13 @@
     {
       "cefr": "A1",
       "gloss": "fried potatoes",
+      "glossClean": "fried potatoes",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "смажена картопля",
       "lemmaId": "смажена-картопля",
       "lemmaPlain": "смажена картопля",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2881,11 +3191,13 @@
     {
       "cefr": "A1",
       "gloss": "tasty",
+      "glossClean": "tasty",
       "heritage": "standard",
       "ipa": null,
       "lemma": "смачний",
       "lemmaId": "смачний",
       "lemmaPlain": "смачний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2896,11 +3208,13 @@
     {
       "cefr": "A1",
       "gloss": "dish",
+      "glossClean": "dish",
       "heritage": "standard",
       "ipa": null,
       "lemma": "страва",
       "lemmaId": "страва",
       "lemmaPlain": "страва",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2940,11 +3254,13 @@
     {
       "cefr": "A1",
       "gloss": "male neighbor",
+      "glossClean": "male neighbor",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сусід",
       "lemmaId": "сусід",
       "lemmaPlain": "сусід",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2955,11 +3271,13 @@
     {
       "cefr": "A1",
       "gloss": "juice",
+      "glossClean": "juice",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сік",
       "lemmaId": "сік",
       "lemmaPlain": "сік",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2970,11 +3288,13 @@
     {
       "cefr": "A1",
       "gloss": "plate",
+      "glossClean": "plate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тарілка",
       "lemmaId": "тарілка",
       "lemmaPlain": "тарілка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3014,11 +3334,13 @@
     {
       "cefr": "A1",
       "gloss": "you like",
+      "glossClean": "you like",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "ти любиш",
       "lemmaId": "ти-любиш",
       "lemmaPlain": "ти любиш",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3029,11 +3351,13 @@
     {
       "cefr": "A1",
       "gloss": "For here, please",
+      "glossClean": "For here",
       "heritage": "standard",
       "ipa": null,
       "lemma": "Тут, будь ласка",
       "lemmaId": "тут-будь-ласка",
       "lemmaPlain": "тут, будь ласка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3044,11 +3368,13 @@
     {
       "cefr": "A1",
       "gloss": "bread",
+      "glossClean": "bread",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хліб",
       "lemmaId": "хліб",
       "lemmaPlain": "хліб",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3059,11 +3385,13 @@
     {
       "cefr": "A1",
       "gloss": "cold",
+      "glossClean": "cold",
       "heritage": "standard",
       "ipa": null,
       "lemma": "холодний",
       "lemmaId": "холодний",
       "lemmaPlain": "холодний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3074,11 +3402,13 @@
     {
       "cefr": "A1",
       "gloss": "price",
+      "glossClean": "price",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ціна",
       "lemmaId": "ціна",
       "lemmaPlain": "ціна",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3118,11 +3448,13 @@
     {
       "cefr": "A1",
       "gloss": "tea",
+      "glossClean": "tea",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чай",
       "lemmaId": "чай",
       "lemmaPlain": "чай",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3133,11 +3465,13 @@
     {
       "cefr": "A1",
       "gloss": "to wait for",
+      "glossClean": "to wait for",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чекати",
       "lemmaId": "чекати",
       "lemmaPlain": "чекати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3148,11 +3482,13 @@
     {
       "cefr": "A1",
       "gloss": "piece of bread",
+      "glossClean": "piece of bread",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "шматок хліба",
       "lemmaId": "шматок-хліба",
       "lemmaPlain": "шматок хліба",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3163,11 +3499,13 @@
     {
       "cefr": "A1",
       "gloss": "I eat dinner",
+      "glossClean": "I eat dinner",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "я вечеряю",
       "lemmaId": "я-вечеряю",
       "lemmaPlain": "я вечеряю",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3178,11 +3516,13 @@
     {
       "cefr": "A1",
       "gloss": "I eat lunch",
+      "glossClean": "I eat lunch",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "я обідаю",
       "lemmaId": "я-обідаю",
       "lemmaPlain": "я обідаю",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3193,11 +3533,13 @@
     {
       "cefr": "A1",
       "gloss": "I drink",
+      "glossClean": "I drink",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "я п'ю",
       "lemmaId": "я-п-ю",
       "lemmaPlain": "я п'ю",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3208,11 +3550,13 @@
     {
       "cefr": "A1",
       "gloss": "I eat breakfast",
+      "glossClean": "I eat breakfast",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "я снідаю",
       "lemmaId": "я-снідаю",
       "lemmaPlain": "я снідаю",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3223,11 +3567,13 @@
     {
       "cefr": "A1",
       "gloss": "I want",
+      "glossClean": "I want",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "я хочу",
       "lemmaId": "я-хочу",
       "lemmaPlain": "я хочу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3238,11 +3584,13 @@
     {
       "cefr": "A1",
       "gloss": "I eat",
+      "glossClean": "I eat",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "я їм",
       "lemmaId": "я-їм",
       "lemmaPlain": "я їм",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3253,11 +3601,13 @@
     {
       "cefr": "A1",
       "gloss": "apple",
+      "glossClean": "apple",
       "heritage": "standard",
       "ipa": null,
       "lemma": "яблуко",
       "lemmaId": "яблуко",
       "lemmaPlain": "яблуко",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3268,11 +3618,13 @@
     {
       "cefr": "A1",
       "gloss": "food",
+      "glossClean": "food",
       "heritage": "standard",
       "ipa": null,
       "lemma": "їжа",
       "lemmaId": "їжа",
       "lemmaPlain": "їжа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3283,11 +3635,13 @@
     {
       "cefr": "A1",
       "gloss": "to eat",
+      "glossClean": "to eat",
       "heritage": "standard",
       "ipa": null,
       "lemma": "їсти",
       "lemmaId": "їсти",
       "lemmaPlain": "їсти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3298,11 +3652,13 @@
     {
       "cefr": "A1",
       "gloss": "light blue, masculine",
+      "glossClean": "light blue",
       "heritage": "standard",
       "ipa": null,
       "lemma": "блакитний",
       "lemmaId": "блакитний",
       "lemmaPlain": "блакитний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3313,11 +3669,13 @@
     {
       "cefr": "A1",
       "gloss": "white, masculine",
+      "glossClean": "white",
       "heritage": "standard",
       "ipa": null,
       "lemma": "білий",
       "lemmaId": "білий",
       "lemmaPlain": "білий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3328,11 +3686,13 @@
     {
       "cefr": "A1",
       "gloss": "white, plural",
+      "glossClean": "white",
       "heritage": "standard",
       "ipa": null,
       "lemma": "білі",
       "lemmaId": "білі",
       "lemmaPlain": "білі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3343,11 +3703,13 @@
     {
       "cefr": "A1",
       "gloss": "big, masculine",
+      "glossClean": "big",
       "heritage": "standard",
       "ipa": null,
       "lemma": "великий",
       "lemmaId": "великий",
       "lemmaPlain": "великий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3358,11 +3720,13 @@
     {
       "cefr": "A1",
       "gloss": "embroidered shirt (recognition)",
+      "glossClean": "embroidered shirt (recognition)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вишиванка",
       "lemmaId": "вишиванка",
       "lemmaPlain": "вишиванка",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3402,11 +3766,13 @@
     {
       "cefr": "A1",
       "gloss": "window",
+      "glossClean": "window",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вікно",
       "lemmaId": "вікно",
       "lemmaPlain": "вікно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3417,11 +3783,13 @@
     {
       "cefr": "A1",
       "gloss": "twenty",
+      "glossClean": "twenty",
       "heritage": "standard",
       "ipa": null,
       "lemma": "двадцять",
       "lemmaId": "двадцять",
       "lemmaPlain": "двадцять",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3432,11 +3800,13 @@
     {
       "cefr": "A1",
       "gloss": "two hundred",
+      "glossClean": "two hundred",
       "heritage": "standard",
       "ipa": null,
       "lemma": "двісті",
       "lemmaId": "двісті",
       "lemmaPlain": "двісті",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3447,11 +3817,13 @@
     {
       "cefr": "A1",
       "gloss": "yellow, masculine",
+      "glossClean": "yellow",
       "heritage": "standard",
       "ipa": null,
       "lemma": "жовтий",
       "lemmaId": "жовтий",
       "lemmaPlain": "жовтий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3462,11 +3834,13 @@
     {
       "cefr": "A1",
       "gloss": "notebook",
+      "glossClean": "notebook",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зошит",
       "lemmaId": "зошит",
       "lemmaPlain": "зошит",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3477,11 +3851,13 @@
     {
       "cefr": "A1",
       "gloss": "armchair",
+      "glossClean": "armchair",
       "heritage": "standard",
       "ipa": null,
       "lemma": "крісло",
       "lemmaId": "крісло",
       "lemmaPlain": "крісло",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3492,11 +3868,13 @@
     {
       "cefr": "A1",
       "gloss": "room",
+      "glossClean": "room",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кімната",
       "lemmaId": "кімната",
       "lemmaPlain": "кімната",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3536,11 +3914,13 @@
     {
       "cefr": "A1",
       "gloss": "lamp",
+      "glossClean": "lamp",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лампа",
       "lemmaId": "лампа",
       "lemmaPlain": "лампа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3580,11 +3960,13 @@
     {
       "cefr": "A1",
       "gloss": "new, masculine",
+      "glossClean": "new",
       "heritage": "standard",
       "ipa": null,
       "lemma": "новий",
       "lemmaId": "новий",
       "lemmaPlain": "новий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3595,11 +3977,13 @@
     {
       "cefr": "A1",
       "gloss": "pen",
+      "glossClean": "pen",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ручка",
       "lemmaId": "ручка",
       "lemmaPlain": "ручка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3639,11 +4023,13 @@
     {
       "cefr": "A1",
       "gloss": "dark blue, masculine",
+      "glossClean": "dark blue",
       "heritage": "standard",
       "ipa": null,
       "lemma": "синій",
       "lemmaId": "синій",
       "lemmaPlain": "синій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3654,11 +4040,13 @@
     {
       "cefr": "A1",
       "gloss": "how much; how many",
+      "glossClean": "how much",
       "heritage": "standard",
       "ipa": null,
       "lemma": "скільки",
       "lemmaId": "скільки",
       "lemmaPlain": "скільки",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3669,11 +4057,13 @@
     {
       "cefr": "A1",
       "gloss": "old, masculine",
+      "glossClean": "old",
       "heritage": "standard",
       "ipa": null,
       "lemma": "старий",
       "lemmaId": "старий",
       "lemmaPlain": "старий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3684,11 +4074,13 @@
     {
       "cefr": "A1",
       "gloss": "old, plural",
+      "glossClean": "old",
       "heritage": "standard",
       "ipa": null,
       "lemma": "старі",
       "lemmaId": "старі",
       "lemmaPlain": "старі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3699,11 +4091,13 @@
     {
       "cefr": "A1",
       "gloss": "one hundred",
+      "glossClean": "one hundred",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сто",
       "lemmaId": "сто",
       "lemmaPlain": "сто",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3714,11 +4108,13 @@
     {
       "cefr": "A1",
       "gloss": "bag",
+      "glossClean": "bag",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сумка",
       "lemmaId": "сумка",
       "lemmaPlain": "сумка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3758,11 +4154,13 @@
     {
       "cefr": "A1",
       "gloss": "that, neuter",
+      "glossClean": "that",
       "heritage": "standard",
       "ipa": null,
       "lemma": "те",
       "lemmaId": "те",
       "lemmaPlain": "те",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3773,11 +4171,13 @@
     {
       "cefr": "A1",
       "gloss": "that, masculine",
+      "glossClean": "that",
       "heritage": "standard",
       "ipa": null,
       "lemma": "той",
       "lemmaId": "той",
       "lemmaPlain": "той",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3788,11 +4188,13 @@
     {
       "cefr": "A1",
       "gloss": "three",
+      "glossClean": "three",
       "heritage": "standard",
       "ipa": null,
       "lemma": "три",
       "lemmaId": "три",
       "lemmaPlain": "три",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3803,11 +4205,13 @@
     {
       "cefr": "A1",
       "gloss": "this; this is",
+      "glossClean": "this",
       "heritage": "standard",
       "ipa": null,
       "lemma": "це",
       "lemmaId": "це",
       "lemmaPlain": "це",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3818,11 +4222,13 @@
     {
       "cefr": "A1",
       "gloss": "this, masculine",
+      "glossClean": "this",
       "heritage": "standard",
       "ipa": null,
       "lemma": "цей",
       "lemmaId": "цей",
       "lemmaPlain": "цей",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3833,11 +4239,13 @@
     {
       "cefr": "A1",
       "gloss": "red, masculine",
+      "glossClean": "red",
       "heritage": "standard",
       "ipa": null,
       "lemma": "червоний",
       "lemmaId": "червоний",
       "lemmaPlain": "червоний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3848,11 +4256,13 @@
     {
       "cefr": "A1",
       "gloss": "black, masculine",
+      "glossClean": "black",
       "heritage": "authentic-archaism",
       "ipa": null,
       "lemma": "чорний",
       "lemmaId": "чорний",
       "lemmaPlain": "чорний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3863,11 +4273,13 @@
     {
       "cefr": "A1",
       "gloss": "black, plural",
+      "glossClean": "black",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чорні",
       "lemmaId": "чорні",
       "lemmaPlain": "чорні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3878,11 +4290,13 @@
     {
       "cefr": "A1",
       "gloss": "in; to",
+      "glossClean": "in",
       "heritage": "standard",
       "ipa": null,
       "lemma": "в",
       "lemmaId": "в",
       "lemmaPlain": "в",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3893,11 +4307,13 @@
     {
       "cefr": "A1",
       "gloss": "to live",
+      "glossClean": "to live",
       "heritage": "standard",
       "ipa": null,
       "lemma": "жити",
       "lemmaId": "жити",
       "lemmaPlain": "жити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3908,11 +4324,13 @@
     {
       "cefr": "A1",
       "gloss": "from",
+      "glossClean": "from",
       "heritage": "standard",
       "ipa": null,
       "lemma": "з",
       "lemmaId": "з",
       "lemmaPlain": "з",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3923,11 +4341,13 @@
     {
       "cefr": "A1",
       "gloss": "where from",
+      "glossClean": "where from",
       "heritage": "standard",
       "ipa": null,
       "lemma": "звідки",
       "lemmaId": "звідки",
       "lemmaPlain": "звідки",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3938,11 +4358,13 @@
     {
       "cefr": "A1",
       "gloss": "from",
+      "glossClean": "from",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зі",
       "lemmaId": "зі",
       "lemmaPlain": "зі",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3953,11 +4375,13 @@
     {
       "cefr": "A1",
       "gloss": "Kyiv",
+      "glossClean": "Kyiv",
       "heritage": "standard",
       "ipa": null,
       "lemma": "Київ",
       "lemmaId": "київ",
       "lemmaPlain": "київ",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3968,11 +4392,13 @@
     {
       "cefr": "A1",
       "gloss": "Lviv",
+      "glossClean": "Lviv",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Львів",
       "lemmaId": "львів",
       "lemmaPlain": "львів",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3983,11 +4409,13 @@
     {
       "cefr": "A1",
       "gloss": "on; to",
+      "glossClean": "on",
       "heritage": "standard",
       "ipa": null,
       "lemma": "на",
       "lemmaId": "на",
       "lemmaPlain": "на",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3998,11 +4426,13 @@
     {
       "cefr": "A1",
       "gloss": "Odesa",
+      "glossClean": "Odesa",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Одеса",
       "lemmaId": "одеса",
       "lemmaPlain": "одеса",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4013,11 +4443,13 @@
     {
       "cefr": "A1",
       "gloss": "work",
+      "glossClean": "work",
       "heritage": "standard",
       "ipa": null,
       "lemma": "робота",
       "lemmaId": "робота",
       "lemmaPlain": "робота",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4057,11 +4489,13 @@
     {
       "cefr": "A1",
       "gloss": "there",
+      "glossClean": "there",
       "heritage": "standard",
       "ipa": null,
       "lemma": "там",
       "lemmaId": "там",
       "lemmaPlain": "там",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4072,11 +4506,13 @@
     {
       "cefr": "A1",
       "gloss": "there; to there",
+      "glossClean": "there",
       "heritage": "standard",
       "ipa": null,
       "lemma": "туди",
       "lemmaId": "туди",
       "lemmaPlain": "туди",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4087,11 +4523,13 @@
     {
       "cefr": "A1",
       "gloss": "in; to",
+      "glossClean": "in",
       "heritage": "standard",
       "ipa": null,
       "lemma": "у",
       "lemmaId": "у",
       "lemmaPlain": "у",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4102,11 +4540,13 @@
     {
       "cefr": "A1",
       "gloss": "Ukraine",
+      "glossClean": "Ukraine",
       "heritage": "standard",
       "ipa": null,
       "lemma": "Україна",
       "lemmaId": "україна",
       "lemmaPlain": "україна",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4117,11 +4557,13 @@
     {
       "cefr": "A1",
       "gloss": "Kharkiv",
+      "glossClean": "Kharkiv",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Харків",
       "lemmaId": "харків",
       "lemmaPlain": "харків",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4132,11 +4574,13 @@
     {
       "cefr": "A1",
       "gloss": "from",
+      "glossClean": "from",
       "heritage": "standard",
       "ipa": null,
       "lemma": "із",
       "lemmaId": "із",
       "lemmaPlain": "із",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4147,11 +4591,13 @@
     {
       "cefr": "A1",
       "gloss": "in winter",
+      "glossClean": "in winter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "взимку",
       "lemmaId": "взимку",
       "lemmaPlain": "взимку",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4162,11 +4608,13 @@
     {
       "cefr": "A1",
       "gloss": "in summer",
+      "glossClean": "in summer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "влітку",
       "lemmaId": "влітку",
       "lemmaPlain": "влітку",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4177,11 +4625,13 @@
     {
       "cefr": "A1",
       "gloss": "in autumn",
+      "glossClean": "in autumn",
       "heritage": "standard",
       "ipa": null,
       "lemma": "восени",
       "lemmaId": "восени",
       "lemmaPlain": "восени",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4192,11 +4642,13 @@
     {
       "cefr": "A1",
       "gloss": "to rest",
+      "glossClean": "to rest",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відпочивати",
       "lemmaId": "відпочивати",
       "lemmaPlain": "відпочивати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4207,11 +4659,13 @@
     {
       "cefr": "A1",
       "gloss": "hour; o'clock",
+      "glossClean": "hour",
       "heritage": "standard",
       "ipa": null,
       "lemma": "година",
       "lemmaId": "година",
       "lemmaPlain": "година",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4251,11 +4705,13 @@
     {
       "cefr": "A1",
       "gloss": "to play football",
+      "glossClean": "to play football",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "грати у футбол",
       "lemmaId": "грати-у-футбол",
       "lemmaPlain": "грати у футбол",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4266,11 +4722,13 @@
     {
       "cefr": "A1",
       "gloss": "ten to six",
+      "glossClean": "ten to six",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "за десять шоста",
       "lemmaId": "за-десять-шоста",
       "lemmaPlain": "за десять шоста",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4281,11 +4739,13 @@
     {
       "cefr": "A1",
       "gloss": "What time is it?",
+      "glossClean": "What time is it?",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Котра година?",
       "lemmaId": "котра-година",
       "lemmaPlain": "котра година?",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4296,11 +4756,13 @@
     {
       "cefr": "A1",
       "gloss": "forest",
+      "glossClean": "forest",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ліс",
       "lemmaId": "ліс",
       "lemmaPlain": "ліс",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4311,11 +4773,13 @@
     {
       "cefr": "A1",
       "gloss": "in spring",
+      "glossClean": "in spring",
       "heritage": "standard",
       "ipa": null,
       "lemma": "навесні",
       "lemmaId": "навесні",
       "lemmaPlain": "навесні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4326,11 +4790,13 @@
     {
       "cefr": "A1",
       "gloss": "at ten",
+      "glossClean": "at ten",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "о десятій",
       "lemmaId": "о-десятій",
       "lemmaPlain": "о десятій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4341,11 +4807,13 @@
     {
       "cefr": "A1",
       "gloss": "At what time?",
+      "glossClean": "At what time?",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "О котрій?",
       "lemmaId": "о-котрій",
       "lemmaPlain": "о котрій?",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4356,11 +4824,13 @@
     {
       "cefr": "A1",
       "gloss": "at eleven",
+      "glossClean": "at eleven",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "об одинадцятій",
       "lemmaId": "об-одинадцятій",
       "lemmaPlain": "об одинадцятій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4371,11 +4841,13 @@
     {
       "cefr": "A1",
       "gloss": "five past eight",
+      "glossClean": "five past eight",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "п'ять по восьмій",
       "lemmaId": "п-ять-по-восьмій",
       "lemmaPlain": "п'ять по восьмій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4386,11 +4858,13 @@
     {
       "cefr": "A1",
       "gloss": "half past seven",
+      "glossClean": "half past seven",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пів на восьму",
       "lemmaId": "пів-на-восьму",
       "lemmaPlain": "пів на восьму",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4401,11 +4875,13 @@
     {
       "cefr": "A1",
       "gloss": "the sun is shining",
+      "glossClean": "the sun is shining",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "світить сонце",
       "lemmaId": "світить-сонце",
       "lemmaPlain": "світить сонце",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4416,11 +4892,13 @@
     {
       "cefr": "A1",
       "gloss": "to listen to music",
+      "glossClean": "to listen to music",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "слухати музику",
       "lemmaId": "слухати-музику",
       "lemmaPlain": "слухати музику",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4431,11 +4909,13 @@
     {
       "cefr": "A1",
       "gloss": "warm",
+      "glossClean": "warm",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тепло",
       "lemmaId": "тепло",
       "lemmaPlain": "тепло",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4446,11 +4926,13 @@
     {
       "cefr": "A1",
       "gloss": "in October",
+      "glossClean": "in October",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у жовтні",
       "lemmaId": "у-жовтні",
       "lemmaPlain": "у жовтні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4461,11 +4943,13 @@
     {
       "cefr": "A1",
       "gloss": "on Monday",
+      "glossClean": "on Monday",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у понеділок",
       "lemmaId": "у-понеділок",
       "lemmaPlain": "у понеділок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4476,11 +4960,13 @@
     {
       "cefr": "A1",
       "gloss": "on Saturday",
+      "glossClean": "on Saturday",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у суботу",
       "lemmaId": "у-суботу",
       "lemmaPlain": "у суботу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4491,11 +4977,13 @@
     {
       "cefr": "A1",
       "gloss": "in January",
+      "glossClean": "in January",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у січні",
       "lemmaId": "у-січні",
       "lemmaPlain": "у січні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4506,11 +4994,13 @@
     {
       "cefr": "A1",
       "gloss": "to go to the cinema",
+      "glossClean": "to go to the cinema",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "ходити в кіно",
       "lemmaId": "ходити-в-кіно",
       "lemmaPlain": "ходити в кіно",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4521,11 +5011,13 @@
     {
       "cefr": "A1",
       "gloss": "to go to a museum",
+      "glossClean": "to go to a museum",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "ходити в музей",
       "lemmaId": "ходити-в-музей",
       "lemmaPlain": "ходити в музей",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4536,11 +5028,13 @@
     {
       "cefr": "A1",
       "gloss": "cold",
+      "glossClean": "cold",
       "heritage": "standard",
       "ipa": null,
       "lemma": "холодно",
       "lemmaId": "холодно",
       "lemmaPlain": "холодно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4551,11 +5045,13 @@
     {
       "cefr": "A1",
       "gloss": "time",
+      "glossClean": "time",
       "heritage": "standard",
       "ipa": null,
       "lemma": "час",
       "lemmaId": "час",
       "lemmaPlain": "час",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4566,11 +5062,13 @@
     {
       "cefr": "A1",
       "gloss": "often",
+      "glossClean": "often",
       "heritage": "standard",
       "ipa": null,
       "lemma": "часто",
       "lemmaId": "часто",
       "lemmaPlain": "часто",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4581,11 +5079,13 @@
     {
       "cefr": "A1",
       "gloss": "quarter past eleven",
+      "glossClean": "quarter past eleven",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "чверть на дванадцяту",
       "lemmaId": "чверть-на-дванадцяту",
       "lemmaPlain": "чверть на дванадцяту",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4596,11 +5096,13 @@
     {
       "cefr": "A1",
       "gloss": "if it rains",
+      "glossClean": "if it rains",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "якщо буде дощ",
       "lemmaId": "якщо-буде-дощ",
       "lemmaPlain": "якщо буде дощ",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4611,11 +5113,13 @@
     {
       "cefr": "A1",
       "gloss": "it is raining",
+      "glossClean": "it is raining",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "іде дощ",
       "lemmaId": "іде-дощ",
       "lemmaPlain": "іде дощ",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4626,11 +5130,13 @@
     {
       "cefr": "A1",
       "gloss": "it is snowing",
+      "glossClean": "it is snowing",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "іде сніг",
       "lemmaId": "іде-сніг",
       "lemmaPlain": "іде сніг",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4641,11 +5147,13 @@
     {
       "cefr": "A1",
       "gloss": "green, masculine",
+      "glossClean": "green",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зелений",
       "lemmaId": "зелений",
       "lemmaPlain": "зелений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4656,11 +5164,13 @@
     {
       "cefr": "A1",
       "gloss": "brown eyes",
+      "glossClean": "brown eyes",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "карі очі",
       "lemmaId": "карі-очі",
       "lemmaPlain": "карі очі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4671,11 +5181,13 @@
     {
       "cefr": "A1",
       "gloss": "color",
+      "glossClean": "color",
       "heritage": "standard",
       "ipa": null,
       "lemma": "колір",
       "lemmaId": "колір",
       "lemmaPlain": "колір",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4686,11 +5198,13 @@
     {
       "cefr": "A1",
       "gloss": "brown, masculine",
+      "glossClean": "brown",
       "heritage": "standard",
       "ipa": null,
       "lemma": "коричневий",
       "lemmaId": "коричневий",
       "lemmaPlain": "коричневий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4701,11 +5215,13 @@
     {
       "cefr": "A1",
       "gloss": "flag",
+      "glossClean": "flag",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прапор",
       "lemmaId": "прапор",
       "lemmaPlain": "прапор",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4716,11 +5232,13 @@
     {
       "cefr": "A1",
       "gloss": "fair or light-brown hair",
+      "glossClean": "fair or light-brown hair",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "русяве волосся",
       "lemmaId": "русяве-волосся",
       "lemmaPlain": "русяве волосся",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4731,11 +5249,13 @@
     {
       "cefr": "A1",
       "gloss": "grey hair",
+      "glossClean": "grey hair",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "сиве волосся",
       "lemmaId": "сиве-волосся",
       "lemmaPlain": "сиве волосся",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4746,11 +5266,13 @@
     {
       "cefr": "A1",
       "gloss": "grey, masculine",
+      "glossClean": "grey",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сірий",
       "lemmaId": "сірий",
       "lemmaPlain": "сірий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4761,11 +5283,13 @@
     {
       "cefr": "A1",
       "gloss": "what color?",
+      "glossClean": "what color?",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "якого кольору?",
       "lemmaId": "якого-кольору",
       "lemmaPlain": "якого кольору?",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4776,11 +5300,13 @@
     {
       "cefr": "A1",
       "gloss": "March",
+      "glossClean": "March",
       "heritage": "standard",
       "ipa": null,
       "lemma": "березень",
       "lemmaId": "березень",
       "lemmaPlain": "березень",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4791,11 +5317,13 @@
     {
       "cefr": "A1",
       "gloss": "on Sunday",
+      "glossClean": "on Sunday",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "в неділю",
       "lemmaId": "в-неділю",
       "lemmaPlain": "в неділю",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4806,11 +5334,13 @@
     {
       "cefr": "A1",
       "gloss": "on Saturday",
+      "glossClean": "on Saturday",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "в суботу",
       "lemmaId": "в-суботу",
       "lemmaPlain": "в суботу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4821,11 +5351,13 @@
     {
       "cefr": "A1",
       "gloss": "September",
+      "glossClean": "September",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вересень",
       "lemmaId": "вересень",
       "lemmaPlain": "вересень",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4836,11 +5368,13 @@
     {
       "cefr": "A1",
       "gloss": "spring",
+      "glossClean": "spring",
       "heritage": "standard",
       "ipa": null,
       "lemma": "весна",
       "lemmaId": "весна",
       "lemmaPlain": "весна",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4880,11 +5414,13 @@
     {
       "cefr": "A1",
       "gloss": "Tuesday",
+      "glossClean": "Tuesday",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вівторок",
       "lemmaId": "вівторок",
       "lemmaPlain": "вівторок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4895,11 +5431,13 @@
     {
       "cefr": "A1",
       "gloss": "December",
+      "glossClean": "December",
       "heritage": "standard",
       "ipa": null,
       "lemma": "грудень",
       "lemmaId": "грудень",
       "lemmaPlain": "грудень",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4910,11 +5448,13 @@
     {
       "cefr": "A1",
       "gloss": "date",
+      "glossClean": "date",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дата",
       "lemmaId": "дата",
       "lemmaPlain": "дата",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4954,11 +5494,13 @@
     {
       "cefr": "A1",
       "gloss": "on August twenty-second",
+      "glossClean": "on August twenty-second",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "двадцять другого серпня",
       "lemmaId": "двадцять-другого-серпня",
       "lemmaPlain": "двадцять другого серпня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4969,11 +5511,13 @@
     {
       "cefr": "A1",
       "gloss": "day",
+      "glossClean": "day",
       "heritage": "standard",
       "ipa": null,
       "lemma": "день",
       "lemmaId": "день",
       "lemmaPlain": "день",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4984,11 +5528,13 @@
     {
       "cefr": "A1",
       "gloss": "birthday",
+      "glossClean": "birthday",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "день народження",
       "lemmaId": "день-народження",
       "lemmaPlain": "день народження",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4999,11 +5545,13 @@
     {
       "cefr": "A1",
       "gloss": "October",
+      "glossClean": "October",
       "heritage": "standard",
       "ipa": null,
       "lemma": "жовтень",
       "lemmaId": "жовтень",
       "lemmaPlain": "жовтень",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5014,11 +5562,13 @@
     {
       "cefr": "A1",
       "gloss": "tomorrow",
+      "glossClean": "tomorrow",
       "heritage": "standard",
       "ipa": null,
       "lemma": "завтра",
       "lemmaId": "завтра",
       "lemmaPlain": "завтра",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5029,11 +5579,13 @@
     {
       "cefr": "A1",
       "gloss": "winter",
+      "glossClean": "winter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зима",
       "lemmaId": "зима",
       "lemmaPlain": "зима",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5073,11 +5625,13 @@
     {
       "cefr": "A1",
       "gloss": "April",
+      "glossClean": "April",
       "heritage": "standard",
       "ipa": null,
       "lemma": "квітень",
       "lemmaId": "квітень",
       "lemmaPlain": "квітень",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5088,11 +5642,13 @@
     {
       "cefr": "A1",
       "gloss": "July",
+      "glossClean": "July",
       "heritage": "standard",
       "ipa": null,
       "lemma": "липень",
       "lemmaId": "липень",
       "lemmaPlain": "липень",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5103,11 +5659,13 @@
     {
       "cefr": "A1",
       "gloss": "November",
+      "glossClean": "November",
       "heritage": "standard",
       "ipa": null,
       "lemma": "листопад",
       "lemmaId": "листопад",
       "lemmaPlain": "листопад",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5118,11 +5676,13 @@
     {
       "cefr": "A1",
       "gloss": "February",
+      "glossClean": "February",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лютий",
       "lemmaId": "лютий",
       "lemmaPlain": "лютий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5133,11 +5693,13 @@
     {
       "cefr": "A1",
       "gloss": "summer",
+      "glossClean": "summer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "літо",
       "lemmaId": "літо",
       "lemmaPlain": "літо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5148,11 +5710,13 @@
     {
       "cefr": "A1",
       "gloss": "month",
+      "glossClean": "month",
       "heritage": "standard",
       "ipa": null,
       "lemma": "місяць",
       "lemmaId": "місяць",
       "lemmaPlain": "місяць",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5163,11 +5727,13 @@
     {
       "cefr": "A1",
       "gloss": "Sunday",
+      "glossClean": "Sunday",
       "heritage": "standard",
       "ipa": null,
       "lemma": "неділя",
       "lemmaId": "неділя",
       "lemmaPlain": "неділя",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5207,11 +5773,13 @@
     {
       "cefr": "A1",
       "gloss": "autumn; fall",
+      "glossClean": "autumn",
       "heritage": "standard",
       "ipa": null,
       "lemma": "осінь",
       "lemmaId": "осінь",
       "lemmaPlain": "осінь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5222,11 +5790,13 @@
     {
       "cefr": "A1",
       "gloss": "on March fifteenth",
+      "glossClean": "on March fifteenth",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "п'ятнадцятого березня",
       "lemmaId": "п-ятнадцятого-березня",
       "lemmaPlain": "п'ятнадцятого березня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5237,11 +5807,13 @@
     {
       "cefr": "A1",
       "gloss": "on September first",
+      "glossClean": "on September first",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "першого вересня",
       "lemmaId": "першого-вересня",
       "lemmaPlain": "першого вересня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5252,11 +5824,13 @@
     {
       "cefr": "A1",
       "gloss": "on January first",
+      "glossClean": "on January first",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "першого січня",
       "lemmaId": "першого-січня",
       "lemmaPlain": "першого січня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5267,11 +5841,13 @@
     {
       "cefr": "A1",
       "gloss": "to plan",
+      "glossClean": "to plan",
       "heritage": "standard",
       "ipa": null,
       "lemma": "планувати",
       "lemmaId": "планувати",
       "lemmaPlain": "планувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5282,11 +5858,13 @@
     {
       "cefr": "A1",
       "gloss": "Monday",
+      "glossClean": "Monday",
       "heritage": "standard",
       "ipa": null,
       "lemma": "понеділок",
       "lemmaId": "понеділок",
       "lemmaPlain": "понеділок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5297,11 +5875,13 @@
     {
       "cefr": "A1",
       "gloss": "year",
+      "glossClean": "year",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рік",
       "lemmaId": "рік",
       "lemmaPlain": "рік",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5312,11 +5892,13 @@
     {
       "cefr": "A1",
       "gloss": "Wednesday",
+      "glossClean": "Wednesday",
       "heritage": "standard",
       "ipa": null,
       "lemma": "середа",
       "lemmaId": "середа",
       "lemmaPlain": "середа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5356,11 +5938,13 @@
     {
       "cefr": "A1",
       "gloss": "August",
+      "glossClean": "August",
       "heritage": "standard",
       "ipa": null,
       "lemma": "серпень",
       "lemmaId": "серпень",
       "lemmaPlain": "серпень",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5371,11 +5955,13 @@
     {
       "cefr": "A1",
       "gloss": "Saturday",
+      "glossClean": "Saturday",
       "heritage": "standard",
       "ipa": null,
       "lemma": "субота",
       "lemmaId": "субота",
       "lemmaPlain": "субота",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5415,11 +6001,13 @@
     {
       "cefr": "A1",
       "gloss": "today",
+      "glossClean": "today",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сьогодні",
       "lemmaId": "сьогодні",
       "lemmaPlain": "сьогодні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5430,11 +6018,13 @@
     {
       "cefr": "A1",
       "gloss": "January",
+      "glossClean": "January",
       "heritage": "standard",
       "ipa": null,
       "lemma": "січень",
       "lemmaId": "січень",
       "lemmaPlain": "січень",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5445,11 +6035,13 @@
     {
       "cefr": "A1",
       "gloss": "week",
+      "glossClean": "week",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тиждень",
       "lemmaId": "тиждень",
       "lemmaPlain": "тиждень",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5460,11 +6052,13 @@
     {
       "cefr": "A1",
       "gloss": "May",
+      "glossClean": "May",
       "heritage": "standard",
       "ipa": null,
       "lemma": "травень",
       "lemmaId": "травень",
       "lemmaPlain": "травень",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5475,11 +6069,13 @@
     {
       "cefr": "A1",
       "gloss": "in March",
+      "glossClean": "in March",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у березні",
       "lemmaId": "у-березні",
       "lemmaPlain": "у березні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5490,11 +6086,13 @@
     {
       "cefr": "A1",
       "gloss": "in September",
+      "glossClean": "in September",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у вересні",
       "lemmaId": "у-вересні",
       "lemmaPlain": "у вересні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5505,11 +6103,13 @@
     {
       "cefr": "A1",
       "gloss": "on Tuesday",
+      "glossClean": "on Tuesday",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у вівторок",
       "lemmaId": "у-вівторок",
       "lemmaPlain": "у вівторок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5520,11 +6120,13 @@
     {
       "cefr": "A1",
       "gloss": "in December",
+      "glossClean": "in December",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у грудні",
       "lemmaId": "у-грудні",
       "lemmaPlain": "у грудні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5535,11 +6137,13 @@
     {
       "cefr": "A1",
       "gloss": "in April",
+      "glossClean": "in April",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у квітні",
       "lemmaId": "у-квітні",
       "lemmaPlain": "у квітні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5550,11 +6154,13 @@
     {
       "cefr": "A1",
       "gloss": "in July",
+      "glossClean": "in July",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у липні",
       "lemmaId": "у-липні",
       "lemmaPlain": "у липні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5565,11 +6171,13 @@
     {
       "cefr": "A1",
       "gloss": "in November",
+      "glossClean": "in November",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у листопаді",
       "lemmaId": "у-листопаді",
       "lemmaPlain": "у листопаді",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5580,11 +6188,13 @@
     {
       "cefr": "A1",
       "gloss": "in February",
+      "glossClean": "in February",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у лютому",
       "lemmaId": "у-лютому",
       "lemmaPlain": "у лютому",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5595,11 +6205,13 @@
     {
       "cefr": "A1",
       "gloss": "on Friday",
+      "glossClean": "on Friday",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у п'ятницю",
       "lemmaId": "у-п-ятницю",
       "lemmaPlain": "у п'ятницю",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5610,11 +6222,13 @@
     {
       "cefr": "A1",
       "gloss": "on Wednesday",
+      "glossClean": "on Wednesday",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у середу",
       "lemmaId": "у-середу",
       "lemmaPlain": "у середу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5625,11 +6239,13 @@
     {
       "cefr": "A1",
       "gloss": "in August",
+      "glossClean": "in August",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у серпні",
       "lemmaId": "у-серпні",
       "lemmaPlain": "у серпні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5640,11 +6256,13 @@
     {
       "cefr": "A1",
       "gloss": "in May",
+      "glossClean": "in May",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у травні",
       "lemmaId": "у-травні",
       "lemmaPlain": "у травні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5655,11 +6273,13 @@
     {
       "cefr": "A1",
       "gloss": "in June",
+      "glossClean": "in June",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у червні",
       "lemmaId": "у-червні",
       "lemmaPlain": "у червні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5670,11 +6290,13 @@
     {
       "cefr": "A1",
       "gloss": "on Thursday",
+      "glossClean": "on Thursday",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у четвер",
       "lemmaId": "у-четвер",
       "lemmaPlain": "у четвер",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5685,11 +6307,13 @@
     {
       "cefr": "A1",
       "gloss": "yesterday",
+      "glossClean": "yesterday",
       "heritage": "standard",
       "ipa": null,
       "lemma": "учора",
       "lemmaId": "учора",
       "lemmaPlain": "учора",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5700,11 +6324,13 @@
     {
       "cefr": "A1",
       "gloss": "June",
+      "glossClean": "June",
       "heritage": "standard",
       "ipa": null,
       "lemma": "червень",
       "lemmaId": "червень",
       "lemmaPlain": "червень",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5715,11 +6341,13 @@
     {
       "cefr": "A1",
       "gloss": "Thursday",
+      "glossClean": "Thursday",
       "heritage": "standard",
       "ipa": null,
       "lemma": "четвер",
       "lemmaId": "четвер",
       "lemmaPlain": "четвер",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5730,11 +6358,13 @@
     {
       "cefr": "A1",
       "gloss": "what date?",
+      "glossClean": "what date?",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "якого числа?",
       "lemmaId": "якого-числа",
       "lemmaPlain": "якого числа?",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -5745,11 +6375,13 @@
     {
       "cefr": "A1",
       "gloss": "address",
+      "glossClean": "address",
       "heritage": "standard",
       "ipa": null,
       "lemma": "адреса",
       "lemmaId": "адреса",
       "lemmaPlain": "адреса",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5789,11 +6421,13 @@
     {
       "cefr": "A1",
       "gloss": "allergy",
+      "glossClean": "allergy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "алергія",
       "lemmaId": "алергія",
       "lemmaPlain": "алергія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5833,11 +6467,13 @@
     {
       "cefr": "A1",
       "gloss": "building",
+      "glossClean": "building",
       "heritage": "standard",
       "ipa": null,
       "lemma": "будинок",
       "lemmaId": "будинок",
       "lemmaPlain": "будинок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5848,11 +6484,13 @@
     {
       "cefr": "A1",
       "gloss": "near",
+      "glossClean": "near",
       "heritage": "standard",
       "ipa": null,
       "lemma": "біля",
       "lemmaId": "біля",
       "lemmaPlain": "біля",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -5863,11 +6501,13 @@
     {
       "cefr": "A1",
       "gloss": "help",
+      "glossClean": "help",
       "heritage": "standard",
       "ipa": null,
       "lemma": "допомога",
       "lemmaId": "допомога",
       "lemmaPlain": "допомога",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5907,11 +6547,13 @@
     {
       "cefr": "A1",
       "gloss": "emergency",
+      "glossClean": "emergency",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "екстрена ситуація",
       "lemmaId": "екстрена-ситуація",
       "lemmaPlain": "екстрена ситуація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5922,11 +6564,13 @@
     {
       "cefr": "A1",
       "gloss": "number",
+      "glossClean": "number",
       "heritage": "standard",
       "ipa": null,
       "lemma": "номер",
       "lemmaId": "номер",
       "lemmaPlain": "номер",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5937,11 +6581,13 @@
     {
       "cefr": "A1",
       "gloss": "passport",
+      "glossClean": "passport",
       "heritage": "standard",
       "ipa": null,
       "lemma": "паспорт",
       "lemmaId": "паспорт",
       "lemmaPlain": "паспорт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5952,11 +6598,13 @@
     {
       "cefr": "A1",
       "gloss": "form",
+      "glossClean": "form",
       "heritage": "standard",
       "ipa": null,
       "lemma": "форма",
       "lemmaId": "форма",
       "lemmaPlain": "форма",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5996,11 +6644,13 @@
     {
       "cefr": "A1",
       "gloss": "to go",
+      "glossClean": "to go",
       "heritage": "standard",
       "ipa": null,
       "lemma": "йти",
       "lemmaId": "йти",
       "lemmaPlain": "йти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6011,11 +6661,13 @@
     {
       "cefr": "A1",
       "gloss": "cinema; movie theater",
+      "glossClean": "cinema",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кіно",
       "lemmaId": "кіно",
       "lemmaPlain": "кіно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6026,11 +6678,13 @@
     {
       "cefr": "A1",
       "gloss": "Maksym",
+      "glossClean": "Maksym",
       "heritage": "standard",
       "ipa": null,
       "lemma": "Максим",
       "lemmaId": "максим",
       "lemmaPlain": "максим",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6041,11 +6695,13 @@
     {
       "cefr": "A1",
       "gloss": "office",
+      "glossClean": "office",
       "heritage": "standard",
       "ipa": null,
       "lemma": "офіс",
       "lemmaId": "офіс",
       "lemmaPlain": "офіс",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6056,11 +6712,13 @@
     {
       "cefr": "A1",
       "gloss": "holiday; celebration",
+      "glossClean": "holiday",
       "heritage": "standard",
       "ipa": null,
       "lemma": "свято",
       "lemmaId": "свято",
       "lemmaPlain": "свято",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6071,11 +6729,13 @@
     {
       "cefr": "A1",
       "gloss": "I",
+      "glossClean": "I",
       "heritage": "standard",
       "ipa": null,
       "lemma": "я",
       "lemmaId": "я",
       "lemmaPlain": "я",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6086,11 +6746,13 @@
     {
       "cefr": "A1",
       "gloss": "Ivan",
+      "glossClean": "Ivan",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Іван",
       "lemmaId": "іван",
       "lemmaPlain": "іван",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6101,11 +6763,13 @@
     {
       "cefr": "A1",
       "gloss": "orange",
+      "glossClean": "orange",
       "heritage": "standard",
       "ipa": null,
       "lemma": "апельсин",
       "lemmaId": "апельсин",
       "lemmaPlain": "апельсин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6116,11 +6780,13 @@
     {
       "cefr": "A1",
       "gloss": "banana",
+      "glossClean": "banana",
       "heritage": "standard",
       "ipa": null,
       "lemma": "банан",
       "lemmaId": "банан",
       "lemmaPlain": "банан",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6131,11 +6797,13 @@
     {
       "cefr": "A1",
       "gloss": "without milk",
+      "glossClean": "without milk",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "без молока",
       "lemmaId": "без-молока",
       "lemmaPlain": "без молока",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6146,11 +6814,13 @@
     {
       "cefr": "A1",
       "gloss": "without sugar",
+      "glossClean": "without sugar",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "без цукру",
       "lemmaId": "без-цукру",
       "lemmaPlain": "без цукру",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6161,11 +6831,13 @@
     {
       "cefr": "A1",
       "gloss": "beet",
+      "glossClean": "beet",
       "heritage": "standard",
       "ipa": null,
       "lemma": "буряк",
       "lemmaId": "буряк",
       "lemmaPlain": "буряк",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6176,11 +6848,13 @@
     {
       "cefr": "A1",
       "gloss": "dinner",
+      "glossClean": "dinner",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вечеря",
       "lemmaId": "вечеря",
       "lemmaPlain": "вечеря",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -6220,11 +6894,13 @@
     {
       "cefr": "A1",
       "gloss": "to have dinner",
+      "glossClean": "to have dinner",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вечеряти",
       "lemmaId": "вечеряти",
       "lemmaPlain": "вечеряти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6235,11 +6911,13 @@
     {
       "cefr": "A1",
       "gloss": "wine",
+      "glossClean": "wine",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вино",
       "lemmaId": "вино",
       "lemmaPlain": "вино",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6250,11 +6928,13 @@
     {
       "cefr": "A1",
       "gloss": "with milk",
+      "glossClean": "with milk",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "з молоком",
       "lemmaId": "з-молоком",
       "lemmaPlain": "з молоком",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6265,11 +6945,13 @@
     {
       "cefr": "A1",
       "gloss": "yogurt",
+      "glossClean": "yogurt",
       "heritage": "standard",
       "ipa": null,
       "lemma": "йогурт",
       "lemmaId": "йогурт",
       "lemmaPlain": "йогурт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6280,11 +6962,13 @@
     {
       "cefr": "A1",
       "gloss": "cabbage",
+      "glossClean": "cabbage",
       "heritage": "standard",
       "ipa": null,
       "lemma": "капуста",
       "lemmaId": "капуста",
       "lemmaPlain": "капуста",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -6324,11 +7008,13 @@
     {
       "cefr": "A1",
       "gloss": "potato",
+      "glossClean": "potato",
       "heritage": "standard",
       "ipa": null,
       "lemma": "картопля",
       "lemmaId": "картопля",
       "lemmaPlain": "картопля",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6339,11 +7025,13 @@
     {
       "cefr": "A1",
       "gloss": "chicken",
+      "glossClean": "chicken",
       "heritage": "standard",
       "ipa": null,
       "lemma": "курка",
       "lemmaId": "курка",
       "lemmaPlain": "курка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6354,11 +7042,13 @@
     {
       "cefr": "A1",
       "gloss": "lemon",
+      "glossClean": "lemon",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лимон",
       "lemmaId": "лимон",
       "lemmaPlain": "лимон",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6369,11 +7059,13 @@
     {
       "cefr": "A1",
       "gloss": "meat",
+      "glossClean": "meat",
       "heritage": "standard",
       "ipa": null,
       "lemma": "м'ясо",
       "lemmaId": "м-ясо",
       "lemmaPlain": "м'ясо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6384,11 +7076,13 @@
     {
       "cefr": "A1",
       "gloss": "pasta",
+      "glossClean": "pasta",
       "heritage": "standard",
       "ipa": null,
       "lemma": "макарони",
       "lemmaId": "макарони",
       "lemmaPlain": "макарони",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6399,11 +7093,13 @@
     {
       "cefr": "A1",
       "gloss": "butter",
+      "glossClean": "butter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "масло",
       "lemmaId": "масло",
       "lemmaPlain": "масло",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6414,11 +7110,13 @@
     {
       "cefr": "A1",
       "gloss": "carrot",
+      "glossClean": "carrot",
       "heritage": "standard",
       "ipa": null,
       "lemma": "морква",
       "lemmaId": "морква",
       "lemmaPlain": "морква",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -6458,11 +7156,13 @@
     {
       "cefr": "A1",
       "gloss": "lunch",
+      "glossClean": "lunch",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обід",
       "lemmaId": "обід",
       "lemmaPlain": "обід",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6473,11 +7173,13 @@
     {
       "cefr": "A1",
       "gloss": "to have lunch",
+      "glossClean": "to have lunch",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обідати",
       "lemmaId": "обідати",
       "lemmaPlain": "обідати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6488,11 +7190,13 @@
     {
       "cefr": "A1",
       "gloss": "cucumber",
+      "glossClean": "cucumber",
       "heritage": "standard",
       "ipa": null,
       "lemma": "огірок",
       "lemmaId": "огірок",
       "lemmaPlain": "огірок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6503,11 +7207,13 @@
     {
       "cefr": "A1",
       "gloss": "beer",
+      "glossClean": "beer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пиво",
       "lemmaId": "пиво",
       "lemmaPlain": "пиво",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6518,11 +7224,13 @@
     {
       "cefr": "A1",
       "gloss": "fish",
+      "glossClean": "fish",
       "heritage": "standard",
       "ipa": null,
       "lemma": "риба",
       "lemmaId": "риба",
       "lemmaPlain": "риба",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6533,11 +7241,13 @@
     {
       "cefr": "A1",
       "gloss": "rice",
+      "glossClean": "rice",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рис",
       "lemmaId": "рис",
       "lemmaPlain": "рис",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6548,11 +7258,13 @@
     {
       "cefr": "A1",
       "gloss": "sour cream",
+      "glossClean": "sour cream",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сметана",
       "lemmaId": "сметана",
       "lemmaPlain": "сметана",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6563,11 +7275,13 @@
     {
       "cefr": "A1",
       "gloss": "breakfast",
+      "glossClean": "breakfast",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сніданок",
       "lemmaId": "сніданок",
       "lemmaPlain": "сніданок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6578,11 +7292,13 @@
     {
       "cefr": "A1",
       "gloss": "sweet",
+      "glossClean": "sweet",
       "heritage": "standard",
       "ipa": null,
       "lemma": "солодкий",
       "lemmaId": "солодкий",
       "lemmaPlain": "солодкий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6593,11 +7309,13 @@
     {
       "cefr": "A1",
       "gloss": "soup",
+      "glossClean": "soup",
       "heritage": "standard",
       "ipa": null,
       "lemma": "суп",
       "lemmaId": "суп",
       "lemmaPlain": "суп",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6608,11 +7326,13 @@
     {
       "cefr": "A1",
       "gloss": "salt",
+      "glossClean": "salt",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сіль",
       "lemmaId": "сіль",
       "lemmaPlain": "сіль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6623,11 +7343,13 @@
     {
       "cefr": "A1",
       "gloss": "warm",
+      "glossClean": "warm",
       "heritage": "standard",
       "ipa": null,
       "lemma": "теплий",
       "lemmaId": "теплий",
       "lemmaPlain": "теплий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6638,11 +7360,13 @@
     {
       "cefr": "A1",
       "gloss": "onion",
+      "glossClean": "onion",
       "heritage": "standard",
       "ipa": null,
       "lemma": "цибуля",
       "lemmaId": "цибуля",
       "lemmaPlain": "цибуля",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -6682,11 +7406,13 @@
     {
       "cefr": "A1",
       "gloss": "sugar",
+      "glossClean": "sugar",
       "heritage": "standard",
       "ipa": null,
       "lemma": "цукор",
       "lemmaId": "цукор",
       "lemmaPlain": "цукор",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6697,11 +7423,13 @@
     {
       "cefr": "A1",
       "gloss": "egg",
+      "glossClean": "egg",
       "heritage": "standard",
       "ipa": null,
       "lemma": "яйце",
       "lemmaId": "яйце",
       "lemmaPlain": "яйце",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6712,11 +7440,13 @@
     {
       "cefr": "A1",
       "gloss": "free time",
+      "glossClean": "free time",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "вільний час",
       "lemmaId": "вільний-час",
       "lemmaPlain": "вільний час",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6727,11 +7457,13 @@
     {
       "cefr": "A1",
       "gloss": "to play guitar",
+      "glossClean": "to play guitar",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "грати на гітарі",
       "lemmaId": "грати-на-гітарі",
       "lemmaPlain": "грати на гітарі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6742,11 +7474,13 @@
     {
       "cefr": "A1",
       "gloss": "twice a week",
+      "glossClean": "twice a week",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "двічі на тиждень",
       "lemmaId": "двічі-на-тиждень",
       "lemmaPlain": "двічі на тиждень",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6757,11 +7491,13 @@
     {
       "cefr": "A1",
       "gloss": "always",
+      "glossClean": "always",
       "heritage": "standard",
       "ipa": null,
       "lemma": "завжди",
       "lemmaId": "завжди",
       "lemmaPlain": "завжди",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6772,11 +7508,13 @@
     {
       "cefr": "A1",
       "gloss": "to do sport",
+      "glossClean": "to do sport",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "займатися спортом",
       "lemmaId": "займатися-спортом",
       "lemmaPlain": "займатися спортом",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6787,11 +7525,13 @@
     {
       "cefr": "A1",
       "gloss": "concert",
+      "glossClean": "concert",
       "heritage": "standard",
       "ipa": null,
       "lemma": "концерт",
       "lemmaId": "концерт",
       "lemmaPlain": "концерт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6802,11 +7542,13 @@
     {
       "cefr": "A1",
       "gloss": "to draw",
+      "glossClean": "to draw",
       "heritage": "standard",
       "ipa": null,
       "lemma": "малювати",
       "lemmaId": "малювати",
       "lemmaPlain": "малювати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6817,11 +7559,13 @@
     {
       "cefr": "A1",
       "gloss": "never",
+      "glossClean": "never",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ніколи",
       "lemmaId": "ніколи",
       "lemmaPlain": "ніколи",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6832,11 +7576,13 @@
     {
       "cefr": "A1",
       "gloss": "once a month",
+      "glossClean": "once a month",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "раз на місяць",
       "lemmaId": "раз-на-місяць",
       "lemmaPlain": "раз на місяць",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6847,11 +7593,13 @@
     {
       "cefr": "A1",
       "gloss": "once a week",
+      "glossClean": "once a week",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "раз на тиждень",
       "lemmaId": "раз-на-тиждень",
       "lemmaPlain": "раз на тиждень",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6862,11 +7610,13 @@
     {
       "cefr": "A1",
       "gloss": "to listen",
+      "glossClean": "to listen",
       "heritage": "standard",
       "ipa": null,
       "lemma": "слухати",
       "lemmaId": "слухати",
       "lemmaPlain": "слухати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6877,11 +7627,13 @@
     {
       "cefr": "A1",
       "gloss": "sport",
+      "glossClean": "sport",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спорт",
       "lemmaId": "спорт",
       "lemmaPlain": "спорт",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6892,11 +7644,13 @@
     {
       "cefr": "A1",
       "gloss": "tennis",
+      "glossClean": "tennis",
       "heritage": "standard",
       "ipa": null,
       "lemma": "теніс",
       "lemmaId": "теніс",
       "lemmaPlain": "теніс",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6907,11 +7661,13 @@
     {
       "cefr": "A1",
       "gloss": "three times a week",
+      "glossClean": "three times a week",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "тричі на тиждень",
       "lemmaId": "тричі-на-тиждень",
       "lemmaPlain": "тричі на тиждень",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6922,11 +7678,13 @@
     {
       "cefr": "A1",
       "gloss": "on weekends",
+      "glossClean": "on weekends",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у вихідні",
       "lemmaId": "у-вихідні",
       "lemmaPlain": "у вихідні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6937,11 +7695,13 @@
     {
       "cefr": "A1",
       "gloss": "to take photos",
+      "glossClean": "to take photos",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фотографувати",
       "lemmaId": "фотографувати",
       "lemmaPlain": "фотографувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6952,11 +7712,13 @@
     {
       "cefr": "A1",
       "gloss": "football; soccer",
+      "glossClean": "football",
       "heritage": "standard",
       "ipa": null,
       "lemma": "футбол",
       "lemmaId": "футбол",
       "lemmaPlain": "футбол",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6967,11 +7729,13 @@
     {
       "cefr": "A1",
       "gloss": "hobby",
+      "glossClean": "hobby",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хобі",
       "lemmaId": "хобі",
       "lemmaPlain": "хобі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -7011,11 +7775,13 @@
     {
       "cefr": "A1",
       "gloss": "to go to the theater",
+      "glossClean": "to go to the theater",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "ходити в театр",
       "lemmaId": "ходити-в-театр",
       "lemmaPlain": "ходити в театр",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -7026,11 +7792,13 @@
     {
       "cefr": "A1",
       "gloss": "to go to a concert",
+      "glossClean": "to go to a concert",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "ходити на концерт",
       "lemmaId": "ходити-на-концерт",
       "lemmaPlain": "ходити на концерт",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -7041,11 +7809,13 @@
     {
       "cefr": "A1",
       "gloss": "how often?",
+      "glossClean": "how often?",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "як часто?",
       "lemmaId": "як-часто",
       "lemmaPlain": "як часто?",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -7056,11 +7826,13 @@
     {
       "cefr": "A1",
       "gloss": "sometimes",
+      "glossClean": "sometimes",
       "heritage": "standard",
       "ipa": null,
       "lemma": "іноді",
       "lemmaId": "іноді",
       "lemmaPlain": "іноді",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7071,11 +7843,13 @@
     {
       "cefr": "A1",
       "gloss": "to hurt, to ache",
+      "glossClean": "to hurt",
       "heritage": "standard",
       "ipa": null,
       "lemma": "боліти",
       "lemmaId": "боліти",
       "lemmaPlain": "боліти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7086,11 +7860,13 @@
     {
       "cefr": "A1",
       "gloss": "ear",
+      "glossClean": "ear",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вухо",
       "lemmaId": "вухо",
       "lemmaPlain": "вухо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7101,11 +7877,13 @@
     {
       "cefr": "A1",
       "gloss": "head",
+      "glossClean": "head",
       "heritage": "standard",
       "ipa": null,
       "lemma": "голова",
       "lemmaId": "голова",
       "lemmaPlain": "голова",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7116,11 +7894,13 @@
     {
       "cefr": "A1",
       "gloss": "throat",
+      "glossClean": "throat",
       "heritage": "standard",
       "ipa": null,
       "lemma": "горло",
       "lemmaId": "горло",
       "lemmaPlain": "горло",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7131,11 +7911,13 @@
     {
       "cefr": "A1",
       "gloss": "stomach",
+      "glossClean": "stomach",
       "heritage": "standard",
       "ipa": null,
       "lemma": "живіт",
       "lemmaId": "живіт",
       "lemmaPlain": "живіт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7146,11 +7928,13 @@
     {
       "cefr": "A1",
       "gloss": "health",
+      "glossClean": "health",
       "heritage": "standard",
       "ipa": null,
       "lemma": "здоров'я",
       "lemmaId": "здоров-я",
       "lemmaPlain": "здоров'я",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7161,11 +7945,13 @@
     {
       "cefr": "A1",
       "gloss": "tooth",
+      "glossClean": "tooth",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зуб",
       "lemmaId": "зуб",
       "lemmaPlain": "зуб",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7176,11 +7962,13 @@
     {
       "cefr": "A1",
       "gloss": "leg, foot",
+      "glossClean": "leg",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нога",
       "lemmaId": "нога",
       "lemmaPlain": "нога",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -7220,11 +8008,13 @@
     {
       "cefr": "A1",
       "gloss": "nose",
+      "glossClean": "nose",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ніс",
       "lemmaId": "ніс",
       "lemmaPlain": "ніс",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7235,11 +8025,13 @@
     {
       "cefr": "A1",
       "gloss": "eye",
+      "glossClean": "eye",
       "heritage": "standard",
       "ipa": null,
       "lemma": "око",
       "lemmaId": "око",
       "lemmaPlain": "око",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7250,11 +8042,13 @@
     {
       "cefr": "A1",
       "gloss": "badly, unwell",
+      "glossClean": "badly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "погано",
       "lemmaId": "погано",
       "lemmaPlain": "погано",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7265,11 +8059,13 @@
     {
       "cefr": "A1",
       "gloss": "hand, arm",
+      "glossClean": "hand",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рука",
       "lemmaId": "рука",
       "lemmaPlain": "рука",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -7309,11 +8105,13 @@
     {
       "cefr": "A1",
       "gloss": "back",
+      "glossClean": "back",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спина",
       "lemmaId": "спина",
       "lemmaPlain": "спина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -7353,11 +8151,13 @@
     {
       "cefr": "A1",
       "gloss": "fever, temperature",
+      "glossClean": "fever",
       "heritage": "standard",
       "ipa": null,
       "lemma": "температура",
       "lemmaId": "температура",
       "lemmaPlain": "температура",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -7397,11 +8197,13 @@
     {
       "cefr": "A1",
       "gloss": "sick, masculine",
+      "glossClean": "sick",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хворий",
       "lemmaId": "хворий",
       "lemmaPlain": "хворий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7412,11 +8214,13 @@
     {
       "cefr": "A1",
       "gloss": "Andrii",
+      "glossClean": "Andrii",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Андрій",
       "lemmaId": "андрій",
       "lemmaPlain": "андрій",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -7427,11 +8231,13 @@
     {
       "cefr": "A1",
       "gloss": "Good afternoon; hello",
+      "glossClean": "Good afternoon",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Добрий день",
       "lemmaId": "добрий-день",
       "lemmaPlain": "добрий день",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7442,11 +8248,13 @@
     {
       "cefr": "A1",
       "gloss": "daughter",
+      "glossClean": "daughter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дочка",
       "lemmaId": "дочка",
       "lemmaPlain": "дочка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7457,11 +8265,13 @@
     {
       "cefr": "A1",
       "gloss": "vocative case; calling form",
+      "glossClean": "vocative case",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кличний відмінок",
       "lemmaId": "кличний-відмінок",
       "lemmaPlain": "кличний відмінок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7472,11 +8282,13 @@
     {
       "cefr": "A1",
       "gloss": "Nadiia",
+      "glossClean": "Nadiia",
       "heritage": "standard",
       "ipa": null,
       "lemma": "Надія",
       "lemmaId": "надія",
       "lemmaPlain": "надія",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -7487,11 +8299,13 @@
     {
       "cefr": "A1",
       "gloss": "Mr.; sir",
+      "glossClean": "Mr.",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пан",
       "lemmaId": "пан",
       "lemmaPlain": "пан",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -7502,11 +8316,13 @@
     {
       "cefr": "A1",
       "gloss": "Ms.; Mrs.; ma'am",
+      "glossClean": "Ms.",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пані",
       "lemmaId": "пані",
       "lemmaPlain": "пані",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -7546,11 +8362,13 @@
     {
       "cefr": "A1",
       "gloss": "female friend",
+      "glossClean": "female friend",
       "heritage": "standard",
       "ipa": null,
       "lemma": "подруга",
       "lemmaId": "подруга",
       "lemmaPlain": "подруга",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7561,11 +8379,13 @@
     {
       "cefr": "A1",
       "gloss": "Serhii",
+      "glossClean": "Serhii",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Сергій",
       "lemmaId": "сергій",
       "lemmaPlain": "сергій",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -7576,11 +8396,13 @@
     {
       "cefr": "A1",
       "gloss": "to wish",
+      "glossClean": "to wish",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бажати",
       "lemmaId": "бажати",
       "lemmaPlain": "бажати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7591,11 +8413,13 @@
     {
       "cefr": "A1",
       "gloss": "Easter",
+      "glossClean": "Easter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "Великдень",
       "lemmaId": "великдень",
       "lemmaPlain": "великдень",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7606,11 +8430,13 @@
     {
       "cefr": "A1",
       "gloss": "to greet; to congratulate",
+      "glossClean": "to greet",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вітати",
       "lemmaId": "вітати",
       "lemmaPlain": "вітати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7621,11 +8447,13 @@
     {
       "cefr": "A1",
       "gloss": "guest",
+      "glossClean": "guest",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гість",
       "lemmaId": "гість",
       "lemmaPlain": "гість",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7636,11 +8464,13 @@
     {
       "cefr": "A1",
       "gloss": "Independence Day of Ukraine",
+      "glossClean": "Independence Day of Ukraine",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "День Незалежності України",
       "lemmaId": "день-незалежності-україни",
       "lemmaPlain": "день незалежності україни",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7651,11 +8481,13 @@
     {
       "cefr": "A1",
       "gloss": "Unity Day of Ukraine",
+      "glossClean": "Unity Day of Ukraine",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "День Соборності України",
       "lemmaId": "день-соборності-україни",
       "lemmaPlain": "день соборності україни",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7666,11 +8498,13 @@
     {
       "cefr": "A1",
       "gloss": "state holiday",
+      "glossClean": "state holiday",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "державне свято",
       "lemmaId": "державне-свято",
       "lemmaPlain": "державне свято",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7681,11 +8515,13 @@
     {
       "cefr": "A1",
       "gloss": "vacation; school break",
+      "glossClean": "vacation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "канікули",
       "lemmaId": "канікули",
       "lemmaPlain": "канікули",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7696,11 +8532,13 @@
     {
       "cefr": "A1",
       "gloss": "New Year",
+      "glossClean": "New Year",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Новий рік",
       "lemmaId": "новий-рік",
       "lemmaPlain": "новий рік",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7711,11 +8549,13 @@
     {
       "cefr": "A1",
       "gloss": "to bake pasky",
+      "glossClean": "to bake pasky",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пекти паски",
       "lemmaId": "пекти-паски",
       "lemmaPlain": "пекти паски",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7726,11 +8566,13 @@
     {
       "cefr": "A1",
       "gloss": "gift",
+      "glossClean": "gift",
       "heritage": "standard",
       "ipa": null,
       "lemma": "подарунок",
       "lemmaId": "подарунок",
       "lemmaPlain": "подарунок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7741,11 +8583,13 @@
     {
       "cefr": "A1",
       "gloss": "Christmas",
+      "glossClean": "Christmas",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Різдво Христове",
       "lemmaId": "різдво-христове",
       "lemmaPlain": "різдво христове",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7756,11 +8600,13 @@
     {
       "cefr": "A1",
       "gloss": "to celebrate",
+      "glossClean": "to celebrate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "святкувати",
       "lemmaId": "святкувати",
       "lemmaPlain": "святкувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7771,11 +8617,13 @@
     {
       "cefr": "A1",
       "gloss": "to dye eggs",
+      "glossClean": "to dye eggs",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "фарбувати яйця",
       "lemmaId": "фарбувати-яйця",
       "lemmaPlain": "фарбувати яйця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7786,11 +8634,13 @@
     {
       "cefr": "A1",
       "gloss": "Christ is risen",
+      "glossClean": "Christ is risen",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Христос воскрес",
       "lemmaId": "христос-воскрес",
       "lemmaPlain": "христос воскрес",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7801,11 +8651,13 @@
     {
       "cefr": "A1",
       "gloss": "Shchedryi Vechir",
+      "glossClean": "Shchedryi Vechir",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Щедрий вечір",
       "lemmaId": "щедрий-вечір",
       "lemmaPlain": "щедрий вечір",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -7816,11 +8668,13 @@
     {
       "cefr": "A1",
       "gloss": "you, formal or plural",
+      "glossClean": "you",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ви",
       "lemmaId": "ви",
       "lemmaPlain": "ви",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -7831,11 +8685,13 @@
     {
       "cefr": "A1",
       "gloss": "she / feminine gender-test word",
+      "glossClean": "she / feminine gender-test word",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вона",
       "lemmaId": "вона",
       "lemmaPlain": "вона",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -7846,11 +8702,13 @@
     {
       "cefr": "A1",
       "gloss": "eight",
+      "glossClean": "eight",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вісім",
       "lemmaId": "вісім",
       "lemmaPlain": "вісім",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7861,11 +8719,13 @@
     {
       "cefr": "A1",
       "gloss": "eighty",
+      "glossClean": "eighty",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вісімдесят",
       "lemmaId": "вісімдесят",
       "lemmaPlain": "вісімдесят",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7876,11 +8736,13 @@
     {
       "cefr": "A1",
       "gloss": "eighteen",
+      "glossClean": "eighteen",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вісімнадцять",
       "lemmaId": "вісімнадцять",
       "lemmaPlain": "вісімнадцять",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7891,11 +8753,13 @@
     {
       "cefr": "A1",
       "gloss": "two, masculine/neuter",
+      "glossClean": "two",
       "heritage": "standard",
       "ipa": null,
       "lemma": "два",
       "lemmaId": "два",
       "lemmaPlain": "два",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7906,11 +8770,13 @@
     {
       "cefr": "A1",
       "gloss": "twelve",
+      "glossClean": "twelve",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дванадцять",
       "lemmaId": "дванадцять",
       "lemmaPlain": "дванадцять",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7921,11 +8787,13 @@
     {
       "cefr": "A1",
       "gloss": "nine",
+      "glossClean": "nine",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дев'ять",
       "lemmaId": "дев-ять",
       "lemmaPlain": "дев'ять",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7936,11 +8804,13 @@
     {
       "cefr": "A1",
       "gloss": "ten",
+      "glossClean": "ten",
       "heritage": "standard",
       "ipa": null,
       "lemma": "десять",
       "lemmaId": "десять",
       "lemmaPlain": "десять",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7951,11 +8821,13 @@
     {
       "cefr": "A1",
       "gloss": "kopeck, singular",
+      "glossClean": "kopeck",
       "heritage": "standard",
       "ipa": null,
       "lemma": "копійка",
       "lemmaId": "копійка",
       "lemmaPlain": "копійка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -7995,11 +8867,13 @@
     {
       "cefr": "A1",
       "gloss": "phone number",
+      "glossClean": "phone number",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "номер телефону",
       "lemmaId": "номер-телефону",
       "lemmaPlain": "номер телефону",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8010,11 +8884,13 @@
     {
       "cefr": "A1",
       "gloss": "zero",
+      "glossClean": "zero",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нуль",
       "lemmaId": "нуль",
       "lemmaPlain": "нуль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8025,11 +8901,13 @@
     {
       "cefr": "A1",
       "gloss": "one, masculine",
+      "glossClean": "one",
       "heritage": "standard",
       "ipa": null,
       "lemma": "один",
       "lemmaId": "один",
       "lemmaPlain": "один",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8040,11 +8918,13 @@
     {
       "cefr": "A1",
       "gloss": "eleven",
+      "glossClean": "eleven",
       "heritage": "standard",
       "ipa": null,
       "lemma": "одинадцять",
       "lemmaId": "одинадцять",
       "lemmaPlain": "одинадцять",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8055,11 +8935,13 @@
     {
       "cefr": "A1",
       "gloss": "five",
+      "glossClean": "five",
       "heritage": "standard",
       "ipa": null,
       "lemma": "п'ять",
       "lemmaId": "п-ять",
       "lemmaPlain": "п'ять",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8070,11 +8952,13 @@
     {
       "cefr": "A1",
       "gloss": "half past five, time",
+      "glossClean": "half past five",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пів на шосту",
       "lemmaId": "пів-на-шосту",
       "lemmaPlain": "пів на шосту",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8085,11 +8969,13 @@
     {
       "cefr": "A1",
       "gloss": "forty",
+      "glossClean": "forty",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сорок",
       "lemmaId": "сорок",
       "lemmaPlain": "сорок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8100,11 +8986,13 @@
     {
       "cefr": "A1",
       "gloss": "seven",
+      "glossClean": "seven",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сім",
       "lemmaId": "сім",
       "lemmaPlain": "сім",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8115,11 +9003,13 @@
     {
       "cefr": "A1",
       "gloss": "seventy",
+      "glossClean": "seventy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сімдесят",
       "lemmaId": "сімдесят",
       "lemmaPlain": "сімдесят",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8130,11 +9020,13 @@
     {
       "cefr": "A1",
       "gloss": "seventeen",
+      "glossClean": "seventeen",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сімнадцять",
       "lemmaId": "сімнадцять",
       "lemmaPlain": "сімнадцять",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8145,11 +9037,13 @@
     {
       "cefr": "A1",
       "gloss": "telephone",
+      "glossClean": "telephone",
       "heritage": "standard",
       "ipa": null,
       "lemma": "телефон",
       "lemmaId": "телефон",
       "lemmaPlain": "телефон",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8160,11 +9054,13 @@
     {
       "cefr": "A1",
       "gloss": "you, informal singular",
+      "glossClean": "you",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ти",
       "lemmaId": "ти",
       "lemmaPlain": "ти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8175,11 +9071,13 @@
     {
       "cefr": "A1",
       "gloss": "one thousand",
+      "glossClean": "one thousand",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тисяча",
       "lemmaId": "тисяча",
       "lemmaPlain": "тисяча",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8190,11 +9088,13 @@
     {
       "cefr": "A1",
       "gloss": "thirty",
+      "glossClean": "thirty",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тридцять",
       "lemmaId": "тридцять",
       "lemmaPlain": "тридцять",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8205,11 +9105,13 @@
     {
       "cefr": "A1",
       "gloss": "thirteen",
+      "glossClean": "thirteen",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тринадцять",
       "lemmaId": "тринадцять",
       "lemmaPlain": "тринадцять",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8220,11 +9122,13 @@
     {
       "cefr": "A1",
       "gloss": "three hundred",
+      "glossClean": "three hundred",
       "heritage": "standard",
       "ipa": null,
       "lemma": "триста",
       "lemmaId": "триста",
       "lemmaPlain": "триста",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8235,11 +9139,13 @@
     {
       "cefr": "A1",
       "gloss": "four",
+      "glossClean": "four",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чотири",
       "lemmaId": "чотири",
       "lemmaPlain": "чотири",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8250,11 +9156,13 @@
     {
       "cefr": "A1",
       "gloss": "four hundred",
+      "glossClean": "four hundred",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чотириста",
       "lemmaId": "чотириста",
       "lemmaPlain": "чотириста",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8265,11 +9173,13 @@
     {
       "cefr": "A1",
       "gloss": "fourteen",
+      "glossClean": "fourteen",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чотирнадцять",
       "lemmaId": "чотирнадцять",
       "lemmaPlain": "чотирнадцять",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8280,11 +9190,13 @@
     {
       "cefr": "A1",
       "gloss": "sixty",
+      "glossClean": "sixty",
       "heritage": "standard",
       "ipa": null,
       "lemma": "шістдесят",
       "lemmaId": "шістдесят",
       "lemmaPlain": "шістдесят",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8295,11 +9207,13 @@
     {
       "cefr": "A1",
       "gloss": "sixteen",
+      "glossClean": "sixteen",
       "heritage": "standard",
       "ipa": null,
       "lemma": "шістнадцять",
       "lemmaId": "шістнадцять",
       "lemmaPlain": "шістнадцять",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8310,11 +9224,13 @@
     {
       "cefr": "A1",
       "gloss": "six",
+      "glossClean": "six",
       "heritage": "standard",
       "ipa": null,
       "lemma": "шість",
       "lemmaId": "шість",
       "lemmaPlain": "шість",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8325,11 +9241,13 @@
     {
       "cefr": "A1",
       "gloss": "eggs",
+      "glossClean": "eggs",
       "heritage": "standard",
       "ipa": null,
       "lemma": "яйця",
       "lemmaId": "яйця",
       "lemmaPlain": "яйця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8340,11 +9258,13 @@
     {
       "cefr": "A1",
       "gloss": "may; is it possible",
+      "glossClean": "may",
       "heritage": "standard",
       "ipa": null,
       "lemma": "можна",
       "lemmaId": "можна",
       "lemmaPlain": "можна",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8355,11 +9275,13 @@
     {
       "cefr": "A1",
       "gloss": "unfortunately",
+      "glossClean": "unfortunately",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "на жаль",
       "lemmaId": "на-жаль",
       "lemmaPlain": "на жаль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8370,11 +9292,13 @@
     {
       "cefr": "A1",
       "gloss": "then",
+      "glossClean": "then",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тоді",
       "lemmaId": "тоді",
       "lemmaPlain": "тоді",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8385,11 +9309,13 @@
     {
       "cefr": "A1",
       "gloss": "need to; should",
+      "glossClean": "need to",
       "heritage": "standard",
       "ipa": null,
       "lemma": "треба",
       "lemmaId": "треба",
       "lemmaPlain": "треба",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8400,11 +9326,13 @@
     {
       "cefr": "A1",
       "gloss": "more; also",
+      "glossClean": "more",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ще",
       "lemmaId": "ще",
       "lemmaPlain": "ще",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8415,11 +9343,13 @@
     {
       "cefr": "A1",
       "gloss": "and; but; while",
+      "glossClean": "and",
       "heritage": "standard",
       "ipa": null,
       "lemma": "а",
       "lemmaId": "а",
       "lemmaPlain": "а",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8430,11 +9360,13 @@
     {
       "cefr": "A1",
       "gloss": "or",
+      "glossClean": "or",
       "heritage": "dialect",
       "ipa": null,
       "lemma": "або",
       "lemmaId": "або",
       "lemmaPlain": "або",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8445,11 +9377,13 @@
     {
       "cefr": "A1",
       "gloss": "to consider; to think",
+      "glossClean": "to consider",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вважати",
       "lemmaId": "вважати",
       "lemmaPlain": "вважати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8460,11 +9394,13 @@
     {
       "cefr": "A1",
       "gloss": "answer",
+      "glossClean": "answer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відповідь",
       "lemmaId": "відповідь",
       "lemmaPlain": "відповідь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8475,11 +9411,13 @@
     {
       "cefr": "A1",
       "gloss": "vacation",
+      "glossClean": "vacation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відпустка",
       "lemmaId": "відпустка",
       "lemmaPlain": "відпустка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -8519,11 +9457,13 @@
     {
       "cefr": "A1",
       "gloss": "mountain",
+      "glossClean": "mountain",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гора",
       "lemmaId": "гора",
       "lemmaPlain": "гора",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -8563,11 +9503,13 @@
     {
       "cefr": "A1",
       "gloss": "to think",
+      "glossClean": "to think",
       "heritage": "standard",
       "ipa": null,
       "lemma": "думати",
       "lemmaId": "думати",
       "lemmaPlain": "думати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8578,11 +9520,13 @@
     {
       "cefr": "A1",
       "gloss": "but; on the other hand",
+      "glossClean": "but",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зате",
       "lemmaId": "зате",
       "lemmaPlain": "зате",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8593,11 +9537,13 @@
     {
       "cefr": "A1",
       "gloss": "and; smooth variant of і",
+      "glossClean": "and",
       "heritage": "standard",
       "ipa": null,
       "lemma": "й",
       "lemmaId": "й",
       "lemmaPlain": "й",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8608,11 +9554,13 @@
     {
       "cefr": "A1",
       "gloss": "sea",
+      "glossClean": "sea",
       "heritage": "standard",
       "ipa": null,
       "lemma": "море",
       "lemmaId": "море",
       "lemmaPlain": "море",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8623,11 +9571,13 @@
     {
       "cefr": "A1",
       "gloss": "incorrectly; wrong",
+      "glossClean": "incorrectly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "неправильно",
       "lemmaId": "неправильно",
       "lemmaPlain": "неправильно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8638,11 +9588,13 @@
     {
       "cefr": "A1",
       "gloss": "question",
+      "glossClean": "question",
       "heritage": "standard",
       "ipa": null,
       "lemma": "питання",
       "lemmaId": "питання",
       "lemmaPlain": "питання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8653,11 +9605,13 @@
     {
       "cefr": "A1",
       "gloss": "correctly; right",
+      "glossClean": "correctly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "правильно",
       "lemmaId": "правильно",
       "lemmaPlain": "правильно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8668,11 +9622,13 @@
     {
       "cefr": "A1",
       "gloss": "also",
+      "glossClean": "also",
       "heritage": "standard",
       "ipa": null,
       "lemma": "також",
       "lemmaId": "також",
       "lemmaPlain": "також",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8683,11 +9639,13 @@
     {
       "cefr": "A1",
       "gloss": "also; too",
+      "glossClean": "also",
       "heritage": "standard",
       "ipa": null,
       "lemma": "теж",
       "lemmaId": "теж",
       "lemmaPlain": "теж",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8698,11 +9656,13 @@
     {
       "cefr": "A1",
       "gloss": "therefore; that is why",
+      "glossClean": "therefore",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тому",
       "lemmaId": "тому",
       "lemmaPlain": "тому",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8713,11 +9673,13 @@
     {
       "cefr": "A1",
       "gloss": "because",
+      "glossClean": "because",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "тому що",
       "lemmaId": "тому-що",
       "lemmaPlain": "тому що",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8728,11 +9690,13 @@
     {
       "cefr": "A1",
       "gloss": "or; whether",
+      "glossClean": "or",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чи",
       "lemmaId": "чи",
       "lemmaPlain": "чи",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8743,11 +9707,13 @@
     {
       "cefr": "A1",
       "gloss": "if",
+      "glossClean": "if",
       "heritage": "standard",
       "ipa": null,
       "lemma": "якщо",
       "lemmaId": "якщо",
       "lemmaPlain": "якщо",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8758,11 +9724,13 @@
     {
       "cefr": "A1",
       "gloss": "and",
+      "glossClean": "and",
       "heritage": "standard",
       "ipa": null,
       "lemma": "і",
       "lemmaId": "і",
       "lemmaPlain": "і",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8773,11 +9741,13 @@
     {
       "cefr": "A1",
       "gloss": "thing",
+      "glossClean": "thing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "річ",
       "lemmaId": "річ",
       "lemmaPlain": "річ",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8788,11 +9758,13 @@
     {
       "cefr": "A1",
       "gloss": "which; what kind, masculine",
+      "glossClean": "which",
       "heritage": "standard",
       "ipa": null,
       "lemma": "який",
       "lemmaId": "який",
       "lemmaPlain": "який",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8803,11 +9775,13 @@
     {
       "cefr": "A1",
       "gloss": "far from",
+      "glossClean": "far from",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "далеко від",
       "lemmaId": "далеко-від",
       "lemmaPlain": "далеко від",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8818,11 +9792,13 @@
     {
       "cefr": "A1",
       "gloss": "home",
+      "glossClean": "home",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дім",
       "lemmaId": "дім",
       "lemmaPlain": "дім",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8833,11 +9809,13 @@
     {
       "cefr": "A1",
       "gloss": "next to; beside",
+      "glossClean": "next to",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "поруч із",
       "lemmaId": "поруч-із",
       "lemmaPlain": "поруч із",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8848,11 +9826,13 @@
     {
       "cefr": "A1",
       "gloss": "university",
+      "glossClean": "university",
       "heritage": "standard",
       "ipa": null,
       "lemma": "університет",
       "lemmaId": "університет",
       "lemmaPlain": "університет",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8863,11 +9843,13 @@
     {
       "cefr": "A1",
       "gloss": "church",
+      "glossClean": "church",
       "heritage": "standard",
       "ipa": null,
       "lemma": "церква",
       "lemmaId": "церква",
       "lemmaPlain": "церква",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -8907,11 +9889,13 @@
     {
       "cefr": "A1",
       "gloss": "there is; there are",
+      "glossClean": "there is",
       "heritage": "standard",
       "ipa": null,
       "lemma": "є",
       "lemmaId": "є",
       "lemmaPlain": "є",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8922,11 +9906,13 @@
     {
       "cefr": "A1",
       "gloss": "to take a shower",
+      "glossClean": "to take a shower",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "брати душ",
       "lemmaId": "брати-душ",
       "lemmaPlain": "брати душ",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8937,11 +9923,13 @@
     {
       "cefr": "A1",
       "gloss": "in the evening",
+      "glossClean": "in the evening",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ввечері",
       "lemmaId": "ввечері",
       "lemmaPlain": "ввечері",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8952,11 +9940,13 @@
     {
       "cefr": "A1",
       "gloss": "during the day",
+      "glossClean": "during the day",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вдень",
       "lemmaId": "вдень",
       "lemmaPlain": "вдень",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8967,11 +9957,13 @@
     {
       "cefr": "A1",
       "gloss": "evening",
+      "glossClean": "evening",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вечір",
       "lemmaId": "вечір",
       "lemmaPlain": "вечір",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8982,11 +9974,13 @@
     {
       "cefr": "A1",
       "gloss": "at night",
+      "glossClean": "at night",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вночі",
       "lemmaId": "вночі",
       "lemmaPlain": "вночі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8997,11 +9991,13 @@
     {
       "cefr": "A1",
       "gloss": "in the morning",
+      "glossClean": "in the morning",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вранці",
       "lemmaId": "вранці",
       "lemmaPlain": "вранці",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9012,11 +10008,13 @@
     {
       "cefr": "A1",
       "gloss": "to go to bed",
+      "glossClean": "to go to bed",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "лягати спати",
       "lemmaId": "лягати-спати",
       "lemmaPlain": "лягати спати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9027,11 +10025,13 @@
     {
       "cefr": "A1",
       "gloss": "night",
+      "glossClean": "night",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ніч",
       "lemmaId": "ніч",
       "lemmaPlain": "ніч",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -9071,11 +10071,13 @@
     {
       "cefr": "A1",
       "gloss": "At what time?",
+      "glossClean": "At what time?",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "О котрій годині?",
       "lemmaId": "о-котрій-годині",
       "lemmaPlain": "о котрій годині?",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -9086,11 +10088,13 @@
     {
       "cefr": "A1",
       "gloss": "at seven",
+      "glossClean": "at seven",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "о сьомій",
       "lemmaId": "о-сьомій",
       "lemmaPlain": "о сьомій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9101,11 +10105,13 @@
     {
       "cefr": "A1",
       "gloss": "to get dressed",
+      "glossClean": "to get dressed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "одягатися",
       "lemmaId": "одягатися",
       "lemmaPlain": "одягатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9116,11 +10122,13 @@
     {
       "cefr": "A1",
       "gloss": "to take medicine",
+      "glossClean": "to take medicine",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пити ліки",
       "lemmaId": "пити-ліки",
       "lemmaPlain": "пити ліки",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9131,11 +10139,13 @@
     {
       "cefr": "A1",
       "gloss": "after lunch; in the afternoon",
+      "glossClean": "after lunch",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "після обіду",
       "lemmaId": "після-обіду",
       "lemmaPlain": "після обіду",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9146,11 +10156,13 @@
     {
       "cefr": "A1",
       "gloss": "morning",
+      "glossClean": "morning",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ранок",
       "lemmaId": "ранок",
       "lemmaPlain": "ранок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9161,11 +10173,13 @@
     {
       "cefr": "A1",
       "gloss": "to exercise",
+      "glossClean": "to exercise",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "робити зарядку",
       "lemmaId": "робити-зарядку",
       "lemmaPlain": "робити зарядку",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9176,11 +10190,13 @@
     {
       "cefr": "A1",
       "gloss": "parents",
+      "glossClean": "parents",
       "heritage": "standard",
       "ipa": null,
       "lemma": "батьки",
       "lemmaId": "батьки",
       "lemmaPlain": "батьки",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9191,11 +10207,13 @@
     {
       "cefr": "A1",
       "gloss": "father",
+      "glossClean": "father",
       "heritage": "standard",
       "ipa": null,
       "lemma": "батько",
       "lemmaId": "батько",
       "lemmaPlain": "батько",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9206,11 +10224,13 @@
     {
       "cefr": "A1",
       "gloss": "child",
+      "glossClean": "child",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дитина",
       "lemmaId": "дитина",
       "lemmaPlain": "дитина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9221,11 +10241,13 @@
     {
       "cefr": "A1",
       "gloss": "daughter",
+      "glossClean": "daughter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "донька",
       "lemmaId": "донька",
       "lemmaPlain": "донька",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9236,11 +10258,13 @@
     {
       "cefr": "A1",
       "gloss": "wife",
+      "glossClean": "wife",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дружина",
       "lemmaId": "дружина",
       "lemmaPlain": "дружина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9251,11 +10275,13 @@
     {
       "cefr": "A1",
       "gloss": "uncle",
+      "glossClean": "uncle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дядько",
       "lemmaId": "дядько",
       "lemmaPlain": "дядько",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9266,11 +10292,13 @@
     {
       "cefr": "A1",
       "gloss": "to call / be named",
+      "glossClean": "to call / be named",
       "heritage": "standard",
       "ipa": null,
       "lemma": "звати",
       "lemmaId": "звати",
       "lemmaPlain": "звати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9281,11 +10309,13 @@
     {
       "cefr": "A1",
       "gloss": "mother",
+      "glossClean": "mother",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мати",
       "lemmaId": "мати",
       "lemmaPlain": "мати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9296,11 +10326,13 @@
     {
       "cefr": "A1",
       "gloss": "younger",
+      "glossClean": "younger",
       "heritage": "standard",
       "ipa": null,
       "lemma": "молодший",
       "lemmaId": "молодший",
       "lemmaPlain": "молодший",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9311,11 +10343,13 @@
     {
       "cefr": "A1",
       "gloss": "married",
+      "glossClean": "married",
       "heritage": "standard",
       "ipa": null,
       "lemma": "одружений",
       "lemmaId": "одружений",
       "lemmaPlain": "одружений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9326,11 +10360,13 @@
     {
       "cefr": "A1",
       "gloss": "patronymic",
+      "glossClean": "patronymic",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "по батькові",
       "lemmaId": "по-батькові",
       "lemmaPlain": "по батькові",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9341,11 +10377,13 @@
     {
       "cefr": "A1",
       "gloss": "son",
+      "glossClean": "son",
       "heritage": "standard",
       "ipa": null,
       "lemma": "син",
       "lemmaId": "син",
       "lemmaPlain": "син",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9356,11 +10394,13 @@
     {
       "cefr": "A1",
       "gloss": "older",
+      "glossClean": "older",
       "heritage": "standard",
       "ipa": null,
       "lemma": "старший",
       "lemmaId": "старший",
       "lemmaPlain": "старший",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9371,11 +10411,13 @@
     {
       "cefr": "A1",
       "gloss": "your, masculine informal",
+      "glossClean": "your",
       "heritage": "standard",
       "ipa": null,
       "lemma": "твій",
       "lemmaId": "твій",
       "lemmaPlain": "твій",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -9386,11 +10428,13 @@
     {
       "cefr": "A1",
       "gloss": "aunt",
+      "glossClean": "aunt",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тітка",
       "lemmaId": "тітка",
       "lemmaPlain": "тітка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9401,11 +10445,13 @@
     {
       "cefr": "A1",
       "gloss": "you have, formal or plural",
+      "glossClean": "you have",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у вас є",
       "lemmaId": "у-вас-є",
       "lemmaPlain": "у вас є",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9416,11 +10462,13 @@
     {
       "cefr": "A1",
       "gloss": "man / husband",
+      "glossClean": "man / husband",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чоловік",
       "lemmaId": "чоловік",
       "lemmaPlain": "чоловік",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9431,11 +10479,13 @@
     {
       "cefr": "A1",
       "gloss": "to get up",
+      "glossClean": "to get up",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вставати",
       "lemmaId": "вставати",
       "lemmaPlain": "вставати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9446,11 +10496,13 @@
     {
       "cefr": "A1",
       "gloss": "toothpaste",
+      "glossClean": "toothpaste",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "зубна паста",
       "lemmaId": "зубна-паста",
       "lemmaPlain": "зубна паста",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9461,11 +10513,13 @@
     {
       "cefr": "A1",
       "gloss": "to lie down",
+      "glossClean": "to lie down",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лежати",
       "lemmaId": "лежати",
       "lemmaPlain": "лежати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9476,11 +10530,13 @@
     {
       "cefr": "A1",
       "gloss": "early",
+      "glossClean": "early",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рано",
       "lemmaId": "рано",
       "lemmaPlain": "рано",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9491,11 +10547,13 @@
     {
       "cefr": "A1",
       "gloss": "towel",
+      "glossClean": "towel",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рушник",
       "lemmaId": "рушник",
       "lemmaPlain": "рушник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9506,11 +10564,13 @@
     {
       "cefr": "A1",
       "gloss": "to brush teeth",
+      "glossClean": "to brush teeth",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "чистити зуби",
       "lemmaId": "чистити-зуби",
       "lemmaPlain": "чистити зуби",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9521,11 +10581,13 @@
     {
       "cefr": "A1",
       "gloss": "quickly",
+      "glossClean": "quickly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "швидко",
       "lemmaId": "швидко",
       "lemmaPlain": "швидко",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9536,11 +10598,13 @@
     {
       "cefr": "A1",
       "gloss": "with pleasure",
+      "glossClean": "with pleasure",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "з задоволенням",
       "lemmaId": "з-задоволенням",
       "lemmaPlain": "з задоволенням",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9551,11 +10615,13 @@
     {
       "cefr": "A1",
       "gloss": "of course",
+      "glossClean": "of course",
       "heritage": "standard",
       "ipa": null,
       "lemma": "звичайно",
       "lemmaId": "звичайно",
       "lemmaPlain": "звичайно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9566,11 +10632,13 @@
     {
       "cefr": "A1",
       "gloss": "meeting",
+      "glossClean": "meeting",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зустріч",
       "lemmaId": "зустріч",
       "lemmaPlain": "зустріч",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -9610,11 +10678,13 @@
     {
       "cefr": "A1",
       "gloss": "apartment",
+      "glossClean": "apartment",
       "heritage": "standard",
       "ipa": null,
       "lemma": "квартира",
       "lemmaId": "квартира",
       "lemmaPlain": "квартира",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -9654,11 +10724,13 @@
     {
       "cefr": "A1",
       "gloss": "at three",
+      "glossClean": "at three",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "о третій",
       "lemmaId": "о-третій",
       "lemmaPlain": "о третій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9669,11 +10741,13 @@
     {
       "cefr": "A1",
       "gloss": "at six",
+      "glossClean": "at six",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "о шостій",
       "lemmaId": "о-шостій",
       "lemmaPlain": "о шостій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9684,11 +10758,13 @@
     {
       "cefr": "A1",
       "gloss": "plan",
+      "glossClean": "plan",
       "heritage": "standard",
       "ipa": null,
       "lemma": "план",
       "lemmaId": "план",
       "lemmaPlain": "план",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -9699,11 +10775,13 @@
     {
       "cefr": "A1",
       "gloss": "lived (feminine)",
+      "glossClean": "lived (feminine)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "жила",
       "lemmaId": "жила",
       "lemmaPlain": "жила",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -9714,11 +10792,13 @@
     {
       "cefr": "A1",
       "gloss": "now",
+      "glossClean": "now",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зараз",
       "lemmaId": "зараз",
       "lemmaPlain": "зараз",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9729,11 +10809,13 @@
     {
       "cefr": "A1",
       "gloss": "in childhood",
+      "glossClean": "in childhood",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у дитинстві",
       "lemmaId": "у-дитинстві",
       "lemmaPlain": "у дитинстві",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9744,11 +10826,13 @@
     {
       "cefr": "A1",
       "gloss": "story, history",
+      "glossClean": "story",
       "heritage": "standard",
       "ipa": null,
       "lemma": "історія",
       "lemmaId": "історія",
       "lemmaPlain": "історія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -9788,11 +10872,13 @@
     {
       "cefr": "A1",
       "gloss": "lecturer",
+      "glossClean": "lecturer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "викладач",
       "lemmaId": "викладач",
       "lemmaPlain": "викладач",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9803,11 +10889,13 @@
     {
       "cefr": "A1",
       "gloss": "they",
+      "glossClean": "they",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вони",
       "lemmaId": "вони",
       "lemmaPlain": "вони",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -9818,11 +10906,13 @@
     {
       "cefr": "A1",
       "gloss": "colleague",
+      "glossClean": "colleague",
       "heritage": "standard",
       "ipa": null,
       "lemma": "колега",
       "lemmaId": "колега",
       "lemmaPlain": "колега",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9833,11 +10923,13 @@
     {
       "cefr": "A1",
       "gloss": "person",
+      "glossClean": "person",
       "heritage": "standard",
       "ipa": null,
       "lemma": "люди́на",
       "lemmaId": "люди-на",
       "lemmaPlain": "людина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9848,11 +10940,13 @@
     {
       "cefr": "A1",
       "gloss": "we",
+      "glossClean": "we",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ми",
       "lemmaId": "ми",
       "lemmaPlain": "ми",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -9863,11 +10957,13 @@
     {
       "cefr": "A1",
       "gloss": "seller",
+      "glossClean": "seller",
       "heritage": "standard",
       "ipa": null,
       "lemma": "продавець",
       "lemmaId": "продавець",
       "lemmaPlain": "продавець",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9878,11 +10974,13 @@
     {
       "cefr": "A1",
       "gloss": "to look for",
+      "glossClean": "to look for",
       "heritage": "standard",
       "ipa": null,
       "lemma": "шукати",
       "lemmaId": "шукати",
       "lemmaPlain": "шукати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9893,11 +10991,13 @@
     {
       "cefr": "A1",
       "gloss": "to open",
+      "glossClean": "to open",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відкрити",
       "lemmaId": "відкрити",
       "lemmaPlain": "відкрити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9908,11 +11008,13 @@
     {
       "cefr": "A1",
       "gloss": "imperative mood; command form",
+      "glossClean": "imperative mood",
       "heritage": "standard",
       "ipa": null,
       "lemma": "наказовий спосіб",
       "lemmaId": "наказовий-спосіб",
       "lemmaPlain": "наказовий спосіб",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9923,11 +11025,13 @@
     {
       "cefr": "A1",
       "gloss": "textbook",
+      "glossClean": "textbook",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підручник",
       "lemmaId": "підручник",
       "lemmaPlain": "підручник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9938,11 +11042,13 @@
     {
       "cefr": "A1",
       "gloss": "sentence",
+      "glossClean": "sentence",
       "heritage": "standard",
       "ipa": null,
       "lemma": "речення",
       "lemmaId": "речення",
       "lemmaPlain": "речення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9953,11 +11059,13 @@
     {
       "cefr": "A1",
       "gloss": "to say; to tell",
+      "glossClean": "to say",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сказати",
       "lemmaId": "сказати",
       "lemmaPlain": "сказати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9968,11 +11076,13 @@
     {
       "cefr": "A1",
       "gloss": "page",
+      "glossClean": "page",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сторінка",
       "lemmaId": "сторінка",
       "lemmaPlain": "сторінка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -10012,11 +11122,13 @@
     {
       "cefr": "A1",
       "gloss": "not",
+      "glossClean": "not",
       "heritage": "standard",
       "ipa": null,
       "lemma": "не",
       "lemmaId": "не",
       "lemmaPlain": "не",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10027,11 +11139,13 @@
     {
       "cefr": "A1",
       "gloss": "no",
+      "glossClean": "no",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ні",
       "lemmaId": "ні",
       "lemmaPlain": "ні",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10042,11 +11156,13 @@
     {
       "cefr": "A1",
       "gloss": "nothing; not anything",
+      "glossClean": "nothing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нічого",
       "lemmaId": "нічого",
       "lemmaPlain": "нічого",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10057,11 +11173,13 @@
     {
       "cefr": "A1",
       "gloss": "to understand",
+      "glossClean": "to understand",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розуміти",
       "lemmaId": "розуміти",
       "lemmaPlain": "розуміти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10072,11 +11190,13 @@
     {
       "cefr": "A1",
       "gloss": "vowel sound",
+      "glossClean": "vowel sound",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "голосни́й звук",
       "lemmaId": "голосни-й-звук",
       "lemmaPlain": "голосний звук",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10087,11 +11207,13 @@
     {
       "cefr": "A1",
       "gloss": "source / spring",
+      "glossClean": "source / spring",
       "heritage": "standard",
       "ipa": null,
       "lemma": "джерело́",
       "lemmaId": "джерело",
       "lemmaPlain": "джерело",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10102,11 +11224,13 @@
     {
       "cefr": "A1",
       "gloss": "soft sign",
+      "glossClean": "soft sign",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "м'яки́й знак",
       "lemmaId": "м-яки-й-знак",
       "lemmaPlain": "м'який знак",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10117,11 +11241,13 @@
     {
       "cefr": "A1",
       "gloss": "consonant sound",
+      "glossClean": "consonant sound",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "при́голосний звук",
       "lemmaId": "при-голосний-звук",
       "lemmaPlain": "приголосний звук",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10132,11 +11258,13 @@
     {
       "cefr": "A1",
       "gloss": "song",
+      "glossClean": "song",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пі́сня",
       "lemmaId": "пі-сня",
       "lemmaPlain": "пісня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10147,11 +11275,13 @@
     {
       "cefr": "A1",
       "gloss": "yes / like this",
+      "glossClean": "yes / like this",
       "heritage": "standard",
       "ipa": null,
       "lemma": "так",
       "lemmaId": "так",
       "lemmaPlain": "так",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10162,11 +11292,13 @@
     {
       "cefr": "A1",
       "gloss": "UAH; hryvnia abbreviation",
+      "glossClean": "UAH",
       "heritage": "standard",
       "ipa": null,
       "lemma": "грн",
       "lemmaId": "грн",
       "lemmaPlain": "грн",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10177,11 +11309,13 @@
     {
       "cefr": "A1",
       "gloss": "two kilograms of tomatoes",
+      "glossClean": "two kilograms of tomatoes",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "два кілограми помідорів",
       "lemmaId": "два-кілограми-помідорів",
       "lemmaPlain": "два кілограми помідорів",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10192,11 +11326,13 @@
     {
       "cefr": "A1",
       "gloss": "liter",
+      "glossClean": "liter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "літр",
       "lemmaId": "літр",
       "lemmaPlain": "літр",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10207,11 +11343,13 @@
     {
       "cefr": "A1",
       "gloss": "a liter of milk",
+      "glossClean": "a liter of milk",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "літр молока",
       "lemmaId": "літр-молока",
       "lemmaPlain": "літр молока",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10222,11 +11360,13 @@
     {
       "cefr": "A1",
       "gloss": "meat department",
+      "glossClean": "meat department",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "м'ясний відділ",
       "lemmaId": "м-ясний-відділ",
       "lemmaPlain": "м'ясний відділ",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10237,11 +11377,13 @@
     {
       "cefr": "A1",
       "gloss": "dairy department",
+      "glossClean": "dairy department",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "молочний відділ",
       "lemmaId": "молочний-відділ",
       "lemmaPlain": "молочний відділ",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10252,11 +11394,13 @@
     {
       "cefr": "A1",
       "gloss": "one kilogram of apples",
+      "glossClean": "one kilogram of apples",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "один кілограм яблук",
       "lemmaId": "один-кілограм-яблук",
       "lemmaPlain": "один кілограм яблук",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10267,11 +11411,13 @@
     {
       "cefr": "A1",
       "gloss": "And you? (after a name question)",
+      "glossClean": "And you? (after a name question)",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "А тебе́?",
       "lemmaId": "а-тебе",
       "lemmaPlain": "а тебе?",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10282,11 +11428,13 @@
     {
       "cefr": "A1",
       "gloss": "And you? (after How are you?)",
+      "glossClean": "And you? (after How are you?)",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "А у тебе́?",
       "lemmaId": "а-у-тебе",
       "lemmaPlain": "а у тебе?",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10297,11 +11445,13 @@
     {
       "cefr": "A1",
       "gloss": "Fine / good",
+      "glossClean": "Fine / good",
       "heritage": "standard",
       "ipa": null,
       "lemma": "До́бре",
       "lemmaId": "до-бре",
       "lemmaPlain": "добре",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10312,11 +11462,13 @@
     {
       "cefr": "A1",
       "gloss": "Good evening",
+      "glossClean": "Good evening",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "До́брий ве́чір",
       "lemmaId": "до-брий-ве-чір",
       "lemmaPlain": "добрий вечір",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10327,11 +11479,13 @@
     {
       "cefr": "A1",
       "gloss": "Good morning",
+      "glossClean": "Good morning",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "До́брого ра́нку",
       "lemmaId": "до-брого-ра-нку",
       "lemmaPlain": "доброго ранку",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10342,11 +11496,13 @@
     {
       "cefr": "A1",
       "gloss": "All the best",
+      "glossClean": "All the best",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "На все до́бре",
       "lemmaId": "на-все-до-бре",
       "lemmaPlain": "на все добре",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10357,11 +11513,13 @@
     {
       "cefr": "A1",
       "gloss": "Okay / normal",
+      "glossClean": "Okay / normal",
       "heritage": "standard",
       "ipa": null,
       "lemma": "Норма́льно",
       "lemmaId": "норма-льно",
       "lemmaPlain": "нормально",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10372,11 +11530,13 @@
     {
       "cefr": "A1",
       "gloss": "Glad to see you (female speaker)",
+      "glossClean": "Glad to see you (female speaker)",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Ра́да тебе́ ба́чити",
       "lemmaId": "ра-да-тебе-ба-чити",
       "lemmaPlain": "рада тебе бачити",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10387,11 +11547,13 @@
     {
       "cefr": "A1",
       "gloss": "Glad to see you (male speaker)",
+      "glossClean": "Glad to see you (male speaker)",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Ра́дий тебе́ ба́чити",
       "lemmaId": "ра-дий-тебе-ба-чити",
       "lemmaPlain": "радий тебе бачити",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10402,11 +11564,13 @@
     {
       "cefr": "A1",
       "gloss": "Great / wonderful",
+      "glossClean": "Great / wonderful",
       "heritage": "standard",
       "ipa": null,
       "lemma": "Чудо́во",
       "lemmaId": "чудо-во",
       "lemmaPlain": "чудово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10417,11 +11581,13 @@
     {
       "cefr": "A1",
       "gloss": "How are you?",
+      "glossClean": "How are you?",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Як спра́ви?",
       "lemmaId": "як-спра-ви",
       "lemmaPlain": "як справи?",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10432,11 +11598,13 @@
     {
       "cefr": "A1",
       "gloss": "horse",
+      "glossClean": "horse",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кінь",
       "lemmaId": "кінь",
       "lemmaPlain": "кінь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10447,11 +11615,13 @@
     {
       "cefr": "A1",
       "gloss": "small",
+      "glossClean": "small",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мале́нький",
       "lemmaId": "мале-нький",
       "lemmaPlain": "маленький",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10462,11 +11632,13 @@
     {
       "cefr": "A1",
       "gloss": "nicely / beautiful",
+      "glossClean": "nicely / beautiful",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гарно",
       "lemmaId": "гарно",
       "lemmaPlain": "гарно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10477,11 +11649,13 @@
     {
       "cefr": "A1",
       "gloss": "heads",
+      "glossClean": "heads",
       "heritage": "standard",
       "ipa": null,
       "lemma": "голови",
       "lemmaId": "голови",
       "lemmaPlain": "голови",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10492,11 +11666,13 @@
     {
       "cefr": "A1",
       "gloss": "organ",
+      "glossClean": "organ",
       "heritage": "standard",
       "ipa": null,
       "lemma": "орган",
       "lemmaId": "орган",
       "lemmaPlain": "орган",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10507,11 +11683,13 @@
     {
       "cefr": "A1",
       "gloss": "word",
+      "glossClean": "word",
       "heritage": "standard",
       "ipa": null,
       "lemma": "слово",
       "lemmaId": "слово",
       "lemmaPlain": "слово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10522,11 +11700,13 @@
     {
       "cefr": "A1",
       "gloss": "Ukrainian",
+      "glossClean": "Ukrainian",
       "heritage": "standard",
       "ipa": null,
       "lemma": "українська",
       "lemmaId": "українська",
       "lemmaPlain": "українська",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10537,11 +11717,13 @@
     {
       "cefr": "A1",
       "gloss": "photograph",
+      "glossClean": "photograph",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фотографія",
       "lemmaId": "фотографія",
       "lemmaPlain": "фотографія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -10581,11 +11763,13 @@
     {
       "cefr": "A1",
       "gloss": "male actor",
+      "glossClean": "male actor",
       "heritage": "standard",
       "ipa": null,
       "lemma": "актор",
       "lemmaId": "актор",
       "lemmaPlain": "актор",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10596,11 +11780,13 @@
     {
       "cefr": "A1",
       "gloss": "female actor",
+      "glossClean": "female actor",
       "heritage": "standard",
       "ipa": null,
       "lemma": "акторка",
       "lemmaId": "акторка",
       "lemmaPlain": "акторка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10611,11 +11797,13 @@
     {
       "cefr": "A1",
       "gloss": "it / neuter gender-test word",
+      "glossClean": "it / neuter gender-test word",
       "heritage": "standard",
       "ipa": null,
       "lemma": "воно",
       "lemmaId": "воно",
       "lemmaPlain": "воно",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10626,11 +11814,13 @@
     {
       "cefr": "A1",
       "gloss": "he / masculine gender-test word",
+      "glossClean": "he / masculine gender-test word",
       "heritage": "standard",
       "ipa": null,
       "lemma": "він",
       "lemmaId": "він",
       "lemmaPlain": "він",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10641,11 +11831,13 @@
     {
       "cefr": "A1",
       "gloss": "bed",
+      "glossClean": "bed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ліжко",
       "lemmaId": "ліжко",
       "lemmaPlain": "ліжко",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -10685,11 +11877,13 @@
     {
       "cefr": "A1",
       "gloss": "female doctor",
+      "glossClean": "female doctor",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лікарка",
       "lemmaId": "лікарка",
       "lemmaPlain": "лікарка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10700,11 +11894,13 @@
     {
       "cefr": "A1",
       "gloss": "Mykola",
+      "glossClean": "Mykola",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Микола",
       "lemmaId": "микола",
       "lemmaPlain": "микола",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10715,11 +11911,13 @@
     {
       "cefr": "A1",
       "gloss": "Pavlo",
+      "glossClean": "Pavlo",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Павло",
       "lemmaId": "павло",
       "lemmaPlain": "павло",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10730,11 +11928,13 @@
     {
       "cefr": "A1",
       "gloss": "grammatical gender",
+      "glossClean": "grammatical gender",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рід",
       "lemmaId": "рід",
       "lemmaPlain": "рід",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10745,11 +11945,13 @@
     {
       "cefr": "A1",
       "gloss": "dog",
+      "glossClean": "dog",
       "heritage": "standard",
       "ipa": null,
       "lemma": "собака",
       "lemmaId": "собака",
       "lemmaPlain": "собака",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10760,11 +11962,13 @@
     {
       "cefr": "A1",
       "gloss": "male singer",
+      "glossClean": "male singer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "співак",
       "lemmaId": "співак",
       "lemmaPlain": "співак",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10775,11 +11979,13 @@
     {
       "cefr": "A1",
       "gloss": "female singer",
+      "glossClean": "female singer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "співачка",
       "lemmaId": "співачка",
       "lemmaPlain": "співачка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10790,11 +11996,13 @@
     {
       "cefr": "A1",
       "gloss": "wall",
+      "glossClean": "wall",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стіна",
       "lemmaId": "стіна",
       "lemmaPlain": "стіна",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -10834,11 +12042,13 @@
     {
       "cefr": "A1",
       "gloss": "photo",
+      "glossClean": "photo",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фото",
       "lemmaId": "фото",
       "lemmaPlain": "фото",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10849,11 +12059,13 @@
     {
       "cefr": "A1",
       "gloss": "who is this?",
+      "glossClean": "who is this?",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "хто це?",
       "lemmaId": "хто-це",
       "lemmaPlain": "хто це?",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10864,11 +12076,13 @@
     {
       "cefr": "A1",
       "gloss": "what is this?",
+      "glossClean": "what is this?",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "що це?",
       "lemmaId": "що-це",
       "lemmaPlain": "що це?",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10879,11 +12093,13 @@
     {
       "cefr": "A1",
       "gloss": "here is; look",
+      "glossClean": "here is",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ось",
       "lemmaId": "ось",
       "lemmaPlain": "ось",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10894,11 +12110,13 @@
     {
       "cefr": "A1",
       "gloss": "that exact one, neuter",
+      "glossClean": "that exact one",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ото",
       "lemmaId": "ото",
       "lemmaPlain": "ото",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10909,11 +12127,13 @@
     {
       "cefr": "A1",
       "gloss": "this exact one, neuter",
+      "glossClean": "this exact one",
       "heritage": "standard",
       "ipa": null,
       "lemma": "оце",
       "lemmaId": "оце",
       "lemmaPlain": "оце",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10924,11 +12144,13 @@
     {
       "cefr": "A1",
       "gloss": "this pencil, recognition",
+      "glossClean": "this pencil",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "цього олівця",
       "lemmaId": "цього-олівця",
       "lemmaPlain": "цього олівця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10939,11 +12161,13 @@
     {
       "cefr": "A1",
       "gloss": "this book, object",
+      "glossClean": "this book",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "цю книгу",
       "lemmaId": "цю-книгу",
       "lemmaPlain": "цю книгу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10954,11 +12178,13 @@
     {
       "cefr": "A1",
       "gloss": "plane",
+      "glossClean": "plane",
       "heritage": "standard",
       "ipa": null,
       "lemma": "літак",
       "lemmaId": "літак",
       "lemmaPlain": "літак",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10969,11 +12195,13 @@
     {
       "cefr": "A1",
       "gloss": "route minibus",
+      "glossClean": "route minibus",
       "heritage": "standard",
       "ipa": null,
       "lemma": "маршрутка",
       "lemmaId": "маршрутка",
       "lemmaPlain": "маршрутка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -11013,11 +12241,13 @@
     {
       "cefr": "A1",
       "gloss": "car",
+      "glossClean": "car",
       "heritage": "standard",
       "ipa": null,
       "lemma": "машина",
       "lemmaId": "машина",
       "lemmaPlain": "машина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -11057,11 +12287,13 @@
     {
       "cefr": "A1",
       "gloss": "one way",
+      "glossClean": "one way",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "один бік",
       "lemmaId": "один-бік",
       "lemmaPlain": "один бік",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11072,11 +12304,13 @@
     {
       "cefr": "A1",
       "gloss": "passenger",
+      "glossClean": "passenger",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пасажир",
       "lemmaId": "пасажир",
       "lemmaPlain": "пасажир",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11087,11 +12321,13 @@
     {
       "cefr": "A1",
       "gloss": "taxi",
+      "glossClean": "taxi",
       "heritage": "standard",
       "ipa": null,
       "lemma": "таксі",
       "lemmaId": "таксі",
       "lemmaPlain": "таксі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -11131,11 +12367,13 @@
     {
       "cefr": "A1",
       "gloss": "transport",
+      "glossClean": "transport",
       "heritage": "standard",
       "ipa": null,
       "lemma": "транспорт",
       "lemmaId": "транспорт",
       "lemmaPlain": "транспорт",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11146,11 +12384,13 @@
     {
       "cefr": "A1",
       "gloss": "trolleybus",
+      "glossClean": "trolleybus",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тролейбус",
       "lemmaId": "тролейбус",
       "lemmaPlain": "тролейбус",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11161,11 +12401,13 @@
     {
       "cefr": "A1",
       "gloss": "round trip; there and back",
+      "glossClean": "round trip",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "туди й назад",
       "lemmaId": "туди-й-назад",
       "lemmaPlain": "туди й назад",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11176,11 +12418,13 @@
     {
       "cefr": "A1",
       "gloss": "he/she cooks",
+      "glossClean": "he/she cooks",
       "heritage": "standard",
       "ipa": null,
       "lemma": "готує",
       "lemmaId": "готує",
       "lemmaPlain": "готує",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11191,11 +12435,13 @@
     {
       "cefr": "A1",
       "gloss": "we know",
+      "glossClean": "we know",
       "heritage": "standard",
       "ipa": null,
       "lemma": "знаємо",
       "lemmaId": "знаємо",
       "lemmaPlain": "знаємо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11206,11 +12452,13 @@
     {
       "cefr": "A1",
       "gloss": "we work; are working",
+      "glossClean": "we work",
       "heritage": "standard",
       "ipa": null,
       "lemma": "працюємо",
       "lemmaId": "працюємо",
       "lemmaPlain": "працюємо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11221,11 +12469,13 @@
     {
       "cefr": "A1",
       "gloss": "text",
+      "glossClean": "text",
       "heritage": "standard",
       "ipa": null,
       "lemma": "текст",
       "lemmaId": "текст",
       "lemmaPlain": "текст",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11236,11 +12486,13 @@
     {
       "cefr": "A1",
       "gloss": "we see",
+      "glossClean": "we see",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бачимо",
       "lemmaId": "бачимо",
       "lemmaPlain": "бачимо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11251,11 +12503,13 @@
     {
       "cefr": "A1",
       "gloss": "you see (plural/formal)",
+      "glossClean": "you see (plural/formal)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бачите",
       "lemmaId": "бачите",
       "lemmaPlain": "бачите",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11266,11 +12520,13 @@
     {
       "cefr": "A1",
       "gloss": "he/she sees",
+      "glossClean": "he/she sees",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бачить",
       "lemmaId": "бачить",
       "lemmaPlain": "бачить",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11281,11 +12537,13 @@
     {
       "cefr": "A1",
       "gloss": "they like; they love",
+      "glossClean": "they like",
       "heritage": "standard",
       "ipa": null,
       "lemma": "люблять",
       "lemmaId": "люблять",
       "lemmaPlain": "люблять",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11296,11 +12554,13 @@
     {
       "cefr": "A1",
       "gloss": "to ask for; to request",
+      "glossClean": "to ask for",
       "heritage": "standard",
       "ipa": null,
       "lemma": "просити",
       "lemmaId": "просити",
       "lemmaPlain": "просити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11311,11 +12571,13 @@
     {
       "cefr": "A1",
       "gloss": "he/she asks for",
+      "glossClean": "he/she asks for",
       "heritage": "standard",
       "ipa": null,
       "lemma": "просить",
       "lemmaId": "просить",
       "lemmaPlain": "просить",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11326,11 +12588,13 @@
     {
       "cefr": "A1",
       "gloss": "they ask for",
+      "glossClean": "they ask for",
       "heritage": "standard",
       "ipa": null,
       "lemma": "просять",
       "lemmaId": "просять",
       "lemmaPlain": "просять",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11341,11 +12605,13 @@
     {
       "cefr": "A1",
       "gloss": "I ask for",
+      "glossClean": "I ask for",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прошу",
       "lemmaId": "прошу",
       "lemmaPlain": "прошу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11356,11 +12622,13 @@
     {
       "cefr": "A1",
       "gloss": "we do",
+      "glossClean": "we do",
       "heritage": "standard",
       "ipa": null,
       "lemma": "робимо",
       "lemmaId": "робимо",
       "lemmaPlain": "робимо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11371,11 +12639,13 @@
     {
       "cefr": "A1",
       "gloss": "he/she does",
+      "glossClean": "he/she does",
       "heritage": "standard",
       "ipa": null,
       "lemma": "робить",
       "lemmaId": "робить",
       "lemmaPlain": "робить",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11386,11 +12656,13 @@
     {
       "cefr": "A1",
       "gloss": "a little",
+      "glossClean": "a little",
       "heritage": "standard",
       "ipa": null,
       "lemma": "трохи",
       "lemmaId": "трохи",
       "lemmaPlain": "трохи",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11401,11 +12673,13 @@
     {
       "cefr": "A1",
       "gloss": "in the evening",
+      "glossClean": "in the evening",
       "heritage": "standard",
       "ipa": null,
       "lemma": "увечері",
       "lemmaId": "увечері",
       "lemmaPlain": "увечері",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11416,11 +12690,13 @@
     {
       "cefr": "A1",
       "gloss": "to go regularly; to walk",
+      "glossClean": "to go regularly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ходити",
       "lemmaId": "ходити",
       "lemmaPlain": "ходити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11431,11 +12707,13 @@
     {
       "cefr": "A1",
       "gloss": "he/she goes regularly; he/she walks",
+      "glossClean": "he/she goes regularly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ходить",
       "lemmaId": "ходить",
       "lemmaPlain": "ходить",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11446,11 +12724,13 @@
     {
       "cefr": "A1",
       "gloss": "yesterday",
+      "glossClean": "yesterday",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вчора",
       "lemmaId": "вчора",
       "lemmaPlain": "вчора",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11461,11 +12741,13 @@
     {
       "cefr": "A1",
       "gloss": "wind",
+      "glossClean": "wind",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вітер",
       "lemmaId": "вітер",
       "lemmaPlain": "вітер",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11476,11 +12758,13 @@
     {
       "cefr": "A1",
       "gloss": "degree",
+      "glossClean": "degree",
       "heritage": "standard",
       "ipa": null,
       "lemma": "градус",
       "lemmaId": "градус",
       "lemmaPlain": "градус",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11491,11 +12775,13 @@
     {
       "cefr": "A1",
       "gloss": "the wind is blowing",
+      "glossClean": "the wind is blowing",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "дме вітер",
       "lemmaId": "дме-вітер",
       "lemmaPlain": "дме вітер",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11506,11 +12792,13 @@
     {
       "cefr": "A1",
       "gloss": "rain",
+      "glossClean": "rain",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дощ",
       "lemmaId": "дощ",
       "lemmaPlain": "дощ",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11521,11 +12809,13 @@
     {
       "cefr": "A1",
       "gloss": "I like...",
+      "glossClean": "I like...",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Мені подобається...",
       "lemmaId": "мені-подобається",
       "lemmaPlain": "мені подобається...",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11536,11 +12826,13 @@
     {
       "cefr": "A1",
       "gloss": "I am cold.",
+      "glossClean": "I am cold.",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Мені холодно.",
       "lemmaId": "мені-холодно",
       "lemmaPlain": "мені холодно.",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11551,11 +12843,13 @@
     {
       "cefr": "A1",
       "gloss": "minus",
+      "glossClean": "minus",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мінус",
       "lemmaId": "мінус",
       "lemmaPlain": "мінус",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11566,11 +12860,13 @@
     {
       "cefr": "A1",
       "gloss": "outside; in the street",
+      "glossClean": "outside",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "на вулиці",
       "lemmaId": "на-вулиці",
       "lemmaPlain": "на вулиці",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11581,11 +12877,13 @@
     {
       "cefr": "A1",
       "gloss": "plus",
+      "glossClean": "plus",
       "heritage": "standard",
       "ipa": null,
       "lemma": "плюс",
       "lemmaId": "плюс",
       "lemmaPlain": "плюс",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11596,11 +12894,13 @@
     {
       "cefr": "A1",
       "gloss": "weather",
+      "glossClean": "weather",
       "heritage": "standard",
       "ipa": null,
       "lemma": "погода",
       "lemmaId": "погода",
       "lemmaPlain": "погода",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -11640,11 +12940,13 @@
     {
       "cefr": "A1",
       "gloss": "snow",
+      "glossClean": "snow",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сніг",
       "lemmaId": "сніг",
       "lemmaPlain": "сніг",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11655,11 +12957,13 @@
     {
       "cefr": "A1",
       "gloss": "sun",
+      "glossClean": "sun",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сонце",
       "lemmaId": "сонце",
       "lemmaPlain": "сонце",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11670,11 +12974,13 @@
     {
       "cefr": "A1",
       "gloss": "book",
+      "glossClean": "book",
       "heritage": "standard",
       "ipa": null,
       "lemma": "книжка",
       "lemmaId": "книжка",
       "lemmaPlain": "книжка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -11714,11 +13020,13 @@
     {
       "cefr": "A1",
       "gloss": "together",
+      "glossClean": "together",
       "heritage": "standard",
       "ipa": null,
       "lemma": "разом",
       "lemmaId": "разом",
       "lemmaPlain": "разом",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11729,11 +13037,13 @@
     {
       "cefr": "A1",
       "gloss": "I do not like",
+      "glossClean": "I do not like",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "не люблю",
       "lemmaId": "не-люблю",
       "lemmaPlain": "не люблю",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11744,11 +13054,13 @@
     {
       "cefr": "A1",
       "gloss": "do not like",
+      "glossClean": "do not like",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "не подобається",
       "lemmaId": "не-подобається",
       "lemmaPlain": "не подобається",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11759,11 +13071,13 @@
     {
       "cefr": "A1",
       "gloss": "to be pleasing; to like",
+      "glossClean": "to be pleasing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "подобатися",
       "lemmaId": "подобатися",
       "lemmaPlain": "подобатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11774,11 +13088,13 @@
     {
       "cefr": "A1",
       "gloss": "you like",
+      "glossClean": "you like",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "тобі подобається",
       "lemmaId": "тобі-подобається",
       "lemmaPlain": "тобі подобається",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11789,11 +13105,13 @@
     {
       "cefr": "A1",
       "gloss": "nice, beautiful, masculine",
+      "glossClean": "nice",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гарний",
       "lemmaId": "гарний",
       "lemmaPlain": "гарний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11804,11 +13122,13 @@
     {
       "cefr": "A1",
       "gloss": "expensive, masculine",
+      "glossClean": "expensive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дорогий",
       "lemmaId": "дорогий",
       "lemmaPlain": "дорогий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11819,11 +13139,13 @@
     {
       "cefr": "A1",
       "gloss": "bad, masculine",
+      "glossClean": "bad",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поганий",
       "lemmaId": "поганий",
       "lemmaPlain": "поганий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11834,11 +13156,13 @@
     {
       "cefr": "A1",
       "gloss": "smart, masculine",
+      "glossClean": "smart",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розумний",
       "lemmaId": "розумний",
       "lemmaPlain": "розумний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11849,11 +13173,13 @@
     {
       "cefr": "A1",
       "gloss": "light, bright, masculine",
+      "glossClean": "light",
       "heritage": "standard",
       "ipa": null,
       "lemma": "світлий",
       "lemmaId": "світлий",
       "lemmaPlain": "світлий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11864,11 +13190,13 @@
     {
       "cefr": "A1",
       "gloss": "old, feminine",
+      "glossClean": "old",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стара",
       "lemmaId": "стара",
       "lemmaPlain": "стара",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11879,11 +13207,13 @@
     {
       "cefr": "A1",
       "gloss": "dark, masculine",
+      "glossClean": "dark",
       "heritage": "standard",
       "ipa": null,
       "lemma": "темний",
       "lemmaId": "темний",
       "lemmaPlain": "темний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11894,11 +13224,13 @@
     {
       "cefr": "A1",
       "gloss": "interesting, masculine",
+      "glossClean": "interesting",
       "heritage": "standard",
       "ipa": null,
       "lemma": "цікавий",
       "lemmaId": "цікавий",
       "lemmaPlain": "цікавий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11909,11 +13241,13 @@
     {
       "cefr": "A1",
       "gloss": "which, that (formal)",
+      "glossClean": "which",
       "heritage": "standard",
       "ipa": null,
       "lemma": "котрий",
       "lemmaId": "котрий",
       "lemmaPlain": "котрий",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11924,11 +13258,13 @@
     {
       "cefr": "A1",
       "gloss": "at eight",
+      "glossClean": "at eight",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "о восьмій",
       "lemmaId": "о-восьмій",
       "lemmaPlain": "о восьмій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11939,11 +13275,13 @@
     {
       "cefr": "A1",
       "gloss": "at twelve",
+      "glossClean": "at twelve",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "о дванадцятій",
       "lemmaId": "о-дванадцятій",
       "lemmaPlain": "о дванадцятій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11954,11 +13292,13 @@
     {
       "cefr": "A1",
       "gloss": "at nine",
+      "glossClean": "at nine",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "о дев'ятій",
       "lemmaId": "о-дев-ятій",
       "lemmaPlain": "о дев'ятій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11969,11 +13309,13 @@
     {
       "cefr": "A1",
       "gloss": "at two",
+      "glossClean": "at two",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "о другій",
       "lemmaId": "о-другій",
       "lemmaPlain": "о другій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11984,11 +13326,13 @@
     {
       "cefr": "A1",
       "gloss": "at five",
+      "glossClean": "at five",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "о п'ятій",
       "lemmaId": "о-п-ятій",
       "lemmaPlain": "о п'ятій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11999,11 +13343,13 @@
     {
       "cefr": "A1",
       "gloss": "at one",
+      "glossClean": "at one",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "о першій",
       "lemmaId": "о-першій",
       "lemmaPlain": "о першій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12014,11 +13360,13 @@
     {
       "cefr": "A1",
       "gloss": "at four",
+      "glossClean": "at four",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "о четвертій",
       "lemmaId": "о-четвертій",
       "lemmaPlain": "о четвертій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12029,11 +13377,13 @@
     {
       "cefr": "A1",
       "gloss": "first",
+      "glossClean": "first",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перший",
       "lemmaId": "перший",
       "lemmaPlain": "перший",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12044,11 +13394,13 @@
     {
       "cefr": "A1",
       "gloss": "half",
+      "glossClean": "half",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пів",
       "lemmaId": "пів",
       "lemmaPlain": "пів",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12059,11 +13411,13 @@
     {
       "cefr": "A1",
       "gloss": "half past one",
+      "glossClean": "half past one",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пів на другу",
       "lemmaId": "пів-на-другу",
       "lemmaPlain": "пів на другу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12074,11 +13428,13 @@
     {
       "cefr": "A1",
       "gloss": "half past six",
+      "glossClean": "half past six",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пів на сьому",
       "lemmaId": "пів-на-сьому",
       "lemmaPlain": "пів на сьому",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12089,11 +13445,13 @@
     {
       "cefr": "A1",
       "gloss": "schedule",
+      "glossClean": "schedule",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розклад",
       "lemmaId": "розклад",
       "lemmaPlain": "розклад",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12104,11 +13462,13 @@
     {
       "cefr": "A1",
       "gloss": "seventh",
+      "glossClean": "seventh",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сьомий",
       "lemmaId": "сьомий",
       "lemmaPlain": "сьомий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12119,11 +13479,13 @@
     {
       "cefr": "A1",
       "gloss": "third",
+      "glossClean": "third",
       "heritage": "standard",
       "ipa": null,
       "lemma": "третій",
       "lemmaId": "третій",
       "lemmaPlain": "третій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12134,11 +13496,13 @@
     {
       "cefr": "A1",
       "gloss": "to be",
+      "glossClean": "to be",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бути",
       "lemmaId": "бути",
       "lemmaPlain": "бути",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12149,11 +13513,13 @@
     {
       "cefr": "A1",
       "gloss": "next",
+      "glossClean": "next",
       "heritage": "standard",
       "ipa": null,
       "lemma": "наступний",
       "lemmaId": "наступний",
       "lemmaPlain": "наступний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12164,11 +13530,13 @@
     {
       "cefr": "A1",
       "gloss": "tree",
+      "glossClean": "tree",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дерево",
       "lemmaId": "дерево",
       "lemmaPlain": "дерево",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12179,11 +13547,13 @@
     {
       "cefr": "A1",
       "gloss": "to say; to tell",
+      "glossClean": "to say",
       "heritage": "standard",
       "ipa": null,
       "lemma": "казати",
       "lemmaId": "казати",
       "lemmaPlain": "казати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12194,11 +13564,13 @@
     {
       "cefr": "A1",
       "gloss": "place",
+      "glossClean": "place",
       "heritage": "standard",
       "ipa": null,
       "lemma": "місце",
       "lemmaId": "місце",
       "lemmaPlain": "місце",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12209,11 +13581,13 @@
     {
       "cefr": "A1",
       "gloss": "not to know",
+      "glossClean": "not to know",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "не знати",
       "lemmaId": "не-знати",
       "lemmaPlain": "не знати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12224,11 +13598,13 @@
     {
       "cefr": "A1",
       "gloss": "lesson",
+      "glossClean": "lesson",
       "heritage": "authentic-archaism",
       "ipa": null,
       "lemma": "урок",
       "lemmaId": "урок",
       "lemmaPlain": "урок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12239,11 +13615,13 @@
     {
       "cefr": "A1",
       "gloss": "part",
+      "glossClean": "part",
       "heritage": "standard",
       "ipa": null,
       "lemma": "частина",
       "lemmaId": "частина",
       "lemmaPlain": "частина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -12283,11 +13661,13 @@
     {
       "cefr": "A1",
       "gloss": "as soon as",
+      "glossClean": "as soon as",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "як тільки",
       "lemmaId": "як-тільки",
       "lemmaPlain": "як тільки",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12298,11 +13678,13 @@
     {
       "cefr": "A1",
       "gloss": "Dnipro",
+      "glossClean": "Dnipro",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Дніпро",
       "lemmaId": "дніпро",
       "lemmaPlain": "дніпро",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -12313,11 +13695,13 @@
     {
       "cefr": "A1",
       "gloss": "country",
+      "glossClean": "country",
       "heritage": "standard",
       "ipa": null,
       "lemma": "країна",
       "lemmaId": "країна",
       "lemmaPlain": "країна",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -12357,11 +13741,13 @@
     {
       "cefr": "A1",
       "gloss": "Germany",
+      "glossClean": "Germany",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Німеччина",
       "lemmaId": "німеччина",
       "lemmaPlain": "німеччина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12372,11 +13758,13 @@
     {
       "cefr": "A1",
       "gloss": "Poland",
+      "glossClean": "Poland",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Польща",
       "lemmaId": "польща",
       "lemmaPlain": "польща",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12387,11 +13775,13 @@
     {
       "cefr": "A1",
       "gloss": "village",
+      "glossClean": "village",
       "heritage": "standard",
       "ipa": null,
       "lemma": "село",
       "lemmaId": "село",
       "lemmaPlain": "село",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12402,11 +13792,13 @@
     {
       "cefr": "A1",
       "gloss": "USA",
+      "glossClean": "USA",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "США",
       "lemmaId": "сша",
       "lemmaPlain": "сша",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12417,11 +13809,13 @@
     {
       "cefr": "A1",
       "gloss": "Ukrainian man",
+      "glossClean": "Ukrainian man",
       "heritage": "standard",
       "ipa": null,
       "lemma": "українець",
       "lemmaId": "українець",
       "lemmaPlain": "українець",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12432,11 +13826,13 @@
     {
       "cefr": "A1",
       "gloss": "France",
+      "glossClean": "France",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Франція",
       "lemmaId": "франція",
       "lemmaPlain": "франція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12447,11 +13843,13 @@
     {
       "cefr": "A1",
       "gloss": "Italy",
+      "glossClean": "Italy",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Італія",
       "lemmaId": "італія",
       "lemmaPlain": "італія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12462,11 +13860,13 @@
     {
       "cefr": "A1",
       "gloss": "sofa",
+      "glossClean": "sofa",
       "heritage": "historism",
       "ipa": null,
       "lemma": "диван",
       "lemmaId": "диван",
       "lemmaPlain": "диван",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12477,11 +13877,13 @@
     {
       "cefr": "A1",
       "gloss": "children",
+      "glossClean": "children",
       "heritage": "standard",
       "ipa": null,
       "lemma": "діти",
       "lemmaId": "діти",
       "lemmaPlain": "діти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12492,11 +13894,13 @@
     {
       "cefr": "A1",
       "gloss": "floor; storey",
+      "glossClean": "floor",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поверх",
       "lemmaId": "поверх",
       "lemmaPlain": "поверх",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12507,11 +13911,13 @@
     {
       "cefr": "A1",
       "gloss": "at home",
+      "glossClean": "at home",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вдома",
       "lemmaId": "вдома",
       "lemmaPlain": "вдома",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12522,11 +13928,13 @@
     {
       "cefr": "A1",
       "gloss": "and yours? formal",
+      "glossClean": "and yours? formal",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "а вас?",
       "lemmaId": "а-вас",
       "lemmaPlain": "а вас?",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -12537,11 +13945,13 @@
     {
       "cefr": "A1",
       "gloss": "thank you",
+      "glossClean": "thank you",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дякую",
       "lemmaId": "дякую",
       "lemmaPlain": "дякую",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -12552,11 +13962,13 @@
     {
       "cefr": "A1",
       "gloss": "male programmer",
+      "glossClean": "male programmer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "програміст",
       "lemmaId": "програміст",
       "lemmaPlain": "програміст",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12567,11 +13979,13 @@
     {
       "cefr": "A1",
       "gloss": "female programmer",
+      "glossClean": "female programmer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "програмістка",
       "lemmaId": "програмістка",
       "lemmaPlain": "програмістка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12582,11 +13996,13 @@
     {
       "cefr": "A1",
       "gloss": "the States",
+      "glossClean": "the States",
       "heritage": "standard",
       "ipa": null,
       "lemma": "Штати",
       "lemmaId": "штати",
       "lemmaPlain": "штати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12597,11 +14013,13 @@
     {
       "cefr": "A1",
       "gloss": "what is your name? formal",
+      "glossClean": "what is your name? formal",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "як вас звати?",
       "lemmaId": "як-вас-звати",
       "lemmaPlain": "як вас звати?",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -12612,11 +14030,13 @@
     {
       "cefr": "A1",
       "gloss": "case",
+      "glossClean": "case",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відмінок",
       "lemmaId": "відмінок",
       "lemmaPlain": "відмінок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12627,11 +14047,13 @@
     {
       "cefr": "A1",
       "gloss": "review, overview",
+      "glossClean": "review",
       "heritage": "standard",
       "ipa": null,
       "lemma": "огляд",
       "lemmaId": "огляд",
       "lemmaPlain": "огляд",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12642,11 +14064,13 @@
     {
       "cefr": "A1",
       "gloss": "rule",
+      "glossClean": "rule",
       "heritage": "standard",
       "ipa": null,
       "lemma": "правило",
       "lemmaId": "правило",
       "lemmaPlain": "правило",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12657,11 +14081,13 @@
     {
       "cefr": "A1",
       "gloss": "grammar",
+      "glossClean": "grammar",
       "heritage": "standard",
       "ipa": null,
       "lemma": "граматика",
       "lemmaId": "граматика",
       "lemmaPlain": "граматика",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -12701,11 +14127,13 @@
     {
       "cefr": "A1",
       "gloss": "signal, cue",
+      "glossClean": "signal",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сигнал",
       "lemmaId": "сигнал",
       "lemmaPlain": "сигнал",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12716,11 +14144,13 @@
     {
       "cefr": "A1",
       "gloss": "to order",
+      "glossClean": "to order",
       "heritage": "standard",
       "ipa": null,
       "lemma": "замовити",
       "lemmaId": "замовити",
       "lemmaPlain": "замовити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12731,11 +14161,13 @@
     {
       "cefr": "A1",
       "gloss": "arrival",
+      "glossClean": "arrival",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прибуття",
       "lemmaId": "прибуття",
       "lemmaPlain": "прибуття",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12746,11 +14178,13 @@
     {
       "cefr": "A1",
       "gloss": "solution",
+      "glossClean": "solution",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розв'язання",
       "lemmaId": "розв-язання",
       "lemmaPlain": "розв'язання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12761,11 +14195,13 @@
     {
       "cefr": "A1",
       "gloss": "task, exercise",
+      "glossClean": "task",
       "heritage": "standard",
       "ipa": null,
       "lemma": "завдання",
       "lemmaId": "завдання",
       "lemmaPlain": "завдання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12776,11 +14212,13 @@
     {
       "cefr": "A1",
       "gloss": "result",
+      "glossClean": "result",
       "heritage": "standard",
       "ipa": null,
       "lemma": "результат",
       "lemmaId": "результат",
       "lemmaPlain": "результат",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12791,11 +14229,13 @@
     {
       "cefr": "A1",
       "gloss": "suitcase",
+      "glossClean": "suitcase",
       "heritage": "standard",
       "ipa": null,
       "lemma": "валіза",
       "lemmaId": "валіза",
       "lemmaPlain": "валіза",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -12835,11 +14275,13 @@
     {
       "cefr": "A1",
       "gloss": "to invite",
+      "glossClean": "to invite",
       "heritage": "standard",
       "ipa": null,
       "lemma": "запрошувати",
       "lemmaId": "запрошувати",
       "lemmaPlain": "запрошувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12850,11 +14292,13 @@
     {
       "cefr": "A1",
       "gloss": "medicine",
+      "glossClean": "medicine",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ліки",
       "lemmaId": "ліки",
       "lemmaPlain": "ліки",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12865,11 +14309,13 @@
     {
       "cefr": "A1",
       "gloss": "patient",
+      "glossClean": "patient",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пацієнт",
       "lemmaId": "пацієнт",
       "lemmaPlain": "пацієнт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12880,11 +14326,13 @@
     {
       "cefr": "A1",
       "gloss": "trip, journey",
+      "glossClean": "trip",
       "heritage": "standard",
       "ipa": null,
       "lemma": "подорож",
       "lemmaId": "подорож",
       "lemmaPlain": "подорож",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -12924,11 +14372,13 @@
     {
       "cefr": "A1",
       "gloss": "prescription, recipe",
+      "glossClean": "prescription",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рецепт",
       "lemmaId": "рецепт",
       "lemmaPlain": "рецепт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12939,11 +14389,13 @@
     {
       "cefr": "A1",
       "gloss": "to see",
+      "glossClean": "to see",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бачити / побачити",
       "lemmaId": "бачити-побачити",
       "lemmaPlain": "бачити / побачити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12954,11 +14406,13 @@
     {
       "cefr": "A1",
       "gloss": "to prepare, to cook",
+      "glossClean": "to prepare",
       "heritage": "standard",
       "ipa": null,
       "lemma": "готувати / приготувати",
       "lemmaId": "готувати-приготувати",
       "lemmaPlain": "готувати / приготувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12969,11 +14423,13 @@
     {
       "cefr": "A1",
       "gloss": "to write",
+      "glossClean": "to write",
       "heritage": "standard",
       "ipa": null,
       "lemma": "писати / написати",
       "lemmaId": "писати-написати",
       "lemmaPlain": "писати / написати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12984,11 +14440,13 @@
     {
       "cefr": "A1",
       "gloss": "to do, to make",
+      "glossClean": "to do",
       "heritage": "standard",
       "ipa": null,
       "lemma": "робити / зробити",
       "lemmaId": "робити-зробити",
       "lemmaPlain": "робити / зробити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12999,11 +14457,13 @@
     {
       "cefr": "A1",
       "gloss": "ongoing, lasting",
+      "glossClean": "ongoing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тривалий",
       "lemmaId": "тривалий",
       "lemmaPlain": "тривалий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13014,11 +14474,13 @@
     {
       "cefr": "A1",
       "gloss": "to read",
+      "glossClean": "to read",
       "heritage": "standard",
       "ipa": null,
       "lemma": "читати / прочитати",
       "lemmaId": "читати-прочитати",
       "lemmaPlain": "читати / прочитати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13029,11 +14491,13 @@
     {
       "cefr": "A1",
       "gloss": "for a long time",
+      "glossClean": "for a long time",
       "heritage": "standard",
       "ipa": null,
       "lemma": "довго",
       "lemmaId": "довго",
       "lemmaPlain": "довго",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13044,11 +14508,13 @@
     {
       "cefr": "A1",
       "gloss": "to finish",
+      "glossClean": "to finish",
       "heritage": "standard",
       "ipa": null,
       "lemma": "закінчувати / закінчити",
       "lemmaId": "закінчувати-закінчити",
       "lemmaPlain": "закінчувати / закінчити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13059,11 +14525,13 @@
     {
       "cefr": "A1",
       "gloss": "to buy",
+      "glossClean": "to buy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "купувати / купити",
       "lemmaId": "купувати-купити",
       "lemmaPlain": "купувати / купити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13074,11 +14542,13 @@
     {
       "cefr": "A1",
       "gloss": "to listen",
+      "glossClean": "to listen",
       "heritage": "standard",
       "ipa": null,
       "lemma": "слухати / послухати",
       "lemmaId": "слухати-послухати",
       "lemmaPlain": "слухати / послухати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13089,11 +14559,13 @@
     {
       "cefr": "A1",
       "gloss": "background",
+      "glossClean": "background",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фон",
       "lemmaId": "фон",
       "lemmaPlain": "фон",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13104,11 +14576,13 @@
     {
       "cefr": "A1",
       "gloss": "to look for, to find",
+      "glossClean": "to look for",
       "heritage": "standard",
       "ipa": null,
       "lemma": "шукати / знайти",
       "lemmaId": "шукати-знайти",
       "lemmaPlain": "шукати / знайти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13119,11 +14593,13 @@
     {
       "cefr": "A1",
       "gloss": "to answer",
+      "glossClean": "to answer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відповідати / відповісти",
       "lemmaId": "відповідати-відповісти",
       "lemmaPlain": "відповідати / відповісти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13134,11 +14610,13 @@
     {
       "cefr": "A1",
       "gloss": "to speak / to say",
+      "glossClean": "to speak / to say",
       "heritage": "standard",
       "ipa": null,
       "lemma": "говорити / сказати",
       "lemmaId": "говорити-сказати",
       "lemmaPlain": "говорити / сказати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13149,11 +14627,13 @@
     {
       "cefr": "A1",
       "gloss": "to help",
+      "glossClean": "to help",
       "heritage": "standard",
       "ipa": null,
       "lemma": "допомагати / допомогти",
       "lemmaId": "допомагати-допомогти",
       "lemmaPlain": "допомагати / допомогти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13164,11 +14644,13 @@
     {
       "cefr": "A1",
       "gloss": "dictionary",
+      "glossClean": "dictionary",
       "heritage": "standard",
       "ipa": null,
       "lemma": "словник",
       "lemmaId": "словник",
       "lemmaPlain": "словник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13179,11 +14661,13 @@
     {
       "cefr": "A1",
       "gloss": "to eat",
+      "glossClean": "to eat",
       "heritage": "standard",
       "ipa": null,
       "lemma": "їсти / з'їсти",
       "lemmaId": "їсти-з-їсти",
       "lemmaPlain": "їсти / з'їсти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13194,11 +14678,13 @@
     {
       "cefr": "A1",
       "gloss": "to give",
+      "glossClean": "to give",
       "heritage": "standard",
       "ipa": null,
       "lemma": "давати / дати",
       "lemmaId": "давати-дати",
       "lemmaPlain": "давати / дати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13209,11 +14695,13 @@
     {
       "cefr": "A1",
       "gloss": "to say, to tell",
+      "glossClean": "to say",
       "heritage": "standard",
       "ipa": null,
       "lemma": "казати / сказати",
       "lemmaId": "казати-сказати",
       "lemmaPlain": "казати / сказати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13224,11 +14712,13 @@
     {
       "cefr": "A1",
       "gloss": "to wash",
+      "glossClean": "to wash",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мити / помити",
       "lemmaId": "мити-помити",
       "lemmaPlain": "мити / помити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13239,11 +14729,13 @@
     {
       "cefr": "A1",
       "gloss": "to translate",
+      "glossClean": "to translate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перекладати / перекласти",
       "lemmaId": "перекладати-перекласти",
       "lemmaPlain": "перекладати / перекласти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13254,11 +14746,13 @@
     {
       "cefr": "A1",
       "gloss": "to ask",
+      "glossClean": "to ask",
       "heritage": "standard",
       "ipa": null,
       "lemma": "питати / запитати",
       "lemmaId": "питати-запитати",
       "lemmaPlain": "питати / запитати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13269,11 +14763,13 @@
     {
       "cefr": "A1",
       "gloss": "to drink",
+      "glossClean": "to drink",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пити / випити",
       "lemmaId": "пити-випити",
       "lemmaPlain": "пити / випити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13284,11 +14780,13 @@
     {
       "cefr": "A1",
       "gloss": "to pay",
+      "glossClean": "to pay",
       "heritage": "standard",
       "ipa": null,
       "lemma": "платити / заплатити",
       "lemmaId": "платити-заплатити",
       "lemmaPlain": "платити / заплатити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13299,11 +14797,13 @@
     {
       "cefr": "A1",
       "gloss": "to begin",
+      "glossClean": "to begin",
       "heritage": "standard",
       "ipa": null,
       "lemma": "починати / почати",
       "lemmaId": "починати-почати",
       "lemmaPlain": "починати / почати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13314,11 +14814,13 @@
     {
       "cefr": "A1",
       "gloss": "to understand",
+      "glossClean": "to understand",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розуміти / зрозуміти",
       "lemmaId": "розуміти-зрозуміти",
       "lemmaPlain": "розуміти / зрозуміти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13329,11 +14831,13 @@
     {
       "cefr": "A1",
       "gloss": "lecture",
+      "glossClean": "lecture",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лекція",
       "lemmaId": "лекція",
       "lemmaPlain": "лекція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -13373,11 +14877,13 @@
     {
       "cefr": "A1",
       "gloss": "plural",
+      "glossClean": "plural",
       "heritage": "standard",
       "ipa": null,
       "lemma": "множина",
       "lemmaId": "множина",
       "lemmaPlain": "множина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -13417,11 +14923,13 @@
     {
       "cefr": "A1",
       "gloss": "singular",
+      "glossClean": "singular",
       "heritage": "standard",
       "ipa": null,
       "lemma": "однина",
       "lemmaId": "однина",
       "lemmaPlain": "однина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13432,11 +14940,13 @@
     {
       "cefr": "A1",
       "gloss": "branch, office",
+      "glossClean": "branch",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відділення",
       "lemmaId": "відділення",
       "lemmaPlain": "відділення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13447,11 +14957,13 @@
     {
       "cefr": "A1",
       "gloss": "to thank",
+      "glossClean": "to thank",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дякувати",
       "lemmaId": "дякувати",
       "lemmaPlain": "дякувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13462,11 +14974,13 @@
     {
       "cefr": "A1",
       "gloss": "letter",
+      "glossClean": "letter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лист",
       "lemmaId": "лист",
       "lemmaPlain": "лист",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13477,11 +14991,13 @@
     {
       "cefr": "A1",
       "gloss": "to give as a gift",
+      "glossClean": "to give as a gift",
       "heritage": "standard",
       "ipa": null,
       "lemma": "подарувати",
       "lemmaId": "подарувати",
       "lemmaPlain": "подарувати",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -13492,11 +15008,13 @@
     {
       "cefr": "A1",
       "gloss": "to call",
+      "glossClean": "to call",
       "heritage": "standard",
       "ipa": null,
       "lemma": "телефонувати",
       "lemmaId": "телефонувати",
       "lemmaPlain": "телефонувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13507,11 +15025,13 @@
     {
       "cefr": "A1",
       "gloss": "option, variant",
+      "glossClean": "option",
       "heritage": "standard",
       "ipa": null,
       "lemma": "варіант",
       "lemmaId": "варіант",
       "lemmaPlain": "варіант",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13522,11 +15042,13 @@
     {
       "cefr": "A1",
       "gloss": "exercise",
+      "glossClean": "exercise",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вправа",
       "lemmaId": "вправа",
       "lemmaPlain": "вправа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -13566,11 +15088,13 @@
     {
       "cefr": "A1",
       "gloss": "excursion, guided tour",
+      "glossClean": "excursion",
       "heritage": "standard",
       "ipa": null,
       "lemma": "екскурсія",
       "lemmaId": "екскурсія",
       "lemmaPlain": "екскурсія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -13610,11 +15134,13 @@
     {
       "cefr": "A1",
       "gloss": "location",
+      "glossClean": "location",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розташування",
       "lemmaId": "розташування",
       "lemmaPlain": "розташування",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13625,11 +15151,13 @@
     {
       "cefr": "A1",
       "gloss": "tourist",
+      "glossClean": "tourist",
       "heritage": "standard",
       "ipa": null,
       "lemma": "турист",
       "lemmaId": "турист",
       "lemmaPlain": "турист",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13640,11 +15168,13 @@
     {
       "cefr": "A1",
       "gloss": "main",
+      "glossClean": "main",
       "heritage": "standard",
       "ipa": null,
       "lemma": "головний",
       "lemmaId": "головний",
       "lemmaPlain": "головний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13655,11 +15185,13 @@
     {
       "cefr": "A1",
       "gloss": "topic, theme",
+      "glossClean": "topic",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тема",
       "lemmaId": "тема",
       "lemmaPlain": "тема",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -13699,11 +15231,13 @@
     {
       "cefr": "A1",
       "gloss": "than, in comparisons",
+      "glossClean": "than",
       "heritage": "standard",
       "ipa": null,
       "lemma": "за",
       "lemmaId": "за",
       "lemmaPlain": "за",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -13714,11 +15248,13 @@
     {
       "cefr": "A1",
       "gloss": "the best",
+      "glossClean": "the best",
       "heritage": "standard",
       "ipa": null,
       "lemma": "найкращий",
       "lemmaId": "найкращий",
       "lemmaPlain": "найкращий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13729,11 +15265,13 @@
     {
       "cefr": "A1",
       "gloss": "than",
+      "glossClean": "than",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ніж",
       "lemmaId": "ніж",
       "lemmaPlain": "ніж",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -13744,11 +15282,13 @@
     {
       "cefr": "A1",
       "gloss": "our",
+      "glossClean": "our",
       "heritage": "standard",
       "ipa": null,
       "lemma": "наш",
       "lemmaId": "наш",
       "lemmaPlain": "наш",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -13759,11 +15299,13 @@
     {
       "cefr": "A1",
       "gloss": "to this",
+      "glossClean": "to this",
       "heritage": "standard",
       "ipa": null,
       "lemma": "цьому",
       "lemmaId": "цьому",
       "lemmaPlain": "цьому",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -13774,11 +15316,13 @@
     {
       "cefr": "A1",
       "gloss": "hero",
+      "glossClean": "hero",
       "heritage": "standard",
       "ipa": null,
       "lemma": "герой",
       "lemmaId": "герой",
       "lemmaPlain": "герой",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13789,11 +15333,13 @@
     {
       "cefr": "A1",
       "gloss": "to show",
+      "glossClean": "to show",
       "heritage": "standard",
       "ipa": null,
       "lemma": "показати",
       "lemmaId": "показати",
       "lemmaPlain": "показати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13804,11 +15350,13 @@
     {
       "cefr": "A1",
       "gloss": "difficult, hard",
+      "glossClean": "difficult",
       "heritage": "standard",
       "ipa": null,
       "lemma": "важко",
       "lemmaId": "важко",
       "lemmaPlain": "важко",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13819,11 +15367,13 @@
     {
       "cefr": "A1",
       "gloss": "pleasant",
+      "glossClean": "pleasant",
       "heritage": "standard",
       "ipa": null,
       "lemma": "приємно",
       "lemmaId": "приємно",
       "lemmaPlain": "приємно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13834,11 +15384,13 @@
     {
       "cefr": "A1",
       "gloss": "interesting, it is interesting",
+      "glossClean": "interesting",
       "heritage": "standard",
       "ipa": null,
       "lemma": "цікаво",
       "lemmaId": "цікаво",
       "lemmaPlain": "цікаво",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13849,11 +15401,13 @@
     {
       "cefr": "A1",
       "gloss": "to answer, to reply",
+      "glossClean": "to answer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відповідати",
       "lemmaId": "відповідати",
       "lemmaPlain": "відповідати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13864,11 +15418,13 @@
     {
       "cefr": "A1",
       "gloss": "swimming pool",
+      "glossClean": "swimming pool",
       "heritage": "standard",
       "ipa": null,
       "lemma": "басейн",
       "lemmaId": "басейн",
       "lemmaPlain": "басейн",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13879,11 +15435,13 @@
     {
       "cefr": "A1",
       "gloss": "company",
+      "glossClean": "company",
       "heritage": "standard",
       "ipa": null,
       "lemma": "компанія",
       "lemmaId": "компанія",
       "lemmaPlain": "компанія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -13923,11 +15481,13 @@
     {
       "cefr": "A1",
       "gloss": "phrase",
+      "glossClean": "phrase",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фраза",
       "lemmaId": "фраза",
       "lemmaPlain": "фраза",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -13967,11 +15527,13 @@
     {
       "cefr": "A1",
       "gloss": "dialogue",
+      "glossClean": "dialogue",
       "heritage": "standard",
       "ipa": null,
       "lemma": "діалог",
       "lemmaId": "діалог",
       "lemmaPlain": "діалог",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13982,11 +15544,13 @@
     {
       "cefr": "A1",
       "gloss": "to order",
+      "glossClean": "to order",
       "heritage": "standard",
       "ipa": null,
       "lemma": "замовляти / замовити",
       "lemmaId": "замовляти-замовити",
       "lemmaPlain": "замовляти / замовити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13997,11 +15561,13 @@
     {
       "cefr": "A1",
       "gloss": "to plan",
+      "glossClean": "to plan",
       "heritage": "standard",
       "ipa": null,
       "lemma": "планувати / запланувати",
       "lemmaId": "планувати-запланувати",
       "lemmaPlain": "планувати / запланувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14012,11 +15578,13 @@
     {
       "cefr": "A1",
       "gloss": "scenario",
+      "glossClean": "scenario",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сценарій",
       "lemmaId": "сценарій",
       "lemmaPlain": "сценарій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14027,11 +15595,13 @@
     {
       "cefr": "A1",
       "gloss": "important",
+      "glossClean": "important",
       "heritage": "standard",
       "ipa": null,
       "lemma": "важливий",
       "lemmaId": "важливий",
       "lemmaPlain": "важливий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14042,11 +15612,13 @@
     {
       "cefr": "A1",
       "gloss": "document",
+      "glossClean": "document",
       "heritage": "standard",
       "ipa": null,
       "lemma": "документ",
       "lemmaId": "документ",
       "lemmaPlain": "документ",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14057,11 +15629,13 @@
     {
       "cefr": "A1",
       "gloss": "March",
+      "glossClean": "March",
       "heritage": "standard",
       "ipa": null,
       "lemma": "березень / березня",
       "lemmaId": "березень-березня",
       "lemmaPlain": "березень / березня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14072,11 +15646,13 @@
     {
       "cefr": "A1",
       "gloss": "September",
+      "glossClean": "September",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вересень / вересня",
       "lemmaId": "вересень-вересня",
       "lemmaPlain": "вересень / вересня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14087,11 +15663,13 @@
     {
       "cefr": "A1",
       "gloss": "December",
+      "glossClean": "December",
       "heritage": "standard",
       "ipa": null,
       "lemma": "грудень / грудня",
       "lemmaId": "грудень-грудня",
       "lemmaPlain": "грудень / грудня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14102,11 +15680,13 @@
     {
       "cefr": "A1",
       "gloss": "October",
+      "glossClean": "October",
       "heritage": "standard",
       "ipa": null,
       "lemma": "жовтень / жовтня",
       "lemmaId": "жовтень-жовтня",
       "lemmaPlain": "жовтень / жовтня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14117,11 +15697,13 @@
     {
       "cefr": "A1",
       "gloss": "April",
+      "glossClean": "April",
       "heritage": "standard",
       "ipa": null,
       "lemma": "квітень / квітня",
       "lemmaId": "квітень-квітня",
       "lemmaPlain": "квітень / квітня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14132,11 +15714,13 @@
     {
       "cefr": "A1",
       "gloss": "July",
+      "glossClean": "July",
       "heritage": "standard",
       "ipa": null,
       "lemma": "липень / липня",
       "lemmaId": "липень-липня",
       "lemmaPlain": "липень / липня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14147,11 +15731,13 @@
     {
       "cefr": "A1",
       "gloss": "November",
+      "glossClean": "November",
       "heritage": "standard",
       "ipa": null,
       "lemma": "листопад / листопада",
       "lemmaId": "листопад-листопада",
       "lemmaPlain": "листопад / листопада",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14162,11 +15748,13 @@
     {
       "cefr": "A1",
       "gloss": "February",
+      "glossClean": "February",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лютий / лютого",
       "lemmaId": "лютий-лютого",
       "lemmaPlain": "лютий / лютого",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14177,11 +15765,13 @@
     {
       "cefr": "A1",
       "gloss": "August",
+      "glossClean": "August",
       "heritage": "standard",
       "ipa": null,
       "lemma": "серпень / серпня",
       "lemmaId": "серпень-серпня",
       "lemmaPlain": "серпень / серпня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14192,11 +15782,13 @@
     {
       "cefr": "A1",
       "gloss": "January",
+      "glossClean": "January",
       "heritage": "standard",
       "ipa": null,
       "lemma": "січень / січня",
       "lemmaId": "січень-січня",
       "lemmaPlain": "січень / січня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14207,11 +15799,13 @@
     {
       "cefr": "A1",
       "gloss": "May",
+      "glossClean": "May",
       "heritage": "standard",
       "ipa": null,
       "lemma": "травень / травня",
       "lemmaId": "травень-травня",
       "lemmaPlain": "травень / травня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14222,11 +15816,13 @@
     {
       "cefr": "A1",
       "gloss": "June",
+      "glossClean": "June",
       "heritage": "standard",
       "ipa": null,
       "lemma": "червень / червня",
       "lemmaId": "червень-червня",
       "lemmaPlain": "червень / червня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14237,11 +15833,13 @@
     {
       "cefr": "A1",
       "gloss": "date, number",
+      "glossClean": "date",
       "heritage": "standard",
       "ipa": null,
       "lemma": "число",
       "lemmaId": "число",
       "lemmaPlain": "число",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14252,11 +15850,13 @@
     {
       "cefr": "A1",
       "gloss": "many, much, a lot",
+      "glossClean": "many",
       "heritage": "standard",
       "ipa": null,
       "lemma": "багато",
       "lemmaId": "багато",
       "lemmaPlain": "багато",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14267,11 +15867,13 @@
     {
       "cefr": "A1",
       "gloss": "money",
+      "glossClean": "money",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гроші",
       "lemmaId": "гроші",
       "lemmaPlain": "гроші",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14282,11 +15884,13 @@
     {
       "cefr": "A1",
       "gloss": "little, few",
+      "glossClean": "little",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мало",
       "lemmaId": "мало",
       "lemmaPlain": "мало",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14297,11 +15901,13 @@
     {
       "cefr": "A1",
       "gloss": "furniture",
+      "glossClean": "furniture",
       "heritage": "standard",
       "ipa": null,
       "lemma": "меблі",
       "lemmaId": "меблі",
       "lemmaPlain": "меблі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14312,11 +15918,13 @@
     {
       "cefr": "A1",
       "gloss": "there is no, do not have",
+      "glossClean": "there is no",
       "heritage": "standard",
       "ipa": null,
       "lemma": "немає",
       "lemmaId": "немає",
       "lemmaPlain": "немає",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14327,11 +15935,13 @@
     {
       "cefr": "A1",
       "gloss": "refrigerator",
+      "glossClean": "refrigerator",
       "heritage": "standard",
       "ipa": null,
       "lemma": "холодильник",
       "lemmaId": "холодильник",
       "lemmaPlain": "холодильник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14342,11 +15952,13 @@
     {
       "cefr": "A1",
       "gloss": "pencil",
+      "glossClean": "pencil",
       "heritage": "standard",
       "ipa": null,
       "lemma": "олівець",
       "lemmaId": "олівець",
       "lemmaPlain": "олівець",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14357,11 +15969,13 @@
     {
       "cefr": "A1",
       "gloss": "exam",
+      "glossClean": "exam",
       "heritage": "standard",
       "ipa": null,
       "lemma": "екзамен",
       "lemmaId": "екзамен",
       "lemmaPlain": "екзамен",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14372,11 +15986,13 @@
     {
       "cefr": "A1",
       "gloss": "river",
+      "glossClean": "river",
       "heritage": "standard",
       "ipa": null,
       "lemma": "річка",
       "lemmaId": "річка",
       "lemmaPlain": "річка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -14416,11 +16032,13 @@
     {
       "cefr": "A1",
       "gloss": "dictation",
+      "glossClean": "dictation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "диктант",
       "lemmaId": "диктант",
       "lemmaPlain": "диктант",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14431,11 +16049,13 @@
     {
       "cefr": "A1",
       "gloss": "not far, nearby",
+      "glossClean": "not far",
       "heritage": "standard",
       "ipa": null,
       "lemma": "недалеко",
       "lemmaId": "недалеко",
       "lemmaPlain": "недалеко",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14446,11 +16066,13 @@
     {
       "cefr": "A1",
       "gloss": "living room",
+      "glossClean": "living room",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вітальня",
       "lemmaId": "вітальня",
       "lemmaPlain": "вітальня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -14490,11 +16112,13 @@
     {
       "cefr": "A1",
       "gloss": "kitchen",
+      "glossClean": "kitchen",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кухня",
       "lemmaId": "кухня",
       "lemmaPlain": "кухня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -14534,11 +16158,13 @@
     {
       "cefr": "A1",
       "gloss": "bedroom",
+      "glossClean": "bedroom",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спальня",
       "lemmaId": "спальня",
       "lemmaPlain": "спальня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -14578,11 +16204,13 @@
     {
       "cefr": "A1",
       "gloss": "be",
+      "glossClean": "be",
       "heritage": "standard",
       "ipa": null,
       "lemma": "будь",
       "lemmaId": "будь",
       "lemmaPlain": "будь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14593,11 +16221,13 @@
     {
       "cefr": "A1",
       "gloss": "ready",
+      "glossClean": "ready",
       "heritage": "standard",
       "ipa": null,
       "lemma": "готовий / готовими",
       "lemmaId": "готовий-готовими",
       "lemmaPlain": "готовий / готовими",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14608,11 +16238,13 @@
     {
       "cefr": "A1",
       "gloss": "healthy",
+      "glossClean": "healthy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "здоровий / здоровим / здоровими",
       "lemmaId": "здоровий-здоровим-здоровими",
       "lemmaPlain": "здоровий / здоровим / здоровими",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14623,11 +16255,13 @@
     {
       "cefr": "A1",
       "gloss": "to do, perfective",
+      "glossClean": "to do",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зробити",
       "lemmaId": "зробити",
       "lemmaPlain": "зробити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14638,11 +16272,13 @@
     {
       "cefr": "A1",
       "gloss": "to read through, perfective",
+      "glossClean": "to read through",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прочитати",
       "lemmaId": "прочитати",
       "lemmaPlain": "прочитати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14653,11 +16289,13 @@
     {
       "cefr": "A1",
       "gloss": "let's say",
+      "glossClean": "let's say",
       "heritage": "standard",
       "ipa": null,
       "lemma": "скажімо",
       "lemmaId": "скажімо",
       "lemmaPlain": "скажімо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14668,11 +16306,13 @@
     {
       "cefr": "A1",
       "gloss": "calm",
+      "glossClean": "calm",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спокійний / спокійною",
       "lemmaId": "спокійний-спокійною",
       "lemmaPlain": "спокійний / спокійною",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14683,11 +16323,13 @@
     {
       "cefr": "A1",
       "gloss": "happy",
+      "glossClean": "happy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "щасливий / щасливою",
       "lemmaId": "щасливий-щасливою",
       "lemmaPlain": "щасливий / щасливою",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14698,11 +16340,13 @@
     {
       "cefr": "A1",
       "gloss": "for some reason",
+      "glossClean": "for some reason",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чомусь",
       "lemmaId": "чомусь",
       "lemmaPlain": "чомусь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14713,11 +16357,13 @@
     {
       "cefr": "A1",
       "gloss": "mushroom",
+      "glossClean": "mushroom",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гриб",
       "lemmaId": "гриб",
       "lemmaPlain": "гриб",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14728,11 +16374,13 @@
     {
       "cefr": "A1",
       "gloss": "honey",
+      "glossClean": "honey",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мед",
       "lemmaId": "мед",
       "lemmaPlain": "мед",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14743,11 +16391,13 @@
     {
       "cefr": "A1",
       "gloss": "your, formal or plural",
+      "glossClean": "your",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ваш",
       "lemmaId": "ваш",
       "lemmaPlain": "ваш",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -14758,11 +16408,13 @@
     {
       "cefr": "A1",
       "gloss": "home, domestic",
+      "glossClean": "home",
       "heritage": "standard",
       "ipa": null,
       "lemma": "домашній",
       "lemmaId": "домашній",
       "lemmaPlain": "домашній",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14773,11 +16425,13 @@
     {
       "cefr": "A1",
       "gloss": "fork",
+      "glossClean": "fork",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виделка",
       "lemmaId": "виделка",
       "lemmaPlain": "виделка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -14817,11 +16471,13 @@
     {
       "cefr": "A1",
       "gloss": "to become",
+      "glossClean": "to become",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стати",
       "lemmaId": "стати",
       "lemmaPlain": "стати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14832,11 +16488,13 @@
     {
       "cefr": "A1",
       "gloss": "cheerful",
+      "glossClean": "cheerful",
       "heritage": "standard",
       "ipa": null,
       "lemma": "веселий",
       "lemmaId": "веселий",
       "lemmaPlain": "веселий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14847,11 +16505,13 @@
     {
       "cefr": "A1",
       "gloss": "tall",
+      "glossClean": "tall",
       "heritage": "standard",
       "ipa": null,
       "lemma": "високий",
       "lemmaId": "високий",
       "lemmaPlain": "високий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14862,11 +16522,13 @@
     {
       "cefr": "A1",
       "gloss": "short, low",
+      "glossClean": "short",
       "heritage": "standard",
       "ipa": null,
       "lemma": "низький",
       "lemmaId": "низький",
       "lemmaPlain": "низький",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14877,11 +16539,13 @@
     {
       "cefr": "A1",
       "gloss": "calm",
+      "glossClean": "calm",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спокійний",
       "lemmaId": "спокійний",
       "lemmaPlain": "спокійний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14892,11 +16556,13 @@
     {
       "cefr": "A1",
       "gloss": "character, personality",
+      "glossClean": "character",
       "heritage": "standard",
       "ipa": null,
       "lemma": "характер",
       "lemmaId": "характер",
       "lemmaPlain": "характер",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14907,11 +16573,13 @@
     {
       "cefr": "A1",
       "gloss": "life",
+      "glossClean": "life",
       "heritage": "standard",
       "ipa": null,
       "lemma": "життя",
       "lemmaId": "життя",
       "lemmaPlain": "життя",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14922,11 +16590,13 @@
     {
       "cefr": "A1",
       "gloss": "connection, communication",
+      "glossClean": "connection",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зв'язок",
       "lemmaId": "зв-язок",
       "lemmaPlain": "зв'язок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14937,11 +16607,13 @@
     {
       "cefr": "A1",
       "gloss": "culture",
+      "glossClean": "culture",
       "heritage": "standard",
       "ipa": null,
       "lemma": "культура",
       "lemmaId": "культура",
       "lemmaPlain": "культура",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -14981,11 +16653,13 @@
     {
       "cefr": "A1",
       "gloss": "news, piece of news",
+      "glossClean": "news",
       "heritage": "standard",
       "ipa": null,
       "lemma": "новина",
       "lemmaId": "новина",
       "lemmaPlain": "новина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -15025,11 +16699,13 @@
     {
       "cefr": "A1",
       "gloss": "problem",
+      "glossClean": "problem",
       "heritage": "standard",
       "ipa": null,
       "lemma": "проблема",
       "lemmaId": "проблема",
       "lemmaPlain": "проблема",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -15069,11 +16745,13 @@
     {
       "cefr": "A1",
       "gloss": "radio",
+      "glossClean": "radio",
       "heritage": "standard",
       "ipa": null,
       "lemma": "радіо",
       "lemmaId": "радіо",
       "lemmaPlain": "радіо",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -15113,11 +16791,13 @@
     {
       "cefr": "A1",
       "gloss": "letter",
+      "glossClean": "letter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "буква",
       "lemmaId": "буква",
       "lemmaPlain": "буква",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15128,11 +16808,13 @@
     {
       "cefr": "A1",
       "gloss": "to write down",
+      "glossClean": "to write down",
       "heritage": "standard",
       "ipa": null,
       "lemma": "записати",
       "lemmaId": "записати",
       "lemmaPlain": "записати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15143,11 +16825,13 @@
     {
       "cefr": "A1",
       "gloss": "airport",
+      "glossClean": "airport",
       "heritage": "standard",
       "ipa": null,
       "lemma": "аеропорт",
       "lemmaId": "аеропорт",
       "lemmaPlain": "аеропорт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15158,11 +16842,13 @@
     {
       "cefr": "A1",
       "gloss": "to say, I say",
+      "glossClean": "to say",
       "heritage": "standard",
       "ipa": null,
       "lemma": "казати / кажу",
       "lemmaId": "казати-кажу",
       "lemmaPlain": "казати / кажу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15173,11 +16859,13 @@
     {
       "cefr": "A1",
       "gloss": "to write, I write",
+      "glossClean": "to write",
       "heritage": "standard",
       "ipa": null,
       "lemma": "писати / пишу",
       "lemmaId": "писати-пишу",
       "lemmaPlain": "писати / пишу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15188,11 +16876,13 @@
     {
       "cefr": "A1",
       "gloss": "to drink, I drink",
+      "glossClean": "to drink",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пити / п'ю",
       "lemmaId": "пити-п-ю",
       "lemmaPlain": "пити / п'ю",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15203,11 +16893,13 @@
     {
       "cefr": "A1",
       "gloss": "to go on foot",
+      "glossClean": "to go on foot",
       "heritage": "standard",
       "ipa": null,
       "lemma": "іти / ходити",
       "lemmaId": "іти-ходити",
       "lemmaPlain": "іти / ходити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15218,11 +16910,13 @@
     {
       "cefr": "A1",
       "gloss": "to go by vehicle",
+      "glossClean": "to go by vehicle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "їхати / їздити",
       "lemmaId": "їхати-їздити",
       "lemmaPlain": "їхати / їздити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15233,11 +16927,13 @@
     {
       "cefr": "A1",
       "gloss": "community",
+      "glossClean": "community",
       "heritage": "standard",
       "ipa": null,
       "lemma": "громада",
       "lemmaId": "громада",
       "lemmaPlain": "громада",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -15277,11 +16973,13 @@
     {
       "cefr": "A1",
       "gloss": "frost",
+      "glossClean": "frost",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мороз",
       "lemmaId": "мороз",
       "lemmaPlain": "мороз",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15292,11 +16990,13 @@
     {
       "cefr": "A1",
       "gloss": "Christmas",
+      "glossClean": "Christmas",
       "heritage": "standard",
       "ipa": null,
       "lemma": "Різдво",
       "lemmaId": "різдво",
       "lemmaPlain": "різдво",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15307,11 +17007,13 @@
     {
       "cefr": "A1",
       "gloss": "tradition",
+      "glossClean": "tradition",
       "heritage": "standard",
       "ipa": null,
       "lemma": "традиція",
       "lemmaId": "традиція",
       "lemmaPlain": "традиція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -15351,11 +17053,13 @@
     {
       "cefr": "A1",
       "gloss": "age",
+      "glossClean": "age",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вік",
       "lemmaId": "вік",
       "lemmaPlain": "вік",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15366,11 +17070,13 @@
     {
       "cefr": "A1",
       "gloss": "class, lesson",
+      "glossClean": "class",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заняття",
       "lemmaId": "заняття",
       "lemmaPlain": "заняття",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15381,11 +17087,13 @@
     {
       "cefr": "A1",
       "gloss": "flowers",
+      "glossClean": "flowers",
       "heritage": "standard",
       "ipa": null,
       "lemma": "квіти",
       "lemmaId": "квіти",
       "lemmaPlain": "квіти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15396,11 +17104,13 @@
     {
       "cefr": "A1",
       "gloss": "absolutely, certainly",
+      "glossClean": "absolutely",
       "heritage": "standard",
       "ipa": null,
       "lemma": "безумовно",
       "lemmaId": "безумовно",
       "lemmaPlain": "безумовно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15411,11 +17121,13 @@
     {
       "cefr": "A1",
       "gloss": "to ask",
+      "glossClean": "to ask",
       "heritage": "standard",
       "ipa": null,
       "lemma": "запитати",
       "lemmaId": "запитати",
       "lemmaPlain": "запитати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15426,11 +17138,13 @@
     {
       "cefr": "A1",
       "gloss": "to understand",
+      "glossClean": "to understand",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зрозуміти",
       "lemmaId": "зрозуміти",
       "lemmaPlain": "зрозуміти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15441,11 +17155,13 @@
     {
       "cefr": "A1",
       "gloss": "to ask, to request",
+      "glossClean": "to ask",
       "heritage": "standard",
       "ipa": null,
       "lemma": "попросити",
       "lemmaId": "попросити",
       "lemmaPlain": "попросити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15456,11 +17172,13 @@
     {
       "cefr": "A1",
       "gloss": "seeds",
+      "glossClean": "seeds",
       "heritage": "standard",
       "ipa": null,
       "lemma": "насіння",
       "lemmaId": "насіння",
       "lemmaPlain": "насіння",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15471,11 +17189,13 @@
     {
       "cefr": "A1",
       "gloss": "to stand, to be situated",
+      "glossClean": "to stand",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стояти",
       "lemmaId": "стояти",
       "lemmaPlain": "стояти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15486,11 +17206,13 @@
     {
       "cefr": "A1",
       "gloss": "to receive, to get",
+      "glossClean": "to receive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "отримати",
       "lemmaId": "отримати",
       "lemmaPlain": "отримати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15501,11 +17223,13 @@
     {
       "cefr": "A1",
       "gloss": "to take",
+      "glossClean": "to take",
       "heritage": "standard",
       "ipa": null,
       "lemma": "приймати",
       "lemmaId": "приймати",
       "lemmaPlain": "приймати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15516,11 +17240,13 @@
     {
       "cefr": "A1",
       "gloss": "significant",
+      "glossClean": "significant",
       "heritage": "standard",
       "ipa": null,
       "lemma": "значний",
       "lemmaId": "значний",
       "lemmaPlain": "значний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15531,11 +17257,13 @@
     {
       "cefr": "A1",
       "gloss": "small, not large",
+      "glossClean": "small",
       "heritage": "standard",
       "ipa": null,
       "lemma": "невеликий",
       "lemmaId": "невеликий",
       "lemmaPlain": "невеликий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15546,11 +17274,13 @@
     {
       "cefr": "A1",
       "gloss": "image, figurative picture",
+      "glossClean": "image",
       "heritage": "standard",
       "ipa": null,
       "lemma": "образ",
       "lemmaId": "образ",
       "lemmaPlain": "образ",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15561,11 +17291,13 @@
     {
       "cefr": "A1",
       "gloss": "to talk, we will be talking",
+      "glossClean": "to talk",
       "heritage": "standard",
       "ipa": null,
       "lemma": "говорити / будемо говорити",
       "lemmaId": "говорити-будемо-говорити",
       "lemmaPlain": "говорити / будемо говорити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15576,11 +17308,13 @@
     {
       "cefr": "A1",
       "gloss": "to do, I will do",
+      "glossClean": "to do",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зробити / зроблю",
       "lemmaId": "зробити-зроблю",
       "lemmaPlain": "зробити / зроблю",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15591,11 +17325,13 @@
     {
       "cefr": "A1",
       "gloss": "to buy, I will buy",
+      "glossClean": "to buy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "купити / куплю",
       "lemmaId": "купити-куплю",
       "lemmaPlain": "купити / куплю",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15606,11 +17342,13 @@
     {
       "cefr": "A1",
       "gloss": "intention",
+      "glossClean": "intention",
       "heritage": "standard",
       "ipa": null,
       "lemma": "намір",
       "lemmaId": "намір",
       "lemmaPlain": "намір",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15621,11 +17359,13 @@
     {
       "cefr": "A1",
       "gloss": "to write, I will write",
+      "glossClean": "to write",
       "heritage": "standard",
       "ipa": null,
       "lemma": "написати / напишу",
       "lemmaId": "написати-напишу",
       "lemmaPlain": "написати / напишу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15636,11 +17376,13 @@
     {
       "cefr": "A1",
       "gloss": "to write, I will be writing",
+      "glossClean": "to write",
       "heritage": "standard",
       "ipa": null,
       "lemma": "писати / буду писати",
       "lemmaId": "писати-буду-писати",
       "lemmaPlain": "писати / буду писати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15651,11 +17393,13 @@
     {
       "cefr": "A1",
       "gloss": "to read through, I will read",
+      "glossClean": "to read through",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прочитати / прочитаю",
       "lemmaId": "прочитати-прочитаю",
       "lemmaPlain": "прочитати / прочитаю",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15666,11 +17410,13 @@
     {
       "cefr": "A1",
       "gloss": "to do, I will be doing",
+      "glossClean": "to do",
       "heritage": "standard",
       "ipa": null,
       "lemma": "робити / буду робити",
       "lemmaId": "робити-буду-робити",
       "lemmaPlain": "робити / буду робити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15681,11 +17427,13 @@
     {
       "cefr": "A1",
       "gloss": "to say, I will say",
+      "glossClean": "to say",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сказати / скажу",
       "lemmaId": "сказати-скажу",
       "lemmaPlain": "сказати / скажу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15696,11 +17444,13 @@
     {
       "cefr": "A1",
       "gloss": "to read, I will be reading",
+      "glossClean": "to read",
       "heritage": "standard",
       "ipa": null,
       "lemma": "читати / буду читати",
       "lemmaId": "читати-буду-читати",
       "lemmaPlain": "читати / буду читати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15711,11 +17461,13 @@
     {
       "cefr": "A1",
       "gloss": "director, principal",
+      "glossClean": "director",
       "heritage": "standard",
       "ipa": null,
       "lemma": "директор",
       "lemmaId": "директор",
       "lemmaPlain": "директор",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15726,11 +17478,13 @@
     {
       "cefr": "A1",
       "gloss": "female director, principal",
+      "glossClean": "female director",
       "heritage": "standard",
       "ipa": null,
       "lemma": "директорка",
       "lemmaId": "директорка",
       "lemmaPlain": "директорка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15741,11 +17495,13 @@
     {
       "cefr": "A1",
       "gloss": "professor",
+      "glossClean": "professor",
       "heritage": "standard",
       "ipa": null,
       "lemma": "професор",
       "lemmaId": "професор",
       "lemmaPlain": "професор",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15756,11 +17512,13 @@
     {
       "cefr": "A1",
       "gloss": "sweater",
+      "glossClean": "sweater",
       "heritage": "standard",
       "ipa": null,
       "lemma": "светр",
       "lemmaId": "светр",
       "lemmaPlain": "светр",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15771,11 +17529,13 @@
     {
       "cefr": "A1",
       "gloss": "known",
+      "glossClean": "known",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відомий",
       "lemmaId": "відомий",
       "lemmaPlain": "відомий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15786,11 +17546,13 @@
     {
       "cefr": "A1",
       "gloss": "end",
+      "glossClean": "end",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кінець",
       "lemmaId": "кінець",
       "lemmaPlain": "кінець",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15801,11 +17563,13 @@
     {
       "cefr": "A1",
       "gloss": "team",
+      "glossClean": "team",
       "heritage": "standard",
       "ipa": null,
       "lemma": "команда",
       "lemmaId": "команда",
       "lemmaPlain": "команда",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -15845,11 +17609,13 @@
     {
       "cefr": "A1",
       "gloss": "boss, manager",
+      "glossClean": "boss",
       "heritage": "standard",
       "ipa": null,
       "lemma": "начальник",
       "lemmaId": "начальник",
       "lemmaPlain": "начальник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15860,11 +17626,13 @@
     {
       "cefr": "A1",
       "gloss": "more",
+      "glossClean": "more",
       "heritage": "standard",
       "ipa": null,
       "lemma": "більш",
       "lemmaId": "більш",
       "lemmaPlain": "більш",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15875,11 +17643,13 @@
     {
       "cefr": "A1",
       "gloss": "than, from",
+      "glossClean": "than",
       "heritage": "standard",
       "ipa": null,
       "lemma": "від",
       "lemmaId": "від",
       "lemmaPlain": "від",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -15890,11 +17660,13 @@
     {
       "cefr": "A1",
       "gloss": "less",
+      "glossClean": "less",
       "heritage": "standard",
       "ipa": null,
       "lemma": "менш",
       "lemmaId": "менш",
       "lemmaPlain": "менш",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15905,11 +17677,13 @@
     {
       "cefr": "A1",
       "gloss": "very, exceedingly",
+      "glossClean": "very",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вельми",
       "lemmaId": "вельми",
       "lemmaPlain": "вельми",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15920,11 +17694,13 @@
     {
       "cefr": "A1",
       "gloss": "extremely",
+      "glossClean": "extremely",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вкрай",
       "lemmaId": "вкрай",
       "lemmaPlain": "вкрай",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15935,11 +17711,13 @@
     {
       "cefr": "A1",
       "gloss": "most",
+      "glossClean": "most",
       "heritage": "standard",
       "ipa": null,
       "lemma": "найбільш",
       "lemmaId": "найбільш",
       "lemmaPlain": "найбільш",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15950,11 +17728,13 @@
     {
       "cefr": "A1",
       "gloss": "all, whole",
+      "glossClean": "all",
       "heritage": "standard",
       "ipa": null,
       "lemma": "весь",
       "lemmaId": "весь",
       "lemmaPlain": "весь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15965,11 +17745,13 @@
     {
       "cefr": "A1",
       "gloss": "each, everyone",
+      "glossClean": "each",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кожен",
       "lemmaId": "кожен",
       "lemmaPlain": "кожен",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15980,11 +17762,13 @@
     {
       "cefr": "A1",
       "gloss": "nobody, no one",
+      "glossClean": "nobody",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нікого",
       "lemmaId": "нікого",
       "lemmaPlain": "нікого",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15995,11 +17779,13 @@
     {
       "cefr": "A1",
       "gloss": "whose",
+      "glossClean": "whose",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чий",
       "lemmaId": "чий",
       "lemmaPlain": "чий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16010,11 +17796,13 @@
     {
       "cefr": "A1",
       "gloss": "to finish, perfective",
+      "glossClean": "to finish",
       "heritage": "standard",
       "ipa": null,
       "lemma": "закінчити",
       "lemmaId": "закінчити",
       "lemmaPlain": "закінчити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16025,11 +17813,13 @@
     {
       "cefr": "A1",
       "gloss": "to be finishing, imperfective",
+      "glossClean": "to be finishing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "закінчувати",
       "lemmaId": "закінчувати",
       "lemmaPlain": "закінчувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16040,11 +17830,13 @@
     {
       "cefr": "A1",
       "gloss": "obligation, commitment",
+      "glossClean": "obligation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зобов'язання",
       "lemmaId": "зобов-язання",
       "lemmaPlain": "зобов'язання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16055,11 +17847,13 @@
     {
       "cefr": "A1",
       "gloss": "to find",
+      "glossClean": "to find",
       "heritage": "standard",
       "ipa": null,
       "lemma": "знайти",
       "lemmaId": "знайти",
       "lemmaPlain": "знайти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16070,11 +17864,13 @@
     {
       "cefr": "A1",
       "gloss": "gradually",
+      "glossClean": "gradually",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поступово",
       "lemmaId": "поступово",
       "lemmaPlain": "поступово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16085,11 +17881,13 @@
     {
       "cefr": "A1",
       "gloss": "to forget",
+      "glossClean": "to forget",
       "heritage": "standard",
       "ipa": null,
       "lemma": "забути",
       "lemmaId": "забути",
       "lemmaPlain": "забути",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16100,11 +17898,13 @@
     {
       "cefr": "A1",
       "gloss": "to close",
+      "glossClean": "to close",
       "heritage": "standard",
       "ipa": null,
       "lemma": "закрити",
       "lemmaId": "закрити",
       "lemmaPlain": "закрити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16115,11 +17915,13 @@
     {
       "cefr": "A1",
       "gloss": "to wash",
+      "glossClean": "to wash",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мити",
       "lemmaId": "мити",
       "lemmaPlain": "мити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16130,11 +17932,13 @@
     {
       "cefr": "A1",
       "gloss": "to begin",
+      "glossClean": "to begin",
       "heritage": "standard",
       "ipa": null,
       "lemma": "почати",
       "lemmaId": "почати",
       "lemmaPlain": "почати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16145,11 +17949,13 @@
     {
       "cefr": "A1",
       "gloss": "to begin",
+      "glossClean": "to begin",
       "heritage": "standard",
       "ipa": null,
       "lemma": "починати",
       "lemmaId": "починати",
       "lemmaPlain": "починати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16160,11 +17966,13 @@
     {
       "cefr": "A1",
       "gloss": "to sit down",
+      "glossClean": "to sit down",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сідати",
       "lemmaId": "сідати",
       "lemmaPlain": "сідати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16175,11 +17983,13 @@
     {
       "cefr": "A1",
       "gloss": "report",
+      "glossClean": "report",
       "heritage": "standard",
       "ipa": null,
       "lemma": "звіт",
       "lemmaId": "звіт",
       "lemmaPlain": "звіт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16190,11 +18000,13 @@
     {
       "cefr": "A1",
       "gloss": "dishes",
+      "glossClean": "dishes",
       "heritage": "standard",
       "ipa": null,
       "lemma": "посуд",
       "lemmaId": "посуд",
       "lemmaPlain": "посуд",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16205,11 +18017,13 @@
     {
       "cefr": "A1",
       "gloss": "to invite once",
+      "glossClean": "to invite once",
       "heritage": "standard",
       "ipa": null,
       "lemma": "запросити",
       "lemmaId": "запросити",
       "lemmaPlain": "запросити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16220,11 +18034,13 @@
     {
       "cefr": "A1",
       "gloss": "musician",
+      "glossClean": "musician",
       "heritage": "standard",
       "ipa": null,
       "lemma": "музикант / музикантка",
       "lemmaId": "музикант-музикантка",
       "lemmaPlain": "музикант / музикантка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16235,11 +18051,13 @@
     {
       "cefr": "A1",
       "gloss": "to announce, complete",
+      "glossClean": "to announce",
       "heritage": "standard",
       "ipa": null,
       "lemma": "оголосити",
       "lemmaId": "оголосити",
       "lemmaPlain": "оголосити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16250,11 +18068,13 @@
     {
       "cefr": "A1",
       "gloss": "for the second time",
+      "glossClean": "for the second time",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вдруге",
       "lemmaId": "вдруге",
       "lemmaPlain": "вдруге",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16265,11 +18085,13 @@
     {
       "cefr": "A1",
       "gloss": "second",
+      "glossClean": "second",
       "heritage": "standard",
       "ipa": null,
       "lemma": "другий",
       "lemmaId": "другий",
       "lemmaPlain": "другий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16280,11 +18102,13 @@
     {
       "cefr": "A1",
       "gloss": "doors",
+      "glossClean": "doors",
       "heritage": "standard",
       "ipa": null,
       "lemma": "двері",
       "lemmaId": "двері",
       "lemmaPlain": "двері",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16295,11 +18119,13 @@
     {
       "cefr": "A1",
       "gloss": "million",
+      "glossClean": "million",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мільйон",
       "lemmaId": "мільйон",
       "lemmaPlain": "мільйон",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16310,11 +18136,13 @@
     {
       "cefr": "A1",
       "gloss": "glasses",
+      "glossClean": "glasses",
       "heritage": "standard",
       "ipa": null,
       "lemma": "окуляри",
       "lemmaId": "окуляри",
       "lemmaPlain": "окуляри",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16325,11 +18153,13 @@
     {
       "cefr": "A1",
       "gloss": "warning",
+      "glossClean": "warning",
       "heritage": "standard",
       "ipa": null,
       "lemma": "попередження",
       "lemmaId": "попередження",
       "lemmaPlain": "попередження",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16340,11 +18170,13 @@
     {
       "cefr": "A1",
       "gloss": "exchange rate",
+      "glossClean": "exchange rate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "курс",
       "lemmaId": "курс",
       "lemmaPlain": "курс",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16355,11 +18187,13 @@
     {
       "cefr": "A1",
       "gloss": "to sit",
+      "glossClean": "to sit",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сидіти",
       "lemmaId": "сидіти",
       "lemmaPlain": "сидіти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16370,11 +18204,13 @@
     {
       "cefr": "A1",
       "gloss": "reaching, attainment",
+      "glossClean": "reaching",
       "heritage": "standard",
       "ipa": null,
       "lemma": "досягнення",
       "lemmaId": "досягнення",
       "lemmaPlain": "досягнення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16385,11 +18221,13 @@
     {
       "cefr": "A1",
       "gloss": "transformation, conversion",
+      "glossClean": "transformation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перетворення",
       "lemmaId": "перетворення",
       "lemmaPlain": "перетворення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16400,11 +18238,13 @@
     {
       "cefr": "A1",
       "gloss": "festival",
+      "glossClean": "festival",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фестиваль",
       "lemmaId": "фестиваль",
       "lemmaPlain": "фестиваль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16415,11 +18255,13 @@
     {
       "cefr": "A1",
       "gloss": "ne/ni negative particles",
+      "glossClean": "ne/ni negative particles",
       "heritage": "standard",
       "ipa": null,
       "lemma": "не/ні",
       "lemmaId": "не-ні",
       "lemmaPlain": "не/ні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16430,11 +18272,13 @@
     {
       "cefr": "A1",
       "gloss": "evaluation",
+      "glossClean": "evaluation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "оцінювання",
       "lemmaId": "оцінювання",
       "lemmaPlain": "оцінювання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16445,11 +18289,13 @@
     {
       "cefr": "A1",
       "gloss": "nature",
+      "glossClean": "nature",
       "heritage": "standard",
       "ipa": null,
       "lemma": "природа",
       "lemmaId": "природа",
       "lemmaPlain": "природа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -16489,11 +18335,13 @@
     {
       "cefr": "A1",
       "gloss": "conditional particle",
+      "glossClean": "conditional particle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "б",
       "lemmaId": "б",
       "lemmaPlain": "б",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -16504,11 +18352,13 @@
     {
       "cefr": "A1",
       "gloss": "conditional particle",
+      "glossClean": "conditional particle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "би",
       "lemmaId": "би",
       "lemmaPlain": "би",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -16519,11 +18369,13 @@
     {
       "cefr": "A1",
       "gloss": "opening; discovery",
+      "glossClean": "opening",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відкриття",
       "lemmaId": "відкриття",
       "lemmaPlain": "відкриття",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16534,11 +18386,13 @@
     {
       "cefr": "A1",
       "gloss": "discussion",
+      "glossClean": "discussion",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обговорення",
       "lemmaId": "обговорення",
       "lemmaPlain": "обговорення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16549,11 +18403,13 @@
     {
       "cefr": "A1",
       "gloss": "search",
+      "glossClean": "search",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пошук",
       "lemmaId": "пошук",
       "lemmaPlain": "пошук",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16564,11 +18420,13 @@
     {
       "cefr": "A1",
       "gloss": "accepted",
+      "glossClean": "accepted",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прийнято",
       "lemmaId": "прийнято",
       "lemmaPlain": "прийнято",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16579,11 +18437,13 @@
     {
       "cefr": "A1",
       "gloss": "signature",
+      "glossClean": "signature",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підпис",
       "lemmaId": "підпис",
       "lemmaPlain": "підпис",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16594,11 +18454,13 @@
     {
       "cefr": "A1",
       "gloss": "signing",
+      "glossClean": "signing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підписання",
       "lemmaId": "підписання",
       "lemmaPlain": "підписання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16609,11 +18471,13 @@
     {
       "cefr": "A1",
       "gloss": "despite (+ Acc.)",
+      "glossClean": "despite (+ Acc.)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "попри",
       "lemmaId": "попри",
       "lemmaPlain": "попри",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -16624,11 +18488,13 @@
     {
       "cefr": "A1",
       "gloss": "for the sake of",
+      "glossClean": "for the sake of",
       "heritage": "standard",
       "ipa": null,
       "lemma": "задля",
       "lemmaId": "задля",
       "lemmaPlain": "задля",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -16639,11 +18505,13 @@
     {
       "cefr": "A1",
       "gloss": "since, because",
+      "glossClean": "since",
       "heritage": "standard",
       "ipa": null,
       "lemma": "оскільки",
       "lemmaId": "оскільки",
       "lemmaPlain": "оскільки",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -16654,11 +18522,13 @@
     {
       "cefr": "A1",
       "gloss": "with which, with whom (plural instrumental)",
+      "glossClean": "with which",
       "heritage": "standard",
       "ipa": null,
       "lemma": "якими",
       "lemmaId": "якими",
       "lemmaPlain": "якими",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16669,11 +18539,13 @@
     {
       "cefr": "A1",
       "gloss": "to which, to whom; in which (masculine/neuter dative or locative)",
+      "glossClean": "to which",
       "heritage": "standard",
       "ipa": null,
       "lemma": "якому",
       "lemmaId": "якому",
       "lemmaPlain": "якому",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16684,11 +18556,13 @@
     {
       "cefr": "A1",
       "gloss": "to which, to whom; in which (feminine dative or locative)",
+      "glossClean": "to which",
       "heritage": "standard",
       "ipa": null,
       "lemma": "якій",
       "lemmaId": "якій",
       "lemmaPlain": "якій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16699,11 +18573,13 @@
     {
       "cefr": "A1",
       "gloss": "readiness",
+      "glossClean": "readiness",
       "heritage": "standard",
       "ipa": null,
       "lemma": "готовність",
       "lemmaId": "готовність",
       "lemmaPlain": "готовність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16714,11 +18590,13 @@
     {
       "cefr": "A1",
       "gloss": "in advance",
+      "glossClean": "in advance",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заздалегідь",
       "lemmaId": "заздалегідь",
       "lemmaPlain": "заздалегідь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16729,11 +18607,13 @@
     {
       "cefr": "A1",
       "gloss": "definitely",
+      "glossClean": "definitely",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обов'язково",
       "lemmaId": "обов-язково",
       "lemmaPlain": "обов'язково",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16744,11 +18624,13 @@
     {
       "cefr": "A1",
       "gloss": "open sandwich",
+      "glossClean": "open sandwich",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бутерброд",
       "lemmaId": "бутерброд",
       "lemmaPlain": "бутерброд",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16759,11 +18641,13 @@
     {
       "cefr": "A1",
       "gloss": "bicycle",
+      "glossClean": "bicycle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "велосипед",
       "lemmaId": "велосипед",
       "lemmaPlain": "велосипед",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16774,11 +18658,13 @@
     {
       "cefr": "A1",
       "gloss": "completion, performance",
+      "glossClean": "completion",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виконання",
       "lemmaId": "виконання",
       "lemmaPlain": "виконання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16789,11 +18675,13 @@
     {
       "cefr": "A1",
       "gloss": "indifferent",
+      "glossClean": "indifferent",
       "heritage": "standard",
       "ipa": null,
       "lemma": "байдуже",
       "lemmaId": "байдуже",
       "lemmaPlain": "байдуже",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16804,11 +18692,13 @@
     {
       "cefr": "A1",
       "gloss": "managed, succeeded",
+      "glossClean": "managed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вдалося",
       "lemmaId": "вдалося",
       "lemmaPlain": "вдалося",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16819,11 +18709,13 @@
     {
       "cefr": "A1",
       "gloss": "to give as a gift",
+      "glossClean": "to give as a gift",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дарувати",
       "lemmaId": "дарувати",
       "lemmaPlain": "дарувати",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -16834,11 +18726,13 @@
     {
       "cefr": "A1",
       "gloss": "had to",
+      "glossClean": "had to",
       "heritage": "standard",
       "ipa": null,
       "lemma": "довелося",
       "lemmaId": "довелося",
       "lemmaPlain": "довелося",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16849,11 +18743,13 @@
     {
       "cefr": "A1",
       "gloss": "was lucky",
+      "glossClean": "was lucky",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пощастило",
       "lemmaId": "пощастило",
       "lemmaPlain": "пощастило",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16864,11 +18760,13 @@
     {
       "cefr": "A1",
       "gloss": "feel like, want softly",
+      "glossClean": "feel like",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хочеться",
       "lemmaId": "хочеться",
       "lemmaPlain": "хочеться",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16879,11 +18777,13 @@
     {
       "cefr": "A1",
       "gloss": "instead, by contrast",
+      "glossClean": "instead",
       "heritage": "standard",
       "ipa": null,
       "lemma": "натомість",
       "lemmaId": "натомість",
       "lemmaPlain": "натомість",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16894,11 +18794,13 @@
     {
       "cefr": "A1",
       "gloss": "application, formal request",
+      "glossClean": "application",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заява",
       "lemmaId": "заява",
       "lemmaPlain": "заява",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -16938,11 +18840,13 @@
     {
       "cefr": "A1",
       "gloss": "it turned out, it worked",
+      "glossClean": "it turned out",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вийшло",
       "lemmaId": "вийшло",
       "lemmaPlain": "вийшло",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16953,11 +18857,13 @@
     {
       "cefr": "A1",
       "gloss": "as a result of",
+      "glossClean": "as a result of",
       "heritage": "standard",
       "ipa": null,
       "lemma": "внаслідок",
       "lemmaId": "внаслідок",
       "lemmaPlain": "внаслідок",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -16968,11 +18874,13 @@
     {
       "cefr": "A1",
       "gloss": "to get rid of",
+      "glossClean": "to get rid of",
       "heritage": "standard",
       "ipa": null,
       "lemma": "позбутися",
       "lemmaId": "позбутися",
       "lemmaPlain": "позбутися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16983,11 +18891,13 @@
     {
       "cefr": "A1",
       "gloss": "having seen",
+      "glossClean": "having seen",
       "heritage": "standard",
       "ipa": null,
       "lemma": "побачивши",
       "lemmaId": "побачивши",
       "lemmaPlain": "побачивши",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16998,11 +18908,13 @@
     {
       "cefr": "A1",
       "gloss": "examination, checkup",
+      "glossClean": "examination",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обстеження",
       "lemmaId": "обстеження",
       "lemmaPlain": "обстеження",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17013,11 +18925,13 @@
     {
       "cefr": "A1",
       "gloss": "vaccination",
+      "glossClean": "vaccination",
       "heritage": "standard",
       "ipa": null,
       "lemma": "щеплення",
       "lemmaId": "щеплення",
       "lemmaPlain": "щеплення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17028,11 +18942,13 @@
     {
       "cefr": "A1",
       "gloss": "list, enumeration",
+      "glossClean": "list",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перелік",
       "lemmaId": "перелік",
       "lemmaPlain": "перелік",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17043,11 +18959,13 @@
     {
       "cefr": "A1",
       "gloss": "water supply",
+      "glossClean": "water supply",
       "heritage": "standard",
       "ipa": null,
       "lemma": "водопостачання",
       "lemmaId": "водопостачання",
       "lemmaPlain": "водопостачання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17058,11 +18976,13 @@
     {
       "cefr": "A1",
       "gloss": "is available for rent; seems",
+      "glossClean": "is available for rent",
       "heritage": "standard",
       "ipa": null,
       "lemma": "здається",
       "lemmaId": "здається",
       "lemmaPlain": "здається",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17073,11 +18993,13 @@
     {
       "cefr": "A1",
       "gloss": "to smoke",
+      "glossClean": "to smoke",
       "heritage": "standard",
       "ipa": null,
       "lemma": "курити",
       "lemmaId": "курити",
       "lemmaPlain": "курити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17088,11 +19010,13 @@
     {
       "cefr": "A1",
       "gloss": "elevator",
+      "glossClean": "elevator",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ліфт",
       "lemmaId": "ліфт",
       "lemmaPlain": "ліфт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17103,11 +19027,13 @@
     {
       "cefr": "A1",
       "gloss": "with an area of",
+      "glossClean": "with an area of",
       "heritage": "standard",
       "ipa": null,
       "lemma": "площею",
       "lemmaId": "площею",
       "lemmaPlain": "площею",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17118,11 +19044,13 @@
     {
       "cefr": "A1",
       "gloss": "toilet",
+      "glossClean": "toilet",
       "heritage": "standard",
       "ipa": null,
       "lemma": "туалет",
       "lemmaId": "туалет",
       "lemmaPlain": "туалет",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17133,11 +19061,13 @@
     {
       "cefr": "A1",
       "gloss": "wardrobe; cabinet",
+      "glossClean": "wardrobe",
       "heritage": "standard",
       "ipa": null,
       "lemma": "шафа",
       "lemmaId": "шафа",
       "lemmaPlain": "шафа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17148,11 +19078,13 @@
     {
       "cefr": "A1",
       "gloss": "internet",
+      "glossClean": "internet",
       "heritage": "standard",
       "ipa": null,
       "lemma": "інтернет",
       "lemmaId": "інтернет",
       "lemmaPlain": "інтернет",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -17163,11 +19095,13 @@
     {
       "cefr": "A1",
       "gloss": "bridge",
+      "glossClean": "bridge",
       "heritage": "standard",
       "ipa": null,
       "lemma": "міст",
       "lemmaId": "міст",
       "lemmaPlain": "міст",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17178,11 +19112,13 @@
     {
       "cefr": "A1",
       "gloss": "in Ukrainian",
+      "glossClean": "in Ukrainian",
       "heritage": "standard",
       "ipa": null,
       "lemma": "українською",
       "lemmaId": "українською",
       "lemmaPlain": "українською",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17193,11 +19129,13 @@
     {
       "cefr": "A1",
       "gloss": "certainly",
+      "glossClean": "certainly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "безперечно",
       "lemmaId": "безперечно",
       "lemmaPlain": "безперечно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17208,11 +19146,13 @@
     {
       "cefr": "A1",
       "gloss": "actually, in fact",
+      "glossClean": "actually",
       "heritage": "standard",
       "ipa": null,
       "lemma": "власне",
       "lemmaId": "власне",
       "lemmaPlain": "власне",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17223,11 +19163,13 @@
     {
       "cefr": "A1",
       "gloss": "for example",
+      "glossClean": "for example",
       "heritage": "standard",
       "ipa": null,
       "lemma": "наприклад",
       "lemmaId": "наприклад",
       "lemmaPlain": "наприклад",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17238,11 +19180,13 @@
     {
       "cefr": "A1",
       "gloss": "theater performance",
+      "glossClean": "theater performance",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вистава",
       "lemmaId": "вистава",
       "lemmaPlain": "вистава",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17253,11 +19197,13 @@
     {
       "cefr": "A1",
       "gloss": "art",
+      "glossClean": "art",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мистецтво",
       "lemmaId": "мистецтво",
       "lemmaPlain": "мистецтво",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17268,11 +19214,13 @@
     {
       "cefr": "A1",
       "gloss": "I think that",
+      "glossClean": "I think that",
       "heritage": "standard",
       "ipa": null,
       "lemma": "я вважаю, що",
       "lemmaId": "я-вважаю-що",
       "lemmaPlain": "я вважаю, що",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17283,11 +19231,13 @@
     {
       "cefr": "A1",
       "gloss": "to run habitually, for exercise, or in various directions",
+      "glossClean": "to run habitually",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бігати",
       "lemmaId": "бігати",
       "lemmaPlain": "бігати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17298,11 +19248,13 @@
     {
       "cefr": "A1",
       "gloss": "to fly habitually, back and forth, or in various directions",
+      "glossClean": "to fly habitually",
       "heritage": "standard",
       "ipa": null,
       "lemma": "літати",
       "lemmaId": "літати",
       "lemmaPlain": "літати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17313,11 +19265,13 @@
     {
       "cefr": "A1",
       "gloss": "to swim habitually or around",
+      "glossClean": "to swim habitually or around",
       "heritage": "standard",
       "ipa": null,
       "lemma": "плавати",
       "lemmaId": "плавати",
       "lemmaPlain": "плавати",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -17328,11 +19282,13 @@
     {
       "cefr": "A1",
       "gloss": "barely, with difficulty",
+      "glossClean": "barely",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ледве",
       "lemmaId": "ледве",
       "lemmaPlain": "ледве",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17343,11 +19299,13 @@
     {
       "cefr": "A1",
       "gloss": "to overcome, cover a distance; perfective",
+      "glossClean": "to overcome",
       "heritage": "standard",
       "ipa": null,
       "lemma": "подолати",
       "lemmaId": "подолати",
       "lemmaPlain": "подолати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17358,11 +19316,13 @@
     {
       "cefr": "A1",
       "gloss": "I will go, I will set off on foot",
+      "glossClean": "I will go",
       "heritage": "standard",
       "ipa": null,
       "lemma": "піду",
       "lemmaId": "піду",
       "lemmaPlain": "піду",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17373,11 +19333,13 @@
     {
       "cefr": "A1",
       "gloss": "went, left on foot; feminine past",
+      "glossClean": "went",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пішла",
       "lemmaId": "пішла",
       "lemmaPlain": "пішла",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17388,11 +19350,13 @@
     {
       "cefr": "A1",
       "gloss": "went, left on foot; masculine past",
+      "glossClean": "went",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пішов",
       "lemmaId": "пішов",
       "lemmaPlain": "пішов",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17403,11 +19367,13 @@
     {
       "cefr": "A1",
       "gloss": "to lead or bring someone out; perfective",
+      "glossClean": "to lead or bring someone out",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вивести",
       "lemmaId": "вивести",
       "lemmaPlain": "вивести",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -17418,11 +19384,13 @@
     {
       "cefr": "A1",
       "gloss": "exited, went out; feminine past",
+      "glossClean": "exited",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вийшла",
       "lemmaId": "вийшла",
       "lemmaPlain": "вийшла",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17433,11 +19401,13 @@
     {
       "cefr": "A1",
       "gloss": "exited, went out; masculine past",
+      "glossClean": "exited",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вийшов",
       "lemmaId": "вийшов",
       "lemmaPlain": "вийшов",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17448,11 +19418,13 @@
     {
       "cefr": "A1",
       "gloss": "entered, dropped by; masculine past",
+      "glossClean": "entered",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зайшов",
       "lemmaId": "зайшов",
       "lemmaPlain": "зайшов",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17463,11 +19435,13 @@
     {
       "cefr": "A1",
       "gloss": "crossed on foot; masculine past",
+      "glossClean": "crossed on foot",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перейшов",
       "lemmaId": "перейшов",
       "lemmaPlain": "перейшов",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17478,11 +19452,13 @@
     {
       "cefr": "A1",
       "gloss": "passed, walked through; masculine past",
+      "glossClean": "passed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пройшов",
       "lemmaId": "пройшов",
       "lemmaPlain": "пройшов",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17493,11 +19469,13 @@
     {
       "cefr": "A1",
       "gloss": "through, across; takes accusative in spatial routes",
+      "glossClean": "through",
       "heritage": "standard",
       "ipa": null,
       "lemma": "через",
       "lemmaId": "через",
       "lemmaPlain": "через",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -17508,11 +19486,13 @@
     {
       "cefr": "A1",
       "gloss": "fog",
+      "glossClean": "fog",
       "heritage": "standard",
       "ipa": null,
       "lemma": "туман",
       "lemmaId": "туман",
       "lemmaPlain": "туман",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17523,11 +19503,13 @@
     {
       "cefr": "A1",
       "gloss": "love",
+      "glossClean": "love",
       "heritage": "standard",
       "ipa": null,
       "lemma": "любов",
       "lemmaId": "любов",
       "lemmaPlain": "любов",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17538,11 +19520,13 @@
     {
       "cefr": "A1",
       "gloss": "instant, moment",
+      "glossClean": "instant",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мить",
       "lemmaId": "мить",
       "lemmaPlain": "мить",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17553,11 +19537,13 @@
     {
       "cefr": "A1",
       "gloss": "heart",
+      "glossClean": "heart",
       "heritage": "standard",
       "ipa": null,
       "lemma": "серце",
       "lemmaId": "серце",
       "lemmaPlain": "серце",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17568,11 +19554,13 @@
     {
       "cefr": "A1",
       "gloss": "school student",
+      "glossClean": "school student",
       "heritage": "standard",
       "ipa": null,
       "lemma": "школяр",
       "lemmaId": "школяр",
       "lemmaPlain": "школяр",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17583,11 +19571,13 @@
     {
       "cefr": "A1",
       "gloss": "automatically",
+      "glossClean": "automatically",
       "heritage": "standard",
       "ipa": null,
       "lemma": "автоматично",
       "lemmaId": "автоматично",
       "lemmaPlain": "автоматично",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17598,11 +19588,13 @@
     {
       "cefr": "A1",
       "gloss": "is considered",
+      "glossClean": "is considered",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вважається",
       "lemmaId": "вважається",
       "lemmaPlain": "вважається",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17613,11 +19605,13 @@
     {
       "cefr": "A1",
       "gloss": "is used",
+      "glossClean": "is used",
       "heritage": "standard",
       "ipa": null,
       "lemma": "використовується",
       "lemmaId": "використовується",
       "lemmaPlain": "використовується",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17628,11 +19622,13 @@
     {
       "cefr": "A1",
       "gloss": "has been installed; set",
+      "glossClean": "has been installed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "встановлено",
       "lemmaId": "встановлено",
       "lemmaPlain": "встановлено",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17643,11 +19639,13 @@
     {
       "cefr": "A1",
       "gloss": "is being prepared; is preparing",
+      "glossClean": "is being prepared",
       "heritage": "standard",
       "ipa": null,
       "lemma": "готується",
       "lemmaId": "готується",
       "lemmaPlain": "готується",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17658,11 +19656,13 @@
     {
       "cefr": "A1",
       "gloss": "access",
+      "glossClean": "access",
       "heritage": "standard",
       "ipa": null,
       "lemma": "доступ",
       "lemmaId": "доступ",
       "lemmaPlain": "доступ",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17673,11 +19673,13 @@
     {
       "cefr": "A1",
       "gloss": "is stored; is being saved",
+      "glossClean": "is stored",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зберігається",
       "lemmaId": "зберігається",
       "lemmaPlain": "зберігається",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17688,11 +19690,13 @@
     {
       "cefr": "A1",
       "gloss": "changes; is being changed",
+      "glossClean": "changes",
       "heritage": "standard",
       "ipa": null,
       "lemma": "змінюється",
       "lemmaId": "змінюється",
       "lemmaPlain": "змінюється",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17703,11 +19707,13 @@
     {
       "cefr": "A1",
       "gloss": "to be called",
+      "glossClean": "to be called",
       "heritage": "standard",
       "ipa": null,
       "lemma": "називатися",
       "lemmaId": "називатися",
       "lemmaPlain": "називатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17718,11 +19724,13 @@
     {
       "cefr": "A1",
       "gloss": "is called",
+      "glossClean": "is called",
       "heritage": "standard",
       "ipa": null,
       "lemma": "називається",
       "lemmaId": "називається",
       "lemmaPlain": "називається",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17733,11 +19741,13 @@
     {
       "cefr": "A1",
       "gloss": "has been written",
+      "glossClean": "has been written",
       "heritage": "standard",
       "ipa": null,
       "lemma": "написано",
       "lemmaId": "написано",
       "lemmaPlain": "написано",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17748,11 +19758,13 @@
     {
       "cefr": "A1",
       "gloss": "online",
+      "glossClean": "online",
       "heritage": "standard",
       "ipa": null,
       "lemma": "онлайн",
       "lemmaId": "онлайн",
       "lemmaPlain": "онлайн",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17763,11 +19775,13 @@
     {
       "cefr": "A1",
       "gloss": "has been damaged",
+      "glossClean": "has been damaged",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пошкоджено",
       "lemmaId": "пошкоджено",
       "lemmaPlain": "пошкоджено",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17778,11 +19792,13 @@
     {
       "cefr": "A1",
       "gloss": "has been held; conducted",
+      "glossClean": "has been held",
       "heritage": "standard",
       "ipa": null,
       "lemma": "проведено",
       "lemmaId": "проведено",
       "lemmaPlain": "проведено",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17793,11 +19809,13 @@
     {
       "cefr": "A1",
       "gloss": "decision",
+      "glossClean": "decision",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рішення",
       "lemmaId": "рішення",
       "lemmaPlain": "рішення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17808,11 +19826,13 @@
     {
       "cefr": "A1",
       "gloss": "face",
+      "glossClean": "face",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обличчя",
       "lemmaId": "обличчя",
       "lemmaPlain": "обличчя",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17823,11 +19843,13 @@
     {
       "cefr": "A1",
       "gloss": "married couple",
+      "glossClean": "married couple",
       "heritage": "standard",
       "ipa": null,
       "lemma": "подружжя",
       "lemmaId": "подружжя",
       "lemmaPlain": "подружжя",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17838,11 +19860,13 @@
     {
       "cefr": "A1",
       "gloss": "support",
+      "glossClean": "support",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підтримка",
       "lemmaId": "підтримка",
       "lemmaPlain": "підтримка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -17882,11 +19906,13 @@
     {
       "cefr": "A1",
       "gloss": "to support",
+      "glossClean": "to support",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підтримувати",
       "lemmaId": "підтримувати",
       "lemmaPlain": "підтримувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17897,11 +19923,13 @@
     {
       "cefr": "A1",
       "gloss": "Sumy",
+      "glossClean": "Sumy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "Суми",
       "lemmaId": "суми",
       "lemmaPlain": "суми",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -17912,11 +19940,13 @@
     {
       "cefr": "A1",
       "gloss": "chess",
+      "glossClean": "chess",
       "heritage": "standard",
       "ipa": null,
       "lemma": "шахи",
       "lemmaId": "шахи",
       "lemmaPlain": "шахи",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17927,11 +19957,13 @@
     {
       "cefr": "A1",
       "gloss": "trousers, pants",
+      "glossClean": "trousers",
       "heritage": "standard",
       "ipa": null,
       "lemma": "штани",
       "lemmaId": "штани",
       "lemmaPlain": "штани",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17942,11 +19974,13 @@
     {
       "cefr": "A1",
       "gloss": "father's",
+      "glossClean": "father's",
       "heritage": "standard",
       "ipa": null,
       "lemma": "батьків",
       "lemmaId": "батьків",
       "lemmaPlain": "батьків",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17957,11 +19991,13 @@
     {
       "cefr": "A1",
       "gloss": "for",
+      "glossClean": "for",
       "heritage": "standard",
       "ipa": null,
       "lemma": "для",
       "lemmaId": "для",
       "lemmaPlain": "для",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -17972,11 +20008,13 @@
     {
       "cefr": "A1",
       "gloss": "nearby, close to; takes genitive",
+      "glossClean": "nearby",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поблизу",
       "lemmaId": "поблизу",
       "lemmaPlain": "поблизу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17987,11 +20025,13 @@
     {
       "cefr": "A1",
       "gloss": "between, among; takes instrumental",
+      "glossClean": "between",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поміж",
       "lemmaId": "поміж",
       "lemmaPlain": "поміж",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -18002,11 +20042,13 @@
     {
       "cefr": "A1",
       "gloss": "in the very middle of; takes genitive",
+      "glossClean": "in the very middle of",
       "heritage": "standard",
       "ipa": null,
       "lemma": "посеред",
       "lemmaId": "посеред",
       "lemmaPlain": "посеред",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -18017,11 +20059,13 @@
     {
       "cefr": "A1",
       "gloss": "throughout",
+      "glossClean": "throughout",
       "heritage": "standard",
       "ipa": null,
       "lemma": "впродовж",
       "lemmaId": "впродовж",
       "lemmaPlain": "впродовж",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -18032,11 +20076,13 @@
     {
       "cefr": "A1",
       "gloss": "clock, watch",
+      "glossClean": "clock",
       "heritage": "standard",
       "ipa": null,
       "lemma": "годинник",
       "lemmaId": "годинник",
       "lemmaPlain": "годинник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18047,11 +20093,13 @@
     {
       "cefr": "A1",
       "gloss": "until, by; to",
+      "glossClean": "until",
       "heritage": "standard",
       "ipa": null,
       "lemma": "до",
       "lemmaId": "до",
       "lemmaPlain": "до",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -18062,11 +20110,13 @@
     {
       "cefr": "A1",
       "gloss": "at, for clock time",
+      "glossClean": "at",
       "heritage": "standard",
       "ipa": null,
       "lemma": "о",
       "lemmaId": "о",
       "lemmaPlain": "о",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -18077,11 +20127,13 @@
     {
       "cefr": "A1",
       "gloss": "at, before a vowel in clock time",
+      "glossClean": "at",
       "heritage": "standard",
       "ipa": null,
       "lemma": "об",
       "lemmaId": "об",
       "lemmaPlain": "об",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -18092,11 +20144,13 @@
     {
       "cefr": "A1",
       "gloss": "equipment",
+      "glossClean": "equipment",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обладнання",
       "lemmaId": "обладнання",
       "lemmaPlain": "обладнання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18107,11 +20161,13 @@
     {
       "cefr": "A1",
       "gloss": "throughout",
+      "glossClean": "throughout",
       "heritage": "standard",
       "ipa": null,
       "lemma": "упродовж",
       "lemmaId": "упродовж",
       "lemmaPlain": "упродовж",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -18122,11 +20178,13 @@
     {
       "cefr": "A1",
       "gloss": "to laugh",
+      "glossClean": "to laugh",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сміятися",
       "lemmaId": "сміятися",
       "lemmaPlain": "сміятися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18137,11 +20195,13 @@
     {
       "cefr": "A1",
       "gloss": "dessert",
+      "glossClean": "dessert",
       "heritage": "standard",
       "ipa": null,
       "lemma": "десерт",
       "lemmaId": "десерт",
       "lemmaPlain": "десерт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18152,11 +20212,13 @@
     {
       "cefr": "A1",
       "gloss": "garlic",
+      "glossClean": "garlic",
       "heritage": "standard",
       "ipa": null,
       "lemma": "часник",
       "lemmaId": "часник",
       "lemmaPlain": "часник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18167,11 +20229,13 @@
     {
       "cefr": "A1",
       "gloss": "cafeteria, canteen",
+      "glossClean": "cafeteria",
       "heritage": "standard",
       "ipa": null,
       "lemma": "їдальня",
       "lemmaId": "їдальня",
       "lemmaPlain": "їдальня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18182,11 +20246,13 @@
     {
       "cefr": "A1",
       "gloss": "market, bazaar",
+      "glossClean": "market",
       "heritage": "standard",
       "ipa": null,
       "lemma": "базар",
       "lemmaId": "базар",
       "lemmaPlain": "базар",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18197,11 +20263,13 @@
     {
       "cefr": "A1",
       "gloss": "size",
+      "glossClean": "size",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розмір",
       "lemmaId": "розмір",
       "lemmaPlain": "розмір",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18212,11 +20280,13 @@
     {
       "cefr": "A1",
       "gloss": "sure, feminine",
+      "glossClean": "sure",
       "heritage": "standard",
       "ipa": null,
       "lemma": "певна",
       "lemmaId": "певна",
       "lemmaPlain": "певна",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18227,11 +20297,13 @@
     {
       "cefr": "A1",
       "gloss": "needed",
+      "glossClean": "needed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "потрібен",
       "lemmaId": "потрібен",
       "lemmaPlain": "потрібен",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18242,11 +20314,13 @@
     {
       "cefr": "A1",
       "gloss": "needed, feminine",
+      "glossClean": "needed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "потрібна",
       "lemmaId": "потрібна",
       "lemmaPlain": "потрібна",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18257,11 +20331,13 @@
     {
       "cefr": "A1",
       "gloss": "glad",
+      "glossClean": "glad",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рад",
       "lemmaId": "рад",
       "lemmaPlain": "рад",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18272,11 +20348,13 @@
     {
       "cefr": "A1",
       "gloss": "glad, feminine",
+      "glossClean": "glad",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рада",
       "lemmaId": "рада",
       "lemmaPlain": "рада",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18287,11 +20365,13 @@
     {
       "cefr": "A1",
       "gloss": "benefit",
+      "glossClean": "benefit",
       "heritage": "standard",
       "ipa": null,
       "lemma": "користь",
       "lemmaId": "користь",
       "lemmaPlain": "користь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18302,11 +20382,13 @@
     {
       "cefr": "A1",
       "gloss": "region, oblast",
+      "glossClean": "region",
       "heritage": "standard",
       "ipa": null,
       "lemma": "область",
       "lemmaId": "область",
       "lemmaPlain": "область",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18317,11 +20399,13 @@
     {
       "cefr": "A1",
       "gloss": "happy",
+      "glossClean": "happy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "щасливий",
       "lemmaId": "щасливий",
       "lemmaPlain": "щасливий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18332,11 +20416,13 @@
     {
       "cefr": "A1",
       "gloss": "happiness",
+      "glossClean": "happiness",
       "heritage": "standard",
       "ipa": null,
       "lemma": "щастя",
       "lemmaId": "щастя",
       "lemmaPlain": "щастя",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18347,11 +20433,13 @@
     {
       "cefr": "A1",
       "gloss": "mass media",
+      "glossClean": "mass media",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "ЗМІ",
       "lemmaId": "змі",
       "lemmaPlain": "змі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18362,11 +20450,13 @@
     {
       "cefr": "A1",
       "gloss": "lead, opening paragraph",
+      "glossClean": "lead",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лід",
       "lemmaId": "лід",
       "lemmaPlain": "лід",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18377,11 +20467,13 @@
     {
       "cefr": "A1",
       "gloss": "society",
+      "glossClean": "society",
       "heritage": "standard",
       "ipa": null,
       "lemma": "суспільство",
       "lemmaId": "суспільство",
       "lemmaPlain": "суспільство",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18392,11 +20484,13 @@
     {
       "cefr": "A1",
       "gloss": "Armed Forces of Ukraine",
+      "glossClean": "Armed Forces of Ukraine",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "ЗСУ",
       "lemmaId": "зсу",
       "lemmaPlain": "зсу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18407,11 +20501,13 @@
     {
       "cefr": "A1",
       "gloss": "Cabinet of Ministers",
+      "glossClean": "Cabinet of Ministers",
       "heritage": "standard",
       "ipa": null,
       "lemma": "Кабмін",
       "lemmaId": "кабмін",
       "lemmaPlain": "кабмін",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18422,11 +20518,13 @@
     {
       "cefr": "A1",
       "gloss": "United Nations",
+      "glossClean": "United Nations",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ООН",
       "lemmaId": "оон",
       "lemmaPlain": "оон",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18437,11 +20535,13 @@
     {
       "cefr": "A1",
       "gloss": "European Union",
+      "glossClean": "European Union",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "ЄС",
       "lemmaId": "єс",
       "lemmaPlain": "єс",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18452,11 +20552,13 @@
     {
       "cefr": "A1",
       "gloss": "authority, powers",
+      "glossClean": "authority",
       "heritage": "standard",
       "ipa": null,
       "lemma": "повноваження",
       "lemmaId": "повноваження",
       "lemmaPlain": "повноваження",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18467,11 +20569,13 @@
     {
       "cefr": "A1",
       "gloss": "minutes, protocol",
+      "glossClean": "minutes",
       "heritage": "standard",
       "ipa": null,
       "lemma": "протокол",
       "lemmaId": "протокол",
       "lemmaPlain": "протокол",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18482,11 +20586,13 @@
     {
       "cefr": "A1",
       "gloss": "order, directive",
+      "glossClean": "order",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розпорядження",
       "lemmaId": "розпорядження",
       "lemmaPlain": "розпорядження",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18497,11 +20603,13 @@
     {
       "cefr": "A1",
       "gloss": "construction",
+      "glossClean": "construction",
       "heritage": "standard",
       "ipa": null,
       "lemma": "будівництво",
       "lemmaId": "будівництво",
       "lemmaPlain": "будівництво",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18512,11 +20620,13 @@
     {
       "cefr": "A1",
       "gloss": "production; manufacturing",
+      "glossClean": "production",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виробництво",
       "lemmaId": "виробництво",
       "lemmaPlain": "виробництво",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18527,11 +20637,13 @@
     {
       "cefr": "A1",
       "gloss": "restoration; renewal",
+      "glossClean": "restoration",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відновлення",
       "lemmaId": "відновлення",
       "lemmaPlain": "відновлення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18542,11 +20654,13 @@
     {
       "cefr": "A1",
       "gloss": "provision; ensuring",
+      "glossClean": "provision",
       "heritage": "standard",
       "ipa": null,
       "lemma": "забезпечення",
       "lemmaId": "забезпечення",
       "lemmaPlain": "забезпечення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18557,11 +20671,13 @@
     {
       "cefr": "A1",
       "gloss": "to provide; ensure",
+      "glossClean": "to provide",
       "heritage": "standard",
       "ipa": null,
       "lemma": "забезпечити",
       "lemmaId": "забезпечити",
       "lemmaPlain": "забезпечити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18572,11 +20688,13 @@
     {
       "cefr": "A1",
       "gloss": "completion; ending",
+      "glossClean": "completion",
       "heritage": "standard",
       "ipa": null,
       "lemma": "завершення",
       "lemmaId": "завершення",
       "lemmaPlain": "завершення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18587,11 +20705,13 @@
     {
       "cefr": "A1",
       "gloss": "closing; closure",
+      "glossClean": "closing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "закриття",
       "lemmaId": "закриття",
       "lemmaPlain": "закриття",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18602,11 +20722,13 @@
     {
       "cefr": "A1",
       "gloss": "thinking",
+      "glossClean": "thinking",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мислення",
       "lemmaId": "мислення",
       "lemmaPlain": "мислення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18617,11 +20739,13 @@
     {
       "cefr": "A1",
       "gloss": "receiving; obtaining",
+      "glossClean": "receiving",
       "heritage": "standard",
       "ipa": null,
       "lemma": "отримання",
       "lemmaId": "отримання",
       "lemmaPlain": "отримання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18632,11 +20756,13 @@
     {
       "cefr": "A1",
       "gloss": "to ask",
+      "glossClean": "to ask",
       "heritage": "standard",
       "ipa": null,
       "lemma": "питати",
       "lemmaId": "питати",
       "lemmaPlain": "питати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18647,11 +20773,13 @@
     {
       "cefr": "A1",
       "gloss": "planning",
+      "glossClean": "planning",
       "heritage": "standard",
       "ipa": null,
       "lemma": "планування",
       "lemmaId": "планування",
       "lemmaPlain": "планування",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18662,11 +20790,13 @@
     {
       "cefr": "A1",
       "gloss": "conducting; holding",
+      "glossClean": "conducting",
       "heritage": "standard",
       "ipa": null,
       "lemma": "проведення",
       "lemmaId": "проведення",
       "lemmaPlain": "проведення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18677,11 +20807,13 @@
     {
       "cefr": "A1",
       "gloss": "confirmation",
+      "glossClean": "confirmation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підтвердження",
       "lemmaId": "підтвердження",
       "lemmaPlain": "підтвердження",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18692,11 +20824,13 @@
     {
       "cefr": "A1",
       "gloss": "to support",
+      "glossClean": "to support",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підтримати",
       "lemmaId": "підтримати",
       "lemmaPlain": "підтримати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18707,11 +20841,13 @@
     {
       "cefr": "A1",
       "gloss": "creation",
+      "glossClean": "creation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "створення",
       "lemmaId": "створення",
       "lemmaPlain": "створення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18722,11 +20858,13 @@
     {
       "cefr": "A1",
       "gloss": "testing",
+      "glossClean": "testing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тестування",
       "lemmaId": "тестування",
       "lemmaPlain": "тестування",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18737,11 +20875,13 @@
     {
       "cefr": "A1",
       "gloss": "course; move; gait",
+      "glossClean": "course",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хід",
       "lemmaId": "хід",
       "lemmaPlain": "хід",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18752,11 +20892,13 @@
     {
       "cefr": "A1",
       "gloss": "journalist",
+      "glossClean": "journalist",
       "heritage": "standard",
       "ipa": null,
       "lemma": "журналіст",
       "lemmaId": "журналіст",
       "lemmaPlain": "журналіст",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18767,11 +20909,13 @@
     {
       "cefr": "A1",
       "gloss": "female journalist",
+      "glossClean": "female journalist",
       "heritage": "standard",
       "ipa": null,
       "lemma": "журналістка",
       "lemmaId": "журналістка",
       "lemmaPlain": "журналістка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18782,11 +20926,13 @@
     {
       "cefr": "A1",
       "gloss": "Zakarpattia, area beyond the Carpathians",
+      "glossClean": "Zakarpattia",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Закарпаття",
       "lemmaId": "закарпаття",
       "lemmaPlain": "закарпаття",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -18797,11 +20943,13 @@
     {
       "cefr": "A1",
       "gloss": "Prykarpattia, area near the Carpathians",
+      "glossClean": "Prykarpattia",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Прикарпаття",
       "lemmaId": "прикарпаття",
       "lemmaPlain": "прикарпаття",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -18812,11 +20960,13 @@
     {
       "cefr": "A1",
       "gloss": "promotion, raise",
+      "glossClean": "promotion",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підвищення",
       "lemmaId": "підвищення",
       "lemmaPlain": "підвищення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18827,11 +20977,13 @@
     {
       "cefr": "A1",
       "gloss": "responsibility",
+      "glossClean": "responsibility",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відповідальність",
       "lemmaId": "відповідальність",
       "lemmaPlain": "відповідальність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18842,11 +20994,13 @@
     {
       "cefr": "A1",
       "gloss": "to carry out",
+      "glossClean": "to carry out",
       "heritage": "standard",
       "ipa": null,
       "lemma": "здійснювати",
       "lemmaId": "здійснювати",
       "lemmaPlain": "здійснювати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18857,11 +21011,13 @@
     {
       "cefr": "A1",
       "gloss": "liberation, release from captivity",
+      "glossClean": "liberation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "визволення",
       "lemmaId": "визволення",
       "lemmaPlain": "визволення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18872,11 +21028,13 @@
     {
       "cefr": "A1",
       "gloss": "captivity, being a prisoner",
+      "glossClean": "captivity",
       "heritage": "standard",
       "ipa": null,
       "lemma": "полон",
       "lemmaId": "полон",
       "lemmaPlain": "полон",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18888,10 +21046,10 @@
   "schema": "atlas-practice-lexemes",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 34833,
+    "gzipBytes": 39367,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 456166,
+    "rawBytes": 526831,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/public/lexicon/practice-lexemes.A2.json
+++ b/site/public/lexicon/practice-lexemes.A2.json
@@ -5,11 +5,13 @@
     {
       "cefr": "A2",
       "gloss": "congratulations",
+      "glossClean": "congratulations",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вітаю",
       "lemmaId": "вітаю",
       "lemmaPlain": "вітаю",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -20,11 +22,13 @@
     {
       "cefr": "A2",
       "gloss": "understood",
+      "glossClean": "understood",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зрозуміло",
       "lemmaId": "зрозуміло",
       "lemmaPlain": "зрозуміло",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -35,11 +39,13 @@
     {
       "cefr": "A2",
       "gloss": "Carpathians",
+      "glossClean": "Carpathians",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Карпати",
       "lemmaId": "карпати",
       "lemmaPlain": "карпати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -50,11 +56,13 @@
     {
       "cefr": "A2",
       "gloss": "croissant",
+      "glossClean": "croissant",
       "heritage": "standard",
       "ipa": null,
       "lemma": "круасан",
       "lemmaId": "круасан",
       "lemmaPlain": "круасан",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -65,11 +73,13 @@
     {
       "cefr": "A2",
       "gloss": "line",
+      "glossClean": "line",
       "heritage": "authentic-archaism",
       "ipa": null,
       "lemma": "лінія",
       "lemmaId": "лінія",
       "lemmaPlain": "лінія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -109,11 +119,13 @@
     {
       "cefr": "A2",
       "gloss": "to review",
+      "glossClean": "to review",
       "heritage": "standard",
       "ipa": null,
       "lemma": "повторювати",
       "lemmaId": "повторювати",
       "lemmaPlain": "повторювати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -124,11 +136,13 @@
     {
       "cefr": "A2",
       "gloss": "souvenir",
+      "glossClean": "souvenir",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сувенір",
       "lemmaId": "сувенір",
       "lemmaPlain": "сувенір",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -139,11 +153,13 @@
     {
       "cefr": "A2",
       "gloss": "finale",
+      "glossClean": "finale",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фінал",
       "lemmaId": "фінал",
       "lemmaPlain": "фінал",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -154,11 +170,13 @@
     {
       "cefr": "A2",
       "gloss": "every day",
+      "glossClean": "every day",
       "heritage": "standard",
       "ipa": null,
       "lemma": "щодня",
       "lemmaId": "щодня",
       "lemmaPlain": "щодня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -169,11 +187,13 @@
     {
       "cefr": "A2",
       "gloss": "close; nearby",
+      "glossClean": "close",
       "heritage": "standard",
       "ipa": null,
       "lemma": "близько",
       "lemmaId": "близько",
       "lemmaPlain": "близько",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -184,11 +204,13 @@
     {
       "cefr": "A2",
       "gloss": "excuse me",
+      "glossClean": "excuse me",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вибачте",
       "lemmaId": "вибачте",
       "lemmaPlain": "вибачте",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -199,11 +221,13 @@
     {
       "cefr": "A2",
       "gloss": "to get to",
+      "glossClean": "to get to",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дістатися",
       "lemmaId": "дістатися",
       "lemmaPlain": "дістатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -214,11 +238,13 @@
     {
       "cefr": "A2",
       "gloss": "on the left",
+      "glossClean": "on the left",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ліворуч",
       "lemmaId": "ліворуч",
       "lemmaPlain": "ліворуч",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -229,11 +255,13 @@
     {
       "cefr": "A2",
       "gloss": "nearby",
+      "glossClean": "nearby",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поруч",
       "lemmaId": "поруч",
       "lemmaPlain": "поруч",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -244,11 +272,13 @@
     {
       "cefr": "A2",
       "gloss": "on the right",
+      "glossClean": "on the right",
       "heritage": "standard",
       "ipa": null,
       "lemma": "праворуч",
       "lemmaId": "праворуч",
       "lemmaPlain": "праворуч",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -259,11 +289,13 @@
     {
       "cefr": "A2",
       "gloss": "cash",
+      "glossClean": "cash",
       "heritage": "standard",
       "ipa": null,
       "lemma": "готівка",
       "lemmaId": "готівка",
       "lemmaPlain": "готівка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -303,11 +335,13 @@
     {
       "cefr": "A2",
       "gloss": "excuse me",
+      "glossClean": "excuse me",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перепрошую",
       "lemmaId": "перепрошую",
       "lemmaPlain": "перепрошую",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -318,11 +352,13 @@
     {
       "cefr": "A2",
       "gloss": "to recommend",
+      "glossClean": "to recommend",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рекомендувати",
       "lemmaId": "рекомендувати",
       "lemmaPlain": "рекомендувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -333,11 +369,13 @@
     {
       "cefr": "A2",
       "gloss": "pastry; small cake",
+      "glossClean": "pastry",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тістечко",
       "lemmaId": "тістечко",
       "lemmaPlain": "тістечко",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -377,11 +415,13 @@
     {
       "cefr": "A2",
       "gloss": "we cook",
+      "glossClean": "we cook",
       "heritage": "standard",
       "ipa": null,
       "lemma": "готуємо",
       "lemmaId": "готуємо",
       "lemmaPlain": "готуємо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -392,11 +432,13 @@
     {
       "cefr": "A2",
       "gloss": "to have to; must",
+      "glossClean": "to have to",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мусити",
       "lemmaId": "мусити",
       "lemmaPlain": "мусити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -407,11 +449,13 @@
     {
       "cefr": "A2",
       "gloss": "finally",
+      "glossClean": "finally",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нарешті",
       "lemmaId": "нарешті",
       "lemmaPlain": "нарешті",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -422,11 +466,13 @@
     {
       "cefr": "A2",
       "gloss": "to clean",
+      "glossClean": "to clean",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прибирати",
       "lemmaId": "прибирати",
       "lemmaPlain": "прибирати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -437,11 +483,13 @@
     {
       "cefr": "A2",
       "gloss": "to wake up",
+      "glossClean": "to wake up",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прокидатися",
       "lemmaId": "прокидатися",
       "lemmaPlain": "прокидатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -452,11 +500,13 @@
     {
       "cefr": "A2",
       "gloss": "busy",
+      "glossClean": "busy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зайнятий",
       "lemmaId": "зайнятий",
       "lemmaPlain": "зайнятий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -467,11 +517,13 @@
     {
       "cefr": "A2",
       "gloss": "to come in, enter",
+      "glossClean": "to come in",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заходити",
       "lemmaId": "заходити",
       "lemmaPlain": "заходити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -482,11 +534,13 @@
     {
       "cefr": "A2",
       "gloss": "checkpoint; check",
+      "glossClean": "checkpoint",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перевірка",
       "lemmaId": "перевірка",
       "lemmaPlain": "перевірка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -526,11 +580,13 @@
     {
       "cefr": "A2",
       "gloss": "put; set up",
+      "glossClean": "put",
       "heritage": "standard",
       "ipa": null,
       "lemma": "постав",
       "lemmaId": "постав",
       "lemmaPlain": "постав",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -541,11 +597,13 @@
     {
       "cefr": "A2",
       "gloss": "to bring by carrying; perfective",
+      "glossClean": "to bring by carrying",
       "heritage": "standard",
       "ipa": null,
       "lemma": "принести",
       "lemmaId": "принести",
       "lemmaPlain": "принести",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -556,11 +614,13 @@
     {
       "cefr": "A2",
       "gloss": "female teacher",
+      "glossClean": "female teacher",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вчителька",
       "lemmaId": "вчителька",
       "lemmaPlain": "вчителька",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -571,11 +631,13 @@
     {
       "cefr": "A2",
       "gloss": "family or kin",
+      "glossClean": "family or kin",
       "heritage": "standard",
       "ipa": null,
       "lemma": "родина",
       "lemmaId": "родина",
       "lemmaPlain": "родина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -615,11 +677,13 @@
     {
       "cefr": "A2",
       "gloss": "Ukrainian woman",
+      "glossClean": "Ukrainian woman",
       "heritage": "standard",
       "ipa": null,
       "lemma": "українка",
       "lemmaId": "українка",
       "lemmaPlain": "українка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -630,11 +694,13 @@
     {
       "cefr": "A2",
       "gloss": "cheap",
+      "glossClean": "cheap",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дешево",
       "lemmaId": "дешево",
       "lemmaPlain": "дешево",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -645,11 +711,13 @@
     {
       "cefr": "A2",
       "gloss": "expensive",
+      "glossClean": "expensive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дорого",
       "lemmaId": "дорого",
       "lemmaPlain": "дорого",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -660,11 +728,13 @@
     {
       "cefr": "A2",
       "gloss": "porridge",
+      "glossClean": "porridge",
       "heritage": "standard",
       "ipa": null,
       "lemma": "каша",
       "lemmaId": "каша",
       "lemmaPlain": "каша",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -704,11 +774,13 @@
     {
       "cefr": "A2",
       "gloss": "market",
+      "glossClean": "market",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ринок",
       "lemmaId": "ринок",
       "lemmaPlain": "ринок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -719,11 +791,13 @@
     {
       "cefr": "A2",
       "gloss": "salo",
+      "glossClean": "salo",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сало",
       "lemmaId": "сало",
       "lemmaPlain": "сало",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -734,11 +808,13 @@
     {
       "cefr": "A2",
       "gloss": "male neighbor (object form)",
+      "glossClean": "male neighbor (object form)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сусіда",
       "lemmaId": "сусіда",
       "lemmaPlain": "сусіда",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -749,11 +825,13 @@
     {
       "cefr": "A2",
       "gloss": "yellow, plural",
+      "glossClean": "yellow",
       "heritage": "standard",
       "ipa": null,
       "lemma": "жовті",
       "lemmaId": "жовті",
       "lemmaPlain": "жовті",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -764,11 +842,13 @@
     {
       "cefr": "A2",
       "gloss": "book",
+      "glossClean": "book",
       "heritage": "standard",
       "ipa": null,
       "lemma": "книга",
       "lemmaId": "книга",
       "lemmaPlain": "книга",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -808,11 +888,13 @@
     {
       "cefr": "A2",
       "gloss": "necklace (recognition)",
+      "glossClean": "necklace (recognition)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "намисто",
       "lemmaId": "намисто",
       "lemmaPlain": "намисто",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -823,11 +905,13 @@
     {
       "cefr": "A2",
       "gloss": "red, plural",
+      "glossClean": "red",
       "heritage": "standard",
       "ipa": null,
       "lemma": "червоні",
       "lemmaId": "червоні",
       "lemmaPlain": "червоні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -838,11 +922,13 @@
     {
       "cefr": "A2",
       "gloss": "clean, masculine",
+      "glossClean": "clean",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чистий",
       "lemmaId": "чистий",
       "lemmaPlain": "чистий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -853,11 +939,13 @@
     {
       "cefr": "A2",
       "gloss": "black, feminine",
+      "glossClean": "black",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чорна",
       "lemmaId": "чорна",
       "lemmaPlain": "чорна",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -868,11 +956,13 @@
     {
       "cefr": "A2",
       "gloss": "to study",
+      "glossClean": "to study",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вчитися",
       "lemmaId": "вчитися",
       "lemmaPlain": "вчитися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -883,11 +973,13 @@
     {
       "cefr": "A2",
       "gloss": "rarely",
+      "glossClean": "rarely",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рідко",
       "lemmaId": "рідко",
       "lemmaPlain": "рідко",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -898,11 +990,13 @@
     {
       "cefr": "A2",
       "gloss": "sunny",
+      "glossClean": "sunny",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сонячно",
       "lemmaId": "сонячно",
       "lemmaPlain": "сонячно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -913,11 +1007,13 @@
     {
       "cefr": "A2",
       "gloss": "grass",
+      "glossClean": "grass",
       "heritage": "standard",
       "ipa": null,
       "lemma": "трава",
       "lemmaId": "трава",
       "lemmaPlain": "трава",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -957,11 +1053,13 @@
     {
       "cefr": "A2",
       "gloss": "cloudy",
+      "glossClean": "cloudy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хмарно",
       "lemmaId": "хмарно",
       "lemmaPlain": "хмарно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -972,11 +1070,13 @@
     {
       "cefr": "A2",
       "gloss": "mood",
+      "glossClean": "mood",
       "heritage": "standard",
       "ipa": null,
       "lemma": "настрій",
       "lemmaId": "настрій",
       "lemmaPlain": "настрій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -987,11 +1087,13 @@
     {
       "cefr": "A2",
       "gloss": "orange, masculine",
+      "glossClean": "orange",
       "heritage": "standard",
       "ipa": null,
       "lemma": "помаранчевий",
       "lemmaId": "помаранчевий",
       "lemmaPlain": "помаранчевий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1002,11 +1104,13 @@
     {
       "cefr": "A2",
       "gloss": "pink, masculine",
+      "glossClean": "pink",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рожевий",
       "lemmaId": "рожевий",
       "lemmaPlain": "рожевий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1017,11 +1121,13 @@
     {
       "cefr": "A2",
       "gloss": "blue-and-yellow",
+      "glossClean": "blue-and-yellow",
       "heritage": "standard",
       "ipa": null,
       "lemma": "синьо-жовтий",
       "lemmaId": "синьо-жовтий",
       "lemmaPlain": "синьо-жовтий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1032,11 +1138,13 @@
     {
       "cefr": "A2",
       "gloss": "sad",
+      "glossClean": "sad",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сумно",
       "lemmaId": "сумно",
       "lemmaPlain": "сумно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1047,11 +1155,13 @@
     {
       "cefr": "A2",
       "gloss": "purple, masculine",
+      "glossClean": "purple",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фіолетовий",
       "lemmaId": "фіолетовий",
       "lemmaPlain": "фіолетовий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1062,11 +1172,13 @@
     {
       "cefr": "A2",
       "gloss": "to summon/call",
+      "glossClean": "to summon/call",
       "heritage": "standard",
       "ipa": null,
       "lemma": "викликати",
       "lemmaId": "викликати",
       "lemmaPlain": "викликати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1077,11 +1189,13 @@
     {
       "cefr": "A2",
       "gloss": "gas",
+      "glossClean": "gas",
       "heritage": "standard",
       "ipa": null,
       "lemma": "газ",
       "lemmaId": "газ",
       "lemmaPlain": "газ",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1092,11 +1206,13 @@
     {
       "cefr": "A2",
       "gloss": "to lose",
+      "glossClean": "to lose",
       "heritage": "standard",
       "ipa": null,
       "lemma": "загубити",
       "lemmaId": "загубити",
       "lemmaPlain": "загубити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1107,11 +1223,13 @@
     {
       "cefr": "A2",
       "gloss": "fire",
+      "glossClean": "fire",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пожежа",
       "lemmaId": "пожежа",
       "lemmaPlain": "пожежа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1151,11 +1269,13 @@
     {
       "cefr": "A2",
       "gloss": "police",
+      "glossClean": "police",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поліція",
       "lemmaId": "поліція",
       "lemmaPlain": "поліція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1195,11 +1315,13 @@
     {
       "cefr": "A2",
       "gloss": "ambulance",
+      "glossClean": "ambulance",
       "heritage": "standard",
       "ipa": null,
       "lemma": "швидка",
       "lemmaId": "швидка",
       "lemmaPlain": "швидка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1239,11 +1361,13 @@
     {
       "cefr": "A2",
       "gloss": "vowel",
+      "glossClean": "vowel",
       "heritage": "standard",
       "ipa": null,
       "lemma": "голосний",
       "lemmaId": "голосний",
       "lemmaPlain": "голосний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1254,11 +1378,13 @@
     {
       "cefr": "A2",
       "gloss": "sound",
+      "glossClean": "sound",
       "heritage": "standard",
       "ipa": null,
       "lemma": "звук",
       "lemmaId": "звук",
       "lemmaPlain": "звук",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1269,11 +1395,13 @@
     {
       "cefr": "A2",
       "gloss": "consonant",
+      "glossClean": "consonant",
       "heritage": "standard",
       "ipa": null,
       "lemma": "приголосний",
       "lemmaId": "приголосний",
       "lemmaPlain": "приголосний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1284,11 +1412,13 @@
     {
       "cefr": "A2",
       "gloss": "Yana",
+      "glossClean": "Yana",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Яна",
       "lemmaId": "яна",
       "lemmaPlain": "яна",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1299,11 +1429,13 @@
     {
       "cefr": "A2",
       "gloss": "hungry",
+      "glossClean": "hungry",
       "heritage": "standard",
       "ipa": null,
       "lemma": "голодний",
       "lemmaId": "голодний",
       "lemmaPlain": "голодний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1314,11 +1446,13 @@
     {
       "cefr": "A2",
       "gloss": "jam",
+      "glossClean": "jam",
       "heritage": "standard",
       "ipa": null,
       "lemma": "джем",
       "lemmaId": "джем",
       "lemmaPlain": "джем",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1329,11 +1463,13 @@
     {
       "cefr": "A2",
       "gloss": "potato; made with potato",
+      "glossClean": "potato",
       "heritage": "standard",
       "ipa": null,
       "lemma": "картопляний",
       "lemmaId": "картопляний",
       "lemmaPlain": "картопляний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1344,11 +1480,13 @@
     {
       "cefr": "A2",
       "gloss": "kefir",
+      "glossClean": "kefir",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кефір",
       "lemmaId": "кефір",
       "lemmaPlain": "кефір",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -1359,11 +1497,13 @@
     {
       "cefr": "A2",
       "gloss": "compote",
+      "glossClean": "compote",
       "heritage": "standard",
       "ipa": null,
       "lemma": "компот",
       "lemmaId": "компот",
       "lemmaPlain": "компот",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1374,11 +1514,13 @@
     {
       "cefr": "A2",
       "gloss": "lemonade",
+      "glossClean": "lemonade",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лимонад",
       "lemmaId": "лимонад",
       "lemmaPlain": "лимонад",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1389,11 +1531,13 @@
     {
       "cefr": "A2",
       "gloss": "oil",
+      "glossClean": "oil",
       "heritage": "standard",
       "ipa": null,
       "lemma": "олія",
       "lemmaId": "олія",
       "lemmaPlain": "олія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1433,11 +1577,13 @@
     {
       "cefr": "A2",
       "gloss": "strawberry",
+      "glossClean": "strawberry",
       "heritage": "standard",
       "ipa": null,
       "lemma": "полуничний",
       "lemmaId": "полуничний",
       "lemmaPlain": "полуничний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1448,11 +1594,13 @@
     {
       "cefr": "A2",
       "gloss": "fried",
+      "glossClean": "fried",
       "heritage": "standard",
       "ipa": null,
       "lemma": "смажений",
       "lemmaId": "смажений",
       "lemmaPlain": "смажений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1463,11 +1611,13 @@
     {
       "cefr": "A2",
       "gloss": "salty",
+      "glossClean": "salty",
       "heritage": "standard",
       "ipa": null,
       "lemma": "солоний",
       "lemmaId": "солоний",
       "lemmaPlain": "солоний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1478,11 +1628,13 @@
     {
       "cefr": "A2",
       "gloss": "basketball",
+      "glossClean": "basketball",
       "heritage": "standard",
       "ipa": null,
       "lemma": "баскетбол",
       "lemmaId": "баскетбол",
       "lemmaPlain": "баскетбол",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1493,11 +1645,13 @@
     {
       "cefr": "A2",
       "gloss": "club; activity group",
+      "glossClean": "club",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гурток",
       "lemmaId": "гурток",
       "lemmaPlain": "гурток",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1508,11 +1662,13 @@
     {
       "cefr": "A2",
       "gloss": "usually",
+      "glossClean": "usually",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зазвичай",
       "lemmaId": "зазвичай",
       "lemmaPlain": "зазвичай",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1523,11 +1679,13 @@
     {
       "cefr": "A2",
       "gloss": "sometimes",
+      "glossClean": "sometimes",
       "heritage": "standard",
       "ipa": null,
       "lemma": "інколи",
       "lemmaId": "інколи",
       "lemmaPlain": "інколи",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1538,11 +1696,13 @@
     {
       "cefr": "A2",
       "gloss": "cough",
+      "glossClean": "cough",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кашель",
       "lemmaId": "кашель",
       "lemmaPlain": "кашель",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1553,11 +1713,13 @@
     {
       "cefr": "A2",
       "gloss": "runny nose",
+      "glossClean": "runny nose",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нежить",
       "lemmaId": "нежить",
       "lemmaPlain": "нежить",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1568,11 +1730,13 @@
     {
       "cefr": "A2",
       "gloss": "sick, feminine",
+      "glossClean": "sick",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хвора",
       "lemmaId": "хвора",
       "lemmaPlain": "хвора",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1583,11 +1747,13 @@
     {
       "cefr": "A2",
       "gloss": "grandmother",
+      "glossClean": "grandmother",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бабуся",
       "lemmaId": "бабуся",
       "lemmaPlain": "бабуся",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1598,11 +1764,13 @@
     {
       "cefr": "A2",
       "gloss": "teacher",
+      "glossClean": "teacher",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вчитель",
       "lemmaId": "вчитель",
       "lemmaPlain": "вчитель",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1613,11 +1781,13 @@
     {
       "cefr": "A2",
       "gloss": "grandfather",
+      "glossClean": "grandfather",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дідусь",
       "lemmaId": "дідусь",
       "lemmaPlain": "дідусь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1628,11 +1798,13 @@
     {
       "cefr": "A2",
       "gloss": "Dad! (vocative)",
+      "glossClean": "Dad! (vocative)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тату",
       "lemmaId": "тату",
       "lemmaPlain": "тату",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -1643,11 +1815,13 @@
     {
       "cefr": "A2",
       "gloss": "Christmas carol",
+      "glossClean": "Christmas carol",
       "heritage": "standard",
       "ipa": null,
       "lemma": "колядка",
       "lemmaId": "колядка",
       "lemmaPlain": "колядка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1687,11 +1861,13 @@
     {
       "cefr": "A2",
       "gloss": "Easter bread",
+      "glossClean": "Easter bread",
       "heritage": "standard",
       "ipa": null,
       "lemma": "паска",
       "lemmaId": "паска",
       "lemmaPlain": "паска",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1731,11 +1907,13 @@
     {
       "cefr": "A2",
       "gloss": "decorated Easter egg",
+      "glossClean": "decorated Easter egg",
       "heritage": "standard",
       "ipa": null,
       "lemma": "писанка",
       "lemmaId": "писанка",
       "lemmaPlain": "писанка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1775,11 +1953,13 @@
     {
       "cefr": "A2",
       "gloss": "joy",
+      "glossClean": "joy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "радість",
       "lemmaId": "радість",
       "lemmaPlain": "радість",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1790,11 +1970,13 @@
     {
       "cefr": "A2",
       "gloss": "two people/things, passive recognition",
+      "glossClean": "two people/things",
       "heritage": "standard",
       "ipa": null,
       "lemma": "двоє",
       "lemmaId": "двоє",
       "lemmaPlain": "двоє",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1805,11 +1987,13 @@
     {
       "cefr": "A2",
       "gloss": "cost, plural",
+      "glossClean": "cost",
       "heritage": "standard",
       "ipa": null,
       "lemma": "коштують",
       "lemmaId": "коштують",
       "lemmaPlain": "коштують",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1820,11 +2004,13 @@
     {
       "cefr": "A2",
       "gloss": "fifty",
+      "glossClean": "fifty",
       "heritage": "standard",
       "ipa": null,
       "lemma": "п'ятдесят",
       "lemmaId": "п-ятдесят",
       "lemmaPlain": "п'ятдесят",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1835,11 +2021,13 @@
     {
       "cefr": "A2",
       "gloss": "fifteen",
+      "glossClean": "fifteen",
       "heritage": "standard",
       "ipa": null,
       "lemma": "п'ятнадцять",
       "lemmaId": "п-ятнадцять",
       "lemmaPlain": "п'ятнадцять",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1850,11 +2038,13 @@
     {
       "cefr": "A2",
       "gloss": "five hundred",
+      "glossClean": "five hundred",
       "heritage": "standard",
       "ipa": null,
       "lemma": "п'ятсот",
       "lemmaId": "п-ятсот",
       "lemmaPlain": "п'ятсот",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1865,11 +2055,13 @@
     {
       "cefr": "A2",
       "gloss": "three people/things, passive recognition",
+      "glossClean": "three people/things",
       "heritage": "standard",
       "ipa": null,
       "lemma": "троє",
       "lemmaId": "троє",
       "lemmaPlain": "троє",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1880,11 +2072,13 @@
     {
       "cefr": "A2",
       "gloss": "four people/things, passive recognition",
+      "glossClean": "four people/things",
       "heritage": "standard",
       "ipa": null,
       "lemma": "четверо",
       "lemmaId": "четверо",
       "lemmaPlain": "четверо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1895,11 +2089,13 @@
     {
       "cefr": "A2",
       "gloss": "cheaper",
+      "glossClean": "cheaper",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дешевше",
       "lemmaId": "дешевше",
       "lemmaPlain": "дешевше",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1910,11 +2106,13 @@
     {
       "cefr": "A2",
       "gloss": "thought; opinion",
+      "glossClean": "thought",
       "heritage": "standard",
       "ipa": null,
       "lemma": "думка",
       "lemmaId": "думка",
       "lemmaPlain": "думка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1954,11 +2152,13 @@
     {
       "cefr": "A2",
       "gloss": "so that; in order to",
+      "glossClean": "so that",
       "heritage": "standard",
       "ipa": null,
       "lemma": "щоб",
       "lemmaId": "щоб",
       "lemmaPlain": "щоб",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -1969,11 +2169,13 @@
     {
       "cefr": "A2",
       "gloss": "mirror, singular",
+      "glossClean": "mirror",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дзеркало",
       "lemmaId": "дзеркало",
       "lemmaPlain": "дзеркало",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1984,11 +2186,13 @@
     {
       "cefr": "A2",
       "gloss": "small, plural",
+      "glossClean": "small",
       "heritage": "standard",
       "ipa": null,
       "lemma": "маленькі",
       "lemmaId": "маленькі",
       "lemmaPlain": "маленькі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1999,11 +2203,13 @@
     {
       "cefr": "A2",
       "gloss": "phones",
+      "glossClean": "phones",
       "heritage": "standard",
       "ipa": null,
       "lemma": "телефони",
       "lemmaId": "телефони",
       "lemmaPlain": "телефони",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2014,11 +2220,13 @@
     {
       "cefr": "A2",
       "gloss": "lake",
+      "glossClean": "lake",
       "heritage": "standard",
       "ipa": null,
       "lemma": "озеро",
       "lemmaId": "озеро",
       "lemmaPlain": "озеро",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2029,11 +2237,13 @@
     {
       "cefr": "A2",
       "gloss": "free",
+      "glossClean": "free",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вільний",
       "lemmaId": "вільний",
       "lemmaPlain": "вільний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2044,11 +2254,13 @@
     {
       "cefr": "A2",
       "gloss": "after",
+      "glossClean": "after",
       "heritage": "standard",
       "ipa": null,
       "lemma": "після",
       "lemmaId": "після",
       "lemmaPlain": "після",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -2059,11 +2271,13 @@
     {
       "cefr": "A2",
       "gloss": "typical",
+      "glossClean": "typical",
       "heritage": "standard",
       "ipa": null,
       "lemma": "типовий",
       "lemmaId": "типовий",
       "lemmaPlain": "типовий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2074,11 +2288,13 @@
     {
       "cefr": "A2",
       "gloss": "relative",
+      "glossClean": "relative",
       "heritage": "standard",
       "ipa": null,
       "lemma": "родич",
       "lemmaId": "родич",
       "lemmaPlain": "родич",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2089,11 +2305,13 @@
     {
       "cefr": "A2",
       "gloss": "to get ready",
+      "glossClean": "to get ready",
       "heritage": "standard",
       "ipa": null,
       "lemma": "збиратися",
       "lemmaId": "збиратися",
       "lemmaPlain": "збиратися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2104,11 +2322,13 @@
     {
       "cefr": "A2",
       "gloss": "soap",
+      "glossClean": "soap",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мило",
       "lemmaId": "мило",
       "lemmaPlain": "мило",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2119,11 +2339,13 @@
     {
       "cefr": "A2",
       "gloss": "to return",
+      "glossClean": "to return",
       "heritage": "standard",
       "ipa": null,
       "lemma": "повертатися",
       "lemmaId": "повертатися",
       "lemmaPlain": "повертатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2134,11 +2356,13 @@
     {
       "cefr": "A2",
       "gloss": "late",
+      "glossClean": "late",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пізно",
       "lemmaId": "пізно",
       "lemmaPlain": "пізно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2149,11 +2373,13 @@
     {
       "cefr": "A2",
       "gloss": "party",
+      "glossClean": "party",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вечірка",
       "lemmaId": "вечірка",
       "lemmaPlain": "вечірка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2193,11 +2419,13 @@
     {
       "cefr": "A2",
       "gloss": "to study, to learn",
+      "glossClean": "to study",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вчити",
       "lemmaId": "вчити",
       "lemmaPlain": "вчити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2208,11 +2436,13 @@
     {
       "cefr": "A2",
       "gloss": "to meet each other once",
+      "glossClean": "to meet each other once",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зустрітися",
       "lemmaId": "зустрітися",
       "lemmaPlain": "зустрітися",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -2223,11 +2453,13 @@
     {
       "cefr": "A2",
       "gloss": "to study",
+      "glossClean": "to study",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вивчати",
       "lemmaId": "вивчати",
       "lemmaPlain": "вивчати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2238,11 +2470,13 @@
     {
       "cefr": "A2",
       "gloss": "next, further",
+      "glossClean": "next",
       "heritage": "standard",
       "ipa": null,
       "lemma": "далі",
       "lemmaId": "далі",
       "lemmaPlain": "далі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2253,11 +2487,13 @@
     {
       "cefr": "A2",
       "gloss": "to be born",
+      "glossClean": "to be born",
       "heritage": "standard",
       "ipa": null,
       "lemma": "народитися",
       "lemmaId": "народитися",
       "lemmaPlain": "народитися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2268,11 +2504,13 @@
     {
       "cefr": "A2",
       "gloss": "earlier, before",
+      "glossClean": "earlier",
       "heritage": "standard",
       "ipa": null,
       "lemma": "раніше",
       "lemmaId": "раніше",
       "lemmaPlain": "раніше",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2283,11 +2521,13 @@
     {
       "cefr": "A2",
       "gloss": "inanimate thing",
+      "glossClean": "inanimate thing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "неістота",
       "lemmaId": "неістота",
       "lemmaPlain": "неістота",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2298,11 +2538,13 @@
     {
       "cefr": "A2",
       "gloss": "buyer",
+      "glossClean": "buyer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "покупець",
       "lemmaId": "покупець",
       "lemmaPlain": "покупець",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2313,11 +2555,13 @@
     {
       "cefr": "A2",
       "gloss": "animate being",
+      "glossClean": "animate being",
       "heritage": "standard",
       "ipa": null,
       "lemma": "істота",
       "lemmaId": "істота",
       "lemmaPlain": "істота",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2328,11 +2572,13 @@
     {
       "cefr": "A2",
       "gloss": "ball",
+      "glossClean": "ball",
       "heritage": "standard",
       "ipa": null,
       "lemma": "м'яч",
       "lemmaId": "м-яч",
       "lemmaPlain": "м'яч",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2343,11 +2589,13 @@
     {
       "cefr": "A2",
       "gloss": "to sit down",
+      "glossClean": "to sit down",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сісти",
       "lemmaId": "сісти",
       "lemmaPlain": "сісти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2358,11 +2606,13 @@
     {
       "cefr": "A2",
       "gloss": "nobody",
+      "glossClean": "nobody",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ніхто",
       "lemmaId": "ніхто",
       "lemmaPlain": "ніхто",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2373,11 +2623,13 @@
     {
       "cefr": "A2",
       "gloss": "nothing",
+      "glossClean": "nothing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ніщо",
       "lemmaId": "ніщо",
       "lemmaPlain": "ніщо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2388,11 +2640,13 @@
     {
       "cefr": "A2",
       "gloss": "capital",
+      "glossClean": "capital",
       "heritage": "standard",
       "ipa": null,
       "lemma": "столи́ця",
       "lemmaId": "столи-ця",
       "lemmaPlain": "столиця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2403,11 +2657,13 @@
     {
       "cefr": "A2",
       "gloss": "cheaper",
+      "glossClean": "cheaper",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дешевший",
       "lemmaId": "дешевший",
       "lemmaPlain": "дешевший",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2418,11 +2674,13 @@
     {
       "cefr": "A2",
       "gloss": "discount",
+      "glossClean": "discount",
       "heritage": "standard",
       "ipa": null,
       "lemma": "знижка",
       "lemmaId": "знижка",
       "lemmaPlain": "знижка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2462,11 +2720,13 @@
     {
       "cefr": "A2",
       "gloss": "bookshop",
+      "glossClean": "bookshop",
       "heritage": "standard",
       "ipa": null,
       "lemma": "книгарня",
       "lemmaId": "книгарня",
       "lemmaPlain": "книгарня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2506,11 +2766,13 @@
     {
       "cefr": "A2",
       "gloss": "pack",
+      "glossClean": "pack",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пачка",
       "lemmaId": "пачка",
       "lemmaPlain": "пачка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2550,11 +2812,13 @@
     {
       "cefr": "A2",
       "gloss": "bottle",
+      "glossClean": "bottle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пляшка",
       "lemmaId": "пляшка",
       "lemmaPlain": "пляшка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2594,11 +2858,13 @@
     {
       "cefr": "A2",
       "gloss": "stress",
+      "glossClean": "stress",
       "heritage": "standard",
       "ipa": null,
       "lemma": "на́голос",
       "lemmaId": "на-голос",
       "lemmaPlain": "наголос",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2609,11 +2875,13 @@
     {
       "cefr": "A2",
       "gloss": "Hi",
+      "glossClean": "Hi",
       "heritage": "standard",
       "ipa": null,
       "lemma": "Приві́т",
       "lemmaId": "приві-т",
       "lemmaPlain": "привіт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2624,11 +2892,13 @@
     {
       "cefr": "A2",
       "gloss": "sleep / dream",
+      "glossClean": "sleep / dream",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сон",
       "lemmaId": "сон",
       "lemmaPlain": "сон",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2639,11 +2909,13 @@
     {
       "cefr": "A2",
       "gloss": "wooden",
+      "glossClean": "wooden",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дерев'я́ний",
       "lemmaId": "дерев-я-ний",
       "lemmaPlain": "дерев'яний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2654,11 +2926,13 @@
     {
       "cefr": "A2",
       "gloss": "sign",
+      "glossClean": "sign",
       "heritage": "standard",
       "ipa": null,
       "lemma": "знак",
       "lemmaId": "знак",
       "lemmaPlain": "знак",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2669,11 +2943,13 @@
     {
       "cefr": "A2",
       "gloss": "computer",
+      "glossClean": "computer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "комп'ю́тер",
       "lemmaId": "комп-ю-тер",
       "lemmaPlain": "комп'ютер",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2684,11 +2960,13 @@
     {
       "cefr": "A2",
       "gloss": "soft",
+      "glossClean": "soft",
       "heritage": "standard",
       "ipa": null,
       "lemma": "м'яки́й",
       "lemmaId": "м-яки-й",
       "lemmaPlain": "м'який",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2699,11 +2977,13 @@
     {
       "cefr": "A2",
       "gloss": "Mariana",
+      "glossClean": "Mariana",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Мар'я́на",
       "lemmaId": "мар-я-на",
       "lemmaPlain": "мар'яна",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -2714,11 +2994,13 @@
     {
       "cefr": "A2",
       "gloss": "hard",
+      "glossClean": "hard",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тверди́й",
       "lemmaId": "тверди-й",
       "lemmaPlain": "твердий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2729,11 +3011,13 @@
     {
       "cefr": "A2",
       "gloss": "rest / vacation",
+      "glossClean": "rest / vacation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відпочинок",
       "lemmaId": "відпочинок",
       "lemmaPlain": "відпочинок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2744,11 +3028,13 @@
     {
       "cefr": "A2",
       "gloss": "castle / lock",
+      "glossClean": "castle / lock",
       "heritage": "standard",
       "ipa": null,
       "lemma": "замок",
       "lemmaId": "замок",
       "lemmaPlain": "замок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2759,11 +3045,13 @@
     {
       "cefr": "A2",
       "gloss": "key",
+      "glossClean": "key",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ключ",
       "lemmaId": "ключ",
       "lemmaPlain": "ключ",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2774,11 +3062,13 @@
     {
       "cefr": "A2",
       "gloss": "Illia",
+      "glossClean": "Illia",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Ілля",
       "lemmaId": "ілля",
       "lemmaPlain": "ілля",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -2789,11 +3079,13 @@
     {
       "cefr": "A2",
       "gloss": "noun",
+      "glossClean": "noun",
       "heritage": "standard",
       "ipa": null,
       "lemma": "іменник",
       "lemmaId": "іменник",
       "lemmaPlain": "іменник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2804,11 +3096,13 @@
     {
       "cefr": "A2",
       "gloss": "that exact one, masculine",
+      "glossClean": "that exact one",
       "heritage": "standard",
       "ipa": null,
       "lemma": "отой",
       "lemmaId": "отой",
       "lemmaPlain": "отой",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -2819,11 +3113,13 @@
     {
       "cefr": "A2",
       "gloss": "this exact one, masculine",
+      "glossClean": "this exact one",
       "heritage": "standard",
       "ipa": null,
       "lemma": "оцей",
       "lemmaId": "оцей",
       "lemmaPlain": "оцей",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -2834,11 +3130,13 @@
     {
       "cefr": "A2",
       "gloss": "to get off; to exit",
+      "glossClean": "to get off",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виходити",
       "lemmaId": "виходити",
       "lemmaPlain": "виходити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2849,11 +3147,13 @@
     {
       "cefr": "A2",
       "gloss": "cashier; ticket clerk",
+      "glossClean": "cashier",
       "heritage": "standard",
       "ipa": null,
       "lemma": "касир",
       "lemmaId": "касир",
       "lemmaPlain": "касир",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2864,11 +3164,13 @@
     {
       "cefr": "A2",
       "gloss": "track; platform track",
+      "glossClean": "track",
       "heritage": "standard",
       "ipa": null,
       "lemma": "колія",
       "lemmaId": "колія",
       "lemmaPlain": "колія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2908,11 +3210,13 @@
     {
       "cefr": "A2",
       "gloss": "to fly",
+      "glossClean": "to fly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "летіти",
       "lemmaId": "летіти",
       "lemmaPlain": "летіти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2923,11 +3227,13 @@
     {
       "cefr": "A2",
       "gloss": "train",
+      "glossClean": "train",
       "heritage": "standard",
       "ipa": null,
       "lemma": "потяг",
       "lemmaId": "потяг",
       "lemmaPlain": "потяг",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2938,11 +3244,13 @@
     {
       "cefr": "A2",
       "gloss": "he/she listens",
+      "glossClean": "he/she listens",
       "heritage": "standard",
       "ipa": null,
       "lemma": "слухає",
       "lemmaId": "слухає",
       "lemmaPlain": "слухає",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2953,11 +3261,13 @@
     {
       "cefr": "A2",
       "gloss": "he/she learns; he/she studies",
+      "glossClean": "he/she learns",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вчить",
       "lemmaId": "вчить",
       "lemmaPlain": "вчить",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2968,11 +3278,13 @@
     {
       "cefr": "A2",
       "gloss": "you speak (plural/formal)",
+      "glossClean": "you speak (plural/formal)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "говорите",
       "lemmaId": "говорите",
       "lemmaPlain": "говорите",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -2983,11 +3295,13 @@
     {
       "cefr": "A2",
       "gloss": "we ask for",
+      "glossClean": "we ask for",
       "heritage": "standard",
       "ipa": null,
       "lemma": "просимо",
       "lemmaId": "просимо",
       "lemmaPlain": "просимо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2998,11 +3312,13 @@
     {
       "cefr": "A2",
       "gloss": "you do (plural/formal)",
+      "glossClean": "you do (plural/formal)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "робите",
       "lemmaId": "робите",
       "lemmaPlain": "робите",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3013,11 +3329,13 @@
     {
       "cefr": "A2",
       "gloss": "outside; outdoors",
+      "glossClean": "outside",
       "heritage": "standard",
       "ipa": null,
       "lemma": "надворі",
       "lemmaId": "надворі",
       "lemmaPlain": "надворі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3028,11 +3346,13 @@
     {
       "cefr": "A2",
       "gloss": "cool",
+      "glossClean": "cool",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прохолодно",
       "lemmaId": "прохолодно",
       "lemmaPlain": "прохолодно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3043,11 +3363,13 @@
     {
       "cefr": "A2",
       "gloss": "ending",
+      "glossClean": "ending",
       "heritage": "standard",
       "ipa": null,
       "lemma": "закінчення",
       "lemmaId": "закінчення",
       "lemmaPlain": "закінчення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3058,11 +3380,13 @@
     {
       "cefr": "A2",
       "gloss": "past",
+      "glossClean": "past",
       "heritage": "standard",
       "ipa": null,
       "lemma": "минулий",
       "lemmaId": "минулий",
       "lemmaPlain": "минулий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3073,11 +3397,13 @@
     {
       "cefr": "A2",
       "gloss": "person",
+      "glossClean": "person",
       "heritage": "standard",
       "ipa": null,
       "lemma": "особа",
       "lemmaId": "особа",
       "lemmaPlain": "особа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3088,11 +3414,13 @@
     {
       "cefr": "A2",
       "gloss": "dirty, masculine",
+      "glossClean": "dirty",
       "heritage": "standard",
       "ipa": null,
       "lemma": "брудний",
       "lemmaId": "брудний",
       "lemmaPlain": "брудний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3103,11 +3431,13 @@
     {
       "cefr": "A2",
       "gloss": "cheap, masculine",
+      "glossClean": "cheap",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дешевий",
       "lemmaId": "дешевий",
       "lemmaPlain": "дешевий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3118,11 +3448,13 @@
     {
       "cefr": "A2",
       "gloss": "lazy, masculine",
+      "glossClean": "lazy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лінивий",
       "lemmaId": "лінивий",
       "lemmaPlain": "лінивий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3133,11 +3465,13 @@
     {
       "cefr": "A2",
       "gloss": "correct, masculine",
+      "glossClean": "correct",
       "heritage": "standard",
       "ipa": null,
       "lemma": "правильний",
       "lemmaId": "правильний",
       "lemmaPlain": "правильний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3148,11 +3482,13 @@
     {
       "cefr": "A2",
       "gloss": "old, neuter",
+      "glossClean": "old",
       "heritage": "standard",
       "ipa": null,
       "lemma": "старе",
       "lemmaId": "старе",
       "lemmaPlain": "старе",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3163,11 +3499,13 @@
     {
       "cefr": "A2",
       "gloss": "to finish",
+      "glossClean": "to finish",
       "heritage": "standard",
       "ipa": null,
       "lemma": "закінчуватися",
       "lemmaId": "закінчуватися",
       "lemmaPlain": "закінчуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3178,11 +3516,13 @@
     {
       "cefr": "A2",
       "gloss": "five o'clock; fifth (feminine)",
+      "glossClean": "five o'clock",
       "heritage": "standard",
       "ipa": null,
       "lemma": "п'ята",
       "lemmaId": "п-ята",
       "lemmaPlain": "п'ята",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3193,11 +3533,13 @@
     {
       "cefr": "A2",
       "gloss": "to begin",
+      "glossClean": "to begin",
       "heritage": "standard",
       "ipa": null,
       "lemma": "починатися",
       "lemmaId": "починатися",
       "lemmaPlain": "починатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3208,11 +3550,13 @@
     {
       "cefr": "A2",
       "gloss": "exactly",
+      "glossClean": "exactly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "саме",
       "lemmaId": "саме",
       "lemmaPlain": "саме",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3223,11 +3567,13 @@
     {
       "cefr": "A2",
       "gloss": "fact",
+      "glossClean": "fact",
       "heritage": "standard",
       "ipa": null,
       "lemma": "факт",
       "lemmaId": "факт",
       "lemmaPlain": "факт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3238,11 +3584,13 @@
     {
       "cefr": "A2",
       "gloss": "England",
+      "glossClean": "England",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Англія",
       "lemmaId": "англія",
       "lemmaPlain": "англія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3253,11 +3601,13 @@
     {
       "cefr": "A2",
       "gloss": "western",
+      "glossClean": "western",
       "heritage": "standard",
       "ipa": null,
       "lemma": "західний",
       "lemmaId": "західний",
       "lemmaPlain": "західний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3268,11 +3618,13 @@
     {
       "cefr": "A2",
       "gloss": "Canada",
+      "glossClean": "Canada",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Канада",
       "lemmaId": "канада",
       "lemmaPlain": "канада",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3283,11 +3635,13 @@
     {
       "cefr": "A2",
       "gloss": "man from Lviv",
+      "glossClean": "man from Lviv",
       "heritage": "standard",
       "ipa": null,
       "lemma": "львів'янин",
       "lemmaId": "львів-янин",
       "lemmaPlain": "львів'янин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3298,11 +3652,13 @@
     {
       "cefr": "A2",
       "gloss": "southern",
+      "glossClean": "southern",
       "heritage": "standard",
       "ipa": null,
       "lemma": "південний",
       "lemmaId": "південний",
       "lemmaPlain": "південний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3313,11 +3669,13 @@
     {
       "cefr": "A2",
       "gloss": "northern",
+      "glossClean": "northern",
       "heritage": "standard",
       "ipa": null,
       "lemma": "північний",
       "lemmaId": "північний",
       "lemmaPlain": "північний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3328,11 +3686,13 @@
     {
       "cefr": "A2",
       "gloss": "eastern",
+      "glossClean": "eastern",
       "heritage": "standard",
       "ipa": null,
       "lemma": "східний",
       "lemmaId": "східний",
       "lemmaPlain": "східний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3343,11 +3703,13 @@
     {
       "cefr": "A2",
       "gloss": "Japan",
+      "glossClean": "Japan",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Японія",
       "lemmaId": "японія",
       "lemmaPlain": "японія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3358,11 +3720,13 @@
     {
       "cefr": "A2",
       "gloss": "cat",
+      "glossClean": "cat",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кішка",
       "lemmaId": "кішка",
       "lemmaPlain": "кішка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3373,11 +3737,13 @@
     {
       "cefr": "A2",
       "gloss": "Khreshchatyk",
+      "glossClean": "Khreshchatyk",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Хрещатик",
       "lemmaId": "хрещатик",
       "lemmaPlain": "хрещатик",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3388,11 +3754,13 @@
     {
       "cefr": "A2",
       "gloss": "American man",
+      "glossClean": "American man",
       "heritage": "standard",
       "ipa": null,
       "lemma": "американець",
       "lemmaId": "американець",
       "lemmaPlain": "американець",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3403,11 +3771,13 @@
     {
       "cefr": "A2",
       "gloss": "thank you",
+      "glossClean": "thank you",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спасибі",
       "lemmaId": "спасибі",
       "lemmaPlain": "спасибі",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3418,11 +3788,13 @@
     {
       "cefr": "A2",
       "gloss": "female engineer",
+      "glossClean": "female engineer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "інженерка",
       "lemmaId": "інженерка",
       "lemmaPlain": "інженерка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3433,11 +3805,13 @@
     {
       "cefr": "A2",
       "gloss": "ordinary",
+      "glossClean": "ordinary",
       "heritage": "standard",
       "ipa": null,
       "lemma": "звичайний",
       "lemmaId": "звичайний",
       "lemmaPlain": "звичайний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3448,11 +3822,13 @@
     {
       "cefr": "A2",
       "gloss": "in the morning",
+      "glossClean": "in the morning",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зранку",
       "lemmaId": "зранку",
       "lemmaPlain": "зранку",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3463,11 +3839,13 @@
     {
       "cefr": "A2",
       "gloss": "to lie down",
+      "glossClean": "to lie down",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лягти",
       "lemmaId": "лягти",
       "lemmaPlain": "лягти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3478,11 +3856,13 @@
     {
       "cefr": "A2",
       "gloss": "to return",
+      "glossClean": "to return",
       "heritage": "standard",
       "ipa": null,
       "lemma": "повернутися",
       "lemmaId": "повернутися",
       "lemmaPlain": "повернутися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3493,11 +3873,13 @@
     {
       "cefr": "A2",
       "gloss": "to have breakfast",
+      "glossClean": "to have breakfast",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поснідати",
       "lemmaId": "поснідати",
       "lemmaPlain": "поснідати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3508,11 +3890,13 @@
     {
       "cefr": "A2",
       "gloss": "to wake up",
+      "glossClean": "to wake up",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прокинутися",
       "lemmaId": "прокинутися",
       "lemmaPlain": "прокинутися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3523,11 +3907,13 @@
     {
       "cefr": "A2",
       "gloss": "TV series",
+      "glossClean": "TV series",
       "heritage": "standard",
       "ipa": null,
       "lemma": "серіал",
       "lemmaId": "серіал",
       "lemmaPlain": "серіал",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3538,11 +3924,13 @@
     {
       "cefr": "A2",
       "gloss": "dative",
+      "glossClean": "dative",
       "heritage": "standard",
       "ipa": null,
       "lemma": "давальний",
       "lemmaId": "давальний",
       "lemmaPlain": "давальний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3553,11 +3941,13 @@
     {
       "cefr": "A2",
       "gloss": "accusative",
+      "glossClean": "accusative",
       "heritage": "standard",
       "ipa": null,
       "lemma": "знахідний",
       "lemmaId": "знахідний",
       "lemmaPlain": "знахідний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3568,11 +3958,13 @@
     {
       "cefr": "A2",
       "gloss": "vocative",
+      "glossClean": "vocative",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кличний",
       "lemmaId": "кличний",
       "lemmaPlain": "кличний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3583,11 +3975,13 @@
     {
       "cefr": "A2",
       "gloss": "locative",
+      "glossClean": "locative",
       "heritage": "standard",
       "ipa": null,
       "lemma": "місцевий",
       "lemmaId": "місцевий",
       "lemmaPlain": "місцевий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3598,11 +3992,13 @@
     {
       "cefr": "A2",
       "gloss": "nominative",
+      "glossClean": "nominative",
       "heritage": "standard",
       "ipa": null,
       "lemma": "називний",
       "lemmaId": "називний",
       "lemmaPlain": "називний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3613,11 +4009,13 @@
     {
       "cefr": "A2",
       "gloss": "instrumental",
+      "glossClean": "instrumental",
       "heritage": "standard",
       "ipa": null,
       "lemma": "орудний",
       "lemmaId": "орудний",
       "lemmaPlain": "орудний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3628,11 +4026,13 @@
     {
       "cefr": "A2",
       "gloss": "genitive",
+      "glossClean": "genitive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "родовий",
       "lemmaId": "родовий",
       "lemmaPlain": "родовий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3643,11 +4043,13 @@
     {
       "cefr": "A2",
       "gloss": "confidence",
+      "glossClean": "confidence",
       "heritage": "standard",
       "ipa": null,
       "lemma": "впевненість",
       "lemmaId": "впевненість",
       "lemmaPlain": "впевненість",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3658,11 +4060,13 @@
     {
       "cefr": "A2",
       "gloss": "case map",
+      "glossClean": "case map",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "відмінкова карта",
       "lemmaId": "відмінкова-карта",
       "lemmaPlain": "відмінкова карта",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3673,11 +4077,13 @@
     {
       "cefr": "A2",
       "gloss": "grammar topic",
+      "glossClean": "grammar topic",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "граматична тема",
       "lemmaId": "граматична-тема",
       "lemmaPlain": "граматична тема",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3688,11 +4094,13 @@
     {
       "cefr": "A2",
       "gloss": "dative case",
+      "glossClean": "dative case",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "давальний відмінок",
       "lemmaId": "давальний-відмінок",
       "lemmaPlain": "давальний відмінок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3703,11 +4111,13 @@
     {
       "cefr": "A2",
       "gloss": "perfective aspect",
+      "glossClean": "perfective aspect",
       "heritage": "standard",
       "ipa": null,
       "lemma": "доконаний вид",
       "lemmaId": "доконаний-вид",
       "lemmaPlain": "доконаний вид",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3718,11 +4128,13 @@
     {
       "cefr": "A2",
       "gloss": "verb",
+      "glossClean": "verb",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дієслово",
       "lemmaId": "дієслово",
       "lemmaPlain": "дієслово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3733,11 +4145,13 @@
     {
       "cefr": "A2",
       "gloss": "pronoun",
+      "glossClean": "pronoun",
       "heritage": "standard",
       "ipa": null,
       "lemma": "займенник",
       "lemmaId": "займенник",
       "lemmaPlain": "займенник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3748,11 +4162,13 @@
     {
       "cefr": "A2",
       "gloss": "negative pronoun",
+      "glossClean": "negative pronoun",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "заперечний займенник",
       "lemmaId": "заперечний-займенник",
       "lemmaPlain": "заперечний займенник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3763,11 +4179,13 @@
     {
       "cefr": "A2",
       "gloss": "reflexive pronoun",
+      "glossClean": "reflexive pronoun",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "зворотний займенник",
       "lemmaId": "зворотний-займенник",
       "lemmaPlain": "зворотний займенник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3778,11 +4196,13 @@
     {
       "cefr": "A2",
       "gloss": "future tense",
+      "glossClean": "future tense",
       "heritage": "standard",
       "ipa": null,
       "lemma": "майбутній час",
       "lemmaId": "майбутній-час",
       "lemmaPlain": "майбутній час",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3793,11 +4213,13 @@
     {
       "cefr": "A2",
       "gloss": "imperfective aspect",
+      "glossClean": "imperfective aspect",
       "heritage": "standard",
       "ipa": null,
       "lemma": "недоконаний вид",
       "lemmaId": "недоконаний-вид",
       "lemmaPlain": "недоконаний вид",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3808,11 +4230,13 @@
     {
       "cefr": "A2",
       "gloss": "indefinite pronoun",
+      "glossClean": "indefinite pronoun",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "неозначений займенник",
       "lemmaId": "неозначений-займенник",
       "lemmaPlain": "неозначений займенник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3823,11 +4247,13 @@
     {
       "cefr": "A2",
       "gloss": "instrumental case",
+      "glossClean": "instrumental case",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "орудний відмінок",
       "lemmaId": "орудний-відмінок",
       "lemmaPlain": "орудний відмінок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3838,11 +4264,13 @@
     {
       "cefr": "A2",
       "gloss": "error, mistake",
+      "glossClean": "error",
       "heritage": "standard",
       "ipa": null,
       "lemma": "помилка",
       "lemmaId": "помилка",
       "lemmaPlain": "помилка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3882,11 +4310,13 @@
     {
       "cefr": "A2",
       "gloss": "adjective",
+      "glossClean": "adjective",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прикметник",
       "lemmaId": "прикметник",
       "lemmaPlain": "прикметник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3897,11 +4327,13 @@
     {
       "cefr": "A2",
       "gloss": "summary map",
+      "glossClean": "summary map",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "підсумкова карта",
       "lemmaId": "підсумкова-карта",
       "lemmaPlain": "підсумкова карта",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3912,11 +4344,13 @@
     {
       "cefr": "A2",
       "gloss": "genitive case",
+      "glossClean": "genitive case",
       "heritage": "standard",
       "ipa": null,
       "lemma": "родовий відмінок",
       "lemmaId": "родовий-відмінок",
       "lemmaPlain": "родовий відмінок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3927,11 +4361,13 @@
     {
       "cefr": "A2",
       "gloss": "role of a word",
+      "glossClean": "role of a word",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "роль слова",
       "lemmaId": "роль-слова",
       "lemmaPlain": "роль слова",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3942,11 +4378,13 @@
     {
       "cefr": "A2",
       "gloss": "degree of comparison",
+      "glossClean": "degree of comparison",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "ступінь порівняння",
       "lemmaId": "ступінь-порівняння",
       "lemmaPlain": "ступінь порівняння",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3957,11 +4395,13 @@
     {
       "cefr": "A2",
       "gloss": "route",
+      "glossClean": "route",
       "heritage": "standard",
       "ipa": null,
       "lemma": "маршрут",
       "lemmaId": "маршрут",
       "lemmaPlain": "маршрут",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3972,11 +4412,13 @@
     {
       "cefr": "A2",
       "gloss": "walk, stroll",
+      "glossClean": "walk",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прогулянка",
       "lemmaId": "прогулянка",
       "lemmaPlain": "прогулянка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4016,11 +4458,13 @@
     {
       "cefr": "A2",
       "gloss": "main idea",
+      "glossClean": "main idea",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "головна думка",
       "lemmaId": "головна-думка",
       "lemmaPlain": "головна думка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4031,11 +4475,13 @@
     {
       "cefr": "A2",
       "gloss": "criterion",
+      "glossClean": "criterion",
       "heritage": "standard",
       "ipa": null,
       "lemma": "критерій",
       "lemmaId": "критерій",
       "lemmaPlain": "критерій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4046,11 +4492,13 @@
     {
       "cefr": "A2",
       "gloss": "limited",
+      "glossClean": "limited",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обмежений",
       "lemmaId": "обмежений",
       "lemmaPlain": "обмежений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4061,11 +4509,13 @@
     {
       "cefr": "A2",
       "gloss": "grade, assessment",
+      "glossClean": "grade",
       "heritage": "standard",
       "ipa": null,
       "lemma": "оцінка",
       "lemmaId": "оцінка",
       "lemmaPlain": "оцінка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4105,11 +4555,13 @@
     {
       "cefr": "A2",
       "gloss": "writing",
+      "glossClean": "writing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "письмо",
       "lemmaId": "письмо",
       "lemmaPlain": "письмо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4120,11 +4572,13 @@
     {
       "cefr": "A2",
       "gloss": "practice exam",
+      "glossClean": "practice exam",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пробний іспит",
       "lemmaId": "пробний-іспит",
       "lemmaPlain": "пробний іспит",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4135,11 +4589,13 @@
     {
       "cefr": "A2",
       "gloss": "to clarify",
+      "glossClean": "to clarify",
       "heritage": "standard",
       "ipa": null,
       "lemma": "уточнити",
       "lemmaId": "уточнити",
       "lemmaPlain": "уточнити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4150,11 +4606,13 @@
     {
       "cefr": "A2",
       "gloss": "targeted review",
+      "glossClean": "targeted review",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "цільове повторення",
       "lemmaId": "цільове-повторення",
       "lemmaPlain": "цільове повторення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4165,11 +4623,13 @@
     {
       "cefr": "A2",
       "gloss": "reading",
+      "glossClean": "reading",
       "heritage": "standard",
       "ipa": null,
       "lemma": "читання",
       "lemmaId": "читання",
       "lemmaPlain": "читання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4180,11 +4640,13 @@
     {
       "cefr": "A2",
       "gloss": "administrator, front desk manager",
+      "glossClean": "administrator",
       "heritage": "standard",
       "ipa": null,
       "lemma": "адміністратор",
       "lemmaId": "адміністратор",
       "lemmaPlain": "адміністратор",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4195,11 +4657,13 @@
     {
       "cefr": "A2",
       "gloss": "landmark, sight",
+      "glossClean": "landmark",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "визначне місце",
       "lemmaId": "визначне-місце",
       "lemmaPlain": "визначне місце",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4210,11 +4674,13 @@
     {
       "cefr": "A2",
       "gloss": "verb aspect",
+      "glossClean": "verb aspect",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "вид дієслова",
       "lemmaId": "вид-дієслова",
       "lemmaPlain": "вид дієслова",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4225,11 +4691,13 @@
     {
       "cefr": "A2",
       "gloss": "context",
+      "glossClean": "context",
       "heritage": "standard",
       "ipa": null,
       "lemma": "контекст",
       "lemmaId": "контекст",
       "lemmaPlain": "контекст",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4240,11 +4708,13 @@
     {
       "cefr": "A2",
       "gloss": "concept",
+      "glossClean": "concept",
       "heritage": "standard",
       "ipa": null,
       "lemma": "концепція",
       "lemmaId": "концепція",
       "lemmaPlain": "концепція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4284,11 +4754,13 @@
     {
       "cefr": "A2",
       "gloss": "process",
+      "glossClean": "process",
       "heritage": "standard",
       "ipa": null,
       "lemma": "процес",
       "lemmaId": "процес",
       "lemmaPlain": "процес",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4299,11 +4771,13 @@
     {
       "cefr": "A2",
       "gloss": "to open",
+      "glossClean": "to open",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відкривати / відкрити",
       "lemmaId": "відкривати-відкрити",
       "lemmaPlain": "відкривати / відкрити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4314,11 +4788,13 @@
     {
       "cefr": "A2",
       "gloss": "to call",
+      "glossClean": "to call",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дзвонити / подзвонити",
       "lemmaId": "дзвонити-подзвонити",
       "lemmaPlain": "дзвонити / подзвонити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4329,11 +4805,13 @@
     {
       "cefr": "A2",
       "gloss": "past tense",
+      "glossClean": "past tense",
       "heritage": "standard",
       "ipa": null,
       "lemma": "минулий час",
       "lemmaId": "минулий-час",
       "lemmaPlain": "минулий час",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4344,11 +4822,13 @@
     {
       "cefr": "A2",
       "gloss": "once, one time",
+      "glossClean": "once",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "одного разу",
       "lemmaId": "одного-разу",
       "lemmaPlain": "одного разу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4359,11 +4839,13 @@
     {
       "cefr": "A2",
       "gloss": "suddenly",
+      "glossClean": "suddenly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "раптом",
       "lemmaId": "раптом",
       "lemmaPlain": "раптом",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4374,11 +4856,13 @@
     {
       "cefr": "A2",
       "gloss": "to take",
+      "glossClean": "to take",
       "heritage": "standard",
       "ipa": null,
       "lemma": "брати / взяти",
       "lemmaId": "брати-взяти",
       "lemmaPlain": "брати / взяти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4389,11 +4873,13 @@
     {
       "cefr": "A2",
       "gloss": "to cook, to boil",
+      "glossClean": "to cook",
       "heritage": "standard",
       "ipa": null,
       "lemma": "варити / зварити",
       "lemmaId": "варити-зварити",
       "lemmaPlain": "варити / зварити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4404,11 +4890,13 @@
     {
       "cefr": "A2",
       "gloss": "aspectual pair",
+      "glossClean": "aspectual pair",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "видова пара",
       "lemmaId": "видова-пара",
       "lemmaPlain": "видова пара",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4419,11 +4907,13 @@
     {
       "cefr": "A2",
       "gloss": "aspectual partner",
+      "glossClean": "aspectual partner",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "видовий партнер",
       "lemmaId": "видовий-партнер",
       "lemmaPlain": "видовий партнер",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4434,11 +4924,13 @@
     {
       "cefr": "A2",
       "gloss": "to decide, to solve",
+      "glossClean": "to decide",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вирішувати / вирішити",
       "lemmaId": "вирішувати-вирішити",
       "lemmaPlain": "вирішувати / вирішити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4449,11 +4941,13 @@
     {
       "cefr": "A2",
       "gloss": "to learn, to study",
+      "glossClean": "to learn",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вчити / вивчити",
       "lemmaId": "вчити-вивчити",
       "lemmaPlain": "вчити / вивчити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4464,11 +4958,13 @@
     {
       "cefr": "A2",
       "gloss": "to write down",
+      "glossClean": "to write down",
       "heritage": "standard",
       "ipa": null,
       "lemma": "записувати",
       "lemmaId": "записувати",
       "lemmaPlain": "записувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4479,11 +4975,13 @@
     {
       "cefr": "A2",
       "gloss": "to find",
+      "glossClean": "to find",
       "heritage": "standard",
       "ipa": null,
       "lemma": "знаходити / знайти",
       "lemmaId": "знаходити-знайти",
       "lemmaPlain": "знаходити / знайти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4494,11 +4992,13 @@
     {
       "cefr": "A2",
       "gloss": "to put",
+      "glossClean": "to put",
       "heritage": "standard",
       "ipa": null,
       "lemma": "класти / покласти",
       "lemmaId": "класти-покласти",
       "lemmaPlain": "класти / покласти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4509,11 +5009,13 @@
     {
       "cefr": "A2",
       "gloss": "to catch",
+      "glossClean": "to catch",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ловити / піймати",
       "lemmaId": "ловити-піймати",
       "lemmaPlain": "ловити / піймати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4524,11 +5026,13 @@
     {
       "cefr": "A2",
       "gloss": "pattern, model",
+      "glossClean": "pattern",
       "heritage": "standard",
       "ipa": null,
       "lemma": "модель",
       "lemmaId": "модель",
       "lemmaPlain": "модель",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4539,11 +5043,13 @@
     {
       "cefr": "A2",
       "gloss": "pair",
+      "glossClean": "pair",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пара",
       "lemmaId": "пара",
       "lemmaPlain": "пара",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4554,11 +5060,13 @@
     {
       "cefr": "A2",
       "gloss": "to return",
+      "glossClean": "to return",
       "heritage": "standard",
       "ipa": null,
       "lemma": "повертати / повернути",
       "lemmaId": "повертати-повернути",
       "lemmaPlain": "повертати / повернути",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4569,11 +5077,13 @@
     {
       "cefr": "A2",
       "gloss": "to close",
+      "glossClean": "to close",
       "heritage": "standard",
       "ipa": null,
       "lemma": "закривати / закрити",
       "lemmaId": "закривати-закрити",
       "lemmaPlain": "закривати / закрити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4584,11 +5094,13 @@
     {
       "cefr": "A2",
       "gloss": "to write down, to record",
+      "glossClean": "to write down",
       "heritage": "standard",
       "ipa": null,
       "lemma": "записувати / записати",
       "lemmaId": "записувати-записати",
       "lemmaPlain": "записувати / записати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4599,11 +5111,13 @@
     {
       "cefr": "A2",
       "gloss": "to explain",
+      "glossClean": "to explain",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пояснювати / пояснити",
       "lemmaId": "пояснювати-пояснити",
       "lemmaPlain": "пояснювати / пояснити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4614,11 +5128,13 @@
     {
       "cefr": "A2",
       "gloss": "to clean, to tidy",
+      "glossClean": "to clean",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прибирати / прибрати",
       "lemmaId": "прибирати-прибрати",
       "lemmaPlain": "прибирати / прибрати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4629,11 +5145,13 @@
     {
       "cefr": "A2",
       "gloss": "nevertheless, despite that",
+      "glossClean": "nevertheless",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "незважаючи на це",
       "lemmaId": "незважаючи-на-це",
       "lemmaPlain": "незважаючи на це",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4644,11 +5162,13 @@
     {
       "cefr": "A2",
       "gloss": "despite this",
+      "glossClean": "despite this",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "попри це",
       "lemmaId": "попри-це",
       "lemmaPlain": "попри це",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4659,11 +5179,13 @@
     {
       "cefr": "A2",
       "gloss": "subordinate clause",
+      "glossClean": "subordinate clause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "підрядна частина",
       "lemmaId": "підрядна-частина",
       "lemmaPlain": "підрядна частина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4674,11 +5196,13 @@
     {
       "cefr": "A2",
       "gloss": "complex sentence",
+      "glossClean": "complex sentence",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "складне речення",
       "lemmaId": "складне-речення",
       "lemmaPlain": "складне речення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4689,11 +5213,13 @@
     {
       "cefr": "A2",
       "gloss": "wedding",
+      "glossClean": "wedding",
       "heritage": "standard",
       "ipa": null,
       "lemma": "весілля",
       "lemmaId": "весілля",
       "lemmaPlain": "весілля",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4704,11 +5230,13 @@
     {
       "cefr": "A2",
       "gloss": "to correct",
+      "glossClean": "to correct",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виправити",
       "lemmaId": "виправити",
       "lemmaPlain": "виправити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4719,11 +5247,13 @@
     {
       "cefr": "A2",
       "gloss": "checkpoint",
+      "glossClean": "checkpoint",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "контрольна точка",
       "lemmaId": "контрольна-точка",
       "lemmaPlain": "контрольна точка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4734,11 +5264,13 @@
     {
       "cefr": "A2",
       "gloss": "candle",
+      "glossClean": "candle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "свічка",
       "lemmaId": "свічка",
       "lemmaPlain": "свічка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4778,11 +5310,13 @@
     {
       "cefr": "A2",
       "gloss": "list",
+      "glossClean": "list",
       "heritage": "standard",
       "ipa": null,
       "lemma": "список",
       "lemmaId": "список",
       "lemmaPlain": "список",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4793,11 +5327,13 @@
     {
       "cefr": "A2",
       "gloss": "to send",
+      "glossClean": "to send",
       "heritage": "standard",
       "ipa": null,
       "lemma": "надіслати",
       "lemmaId": "надіслати",
       "lemmaPlain": "надіслати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4808,11 +5344,13 @@
     {
       "cefr": "A2",
       "gloss": "necessary, needed",
+      "glossClean": "necessary",
       "heritage": "standard",
       "ipa": null,
       "lemma": "потрібно",
       "lemmaId": "потрібно",
       "lemmaPlain": "потрібно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4823,11 +5361,13 @@
     {
       "cefr": "A2",
       "gloss": "worker, staff member",
+      "glossClean": "worker",
       "heritage": "standard",
       "ipa": null,
       "lemma": "працівник",
       "lemmaId": "працівник",
       "lemmaPlain": "працівник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4838,11 +5378,13 @@
     {
       "cefr": "A2",
       "gloss": "to choose",
+      "glossClean": "to choose",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вибрати",
       "lemmaId": "вибрати",
       "lemmaPlain": "вибрати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4853,11 +5395,13 @@
     {
       "cefr": "A2",
       "gloss": "guide",
+      "glossClean": "guide",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гід",
       "lemmaId": "гід",
       "lemmaPlain": "гід",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4868,11 +5412,13 @@
     {
       "cefr": "A2",
       "gloss": "cathedral",
+      "glossClean": "cathedral",
       "heritage": "standard",
       "ipa": null,
       "lemma": "собор",
       "lemmaId": "собор",
       "lemmaPlain": "собор",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4883,11 +5429,13 @@
     {
       "cefr": "A2",
       "gloss": "to identify, to determine",
+      "glossClean": "to identify",
       "heritage": "standard",
       "ipa": null,
       "lemma": "визначити",
       "lemmaId": "визначити",
       "lemmaPlain": "визначити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4898,11 +5446,13 @@
     {
       "cefr": "A2",
       "gloss": "tool, instrument",
+      "glossClean": "tool",
       "heritage": "standard",
       "ipa": null,
       "lemma": "знаряддя",
       "lemmaId": "знаряддя",
       "lemmaPlain": "знаряддя",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4913,11 +5463,13 @@
     {
       "cefr": "A2",
       "gloss": "accompaniment, company",
+      "glossClean": "accompaniment",
       "heritage": "standard",
       "ipa": null,
       "lemma": "супровід",
       "lemmaId": "супровід",
       "lemmaPlain": "супровід",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4928,11 +5480,13 @@
     {
       "cefr": "A2",
       "gloss": "reported speech",
+      "glossClean": "reported speech",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "непряма мова",
       "lemmaId": "непряма-мова",
       "lemmaPlain": "непряма мова",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4943,11 +5497,13 @@
     {
       "cefr": "A2",
       "gloss": "direct word order",
+      "glossClean": "direct word order",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "прямий порядок",
       "lemmaId": "прямий-порядок",
       "lemmaPlain": "прямий порядок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4958,11 +5514,13 @@
     {
       "cefr": "A2",
       "gloss": "one-time event",
+      "glossClean": "one-time event",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "одноразова подія",
       "lemmaId": "одноразова-подія",
       "lemmaPlain": "одноразова подія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4973,11 +5531,13 @@
     {
       "cefr": "A2",
       "gloss": "bigger",
+      "glossClean": "bigger",
       "heritage": "standard",
       "ipa": null,
       "lemma": "більший",
       "lemmaId": "більший",
       "lemmaPlain": "більший",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4988,11 +5548,13 @@
     {
       "cefr": "A2",
       "gloss": "heavier",
+      "glossClean": "heavier",
       "heritage": "standard",
       "ipa": null,
       "lemma": "важчий",
       "lemmaId": "важчий",
       "lemmaPlain": "важчий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5003,11 +5565,13 @@
     {
       "cefr": "A2",
       "gloss": "worse",
+      "glossClean": "worse",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гірший",
       "lemmaId": "гірший",
       "lemmaPlain": "гірший",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5018,11 +5582,13 @@
     {
       "cefr": "A2",
       "gloss": "more expensive",
+      "glossClean": "more expensive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дорожчий",
       "lemmaId": "дорожчий",
       "lemmaPlain": "дорожчий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5033,11 +5599,13 @@
     {
       "cefr": "A2",
       "gloss": "more convenient",
+      "glossClean": "more convenient",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зручніший",
       "lemmaId": "зручніший",
       "lemmaPlain": "зручніший",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5048,11 +5616,13 @@
     {
       "cefr": "A2",
       "gloss": "better",
+      "glossClean": "better",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кращий",
       "lemmaId": "кращий",
       "lemmaPlain": "кращий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5063,11 +5633,13 @@
     {
       "cefr": "A2",
       "gloss": "smaller",
+      "glossClean": "smaller",
       "heritage": "standard",
       "ipa": null,
       "lemma": "менший",
       "lemmaId": "менший",
       "lemmaPlain": "менший",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5078,11 +5650,13 @@
     {
       "cefr": "A2",
       "gloss": "much, significantly",
+      "glossClean": "much",
       "heritage": "standard",
       "ipa": null,
       "lemma": "набагато",
       "lemmaId": "набагато",
       "lemmaPlain": "набагато",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5093,11 +5667,13 @@
     {
       "cefr": "A2",
       "gloss": "the biggest",
+      "glossClean": "the biggest",
       "heritage": "standard",
       "ipa": null,
       "lemma": "найбільший",
       "lemmaId": "найбільший",
       "lemmaPlain": "найбільший",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5108,11 +5684,13 @@
     {
       "cefr": "A2",
       "gloss": "the smallest",
+      "glossClean": "the smallest",
       "heritage": "standard",
       "ipa": null,
       "lemma": "найменший",
       "lemmaId": "найменший",
       "lemmaPlain": "найменший",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5123,11 +5701,13 @@
     {
       "cefr": "A2",
       "gloss": "sweeter",
+      "glossClean": "sweeter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "солодший",
       "lemmaId": "солодший",
       "lemmaPlain": "солодший",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5138,11 +5718,13 @@
     {
       "cefr": "A2",
       "gloss": "quieter",
+      "glossClean": "quieter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тихіший",
       "lemmaId": "тихіший",
       "lemmaPlain": "тихіший",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5153,11 +5735,13 @@
     {
       "cefr": "A2",
       "gloss": "more interesting",
+      "glossClean": "more interesting",
       "heritage": "standard",
       "ipa": null,
       "lemma": "цікавіший",
       "lemmaId": "цікавіший",
       "lemmaPlain": "цікавіший",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5168,11 +5752,13 @@
     {
       "cefr": "A2",
       "gloss": "noun phrase",
+      "glossClean": "noun phrase",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "іменникова група",
       "lemmaId": "іменникова-група",
       "lemmaPlain": "іменникова група",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5183,11 +5769,13 @@
     {
       "cefr": "A2",
       "gloss": "to answer, to reply",
+      "glossClean": "to answer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відповісти",
       "lemmaId": "відповісти",
       "lemmaPlain": "відповісти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5198,11 +5786,13 @@
     {
       "cefr": "A2",
       "gloss": "to explain",
+      "glossClean": "to explain",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пояснити",
       "lemmaId": "пояснити",
       "lemmaPlain": "пояснити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5213,11 +5803,13 @@
     {
       "cefr": "A2",
       "gloss": "to tell, to narrate",
+      "glossClean": "to tell",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розповісти",
       "lemmaId": "розповісти",
       "lemmaPlain": "розповісти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5228,11 +5820,13 @@
     {
       "cefr": "A2",
       "gloss": "boring, bored",
+      "glossClean": "boring",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нудно",
       "lemmaId": "нудно",
       "lemmaPlain": "нудно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5243,11 +5837,13 @@
     {
       "cefr": "A2",
       "gloss": "to call, to phone",
+      "glossClean": "to call",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дзвонити",
       "lemmaId": "дзвонити",
       "lemmaPlain": "дзвонити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5258,11 +5854,13 @@
     {
       "cefr": "A2",
       "gloss": "teacher",
+      "glossClean": "teacher",
       "heritage": "standard",
       "ipa": null,
       "lemma": "учитель",
       "lemmaId": "учитель",
       "lemmaPlain": "учитель",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5273,11 +5871,13 @@
     {
       "cefr": "A2",
       "gloss": "exhibition",
+      "glossClean": "exhibition",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виставка",
       "lemmaId": "виставка",
       "lemmaPlain": "виставка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5317,11 +5917,13 @@
     {
       "cefr": "A2",
       "gloss": "leisure, free time",
+      "glossClean": "leisure",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дозвілля",
       "lemmaId": "дозвілля",
       "lemmaPlain": "дозвілля",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5332,11 +5934,13 @@
     {
       "cefr": "A2",
       "gloss": "to do, to be engaged in",
+      "glossClean": "to do",
       "heritage": "standard",
       "ipa": null,
       "lemma": "займатися",
       "lemmaId": "займатися",
       "lemmaPlain": "займатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5347,11 +5951,13 @@
     {
       "cefr": "A2",
       "gloss": "to be passionate about",
+      "glossClean": "to be passionate about",
       "heritage": "standard",
       "ipa": null,
       "lemma": "захоплюватися",
       "lemmaId": "захоплюватися",
       "lemmaPlain": "захоплюватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5362,11 +5968,13 @@
     {
       "cefr": "A2",
       "gloss": "competition",
+      "glossClean": "competition",
       "heritage": "standard",
       "ipa": null,
       "lemma": "змагання",
       "lemmaId": "змагання",
       "lemmaPlain": "змагання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5377,11 +5985,13 @@
     {
       "cefr": "A2",
       "gloss": "drawing, painting",
+      "glossClean": "drawing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "малювання",
       "lemmaId": "малювання",
       "lemmaPlain": "малювання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5392,11 +6002,13 @@
     {
       "cefr": "A2",
       "gloss": "swimming",
+      "glossClean": "swimming",
       "heritage": "standard",
       "ipa": null,
       "lemma": "плавання",
       "lemmaId": "плавання",
       "lemmaPlain": "плавання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5407,11 +6019,13 @@
     {
       "cefr": "A2",
       "gloss": "to be interested in",
+      "glossClean": "to be interested in",
       "heritage": "standard",
       "ipa": null,
       "lemma": "цікавитися",
       "lemmaId": "цікавитися",
       "lemmaPlain": "цікавитися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5422,11 +6036,13 @@
     {
       "cefr": "A2",
       "gloss": "schedule",
+      "glossClean": "schedule",
       "heritage": "standard",
       "ipa": null,
       "lemma": "графік",
       "lemmaId": "графік",
       "lemmaPlain": "графік",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5437,11 +6053,13 @@
     {
       "cefr": "A2",
       "gloss": "manager, supervisor",
+      "glossClean": "manager",
       "heritage": "standard",
       "ipa": null,
       "lemma": "керівник",
       "lemmaId": "керівник",
       "lemmaPlain": "керівник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5452,11 +6070,13 @@
     {
       "cefr": "A2",
       "gloss": "skills",
+      "glossClean": "skills",
       "heritage": "standard",
       "ipa": null,
       "lemma": "навички",
       "lemmaId": "навички",
       "lemmaPlain": "навички",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5467,11 +6087,13 @@
     {
       "cefr": "A2",
       "gloss": "to use",
+      "glossClean": "to use",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вживати",
       "lemmaId": "вживати",
       "lemmaPlain": "вживати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5482,11 +6104,13 @@
     {
       "cefr": "A2",
       "gloss": "to avoid",
+      "glossClean": "to avoid",
       "heritage": "standard",
       "ipa": null,
       "lemma": "уникати",
       "lemmaId": "уникати",
       "lemmaPlain": "уникати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5497,11 +6121,13 @@
     {
       "cefr": "A2",
       "gloss": "napkin",
+      "glossClean": "napkin",
       "heritage": "standard",
       "ipa": null,
       "lemma": "серветка",
       "lemmaId": "серветка",
       "lemmaPlain": "серветка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5541,11 +6167,13 @@
     {
       "cefr": "A2",
       "gloss": "lost and found office",
+      "glossClean": "lost and found office",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "бюро знахідок",
       "lemmaId": "бюро-знахідок",
       "lemmaPlain": "бюро знахідок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5556,11 +6184,13 @@
     {
       "cefr": "A2",
       "gloss": "umbrella",
+      "glossClean": "umbrella",
       "heritage": "standard",
       "ipa": null,
       "lemma": "парасолька",
       "lemmaId": "парасолька",
       "lemmaPlain": "парасолька",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5600,11 +6230,13 @@
     {
       "cefr": "A2",
       "gloss": "backpack",
+      "glossClean": "backpack",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рюкзак",
       "lemmaId": "рюкзак",
       "lemmaPlain": "рюкзак",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5615,11 +6247,13 @@
     {
       "cefr": "A2",
       "gloss": "booking, reservation",
+      "glossClean": "booking",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бронювання",
       "lemmaId": "бронювання",
       "lemmaPlain": "бронювання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5630,11 +6264,13 @@
     {
       "cefr": "A2",
       "gloss": "numeral",
+      "glossClean": "numeral",
       "heritage": "standard",
       "ipa": null,
       "lemma": "числівник",
       "lemmaId": "числівник",
       "lemmaPlain": "числівник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5645,11 +6281,13 @@
     {
       "cefr": "A2",
       "gloss": "a few, several",
+      "glossClean": "a few",
       "heritage": "standard",
       "ipa": null,
       "lemma": "декілька",
       "lemmaId": "декілька",
       "lemmaPlain": "декілька",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5660,11 +6298,13 @@
     {
       "cefr": "A2",
       "gloss": "stove",
+      "glossClean": "stove",
       "heritage": "standard",
       "ipa": null,
       "lemma": "плита",
       "lemmaId": "плита",
       "lemmaPlain": "плита",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5704,11 +6344,13 @@
     {
       "cefr": "A2",
       "gloss": "jar, can",
+      "glossClean": "jar",
       "heritage": "standard",
       "ipa": null,
       "lemma": "банка",
       "lemmaId": "банка",
       "lemmaPlain": "банка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5748,11 +6390,13 @@
     {
       "cefr": "A2",
       "gloss": "exception",
+      "glossClean": "exception",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виняток",
       "lemmaId": "виняток",
       "lemmaPlain": "виняток",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5763,11 +6407,13 @@
     {
       "cefr": "A2",
       "gloss": "inserted vowel",
+      "glossClean": "inserted vowel",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "вставний голосний",
       "lemmaId": "вставний-голосний",
       "lemmaPlain": "вставний голосний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5778,11 +6424,13 @@
     {
       "cefr": "A2",
       "gloss": "supply, stock",
+      "glossClean": "supply",
       "heritage": "standard",
       "ipa": null,
       "lemma": "запас",
       "lemmaId": "запас",
       "lemmaPlain": "запас",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5793,11 +6441,13 @@
     {
       "cefr": "A2",
       "gloss": "zero ending",
+      "glossClean": "zero ending",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "нульове закінчення",
       "lemmaId": "нульове-закінчення",
       "lemmaPlain": "нульове закінчення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5808,11 +6458,13 @@
     {
       "cefr": "A2",
       "gloss": "bag, packet",
+      "glossClean": "bag",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пакет",
       "lemmaId": "пакет",
       "lemmaPlain": "пакет",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5823,11 +6475,13 @@
     {
       "cefr": "A2",
       "gloss": "article",
+      "glossClean": "article",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стаття",
       "lemmaId": "стаття",
       "lemmaPlain": "стаття",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5838,11 +6492,13 @@
     {
       "cefr": "A2",
       "gloss": "deadline, term",
+      "glossClean": "deadline",
       "heritage": "standard",
       "ipa": null,
       "lemma": "термін",
       "lemmaId": "термін",
       "lemmaPlain": "термін",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5853,11 +6509,13 @@
     {
       "cefr": "A2",
       "gloss": "central",
+      "glossClean": "central",
       "heritage": "standard",
       "ipa": null,
       "lemma": "центральний",
       "lemmaId": "центральний",
       "lemmaPlain": "центральний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5868,11 +6526,13 @@
     {
       "cefr": "A2",
       "gloss": "interest",
+      "glossClean": "interest",
       "heritage": "standard",
       "ipa": null,
       "lemma": "інтерес",
       "lemmaId": "інтерес",
       "lemmaPlain": "інтерес",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5883,11 +6543,13 @@
     {
       "cefr": "A2",
       "gloss": "fire",
+      "glossClean": "fire",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вогонь",
       "lemmaId": "вогонь",
       "lemmaPlain": "вогонь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5898,11 +6560,13 @@
     {
       "cefr": "A2",
       "gloss": "road",
+      "glossClean": "road",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дорога",
       "lemmaId": "дорога",
       "lemmaPlain": "дорога",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5942,11 +6606,13 @@
     {
       "cefr": "A2",
       "gloss": "blanket",
+      "glossClean": "blanket",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ковдра",
       "lemmaId": "ковдра",
       "lemmaPlain": "ковдра",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5986,11 +6652,13 @@
     {
       "cefr": "A2",
       "gloss": "doubt",
+      "glossClean": "doubt",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сумнів",
       "lemmaId": "сумнів",
       "lemmaPlain": "сумнів",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6001,11 +6669,13 @@
     {
       "cefr": "A2",
       "gloss": "gold",
+      "glossClean": "gold",
       "heritage": "standard",
       "ipa": null,
       "lemma": "золото",
       "lemmaId": "золото",
       "lemmaPlain": "золото",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6016,11 +6686,13 @@
     {
       "cefr": "A2",
       "gloss": "material",
+      "glossClean": "material",
       "heritage": "standard",
       "ipa": null,
       "lemma": "матеріал",
       "lemmaId": "матеріал",
       "lemmaPlain": "матеріал",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6031,11 +6703,13 @@
     {
       "cefr": "A2",
       "gloss": "advice, recommendation",
+      "glossClean": "advice",
       "heritage": "standard",
       "ipa": null,
       "lemma": "порада",
       "lemmaId": "порада",
       "lemmaPlain": "порада",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -6075,11 +6749,13 @@
     {
       "cefr": "A2",
       "gloss": "balcony",
+      "glossClean": "balcony",
       "heritage": "standard",
       "ipa": null,
       "lemma": "балкон",
       "lemmaId": "балкон",
       "lemmaPlain": "балкон",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6090,11 +6766,13 @@
     {
       "cefr": "A2",
       "gloss": "bathroom",
+      "glossClean": "bathroom",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "ванна кімната",
       "lemmaId": "ванна-кімната",
       "lemmaPlain": "ванна кімната",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6105,11 +6783,13 @@
     {
       "cefr": "A2",
       "gloss": "host",
+      "glossClean": "host",
       "heritage": "standard",
       "ipa": null,
       "lemma": "господар",
       "lemmaId": "господар",
       "lemmaPlain": "господар",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6120,11 +6800,13 @@
     {
       "cefr": "A2",
       "gloss": "study, home office",
+      "glossClean": "study",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кабінет",
       "lemmaId": "кабінет",
       "lemmaPlain": "кабінет",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6135,11 +6817,13 @@
     {
       "cefr": "A2",
       "gloss": "shelf",
+      "glossClean": "shelf",
       "heritage": "standard",
       "ipa": null,
       "lemma": "полиця",
       "lemmaId": "полиця",
       "lemmaPlain": "полиця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -6179,11 +6863,13 @@
     {
       "cefr": "A2",
       "gloss": "daily routine",
+      "glossClean": "daily routine",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "розпорядок дня",
       "lemmaId": "розпорядок-дня",
       "lemmaPlain": "розпорядок дня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6194,11 +6880,13 @@
     {
       "cefr": "A2",
       "gloss": "be",
+      "glossClean": "be",
       "heritage": "standard",
       "ipa": null,
       "lemma": "будьте",
       "lemmaId": "будьте",
       "lemmaPlain": "будьте",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6209,11 +6897,13 @@
     {
       "cefr": "A2",
       "gloss": "to chop, slice",
+      "glossClean": "to chop",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нарізати",
       "lemmaId": "нарізати",
       "lemmaPlain": "нарізати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6224,11 +6914,13 @@
     {
       "cefr": "A2",
       "gloss": "do not open",
+      "glossClean": "do not open",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "не відкривайте",
       "lemmaId": "не-відкривайте",
       "lemmaPlain": "не відкривайте",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6239,11 +6931,13 @@
     {
       "cefr": "A2",
       "gloss": "do not forget",
+      "glossClean": "do not forget",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "не забудь",
       "lemmaId": "не-забудь",
       "lemmaPlain": "не забудь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6254,11 +6948,13 @@
     {
       "cefr": "A2",
       "gloss": "to go, to leave by vehicle",
+      "glossClean": "to go",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поїхати",
       "lemmaId": "поїхати",
       "lemmaPlain": "поїхати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6269,11 +6965,13 @@
     {
       "cefr": "A2",
       "gloss": "let, may",
+      "glossClean": "let",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хай",
       "lemmaId": "хай",
       "lemmaPlain": "хай",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6284,11 +6982,13 @@
     {
       "cefr": "A2",
       "gloss": "anytime",
+      "glossClean": "anytime",
       "heritage": "standard",
       "ipa": null,
       "lemma": "будь-коли",
       "lemmaId": "будь-коли",
       "lemmaPlain": "будь-коли",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6299,11 +6999,13 @@
     {
       "cefr": "A2",
       "gloss": "anyone, whoever",
+      "glossClean": "anyone",
       "heritage": "standard",
       "ipa": null,
       "lemma": "будь-хто",
       "lemmaId": "будь-хто",
       "lemmaPlain": "будь-хто",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6314,11 +7016,13 @@
     {
       "cefr": "A2",
       "gloss": "anything, whatever",
+      "glossClean": "anything",
       "heritage": "standard",
       "ipa": null,
       "lemma": "будь-що",
       "lemmaId": "будь-що",
       "lemmaPlain": "будь-що",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6329,11 +7033,13 @@
     {
       "cefr": "A2",
       "gloss": "sometimes",
+      "glossClean": "sometimes",
       "heritage": "standard",
       "ipa": null,
       "lemma": "деколи",
       "lemmaId": "деколи",
       "lemmaPlain": "деколи",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6344,11 +7050,13 @@
     {
       "cefr": "A2",
       "gloss": "somewhere",
+      "glossClean": "somewhere",
       "heritage": "standard",
       "ipa": null,
       "lemma": "десь",
       "lemmaId": "десь",
       "lemmaPlain": "десь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6359,11 +7067,13 @@
     {
       "cefr": "A2",
       "gloss": "once, sometime",
+      "glossClean": "once",
       "heritage": "standard",
       "ipa": null,
       "lemma": "колись",
       "lemmaId": "колись",
       "lemmaPlain": "колись",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6374,11 +7084,13 @@
     {
       "cefr": "A2",
       "gloss": "with nobody",
+      "glossClean": "with nobody",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "ні з ким",
       "lemmaId": "ні-з-ким",
       "lemmaPlain": "ні з ким",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6389,11 +7101,13 @@
     {
       "cefr": "A2",
       "gloss": "about nothing",
+      "glossClean": "about nothing",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "ні про що",
       "lemmaId": "ні-про-що",
       "lemmaPlain": "ні про що",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6404,11 +7118,13 @@
     {
       "cefr": "A2",
       "gloss": "someone",
+      "glossClean": "someone",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хтось",
       "lemmaId": "хтось",
       "lemmaPlain": "хтось",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6419,11 +7135,13 @@
     {
       "cefr": "A2",
       "gloss": "something",
+      "glossClean": "something",
       "heritage": "standard",
       "ipa": null,
       "lemma": "щось",
       "lemmaId": "щось",
       "lemmaPlain": "щось",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6434,11 +7152,13 @@
     {
       "cefr": "A2",
       "gloss": "summer, related to summer",
+      "glossClean": "summer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "літній",
       "lemmaId": "літній",
       "lemmaPlain": "літній",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6449,11 +7169,13 @@
     {
       "cefr": "A2",
       "gloss": "female neighbor",
+      "glossClean": "female neighbor",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сусідка",
       "lemmaId": "сусідка",
       "lemmaPlain": "сусідка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6464,11 +7186,13 @@
     {
       "cefr": "A2",
       "gloss": "meanwhile",
+      "glossClean": "meanwhile",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "тим часом",
       "lemmaId": "тим-часом",
       "lemmaPlain": "тим часом",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6479,11 +7203,13 @@
     {
       "cefr": "A2",
       "gloss": "this evening",
+      "glossClean": "this evening",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "цим вечором",
       "lemmaId": "цим-вечором",
       "lemmaPlain": "цим вечором",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6494,11 +7220,13 @@
     {
       "cefr": "A2",
       "gloss": "fir tree",
+      "glossClean": "fir tree",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ялинка",
       "lemmaId": "ялинка",
       "lemmaPlain": "ялинка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -6538,11 +7266,13 @@
     {
       "cefr": "A2",
       "gloss": "ruler",
+      "glossClean": "ruler",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лінійка",
       "lemmaId": "лінійка",
       "lemmaPlain": "лінійка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -6582,11 +7312,13 @@
     {
       "cefr": "A2",
       "gloss": "scissors",
+      "glossClean": "scissors",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ножиці",
       "lemmaId": "ножиці",
       "lemmaPlain": "ножиці",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6597,11 +7329,13 @@
     {
       "cefr": "A2",
       "gloss": "paint",
+      "glossClean": "paint",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фарба",
       "lemmaId": "фарба",
       "lemmaPlain": "фарба",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -6641,11 +7375,13 @@
     {
       "cefr": "A2",
       "gloss": "fireplace",
+      "glossClean": "fireplace",
       "heritage": "standard",
       "ipa": null,
       "lemma": "камін",
       "lemmaId": "камін",
       "lemmaPlain": "камін",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6656,11 +7392,13 @@
     {
       "cefr": "A2",
       "gloss": "between",
+      "glossClean": "between",
       "heritage": "standard",
       "ipa": null,
       "lemma": "між",
       "lemmaId": "між",
       "lemmaPlain": "між",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6671,11 +7409,13 @@
     {
       "cefr": "A2",
       "gloss": "above, over",
+      "glossClean": "above",
       "heritage": "standard",
       "ipa": null,
       "lemma": "над",
       "lemmaId": "над",
       "lemmaPlain": "над",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6686,11 +7426,13 @@
     {
       "cefr": "A2",
       "gloss": "under, below",
+      "glossClean": "under",
       "heritage": "standard",
       "ipa": null,
       "lemma": "під",
       "lemmaId": "під",
       "lemmaPlain": "під",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6701,11 +7443,13 @@
     {
       "cefr": "A2",
       "gloss": "floor",
+      "glossClean": "floor",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підлога",
       "lemmaId": "підлога",
       "lemmaPlain": "підлога",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -6745,11 +7489,13 @@
     {
       "cefr": "A2",
       "gloss": "ceiling",
+      "glossClean": "ceiling",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стеля",
       "lemmaId": "стеля",
       "lemmaPlain": "стеля",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -6789,11 +7535,13 @@
     {
       "cefr": "A2",
       "gloss": "specialty, profession",
+      "glossClean": "specialty",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фах",
       "lemmaId": "фах",
       "lemmaPlain": "фах",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6804,11 +7552,13 @@
     {
       "cefr": "A2",
       "gloss": "to look, to appear",
+      "glossClean": "to look",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виглядати",
       "lemmaId": "виглядати",
       "lemmaPlain": "виглядати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6819,11 +7569,13 @@
     {
       "cefr": "A2",
       "gloss": "responsible",
+      "glossClean": "responsible",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відповідальний",
       "lemmaId": "відповідальний",
       "lemmaPlain": "відповідальний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6834,11 +7586,13 @@
     {
       "cefr": "A2",
       "gloss": "acquaintance",
+      "glossClean": "acquaintance",
       "heritage": "standard",
       "ipa": null,
       "lemma": "знайомий",
       "lemmaId": "знайомий",
       "lemmaPlain": "знайомий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6849,11 +7603,13 @@
     {
       "cefr": "A2",
       "gloss": "to describe",
+      "glossClean": "to describe",
       "heritage": "standard",
       "ipa": null,
       "lemma": "описувати",
       "lemmaId": "описувати",
       "lemmaPlain": "описувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6864,11 +7620,13 @@
     {
       "cefr": "A2",
       "gloss": "friendly, welcoming",
+      "glossClean": "friendly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "привітний",
       "lemmaId": "привітний",
       "lemmaPlain": "привітний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6879,11 +7637,13 @@
     {
       "cefr": "A2",
       "gloss": "fair, just",
+      "glossClean": "fair",
       "heritage": "standard",
       "ipa": null,
       "lemma": "справедливий",
       "lemmaId": "справедливий",
       "lemmaPlain": "справедливий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6894,11 +7654,13 @@
     {
       "cefr": "A2",
       "gloss": "politics",
+      "glossClean": "politics",
       "heritage": "standard",
       "ipa": null,
       "lemma": "політика",
       "lemmaId": "політика",
       "lemmaPlain": "політика",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -6938,11 +7700,13 @@
     {
       "cefr": "A2",
       "gloss": "word structure",
+      "glossClean": "word structure",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "будова слова",
       "lemmaId": "будова-слова",
       "lemmaPlain": "будова слова",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6953,11 +7717,13 @@
     {
       "cefr": "A2",
       "gloss": "grammatical meaning",
+      "glossClean": "grammatical meaning",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "граматичне значення",
       "lemmaId": "граматичне-значення",
       "lemmaPlain": "граматичне значення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6968,11 +7734,13 @@
     {
       "cefr": "A2",
       "gloss": "expressed ending",
+      "glossClean": "expressed ending",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "звукове закінчення",
       "lemmaId": "звукове-закінчення",
       "lemmaPlain": "звукове закінчення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6983,11 +7751,13 @@
     {
       "cefr": "A2",
       "gloss": "to change",
+      "glossClean": "to change",
       "heritage": "standard",
       "ipa": null,
       "lemma": "змінюватися",
       "lemmaId": "змінюватися",
       "lemmaPlain": "змінюватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6998,11 +7768,13 @@
     {
       "cefr": "A2",
       "gloss": "lexical meaning",
+      "glossClean": "lexical meaning",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "лексичне значення",
       "lemmaId": "лексичне-значення",
       "lemmaPlain": "лексичне значення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7013,11 +7785,13 @@
     {
       "cefr": "A2",
       "gloss": "adverb",
+      "glossClean": "adverb",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прислівник",
       "lemmaId": "прислівник",
       "lemmaPlain": "прислівник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7028,11 +7802,13 @@
     {
       "cefr": "A2",
       "gloss": "morphemic analysis",
+      "glossClean": "morphemic analysis",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "розбір слова за будовою",
       "lemmaId": "розбір-слова-за-будовою",
       "lemmaPlain": "розбір слова за будовою",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7043,11 +7819,13 @@
     {
       "cefr": "A2",
       "gloss": "independent part of speech",
+      "glossClean": "independent part of speech",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "самостійна частина мови",
       "lemmaId": "самостійна-частина-мови",
       "lemmaPlain": "самостійна частина мови",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7058,11 +7836,13 @@
     {
       "cefr": "A2",
       "gloss": "function word",
+      "glossClean": "function word",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "службова частина мови",
       "lemmaId": "службова-частина-мови",
       "lemmaPlain": "службова частина мови",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7073,11 +7853,13 @@
     {
       "cefr": "A2",
       "gloss": "free stress",
+      "glossClean": "free stress",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "вільний наголос",
       "lemmaId": "вільний-наголос",
       "lemmaPlain": "вільний наголос",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7088,11 +7870,13 @@
     {
       "cefr": "A2",
       "gloss": "writing system",
+      "glossClean": "writing system",
       "heritage": "standard",
       "ipa": null,
       "lemma": "графіка",
       "lemmaId": "графіка",
       "lemmaPlain": "графіка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -7132,11 +7916,13 @@
     {
       "cefr": "A2",
       "gloss": "pronunciation error",
+      "glossClean": "pronunciation error",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "орфоепічна помилка",
       "lemmaId": "орфоепічна-помилка",
       "lemmaPlain": "орфоепічна помилка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7147,11 +7933,13 @@
     {
       "cefr": "A2",
       "gloss": "mobile stress",
+      "glossClean": "mobile stress",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "рухомий наголос",
       "lemmaId": "рухомий-наголос",
       "lemmaPlain": "рухомий наголос",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7162,11 +7950,13 @@
     {
       "cefr": "A2",
       "gloss": "grammatical core",
+      "glossClean": "grammatical core",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "граматична основа",
       "lemmaId": "граматична-основа",
       "lemmaPlain": "граматична основа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7177,11 +7967,13 @@
     {
       "cefr": "A2",
       "gloss": "answer",
+      "glossClean": "answer",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "дайте відповідь",
       "lemmaId": "дайте-відповідь",
       "lemmaPlain": "дайте відповідь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7192,11 +7984,13 @@
     {
       "cefr": "A2",
       "gloss": "morphemic analysis",
+      "glossClean": "morphemic analysis",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "морфемний аналіз",
       "lemmaId": "морфемний-аналіз",
       "lemmaPlain": "морфемний аналіз",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7207,11 +8001,13 @@
     {
       "cefr": "A2",
       "gloss": "to compare",
+      "glossClean": "to compare",
       "heritage": "standard",
       "ipa": null,
       "lemma": "порівняти",
       "lemmaId": "порівняти",
       "lemmaPlain": "порівняти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7222,11 +8018,13 @@
     {
       "cefr": "A2",
       "gloss": "related words",
+      "glossClean": "related words",
       "heritage": "standard",
       "ipa": null,
       "lemma": "споріднені слова",
       "lemmaId": "споріднені-слова",
       "lemmaPlain": "споріднені слова",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7237,11 +8035,13 @@
     {
       "cefr": "A2",
       "gloss": "sentence member",
+      "glossClean": "sentence member",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "член речення",
       "lemmaId": "член-речення",
       "lemmaPlain": "член речення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7252,11 +8052,13 @@
     {
       "cefr": "A2",
       "gloss": "asyndetic connection",
+      "glossClean": "asyndetic connection",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "безсполучниковий зв'язок",
       "lemmaId": "безсполучниковий-зв-язок",
       "lemmaPlain": "безсполучниковий зв'язок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7267,11 +8069,13 @@
     {
       "cefr": "A2",
       "gloss": "main word",
+      "glossClean": "main word",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "головне слово",
       "lemmaId": "головне-слово",
       "lemmaPlain": "головне слово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7282,11 +8086,13 @@
     {
       "cefr": "A2",
       "gloss": "secondary sentence member",
+      "glossClean": "secondary sentence member",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "другорядний член",
       "lemmaId": "другорядний-член",
       "lemmaPlain": "другорядний член",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7297,11 +8103,13 @@
     {
       "cefr": "A2",
       "gloss": "dependent word",
+      "glossClean": "dependent word",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "залежне слово",
       "lemmaId": "залежне-слово",
       "lemmaPlain": "залежне слово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7312,11 +8120,13 @@
     {
       "cefr": "A2",
       "gloss": "to govern a form",
+      "glossClean": "to govern a form",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "керувати формою",
       "lemmaId": "керувати-формою",
       "lemmaPlain": "керувати формою",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7327,11 +8137,13 @@
     {
       "cefr": "A2",
       "gloss": "nominative case",
+      "glossClean": "nominative case",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "називний відмінок",
       "lemmaId": "називний-відмінок",
       "lemmaPlain": "називний відмінок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7342,11 +8154,13 @@
     {
       "cefr": "A2",
       "gloss": "simple sentence",
+      "glossClean": "simple sentence",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "просте речення",
       "lemmaId": "просте-речення",
       "lemmaPlain": "просте речення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7357,11 +8171,13 @@
     {
       "cefr": "A2",
       "gloss": "punctuation mark",
+      "glossClean": "punctuation mark",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "розділовий знак",
       "lemmaId": "розділовий-знак",
       "lemmaPlain": "розділовий знак",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7372,11 +8188,13 @@
     {
       "cefr": "A2",
       "gloss": "connective word",
+      "glossClean": "connective word",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "сполучне слово",
       "lemmaId": "сполучне-слово",
       "lemmaPlain": "сполучне слово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7387,11 +8205,13 @@
     {
       "cefr": "A2",
       "gloss": "conjunctional connection",
+      "glossClean": "conjunctional connection",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "сполучниковий зв'язок",
       "lemmaId": "сполучниковий-зв-язок",
       "lemmaPlain": "сполучниковий зв'язок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7402,11 +8222,13 @@
     {
       "cefr": "A2",
       "gloss": "verbal aspect",
+      "glossClean": "verbal aspect",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вид",
       "lemmaId": "вид",
       "lemmaPlain": "вид",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7417,11 +8239,13 @@
     {
       "cefr": "A2",
       "gloss": "grammatical information",
+      "glossClean": "grammatical information",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "граматична інформація",
       "lemmaId": "граматична-інформація",
       "lemmaPlain": "граматична інформація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7432,11 +8256,13 @@
     {
       "cefr": "A2",
       "gloss": "second person",
+      "glossClean": "second person",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "друга особа",
       "lemmaId": "друга-особа",
       "lemmaPlain": "друга особа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7447,11 +8273,13 @@
     {
       "cefr": "A2",
       "gloss": "indicative mood",
+      "glossClean": "indicative mood",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "дійсний спосіб",
       "lemmaId": "дійсний-спосіб",
       "lemmaPlain": "дійсний спосіб",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7462,11 +8290,13 @@
     {
       "cefr": "A2",
       "gloss": "verb form",
+      "glossClean": "verb form",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "дієслівна форма",
       "lemmaId": "дієслівна-форма",
       "lemmaPlain": "дієслівна форма",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7477,11 +8307,13 @@
     {
       "cefr": "A2",
       "gloss": "headword",
+      "glossClean": "headword",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "заголовне слово",
       "lemmaId": "заголовне-слово",
       "lemmaPlain": "заголовне слово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7492,11 +8324,13 @@
     {
       "cefr": "A2",
       "gloss": "first person",
+      "glossClean": "first person",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "перша особа",
       "lemmaId": "перша-особа",
       "lemmaPlain": "перша особа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7507,11 +8341,13 @@
     {
       "cefr": "A2",
       "gloss": "adverb of place",
+      "glossClean": "adverb of place",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "прислівник місця",
       "lemmaId": "прислівник-місця",
       "lemmaPlain": "прислівник місця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7522,11 +8358,13 @@
     {
       "cefr": "A2",
       "gloss": "adverb of manner",
+      "glossClean": "adverb of manner",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "прислівник способу дії",
       "lemmaId": "прислівник-способу-дії",
       "lemmaPlain": "прислівник способу дії",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7537,11 +8375,13 @@
     {
       "cefr": "A2",
       "gloss": "adverb of time",
+      "glossClean": "adverb of time",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "прислівник часу",
       "lemmaId": "прислівник-часу",
       "lemmaPlain": "прислівник часу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7552,11 +8392,13 @@
     {
       "cefr": "A2",
       "gloss": "dictionary entry",
+      "glossClean": "dictionary entry",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "словникова стаття",
       "lemmaId": "словникова-стаття",
       "lemmaPlain": "словникова стаття",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7567,11 +8409,13 @@
     {
       "cefr": "A2",
       "gloss": "present tense",
+      "glossClean": "present tense",
       "heritage": "standard",
       "ipa": null,
       "lemma": "теперішній час",
       "lemmaId": "теперішній-час",
       "lemmaPlain": "теперішній час",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7582,11 +8426,13 @@
     {
       "cefr": "A2",
       "gloss": "third person",
+      "glossClean": "third person",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "третя особа",
       "lemmaId": "третя-особа",
       "lemmaPlain": "третя особа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7597,11 +8443,13 @@
     {
       "cefr": "A2",
       "gloss": "conditional mood",
+      "glossClean": "conditional mood",
       "heritage": "standard",
       "ipa": null,
       "lemma": "умовний спосіб",
       "lemmaId": "умовний-спосіб",
       "lemmaPlain": "умовний спосіб",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7612,11 +8460,13 @@
     {
       "cefr": "A2",
       "gloss": "feminine gender",
+      "glossClean": "feminine gender",
       "heritage": "standard",
       "ipa": null,
       "lemma": "жіночий рід",
       "lemmaId": "жіночий-рід",
       "lemmaPlain": "жіночий рід",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7627,11 +8477,13 @@
     {
       "cefr": "A2",
       "gloss": "role in a sentence",
+      "glossClean": "role in a sentence",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "роль у реченні",
       "lemmaId": "роль-у-реченні",
       "lemmaPlain": "роль у реченні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7642,11 +8494,13 @@
     {
       "cefr": "A2",
       "gloss": "neuter gender",
+      "glossClean": "neuter gender",
       "heritage": "standard",
       "ipa": null,
       "lemma": "середній рід",
       "lemmaId": "середній-рід",
       "lemmaPlain": "середній рід",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7657,11 +8511,13 @@
     {
       "cefr": "A2",
       "gloss": "part of speech",
+      "glossClean": "part of speech",
       "heritage": "standard",
       "ipa": null,
       "lemma": "частина мови",
       "lemmaId": "частина-мови",
       "lemmaPlain": "частина мови",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7672,11 +8528,13 @@
     {
       "cefr": "A2",
       "gloss": "masculine gender",
+      "glossClean": "masculine gender",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чоловічий рід",
       "lemmaId": "чоловічий-рід",
       "lemmaPlain": "чоловічий рід",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7687,11 +8545,13 @@
     {
       "cefr": "A2",
       "gloss": "to, toward",
+      "glossClean": "to",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "до + родовий",
       "lemmaId": "до-родовий",
       "lemmaPlain": "до + родовий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7702,11 +8562,13 @@
     {
       "cefr": "A2",
       "gloss": "from",
+      "glossClean": "from",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "з + родовий",
       "lemmaId": "з-родовий",
       "lemmaPlain": "з + родовий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7717,11 +8579,13 @@
     {
       "cefr": "A2",
       "gloss": "to fly",
+      "glossClean": "to fly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "летіти / літати",
       "lemmaId": "летіти-літати",
       "lemmaPlain": "летіти / літати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7732,11 +8596,13 @@
     {
       "cefr": "A2",
       "gloss": "to, onto",
+      "glossClean": "to",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "на + знахідний",
       "lemmaId": "на-знахідний",
       "lemmaPlain": "на + знахідний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7747,11 +8613,13 @@
     {
       "cefr": "A2",
       "gloss": "movement, motion",
+      "glossClean": "movement",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рух",
       "lemmaId": "рух",
       "lemmaPlain": "рух",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7762,11 +8630,13 @@
     {
       "cefr": "A2",
       "gloss": "through, across",
+      "glossClean": "through",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "через + знахідний",
       "lemmaId": "через-знахідний",
       "lemmaPlain": "через + знахідний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7777,11 +8647,13 @@
     {
       "cefr": "A2",
       "gloss": "Palm Sunday",
+      "glossClean": "Palm Sunday",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Вербна неділя",
       "lemmaId": "вербна-неділя",
       "lemmaPlain": "вербна неділя",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7792,11 +8664,13 @@
     {
       "cefr": "A2",
       "gloss": "harvest",
+      "glossClean": "harvest",
       "heritage": "standard",
       "ipa": null,
       "lemma": "врожай",
       "lemmaId": "врожай",
       "lemmaPlain": "врожай",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7807,11 +8681,13 @@
     {
       "cefr": "A2",
       "gloss": "Constitution Day",
+      "glossClean": "Constitution Day",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "День Конституції",
       "lemmaId": "день-конституції",
       "lemmaPlain": "день конституції",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7822,11 +8698,13 @@
     {
       "cefr": "A2",
       "gloss": "Independence Day",
+      "glossClean": "Independence Day",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "День Незалежності",
       "lemmaId": "день-незалежності",
       "lemmaPlain": "день незалежності",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7837,11 +8715,13 @@
     {
       "cefr": "A2",
       "gloss": "defender, masculine",
+      "glossClean": "defender",
       "heritage": "standard",
       "ipa": null,
       "lemma": "захисник",
       "lemmaId": "захисник",
       "lemmaPlain": "захисник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7852,11 +8732,13 @@
     {
       "cefr": "A2",
       "gloss": "season",
+      "glossClean": "season",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пора року",
       "lemmaId": "пора-року",
       "lemmaPlain": "пора року",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7867,11 +8749,13 @@
     {
       "cefr": "A2",
       "gloss": "Christmas Eve, Holy Evening",
+      "glossClean": "Christmas Eve",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Святий Вечір",
       "lemmaId": "святий-вечір",
       "lemmaPlain": "святий вечір",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7882,11 +8766,13 @@
     {
       "cefr": "A2",
       "gloss": "a ten, a dozen",
+      "glossClean": "a ten",
       "heritage": "standard",
       "ipa": null,
       "lemma": "десяток",
       "lemmaId": "десяток",
       "lemmaPlain": "десяток",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7897,11 +8783,13 @@
     {
       "cefr": "A2",
       "gloss": "fifth",
+      "glossClean": "fifth",
       "heritage": "standard",
       "ipa": null,
       "lemma": "п'ятий",
       "lemmaId": "п-ятий",
       "lemmaPlain": "п'ятий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7912,11 +8800,13 @@
     {
       "cefr": "A2",
       "gloss": "genitive plural",
+      "glossClean": "genitive plural",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "родовий множини",
       "lemmaId": "родовий-множини",
       "lemmaPlain": "родовий множини",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7927,11 +8817,13 @@
     {
       "cefr": "A2",
       "gloss": "animate, living",
+      "glossClean": "animate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "живий",
       "lemmaId": "живий",
       "lemmaPlain": "живий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7942,11 +8834,13 @@
     {
       "cefr": "A2",
       "gloss": "with whom",
+      "glossClean": "with whom",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "з ким",
       "lemmaId": "з-ким",
       "lemmaPlain": "з ким",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7957,11 +8851,13 @@
     {
       "cefr": "A2",
       "gloss": "to explain",
+      "glossClean": "to explain",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пояснювати",
       "lemmaId": "пояснювати",
       "lemmaPlain": "пояснювати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7972,11 +8868,13 @@
     {
       "cefr": "A2",
       "gloss": "to decorate",
+      "glossClean": "to decorate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прикрашати",
       "lemmaId": "прикрашати",
       "lemmaPlain": "прикрашати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7987,11 +8885,13 @@
     {
       "cefr": "A2",
       "gloss": "compromise",
+      "glossClean": "compromise",
       "heritage": "standard",
       "ipa": null,
       "lemma": "компроміс",
       "lemmaId": "компроміс",
       "lemmaPlain": "компроміс",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8002,11 +8902,13 @@
     {
       "cefr": "A2",
       "gloss": "besides, moreover",
+      "glossClean": "besides",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "крім того",
       "lemmaId": "крім-того",
       "lemmaPlain": "крім того",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8017,11 +8919,13 @@
     {
       "cefr": "A2",
       "gloss": "in conclusion, to finish",
+      "glossClean": "in conclusion",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "на завершення",
       "lemmaId": "на-завершення",
       "lemmaPlain": "на завершення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8032,11 +8936,13 @@
     {
       "cefr": "A2",
       "gloss": "secondly",
+      "glossClean": "secondly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "по-друге",
       "lemmaId": "по-друге",
       "lemmaPlain": "по-друге",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8047,11 +8953,13 @@
     {
       "cefr": "A2",
       "gloss": "firstly",
+      "glossClean": "firstly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "по-перше",
       "lemmaId": "по-перше",
       "lemmaPlain": "по-перше",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8062,11 +8970,13 @@
     {
       "cefr": "A2",
       "gloss": "for what purpose",
+      "glossClean": "for what purpose",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "для чого",
       "lemmaId": "для-чого",
       "lemmaPlain": "для чого",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8077,11 +8987,13 @@
     {
       "cefr": "A2",
       "gloss": "to add",
+      "glossClean": "to add",
       "heritage": "standard",
       "ipa": null,
       "lemma": "додати",
       "lemmaId": "додати",
       "lemmaPlain": "додати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8092,11 +9004,13 @@
     {
       "cefr": "A2",
       "gloss": "to check",
+      "glossClean": "to check",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перевірити",
       "lemmaId": "перевірити",
       "lemmaPlain": "перевірити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8107,11 +9021,13 @@
     {
       "cefr": "A2",
       "gloss": "to pass on, to relay",
+      "glossClean": "to pass on",
       "heritage": "standard",
       "ipa": null,
       "lemma": "передати",
       "lemmaId": "передати",
       "lemmaPlain": "передати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8122,11 +9038,13 @@
     {
       "cefr": "A2",
       "gloss": "message",
+      "glossClean": "message",
       "heritage": "standard",
       "ipa": null,
       "lemma": "повідомлення",
       "lemmaId": "повідомлення",
       "lemmaPlain": "повідомлення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8137,11 +9055,13 @@
     {
       "cefr": "A2",
       "gloss": "direct speech",
+      "glossClean": "direct speech",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пряма мова",
       "lemmaId": "пряма-мова",
       "lemmaPlain": "пряма мова",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8152,11 +9072,13 @@
     {
       "cefr": "A2",
       "gloss": "to stay, to remain",
+      "glossClean": "to stay",
       "heritage": "standard",
       "ipa": null,
       "lemma": "залишитися",
       "lemmaId": "залишитися",
       "lemmaPlain": "залишитися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8167,11 +9089,13 @@
     {
       "cefr": "A2",
       "gloss": "to be late",
+      "glossClean": "to be late",
       "heritage": "standard",
       "ipa": null,
       "lemma": "запізнитися",
       "lemmaId": "запізнитися",
       "lemmaPlain": "запізнитися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8182,11 +9106,13 @@
     {
       "cefr": "A2",
       "gloss": "then",
+      "glossClean": "then",
       "heritage": "standard",
       "ipa": null,
       "lemma": "то",
       "lemmaId": "то",
       "lemmaPlain": "то",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8197,11 +9123,13 @@
     {
       "cefr": "A2",
       "gloss": "cozy",
+      "glossClean": "cozy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "затишний",
       "lemmaId": "затишний",
       "lemmaPlain": "затишний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8212,11 +9140,13 @@
     {
       "cefr": "A2",
       "gloss": "description",
+      "glossClean": "description",
       "heritage": "standard",
       "ipa": null,
       "lemma": "опис",
       "lemmaId": "опис",
       "lemmaPlain": "опис",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8227,11 +9157,13 @@
     {
       "cefr": "A2",
       "gloss": "envelope",
+      "glossClean": "envelope",
       "heritage": "standard",
       "ipa": null,
       "lemma": "конверт",
       "lemmaId": "конверт",
       "lemmaPlain": "конверт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8242,11 +9174,13 @@
     {
       "cefr": "A2",
       "gloss": "stamp",
+      "glossClean": "stamp",
       "heritage": "standard",
       "ipa": null,
       "lemma": "марка",
       "lemmaId": "марка",
       "lemmaPlain": "марка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -8286,11 +9220,13 @@
     {
       "cefr": "A2",
       "gloss": "postal code",
+      "glossClean": "postal code",
       "heritage": "standard",
       "ipa": null,
       "lemma": "індекс",
       "lemmaId": "індекс",
       "lemmaPlain": "індекс",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8301,11 +9237,13 @@
     {
       "cefr": "A2",
       "gloss": "pain",
+      "glossClean": "pain",
       "heritage": "standard",
       "ipa": null,
       "lemma": "біль",
       "lemmaId": "біль",
       "lemmaPlain": "біль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8316,11 +9254,13 @@
     {
       "cefr": "A2",
       "gloss": "pill, tablet",
+      "glossClean": "pill",
       "heritage": "standard",
       "ipa": null,
       "lemma": "таблетка",
       "lemmaId": "таблетка",
       "lemmaPlain": "таблетка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -8360,11 +9300,13 @@
     {
       "cefr": "A2",
       "gloss": "cold",
+      "glossClean": "cold",
       "heritage": "standard",
       "ipa": null,
       "lemma": "холод",
       "lemmaId": "холод",
       "lemmaPlain": "холод",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8375,11 +9317,13 @@
     {
       "cefr": "A2",
       "gloss": "piece",
+      "glossClean": "piece",
       "heritage": "standard",
       "ipa": null,
       "lemma": "шматок",
       "lemmaId": "шматок",
       "lemmaPlain": "шматок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8390,11 +9334,13 @@
     {
       "cefr": "A2",
       "gloss": "to be oneself",
+      "glossClean": "to be oneself",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "бути собою",
       "lemmaId": "бути-собою",
       "lemmaPlain": "бути собою",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8405,11 +9351,13 @@
     {
       "cefr": "A2",
       "gloss": "to behave",
+      "glossClean": "to behave",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "вести себе",
       "lemmaId": "вести-себе",
       "lemmaPlain": "вести себе",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8420,11 +9368,13 @@
     {
       "cefr": "A2",
       "gloss": "own",
+      "glossClean": "own",
       "heritage": "standard",
       "ipa": null,
       "lemma": "власний",
       "lemmaId": "власний",
       "lemmaPlain": "власний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8435,11 +9385,13 @@
     {
       "cefr": "A2",
       "gloss": "with oneself",
+      "glossClean": "with oneself",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "з собою",
       "lemmaId": "з-собою",
       "lemmaPlain": "з собою",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8450,11 +9402,13 @@
     {
       "cefr": "A2",
       "gloss": "manager, supervisor",
+      "glossClean": "manager",
       "heritage": "standard",
       "ipa": null,
       "lemma": "керівниця",
       "lemmaId": "керівниця",
       "lemmaPlain": "керівниця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8465,11 +9419,13 @@
     {
       "cefr": "A2",
       "gloss": "to feel oneself",
+      "glossClean": "to feel oneself",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "почувати себе",
       "lemmaId": "почувати-себе",
       "lemmaPlain": "почувати себе",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8480,11 +9436,13 @@
     {
       "cefr": "A2",
       "gloss": "to feel",
+      "glossClean": "to feel",
       "heritage": "standard",
       "ipa": null,
       "lemma": "почуватися",
       "lemmaId": "почуватися",
       "lemmaPlain": "почуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8495,11 +9453,13 @@
     {
       "cefr": "A2",
       "gloss": "on oneself, with oneself",
+      "glossClean": "on oneself",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "при собі",
       "lemmaId": "при-собі",
       "lemmaPlain": "при собі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8510,11 +9470,13 @@
     {
       "cefr": "A2",
       "gloss": "by itself",
+      "glossClean": "by itself",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "сам по собі",
       "lemmaId": "сам-по-собі",
       "lemmaPlain": "сам по собі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8525,11 +9487,13 @@
     {
       "cefr": "A2",
       "gloss": "oneself, accusative/genitive",
+      "glossClean": "oneself",
       "heritage": "standard",
       "ipa": null,
       "lemma": "себе",
       "lemmaId": "себе",
       "lemmaPlain": "себе",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8540,11 +9504,13 @@
     {
       "cefr": "A2",
       "gloss": "at one's place, in oneself",
+      "glossClean": "at one's place",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у себе",
       "lemmaId": "у-себе",
       "lemmaPlain": "у себе",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8555,11 +9521,13 @@
     {
       "cefr": "A2",
       "gloss": "official, formal",
+      "glossClean": "official",
       "heritage": "standard",
       "ipa": null,
       "lemma": "офіційний",
       "lemmaId": "офіційний",
       "lemmaPlain": "офіційний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8570,11 +9538,13 @@
     {
       "cefr": "A2",
       "gloss": "style",
+      "glossClean": "style",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стиль",
       "lemmaId": "стиль",
       "lemmaPlain": "стиль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8585,11 +9555,13 @@
     {
       "cefr": "A2",
       "gloss": "by spring",
+      "glossClean": "by spring",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "до весни",
       "lemmaId": "до-весни",
       "lemmaPlain": "до весни",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8600,11 +9572,13 @@
     {
       "cefr": "A2",
       "gloss": "next week",
+      "glossClean": "next week",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "наступного тижня",
       "lemmaId": "наступного-тижня",
       "lemmaPlain": "наступного тижня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8615,11 +9589,13 @@
     {
       "cefr": "A2",
       "gloss": "New Year's resolution",
+      "glossClean": "New Year's resolution",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "новорічна обіцянка",
       "lemmaId": "новорічна-обіцянка",
       "lemmaPlain": "новорічна обіцянка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8630,11 +9606,13 @@
     {
       "cefr": "A2",
       "gloss": "to call, I will call",
+      "glossClean": "to call",
       "heritage": "standard",
       "ipa": null,
       "lemma": "подзвонити / подзвоню",
       "lemmaId": "подзвонити-подзвоню",
       "lemmaPlain": "подзвонити / подзвоню",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8645,11 +9623,13 @@
     {
       "cefr": "A2",
       "gloss": "simple future",
+      "glossClean": "simple future",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "простий майбутній",
       "lemmaId": "простий-майбутній",
       "lemmaPlain": "простий майбутній",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8660,11 +9640,13 @@
     {
       "cefr": "A2",
       "gloss": "to take/pass an exam",
+      "glossClean": "to take/pass an exam",
       "heritage": "standard",
       "ipa": null,
       "lemma": "складати / скласти іспит",
       "lemmaId": "складати-скласти-іспит",
       "lemmaPlain": "складати / скласти іспит",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8675,11 +9657,13 @@
     {
       "cefr": "A2",
       "gloss": "duration",
+      "glossClean": "duration",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тривалість",
       "lemmaId": "тривалість",
       "lemmaPlain": "тривалість",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8690,11 +9674,13 @@
     {
       "cefr": "A2",
       "gloss": "to stop, to stay",
+      "glossClean": "to stop",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зупинитися",
       "lemmaId": "зупинитися",
       "lemmaPlain": "зупинитися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8705,11 +9691,13 @@
     {
       "cefr": "A2",
       "gloss": "to go once / to go and return regularly",
+      "glossClean": "to go once / to go and return regularly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поїхати / їздити",
       "lemmaId": "поїхати-їздити",
       "lemmaPlain": "поїхати / їздити",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8720,11 +9708,13 @@
     {
       "cefr": "A2",
       "gloss": "to like, to enjoy",
+      "glossClean": "to like",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сподобатися",
       "lemmaId": "сподобатися",
       "lemmaPlain": "сподобатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8735,11 +9725,13 @@
     {
       "cefr": "A2",
       "gloss": "to walk around the city",
+      "glossClean": "to walk around the city",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "ходити по місту",
       "lemmaId": "ходити-по-місту",
       "lemmaPlain": "ходити по місту",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8750,11 +9742,13 @@
     {
       "cefr": "A2",
       "gloss": "emotional",
+      "glossClean": "emotional",
       "heritage": "standard",
       "ipa": null,
       "lemma": "емоційний",
       "lemmaId": "емоційний",
       "lemmaPlain": "емоційний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8765,11 +9759,13 @@
     {
       "cefr": "A2",
       "gloss": "algorithm",
+      "glossClean": "algorithm",
       "heritage": "standard",
       "ipa": null,
       "lemma": "алгоритм",
       "lemmaId": "алгоритм",
       "lemmaPlain": "алгоритм",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8780,11 +9776,13 @@
     {
       "cefr": "A2",
       "gloss": "to be afraid of",
+      "glossClean": "to be afraid of",
       "heritage": "standard",
       "ipa": null,
       "lemma": "боятися",
       "lemmaId": "боятися",
       "lemmaPlain": "боятися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8795,11 +9793,13 @@
     {
       "cefr": "A2",
       "gloss": "accent, emphasis",
+      "glossClean": "accent",
       "heritage": "standard",
       "ipa": null,
       "lemma": "акцент",
       "lemmaId": "акцент",
       "lemmaPlain": "акцент",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8810,11 +9810,13 @@
     {
       "cefr": "A2",
       "gloss": "to move to the front",
+      "glossClean": "to move to the front",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "винести наперед",
       "lemmaId": "винести-наперед",
       "lemmaPlain": "винести наперед",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8825,11 +9827,13 @@
     {
       "cefr": "A2",
       "gloss": "to correct",
+      "glossClean": "to correct",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виправляти",
       "lemmaId": "виправляти",
       "lemmaPlain": "виправляти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8840,11 +9844,13 @@
     {
       "cefr": "A2",
       "gloss": "not..., but...",
+      "glossClean": "not...",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "не..., а...",
       "lemmaId": "не-а",
       "lemmaPlain": "не..., а...",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8855,11 +9861,13 @@
     {
       "cefr": "A2",
       "gloss": "order",
+      "glossClean": "order",
       "heritage": "standard",
       "ipa": null,
       "lemma": "порядок",
       "lemmaId": "порядок",
       "lemmaPlain": "порядок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8870,11 +9878,13 @@
     {
       "cefr": "A2",
       "gloss": "who exactly",
+      "glossClean": "who exactly",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "хто саме",
       "lemmaId": "хто-саме",
       "lemmaPlain": "хто саме",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8885,11 +9895,13 @@
     {
       "cefr": "A2",
       "gloss": "what exactly",
+      "glossClean": "what exactly",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "що саме",
       "lemmaId": "що-саме",
       "lemmaPlain": "що саме",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8900,11 +9912,13 @@
     {
       "cefr": "A2",
       "gloss": "to stir, to mix",
+      "glossClean": "to stir",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мішати",
       "lemmaId": "мішати",
       "lemmaPlain": "мішати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8915,11 +9929,13 @@
     {
       "cefr": "A2",
       "gloss": "meeting",
+      "glossClean": "meeting",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нарада",
       "lemmaId": "нарада",
       "lemmaPlain": "нарада",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -8959,11 +9975,13 @@
     {
       "cefr": "A2",
       "gloss": "to cut",
+      "glossClean": "to cut",
       "heritage": "standard",
       "ipa": null,
       "lemma": "різати",
       "lemmaId": "різати",
       "lemmaPlain": "різати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8974,11 +9992,13 @@
     {
       "cefr": "A2",
       "gloss": "closer",
+      "glossClean": "closer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ближчий",
       "lemmaId": "ближчий",
       "lemmaPlain": "ближчий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8989,11 +10009,13 @@
     {
       "cefr": "A2",
       "gloss": "higher, taller",
+      "glossClean": "higher",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вищий",
       "lemmaId": "вищий",
       "lemmaPlain": "вищий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9004,11 +10026,13 @@
     {
       "cefr": "A2",
       "gloss": "lower, shorter",
+      "glossClean": "lower",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нижчий",
       "lemmaId": "нижчий",
       "lemmaPlain": "нижчий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9019,11 +10043,13 @@
     {
       "cefr": "A2",
       "gloss": "highest, tallest",
+      "glossClean": "highest",
       "heritage": "standard",
       "ipa": null,
       "lemma": "найвищий",
       "lemmaId": "найвищий",
       "lemmaPlain": "найвищий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9034,11 +10060,13 @@
     {
       "cefr": "A2",
       "gloss": "worst",
+      "glossClean": "worst",
       "heritage": "standard",
       "ipa": null,
       "lemma": "найгірший",
       "lemmaId": "найгірший",
       "lemmaPlain": "найгірший",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9049,11 +10077,13 @@
     {
       "cefr": "A2",
       "gloss": "most expensive",
+      "glossClean": "most expensive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "найдорожчий",
       "lemmaId": "найдорожчий",
       "lemmaPlain": "найдорожчий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9064,11 +10094,13 @@
     {
       "cefr": "A2",
       "gloss": "least",
+      "glossClean": "least",
       "heritage": "standard",
       "ipa": null,
       "lemma": "найменш",
       "lemmaId": "найменш",
       "lemmaPlain": "найменш",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9079,11 +10111,13 @@
     {
       "cefr": "A2",
       "gloss": "self, alone",
+      "glossClean": "self",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сам",
       "lemmaId": "сам",
       "lemmaPlain": "сам",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9094,11 +10128,13 @@
     {
       "cefr": "A2",
       "gloss": "some, some kind of",
+      "glossClean": "some",
       "heritage": "standard",
       "ipa": null,
       "lemma": "якийсь",
       "lemmaId": "якийсь",
       "lemmaPlain": "якийсь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9109,11 +10145,13 @@
     {
       "cefr": "A2",
       "gloss": "other, another",
+      "glossClean": "other",
       "heritage": "standard",
       "ipa": null,
       "lemma": "інший",
       "lemmaId": "інший",
       "lemmaPlain": "інший",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9124,11 +10162,13 @@
     {
       "cefr": "A2",
       "gloss": "more expensively",
+      "glossClean": "more expensively",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дорожче",
       "lemmaId": "дорожче",
       "lemmaPlain": "дорожче",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9139,11 +10179,13 @@
     {
       "cefr": "A2",
       "gloss": "better",
+      "glossClean": "better",
       "heritage": "standard",
       "ipa": null,
       "lemma": "краще",
       "lemmaId": "краще",
       "lemmaPlain": "краще",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9154,11 +10196,13 @@
     {
       "cefr": "A2",
       "gloss": "involuntarily",
+      "glossClean": "involuntarily",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мимоволі",
       "lemmaId": "мимоволі",
       "lemmaPlain": "мимоволі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9169,11 +10213,13 @@
     {
       "cefr": "A2",
       "gloss": "in Ukrainian, Ukrainian-style",
+      "glossClean": "in Ukrainian",
       "heritage": "standard",
       "ipa": null,
       "lemma": "по-українськи",
       "lemmaId": "по-українськи",
       "lemmaPlain": "по-українськи",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9184,11 +10230,13 @@
     {
       "cefr": "A2",
       "gloss": "slowly, gradually",
+      "glossClean": "slowly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "помалу",
       "lemmaId": "помалу",
       "lemmaPlain": "помалу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9199,11 +10247,13 @@
     {
       "cefr": "A2",
       "gloss": "little by little",
+      "glossClean": "little by little",
       "heritage": "standard",
       "ipa": null,
       "lemma": "потроху",
       "lemmaId": "потроху",
       "lemmaPlain": "потроху",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9214,11 +10264,13 @@
     {
       "cefr": "A2",
       "gloss": "compounding",
+      "glossClean": "compounding",
       "heritage": "standard",
       "ipa": null,
       "lemma": "складання",
       "lemmaId": "складання",
       "lemmaPlain": "складання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9229,11 +10281,13 @@
     {
       "cefr": "A2",
       "gloss": "faster, more quickly",
+      "glossClean": "faster",
       "heritage": "standard",
       "ipa": null,
       "lemma": "швидше",
       "lemmaId": "швидше",
       "lemmaPlain": "швидше",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9244,11 +10298,13 @@
     {
       "cefr": "A2",
       "gloss": "to wait until something arrives, perfective",
+      "glossClean": "to wait until something arrives",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дочекатися",
       "lemmaId": "дочекатися",
       "lemmaPlain": "дочекатися",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -9259,11 +10315,13 @@
     {
       "cefr": "A2",
       "gloss": "to book, to reserve",
+      "glossClean": "to book",
       "heritage": "standard",
       "ipa": null,
       "lemma": "забронювати",
       "lemmaId": "забронювати",
       "lemmaPlain": "забронювати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9274,11 +10332,13 @@
     {
       "cefr": "A2",
       "gloss": "construction",
+      "glossClean": "construction",
       "heritage": "standard",
       "ipa": null,
       "lemma": "конструкція",
       "lemmaId": "конструкція",
       "lemmaPlain": "конструкція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9289,11 +10349,13 @@
     {
       "cefr": "A2",
       "gloss": "to work for a limited time, perfective",
+      "glossClean": "to work for a limited time",
       "heritage": "standard",
       "ipa": null,
       "lemma": "попрацювати",
       "lemmaId": "попрацювати",
       "lemmaPlain": "попрацювати",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -9304,11 +10366,13 @@
     {
       "cefr": "A2",
       "gloss": "prediction",
+      "glossClean": "prediction",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прогноз",
       "lemmaId": "прогноз",
       "lemmaPlain": "прогноз",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9319,11 +10383,13 @@
     {
       "cefr": "A2",
       "gloss": "to win",
+      "glossClean": "to win",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виграти",
       "lemmaId": "виграти",
       "lemmaPlain": "виграти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9334,11 +10400,13 @@
     {
       "cefr": "A2",
       "gloss": "to know how to, to be able",
+      "glossClean": "to know how to",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вміти",
       "lemmaId": "вміти",
       "lemmaPlain": "вміти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9349,11 +10417,13 @@
     {
       "cefr": "A2",
       "gloss": "to manage to, to be able",
+      "glossClean": "to manage to",
       "heritage": "standard",
       "ipa": null,
       "lemma": "змогти",
       "lemmaId": "змогти",
       "lemmaPlain": "змогти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9364,11 +10434,13 @@
     {
       "cefr": "A2",
       "gloss": "impossibility",
+      "glossClean": "impossibility",
       "heritage": "standard",
       "ipa": null,
       "lemma": "неможливість",
       "lemmaId": "неможливість",
       "lemmaPlain": "неможливість",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9379,11 +10451,13 @@
     {
       "cefr": "A2",
       "gloss": "assumption, hypothesis",
+      "glossClean": "assumption",
       "heritage": "standard",
       "ipa": null,
       "lemma": "припущення",
       "lemmaId": "припущення",
       "lemmaPlain": "припущення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9394,11 +10468,13 @@
     {
       "cefr": "A2",
       "gloss": "to take",
+      "glossClean": "to take",
       "heritage": "standard",
       "ipa": null,
       "lemma": "брати",
       "lemmaId": "брати",
       "lemmaPlain": "брати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9409,11 +10485,13 @@
     {
       "cefr": "A2",
       "gloss": "to take",
+      "glossClean": "to take",
       "heritage": "standard",
       "ipa": null,
       "lemma": "взяти",
       "lemmaId": "взяти",
       "lemmaPlain": "взяти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9424,11 +10502,13 @@
     {
       "cefr": "A2",
       "gloss": "to fall",
+      "glossClean": "to fall",
       "heritage": "standard",
       "ipa": null,
       "lemma": "впасти",
       "lemmaId": "впасти",
       "lemmaPlain": "впасти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9439,11 +10519,13 @@
     {
       "cefr": "A2",
       "gloss": "to open (file/app/book)",
+      "glossClean": "to open (file/app/book)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відкривати",
       "lemmaId": "відкривати",
       "lemmaPlain": "відкривати",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -9454,11 +10536,13 @@
     {
       "cefr": "A2",
       "gloss": "to open (door/window)",
+      "glossClean": "to open (door/window)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відчинити",
       "lemmaId": "відчинити",
       "lemmaPlain": "відчинити",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -9469,11 +10553,13 @@
     {
       "cefr": "A2",
       "gloss": "to add",
+      "glossClean": "to add",
       "heritage": "standard",
       "ipa": null,
       "lemma": "додавати",
       "lemmaId": "додавати",
       "lemmaPlain": "додавати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9484,11 +10570,13 @@
     {
       "cefr": "A2",
       "gloss": "to forget",
+      "glossClean": "to forget",
       "heritage": "standard",
       "ipa": null,
       "lemma": "забувати",
       "lemmaId": "забувати",
       "lemmaPlain": "забувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9499,11 +10587,13 @@
     {
       "cefr": "A2",
       "gloss": "to enter, drop in",
+      "glossClean": "to enter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зайти",
       "lemmaId": "зайти",
       "lemmaPlain": "зайти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9514,11 +10604,13 @@
     {
       "cefr": "A2",
       "gloss": "to close",
+      "glossClean": "to close",
       "heritage": "standard",
       "ipa": null,
       "lemma": "закривати",
       "lemmaId": "закривати",
       "lemmaPlain": "закривати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9529,11 +10621,13 @@
     {
       "cefr": "A2",
       "gloss": "invitation",
+      "glossClean": "invitation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "запрошення",
       "lemmaId": "запрошення",
       "lemmaPlain": "запрошення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9544,11 +10638,13 @@
     {
       "cefr": "A2",
       "gloss": "to be late",
+      "glossClean": "to be late",
       "heritage": "standard",
       "ipa": null,
       "lemma": "запізнюватися",
       "lemmaId": "запізнюватися",
       "lemmaPlain": "запізнюватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9559,11 +10655,13 @@
     {
       "cefr": "A2",
       "gloss": "warning, caution",
+      "glossClean": "warning",
       "heritage": "standard",
       "ipa": null,
       "lemma": "застереження",
       "lemmaId": "застереження",
       "lemmaPlain": "застереження",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9574,11 +10672,13 @@
     {
       "cefr": "A2",
       "gloss": "to send",
+      "glossClean": "to send",
       "heritage": "standard",
       "ipa": null,
       "lemma": "надсилати",
       "lemmaId": "надсилати",
       "lemmaPlain": "надсилати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9589,11 +10689,13 @@
     {
       "cefr": "A2",
       "gloss": "carefully, watch out",
+      "glossClean": "carefully",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обережно",
       "lemmaId": "обережно",
       "lemmaPlain": "обережно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9604,11 +10706,13 @@
     {
       "cefr": "A2",
       "gloss": "to fall",
+      "glossClean": "to fall",
       "heritage": "standard",
       "ipa": null,
       "lemma": "падати",
       "lemmaId": "падати",
       "lemmaPlain": "падати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9619,11 +10723,13 @@
     {
       "cefr": "A2",
       "gloss": "to check",
+      "glossClean": "to check",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перевіряти",
       "lemmaId": "перевіряти",
       "lemmaPlain": "перевіряти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9634,11 +10740,13 @@
     {
       "cefr": "A2",
       "gloss": "to wash",
+      "glossClean": "to wash",
       "heritage": "standard",
       "ipa": null,
       "lemma": "помити",
       "lemmaId": "помити",
       "lemmaPlain": "помити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9649,11 +10757,13 @@
     {
       "cefr": "A2",
       "gloss": "request",
+      "glossClean": "request",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прохання",
       "lemmaId": "прохання",
       "lemmaPlain": "прохання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9664,11 +10774,13 @@
     {
       "cefr": "A2",
       "gloss": "regularly",
+      "glossClean": "regularly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "регулярно",
       "lemmaId": "регулярно",
       "lemmaPlain": "регулярно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9679,11 +10791,13 @@
     {
       "cefr": "A2",
       "gloss": "setting",
+      "glossClean": "setting",
       "heritage": "russianism",
       "ipa": null,
       "lemma": "обстановка",
       "lemmaId": "обстановка",
       "lemmaPlain": "обстановка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9694,11 +10808,13 @@
     {
       "cefr": "A2",
       "gloss": "narrative, story",
+      "glossClean": "narrative",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розповідь",
       "lemmaId": "розповідь",
       "lemmaPlain": "розповідь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9709,11 +10825,13 @@
     {
       "cefr": "A2",
       "gloss": "role",
+      "glossClean": "role",
       "heritage": "standard",
       "ipa": null,
       "lemma": "роль",
       "lemmaId": "роль",
       "lemmaPlain": "роль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9724,11 +10842,13 @@
     {
       "cefr": "A2",
       "gloss": "scene",
+      "glossClean": "scene",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сцена",
       "lemmaId": "сцена",
       "lemmaPlain": "сцена",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9739,11 +10859,13 @@
     {
       "cefr": "A2",
       "gloss": "pace",
+      "glossClean": "pace",
       "heritage": "standard",
       "ipa": null,
       "lemma": "темп",
       "lemmaId": "темп",
       "lemmaPlain": "темп",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9754,11 +10876,13 @@
     {
       "cefr": "A2",
       "gloss": "to decide; perfective",
+      "glossClean": "to decide",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вирішити",
       "lemmaId": "вирішити",
       "lemmaPlain": "вирішити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9769,11 +10893,13 @@
     {
       "cefr": "A2",
       "gloss": "to decide; imperfective",
+      "glossClean": "to decide",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вирішувати",
       "lemmaId": "вирішувати",
       "lemmaPlain": "вирішувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9784,11 +10910,13 @@
     {
       "cefr": "A2",
       "gloss": "to phone; perfective",
+      "glossClean": "to phone",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зателефонувати",
       "lemmaId": "зателефонувати",
       "lemmaPlain": "зателефонувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9799,11 +10927,13 @@
     {
       "cefr": "A2",
       "gloss": "to learn thoroughly",
+      "glossClean": "to learn thoroughly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вивчити",
       "lemmaId": "вивчити",
       "lemmaPlain": "вивчити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9814,11 +10944,13 @@
     {
       "cefr": "A2",
       "gloss": "to prepare, to cook, finish",
+      "glossClean": "to prepare",
       "heritage": "standard",
       "ipa": null,
       "lemma": "приготувати",
       "lemmaId": "приготувати",
       "lemmaPlain": "приготувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9829,11 +10961,13 @@
     {
       "cefr": "A2",
       "gloss": "classroom, lecture hall",
+      "glossClean": "classroom",
       "heritage": "standard",
       "ipa": null,
       "lemma": "аудиторія",
       "lemmaId": "аудиторія",
       "lemmaPlain": "аудиторія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -9873,11 +11007,13 @@
     {
       "cefr": "A2",
       "gloss": "volunteer",
+      "glossClean": "volunteer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "волонтер / волонтерка",
       "lemmaId": "волонтер-волонтерка",
       "lemmaPlain": "волонтер / волонтерка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9888,11 +11024,13 @@
     {
       "cefr": "A2",
       "gloss": "to prepare oneself",
+      "glossClean": "to prepare oneself",
       "heritage": "standard",
       "ipa": null,
       "lemma": "готуватися",
       "lemmaId": "готуватися",
       "lemmaPlain": "готуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9903,11 +11041,13 @@
     {
       "cefr": "A2",
       "gloss": "agreement, arrangement",
+      "glossClean": "agreement",
       "heritage": "standard",
       "ipa": null,
       "lemma": "домовленість",
       "lemmaId": "домовленість",
       "lemmaPlain": "домовленість",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9918,11 +11058,13 @@
     {
       "cefr": "A2",
       "gloss": "to arrange, negotiate",
+      "glossClean": "to arrange",
       "heritage": "standard",
       "ipa": null,
       "lemma": "домовлятися",
       "lemmaId": "домовлятися",
       "lemmaPlain": "домовлятися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9933,11 +11075,13 @@
     {
       "cefr": "A2",
       "gloss": "to collect",
+      "glossClean": "to collect",
       "heritage": "standard",
       "ipa": null,
       "lemma": "збирати",
       "lemmaId": "збирати",
       "lemmaPlain": "збирати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9948,11 +11092,13 @@
     {
       "cefr": "A2",
       "gloss": "to meet, welcome",
+      "glossClean": "to meet",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зустрічати",
       "lemmaId": "зустрічати",
       "lemmaPlain": "зустрічати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9963,11 +11109,13 @@
     {
       "cefr": "A2",
       "gloss": "to distribute, complete",
+      "glossClean": "to distribute",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поширити",
       "lemmaId": "поширити",
       "lemmaPlain": "поширити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9978,11 +11126,13 @@
     {
       "cefr": "A2",
       "gloss": "to distribute, share",
+      "glossClean": "to distribute",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поширювати",
       "lemmaId": "поширювати",
       "lemmaPlain": "поширювати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9993,11 +11143,13 @@
     {
       "cefr": "A2",
       "gloss": "registration",
+      "glossClean": "registration",
       "heritage": "standard",
       "ipa": null,
       "lemma": "реєстрація",
       "lemmaId": "реєстрація",
       "lemmaPlain": "реєстрація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -10037,11 +11189,13 @@
     {
       "cefr": "A2",
       "gloss": "to see, catch sight of",
+      "glossClean": "to see",
       "heritage": "standard",
       "ipa": null,
       "lemma": "побачити",
       "lemmaId": "побачити",
       "lemmaPlain": "побачити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10052,11 +11206,13 @@
     {
       "cefr": "A2",
       "gloss": "after saying",
+      "glossClean": "after saying",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сказавши",
       "lemmaId": "сказавши",
       "lemmaPlain": "сказавши",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10067,11 +11223,13 @@
     {
       "cefr": "A2",
       "gloss": "train car",
+      "glossClean": "train car",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вагон",
       "lemmaId": "вагон",
       "lemmaPlain": "вагон",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10082,11 +11240,13 @@
     {
       "cefr": "A2",
       "gloss": "platform",
+      "glossClean": "platform",
       "heritage": "standard",
       "ipa": null,
       "lemma": "платформа",
       "lemmaId": "платформа",
       "lemmaPlain": "платформа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -10126,11 +11286,13 @@
     {
       "cefr": "A2",
       "gloss": "century",
+      "glossClean": "century",
       "heritage": "standard",
       "ipa": null,
       "lemma": "століття",
       "lemmaId": "століття",
       "lemmaPlain": "століття",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10141,11 +11303,13 @@
     {
       "cefr": "A2",
       "gloss": "percent",
+      "glossClean": "percent",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відсоток",
       "lemmaId": "відсоток",
       "lemmaPlain": "відсоток",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10156,11 +11320,13 @@
     {
       "cefr": "A2",
       "gloss": "gram",
+      "glossClean": "gram",
       "heritage": "standard",
       "ipa": null,
       "lemma": "грам",
       "lemmaId": "грам",
       "lemmaPlain": "грам",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10171,11 +11337,13 @@
     {
       "cefr": "A2",
       "gloss": "too much, too many",
+      "glossClean": "too much",
       "heritage": "standard",
       "ipa": null,
       "lemma": "забагато",
       "lemmaId": "забагато",
       "lemmaPlain": "забагато",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10186,11 +11354,13 @@
     {
       "cefr": "A2",
       "gloss": "too little, too few",
+      "glossClean": "too little",
       "heritage": "standard",
       "ipa": null,
       "lemma": "замало",
       "lemmaId": "замало",
       "lemmaPlain": "замало",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10201,11 +11371,13 @@
     {
       "cefr": "A2",
       "gloss": "third",
+      "glossClean": "third",
       "heritage": "standard",
       "ipa": null,
       "lemma": "третина",
       "lemmaId": "третина",
       "lemmaPlain": "третина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -10245,11 +11417,13 @@
     {
       "cefr": "A2",
       "gloss": "comprehensive, integrated",
+      "glossClean": "comprehensive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "комплексний",
       "lemmaId": "комплексний",
       "lemmaPlain": "комплексний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10260,11 +11434,13 @@
     {
       "cefr": "A2",
       "gloss": "review",
+      "glossClean": "review",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відгук",
       "lemmaId": "відгук",
       "lemmaPlain": "відгук",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10275,11 +11451,13 @@
     {
       "cefr": "A2",
       "gloss": "warranty",
+      "glossClean": "warranty",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гарантія",
       "lemmaId": "гарантія",
       "lemmaPlain": "гарантія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -10319,11 +11497,13 @@
     {
       "cefr": "A2",
       "gloss": "receipt",
+      "glossClean": "receipt",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чек",
       "lemmaId": "чек",
       "lemmaPlain": "чек",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10334,11 +11514,13 @@
     {
       "cefr": "A2",
       "gloss": "to drive, to take regularly",
+      "glossClean": "to drive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "водити",
       "lemmaId": "водити",
       "lemmaPlain": "водити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10349,11 +11531,13 @@
     {
       "cefr": "A2",
       "gloss": "to pay",
+      "glossClean": "to pay",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заплатити",
       "lemmaId": "заплатити",
       "lemmaPlain": "заплатити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10364,11 +11548,13 @@
     {
       "cefr": "A2",
       "gloss": "blood",
+      "glossClean": "blood",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кров",
       "lemmaId": "кров",
       "lemmaPlain": "кров",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10379,11 +11565,13 @@
     {
       "cefr": "A2",
       "gloss": "to carry, to wear",
+      "glossClean": "to carry",
       "heritage": "standard",
       "ipa": null,
       "lemma": "носити",
       "lemmaId": "носити",
       "lemmaPlain": "носити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10394,11 +11582,13 @@
     {
       "cefr": "A2",
       "gloss": "consonant simplification",
+      "glossClean": "consonant simplification",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спрощення",
       "lemmaId": "спрощення",
       "lemmaPlain": "спрощення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10409,11 +11599,13 @@
     {
       "cefr": "A2",
       "gloss": "friend, companion",
+      "glossClean": "friend",
       "heritage": "standard",
       "ipa": null,
       "lemma": "товариш",
       "lemmaId": "товариш",
       "lemmaPlain": "товариш",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10424,11 +11616,13 @@
     {
       "cefr": "A2",
       "gloss": "exit",
+      "glossClean": "exit",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вихід",
       "lemmaId": "вихід",
       "lemmaPlain": "вихід",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10439,11 +11633,13 @@
     {
       "cefr": "A2",
       "gloss": "entry",
+      "glossClean": "entry",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вхід",
       "lemmaId": "вхід",
       "lemmaPlain": "вхід",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10454,11 +11650,13 @@
     {
       "cefr": "A2",
       "gloss": "approach",
+      "glossClean": "approach",
       "heritage": "standard",
       "ipa": null,
       "lemma": "наближення",
       "lemmaId": "наближення",
       "lemmaPlain": "наближення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10469,11 +11667,13 @@
     {
       "cefr": "A2",
       "gloss": "crossing",
+      "glossClean": "crossing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перетин",
       "lemmaId": "перетин",
       "lemmaPlain": "перетин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10484,11 +11684,13 @@
     {
       "cefr": "A2",
       "gloss": "flight, service",
+      "glossClean": "flight",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рейс",
       "lemmaId": "рейс",
       "lemmaPlain": "рейс",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10499,11 +11701,13 @@
     {
       "cefr": "A2",
       "gloss": "separation by punctuation",
+      "glossClean": "separation by punctuation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відокремлення",
       "lemmaId": "відокремлення",
       "lemmaPlain": "відокремлення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10514,11 +11718,13 @@
     {
       "cefr": "A2",
       "gloss": "discussion",
+      "glossClean": "discussion",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дискусія",
       "lemmaId": "дискусія",
       "lemmaPlain": "дискусія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -10558,11 +11764,13 @@
     {
       "cefr": "A2",
       "gloss": "environment",
+      "glossClean": "environment",
       "heritage": "standard",
       "ipa": null,
       "lemma": "довкілля",
       "lemmaId": "довкілля",
       "lemmaPlain": "довкілля",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10573,11 +11781,13 @@
     {
       "cefr": "A2",
       "gloss": "is being built",
+      "glossClean": "is being built",
       "heritage": "standard",
       "ipa": null,
       "lemma": "будується",
       "lemmaId": "будується",
       "lemmaPlain": "будується",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10588,11 +11798,13 @@
     {
       "cefr": "A2",
       "gloss": "to meet each other",
+      "glossClean": "to meet each other",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зустрічатися",
       "lemmaId": "зустрічатися",
       "lemmaPlain": "зустрічатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10603,11 +11815,13 @@
     {
       "cefr": "A2",
       "gloss": "to shout",
+      "glossClean": "to shout",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кричати",
       "lemmaId": "кричати",
       "lemmaPlain": "кричати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10618,11 +11832,13 @@
     {
       "cefr": "A2",
       "gloss": "is sold; is for sale",
+      "glossClean": "is sold",
       "heritage": "standard",
       "ipa": null,
       "lemma": "продається",
       "lemmaId": "продається",
       "lemmaPlain": "продається",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10633,11 +11849,13 @@
     {
       "cefr": "A2",
       "gloss": "prepared",
+      "glossClean": "prepared",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підготовлено",
       "lemmaId": "підготовлено",
       "lemmaPlain": "підготовлено",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10648,11 +11866,13 @@
     {
       "cefr": "A2",
       "gloss": "signed",
+      "glossClean": "signed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підписано",
       "lemmaId": "підписано",
       "lemmaPlain": "підписано",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10663,11 +11883,13 @@
     {
       "cefr": "A2",
       "gloss": "approved; adopted",
+      "glossClean": "approved",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ухвалено",
       "lemmaId": "ухвалено",
       "lemmaPlain": "ухвалено",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10678,11 +11900,13 @@
     {
       "cefr": "A2",
       "gloss": "contrary to (variant of усупереч)",
+      "glossClean": "contrary to (variant of усупереч)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "всупереч",
       "lemmaId": "всупереч",
       "lemmaPlain": "всупереч",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10693,11 +11917,13 @@
     {
       "cefr": "A2",
       "gloss": "debate (pl. only)",
+      "glossClean": "debate (pl. only)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дебати",
       "lemmaId": "дебати",
       "lemmaPlain": "дебати",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10708,11 +11934,13 @@
     {
       "cefr": "A2",
       "gloss": "aim, objective",
+      "glossClean": "aim",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ціль",
       "lemmaId": "ціль",
       "lemmaPlain": "ціль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -10752,11 +11980,13 @@
     {
       "cefr": "A2",
       "gloss": "justification, grounding",
+      "glossClean": "justification",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обґрунтування",
       "lemmaId": "обґрунтування",
       "lemmaPlain": "обґрунтування",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10767,11 +11997,13 @@
     {
       "cefr": "A2",
       "gloss": "to reinforce",
+      "glossClean": "to reinforce",
       "heritage": "standard",
       "ipa": null,
       "lemma": "закріпити",
       "lemmaId": "закріпити",
       "lemmaPlain": "закріпити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10782,11 +12014,13 @@
     {
       "cefr": "A2",
       "gloss": "wish, desire",
+      "glossClean": "wish",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бажання",
       "lemmaId": "бажання",
       "lemmaPlain": "бажання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10797,11 +12031,13 @@
     {
       "cefr": "A2",
       "gloss": "to postpone, reschedule",
+      "glossClean": "to postpone",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перенести",
       "lemmaId": "перенести",
       "lemmaPlain": "перенести",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10812,11 +12048,13 @@
     {
       "cefr": "A2",
       "gloss": "to warn, notify",
+      "glossClean": "to warn",
       "heritage": "standard",
       "ipa": null,
       "lemma": "попередити",
       "lemmaId": "попередити",
       "lemmaPlain": "попередити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10827,11 +12065,13 @@
     {
       "cefr": "A2",
       "gloss": "to prepare",
+      "glossClean": "to prepare",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підготувати",
       "lemmaId": "підготувати",
       "lemmaPlain": "підготувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10842,11 +12082,13 @@
     {
       "cefr": "A2",
       "gloss": "to confirm",
+      "glossClean": "to confirm",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підтвердити",
       "lemmaId": "підтвердити",
       "lemmaPlain": "підтвердити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10857,11 +12099,13 @@
     {
       "cefr": "A2",
       "gloss": "to manage, to cope",
+      "glossClean": "to manage",
       "heritage": "standard",
       "ipa": null,
       "lemma": "впоратися",
       "lemmaId": "впоратися",
       "lemmaPlain": "впоратися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10872,11 +12116,13 @@
     {
       "cefr": "A2",
       "gloss": "dream",
+      "glossClean": "dream",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мрія",
       "lemmaId": "мрія",
       "lemmaPlain": "мрія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10887,11 +12133,13 @@
     {
       "cefr": "A2",
       "gloss": "opportunity",
+      "glossClean": "opportunity",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нагода",
       "lemmaId": "нагода",
       "lemmaPlain": "нагода",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10902,11 +12150,13 @@
     {
       "cefr": "A2",
       "gloss": "it is worth, should",
+      "glossClean": "it is worth",
       "heritage": "standard",
       "ipa": null,
       "lemma": "варто",
       "lemmaId": "варто",
       "lemmaPlain": "варто",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10917,11 +12167,13 @@
     {
       "cefr": "A2",
       "gloss": "almost",
+      "glossClean": "almost",
       "heritage": "standard",
       "ipa": null,
       "lemma": "майже",
       "lemmaId": "майже",
       "lemmaPlain": "майже",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10932,11 +12184,13 @@
     {
       "cefr": "A2",
       "gloss": "argument, reason",
+      "glossClean": "argument",
       "heritage": "standard",
       "ipa": null,
       "lemma": "аргумент",
       "lemmaId": "аргумент",
       "lemmaPlain": "аргумент",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10947,11 +12201,13 @@
     {
       "cefr": "A2",
       "gloss": "proof, reasoning",
+      "glossClean": "proof",
       "heritage": "standard",
       "ipa": null,
       "lemma": "доведення",
       "lemmaId": "доведення",
       "lemmaPlain": "доведення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10962,11 +12218,13 @@
     {
       "cefr": "A2",
       "gloss": "reasoning",
+      "glossClean": "reasoning",
       "heritage": "standard",
       "ipa": null,
       "lemma": "міркування",
       "lemmaId": "міркування",
       "lemmaPlain": "міркування",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10977,11 +12235,13 @@
     {
       "cefr": "A2",
       "gloss": "therefore",
+      "glossClean": "therefore",
       "heritage": "standard",
       "ipa": null,
       "lemma": "отже",
       "lemmaId": "отже",
       "lemmaPlain": "отже",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10992,11 +12252,13 @@
     {
       "cefr": "A2",
       "gloss": "to persuade",
+      "glossClean": "to persuade",
       "heritage": "standard",
       "ipa": null,
       "lemma": "переконувати",
       "lemmaId": "переконувати",
       "lemmaPlain": "переконувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11007,11 +12269,13 @@
     {
       "cefr": "A2",
       "gloss": "thesis, claim",
+      "glossClean": "thesis",
       "heritage": "standard",
       "ipa": null,
       "lemma": "теза",
       "lemmaId": "теза",
       "lemmaPlain": "теза",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -11051,11 +12315,13 @@
     {
       "cefr": "A2",
       "gloss": "points, score",
+      "glossClean": "points",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бали",
       "lemmaId": "бали",
       "lemmaPlain": "бали",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11066,11 +12332,13 @@
     {
       "cefr": "A2",
       "gloss": "dormitory",
+      "glossClean": "dormitory",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гуртожиток",
       "lemmaId": "гуртожиток",
       "lemmaPlain": "гуртожиток",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11081,11 +12349,13 @@
     {
       "cefr": "A2",
       "gloss": "building, campus building",
+      "glossClean": "building",
       "heritage": "standard",
       "ipa": null,
       "lemma": "корпус",
       "lemmaId": "корпус",
       "lemmaPlain": "корпус",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11096,11 +12366,13 @@
     {
       "cefr": "A2",
       "gloss": "semester",
+      "glossClean": "semester",
       "heritage": "standard",
       "ipa": null,
       "lemma": "семестр",
       "lemmaId": "семестр",
       "lemmaPlain": "семестр",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11111,11 +12383,13 @@
     {
       "cefr": "A2",
       "gloss": "seminar",
+      "glossClean": "seminar",
       "heritage": "standard",
       "ipa": null,
       "lemma": "семінар",
       "lemmaId": "семінар",
       "lemmaPlain": "семінар",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11126,11 +12400,13 @@
     {
       "cefr": "A2",
       "gloss": "worth, worthy of",
+      "glossClean": "worth",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вартий",
       "lemmaId": "вартий",
       "lemmaPlain": "вартий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11141,11 +12417,13 @@
     {
       "cefr": "A2",
       "gloss": "worthy",
+      "glossClean": "worthy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гідний",
       "lemmaId": "гідний",
       "lemmaPlain": "гідний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11156,11 +12434,13 @@
     {
       "cefr": "A2",
       "gloss": "from among",
+      "glossClean": "from among",
       "heritage": "standard",
       "ipa": null,
       "lemma": "з-поміж",
       "lemmaId": "з-поміж",
       "lemmaPlain": "з-поміж",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11171,11 +12451,13 @@
     {
       "cefr": "A2",
       "gloss": "measure",
+      "glossClean": "measure",
       "heritage": "standard",
       "ipa": null,
       "lemma": "міра",
       "lemmaId": "міра",
       "lemmaPlain": "міра",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -11215,11 +12497,13 @@
     {
       "cefr": "A2",
       "gloss": "to acquire, to gain",
+      "glossClean": "to acquire",
       "heritage": "standard",
       "ipa": null,
       "lemma": "набути",
       "lemmaId": "набути",
       "lemmaPlain": "набути",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11230,11 +12514,13 @@
     {
       "cefr": "A2",
       "gloss": "whole",
+      "glossClean": "whole",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ціле",
       "lemmaId": "ціле",
       "lemmaPlain": "ціле",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11245,11 +12531,13 @@
     {
       "cefr": "A2",
       "gloss": "while speaking",
+      "glossClean": "while speaking",
       "heritage": "standard",
       "ipa": null,
       "lemma": "говорячи",
       "lemmaId": "говорячи",
       "lemmaPlain": "говорячи",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11260,11 +12548,13 @@
     {
       "cefr": "A2",
       "gloss": "while working",
+      "glossClean": "while working",
       "heritage": "standard",
       "ipa": null,
       "lemma": "працюючи",
       "lemmaId": "працюючи",
       "lemmaPlain": "працюючи",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11275,11 +12565,13 @@
     {
       "cefr": "A2",
       "gloss": "while listening",
+      "glossClean": "while listening",
       "heritage": "standard",
       "ipa": null,
       "lemma": "слухаючи",
       "lemmaId": "слухаючи",
       "lemmaPlain": "слухаючи",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11290,11 +12582,13 @@
     {
       "cefr": "A2",
       "gloss": "having received",
+      "glossClean": "having received",
       "heritage": "standard",
       "ipa": null,
       "lemma": "отримавши",
       "lemmaId": "отримавши",
       "lemmaPlain": "отримавши",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11305,11 +12599,13 @@
     {
       "cefr": "A2",
       "gloss": "having returned",
+      "glossClean": "having returned",
       "heritage": "standard",
       "ipa": null,
       "lemma": "повернувшись",
       "lemmaId": "повернувшись",
       "lemmaPlain": "повернувшись",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11320,11 +12616,13 @@
     {
       "cefr": "A2",
       "gloss": "pharmacist, pharmacy worker",
+      "glossClean": "pharmacist",
       "heritage": "standard",
       "ipa": null,
       "lemma": "аптекар",
       "lemmaId": "аптекар",
       "lemmaPlain": "аптекар",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11335,11 +12633,13 @@
     {
       "cefr": "A2",
       "gloss": "flu",
+      "glossClean": "flu",
       "heritage": "standard",
       "ipa": null,
       "lemma": "грип",
       "lemmaId": "грип",
       "lemmaPlain": "грип",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11350,11 +12650,13 @@
     {
       "cefr": "A2",
       "gloss": "cold",
+      "glossClean": "cold",
       "heritage": "standard",
       "ipa": null,
       "lemma": "застуда",
       "lemmaId": "застуда",
       "lemmaPlain": "застуда",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11365,11 +12667,13 @@
     {
       "cefr": "A2",
       "gloss": "to treat",
+      "glossClean": "to treat",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лікувати",
       "lemmaId": "лікувати",
       "lemmaPlain": "лікувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11380,11 +12684,13 @@
     {
       "cefr": "A2",
       "gloss": "clinic, outpatient clinic",
+      "glossClean": "clinic",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поліклініка",
       "lemmaId": "поліклініка",
       "lemmaPlain": "поліклініка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11395,11 +12701,13 @@
     {
       "cefr": "A2",
       "gloss": "to prescribe",
+      "glossClean": "to prescribe",
       "heritage": "standard",
       "ipa": null,
       "lemma": "призначити",
       "lemmaId": "призначити",
       "lemmaPlain": "призначити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11410,11 +12718,13 @@
     {
       "cefr": "A2",
       "gloss": "X-ray",
+      "glossClean": "X-ray",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рентген",
       "lemmaId": "рентген",
       "lemmaPlain": "рентген",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11425,11 +12735,13 @@
     {
       "cefr": "A2",
       "gloss": "symptom",
+      "glossClean": "symptom",
       "heritage": "standard",
       "ipa": null,
       "lemma": "симптом",
       "lemmaId": "симптом",
       "lemmaPlain": "симптом",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11440,11 +12752,13 @@
     {
       "cefr": "A2",
       "gloss": "dentist",
+      "glossClean": "dentist",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стоматолог",
       "lemmaId": "стоматолог",
       "lemmaPlain": "стоматолог",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11455,11 +12769,13 @@
     {
       "cefr": "A2",
       "gloss": "disease, illness",
+      "glossClean": "disease",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хвороба",
       "lemmaId": "хвороба",
       "lemmaPlain": "хвороба",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11470,11 +12786,13 @@
     {
       "cefr": "A2",
       "gloss": "to be ill with",
+      "glossClean": "to be ill with",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хворіти",
       "lemmaId": "хворіти",
       "lemmaPlain": "хворіти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11485,11 +12803,13 @@
     {
       "cefr": "A2",
       "gloss": "included",
+      "glossClean": "included",
       "heritage": "standard",
       "ipa": null,
       "lemma": "включено",
       "lemmaId": "включено",
       "lemmaPlain": "включено",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11500,11 +12820,13 @@
     {
       "cefr": "A2",
       "gloss": "attic",
+      "glossClean": "attic",
       "heritage": "standard",
       "ipa": null,
       "lemma": "горище",
       "lemmaId": "горище",
       "lemmaPlain": "горище",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11515,11 +12837,13 @@
     {
       "cefr": "A2",
       "gloss": "utilities",
+      "glossClean": "utilities",
       "heritage": "standard",
       "ipa": null,
       "lemma": "комунальні",
       "lemmaId": "комунальні",
       "lemmaPlain": "комунальні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11530,11 +12854,13 @@
     {
       "cefr": "A2",
       "gloss": "air conditioner",
+      "glossClean": "air conditioner",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кондиціонер",
       "lemmaId": "кондиціонер",
       "lemmaPlain": "кондиціонер",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11545,11 +12871,13 @@
     {
       "cefr": "A2",
       "gloss": "hallway",
+      "glossClean": "hallway",
       "heritage": "standard",
       "ipa": null,
       "lemma": "коридор",
       "lemmaId": "коридор",
       "lemmaPlain": "коридор",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11560,11 +12888,13 @@
     {
       "cefr": "A2",
       "gloss": "repair person; technician",
+      "glossClean": "repair person",
       "heritage": "standard",
       "ipa": null,
       "lemma": "майстер",
       "lemmaId": "майстер",
       "lemmaPlain": "майстер",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11575,11 +12905,13 @@
     {
       "cefr": "A2",
       "gloss": "advertisement; listing",
+      "glossClean": "advertisement",
       "heritage": "standard",
       "ipa": null,
       "lemma": "оголошення",
       "lemmaId": "оголошення",
       "lemmaPlain": "оголошення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11590,11 +12922,13 @@
     {
       "cefr": "A2",
       "gloss": "rent; rental",
+      "glossClean": "rent",
       "heritage": "standard",
       "ipa": null,
       "lemma": "оренда",
       "lemmaId": "оренда",
       "lemmaPlain": "оренда",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11605,11 +12939,13 @@
     {
       "cefr": "A2",
       "gloss": "courtyard",
+      "glossClean": "courtyard",
       "heritage": "standard",
       "ipa": null,
       "lemma": "подвір'я",
       "lemmaId": "подвір-я",
       "lemmaPlain": "подвір'я",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11620,11 +12956,13 @@
     {
       "cefr": "A2",
       "gloss": "basement",
+      "glossClean": "basement",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підвал",
       "lemmaId": "підвал",
       "lemmaPlain": "підвал",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11635,11 +12973,13 @@
     {
       "cefr": "A2",
       "gloss": "renovation; repair",
+      "glossClean": "renovation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ремонт",
       "lemmaId": "ремонт",
       "lemmaPlain": "ремонт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11650,11 +12990,13 @@
     {
       "cefr": "A2",
       "gloss": "garbage",
+      "glossClean": "garbage",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сміття",
       "lemmaId": "сміття",
       "lemmaPlain": "сміття",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11665,11 +13007,13 @@
     {
       "cefr": "A2",
       "gloss": "urgently",
+      "glossClean": "urgently",
       "heritage": "standard",
       "ipa": null,
       "lemma": "терміново",
       "lemmaId": "терміново",
       "lemmaPlain": "терміново",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11680,11 +13024,13 @@
     {
       "cefr": "A2",
       "gloss": "let's, give; informal prompt",
+      "glossClean": "let's",
       "heritage": "standard",
       "ipa": null,
       "lemma": "давай / давайте",
       "lemmaId": "давай-давайте",
       "lemmaPlain": "давай / давайте",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11695,11 +13041,13 @@
     {
       "cefr": "A2",
       "gloss": "direct",
+      "glossClean": "direct",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прямий",
       "lemmaId": "прямий",
       "lemmaPlain": "прямий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11710,11 +13058,13 @@
     {
       "cefr": "A2",
       "gloss": "rehearsal",
+      "glossClean": "rehearsal",
       "heritage": "standard",
       "ipa": null,
       "lemma": "репетиція",
       "lemmaId": "репетиція",
       "lemmaPlain": "репетиція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11725,11 +13075,13 @@
     {
       "cefr": "A2",
       "gloss": "to be considered",
+      "glossClean": "to be considered",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вважатися",
       "lemmaId": "вважатися",
       "lemmaPlain": "вважатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11740,11 +13092,13 @@
     {
       "cefr": "A2",
       "gloss": "has been performed",
+      "glossClean": "has been performed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виконано",
       "lemmaId": "виконано",
       "lemmaPlain": "виконано",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11755,11 +13109,13 @@
     {
       "cefr": "A2",
       "gloss": "to possess, master",
+      "glossClean": "to possess",
       "heritage": "standard",
       "ipa": null,
       "lemma": "володіти",
       "lemmaId": "володіти",
       "lemmaPlain": "володіти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11770,11 +13126,13 @@
     {
       "cefr": "A2",
       "gloss": "to remain",
+      "glossClean": "to remain",
       "heritage": "standard",
       "ipa": null,
       "lemma": "залишатися",
       "lemmaId": "залишатися",
       "lemmaPlain": "залишатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11785,11 +13143,13 @@
     {
       "cefr": "A2",
       "gloss": "perhaps",
+      "glossClean": "perhaps",
       "heritage": "standard",
       "ipa": null,
       "lemma": "либонь",
       "lemmaId": "либонь",
       "lemmaPlain": "либонь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11800,11 +13160,13 @@
     {
       "cefr": "A2",
       "gloss": "probably",
+      "glossClean": "probably",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мабуть",
       "lemmaId": "мабуть",
       "lemmaPlain": "мабуть",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11815,11 +13177,13 @@
     {
       "cefr": "A2",
       "gloss": "possibly",
+      "glossClean": "possibly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "можливо",
       "lemmaId": "можливо",
       "lemmaPlain": "можливо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11830,11 +13194,13 @@
     {
       "cefr": "A2",
       "gloss": "indeed",
+      "glossClean": "indeed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "справді",
       "lemmaId": "справді",
       "lemmaPlain": "справді",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11845,11 +13211,13 @@
     {
       "cefr": "A2",
       "gloss": "order",
+      "glossClean": "order",
       "heritage": "standard",
       "ipa": null,
       "lemma": "замовлення",
       "lemmaId": "замовлення",
       "lemmaPlain": "замовлення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11860,11 +13228,13 @@
     {
       "cefr": "A2",
       "gloss": "hobby, passion",
+      "glossClean": "hobby",
       "heritage": "standard",
       "ipa": null,
       "lemma": "захоплення",
       "lemmaId": "захоплення",
       "lemmaPlain": "захоплення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11875,11 +13245,13 @@
     {
       "cefr": "A2",
       "gloss": "sculpture",
+      "glossClean": "sculpture",
       "heritage": "standard",
       "ipa": null,
       "lemma": "скульптура",
       "lemmaId": "скульптура",
       "lemmaPlain": "скульптура",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11890,11 +13262,13 @@
     {
       "cefr": "A2",
       "gloss": "to run in one direction",
+      "glossClean": "to run in one direction",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бігти",
       "lemmaId": "бігти",
       "lemmaPlain": "бігти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11905,11 +13279,13 @@
     {
       "cefr": "A2",
       "gloss": "to carry on foot in one direction",
+      "glossClean": "to carry on foot in one direction",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нести",
       "lemmaId": "нести",
       "lemmaPlain": "нести",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11920,11 +13296,13 @@
     {
       "cefr": "A2",
       "gloss": "to swim or sail in one direction",
+      "glossClean": "to swim or sail in one direction",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пливти",
       "lemmaId": "пливти",
       "lemmaPlain": "пливти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11935,11 +13313,13 @@
     {
       "cefr": "A2",
       "gloss": "by transport",
+      "glossClean": "by transport",
       "heritage": "standard",
       "ipa": null,
       "lemma": "транспортом",
       "lemmaId": "транспортом",
       "lemmaPlain": "транспортом",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11950,11 +13330,13 @@
     {
       "cefr": "A2",
       "gloss": "to go by vehicle habitually, back and forth, or in various directions",
+      "glossClean": "to go by vehicle habitually",
       "heritage": "standard",
       "ipa": null,
       "lemma": "їздити",
       "lemmaId": "їздити",
       "lemmaPlain": "їздити",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11965,11 +13347,13 @@
     {
       "cefr": "A2",
       "gloss": "shore, bank",
+      "glossClean": "shore",
       "heritage": "standard",
       "ipa": null,
       "lemma": "берег",
       "lemmaId": "берег",
       "lemmaPlain": "берег",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11980,11 +13364,13 @@
     {
       "cefr": "A2",
       "gloss": "ship",
+      "glossClean": "ship",
       "heritage": "standard",
       "ipa": null,
       "lemma": "корабель",
       "lemmaId": "корабель",
       "lemmaPlain": "корабель",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11995,11 +13381,13 @@
     {
       "cefr": "A2",
       "gloss": "they are flying",
+      "glossClean": "they are flying",
       "heritage": "standard",
       "ipa": null,
       "lemma": "летять",
       "lemmaId": "летять",
       "lemmaPlain": "летять",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12010,11 +13398,13 @@
     {
       "cefr": "A2",
       "gloss": "island",
+      "glossClean": "island",
       "heritage": "standard",
       "ipa": null,
       "lemma": "острів",
       "lemmaId": "острів",
       "lemmaPlain": "острів",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12025,11 +13415,13 @@
     {
       "cefr": "A2",
       "gloss": "terminal",
+      "glossClean": "terminal",
       "heritage": "standard",
       "ipa": null,
       "lemma": "термінал",
       "lemmaId": "термінал",
       "lemmaPlain": "термінал",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -12040,11 +13432,13 @@
     {
       "cefr": "A2",
       "gloss": "boat",
+      "glossClean": "boat",
       "heritage": "standard",
       "ipa": null,
       "lemma": "човен",
       "lemmaId": "човен",
       "lemmaPlain": "човен",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12055,11 +13449,13 @@
     {
       "cefr": "A2",
       "gloss": "to carry all the way to; perfective",
+      "glossClean": "to carry all the way to",
       "heritage": "standard",
       "ipa": null,
       "lemma": "донести",
       "lemmaId": "донести",
       "lemmaPlain": "донести",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -12070,11 +13466,13 @@
     {
       "cefr": "A2",
       "gloss": "to come, arrive on foot; perfective",
+      "glossClean": "to come",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прийти",
       "lemmaId": "прийти",
       "lemmaPlain": "прийти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12085,11 +13483,13 @@
     {
       "cefr": "A2",
       "gloss": "to come habitually or repeatedly; imperfective",
+      "glossClean": "to come habitually or repeatedly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "приходити",
       "lemmaId": "приходити",
       "lemmaPlain": "приходити",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -12100,11 +13500,13 @@
     {
       "cefr": "A2",
       "gloss": "to arrive or visit by transport habitually; common imperfective",
+      "glossClean": "to arrive or visit by transport habitually",
       "heritage": "standard",
       "ipa": null,
       "lemma": "приїжджати",
       "lemmaId": "приїжджати",
       "lemmaPlain": "приїжджати",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -12115,11 +13517,13 @@
     {
       "cefr": "A2",
       "gloss": "to arrive by transport; perfective",
+      "glossClean": "to arrive by transport",
       "heritage": "standard",
       "ipa": null,
       "lemma": "приїхати",
       "lemmaId": "приїхати",
       "lemmaPlain": "приїхати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12130,11 +13534,13 @@
     {
       "cefr": "A2",
       "gloss": "rural guesthouse, estate",
+      "glossClean": "rural guesthouse",
       "heritage": "standard",
       "ipa": null,
       "lemma": "садиба",
       "lemmaId": "садиба",
       "lemmaPlain": "садиба",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12145,11 +13551,13 @@
     {
       "cefr": "A2",
       "gloss": "stepped away, moved away; masculine past",
+      "glossClean": "stepped away",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відійшов",
       "lemmaId": "відійшов",
       "lemmaPlain": "відійшов",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12160,11 +13568,13 @@
     {
       "cefr": "A2",
       "gloss": "to take off running, run off; perfective",
+      "glossClean": "to take off running",
       "heritage": "standard",
       "ipa": null,
       "lemma": "побігти",
       "lemmaId": "побігти",
       "lemmaPlain": "побігти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12175,11 +13585,13 @@
     {
       "cefr": "A2",
       "gloss": "I will go by transport",
+      "glossClean": "I will go by transport",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поїду",
       "lemmaId": "поїду",
       "lemmaPlain": "поїду",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -12190,11 +13602,13 @@
     {
       "cefr": "A2",
       "gloss": "to transport out; perfective",
+      "glossClean": "to transport out",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вивезти",
       "lemmaId": "вивезти",
       "lemmaPlain": "вивезти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12205,11 +13619,13 @@
     {
       "cefr": "A2",
       "gloss": "to exit, go out; perfective",
+      "glossClean": "to exit",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вийти",
       "lemmaId": "вийти",
       "lemmaPlain": "вийти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12220,11 +13636,13 @@
     {
       "cefr": "A2",
       "gloss": "to carry out; perfective",
+      "glossClean": "to carry out",
       "heritage": "standard",
       "ipa": null,
       "lemma": "винести",
       "lemmaId": "винести",
       "lemmaPlain": "винести",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12235,11 +13653,13 @@
     {
       "cefr": "A2",
       "gloss": "to carry out habitually or repeatedly",
+      "glossClean": "to carry out habitually or repeatedly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виносити",
       "lemmaId": "виносити",
       "lemmaPlain": "виносити",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -12250,11 +13670,13 @@
     {
       "cefr": "A2",
       "gloss": "to lead or bring someone in; perfective",
+      "glossClean": "to lead or bring someone in",
       "heritage": "standard",
       "ipa": null,
       "lemma": "завести",
       "lemmaId": "завести",
       "lemmaPlain": "завести",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -12265,11 +13687,13 @@
     {
       "cefr": "A2",
       "gloss": "entered, dropped by; feminine past",
+      "glossClean": "entered",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зайшла",
       "lemmaId": "зайшла",
       "lemmaPlain": "зайшла",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12280,11 +13704,13 @@
     {
       "cefr": "A2",
       "gloss": "border",
+      "glossClean": "border",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кордон",
       "lemmaId": "кордон",
       "lemmaPlain": "кордон",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12295,11 +13721,13 @@
     {
       "cefr": "A2",
       "gloss": "right through, from one side to the other",
+      "glossClean": "right through",
       "heritage": "standard",
       "ipa": null,
       "lemma": "наскрізь",
       "lemmaId": "наскрізь",
       "lemmaPlain": "наскрізь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12310,11 +13738,13 @@
     {
       "cefr": "A2",
       "gloss": "to lead across, transfer, translate; perfective",
+      "glossClean": "to lead across",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перевести",
       "lemmaId": "перевести",
       "lemmaPlain": "перевести",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12325,11 +13755,13 @@
     {
       "cefr": "A2",
       "gloss": "to cross on foot; perfective",
+      "glossClean": "to cross on foot",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перейти",
       "lemmaId": "перейти",
       "lemmaPlain": "перейти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12340,11 +13772,13 @@
     {
       "cefr": "A2",
       "gloss": "crossed on foot; feminine past",
+      "glossClean": "crossed on foot",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перейшла",
       "lemmaId": "перейшла",
       "lemmaPlain": "перейшла",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12355,11 +13789,13 @@
     {
       "cefr": "A2",
       "gloss": "to cross, cross habitually; imperfective",
+      "glossClean": "to cross",
       "heritage": "standard",
       "ipa": null,
       "lemma": "переходити",
       "lemmaId": "переходити",
       "lemmaPlain": "переходити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12370,11 +13806,13 @@
     {
       "cefr": "A2",
       "gloss": "intersection, crossroads",
+      "glossClean": "intersection",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перехрестя",
       "lemmaId": "перехрестя",
       "lemmaPlain": "перехрестя",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12385,11 +13823,13 @@
     {
       "cefr": "A2",
       "gloss": "to cross by vehicle, relocate habitually; imperfective",
+      "glossClean": "to cross by vehicle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "переїжджати",
       "lemmaId": "переїжджати",
       "lemmaPlain": "переїжджати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12400,11 +13840,13 @@
     {
       "cefr": "A2",
       "gloss": "along, over a surface; takes dative in this spatial use",
+      "glossClean": "along",
       "heritage": "standard",
       "ipa": null,
       "lemma": "по",
       "lemmaId": "по",
       "lemmaPlain": "по",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -12415,11 +13857,13 @@
     {
       "cefr": "A2",
       "gloss": "to guide through, lead along; perfective",
+      "glossClean": "to guide through",
       "heritage": "standard",
       "ipa": null,
       "lemma": "провести",
       "lemmaId": "провести",
       "lemmaPlain": "провести",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12430,11 +13874,13 @@
     {
       "cefr": "A2",
       "gloss": "pollution",
+      "glossClean": "pollution",
       "heritage": "standard",
       "ipa": null,
       "lemma": "забруднення",
       "lemmaId": "забруднення",
       "lemmaPlain": "забруднення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12445,11 +13891,13 @@
     {
       "cefr": "A2",
       "gloss": "precipitation",
+      "glossClean": "precipitation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "опади",
       "lemmaId": "опади",
       "lemmaPlain": "опади",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12460,11 +13908,13 @@
     {
       "cefr": "A2",
       "gloss": "sunflower",
+      "glossClean": "sunflower",
       "heritage": "standard",
       "ipa": null,
       "lemma": "соняшник",
       "lemmaId": "соняшник",
       "lemmaPlain": "соняшник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12475,11 +13925,13 @@
     {
       "cefr": "A2",
       "gloss": "harvest",
+      "glossClean": "harvest",
       "heritage": "standard",
       "ipa": null,
       "lemma": "урожай",
       "lemmaId": "урожай",
       "lemmaPlain": "урожай",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12490,11 +13942,13 @@
     {
       "cefr": "A2",
       "gloss": "dignity",
+      "glossClean": "dignity",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гідність",
       "lemmaId": "гідність",
       "lemmaPlain": "гідність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12505,11 +13959,13 @@
     {
       "cefr": "A2",
       "gloss": "fury",
+      "glossClean": "fury",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лють",
       "lemmaId": "лють",
       "lemmaPlain": "лють",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12520,11 +13976,13 @@
     {
       "cefr": "A2",
       "gloss": "stove, oven",
+      "glossClean": "stove",
       "heritage": "standard",
       "ipa": null,
       "lemma": "піч",
       "lemmaId": "піч",
       "lemmaPlain": "піч",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12535,11 +13993,13 @@
     {
       "cefr": "A2",
       "gloss": "luxury",
+      "glossClean": "luxury",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розкіш",
       "lemmaId": "розкіш",
       "lemmaPlain": "розкіш",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12550,11 +14010,13 @@
     {
       "cefr": "A2",
       "gloss": "spectacle",
+      "glossClean": "spectacle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "видовище",
       "lemmaId": "видовище",
       "lemmaPlain": "видовище",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12565,11 +14027,13 @@
     {
       "cefr": "A2",
       "gloss": "correction",
+      "glossClean": "correction",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виправлення",
       "lemmaId": "виправлення",
       "lemmaPlain": "виправлення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12580,11 +14044,13 @@
     {
       "cefr": "A2",
       "gloss": "garage",
+      "glossClean": "garage",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гараж",
       "lemmaId": "гараж",
       "lemmaPlain": "гараж",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12595,11 +14061,13 @@
     {
       "cefr": "A2",
       "gloss": "cemetery",
+      "glossClean": "cemetery",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кладовище",
       "lemmaId": "кладовище",
       "lemmaPlain": "кладовище",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12610,11 +14078,13 @@
     {
       "cefr": "A2",
       "gloss": "raincoat",
+      "glossClean": "raincoat",
       "heritage": "standard",
       "ipa": null,
       "lemma": "плащ",
       "lemmaId": "плащ",
       "lemmaPlain": "плащ",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12625,11 +14095,13 @@
     {
       "cefr": "A2",
       "gloss": "shoulder",
+      "glossClean": "shoulder",
       "heritage": "standard",
       "ipa": null,
       "lemma": "плече",
       "lemmaId": "плече",
       "lemmaPlain": "плече",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12640,11 +14112,13 @@
     {
       "cefr": "A2",
       "gloss": "citizen",
+      "glossClean": "citizen",
       "heritage": "standard",
       "ipa": null,
       "lemma": "громадянин",
       "lemmaId": "громадянин",
       "lemmaPlain": "громадянин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12655,11 +14129,13 @@
     {
       "cefr": "A2",
       "gloss": "head, manager",
+      "glossClean": "head",
       "heritage": "standard",
       "ipa": null,
       "lemma": "завідувач",
       "lemmaId": "завідувач",
       "lemmaPlain": "завідувач",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12670,11 +14146,13 @@
     {
       "cefr": "A2",
       "gloss": "current, valid",
+      "glossClean": "current",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чинний",
       "lemmaId": "чинний",
       "lemmaPlain": "чинний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12685,11 +14163,13 @@
     {
       "cefr": "A2",
       "gloss": "boiled, cooked",
+      "glossClean": "boiled",
       "heritage": "standard",
       "ipa": null,
       "lemma": "варений",
       "lemmaId": "варений",
       "lemmaPlain": "варений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12700,11 +14180,13 @@
     {
       "cefr": "A2",
       "gloss": "embroidered",
+      "glossClean": "embroidered",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вишитий",
       "lemmaId": "вишитий",
       "lemmaPlain": "вишитий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12715,11 +14197,13 @@
     {
       "cefr": "A2",
       "gloss": "has been published; issued",
+      "glossClean": "has been published",
       "heritage": "standard",
       "ipa": null,
       "lemma": "видано",
       "lemmaId": "видано",
       "lemmaPlain": "видано",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12730,11 +14214,13 @@
     {
       "cefr": "A2",
       "gloss": "property; feature",
+      "glossClean": "property",
       "heritage": "standard",
       "ipa": null,
       "lemma": "властивість",
       "lemmaId": "властивість",
       "lemmaPlain": "властивість",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12745,11 +14231,13 @@
     {
       "cefr": "A2",
       "gloss": "is being installed",
+      "glossClean": "is being installed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "встановлюється",
       "lemmaId": "встановлюється",
       "lemmaPlain": "встановлюється",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12760,11 +14248,13 @@
     {
       "cefr": "A2",
       "gloss": "opens; is opening",
+      "glossClean": "opens",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відкривається",
       "lemmaId": "відкривається",
       "lemmaPlain": "відкривається",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12775,11 +14265,13 @@
     {
       "cefr": "A2",
       "gloss": "has been opened",
+      "glossClean": "has been opened",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відкрито",
       "lemmaId": "відкрито",
       "lemmaPlain": "відкрито",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12790,11 +14282,13 @@
     {
       "cefr": "A2",
       "gloss": "has been completed",
+      "glossClean": "has been completed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "завершено",
       "lemmaId": "завершено",
       "lemmaPlain": "завершено",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12805,11 +14299,13 @@
     {
       "cefr": "A2",
       "gloss": "is ending; is being completed",
+      "glossClean": "is ending",
       "heritage": "standard",
       "ipa": null,
       "lemma": "завершується",
       "lemmaId": "завершується",
       "lemmaPlain": "завершується",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12820,11 +14316,13 @@
     {
       "cefr": "A2",
       "gloss": "has been closed",
+      "glossClean": "has been closed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "закрито",
       "lemmaId": "закрито",
       "lemmaPlain": "закрито",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12835,11 +14333,13 @@
     {
       "cefr": "A2",
       "gloss": "has been shut",
+      "glossClean": "has been shut",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зачинено",
       "lemmaId": "зачинено",
       "lemmaPlain": "зачинено",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12850,11 +14350,13 @@
     {
       "cefr": "A2",
       "gloss": "has been built",
+      "glossClean": "has been built",
       "heritage": "standard",
       "ipa": null,
       "lemma": "збудовано",
       "lemmaId": "збудовано",
       "lemmaPlain": "збудовано",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12865,11 +14367,13 @@
     {
       "cefr": "A2",
       "gloss": "has been changed",
+      "glossClean": "has been changed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "змінено",
       "lemmaId": "змінено",
       "lemmaPlain": "змінено",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12880,11 +14384,13 @@
     {
       "cefr": "A2",
       "gloss": "has been updated",
+      "glossClean": "has been updated",
       "heritage": "standard",
       "ipa": null,
       "lemma": "оновлено",
       "lemmaId": "оновлено",
       "lemmaPlain": "оновлено",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12895,11 +14401,13 @@
     {
       "cefr": "A2",
       "gloss": "payment",
+      "glossClean": "payment",
       "heritage": "standard",
       "ipa": null,
       "lemma": "оплата",
       "lemmaId": "оплата",
       "lemmaPlain": "оплата",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12910,11 +14418,13 @@
     {
       "cefr": "A2",
       "gloss": "has been published",
+      "glossClean": "has been published",
       "heritage": "standard",
       "ipa": null,
       "lemma": "опубліковано",
       "lemmaId": "опубліковано",
       "lemmaPlain": "опубліковано",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12925,11 +14435,13 @@
     {
       "cefr": "A2",
       "gloss": "password",
+      "glossClean": "password",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пароль",
       "lemmaId": "пароль",
       "lemmaPlain": "пароль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12940,11 +14452,13 @@
     {
       "cefr": "A2",
       "gloss": "to be held; conducted",
+      "glossClean": "to be held",
       "heritage": "standard",
       "ipa": null,
       "lemma": "проводитися",
       "lemmaId": "проводитися",
       "lemmaPlain": "проводитися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12955,11 +14469,13 @@
     {
       "cefr": "A2",
       "gloss": "has been sold",
+      "glossClean": "has been sold",
       "heritage": "standard",
       "ipa": null,
       "lemma": "продано",
       "lemmaId": "продано",
       "lemmaPlain": "продано",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12970,11 +14486,13 @@
     {
       "cefr": "A2",
       "gloss": "has been confirmed",
+      "glossClean": "has been confirmed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підтверджено",
       "lemmaId": "підтверджено",
       "lemmaPlain": "підтверджено",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12985,11 +14503,13 @@
     {
       "cefr": "A2",
       "gloss": "is being confirmed; is confirmed",
+      "glossClean": "is being confirmed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підтверджується",
       "lemmaId": "підтверджується",
       "lemmaPlain": "підтверджується",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13000,11 +14520,13 @@
     {
       "cefr": "A2",
       "gloss": "to be reviewed; considered",
+      "glossClean": "to be reviewed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розглядатися",
       "lemmaId": "розглядатися",
       "lemmaPlain": "розглядатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13015,11 +14537,13 @@
     {
       "cefr": "A2",
       "gloss": "has been reviewed",
+      "glossClean": "has been reviewed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розглянуто",
       "lemmaId": "розглянуто",
       "lemmaPlain": "розглянуто",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13030,11 +14554,13 @@
     {
       "cefr": "A2",
       "gloss": "located",
+      "glossClean": "located",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розташований",
       "lemmaId": "розташований",
       "lemmaPlain": "розташований",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13045,11 +14571,13 @@
     {
       "cefr": "A2",
       "gloss": "to adopt; to pass",
+      "glossClean": "to adopt",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ухвалювати",
       "lemmaId": "ухвалювати",
       "lemmaPlain": "ухвалювати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13060,11 +14588,13 @@
     {
       "cefr": "A2",
       "gloss": "file",
+      "glossClean": "file",
       "heritage": "standard",
       "ipa": null,
       "lemma": "файл",
       "lemmaId": "файл",
       "lemmaPlain": "файл",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13075,11 +14605,13 @@
     {
       "cefr": "A2",
       "gloss": "mutual relations",
+      "glossClean": "mutual relations",
       "heritage": "standard",
       "ipa": null,
       "lemma": "взаємини",
       "lemmaId": "взаємини",
       "lemmaPlain": "взаємини",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13090,11 +14622,13 @@
     {
       "cefr": "A2",
       "gloss": "trust",
+      "glossClean": "trust",
       "heritage": "standard",
       "ipa": null,
       "lemma": "довіра",
       "lemmaId": "довіра",
       "lemmaPlain": "довіра",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13105,11 +14639,13 @@
     {
       "cefr": "A2",
       "gloss": "height",
+      "glossClean": "height",
       "heritage": "historism",
       "ipa": null,
       "lemma": "зріст",
       "lemmaId": "зріст",
       "lemmaPlain": "зріст",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13120,11 +14656,13 @@
     {
       "cefr": "A2",
       "gloss": "chestnut-colored",
+      "glossClean": "chestnut-colored",
       "heritage": "standard",
       "ipa": null,
       "lemma": "каштановий",
       "lemmaId": "каштановий",
       "lemmaPlain": "каштановий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13135,11 +14673,13 @@
     {
       "cefr": "A2",
       "gloss": "curly",
+      "glossClean": "curly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кучерявий",
       "lemmaId": "кучерявий",
       "lemmaPlain": "кучерявий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13150,11 +14690,13 @@
     {
       "cefr": "A2",
       "gloss": "nephew",
+      "glossClean": "nephew",
       "heritage": "standard",
       "ipa": null,
       "lemma": "племінник",
       "lemmaId": "племінник",
       "lemmaPlain": "племінник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13165,11 +14707,13 @@
     {
       "cefr": "A2",
       "gloss": "niece",
+      "glossClean": "niece",
       "heritage": "standard",
       "ipa": null,
       "lemma": "племінниця",
       "lemmaId": "племінниця",
       "lemmaPlain": "племінниця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13180,11 +14724,13 @@
     {
       "cefr": "A2",
       "gloss": "portrait",
+      "glossClean": "portrait",
       "heritage": "standard",
       "ipa": null,
       "lemma": "портрет",
       "lemmaId": "портрет",
       "lemmaPlain": "портрет",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13195,11 +14741,13 @@
     {
       "cefr": "A2",
       "gloss": "reconciliation",
+      "glossClean": "reconciliation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "примирення",
       "lemmaId": "примирення",
       "lemmaPlain": "примирення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13210,11 +14758,13 @@
     {
       "cefr": "A2",
       "gloss": "fair-haired, light brown-haired",
+      "glossClean": "fair-haired",
       "heritage": "standard",
       "ipa": null,
       "lemma": "русявий",
       "lemmaId": "русявий",
       "lemmaPlain": "русявий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13225,11 +14775,13 @@
     {
       "cefr": "A2",
       "gloss": "gray-haired",
+      "glossClean": "gray-haired",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сивий",
       "lemmaId": "сивий",
       "lemmaPlain": "сивий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13240,11 +14792,13 @@
     {
       "cefr": "A2",
       "gloss": "slender, upright",
+      "glossClean": "slender",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стрункий",
       "lemmaId": "стрункий",
       "lemmaPlain": "стрункий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13255,11 +14809,13 @@
     {
       "cefr": "A2",
       "gloss": "argument, dispute",
+      "glossClean": "argument",
       "heritage": "standard",
       "ipa": null,
       "lemma": "суперечка",
       "lemmaId": "суперечка",
       "lemmaPlain": "суперечка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -13299,11 +14855,13 @@
     {
       "cefr": "A2",
       "gloss": "wavy",
+      "glossClean": "wavy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хвилястий",
       "lemmaId": "хвилястий",
       "lemmaPlain": "хвилястий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13314,11 +14872,13 @@
     {
       "cefr": "A2",
       "gloss": "gait",
+      "glossClean": "gait",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хода",
       "lemmaId": "хода",
       "lemmaPlain": "хода",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -13358,11 +14918,13 @@
     {
       "cefr": "A2",
       "gloss": "suburb",
+      "glossClean": "suburb",
       "heritage": "standard",
       "ipa": null,
       "lemma": "передмістя",
       "lemmaId": "передмістя",
       "lemmaPlain": "передмістя",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13373,11 +14935,13 @@
     {
       "cefr": "A2",
       "gloss": "set",
+      "glossClean": "set",
       "heritage": "standard",
       "ipa": null,
       "lemma": "комплект",
       "lemmaId": "комплект",
       "lemmaPlain": "комплект",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13388,11 +14952,13 @@
     {
       "cefr": "A2",
       "gloss": "Cherkasy",
+      "glossClean": "Cherkasy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "Черкаси",
       "lemmaId": "черкаси",
       "lemmaPlain": "черкаси",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -13403,11 +14969,13 @@
     {
       "cefr": "A2",
       "gloss": "Chernivtsi",
+      "glossClean": "Chernivtsi",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Чернівці",
       "lemmaId": "чернівці",
       "lemmaPlain": "чернівці",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -13418,11 +14986,13 @@
     {
       "cefr": "A2",
       "gloss": "poetry",
+      "glossClean": "poetry",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поезія",
       "lemmaId": "поезія",
       "lemmaPlain": "поезія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -13462,11 +15032,13 @@
     {
       "cefr": "A2",
       "gloss": "Franko's",
+      "glossClean": "Franko's",
       "heritage": "standard",
       "ipa": null,
       "lemma": "Франків",
       "lemmaId": "франків",
       "lemmaPlain": "франків",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13477,11 +15049,13 @@
     {
       "cefr": "A2",
       "gloss": "interaction",
+      "glossClean": "interaction",
       "heritage": "standard",
       "ipa": null,
       "lemma": "взаємодія",
       "lemmaId": "взаємодія",
       "lemmaPlain": "взаємодія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -13521,11 +15095,13 @@
     {
       "cefr": "A2",
       "gloss": "as a result of",
+      "glossClean": "as a result of",
       "heritage": "standard",
       "ipa": null,
       "lemma": "унаслідок",
       "lemmaId": "унаслідок",
       "lemmaPlain": "унаслідок",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -13536,11 +15112,13 @@
     {
       "cefr": "A2",
       "gloss": "near, by; takes genitive",
+      "glossClean": "near",
       "heritage": "standard",
       "ipa": null,
       "lemma": "коло",
       "lemmaId": "коло",
       "lemmaPlain": "коло",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -13551,11 +15129,13 @@
     {
       "cefr": "A2",
       "gloss": "around; takes genitive",
+      "glossClean": "around",
       "heritage": "standard",
       "ipa": null,
       "lemma": "навколо",
       "lemmaId": "навколо",
       "lemmaPlain": "навколо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13566,11 +15146,13 @@
     {
       "cefr": "A2",
       "gloss": "fence",
+      "glossClean": "fence",
       "heritage": "standard",
       "ipa": null,
       "lemma": "паркан",
       "lemmaId": "паркан",
       "lemmaPlain": "паркан",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13581,11 +15163,13 @@
     {
       "cefr": "A2",
       "gloss": "along under or near the base of; takes instrumental",
+      "glossClean": "along under or near the base of",
       "heritage": "standard",
       "ipa": null,
       "lemma": "попід",
       "lemmaId": "попід",
       "lemmaPlain": "попід",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -13596,11 +15180,13 @@
     {
       "cefr": "A2",
       "gloss": "passage",
+      "glossClean": "passage",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прохід",
       "lemmaId": "прохід",
       "lemmaPlain": "прохід",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13611,11 +15197,13 @@
     {
       "cefr": "A2",
       "gloss": "corner",
+      "glossClean": "corner",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ріг",
       "lemmaId": "ріг",
       "lemmaPlain": "ріг",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13626,11 +15214,13 @@
     {
       "cefr": "A2",
       "gloss": "shelter",
+      "glossClean": "shelter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "укриття",
       "lemmaId": "укриття",
       "lemmaPlain": "укриття",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13641,11 +15231,13 @@
     {
       "cefr": "A2",
       "gloss": "volunteer",
+      "glossClean": "volunteer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "волонтер",
       "lemmaId": "волонтер",
       "lemmaPlain": "волонтер",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13656,11 +15248,13 @@
     {
       "cefr": "A2",
       "gloss": "hall, room",
+      "glossClean": "hall",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зал",
       "lemmaId": "зал",
       "lemmaPlain": "зал",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13671,11 +15265,13 @@
     {
       "cefr": "A2",
       "gloss": "every year",
+      "glossClean": "every year",
       "heritage": "standard",
       "ipa": null,
       "lemma": "щороку",
       "lemmaId": "щороку",
       "lemmaPlain": "щороку",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13686,11 +15282,13 @@
     {
       "cefr": "A2",
       "gloss": "poem",
+      "glossClean": "poem",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вірш",
       "lemmaId": "вірш",
       "lemmaPlain": "вірш",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13701,11 +15299,13 @@
     {
       "cefr": "A2",
       "gloss": "rhythm",
+      "glossClean": "rhythm",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ритм",
       "lemmaId": "ритм",
       "lemmaPlain": "ритм",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13716,11 +15316,13 @@
     {
       "cefr": "A2",
       "gloss": "to shave oneself",
+      "glossClean": "to shave oneself",
       "heritage": "standard",
       "ipa": null,
       "lemma": "голитися",
       "lemmaId": "голитися",
       "lemmaPlain": "голитися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13731,11 +15333,13 @@
     {
       "cefr": "A2",
       "gloss": "spelling",
+      "glossClean": "spelling",
       "heritage": "standard",
       "ipa": null,
       "lemma": "написання",
       "lemmaId": "написання",
       "lemmaPlain": "написання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13746,11 +15350,13 @@
     {
       "cefr": "A2",
       "gloss": "to return something; to turn",
+      "glossClean": "to return something",
       "heritage": "standard",
       "ipa": null,
       "lemma": "повертати",
       "lemmaId": "повертати",
       "lemmaPlain": "повертати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13761,11 +15367,13 @@
     {
       "cefr": "A2",
       "gloss": "to hope",
+      "glossClean": "to hope",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сподіватися",
       "lemmaId": "сподіватися",
       "lemmaPlain": "сподіватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13776,11 +15384,13 @@
     {
       "cefr": "A2",
       "gloss": "side dish",
+      "glossClean": "side dish",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гарнір",
       "lemmaId": "гарнір",
       "lemmaPlain": "гарнір",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13791,11 +15401,13 @@
     {
       "cefr": "A2",
       "gloss": "spicy, sharp",
+      "glossClean": "spicy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гострий",
       "lemmaId": "гострий",
       "lemmaPlain": "гострий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13806,11 +15418,13 @@
     {
       "cefr": "A2",
       "gloss": "bitter",
+      "glossClean": "bitter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гіркий",
       "lemmaId": "гіркий",
       "lemmaPlain": "гіркий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13821,11 +15435,13 @@
     {
       "cefr": "A2",
       "gloss": "appetizer, starter",
+      "glossClean": "appetizer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "закуска",
       "lemmaId": "закуска",
       "lemmaPlain": "закуска",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13836,11 +15452,13 @@
     {
       "cefr": "A2",
       "gloss": "sour",
+      "glossClean": "sour",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кислий",
       "lemmaId": "кислий",
       "lemmaPlain": "кислий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13851,11 +15469,13 @@
     {
       "cefr": "A2",
       "gloss": "portion, serving",
+      "glossClean": "portion",
       "heritage": "standard",
       "ipa": null,
       "lemma": "порція",
       "lemmaId": "порція",
       "lemmaPlain": "порція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13866,11 +15486,13 @@
     {
       "cefr": "A2",
       "gloss": "to try once",
+      "glossClean": "to try once",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спробувати",
       "lemmaId": "спробувати",
       "lemmaPlain": "спробувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13881,11 +15503,13 @@
     {
       "cefr": "A2",
       "gloss": "hairdresser, barber",
+      "glossClean": "hairdresser",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перукар",
       "lemmaId": "перукар",
       "lemmaPlain": "перукар",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13896,11 +15520,13 @@
     {
       "cefr": "A2",
       "gloss": "female hairdresser",
+      "glossClean": "female hairdresser",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перукарка",
       "lemmaId": "перукарка",
       "lemmaPlain": "перукарка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13911,11 +15537,13 @@
     {
       "cefr": "A2",
       "gloss": "worth, feminine",
+      "glossClean": "worth",
       "heritage": "standard",
       "ipa": null,
       "lemma": "варта",
       "lemmaId": "варта",
       "lemmaPlain": "варта",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13926,11 +15554,13 @@
     {
       "cefr": "A2",
       "gloss": "ready, willing",
+      "glossClean": "ready",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ладен",
       "lemmaId": "ладен",
       "lemmaPlain": "ладен",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13941,11 +15571,13 @@
     {
       "cefr": "A2",
       "gloss": "sure, certain",
+      "glossClean": "sure",
       "heritage": "standard",
       "ipa": null,
       "lemma": "певен",
       "lemmaId": "певен",
       "lemmaPlain": "певен",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13956,11 +15588,13 @@
     {
       "cefr": "A2",
       "gloss": "useful",
+      "glossClean": "useful",
       "heritage": "standard",
       "ipa": null,
       "lemma": "корисний",
       "lemmaId": "корисний",
       "lemmaPlain": "корисний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13971,11 +15605,13 @@
     {
       "cefr": "A2",
       "gloss": "regional, oblast-level",
+      "glossClean": "regional",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обласний",
       "lemmaId": "обласний",
       "lemmaPlain": "обласний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13986,11 +15622,13 @@
     {
       "cefr": "A2",
       "gloss": "travel, fare",
+      "glossClean": "travel",
       "heritage": "standard",
       "ipa": null,
       "lemma": "проїзд",
       "lemmaId": "проїзд",
       "lemmaPlain": "проїзд",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14001,11 +15639,13 @@
     {
       "cefr": "A2",
       "gloss": "sunny, solar",
+      "glossClean": "sunny",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сонячний",
       "lemmaId": "сонячний",
       "lemmaPlain": "сонячний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14016,11 +15656,13 @@
     {
       "cefr": "A2",
       "gloss": "citizen",
+      "glossClean": "citizen",
       "heritage": "standard",
       "ipa": null,
       "lemma": "громадянка",
       "lemmaId": "громадянка",
       "lemmaPlain": "громадянка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14031,11 +15673,13 @@
     {
       "cefr": "A2",
       "gloss": "to state officially",
+      "glossClean": "to state officially",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заявити",
       "lemmaId": "заявити",
       "lemmaPlain": "заявити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14046,11 +15690,13 @@
     {
       "cefr": "A2",
       "gloss": "to report, to inform",
+      "glossClean": "to report",
       "heritage": "standard",
       "ipa": null,
       "lemma": "повідомляти",
       "lemmaId": "повідомляти",
       "lemmaPlain": "повідомляти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14061,11 +15707,13 @@
     {
       "cefr": "A2",
       "gloss": "to refute, to deny",
+      "glossClean": "to refute",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спростувати",
       "lemmaId": "спростувати",
       "lemmaPlain": "спростувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14076,11 +15724,13 @@
     {
       "cefr": "A2",
       "gloss": "sovereignty",
+      "glossClean": "sovereignty",
       "heritage": "standard",
       "ipa": null,
       "lemma": "суверенітет",
       "lemmaId": "суверенітет",
       "lemmaPlain": "суверенітет",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14091,11 +15741,13 @@
     {
       "cefr": "A2",
       "gloss": "centimeter",
+      "glossClean": "centimeter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сантиметр",
       "lemmaId": "сантиметр",
       "lemmaPlain": "сантиметр",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14106,11 +15758,13 @@
     {
       "cefr": "A2",
       "gloss": "excerpt, extract",
+      "glossClean": "excerpt",
       "heritage": "standard",
       "ipa": null,
       "lemma": "витяг",
       "lemmaId": "витяг",
       "lemmaPlain": "витяг",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14121,11 +15775,13 @@
     {
       "cefr": "A2",
       "gloss": "amenities, conveniences",
+      "glossClean": "amenities",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вигоди",
       "lemmaId": "вигоди",
       "lemmaPlain": "вигоди",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14136,11 +15792,13 @@
     {
       "cefr": "A2",
       "gloss": "train compartment",
+      "glossClean": "train compartment",
       "heritage": "standard",
       "ipa": null,
       "lemma": "купе",
       "lemmaId": "купе",
       "lemmaPlain": "купе",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14151,11 +15809,13 @@
     {
       "cefr": "A2",
       "gloss": "open sleeping car",
+      "glossClean": "open sleeping car",
       "heritage": "standard",
       "ipa": null,
       "lemma": "плацкарт",
       "lemmaId": "плацкарт",
       "lemmaPlain": "плацкарт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14166,11 +15826,13 @@
     {
       "cefr": "A2",
       "gloss": "to arrive; formal or schedule style",
+      "glossClean": "to arrive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прибувати",
       "lemmaId": "прибувати",
       "lemmaPlain": "прибувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14181,11 +15843,13 @@
     {
       "cefr": "A2",
       "gloss": "to build",
+      "glossClean": "to build",
       "heritage": "standard",
       "ipa": null,
       "lemma": "будувати",
       "lemmaId": "будувати",
       "lemmaPlain": "будувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14196,11 +15860,13 @@
     {
       "cefr": "A2",
       "gloss": "to reproduce; to play back",
+      "glossClean": "to reproduce",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відтворити",
       "lemmaId": "відтворити",
       "lemmaPlain": "відтворити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14211,11 +15877,13 @@
     {
       "cefr": "A2",
       "gloss": "to start singing; to sing",
+      "glossClean": "to start singing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заспівати",
       "lemmaId": "заспівати",
       "lemmaPlain": "заспівати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14226,11 +15894,13 @@
     {
       "cefr": "A2",
       "gloss": "to gather; to dial; to gain",
+      "glossClean": "to gather",
       "heritage": "standard",
       "ipa": null,
       "lemma": "набрати",
       "lemmaId": "набрати",
       "lemmaPlain": "набрати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14241,11 +15911,13 @@
     {
       "cefr": "A2",
       "gloss": "accumulation",
+      "glossClean": "accumulation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "накопичення",
       "lemmaId": "накопичення",
       "lemmaPlain": "накопичення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14256,11 +15928,13 @@
     {
       "cefr": "A2",
       "gloss": "to organize",
+      "glossClean": "to organize",
       "heritage": "standard",
       "ipa": null,
       "lemma": "організувати",
       "lemmaId": "організувати",
       "lemmaPlain": "організувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14271,11 +15945,13 @@
     {
       "cefr": "A2",
       "gloss": "to rewrite; to copy again",
+      "glossClean": "to rewrite",
       "heritage": "standard",
       "ipa": null,
       "lemma": "переписати",
       "lemmaId": "переписати",
       "lemmaPlain": "переписати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14286,11 +15962,13 @@
     {
       "cefr": "A2",
       "gloss": "to wait a little",
+      "glossClean": "to wait a little",
       "heritage": "standard",
       "ipa": null,
       "lemma": "почекати",
       "lemmaId": "почекати",
       "lemmaPlain": "почекати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14301,11 +15979,13 @@
     {
       "cefr": "A2",
       "gloss": "to sign",
+      "glossClean": "to sign",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підписати",
       "lemmaId": "підписати",
       "lemmaPlain": "підписати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14316,11 +15996,13 @@
     {
       "cefr": "A2",
       "gloss": "to cut apart",
+      "glossClean": "to cut apart",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розрізати",
       "lemmaId": "розрізати",
       "lemmaPlain": "розрізати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14331,11 +16013,13 @@
     {
       "cefr": "A2",
       "gloss": "to bake",
+      "glossClean": "to bake",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спекти",
       "lemmaId": "спекти",
       "lemmaPlain": "спекти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14346,11 +16030,13 @@
     {
       "cefr": "A2",
       "gloss": "oblivion; forgetting",
+      "glossClean": "oblivion",
       "heritage": "standard",
       "ipa": null,
       "lemma": "забуття",
       "lemmaId": "забуття",
       "lemmaPlain": "забуття",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14361,11 +16047,13 @@
     {
       "cefr": "A2",
       "gloss": "obtaining; attainment",
+      "glossClean": "obtaining",
       "heritage": "standard",
       "ipa": null,
       "lemma": "здобуття",
       "lemmaId": "здобуття",
       "lemmaPlain": "здобуття",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14376,11 +16064,13 @@
     {
       "cefr": "A2",
       "gloss": "to think",
+      "glossClean": "to think",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мислити",
       "lemmaId": "мислити",
       "lemmaPlain": "мислити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14391,11 +16081,13 @@
     {
       "cefr": "A2",
       "gloss": "writing as process",
+      "glossClean": "writing as process",
       "heritage": "standard",
       "ipa": null,
       "lemma": "писання",
       "lemmaId": "писання",
       "lemmaPlain": "писання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14406,11 +16098,13 @@
     {
       "cefr": "A2",
       "gloss": "arrival; coming",
+      "glossClean": "arrival",
       "heritage": "standard",
       "ipa": null,
       "lemma": "приїзд",
       "lemmaId": "приїзд",
       "lemmaPlain": "приїзд",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14421,11 +16115,13 @@
     {
       "cefr": "A2",
       "gloss": "to solve",
+      "glossClean": "to solve",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розв'язати",
       "lemmaId": "розв-язати",
       "lemmaPlain": "розв'язати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14436,11 +16132,13 @@
     {
       "cefr": "A2",
       "gloss": "coordinator",
+      "glossClean": "coordinator",
       "heritage": "standard",
       "ipa": null,
       "lemma": "координатор",
       "lemmaId": "координатор",
       "lemmaPlain": "координатор",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14451,11 +16149,13 @@
     {
       "cefr": "A2",
       "gloss": "correspondence",
+      "glossClean": "correspondence",
       "heritage": "standard",
       "ipa": null,
       "lemma": "листування",
       "lemmaId": "листування",
       "lemmaPlain": "листування",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14466,11 +16166,13 @@
     {
       "cefr": "A2",
       "gloss": "gentlemen, sirs",
+      "glossClean": "gentlemen",
       "heritage": "standard",
       "ipa": null,
       "lemma": "панове",
       "lemmaId": "панове",
       "lemmaPlain": "панове",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14481,11 +16183,13 @@
     {
       "cefr": "A2",
       "gloss": "daytime, daily",
+      "glossClean": "daytime",
       "heritage": "standard",
       "ipa": null,
       "lemma": "денний",
       "lemmaId": "денний",
       "lemmaPlain": "денний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14496,11 +16200,13 @@
     {
       "cefr": "A2",
       "gloss": "Kyivan",
+      "glossClean": "Kyivan",
       "heritage": "standard",
       "ipa": null,
       "lemma": "київський",
       "lemmaId": "київський",
       "lemmaPlain": "київський",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14511,11 +16217,13 @@
     {
       "cefr": "A2",
       "gloss": "autumnal",
+      "glossClean": "autumnal",
       "heritage": "standard",
       "ipa": null,
       "lemma": "осінній",
       "lemmaId": "осінній",
       "lemmaPlain": "осінній",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14526,11 +16234,13 @@
     {
       "cefr": "A2",
       "gloss": "height",
+      "glossClean": "height",
       "heritage": "standard",
       "ipa": null,
       "lemma": "висота",
       "lemmaId": "висота",
       "lemmaPlain": "висота",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -14570,11 +16280,13 @@
     {
       "cefr": "A2",
       "gloss": "artist, creator",
+      "glossClean": "artist",
       "heritage": "standard",
       "ipa": null,
       "lemma": "митець",
       "lemmaId": "митець",
       "lemmaPlain": "митець",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14585,11 +16297,13 @@
     {
       "cefr": "A2",
       "gloss": "female worker, employee",
+      "glossClean": "female worker",
       "heritage": "standard",
       "ipa": null,
       "lemma": "працівниця",
       "lemmaId": "працівниця",
       "lemmaPlain": "працівниця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14600,11 +16314,13 @@
     {
       "cefr": "A2",
       "gloss": "female school pupil",
+      "glossClean": "female school pupil",
       "heritage": "standard",
       "ipa": null,
       "lemma": "школярка",
       "lemmaId": "школярка",
       "lemmaPlain": "школярка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14615,11 +16331,13 @@
     {
       "cefr": "A2",
       "gloss": "employment, hiring process",
+      "glossClean": "employment",
       "heritage": "standard",
       "ipa": null,
       "lemma": "працевлаштування",
       "lemmaId": "працевлаштування",
       "lemmaPlain": "працевлаштування",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14630,11 +16348,13 @@
     {
       "cefr": "A2",
       "gloss": "internship, traineeship",
+      "glossClean": "internship",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стажування",
       "lemmaId": "стажування",
       "lemmaPlain": "стажування",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14645,11 +16365,13 @@
     {
       "cefr": "A2",
       "gloss": "to implement",
+      "glossClean": "to implement",
       "heritage": "standard",
       "ipa": null,
       "lemma": "впроваджувати",
       "lemmaId": "впроваджувати",
       "lemmaPlain": "впроваджувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14660,11 +16382,13 @@
     {
       "cefr": "A2",
       "gloss": "appropriate, advisable",
+      "glossClean": "appropriate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "доцільно",
       "lemmaId": "доцільно",
       "lemmaPlain": "доцільно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14675,11 +16399,13 @@
     {
       "cefr": "A2",
       "gloss": "reporting",
+      "glossClean": "reporting",
       "heritage": "standard",
       "ipa": null,
       "lemma": "звітність",
       "lemmaId": "звітність",
       "lemmaPlain": "звітність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14690,11 +16416,13 @@
     {
       "cefr": "A2",
       "gloss": "monitoring",
+      "glossClean": "monitoring",
       "heritage": "standard",
       "ipa": null,
       "lemma": "моніторинг",
       "lemmaId": "моніторинг",
       "lemmaPlain": "моніторинг",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14705,11 +16433,13 @@
     {
       "cefr": "A2",
       "gloss": "published, made public",
+      "glossClean": "published",
       "heritage": "standard",
       "ipa": null,
       "lemma": "оприлюднено",
       "lemmaId": "оприлюднено",
       "lemmaPlain": "оприлюднено",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14720,11 +16450,13 @@
     {
       "cefr": "A2",
       "gloss": "to publish, make public",
+      "glossClean": "to publish",
       "heritage": "standard",
       "ipa": null,
       "lemma": "оприлюднити",
       "lemmaId": "оприлюднити",
       "lemmaPlain": "оприлюднити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14735,11 +16467,13 @@
     {
       "cefr": "A2",
       "gloss": "to adopt, approve",
+      "glossClean": "to adopt",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ухвалити",
       "lemmaId": "ухвалити",
       "lemmaPlain": "ухвалити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14750,11 +16484,13 @@
     {
       "cefr": "A2",
       "gloss": "approved, confirmed",
+      "glossClean": "approved",
       "heritage": "standard",
       "ipa": null,
       "lemma": "затверджений",
       "lemmaId": "затверджений",
       "lemmaPlain": "затверджений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14765,11 +16501,13 @@
     {
       "cefr": "A2",
       "gloss": "signed",
+      "glossClean": "signed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підписаний",
       "lemmaId": "підписаний",
       "lemmaPlain": "підписаний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14780,11 +16518,13 @@
     {
       "cefr": "A2",
       "gloss": "ransom",
+      "glossClean": "ransom",
       "heritage": "standard",
       "ipa": null,
       "lemma": "викуп",
       "lemmaId": "викуп",
       "lemmaPlain": "викуп",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14795,11 +16535,13 @@
     {
       "cefr": "A2",
       "gloss": "motif; recurring image or formula",
+      "glossClean": "motif",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мотив",
       "lemmaId": "мотив",
       "lemmaPlain": "мотив",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14810,11 +16552,13 @@
     {
       "cefr": "A2",
       "gloss": "hostess; mistress of the house",
+      "glossClean": "hostess",
       "heritage": "standard",
       "ipa": null,
       "lemma": "господиня",
       "lemmaId": "господиня",
       "lemmaPlain": "господиня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14825,11 +16569,13 @@
     {
       "cefr": "A2",
       "gloss": "appropriation (here: cultural appropriation)",
+      "glossClean": "appropriation (here: cultural appropriation)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "привласнення",
       "lemmaId": "привласнення",
       "lemmaPlain": "привласнення",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -14840,11 +16586,13 @@
     {
       "cefr": "A2",
       "gloss": "reconstruction (e.g. of an archaic layer by later scholars)",
+      "glossClean": "reconstruction (e.g. of an archaic layer by later scholars)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "реконструкція",
       "lemmaId": "реконструкція",
       "lemmaPlain": "реконструкція",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -14884,11 +16632,13 @@
     {
       "cefr": "A2",
       "gloss": "resistance",
+      "glossClean": "resistance",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спротив",
       "lemmaId": "спротив",
       "lemmaPlain": "спротив",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14899,11 +16649,13 @@
     {
       "cefr": "A2",
       "gloss": "identity (cultural)",
+      "glossClean": "identity (cultural)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ідентичність",
       "lemmaId": "ідентичність",
       "lemmaPlain": "ідентичність",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -14914,11 +16666,13 @@
     {
       "cefr": "A2",
       "gloss": "bandura",
+      "glossClean": "bandura",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бандура",
       "lemmaId": "бандура",
       "lemmaPlain": "бандура",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -14958,11 +16712,13 @@
     {
       "cefr": "A2",
       "gloss": "ritual procession, the round",
+      "glossClean": "ritual procession",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обхід",
       "lemmaId": "обхід",
       "lemmaPlain": "обхід",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14973,11 +16729,13 @@
     {
       "cefr": "A2",
       "gloss": "folklore",
+      "glossClean": "folklore",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фольклор",
       "lemmaId": "фольклор",
       "lemmaPlain": "фольклор",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14988,11 +16746,13 @@
     {
       "cefr": "A2",
       "gloss": "worldview",
+      "glossClean": "worldview",
       "heritage": "standard",
       "ipa": null,
       "lemma": "світогляд",
       "lemmaId": "світогляд",
       "lemmaPlain": "світогляд",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15003,11 +16763,13 @@
     {
       "cefr": "A2",
       "gloss": "blessing",
+      "glossClean": "blessing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "благословення",
       "lemmaId": "благословення",
       "lemmaPlain": "благословення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15018,11 +16780,13 @@
     {
       "cefr": "A2",
       "gloss": "healing herbs, potion",
+      "glossClean": "healing herbs",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зілля",
       "lemmaId": "зілля",
       "lemmaPlain": "зілля",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15033,11 +16797,13 @@
     {
       "cefr": "A2",
       "gloss": "transfer (of harm to another place)",
+      "glossClean": "transfer (of harm to another place)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перенесення",
       "lemmaId": "перенесення",
       "lemmaPlain": "перенесення",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -15049,10 +16815,10 @@
   "schema": "atlas-practice-lexemes",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 29183,
+    "gzipBytes": 33048,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 367978,
+    "rawBytes": 427031,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/public/lexicon/practice-lexemes.B1.json
+++ b/site/public/lexicon/practice-lexemes.B1.json
@@ -5,11 +5,13 @@
     {
       "cefr": "B1",
       "gloss": "Lavra",
+      "glossClean": "Lavra",
       "heritage": "standard",
       "ipa": null,
       "lemma": "Лавра",
       "lemmaId": "лавра",
       "lemmaPlain": "лавра",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -20,11 +22,13 @@
     {
       "cefr": "B1",
       "gloss": "to meet",
+      "glossClean": "to meet",
       "heritage": "standard",
       "ipa": null,
       "lemma": "познайомитися",
       "lemmaId": "познайомитися",
       "lemmaPlain": "познайомитися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -35,11 +39,13 @@
     {
       "cefr": "B1",
       "gloss": "spicy",
+      "glossClean": "spicy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гостре",
       "lemmaId": "гостре",
       "lemmaPlain": "гостре",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -50,11 +56,13 @@
     {
       "cefr": "B1",
       "gloss": "coffee shop",
+      "glossClean": "coffee shop",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кав'ярня",
       "lemmaId": "кав-ярня",
       "lemmaPlain": "кав'ярня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -94,11 +102,13 @@
     {
       "cefr": "B1",
       "gloss": "small bag",
+      "glossClean": "small bag",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пакетик",
       "lemmaId": "пакетик",
       "lemmaPlain": "пакетик",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -109,11 +119,13 @@
     {
       "cefr": "B1",
       "gloss": "they walk",
+      "glossClean": "they walk",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гуляють",
       "lemmaId": "гуляють",
       "lemmaPlain": "гуляють",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -124,11 +136,13 @@
     {
       "cefr": "B1",
       "gloss": "I help",
+      "glossClean": "I help",
       "heritage": "standard",
       "ipa": null,
       "lemma": "допомагаю",
       "lemmaId": "допомагаю",
       "lemmaPlain": "допомагаю",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -139,11 +153,13 @@
     {
       "cefr": "B1",
       "gloss": "action",
+      "glossClean": "action",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дія",
       "lemmaId": "дія",
       "lemmaPlain": "дія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -183,11 +199,13 @@
     {
       "cefr": "B1",
       "gloss": "to study; to learn",
+      "glossClean": "to study",
       "heritage": "standard",
       "ipa": null,
       "lemma": "навчатися",
       "lemmaId": "навчатися",
       "lemmaPlain": "навчатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -198,11 +216,13 @@
     {
       "cefr": "B1",
       "gloss": "you write (plural/formal)",
+      "glossClean": "you write (plural/formal)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пишете",
       "lemmaId": "пишете",
       "lemmaPlain": "пишете",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -213,11 +233,13 @@
     {
       "cefr": "B1",
       "gloss": "you work (plural/formal)",
+      "glossClean": "you work (plural/formal)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "працюєте",
       "lemmaId": "працюєте",
       "lemmaPlain": "працюєте",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -228,11 +250,13 @@
     {
       "cefr": "B1",
       "gloss": "how",
+      "glossClean": "how",
       "heritage": "standard",
       "ipa": null,
       "lemma": "як",
       "lemmaId": "як",
       "lemmaPlain": "як",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -243,11 +267,13 @@
     {
       "cefr": "B1",
       "gloss": "greeting",
+      "glossClean": "greeting",
       "heritage": "standard",
       "ipa": null,
       "lemma": "привітання",
       "lemmaId": "привітання",
       "lemmaPlain": "привітання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -258,11 +284,13 @@
     {
       "cefr": "B1",
       "gloss": "communication",
+      "glossClean": "communication",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спілкування",
       "lemmaId": "спілкування",
       "lemmaPlain": "спілкування",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -273,11 +301,13 @@
     {
       "cefr": "B1",
       "gloss": "fair",
+      "glossClean": "fair",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ярмарок",
       "lemmaId": "ярмарок",
       "lemmaPlain": "ярмарок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -288,11 +318,13 @@
     {
       "cefr": "B1",
       "gloss": "acquaintance / introduction",
+      "glossClean": "acquaintance / introduction",
       "heritage": "standard",
       "ipa": null,
       "lemma": "знайомство",
       "lemmaId": "знайомство",
       "lemmaPlain": "знайомство",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -303,11 +335,13 @@
     {
       "cefr": "B1",
       "gloss": "origin",
+      "glossClean": "origin",
       "heritage": "standard",
       "ipa": null,
       "lemma": "походження",
       "lemmaId": "походження",
       "lemmaPlain": "походження",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -318,11 +352,13 @@
     {
       "cefr": "B1",
       "gloss": "saleswoman",
+      "glossClean": "saleswoman",
       "heritage": "standard",
       "ipa": null,
       "lemma": "продавчиня",
       "lemmaId": "продавчиня",
       "lemmaPlain": "продавчиня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -333,11 +369,13 @@
     {
       "cefr": "B1",
       "gloss": "checkpoint; summary",
+      "glossClean": "checkpoint",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підсумок",
       "lemmaId": "підсумок",
       "lemmaPlain": "підсумок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -348,11 +386,13 @@
     {
       "cefr": "B1",
       "gloss": "clay jug (recognition)",
+      "glossClean": "clay jug (recognition)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "глечик",
       "lemmaId": "глечик",
       "lemmaPlain": "глечик",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -363,11 +403,13 @@
     {
       "cefr": "B1",
       "gloss": "decorated Easter eggs (recognition)",
+      "glossClean": "decorated Easter eggs (recognition)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "писанки",
       "lemmaId": "писанки",
       "lemmaPlain": "писанки",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -378,11 +420,13 @@
     {
       "cefr": "B1",
       "gloss": "that, feminine",
+      "glossClean": "that",
       "heritage": "standard",
       "ipa": null,
       "lemma": "та",
       "lemmaId": "та",
       "lemmaPlain": "та",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -393,11 +437,13 @@
     {
       "cefr": "B1",
       "gloss": "Friday",
+      "glossClean": "Friday",
       "heritage": "standard",
       "ipa": null,
       "lemma": "п'ятниця",
       "lemmaId": "п-ятниця",
       "lemmaPlain": "п'ятниця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -437,11 +483,13 @@
     {
       "cefr": "B1",
       "gloss": "accident",
+      "glossClean": "accident",
       "heritage": "standard",
       "ipa": null,
       "lemma": "аварія",
       "lemmaId": "аварія",
       "lemmaPlain": "аварія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -481,11 +529,13 @@
     {
       "cefr": "B1",
       "gloss": "opposite",
+      "glossClean": "opposite",
       "heritage": "standard",
       "ipa": null,
       "lemma": "навпроти",
       "lemmaId": "навпроти",
       "lemmaPlain": "навпроти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -496,11 +546,13 @@
     {
       "cefr": "B1",
       "gloss": "more slowly",
+      "glossClean": "more slowly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "повільніше",
       "lemmaId": "повільніше",
       "lemmaPlain": "повільніше",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -511,11 +563,13 @@
     {
       "cefr": "B1",
       "gloss": "service",
+      "glossClean": "service",
       "heritage": "standard",
       "ipa": null,
       "lemma": "служба",
       "lemmaId": "служба",
       "lemmaPlain": "служба",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -555,11 +609,13 @@
     {
       "cefr": "B1",
       "gloss": "hey",
+      "glossClean": "hey",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гей",
       "lemmaId": "гей",
       "lemmaPlain": "гей",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -570,11 +626,13 @@
     {
       "cefr": "B1",
       "gloss": "goodness; kindness",
+      "glossClean": "goodness",
       "heritage": "standard",
       "ipa": null,
       "lemma": "добро",
       "lemmaId": "добро",
       "lemmaPlain": "добро",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -585,11 +643,13 @@
     {
       "cefr": "B1",
       "gloss": "peace",
+      "glossClean": "peace",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мир",
       "lemmaId": "мир",
       "lemmaPlain": "мир",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -600,11 +660,13 @@
     {
       "cefr": "B1",
       "gloss": "event",
+      "glossClean": "event",
       "heritage": "standard",
       "ipa": null,
       "lemma": "подія",
       "lemmaId": "подія",
       "lemmaPlain": "подія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -644,11 +706,13 @@
     {
       "cefr": "B1",
       "gloss": "Christmas Eve supper time",
+      "glossClean": "Christmas Eve supper time",
       "heritage": "standard",
       "ipa": null,
       "lemma": "святвечір",
       "lemmaId": "святвечір",
       "lemmaPlain": "святвечір",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -659,11 +723,13 @@
     {
       "cefr": "B1",
       "gloss": "Shchedryi Vechir song",
+      "glossClean": "Shchedryi Vechir song",
       "heritage": "standard",
       "ipa": null,
       "lemma": "щедрівка",
       "lemmaId": "щедрівка",
       "lemmaPlain": "щедрівка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -703,11 +769,13 @@
     {
       "cefr": "B1",
       "gloss": "ninety",
+      "glossClean": "ninety",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дев'яносто",
       "lemmaId": "дев-яносто",
       "lemmaPlain": "дев'яносто",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -718,11 +786,13 @@
     {
       "cefr": "B1",
       "gloss": "nineteen",
+      "glossClean": "nineteen",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дев'ятнадцять",
       "lemmaId": "дев-ятнадцять",
       "lemmaPlain": "дев'ятнадцять",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -733,11 +803,13 @@
     {
       "cefr": "B1",
       "gloss": "butter (with butter form)",
+      "glossClean": "butter (with butter form)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "маслом",
       "lemmaId": "маслом",
       "lemmaPlain": "маслом",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -748,11 +820,13 @@
     {
       "cefr": "B1",
       "gloss": "to recommend; to advise",
+      "glossClean": "to recommend",
       "heritage": "standard",
       "ipa": null,
       "lemma": "порадити",
       "lemmaId": "порадити",
       "lemmaPlain": "порадити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -763,11 +837,13 @@
     {
       "cefr": "B1",
       "gloss": "that's a pity; unfortunately",
+      "glossClean": "that's a pity",
       "heritage": "standard",
       "ipa": null,
       "lemma": "шкода",
       "lemmaId": "шкода",
       "lemmaPlain": "шкода",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -778,11 +854,13 @@
     {
       "cefr": "B1",
       "gloss": "but",
+      "glossClean": "but",
       "heritage": "standard",
       "ipa": null,
       "lemma": "але",
       "lemmaId": "але",
       "lemmaPlain": "але",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -793,11 +871,13 @@
     {
       "cefr": "B1",
       "gloss": "diet",
+      "glossClean": "diet",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дієта",
       "lemmaId": "дієта",
       "lemmaPlain": "дієта",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -837,11 +917,13 @@
     {
       "cefr": "B1",
       "gloss": "while; until",
+      "glossClean": "while",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поки",
       "lemmaId": "поки",
       "lemmaPlain": "поки",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -852,11 +934,13 @@
     {
       "cefr": "B1",
       "gloss": "reason; cause",
+      "glossClean": "reason",
       "heritage": "standard",
       "ipa": null,
       "lemma": "причина",
       "lemmaId": "причина",
       "lemmaPlain": "причина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -896,11 +980,13 @@
     {
       "cefr": "B1",
       "gloss": "however; but",
+      "glossClean": "however",
       "heritage": "standard",
       "ipa": null,
       "lemma": "проте",
       "lemmaId": "проте",
       "lemmaPlain": "проте",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -911,11 +997,13 @@
     {
       "cefr": "B1",
       "gloss": "conjunction; connector",
+      "glossClean": "conjunction",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сполучник",
       "lemmaId": "сполучник",
       "lemmaPlain": "сполучник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -926,11 +1014,13 @@
     {
       "cefr": "B1",
       "gloss": "only",
+      "glossClean": "only",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тільки",
       "lemmaId": "тільки",
       "lemmaPlain": "тільки",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -941,11 +1031,13 @@
     {
       "cefr": "B1",
       "gloss": "alarm clock",
+      "glossClean": "alarm clock",
       "heritage": "standard",
       "ipa": null,
       "lemma": "будильник",
       "lemmaId": "будильник",
       "lemmaPlain": "будильник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -956,11 +1048,13 @@
     {
       "cefr": "B1",
       "gloss": "to wash oneself",
+      "glossClean": "to wash oneself",
       "heritage": "standard",
       "ipa": null,
       "lemma": "митися",
       "lemmaId": "митися",
       "lemmaPlain": "митися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -971,11 +1065,13 @@
     {
       "cefr": "B1",
       "gloss": "to hurry",
+      "glossClean": "to hurry",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поспішати",
       "lemmaId": "поспішати",
       "lemmaPlain": "поспішати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -986,11 +1082,13 @@
     {
       "cefr": "B1",
       "gloss": "until late",
+      "glossClean": "until late",
       "heritage": "standard",
       "ipa": null,
       "lemma": "допізна",
       "lemmaId": "допізна",
       "lemmaPlain": "допізна",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -1001,11 +1099,13 @@
     {
       "cefr": "B1",
       "gloss": "to move, relocate",
+      "glossClean": "to move",
       "heritage": "standard",
       "ipa": null,
       "lemma": "переїхати",
       "lemmaId": "переїхати",
       "lemmaPlain": "переїхати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1016,11 +1116,13 @@
     {
       "cefr": "B1",
       "gloss": "bride",
+      "glossClean": "bride",
       "heritage": "standard",
       "ipa": null,
       "lemma": "наречена",
       "lemmaId": "наречена",
       "lemmaPlain": "наречена",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1031,11 +1133,13 @@
     {
       "cefr": "B1",
       "gloss": "groom",
+      "glossClean": "groom",
       "heritage": "standard",
       "ipa": null,
       "lemma": "наречений",
       "lemmaId": "наречений",
       "lemmaPlain": "наречений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1046,11 +1150,13 @@
     {
       "cefr": "B1",
       "gloss": "to introduce",
+      "glossClean": "to introduce",
       "heritage": "standard",
       "ipa": null,
       "lemma": "познайомити",
       "lemmaId": "познайомити",
       "lemmaPlain": "познайомити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1061,11 +1167,13 @@
     {
       "cefr": "B1",
       "gloss": "bench",
+      "glossClean": "bench",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лавка",
       "lemmaId": "лавка",
       "lemmaPlain": "лавка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1105,11 +1213,13 @@
     {
       "cefr": "B1",
       "gloss": "net",
+      "glossClean": "net",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сітка",
       "lemmaId": "сітка",
       "lemmaPlain": "сітка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1149,11 +1259,13 @@
     {
       "cefr": "B1",
       "gloss": "nowhere",
+      "glossClean": "nowhere",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ніде",
       "lemmaId": "ніде",
       "lemmaPlain": "ніде",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1164,11 +1276,13 @@
     {
       "cefr": "B1",
       "gloss": "syllable",
+      "glossClean": "syllable",
       "heritage": "standard",
       "ipa": null,
       "lemma": "склад",
       "lemmaId": "склад",
       "lemmaPlain": "склад",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1179,11 +1293,13 @@
     {
       "cefr": "B1",
       "gloss": "to try on",
+      "glossClean": "to try on",
       "heritage": "standard",
       "ipa": null,
       "lemma": "приміряти",
       "lemmaId": "приміряти",
       "lemmaPlain": "приміряти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1194,11 +1310,13 @@
     {
       "cefr": "B1",
       "gloss": "letter",
+      "glossClean": "letter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лі́тера",
       "lemmaId": "лі-тера",
       "lemmaPlain": "літера",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1209,11 +1327,13 @@
     {
       "cefr": "B1",
       "gloss": "weed",
+      "glossClean": "weed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бур'я́н",
       "lemmaId": "бур-я-н",
       "lemmaPlain": "бур'ян",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1224,11 +1344,13 @@
     {
       "cefr": "B1",
       "gloss": "spoon",
+      "glossClean": "spoon",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ло́жка",
       "lemmaId": "ло-жка",
       "lemmaPlain": "ложка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1239,11 +1361,13 @@
     {
       "cefr": "B1",
       "gloss": "nail",
+      "glossClean": "nail",
       "heritage": "standard",
       "ipa": null,
       "lemma": "цвях",
       "lemmaId": "цвях",
       "lemmaPlain": "цвях",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1254,11 +1378,13 @@
     {
       "cefr": "B1",
       "gloss": "female teacher",
+      "glossClean": "female teacher",
       "heritage": "standard",
       "ipa": null,
       "lemma": "учителька",
       "lemmaId": "учителька",
       "lemmaPlain": "учителька",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1269,11 +1395,13 @@
     {
       "cefr": "B1",
       "gloss": "departure",
+      "glossClean": "departure",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відправлення",
       "lemmaId": "відправлення",
       "lemmaPlain": "відправлення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1284,11 +1412,13 @@
     {
       "cefr": "B1",
       "gloss": "he/she walks",
+      "glossClean": "he/she walks",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гуляє",
       "lemmaId": "гуляє",
       "lemmaPlain": "гуляє",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1299,11 +1429,13 @@
     {
       "cefr": "B1",
       "gloss": "you listen; are listening",
+      "glossClean": "you listen",
       "heritage": "standard",
       "ipa": null,
       "lemma": "слухаєш",
       "lemmaId": "слухаєш",
       "lemmaPlain": "слухаєш",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1314,11 +1446,13 @@
     {
       "cefr": "B1",
       "gloss": "they learn; they study",
+      "glossClean": "they learn",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вчать",
       "lemmaId": "вчать",
       "lemmaPlain": "вчать",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1329,11 +1463,13 @@
     {
       "cefr": "B1",
       "gloss": "we go regularly; we walk",
+      "glossClean": "we go regularly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ходимо",
       "lemmaId": "ходимо",
       "lemmaPlain": "ходимо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1344,11 +1480,13 @@
     {
       "cefr": "B1",
       "gloss": "you go regularly; you walk",
+      "glossClean": "you go regularly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ходиш",
       "lemmaId": "ходиш",
       "lemmaPlain": "ходиш",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1359,11 +1497,13 @@
     {
       "cefr": "B1",
       "gloss": "hot",
+      "glossClean": "hot",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спекотно",
       "lemmaId": "спекотно",
       "lemmaPlain": "спекотно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1374,11 +1514,13 @@
     {
       "cefr": "B1",
       "gloss": "clear",
+      "glossClean": "clear",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ясно",
       "lemmaId": "ясно",
       "lemmaPlain": "ясно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1389,11 +1531,13 @@
     {
       "cefr": "B1",
       "gloss": "at noon",
+      "glossClean": "at noon",
       "heritage": "standard",
       "ipa": null,
       "lemma": "опівдні",
       "lemmaId": "опівдні",
       "lemmaPlain": "опівдні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1404,11 +1548,13 @@
     {
       "cefr": "B1",
       "gloss": "at midnight",
+      "glossClean": "at midnight",
       "heritage": "standard",
       "ipa": null,
       "lemma": "опівночі",
       "lemmaId": "опівночі",
       "lemmaPlain": "опівночі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1419,11 +1565,13 @@
     {
       "cefr": "B1",
       "gloss": "quarter",
+      "glossClean": "quarter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чверть",
       "lemmaId": "чверть",
       "lemmaPlain": "чверть",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1434,11 +1582,13 @@
     {
       "cefr": "B1",
       "gloss": "to sound",
+      "glossClean": "to sound",
       "heritage": "standard",
       "ipa": null,
       "lemma": "звучати",
       "lemmaId": "звучати",
       "lemmaPlain": "звучати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1449,11 +1599,13 @@
     {
       "cefr": "B1",
       "gloss": "since then",
+      "glossClean": "since then",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відтоді",
       "lemmaId": "відтоді",
       "lemmaPlain": "відтоді",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1464,11 +1616,13 @@
     {
       "cefr": "B1",
       "gloss": "detail",
+      "glossClean": "detail",
       "heritage": "standard",
       "ipa": null,
       "lemma": "деталь",
       "lemmaId": "деталь",
       "lemmaPlain": "деталь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1479,11 +1633,13 @@
     {
       "cefr": "B1",
       "gloss": "comma",
+      "glossClean": "comma",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кома",
       "lemmaId": "кома",
       "lemmaPlain": "кома",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1523,11 +1679,13 @@
     {
       "cefr": "B1",
       "gloss": "fountain",
+      "glossClean": "fountain",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фонтан",
       "lemmaId": "фонтан",
       "lemmaPlain": "фонтан",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1538,11 +1696,13 @@
     {
       "cefr": "B1",
       "gloss": "just now",
+      "glossClean": "just now",
       "heritage": "standard",
       "ipa": null,
       "lemma": "щойно",
       "lemmaId": "щойно",
       "lemmaPlain": "щойно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1553,11 +1713,13 @@
     {
       "cefr": "B1",
       "gloss": "man from Kyiv",
+      "glossClean": "man from Kyiv",
       "heritage": "standard",
       "ipa": null,
       "lemma": "киянин",
       "lemmaId": "киянин",
       "lemmaPlain": "киянин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1568,11 +1730,13 @@
     {
       "cefr": "B1",
       "gloss": "woman from Kyiv",
+      "glossClean": "woman from Kyiv",
       "heritage": "standard",
       "ipa": null,
       "lemma": "киянка",
       "lemmaId": "киянка",
       "lemmaPlain": "киянка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1583,11 +1747,13 @@
     {
       "cefr": "B1",
       "gloss": "woman from Lviv",
+      "glossClean": "woman from Lviv",
       "heritage": "standard",
       "ipa": null,
       "lemma": "львів'янка",
       "lemmaId": "львів-янка",
       "lemmaPlain": "львів'янка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1598,11 +1764,13 @@
     {
       "cefr": "B1",
       "gloss": "to travel",
+      "glossClean": "to travel",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мандрувати",
       "lemmaId": "мандрувати",
       "lemmaPlain": "мандрувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1613,11 +1781,13 @@
     {
       "cefr": "B1",
       "gloss": "man from Kharkiv",
+      "glossClean": "man from Kharkiv",
       "heritage": "standard",
       "ipa": null,
       "lemma": "харків'янин",
       "lemmaId": "харків-янин",
       "lemmaPlain": "харків'янин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1628,11 +1798,13 @@
     {
       "cefr": "B1",
       "gloss": "American woman",
+      "glossClean": "American woman",
       "heritage": "standard",
       "ipa": null,
       "lemma": "американка",
       "lemmaId": "американка",
       "lemmaPlain": "американка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1643,11 +1815,13 @@
     {
       "cefr": "B1",
       "gloss": "excuse me / forgive me",
+      "glossClean": "excuse me / forgive me",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пробачте",
       "lemmaId": "пробачте",
       "lemmaPlain": "пробачте",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -1658,11 +1832,13 @@
     {
       "cefr": "B1",
       "gloss": "stem, base",
+      "glossClean": "stem",
       "heritage": "standard",
       "ipa": null,
       "lemma": "основа",
       "lemmaId": "основа",
       "lemmaPlain": "основа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1702,11 +1878,13 @@
     {
       "cefr": "B1",
       "gloss": "review, revision",
+      "glossClean": "review",
       "heritage": "standard",
       "ipa": null,
       "lemma": "повторення",
       "lemmaId": "повторення",
       "lemmaPlain": "повторення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1717,11 +1895,13 @@
     {
       "cefr": "B1",
       "gloss": "complex, compound",
+      "glossClean": "complex",
       "heritage": "standard",
       "ipa": null,
       "lemma": "складний",
       "lemmaId": "складний",
       "lemmaPlain": "складний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1732,11 +1912,13 @@
     {
       "cefr": "B1",
       "gloss": "building",
+      "glossClean": "building",
       "heritage": "standard",
       "ipa": null,
       "lemma": "будівля",
       "lemmaId": "будівля",
       "lemmaPlain": "будівля",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1776,11 +1958,13 @@
     {
       "cefr": "B1",
       "gloss": "impression",
+      "glossClean": "impression",
       "heritage": "standard",
       "ipa": null,
       "lemma": "враження",
       "lemmaId": "враження",
       "lemmaPlain": "враження",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1791,11 +1975,13 @@
     {
       "cefr": "B1",
       "gloss": "congratulations",
+      "glossClean": "congratulations",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вітаємо",
       "lemmaId": "вітаємо",
       "lemmaPlain": "вітаємо",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -1806,11 +1992,13 @@
     {
       "cefr": "B1",
       "gloss": "to arrange, agree",
+      "glossClean": "to arrange",
       "heritage": "standard",
       "ipa": null,
       "lemma": "домовитися",
       "lemmaId": "домовитися",
       "lemmaPlain": "домовитися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1821,11 +2009,13 @@
     {
       "cefr": "B1",
       "gloss": "to find out, to learn",
+      "glossClean": "to find out",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дізнатися",
       "lemmaId": "дізнатися",
       "lemmaPlain": "дізнатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1836,11 +2026,13 @@
     {
       "cefr": "B1",
       "gloss": "app",
+      "glossClean": "app",
       "heritage": "standard",
       "ipa": null,
       "lemma": "застосунок",
       "lemmaId": "застосунок",
       "lemmaPlain": "застосунок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1851,11 +2043,13 @@
     {
       "cefr": "B1",
       "gloss": "traffic jam",
+      "glossClean": "traffic jam",
       "heritage": "standard",
       "ipa": null,
       "lemma": "затор",
       "lemmaId": "затор",
       "lemmaPlain": "затор",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1866,11 +2060,13 @@
     {
       "cefr": "B1",
       "gloss": "sequence",
+      "glossClean": "sequence",
       "heritage": "standard",
       "ipa": null,
       "lemma": "послідовність",
       "lemmaId": "послідовність",
       "lemmaPlain": "послідовність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1881,11 +2077,13 @@
     {
       "cefr": "B1",
       "gloss": "exam",
+      "glossClean": "exam",
       "heritage": "standard",
       "ipa": null,
       "lemma": "іспит",
       "lemmaId": "іспит",
       "lemmaPlain": "іспит",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1896,11 +2094,13 @@
     {
       "cefr": "B1",
       "gloss": "to admire",
+      "glossClean": "to admire",
       "heritage": "standard",
       "ipa": null,
       "lemma": "милуватися",
       "lemmaId": "милуватися",
       "lemmaPlain": "милуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1911,11 +2111,13 @@
     {
       "cefr": "B1",
       "gloss": "decoration",
+      "glossClean": "decoration",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прикраса",
       "lemmaId": "прикраса",
       "lemmaPlain": "прикраса",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1955,11 +2157,13 @@
     {
       "cefr": "B1",
       "gloss": "habit",
+      "glossClean": "habit",
       "heritage": "standard",
       "ipa": null,
       "lemma": "звичка",
       "lemmaId": "звичка",
       "lemmaPlain": "звичка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1999,11 +2203,13 @@
     {
       "cefr": "B1",
       "gloss": "one-time",
+      "glossClean": "one-time",
       "heritage": "standard",
       "ipa": null,
       "lemma": "одноразовий",
       "lemmaId": "одноразовий",
       "lemmaPlain": "одноразовий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2014,11 +2220,13 @@
     {
       "cefr": "B1",
       "gloss": "view, way of looking",
+      "glossClean": "view",
       "heritage": "standard",
       "ipa": null,
       "lemma": "погляд",
       "lemmaId": "погляд",
       "lemmaPlain": "погляд",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2029,11 +2237,13 @@
     {
       "cefr": "B1",
       "gloss": "focus",
+      "glossClean": "focus",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фокус",
       "lemmaId": "фокус",
       "lemmaPlain": "фокус",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2044,11 +2254,13 @@
     {
       "cefr": "B1",
       "gloss": "basic",
+      "glossClean": "basic",
       "heritage": "standard",
       "ipa": null,
       "lemma": "базовий",
       "lemmaId": "базовий",
       "lemmaPlain": "базовий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2059,11 +2271,13 @@
     {
       "cefr": "B1",
       "gloss": "root",
+      "glossClean": "root",
       "heritage": "standard",
       "ipa": null,
       "lemma": "корінь",
       "lemmaId": "корінь",
       "lemmaPlain": "корінь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2074,11 +2288,13 @@
     {
       "cefr": "B1",
       "gloss": "to shape, to make by hand",
+      "glossClean": "to shape",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ліпити / зліпити",
       "lemmaId": "ліпити-зліпити",
       "lemmaPlain": "ліпити / зліпити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2089,11 +2305,13 @@
     {
       "cefr": "B1",
       "gloss": "to form",
+      "glossClean": "to form",
       "heritage": "standard",
       "ipa": null,
       "lemma": "утворювати",
       "lemmaId": "утворювати",
       "lemmaPlain": "утворювати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2104,11 +2322,13 @@
     {
       "cefr": "B1",
       "gloss": "to iron",
+      "glossClean": "to iron",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прасувати / випрасувати",
       "lemmaId": "прасувати-випрасувати",
       "lemmaPlain": "прасувати / випрасувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2119,11 +2339,13 @@
     {
       "cefr": "B1",
       "gloss": "to tell, to narrate",
+      "glossClean": "to tell",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розповідати / розповісти",
       "lemmaId": "розповідати-розповісти",
       "lemmaPlain": "розповідати / розповісти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2134,11 +2356,13 @@
     {
       "cefr": "B1",
       "gloss": "on the contrary",
+      "glossClean": "on the contrary",
       "heritage": "standard",
       "ipa": null,
       "lemma": "навпаки",
       "lemmaId": "навпаки",
       "lemmaPlain": "навпаки",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2149,11 +2373,13 @@
     {
       "cefr": "B1",
       "gloss": "contrast",
+      "glossClean": "contrast",
       "heritage": "standard",
       "ipa": null,
       "lemma": "протиставлення",
       "lemmaId": "протиставлення",
       "lemmaPlain": "протиставлення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2164,11 +2390,13 @@
     {
       "cefr": "B1",
       "gloss": "newlyweds",
+      "glossClean": "newlyweds",
       "heritage": "standard",
       "ipa": null,
       "lemma": "молодята",
       "lemmaId": "молодята",
       "lemmaPlain": "молодята",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2179,11 +2407,13 @@
     {
       "cefr": "B1",
       "gloss": "parcel, package",
+      "glossClean": "parcel",
       "heritage": "standard",
       "ipa": null,
       "lemma": "посилка",
       "lemmaId": "посилка",
       "lemmaPlain": "посилка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2223,11 +2453,13 @@
     {
       "cefr": "B1",
       "gloss": "to choose",
+      "glossClean": "to choose",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обрати",
       "lemmaId": "обрати",
       "lemmaPlain": "обрати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2238,11 +2470,13 @@
     {
       "cefr": "B1",
       "gloss": "to recognize",
+      "glossClean": "to recognize",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розпізнавати",
       "lemmaId": "розпізнавати",
       "lemmaPlain": "розпізнавати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2253,11 +2487,13 @@
     {
       "cefr": "B1",
       "gloss": "transformation",
+      "glossClean": "transformation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "трансформація",
       "lemmaId": "трансформація",
       "lemmaPlain": "трансформація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2297,11 +2533,13 @@
     {
       "cefr": "B1",
       "gloss": "to recognize",
+      "glossClean": "to recognize",
       "heritage": "standard",
       "ipa": null,
       "lemma": "впізнати",
       "lemmaId": "впізнати",
       "lemmaPlain": "впізнати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2312,11 +2550,13 @@
     {
       "cefr": "B1",
       "gloss": "direction",
+      "glossClean": "direction",
       "heritage": "standard",
       "ipa": null,
       "lemma": "напрямок",
       "lemmaId": "напрямок",
       "lemmaPlain": "напрямок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2327,11 +2567,13 @@
     {
       "cefr": "B1",
       "gloss": "preposition",
+      "glossClean": "preposition",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прийменник",
       "lemmaId": "прийменник",
       "lemmaPlain": "прийменник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2342,11 +2584,13 @@
     {
       "cefr": "B1",
       "gloss": "means",
+      "glossClean": "means",
       "heritage": "standard",
       "ipa": null,
       "lemma": "засіб",
       "lemmaId": "засіб",
       "lemmaPlain": "засіб",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2357,11 +2601,13 @@
     {
       "cefr": "B1",
       "gloss": "to describe",
+      "glossClean": "to describe",
       "heritage": "standard",
       "ipa": null,
       "lemma": "описати",
       "lemmaId": "описати",
       "lemmaPlain": "описати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2372,11 +2618,13 @@
     {
       "cefr": "B1",
       "gloss": "phrase, word combination",
+      "glossClean": "phrase",
       "heritage": "standard",
       "ipa": null,
       "lemma": "словосполучення",
       "lemmaId": "словосполучення",
       "lemmaPlain": "словосполучення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2387,11 +2635,13 @@
     {
       "cefr": "B1",
       "gloss": "purpose, goal",
+      "glossClean": "purpose",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мета",
       "lemmaId": "мета",
       "lemmaPlain": "мета",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2431,11 +2681,13 @@
     {
       "cefr": "B1",
       "gloss": "description, attribute",
+      "glossClean": "description",
       "heritage": "standard",
       "ipa": null,
       "lemma": "означення",
       "lemmaId": "означення",
       "lemmaPlain": "означення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2446,11 +2698,13 @@
     {
       "cefr": "B1",
       "gloss": "condition",
+      "glossClean": "condition",
       "heritage": "standard",
       "ipa": null,
       "lemma": "умова",
       "lemmaId": "умова",
       "lemmaPlain": "умова",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2490,11 +2744,13 @@
     {
       "cefr": "B1",
       "gloss": "wish, blessing",
+      "glossClean": "wish",
       "heritage": "standard",
       "ipa": null,
       "lemma": "побажання",
       "lemmaId": "побажання",
       "lemmaPlain": "побажання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2505,11 +2761,13 @@
     {
       "cefr": "B1",
       "gloss": "background",
+      "glossClean": "background",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тло",
       "lemmaId": "тло",
       "lemmaPlain": "тло",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2520,11 +2778,13 @@
     {
       "cefr": "B1",
       "gloss": "considerably",
+      "glossClean": "considerably",
       "heritage": "standard",
       "ipa": null,
       "lemma": "значно",
       "lemmaId": "значно",
       "lemmaPlain": "значно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2535,11 +2795,13 @@
     {
       "cefr": "B1",
       "gloss": "lighter, easier",
+      "glossClean": "lighter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "легший",
       "lemmaId": "легший",
       "lemmaPlain": "легший",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2550,11 +2812,13 @@
     {
       "cefr": "B1",
       "gloss": "demonstrative",
+      "glossClean": "demonstrative",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вказівний",
       "lemmaId": "вказівний",
       "lemmaPlain": "вказівний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2565,11 +2829,13 @@
     {
       "cefr": "B1",
       "gloss": "possessive",
+      "glossClean": "possessive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "присвійний",
       "lemmaId": "присвійний",
       "lemmaPlain": "присвійний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2580,11 +2846,13 @@
     {
       "cefr": "B1",
       "gloss": "declension",
+      "glossClean": "declension",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відміна",
       "lemmaId": "відміна",
       "lemmaPlain": "відміна",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2624,11 +2892,13 @@
     {
       "cefr": "B1",
       "gloss": "chick",
+      "glossClean": "chick",
       "heritage": "standard",
       "ipa": null,
       "lemma": "курча",
       "lemmaId": "курча",
       "lemmaPlain": "курча",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2639,11 +2909,13 @@
     {
       "cefr": "B1",
       "gloss": "baby, infant",
+      "glossClean": "baby",
       "heritage": "standard",
       "ipa": null,
       "lemma": "немовля",
       "lemmaId": "немовля",
       "lemmaPlain": "немовля",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2654,11 +2926,13 @@
     {
       "cefr": "B1",
       "gloss": "to forgive",
+      "glossClean": "to forgive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вибачати",
       "lemmaId": "вибачати",
       "lemmaPlain": "вибачати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2669,11 +2943,13 @@
     {
       "cefr": "B1",
       "gloss": "to smile",
+      "glossClean": "to smile",
       "heritage": "standard",
       "ipa": null,
       "lemma": "посміхатися",
       "lemmaId": "посміхатися",
       "lemmaPlain": "посміхатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2684,11 +2960,13 @@
     {
       "cefr": "B1",
       "gloss": "to advise",
+      "glossClean": "to advise",
       "heritage": "standard",
       "ipa": null,
       "lemma": "радити",
       "lemmaId": "радити",
       "lemmaPlain": "радити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2699,11 +2977,13 @@
     {
       "cefr": "B1",
       "gloss": "preferences, interests",
+      "glossClean": "preferences",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вподобання",
       "lemmaId": "вподобання",
       "lemmaPlain": "вподобання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2714,11 +2994,13 @@
     {
       "cefr": "B1",
       "gloss": "job opening",
+      "glossClean": "job opening",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вакансія",
       "lemmaId": "вакансія",
       "lemmaPlain": "вакансія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2758,11 +3040,13 @@
     {
       "cefr": "B1",
       "gloss": "diploma, degree",
+      "glossClean": "diploma",
       "heritage": "standard",
       "ipa": null,
       "lemma": "диплом",
       "lemmaId": "диплом",
       "lemmaPlain": "диплом",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2773,11 +3057,13 @@
     {
       "cefr": "B1",
       "gloss": "experience",
+      "glossClean": "experience",
       "heritage": "standard",
       "ipa": null,
       "lemma": "досвід",
       "lemmaId": "досвід",
       "lemmaPlain": "досвід",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2788,11 +3074,13 @@
     {
       "cefr": "B1",
       "gloss": "pass/fail exam, credit",
+      "glossClean": "pass/fail exam",
       "heritage": "standard",
       "ipa": null,
       "lemma": "залік",
       "lemmaId": "залік",
       "lemmaPlain": "залік",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2803,11 +3091,13 @@
     {
       "cefr": "B1",
       "gloss": "salary",
+      "glossClean": "salary",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зарплата",
       "lemmaId": "зарплата",
       "lemmaPlain": "зарплата",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2847,11 +3137,13 @@
     {
       "cefr": "B1",
       "gloss": "studies, learning",
+      "glossClean": "studies",
       "heritage": "standard",
       "ipa": null,
       "lemma": "навчання",
       "lemmaId": "навчання",
       "lemmaPlain": "навчання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2862,11 +3154,13 @@
     {
       "cefr": "B1",
       "gloss": "education",
+      "glossClean": "education",
       "heritage": "standard",
       "ipa": null,
       "lemma": "освіта",
       "lemmaId": "освіта",
       "lemmaPlain": "освіта",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2906,11 +3200,13 @@
     {
       "cefr": "B1",
       "gloss": "position",
+      "glossClean": "position",
       "heritage": "standard",
       "ipa": null,
       "lemma": "посада",
       "lemmaId": "посада",
       "lemmaPlain": "посада",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2950,11 +3246,13 @@
     {
       "cefr": "B1",
       "gloss": "project",
+      "glossClean": "project",
       "heritage": "standard",
       "ipa": null,
       "lemma": "проєкт",
       "lemmaId": "проєкт",
       "lemmaPlain": "проєкт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2965,11 +3263,13 @@
     {
       "cefr": "B1",
       "gloss": "resume, CV",
+      "glossClean": "resume",
       "heritage": "standard",
       "ipa": null,
       "lemma": "резюме",
       "lemmaId": "резюме",
       "lemmaPlain": "резюме",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3009,11 +3309,13 @@
     {
       "cefr": "B1",
       "gloss": "specialty, major",
+      "glossClean": "specialty",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спеціальність",
       "lemmaId": "спеціальність",
       "lemmaPlain": "спеціальність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3024,11 +3326,13 @@
     {
       "cefr": "B1",
       "gloss": "job interview",
+      "glossClean": "job interview",
       "heritage": "standard",
       "ipa": null,
       "lemma": "співбесіда",
       "lemmaId": "співбесіда",
       "lemmaPlain": "співбесіда",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3068,11 +3372,13 @@
     {
       "cefr": "B1",
       "gloss": "faculty, department",
+      "glossClean": "faculty",
       "heritage": "standard",
       "ipa": null,
       "lemma": "факультет",
       "lemmaId": "факультет",
       "lemmaPlain": "факультет",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3083,11 +3389,13 @@
     {
       "cefr": "B1",
       "gloss": "pleasure",
+      "glossClean": "pleasure",
       "heritage": "standard",
       "ipa": null,
       "lemma": "задоволення",
       "lemmaId": "задоволення",
       "lemmaPlain": "задоволення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3098,11 +3406,13 @@
     {
       "cefr": "B1",
       "gloss": "cluster, collision",
+      "glossClean": "cluster",
       "heritage": "standard",
       "ipa": null,
       "lemma": "збіг",
       "lemmaId": "збіг",
       "lemmaPlain": "збіг",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3113,11 +3423,13 @@
     {
       "cefr": "B1",
       "gloss": "pause",
+      "glossClean": "pause",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пауза",
       "lemmaId": "пауза",
       "lemmaPlain": "пауза",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3157,11 +3469,13 @@
     {
       "cefr": "B1",
       "gloss": "natural",
+      "glossClean": "natural",
       "heritage": "standard",
       "ipa": null,
       "lemma": "природний",
       "lemmaId": "природний",
       "lemmaPlain": "природний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3172,11 +3486,13 @@
     {
       "cefr": "B1",
       "gloss": "to discuss",
+      "glossClean": "to discuss",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обговорювати",
       "lemmaId": "обговорювати",
       "lemmaPlain": "обговорювати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3187,11 +3503,13 @@
     {
       "cefr": "B1",
       "gloss": "permission",
+      "glossClean": "permission",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дозвіл",
       "lemmaId": "дозвіл",
       "lemmaPlain": "дозвіл",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3202,11 +3520,13 @@
     {
       "cefr": "B1",
       "gloss": "ribbon, strip",
+      "glossClean": "ribbon",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стрічка",
       "lemmaId": "стрічка",
       "lemmaPlain": "стрічка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3246,11 +3566,13 @@
     {
       "cefr": "B1",
       "gloss": "grammatical object",
+      "glossClean": "grammatical object",
       "heritage": "standard",
       "ipa": null,
       "lemma": "додаток",
       "lemmaId": "додаток",
       "lemmaPlain": "додаток",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3261,11 +3583,13 @@
     {
       "cefr": "B1",
       "gloss": "a few, several",
+      "glossClean": "a few",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кілька",
       "lemmaId": "кілька",
       "lemmaPlain": "кілька",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3276,11 +3600,13 @@
     {
       "cefr": "B1",
       "gloss": "quantity",
+      "glossClean": "quantity",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кількість",
       "lemmaId": "кількість",
       "lemmaPlain": "кількість",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3291,11 +3617,13 @@
     {
       "cefr": "B1",
       "gloss": "bun, roll",
+      "glossClean": "bun",
       "heritage": "standard",
       "ipa": null,
       "lemma": "булка",
       "lemmaId": "булка",
       "lemmaPlain": "булка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3335,11 +3663,13 @@
     {
       "cefr": "B1",
       "gloss": "visit, appointment",
+      "glossClean": "visit",
       "heritage": "standard",
       "ipa": null,
       "lemma": "візит",
       "lemmaId": "візит",
       "lemmaPlain": "візит",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3350,11 +3680,13 @@
     {
       "cefr": "B1",
       "gloss": "meeting, date; goodbye in до побачення",
+      "glossClean": "meeting",
       "heritage": "standard",
       "ipa": null,
       "lemma": "побачення",
       "lemmaId": "побачення",
       "lemmaPlain": "побачення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3365,11 +3697,13 @@
     {
       "cefr": "B1",
       "gloss": "flashlight",
+      "glossClean": "flashlight",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ліхтарик",
       "lemmaId": "ліхтарик",
       "lemmaPlain": "ліхтарик",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3380,11 +3714,13 @@
     {
       "cefr": "B1",
       "gloss": "tent",
+      "glossClean": "tent",
       "heritage": "standard",
       "ipa": null,
       "lemma": "намет",
       "lemmaId": "намет",
       "lemmaPlain": "намет",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3395,11 +3731,13 @@
     {
       "cefr": "B1",
       "gloss": "landmark, reference point",
+      "glossClean": "landmark",
       "heritage": "standard",
       "ipa": null,
       "lemma": "орієнтир",
       "lemmaId": "орієнтир",
       "lemmaPlain": "орієнтир",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3410,11 +3748,13 @@
     {
       "cefr": "B1",
       "gloss": "camp",
+      "glossClean": "camp",
       "heritage": "standard",
       "ipa": null,
       "lemma": "табір",
       "lemmaId": "табір",
       "lemmaPlain": "табір",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3425,11 +3765,13 @@
     {
       "cefr": "B1",
       "gloss": "childhood",
+      "glossClean": "childhood",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дитинство",
       "lemmaId": "дитинство",
       "lemmaPlain": "дитинство",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3440,11 +3782,13 @@
     {
       "cefr": "B1",
       "gloss": "line, row",
+      "glossClean": "line",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рядок",
       "lemmaId": "рядок",
       "lemmaPlain": "рядок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3455,11 +3799,13 @@
     {
       "cefr": "B1",
       "gloss": "silk",
+      "glossClean": "silk",
       "heritage": "standard",
       "ipa": null,
       "lemma": "шовк",
       "lemmaId": "шовк",
       "lemmaPlain": "шовк",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3470,11 +3816,13 @@
     {
       "cefr": "B1",
       "gloss": "dwelling, place to live",
+      "glossClean": "dwelling",
       "heritage": "standard",
       "ipa": null,
       "lemma": "помешкання",
       "lemmaId": "помешкання",
       "lemmaPlain": "помешкання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3485,11 +3833,13 @@
     {
       "cefr": "B1",
       "gloss": "let, may",
+      "glossClean": "let",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нехай",
       "lemmaId": "нехай",
       "lemmaPlain": "нехай",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3500,11 +3850,13 @@
     {
       "cefr": "B1",
       "gloss": "attentive",
+      "glossClean": "attentive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "уважний / уважним",
       "lemmaId": "уважний-уважним",
       "lemmaPlain": "уважний / уважним",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3515,11 +3867,13 @@
     {
       "cefr": "B1",
       "gloss": "carelessly, anyhow",
+      "glossClean": "carelessly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "абияк",
       "lemmaId": "абияк",
       "lemmaPlain": "абияк",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3530,11 +3884,13 @@
     {
       "cefr": "B1",
       "gloss": "anywhere",
+      "glossClean": "anywhere",
       "heritage": "standard",
       "ipa": null,
       "lemma": "будь-де",
       "lemmaId": "будь-де",
       "lemmaPlain": "будь-де",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3545,11 +3901,13 @@
     {
       "cefr": "B1",
       "gloss": "some people",
+      "glossClean": "some people",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дехто",
       "lemmaId": "дехто",
       "lemmaPlain": "дехто",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3560,11 +3918,13 @@
     {
       "cefr": "B1",
       "gloss": "something, somewhat",
+      "glossClean": "something",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дещо",
       "lemmaId": "дещо",
       "lemmaPlain": "дещо",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3575,11 +3935,13 @@
     {
       "cefr": "B1",
       "gloss": "some, certain",
+      "glossClean": "some",
       "heritage": "standard",
       "ipa": null,
       "lemma": "деякий",
       "lemmaId": "деякий",
       "lemmaPlain": "деякий",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3590,11 +3952,13 @@
     {
       "cefr": "B1",
       "gloss": "no, not any",
+      "glossClean": "no",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ніякий",
       "lemmaId": "ніякий",
       "lemmaPlain": "ніякий",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3605,11 +3969,13 @@
     {
       "cefr": "B1",
       "gloss": "anyone, someone at all",
+      "glossClean": "anyone",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хто-небудь",
       "lemmaId": "хто-небудь",
       "lemmaPlain": "хто-небудь",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3620,11 +3986,13 @@
     {
       "cefr": "B1",
       "gloss": "someone's",
+      "glossClean": "someone's",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чийсь",
       "lemmaId": "чийсь",
       "lemmaPlain": "чийсь",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3635,11 +4003,13 @@
     {
       "cefr": "B1",
       "gloss": "anything, something at all",
+      "glossClean": "anything",
       "heritage": "standard",
       "ipa": null,
       "lemma": "що-небудь",
       "lemmaId": "що-небудь",
       "lemmaPlain": "що-небудь",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3650,11 +4020,13 @@
     {
       "cefr": "B1",
       "gloss": "somehow, once",
+      "glossClean": "somehow",
       "heritage": "standard",
       "ipa": null,
       "lemma": "якось",
       "lemmaId": "якось",
       "lemmaPlain": "якось",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3665,11 +4037,13 @@
     {
       "cefr": "B1",
       "gloss": "corner",
+      "glossClean": "corner",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кут",
       "lemmaId": "кут",
       "lemmaPlain": "кут",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3680,11 +4054,13 @@
     {
       "cefr": "B1",
       "gloss": "in front of; before",
+      "glossClean": "in front of",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перед",
       "lemmaId": "перед",
       "lemmaPlain": "перед",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3695,11 +4071,13 @@
     {
       "cefr": "B1",
       "gloss": "to dream",
+      "glossClean": "to dream",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мріяти",
       "lemmaId": "мріяти",
       "lemmaPlain": "мріяти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3710,11 +4088,13 @@
     {
       "cefr": "B1",
       "gloss": "to be proud of",
+      "glossClean": "to be proud of",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пишатися",
       "lemmaId": "пишатися",
       "lemmaPlain": "пишатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3725,11 +4105,13 @@
     {
       "cefr": "B1",
       "gloss": "stubborn, persistent",
+      "glossClean": "stubborn",
       "heritage": "standard",
       "ipa": null,
       "lemma": "впертий",
       "lemmaId": "впертий",
       "lemmaPlain": "впертий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3740,11 +4122,13 @@
     {
       "cefr": "B1",
       "gloss": "appearance",
+      "glossClean": "appearance",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зовнішність",
       "lemmaId": "зовнішність",
       "lemmaPlain": "зовнішність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3755,11 +4139,13 @@
     {
       "cefr": "B1",
       "gloss": "to respect",
+      "glossClean": "to respect",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поважати",
       "lemmaId": "поважати",
       "lemmaPlain": "поважати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3770,11 +4156,13 @@
     {
       "cefr": "B1",
       "gloss": "hardworking",
+      "glossClean": "hardworking",
       "heritage": "standard",
       "ipa": null,
       "lemma": "працьовитий",
       "lemmaId": "працьовитий",
       "lemmaPlain": "працьовитий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3785,11 +4173,13 @@
     {
       "cefr": "B1",
       "gloss": "relationship",
+      "glossClean": "relationship",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стосунок",
       "lemmaId": "стосунок",
       "lemmaPlain": "стосунок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3800,11 +4190,13 @@
     {
       "cefr": "B1",
       "gloss": "sincere, genuine",
+      "glossClean": "sincere",
       "heritage": "standard",
       "ipa": null,
       "lemma": "щирий",
       "lemmaId": "щирий",
       "lemmaPlain": "щирий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3815,11 +4207,13 @@
     {
       "cefr": "B1",
       "gloss": "abstract",
+      "glossClean": "abstract",
       "heritage": "standard",
       "ipa": null,
       "lemma": "абстрактний",
       "lemmaId": "абстрактний",
       "lemmaPlain": "абстрактний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3830,11 +4224,13 @@
     {
       "cefr": "B1",
       "gloss": "youth",
+      "glossClean": "youth",
       "heritage": "standard",
       "ipa": null,
       "lemma": "молодість",
       "lemmaId": "молодість",
       "lemmaPlain": "молодість",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3845,11 +4241,13 @@
     {
       "cefr": "B1",
       "gloss": "science",
+      "glossClean": "science",
       "heritage": "standard",
       "ipa": null,
       "lemma": "наука",
       "lemmaId": "наука",
       "lemmaPlain": "наука",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3889,11 +4287,13 @@
     {
       "cefr": "B1",
       "gloss": "sphere, field",
+      "glossClean": "sphere",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сфера",
       "lemmaId": "сфера",
       "lemmaPlain": "сфера",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3933,11 +4333,13 @@
     {
       "cefr": "B1",
       "gloss": "unchangeable",
+      "glossClean": "unchangeable",
       "heritage": "standard",
       "ipa": null,
       "lemma": "незмінний",
       "lemmaId": "незмінний",
       "lemmaPlain": "незмінний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3948,11 +4350,13 @@
     {
       "cefr": "B1",
       "gloss": "independent",
+      "glossClean": "independent",
       "heritage": "standard",
       "ipa": null,
       "lemma": "самостійний",
       "lemmaId": "самостійний",
       "lemmaPlain": "самостійний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3963,11 +4367,13 @@
     {
       "cefr": "B1",
       "gloss": "function",
+      "glossClean": "function",
       "heritage": "standard",
       "ipa": null,
       "lemma": "службовий",
       "lemmaId": "службовий",
       "lemmaPlain": "службовий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3978,11 +4384,13 @@
     {
       "cefr": "B1",
       "gloss": "voiceless",
+      "glossClean": "voiceless",
       "heritage": "standard",
       "ipa": null,
       "lemma": "глухий",
       "lemmaId": "глухий",
       "lemmaPlain": "глухий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3993,11 +4401,13 @@
     {
       "cefr": "B1",
       "gloss": "voiced",
+      "glossClean": "voiced",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дзвінкий",
       "lemmaId": "дзвінкий",
       "lemmaPlain": "дзвінкий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4008,11 +4418,13 @@
     {
       "cefr": "B1",
       "gloss": "to mark, denote",
+      "glossClean": "to mark",
       "heritage": "standard",
       "ipa": null,
       "lemma": "позначати",
       "lemmaId": "позначати",
       "lemmaPlain": "позначати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4023,11 +4435,13 @@
     {
       "cefr": "B1",
       "gloss": "adverbial modifier",
+      "glossClean": "adverbial modifier",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обставина",
       "lemmaId": "обставина",
       "lemmaPlain": "обставина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4067,11 +4481,13 @@
     {
       "cefr": "B1",
       "gloss": "instruction",
+      "glossClean": "instruction",
       "heritage": "standard",
       "ipa": null,
       "lemma": "інструкція",
       "lemmaId": "інструкція",
       "lemmaPlain": "інструкція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4111,11 +4527,13 @@
     {
       "cefr": "B1",
       "gloss": "addressee or recipient",
+      "glossClean": "addressee or recipient",
       "heritage": "standard",
       "ipa": null,
       "lemma": "адресат",
       "lemmaId": "адресат",
       "lemmaPlain": "адресат",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4126,11 +4544,13 @@
     {
       "cefr": "B1",
       "gloss": "explanation",
+      "glossClean": "explanation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пояснення",
       "lemmaId": "пояснення",
       "lemmaPlain": "пояснення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4141,11 +4561,13 @@
     {
       "cefr": "B1",
       "gloss": "structure",
+      "glossClean": "structure",
       "heritage": "standard",
       "ipa": null,
       "lemma": "структура",
       "lemmaId": "структура",
       "lemmaPlain": "структура",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4185,11 +4607,13 @@
     {
       "cefr": "B1",
       "gloss": "mood",
+      "glossClean": "mood",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спосіб",
       "lemmaId": "спосіб",
       "lemmaPlain": "спосіб",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4200,11 +4624,13 @@
     {
       "cefr": "B1",
       "gloss": "to struggle, I struggle",
+      "glossClean": "to struggle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "боротися / борюся",
       "lemmaId": "боротися-борюся",
       "lemmaPlain": "боротися / борюся",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4215,11 +4641,13 @@
     {
       "cefr": "B1",
       "gloss": "to fly off, to depart by air",
+      "glossClean": "to fly off",
       "heritage": "standard",
       "ipa": null,
       "lemma": "полетіти",
       "lemmaId": "полетіти",
       "lemmaPlain": "полетіти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4230,11 +4658,13 @@
     {
       "cefr": "B1",
       "gloss": "bonfire",
+      "glossClean": "bonfire",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вогнище",
       "lemmaId": "вогнище",
       "lemmaPlain": "вогнище",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4245,11 +4675,13 @@
     {
       "cefr": "B1",
       "gloss": "wreath",
+      "glossClean": "wreath",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вінок",
       "lemmaId": "вінок",
       "lemmaPlain": "вінок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4260,11 +4692,13 @@
     {
       "cefr": "B1",
       "gloss": "kutia, Christmas ritual dish",
+      "glossClean": "kutia",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кутя",
       "lemmaId": "кутя",
       "lemmaPlain": "кутя",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4304,11 +4738,13 @@
     {
       "cefr": "B1",
       "gloss": "both, masculine",
+      "glossClean": "both",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обидва",
       "lemmaId": "обидва",
       "lemmaPlain": "обидва",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4319,11 +4755,13 @@
     {
       "cefr": "B1",
       "gloss": "both, feminine",
+      "glossClean": "both",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обидві",
       "lemmaId": "обидві",
       "lemmaPlain": "обидві",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4334,11 +4772,13 @@
     {
       "cefr": "B1",
       "gloss": "ordinal",
+      "glossClean": "ordinal",
       "heritage": "standard",
       "ipa": null,
       "lemma": "порядковий",
       "lemmaId": "порядковий",
       "lemmaPlain": "порядковий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4349,11 +4789,13 @@
     {
       "cefr": "B1",
       "gloss": "giraffe",
+      "glossClean": "giraffe",
       "heritage": "standard",
       "ipa": null,
       "lemma": "жираф",
       "lemmaId": "жираф",
       "lemmaPlain": "жираф",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4364,11 +4806,13 @@
     {
       "cefr": "B1",
       "gloss": "monkey",
+      "glossClean": "monkey",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мавпа",
       "lemmaId": "мавпа",
       "lemmaPlain": "мавпа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4379,11 +4823,13 @@
     {
       "cefr": "B1",
       "gloss": "with what, by what",
+      "glossClean": "with what",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чим",
       "lemmaId": "чим",
       "lemmaPlain": "чим",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4394,11 +4840,13 @@
     {
       "cefr": "B1",
       "gloss": "after all, because",
+      "glossClean": "after all",
       "heritage": "standard",
       "ipa": null,
       "lemma": "адже",
       "lemmaId": "адже",
       "lemmaPlain": "адже",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4409,11 +4857,13 @@
     {
       "cefr": "B1",
       "gloss": "choice",
+      "glossClean": "choice",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вибір",
       "lemmaId": "вибір",
       "lemmaPlain": "вибір",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4424,11 +4874,13 @@
     {
       "cefr": "B1",
       "gloss": "to allow, to permit",
+      "glossClean": "to allow",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дозволити",
       "lemmaId": "дозволити",
       "lemmaPlain": "дозволити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4439,11 +4891,13 @@
     {
       "cefr": "B1",
       "gloss": "to choose",
+      "glossClean": "to choose",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обирати",
       "lemmaId": "обирати",
       "lemmaPlain": "обирати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4454,11 +4908,13 @@
     {
       "cefr": "B1",
       "gloss": "to agree",
+      "glossClean": "to agree",
       "heritage": "standard",
       "ipa": null,
       "lemma": "погоджуватися",
       "lemmaId": "погоджуватися",
       "lemmaPlain": "погоджуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4469,11 +4925,13 @@
     {
       "cefr": "B1",
       "gloss": "partial",
+      "glossClean": "partial",
       "heritage": "standard",
       "ipa": null,
       "lemma": "частковий",
       "lemmaId": "частковий",
       "lemmaPlain": "частковий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4484,11 +4942,13 @@
     {
       "cefr": "B1",
       "gloss": "differently, otherwise",
+      "glossClean": "differently",
       "heritage": "standard",
       "ipa": null,
       "lemma": "інакше",
       "lemmaId": "інакше",
       "lemmaPlain": "інакше",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4499,11 +4959,13 @@
     {
       "cefr": "B1",
       "gloss": "what for, why",
+      "glossClean": "what for",
       "heritage": "standard",
       "ipa": null,
       "lemma": "навіщо",
       "lemmaId": "навіщо",
       "lemmaPlain": "навіщо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4514,11 +4976,13 @@
     {
       "cefr": "B1",
       "gloss": "to retell, to relay",
+      "glossClean": "to retell",
       "heritage": "standard",
       "ipa": null,
       "lemma": "переказати",
       "lemmaId": "переказати",
       "lemmaPlain": "переказати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4529,11 +4993,13 @@
     {
       "cefr": "B1",
       "gloss": "to inform",
+      "glossClean": "to inform",
       "heritage": "standard",
       "ipa": null,
       "lemma": "повідомити",
       "lemmaId": "повідомити",
       "lemmaPlain": "повідомити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4544,11 +5010,13 @@
     {
       "cefr": "B1",
       "gloss": "likely, probable",
+      "glossClean": "likely",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ймовірний",
       "lemmaId": "ймовірний",
       "lemmaPlain": "ймовірний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4559,11 +5027,13 @@
     {
       "cefr": "B1",
       "gloss": "possible",
+      "glossClean": "possible",
       "heritage": "standard",
       "ipa": null,
       "lemma": "можливий",
       "lemmaId": "можливий",
       "lemmaPlain": "можливий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4574,11 +5044,13 @@
     {
       "cefr": "B1",
       "gloss": "to promise",
+      "glossClean": "to promise",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обіцяти",
       "lemmaId": "обіцяти",
       "lemmaPlain": "обіцяти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4589,11 +5061,13 @@
     {
       "cefr": "B1",
       "gloss": "to warn",
+      "glossClean": "to warn",
       "heritage": "standard",
       "ipa": null,
       "lemma": "попереджати",
       "lemmaId": "попереджати",
       "lemmaPlain": "попереджати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4604,11 +5078,13 @@
     {
       "cefr": "B1",
       "gloss": "to hurry",
+      "glossClean": "to hurry",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поспішити",
       "lemmaId": "поспішити",
       "lemmaPlain": "поспішити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4619,11 +5095,13 @@
     {
       "cefr": "B1",
       "gloss": "real",
+      "glossClean": "real",
       "heritage": "standard",
       "ipa": null,
       "lemma": "реальний",
       "lemmaId": "реальний",
       "lemmaPlain": "реальний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4634,11 +5112,13 @@
     {
       "cefr": "B1",
       "gloss": "if (hypothetical)",
+      "glossClean": "if (hypothetical)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "якби",
       "lemmaId": "якби",
       "lemmaPlain": "якби",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4649,11 +5129,13 @@
     {
       "cefr": "B1",
       "gloss": "to be located",
+      "glossClean": "to be located",
       "heritage": "standard",
       "ipa": null,
       "lemma": "знаходитися",
       "lemmaId": "знаходитися",
       "lemmaPlain": "знаходитися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4664,11 +5146,13 @@
     {
       "cefr": "B1",
       "gloss": "form",
+      "glossClean": "form",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бланк",
       "lemmaId": "бланк",
       "lemmaPlain": "бланк",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4679,11 +5163,13 @@
     {
       "cefr": "B1",
       "gloss": "to dispatch, to send",
+      "glossClean": "to dispatch",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відправити",
       "lemmaId": "відправити",
       "lemmaPlain": "відправити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4694,11 +5180,13 @@
     {
       "cefr": "B1",
       "gloss": "receipt",
+      "glossClean": "receipt",
       "heritage": "standard",
       "ipa": null,
       "lemma": "квитанція",
       "lemmaId": "квитанція",
       "lemmaPlain": "квитанція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4738,11 +5226,13 @@
     {
       "cefr": "B1",
       "gloss": "mail carrier",
+      "glossClean": "mail carrier",
       "heritage": "standard",
       "ipa": null,
       "lemma": "листоноша",
       "lemmaId": "листоноша",
       "lemmaPlain": "листоноша",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4753,11 +5243,13 @@
     {
       "cefr": "B1",
       "gloss": "appetite",
+      "glossClean": "appetite",
       "heritage": "standard",
       "ipa": null,
       "lemma": "апетит",
       "lemmaId": "апетит",
       "lemmaPlain": "апетит",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4768,11 +5260,13 @@
     {
       "cefr": "B1",
       "gloss": "to bother, concern",
+      "glossClean": "to bother",
       "heritage": "standard",
       "ipa": null,
       "lemma": "турбувати",
       "lemmaId": "турбувати",
       "lemmaPlain": "турбувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4783,11 +5277,13 @@
     {
       "cefr": "B1",
       "gloss": "to protect, to take care of",
+      "glossClean": "to protect",
       "heritage": "standard",
       "ipa": null,
       "lemma": "берегти",
       "lemmaId": "берегти",
       "lemmaPlain": "берегти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4798,11 +5294,13 @@
     {
       "cefr": "B1",
       "gloss": "to remind",
+      "glossClean": "to remind",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нагадувати",
       "lemmaId": "нагадувати",
       "lemmaPlain": "нагадувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4813,11 +5311,13 @@
     {
       "cefr": "B1",
       "gloss": "tense, stressful",
+      "glossClean": "tense",
       "heritage": "standard",
       "ipa": null,
       "lemma": "напружений",
       "lemmaId": "напружений",
       "lemmaPlain": "напружений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4828,11 +5328,13 @@
     {
       "cefr": "B1",
       "gloss": "independently",
+      "glossClean": "independently",
       "heritage": "standard",
       "ipa": null,
       "lemma": "самостійно",
       "lemmaId": "самостійно",
       "lemmaPlain": "самостійно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4843,11 +5345,13 @@
     {
       "cefr": "B1",
       "gloss": "one's own, masculine",
+      "glossClean": "one's own",
       "heritage": "standard",
       "ipa": null,
       "lemma": "свій",
       "lemmaId": "свій",
       "lemmaPlain": "свій",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4858,11 +5362,13 @@
     {
       "cefr": "B1",
       "gloss": "oneself, dative/locative",
+      "glossClean": "oneself",
       "heritage": "standard",
       "ipa": null,
       "lemma": "собі",
       "lemmaId": "собі",
       "lemmaPlain": "собі",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4873,11 +5379,13 @@
     {
       "cefr": "B1",
       "gloss": "to imagine",
+      "glossClean": "to imagine",
       "heritage": "standard",
       "ipa": null,
       "lemma": "уявити",
       "lemmaId": "уявити",
       "lemmaPlain": "уявити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4888,11 +5396,13 @@
     {
       "cefr": "B1",
       "gloss": "daily",
+      "glossClean": "daily",
       "heritage": "standard",
       "ipa": null,
       "lemma": "щоденний",
       "lemmaId": "щоденний",
       "lemmaPlain": "щоденний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4903,11 +5413,13 @@
     {
       "cefr": "B1",
       "gloss": "antonym",
+      "glossClean": "antonym",
       "heritage": "standard",
       "ipa": null,
       "lemma": "антонім",
       "lemmaId": "антонім",
       "lemmaPlain": "антонім",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4918,11 +5430,13 @@
     {
       "cefr": "B1",
       "gloss": "expressive",
+      "glossClean": "expressive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виразний",
       "lemmaId": "виразний",
       "lemmaPlain": "виразний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4933,11 +5447,13 @@
     {
       "cefr": "B1",
       "gloss": "nuance, shade of meaning",
+      "glossClean": "nuance",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відтінок",
       "lemmaId": "відтінок",
       "lemmaPlain": "відтінок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4948,11 +5464,13 @@
     {
       "cefr": "B1",
       "gloss": "loud",
+      "glossClean": "loud",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гучний",
       "lemmaId": "гучний",
       "lemmaPlain": "гучний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4963,11 +5481,13 @@
     {
       "cefr": "B1",
       "gloss": "contrast",
+      "glossClean": "contrast",
       "heritage": "standard",
       "ipa": null,
       "lemma": "контраст",
       "lemmaId": "контраст",
       "lemmaPlain": "контраст",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4978,11 +5498,13 @@
     {
       "cefr": "B1",
       "gloss": "metaphor",
+      "glossClean": "metaphor",
       "heritage": "standard",
       "ipa": null,
       "lemma": "метафора",
       "lemmaId": "метафора",
       "lemmaPlain": "метафора",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5022,11 +5544,13 @@
     {
       "cefr": "B1",
       "gloss": "neutral",
+      "glossClean": "neutral",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нейтральний",
       "lemmaId": "нейтральний",
       "lemmaPlain": "нейтральний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5037,11 +5561,13 @@
     {
       "cefr": "B1",
       "gloss": "informal",
+      "glossClean": "informal",
       "heritage": "standard",
       "ipa": null,
       "lemma": "неформальний",
       "lemmaId": "неформальний",
       "lemmaPlain": "неформальний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5052,11 +5578,13 @@
     {
       "cefr": "B1",
       "gloss": "to narrate, to tell",
+      "glossClean": "to narrate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "оповідати",
       "lemmaId": "оповідати",
       "lemmaPlain": "оповідати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5067,11 +5595,13 @@
     {
       "cefr": "B1",
       "gloss": "proverb",
+      "glossClean": "proverb",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прислів'я",
       "lemmaId": "прислів-я",
       "lemmaPlain": "прислів'я",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5082,11 +5612,13 @@
     {
       "cefr": "B1",
       "gloss": "spacious",
+      "glossClean": "spacious",
       "heritage": "standard",
       "ipa": null,
       "lemma": "просторий",
       "lemmaId": "просторий",
       "lemmaPlain": "просторий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5097,11 +5629,13 @@
     {
       "cefr": "B1",
       "gloss": "conversational",
+      "glossClean": "conversational",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розмовний",
       "lemmaId": "розмовний",
       "lemmaPlain": "розмовний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5112,11 +5646,13 @@
     {
       "cefr": "B1",
       "gloss": "synonym",
+      "glossClean": "synonym",
       "heritage": "standard",
       "ipa": null,
       "lemma": "синонім",
       "lemmaId": "синонім",
       "lemmaPlain": "синонім",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5127,11 +5663,13 @@
     {
       "cefr": "B1",
       "gloss": "precise",
+      "glossClean": "precise",
       "heritage": "standard",
       "ipa": null,
       "lemma": "точний",
       "lemmaId": "точний",
       "lemmaPlain": "точний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5142,11 +5680,13 @@
     {
       "cefr": "B1",
       "gloss": "promise",
+      "glossClean": "promise",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обіцянка",
       "lemmaId": "обіцянка",
       "lemmaPlain": "обіцянка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5186,11 +5726,13 @@
     {
       "cefr": "B1",
       "gloss": "to set off",
+      "glossClean": "to set off",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вирушити",
       "lemmaId": "вирушити",
       "lemmaPlain": "вирушити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5201,11 +5743,13 @@
     {
       "cefr": "B1",
       "gloss": "to arrive by vehicle",
+      "glossClean": "to arrive by vehicle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "доїхати",
       "lemmaId": "доїхати",
       "lemmaPlain": "доїхати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5216,11 +5760,13 @@
     {
       "cefr": "B1",
       "gloss": "to transfer, to change seats/vehicles",
+      "glossClean": "to transfer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пересісти",
       "lemmaId": "пересісти",
       "lemmaPlain": "пересісти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5231,11 +5777,13 @@
     {
       "cefr": "B1",
       "gloss": "to happen",
+      "glossClean": "to happen",
       "heritage": "standard",
       "ipa": null,
       "lemma": "трапитися",
       "lemmaId": "трапитися",
       "lemmaPlain": "трапитися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5246,11 +5794,13 @@
     {
       "cefr": "B1",
       "gloss": "certificate, note",
+      "glossClean": "certificate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "довідка",
       "lemmaId": "довідка",
       "lemmaPlain": "довідка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5290,11 +5840,13 @@
     {
       "cefr": "B1",
       "gloss": "tender, affectionate",
+      "glossClean": "tender",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ніжний",
       "lemmaId": "ніжний",
       "lemmaPlain": "ніжний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5305,11 +5857,13 @@
     {
       "cefr": "B1",
       "gloss": "to worry",
+      "glossClean": "to worry",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хвилюватися",
       "lemmaId": "хвилюватися",
       "lemmaPlain": "хвилюватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5320,11 +5874,13 @@
     {
       "cefr": "B1",
       "gloss": "to govern, to control",
+      "glossClean": "to govern",
       "heritage": "standard",
       "ipa": null,
       "lemma": "керувати",
       "lemmaId": "керувати",
       "lemmaPlain": "керувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5335,11 +5891,13 @@
     {
       "cefr": "B1",
       "gloss": "to use",
+      "glossClean": "to use",
       "heritage": "standard",
       "ipa": null,
       "lemma": "користуватися",
       "lemmaId": "користуватися",
       "lemmaPlain": "користуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5350,11 +5908,13 @@
     {
       "cefr": "B1",
       "gloss": "future",
+      "glossClean": "future",
       "heritage": "standard",
       "ipa": null,
       "lemma": "майбутнє",
       "lemmaId": "майбутнє",
       "lemmaPlain": "майбутнє",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5365,11 +5925,13 @@
     {
       "cefr": "B1",
       "gloss": "path, route",
+      "glossClean": "path",
       "heritage": "standard",
       "ipa": null,
       "lemma": "шлях",
       "lemmaId": "шлях",
       "lemmaPlain": "шлях",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5380,11 +5942,13 @@
     {
       "cefr": "B1",
       "gloss": "to serve",
+      "glossClean": "to serve",
       "heritage": "standard",
       "ipa": null,
       "lemma": "подавати",
       "lemmaId": "подавати",
       "lemmaPlain": "подавати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5395,11 +5959,13 @@
     {
       "cefr": "B1",
       "gloss": "to pour over, to dress",
+      "glossClean": "to pour over",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поливати",
       "lemmaId": "поливати",
       "lemmaPlain": "поливати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5410,11 +5976,13 @@
     {
       "cefr": "B1",
       "gloss": "absolute quality",
+      "glossClean": "absolute quality",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "абсолютна ознака",
       "lemmaId": "абсолютна-ознака",
       "lemmaPlain": "абсолютна ознака",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5425,11 +5993,13 @@
     {
       "cefr": "B1",
       "gloss": "comparative degree",
+      "glossClean": "comparative degree",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "вищий ступінь",
       "lemmaId": "вищий-ступінь",
       "lemmaPlain": "вищий ступінь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5440,11 +6010,13 @@
     {
       "cefr": "B1",
       "gloss": "relative adjective",
+      "glossClean": "relative adjective",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "відносний прикметник",
       "lemmaId": "відносний-прикметник",
       "lemmaPlain": "відносний прикметник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5455,11 +6027,13 @@
     {
       "cefr": "B1",
       "gloss": "comparison construction",
+      "glossClean": "comparison construction",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "порівняльна конструкція",
       "lemmaId": "порівняльна-конструкція",
       "lemmaPlain": "порівняльна конструкція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5470,11 +6044,13 @@
     {
       "cefr": "B1",
       "gloss": "base form",
+      "glossClean": "base form",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "початкова форма",
       "lemmaId": "початкова-форма",
       "lemmaPlain": "початкова форма",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5485,11 +6061,13 @@
     {
       "cefr": "B1",
       "gloss": "simple, synthetic form",
+      "glossClean": "simple",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "проста форма",
       "lemmaId": "проста-форма",
       "lemmaPlain": "проста форма",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5500,11 +6078,13 @@
     {
       "cefr": "B1",
       "gloss": "compound, analytic form",
+      "glossClean": "compound",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "складена форма",
       "lemmaId": "складена-форма",
       "lemmaPlain": "складена форма",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5515,11 +6095,13 @@
     {
       "cefr": "B1",
       "gloss": "degrees of comparison",
+      "glossClean": "degrees of comparison",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "ступені порівняння",
       "lemmaId": "ступені-порівняння",
       "lemmaPlain": "ступені порівняння",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5530,11 +6112,13 @@
     {
       "cefr": "B1",
       "gloss": "consonant alternation",
+      "glossClean": "consonant alternation",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "чергування приголосних",
       "lemmaId": "чергування-приголосних",
       "lemmaPlain": "чергування приголосних",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5545,11 +6129,13 @@
     {
       "cefr": "B1",
       "gloss": "the... the...",
+      "glossClean": "the... the...",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "чим... тим...",
       "lemmaId": "чим-тим",
       "lemmaPlain": "чим... тим...",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -5560,11 +6146,13 @@
     {
       "cefr": "B1",
       "gloss": "qualitative adjective",
+      "glossClean": "qualitative adjective",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "якісний прикметник",
       "lemmaId": "якісний-прикметник",
       "lemmaPlain": "якісний прикметник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5575,11 +6163,13 @@
     {
       "cefr": "B1",
       "gloss": "too, excessively",
+      "glossClean": "too",
       "heritage": "standard",
       "ipa": null,
       "lemma": "занадто",
       "lemmaId": "занадто",
       "lemmaPlain": "занадто",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5590,11 +6180,13 @@
     {
       "cefr": "B1",
       "gloss": "extraordinarily",
+      "glossClean": "extraordinarily",
       "heritage": "standard",
       "ipa": null,
       "lemma": "надзвичайно",
       "lemmaId": "надзвичайно",
       "lemmaPlain": "надзвичайно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5605,11 +6197,13 @@
     {
       "cefr": "B1",
       "gloss": "superlative degree",
+      "glossClean": "superlative degree",
       "heritage": "standard",
       "ipa": null,
       "lemma": "найвищий ступінь",
       "lemmaId": "найвищий-ступінь",
       "lemmaPlain": "найвищий ступінь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5620,11 +6214,13 @@
     {
       "cefr": "B1",
       "gloss": "any",
+      "glossClean": "any",
       "heritage": "standard",
       "ipa": null,
       "lemma": "будь-який",
       "lemmaId": "будь-який",
       "lemmaPlain": "будь-який",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5635,11 +6231,13 @@
     {
       "cefr": "B1",
       "gloss": "relative pronoun",
+      "glossClean": "relative pronoun",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "відносний займенник",
       "lemmaId": "відносний-займенник",
       "lemmaPlain": "відносний займенник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5650,11 +6248,13 @@
     {
       "cefr": "B1",
       "gloss": "in nothing",
+      "glossClean": "in nothing",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "ні в чому",
       "lemmaId": "ні-в-чому",
       "lemmaPlain": "ні в чому",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5665,11 +6265,13 @@
     {
       "cefr": "B1",
       "gloss": "determinative pronoun",
+      "glossClean": "determinative pronoun",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "означальний займенник",
       "lemmaId": "означальний-займенник",
       "lemmaPlain": "означальний займенник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5680,11 +6282,13 @@
     {
       "cefr": "B1",
       "gloss": "separately",
+      "glossClean": "separately",
       "heritage": "standard",
       "ipa": null,
       "lemma": "окремо",
       "lemmaId": "окремо",
       "lemmaPlain": "окремо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5695,11 +6299,13 @@
     {
       "cefr": "B1",
       "gloss": "interrogative pronoun",
+      "glossClean": "interrogative pronoun",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "питальний займенник",
       "lemmaId": "питальний-займенник",
       "lemmaPlain": "питальний займенник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5710,11 +6316,13 @@
     {
       "cefr": "B1",
       "gloss": "the same",
+      "glossClean": "the same",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "той самий",
       "lemmaId": "той-самий",
       "lemmaPlain": "той самий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5725,11 +6333,13 @@
     {
       "cefr": "B1",
       "gloss": "with a hyphen",
+      "glossClean": "with a hyphen",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "через дефіс",
       "lemmaId": "через-дефіс",
       "lemmaPlain": "через дефіс",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5740,11 +6350,13 @@
     {
       "cefr": "B1",
       "gloss": "higher",
+      "glossClean": "higher",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вище",
       "lemmaId": "вище",
       "lemmaPlain": "вище",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5755,11 +6367,13 @@
     {
       "cefr": "B1",
       "gloss": "worse",
+      "glossClean": "worse",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гірше",
       "lemmaId": "гірше",
       "lemmaPlain": "гірше",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5770,11 +6384,13 @@
     {
       "cefr": "B1",
       "gloss": "most often",
+      "glossClean": "most often",
       "heritage": "standard",
       "ipa": null,
       "lemma": "найчастіше",
       "lemmaId": "найчастіше",
       "lemmaPlain": "найчастіше",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5785,11 +6401,13 @@
     {
       "cefr": "B1",
       "gloss": "fastest, most quickly",
+      "glossClean": "fastest",
       "heritage": "standard",
       "ipa": null,
       "lemma": "найшвидше",
       "lemmaId": "найшвидше",
       "lemmaPlain": "найшвидше",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5800,11 +6418,13 @@
     {
       "cefr": "B1",
       "gloss": "kindly, in a kind way",
+      "glossClean": "kindly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "по-доброму",
       "lemmaId": "по-доброму",
       "lemmaPlain": "по-доброму",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5815,11 +6435,13 @@
     {
       "cefr": "B1",
       "gloss": "more quietly",
+      "glossClean": "more quietly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тихіше",
       "lemmaId": "тихіше",
       "lemmaPlain": "тихіше",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5830,11 +6452,13 @@
     {
       "cefr": "B1",
       "gloss": "as quickly as possible",
+      "glossClean": "as quickly as possible",
       "heritage": "standard",
       "ipa": null,
       "lemma": "якнайшвидше",
       "lemmaId": "якнайшвидше",
       "lemmaPlain": "якнайшвидше",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5845,11 +6469,13 @@
     {
       "cefr": "B1",
       "gloss": "vocative form",
+      "glossClean": "vocative form",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "клична форма",
       "lemmaId": "клична-форма",
       "lemmaPlain": "клична форма",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5860,11 +6486,13 @@
     {
       "cefr": "B1",
       "gloss": "soft group",
+      "glossClean": "soft group",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "м'яка група",
       "lemmaId": "м-яка-група",
       "lemmaPlain": "м'яка група",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5875,11 +6503,13 @@
     {
       "cefr": "B1",
       "gloss": "mixed group",
+      "glossClean": "mixed group",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "мішана група",
       "lemmaId": "мішана-група",
       "lemmaPlain": "мішана група",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5890,11 +6520,13 @@
     {
       "cefr": "B1",
       "gloss": "hard group",
+      "glossClean": "hard group",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "тверда група",
       "lemmaId": "тверда-група",
       "lemmaPlain": "тверда група",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5905,11 +6537,13 @@
     {
       "cefr": "B1",
       "gloss": "inserted sound",
+      "glossClean": "inserted sound",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "вставний звук",
       "lemmaId": "вставний-звук",
       "lemmaPlain": "вставний звук",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5920,11 +6554,13 @@
     {
       "cefr": "B1",
       "gloss": "labial consonant",
+      "glossClean": "labial consonant",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "губний приголосний",
       "lemmaId": "губний-приголосний",
       "lemmaPlain": "губний приголосний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5935,11 +6571,13 @@
     {
       "cefr": "B1",
       "gloss": "velar consonant",
+      "glossClean": "velar consonant",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "задньоязиковий приголосний",
       "lemmaId": "задньоязиковий-приголосний",
       "lemmaPlain": "задньоязиковий приголосний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5950,11 +6588,13 @@
     {
       "cefr": "B1",
       "gloss": "regular pattern",
+      "glossClean": "regular pattern",
       "heritage": "standard",
       "ipa": null,
       "lemma": "закономірність",
       "lemmaId": "закономірність",
       "lemmaPlain": "закономірність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5965,11 +6605,13 @@
     {
       "cefr": "B1",
       "gloss": "dental consonant",
+      "glossClean": "dental consonant",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "зубний приголосний",
       "lemmaId": "зубний-приголосний",
       "lemmaPlain": "зубний приголосний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5980,11 +6622,13 @@
     {
       "cefr": "B1",
       "gloss": "standard, normative",
+      "glossClean": "standard",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нормативний",
       "lemmaId": "нормативний",
       "lemmaPlain": "нормативний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5995,11 +6639,13 @@
     {
       "cefr": "B1",
       "gloss": "paradigm",
+      "glossClean": "paradigm",
       "heritage": "standard",
       "ipa": null,
       "lemma": "парадигма",
       "lemmaId": "парадигма",
       "lemmaPlain": "парадигма",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6010,11 +6656,13 @@
     {
       "cefr": "B1",
       "gloss": "first person singular",
+      "glossClean": "first person singular",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "перша особа однини",
       "lemmaId": "перша-особа-однини",
       "lemmaPlain": "перша особа однини",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6025,11 +6673,13 @@
     {
       "cefr": "B1",
       "gloss": "simple future tense",
+      "glossClean": "simple future tense",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "простий майбутній час",
       "lemmaId": "простий-майбутній-час",
       "lemmaPlain": "простий майбутній час",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6040,11 +6690,13 @@
     {
       "cefr": "B1",
       "gloss": "sibilant consonant",
+      "glossClean": "sibilant consonant",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "свистячий приголосний",
       "lemmaId": "свистячий-приголосний",
       "lemmaPlain": "свистячий приголосний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6055,11 +6707,13 @@
     {
       "cefr": "B1",
       "gloss": "fleeting vowel",
+      "glossClean": "fleeting vowel",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "біглий голосний",
       "lemmaId": "біглий-голосний",
       "lemmaPlain": "біглий голосний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6070,11 +6724,13 @@
     {
       "cefr": "B1",
       "gloss": "open",
+      "glossClean": "open",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відкритий",
       "lemmaId": "відкритий",
       "lemmaPlain": "відкритий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6085,11 +6741,13 @@
     {
       "cefr": "B1",
       "gloss": "open syllable",
+      "glossClean": "open syllable",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "відкритий склад",
       "lemmaId": "відкритий-склад",
       "lemmaPlain": "відкритий склад",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6100,11 +6758,13 @@
     {
       "cefr": "B1",
       "gloss": "closed",
+      "glossClean": "closed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "закритий",
       "lemmaId": "закритий",
       "lemmaPlain": "закритий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6115,11 +6775,13 @@
     {
       "cefr": "B1",
       "gloss": "closed syllable",
+      "glossClean": "closed syllable",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "закритий склад",
       "lemmaId": "закритий-склад",
       "lemmaPlain": "закритий склад",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6130,11 +6792,13 @@
     {
       "cefr": "B1",
       "gloss": "standard form",
+      "glossClean": "standard form",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "нормативна форма",
       "lemmaId": "нормативна-форма",
       "lemmaPlain": "нормативна форма",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6145,11 +6809,13 @@
     {
       "cefr": "B1",
       "gloss": "zero sound",
+      "glossClean": "zero sound",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "нуль звука",
       "lemmaId": "нуль-звука",
       "lemmaPlain": "нуль звука",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6160,11 +6826,13 @@
     {
       "cefr": "B1",
       "gloss": "checking word",
+      "glossClean": "checking word",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "перевірне слово",
       "lemmaId": "перевірне-слово",
       "lemmaPlain": "перевірне слово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6175,11 +6843,13 @@
     {
       "cefr": "B1",
       "gloss": "orthography, spelling",
+      "glossClean": "orthography",
       "heritage": "standard",
       "ipa": null,
       "lemma": "правопис",
       "lemmaId": "правопис",
       "lemmaPlain": "правопис",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6190,11 +6860,13 @@
     {
       "cefr": "B1",
       "gloss": "family of forms",
+      "glossClean": "family of forms",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "родина форм",
       "lemmaId": "родина-форм",
       "lemmaPlain": "родина форм",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6205,11 +6877,13 @@
     {
       "cefr": "B1",
       "gloss": "word form",
+      "glossClean": "word form",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "форма слова",
       "lemmaId": "форма-слова",
       "lemmaPlain": "форма слова",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6220,11 +6894,13 @@
     {
       "cefr": "B1",
       "gloss": "analytic form",
+      "glossClean": "analytic form",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "аналітична форма",
       "lemmaId": "аналітична-форма",
       "lemmaPlain": "аналітична форма",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6235,11 +6911,13 @@
     {
       "cefr": "B1",
       "gloss": "auxiliary verb",
+      "glossClean": "auxiliary verb",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "допоміжне дієслово",
       "lemmaId": "допоміжне-дієслово",
       "lemmaPlain": "допоміжне дієслово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6250,11 +6928,13 @@
     {
       "cefr": "B1",
       "gloss": "to schedule, perfective",
+      "glossClean": "to schedule",
       "heritage": "standard",
       "ipa": null,
       "lemma": "запланувати",
       "lemmaId": "запланувати",
       "lemmaPlain": "запланувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6265,11 +6945,13 @@
     {
       "cefr": "B1",
       "gloss": "communicative intention",
+      "glossClean": "communicative intention",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "комунікативний намір",
       "lemmaId": "комунікативний-намір",
       "lemmaPlain": "комунікативний намір",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6280,11 +6962,13 @@
     {
       "cefr": "B1",
       "gloss": "to enjoy, imperfective",
+      "glossClean": "to enjoy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "насолоджуватися",
       "lemmaId": "насолоджуватися",
       "lemmaPlain": "насолоджуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6295,11 +6979,13 @@
     {
       "cefr": "B1",
       "gloss": "personal ending",
+      "glossClean": "personal ending",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "особове закінчення",
       "lemmaId": "особове-закінчення",
       "lemmaPlain": "особове закінчення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6310,11 +6996,13 @@
     {
       "cefr": "B1",
       "gloss": "written style",
+      "glossClean": "written style",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "писемний стиль",
       "lemmaId": "писемний-стиль",
       "lemmaPlain": "писемний стиль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6325,11 +7013,13 @@
     {
       "cefr": "B1",
       "gloss": "to make a promise, perfective",
+      "glossClean": "to make a promise",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пообіцяти",
       "lemmaId": "пообіцяти",
       "lemmaPlain": "пообіцяти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6340,11 +7030,13 @@
     {
       "cefr": "B1",
       "gloss": "conversational style",
+      "glossClean": "conversational style",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "розмовний стиль",
       "lemmaId": "розмовний-стиль",
       "lemmaPlain": "розмовний стиль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6355,11 +7047,13 @@
     {
       "cefr": "B1",
       "gloss": "synthetic form",
+      "glossClean": "synthetic form",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "синтетична форма",
       "lemmaId": "синтетична-форма",
       "lemmaPlain": "синтетична форма",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6370,11 +7064,13 @@
     {
       "cefr": "B1",
       "gloss": "synthetic one-word future form",
+      "glossClean": "synthetic one-word future form",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "складна форма",
       "lemmaId": "складна-форма",
       "lemmaPlain": "складна форма",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6385,11 +7081,13 @@
     {
       "cefr": "B1",
       "gloss": "to try, imperfective",
+      "glossClean": "to try",
       "heritage": "standard",
       "ipa": null,
       "lemma": "старатися",
       "lemmaId": "старатися",
       "lemmaPlain": "старатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6400,11 +7098,13 @@
     {
       "cefr": "B1",
       "gloss": "suffix -m in synthetic future",
+      "glossClean": "suffix -m in synthetic future",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "суфікс -м",
       "lemmaId": "суфікс-м",
       "lemmaPlain": "суфікс -м",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6415,11 +7115,13 @@
     {
       "cefr": "B1",
       "gloss": "form of бути",
+      "glossClean": "form of бути",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "форма бути",
       "lemmaId": "форма-бути",
       "lemmaPlain": "форма бути",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6430,11 +7132,13 @@
     {
       "cefr": "B1",
       "gloss": "time marker",
+      "glossClean": "time marker",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "часовий маркер",
       "lemmaId": "часовий-маркер",
       "lemmaPlain": "часовий маркер",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6445,11 +7149,13 @@
     {
       "cefr": "B1",
       "gloss": "to win",
+      "glossClean": "to win",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вигравати",
       "lemmaId": "вигравати",
       "lemmaPlain": "вигравати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6460,11 +7166,13 @@
     {
       "cefr": "B1",
       "gloss": "to the end",
+      "glossClean": "to the end",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "до кінця",
       "lemmaId": "до-кінця",
       "lemmaPlain": "до кінця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6475,11 +7183,13 @@
     {
       "cefr": "B1",
       "gloss": "possibility",
+      "glossClean": "possibility",
       "heritage": "standard",
       "ipa": null,
       "lemma": "можливість",
       "lemmaId": "можливість",
       "lemmaPlain": "можливість",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6490,11 +7200,13 @@
     {
       "cefr": "B1",
       "gloss": "consequence, result",
+      "glossClean": "consequence",
       "heritage": "standard",
       "ipa": null,
       "lemma": "наслідок",
       "lemmaId": "наслідок",
       "lemmaPlain": "наслідок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6505,11 +7217,13 @@
     {
       "cefr": "B1",
       "gloss": "unreal condition",
+      "glossClean": "unreal condition",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "нереальна умова",
       "lemmaId": "нереальна-умова",
       "lemmaPlain": "нереальна умова",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6520,11 +7234,13 @@
     {
       "cefr": "B1",
       "gloss": "opposite, contrary",
+      "glossClean": "opposite",
       "heritage": "standard",
       "ipa": null,
       "lemma": "протилежний",
       "lemmaId": "протилежний",
       "lemmaPlain": "протилежний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6535,11 +7251,13 @@
     {
       "cefr": "B1",
       "gloss": "real condition",
+      "glossClean": "real condition",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "реальна умова",
       "lemmaId": "реальна-умова",
       "lemmaPlain": "реальна умова",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6550,11 +7268,13 @@
     {
       "cefr": "B1",
       "gloss": "state",
+      "glossClean": "state",
       "heritage": "historism",
       "ipa": null,
       "lemma": "стан",
       "lemmaId": "стан",
       "lemmaPlain": "стан",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6565,11 +7285,13 @@
     {
       "cefr": "B1",
       "gloss": "conditional sentence",
+      "glossClean": "conditional sentence",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "умовне речення",
       "lemmaId": "умовне-речення",
       "lemmaPlain": "умовне речення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6580,11 +7302,13 @@
     {
       "cefr": "B1",
       "gloss": "to imagine",
+      "glossClean": "to imagine",
       "heritage": "standard",
       "ipa": null,
       "lemma": "уявляти",
       "lemmaId": "уявляти",
       "lemmaPlain": "уявляти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6595,11 +7319,13 @@
     {
       "cefr": "B1",
       "gloss": "accidental",
+      "glossClean": "accidental",
       "heritage": "standard",
       "ipa": null,
       "lemma": "випадковий",
       "lemmaId": "випадковий",
       "lemmaPlain": "випадковий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6610,11 +7336,13 @@
     {
       "cefr": "B1",
       "gloss": "to open (door/window)",
+      "glossClean": "to open (door/window)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відчиняти",
       "lemmaId": "відчиняти",
       "lemmaPlain": "відчиняти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6625,11 +7353,13 @@
     {
       "cefr": "B1",
       "gloss": "to lose",
+      "glossClean": "to lose",
       "heritage": "standard",
       "ipa": null,
       "lemma": "губити",
       "lemmaId": "губити",
       "lemmaPlain": "губити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6640,11 +7370,13 @@
     {
       "cefr": "B1",
       "gloss": "prohibition",
+      "glossClean": "prohibition",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заборона",
       "lemmaId": "заборона",
       "lemmaPlain": "заборона",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6655,11 +7387,13 @@
     {
       "cefr": "B1",
       "gloss": "general",
+      "glossClean": "general",
       "heritage": "standard",
       "ipa": null,
       "lemma": "загальний",
       "lemmaId": "загальний",
       "lemmaPlain": "загальний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6670,11 +7404,13 @@
     {
       "cefr": "B1",
       "gloss": "to save, keep",
+      "glossClean": "to save",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зберігати",
       "lemmaId": "зберігати",
       "lemmaPlain": "зберігати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6685,11 +7421,13 @@
     {
       "cefr": "B1",
       "gloss": "specific, concrete",
+      "glossClean": "specific",
       "heritage": "standard",
       "ipa": null,
       "lemma": "конкретний",
       "lemmaId": "конкретний",
       "lemmaPlain": "конкретний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6700,11 +7438,13 @@
     {
       "cefr": "B1",
       "gloss": "to mix",
+      "glossClean": "to mix",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перемішати",
       "lemmaId": "перемішати",
       "lemmaPlain": "перемішати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6715,11 +7455,13 @@
     {
       "cefr": "B1",
       "gloss": "suspicious",
+      "glossClean": "suspicious",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підозрілий",
       "lemmaId": "підозрілий",
       "lemmaPlain": "підозрілий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6730,11 +7472,13 @@
     {
       "cefr": "B1",
       "gloss": "to break, smash",
+      "glossClean": "to break",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розбити",
       "lemmaId": "розбити",
       "lemmaPlain": "розбити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6745,11 +7489,13 @@
     {
       "cefr": "B1",
       "gloss": "to touch",
+      "glossClean": "to touch",
       "heritage": "standard",
       "ipa": null,
       "lemma": "торкатися",
       "lemmaId": "торкатися",
       "lemmaPlain": "торкатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6760,11 +7506,13 @@
     {
       "cefr": "B1",
       "gloss": "to touch once",
+      "glossClean": "to touch once",
       "heritage": "standard",
       "ipa": null,
       "lemma": "торкнутися",
       "lemmaId": "торкнутися",
       "lemmaPlain": "торкнутися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6775,11 +7523,13 @@
     {
       "cefr": "B1",
       "gloss": "hall, room",
+      "glossClean": "hall",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зала",
       "lemmaId": "зала",
       "lemmaPlain": "зала",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6790,11 +7540,13 @@
     {
       "cefr": "B1",
       "gloss": "narrative step",
+      "glossClean": "narrative step",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "крок сюжету",
       "lemmaId": "крок-сюжету",
       "lemmaPlain": "крок сюжету",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6805,11 +7557,13 @@
     {
       "cefr": "B1",
       "gloss": "simultaneously",
+      "glossClean": "simultaneously",
       "heritage": "standard",
       "ipa": null,
       "lemma": "одночасно",
       "lemmaId": "одночасно",
       "lemmaPlain": "одночасно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6820,11 +7574,13 @@
     {
       "cefr": "B1",
       "gloss": "short story, narration",
+      "glossClean": "short story",
       "heritage": "standard",
       "ipa": null,
       "lemma": "оповідання",
       "lemmaId": "оповідання",
       "lemmaPlain": "оповідання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6835,11 +7591,13 @@
     {
       "cefr": "B1",
       "gloss": "narrator",
+      "glossClean": "narrator",
       "heritage": "standard",
       "ipa": null,
       "lemma": "оповідач",
       "lemmaId": "оповідач",
       "lemmaPlain": "оповідач",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6850,11 +7608,13 @@
     {
       "cefr": "B1",
       "gloss": "turning point",
+      "glossClean": "turning point",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "поворотний момент",
       "lemmaId": "поворотний-момент",
       "lemmaPlain": "поворотний момент",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6865,11 +7625,13 @@
     {
       "cefr": "B1",
       "gloss": "memory, recollection",
+      "glossClean": "memory",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спогад",
       "lemmaId": "спогад",
       "lemmaPlain": "спогад",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6880,11 +7642,13 @@
     {
       "cefr": "B1",
       "gloss": "plot",
+      "glossClean": "plot",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сюжет",
       "lemmaId": "сюжет",
       "lemmaPlain": "сюжет",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6895,11 +7659,13 @@
     {
       "cefr": "B1",
       "gloss": "general negation; factual denial",
+      "glossClean": "general negation",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "загальне заперечення",
       "lemmaId": "загальне-заперечення",
       "lemmaPlain": "загальне заперечення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6910,11 +7676,13 @@
     {
       "cefr": "B1",
       "gloss": "to discuss; perfective",
+      "glossClean": "to discuss",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обговорити",
       "lemmaId": "обговорити",
       "lemmaPlain": "обговорити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6925,11 +7693,13 @@
     {
       "cefr": "B1",
       "gloss": "expected completion; pending result",
+      "glossClean": "expected completion",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "очікуване завершення",
       "lemmaId": "очікуване-завершення",
       "lemmaPlain": "очікуване завершення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6940,11 +7710,13 @@
     {
       "cefr": "B1",
       "gloss": "predicative word",
+      "glossClean": "predicative word",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "предикативне слово",
       "lemmaId": "предикативне-слово",
       "lemmaPlain": "предикативне слово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6955,11 +7727,13 @@
     {
       "cefr": "B1",
       "gloss": "habitual past",
+      "glossClean": "habitual past",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "звичне минуле",
       "lemmaId": "звичне-минуле",
       "lemmaPlain": "звичне минуле",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6970,11 +7744,13 @@
     {
       "cefr": "B1",
       "gloss": "speaker's intention",
+      "glossClean": "speaker's intention",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "намір мовця",
       "lemmaId": "намір-мовця",
       "lemmaPlain": "намір мовця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6985,11 +7761,13 @@
     {
       "cefr": "B1",
       "gloss": "for three hours",
+      "glossClean": "for three hours",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "три години",
       "lemmaId": "три-години",
       "lemmaPlain": "три години",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7000,11 +7778,13 @@
     {
       "cefr": "B1",
       "gloss": "all day",
+      "glossClean": "all day",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "цілий день",
       "lemmaId": "цілий-день",
       "lemmaPlain": "цілий день",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7015,11 +7795,13 @@
     {
       "cefr": "B1",
       "gloss": "every time",
+      "glossClean": "every time",
       "heritage": "standard",
       "ipa": null,
       "lemma": "щоразу",
       "lemmaId": "щоразу",
       "lemmaPlain": "щоразу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7030,11 +7812,13 @@
     {
       "cefr": "B1",
       "gloss": "charity concert",
+      "glossClean": "charity concert",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "благодійний концерт",
       "lemmaId": "благодійний-концерт",
       "lemmaPlain": "благодійний концерт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7045,11 +7829,13 @@
     {
       "cefr": "B1",
       "gloss": "biaspectual",
+      "glossClean": "biaspectual",
       "heritage": "standard",
       "ipa": null,
       "lemma": "двовидовий",
       "lemmaId": "двовидовий",
       "lemmaPlain": "двовидовий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7060,11 +7846,13 @@
     {
       "cefr": "B1",
       "gloss": "auxiliary construction",
+      "glossClean": "auxiliary construction",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "допоміжна конструкція",
       "lemmaId": "допоміжна-конструкція",
       "lemmaPlain": "допоміжна конструкція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7075,11 +7863,13 @@
     {
       "cefr": "B1",
       "gloss": "completed action",
+      "glossClean": "completed action",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "завершена дія",
       "lemmaId": "завершена-дія",
       "lemmaPlain": "завершена дія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7090,11 +7880,13 @@
     {
       "cefr": "B1",
       "gloss": "to collect, finish collecting",
+      "glossClean": "to collect",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зібрати",
       "lemmaId": "зібрати",
       "lemmaPlain": "зібрати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7105,11 +7897,13 @@
     {
       "cefr": "B1",
       "gloss": "to announce",
+      "glossClean": "to announce",
       "heritage": "standard",
       "ipa": null,
       "lemma": "оголошувати",
       "lemmaId": "оголошувати",
       "lemmaPlain": "оголошувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7120,11 +7914,13 @@
     {
       "cefr": "B1",
       "gloss": "organizing committee",
+      "glossClean": "organizing committee",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "організаційний комітет",
       "lemmaId": "організаційний-комітет",
       "lemmaPlain": "організаційний комітет",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7135,11 +7931,13 @@
     {
       "cefr": "B1",
       "gloss": "repeated action",
+      "glossClean": "repeated action",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "повторювана дія",
       "lemmaId": "повторювана-дія",
       "lemmaPlain": "повторювана дія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7150,11 +7948,13 @@
     {
       "cefr": "B1",
       "gloss": "to get prepared",
+      "glossClean": "to get prepared",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підготуватися",
       "lemmaId": "підготуватися",
       "lemmaPlain": "підготуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7165,11 +7965,13 @@
     {
       "cefr": "B1",
       "gloss": "to count up, tally completely",
+      "glossClean": "to count up",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підрахувати",
       "lemmaId": "підрахувати",
       "lemmaPlain": "підрахувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7180,11 +7982,13 @@
     {
       "cefr": "B1",
       "gloss": "ongoing action",
+      "glossClean": "ongoing action",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "тривала дія",
       "lemmaId": "тривала-дія",
       "lemmaPlain": "тривала дія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7195,11 +7999,13 @@
     {
       "cefr": "B1",
       "gloss": "Ukrainian rhythm",
+      "glossClean": "Ukrainian rhythm",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "український ритм",
       "lemmaId": "український-ритм",
       "lemmaPlain": "український ритм",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7210,11 +8016,13 @@
     {
       "cefr": "B1",
       "gloss": "participle",
+      "glossClean": "participle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дієприкметник",
       "lemmaId": "дієприкметник",
       "lemmaPlain": "дієприкметник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7225,11 +8033,13 @@
     {
       "cefr": "B1",
       "gloss": "adverbial participle",
+      "glossClean": "adverbial participle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дієприслівник",
       "lemmaId": "дієприслівник",
       "lemmaPlain": "дієприслівник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7240,11 +8050,13 @@
     {
       "cefr": "B1",
       "gloss": "adverbial-participle phrase",
+      "glossClean": "adverbial-participle phrase",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "дієприслівниковий зворот",
       "lemmaId": "дієприслівниковий-зворот",
       "lemmaPlain": "дієприслівниковий зворот",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7255,11 +8067,13 @@
     {
       "cefr": "B1",
       "gloss": "reflexive verb",
+      "glossClean": "reflexive verb",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "зворотне дієслово",
       "lemmaId": "зворотне-дієслово",
       "lemmaPlain": "зворотне дієслово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7270,11 +8084,13 @@
     {
       "cefr": "B1",
       "gloss": "zero suffix",
+      "glossClean": "zero suffix",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "нульовий суфікс",
       "lemmaId": "нульовий-суфікс",
       "lemmaPlain": "нульовий суфікс",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7285,11 +8101,13 @@
     {
       "cefr": "B1",
       "gloss": "circumstances of the situation",
+      "glossClean": "circumstances of the situation",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "обставини ситуації",
       "lemmaId": "обставини-ситуації",
       "lemmaPlain": "обставини ситуації",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7300,11 +8118,13 @@
     {
       "cefr": "B1",
       "gloss": "present-tense stem",
+      "glossClean": "present-tense stem",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "основа теперішнього часу",
       "lemmaId": "основа-теперішнього-часу",
       "lemmaPlain": "основа теперішнього часу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7315,11 +8135,13 @@
     {
       "cefr": "B1",
       "gloss": "infinitive stem",
+      "glossClean": "infinitive stem",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "основа інфінітива",
       "lemmaId": "основа-інфінітива",
       "lemmaPlain": "основа інфінітива",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7330,11 +8152,13 @@
     {
       "cefr": "B1",
       "gloss": "sequence of actions",
+      "glossClean": "sequence of actions",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "послідовність дій",
       "lemmaId": "послідовність-дій",
       "lemmaPlain": "послідовність дій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7345,11 +8169,13 @@
     {
       "cefr": "B1",
       "gloss": "past-tense suffix",
+      "glossClean": "past-tense suffix",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "суфікс минулого часу",
       "lemmaId": "суфікс-минулого-часу",
       "lemmaPlain": "суфікс минулого часу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7360,11 +8186,13 @@
     {
       "cefr": "B1",
       "gloss": "while reading",
+      "glossClean": "while reading",
       "heritage": "standard",
       "ipa": null,
       "lemma": "читаючи",
       "lemmaId": "читаючи",
       "lemmaPlain": "читаючи",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -7375,11 +8203,13 @@
     {
       "cefr": "B1",
       "gloss": "twenty-first",
+      "glossClean": "twenty-first",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "двадцять перший",
       "lemmaId": "двадцять-перший",
       "lemmaPlain": "двадцять перший",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7390,11 +8220,13 @@
     {
       "cefr": "B1",
       "gloss": "ten to",
+      "glossClean": "ten to",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "за десять",
       "lemmaId": "за-десять",
       "lemmaPlain": "за десять",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7405,11 +8237,13 @@
     {
       "cefr": "B1",
       "gloss": "cardinal numeral",
+      "glossClean": "cardinal numeral",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "кількісний числівник",
       "lemmaId": "кількісний-числівник",
       "lemmaPlain": "кількісний числівник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7420,11 +8254,13 @@
     {
       "cefr": "B1",
       "gloss": "toward five, after four",
+      "glossClean": "toward five",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "на п'яту",
       "lemmaId": "на-п-яту",
       "lemmaPlain": "на п'яту",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7435,11 +8271,13 @@
     {
       "cefr": "B1",
       "gloss": "first of all",
+      "glossClean": "first of all",
       "heritage": "standard",
       "ipa": null,
       "lemma": "насамперед",
       "lemmaId": "насамперед",
       "lemmaPlain": "насамперед",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7450,11 +8288,13 @@
     {
       "cefr": "B1",
       "gloss": "last word",
+      "glossClean": "last word",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "останнє слово",
       "lemmaId": "останнє-слово",
       "lemmaPlain": "останнє слово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7465,11 +8305,13 @@
     {
       "cefr": "B1",
       "gloss": "half",
+      "glossClean": "half",
       "heritage": "standard",
       "ipa": null,
       "lemma": "половина",
       "lemmaId": "половина",
       "lemmaPlain": "половина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -7509,11 +8351,13 @@
     {
       "cefr": "B1",
       "gloss": "ordinal numeral",
+      "glossClean": "ordinal numeral",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "порядковий числівник",
       "lemmaId": "порядковий-числівник",
       "lemmaPlain": "порядковий числівник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7524,11 +8368,13 @@
     {
       "cefr": "B1",
       "gloss": "half past, literally half toward",
+      "glossClean": "half past",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пів на",
       "lemmaId": "пів-на",
       "lemmaPlain": "пів на",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7539,11 +8385,13 @@
     {
       "cefr": "B1",
       "gloss": "compound ordinal numeral",
+      "glossClean": "compound ordinal numeral",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "складений порядковий числівник",
       "lemmaId": "складений-порядковий-числівник",
       "lemmaPlain": "складений порядковий числівник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7554,11 +8402,13 @@
     {
       "cefr": "B1",
       "gloss": "twenty-two",
+      "glossClean": "twenty-two",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "двадцять два",
       "lemmaId": "двадцять-два",
       "lemmaPlain": "двадцять два",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7569,11 +8419,13 @@
     {
       "cefr": "B1",
       "gloss": "twenty-one",
+      "glossClean": "twenty-one",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "двадцять один",
       "lemmaId": "двадцять-один",
       "lemmaPlain": "двадцять один",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7584,11 +8436,13 @@
     {
       "cefr": "B1",
       "gloss": "twenty-five",
+      "glossClean": "twenty-five",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "двадцять п'ять",
       "lemmaId": "двадцять-п-ять",
       "lemmaPlain": "двадцять п'ять",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7599,11 +8453,13 @@
     {
       "cefr": "B1",
       "gloss": "enough",
+      "glossClean": "enough",
       "heritage": "standard",
       "ipa": null,
       "lemma": "достатньо",
       "lemmaId": "достатньо",
       "lemmaPlain": "достатньо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7614,11 +8470,13 @@
     {
       "cefr": "B1",
       "gloss": "collective numeral",
+      "glossClean": "collective numeral",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "збірний числівник",
       "lemmaId": "збірний-числівник",
       "lemmaPlain": "збірний числівник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7629,11 +8487,13 @@
     {
       "cefr": "B1",
       "gloss": "nominative plural",
+      "glossClean": "nominative plural",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "називний множини",
       "lemmaId": "називний-множини",
       "lemmaPlain": "називний множини",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7644,11 +8504,13 @@
     {
       "cefr": "B1",
       "gloss": "oblique case",
+      "glossClean": "oblique case",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "непрямий відмінок",
       "lemmaId": "непрямий-відмінок",
       "lemmaPlain": "непрямий відмінок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7659,11 +8521,13 @@
     {
       "cefr": "B1",
       "gloss": "last component",
+      "glossClean": "last component",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "останній компонент",
       "lemmaId": "останній-компонент",
       "lemmaPlain": "останній компонент",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7674,11 +8538,13 @@
     {
       "cefr": "B1",
       "gloss": "more than",
+      "glossClean": "more than",
       "heritage": "standard",
       "ipa": null,
       "lemma": "понад",
       "lemmaId": "понад",
       "lemmaPlain": "понад",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -7689,11 +8555,13 @@
     {
       "cefr": "B1",
       "gloss": "one and a half, masculine/neuter",
+      "glossClean": "one and a half",
       "heritage": "standard",
       "ipa": null,
       "lemma": "півтора",
       "lemmaId": "півтора",
       "lemmaPlain": "півтора",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7704,11 +8572,13 @@
     {
       "cefr": "B1",
       "gloss": "one and a half, feminine",
+      "glossClean": "one and a half",
       "heritage": "standard",
       "ipa": null,
       "lemma": "півтори",
       "lemmaId": "півтори",
       "lemmaPlain": "півтори",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7719,11 +8589,13 @@
     {
       "cefr": "B1",
       "gloss": "genitive singular",
+      "glossClean": "genitive singular",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "родовий однини",
       "lemmaId": "родовий-однини",
       "lemmaPlain": "родовий однини",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7734,11 +8606,13 @@
     {
       "cefr": "B1",
       "gloss": "quite a lot",
+      "glossClean": "quite a lot",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чимало",
       "lemmaId": "чимало",
       "lemmaPlain": "чимало",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7749,11 +8623,13 @@
     {
       "cefr": "B1",
       "gloss": "analytic future",
+      "glossClean": "analytic future",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "аналітичний майбутній",
       "lemmaId": "аналітичний-майбутній",
       "lemmaPlain": "аналітичний майбутній",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7764,11 +8640,13 @@
     {
       "cefr": "B1",
       "gloss": "diagnostics, assessment",
+      "glossClean": "diagnostics",
       "heritage": "standard",
       "ipa": null,
       "lemma": "діагностика",
       "lemmaId": "діагностика",
       "lemmaPlain": "діагностика",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7779,11 +8657,13 @@
     {
       "cefr": "B1",
       "gloss": "test, checkpoint assessment",
+      "glossClean": "test",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "контрольна робота",
       "lemmaId": "контрольна-робота",
       "lemmaPlain": "контрольна робота",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7794,11 +8674,13 @@
     {
       "cefr": "B1",
       "gloss": "unrealized result",
+      "glossClean": "unrealized result",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "нереалізований результат",
       "lemmaId": "нереалізований-результат",
       "lemmaPlain": "нереалізований результат",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7809,11 +8691,13 @@
     {
       "cefr": "B1",
       "gloss": "event chain",
+      "glossClean": "event chain",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "подієвий ланцюг",
       "lemmaId": "подієвий-ланцюг",
       "lemmaPlain": "подієвий ланцюг",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7824,11 +8708,13 @@
     {
       "cefr": "B1",
       "gloss": "sequence of events",
+      "glossClean": "sequence of events",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "послідовність подій",
       "lemmaId": "послідовність-подій",
       "lemmaPlain": "послідовність подій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7839,11 +8725,13 @@
     {
       "cefr": "B1",
       "gloss": "resultativity",
+      "glossClean": "resultativity",
       "heritage": "standard",
       "ipa": null,
       "lemma": "результативність",
       "lemmaId": "результативність",
       "lemmaPlain": "результативність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7854,11 +8742,13 @@
     {
       "cefr": "B1",
       "gloss": "synthetic future",
+      "glossClean": "synthetic future",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "синтетичний майбутній",
       "lemmaId": "синтетичний-майбутній",
       "lemmaPlain": "синтетичний майбутній",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7869,11 +8759,13 @@
     {
       "cefr": "B1",
       "gloss": "narrative background",
+      "glossClean": "narrative background",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "тло розповіді",
       "lemmaId": "тло-розповіді",
       "lemmaPlain": "тло розповіді",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7884,11 +8776,13 @@
     {
       "cefr": "B1",
       "gloss": "error analysis",
+      "glossClean": "error analysis",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "аналіз помилок",
       "lemmaId": "аналіз-помилок",
       "lemmaPlain": "аналіз помилок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7899,11 +8793,13 @@
     {
       "cefr": "B1",
       "gloss": "impersonal construction",
+      "glossClean": "impersonal construction",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "безособова конструкція",
       "lemmaId": "безособова-конструкція",
       "lemmaPlain": "безособова конструкція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7914,11 +8810,13 @@
     {
       "cefr": "B1",
       "gloss": "dative subject of state",
+      "glossClean": "dative subject of state",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "давальний суб'єкта стану",
       "lemmaId": "давальний-суб-єкта-стану",
       "lemmaPlain": "давальний суб'єкта стану",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7929,11 +8827,13 @@
     {
       "cefr": "B1",
       "gloss": "utilities",
+      "glossClean": "utilities",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "комунальні послуги",
       "lemmaId": "комунальні-послуги",
       "lemmaPlain": "комунальні послуги",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7944,11 +8844,13 @@
     {
       "cefr": "B1",
       "gloss": "quantitative expression",
+      "glossClean": "quantitative expression",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "кількісний вираз",
       "lemmaId": "кількісний-вираз",
       "lemmaPlain": "кількісний вираз",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7959,11 +8861,13 @@
     {
       "cefr": "B1",
       "gloss": "instrumental of means",
+      "glossClean": "instrumental of means",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "орудний засобу",
       "lemmaId": "орудний-засобу",
       "lemmaPlain": "орудний засобу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7974,11 +8878,13 @@
     {
       "cefr": "B1",
       "gloss": "instrumental of characteristic",
+      "glossClean": "instrumental of characteristic",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "орудний характеристики",
       "lemmaId": "орудний-характеристики",
       "lemmaPlain": "орудний характеристики",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7989,11 +8895,13 @@
     {
       "cefr": "B1",
       "gloss": "instrumental of route",
+      "glossClean": "instrumental of route",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "орудний шляху",
       "lemmaId": "орудний-шляху",
       "lemmaPlain": "орудний шляху",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8004,11 +8912,13 @@
     {
       "cefr": "B1",
       "gloss": "passive agent",
+      "glossClean": "passive agent",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пасивний агент",
       "lemmaId": "пасивний-агент",
       "lemmaPlain": "пасивний агент",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8019,11 +8929,13 @@
     {
       "cefr": "B1",
       "gloss": "interrogative-relative pronoun",
+      "glossClean": "interrogative-relative pronoun",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "питально-відносний займенник",
       "lemmaId": "питально-відносний-займенник",
       "lemmaPlain": "питально-відносний займенник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8034,11 +8946,13 @@
     {
       "cefr": "B1",
       "gloss": "preposition of cause",
+      "glossClean": "preposition of cause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "причиновий прийменник",
       "lemmaId": "причиновий-прийменник",
       "lemmaPlain": "причиновий прийменник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8049,11 +8963,13 @@
     {
       "cefr": "B1",
       "gloss": "genitive of negation",
+      "glossClean": "genitive of negation",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "родовий заперечення",
       "lemmaId": "родовий-заперечення",
       "lemmaPlain": "родовий заперечення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8064,11 +8980,13 @@
     {
       "cefr": "B1",
       "gloss": "rental terms",
+      "glossClean": "rental terms",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "умови оренди",
       "lemmaId": "умови-оренди",
       "lemmaPlain": "умови оренди",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8079,11 +8997,13 @@
     {
       "cefr": "B1",
       "gloss": "university seminar",
+      "glossClean": "university seminar",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "університетський семінар",
       "lemmaId": "університетський-семінар",
       "lemmaPlain": "університетський семінар",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8094,11 +9014,13 @@
     {
       "cefr": "B1",
       "gloss": "purpose construction",
+      "glossClean": "purpose construction",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "цільова конструкція",
       "lemmaId": "цільова-конструкція",
       "lemmaPlain": "цільова конструкція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8109,11 +9031,13 @@
     {
       "cefr": "B1",
       "gloss": "temporal preposition",
+      "glossClean": "temporal preposition",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "часовий прийменник",
       "lemmaId": "часовий-прийменник",
       "lemmaPlain": "часовий прийменник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8124,11 +9048,13 @@
     {
       "cefr": "B1",
       "gloss": "partitive genitive",
+      "glossClean": "partitive genitive",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "частковий родовий",
       "lemmaId": "частковий-родовий",
       "lemmaPlain": "частковий родовий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8139,11 +9065,13 @@
     {
       "cefr": "B1",
       "gloss": "patronymic",
+      "glossClean": "patronymic",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "ім'я по батькові",
       "lemmaId": "ім-я-по-батькові",
       "lemmaPlain": "ім'я по батькові",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8154,11 +9082,13 @@
     {
       "cefr": "B1",
       "gloss": "zero derivation",
+      "glossClean": "zero derivation",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "безафіксний спосіб",
       "lemmaId": "безафіксний-спосіб",
       "lemmaPlain": "безафіксний спосіб",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8169,11 +9099,13 @@
     {
       "cefr": "B1",
       "gloss": "verbal noun",
+      "glossClean": "verbal noun",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "віддієслівний іменник",
       "lemmaId": "віддієслівний-іменник",
       "lemmaPlain": "віддієслівний іменник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8184,11 +9116,13 @@
     {
       "cefr": "B1",
       "gloss": "comparison set boundary",
+      "glossClean": "comparison set boundary",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "межа групи",
       "lemmaId": "межа-групи",
       "lemmaPlain": "межа групи",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8199,11 +9133,13 @@
     {
       "cefr": "B1",
       "gloss": "place name",
+      "glossClean": "place name",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "назва місця",
       "lemmaId": "назва-місця",
       "lemmaPlain": "назва місця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8214,11 +9150,13 @@
     {
       "cefr": "B1",
       "gloss": "transfer",
+      "glossClean": "transfer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "переказ",
       "lemmaId": "переказ",
       "lemmaPlain": "переказ",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8229,11 +9167,13 @@
     {
       "cefr": "B1",
       "gloss": "return",
+      "glossClean": "return",
       "heritage": "standard",
       "ipa": null,
       "lemma": "повернення",
       "lemmaId": "повернення",
       "lemmaPlain": "повернення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8244,11 +9184,13 @@
     {
       "cefr": "B1",
       "gloss": "derivational chain",
+      "glossClean": "derivational chain",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "словотвірний ланцюжок",
       "lemmaId": "словотвірний-ланцюжок",
       "lemmaPlain": "словотвірний ланцюжок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8259,11 +9201,13 @@
     {
       "cefr": "B1",
       "gloss": "suppletive form",
+      "glossClean": "suppletive form",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "суплетивна форма",
       "lemmaId": "суплетивна-форма",
       "lemmaPlain": "суплетивна форма",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8274,11 +9218,13 @@
     {
       "cefr": "B1",
       "gloss": "grammatical government",
+      "glossClean": "grammatical government",
       "heritage": "standard",
       "ipa": null,
       "lemma": "керування",
       "lemmaId": "керування",
       "lemmaPlain": "керування",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8289,11 +9235,13 @@
     {
       "cefr": "B1",
       "gloss": "to be treated for",
+      "glossClean": "to be treated for",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "лікуватися від",
       "lemmaId": "лікуватися-від",
       "lemmaPlain": "лікуватися від",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8304,11 +9252,13 @@
     {
       "cefr": "B1",
       "gloss": "morphophonemics",
+      "glossClean": "morphophonemics",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "морфонеміка",
       "lemmaId": "морфонеміка",
       "lemmaPlain": "морфонеміка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8319,11 +9269,13 @@
     {
       "cefr": "B1",
       "gloss": "to recover",
+      "glossClean": "to recover",
       "heritage": "standard",
       "ipa": null,
       "lemma": "одужати",
       "lemmaId": "одужати",
       "lemmaPlain": "одужати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8334,11 +9286,13 @@
     {
       "cefr": "B1",
       "gloss": "editing check",
+      "glossClean": "editing check",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "редакторська перевірка",
       "lemmaId": "редакторська-перевірка",
       "lemmaPlain": "редакторська перевірка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8349,11 +9303,13 @@
     {
       "cefr": "B1",
       "gloss": "to complain of",
+      "glossClean": "to complain of",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "скаржитися на",
       "lemmaId": "скаржитися-на",
       "lemmaPlain": "скаржитися на",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8364,11 +9320,13 @@
     {
       "cefr": "B1",
       "gloss": "guard",
+      "glossClean": "guard",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сторож",
       "lemmaId": "сторож",
       "lemmaPlain": "сторож",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8379,11 +9337,13 @@
     {
       "cefr": "B1",
       "gloss": "third declension",
+      "glossClean": "third declension",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "третя відміна",
       "lemmaId": "третя-відміна",
       "lemmaPlain": "третя відміна",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8394,11 +9354,13 @@
     {
       "cefr": "B1",
       "gloss": "to be ill with",
+      "glossClean": "to be ill with",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "хворіти на",
       "lemmaId": "хворіти-на",
       "lemmaPlain": "хворіти на",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8409,11 +9371,13 @@
     {
       "cefr": "B1",
       "gloss": "to conduct negotiations",
+      "glossClean": "to conduct negotiations",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "вести переговори",
       "lemmaId": "вести-переговори",
       "lemmaPlain": "вести переговори",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8424,11 +9388,13 @@
     {
       "cefr": "B1",
       "gloss": "to correct an error",
+      "glossClean": "to correct an error",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "виправити помилку",
       "lemmaId": "виправити-помилку",
       "lemmaPlain": "виправити помилку",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8439,11 +9405,13 @@
     {
       "cefr": "B1",
       "gloss": "to deceive, lead on",
+      "glossClean": "to deceive",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "водити за ніс",
       "lemmaId": "водити-за-ніс",
       "lemmaPlain": "водити за ніс",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8454,11 +9422,13 @@
     {
       "cefr": "B1",
       "gloss": "it is raining",
+      "glossClean": "it is raining",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "дощ іде",
       "lemmaId": "дощ-іде",
       "lemmaPlain": "дощ іде",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8469,11 +9439,13 @@
     {
       "cefr": "B1",
       "gloss": "it is about",
+      "glossClean": "it is about",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "йдеться про",
       "lemmaId": "йдеться-про",
       "lemmaPlain": "йдеться про",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8484,11 +9456,13 @@
     {
       "cefr": "B1",
       "gloss": "to bear responsibility",
+      "glossClean": "to bear responsibility",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "нести відповідальність",
       "lemmaId": "нести-відповідальність",
       "lemmaPlain": "нести відповідальність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8499,11 +9473,13 @@
     {
       "cefr": "B1",
       "gloss": "figurative meaning",
+      "glossClean": "figurative meaning",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "переносне значення",
       "lemmaId": "переносне-значення",
       "lemmaPlain": "переносне значення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8514,11 +9490,13 @@
     {
       "cefr": "B1",
       "gloss": "to explain the choice",
+      "glossClean": "to explain the choice",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пояснити вибір",
       "lemmaId": "пояснити-вибір",
       "lemmaPlain": "пояснити вибір",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8529,11 +9507,13 @@
     {
       "cefr": "B1",
       "gloss": "spatial preposition",
+      "glossClean": "spatial preposition",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "просторовий прийменник",
       "lemmaId": "просторовий-прийменник",
       "lemmaPlain": "просторовий прийменник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8544,11 +9524,13 @@
     {
       "cefr": "B1",
       "gloss": "literal meaning",
+      "glossClean": "literal meaning",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пряме значення",
       "lemmaId": "пряме-значення",
       "lemmaPlain": "пряме значення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8559,11 +9541,13 @@
     {
       "cefr": "B1",
       "gloss": "movement around",
+      "glossClean": "movement around",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "рух навколо",
       "lemmaId": "рух-навколо",
       "lemmaPlain": "рух навколо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8574,11 +9558,13 @@
     {
       "cefr": "B1",
       "gloss": "movement past",
+      "glossClean": "movement past",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "рух повз",
       "lemmaId": "рух-повз",
       "lemmaPlain": "рух повз",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8589,11 +9575,13 @@
     {
       "cefr": "B1",
       "gloss": "things are going",
+      "glossClean": "things are going",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "справи йдуть",
       "lemmaId": "справи-йдуть",
       "lemmaPlain": "справи йдуть",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8604,11 +9592,13 @@
     {
       "cefr": "B1",
       "gloss": "time flies",
+      "glossClean": "time flies",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "час летить",
       "lemmaId": "час-летить",
       "lemmaPlain": "час летить",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8619,11 +9609,13 @@
     {
       "cefr": "B1",
       "gloss": "academic style",
+      "glossClean": "academic style",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "академічний стиль",
       "lemmaId": "академічний-стиль",
       "lemmaPlain": "академічний стиль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8634,11 +9626,13 @@
     {
       "cefr": "B1",
       "gloss": "active participle",
+      "glossClean": "active participle",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "активний дієприкметник",
       "lemmaId": "активний-дієприкметник",
       "lemmaPlain": "активний дієприкметник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8649,11 +9643,13 @@
     {
       "cefr": "B1",
       "gloss": "readiness for syntax",
+      "glossClean": "readiness for syntax",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "готовність до синтаксису",
       "lemmaId": "готовність-до-синтаксису",
       "lemmaPlain": "готовність до синтаксису",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8664,11 +9660,13 @@
     {
       "cefr": "B1",
       "gloss": "source of information",
+      "glossClean": "source of information",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "джерело інформації",
       "lemmaId": "джерело-інформації",
       "lemmaPlain": "джерело інформації",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8679,11 +9677,13 @@
     {
       "cefr": "B1",
       "gloss": "diagnostic map",
+      "glossClean": "diagnostic map",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "діагностична карта",
       "lemmaId": "діагностична-карта",
       "lemmaPlain": "діагностична карта",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8694,11 +9694,13 @@
     {
       "cefr": "B1",
       "gloss": "participle phrase",
+      "glossClean": "participle phrase",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "дієприкметниковий зворот",
       "lemmaId": "дієприкметниковий-зворот",
       "lemmaPlain": "дієприкметниковий зворот",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8709,11 +9711,13 @@
     {
       "cefr": "B1",
       "gloss": "reflexive gerund",
+      "glossClean": "reflexive gerund",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "зворотний дієприслівник",
       "lemmaId": "зворотний-дієприслівник",
       "lemmaPlain": "зворотний дієприслівник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8724,11 +9728,13 @@
     {
       "cefr": "B1",
       "gloss": "short-form adjective",
+      "glossClean": "short-form adjective",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "короткий прикметник",
       "lemmaId": "короткий-прикметник",
       "lemmaPlain": "короткий прикметник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8739,11 +9745,13 @@
     {
       "cefr": "B1",
       "gloss": "modified noun",
+      "glossClean": "modified noun",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "означуване слово",
       "lemmaId": "означуване-слово",
       "lemmaPlain": "означуване слово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8754,11 +9762,13 @@
     {
       "cefr": "B1",
       "gloss": "passive participle",
+      "glossClean": "passive participle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пасивний дієприкметник",
       "lemmaId": "пасивний-дієприкметник",
       "lemmaPlain": "пасивний дієприкметник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8769,11 +9779,13 @@
     {
       "cefr": "B1",
       "gloss": "full uncontracted adjective form",
+      "glossClean": "full uncontracted adjective form",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "повна нестягнена форма",
       "lemmaId": "повна-нестягнена-форма",
       "lemmaPlain": "повна нестягнена форма",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8784,11 +9796,13 @@
     {
       "cefr": "B1",
       "gloss": "natural equivalent",
+      "glossClean": "natural equivalent",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "природний відповідник",
       "lemmaId": "природний-відповідник",
       "lemmaPlain": "природний відповідник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8799,11 +9813,13 @@
     {
       "cefr": "B1",
       "gloss": "predicative pattern",
+      "glossClean": "predicative pattern",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "присудкова модель",
       "lemmaId": "присудкова-модель",
       "lemmaPlain": "присудкова модель",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8814,11 +9830,13 @@
     {
       "cefr": "B1",
       "gloss": "editing",
+      "glossClean": "editing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "редагування",
       "lemmaId": "редагування",
       "lemmaPlain": "редагування",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8829,11 +9847,13 @@
     {
       "cefr": "B1",
       "gloss": "shared subject",
+      "glossClean": "shared subject",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "спільний підмет",
       "lemmaId": "спільний-підмет",
       "lemmaPlain": "спільний підмет",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8844,11 +9864,13 @@
     {
       "cefr": "B1",
       "gloss": "idiomatized phrase",
+      "glossClean": "idiomatized phrase",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "фразеологізований зворот",
       "lemmaId": "фразеологізований-зворот",
       "lemmaPlain": "фразеологізований зворот",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8859,11 +9881,13 @@
     {
       "cefr": "B1",
       "gloss": "deictic word",
+      "glossClean": "deictic word",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "вказівне слово",
       "lemmaId": "вказівне-слово",
       "lemmaPlain": "вказівне слово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8874,11 +9898,13 @@
     {
       "cefr": "B1",
       "gloss": "female volunteer",
+      "glossClean": "female volunteer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "волонтерка",
       "lemmaId": "волонтерка",
       "lemmaPlain": "волонтерка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8889,11 +9915,13 @@
     {
       "cefr": "B1",
       "gloss": "main clause",
+      "glossClean": "main clause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "головна частина",
       "lemmaId": "головна-частина",
       "lemmaPlain": "головна частина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8904,11 +9932,13 @@
     {
       "cefr": "B1",
       "gloss": "content clause",
+      "glossClean": "content clause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "з'ясувальна частина",
       "lemmaId": "з-ясувальна-частина",
       "lemmaPlain": "з'ясувальна частина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8919,11 +9949,13 @@
     {
       "cefr": "B1",
       "gloss": "person shift",
+      "glossClean": "person shift",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "зміна особи",
       "lemmaId": "зміна-особи",
       "lemmaPlain": "зміна особи",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8934,11 +9966,13 @@
     {
       "cefr": "B1",
       "gloss": "classification",
+      "glossClean": "classification",
       "heritage": "standard",
       "ipa": null,
       "lemma": "класифікація",
       "lemmaId": "класифікація",
       "lemmaPlain": "класифікація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -8978,11 +10012,13 @@
     {
       "cefr": "B1",
       "gloss": "book club",
+      "glossClean": "book club",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "книжковий клуб",
       "lemmaId": "книжковий-клуб",
       "lemmaPlain": "книжковий клуб",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8993,11 +10029,13 @@
     {
       "cefr": "B1",
       "gloss": "cultural event",
+      "glossClean": "cultural event",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "культурна подія",
       "lemmaId": "культурна-подія",
       "lemmaPlain": "культурна подія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9008,11 +10046,13 @@
     {
       "cefr": "B1",
       "gloss": "quotation marks",
+      "glossClean": "quotation marks",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лапки",
       "lemmaId": "лапки",
       "lemmaPlain": "лапки",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9023,11 +10063,13 @@
     {
       "cefr": "B1",
       "gloss": "relative clause",
+      "glossClean": "relative clause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "означальна частина",
       "lemmaId": "означальна-частина",
       "lemmaPlain": "означальна частина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9038,11 +10080,13 @@
     {
       "cefr": "B1",
       "gloss": "adversative conjunction",
+      "glossClean": "adversative conjunction",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "протиставний сполучник",
       "lemmaId": "протиставний-сполучник",
       "lemmaPlain": "протиставний сполучник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9053,11 +10097,13 @@
     {
       "cefr": "B1",
       "gloss": "subordinate clause construction",
+      "glossClean": "subordinate clause construction",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "підрядне речення",
       "lemmaId": "підрядне-речення",
       "lemmaPlain": "підрядне речення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9068,11 +10114,13 @@
     {
       "cefr": "B1",
       "gloss": "concessive clause",
+      "glossClean": "concessive clause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "речення допусту",
       "lemmaId": "речення-допусту",
       "lemmaPlain": "речення допусту",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9083,11 +10131,13 @@
     {
       "cefr": "B1",
       "gloss": "purpose clause",
+      "glossClean": "purpose clause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "речення мети",
       "lemmaId": "речення-мети",
       "lemmaPlain": "речення мети",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9098,11 +10148,13 @@
     {
       "cefr": "B1",
       "gloss": "reason clause",
+      "glossClean": "reason clause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "речення причини",
       "lemmaId": "речення-причини",
       "lemmaPlain": "речення причини",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9113,11 +10165,13 @@
     {
       "cefr": "B1",
       "gloss": "conditional clause",
+      "glossClean": "conditional clause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "речення умови",
       "lemmaId": "речення-умови",
       "lemmaPlain": "речення умови",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9128,11 +10182,13 @@
     {
       "cefr": "B1",
       "gloss": "time clause",
+      "glossClean": "time clause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "речення часу",
       "lemmaId": "речення-часу",
       "lemmaPlain": "речення часу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9143,11 +10199,13 @@
     {
       "cefr": "B1",
       "gloss": "disjunctive conjunction",
+      "glossClean": "disjunctive conjunction",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "розділовий сполучник",
       "lemmaId": "розділовий-сполучник",
       "lemmaPlain": "розділовий сполучник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9158,11 +10216,13 @@
     {
       "cefr": "B1",
       "gloss": "compound conjunction",
+      "glossClean": "compound conjunction",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "складений сполучник",
       "lemmaId": "складений-сполучник",
       "lemmaPlain": "складений сполучник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9173,11 +10233,13 @@
     {
       "cefr": "B1",
       "gloss": "complex sentence with subordinate clause",
+      "glossClean": "complex sentence with subordinate clause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "складнопідрядне речення",
       "lemmaId": "складнопідрядне-речення",
       "lemmaPlain": "складнопідрядне речення",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -9188,11 +10250,13 @@
     {
       "cefr": "B1",
       "gloss": "compound sentence",
+      "glossClean": "compound sentence",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "складносурядне речення",
       "lemmaId": "складносурядне-речення",
       "lemmaPlain": "складносурядне речення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9203,11 +10267,13 @@
     {
       "cefr": "B1",
       "gloss": "reporting clause, author's words",
+      "glossClean": "reporting clause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "слова автора",
       "lemmaId": "слова-автора",
       "lemmaPlain": "слова автора",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9218,11 +10284,13 @@
     {
       "cefr": "B1",
       "gloss": "coordination",
+      "glossClean": "coordination",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "сурядний зв'язок",
       "lemmaId": "сурядний-зв-язок",
       "lemmaPlain": "сурядний зв'язок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9233,11 +10301,13 @@
     {
       "cefr": "B1",
       "gloss": "additive coordinating conjunction",
+      "glossClean": "additive coordinating conjunction",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "єднальний сполучник",
       "lemmaId": "єднальний-сполучник",
       "lemmaPlain": "єднальний сполучник",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -9248,11 +10318,13 @@
     {
       "cefr": "B1",
       "gloss": "parenthetical word",
+      "glossClean": "parenthetical word",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "вставне слово",
       "lemmaId": "вставне-слово",
       "lemmaPlain": "вставне слово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9263,11 +10335,13 @@
     {
       "cefr": "B1",
       "gloss": "graphic abbreviation",
+      "glossClean": "graphic abbreviation",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "графічне скорочення",
       "lemmaId": "графічне-скорочення",
       "lemmaPlain": "графічне скорочення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9278,11 +10352,13 @@
     {
       "cefr": "B1",
       "gloss": "ecological",
+      "glossClean": "ecological",
       "heritage": "standard",
       "ipa": null,
       "lemma": "екологічний",
       "lemmaId": "екологічний",
       "lemmaPlain": "екологічний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9293,11 +10369,13 @@
     {
       "cefr": "B1",
       "gloss": "homogeneous sentence members",
+      "glossClean": "homogeneous sentence members",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "однорідні члени речення",
       "lemmaId": "однорідні-члени-речення",
       "lemmaPlain": "однорідні члени речення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9308,11 +10386,13 @@
     {
       "cefr": "B1",
       "gloss": "official-business style",
+      "glossClean": "official-business style",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "офіційно-діловий стиль",
       "lemmaId": "офіційно-діловий-стиль",
       "lemmaPlain": "офіційно-діловий стиль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9323,11 +10403,13 @@
     {
       "cefr": "B1",
       "gloss": "double negation",
+      "glossClean": "double negation",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "подвійне заперечення",
       "lemmaId": "подвійне-заперечення",
       "lemmaPlain": "подвійне заперечення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9338,11 +10420,13 @@
     {
       "cefr": "B1",
       "gloss": "to expand, decode",
+      "glossClean": "to expand",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розшифрувати",
       "lemmaId": "розшифрувати",
       "lemmaPlain": "розшифрувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9353,11 +10437,13 @@
     {
       "cefr": "B1",
       "gloss": "water condition",
+      "glossClean": "water condition",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "стан води",
       "lemmaId": "стан-води",
       "lemmaPlain": "стан води",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9368,11 +10454,13 @@
     {
       "cefr": "B1",
       "gloss": "speech style, register",
+      "glossClean": "speech style",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "стиль мовлення",
       "lemmaId": "стиль-мовлення",
       "lemmaPlain": "стиль мовлення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9383,11 +10471,13 @@
     {
       "cefr": "B1",
       "gloss": "generalizing word",
+      "glossClean": "generalizing word",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "узагальнювальне слово",
       "lemmaId": "узагальнювальне-слово",
       "lemmaPlain": "узагальнювальне слово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9398,11 +10488,13 @@
     {
       "cefr": "B1",
       "gloss": "literary device",
+      "glossClean": "literary device",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "художній засіб",
       "lemmaId": "художній-засіб",
       "lemmaPlain": "художній засіб",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9413,11 +10505,13 @@
     {
       "cefr": "B1",
       "gloss": "literary style",
+      "glossClean": "literary style",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "художній стиль",
       "lemmaId": "художній-стиль",
       "lemmaPlain": "художній стиль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9428,11 +10522,13 @@
     {
       "cefr": "B1",
       "gloss": "active voice",
+      "glossClean": "active voice",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "активний стан",
       "lemmaId": "активний-стан",
       "lemmaPlain": "активний стан",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9443,11 +10539,13 @@
     {
       "cefr": "B1",
       "gloss": "record; note",
+      "glossClean": "record",
       "heritage": "standard",
       "ipa": null,
       "lemma": "запис",
       "lemmaId": "запис",
       "lemmaPlain": "запис",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9458,11 +10556,13 @@
     {
       "cefr": "B1",
       "gloss": "to neutralize",
+      "glossClean": "to neutralize",
       "heritage": "standard",
       "ipa": null,
       "lemma": "знешкодити",
       "lemmaId": "знешкодити",
       "lemmaPlain": "знешкодити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9473,11 +10573,13 @@
     {
       "cefr": "B1",
       "gloss": "shout",
+      "glossClean": "shout",
       "heritage": "standard",
       "ipa": null,
       "lemma": "крик",
       "lemmaId": "крик",
       "lemmaPlain": "крик",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9488,11 +10590,13 @@
     {
       "cefr": "B1",
       "gloss": "to shout once",
+      "glossClean": "to shout once",
       "heritage": "standard",
       "ipa": null,
       "lemma": "крикнути",
       "lemmaId": "крикнути",
       "lemmaPlain": "крикнути",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9503,11 +10607,13 @@
     {
       "cefr": "B1",
       "gloss": "could (polite)",
+      "glossClean": "could (polite)",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "могли б",
       "lemmaId": "могли-б",
       "lemmaPlain": "могли б",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -9518,11 +10624,13 @@
     {
       "cefr": "B1",
       "gloss": "sent",
+      "glossClean": "sent",
       "heritage": "standard",
       "ipa": null,
       "lemma": "надіслано",
       "lemmaId": "надіслано",
       "lemmaPlain": "надіслано",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9533,11 +10641,13 @@
     {
       "cefr": "B1",
       "gloss": "do not forget habitually",
+      "glossClean": "do not forget habitually",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "не забувайте",
       "lemmaId": "не-забувайте",
       "lemmaPlain": "не забувайте",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9548,11 +10658,13 @@
     {
       "cefr": "B1",
       "gloss": "do not forget",
+      "glossClean": "do not forget",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "не забудьте",
       "lemmaId": "не-забудьте",
       "lemmaPlain": "не забудьте",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9563,11 +10675,13 @@
     {
       "cefr": "B1",
       "gloss": "cannot sleep",
+      "glossClean": "cannot sleep",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "не спиться",
       "lemmaId": "не-спиться",
       "lemmaPlain": "не спиться",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9578,11 +10692,13 @@
     {
       "cefr": "B1",
       "gloss": "passive voice",
+      "glossClean": "passive voice",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пасивний стан",
       "lemmaId": "пасивний-стан",
       "lemmaPlain": "пасивний стан",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9593,11 +10709,13 @@
     {
       "cefr": "B1",
       "gloss": "checked",
+      "glossClean": "checked",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перевірено",
       "lemmaId": "перевірено",
       "lemmaPlain": "перевірено",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9608,11 +10726,13 @@
     {
       "cefr": "B1",
       "gloss": "to overestimate",
+      "glossClean": "to overestimate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "переоцінити",
       "lemmaId": "переоцінити",
       "lemmaPlain": "переоцінити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9623,11 +10743,13 @@
     {
       "cefr": "B1",
       "gloss": "transitive verb",
+      "glossClean": "transitive verb",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перехідне дієслово",
       "lemmaId": "перехідне-дієслово",
       "lemmaPlain": "перехідне дієслово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9638,11 +10760,13 @@
     {
       "cefr": "B1",
       "gloss": "to reread",
+      "glossClean": "to reread",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перечитати",
       "lemmaId": "перечитати",
       "lemmaPlain": "перечитати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9653,11 +10777,13 @@
     {
       "cefr": "B1",
       "gloss": "prefixal word formation",
+      "glossClean": "prefixal word formation",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "префіксальний спосіб",
       "lemmaId": "префіксальний-спосіб",
       "lemmaPlain": "префіксальний спосіб",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9668,11 +10794,13 @@
     {
       "cefr": "B1",
       "gloss": "to knock repeatedly",
+      "glossClean": "to knock repeatedly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стукати",
       "lemmaId": "стукати",
       "lemmaPlain": "стукати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9683,11 +10811,13 @@
     {
       "cefr": "B1",
       "gloss": "to knock once",
+      "glossClean": "to knock once",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стукнути",
       "lemmaId": "стукнути",
       "lemmaPlain": "стукнути",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9698,11 +10828,13 @@
     {
       "cefr": "B1",
       "gloss": "suffixal word formation",
+      "glossClean": "suffixal word formation",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "суфіксальний спосіб",
       "lemmaId": "суфіксальний-спосіб",
       "lemmaPlain": "суфіксальний спосіб",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9713,11 +10845,13 @@
     {
       "cefr": "B1",
       "gloss": "would like",
+      "glossClean": "would like",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "хотів би",
       "lemmaId": "хотів-би",
       "lemmaPlain": "хотів би",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9728,11 +10862,13 @@
     {
       "cefr": "B1",
       "gloss": "juxtaposition, comparison",
+      "glossClean": "juxtaposition",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зіставлення",
       "lemmaId": "зіставлення",
       "lemmaPlain": "зіставлення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9743,11 +10879,13 @@
     {
       "cefr": "B1",
       "gloss": "semicolon",
+      "glossClean": "semicolon",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "крапка з комою",
       "lemmaId": "крапка-з-комою",
       "lemmaPlain": "крапка з комою",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9758,11 +10896,13 @@
     {
       "cefr": "B1",
       "gloss": "modal particle",
+      "glossClean": "modal particle",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "модальна частка",
       "lemmaId": "модальна-частка",
       "lemmaPlain": "модальна частка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9773,11 +10913,13 @@
     {
       "cefr": "B1",
       "gloss": "non-repeated conjunction",
+      "glossClean": "non-repeated conjunction",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "неповторюваний сполучник",
       "lemmaId": "неповторюваний-сполучник",
       "lemmaPlain": "неповторюваний сполучник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9788,11 +10930,13 @@
     {
       "cefr": "B1",
       "gloss": "homogeneous sentence members",
+      "glossClean": "homogeneous sentence members",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "однорідні члени",
       "lemmaId": "однорідні-члени",
       "lemmaPlain": "однорідні члени",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9803,11 +10947,13 @@
     {
       "cefr": "B1",
       "gloss": "repeated conjunction",
+      "glossClean": "repeated conjunction",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "повторюваний сполучник",
       "lemmaId": "повторюваний-сполучник",
       "lemmaPlain": "повторюваний сполучник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9818,11 +10964,13 @@
     {
       "cefr": "B1",
       "gloss": "cause-result relation",
+      "glossClean": "cause-result relation",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "причиново-наслідковий зв'язок",
       "lemmaId": "причиново-наслідковий-зв-язок",
       "lemmaPlain": "причиново-наслідковий зв'язок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9833,11 +10981,13 @@
     {
       "cefr": "B1",
       "gloss": "punctuation decision",
+      "glossClean": "punctuation decision",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пунктуаційне рішення",
       "lemmaId": "пунктуаційне-рішення",
       "lemmaPlain": "пунктуаційне рішення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9848,11 +10998,13 @@
     {
       "cefr": "B1",
       "gloss": "coordinate parts",
+      "glossClean": "coordinate parts",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "рівноправні частини",
       "lemmaId": "рівноправні-частини",
       "lemmaPlain": "рівноправні частини",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9863,11 +11015,13 @@
     {
       "cefr": "B1",
       "gloss": "coordinating conjunction",
+      "glossClean": "coordinating conjunction",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "сполучник сурядності",
       "lemmaId": "сполучник-сурядності",
       "lemmaPlain": "сполучник сурядності",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9878,11 +11032,13 @@
     {
       "cefr": "B1",
       "gloss": "shared parenthetical word",
+      "glossClean": "shared parenthetical word",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "спільне вставне слово",
       "lemmaId": "спільне-вставне-слово",
       "lemmaPlain": "спільне вставне слово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9893,11 +11049,13 @@
     {
       "cefr": "B1",
       "gloss": "shared secondary member",
+      "glossClean": "shared secondary member",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "спільний другорядний член",
       "lemmaId": "спільний-другорядний-член",
       "lemmaPlain": "спільний другорядний член",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9908,11 +11066,13 @@
     {
       "cefr": "B1",
       "gloss": "coordinating conjunction",
+      "glossClean": "coordinating conjunction",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "сурядний сполучник",
       "lemmaId": "сурядний-сполучник",
       "lemmaPlain": "сурядний сполучник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9923,11 +11083,13 @@
     {
       "cefr": "B1",
       "gloss": "sentence scheme",
+      "glossClean": "sentence scheme",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "схема речення",
       "lemmaId": "схема-речення",
       "lemmaPlain": "схема речення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9938,11 +11100,13 @@
     {
       "cefr": "B1",
       "gloss": "rapid change of events",
+      "glossClean": "rapid change of events",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "швидка зміна подій",
       "lemmaId": "швидка-зміна-подій",
       "lemmaPlain": "швидка зміна подій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9953,11 +11117,13 @@
     {
       "cefr": "B1",
       "gloss": "listing intonation",
+      "glossClean": "listing intonation",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "інтонація переліку",
       "lemmaId": "інтонація-переліку",
       "lemmaPlain": "інтонація переліку",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9968,11 +11134,13 @@
     {
       "cefr": "B1",
       "gloss": "contrastive intonation",
+      "glossClean": "contrastive intonation",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "інтонація протиставлення",
       "lemmaId": "інтонація-протиставлення",
       "lemmaPlain": "інтонація протиставлення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -9983,11 +11151,13 @@
     {
       "cefr": "B1",
       "gloss": "argumentation",
+      "glossClean": "argumentation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "аргументація",
       "lemmaId": "аргументація",
       "lemmaPlain": "аргументація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -10027,11 +11197,13 @@
     {
       "cefr": "B1",
       "gloss": "still, nevertheless",
+      "glossClean": "still",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "все ж",
       "lemmaId": "все-ж",
       "lemmaPlain": "все ж",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10042,11 +11214,13 @@
     {
       "cefr": "B1",
       "gloss": "even though (stresses futility)",
+      "glossClean": "even though (stresses futility)",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "дарма що",
       "lemmaId": "дарма-що",
       "lemmaPlain": "дарма що",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10057,11 +11231,13 @@
     {
       "cefr": "B1",
       "gloss": "boundary between clauses",
+      "glossClean": "boundary between clauses",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "межа частин",
       "lemmaId": "межа-частин",
       "lemmaPlain": "межа частин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10072,11 +11248,13 @@
     {
       "cefr": "B1",
       "gloss": "despite (+ Acc.)",
+      "glossClean": "despite (+ Acc.)",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "незважаючи на",
       "lemmaId": "незважаючи-на",
       "lemmaPlain": "незважаючи на",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10087,11 +11265,13 @@
     {
       "cefr": "B1",
       "gloss": "despite the fact that (formal)",
+      "glossClean": "despite the fact that (formal)",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "незважаючи на те що",
       "lemmaId": "незважаючи-на-те-що",
       "lemmaPlain": "незважаючи на те що",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10102,11 +11282,13 @@
     {
       "cefr": "B1",
       "gloss": "obstacle",
+      "glossClean": "obstacle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перешкода",
       "lemmaId": "перешкода",
       "lemmaPlain": "перешкода",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -10146,11 +11328,13 @@
     {
       "cefr": "B1",
       "gloss": "despite the fact that",
+      "glossClean": "despite the fact that",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "попри те що",
       "lemmaId": "попри-те-що",
       "lemmaPlain": "попри те що",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10161,11 +11345,13 @@
     {
       "cefr": "B1",
       "gloss": "concessive subordinate (adverbial) clause",
+      "glossClean": "concessive subordinate (adverbial) clause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "підрядне обставинне допусту",
       "lemmaId": "підрядне-обставинне-допусту",
       "lemmaPlain": "підрядне обставинне допусту",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10176,11 +11362,13 @@
     {
       "cefr": "B1",
       "gloss": "contradiction",
+      "glossClean": "contradiction",
       "heritage": "standard",
       "ipa": null,
       "lemma": "суперечність",
       "lemmaId": "суперечність",
       "lemmaPlain": "суперечність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10191,11 +11379,13 @@
     {
       "cefr": "B1",
       "gloss": "contrary to, despite (+ Dat.)",
+      "glossClean": "contrary to",
       "heritage": "standard",
       "ipa": null,
       "lemma": "усупереч",
       "lemmaId": "усупереч",
       "lemmaPlain": "усупереч",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10206,11 +11396,13 @@
     {
       "cefr": "B1",
       "gloss": "although (neutral, slightly colloquial)",
+      "glossClean": "although (neutral",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хоч",
       "lemmaId": "хоч",
       "lemmaPlain": "хоч",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10221,11 +11413,13 @@
     {
       "cefr": "B1",
       "gloss": "provided that, on the condition that",
+      "glossClean": "provided that",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "за умови що",
       "lemmaId": "за-умови-що",
       "lemmaPlain": "за умови що",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10236,11 +11430,13 @@
     {
       "cefr": "B1",
       "gloss": "if, if only",
+      "glossClean": "if",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "коли б",
       "lemmaId": "коли-б",
       "lemmaPlain": "коли б",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10251,11 +11447,13 @@
     {
       "cefr": "B1",
       "gloss": "conditional adverbial subordinate clause",
+      "glossClean": "conditional adverbial subordinate clause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "підрядна обставинна частина умови",
       "lemmaId": "підрядна-обставинна-частина-умови",
       "lemmaPlain": "підрядна обставинна частина умови",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10266,11 +11464,13 @@
     {
       "cefr": "B1",
       "gloss": "correlative word",
+      "glossClean": "correlative word",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "співвідносне слово",
       "lemmaId": "співвідносне-слово",
       "lemmaPlain": "співвідносне слово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10281,11 +11481,13 @@
     {
       "cefr": "B1",
       "gloss": "in case, if",
+      "glossClean": "in case",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у випадку якщо",
       "lemmaId": "у-випадку-якщо",
       "lemmaPlain": "у випадку якщо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10296,11 +11498,13 @@
     {
       "cefr": "B1",
       "gloss": "conditional коли",
+      "glossClean": "conditional коли",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "умовне коли",
       "lemmaId": "умовне-коли",
       "lemmaPlain": "умовне коли",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10311,11 +11515,13 @@
     {
       "cefr": "B1",
       "gloss": "formal condition",
+      "glossClean": "formal condition",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "формальна умова",
       "lemmaId": "формальна-умова",
       "lemmaPlain": "формальна умова",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10326,11 +11532,13 @@
     {
       "cefr": "B1",
       "gloss": "temporal коли",
+      "glossClean": "temporal коли",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "часове коли",
       "lemmaId": "часове-коли",
       "lemmaPlain": "часове коли",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10341,11 +11549,13 @@
     {
       "cefr": "B1",
       "gloss": "unless, provided that",
+      "glossClean": "unless",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "якщо тільки",
       "lemmaId": "якщо-тільки",
       "lemmaPlain": "якщо тільки",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10356,11 +11566,13 @@
     {
       "cefr": "B1",
       "gloss": "verb of volition",
+      "glossClean": "verb of volition",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "дієслово волевиявлення",
       "lemmaId": "дієслово-волевиявлення",
       "lemmaPlain": "дієслово волевиявлення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10371,11 +11583,13 @@
     {
       "cefr": "B1",
       "gloss": "verb of thought",
+      "glossClean": "verb of thought",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "дієслово мислення",
       "lemmaId": "дієслово-мислення",
       "lemmaPlain": "дієслово мислення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10386,11 +11600,13 @@
     {
       "cefr": "B1",
       "gloss": "verb of speech",
+      "glossClean": "verb of speech",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "дієслово мовлення",
       "lemmaId": "дієслово-мовлення",
       "lemmaPlain": "дієслово мовлення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10401,11 +11617,13 @@
     {
       "cefr": "B1",
       "gloss": "verb of perception",
+      "glossClean": "verb of perception",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "дієслово сприйняття",
       "lemmaId": "дієслово-сприйняття",
       "lemmaPlain": "дієслово сприйняття",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10416,11 +11634,13 @@
     {
       "cefr": "B1",
       "gloss": "object clause, explanatory subordinate clause",
+      "glossClean": "object clause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "з'ясувальне речення",
       "lemmaId": "з-ясувальне-речення",
       "lemmaPlain": "з'ясувальне речення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10431,11 +11651,13 @@
     {
       "cefr": "B1",
       "gloss": "content of a message",
+      "glossClean": "content of a message",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "зміст повідомлення",
       "lemmaId": "зміст-повідомлення",
       "lemmaPlain": "зміст повідомлення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10446,11 +11668,13 @@
     {
       "cefr": "B1",
       "gloss": "comma before a subordinate clause",
+      "glossClean": "comma before a subordinate clause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "кома перед підрядною частиною",
       "lemmaId": "кома-перед-підрядною-частиною",
       "lemmaPlain": "кома перед підрядною частиною",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10461,11 +11685,13 @@
     {
       "cefr": "B1",
       "gloss": "indirect question",
+      "glossClean": "indirect question",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "непряме питання",
       "lemmaId": "непряме-питання",
       "lemmaPlain": "непряме питання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10476,11 +11702,13 @@
     {
       "cefr": "B1",
       "gloss": "indirect cases",
+      "glossClean": "indirect cases",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "непрямі відмінки",
       "lemmaId": "непрямі-відмінки",
       "lemmaPlain": "непрямі відмінки",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10491,11 +11719,13 @@
     {
       "cefr": "B1",
       "gloss": "explained word",
+      "glossClean": "explained word",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пояснюване слово",
       "lemmaId": "пояснюване-слово",
       "lemmaPlain": "пояснюване слово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10506,11 +11736,13 @@
     {
       "cefr": "B1",
       "gloss": "direct case, nominative-like direct question in school terminology",
+      "glossClean": "direct case",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "прямий відмінок",
       "lemmaId": "прямий-відмінок",
       "lemmaPlain": "прямий відмінок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10521,11 +11753,13 @@
     {
       "cefr": "B1",
       "gloss": "subordinate connection",
+      "glossClean": "subordinate connection",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "підрядний зв'язок",
       "lemmaId": "підрядний-зв-язок",
       "lemmaPlain": "підрядний зв'язок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10536,11 +11770,13 @@
     {
       "cefr": "B1",
       "gloss": "subordinating conjunction",
+      "glossClean": "subordinating conjunction",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "сполучник підрядності",
       "lemmaId": "сполучник-підрядності",
       "lemmaPlain": "сполучник підрядності",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10551,11 +11787,13 @@
     {
       "cefr": "B1",
       "gloss": "in order to, so that",
+      "glossClean": "in order to",
       "heritage": "standard",
       "ipa": null,
       "lemma": "аби",
       "lemmaId": "аби",
       "lemmaPlain": "аби",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10566,11 +11804,13 @@
     {
       "cefr": "B1",
       "gloss": "the whole main action",
+      "glossClean": "the whole main action",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "вся головна дія",
       "lemmaId": "вся-головна-дія",
       "lemmaPlain": "вся головна дія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10581,11 +11821,13 @@
     {
       "cefr": "B1",
       "gloss": "for + genitive",
+      "glossClean": "for + genitive",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "для + родовий",
       "lemmaId": "для-родовий",
       "lemmaPlain": "для + родовий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10596,11 +11838,13 @@
     {
       "cefr": "B1",
       "gloss": "in order to",
+      "glossClean": "in order to",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "для того щоб",
       "lemmaId": "для-того-щоб",
       "lemmaPlain": "для того щоб",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10611,11 +11855,13 @@
     {
       "cefr": "B1",
       "gloss": "with the aim of",
+      "glossClean": "with the aim of",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "з метою",
       "lemmaId": "з-метою",
       "lemmaPlain": "з метою",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10626,11 +11872,13 @@
     {
       "cefr": "B1",
       "gloss": "with the aim of, in order to",
+      "glossClean": "with the aim of",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "з тим щоб",
       "lemmaId": "з-тим-щоб",
       "lemmaPlain": "з тим щоб",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10641,11 +11889,13 @@
     {
       "cefr": "B1",
       "gloss": "with what purpose",
+      "glossClean": "with what purpose",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "з якою метою",
       "lemmaId": "з-якою-метою",
       "lemmaPlain": "з якою метою",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10656,11 +11906,13 @@
     {
       "cefr": "B1",
       "gloss": "object-clause щоб",
+      "glossClean": "object-clause щоб",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "з'ясувальне щоб",
       "lemmaId": "з-ясувальне-щоб",
       "lemmaPlain": "з'ясувальне щоб",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10671,11 +11923,13 @@
     {
       "cefr": "B1",
       "gloss": "not in order to",
+      "glossClean": "not in order to",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "не для того щоб",
       "lemmaId": "не-для-того-щоб",
       "lemmaPlain": "не для того щоб",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10686,11 +11940,13 @@
     {
       "cefr": "B1",
       "gloss": "same subject",
+      "glossClean": "same subject",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "однаковий підмет",
       "lemmaId": "однаковий-підмет",
       "lemmaPlain": "однаковий підмет",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10701,11 +11957,13 @@
     {
       "cefr": "B1",
       "gloss": "adverbial subordinate clause of purpose",
+      "glossClean": "adverbial subordinate clause of purpose",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "підрядна обставинна частина мети",
       "lemmaId": "підрядна-обставинна-частина-мети",
       "lemmaPlain": "підрядна обставинна частина мети",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10716,11 +11974,13 @@
     {
       "cefr": "B1",
       "gloss": "different subjects",
+      "glossClean": "different subjects",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "різні підмети",
       "lemmaId": "різні-підмети",
       "lemmaPlain": "різні підмети",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10731,11 +11991,13 @@
     {
       "cefr": "B1",
       "gloss": "stylistic weight",
+      "glossClean": "stylistic weight",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "стилістична вага",
       "lemmaId": "стилістична-вага",
       "lemmaPlain": "стилістична вага",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10746,11 +12008,13 @@
     {
       "cefr": "B1",
       "gloss": "subjunctive-like nuance",
+      "glossClean": "subjunctive-like nuance",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "умовний відтінок",
       "lemmaId": "умовний-відтінок",
       "lemmaPlain": "умовний відтінок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10761,11 +12025,13 @@
     {
       "cefr": "B1",
       "gloss": "past-tense form after щоб",
+      "glossClean": "past-tense form after щоб",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "форма минулого часу після щоб",
       "lemmaId": "форма-минулого-часу-після-щоб",
       "lemmaPlain": "форма минулого часу після щоб",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10776,11 +12042,13 @@
     {
       "cefr": "B1",
       "gloss": "purpose щоб",
+      "glossClean": "purpose щоб",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "цільове щоб",
       "lemmaId": "цільове-щоб",
       "lemmaPlain": "цільове щоб",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10791,11 +12059,13 @@
     {
       "cefr": "B1",
       "gloss": "for the reason that",
+      "glossClean": "for the reason that",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "з тієї причини що",
       "lemmaId": "з-тієї-причини-що",
       "lemmaPlain": "з тієї причини що",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10806,11 +12076,13 @@
     {
       "cefr": "B1",
       "gloss": "thanks to the fact that",
+      "glossClean": "thanks to the fact that",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "завдяки тому що",
       "lemmaId": "завдяки-тому-що",
       "lemmaPlain": "завдяки тому що",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10821,11 +12093,13 @@
     {
       "cefr": "B1",
       "gloss": "logical emphasis",
+      "glossClean": "logical emphasis",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "логічний наголос",
       "lemmaId": "логічний-наголос",
       "lemmaPlain": "логічний наголос",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10836,11 +12110,13 @@
     {
       "cefr": "B1",
       "gloss": "formal style",
+      "glossClean": "formal style",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "офіційний стиль",
       "lemmaId": "офіційний-стиль",
       "lemmaPlain": "офіційний стиль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10851,11 +12127,13 @@
     {
       "cefr": "B1",
       "gloss": "positive cause",
+      "glossClean": "positive cause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "позитивна причина",
       "lemmaId": "позитивна-причина",
       "lemmaPlain": "позитивна причина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10866,11 +12144,13 @@
     {
       "cefr": "B1",
       "gloss": "causal conjunction",
+      "glossClean": "causal conjunction",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "причинний сполучник",
       "lemmaId": "причинний-сполучник",
       "lemmaPlain": "причинний сполучник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10881,11 +12161,13 @@
     {
       "cefr": "B1",
       "gloss": "causal adverbial subordinate clause",
+      "glossClean": "causal adverbial subordinate clause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "підрядна обставинна частина причини",
       "lemmaId": "підрядна-обставинна-частина-причини",
       "lemmaPlain": "підрядна обставинна частина причини",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10896,11 +12178,13 @@
     {
       "cefr": "B1",
       "gloss": "split construction",
+      "glossClean": "split construction",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "розщеплена конструкція",
       "lemmaId": "розщеплена-конструкція",
       "lemmaPlain": "розщеплена конструкція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10911,11 +12195,13 @@
     {
       "cefr": "B1",
       "gloss": "in connection with the fact that",
+      "glossClean": "in connection with the fact that",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у зв'язку з тим що",
       "lemmaId": "у-зв-язку-з-тим-що",
       "lemmaPlain": "у зв'язку з тим що",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10926,11 +12212,13 @@
     {
       "cefr": "B1",
       "gloss": "because of the fact that",
+      "glossClean": "because of the fact that",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "через те що",
       "lemmaId": "через-те-що",
       "lemmaPlain": "через те що",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -10941,11 +12229,13 @@
     {
       "cefr": "B1",
       "gloss": "zero relative pronoun",
+      "glossClean": "zero relative pronoun",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "нульовий відносний займенник",
       "lemmaId": "нульовий-відносний-займенник",
       "lemmaPlain": "нульовий відносний займенник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10956,11 +12246,13 @@
     {
       "cefr": "B1",
       "gloss": "attributive clause, relative clause",
+      "glossClean": "attributive clause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "означальне речення",
       "lemmaId": "означальне-речення",
       "lemmaPlain": "означальне речення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10971,11 +12263,13 @@
     {
       "cefr": "B1",
       "gloss": "subordinate attributive clause",
+      "glossClean": "subordinate attributive clause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "підрядна означальна частина",
       "lemmaId": "підрядна-означальна-частина",
       "lemmaPlain": "підрядна означальна частина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -10986,11 +12280,13 @@
     {
       "cefr": "B1",
       "gloss": "role inside the subordinate clause",
+      "glossClean": "role inside the subordinate clause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "роль у підрядній частині",
       "lemmaId": "роль-у-підрядній-частині",
       "lemmaPlain": "роль у підрядній частині",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11001,11 +12297,13 @@
     {
       "cefr": "B1",
       "gloss": "aspect-tense correlation",
+      "glossClean": "aspect-tense correlation",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "видо-часова кореляція",
       "lemmaId": "видо-часова-кореляція",
       "lemmaPlain": "видо-часова кореляція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11016,11 +12314,13 @@
     {
       "cefr": "B1",
       "gloss": "since",
+      "glossClean": "since",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "відтоді як",
       "lemmaId": "відтоді-як",
       "lemmaPlain": "відтоді як",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11031,11 +12331,13 @@
     {
       "cefr": "B1",
       "gloss": "until, as long as",
+      "glossClean": "until",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "доти...доки",
       "lemmaId": "доти-доки",
       "lemmaPlain": "доти...доки",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11046,11 +12348,13 @@
     {
       "cefr": "B1",
       "gloss": "comma between clauses",
+      "glossClean": "comma between clauses",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "кома між частинами",
       "lemmaId": "кома-між-частинами",
       "lemmaPlain": "кома між частинами",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11061,11 +12365,13 @@
     {
       "cefr": "B1",
       "gloss": "boundary of an action",
+      "glossClean": "boundary of an action",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "межа дії",
       "lemmaId": "межа-дії",
       "lemmaPlain": "межа дії",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11076,11 +12382,13 @@
     {
       "cefr": "B1",
       "gloss": "before",
+      "glossClean": "before",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "перед тим як",
       "lemmaId": "перед-тим-як",
       "lemmaPlain": "перед тим як",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11091,11 +12399,13 @@
     {
       "cefr": "B1",
       "gloss": "before",
+      "glossClean": "before",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "перш ніж",
       "lemmaId": "перш-ніж",
       "lemmaPlain": "перш ніж",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11106,11 +12416,13 @@
     {
       "cefr": "B1",
       "gloss": "until",
+      "glossClean": "until",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "поки не",
       "lemmaId": "поки-не",
       "lemmaPlain": "поки не",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11121,11 +12433,13 @@
     {
       "cefr": "B1",
       "gloss": "temporal adverbial subordinate clause",
+      "glossClean": "temporal adverbial subordinate clause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "підрядна обставинна частина часу",
       "lemmaId": "підрядна-обставинна-частина-часу",
       "lemmaPlain": "підрядна обставинна частина часу",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11136,11 +12450,13 @@
     {
       "cefr": "B1",
       "gloss": "after",
+      "glossClean": "after",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "після того як",
       "lemmaId": "після-того-як",
       "lemmaPlain": "після того як",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11151,11 +12467,13 @@
     {
       "cefr": "B1",
       "gloss": "temporal clause",
+      "glossClean": "temporal clause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "часове речення",
       "lemmaId": "часове-речення",
       "lemmaPlain": "часове речення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11166,11 +12484,13 @@
     {
       "cefr": "B1",
       "gloss": "range",
+      "glossClean": "range",
       "heritage": "standard",
       "ipa": null,
       "lemma": "діапазон",
       "lemmaId": "діапазон",
       "lemmaPlain": "діапазон",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11181,11 +12501,13 @@
     {
       "cefr": "B1",
       "gloss": "review map",
+      "glossClean": "review map",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "карта повторення",
       "lemmaId": "карта-повторення",
       "lemmaPlain": "карта повторення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11196,11 +12518,13 @@
     {
       "cefr": "B1",
       "gloss": "to systematize",
+      "glossClean": "to systematize",
       "heritage": "standard",
       "ipa": null,
       "lemma": "систематизувати",
       "lemmaId": "систематизувати",
       "lemmaPlain": "систематизувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11211,11 +12535,13 @@
     {
       "cefr": "B1",
       "gloss": "weak point",
+      "glossClean": "weak point",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "слабке місце",
       "lemmaId": "слабке-місце",
       "lemmaPlain": "слабке місце",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11226,11 +12552,13 @@
     {
       "cefr": "B1",
       "gloss": "integrated",
+      "glossClean": "integrated",
       "heritage": "standard",
       "ipa": null,
       "lemma": "інтегрований",
       "lemmaId": "інтегрований",
       "lemmaPlain": "інтегрований",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11241,11 +12569,13 @@
     {
       "cefr": "B1",
       "gloss": "to manage in time",
+      "glossClean": "to manage in time",
       "heritage": "standard",
       "ipa": null,
       "lemma": "встигнути",
       "lemmaId": "встигнути",
       "lemmaPlain": "встигнути",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11256,11 +12586,13 @@
     {
       "cefr": "B1",
       "gloss": "to finish, complete",
+      "glossClean": "to finish",
       "heritage": "standard",
       "ipa": null,
       "lemma": "завершити",
       "lemmaId": "завершити",
       "lemmaPlain": "завершити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11271,11 +12603,13 @@
     {
       "cefr": "B1",
       "gloss": "to contact, seek help",
+      "glossClean": "to contact",
       "heritage": "standard",
       "ipa": null,
       "lemma": "звернутися",
       "lemmaId": "звернутися",
       "lemmaPlain": "звернутися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11286,11 +12620,13 @@
     {
       "cefr": "B1",
       "gloss": "content word",
+      "glossClean": "content word",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "повнозначне слово",
       "lemmaId": "повнозначне-слово",
       "lemmaPlain": "повнозначне слово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11301,11 +12637,13 @@
     {
       "cefr": "B1",
       "gloss": "would like",
+      "glossClean": "would like",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "хотів би / хотіла б",
       "lemmaId": "хотів-би-хотіла-б",
       "lemmaPlain": "хотів би / хотіла б",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11316,11 +12654,13 @@
     {
       "cefr": "B1",
       "gloss": "straw",
+      "glossClean": "straw",
       "heritage": "standard",
       "ipa": null,
       "lemma": "соломка",
       "lemmaId": "соломка",
       "lemmaPlain": "соломка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11331,11 +12671,13 @@
     {
       "cefr": "B1",
       "gloss": "how would",
+      "glossClean": "how would",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "як би",
       "lemmaId": "як-би",
       "lemmaPlain": "як би",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11346,11 +12688,13 @@
     {
       "cefr": "B1",
       "gloss": "if, if it were",
+      "glossClean": "if",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "якщо б",
       "lemmaId": "якщо-б",
       "lemmaPlain": "якщо б",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11361,11 +12705,13 @@
     {
       "cefr": "B1",
       "gloss": "to take out the trash",
+      "glossClean": "to take out the trash",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "виносити сміття",
       "lemmaId": "виносити-сміття",
       "lemmaPlain": "виносити сміття",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11376,11 +12722,13 @@
     {
       "cefr": "B1",
       "gloss": "to grow",
+      "glossClean": "to grow",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вирощувати",
       "lemmaId": "вирощувати",
       "lemmaPlain": "вирощувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11391,11 +12739,13 @@
     {
       "cefr": "B1",
       "gloss": "to dust",
+      "glossClean": "to dust",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "витирати пил",
       "lemmaId": "витирати-пил",
       "lemmaPlain": "витирати пил",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11406,11 +12756,13 @@
     {
       "cefr": "B1",
       "gloss": "to leave home",
+      "glossClean": "to leave home",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "виходити з дому",
       "lemmaId": "виходити-з-дому",
       "lemmaPlain": "виходити з дому",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11421,11 +12773,13 @@
     {
       "cefr": "B1",
       "gloss": "to postpone",
+      "glossClean": "to postpone",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відкладати",
       "lemmaId": "відкладати",
       "lemmaPlain": "відкладати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11436,11 +12790,13 @@
     {
       "cefr": "B1",
       "gloss": "to cook food",
+      "glossClean": "to cook food",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "готувати їжу",
       "lemmaId": "готувати-їжу",
       "lemmaPlain": "готувати їжу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11451,11 +12807,13 @@
     {
       "cefr": "B1",
       "gloss": "email",
+      "glossClean": "email",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "електронна пошта",
       "lemmaId": "електронна-пошта",
       "lemmaPlain": "електронна пошта",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11466,11 +12824,13 @@
     {
       "cefr": "B1",
       "gloss": "to wash dishes",
+      "glossClean": "to wash dishes",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "помити посуд",
       "lemmaId": "помити-посуд",
       "lemmaPlain": "помити посуд",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11481,11 +12841,13 @@
     {
       "cefr": "B1",
       "gloss": "job search",
+      "glossClean": "job search",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пошук роботи",
       "lemmaId": "пошук-роботи",
       "lemmaPlain": "пошук роботи",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11496,11 +12858,13 @@
     {
       "cefr": "B1",
       "gloss": "to iron",
+      "glossClean": "to iron",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прасувати",
       "lemmaId": "прасувати",
       "lemmaPlain": "прасувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11511,11 +12875,13 @@
     {
       "cefr": "B1",
       "gloss": "to do laundry",
+      "glossClean": "to do laundry",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "прати білизну",
       "lemmaId": "прати-білизну",
       "lemmaPlain": "прати білизну",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11526,11 +12892,13 @@
     {
       "cefr": "B1",
       "gloss": "workplace",
+      "glossClean": "workplace",
       "heritage": "standard",
       "ipa": null,
       "lemma": "робоче місце",
       "lemmaId": "робоче-місце",
       "lemmaPlain": "робоче місце",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11541,11 +12909,13 @@
     {
       "cefr": "B1",
       "gloss": "workday",
+      "glossClean": "workday",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "робочий день",
       "lemmaId": "робочий-день",
       "lemmaPlain": "робочий день",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11556,11 +12926,13 @@
     {
       "cefr": "B1",
       "gloss": "household chores",
+      "glossClean": "household chores",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "хатні справи",
       "lemmaId": "хатні-справи",
       "lemmaPlain": "хатні справи",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11571,11 +12943,13 @@
     {
       "cefr": "B1",
       "gloss": "over forty",
+      "glossClean": "over forty",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "за сорок",
       "lemmaId": "за-сорок",
       "lemmaPlain": "за сорок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11586,11 +12960,13 @@
     {
       "cefr": "B1",
       "gloss": "thanks to",
+      "glossClean": "thanks to",
       "heritage": "standard",
       "ipa": null,
       "lemma": "завдяки",
       "lemmaId": "завдяки",
       "lemmaPlain": "завдяки",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11601,11 +12977,13 @@
     {
       "cefr": "B1",
       "gloss": "interested/affected person",
+      "glossClean": "interested/affected person",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "зацікавлена особа",
       "lemmaId": "зацікавлена-особа",
       "lemmaPlain": "зацікавлена особа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11616,11 +12994,13 @@
     {
       "cefr": "B1",
       "gloss": "towards, to meet",
+      "glossClean": "towards",
       "heritage": "standard",
       "ipa": null,
       "lemma": "назустріч",
       "lemmaId": "назустріч",
       "lemmaPlain": "назустріч",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -11631,11 +13011,13 @@
     {
       "cefr": "B1",
       "gloss": "need",
+      "glossClean": "need",
       "heritage": "standard",
       "ipa": null,
       "lemma": "потреба",
       "lemmaId": "потреба",
       "lemmaPlain": "потреба",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -11675,11 +13057,13 @@
     {
       "cefr": "B1",
       "gloss": "nearly fifty",
+      "glossClean": "nearly fifty",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "під п'ятдесят",
       "lemmaId": "під-п-ятдесят",
       "lemmaPlain": "під п'ятдесят",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11690,11 +13074,13 @@
     {
       "cefr": "B1",
       "gloss": "how old",
+      "glossClean": "how old",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "скільки років",
       "lemmaId": "скільки-років",
       "lemmaPlain": "скільки років",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11705,11 +13091,13 @@
     {
       "cefr": "B1",
       "gloss": "ashamed",
+      "glossClean": "ashamed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "соромно",
       "lemmaId": "соромно",
       "lemmaPlain": "соромно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11720,11 +13108,13 @@
     {
       "cefr": "B1",
       "gloss": "experiencer of a state",
+      "glossClean": "experiencer of a state",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "суб'єкт стану",
       "lemmaId": "суб-єкт-стану",
       "lemmaPlain": "суб'єкт стану",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11735,11 +13125,13 @@
     {
       "cefr": "B1",
       "gloss": "ad hominem",
+      "glossClean": "ad hominem",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "аргумент до особи",
       "lemmaId": "аргумент-до-особи",
       "lemmaPlain": "аргумент до особи",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11750,11 +13142,13 @@
     {
       "cefr": "B1",
       "gloss": "to take part",
+      "glossClean": "to take part",
       "heritage": "standard",
       "ipa": null,
       "lemma": "брати участь",
       "lemmaId": "брати-участь",
       "lemmaPlain": "брати участь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11765,11 +13159,13 @@
     {
       "cefr": "B1",
       "gloss": "to object, disagree",
+      "glossClean": "to object",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заперечувати",
       "lemmaId": "заперечувати",
       "lemmaPlain": "заперечувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11780,11 +13176,13 @@
     {
       "cefr": "B1",
       "gloss": "opponent, interlocutor in debate",
+      "glossClean": "opponent",
       "heritage": "standard",
       "ipa": null,
       "lemma": "опонент",
       "lemmaId": "опонент",
       "lemmaPlain": "опонент",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11795,11 +13193,13 @@
     {
       "cefr": "B1",
       "gloss": "position",
+      "glossClean": "position",
       "heritage": "standard",
       "ipa": null,
       "lemma": "позиція",
       "lemmaId": "позиція",
       "lemmaPlain": "позиція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -11839,11 +13239,13 @@
     {
       "cefr": "B1",
       "gloss": "hasty generalization",
+      "glossClean": "hasty generalization",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "поспішне узагальнення",
       "lemmaId": "поспішне-узагальнення",
       "lemmaPlain": "поспішне узагальнення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11854,11 +13256,13 @@
     {
       "cefr": "B1",
       "gloss": "straw man, changing the claim",
+      "glossClean": "straw man",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "підміна тези",
       "lemmaId": "підміна-тези",
       "lemmaPlain": "підміна тези",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11869,11 +13273,13 @@
     {
       "cefr": "B1",
       "gloss": "false dilemma",
+      "glossClean": "false dilemma",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "хибна дилема",
       "lemmaId": "хибна-дилема",
       "lemmaPlain": "хибна дилема",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11884,11 +13290,13 @@
     {
       "cefr": "B1",
       "gloss": "bachelor's degree holder, bachelor level",
+      "glossClean": "bachelor's degree holder",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бакалавр",
       "lemmaId": "бакалавр",
       "lemmaPlain": "бакалавр",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11899,11 +13307,13 @@
     {
       "cefr": "B1",
       "gloss": "state-funded place",
+      "glossClean": "state-funded place",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "бюджетне місце",
       "lemmaId": "бюджетне-місце",
       "lemmaPlain": "бюджетне місце",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11914,11 +13324,13 @@
     {
       "cefr": "B1",
       "gloss": "higher education",
+      "glossClean": "higher education",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "вища освіта",
       "lemmaId": "вища-освіта",
       "lemmaPlain": "вища освіта",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11929,11 +13341,13 @@
     {
       "cefr": "B1",
       "gloss": "to enter, to be admitted",
+      "glossClean": "to enter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вступити",
       "lemmaId": "вступити",
       "lemmaPlain": "вступити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11944,11 +13358,13 @@
     {
       "cefr": "B1",
       "gloss": "dean",
+      "glossClean": "dean",
       "heritage": "standard",
       "ipa": null,
       "lemma": "декан",
       "lemmaId": "декан",
       "lemmaPlain": "декан",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11959,11 +13375,13 @@
     {
       "cefr": "B1",
       "gloss": "dean's office",
+      "glossClean": "dean's office",
       "heritage": "standard",
       "ipa": null,
       "lemma": "деканат",
       "lemmaId": "деканат",
       "lemmaPlain": "деканат",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11974,11 +13392,13 @@
     {
       "cefr": "B1",
       "gloss": "thesis",
+      "glossClean": "thesis",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "дипломна робота",
       "lemmaId": "дипломна-робота",
       "lemmaPlain": "дипломна робота",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -11989,11 +13409,13 @@
     {
       "cefr": "B1",
       "gloss": "academic subject, discipline",
+      "glossClean": "academic subject",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дисципліна",
       "lemmaId": "дисципліна",
       "lemmaPlain": "дисципліна",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -12033,11 +13455,13 @@
     {
       "cefr": "B1",
       "gloss": "Doctor of Philosophy, PhD",
+      "glossClean": "Doctor of Philosophy",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "доктор філософії",
       "lemmaId": "доктор-філософії",
       "lemmaPlain": "доктор філософії",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12048,11 +13472,13 @@
     {
       "cefr": "B1",
       "gloss": "research",
+      "glossClean": "research",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дослідження",
       "lemmaId": "дослідження",
       "lemmaPlain": "дослідження",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12063,11 +13489,13 @@
     {
       "cefr": "B1",
       "gloss": "online account, electronic cabinet",
+      "glossClean": "online account",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "електронний кабінет",
       "lemmaId": "електронний-кабінет",
       "lemmaPlain": "електронний кабінет",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12078,11 +13506,13 @@
     {
       "cefr": "B1",
       "gloss": "educational institution",
+      "glossClean": "educational institution",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "заклад освіти",
       "lemmaId": "заклад-освіти",
       "lemmaPlain": "заклад освіти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12093,11 +13523,13 @@
     {
       "cefr": "B1",
       "gloss": "grade book",
+      "glossClean": "grade book",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "залікова книжка",
       "lemmaId": "залікова-книжка",
       "lemmaPlain": "залікова книжка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12108,11 +13540,13 @@
     {
       "cefr": "B1",
       "gloss": "academic department, chair",
+      "glossClean": "academic department",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кафедра",
       "lemmaId": "кафедра",
       "lemmaPlain": "кафедра",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -12152,11 +13586,13 @@
     {
       "cefr": "B1",
       "gloss": "consultation, office-hour session",
+      "glossClean": "consultation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "консультація",
       "lemmaId": "консультація",
       "lemmaPlain": "консультація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -12196,11 +13632,13 @@
     {
       "cefr": "B1",
       "gloss": "fee-paying form of study",
+      "glossClean": "fee-paying form of study",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "контрактна форма",
       "lemmaId": "контрактна-форма",
       "lemmaPlain": "контрактна форма",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12211,11 +13649,13 @@
     {
       "cefr": "B1",
       "gloss": "student group advisor",
+      "glossClean": "student group advisor",
       "heritage": "standard",
       "ipa": null,
       "lemma": "куратор",
       "lemmaId": "куратор",
       "lemmaPlain": "куратор",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12226,11 +13666,13 @@
     {
       "cefr": "B1",
       "gloss": "term paper",
+      "glossClean": "term paper",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "курсова робота",
       "lemmaId": "курсова-робота",
       "lemmaPlain": "курсова робота",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12241,11 +13683,13 @@
     {
       "cefr": "B1",
       "gloss": "lab work",
+      "glossClean": "lab work",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "лабораторна робота",
       "lemmaId": "лабораторна-робота",
       "lemmaPlain": "лабораторна робота",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12256,11 +13700,13 @@
     {
       "cefr": "B1",
       "gloss": "master's degree holder, master level",
+      "glossClean": "master's degree holder",
       "heritage": "standard",
       "ipa": null,
       "lemma": "магістр",
       "lemmaId": "магістр",
       "lemmaPlain": "магістр",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12271,11 +13717,13 @@
     {
       "cefr": "B1",
       "gloss": "curriculum, study plan",
+      "glossClean": "curriculum",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "навчальний план",
       "lemmaId": "навчальний-план",
       "lemmaPlain": "навчальний план",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12286,11 +13734,13 @@
     {
       "cefr": "B1",
       "gloss": "academic advisor, research supervisor",
+      "glossClean": "academic advisor",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "науковий керівник",
       "lemmaId": "науковий-керівник",
       "lemmaPlain": "науковий керівник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12301,11 +13751,13 @@
     {
       "cefr": "B1",
       "gloss": "National Multi-Subject Test",
+      "glossClean": "National Multi-Subject Test",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "НМТ",
       "lemmaId": "нмт",
       "lemmaPlain": "нмт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12316,11 +13768,13 @@
     {
       "cefr": "B1",
       "gloss": "groupmate",
+      "glossClean": "groupmate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "одногрупник",
       "lemmaId": "одногрупник",
       "lemmaPlain": "одногрупник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12331,11 +13785,13 @@
     {
       "cefr": "B1",
       "gloss": "degree program, educational program",
+      "glossClean": "degree program",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "освітня програма",
       "lemmaId": "освітня-програма",
       "lemmaPlain": "освітня програма",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12346,11 +13802,13 @@
     {
       "cefr": "B1",
       "gloss": "practical class",
+      "glossClean": "practical class",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "практичне заняття",
       "lemmaId": "практичне-заняття",
       "lemmaPlain": "практичне заняття",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12361,11 +13819,13 @@
     {
       "cefr": "B1",
       "gloss": "recommended reading",
+      "glossClean": "recommended reading",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "рекомендована література",
       "lemmaId": "рекомендована-література",
       "lemmaPlain": "рекомендована література",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12376,11 +13836,13 @@
     {
       "cefr": "B1",
       "gloss": "exam period",
+      "glossClean": "exam period",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сесія",
       "lemmaId": "сесія",
       "lemmaPlain": "сесія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -12420,11 +13882,13 @@
     {
       "cefr": "B1",
       "gloss": "stipend, scholarship",
+      "glossClean": "stipend",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стипендія",
       "lemmaId": "стипендія",
       "lemmaPlain": "стипендія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -12464,11 +13928,13 @@
     {
       "cefr": "B1",
       "gloss": "student ID card",
+      "glossClean": "student ID card",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "студентський квиток",
       "lemmaId": "студентський-квиток",
       "lemmaPlain": "студентський квиток",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12479,11 +13945,13 @@
     {
       "cefr": "B1",
       "gloss": "reading room",
+      "glossClean": "reading room",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "читальний зал",
       "lemmaId": "читальний-зал",
       "lemmaPlain": "читальний зал",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12494,11 +13962,13 @@
     {
       "cefr": "B1",
       "gloss": "polysemous word",
+      "glossClean": "polysemous word",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "багатозначне слово",
       "lemmaId": "багатозначне-слово",
       "lemmaPlain": "багатозначне слово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12509,11 +13979,13 @@
     {
       "cefr": "B1",
       "gloss": "thoughts drift",
+      "glossClean": "thoughts drift",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "думки пливуть",
       "lemmaId": "думки-пливуть",
       "lemmaPlain": "думки пливуть",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12524,11 +13996,13 @@
     {
       "cefr": "B1",
       "gloss": "to reach a conclusion",
+      "glossClean": "to reach a conclusion",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "дійти до висновку",
       "lemmaId": "дійти-до-висновку",
       "lemmaPlain": "дійти до висновку",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12539,11 +14013,13 @@
     {
       "cefr": "B1",
       "gloss": "to go too far",
+      "glossClean": "to go too far",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "зайти далеко",
       "lemmaId": "зайти-далеко",
       "lemmaPlain": "зайти далеко",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12554,11 +14030,13 @@
     {
       "cefr": "B1",
       "gloss": "a melody flows",
+      "glossClean": "a melody flows",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "мелодія пливе",
       "lemmaId": "мелодія-пливе",
       "lemmaPlain": "мелодія пливе",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12569,11 +14047,13 @@
     {
       "cefr": "B1",
       "gloss": "the topic is about",
+      "glossClean": "the topic is about",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "мова йде про",
       "lemmaId": "мова-йде-про",
       "lemmaPlain": "мова йде про",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12584,11 +14064,13 @@
     {
       "cefr": "B1",
       "gloss": "goosebumps run",
+      "glossClean": "goosebumps run",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "мурашки біжать",
       "lemmaId": "мурашки-біжать",
       "lemmaPlain": "мурашки біжать",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12599,11 +14081,13 @@
     {
       "cefr": "B1",
       "gloss": "it did not work out",
+      "glossClean": "it did not work out",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "не вийшло",
       "lemmaId": "не-вийшло",
       "lemmaPlain": "не вийшло",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -12614,11 +14098,13 @@
     {
       "cefr": "B1",
       "gloss": "to bear a name",
+      "glossClean": "to bear a name",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "носити ім'я",
       "lemmaId": "носити-ім-я",
       "lemmaPlain": "носити ім'я",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12629,11 +14115,13 @@
     {
       "cefr": "B1",
       "gloss": "to get by without",
+      "glossClean": "to get by without",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "обійтися без",
       "lemmaId": "обійтися-без",
       "lemmaPlain": "обійтися без",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12644,11 +14132,13 @@
     {
       "cefr": "B1",
       "gloss": "negotiations are underway",
+      "glossClean": "negotiations are underway",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "переговори йдуть",
       "lemmaId": "переговори-йдуть",
       "lemmaPlain": "переговори йдуть",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12659,11 +14149,13 @@
     {
       "cefr": "B1",
       "gloss": "an idea came",
+      "glossClean": "an idea came",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "прийшла ідея",
       "lemmaId": "прийшла-ідея",
       "lemmaPlain": "прийшла ідея",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12674,11 +14166,13 @@
     {
       "cefr": "B1",
       "gloss": "the time has come",
+      "glossClean": "the time has come",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "прийшов час",
       "lemmaId": "прийшов-час",
       "lemmaPlain": "прийшов час",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12689,11 +14183,13 @@
     {
       "cefr": "B1",
       "gloss": "to suit, to fit",
+      "glossClean": "to suit",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підійти",
       "lemmaId": "підійти",
       "lemmaPlain": "підійти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12704,11 +14200,13 @@
     {
       "cefr": "B1",
       "gloss": "it is snowing",
+      "glossClean": "it is snowing",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "сніг іде",
       "lemmaId": "сніг-іде",
       "lemmaPlain": "сніг іде",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12719,11 +14217,13 @@
     {
       "cefr": "B1",
       "gloss": "a lesson is in progress",
+      "glossClean": "a lesson is in progress",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "урок іде",
       "lemmaId": "урок-іде",
       "lemmaPlain": "урок іде",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -12734,11 +14234,13 @@
     {
       "cefr": "B1",
       "gloss": "a film is playing",
+      "glossClean": "a film is playing",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "фільм іде",
       "lemmaId": "фільм-іде",
       "lemmaPlain": "фільм іде",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12749,11 +14251,13 @@
     {
       "cefr": "B1",
       "gloss": "clouds drift",
+      "glossClean": "clouds drift",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "хмари пливуть",
       "lemmaId": "хмари-пливуть",
       "lemmaPlain": "хмари пливуть",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12764,11 +14268,13 @@
     {
       "cefr": "B1",
       "gloss": "time runs",
+      "glossClean": "time runs",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "час біжить",
       "lemmaId": "час-біжить",
       "lemmaPlain": "час біжить",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12779,11 +14285,13 @@
     {
       "cefr": "B1",
       "gloss": "time drifts, time flows slowly",
+      "glossClean": "time drifts",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "час пливе",
       "lemmaId": "час-пливе",
       "lemmaPlain": "час пливе",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12794,11 +14302,13 @@
     {
       "cefr": "B1",
       "gloss": "time passes",
+      "glossClean": "time passes",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "час іде",
       "lemmaId": "час-іде",
       "lemmaPlain": "час іде",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12809,11 +14319,13 @@
     {
       "cefr": "B1",
       "gloss": "to achieve, to reach",
+      "glossClean": "to achieve",
       "heritage": "standard",
       "ipa": null,
       "lemma": "досягти",
       "lemmaId": "досягти",
       "lemmaPlain": "досягти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12824,11 +14336,13 @@
     {
       "cefr": "B1",
       "gloss": "from behind",
+      "glossClean": "from behind",
       "heritage": "standard",
       "ipa": null,
       "lemma": "з-за",
       "lemmaId": "з-за",
       "lemmaPlain": "з-за",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -12839,11 +14353,13 @@
     {
       "cefr": "B1",
       "gloss": "instead of",
+      "glossClean": "instead of",
       "heritage": "standard",
       "ipa": null,
       "lemma": "замість",
       "lemmaId": "замість",
       "lemmaPlain": "замість",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -12854,11 +14370,13 @@
     {
       "cefr": "B1",
       "gloss": "except, besides",
+      "glossClean": "except",
       "heritage": "standard",
       "ipa": null,
       "lemma": "крім",
       "lemmaId": "крім",
       "lemmaPlain": "крім",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -12869,11 +14387,13 @@
     {
       "cefr": "B1",
       "gloss": "to need, to require",
+      "glossClean": "to need",
       "heritage": "standard",
       "ipa": null,
       "lemma": "потребувати",
       "lemmaId": "потребувати",
       "lemmaPlain": "потребувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12884,11 +14404,13 @@
     {
       "cefr": "B1",
       "gloss": "substance, material",
+      "glossClean": "substance",
       "heritage": "standard",
       "ipa": null,
       "lemma": "речовина",
       "lemmaId": "речовина",
       "lemmaPlain": "речовина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -12928,11 +14450,13 @@
     {
       "cefr": "B1",
       "gloss": "time expression",
+      "glossClean": "time expression",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "часовий вираз",
       "lemmaId": "часовий-вираз",
       "lemmaPlain": "часовий вираз",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12943,11 +14467,13 @@
     {
       "cefr": "B1",
       "gloss": "regarding",
+      "glossClean": "regarding",
       "heritage": "standard",
       "ipa": null,
       "lemma": "щодо",
       "lemmaId": "щодо",
       "lemmaPlain": "щодо",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -12958,11 +14484,13 @@
     {
       "cefr": "B1",
       "gloss": "natural phenomenon",
+      "glossClean": "natural phenomenon",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "явище природи",
       "lemmaId": "явище-природи",
       "lemmaPlain": "явище природи",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12973,11 +14501,13 @@
     {
       "cefr": "B1",
       "gloss": "second declension",
+      "glossClean": "second declension",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "ІІ відміна",
       "lemmaId": "іі-відміна",
       "lemmaPlain": "іі відміна",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12988,11 +14518,13 @@
     {
       "cefr": "B1",
       "gloss": "dependent words",
+      "glossClean": "dependent words",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "залежні слова",
       "lemmaId": "залежні-слова",
       "lemmaPlain": "залежні слова",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13003,11 +14535,13 @@
     {
       "cefr": "B1",
       "gloss": "holding one's breath",
+      "glossClean": "holding one's breath",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "затамувавши подих",
       "lemmaId": "затамувавши-подих",
       "lemmaPlain": "затамувавши подих",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13018,11 +14552,13 @@
     {
       "cefr": "B1",
       "gloss": "logical subject",
+      "glossClean": "logical subject",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "логічний підмет",
       "lemmaId": "логічний-підмет",
       "lemmaPlain": "логічний підмет",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13033,11 +14569,13 @@
     {
       "cefr": "B1",
       "gloss": "phrase boundary",
+      "glossClean": "phrase boundary",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "межа звороту",
       "lemmaId": "межа-звороту",
       "lemmaPlain": "межа звороту",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13048,11 +14586,13 @@
     {
       "cefr": "B1",
       "gloss": "without taking a step",
+      "glossClean": "without taking a step",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "не зробивши кроку",
       "lemmaId": "не-зробивши-кроку",
       "lemmaPlain": "не зробивши кроку",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13063,11 +14603,13 @@
     {
       "cefr": "B1",
       "gloss": "tirelessly, without rest",
+      "glossClean": "tirelessly",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "не покладаючи рук",
       "lemmaId": "не-покладаючи-рук",
       "lemmaPlain": "не покладаючи рук",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13078,11 +14620,13 @@
     {
       "cefr": "B1",
       "gloss": "without saying goodbye",
+      "glossClean": "without saying goodbye",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "не прощаючись",
       "lemmaId": "не-прощаючись",
       "lemmaPlain": "не прощаючись",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13093,11 +14637,13 @@
     {
       "cefr": "B1",
       "gloss": "with no feeling in one's legs, exhausted",
+      "glossClean": "with no feeling in one's legs",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "не чуючи ніг",
       "lemmaId": "не-чуючи-ніг",
       "lemmaPlain": "не чуючи ніг",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -13108,11 +14654,13 @@
     {
       "cefr": "B1",
       "gloss": "homogeneous adverbial modifiers",
+      "glossClean": "homogeneous adverbial modifiers",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "однорідні обставини",
       "lemmaId": "однорідні-обставини",
       "lemmaPlain": "однорідні обставини",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13123,11 +14671,13 @@
     {
       "cefr": "B1",
       "gloss": "working on oneself",
+      "glossClean": "working on oneself",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "працюючи над собою",
       "lemmaId": "працюючи-над-собою",
       "lemmaPlain": "працюючи над собою",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13138,11 +14688,13 @@
     {
       "cefr": "B1",
       "gloss": "having read the book",
+      "glossClean": "having read the book",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "прочитавши книгу",
       "lemmaId": "прочитавши-книгу",
       "lemmaPlain": "прочитавши книгу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13153,11 +14705,13 @@
     {
       "cefr": "B1",
       "gloss": "intensifying particle",
+      "glossClean": "intensifying particle",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "підсилювальна частка",
       "lemmaId": "підсилювальна-частка",
       "lemmaPlain": "підсилювальна частка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13168,11 +14722,13 @@
     {
       "cefr": "B1",
       "gloss": "idly, with folded hands",
+      "glossClean": "idly",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "склавши руки",
       "lemmaId": "склавши-руки",
       "lemmaPlain": "склавши руки",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13183,11 +14739,13 @@
     {
       "cefr": "B1",
       "gloss": "manner of action",
+      "glossClean": "manner of action",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спосіб дії",
       "lemmaId": "спосіб-дії",
       "lemmaPlain": "спосіб дії",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13198,11 +14756,13 @@
     {
       "cefr": "B1",
       "gloss": "phraseological expression",
+      "glossClean": "phraseological expression",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "фразеологічний зворот",
       "lemmaId": "фразеологічний-зворот",
       "lemmaPlain": "фразеологічний зворот",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13213,11 +14773,13 @@
     {
       "cefr": "B1",
       "gloss": "secondary action",
+      "glossClean": "secondary action",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "додаткова дія",
       "lemmaId": "додаткова-дія",
       "lemmaPlain": "додаткова дія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13228,11 +14790,13 @@
     {
       "cefr": "B1",
       "gloss": "without thinking",
+      "glossClean": "without thinking",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "не думаючи",
       "lemmaId": "не-думаючи",
       "lemmaPlain": "не думаючи",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13243,11 +14807,13 @@
     {
       "cefr": "B1",
       "gloss": "while writing",
+      "glossClean": "while writing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пишучи",
       "lemmaId": "пишучи",
       "lemmaPlain": "пишучи",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -13258,11 +14824,13 @@
     {
       "cefr": "B1",
       "gloss": "while smiling",
+      "glossClean": "while smiling",
       "heritage": "standard",
       "ipa": null,
       "lemma": "усміхаючись",
       "lemmaId": "усміхаючись",
       "lemmaPlain": "усміхаючись",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -13273,11 +14841,13 @@
     {
       "cefr": "B1",
       "gloss": "having found out",
+      "glossClean": "having found out",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дізнавшись",
       "lemmaId": "дізнавшись",
       "lemmaPlain": "дізнавшись",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13288,11 +14858,13 @@
     {
       "cefr": "B1",
       "gloss": "perfective adverbial participle, perfective gerund",
+      "glossClean": "perfective adverbial participle",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "дієприслівник доконаного виду",
       "lemmaId": "дієприслівник-доконаного-виду",
       "lemmaPlain": "дієприслівник доконаного виду",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13303,11 +14875,13 @@
     {
       "cefr": "B1",
       "gloss": "having inspected",
+      "glossClean": "having inspected",
       "heritage": "standard",
       "ipa": null,
       "lemma": "оглянувши",
       "lemmaId": "оглянувши",
       "lemmaPlain": "оглянувши",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13318,11 +14892,13 @@
     {
       "cefr": "B1",
       "gloss": "main action",
+      "glossClean": "main action",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "основна дія",
       "lemmaId": "основна-дія",
       "lemmaPlain": "основна дія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13333,11 +14909,13 @@
     {
       "cefr": "B1",
       "gloss": "having woken up",
+      "glossClean": "having woken up",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прокинувшись",
       "lemmaId": "прокинувшись",
       "lemmaPlain": "прокинувшись",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13348,11 +14926,13 @@
     {
       "cefr": "B1",
       "gloss": "stylistic choice",
+      "glossClean": "stylistic choice",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "стилістичний вибір",
       "lemmaId": "стилістичний-вибір",
       "lemmaPlain": "стилістичний вибір",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13363,11 +14943,13 @@
     {
       "cefr": "B1",
       "gloss": "blood test",
+      "glossClean": "blood test",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "аналіз крові",
       "lemmaId": "аналіз-крові",
       "lemmaPlain": "аналіз крові",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13378,11 +14960,13 @@
     {
       "cefr": "B1",
       "gloss": "urine test",
+      "glossClean": "urine test",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "аналіз сечі",
       "lemmaId": "аналіз-сечі",
       "lemmaPlain": "аналіз сечі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13393,11 +14977,13 @@
     {
       "cefr": "B1",
       "gloss": "diagnosis",
+      "glossClean": "diagnosis",
       "heritage": "standard",
       "ipa": null,
       "lemma": "діагноз",
       "lemmaId": "діагноз",
       "lemmaPlain": "діагноз",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13408,11 +14994,13 @@
     {
       "cefr": "B1",
       "gloss": "to receive treatment, to treat oneself",
+      "glossClean": "to receive treatment",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лікуватися",
       "lemmaId": "лікуватися",
       "lemmaPlain": "лікуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13423,11 +15011,13 @@
     {
       "cefr": "B1",
       "gloss": "medical conclusion, report",
+      "glossClean": "medical conclusion",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "медичний висновок",
       "lemmaId": "медичний-висновок",
       "lemmaPlain": "медичний висновок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13438,11 +15028,13 @@
     {
       "cefr": "B1",
       "gloss": "eye doctor",
+      "glossClean": "eye doctor",
       "heritage": "standard",
       "ipa": null,
       "lemma": "окуліст",
       "lemmaId": "окуліст",
       "lemmaPlain": "окуліст",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13453,11 +15045,13 @@
     {
       "cefr": "B1",
       "gloss": "complaint, symptom report",
+      "glossClean": "complaint",
       "heritage": "standard",
       "ipa": null,
       "lemma": "скарга",
       "lemmaId": "скарга",
       "lemmaPlain": "скарга",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13468,11 +15062,13 @@
     {
       "cefr": "B1",
       "gloss": "to complain of",
+      "glossClean": "to complain of",
       "heritage": "standard",
       "ipa": null,
       "lemma": "скаржитися",
       "lemmaId": "скаржитися",
       "lemmaPlain": "скаржитися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13483,11 +15079,13 @@
     {
       "cefr": "B1",
       "gloss": "general physician, internist",
+      "glossClean": "general physician",
       "heritage": "standard",
       "ipa": null,
       "lemma": "терапевт",
       "lemmaId": "терапевт",
       "lemmaPlain": "терапевт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13498,11 +15096,13 @@
     {
       "cefr": "B1",
       "gloss": "blood pressure",
+      "glossClean": "blood pressure",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тиск",
       "lemmaId": "тиск",
       "lemmaPlain": "тиск",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13513,11 +15113,13 @@
     {
       "cefr": "B1",
       "gloss": "ultrasound",
+      "glossClean": "ultrasound",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "УЗД",
       "lemmaId": "узд",
       "lemmaPlain": "узд",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13528,11 +15130,13 @@
     {
       "cefr": "B1",
       "gloss": "surgeon",
+      "glossClean": "surgeon",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хірург",
       "lemmaId": "хірург",
       "lemmaPlain": "хірург",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13543,11 +15147,13 @@
     {
       "cefr": "B1",
       "gloss": "colon plus dash",
+      "glossClean": "colon plus dash",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "двокрапка з тире",
       "lemmaId": "двокрапка-з-тире",
       "lemmaPlain": "двокрапка з тире",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13558,11 +15164,13 @@
     {
       "cefr": "B1",
       "gloss": "to depend on, be governed by",
+      "glossClean": "to depend on",
       "heritage": "standard",
       "ipa": null,
       "lemma": "залежати",
       "lemmaId": "залежати",
       "lemmaPlain": "залежати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13573,11 +15181,13 @@
     {
       "cefr": "B1",
       "gloss": "single conjunction",
+      "glossClean": "single conjunction",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "одиничний сполучник",
       "lemmaId": "одиничний-сполучник",
       "lemmaPlain": "одиничний сполучник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13588,11 +15198,13 @@
     {
       "cefr": "B1",
       "gloss": "enumerative intonation",
+      "glossClean": "enumerative intonation",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "перелічувальна інтонація",
       "lemmaId": "перелічувальна-інтонація",
       "lemmaPlain": "перелічувальна інтонація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13603,11 +15215,13 @@
     {
       "cefr": "B1",
       "gloss": "syntactic role",
+      "glossClean": "syntactic role",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "синтаксична роль",
       "lemmaId": "синтаксична-роль",
       "lemmaPlain": "синтаксична роль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13618,11 +15232,13 @@
     {
       "cefr": "B1",
       "gloss": "complicated simple sentence",
+      "glossClean": "complicated simple sentence",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "ускладнене речення",
       "lemmaId": "ускладнене-речення",
       "lemmaPlain": "ускладнене речення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13633,11 +15249,13 @@
     {
       "cefr": "B1",
       "gloss": "emergency maintenance service",
+      "glossClean": "emergency maintenance service",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "аварійна служба",
       "lemmaId": "аварійна-служба",
       "lemmaPlain": "аварійна служба",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13648,11 +15266,13 @@
     {
       "cefr": "B1",
       "gloss": "radiator",
+      "glossClean": "radiator",
       "heritage": "standard",
       "ipa": null,
       "lemma": "батарея",
       "lemmaId": "батарея",
       "lemmaPlain": "батарея",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13663,11 +15283,13 @@
     {
       "cefr": "B1",
       "gloss": "without intermediaries",
+      "glossClean": "without intermediaries",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "без посередників",
       "lemmaId": "без-посередників",
       "lemmaPlain": "без посередників",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13678,11 +15300,13 @@
     {
       "cefr": "B1",
       "gloss": "no pets",
+      "glossClean": "no pets",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "без тварин",
       "lemmaId": "без-тварин",
       "lemmaPlain": "без тварин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13693,11 +15317,13 @@
     {
       "cefr": "B1",
       "gloss": "near the metro",
+      "glossClean": "near the metro",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "біля метро",
       "lemmaId": "біля-метро",
       "lemmaPlain": "біля метро",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13708,11 +15334,13 @@
     {
       "cefr": "B1",
       "gloss": "move-out; departure",
+      "glossClean": "move-out",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виїзд",
       "lemmaId": "виїзд",
       "lemmaPlain": "виїзд",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13723,11 +15351,13 @@
     {
       "cefr": "B1",
       "gloss": "owner",
+      "glossClean": "owner",
       "heritage": "standard",
       "ipa": null,
       "lemma": "власник",
       "lemmaId": "власник",
       "lemmaPlain": "власник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13738,11 +15368,13 @@
     {
       "cefr": "B1",
       "gloss": "hot water",
+      "glossClean": "hot water",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "гаряча вода",
       "lemmaId": "гаряча-вода",
       "lemmaPlain": "гаряча вода",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13753,11 +15385,13 @@
     {
       "cefr": "B1",
       "gloss": "lease agreement",
+      "glossClean": "lease agreement",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "договір оренди",
       "lemmaId": "договір-оренди",
       "lemmaPlain": "договір оренди",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13768,11 +15402,13 @@
     {
       "cefr": "B1",
       "gloss": "electrician",
+      "glossClean": "electrician",
       "heritage": "standard",
       "ipa": null,
       "lemma": "електрик",
       "lemmaId": "електрик",
       "lemmaPlain": "електрик",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13783,11 +15419,13 @@
     {
       "cefr": "B1",
       "gloss": "electricity",
+      "glossClean": "electricity",
       "heritage": "standard",
       "ipa": null,
       "lemma": "електрика",
       "lemmaId": "електрика",
       "lemmaPlain": "електрика",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13798,11 +15436,13 @@
     {
       "cefr": "B1",
       "gloss": "with pets",
+      "glossClean": "with pets",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "з тваринами",
       "lemmaId": "з-тваринами",
       "lemmaPlain": "з тваринами",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13813,11 +15453,13 @@
     {
       "cefr": "B1",
       "gloss": "to move in",
+      "glossClean": "to move in",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заїхати",
       "lemmaId": "заїхати",
       "lemmaPlain": "заїхати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13828,11 +15470,13 @@
     {
       "cefr": "B1",
       "gloss": "square metre",
+      "glossClean": "square metre",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "квадратний метр",
       "lemmaId": "квадратний-метр",
       "lemmaPlain": "квадратний метр",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13843,11 +15487,13 @@
     {
       "cefr": "B1",
       "gloss": "commission; fee",
+      "glossClean": "commission",
       "heritage": "standard",
       "ipa": null,
       "lemma": "комісія",
       "lemmaId": "комісія",
       "lemmaPlain": "комісія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13858,11 +15504,13 @@
     {
       "cefr": "B1",
       "gloss": "per month; for one month",
+      "glossClean": "per month",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "на місяць",
       "lemmaId": "на-місяць",
       "lemmaPlain": "на місяць",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13873,11 +15521,13 @@
     {
       "cefr": "B1",
       "gloss": "for one year",
+      "glossClean": "for one year",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "на рік",
       "lemmaId": "на-рік",
       "lemmaPlain": "на рік",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13888,11 +15538,13 @@
     {
       "cefr": "B1",
       "gloss": "does not work",
+      "glossClean": "does not work",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "не працює",
       "lemmaId": "не-працює",
       "lemmaPlain": "не працює",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13903,11 +15555,13 @@
     {
       "cefr": "B1",
       "gloss": "heating",
+      "glossClean": "heating",
       "heritage": "standard",
       "ipa": null,
       "lemma": "опалення",
       "lemmaId": "опалення",
       "lemmaPlain": "опалення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13918,11 +15572,13 @@
     {
       "cefr": "B1",
       "gloss": "tenant",
+      "glossClean": "tenant",
       "heritage": "standard",
       "ipa": null,
       "lemma": "орендар",
       "lemmaId": "орендар",
       "lemmaPlain": "орендар",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13933,11 +15589,13 @@
     {
       "cefr": "B1",
       "gloss": "to view an apartment",
+      "glossClean": "to view an apartment",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "подивитися квартиру",
       "lemmaId": "подивитися-квартиру",
       "lemmaPlain": "подивитися квартиру",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13948,11 +15606,13 @@
     {
       "cefr": "B1",
       "gloss": "to fix; repair",
+      "glossClean": "to fix",
       "heritage": "standard",
       "ipa": null,
       "lemma": "полагодити",
       "lemmaId": "полагодити",
       "lemmaPlain": "полагодити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13963,11 +15623,13 @@
     {
       "cefr": "B1",
       "gloss": "intermediary; agent",
+      "glossClean": "intermediary",
       "heritage": "standard",
       "ipa": null,
       "lemma": "посередник",
       "lemmaId": "посередник",
       "lemmaPlain": "посередник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13978,11 +15640,13 @@
     {
       "cefr": "B1",
       "gloss": "washing machine",
+      "glossClean": "washing machine",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пральна машина",
       "lemmaId": "пральна-машина",
       "lemmaPlain": "пральна машина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -13993,11 +15657,13 @@
     {
       "cefr": "B1",
       "gloss": "private house",
+      "glossClean": "private house",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "приватний будинок",
       "lemmaId": "приватний-будинок",
       "lemmaPlain": "приватний будинок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14008,11 +15674,13 @@
     {
       "cefr": "B1",
       "gloss": "the faucet is leaking",
+      "glossClean": "the faucet is leaking",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "протікає кран",
       "lemmaId": "протікає-кран",
       "lemmaPlain": "протікає кран",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14023,11 +15691,13 @@
     {
       "cefr": "B1",
       "gloss": "the pipe is leaking",
+      "glossClean": "the pipe is leaking",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "протікає труба",
       "lemmaId": "протікає-труба",
       "lemmaPlain": "протікає труба",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14038,11 +15708,13 @@
     {
       "cefr": "B1",
       "gloss": "turnkey; ready to move in",
+      "glossClean": "turnkey",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "під ключ",
       "lemmaId": "під-ключ",
       "lemmaPlain": "під ключ",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14053,11 +15725,13 @@
     {
       "cefr": "B1",
       "gloss": "please tell me",
+      "glossClean": "please tell me",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підкажіть, будь ласка",
       "lemmaId": "підкажіть-будь-ласка",
       "lemmaPlain": "підкажіть, будь ласка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14068,11 +15742,13 @@
     {
       "cefr": "B1",
       "gloss": "electrical outlet",
+      "glossClean": "electrical outlet",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розетка",
       "lemmaId": "розетка",
       "lemmaPlain": "розетка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14083,11 +15759,13 @@
     {
       "cefr": "B1",
       "gloss": "gas service",
+      "glossClean": "gas service",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "служба газу",
       "lemmaId": "служба-газу",
       "lemmaPlain": "служба газу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14098,11 +15776,13 @@
     {
       "cefr": "B1",
       "gloss": "I would like to clarify",
+      "glossClean": "I would like to clarify",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "хочу уточнити",
       "lemmaId": "хочу-уточнити",
       "lemmaPlain": "хочу уточнити",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -14113,11 +15793,13 @@
     {
       "cefr": "B1",
       "gloss": "dear landlord",
+      "glossClean": "dear landlord",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "шановний орендодавцю",
       "lemmaId": "шановний-орендодавцю",
       "lemmaPlain": "шановний орендодавцю",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14128,11 +15810,13 @@
     {
       "cefr": "B1",
       "gloss": "Dear Mr.",
+      "glossClean": "Dear Mr.",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Шановний пане",
       "lemmaId": "шановний-пане",
       "lemmaPlain": "шановний пане",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -14143,11 +15827,13 @@
     {
       "cefr": "B1",
       "gloss": "individual heating",
+      "glossClean": "individual heating",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "індивідуальне опалення",
       "lemmaId": "індивідуальне-опалення",
       "lemmaPlain": "індивідуальне опалення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14158,11 +15844,13 @@
     {
       "cefr": "B1",
       "gloss": "let us be",
+      "glossClean": "let us be",
       "heritage": "standard",
       "ipa": null,
       "lemma": "будьмо",
       "lemmaId": "будьмо",
       "lemmaPlain": "будьмо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14173,11 +15861,13 @@
     {
       "cefr": "B1",
       "gloss": "to turn off",
+      "glossClean": "to turn off",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вимикати",
       "lemmaId": "вимикати",
       "lemmaPlain": "вимикати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14188,11 +15878,13 @@
     {
       "cefr": "B1",
       "gloss": "look, take a look",
+      "glossClean": "look",
       "heritage": "standard",
       "ipa": null,
       "lemma": "глянь",
       "lemmaId": "глянь",
       "lemmaPlain": "глянь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14203,11 +15895,13 @@
     {
       "cefr": "B1",
       "gloss": "climb",
+      "glossClean": "climb",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лізь",
       "lemmaId": "лізь",
       "lemmaPlain": "лізь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14218,11 +15912,13 @@
     {
       "cefr": "B1",
       "gloss": "do not open",
+      "glossClean": "do not open",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "не відчиняй",
       "lemmaId": "не-відчиняй",
       "lemmaPlain": "не відчиняй",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14233,11 +15929,13 @@
     {
       "cefr": "B1",
       "gloss": "do not forget",
+      "glossClean": "do not forget",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "не забувай",
       "lemmaId": "не-забувай",
       "lemmaPlain": "не забувай",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14248,11 +15946,13 @@
     {
       "cefr": "B1",
       "gloss": "director",
+      "glossClean": "director",
       "heritage": "standard",
       "ipa": null,
       "lemma": "режисер",
       "lemmaId": "режисер",
       "lemmaPlain": "режисер",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14263,11 +15963,13 @@
     {
       "cefr": "B1",
       "gloss": "hold on, stay strong",
+      "glossClean": "hold on",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тримайся",
       "lemmaId": "тримайся",
       "lemmaPlain": "тримайся",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14278,11 +15980,13 @@
     {
       "cefr": "B1",
       "gloss": "could you possibly",
+      "glossClean": "could you possibly",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "чи не могли б ви",
       "lemmaId": "чи-не-могли-б-ви",
       "lemmaPlain": "чи не могли б ви",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14293,11 +15997,13 @@
     {
       "cefr": "B1",
       "gloss": "to honor, to respect",
+      "glossClean": "to honor",
       "heritage": "standard",
       "ipa": null,
       "lemma": "шанувати",
       "lemmaId": "шанувати",
       "lemmaPlain": "шанувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14308,11 +16014,13 @@
     {
       "cefr": "B1",
       "gloss": "passive agent",
+      "glossClean": "passive agent",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "агент пасиву",
       "lemmaId": "агент-пасиву",
       "lemmaPlain": "агент пасиву",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14323,11 +16031,13 @@
     {
       "cefr": "B1",
       "gloss": "with a friend",
+      "glossClean": "with a friend",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "з другом",
       "lemmaId": "з-другом",
       "lemmaPlain": "з другом",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14338,11 +16048,13 @@
     {
       "cefr": "B1",
       "gloss": "according to",
+      "glossClean": "according to",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "згідно з",
       "lemmaId": "згідно-з",
       "lemmaPlain": "згідно з",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -14353,11 +16065,13 @@
     {
       "cefr": "B1",
       "gloss": "with me",
+      "glossClean": "with me",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "зі мною",
       "lemmaId": "зі-мною",
       "lemmaPlain": "зі мною",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14368,11 +16082,13 @@
     {
       "cefr": "B1",
       "gloss": "compared with",
+      "glossClean": "compared with",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "порівняно з",
       "lemmaId": "порівняно-з",
       "lemmaPlain": "порівняно з",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -14383,11 +16099,13 @@
     {
       "cefr": "B1",
       "gloss": "professional role",
+      "glossClean": "professional role",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "професійна роль",
       "lemmaId": "професійна-роль",
       "lemmaPlain": "професійна роль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14398,11 +16116,13 @@
     {
       "cefr": "B1",
       "gloss": "path, trail",
+      "glossClean": "path",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стежка",
       "lemmaId": "стежка",
       "lemmaPlain": "стежка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -14442,11 +16162,13 @@
     {
       "cefr": "B1",
       "gloss": "in connection with, due to",
+      "glossClean": "in connection with",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у зв'язку з",
       "lemmaId": "у-зв-язку-з",
       "lemmaPlain": "у зв'язку з",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -14457,11 +16179,13 @@
     {
       "cefr": "B1",
       "gloss": "specialist",
+      "glossClean": "specialist",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фахівець",
       "lemmaId": "фахівець",
       "lemmaPlain": "фахівець",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14472,11 +16196,13 @@
     {
       "cefr": "B1",
       "gloss": "with a sister",
+      "glossClean": "with a sister",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "із сестрою",
       "lemmaId": "із-сестрою",
       "lemmaPlain": "із сестрою",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14487,11 +16213,13 @@
     {
       "cefr": "B1",
       "gloss": "parenthetical construction",
+      "glossClean": "parenthetical construction",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "вставна конструкція",
       "lemmaId": "вставна-конструкція",
       "lemmaPlain": "вставна конструкція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14502,11 +16230,13 @@
     {
       "cefr": "B1",
       "gloss": "by the way",
+      "glossClean": "by the way",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "до речі",
       "lemmaId": "до-речі",
       "lemmaPlain": "до речі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14517,11 +16247,13 @@
     {
       "cefr": "B1",
       "gloss": "according to data",
+      "glossClean": "according to data",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "за даними",
       "lemmaId": "за-даними",
       "lemmaPlain": "за даними",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14532,11 +16264,13 @@
     {
       "cefr": "B1",
       "gloss": "after all, finally",
+      "glossClean": "after all",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зрештою",
       "lemmaId": "зрештою",
       "lemmaPlain": "зрештою",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14547,11 +16281,13 @@
     {
       "cefr": "B1",
       "gloss": "surprisingly",
+      "glossClean": "surprisingly",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "на диво",
       "lemmaId": "на-диво",
       "lemmaPlain": "на диво",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14562,11 +16298,13 @@
     {
       "cefr": "B1",
       "gloss": "in the opinion of",
+      "glossClean": "in the opinion of",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "на думку",
       "lemmaId": "на-думку",
       "lemmaPlain": "на думку",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14577,11 +16315,13 @@
     {
       "cefr": "B1",
       "gloss": "fortunately",
+      "glossClean": "fortunately",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "на щастя",
       "lemmaId": "на-щастя",
       "lemmaPlain": "на щастя",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14592,11 +16332,13 @@
     {
       "cefr": "B1",
       "gloss": "imagine",
+      "glossClean": "imagine",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "уяви собі",
       "lemmaId": "уяви-собі",
       "lemmaPlain": "уяви собі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14607,11 +16349,13 @@
     {
       "cefr": "B1",
       "gloss": "exhibition display",
+      "glossClean": "exhibition display",
       "heritage": "standard",
       "ipa": null,
       "lemma": "експозиція",
       "lemmaId": "експозиція",
       "lemmaPlain": "експозиція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14622,11 +16366,13 @@
     {
       "cefr": "B1",
       "gloss": "painting as an art form",
+      "glossClean": "painting as an art form",
       "heritage": "standard",
       "ipa": null,
       "lemma": "живопис",
       "lemmaId": "живопис",
       "lemmaPlain": "живопис",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -14637,11 +16383,13 @@
     {
       "cefr": "B1",
       "gloss": "custom",
+      "glossClean": "custom",
       "heritage": "standard",
       "ipa": null,
       "lemma": "звичай",
       "lemmaId": "звичай",
       "lemmaPlain": "звичай",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14652,11 +16400,13 @@
     {
       "cefr": "B1",
       "gloss": "in my opinion",
+      "glossClean": "in my opinion",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "на мою думку",
       "lemmaId": "на-мою-думку",
       "lemmaPlain": "на мою думку",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14667,11 +16417,13 @@
     {
       "cefr": "B1",
       "gloss": "ritual",
+      "glossClean": "ritual",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обряд",
       "lemmaId": "обряд",
       "lemmaPlain": "обряд",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14682,11 +16434,13 @@
     {
       "cefr": "B1",
       "gloss": "regional cuisine",
+      "glossClean": "regional cuisine",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "регіональна кухня",
       "lemmaId": "регіональна-кухня",
       "lemmaPlain": "регіональна кухня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14697,11 +16451,13 @@
     {
       "cefr": "B1",
       "gloss": "dried fruit drink",
+      "glossClean": "dried fruit drink",
       "heritage": "standard",
       "ipa": null,
       "lemma": "узвар",
       "lemmaId": "узвар",
       "lemmaPlain": "узвар",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14712,11 +16468,13 @@
     {
       "cefr": "B1",
       "gloss": "chef",
+      "glossClean": "chef",
       "heritage": "standard",
       "ipa": null,
       "lemma": "шеф-кухар",
       "lemmaId": "шеф-кухар",
       "lemmaPlain": "шеф-кухар",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14727,11 +16485,13 @@
     {
       "cefr": "B1",
       "gloss": "Ivan Kupala holiday",
+      "glossClean": "Ivan Kupala holiday",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Івана Купала",
       "lemmaId": "івана-купала",
       "lemmaPlain": "івана купала",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14742,11 +16502,13 @@
     {
       "cefr": "B1",
       "gloss": "both ways, there and back",
+      "glossClean": "both ways",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "в обидва боки",
       "lemmaId": "в-обидва-боки",
       "lemmaPlain": "в обидва боки",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14757,11 +16519,13 @@
     {
       "cefr": "B1",
       "gloss": "to transport by vehicle in one direction",
+      "glossClean": "to transport by vehicle in one direction",
       "heritage": "standard",
       "ipa": null,
       "lemma": "везти",
       "lemmaId": "везти",
       "lemmaPlain": "везти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -14772,11 +16536,13 @@
     {
       "cefr": "B1",
       "gloss": "to lead someone or something in one direction",
+      "glossClean": "to lead someone or something in one direction",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вести",
       "lemmaId": "вести",
       "lemmaPlain": "вести",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -14787,11 +16553,13 @@
     {
       "cefr": "B1",
       "gloss": "to transport habitually, back and forth, or around",
+      "glossClean": "to transport habitually",
       "heritage": "standard",
       "ipa": null,
       "lemma": "возити",
       "lemmaId": "возити",
       "lemmaPlain": "возити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14802,11 +16570,13 @@
     {
       "cefr": "B1",
       "gloss": "habitual action",
+      "glossClean": "habitual action",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "звична дія",
       "lemmaId": "звична-дія",
       "lemmaPlain": "звична дія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14817,11 +16587,13 @@
     {
       "cefr": "B1",
       "gloss": "back and forth",
+      "glossClean": "back and forth",
       "heritage": "standard",
       "ipa": null,
       "lemma": "туди-сюди",
       "lemmaId": "туди-сюди",
       "lemmaPlain": "туди-сюди",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14832,11 +16604,13 @@
     {
       "cefr": "B1",
       "gloss": "to fly out, depart from an airport; perfective",
+      "glossClean": "to fly out",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вилетіти",
       "lemmaId": "вилетіти",
       "lemmaPlain": "вилетіти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14847,11 +16621,13 @@
     {
       "cefr": "B1",
       "gloss": "departure by air",
+      "glossClean": "departure by air",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виліт",
       "lemmaId": "виліт",
       "lemmaPlain": "виліт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14862,11 +16638,13 @@
     {
       "cefr": "B1",
       "gloss": "lighthouse",
+      "glossClean": "lighthouse",
       "heritage": "standard",
       "ipa": null,
       "lemma": "маяк",
       "lemmaId": "маяк",
       "lemmaPlain": "маяк",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14877,11 +16655,13 @@
     {
       "cefr": "B1",
       "gloss": "to fly across; perfective",
+      "glossClean": "to fly across",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перелетіти",
       "lemmaId": "перелетіти",
       "lemmaPlain": "перелетіти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14892,11 +16672,13 @@
     {
       "cefr": "B1",
       "gloss": "they are swimming or sailing",
+      "glossClean": "they are swimming or sailing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пливуть",
       "lemmaId": "пливуть",
       "lemmaPlain": "пливуть",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -14907,11 +16689,13 @@
     {
       "cefr": "B1",
       "gloss": "port, harbor",
+      "glossClean": "port",
       "heritage": "standard",
       "ipa": null,
       "lemma": "порт",
       "lemmaId": "порт",
       "lemmaPlain": "порт",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -14922,11 +16706,13 @@
     {
       "cefr": "B1",
       "gloss": "boarding a flight",
+      "glossClean": "boarding a flight",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "посадка на рейс",
       "lemmaId": "посадка-на-рейс",
       "lemmaPlain": "посадка на рейс",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14937,11 +16723,13 @@
     {
       "cefr": "B1",
       "gloss": "boarding pass",
+      "glossClean": "boarding pass",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "посадковий талон",
       "lemmaId": "посадковий-талон",
       "lemmaPlain": "посадковий талон",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14952,11 +16740,13 @@
     {
       "cefr": "B1",
       "gloss": "to arrive by air; perfective",
+      "glossClean": "to arrive by air",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прилетіти",
       "lemmaId": "прилетіти",
       "lemmaPlain": "прилетіти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14967,11 +16757,13 @@
     {
       "cefr": "B1",
       "gloss": "arrival by air",
+      "glossClean": "arrival by air",
       "heritage": "standard",
       "ipa": null,
       "lemma": "приліт",
       "lemmaId": "приліт",
       "lemmaPlain": "приліт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -14982,11 +16774,13 @@
     {
       "cefr": "B1",
       "gloss": "to arrive by air habitually or in process",
+      "glossClean": "to arrive by air habitually or in process",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прилітати",
       "lemmaId": "прилітати",
       "lemmaPlain": "прилітати",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -14997,11 +16791,13 @@
     {
       "cefr": "B1",
       "gloss": "landing stage, small pier",
+      "glossClean": "landing stage",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пристань",
       "lemmaId": "пристань",
       "lemmaPlain": "пристань",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15012,11 +16808,13 @@
     {
       "cefr": "B1",
       "gloss": "summit, peak",
+      "glossClean": "summit",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вершина",
       "lemmaId": "вершина",
       "lemmaPlain": "вершина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15027,11 +16825,13 @@
     {
       "cefr": "B1",
       "gloss": "on time",
+      "glossClean": "on time",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вчасно",
       "lemmaId": "вчасно",
       "lemmaPlain": "вчасно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15042,11 +16842,13 @@
     {
       "cefr": "B1",
       "gloss": "to be reaching or regularly get to by transport; common imperfective",
+      "glossClean": "to be reaching or regularly get to by transport",
       "heritage": "standard",
       "ipa": null,
       "lemma": "доїжджати",
       "lemmaId": "доїжджати",
       "lemmaPlain": "доїжджати",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -15057,11 +16859,13 @@
     {
       "cefr": "B1",
       "gloss": "to reach on foot, walk all the way to; perfective",
+      "glossClean": "to reach on foot",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дійти",
       "lemmaId": "дійти",
       "lemmaPlain": "дійти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15072,11 +16876,13 @@
     {
       "cefr": "B1",
       "gloss": "according to schedule",
+      "glossClean": "according to schedule",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "за розкладом",
       "lemmaId": "за-розкладом",
       "lemmaPlain": "за розкладом",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15087,11 +16893,13 @@
     {
       "cefr": "B1",
       "gloss": "courier",
+      "glossClean": "courier",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кур'єр",
       "lemmaId": "кур-єр",
       "lemmaPlain": "кур'єр",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15102,11 +16910,13 @@
     {
       "cefr": "B1",
       "gloss": "endpoint, final point",
+      "glossClean": "endpoint",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "кінцева точка",
       "lemmaId": "кінцева-точка",
       "lemmaPlain": "кінцева точка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15117,11 +16927,13 @@
     {
       "cefr": "B1",
       "gloss": "to come running habitually; imperfective",
+      "glossClean": "to come running habitually",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прибігати",
       "lemmaId": "прибігати",
       "lemmaPlain": "прибігати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15132,11 +16944,13 @@
     {
       "cefr": "B1",
       "gloss": "to come running, run up; perfective",
+      "glossClean": "to come running",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прибігти",
       "lemmaId": "прибігти",
       "lemmaPlain": "прибігти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15147,11 +16961,13 @@
     {
       "cefr": "B1",
       "gloss": "to bring or deliver by vehicle; perfective",
+      "glossClean": "to bring or deliver by vehicle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "привезти",
       "lemmaId": "привезти",
       "lemmaPlain": "привезти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -15162,11 +16978,13 @@
     {
       "cefr": "B1",
       "gloss": "to bring or lead someone; perfective",
+      "glossClean": "to bring or lead someone",
       "heritage": "standard",
       "ipa": null,
       "lemma": "привести",
       "lemmaId": "привести",
       "lemmaPlain": "привести",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -15177,11 +16995,13 @@
     {
       "cefr": "B1",
       "gloss": "to bring by vehicle habitually; imperfective",
+      "glossClean": "to bring by vehicle habitually",
       "heritage": "standard",
       "ipa": null,
       "lemma": "привозити",
       "lemmaId": "привозити",
       "lemmaPlain": "привозити",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -15192,11 +17012,13 @@
     {
       "cefr": "B1",
       "gloss": "to bring habitually or repeatedly; imperfective",
+      "glossClean": "to bring habitually or repeatedly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "приносити",
       "lemmaId": "приносити",
       "lemmaPlain": "приносити",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -15207,11 +17029,13 @@
     {
       "cefr": "B1",
       "gloss": "destination",
+      "glossClean": "destination",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пункт призначення",
       "lemmaId": "пункт-призначення",
       "lemmaPlain": "пункт призначення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15222,11 +17046,13 @@
     {
       "cefr": "B1",
       "gloss": "to leave by vehicle, set out; imperfective",
+      "glossClean": "to leave by vehicle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виїжджати",
       "lemmaId": "виїжджати",
       "lemmaPlain": "виїжджати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15237,11 +17063,13 @@
     {
       "cefr": "B1",
       "gloss": "departure",
+      "glossClean": "departure",
       "heritage": "standard",
       "ipa": null,
       "lemma": "від'їзд",
       "lemmaId": "від-їзд",
       "lemmaPlain": "від'їзд",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15252,11 +17080,13 @@
     {
       "cefr": "B1",
       "gloss": "to depart, be scheduled to depart; native Ukrainian for transport",
+      "glossClean": "to depart",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відбувати",
       "lemmaId": "відбувати",
       "lemmaPlain": "відбувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15267,11 +17097,13 @@
     {
       "cefr": "B1",
       "gloss": "to transport away, drive someone or something away; perfective",
+      "glossClean": "to transport away",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відвезти",
       "lemmaId": "відвезти",
       "lemmaPlain": "відвезти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15282,11 +17114,13 @@
     {
       "cefr": "B1",
       "gloss": "to lead someone away; perfective",
+      "glossClean": "to lead someone away",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відвести",
       "lemmaId": "відвести",
       "lemmaPlain": "відвести",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15297,11 +17131,13 @@
     {
       "cefr": "B1",
       "gloss": "to carry away, take something away by hand; perfective",
+      "glossClean": "to carry away",
       "heritage": "standard",
       "ipa": null,
       "lemma": "віднести",
       "lemmaId": "віднести",
       "lemmaPlain": "віднести",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15312,11 +17148,13 @@
     {
       "cefr": "B1",
       "gloss": "to depart, move away habitually or by schedule; imperfective",
+      "glossClean": "to depart",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відходити",
       "lemmaId": "відходити",
       "lemmaPlain": "відходити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15327,11 +17165,13 @@
     {
       "cefr": "B1",
       "gloss": "to step away, move away on foot; perfective",
+      "glossClean": "to step away",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відійти",
       "lemmaId": "відійти",
       "lemmaPlain": "відійти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15342,11 +17182,13 @@
     {
       "cefr": "B1",
       "gloss": "left-luggage office, storage locker",
+      "glossClean": "left-luggage office",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "камера схову",
       "lemmaId": "камера-схову",
       "lemmaPlain": "камера схову",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15357,11 +17199,13 @@
     {
       "cefr": "B1",
       "gloss": "edge of the platform",
+      "glossClean": "edge of the platform",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "край платформи",
       "lemmaId": "край-платформи",
       "lemmaPlain": "край платформи",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15372,11 +17216,13 @@
     {
       "cefr": "B1",
       "gloss": "train platform",
+      "glossClean": "train platform",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перон",
       "lemmaId": "перон",
       "lemmaPlain": "перон",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15387,11 +17233,13 @@
     {
       "cefr": "B1",
       "gloss": "to start transporting, take by vehicle; perfective",
+      "glossClean": "to start transporting",
       "heritage": "standard",
       "ipa": null,
       "lemma": "повезти",
       "lemmaId": "повезти",
       "lemmaPlain": "повезти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15402,11 +17250,13 @@
     {
       "cefr": "B1",
       "gloss": "to lead or take someone; perfective",
+      "glossClean": "to lead or take someone",
       "heritage": "standard",
       "ipa": null,
       "lemma": "повести",
       "lemmaId": "повести",
       "lemmaPlain": "повести",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -15417,11 +17267,13 @@
     {
       "cefr": "B1",
       "gloss": "to see someone off",
+      "glossClean": "to see someone off",
       "heritage": "standard",
       "ipa": null,
       "lemma": "проводжати",
       "lemmaId": "проводжати",
       "lemmaPlain": "проводжати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15432,11 +17284,13 @@
     {
       "cefr": "B1",
       "gloss": "seeing-off, farewell at departure",
+      "glossClean": "seeing-off",
       "heritage": "standard",
       "ipa": null,
       "lemma": "проводи",
       "lemmaId": "проводи",
       "lemmaPlain": "проводи",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15447,11 +17301,13 @@
     {
       "cefr": "B1",
       "gloss": "side entrance",
+      "glossClean": "side entrance",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "бічний вхід",
       "lemmaId": "бічний-вхід",
       "lemmaPlain": "бічний вхід",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15462,11 +17318,13 @@
     {
       "cefr": "B1",
       "gloss": "I will exit, I will go out",
+      "glossClean": "I will exit",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вийду",
       "lemmaId": "вийду",
       "lemmaPlain": "вийду",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15477,11 +17335,13 @@
     {
       "cefr": "B1",
       "gloss": "to drive out, leave by vehicle; perfective",
+      "glossClean": "to drive out",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виїхати",
       "lemmaId": "виїхати",
       "lemmaPlain": "виїхати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15492,11 +17352,13 @@
     {
       "cefr": "B1",
       "gloss": "to run in, pop in briefly; perfective",
+      "glossClean": "to run in",
       "heritage": "standard",
       "ipa": null,
       "lemma": "забігти",
       "lemmaId": "забігти",
       "lemmaPlain": "забігти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15507,11 +17369,13 @@
     {
       "cefr": "B1",
       "gloss": "to deliver or transport in; perfective",
+      "glossClean": "to deliver or transport in",
       "heritage": "standard",
       "ipa": null,
       "lemma": "завезти",
       "lemmaId": "завезти",
       "lemmaPlain": "завезти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -15522,11 +17386,13 @@
     {
       "cefr": "B1",
       "gloss": "I will enter, I will drop by",
+      "glossClean": "I will enter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зайду",
       "lemmaId": "зайду",
       "lemmaPlain": "зайду",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15537,11 +17403,13 @@
     {
       "cefr": "B1",
       "gloss": "to carry in; perfective",
+      "glossClean": "to carry in",
       "heritage": "standard",
       "ipa": null,
       "lemma": "занести",
       "lemmaId": "занести",
       "lemmaPlain": "занести",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15552,11 +17420,13 @@
     {
       "cefr": "B1",
       "gloss": "to transport across; perfective",
+      "glossClean": "to transport across",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перевезти",
       "lemmaId": "перевезти",
       "lemmaPlain": "перевезти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15567,11 +17437,13 @@
     {
       "cefr": "B1",
       "gloss": "past, by; takes accusative",
+      "glossClean": "past",
       "heritage": "standard",
       "ipa": null,
       "lemma": "повз",
       "lemmaId": "повз",
       "lemmaPlain": "повз",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -15582,11 +17454,13 @@
     {
       "cefr": "B1",
       "gloss": "to pass, walk past, go through; perfective",
+      "glossClean": "to pass",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пройти",
       "lemmaId": "пройти",
       "lemmaPlain": "пройти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15597,11 +17471,13 @@
     {
       "cefr": "B1",
       "gloss": "to pass, go through habitually or in process",
+      "glossClean": "to pass",
       "heritage": "standard",
       "ipa": null,
       "lemma": "проходити",
       "lemmaId": "проходити",
       "lemmaPlain": "проходити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15612,11 +17488,13 @@
     {
       "cefr": "B1",
       "gloss": "to drive past, drive through, miss a stop; perfective",
+      "glossClean": "to drive past",
       "heritage": "standard",
       "ipa": null,
       "lemma": "проїхати",
       "lemmaId": "проїхати",
       "lemmaPlain": "проїхати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15627,11 +17505,13 @@
     {
       "cefr": "B1",
       "gloss": "pedestrian crossing",
+      "glossClean": "pedestrian crossing",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пішохідний перехід",
       "lemmaId": "пішохідний-перехід",
       "lemmaPlain": "пішохідний перехід",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15642,11 +17522,13 @@
     {
       "cefr": "B1",
       "gloss": "unexpectedly",
+      "glossClean": "unexpectedly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "несподівано",
       "lemmaId": "несподівано",
       "lemmaPlain": "несподівано",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15657,11 +17539,13 @@
     {
       "cefr": "B1",
       "gloss": "to go around",
+      "glossClean": "to go around",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обійти",
       "lemmaId": "обійти",
       "lemmaPlain": "обійти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15672,11 +17556,13 @@
     {
       "cefr": "B1",
       "gloss": "resolution",
+      "glossClean": "resolution",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розв'язка",
       "lemmaId": "розв-язка",
       "lemmaPlain": "розв'язка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -15716,11 +17602,13 @@
     {
       "cefr": "B1",
       "gloss": "Indian summer, warm autumn spell",
+      "glossClean": "Indian summer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бабине літо",
       "lemmaId": "бабине-літо",
       "lemmaPlain": "бабине літо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15731,11 +17619,13 @@
     {
       "cefr": "B1",
       "gloss": "extinction",
+      "glossClean": "extinction",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вимирання",
       "lemmaId": "вимирання",
       "lemmaPlain": "вимирання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15746,11 +17636,13 @@
     {
       "cefr": "B1",
       "gloss": "harvest season",
+      "glossClean": "harvest season",
       "heritage": "standard",
       "ipa": null,
       "lemma": "жнива",
       "lemmaId": "жнива",
       "lemmaPlain": "жнива",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15761,11 +17653,13 @@
     {
       "cefr": "B1",
       "gloss": "nature reserve",
+      "glossClean": "nature reserve",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заповідник",
       "lemmaId": "заповідник",
       "lemmaPlain": "заповідник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15776,11 +17670,13 @@
     {
       "cefr": "B1",
       "gloss": "viburnum, guelder rose",
+      "glossClean": "viburnum",
       "heritage": "standard",
       "ipa": null,
       "lemma": "калина",
       "lemmaId": "калина",
       "lemmaPlain": "калина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -15820,11 +17716,13 @@
     {
       "cefr": "B1",
       "gloss": "landscape, scenic view",
+      "glossClean": "landscape",
       "heritage": "standard",
       "ipa": null,
       "lemma": "краєвид",
       "lemmaId": "краєвид",
       "lemmaPlain": "краєвид",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15835,11 +17733,13 @@
     {
       "cefr": "B1",
       "gloss": "stork",
+      "glossClean": "stork",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лелека",
       "lemmaId": "лелека",
       "lemmaPlain": "лелека",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15850,11 +17750,13 @@
     {
       "cefr": "B1",
       "gloss": "ice on roads, glaze ice",
+      "glossClean": "ice on roads",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ожеледиця",
       "lemmaId": "ожеледиця",
       "lemmaPlain": "ожеледиця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -15894,11 +17796,13 @@
     {
       "cefr": "B1",
       "gloss": "recycling",
+      "glossClean": "recycling",
       "heritage": "standard",
       "ipa": null,
       "lemma": "переробка",
       "lemmaId": "переробка",
       "lemmaPlain": "переробка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -15938,11 +17842,13 @@
     {
       "cefr": "B1",
       "gloss": "pride",
+      "glossClean": "pride",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гордість",
       "lemmaId": "гордість",
       "lemmaPlain": "гордість",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15953,11 +17859,13 @@
     {
       "cefr": "B1",
       "gloss": "consonant cluster",
+      "glossClean": "consonant cluster",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "збіг приголосних",
       "lemmaId": "збіг-приголосних",
       "lemmaPlain": "збіг приголосних",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15968,11 +17876,13 @@
     {
       "cefr": "B1",
       "gloss": "youth",
+      "glossClean": "youth",
       "heritage": "standard",
       "ipa": null,
       "lemma": "молодь",
       "lemmaId": "молодь",
       "lemmaPlain": "молодь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15983,11 +17893,13 @@
     {
       "cefr": "B1",
       "gloss": "parallel forms",
+      "glossClean": "parallel forms",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "паралельні форми",
       "lemmaId": "паралельні-форми",
       "lemmaPlain": "паралельні форми",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15998,11 +17910,13 @@
     {
       "cefr": "B1",
       "gloss": "shadow",
+      "glossClean": "shadow",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тінь",
       "lemmaId": "тінь",
       "lemmaPlain": "тінь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16013,11 +17927,13 @@
     {
       "cefr": "B1",
       "gloss": "hissing consonant",
+      "glossClean": "hissing consonant",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "шиплячий приголосний",
       "lemmaId": "шиплячий-приголосний",
       "lemmaPlain": "шиплячий приголосний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16028,11 +17944,13 @@
     {
       "cefr": "B1",
       "gloss": "generosity",
+      "glossClean": "generosity",
       "heritage": "standard",
       "ipa": null,
       "lemma": "щедрість",
       "lemmaId": "щедрість",
       "lemmaPlain": "щедрість",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16043,11 +17961,13 @@
     {
       "cefr": "B1",
       "gloss": "presenter, speaker",
+      "glossClean": "presenter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "доповідач",
       "lemmaId": "доповідач",
       "lemmaPlain": "доповідач",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16058,11 +17978,13 @@
     {
       "cefr": "B1",
       "gloss": "massage",
+      "glossClean": "massage",
       "heritage": "standard",
       "ipa": null,
       "lemma": "масаж",
       "lemmaId": "масаж",
       "lemmaPlain": "масаж",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16073,11 +17995,13 @@
     {
       "cefr": "B1",
       "gloss": "editing, installation",
+      "glossClean": "editing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "монтаж",
       "lemmaId": "монтаж",
       "lemmaPlain": "монтаж",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16088,11 +18012,13 @@
     {
       "cefr": "B1",
       "gloss": "parallel endings",
+      "glossClean": "parallel endings",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "паралельні закінчення",
       "lemmaId": "паралельні-закінчення",
       "lemmaPlain": "паралельні закінчення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16103,11 +18029,13 @@
     {
       "cefr": "B1",
       "gloss": "landscape",
+      "glossClean": "landscape",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пейзаж",
       "lemmaId": "пейзаж",
       "lemmaPlain": "пейзаж",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16118,11 +18046,13 @@
     {
       "cefr": "B1",
       "gloss": "reader",
+      "glossClean": "reader",
       "heritage": "standard",
       "ipa": null,
       "lemma": "читач",
       "lemmaId": "читач",
       "lemmaPlain": "читач",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16133,11 +18063,13 @@
     {
       "cefr": "B1",
       "gloss": "civic, public",
+      "glossClean": "civic",
       "heritage": "standard",
       "ipa": null,
       "lemma": "громадський",
       "lemmaId": "громадський",
       "lemmaPlain": "громадський",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16148,11 +18080,13 @@
     {
       "cefr": "B1",
       "gloss": "to be preserved",
+      "glossClean": "to be preserved",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зберігатися",
       "lemmaId": "зберігатися",
       "lemmaPlain": "зберігатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16163,11 +18097,13 @@
     {
       "cefr": "B1",
       "gloss": "cultural context",
+      "glossClean": "cultural context",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "культурний контекст",
       "lemmaId": "культурний-контекст",
       "lemmaPlain": "культурний контекст",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16178,11 +18114,13 @@
     {
       "cefr": "B1",
       "gloss": "craft",
+      "glossClean": "craft",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ремесло",
       "lemmaId": "ремесло",
       "lemmaPlain": "ремесло",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16193,11 +18131,13 @@
     {
       "cefr": "B1",
       "gloss": "mechanic, fitter",
+      "glossClean": "mechanic",
       "heritage": "standard",
       "ipa": null,
       "lemma": "слюсар",
       "lemmaId": "слюсар",
       "lemmaPlain": "слюсар",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16208,11 +18148,13 @@
     {
       "cefr": "B1",
       "gloss": "detached attribute",
+      "glossClean": "detached attribute",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "відокремлене означення",
       "lemmaId": "відокремлене-означення",
       "lemmaPlain": "відокремлене означення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16223,11 +18165,13 @@
     {
       "cefr": "B1",
       "gloss": "literary style",
+      "glossClean": "literary style",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "літературний стиль",
       "lemmaId": "літературний-стиль",
       "lemmaPlain": "літературний стиль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16238,11 +18182,13 @@
     {
       "cefr": "B1",
       "gloss": "overuse",
+      "glossClean": "overuse",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "надмірне вживання",
       "lemmaId": "надмірне-вживання",
       "lemmaPlain": "надмірне вживання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16253,11 +18199,13 @@
     {
       "cefr": "B1",
       "gloss": "adverbial shade",
+      "glossClean": "adverbial shade",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "обставинний відтінок",
       "lemmaId": "обставинний-відтінок",
       "lemmaPlain": "обставинний відтінок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16268,11 +18216,13 @@
     {
       "cefr": "B1",
       "gloss": "formal text",
+      "glossClean": "formal text",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "офіційний текст",
       "lemmaId": "офіційний-текст",
       "lemmaPlain": "офіційний текст",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16283,11 +18233,13 @@
     {
       "cefr": "B1",
       "gloss": "expanded attribute",
+      "glossClean": "expanded attribute",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "поширене означення",
       "lemmaId": "поширене-означення",
       "lemmaPlain": "поширене означення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16298,11 +18250,13 @@
     {
       "cefr": "B1",
       "gloss": "to place commas",
+      "glossClean": "to place commas",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "розставляти коми",
       "lemmaId": "розставляти-коми",
       "lemmaPlain": "розставляти коми",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16313,11 +18267,13 @@
     {
       "cefr": "B1",
       "gloss": "vagus nerve",
+      "glossClean": "vagus nerve",
       "heritage": "standard",
       "ipa": null,
       "lemma": "блукаючий нерв",
       "lemmaId": "блукаючий-нерв",
       "lemmaPlain": "блукаючий нерв",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16328,11 +18284,13 @@
     {
       "cefr": "B1",
       "gloss": "chair of a meeting",
+      "glossClean": "chair of a meeting",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "голова зборів",
       "lemmaId": "голова-зборів",
       "lemmaPlain": "голова зборів",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16343,11 +18301,13 @@
     {
       "cefr": "B1",
       "gloss": "bedridden patient",
+      "glossClean": "bedridden patient",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "лежачий хворий",
       "lemmaId": "лежачий-хворий",
       "lemmaPlain": "лежачий хворий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16358,11 +18318,13 @@
     {
       "cefr": "B1",
       "gloss": "available, existing",
+      "glossClean": "available",
       "heritage": "standard",
       "ipa": null,
       "lemma": "наявний",
       "lemmaId": "наявний",
       "lemmaPlain": "наявний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16373,11 +18335,13 @@
     {
       "cefr": "B1",
       "gloss": "load-bearing structure",
+      "glossClean": "load-bearing structure",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "несуча конструкція",
       "lemmaId": "несуча-конструкція",
       "lemmaPlain": "несуча конструкція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16388,11 +18352,13 @@
     {
       "cefr": "B1",
       "gloss": "attribute based on an action",
+      "glossClean": "attribute based on an action",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "ознака за дією",
       "lemmaId": "ознака-за-дією",
       "lemmaPlain": "ознака за дією",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -16403,11 +18369,13 @@
     {
       "cefr": "B1",
       "gloss": "descriptive phrase",
+      "glossClean": "descriptive phrase",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "описовий зворот",
       "lemmaId": "описовий-зворот",
       "lemmaPlain": "описовий зворот",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16418,11 +18386,13 @@
     {
       "cefr": "B1",
       "gloss": "fertile soil",
+      "glossClean": "fertile soil",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "родючий ґрунт",
       "lemmaId": "родючий-ґрунт",
       "lemmaPlain": "родючий ґрунт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16433,11 +18403,13 @@
     {
       "cefr": "B1",
       "gloss": "performer of an action",
+      "glossClean": "performer of an action",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "виконавець дії",
       "lemmaId": "виконавець-дії",
       "lemmaPlain": "виконавець дії",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16448,11 +18420,13 @@
     {
       "cefr": "B1",
       "gloss": "action performed on an object",
+      "glossClean": "action performed on an object",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "дія над предметом",
       "lemmaId": "дія-над-предметом",
       "lemmaPlain": "дія над предметом",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -16463,11 +18437,13 @@
     {
       "cefr": "B1",
       "gloss": "boiled, cooked",
+      "glossClean": "boiled",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зварений",
       "lemmaId": "зварений",
       "lemmaPlain": "зварений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16478,11 +18454,13 @@
     {
       "cefr": "B1",
       "gloss": "made, done",
+      "glossClean": "made",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зроблений",
       "lemmaId": "зроблений",
       "lemmaPlain": "зроблений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16493,11 +18471,13 @@
     {
       "cefr": "B1",
       "gloss": "written",
+      "glossClean": "written",
       "heritage": "standard",
       "ipa": null,
       "lemma": "написаний",
       "lemmaId": "написаний",
       "lemmaPlain": "написаний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16508,11 +18488,13 @@
     {
       "cefr": "B1",
       "gloss": "instrumental of the performer",
+      "glossClean": "instrumental of the performer",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "орудний виконавця",
       "lemmaId": "орудний-виконавця",
       "lemmaPlain": "орудний виконавця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16523,11 +18505,13 @@
     {
       "cefr": "B1",
       "gloss": "painted",
+      "glossClean": "painted",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пофарбований",
       "lemmaId": "пофарбований",
       "lemmaPlain": "пофарбований",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16538,11 +18522,13 @@
     {
       "cefr": "B1",
       "gloss": "read",
+      "glossClean": "read",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прочитаний",
       "lemmaId": "прочитаний",
       "lemmaPlain": "прочитаний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16553,11 +18539,13 @@
     {
       "cefr": "B1",
       "gloss": "impersonal passive form in -no/-to",
+      "glossClean": "impersonal passive form in -no/-to",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "форма на -но/-то",
       "lemmaId": "форма-на-но-то",
       "lemmaPlain": "форма на -но/-то",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -16568,11 +18556,13 @@
     {
       "cefr": "B1",
       "gloss": "active construction",
+      "glossClean": "active construction",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "активна конструкція",
       "lemmaId": "активна-конструкція",
       "lemmaPlain": "активна конструкція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16583,11 +18573,13 @@
     {
       "cefr": "B1",
       "gloss": "impersonal form",
+      "glossClean": "impersonal form",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "безособова форма",
       "lemmaId": "безособова-форма",
       "lemmaPlain": "безособова форма",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16598,11 +18590,13 @@
     {
       "cefr": "B1",
       "gloss": "to publish; to issue",
+      "glossClean": "to publish",
       "heritage": "standard",
       "ipa": null,
       "lemma": "видавати",
       "lemmaId": "видавати",
       "lemmaPlain": "видавати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16613,11 +18607,13 @@
     {
       "cefr": "B1",
       "gloss": "agent; performer",
+      "glossClean": "agent",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виконавець",
       "lemmaId": "виконавець",
       "lemmaPlain": "виконавець",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16628,11 +18624,13 @@
     {
       "cefr": "B1",
       "gloss": "to be carried out",
+      "glossClean": "to be carried out",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виконуватися",
       "lemmaId": "виконуватися",
       "lemmaPlain": "виконуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16643,11 +18641,13 @@
     {
       "cefr": "B1",
       "gloss": "to be used",
+      "glossClean": "to be used",
       "heritage": "standard",
       "ipa": null,
       "lemma": "використовуватися",
       "lemmaId": "використовуватися",
       "lemmaPlain": "використовуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16658,11 +18658,13 @@
     {
       "cefr": "B1",
       "gloss": "has been repaired; renovated",
+      "glossClean": "has been repaired",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відремонтовано",
       "lemmaId": "відремонтовано",
       "lemmaPlain": "відремонтовано",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16673,11 +18675,13 @@
     {
       "cefr": "B1",
       "gloss": "has been replaced",
+      "glossClean": "has been replaced",
       "heritage": "standard",
       "ipa": null,
       "lemma": "замінено",
       "lemmaId": "замінено",
       "lemmaPlain": "замінено",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16688,11 +18692,13 @@
     {
       "cefr": "B1",
       "gloss": "application; request",
+      "glossClean": "application",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заявка",
       "lemmaId": "заявка",
       "lemmaPlain": "заявка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16703,11 +18709,13 @@
     {
       "cefr": "B1",
       "gloss": "has been saved",
+      "glossClean": "has been saved",
       "heritage": "standard",
       "ipa": null,
       "lemma": "збережено",
       "lemmaId": "збережено",
       "lemmaPlain": "збережено",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16718,11 +18726,13 @@
     {
       "cefr": "B1",
       "gloss": "is being sent; is sent regularly",
+      "glossClean": "is being sent",
       "heritage": "standard",
       "ipa": null,
       "lemma": "надсилається",
       "lemmaId": "надсилається",
       "lemmaPlain": "надсилається",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16733,11 +18743,13 @@
     {
       "cefr": "B1",
       "gloss": "intransitive verb",
+      "glossClean": "intransitive verb",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "неперехідне дієслово",
       "lemmaId": "неперехідне-дієслово",
       "lemmaPlain": "неперехідне дієслово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16748,11 +18760,13 @@
     {
       "cefr": "B1",
       "gloss": "is updated; is being updated",
+      "glossClean": "is updated",
       "heritage": "standard",
       "ipa": null,
       "lemma": "оновлюється",
       "lemmaId": "оновлюється",
       "lemmaPlain": "оновлюється",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16763,11 +18777,13 @@
     {
       "cefr": "B1",
       "gloss": "passive construction",
+      "glossClean": "passive construction",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пасивна конструкція",
       "lemmaId": "пасивна-конструкція",
       "lemmaPlain": "пасивна конструкція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16778,11 +18794,13 @@
     {
       "cefr": "B1",
       "gloss": "is being checked",
+      "glossClean": "is being checked",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перевіряється",
       "lemmaId": "перевіряється",
       "lemmaPlain": "перевіряється",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16793,11 +18811,13 @@
     {
       "cefr": "B1",
       "gloss": "to be transmitted; passed on",
+      "glossClean": "to be transmitted",
       "heritage": "standard",
       "ipa": null,
       "lemma": "передаватися",
       "lemmaId": "передаватися",
       "lemmaPlain": "передаватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16808,11 +18828,13 @@
     {
       "cefr": "B1",
       "gloss": "is being written; is written",
+      "glossClean": "is being written",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пишеться",
       "lemmaId": "пишеться",
       "lemmaPlain": "пишеться",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16823,11 +18845,13 @@
     {
       "cefr": "B1",
       "gloss": "to be accepted",
+      "glossClean": "to be accepted",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прийматися",
       "lemmaId": "прийматися",
       "lemmaPlain": "прийматися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16838,11 +18862,13 @@
     {
       "cefr": "B1",
       "gloss": "to be sold",
+      "glossClean": "to be sold",
       "heritage": "standard",
       "ipa": null,
       "lemma": "продаватися",
       "lemmaId": "продаватися",
       "lemmaPlain": "продаватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16853,11 +18879,13 @@
     {
       "cefr": "B1",
       "gloss": "news report",
+      "glossClean": "news report",
       "heritage": "standard",
       "ipa": null,
       "lemma": "репортаж",
       "lemmaId": "репортаж",
       "lemmaPlain": "репортаж",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16868,11 +18896,13 @@
     {
       "cefr": "B1",
       "gloss": "has been expanded",
+      "glossClean": "has been expanded",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розширено",
       "lemmaId": "розширено",
       "lemmaPlain": "розширено",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16883,11 +18913,13 @@
     {
       "cefr": "B1",
       "gloss": "official report",
+      "glossClean": "official report",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "службовий звіт",
       "lemmaId": "службовий-звіт",
       "lemmaPlain": "службовий звіт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16898,11 +18930,13 @@
     {
       "cefr": "B1",
       "gloss": "form ending in -но",
+      "glossClean": "form ending in -но",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "форма на -но",
       "lemmaId": "форма-на-но",
       "lemmaPlain": "форма на -но",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16913,11 +18947,13 @@
     {
       "cefr": "B1",
       "gloss": "form ending in -то",
+      "glossClean": "form ending in -то",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "форма на -то",
       "lemmaId": "форма-на-то",
       "lemmaPlain": "форма на -то",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16928,11 +18964,13 @@
     {
       "cefr": "B1",
       "gloss": "is read; reads",
+      "glossClean": "is read",
       "heritage": "standard",
       "ipa": null,
       "lemma": "читається",
       "lemmaId": "читається",
       "lemmaPlain": "читається",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16943,11 +18981,13 @@
     {
       "cefr": "B1",
       "gloss": "explicit agent",
+      "glossClean": "explicit agent",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "явний виконавець",
       "lemmaId": "явний-виконавець",
       "lemmaPlain": "явний виконавець",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16958,11 +18998,13 @@
     {
       "cefr": "B1",
       "gloss": "close relatives",
+      "glossClean": "close relatives",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "близькі родичі",
       "lemmaId": "близькі-родичі",
       "lemmaPlain": "близькі родичі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16973,11 +19015,13 @@
     {
       "cefr": "B1",
       "gloss": "pale",
+      "glossClean": "pale",
       "heritage": "standard",
       "ipa": null,
       "lemma": "блідий",
       "lemmaId": "блідий",
       "lemmaPlain": "блідий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -16988,11 +19032,13 @@
     {
       "cefr": "B1",
       "gloss": "beautiful, handsome",
+      "glossClean": "beautiful",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вродливий",
       "lemmaId": "вродливий",
       "lemmaPlain": "вродливий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17003,11 +19049,13 @@
     {
       "cefr": "B1",
       "gloss": "distant relatives",
+      "glossClean": "distant relatives",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "далекі родичі",
       "lemmaId": "далекі-родичі",
       "lemmaPlain": "далекі родичі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17018,11 +19066,13 @@
     {
       "cefr": "B1",
       "gloss": "female cousin",
+      "glossClean": "female cousin",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "двоюрідна сестра",
       "lemmaId": "двоюрідна-сестра",
       "lemmaPlain": "двоюрідна сестра",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17033,11 +19083,13 @@
     {
       "cefr": "B1",
       "gloss": "male cousin",
+      "glossClean": "male cousin",
       "heritage": "standard",
       "ipa": null,
       "lemma": "двоюрідний брат",
       "lemmaId": "двоюрідний-брат",
       "lemmaPlain": "двоюрідний брат",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17048,11 +19100,13 @@
     {
       "cefr": "B1",
       "gloss": "to be friends",
+      "glossClean": "to be friends",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дружити",
       "lemmaId": "дружити",
       "lemmaPlain": "дружити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17063,11 +19117,13 @@
     {
       "cefr": "B1",
       "gloss": "son-in-law",
+      "glossClean": "son-in-law",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зять",
       "lemmaId": "зять",
       "lemmaPlain": "зять",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17078,11 +19134,13 @@
     {
       "cefr": "B1",
       "gloss": "category",
+      "glossClean": "category",
       "heritage": "standard",
       "ipa": null,
       "lemma": "категорія",
       "lemmaId": "категорія",
       "lemmaPlain": "категорія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -17122,11 +19180,13 @@
     {
       "cefr": "B1",
       "gloss": "sturdy, stocky",
+      "glossClean": "sturdy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кремезний",
       "lemmaId": "кремезний",
       "lemmaPlain": "кремезний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17137,11 +19197,13 @@
     {
       "cefr": "B1",
       "gloss": "gentle",
+      "glossClean": "gentle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лагідний",
       "lemmaId": "лагідний",
       "lemmaPlain": "лагідний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17152,11 +19214,13 @@
     {
       "cefr": "B1",
       "gloss": "to make peace",
+      "glossClean": "to make peace",
       "heritage": "standard",
       "ipa": null,
       "lemma": "миритися",
       "lemmaId": "миритися",
       "lemmaPlain": "миритися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17167,11 +19231,13 @@
     {
       "cefr": "B1",
       "gloss": "daughter-in-law, brother's wife",
+      "glossClean": "daughter-in-law",
       "heritage": "standard",
       "ipa": null,
       "lemma": "невістка",
       "lemmaId": "невістка",
       "lemmaPlain": "невістка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17182,11 +19248,13 @@
     {
       "cefr": "B1",
       "gloss": "main body",
+      "glossClean": "main body",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "основна частина",
       "lemmaId": "основна-частина",
       "lemmaPlain": "основна частина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17197,11 +19265,13 @@
     {
       "cefr": "B1",
       "gloss": "translation-like construction",
+      "glossClean": "translation-like construction",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "перекладна конструкція",
       "lemmaId": "перекладна-конструкція",
       "lemmaPlain": "перекладна конструкція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17212,11 +19282,13 @@
     {
       "cefr": "B1",
       "gloss": "respect",
+      "glossClean": "respect",
       "heritage": "standard",
       "ipa": null,
       "lemma": "повага",
       "lemmaId": "повага",
       "lemmaPlain": "повага",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17227,11 +19299,13 @@
     {
       "cefr": "B1",
       "gloss": "portrait detail",
+      "glossClean": "portrait detail",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "портретна деталь",
       "lemmaId": "портретна-деталь",
       "lemmaPlain": "портретна деталь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17242,11 +19316,13 @@
     {
       "cefr": "B1",
       "gloss": "portrait vocabulary",
+      "glossClean": "portrait vocabulary",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "портретна лексика",
       "lemmaId": "портретна-лексика",
       "lemmaPlain": "портретна лексика",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17257,11 +19333,13 @@
     {
       "cefr": "B1",
       "gloss": "posture, bearing",
+      "glossClean": "posture",
       "heritage": "standard",
       "ipa": null,
       "lemma": "постава",
       "lemmaId": "постава",
       "lemmaPlain": "постава",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -17301,11 +19379,13 @@
     {
       "cefr": "B1",
       "gloss": "to introduce someone",
+      "glossClean": "to introduce someone",
       "heritage": "standard",
       "ipa": null,
       "lemma": "представити",
       "lemmaId": "представити",
       "lemmaPlain": "представити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17316,11 +19396,13 @@
     {
       "cefr": "B1",
       "gloss": "to quarrel",
+      "glossClean": "to quarrel",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сваритися",
       "lemmaId": "сваритися",
       "lemmaPlain": "сваритися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17331,11 +19413,13 @@
     {
       "cefr": "B1",
       "gloss": "husband's father",
+      "glossClean": "husband's father",
       "heritage": "standard",
       "ipa": null,
       "lemma": "свекор",
       "lemmaId": "свекор",
       "lemmaPlain": "свекор",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17346,11 +19430,13 @@
     {
       "cefr": "B1",
       "gloss": "husband's mother",
+      "glossClean": "husband's mother",
       "heritage": "standard",
       "ipa": null,
       "lemma": "свекруха",
       "lemmaId": "свекруха",
       "lemmaPlain": "свекруха",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17361,11 +19447,13 @@
     {
       "cefr": "B1",
       "gloss": "reserved, restrained",
+      "glossClean": "reserved",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стриманий",
       "lemmaId": "стриманий",
       "lemmaPlain": "стриманий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17376,11 +19464,13 @@
     {
       "cefr": "B1",
       "gloss": "wife's father",
+      "glossClean": "wife's father",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тесть",
       "lemmaId": "тесть",
       "lemmaPlain": "тесть",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17391,11 +19481,13 @@
     {
       "cefr": "B1",
       "gloss": "wife's mother",
+      "glossClean": "wife's mother",
       "heritage": "standard",
       "ipa": null,
       "lemma": "теща",
       "lemmaId": "теща",
       "lemmaPlain": "теща",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17406,11 +19498,13 @@
     {
       "cefr": "B1",
       "gloss": "sociable",
+      "glossClean": "sociable",
       "heritage": "standard",
       "ipa": null,
       "lemma": "товариський",
       "lemmaId": "товариський",
       "lemmaPlain": "товариський",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17421,11 +19515,13 @@
     {
       "cefr": "B1",
       "gloss": "slim, lean",
+      "glossClean": "slim",
       "heritage": "standard",
       "ipa": null,
       "lemma": "худорлявий",
       "lemmaId": "худорлявий",
       "lemmaPlain": "худорлявий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17436,11 +19532,13 @@
     {
       "cefr": "B1",
       "gloss": "valley",
+      "glossClean": "valley",
       "heritage": "standard",
       "ipa": null,
       "lemma": "долина",
       "lemmaId": "долина",
       "lemmaPlain": "долина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -17480,11 +19578,13 @@
     {
       "cefr": "B1",
       "gloss": "area, locality",
+      "glossClean": "area",
       "heritage": "standard",
       "ipa": null,
       "lemma": "місцевість",
       "lemmaId": "місцевість",
       "lemmaPlain": "місцевість",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17495,11 +19595,13 @@
     {
       "cefr": "B1",
       "gloss": "national park",
+      "glossClean": "national park",
       "heritage": "standard",
       "ipa": null,
       "lemma": "національний парк",
       "lemmaId": "національний-парк",
       "lemmaPlain": "національний парк",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17510,11 +19612,13 @@
     {
       "cefr": "B1",
       "gloss": "hill",
+      "glossClean": "hill",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пагорб",
       "lemmaId": "пагорб",
       "lemmaPlain": "пагорб",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17525,11 +19629,13 @@
     {
       "cefr": "B1",
       "gloss": "landmark, monument, site",
+      "glossClean": "landmark",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пам'ятка",
       "lemmaId": "пам-ятка",
       "lemmaPlain": "пам'ятка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -17569,11 +19675,13 @@
     {
       "cefr": "B1",
       "gloss": "lane, alley",
+      "glossClean": "lane",
       "heritage": "standard",
       "ipa": null,
       "lemma": "провулок",
       "lemmaId": "провулок",
       "lemmaPlain": "провулок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17584,11 +19692,13 @@
     {
       "cefr": "B1",
       "gloss": "peninsula",
+      "glossClean": "peninsula",
       "heritage": "standard",
       "ipa": null,
       "lemma": "півострів",
       "lemmaId": "півострів",
       "lemmaPlain": "півострів",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17599,11 +19709,13 @@
     {
       "cefr": "B1",
       "gloss": "coast, shoreline",
+      "glossClean": "coast",
       "heritage": "standard",
       "ipa": null,
       "lemma": "узбережжя",
       "lemmaId": "узбережжя",
       "lemmaPlain": "узбережжя",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17614,11 +19726,13 @@
     {
       "cefr": "B1",
       "gloss": "city center",
+      "glossClean": "city center",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "центр міста",
       "lemmaId": "центр-міста",
       "lemmaPlain": "центр міста",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17629,11 +19743,13 @@
     {
       "cefr": "B1",
       "gloss": "ravine",
+      "glossClean": "ravine",
       "heritage": "standard",
       "ipa": null,
       "lemma": "яр",
       "lemmaId": "яр",
       "lemmaPlain": "яр",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17644,11 +19760,13 @@
     {
       "cefr": "B1",
       "gloss": "Athens",
+      "glossClean": "Athens",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Афіни",
       "lemmaId": "афіни",
       "lemmaPlain": "афіни",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17659,11 +19777,13 @@
     {
       "cefr": "B1",
       "gloss": "elections",
+      "glossClean": "elections",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вибори",
       "lemmaId": "вибори",
       "lemmaPlain": "вибори",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17674,11 +19794,13 @@
     {
       "cefr": "B1",
       "gloss": "gate",
+      "glossClean": "gate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ворота",
       "lemmaId": "ворота",
       "lemmaPlain": "ворота",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17689,11 +19811,13 @@
     {
       "cefr": "B1",
       "gloss": "rake",
+      "glossClean": "rake",
       "heritage": "standard",
       "ipa": null,
       "lemma": "граблі",
       "lemmaId": "граблі",
       "lemmaPlain": "граблі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17704,11 +19828,13 @@
     {
       "cefr": "B1",
       "gloss": "yeast",
+      "glossClean": "yeast",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дріжджі",
       "lemmaId": "дріжджі",
       "lemmaPlain": "дріжджі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17719,11 +19845,13 @@
     {
       "cefr": "B1",
       "gloss": "engagement",
+      "glossClean": "engagement",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заручини",
       "lemmaId": "заручини",
       "lemmaPlain": "заручини",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17734,11 +19862,13 @@
     {
       "cefr": "B1",
       "gloss": "plural-only noun",
+      "glossClean": "plural-only noun",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "множинний іменник",
       "lemmaId": "множинний-іменник",
       "lemmaPlain": "множинний іменник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17749,11 +19879,13 @@
     {
       "cefr": "B1",
       "gloss": "joys",
+      "glossClean": "joys",
       "heritage": "standard",
       "ipa": null,
       "lemma": "радощі",
       "lemmaId": "радощі",
       "lemmaPlain": "радощі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17764,11 +19896,13 @@
     {
       "cefr": "B1",
       "gloss": "sleigh, sled",
+      "glossClean": "sleigh",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сани",
       "lemmaId": "сани",
       "lemmaPlain": "сани",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17779,11 +19913,13 @@
     {
       "cefr": "B1",
       "gloss": "tricks, cunning devices",
+      "glossClean": "tricks",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хитрощі",
       "lemmaId": "хитрощі",
       "lemmaPlain": "хитрощі",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17794,11 +19930,13 @@
     {
       "cefr": "B1",
       "gloss": "name day",
+      "glossClean": "name day",
       "heritage": "standard",
       "ipa": null,
       "lemma": "іменини",
       "lemmaId": "іменини",
       "lemmaPlain": "іменини",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17809,11 +19947,13 @@
     {
       "cefr": "B1",
       "gloss": "proper name",
+      "glossClean": "proper name",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "власна назва",
       "lemmaId": "власна-назва",
       "lemmaPlain": "власна назва",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17824,11 +19964,13 @@
     {
       "cefr": "B1",
       "gloss": "grandfather's",
+      "glossClean": "grandfather's",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дідусів",
       "lemmaId": "дідусів",
       "lemmaPlain": "дідусів",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17839,11 +19981,13 @@
     {
       "cefr": "B1",
       "gloss": "mixed declension",
+      "glossClean": "mixed declension",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "змішане відмінювання",
       "lemmaId": "змішане-відмінювання",
       "lemmaPlain": "змішане відмінювання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17854,11 +19998,13 @@
     {
       "cefr": "B1",
       "gloss": "short form",
+      "glossClean": "short form",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "коротка форма",
       "lemmaId": "коротка-форма",
       "lemmaPlain": "коротка форма",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17869,11 +20015,13 @@
     {
       "cefr": "B1",
       "gloss": "Petro's",
+      "glossClean": "Petro's",
       "heritage": "standard",
       "ipa": null,
       "lemma": "Петрів",
       "lemmaId": "петрів",
       "lemmaPlain": "петрів",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17884,11 +20032,13 @@
     {
       "cefr": "B1",
       "gloss": "full form",
+      "glossClean": "full form",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "повна форма",
       "lemmaId": "повна-форма",
       "lemmaPlain": "повна форма",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17899,11 +20049,13 @@
     {
       "cefr": "B1",
       "gloss": "female friend's",
+      "glossClean": "female friend's",
       "heritage": "standard",
       "ipa": null,
       "lemma": "подружин",
       "lemmaId": "подружин",
       "lemmaPlain": "подружин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17914,11 +20066,13 @@
     {
       "cefr": "B1",
       "gloss": "possessive adjective",
+      "glossClean": "possessive adjective",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "присвійний прикметник",
       "lemmaId": "присвійний-прикметник",
       "lemmaPlain": "присвійний прикметник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17929,11 +20083,13 @@
     {
       "cefr": "B1",
       "gloss": "yn/-yin suffix",
+      "glossClean": "yn/-yin suffix",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "суфікс -ин/-їн",
       "lemmaId": "суфікс-ин-їн",
       "lemmaPlain": "суфікс -ин/-їн",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17944,11 +20100,13 @@
     {
       "cefr": "B1",
       "gloss": "iv/-yiv suffix",
+      "glossClean": "iv/-yiv suffix",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "суфікс -ів/-їв",
       "lemmaId": "суфікс-ів-їв",
       "lemmaPlain": "суфікс -ів/-їв",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17959,11 +20117,13 @@
     {
       "cefr": "B1",
       "gloss": "creative work, oeuvre",
+      "glossClean": "creative work",
       "heritage": "standard",
       "ipa": null,
       "lemma": "творчість",
       "lemmaId": "творчість",
       "lemmaPlain": "творчість",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17974,11 +20134,13 @@
     {
       "cefr": "B1",
       "gloss": "notes",
+      "glossClean": "notes",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нотатки",
       "lemmaId": "нотатки",
       "lemmaPlain": "нотатки",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -17989,11 +20151,13 @@
     {
       "cefr": "B1",
       "gloss": "practice exam",
+      "glossClean": "practice exam",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пробний екзамен",
       "lemmaId": "пробний-екзамен",
       "lemmaPlain": "пробний екзамен",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18004,11 +20168,13 @@
     {
       "cefr": "B1",
       "gloss": "comprehension",
+      "glossClean": "comprehension",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розуміння",
       "lemmaId": "розуміння",
       "lemmaPlain": "розуміння",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18019,11 +20185,13 @@
     {
       "cefr": "B1",
       "gloss": "internal motivation",
+      "glossClean": "internal motivation",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "внутрішня мотивація",
       "lemmaId": "внутрішня-мотивація",
       "lemmaPlain": "внутрішня мотивація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18034,11 +20202,13 @@
     {
       "cefr": "B1",
       "gloss": "from joy",
+      "glossClean": "from joy",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "від радості",
       "lemmaId": "від-радості",
       "lemmaPlain": "від радості",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18049,11 +20219,13 @@
     {
       "cefr": "B1",
       "gloss": "from cold",
+      "glossClean": "from cold",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "від холоду",
       "lemmaId": "від-холоду",
       "lemmaPlain": "від холоду",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18064,11 +20236,13 @@
     {
       "cefr": "B1",
       "gloss": "through someone's fault",
+      "glossClean": "through someone's fault",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "з вини",
       "lemmaId": "з-вини",
       "lemmaPlain": "з вини",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18079,11 +20253,13 @@
     {
       "cefr": "B1",
       "gloss": "out of respect",
+      "glossClean": "out of respect",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "з поваги",
       "lemmaId": "з-поваги",
       "lemmaPlain": "з поваги",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18094,11 +20270,13 @@
     {
       "cefr": "B1",
       "gloss": "for the reason of, because of",
+      "glossClean": "for the reason of",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "з причини",
       "lemmaId": "з-причини",
       "lemmaPlain": "з причини",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18109,11 +20287,13 @@
     {
       "cefr": "B1",
       "gloss": "out of curiosity",
+      "glossClean": "out of curiosity",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "з цікавості",
       "lemmaId": "з-цікавості",
       "lemmaPlain": "з цікавості",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18124,11 +20304,13 @@
     {
       "cefr": "B1",
       "gloss": "for the sake of doing",
+      "glossClean": "for the sake of doing",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "заради того щоб",
       "lemmaId": "заради-того-щоб",
       "lemmaPlain": "заради того щоб",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -18139,11 +20321,13 @@
     {
       "cefr": "B1",
       "gloss": "negative cause",
+      "glossClean": "negative cause",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "негативна причина",
       "lemmaId": "негативна-причина",
       "lemmaPlain": "негативна причина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18154,11 +20338,13 @@
     {
       "cefr": "B1",
       "gloss": "neutral reason",
+      "glossClean": "neutral reason",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "нейтральна причина",
       "lemmaId": "нейтральна-причина",
       "lemmaPlain": "нейтральна причина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18169,11 +20355,13 @@
     {
       "cefr": "B1",
       "gloss": "formal reason",
+      "glossClean": "formal reason",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "офіційна причина",
       "lemmaId": "офіційна-причина",
       "lemmaPlain": "офіційна причина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18184,11 +20372,13 @@
     {
       "cefr": "B1",
       "gloss": "as a result of",
+      "glossClean": "as a result of",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "у результаті",
       "lemmaId": "у-результаті",
       "lemmaPlain": "у результаті",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18199,11 +20389,13 @@
     {
       "cefr": "B1",
       "gloss": "around; takes genitive",
+      "glossClean": "around",
       "heritage": "standard",
       "ipa": null,
       "lemma": "довкола",
       "lemmaId": "довкола",
       "lemmaPlain": "довкола",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18214,11 +20406,13 @@
     {
       "cefr": "B1",
       "gloss": "chestnut tree",
+      "glossClean": "chestnut tree",
       "heritage": "standard",
       "ipa": null,
       "lemma": "каштан",
       "lemmaId": "каштан",
       "lemmaPlain": "каштан",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18229,11 +20423,13 @@
     {
       "cefr": "B1",
       "gloss": "city block",
+      "glossClean": "city block",
       "heritage": "standard",
       "ipa": null,
       "lemma": "квартал",
       "lemmaId": "квартал",
       "lemmaPlain": "квартал",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18244,11 +20440,13 @@
     {
       "cefr": "B1",
       "gloss": "small rug, mat",
+      "glossClean": "small rug",
       "heritage": "standard",
       "ipa": null,
       "lemma": "килимок",
       "lemmaId": "килимок",
       "lemmaPlain": "килимок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18259,11 +20457,13 @@
     {
       "cefr": "B1",
       "gloss": "kiosk",
+      "glossClean": "kiosk",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кіоск",
       "lemmaId": "кіоск",
       "lemmaPlain": "кіоск",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -18274,11 +20474,13 @@
     {
       "cefr": "B1",
       "gloss": "not far from; takes genitive after від",
+      "glossClean": "not far from",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "неподалік від",
       "lemmaId": "неподалік-від",
       "lemmaPlain": "неподалік від",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18289,11 +20491,13 @@
     {
       "cefr": "B1",
       "gloss": "on both sides of; takes genitive",
+      "glossClean": "on both sides of",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обабіч",
       "lemmaId": "обабіч",
       "lemmaPlain": "обабіч",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -18304,11 +20508,13 @@
     {
       "cefr": "B1",
       "gloss": "next to; з/із/зі plus instrumental",
+      "glossClean": "next to",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "поруч з",
       "lemmaId": "поруч-з",
       "lemmaPlain": "поруч з",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18319,11 +20525,13 @@
     {
       "cefr": "B1",
       "gloss": "building entrance",
+      "glossClean": "building entrance",
       "heritage": "standard",
       "ipa": null,
       "lemma": "під'їзд",
       "lemmaId": "під-їзд",
       "lemmaPlain": "під'їзд",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18334,11 +20542,13 @@
     {
       "cefr": "B1",
       "gloss": "among, in the middle of; takes genitive",
+      "glossClean": "among",
       "heritage": "standard",
       "ipa": null,
       "lemma": "серед",
       "lemmaId": "серед",
       "lemmaPlain": "серед",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -18349,11 +20559,13 @@
     {
       "cefr": "B1",
       "gloss": "small public garden",
+      "glossClean": "small public garden",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сквер",
       "lemmaId": "сквер",
       "lemmaPlain": "сквер",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18364,11 +20576,13 @@
     {
       "cefr": "B1",
       "gloss": "roadside",
+      "glossClean": "roadside",
       "heritage": "standard",
       "ipa": null,
       "lemma": "узбіччя",
       "lemmaId": "узбіччя",
       "lemmaPlain": "узбіччя",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18379,11 +20593,13 @@
     {
       "cefr": "B1",
       "gloss": "countdown, point of reckoning",
+      "glossClean": "countdown",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відлік",
       "lemmaId": "відлік",
       "lemmaPlain": "відлік",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18394,11 +20610,13 @@
     {
       "cefr": "B1",
       "gloss": "ten minutes to six",
+      "glossClean": "ten minutes to six",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "за десять хвилин шоста",
       "lemmaId": "за-десять-хвилин-шоста",
       "lemmaPlain": "за десять хвилин шоста",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18409,11 +20627,13 @@
     {
       "cefr": "B1",
       "gloss": "coordinator (female)",
+      "glossClean": "coordinator (female)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "координаторка",
       "lemmaId": "координаторка",
       "lemmaPlain": "координаторка",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -18424,11 +20644,13 @@
     {
       "cefr": "B1",
       "gloss": "deadline, final date",
+      "glossClean": "deadline",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "крайній термін",
       "lemmaId": "крайній-термін",
       "lemmaPlain": "крайній термін",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18439,11 +20661,13 @@
     {
       "cefr": "B1",
       "gloss": "cultural center",
+      "glossClean": "cultural center",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "культурний центр",
       "lemmaId": "культурний-центр",
       "lemmaPlain": "культурний центр",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18454,11 +20678,13 @@
     {
       "cefr": "B1",
       "gloss": "after completion",
+      "glossClean": "after completion",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "по завершенні",
       "lemmaId": "по-завершенні",
       "lemmaPlain": "по завершенні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18469,11 +20695,13 @@
     {
       "cefr": "B1",
       "gloss": "after the end of",
+      "glossClean": "after the end of",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "по закінченні",
       "lemmaId": "по-закінченні",
       "lemmaPlain": "по закінченні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18484,11 +20712,13 @@
     {
       "cefr": "B1",
       "gloss": "after lunch",
+      "glossClean": "after lunch",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "по обіді",
       "lemmaId": "по-обіді",
       "lemmaPlain": "по обіді",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18499,11 +20729,13 @@
     {
       "cefr": "B1",
       "gloss": "time interval",
+      "glossClean": "time interval",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "проміжок часу",
       "lemmaId": "проміжок-часу",
       "lemmaPlain": "проміжок часу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18514,11 +20746,13 @@
     {
       "cefr": "B1",
       "gloss": "throughout, during",
+      "glossClean": "throughout",
       "heritage": "standard",
       "ipa": null,
       "lemma": "протягом",
       "lemmaId": "протягом",
       "lemmaPlain": "протягом",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -18529,11 +20763,13 @@
     {
       "cefr": "B1",
       "gloss": "during",
+      "glossClean": "during",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "під час",
       "lemmaId": "під-час",
       "lemmaPlain": "під час",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -18544,3129 +20780,17 @@
     {
       "cefr": "B1",
       "gloss": "participant",
+      "glossClean": "participant",
       "heritage": "standard",
       "ipa": null,
       "lemma": "учасник",
       "lemmaId": "учасник",
       "lemmaPlain": "учасник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
       "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "this year",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "цього року",
-      "lemmaId": "цього-року",
-      "lemmaPlain": "цього року",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "temporal, related to time",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "часовий",
-      "lemmaId": "часовий",
-      "lemmaPlain": "часовий",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "every Monday",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "щопонеділка",
-      "lemmaId": "щопонеділка",
-      "lemmaPlain": "щопонеділка",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adverb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "every Wednesday",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "щосереди",
-      "lemmaId": "щосереди",
-      "lemmaPlain": "щосереди",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adverb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "lyrical persona",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "ліричний герой",
-      "lemmaId": "ліричний-герой",
-      "lemmaPlain": "ліричний герой",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "character",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "персонаж",
-      "lemmaId": "персонаж",
-      "lemmaPlain": "персонаж",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "prose",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "проза",
-      "lemmaId": "проза",
-      "lemmaPlain": "проза",
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "прозам",
-            "singular": "прозі"
-          },
-          "знахідний": {
-            "plural": "прози",
-            "singular": "прозу"
-          },
-          "кличний": {
-            "plural": "прози",
-            "singular": "прозо"
-          },
-          "місцевий": {
-            "plural": "прозах",
-            "singular": "прозі"
-          },
-          "називний": {
-            "plural": "прози",
-            "singular": "проза"
-          },
-          "орудний": {
-            "plural": "прозами",
-            "singular": "прозою"
-          },
-          "родовий": {
-            "plural": "проз",
-            "singular": "прози"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "excerpt",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "уривок",
-      "lemmaId": "уривок",
-      "lemmaPlain": "уривок",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to see each other",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "бачитися",
-      "lemmaId": "бачитися",
-      "lemmaPlain": "бачитися",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb:impf",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "reciprocal",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "взаємний",
-      "lemmaId": "взаємний",
-      "lemmaPlain": "взаємний",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "properly reflexive",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "власне зворотний",
-      "lemmaId": "власне-зворотний",
-      "lemmaPlain": "власне зворотний",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to open; become available",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "відкриватися",
-      "lemmaId": "відкриватися",
-      "lemmaPlain": "відкриватися",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb:impf",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to open; to be opened",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "відчинятися",
-      "lemmaId": "відчинятися",
-      "lemmaPlain": "відчинятися",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb:impf",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to greet each other",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вітатися",
-      "lemmaId": "вітатися",
-      "lemmaPlain": "вітатися",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb:impf",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "emotion",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "емоція",
-      "lemmaId": "емоція",
-      "lemmaPlain": "емоція",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:f",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to close; to be closed",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "зачинятися",
-      "lemmaId": "зачинятися",
-      "lemmaPlain": "зачинятися",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb:impf",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to introduce people",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "знайомити",
-      "lemmaId": "знайомити",
-      "lemmaPlain": "знайомити",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb:impf",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to get acquainted",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "знайомитися",
-      "lemmaId": "знайомитися",
-      "lemmaPlain": "знайомитися",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb:impf",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to be submitted; to be served",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "подаватися",
-      "lemmaId": "подаватися",
-      "lemmaPlain": "подаватися",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb:impf",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "I apologize",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "прошу вибачення",
-      "lemmaId": "прошу-вибачення",
-      "lemmaPlain": "прошу вибачення",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to be glad",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "радіти",
-      "lemmaId": "радіти",
-      "lemmaPlain": "радіти",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb:impf",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to be angry",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "сердитися",
-      "lemmaId": "сердитися",
-      "lemmaPlain": "сердитися",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb:impf",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to communicate",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "спілкуватися",
-      "lemmaId": "спілкуватися",
-      "lemmaPlain": "спілкуватися",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb:impf",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to miss, be sad",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "сумувати",
-      "lemmaId": "сумувати",
-      "lemmaPlain": "сумувати",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb:impf",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to kiss each other",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "цілуватися",
-      "lemmaId": "цілуватися",
-      "lemmaPlain": "цілуватися",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb:impf",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "authorial remark, stage direction",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "авторська ремарка",
-      "lemmaId": "авторська-ремарка",
-      "lemmaPlain": "авторська ремарка",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "verbatim",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "дослівно",
-      "lemmaId": "дослівно",
-      "lemmaPlain": "дослівно",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adverb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "the next day",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "наступного дня",
-      "lemmaId": "наступного-дня",
-      "lemmaPlain": "наступного дня",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "question word",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "питальне слово",
-      "lemmaId": "питальне-слово",
-      "lemmaPlain": "питальне слово",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "that day",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "того дня",
-      "lemmaId": "того-дня",
-      "lemmaPlain": "того дня",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "whether particle",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "частка чи",
-      "lemmaId": "частка-чи",
-      "lemmaPlain": "частка чи",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "main course",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "друга страва",
-      "lemmaId": "друга-страва",
-      "lemmaPlain": "друга страва",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to taste, to eat and experience",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "куштувати",
-      "lemmaId": "куштувати",
-      "lemmaPlain": "куштувати",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "first course, soup course",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "перша страва",
-      "lemmaId": "перша-страва",
-      "lemmaPlain": "перша страва",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "fish soup, light broth",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "юшка",
-      "lemmaId": "юшка",
-      "lemmaPlain": "юшка",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:f",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "tailor's shop, atelier",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "ательє",
-      "lemmaId": "ательє",
-      "lemmaPlain": "ательє",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:n",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "change, money returned",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "здача",
-      "lemmaId": "здача",
-      "lemmaPlain": "здача",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:f",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "workshop, repair shop",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "майстерня",
-      "lemmaId": "майстерня",
-      "lemmaPlain": "майстерня",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:f",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "currency exchange",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "обмін валют",
-      "lemmaId": "обмін-валют",
-      "lemmaPlain": "обмін валют",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "service, customer service",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "обслуговування",
-      "lemmaId": "обслуговування",
-      "lemmaPlain": "обслуговування",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:n",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "hair salon",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "перукарня",
-      "lemmaId": "перукарня",
-      "lemmaPlain": "перукарня",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:f",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "slower",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "повільніший",
-      "lemmaId": "повільніший",
-      "lemmaPlain": "повільніший",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "fabric",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "тканина",
-      "lemmaId": "тканина",
-      "lemmaPlain": "тканина",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:f",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "high-quality",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "якісний",
-      "lemmaId": "якісний",
-      "lemmaPlain": "якісний",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "quality",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "якість",
-      "lemmaId": "якість",
-      "lemmaPlain": "якість",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:f",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "worth",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "варт",
-      "lemmaId": "варт",
-      "lemmaPlain": "варт",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "capable, fit",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "годен",
-      "lemmaId": "годен",
-      "lemmaPlain": "годен",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "ready, willing, feminine",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "ладна",
-      "lemmaId": "ладна",
-      "lemmaPlain": "ладна",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "uncontracted full form",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "нестягнена форма",
-      "lemmaId": "нестягнена-форма",
-      "lemmaPlain": "нестягнена форма",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "non-agreeing",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "неузгоджуваний",
-      "lemmaId": "неузгоджуваний",
-      "lemmaPlain": "неузгоджуваний",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "full, poetic or predicative short form",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "повен",
-      "lemmaId": "повен",
-      "lemmaPlain": "повен",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "full adjective form",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "повний прикметник",
-      "lemmaId": "повний-прикметник",
-      "lemmaPlain": "повний прикметник",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "contracted full form",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "стягнена форма",
-      "lemmaId": "стягнена-форма",
-      "lemmaPlain": "стягнена форма",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "bright, clear, poetic short form",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "ясен",
-      "lemmaId": "ясен",
-      "lemmaPlain": "ясен",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "consonant cluster",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "група приголосних",
-      "lemmaId": "група-приголосних",
-      "lemmaPlain": "група приголосних",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "fixed, established",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "закріплений",
-      "lemmaId": "закріплений",
-      "lemmaPlain": "закріплений",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to disappear",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "зникати",
-      "lemmaId": "зникати",
-      "lemmaPlain": "зникати",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "joyful",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "радісний",
-      "lemmaId": "радісний",
-      "lemmaPlain": "радісний",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to press",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "тиснути",
-      "lemmaId": "тиснути",
-      "lemmaPlain": "тиснути",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "honest",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "чесний",
-      "lemmaId": "чесний",
-      "lemmaPlain": "чесний",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "charity",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "благодійність",
-      "lemmaId": "благодійність",
-      "lemmaPlain": "благодійність",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:f",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "civil society",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "громадянське суспільство",
-      "lemmaId": "громадянське-суспільство",
-      "lemmaPlain": "громадянське суспільство",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "social media post",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "допис",
-      "lemmaId": "допис",
-      "lemmaPlain": "допис",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "electorate",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "електорат",
-      "lemmaId": "електорат",
-      "lemmaPlain": "електорат",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "mass media",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "засоби масової інформації",
-      "lemmaId": "засоби-масової-інформації",
-      "lemmaPlain": "засоби масової інформації",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "comment",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "коментар",
-      "lemmaId": "коментар",
-      "lemmaPlain": "коментар",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "correspondent, reporter",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "кореспондент",
-      "lemmaId": "кореспондент",
-      "lemmaPlain": "кореспондент",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "correspondent, reporter",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "кореспондентка",
-      "lemmaId": "кореспондентка",
-      "lemmaPlain": "кореспондентка",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:f",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "manipulation",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "маніпулювання",
-      "lemmaId": "маніпулювання",
-      "lemmaPlain": "маніпулювання",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:n",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "media manipulation",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "медіаманіпулювання",
-      "lemmaId": "медіаманіпулювання",
-      "lemmaPlain": "медіаманіпулювання",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:n",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "petition",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "петиція",
-      "lemmaId": "петиція",
-      "lemmaPlain": "петиція",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:f",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "press conference",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "прес-конференція",
-      "lemmaId": "прес-конференція",
-      "lemmaPlain": "прес-конференція",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:f",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "publicistic style, media register",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "публіцистичний стиль",
-      "lemmaId": "публіцистичний-стиль",
-      "lemmaPlain": "публіцистичний стиль",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "fake news, false claim",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "фейк",
-      "lemmaId": "фейк",
-      "lemmaPlain": "фейк",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "Supreme Council, Ukrainian parliament",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "Верховна Рада",
-      "lemmaId": "верховна-рада",
-      "lemmaPlain": "верховна рада",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "proper noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "sound abbreviation",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "звукова абревіатура",
-      "lemmaId": "звукова-абревіатура",
-      "lemmaPlain": "звукова абревіатура",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "period, full stop",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "крапка",
-      "lemmaId": "крапка",
-      "lemmaPlain": "крапка",
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "крапкам",
-            "singular": "крапці"
-          },
-          "знахідний": {
-            "plural": "крапки",
-            "singular": "крапку"
-          },
-          "кличний": {
-            "plural": "крапки",
-            "singular": "крапко"
-          },
-          "місцевий": {
-            "plural": "крапках",
-            "singular": "крапці"
-          },
-          "називний": {
-            "plural": "крапки",
-            "singular": "крапка"
-          },
-          "орудний": {
-            "plural": "крапками",
-            "singular": "крапкою"
-          },
-          "родовий": {
-            "plural": "крапок",
-            "singular": "крапки"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "letter abbreviation",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "літерна абревіатура",
-      "lemmaId": "літерна-абревіатура",
-      "lemmaPlain": "літерна абревіатура",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "units of measurement",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "одиниці виміру",
-      "lemmaId": "одиниці-виміру",
-      "lemmaPlain": "одиниці виміру",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "abbreviated compound word",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "складноскорочене слово",
-      "lemmaId": "складноскорочене-слово",
-      "lemmaPlain": "складноскорочене слово",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "administrative service center",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "ЦНАП",
-      "lemmaId": "цнап",
-      "lemmaPlain": "цнап",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "abbreviation",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "autobiography",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "автобіографія",
-      "lemmaId": "автобіографія",
-      "lemmaPlain": "автобіографія",
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "автобіографіям",
-            "singular": "автобіографії"
-          },
-          "знахідний": {
-            "plural": "автобіографії",
-            "singular": "автобіографію"
-          },
-          "кличний": {
-            "plural": "автобіографії",
-            "singular": "автобіографіє"
-          },
-          "місцевий": {
-            "plural": "автобіографіях",
-            "singular": "автобіографії"
-          },
-          "називний": {
-            "plural": "автобіографії",
-            "singular": "автобіографія"
-          },
-          "орудний": {
-            "plural": "автобіографіями",
-            "singular": "автобіографією"
-          },
-          "родовий": {
-            "plural": "автобіографій",
-            "singular": "автобіографії"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "in accordance with",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "відповідно до",
-      "lemmaId": "відповідно-до",
-      "lemmaPlain": "відповідно до",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "I bring to your attention",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "доводжу до вашого відома",
-      "lemmaId": "доводжу-до-вашого-відома",
-      "lemmaPlain": "доводжу до вашого відома",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "business correspondence",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "ділове листування",
-      "lemmaId": "ділове-листування",
-      "lemmaPlain": "ділове листування",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "required document elements",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "реквізити",
-      "lemmaId": "реквізити",
-      "lemmaPlain": "реквізити",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "politeness formula",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "формула ввічливості",
-      "lemmaId": "формула-ввічливості",
-      "lemmaPlain": "формула ввічливості",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "esteemed, dear",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "шановний",
-      "lemmaId": "шановний",
-      "lemmaPlain": "шановний",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "fixed cliche, standard phrase",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "штамп",
-      "lemmaId": "штамп",
-      "lemmaPlain": "штамп",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "emotionally colored vocabulary",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "емоційно забарвлена лексика",
-      "lemmaId": "емоційно-забарвлена-лексика",
-      "lemmaPlain": "емоційно забарвлена лексика",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "diminutive-affectionate form",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "зменшувально-пестлива форма",
-      "lemmaId": "зменшувально-пестлива-форма",
-      "lemmaPlain": "зменшувально-пестлива форма",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "in short",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "коротше кажучи",
-      "lemmaId": "коротше-кажучи",
-      "lemmaPlain": "коротше кажучи",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "really?, is it possible?",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "невже",
-      "lemmaId": "невже",
-      "lemmaPlain": "невже",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "particle",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "elliptical sentence",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "неповне речення",
-      "lemmaId": "неповне-речення",
-      "lemmaPlain": "неповне речення",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "wow, oh my",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "овва",
-      "lemmaId": "овва",
-      "lemmaPlain": "овва",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "interjection",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "exactly, that's right",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "отож",
-      "lemmaId": "отож",
-      "lemmaPlain": "отож",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "particle",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "everyday topic",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "побутова тема",
-      "lemmaId": "побутова-тема",
-      "lemmaPlain": "побутова тема",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "everyday, domestic",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "побутовий",
-      "lemmaId": "побутовий",
-      "lemmaPlain": "побутовий",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "nice, pretty",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "файний",
-      "lemmaId": "файний",
-      "lemmaPlain": "файний",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "surely not?, is it really?",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "хіба",
-      "lemmaId": "хіба",
-      "lemmaPlain": "хіба",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "particle",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "luggage",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "багаж",
-      "lemmaId": "багаж",
-      "lemmaPlain": "багаж",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to set off",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вирушати",
-      "lemmaId": "вирушати",
-      "lemmaPlain": "вирушати",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "passport for international travel",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "закордонний паспорт",
-      "lemmaId": "закордонний-паспорт",
-      "lemmaPlain": "закордонний паспорт",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "waiting hall",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "зал очікування",
-      "lemmaId": "зал-очікування",
-      "lemmaPlain": "зал очікування",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "delay",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "затримка",
-      "lemmaId": "затримка",
-      "lemmaPlain": "затримка",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:f",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "return ticket",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "зворотний квиток",
-      "lemmaId": "зворотний-квиток",
-      "lemmaPlain": "зворотний квиток",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "journey, trip; slightly more literary",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "мандрівка",
-      "lemmaId": "мандрівка",
-      "lemmaPlain": "мандрівка",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:f",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "boarding",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "посадка",
-      "lemmaId": "посадка",
-      "lemmaPlain": "посадка",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:f",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "border control",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "прикордонний контроль",
-      "lemmaId": "прикордонний-контроль",
-      "lemmaPlain": "прикордонний контроль",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "train attendant, conductor",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "провідник",
-      "lemmaId": "провідник",
-      "lemmaPlain": "провідник",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "transport schedule, timetable",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "розклад руху",
-      "lemmaId": "розклад-руху",
-      "lemmaPlain": "розклад руху",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "seated carriage",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "сидячий вагон",
-      "lemmaId": "сидячий-вагон",
-      "lemmaPlain": "сидячий вагон",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "hostel",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "хостел",
-      "lemmaId": "хостел",
-      "lemmaPlain": "хостел",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to turn off",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вимкнути",
-      "lemmaId": "вимкнути",
-      "lemmaPlain": "вимкнути",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to install; to establish",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "встановити",
-      "lemmaId": "встановити",
-      "lemmaPlain": "встановити",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to disconnect; to turn off",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "відключити",
-      "lemmaId": "відключити",
-      "lemmaPlain": "відключити",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to cut off",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "відрізати",
-      "lemmaId": "відрізати",
-      "lemmaPlain": "відрізати",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "completion of an action",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "завершення дії",
-      "lemmaId": "завершення-дії",
-      "lemmaPlain": "завершення дії",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to start crying",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "заплакати",
-      "lemmaId": "заплакати",
-      "lemmaPlain": "заплакати",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "meaning",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "значення",
-      "lemmaId": "значення",
-      "lemmaPlain": "значення",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:n",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to copy",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "копіювати",
-      "lemmaId": "копіювати",
-      "lemmaPlain": "копіювати",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "mechanical",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "механічний",
-      "lemmaId": "механічний",
-      "lemmaPlain": "механічний",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "single action",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "одноразова дія",
-      "lemmaId": "одноразова-дія",
-      "lemmaPlain": "одноразова дія",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "beginning of an action",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "початок дії",
-      "lemmaId": "початок-дії",
-      "lemmaPlain": "початок дії",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to speed up; to make faster",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "пришвидшити",
-      "lemmaId": "пришвидшити",
-      "lemmaPlain": "пришвидшити",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to attach; to join",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "приєднати",
-      "lemmaId": "приєднати",
-      "lemmaPlain": "приєднати",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to program",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "програмувати",
-      "lemmaId": "програмувати",
-      "lemmaPlain": "програмувати",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to strengthen; to reinforce",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "підсилити",
-      "lemmaId": "підсилити",
-      "lemmaPlain": "підсилити",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "analysis; parsing",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "розбір",
-      "lemmaId": "розбір",
-      "lemmaPlain": "розбір",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to decompose; to break down",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "розкласти",
-      "lemmaId": "розкласти",
-      "lemmaPlain": "розкласти",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "derivational base",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "словотвірна основа",
-      "lemmaId": "словотвірна-основа",
-      "lemmaPlain": "словотвірна основа",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "formation method",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "спосіб творення",
-      "lemmaId": "спосіб-творення",
-      "lemmaPlain": "спосіб творення",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "verb formation",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "творення дієслів",
-      "lemmaId": "творення-дієслів",
-      "lemmaPlain": "творення дієслів",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to turn on",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "увімкнути",
-      "lemmaId": "увімкнути",
-      "lemmaPlain": "увімкнути",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "vision; way of seeing",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "бачення",
-      "lemmaId": "бачення",
-      "lemmaPlain": "бачення",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:n",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "running",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "біг",
-      "lemmaId": "біг",
-      "lemmaPlain": "біг",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "study; learning of a subject",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вивчення",
-      "lemmaId": "вивчення",
-      "lemmaPlain": "вивчення",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:n",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to produce; manufacture",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "виробляти",
-      "lemmaId": "виробляти",
-      "lemmaPlain": "виробляти",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "documentation",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "документація",
-      "lemmaId": "документація",
-      "lemmaPlain": "документація",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:f",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to obtain; gain",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "здобути",
-      "lemmaId": "здобути",
-      "lemmaPlain": "здобути",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "knowledge",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "знання",
-      "lemmaId": "знання",
-      "lemmaPlain": "знання",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:n",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "copying",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "копіювання",
-      "lemmaId": "копіювання",
-      "lemmaPlain": "копіювання",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:n",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "flight",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "лет",
-      "lemmaId": "лет",
-      "lemmaPlain": "лет",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "learning center",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "навчальний центр",
-      "lemmaId": "навчальний-центр",
-      "lemmaPlain": "навчальний центр",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to teach",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "навчати",
-      "lemmaId": "навчати",
-      "lemmaPlain": "навчати",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "sending",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "надсилання",
-      "lemmaId": "надсилання",
-      "lemmaPlain": "надсилання",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:n",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "exchange",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "обмін",
-      "lemmaId": "обмін",
-      "lemmaPlain": "обмін",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to pay",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "оплатити",
-      "lemmaId": "оплатити",
-      "lemmaPlain": "оплатити",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to develop",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "розвивати",
-      "lemmaId": "розвивати",
-      "lemmaPlain": "розвивати",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "development",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "розвиток",
-      "lemmaId": "розвиток",
-      "lemmaPlain": "розвиток",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "scanning",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "сканування",
-      "lemmaId": "сканування",
-      "lemmaPlain": "сканування",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:n",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "singing",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "спів",
-      "lemmaId": "спів",
-      "lemmaPlain": "спів",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to create",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "створити",
-      "lemmaId": "створити",
-      "lemmaPlain": "створити",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "to test",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "тестувати",
-      "lemmaId": "тестувати",
-      "lemmaPlain": "тестувати",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "walking as process",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "ходіння",
-      "lemmaId": "ходіння",
-      "lemmaPlain": "ходіння",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:n",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "digital skills",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "цифрові навички",
-      "lemmaId": "цифрові-навички",
-      "lemmaPlain": "цифрові навички",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "chair, head (vocative)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "голово",
-      "lemmaId": "голово",
-      "lemmaPlain": "голово",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "vocative",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "civil servant",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "державний службовець",
-      "lemmaId": "державний-службовець",
-      "lemmaPlain": "державний службовець",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "sir, gentleman",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "добродій",
-      "lemmaId": "добродій",
-      "lemmaPlain": "добродій",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "sir (very formal vocative)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "добродію",
-      "lemmaId": "добродію",
-      "lemmaPlain": "добродію",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "vocative",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "business, professional",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "діловий",
-      "lemmaId": "діловий",
-      "lemmaPlain": "діловий",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "email",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "електронний лист",
-      "lemmaId": "електронний-лист",
-      "lemmaPlain": "електронний лист",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "exclamation mark",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "знак оклику",
-      "lemmaId": "знак-оклику",
-      "lemmaPlain": "знак оклику",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "colleague (vocative)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "колего",
-      "lemmaId": "колего",
-      "lemmaPlain": "колего",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "vocative",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "conference",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "конференція",
-      "lemmaId": "конференція",
-      "lemmaPlain": "конференція",
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "конференціям",
-            "singular": "конференції"
-          },
-          "знахідний": {
-            "plural": "конференції",
-            "singular": "конференцію"
-          },
-          "кличний": {
-            "plural": "конференції",
-            "singular": "конференціє"
-          },
-          "місцевий": {
-            "plural": "конференціях",
-            "singular": "конференції"
-          },
-          "називний": {
-            "plural": "конференції",
-            "singular": "конференція"
-          },
-          "орудний": {
-            "plural": "конференціями",
-            "singular": "конференцією"
-          },
-          "родовий": {
-            "plural": "конференцій",
-            "singular": "конференції"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "doctor (vocative)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "лікарю",
-      "lemmaId": "лікарю",
-      "lemmaPlain": "лікарю",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "vocative",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "ladies and gentlemen",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "пані та панове",
-      "lemmaId": "пані-та-панове",
-      "lemmaPlain": "пані та панове",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "professor (vocative)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "професоре",
-      "lemmaId": "професоре",
-      "lemmaPlain": "професоре",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "vocative",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "editor (female)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "редакторка",
-      "lemmaId": "редакторка",
-      "lemmaPlain": "редакторка",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "ceremonial",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "урочистий",
-      "lemmaId": "урочистий",
-      "lemmaPlain": "урочистий",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "participant (female)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "учасниця",
-      "lemmaId": "учасниця",
-      "lemmaPlain": "учасниця",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "formal",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "формальний",
-      "lemmaId": "формальний",
-      "lemmaPlain": "формальний",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "address formula",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "формула звертання",
-      "lemmaId": "формула-звертання",
-      "lemmaPlain": "формула звертання",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "ceremony",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "церемонія",
-      "lemmaId": "церемонія",
-      "lemmaPlain": "церемонія",
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "церемоніям",
-            "singular": "церемонії"
-          },
-          "знахідний": {
-            "plural": "церемонії",
-            "singular": "церемонію"
-          },
-          "кличний": {
-            "plural": "церемонії",
-            "singular": "церемоніє"
-          },
-          "місцевий": {
-            "plural": "церемоніях",
-            "singular": "церемонії"
-          },
-          "називний": {
-            "plural": "церемонії",
-            "singular": "церемонія"
-          },
-          "орудний": {
-            "plural": "церемоніями",
-            "singular": "церемонією"
-          },
-          "родовий": {
-            "plural": "церемоній",
-            "singular": "церемонії"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "respected, dear (feminine)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "шановна",
-      "lemmaId": "шановна",
-      "lemmaPlain": "шановна",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "Cossack, related to Cossacks",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "козацький",
-      "lemmaId": "козацький",
-      "lemmaPlain": "козацький",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "motivating word",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "мотивувальне слово",
-      "lemmaId": "мотивувальне-слово",
-      "lemmaPlain": "мотивувальне слово",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "derived word",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "похідне слово",
-      "lemmaId": "похідне-слово",
-      "lemmaPlain": "похідне слово",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "postwar",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "післявоєнний",
-      "lemmaId": "післявоєнний",
-      "lemmaPlain": "післявоєнний",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "compound adjective",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "складний прикметник",
-      "lemmaId": "складний-прикметник",
-      "lemmaPlain": "складний прикметник",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "connecting vowel",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "сполучна голосна",
-      "lemmaId": "сполучна-голосна",
-      "lemmaPlain": "сполучна голосна",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "zk- suffix",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "суфікс -зьк-",
-      "lemmaId": "суфікс-зьк",
-      "lemmaPlain": "суфікс -зьк-",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "suffix",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "sk- suffix",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "суфікс -ськ-",
-      "lemmaId": "суфікс-ськ",
-      "lemmaPlain": "суфікс -ськ-",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "suffix",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "tsk- suffix",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "суфікс -цьк-",
-      "lemmaId": "суфікс-цьк",
-      "lemmaPlain": "суфікс -цьк-",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "suffix",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "derivational base",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "твірна основа",
-      "lemmaId": "твірна-основа",
-      "lemmaPlain": "твірна основа",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "kindness",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "доброта",
-      "lemmaId": "доброта",
-      "lemmaPlain": "доброта",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "collective noun",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "збірний іменник",
-      "lemmaId": "збірний-іменник",
-      "lemmaPlain": "збірний іменник",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "Cossackdom",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "козацтво",
-      "lemmaId": "козацтво",
-      "lemmaPlain": "козацтво",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "agent noun, noun naming a person",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "назва особи",
-      "lemmaId": "назва-особи",
-      "lemmaPlain": "назва особи",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "room or facility name",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "назва приміщення",
-      "lemmaId": "назва-приміщення",
-      "lemmaPlain": "назва приміщення",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "unproductive suffix",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "непродуктивний суфікс",
-      "lemmaId": "непродуктивний-суфікс",
-      "lemmaPlain": "непродуктивний суфікс",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "bakery",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "пекарня",
-      "lemmaId": "пекарня",
-      "lemmaPlain": "пекарня",
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "пекарням",
-            "singular": "пекарні"
-          },
-          "знахідний": {
-            "plural": "пекарні",
-            "singular": "пекарню"
-          },
-          "кличний": {
-            "plural": "пекарні",
-            "singular": "пекарне"
-          },
-          "місцевий": {
-            "plural": "пекарнях",
-            "singular": "пекарні"
-          },
-          "називний": {
-            "plural": "пекарні",
-            "singular": "пекарня"
-          },
-          "орудний": {
-            "plural": "пекарнями",
-            "singular": "пекарнею"
-          },
-          "родовий": {
-            "plural": "пекарень",
-            "singular": "пекарні"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "crossing, transition",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "перехід",
-      "lemmaId": "перехід",
-      "lemmaPlain": "перехід",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "derived noun",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "похідний іменник",
-      "lemmaId": "похідний-іменник",
-      "lemmaPlain": "похідний іменник",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "prefixal-suffixal derivation",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "префіксально-суфіксальний спосіб",
-      "lemmaId": "префіксально-суфіксальний-спосіб",
-      "lemmaPlain": "префіксально-суфіксальний спосіб",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "productive suffix",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "продуктивний суфікс",
-      "lemmaId": "продуктивний-суфікс",
-      "lemmaPlain": "продуктивний суфікс",
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
       "semanticBucket": null,
       "severity": null
     }
@@ -21674,10 +20798,10 @@
   "schema": "atlas-practice-lexemes",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 46645,
+    "gzipBytes": 44971,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 549842,
+    "rawBytes": 549943,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/public/lexicon/practice-lexemes.B2.json
+++ b/site/public/lexicon/practice-lexemes.B2.json
@@ -5,11 +5,13 @@
     {
       "cefr": "B2",
       "gloss": "magnet",
+      "glossClean": "magnet",
       "heritage": "standard",
       "ipa": null,
       "lemma": "магніт",
       "lemmaId": "магніт",
       "lemmaPlain": "магніт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -20,11 +22,13 @@
     {
       "cefr": "B2",
       "gloss": "barista",
+      "glossClean": "barista",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бариста",
       "lemmaId": "бариста",
       "lemmaPlain": "бариста",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -35,11 +39,13 @@
     {
       "cefr": "B2",
       "gloss": "tip; gratuity",
+      "glossClean": "tip",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чайові",
       "lemmaId": "чайові",
       "lemmaPlain": "чайові",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -50,11 +56,13 @@
     {
       "cefr": "B2",
       "gloss": "to wash up",
+      "glossClean": "to wash up",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вмиватися",
       "lemmaId": "вмиватися",
       "lemmaPlain": "вмиватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -65,11 +73,13 @@
     {
       "cefr": "B2",
       "gloss": "I walk",
+      "glossClean": "I walk",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гуляю",
       "lemmaId": "гуляю",
       "lemmaPlain": "гуляю",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -80,11 +90,13 @@
     {
       "cefr": "B2",
       "gloss": "ready",
+      "glossClean": "ready",
       "heritage": "standard",
       "ipa": null,
       "lemma": "готово",
       "lemmaId": "готово",
       "lemmaPlain": "готово",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -95,11 +107,13 @@
     {
       "cefr": "B2",
       "gloss": "poster",
+      "glossClean": "poster",
       "heritage": "standard",
       "ipa": null,
       "lemma": "плакат",
       "lemmaId": "плакат",
       "lemmaPlain": "плакат",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -110,11 +124,13 @@
     {
       "cefr": "B2",
       "gloss": "new, neuter",
+      "glossClean": "new",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нове",
       "lemmaId": "нове",
       "lemmaPlain": "нове",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -125,11 +141,13 @@
     {
       "cefr": "B2",
       "gloss": "from there",
+      "glossClean": "from there",
       "heritage": "standard",
       "ipa": null,
       "lemma": "звідти",
       "lemmaId": "звідти",
       "lemmaPlain": "звідти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -140,11 +158,13 @@
     {
       "cefr": "B2",
       "gloss": "rescue",
+      "glossClean": "rescue",
       "heritage": "standard",
       "ipa": null,
       "lemma": "порятунок",
       "lemmaId": "порятунок",
       "lemmaPlain": "порятунок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -155,11 +175,13 @@
     {
       "cefr": "B2",
       "gloss": "address; speaking to someone",
+      "glossClean": "address",
       "heritage": "standard",
       "ipa": null,
       "lemma": "звертання",
       "lemmaId": "звертання",
       "lemmaPlain": "звертання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -170,11 +192,13 @@
     {
       "cefr": "B2",
       "gloss": "because",
+      "glossClean": "because",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бо",
       "lemmaId": "бо",
       "lemmaPlain": "бо",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -185,11 +209,13 @@
     {
       "cefr": "B2",
       "gloss": "since when",
+      "glossClean": "since when",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відколи",
       "lemmaId": "відколи",
       "lemmaPlain": "відколи",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -200,11 +226,13 @@
     {
       "cefr": "B2",
       "gloss": "however",
+      "glossClean": "however",
       "heritage": "standard",
       "ipa": null,
       "lemma": "однак",
       "lemmaId": "однак",
       "lemmaPlain": "однак",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -215,11 +243,13 @@
     {
       "cefr": "B2",
       "gloss": "alphabet",
+      "glossClean": "alphabet",
       "heritage": "standard",
       "ipa": null,
       "lemma": "абе́тка",
       "lemmaId": "абе-тка",
       "lemmaPlain": "абетка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -230,11 +260,13 @@
     {
       "cefr": "B2",
       "gloss": "cashier",
+      "glossClean": "cashier",
       "heritage": "standard",
       "ipa": null,
       "lemma": "касирка",
       "lemmaId": "касирка",
       "lemmaPlain": "касирка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -245,11 +277,13 @@
     {
       "cefr": "B2",
       "gloss": "atlas / satin",
+      "glossClean": "atlas / satin",
       "heritage": "standard",
       "ipa": null,
       "lemma": "атлас",
       "lemmaId": "атлас",
       "lemmaPlain": "атлас",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -260,11 +294,13 @@
     {
       "cefr": "B2",
       "gloss": "stressed",
+      "glossClean": "stressed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "наголошений",
       "lemmaId": "наголошений",
       "lemmaPlain": "наголошений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -275,11 +311,13 @@
     {
       "cefr": "B2",
       "gloss": "I study; I am learning",
+      "glossClean": "I study",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вивчаю",
       "lemmaId": "вивчаю",
       "lemmaPlain": "вивчаю",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -290,11 +328,13 @@
     {
       "cefr": "B2",
       "gloss": "we learn; we study",
+      "glossClean": "we learn",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вчимо",
       "lemmaId": "вчимо",
       "lemmaPlain": "вчимо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -305,11 +345,13 @@
     {
       "cefr": "B2",
       "gloss": "I am learning; I study (preview)",
+      "glossClean": "I am learning",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вчуся",
       "lemmaId": "вчуся",
       "lemmaPlain": "вчуся",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -320,11 +362,13 @@
     {
       "cefr": "B2",
       "gloss": "you ask for (plural/formal)",
+      "glossClean": "you ask for (plural/formal)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "просите",
       "lemmaId": "просите",
       "lemmaPlain": "просите",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -335,11 +379,13 @@
     {
       "cefr": "B2",
       "gloss": "you ask for",
+      "glossClean": "you ask for",
       "heritage": "standard",
       "ipa": null,
       "lemma": "просиш",
       "lemmaId": "просиш",
       "lemmaPlain": "просиш",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -350,11 +396,13 @@
     {
       "cefr": "B2",
       "gloss": "you go regularly; you walk (plural/formal)",
+      "glossClean": "you go regularly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ходите",
       "lemmaId": "ходите",
       "lemmaPlain": "ходите",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -365,11 +413,13 @@
     {
       "cefr": "B2",
       "gloss": "man from Odesa",
+      "glossClean": "man from Odesa",
       "heritage": "standard",
       "ipa": null,
       "lemma": "одесит",
       "lemmaId": "одесит",
       "lemmaPlain": "одесит",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -380,11 +430,13 @@
     {
       "cefr": "B2",
       "gloss": "woman from Odesa",
+      "glossClean": "woman from Odesa",
       "heritage": "standard",
       "ipa": null,
       "lemma": "одеситка",
       "lemmaId": "одеситка",
       "lemmaPlain": "одеситка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -395,11 +447,13 @@
     {
       "cefr": "B2",
       "gloss": "woman from Kharkiv",
+      "glossClean": "woman from Kharkiv",
       "heritage": "standard",
       "ipa": null,
       "lemma": "харків'янка",
       "lemmaId": "харків-янка",
       "lemmaPlain": "харків'янка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -410,11 +464,13 @@
     {
       "cefr": "B2",
       "gloss": "alternation",
+      "glossClean": "alternation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чергування",
       "lemmaId": "чергування",
       "lemmaPlain": "чергування",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -425,11 +481,13 @@
     {
       "cefr": "B2",
       "gloss": "self-assessment",
+      "glossClean": "self-assessment",
       "heritage": "standard",
       "ipa": null,
       "lemma": "самооцінка",
       "lemmaId": "самооцінка",
       "lemmaPlain": "самооцінка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -469,11 +527,13 @@
     {
       "cefr": "B2",
       "gloss": "confidently",
+      "glossClean": "confidently",
       "heritage": "standard",
       "ipa": null,
       "lemma": "впевнено",
       "lemmaId": "впевнено",
       "lemmaPlain": "впевнено",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -484,11 +544,13 @@
     {
       "cefr": "B2",
       "gloss": "appropriate",
+      "glossClean": "appropriate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "доречний",
       "lemmaId": "доречний",
       "lemmaPlain": "доречний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -499,11 +561,13 @@
     {
       "cefr": "B2",
       "gloss": "to register",
+      "glossClean": "to register",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зареєструватися",
       "lemmaId": "зареєструватися",
       "lemmaPlain": "зареєструватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -514,11 +578,13 @@
     {
       "cefr": "B2",
       "gloss": "timer",
+      "glossClean": "timer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "таймер",
       "lemmaId": "таймер",
       "lemmaPlain": "таймер",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -529,11 +595,13 @@
     {
       "cefr": "B2",
       "gloss": "completed",
+      "glossClean": "completed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "завершений",
       "lemmaId": "завершений",
       "lemmaPlain": "завершений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -544,11 +612,13 @@
     {
       "cefr": "B2",
       "gloss": "boundary, endpoint",
+      "glossClean": "boundary",
       "heritage": "standard",
       "ipa": null,
       "lemma": "межа",
       "lemmaId": "межа",
       "lemmaPlain": "межа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -588,11 +658,13 @@
     {
       "cefr": "B2",
       "gloss": "to memorize",
+      "glossClean": "to memorize",
       "heritage": "standard",
       "ipa": null,
       "lemma": "запам'ятовувати",
       "lemmaId": "запам-ятовувати",
       "lemmaPlain": "запам'ятовувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -603,11 +675,13 @@
     {
       "cefr": "B2",
       "gloss": "prefix",
+      "glossClean": "prefix",
       "heritage": "standard",
       "ipa": null,
       "lemma": "префікс",
       "lemmaId": "префікс",
       "lemmaPlain": "префікс",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -618,11 +692,13 @@
     {
       "cefr": "B2",
       "gloss": "suffix",
+      "glossClean": "suffix",
       "heritage": "standard",
       "ipa": null,
       "lemma": "суфікс",
       "lemmaId": "суфікс",
       "lemmaPlain": "суфікс",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -633,11 +709,13 @@
     {
       "cefr": "B2",
       "gloss": "negation",
+      "glossClean": "negation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заперечення",
       "lemmaId": "заперечення",
       "lemmaPlain": "заперечення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -648,11 +726,13 @@
     {
       "cefr": "B2",
       "gloss": "addition",
+      "glossClean": "addition",
       "heritage": "standard",
       "ipa": null,
       "lemma": "додавання",
       "lemmaId": "додавання",
       "lemmaPlain": "додавання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -663,11 +743,13 @@
     {
       "cefr": "B2",
       "gloss": "test",
+      "glossClean": "test",
       "heritage": "standard",
       "ipa": null,
       "lemma": "контрольна",
       "lemmaId": "контрольна",
       "lemmaPlain": "контрольна",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -707,11 +789,13 @@
     {
       "cefr": "B2",
       "gloss": "absence",
+      "glossClean": "absence",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відсутність",
       "lemmaId": "відсутність",
       "lemmaPlain": "відсутність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -722,11 +806,13 @@
     {
       "cefr": "B2",
       "gloss": "purpose, intended recipient",
+      "glossClean": "purpose",
       "heritage": "standard",
       "ipa": null,
       "lemma": "призначення",
       "lemmaId": "призначення",
       "lemmaPlain": "призначення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -737,11 +823,13 @@
     {
       "cefr": "B2",
       "gloss": "agreement",
+      "glossClean": "agreement",
       "heritage": "standard",
       "ipa": null,
       "lemma": "узгодження",
       "lemmaId": "узгодження",
       "lemmaPlain": "узгодження",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -752,11 +840,13 @@
     {
       "cefr": "B2",
       "gloss": "function",
+      "glossClean": "function",
       "heritage": "standard",
       "ipa": null,
       "lemma": "функція",
       "lemmaId": "функція",
       "lemmaPlain": "функція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -796,11 +886,13 @@
     {
       "cefr": "B2",
       "gloss": "ingredient",
+      "glossClean": "ingredient",
       "heritage": "standard",
       "ipa": null,
       "lemma": "інгредієнт",
       "lemmaId": "інгредієнт",
       "lemmaPlain": "інгредієнт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -811,11 +903,13 @@
     {
       "cefr": "B2",
       "gloss": "subordinate",
+      "glossClean": "subordinate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підрядний",
       "lemmaId": "підрядний",
       "lemmaPlain": "підрядний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -826,11 +920,13 @@
     {
       "cefr": "B2",
       "gloss": "to edit",
+      "glossClean": "to edit",
       "heritage": "standard",
       "ipa": null,
       "lemma": "редагувати",
       "lemmaId": "редагувати",
       "lemmaPlain": "редагувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -841,11 +937,13 @@
     {
       "cefr": "B2",
       "gloss": "inversion",
+      "glossClean": "inversion",
       "heritage": "standard",
       "ipa": null,
       "lemma": "інверсія",
       "lemmaId": "інверсія",
       "lemmaPlain": "інверсія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -885,11 +983,13 @@
     {
       "cefr": "B2",
       "gloss": "comparison",
+      "glossClean": "comparison",
       "heritage": "standard",
       "ipa": null,
       "lemma": "порівняння",
       "lemmaId": "порівняння",
       "lemmaPlain": "порівняння",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -900,11 +1000,13 @@
     {
       "cefr": "B2",
       "gloss": "recipient",
+      "glossClean": "recipient",
       "heritage": "standard",
       "ipa": null,
       "lemma": "одержувач",
       "lemmaId": "одержувач",
       "lemmaPlain": "одержувач",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -915,11 +1017,13 @@
     {
       "cefr": "B2",
       "gloss": "to trust",
+      "glossClean": "to trust",
       "heritage": "standard",
       "ipa": null,
       "lemma": "довіряти",
       "lemmaId": "довіряти",
       "lemmaPlain": "довіряти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -930,11 +1034,13 @@
     {
       "cefr": "B2",
       "gloss": "to bother, to disturb",
+      "glossClean": "to bother",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заважати",
       "lemmaId": "заважати",
       "lemmaPlain": "заважати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -945,11 +1051,13 @@
     {
       "cefr": "B2",
       "gloss": "to envy",
+      "glossClean": "to envy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заздрити",
       "lemmaId": "заздрити",
       "lemmaPlain": "заздрити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -960,11 +1068,13 @@
     {
       "cefr": "B2",
       "gloss": "to sympathize",
+      "glossClean": "to sympathize",
       "heritage": "standard",
       "ipa": null,
       "lemma": "співчувати",
       "lemmaId": "співчувати",
       "lemmaPlain": "співчувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -975,11 +1085,13 @@
     {
       "cefr": "B2",
       "gloss": "entertainment",
+      "glossClean": "entertainment",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розвага",
       "lemmaId": "розвага",
       "lemmaPlain": "розвага",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1019,11 +1131,13 @@
     {
       "cefr": "B2",
       "gloss": "smooth",
+      "glossClean": "smooth",
       "heritage": "standard",
       "ipa": null,
       "lemma": "плавний",
       "lemmaId": "плавний",
       "lemmaPlain": "плавний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1034,11 +1148,13 @@
     {
       "cefr": "B2",
       "gloss": "housewarming party",
+      "glossClean": "housewarming party",
       "heritage": "standard",
       "ipa": null,
       "lemma": "новосілля",
       "lemmaId": "новосілля",
       "lemmaPlain": "новосілля",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1049,11 +1165,13 @@
     {
       "cefr": "B2",
       "gloss": "cover",
+      "glossClean": "cover",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обкладинка",
       "lemmaId": "обкладинка",
       "lemmaPlain": "обкладинка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1093,11 +1211,13 @@
     {
       "cefr": "B2",
       "gloss": "attitude",
+      "glossClean": "attitude",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ставлення",
       "lemmaId": "ставлення",
       "lemmaPlain": "ставлення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1108,11 +1228,13 @@
     {
       "cefr": "B2",
       "gloss": "to help oneself to food",
+      "glossClean": "to help oneself to food",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пригощатися",
       "lemmaId": "пригощатися",
       "lemmaPlain": "пригощатися",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -1123,11 +1245,13 @@
     {
       "cefr": "B2",
       "gloss": "nobody's, belonging to nobody",
+      "glossClean": "nobody's",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нічий",
       "lemmaId": "нічий",
       "lemmaPlain": "нічий",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -1138,11 +1262,13 @@
     {
       "cefr": "B2",
       "gloss": "in no way, not at all",
+      "glossClean": "in no way",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ніяк",
       "lemmaId": "ніяк",
       "lemmaPlain": "ніяк",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1153,11 +1279,13 @@
     {
       "cefr": "B2",
       "gloss": "persistent, determined",
+      "glossClean": "persistent",
       "heritage": "standard",
       "ipa": null,
       "lemma": "наполегливий",
       "lemmaId": "наполегливий",
       "lemmaPlain": "наполегливий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1168,11 +1296,13 @@
     {
       "cefr": "B2",
       "gloss": "to prompt, to give one helpful hint",
+      "glossClean": "to prompt",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підказати",
       "lemmaId": "підказати",
       "lemmaPlain": "підказати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1183,11 +1313,13 @@
     {
       "cefr": "B2",
       "gloss": "to prompt, to give hints habitually",
+      "glossClean": "to prompt",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підказувати",
       "lemmaId": "підказувати",
       "lemmaPlain": "підказувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1198,11 +1330,13 @@
     {
       "cefr": "B2",
       "gloss": "patient",
+      "glossClean": "patient",
       "heritage": "standard",
       "ipa": null,
       "lemma": "терплячий",
       "lemmaId": "терплячий",
       "lemmaPlain": "терплячий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1213,11 +1347,13 @@
     {
       "cefr": "B2",
       "gloss": "caring, responsive",
+      "glossClean": "caring",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чуйний",
       "lemmaId": "чуйний",
       "lemmaPlain": "чуйний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1228,11 +1364,13 @@
     {
       "cefr": "B2",
       "gloss": "interjection",
+      "glossClean": "interjection",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вигук",
       "lemmaId": "вигук",
       "lemmaPlain": "вигук",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1243,11 +1381,13 @@
     {
       "cefr": "B2",
       "gloss": "changeable",
+      "glossClean": "changeable",
       "heritage": "standard",
       "ipa": null,
       "lemma": "змінний",
       "lemmaId": "змінний",
       "lemmaPlain": "змінний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1258,11 +1398,13 @@
     {
       "cefr": "B2",
       "gloss": "related",
+      "glossClean": "related",
       "heritage": "standard",
       "ipa": null,
       "lemma": "споріднений",
       "lemmaId": "споріднений",
       "lemmaPlain": "споріднений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1273,11 +1415,13 @@
     {
       "cefr": "B2",
       "gloss": "particle",
+      "glossClean": "particle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "частка",
       "lemmaId": "частка",
       "lemmaPlain": "частка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1317,11 +1461,13 @@
     {
       "cefr": "B2",
       "gloss": "to pronounce",
+      "glossClean": "to pronounce",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вимовляти",
       "lemmaId": "вимовляти",
       "lemmaPlain": "вимовляти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1332,11 +1478,13 @@
     {
       "cefr": "B2",
       "gloss": "linguistics",
+      "glossClean": "linguistics",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мовознавство",
       "lemmaId": "мовознавство",
       "lemmaPlain": "мовознавство",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1347,11 +1495,13 @@
     {
       "cefr": "B2",
       "gloss": "phonetics",
+      "glossClean": "phonetics",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фонетика",
       "lemmaId": "фонетика",
       "lemmaPlain": "фонетика",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1391,11 +1541,13 @@
     {
       "cefr": "B2",
       "gloss": "predicate",
+      "glossClean": "predicate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "присудок",
       "lemmaId": "присудок",
       "lemmaPlain": "присудок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1406,11 +1558,13 @@
     {
       "cefr": "B2",
       "gloss": "subject",
+      "glossClean": "subject",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підмет",
       "lemmaId": "підмет",
       "lemmaPlain": "підмет",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1421,11 +1575,13 @@
     {
       "cefr": "B2",
       "gloss": "to combine",
+      "glossClean": "to combine",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поєднуватися",
       "lemmaId": "поєднуватися",
       "lemmaPlain": "поєднуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1436,11 +1592,13 @@
     {
       "cefr": "B2",
       "gloss": "syntax",
+      "glossClean": "syntax",
       "heritage": "standard",
       "ipa": null,
       "lemma": "синтаксис",
       "lemmaId": "синтаксис",
       "lemmaPlain": "синтаксис",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1451,11 +1609,13 @@
     {
       "cefr": "B2",
       "gloss": "dash",
+      "glossClean": "dash",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тире",
       "lemmaId": "тире",
       "lemmaPlain": "тире",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1495,11 +1655,13 @@
     {
       "cefr": "B2",
       "gloss": "conjugation class",
+      "glossClean": "conjugation class",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дієвідміна",
       "lemmaId": "дієвідміна",
       "lemmaPlain": "дієвідміна",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1539,11 +1701,13 @@
     {
       "cefr": "B2",
       "gloss": "abbreviation",
+      "glossClean": "abbreviation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "скорочення",
       "lemmaId": "скорочення",
       "lemmaPlain": "скорочення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1554,11 +1718,13 @@
     {
       "cefr": "B2",
       "gloss": "to agree grammatically",
+      "glossClean": "to agree grammatically",
       "heritage": "standard",
       "ipa": null,
       "lemma": "узгоджуватися",
       "lemmaId": "узгоджуватися",
       "lemmaPlain": "узгоджуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1569,11 +1735,13 @@
     {
       "cefr": "B2",
       "gloss": "cardinal",
+      "glossClean": "cardinal",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кількісний",
       "lemmaId": "кількісний",
       "lemmaPlain": "кількісний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1584,11 +1752,13 @@
     {
       "cefr": "B2",
       "gloss": "lion",
+      "glossClean": "lion",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лев",
       "lemmaId": "лев",
       "lemmaPlain": "лев",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1599,11 +1769,13 @@
     {
       "cefr": "B2",
       "gloss": "inanimate, non-living",
+      "glossClean": "inanimate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "неживий",
       "lemmaId": "неживий",
       "lemmaPlain": "неживий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1614,11 +1786,13 @@
     {
       "cefr": "B2",
       "gloss": "disagreement",
+      "glossClean": "disagreement",
       "heritage": "standard",
       "ipa": null,
       "lemma": "незгода",
       "lemmaId": "незгода",
       "lemmaPlain": "незгода",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1658,11 +1832,13 @@
     {
       "cefr": "B2",
       "gloss": "convinced, masculine",
+      "glossClean": "convinced",
       "heritage": "standard",
       "ipa": null,
       "lemma": "переконаний",
       "lemmaId": "переконаний",
       "lemmaPlain": "переконаний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1673,11 +1849,13 @@
     {
       "cefr": "B2",
       "gloss": "rightness, reason in the phrase мати рацію",
+      "glossClean": "rightness",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рація",
       "lemmaId": "рація",
       "lemmaPlain": "рація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1717,11 +1895,13 @@
     {
       "cefr": "B2",
       "gloss": "to water",
+      "glossClean": "to water",
       "heritage": "standard",
       "ipa": null,
       "lemma": "полити",
       "lemmaId": "полити",
       "lemmaPlain": "полити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1732,11 +1912,13 @@
     {
       "cefr": "B2",
       "gloss": "attributive, descriptive",
+      "glossClean": "attributive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "означальний",
       "lemmaId": "означальний",
       "lemmaPlain": "означальний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1747,11 +1929,13 @@
     {
       "cefr": "B2",
       "gloss": "sender",
+      "glossClean": "sender",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відправник",
       "lemmaId": "відправник",
       "lemmaPlain": "відправник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1762,11 +1946,13 @@
     {
       "cefr": "B2",
       "gloss": "pharmacist",
+      "glossClean": "pharmacist",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фармацевт",
       "lemmaId": "фармацевт",
       "lemmaPlain": "фармацевт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1777,11 +1963,13 @@
     {
       "cefr": "B2",
       "gloss": "expressiveness",
+      "glossClean": "expressiveness",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виразність",
       "lemmaId": "виразність",
       "lemmaPlain": "виразність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1792,11 +1980,13 @@
     {
       "cefr": "B2",
       "gloss": "epithet",
+      "glossClean": "epithet",
       "heritage": "standard",
       "ipa": null,
       "lemma": "епітет",
       "lemmaId": "епітет",
       "lemmaPlain": "епітет",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1807,11 +1997,13 @@
     {
       "cefr": "B2",
       "gloss": "tender, affectionate",
+      "glossClean": "tender",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ласкавий",
       "lemmaId": "ласкавий",
       "lemmaPlain": "ласкавий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1822,11 +2014,13 @@
     {
       "cefr": "B2",
       "gloss": "figurative, expressive",
+      "glossClean": "figurative",
       "heritage": "standard",
       "ipa": null,
       "lemma": "образний",
       "lemmaId": "образний",
       "lemmaPlain": "образний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1837,11 +2031,13 @@
     {
       "cefr": "B2",
       "gloss": "repetition",
+      "glossClean": "repetition",
       "heritage": "standard",
       "ipa": null,
       "lemma": "повтор",
       "lemmaId": "повтор",
       "lemmaPlain": "повтор",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1852,11 +2048,13 @@
     {
       "cefr": "B2",
       "gloss": "quickly, briskly",
+      "glossClean": "quickly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прудко",
       "lemmaId": "прудко",
       "lemmaPlain": "прудко",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1867,11 +2065,13 @@
     {
       "cefr": "B2",
       "gloss": "stylistics",
+      "glossClean": "stylistics",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стилістика",
       "lemmaId": "стилістика",
       "lemmaPlain": "стилістика",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1911,11 +2111,13 @@
     {
       "cefr": "B2",
       "gloss": "waterfront, embankment",
+      "glossClean": "waterfront",
       "heritage": "standard",
       "ipa": null,
       "lemma": "набережна",
       "lemmaId": "набережна",
       "lemmaPlain": "набережна",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1955,11 +2157,13 @@
     {
       "cefr": "B2",
       "gloss": "transfer, change",
+      "glossClean": "transfer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пересадка",
       "lemmaId": "пересадка",
       "lemmaPlain": "пересадка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1999,11 +2203,13 @@
     {
       "cefr": "B2",
       "gloss": "train attendant",
+      "glossClean": "train attendant",
       "heritage": "standard",
       "ipa": null,
       "lemma": "провідниця",
       "lemmaId": "провідниця",
       "lemmaPlain": "провідниця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2014,11 +2220,13 @@
     {
       "cefr": "B2",
       "gloss": "small cottage",
+      "glossClean": "small cottage",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хатинка",
       "lemmaId": "хатинка",
       "lemmaPlain": "хатинка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2058,11 +2266,13 @@
     {
       "cefr": "B2",
       "gloss": "polite",
+      "glossClean": "polite",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ввічливий",
       "lemmaId": "ввічливий",
       "lemmaPlain": "ввічливий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2073,11 +2283,13 @@
     {
       "cefr": "B2",
       "gloss": "compass",
+      "glossClean": "compass",
       "heritage": "standard",
       "ipa": null,
       "lemma": "компас",
       "lemmaId": "компас",
       "lemmaPlain": "компас",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2088,11 +2300,13 @@
     {
       "cefr": "B2",
       "gloss": "characteristic, description",
+      "glossClean": "characteristic",
       "heritage": "standard",
       "ipa": null,
       "lemma": "характеристика",
       "lemmaId": "характеристика",
       "lemmaPlain": "характеристика",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2132,11 +2346,13 @@
     {
       "cefr": "B2",
       "gloss": "to highlight, to single out",
+      "glossClean": "to highlight",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виділяти",
       "lemmaId": "виділяти",
       "lemmaPlain": "виділяти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2147,11 +2363,13 @@
     {
       "cefr": "B2",
       "gloss": "to emphasize",
+      "glossClean": "to emphasize",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підкреслювати",
       "lemmaId": "підкреслювати",
       "lemmaPlain": "підкреслювати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2162,11 +2380,13 @@
     {
       "cefr": "B2",
       "gloss": "to sprinkle",
+      "glossClean": "to sprinkle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "посипати",
       "lemmaId": "посипати",
       "lemmaPlain": "посипати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2177,11 +2397,13 @@
     {
       "cefr": "B2",
       "gloss": "very beautiful",
+      "glossClean": "very beautiful",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прегарний",
       "lemmaId": "прегарний",
       "lemmaPlain": "прегарний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2192,11 +2414,13 @@
     {
       "cefr": "B2",
       "gloss": "intensified",
+      "glossClean": "intensified",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підсилений",
       "lemmaId": "підсилений",
       "lemmaPlain": "підсилений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2207,11 +2431,13 @@
     {
       "cefr": "B2",
       "gloss": "stylistic",
+      "glossClean": "stylistic",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стилістичний",
       "lemmaId": "стилістичний",
       "lemmaPlain": "стилістичний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2222,11 +2448,13 @@
     {
       "cefr": "B2",
       "gloss": "negative",
+      "glossClean": "negative",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заперечний",
       "lemmaId": "заперечний",
       "lemmaPlain": "заперечний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2237,11 +2465,13 @@
     {
       "cefr": "B2",
       "gloss": "reflexive",
+      "glossClean": "reflexive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зворотний",
       "lemmaId": "зворотний",
       "lemmaPlain": "зворотний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2252,11 +2482,13 @@
     {
       "cefr": "B2",
       "gloss": "indefinite",
+      "glossClean": "indefinite",
       "heritage": "standard",
       "ipa": null,
       "lemma": "неозначений",
       "lemmaId": "неозначений",
       "lemmaPlain": "неозначений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2267,11 +2499,13 @@
     {
       "cefr": "B2",
       "gloss": "prefixal",
+      "glossClean": "prefixal",
       "heritage": "standard",
       "ipa": null,
       "lemma": "префіксальний",
       "lemmaId": "префіксальний",
       "lemmaPlain": "префіксальний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2282,11 +2516,13 @@
     {
       "cefr": "B2",
       "gloss": "of one's own will",
+      "glossClean": "of one's own will",
       "heritage": "standard",
       "ipa": null,
       "lemma": "самохіть",
       "lemmaId": "самохіть",
       "lemmaPlain": "самохіть",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2297,11 +2533,13 @@
     {
       "cefr": "B2",
       "gloss": "suffixal",
+      "glossClean": "suffixal",
       "heritage": "standard",
       "ipa": null,
       "lemma": "суфіксальний",
       "lemmaId": "суфіксальний",
       "lemmaPlain": "суфіксальний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2312,11 +2550,13 @@
     {
       "cefr": "B2",
       "gloss": "formation",
+      "glossClean": "formation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "творення",
       "lemmaId": "творення",
       "lemmaPlain": "творення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2327,11 +2567,13 @@
     {
       "cefr": "B2",
       "gloss": "productive",
+      "glossClean": "productive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "продуктивний",
       "lemmaId": "продуктивний",
       "lemmaPlain": "продуктивний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2342,11 +2584,13 @@
     {
       "cefr": "B2",
       "gloss": "word formation",
+      "glossClean": "word formation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "словотворення",
       "lemmaId": "словотворення",
       "lemmaPlain": "словотворення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2357,11 +2601,13 @@
     {
       "cefr": "B2",
       "gloss": "pronunciation",
+      "glossClean": "pronunciation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вимова",
       "lemmaId": "вимова",
       "lemmaPlain": "вимова",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2372,11 +2618,13 @@
     {
       "cefr": "B2",
       "gloss": "dropping, disappearance",
+      "glossClean": "dropping",
       "heritage": "standard",
       "ipa": null,
       "lemma": "випадіння",
       "lemmaId": "випадіння",
       "lemmaPlain": "випадіння",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2387,11 +2635,13 @@
     {
       "cefr": "B2",
       "gloss": "completion",
+      "glossClean": "completion",
       "heritage": "standard",
       "ipa": null,
       "lemma": "завершеність",
       "lemmaId": "завершеність",
       "lemmaPlain": "завершеність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2402,11 +2652,13 @@
     {
       "cefr": "B2",
       "gloss": "repetition",
+      "glossClean": "repetition",
       "heritage": "standard",
       "ipa": null,
       "lemma": "повторюваність",
       "lemmaId": "повторюваність",
       "lemmaPlain": "повторюваність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2417,11 +2669,13 @@
     {
       "cefr": "B2",
       "gloss": "to make an effort, perfective",
+      "glossClean": "to make an effort",
       "heritage": "standard",
       "ipa": null,
       "lemma": "постаратися",
       "lemmaId": "постаратися",
       "lemmaPlain": "постаратися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2432,11 +2686,13 @@
     {
       "cefr": "B2",
       "gloss": "hypothetical",
+      "glossClean": "hypothetical",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гіпотетичний",
       "lemmaId": "гіпотетичний",
       "lemmaPlain": "гіпотетичний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2447,11 +2703,13 @@
     {
       "cefr": "B2",
       "gloss": "you will write, you will have written",
+      "glossClean": "you will write",
       "heritage": "standard",
       "ipa": null,
       "lemma": "напишеш",
       "lemmaId": "напишеш",
       "lemmaPlain": "напишеш",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2462,11 +2720,13 @@
     {
       "cefr": "B2",
       "gloss": "to save",
+      "glossClean": "to save",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зберегти",
       "lemmaId": "зберегти",
       "lemmaPlain": "зберегти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2477,11 +2737,13 @@
     {
       "cefr": "B2",
       "gloss": "categorical, firm",
+      "glossClean": "categorical",
       "heritage": "standard",
       "ipa": null,
       "lemma": "категоричний",
       "lemmaId": "категоричний",
       "lemmaPlain": "категоричний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2492,11 +2754,13 @@
     {
       "cefr": "B2",
       "gloss": "controlled",
+      "glossClean": "controlled",
       "heritage": "standard",
       "ipa": null,
       "lemma": "контрольований",
       "lemmaId": "контрольований",
       "lemmaPlain": "контрольований",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2507,11 +2771,13 @@
     {
       "cefr": "B2",
       "gloss": "to mix",
+      "glossClean": "to mix",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перемішувати",
       "lemmaId": "перемішувати",
       "lemmaPlain": "перемішувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2522,11 +2788,13 @@
     {
       "cefr": "B2",
       "gloss": "pragmatic",
+      "glossClean": "pragmatic",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прагматичний",
       "lemmaId": "прагматичний",
       "lemmaPlain": "прагматичний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2537,11 +2805,13 @@
     {
       "cefr": "B2",
       "gloss": "to break, smash",
+      "glossClean": "to break",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розбивати",
       "lemmaId": "розбивати",
       "lemmaPlain": "розбивати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2552,11 +2822,13 @@
     {
       "cefr": "B2",
       "gloss": "to watch, monitor",
+      "glossClean": "to watch",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стежити",
       "lemmaId": "стежити",
       "lemmaPlain": "стежити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2567,11 +2839,13 @@
     {
       "cefr": "B2",
       "gloss": "atmosphere",
+      "glossClean": "atmosphere",
       "heritage": "standard",
       "ipa": null,
       "lemma": "атмосфера",
       "lemmaId": "атмосфера",
       "lemmaPlain": "атмосфера",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2582,11 +2856,13 @@
     {
       "cefr": "B2",
       "gloss": "sequentially",
+      "glossClean": "sequentially",
       "heritage": "standard",
       "ipa": null,
       "lemma": "послідовно",
       "lemmaId": "послідовно",
       "lemmaPlain": "послідовно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2597,11 +2873,13 @@
     {
       "cefr": "B2",
       "gloss": "to finish doing",
+      "glossClean": "to finish doing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "доробити",
       "lemmaId": "доробити",
       "lemmaPlain": "доробити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2612,11 +2890,13 @@
     {
       "cefr": "B2",
       "gloss": "to finish reading",
+      "glossClean": "to finish reading",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дочитати",
       "lemmaId": "дочитати",
       "lemmaPlain": "дочитати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2627,11 +2907,13 @@
     {
       "cefr": "B2",
       "gloss": "statement of fact",
+      "glossClean": "statement of fact",
       "heritage": "standard",
       "ipa": null,
       "lemma": "констатація",
       "lemmaId": "констатація",
       "lemmaPlain": "констатація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2642,11 +2924,13 @@
     {
       "cefr": "B2",
       "gloss": "unfinished; incomplete",
+      "glossClean": "unfinished",
       "heritage": "standard",
       "ipa": null,
       "lemma": "незавершений",
       "lemmaId": "незавершений",
       "lemmaPlain": "незавершений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2657,11 +2941,13 @@
     {
       "cefr": "B2",
       "gloss": "expectation",
+      "glossClean": "expectation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "очікування",
       "lemmaId": "очікування",
       "lemmaPlain": "очікування",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2672,11 +2958,13 @@
     {
       "cefr": "B2",
       "gloss": "progress",
+      "glossClean": "progress",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прогрес",
       "lemmaId": "прогрес",
       "lemmaPlain": "прогрес",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2687,11 +2975,13 @@
     {
       "cefr": "B2",
       "gloss": "incompleteness",
+      "glossClean": "incompleteness",
       "heritage": "standard",
       "ipa": null,
       "lemma": "незавершеність",
       "lemmaId": "незавершеність",
       "lemmaPlain": "незавершеність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2702,11 +2992,13 @@
     {
       "cefr": "B2",
       "gloss": "poster, event announcement",
+      "glossClean": "poster",
       "heritage": "standard",
       "ipa": null,
       "lemma": "афіша",
       "lemmaId": "афіша",
       "lemmaPlain": "афіша",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2746,11 +3038,13 @@
     {
       "cefr": "B2",
       "gloss": "conjugation",
+      "glossClean": "conjugation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дієвідмінювання",
       "lemmaId": "дієвідмінювання",
       "lemmaPlain": "дієвідмінювання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2761,11 +3055,13 @@
     {
       "cefr": "B2",
       "gloss": "calque",
+      "glossClean": "calque",
       "heritage": "standard",
       "ipa": null,
       "lemma": "калька",
       "lemmaId": "калька",
       "lemmaPlain": "калька",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2805,11 +3101,13 @@
     {
       "cefr": "B2",
       "gloss": "donation",
+      "glossClean": "donation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пожертва",
       "lemmaId": "пожертва",
       "lemmaPlain": "пожертва",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2849,11 +3147,13 @@
     {
       "cefr": "B2",
       "gloss": "to count, tally",
+      "glossClean": "to count",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підраховувати",
       "lemmaId": "підраховувати",
       "lemmaPlain": "підраховувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2864,11 +3164,13 @@
     {
       "cefr": "B2",
       "gloss": "conversation partner",
+      "glossClean": "conversation partner",
       "heritage": "standard",
       "ipa": null,
       "lemma": "співрозмовник / співрозмовниця",
       "lemmaId": "співрозмовник-співрозмовниця",
       "lemmaPlain": "співрозмовник / співрозмовниця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2879,11 +3181,13 @@
     {
       "cefr": "B2",
       "gloss": "after reading",
+      "glossClean": "after reading",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прочитавши",
       "lemmaId": "прочитавши",
       "lemmaPlain": "прочитавши",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2894,11 +3198,13 @@
     {
       "cefr": "B2",
       "gloss": "declension",
+      "glossClean": "declension",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відмінювання",
       "lemmaId": "відмінювання",
       "lemmaPlain": "відмінювання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2909,11 +3215,13 @@
     {
       "cefr": "B2",
       "gloss": "for the third time",
+      "glossClean": "for the third time",
       "heritage": "standard",
       "ipa": null,
       "lemma": "утретє",
       "lemmaId": "утретє",
       "lemmaPlain": "утретє",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2924,11 +3232,13 @@
     {
       "cefr": "B2",
       "gloss": "deadline",
+      "glossClean": "deadline",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дедлайн",
       "lemmaId": "дедлайн",
       "lemmaPlain": "дедлайн",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2939,11 +3249,13 @@
     {
       "cefr": "B2",
       "gloss": "fraction",
+      "glossClean": "fraction",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дріб",
       "lemmaId": "дріб",
       "lemmaPlain": "дріб",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2954,11 +3266,13 @@
     {
       "cefr": "B2",
       "gloss": "landlord",
+      "glossClean": "landlord",
       "heritage": "standard",
       "ipa": null,
       "lemma": "орендодавець",
       "lemmaId": "орендодавець",
       "lemmaPlain": "орендодавець",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2969,11 +3283,13 @@
     {
       "cefr": "B2",
       "gloss": "gap in knowledge",
+      "glossClean": "gap in knowledge",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прогалина",
       "lemmaId": "прогалина",
       "lemmaPlain": "прогалина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3013,11 +3329,13 @@
     {
       "cefr": "B2",
       "gloss": "rubric",
+      "glossClean": "rubric",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рубрика",
       "lemmaId": "рубрика",
       "lemmaPlain": "рубрика",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3057,11 +3375,13 @@
     {
       "cefr": "B2",
       "gloss": "agent, person who acts",
+      "glossClean": "agent",
       "heritage": "standard",
       "ipa": null,
       "lemma": "діяч",
       "lemmaId": "діяч",
       "lemmaPlain": "діяч",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3072,11 +3392,13 @@
     {
       "cefr": "B2",
       "gloss": "doubling",
+      "glossClean": "doubling",
       "heritage": "standard",
       "ipa": null,
       "lemma": "подвоєння",
       "lemmaId": "подвоєння",
       "lemmaPlain": "подвоєння",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3087,11 +3409,13 @@
     {
       "cefr": "B2",
       "gloss": "moving away",
+      "glossClean": "moving away",
       "heritage": "standard",
       "ipa": null,
       "lemma": "віддалення",
       "lemmaId": "віддалення",
       "lemmaPlain": "віддалення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3102,11 +3426,13 @@
     {
       "cefr": "B2",
       "gloss": "unidirectional",
+      "glossClean": "unidirectional",
       "heritage": "standard",
       "ipa": null,
       "lemma": "односпрямований",
       "lemmaId": "односпрямований",
       "lemmaPlain": "односпрямований",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3117,11 +3443,13 @@
     {
       "cefr": "B2",
       "gloss": "pier, dock",
+      "glossClean": "pier",
       "heritage": "standard",
       "ipa": null,
       "lemma": "причал",
       "lemmaId": "причал",
       "lemmaPlain": "причал",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3132,11 +3460,13 @@
     {
       "cefr": "B2",
       "gloss": "film screening",
+      "glossClean": "film screening",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кінопоказ",
       "lemmaId": "кінопоказ",
       "lemmaPlain": "кінопоказ",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3147,11 +3477,13 @@
     {
       "cefr": "B2",
       "gloss": "dialogue line, utterance",
+      "glossClean": "dialogue line",
       "heritage": "standard",
       "ipa": null,
       "lemma": "репліка",
       "lemmaId": "репліка",
       "lemmaPlain": "репліка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3191,11 +3523,13 @@
     {
       "cefr": "B2",
       "gloss": "abbreviation, acronym",
+      "glossClean": "abbreviation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "абревіатура",
       "lemmaId": "абревіатура",
       "lemmaPlain": "абревіатура",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3235,11 +3569,13 @@
     {
       "cefr": "B2",
       "gloss": "register",
+      "glossClean": "register",
       "heritage": "standard",
       "ipa": null,
       "lemma": "регістр",
       "lemmaId": "регістр",
       "lemmaPlain": "регістр",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3250,11 +3586,13 @@
     {
       "cefr": "B2",
       "gloss": "to become green",
+      "glossClean": "to become green",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зеленіти",
       "lemmaId": "зеленіти",
       "lemmaPlain": "зеленіти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3265,11 +3603,13 @@
     {
       "cefr": "B2",
       "gloss": "work goes; it is working for someone",
+      "glossClean": "work goes",
       "heritage": "standard",
       "ipa": null,
       "lemma": "працюється",
       "lemmaId": "працюється",
       "lemmaPlain": "працюється",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3280,11 +3620,13 @@
     {
       "cefr": "B2",
       "gloss": "to distribute; to spread",
+      "glossClean": "to distribute",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розповсюдити",
       "lemmaId": "розповсюдити",
       "lemmaPlain": "розповсюдити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3295,11 +3637,13 @@
     {
       "cefr": "B2",
       "gloss": "to filter",
+      "glossClean": "to filter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фільтрувати",
       "lemmaId": "фільтрувати",
       "lemmaPlain": "фільтрувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3310,11 +3654,13 @@
     {
       "cefr": "B2",
       "gloss": "equal, coordinate",
+      "glossClean": "equal",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рівноправний",
       "lemmaId": "рівноправний",
       "lemmaPlain": "рівноправний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3325,11 +3671,13 @@
     {
       "cefr": "B2",
       "gloss": "concession (in argument)",
+      "glossClean": "concession (in argument)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поступка",
       "lemmaId": "поступка",
       "lemmaPlain": "поступка",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3369,11 +3717,13 @@
     {
       "cefr": "B2",
       "gloss": "restriction, limitation",
+      "glossClean": "restriction",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обмеження",
       "lemmaId": "обмеження",
       "lemmaPlain": "обмеження",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3384,11 +3734,13 @@
     {
       "cefr": "B2",
       "gloss": "for the sake of",
+      "glossClean": "for the sake of",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заради",
       "lemmaId": "заради",
       "lemmaPlain": "заради",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3399,11 +3751,13 @@
     {
       "cefr": "B2",
       "gloss": "while, until",
+      "glossClean": "while",
       "heritage": "standard",
       "ipa": null,
       "lemma": "доки",
       "lemmaId": "доки",
       "lemmaPlain": "доки",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3414,11 +3768,13 @@
     {
       "cefr": "B2",
       "gloss": "avoidance",
+      "glossClean": "avoidance",
       "heritage": "standard",
       "ipa": null,
       "lemma": "уникнення",
       "lemmaId": "уникнення",
       "lemmaPlain": "уникнення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3429,11 +3785,13 @@
     {
       "cefr": "B2",
       "gloss": "politeness",
+      "glossClean": "politeness",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ввічливість",
       "lemmaId": "ввічливість",
       "lemmaPlain": "ввічливість",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3444,11 +3802,13 @@
     {
       "cefr": "B2",
       "gloss": "open",
+      "glossClean": "open",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відчинений",
       "lemmaId": "відчинений",
       "lemmaPlain": "відчинений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3459,11 +3819,13 @@
     {
       "cefr": "B2",
       "gloss": "to be late",
+      "glossClean": "to be late",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спізнитися",
       "lemmaId": "спізнитися",
       "lemmaPlain": "спізнитися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3474,11 +3836,13 @@
     {
       "cefr": "B2",
       "gloss": "imagined, hypothetical",
+      "glossClean": "imagined",
       "heritage": "standard",
       "ipa": null,
       "lemma": "уявний",
       "lemmaId": "уявний",
       "lemmaPlain": "уявний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3489,11 +3853,13 @@
     {
       "cefr": "B2",
       "gloss": "to manage in time",
+      "glossClean": "to manage in time",
       "heritage": "standard",
       "ipa": null,
       "lemma": "встигати",
       "lemmaId": "встигати",
       "lemmaPlain": "встигати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3504,11 +3870,13 @@
     {
       "cefr": "B2",
       "gloss": "to get up, rise",
+      "glossClean": "to get up",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підводитися",
       "lemmaId": "підводитися",
       "lemmaPlain": "підводитися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3519,11 +3887,13 @@
     {
       "cefr": "B2",
       "gloss": "to have fun",
+      "glossClean": "to have fun",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розважатися",
       "lemmaId": "розважатися",
       "lemmaPlain": "розважатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3534,11 +3904,13 @@
     {
       "cefr": "B2",
       "gloss": "to owe gratitude to",
+      "glossClean": "to owe gratitude to",
       "heritage": "standard",
       "ipa": null,
       "lemma": "завдячувати",
       "lemmaId": "завдячувати",
       "lemmaPlain": "завдячувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3549,11 +3921,13 @@
     {
       "cefr": "B2",
       "gloss": "recipient",
+      "glossClean": "recipient",
       "heritage": "standard",
       "ipa": null,
       "lemma": "отримувач",
       "lemmaId": "отримувач",
       "lemmaPlain": "отримувач",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3564,11 +3938,13 @@
     {
       "cefr": "B2",
       "gloss": "conclusion",
+      "glossClean": "conclusion",
       "heritage": "standard",
       "ipa": null,
       "lemma": "висновок",
       "lemmaId": "висновок",
       "lemmaPlain": "висновок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3579,11 +3955,13 @@
     {
       "cefr": "B2",
       "gloss": "applicant, prospective student",
+      "glossClean": "applicant",
       "heritage": "standard",
       "ipa": null,
       "lemma": "абітурієнт",
       "lemmaId": "абітурієнт",
       "lemmaPlain": "абітурієнт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3594,11 +3972,13 @@
     {
       "cefr": "B2",
       "gloss": "to soar, rise sharply",
+      "glossClean": "to soar",
       "heritage": "standard",
       "ipa": null,
       "lemma": "злетіти",
       "lemmaId": "злетіти",
       "lemmaPlain": "злетіти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3609,11 +3989,13 @@
     {
       "cefr": "B2",
       "gloss": "to behave",
+      "glossClean": "to behave",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поводитися",
       "lemmaId": "поводитися",
       "lemmaPlain": "поводитися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3624,11 +4006,13 @@
     {
       "cefr": "B2",
       "gloss": "to pass quickly",
+      "glossClean": "to pass quickly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пролетіти",
       "lemmaId": "пролетіти",
       "lemmaPlain": "пролетіти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3639,11 +4023,13 @@
     {
       "cefr": "B2",
       "gloss": "idiom, phraseological unit",
+      "glossClean": "idiom",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фразеологізм",
       "lemmaId": "фразеологізм",
       "lemmaPlain": "фразеологізм",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3654,11 +4040,13 @@
     {
       "cefr": "B2",
       "gloss": "from under",
+      "glossClean": "from under",
       "heritage": "standard",
       "ipa": null,
       "lemma": "з-під",
       "lemmaId": "з-під",
       "lemmaPlain": "з-під",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3669,11 +4057,13 @@
     {
       "cefr": "B2",
       "gloss": "while running",
+      "glossClean": "while running",
       "heritage": "standard",
       "ipa": null,
       "lemma": "біжучи",
       "lemmaId": "біжучи",
       "lemmaPlain": "біжучи",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3684,11 +4074,13 @@
     {
       "cefr": "B2",
       "gloss": "while watching, looking",
+      "glossClean": "while watching",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дивлячись",
       "lemmaId": "дивлячись",
       "lemmaPlain": "дивлячись",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3699,11 +4091,13 @@
     {
       "cefr": "B2",
       "gloss": "while studying",
+      "glossClean": "while studying",
       "heritage": "standard",
       "ipa": null,
       "lemma": "навчаючись",
       "lemmaId": "навчаючись",
       "lemmaPlain": "навчаючись",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3714,11 +4108,13 @@
     {
       "cefr": "B2",
       "gloss": "invariable",
+      "glossClean": "invariable",
       "heritage": "standard",
       "ipa": null,
       "lemma": "незмінюваний",
       "lemmaId": "незмінюваний",
       "lemmaPlain": "незмінюваний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3729,11 +4125,13 @@
     {
       "cefr": "B2",
       "gloss": "while sitting",
+      "glossClean": "while sitting",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сидячи",
       "lemmaId": "сидячи",
       "lemmaPlain": "сидячи",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3744,11 +4142,13 @@
     {
       "cefr": "B2",
       "gloss": "while standing",
+      "glossClean": "while standing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стоячи",
       "lemmaId": "стоячи",
       "lemmaPlain": "стоячи",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3759,11 +4159,13 @@
     {
       "cefr": "B2",
       "gloss": "while worrying",
+      "glossClean": "while worrying",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хвилюючись",
       "lemmaId": "хвилюючись",
       "lemmaPlain": "хвилюючись",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3774,11 +4176,13 @@
     {
       "cefr": "B2",
       "gloss": "having finished",
+      "glossClean": "having finished",
       "heritage": "standard",
       "ipa": null,
       "lemma": "завершивши",
       "lemmaId": "завершивши",
       "lemmaPlain": "завершивши",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3789,11 +4193,13 @@
     {
       "cefr": "B2",
       "gloss": "having met",
+      "glossClean": "having met",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зустрівшись",
       "lemmaId": "зустрівшись",
       "lemmaPlain": "зустрівшись",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3804,11 +4210,13 @@
     {
       "cefr": "B2",
       "gloss": "having gathered, having got ready",
+      "glossClean": "having gathered",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зібравшись",
       "lemmaId": "зібравшись",
       "lemmaPlain": "зібравшись",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3819,11 +4227,13 @@
     {
       "cefr": "B2",
       "gloss": "having bought",
+      "glossClean": "having bought",
       "heritage": "standard",
       "ipa": null,
       "lemma": "купивши",
       "lemmaId": "купивши",
       "lemmaPlain": "купивши",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3834,11 +4244,13 @@
     {
       "cefr": "B2",
       "gloss": "having written",
+      "glossClean": "having written",
       "heritage": "standard",
       "ipa": null,
       "lemma": "написавши",
       "lemmaId": "написавши",
       "lemmaPlain": "написавши",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3849,11 +4261,13 @@
     {
       "cefr": "B2",
       "gloss": "having had breakfast",
+      "glossClean": "having had breakfast",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поснідавши",
       "lemmaId": "поснідавши",
       "lemmaPlain": "поснідавши",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3864,11 +4278,13 @@
     {
       "cefr": "B2",
       "gloss": "having brought",
+      "glossClean": "having brought",
       "heritage": "standard",
       "ipa": null,
       "lemma": "принісши",
       "lemmaId": "принісши",
       "lemmaPlain": "принісши",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3879,11 +4295,13 @@
     {
       "cefr": "B2",
       "gloss": "rash",
+      "glossClean": "rash",
       "heritage": "standard",
       "ipa": null,
       "lemma": "висип",
       "lemmaId": "висип",
       "lemmaPlain": "висип",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3894,11 +4312,13 @@
     {
       "cefr": "B2",
       "gloss": "dosage",
+      "glossClean": "dosage",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дозування",
       "lemmaId": "дозування",
       "lemmaPlain": "дозування",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3909,11 +4329,13 @@
     {
       "cefr": "B2",
       "gloss": "ointment",
+      "glossClean": "ointment",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мазь",
       "lemmaId": "мазь",
       "lemmaPlain": "мазь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3924,11 +4346,13 @@
     {
       "cefr": "B2",
       "gloss": "state of health, how one feels",
+      "glossClean": "state of health",
       "heritage": "standard",
       "ipa": null,
       "lemma": "самопочуття",
       "lemmaId": "самопочуття",
       "lemmaPlain": "самопочуття",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3939,11 +4363,13 @@
     {
       "cefr": "B2",
       "gloss": "spray",
+      "glossClean": "spray",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спрей",
       "lemmaId": "спрей",
       "lemmaPlain": "спрей",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3954,11 +4380,13 @@
     {
       "cefr": "B2",
       "gloss": "homogeneous, syntactically parallel",
+      "glossClean": "homogeneous",
       "heritage": "standard",
       "ipa": null,
       "lemma": "однорідний",
       "lemmaId": "однорідний",
       "lemmaPlain": "однорідний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3969,11 +4397,13 @@
     {
       "cefr": "B2",
       "gloss": "water heater",
+      "glossClean": "water heater",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бойлер",
       "lemmaId": "бойлер",
       "lemmaPlain": "бойлер",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3984,11 +4414,13 @@
     {
       "cefr": "B2",
       "gloss": "deposit",
+      "glossClean": "deposit",
       "heritage": "standard",
       "ipa": null,
       "lemma": "завдаток",
       "lemmaId": "завдаток",
       "lemmaPlain": "завдаток",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3999,11 +4431,13 @@
     {
       "cefr": "B2",
       "gloss": "broke down",
+      "glossClean": "broke down",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зламалася",
       "lemmaId": "зламалася",
       "lemmaPlain": "зламалася",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4014,11 +4448,13 @@
     {
       "cefr": "B2",
       "gloss": "storage room",
+      "glossClean": "storage room",
       "heritage": "standard",
       "ipa": null,
       "lemma": "комора",
       "lemmaId": "комора",
       "lemmaPlain": "комора",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4029,11 +4465,13 @@
     {
       "cefr": "B2",
       "gloss": "to leak",
+      "glossClean": "to leak",
       "heritage": "standard",
       "ipa": null,
       "lemma": "протікати",
       "lemmaId": "протікати",
       "lemmaPlain": "протікати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4044,11 +4482,13 @@
     {
       "cefr": "B2",
       "gloss": "bathroom/toilet unit",
+      "glossClean": "bathroom/toilet unit",
       "heritage": "standard",
       "ipa": null,
       "lemma": "санвузол",
       "lemmaId": "санвузол",
       "lemmaPlain": "санвузол",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4059,11 +4499,13 @@
     {
       "cefr": "B2",
       "gloss": "mold",
+      "glossClean": "mold",
       "heritage": "standard",
       "ipa": null,
       "lemma": "цвіль",
       "lemmaId": "цвіль",
       "lemmaPlain": "цвіль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4074,11 +4516,13 @@
     {
       "cefr": "B2",
       "gloss": "to make noise",
+      "glossClean": "to make noise",
       "heritage": "standard",
       "ipa": null,
       "lemma": "шуміти",
       "lemmaId": "шуміти",
       "lemmaPlain": "шуміти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4089,11 +4533,13 @@
     {
       "cefr": "B2",
       "gloss": "instruction, direction",
+      "glossClean": "instruction",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вказівка",
       "lemmaId": "вказівка",
       "lemmaPlain": "вказівка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4104,11 +4550,13 @@
     {
       "cefr": "B2",
       "gloss": "command, order",
+      "glossClean": "command",
       "heritage": "standard",
       "ipa": null,
       "lemma": "наказ",
       "lemmaId": "наказ",
       "lemmaPlain": "наказ",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4119,11 +4567,13 @@
     {
       "cefr": "B2",
       "gloss": "prompting, encouragement to act",
+      "glossClean": "prompting",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спонукання",
       "lemmaId": "спонукання",
       "lemmaPlain": "спонукання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4134,11 +4584,13 @@
     {
       "cefr": "B2",
       "gloss": "to unite",
+      "glossClean": "to unite",
       "heritage": "standard",
       "ipa": null,
       "lemma": "єднатися",
       "lemmaId": "єднатися",
       "lemmaPlain": "єднатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4149,11 +4601,13 @@
     {
       "cefr": "B2",
       "gloss": "to be satisfied with",
+      "glossClean": "to be satisfied with",
       "heritage": "standard",
       "ipa": null,
       "lemma": "задовольнятися",
       "lemmaId": "задовольнятися",
       "lemmaPlain": "задовольнятися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4164,11 +4618,13 @@
     {
       "cefr": "B2",
       "gloss": "accompaniment, togetherness",
+      "glossClean": "accompaniment",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сумісність",
       "lemmaId": "сумісність",
       "lemmaPlain": "сумісність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4179,11 +4635,13 @@
     {
       "cefr": "B2",
       "gloss": "reportedly, as if saying",
+      "glossClean": "reportedly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мовляв",
       "lemmaId": "мовляв",
       "lemmaPlain": "мовляв",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4194,11 +4652,13 @@
     {
       "cefr": "B2",
       "gloss": "to be fair",
+      "glossClean": "to be fair",
       "heritage": "standard",
       "ipa": null,
       "lemma": "щоправда",
       "lemmaId": "щоправда",
       "lemmaPlain": "щоправда",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4209,11 +4669,13 @@
     {
       "cefr": "B2",
       "gloss": "spring ritual songs and dances",
+      "glossClean": "spring ritual songs and dances",
       "heritage": "dialect",
       "ipa": null,
       "lemma": "гаївки",
       "lemmaId": "гаївки",
       "lemmaPlain": "гаївки",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4224,11 +4686,13 @@
     {
       "cefr": "B2",
       "gloss": "to swim or sail out, emerge on water; perfective",
+      "glossClean": "to swim or sail out",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виплисти",
       "lemmaId": "виплисти",
       "lemmaPlain": "виплисти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4239,11 +4703,13 @@
     {
       "cefr": "B2",
       "gloss": "to fly away, depart by air; perfective",
+      "glossClean": "to fly away",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відлетіти",
       "lemmaId": "відлетіти",
       "lemmaPlain": "відлетіти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4254,11 +4720,13 @@
     {
       "cefr": "B2",
       "gloss": "to fly all the way to; perfective",
+      "glossClean": "to fly all the way to",
       "heritage": "standard",
       "ipa": null,
       "lemma": "долетіти",
       "lemmaId": "долетіти",
       "lemmaPlain": "долетіти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4269,11 +4737,13 @@
     {
       "cefr": "B2",
       "gloss": "bay",
+      "glossClean": "bay",
       "heritage": "standard",
       "ipa": null,
       "lemma": "затока",
       "lemmaId": "затока",
       "lemmaPlain": "затока",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4284,11 +4754,13 @@
     {
       "cefr": "B2",
       "gloss": "you are flying",
+      "glossClean": "you are flying",
       "heritage": "standard",
       "ipa": null,
       "lemma": "летиш",
       "lemmaId": "летиш",
       "lemmaPlain": "летиш",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4299,11 +4771,13 @@
     {
       "cefr": "B2",
       "gloss": "I am flying",
+      "glossClean": "I am flying",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лечу",
       "lemmaId": "лечу",
       "lemmaPlain": "лечу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4314,11 +4788,13 @@
     {
       "cefr": "B2",
       "gloss": "deck",
+      "glossClean": "deck",
       "heritage": "standard",
       "ipa": null,
       "lemma": "палуба",
       "lemmaId": "палуба",
       "lemmaPlain": "палуба",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4329,11 +4805,13 @@
     {
       "cefr": "B2",
       "gloss": "to swim or sail across; perfective",
+      "glossClean": "to swim or sail across",
       "heritage": "standard",
       "ipa": null,
       "lemma": "переплисти",
       "lemmaId": "переплисти",
       "lemmaPlain": "переплисти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4344,11 +4822,13 @@
     {
       "cefr": "B2",
       "gloss": "I am swimming or sailing",
+      "glossClean": "I am swimming or sailing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пливу",
       "lemmaId": "пливу",
       "lemmaPlain": "пливу",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4359,11 +4839,13 @@
     {
       "cefr": "B2",
       "gloss": "to set sail, start swimming; perfective",
+      "glossClean": "to set sail",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поплисти",
       "lemmaId": "поплисти",
       "lemmaPlain": "поплисти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4374,11 +4856,13 @@
     {
       "cefr": "B2",
       "gloss": "ferry",
+      "glossClean": "ferry",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пором",
       "lemmaId": "пором",
       "lemmaPlain": "пором",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4389,11 +4873,13 @@
     {
       "cefr": "B2",
       "gloss": "to run as far as, reach running; perfective",
+      "glossClean": "to run as far as",
       "heritage": "standard",
       "ipa": null,
       "lemma": "добігти",
       "lemmaId": "добігти",
       "lemmaPlain": "добігти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4404,11 +4890,13 @@
     {
       "cefr": "B2",
       "gloss": "to transport all the way to; perfective",
+      "glossClean": "to transport all the way to",
       "heritage": "standard",
       "ipa": null,
       "lemma": "довезти",
       "lemmaId": "довезти",
       "lemmaPlain": "довезти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4419,11 +4907,13 @@
     {
       "cefr": "B2",
       "gloss": "to lead all the way to; perfective",
+      "glossClean": "to lead all the way to",
       "heritage": "standard",
       "ipa": null,
       "lemma": "довести",
       "lemmaId": "довести",
       "lemmaPlain": "довести",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4434,11 +4924,13 @@
     {
       "cefr": "B2",
       "gloss": "to reach habitually, extend as far as; imperfective",
+      "glossClean": "to reach habitually",
       "heritage": "standard",
       "ipa": null,
       "lemma": "доходити",
       "lemmaId": "доходити",
       "lemmaPlain": "доходити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4449,11 +4941,13 @@
     {
       "cefr": "B2",
       "gloss": "to come by transport habitually; imperfective",
+      "glossClean": "to come by transport habitually",
       "heritage": "standard",
       "ipa": null,
       "lemma": "приїздити",
       "lemmaId": "приїздити",
       "lemmaPlain": "приїздити",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4464,11 +4958,13 @@
     {
       "cefr": "B2",
       "gloss": "to be leaving by vehicle; imperfective",
+      "glossClean": "to be leaving by vehicle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "від'їжджати",
       "lemmaId": "від-їжджати",
       "lemmaPlain": "від'їжджати",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4479,11 +4975,13 @@
     {
       "cefr": "B2",
       "gloss": "to drive or ride away; perfective",
+      "glossClean": "to drive or ride away",
       "heritage": "standard",
       "ipa": null,
       "lemma": "від'їхати",
       "lemmaId": "від-їхати",
       "lemmaPlain": "від'їхати",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4494,11 +4992,13 @@
     {
       "cefr": "B2",
       "gloss": "I will step away",
+      "glossClean": "I will step away",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відійду",
       "lemmaId": "відійду",
       "lemmaPlain": "відійду",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4509,11 +5009,13 @@
     {
       "cefr": "B2",
       "gloss": "to start carrying, carry away; perfective",
+      "glossClean": "to start carrying",
       "heritage": "standard",
       "ipa": null,
       "lemma": "понести",
       "lemmaId": "понести",
       "lemmaPlain": "понести",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4524,11 +5026,13 @@
     {
       "cefr": "B2",
       "gloss": "to run out habitually or in process",
+      "glossClean": "to run out habitually or in process",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вибігати",
       "lemmaId": "вибігати",
       "lemmaPlain": "вибігати",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4539,11 +5043,13 @@
     {
       "cefr": "B2",
       "gloss": "to run out; perfective",
+      "glossClean": "to run out",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вибігти",
       "lemmaId": "вибігти",
       "lemmaPlain": "вибігти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4554,11 +5060,13 @@
     {
       "cefr": "B2",
       "gloss": "I will carry out",
+      "glossClean": "I will carry out",
       "heritage": "standard",
       "ipa": null,
       "lemma": "винесу",
       "lemmaId": "винесу",
       "lemmaPlain": "винесу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4569,11 +5077,13 @@
     {
       "cefr": "B2",
       "gloss": "I will drive out",
+      "glossClean": "I will drive out",
       "heritage": "standard",
       "ipa": null,
       "lemma": "виїду",
       "lemmaId": "виїду",
       "lemmaPlain": "виїду",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4584,11 +5094,13 @@
     {
       "cefr": "B2",
       "gloss": "courtyard, yard",
+      "glossClean": "courtyard",
       "heritage": "standard",
       "ipa": null,
       "lemma": "двір",
       "lemmaId": "двір",
       "lemmaPlain": "двір",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4599,11 +5111,13 @@
     {
       "cefr": "B2",
       "gloss": "to run in, pop in habitually; imperfective",
+      "glossClean": "to run in",
       "heritage": "standard",
       "ipa": null,
       "lemma": "забігати",
       "lemmaId": "забігати",
       "lemmaPlain": "забігати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4614,11 +5128,13 @@
     {
       "cefr": "B2",
       "gloss": "to carry in habitually or repeatedly",
+      "glossClean": "to carry in habitually or repeatedly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заносити",
       "lemmaId": "заносити",
       "lemmaPlain": "заносити",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4629,11 +5145,13 @@
     {
       "cefr": "B2",
       "gloss": "I will drive in, I will stop by",
+      "glossClean": "I will drive in",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заїду",
       "lemmaId": "заїду",
       "lemmaPlain": "заїду",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4644,11 +5162,13 @@
     {
       "cefr": "B2",
       "gloss": "to drive in, stop by habitually; imperfective",
+      "glossClean": "to drive in",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заїжджати",
       "lemmaId": "заїжджати",
       "lemmaPlain": "заїжджати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4659,11 +5179,13 @@
     {
       "cefr": "B2",
       "gloss": "to run across habitually or in process",
+      "glossClean": "to run across habitually or in process",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перебігати",
       "lemmaId": "перебігати",
       "lemmaPlain": "перебігати",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4674,11 +5196,13 @@
     {
       "cefr": "B2",
       "gloss": "to run across; perfective",
+      "glossClean": "to run across",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перебігти",
       "lemmaId": "перебігти",
       "lemmaPlain": "перебігти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4689,11 +5213,13 @@
     {
       "cefr": "B2",
       "gloss": "I will cross on foot",
+      "glossClean": "I will cross on foot",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перейду",
       "lemmaId": "перейду",
       "lemmaPlain": "перейду",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4704,11 +5230,13 @@
     {
       "cefr": "B2",
       "gloss": "to run past or through; perfective",
+      "glossClean": "to run past or through",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пробігти",
       "lemmaId": "пробігти",
       "lemmaPlain": "пробігти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4719,11 +5247,13 @@
     {
       "cefr": "B2",
       "gloss": "to transport through or past; perfective",
+      "glossClean": "to transport through or past",
       "heritage": "standard",
       "ipa": null,
       "lemma": "провезти",
       "lemmaId": "провезти",
       "lemmaPlain": "провезти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4734,11 +5264,13 @@
     {
       "cefr": "B2",
       "gloss": "I will pass, I will go through",
+      "glossClean": "I will pass",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пройду",
       "lemmaId": "пройду",
       "lemmaPlain": "пройду",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4749,11 +5281,13 @@
     {
       "cefr": "B2",
       "gloss": "to carry through or past; perfective",
+      "glossClean": "to carry through or past",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пронести",
       "lemmaId": "пронести",
       "lemmaPlain": "пронести",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4764,11 +5298,13 @@
     {
       "cefr": "B2",
       "gloss": "to drive past or through habitually; imperfective",
+      "glossClean": "to drive past or through habitually",
       "heritage": "standard",
       "ipa": null,
       "lemma": "проїжджати",
       "lemmaId": "проїжджати",
       "lemmaPlain": "проїжджати",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4779,11 +5315,13 @@
     {
       "cefr": "B2",
       "gloss": "climax",
+      "glossClean": "climax",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кульмінація",
       "lemmaId": "кульмінація",
       "lemmaPlain": "кульмінація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4823,11 +5361,13 @@
     {
       "cefr": "B2",
       "gloss": "ending",
+      "glossClean": "ending",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кінцівка",
       "lemmaId": "кінцівка",
       "lemmaPlain": "кінцівка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4867,11 +5407,13 @@
     {
       "cefr": "B2",
       "gloss": "periwinkle",
+      "glossClean": "periwinkle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "барвінок",
       "lemmaId": "барвінок",
       "lemmaPlain": "барвінок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4882,11 +5424,13 @@
     {
       "cefr": "B2",
       "gloss": "deforestation, logging",
+      "glossClean": "deforestation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вирубка",
       "lemmaId": "вирубка",
       "lemmaPlain": "вирубка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4926,11 +5470,13 @@
     {
       "cefr": "B2",
       "gloss": "ecosystem",
+      "glossClean": "ecosystem",
       "heritage": "standard",
       "ipa": null,
       "lemma": "екосистема",
       "lemmaId": "екосистема",
       "lemmaPlain": "екосистема",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4970,11 +5516,13 @@
     {
       "cefr": "B2",
       "gloss": "blizzard",
+      "glossClean": "blizzard",
       "heritage": "standard",
       "ipa": null,
       "lemma": "завірюха",
       "lemmaId": "завірюха",
       "lemmaPlain": "завірюха",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5014,11 +5562,13 @@
     {
       "cefr": "B2",
       "gloss": "preservation, conservation",
+      "glossClean": "preservation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "збереження",
       "lemmaId": "збереження",
       "lemmaPlain": "збереження",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5029,11 +5579,13 @@
     {
       "cefr": "B2",
       "gloss": "European bison",
+      "glossClean": "European bison",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зубр",
       "lemmaId": "зубр",
       "lemmaPlain": "зубр",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5044,11 +5596,13 @@
     {
       "cefr": "B2",
       "gloss": "drizzle",
+      "glossClean": "drizzle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мряка",
       "lemmaId": "мряка",
       "lemmaPlain": "мряка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5059,11 +5613,13 @@
     {
       "cefr": "B2",
       "gloss": "dew",
+      "glossClean": "dew",
       "heritage": "standard",
       "ipa": null,
       "lemma": "роса",
       "lemmaId": "роса",
       "lemmaPlain": "роса",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5103,11 +5659,13 @@
     {
       "cefr": "B2",
       "gloss": "to sort",
+      "glossClean": "to sort",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сортувати",
       "lemmaId": "сортувати",
       "lemmaPlain": "сортувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5118,11 +5676,13 @@
     {
       "cefr": "B2",
       "gloss": "marigolds",
+      "glossClean": "marigolds",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чорнобривці",
       "lemmaId": "чорнобривці",
       "lemmaPlain": "чорнобривці",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5133,11 +5693,13 @@
     {
       "cefr": "B2",
       "gloss": "hoarfrost",
+      "glossClean": "hoarfrost",
       "heritage": "standard",
       "ipa": null,
       "lemma": "іній",
       "lemmaId": "іній",
       "lemmaPlain": "іній",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5148,11 +5710,13 @@
     {
       "cefr": "B2",
       "gloss": "wisdom",
+      "glossClean": "wisdom",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мудрість",
       "lemmaId": "мудрість",
       "lemmaPlain": "мудрість",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5163,11 +5727,13 @@
     {
       "cefr": "B2",
       "gloss": "copper",
+      "glossClean": "copper",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мідь",
       "lemmaId": "мідь",
       "lemmaPlain": "мідь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5178,11 +5744,13 @@
     {
       "cefr": "B2",
       "gloss": "tenderness",
+      "glossClean": "tenderness",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ніжність",
       "lemmaId": "ніжність",
       "lemmaPlain": "ніжність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5193,11 +5761,13 @@
     {
       "cefr": "B2",
       "gloss": "mixture",
+      "glossClean": "mixture",
       "heritage": "standard",
       "ipa": null,
       "lemma": "суміш",
       "lemmaId": "суміш",
       "lemmaPlain": "суміш",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5208,11 +5778,13 @@
     {
       "cefr": "B2",
       "gloss": "ladle, dipper",
+      "glossClean": "ladle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ківш",
       "lemmaId": "ківш",
       "lemmaPlain": "ківш",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5223,11 +5795,13 @@
     {
       "cefr": "B2",
       "gloss": "personification",
+      "glossClean": "personification",
       "heritage": "standard",
       "ipa": null,
       "lemma": "персоніфікація",
       "lemmaId": "персоніфікація",
       "lemmaPlain": "персоніфікація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5238,11 +5812,13 @@
     {
       "cefr": "B2",
       "gloss": "listener, course participant",
+      "glossClean": "listener",
       "heritage": "standard",
       "ipa": null,
       "lemma": "слухач",
       "lemmaId": "слухач",
       "lemmaPlain": "слухач",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5253,11 +5829,13 @@
     {
       "cefr": "B2",
       "gloss": "situation, position",
+      "glossClean": "situation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "становище",
       "lemmaId": "становище",
       "lemmaPlain": "становище",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5268,11 +5846,13 @@
     {
       "cefr": "B2",
       "gloss": "to drop out",
+      "glossClean": "to drop out",
       "heritage": "standard",
       "ipa": null,
       "lemma": "випадати",
       "lemmaId": "випадати",
       "lemmaPlain": "випадати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5283,11 +5863,13 @@
     {
       "cefr": "B2",
       "gloss": "potter",
+      "glossClean": "potter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гончар",
       "lemmaId": "гончар",
       "lemmaPlain": "гончар",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5298,11 +5880,13 @@
     {
       "cefr": "B2",
       "gloss": "Georgian man",
+      "glossClean": "Georgian man",
       "heritage": "standard",
       "ipa": null,
       "lemma": "грузин",
       "lemmaId": "грузин",
       "lemmaPlain": "грузин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5313,11 +5897,13 @@
     {
       "cefr": "B2",
       "gloss": "kobza player",
+      "glossClean": "kobza player",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кобзар",
       "lemmaId": "кобзар",
       "lemmaPlain": "кобзар",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5328,11 +5914,13 @@
     {
       "cefr": "B2",
       "gloss": "townsperson; burgher in historical contexts",
+      "glossClean": "townsperson",
       "heritage": "standard",
       "ipa": null,
       "lemma": "міщанин",
       "lemmaId": "міщанин",
       "lemmaPlain": "міщанин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5343,11 +5931,13 @@
     {
       "cefr": "B2",
       "gloss": "baker",
+      "glossClean": "baker",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пекар",
       "lemmaId": "пекар",
       "lemmaPlain": "пекар",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5358,11 +5948,13 @@
     {
       "cefr": "B2",
       "gloss": "villager; peasant in historical contexts",
+      "glossClean": "villager",
       "heritage": "standard",
       "ipa": null,
       "lemma": "селянин",
       "lemmaId": "селянин",
       "lemmaPlain": "селянин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5373,11 +5965,13 @@
     {
       "cefr": "B2",
       "gloss": "carpenter",
+      "glossClean": "carpenter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "столяр",
       "lemmaId": "столяр",
       "lemmaPlain": "столяр",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5388,11 +5982,13 @@
     {
       "cefr": "B2",
       "gloss": "lathe operator",
+      "glossClean": "lathe operator",
       "heritage": "standard",
       "ipa": null,
       "lemma": "токар",
       "lemmaId": "токар",
       "lemmaPlain": "токар",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5403,11 +5999,13 @@
     {
       "cefr": "B2",
       "gloss": "worn, emaciated",
+      "glossClean": "worn",
       "heritage": "standard",
       "ipa": null,
       "lemma": "змарнілий",
       "lemmaId": "змарнілий",
       "lemmaPlain": "змарнілий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5418,11 +6016,13 @@
     {
       "cefr": "B2",
       "gloss": "disappeared, missing",
+      "glossClean": "disappeared",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зниклий",
       "lemmaId": "зниклий",
       "lemmaPlain": "зниклий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5433,11 +6033,13 @@
     {
       "cefr": "B2",
       "gloss": "blooming",
+      "glossClean": "blooming",
       "heritage": "standard",
       "ipa": null,
       "lemma": "квітучий",
       "lemmaId": "квітучий",
       "lemmaPlain": "квітучий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5448,11 +6050,13 @@
     {
       "cefr": "B2",
       "gloss": "willing, eager",
+      "glossClean": "willing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "охочий",
       "lemmaId": "охочий",
       "lemmaPlain": "охочий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5463,11 +6067,13 @@
     {
       "cefr": "B2",
       "gloss": "melodious, songlike",
+      "glossClean": "melodious",
       "heritage": "standard",
       "ipa": null,
       "lemma": "співучий",
       "lemmaId": "співучий",
       "lemmaPlain": "співучий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5478,11 +6084,13 @@
     {
       "cefr": "B2",
       "gloss": "beaten, broken-in",
+      "glossClean": "beaten",
       "heritage": "standard",
       "ipa": null,
       "lemma": "битий",
       "lemmaId": "битий",
       "lemmaPlain": "битий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5493,11 +6101,13 @@
     {
       "cefr": "B2",
       "gloss": "built",
+      "glossClean": "built",
       "heritage": "standard",
       "ipa": null,
       "lemma": "збудований",
       "lemmaId": "збудований",
       "lemmaPlain": "збудований",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5508,11 +6118,13 @@
     {
       "cefr": "B2",
       "gloss": "washed",
+      "glossClean": "washed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "митий",
       "lemmaId": "митий",
       "lemmaPlain": "митий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5523,11 +6135,13 @@
     {
       "cefr": "B2",
       "gloss": "brought",
+      "glossClean": "brought",
       "heritage": "standard",
       "ipa": null,
       "lemma": "принесений",
       "lemmaId": "принесений",
       "lemmaPlain": "принесений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5538,11 +6152,13 @@
     {
       "cefr": "B2",
       "gloss": "was being built",
+      "glossClean": "was being built",
       "heritage": "standard",
       "ipa": null,
       "lemma": "будувався",
       "lemmaId": "будувався",
       "lemmaPlain": "будувався",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5553,11 +6169,13 @@
     {
       "cefr": "B2",
       "gloss": "to be built; to be under construction",
+      "glossClean": "to be built",
       "heritage": "standard",
       "ipa": null,
       "lemma": "будуватися",
       "lemmaId": "будуватися",
       "lemmaPlain": "будуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5568,11 +6186,13 @@
     {
       "cefr": "B2",
       "gloss": "to be produced",
+      "glossClean": "to be produced",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вироблятися",
       "lemmaId": "вироблятися",
       "lemmaPlain": "вироблятися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5583,11 +6203,13 @@
     {
       "cefr": "B2",
       "gloss": "has been uploaded; loaded",
+      "glossClean": "has been uploaded",
       "heritage": "standard",
       "ipa": null,
       "lemma": "завантажено",
       "lemmaId": "завантажено",
       "lemmaPlain": "завантажено",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5598,11 +6220,13 @@
     {
       "cefr": "B2",
       "gloss": "closes; is closing",
+      "glossClean": "closes",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зачиняється",
       "lemmaId": "зачиняється",
       "lemmaPlain": "зачиняється",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5613,11 +6237,13 @@
     {
       "cefr": "B2",
       "gloss": "unnatural",
+      "glossClean": "unnatural",
       "heritage": "standard",
       "ipa": null,
       "lemma": "неприродний",
       "lemmaId": "неприродний",
       "lemmaPlain": "неприродний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5628,11 +6254,13 @@
     {
       "cefr": "B2",
       "gloss": "has been read",
+      "glossClean": "has been read",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прочитано",
       "lemmaId": "прочитано",
       "lemmaPlain": "прочитано",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5643,11 +6271,13 @@
     {
       "cefr": "B2",
       "gloss": "to design",
+      "glossClean": "to design",
       "heritage": "standard",
       "ipa": null,
       "lemma": "проєктувати",
       "lemmaId": "проєктувати",
       "lemmaPlain": "проєктувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5658,11 +6288,13 @@
     {
       "cefr": "B2",
       "gloss": "to be published; to publish oneself",
+      "glossClean": "to be published",
       "heritage": "standard",
       "ipa": null,
       "lemma": "публікуватися",
       "lemmaId": "публікуватися",
       "lemmaPlain": "публікуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5673,11 +6305,13 @@
     {
       "cefr": "B2",
       "gloss": "is being repaired",
+      "glossClean": "is being repaired",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ремонтується",
       "lemmaId": "ремонтується",
       "lemmaPlain": "ремонтується",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5688,11 +6322,13 @@
     {
       "cefr": "B2",
       "gloss": "talkative",
+      "glossClean": "talkative",
       "heritage": "standard",
       "ipa": null,
       "lemma": "балакучий",
       "lemmaId": "балакучий",
       "lemmaPlain": "балакучий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5703,11 +6339,13 @@
     {
       "cefr": "B2",
       "gloss": "formal relations",
+      "glossClean": "formal relations",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відносини",
       "lemmaId": "відносини",
       "lemmaPlain": "відносини",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5718,11 +6356,13 @@
     {
       "cefr": "B2",
       "gloss": "to introduce oneself formally",
+      "glossClean": "to introduce oneself formally",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відрекомендуватися",
       "lemmaId": "відрекомендуватися",
       "lemmaPlain": "відрекомендуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5733,11 +6373,13 @@
     {
       "cefr": "B2",
       "gloss": "tact, delicacy",
+      "glossClean": "tact",
       "heritage": "standard",
       "ipa": null,
       "lemma": "делікатність",
       "lemmaId": "делікатність",
       "lemmaPlain": "делікатність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5748,11 +6390,13 @@
     {
       "cefr": "B2",
       "gloss": "withdrawn",
+      "glossClean": "withdrawn",
       "heritage": "standard",
       "ipa": null,
       "lemma": "замкнутий",
       "lemmaId": "замкнутий",
       "lemmaPlain": "замкнутий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5763,11 +6407,13 @@
     {
       "cefr": "B2",
       "gloss": "quick-witted",
+      "glossClean": "quick-witted",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кмітливий",
       "lemmaId": "кмітливий",
       "lemmaPlain": "кмітливий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5778,11 +6424,13 @@
     {
       "cefr": "B2",
       "gloss": "facial expression",
+      "glossClean": "facial expression",
       "heritage": "standard",
       "ipa": null,
       "lemma": "міміка",
       "lemmaId": "міміка",
       "lemmaPlain": "міміка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5822,11 +6470,13 @@
     {
       "cefr": "B2",
       "gloss": "impatient",
+      "glossClean": "impatient",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нетерплячий",
       "lemmaId": "нетерплячий",
       "lemmaPlain": "нетерплячий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5837,11 +6487,13 @@
     {
       "cefr": "B2",
       "gloss": "rosy",
+      "glossClean": "rosy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рум'яний",
       "lemmaId": "рум-яний",
       "lemmaPlain": "рум'яний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5852,11 +6504,13 @@
     {
       "cefr": "B2",
       "gloss": "overconfident",
+      "glossClean": "overconfident",
       "heritage": "standard",
       "ipa": null,
       "lemma": "самовпевнений",
       "lemmaId": "самовпевнений",
       "lemmaPlain": "самовпевнений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5867,11 +6521,13 @@
     {
       "cefr": "B2",
       "gloss": "swarthy, dark-complexioned",
+      "glossClean": "swarthy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "смаглявий",
       "lemmaId": "смаглявий",
       "lemmaPlain": "смаглявий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5882,11 +6538,13 @@
     {
       "cefr": "B2",
       "gloss": "build, physique",
+      "glossClean": "build",
       "heritage": "standard",
       "ipa": null,
       "lemma": "статура",
       "lemmaId": "статура",
       "lemmaPlain": "статура",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5926,11 +6584,13 @@
     {
       "cefr": "B2",
       "gloss": "delicate, slender",
+      "glossClean": "delicate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тендітний",
       "lemmaId": "тендітний",
       "lemmaPlain": "тендітний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5941,11 +6601,13 @@
     {
       "cefr": "B2",
       "gloss": "to be companions, to socialize",
+      "glossClean": "to be companions",
       "heritage": "standard",
       "ipa": null,
       "lemma": "товаришувати",
       "lemmaId": "товаришувати",
       "lemmaPlain": "товаришувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5956,11 +6618,13 @@
     {
       "cefr": "B2",
       "gloss": "stubborn",
+      "glossClean": "stubborn",
       "heritage": "standard",
       "ipa": null,
       "lemma": "упертий",
       "lemmaId": "упертий",
       "lemmaPlain": "упертий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5971,11 +6635,13 @@
     {
       "cefr": "B2",
       "gloss": "broad-shouldered",
+      "glossClean": "broad-shouldered",
       "heritage": "standard",
       "ipa": null,
       "lemma": "широкоплечий",
       "lemmaId": "широкоплечий",
       "lemmaPlain": "широкоплечий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5986,11 +6652,13 @@
     {
       "cefr": "B2",
       "gloss": "outskirts, surrounding area",
+      "glossClean": "outskirts",
       "heritage": "standard",
       "ipa": null,
       "lemma": "околиця",
       "lemmaId": "околиця",
       "lemmaPlain": "околиця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -6030,11 +6698,13 @@
     {
       "cefr": "B2",
       "gloss": "plain",
+      "glossClean": "plain",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рівнина",
       "lemmaId": "рівнина",
       "lemmaPlain": "рівнина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -6074,11 +6744,13 @@
     {
       "cefr": "B2",
       "gloss": "steppe",
+      "glossClean": "steppe",
       "heritage": "standard",
       "ipa": null,
       "lemma": "степ",
       "lemmaId": "степ",
       "lemmaPlain": "степ",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6089,11 +6761,13 @@
     {
       "cefr": "B2",
       "gloss": "friendship",
+      "glossClean": "friendship",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дружба",
       "lemmaId": "дружба",
       "lemmaPlain": "дружба",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6104,11 +6778,13 @@
     {
       "cefr": "B2",
       "gloss": "Andrii's",
+      "glossClean": "Andrii's",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Андріїв",
       "lemmaId": "андріїв",
       "lemmaPlain": "андріїв",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6119,11 +6795,13 @@
     {
       "cefr": "B2",
       "gloss": "grandmother's",
+      "glossClean": "grandmother's",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бабусин",
       "lemmaId": "бабусин",
       "lemmaPlain": "бабусин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6134,11 +6812,13 @@
     {
       "cefr": "B2",
       "gloss": "father's, feminine nominative",
+      "glossClean": "father's",
       "heritage": "standard",
       "ipa": null,
       "lemma": "батькова",
       "lemmaId": "батькова",
       "lemmaPlain": "батькова",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6149,11 +6829,13 @@
     {
       "cefr": "B2",
       "gloss": "brother's",
+      "glossClean": "brother's",
       "heritage": "standard",
       "ipa": null,
       "lemma": "братів",
       "lemmaId": "братів",
       "lemmaPlain": "братів",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6164,11 +6846,13 @@
     {
       "cefr": "B2",
       "gloss": "mother's",
+      "glossClean": "mother's",
       "heritage": "standard",
       "ipa": null,
       "lemma": "материн",
       "lemmaId": "материн",
       "lemmaPlain": "материн",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6179,11 +6863,13 @@
     {
       "cefr": "B2",
       "gloss": "mother's, feminine nominative",
+      "glossClean": "mother's",
       "heritage": "standard",
       "ipa": null,
       "lemma": "материна",
       "lemmaId": "материна",
       "lemmaPlain": "материна",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6194,11 +6880,13 @@
     {
       "cefr": "B2",
       "gloss": "heritage, legacy",
+      "glossClean": "heritage",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спадщина",
       "lemmaId": "спадщина",
       "lemmaPlain": "спадщина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -6238,11 +6926,13 @@
     {
       "cefr": "B2",
       "gloss": "Shevchenko's",
+      "glossClean": "Shevchenko's",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Шевченків",
       "lemmaId": "шевченків",
       "lemmaPlain": "шевченків",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6253,11 +6943,13 @@
     {
       "cefr": "B2",
       "gloss": "listening comprehension",
+      "glossClean": "listening comprehension",
       "heritage": "standard",
       "ipa": null,
       "lemma": "аудіювання",
       "lemmaId": "аудіювання",
       "lemmaPlain": "аудіювання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6268,11 +6960,13 @@
     {
       "cefr": "B2",
       "gloss": "speaking",
+      "glossClean": "speaking",
       "heritage": "standard",
       "ipa": null,
       "lemma": "говоріння",
       "lemmaId": "говоріння",
       "lemmaPlain": "говоріння",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6283,11 +6977,13 @@
     {
       "cefr": "B2",
       "gloss": "reaction",
+      "glossClean": "reaction",
       "heritage": "standard",
       "ipa": null,
       "lemma": "реакція",
       "lemmaId": "реакція",
       "lemmaPlain": "реакція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -6327,11 +7023,13 @@
     {
       "cefr": "B2",
       "gloss": "navigation",
+      "glossClean": "navigation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "навігація",
       "lemmaId": "навігація",
       "lemmaPlain": "навігація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6342,11 +7040,13 @@
     {
       "cefr": "B2",
       "gloss": "behind; takes genitive when prepositional",
+      "glossClean": "behind",
       "heritage": "standard",
       "ipa": null,
       "lemma": "позаду",
       "lemmaId": "позаду",
       "lemmaPlain": "позаду",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6357,11 +7057,13 @@
     {
       "cefr": "B2",
       "gloss": "in front of, ahead of; takes genitive when prepositional",
+      "glossClean": "in front of",
       "heritage": "standard",
       "ipa": null,
       "lemma": "попереду",
       "lemmaId": "попереду",
       "lemmaPlain": "попереду",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6372,11 +7074,13 @@
     {
       "cefr": "B2",
       "gloss": "to impress, move",
+      "glossClean": "to impress",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вразити",
       "lemmaId": "вразити",
       "lemmaPlain": "вразити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6387,11 +7091,13 @@
     {
       "cefr": "B2",
       "gloss": "to inspire",
+      "glossClean": "to inspire",
       "heritage": "standard",
       "ipa": null,
       "lemma": "надихнути",
       "lemmaId": "надихнути",
       "lemmaPlain": "надихнути",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6402,11 +7108,13 @@
     {
       "cefr": "B2",
       "gloss": "imagery",
+      "glossClean": "imagery",
       "heritage": "standard",
       "ipa": null,
       "lemma": "образність",
       "lemmaId": "образність",
       "lemmaPlain": "образність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6417,11 +7125,13 @@
     {
       "cefr": "B2",
       "gloss": "stanza",
+      "glossClean": "stanza",
       "heritage": "standard",
       "ipa": null,
       "lemma": "строфа",
       "lemmaId": "строфа",
       "lemmaPlain": "строфа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -6461,11 +7171,13 @@
     {
       "cefr": "B2",
       "gloss": "to be surprised",
+      "glossClean": "to be surprised",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дивуватися",
       "lemmaId": "дивуватися",
       "lemmaPlain": "дивуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6476,11 +7188,13 @@
     {
       "cefr": "B2",
       "gloss": "one breathes, it is breathable",
+      "glossClean": "one breathes",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дихається",
       "lemmaId": "дихається",
       "lemmaPlain": "дихається",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6491,11 +7205,13 @@
     {
       "cefr": "B2",
       "gloss": "to correspond",
+      "glossClean": "to correspond",
       "heritage": "standard",
       "ipa": null,
       "lemma": "листуватися",
       "lemmaId": "листуватися",
       "lemmaPlain": "листуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6506,11 +7222,13 @@
     {
       "cefr": "B2",
       "gloss": "to hug each other",
+      "glossClean": "to hug each other",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обійматися",
       "lemmaId": "обійматися",
       "lemmaPlain": "обійматися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6521,11 +7239,13 @@
     {
       "cefr": "B2",
       "gloss": "to be ashamed, shy",
+      "glossClean": "to be ashamed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "соромитися",
       "lemmaId": "соромитися",
       "lemmaPlain": "соромитися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6536,11 +7256,13 @@
     {
       "cefr": "B2",
       "gloss": "to worry, move emotionally",
+      "glossClean": "to worry",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хвилювати",
       "lemmaId": "хвилювати",
       "lemmaPlain": "хвилювати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6551,11 +7273,13 @@
     {
       "cefr": "B2",
       "gloss": "the day before",
+      "glossClean": "the day before",
       "heritage": "standard",
       "ipa": null,
       "lemma": "напередодні",
       "lemmaId": "напередодні",
       "lemmaPlain": "напередодні",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6566,11 +7290,13 @@
     {
       "cefr": "B2",
       "gloss": "smoked",
+      "glossClean": "smoked",
       "heritage": "standard",
       "ipa": null,
       "lemma": "копчений",
       "lemmaId": "копчений",
       "lemmaPlain": "копчений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6581,11 +7307,13 @@
     {
       "cefr": "B2",
       "gloss": "grain, groats",
+      "glossClean": "grain",
       "heritage": "standard",
       "ipa": null,
       "lemma": "крупа",
       "lemmaId": "крупа",
       "lemmaPlain": "крупа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6596,11 +7324,13 @@
     {
       "cefr": "B2",
       "gloss": "politely",
+      "glossClean": "politely",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ввічливо",
       "lemmaId": "ввічливо",
       "lemmaPlain": "ввічливо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6611,11 +7341,13 @@
     {
       "cefr": "B2",
       "gloss": "tailor",
+      "glossClean": "tailor",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кравець",
       "lemmaId": "кравець",
       "lemmaPlain": "кравець",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6626,11 +7358,13 @@
     {
       "cefr": "B2",
       "gloss": "female tailor",
+      "glossClean": "female tailor",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кравчиня",
       "lemmaId": "кравчиня",
       "lemmaPlain": "кравчиня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6641,11 +7375,13 @@
     {
       "cefr": "B2",
       "gloss": "haircut",
+      "glossClean": "haircut",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стрижка",
       "lemmaId": "стрижка",
       "lemmaPlain": "стрижка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6656,11 +7392,13 @@
     {
       "cefr": "B2",
       "gloss": "faster",
+      "glossClean": "faster",
       "heritage": "standard",
       "ipa": null,
       "lemma": "швидший",
       "lemmaId": "швидший",
       "lemmaPlain": "швидший",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6671,11 +7409,13 @@
     {
       "cefr": "B2",
       "gloss": "capable, feminine",
+      "glossClean": "capable",
       "heritage": "standard",
       "ipa": null,
       "lemma": "годна",
       "lemmaId": "годна",
       "lemmaPlain": "годна",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6686,11 +7426,13 @@
     {
       "cefr": "B2",
       "gloss": "contrasting, high-contrast",
+      "glossClean": "contrasting",
       "heritage": "standard",
       "ipa": null,
       "lemma": "контрастний",
       "lemmaId": "контрастний",
       "lemmaPlain": "контрастний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6701,11 +7443,13 @@
     {
       "cefr": "B2",
       "gloss": "derived",
+      "glossClean": "derived",
       "heritage": "standard",
       "ipa": null,
       "lemma": "похідний",
       "lemmaId": "похідний",
       "lemmaPlain": "похідний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6716,11 +7460,13 @@
     {
       "cefr": "B2",
       "gloss": "travel pass; for travel",
+      "glossClean": "travel pass",
       "heritage": "standard",
       "ipa": null,
       "lemma": "проїзний",
       "lemmaId": "проїзний",
       "lemmaPlain": "проїзний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6731,11 +7477,13 @@
     {
       "cefr": "B2",
       "gloss": "heartfelt, cordial; cardiac in some contexts",
+      "glossClean": "heartfelt",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сердечний",
       "lemmaId": "сердечний",
       "lemmaPlain": "сердечний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6746,11 +7494,13 @@
     {
       "cefr": "B2",
       "gloss": "weekly",
+      "glossClean": "weekly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тижневий",
       "lemmaId": "тижневий",
       "lemmaPlain": "тижневий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6761,11 +7511,13 @@
     {
       "cefr": "B2",
       "gloss": "honor",
+      "glossClean": "honor",
       "heritage": "standard",
       "ipa": null,
       "lemma": "честь",
       "lemmaId": "честь",
       "lemmaPlain": "честь",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6776,11 +7528,13 @@
     {
       "cefr": "B2",
       "gloss": "reliable, trustworthy",
+      "glossClean": "reliable",
       "heritage": "russianism",
       "ipa": null,
       "lemma": "достовірний",
       "lemmaId": "достовірний",
       "lemmaPlain": "достовірний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6791,11 +7545,13 @@
     {
       "cefr": "B2",
       "gloss": "headline",
+      "glossClean": "headline",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заголовок",
       "lemmaId": "заголовок",
       "lemmaPlain": "заголовок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6806,11 +7562,13 @@
     {
       "cefr": "B2",
       "gloss": "mass media",
+      "glossClean": "mass media",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "масмедіа",
       "lemmaId": "масмедіа",
       "lemmaPlain": "масмедіа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6821,11 +7579,13 @@
     {
       "cefr": "B2",
       "gloss": "label",
+      "glossClean": "label",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ярлик",
       "lemmaId": "ярлик",
       "lemmaPlain": "ярлик",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6836,11 +7596,13 @@
     {
       "cefr": "B2",
       "gloss": "sender, applicant",
+      "glossClean": "sender",
       "heritage": "standard",
       "ipa": null,
       "lemma": "адресант",
       "lemmaId": "адресант",
       "lemmaPlain": "адресант",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6851,11 +7613,13 @@
     {
       "cefr": "B2",
       "gloss": "ugly, disgusting",
+      "glossClean": "ugly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бридкий",
       "lemmaId": "бридкий",
       "lemmaPlain": "бридкий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6866,11 +7630,13 @@
     {
       "cefr": "B2",
       "gloss": "bye, see you",
+      "glossClean": "bye",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бувай",
       "lemmaId": "бувай",
       "lemmaPlain": "бувай",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6881,11 +7647,13 @@
     {
       "cefr": "B2",
       "gloss": "impudent, brazen",
+      "glossClean": "impudent",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нахабний",
       "lemmaId": "нахабний",
       "lemmaPlain": "нахабний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6896,11 +7664,13 @@
     {
       "cefr": "B2",
       "gloss": "surzhyk",
+      "glossClean": "surzhyk",
       "heritage": "standard",
       "ipa": null,
       "lemma": "суржик",
       "lemmaId": "суржик",
       "lemmaPlain": "суржик",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6911,11 +7681,13 @@
     {
       "cefr": "B2",
       "gloss": "intonation",
+      "glossClean": "intonation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "інтонація",
       "lemmaId": "інтонація",
       "lemmaPlain": "інтонація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -6955,11 +7727,13 @@
     {
       "cefr": "B2",
       "gloss": "to depart by air, take off",
+      "glossClean": "to depart by air",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вилітати",
       "lemmaId": "вилітати",
       "lemmaPlain": "вилітати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6970,11 +7744,13 @@
     {
       "cefr": "B2",
       "gloss": "to book; to reserve",
+      "glossClean": "to book",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бронювати",
       "lemmaId": "бронювати",
       "lemmaPlain": "бронювати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6985,11 +7761,13 @@
     {
       "cefr": "B2",
       "gloss": "to winter; to spend the winter",
+      "glossClean": "to winter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зимувати",
       "lemmaId": "зимувати",
       "lemmaPlain": "зимувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7000,11 +7778,13 @@
     {
       "cefr": "B2",
       "gloss": "excess",
+      "glossClean": "excess",
       "heritage": "standard",
       "ipa": null,
       "lemma": "надмірність",
       "lemmaId": "надмірність",
       "lemmaPlain": "надмірність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7015,11 +7795,13 @@
     {
       "cefr": "B2",
       "gloss": "to not eat enough; to leave uneaten",
+      "glossClean": "to not eat enough",
       "heritage": "standard",
       "ipa": null,
       "lemma": "недоїсти",
       "lemmaId": "недоїсти",
       "lemmaPlain": "недоїсти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7030,11 +7812,13 @@
     {
       "cefr": "B2",
       "gloss": "to think over",
+      "glossClean": "to think over",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обдумати",
       "lemmaId": "обдумати",
       "lemmaPlain": "обдумати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7045,11 +7829,13 @@
     {
       "cefr": "B2",
       "gloss": "to arm; to equip",
+      "glossClean": "to arm",
       "heritage": "standard",
       "ipa": null,
       "lemma": "озброїти",
       "lemmaId": "озброїти",
       "lemmaPlain": "озброїти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7060,11 +7846,13 @@
     {
       "cefr": "B2",
       "gloss": "to switch",
+      "glossClean": "to switch",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перемкнути",
       "lemmaId": "перемкнути",
       "lemmaPlain": "перемкнути",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7075,11 +7863,13 @@
     {
       "cefr": "B2",
       "gloss": "to attach; to fasten",
+      "glossClean": "to attach",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прикріпити",
       "lemmaId": "прикріпити",
       "lemmaPlain": "прикріпити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7090,11 +7880,13 @@
     {
       "cefr": "B2",
       "gloss": "to forge; to work extra",
+      "glossClean": "to forge",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підробити",
       "lemmaId": "підробити",
       "lemmaPlain": "підробити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7105,11 +7897,13 @@
     {
       "cefr": "B2",
       "gloss": "separation; splitting apart",
+      "glossClean": "separation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "роз'єднання",
       "lemmaId": "роз-єднання",
       "lemmaPlain": "роз'єднання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7120,11 +7914,13 @@
     {
       "cefr": "B2",
       "gloss": "to disarm",
+      "glossClean": "to disarm",
       "heritage": "standard",
       "ipa": null,
       "lemma": "роззброїти",
       "lemmaId": "роззброїти",
       "lemmaPlain": "роззброїти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7135,11 +7931,13 @@
     {
       "cefr": "B2",
       "gloss": "to decompose; to break down",
+      "glossClean": "to decompose",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розкладати",
       "lemmaId": "розкладати",
       "lemmaPlain": "розкладати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7150,11 +7948,13 @@
     {
       "cefr": "B2",
       "gloss": "to turn red; to blush",
+      "glossClean": "to turn red",
       "heritage": "standard",
       "ipa": null,
       "lemma": "червоніти",
       "lemmaId": "червоніти",
       "lemmaPlain": "червоніти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7165,11 +7965,13 @@
     {
       "cefr": "B2",
       "gloss": "to push repeatedly",
+      "glossClean": "to push repeatedly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "штовхати",
       "lemmaId": "штовхати",
       "lemmaPlain": "штовхати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7180,11 +7982,13 @@
     {
       "cefr": "B2",
       "gloss": "to push once",
+      "glossClean": "to push once",
       "heritage": "standard",
       "ipa": null,
       "lemma": "штовхнути",
       "lemmaId": "штовхнути",
       "lemmaPlain": "штовхнути",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7195,11 +7999,13 @@
     {
       "cefr": "B2",
       "gloss": "admission; entrance",
+      "glossClean": "admission",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вступ",
       "lemmaId": "вступ",
       "lemmaPlain": "вступ",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7210,11 +8016,13 @@
     {
       "cefr": "B2",
       "gloss": "to restore; renew",
+      "glossClean": "to restore",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відновити",
       "lemmaId": "відновити",
       "lemmaPlain": "відновити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7225,11 +8033,13 @@
     {
       "cefr": "B2",
       "gloss": "to research; investigate",
+      "glossClean": "to research",
       "heritage": "standard",
       "ipa": null,
       "lemma": "досліджувати",
       "lemmaId": "досліджувати",
       "lemmaPlain": "досліджувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7240,11 +8050,13 @@
     {
       "cefr": "B2",
       "gloss": "speech; speaking",
+      "glossClean": "speech",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мовлення",
       "lemmaId": "мовлення",
       "lemmaPlain": "мовлення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7255,11 +8067,13 @@
     {
       "cefr": "B2",
       "gloss": "to exchange",
+      "glossClean": "to exchange",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обміняти",
       "lemmaId": "обміняти",
       "lemmaPlain": "обміняти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7270,11 +8084,13 @@
     {
       "cefr": "B2",
       "gloss": "concept",
+      "glossClean": "concept",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поняття",
       "lemmaId": "поняття",
       "lemmaPlain": "поняття",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7285,11 +8101,13 @@
     {
       "cefr": "B2",
       "gloss": "preparation",
+      "glossClean": "preparation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підготовка",
       "lemmaId": "підготовка",
       "lemmaPlain": "підготовка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7300,11 +8118,13 @@
     {
       "cefr": "B2",
       "gloss": "most respected",
+      "glossClean": "most respected",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вельмишановний",
       "lemmaId": "вельмишановний",
       "lemmaPlain": "вельмишановний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7315,11 +8135,13 @@
     {
       "cefr": "B2",
       "gloss": "director (vocative)",
+      "glossClean": "director (vocative)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "директоре",
       "lemmaId": "директоре",
       "lemmaPlain": "директоре",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -7330,11 +8152,13 @@
     {
       "cefr": "B2",
       "gloss": "madam (very formal vocative)",
+      "glossClean": "madam (very formal vocative)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "добродійко",
       "lemmaId": "добродійко",
       "lemmaPlain": "добродійко",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -7345,11 +8169,13 @@
     {
       "cefr": "B2",
       "gloss": "institution",
+      "glossClean": "institution",
       "heritage": "standard",
       "ipa": null,
       "lemma": "установа",
       "lemmaId": "установа",
       "lemmaPlain": "установа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -7389,11 +8215,13 @@
     {
       "cefr": "B2",
       "gloss": "approximate",
+      "glossClean": "approximate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "наближений",
       "lemmaId": "наближений",
       "lemmaPlain": "наближений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7404,11 +8232,13 @@
     {
       "cefr": "B2",
       "gloss": "Parisian",
+      "glossClean": "Parisian",
       "heritage": "standard",
       "ipa": null,
       "lemma": "паризький",
       "lemmaId": "паризький",
       "lemmaPlain": "паризький",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7419,11 +8249,13 @@
     {
       "cefr": "B2",
       "gloss": "sandy",
+      "glossClean": "sandy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "піщаний",
       "lemmaId": "піщаний",
       "lemmaPlain": "піщаний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7434,11 +8266,13 @@
     {
       "cefr": "B2",
       "gloss": "female defender",
+      "glossClean": "female defender",
       "heritage": "standard",
       "ipa": null,
       "lemma": "захисниця",
       "lemmaId": "захисниця",
       "lemmaPlain": "захисниця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7449,11 +8283,13 @@
     {
       "cefr": "B2",
       "gloss": "female artist, creator",
+      "glossClean": "female artist",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мисткиня",
       "lemmaId": "мисткиня",
       "lemmaPlain": "мисткиня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7464,11 +8300,13 @@
     {
       "cefr": "B2",
       "gloss": "student body",
+      "glossClean": "student body",
       "heritage": "standard",
       "ipa": null,
       "lemma": "студентство",
       "lemmaId": "студентство",
       "lemmaPlain": "студентство",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7479,11 +8317,13 @@
     {
       "cefr": "B2",
       "gloss": "female specialist, expert",
+      "glossClean": "female specialist",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фахівчиня",
       "lemmaId": "фахівчиня",
       "lemmaPlain": "фахівчиня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7494,11 +8334,13 @@
     {
       "cefr": "B2",
       "gloss": "reading room",
+      "glossClean": "reading room",
       "heritage": "standard",
       "ipa": null,
       "lemma": "читальня",
       "lemmaId": "читальня",
       "lemmaPlain": "читальня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -7538,11 +8380,13 @@
     {
       "cefr": "B2",
       "gloss": "to be getting hired, to apply for a job",
+      "glossClean": "to be getting hired",
       "heritage": "standard",
       "ipa": null,
       "lemma": "влаштовуватися",
       "lemmaId": "влаштовуватися",
       "lemmaPlain": "влаштовуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7553,11 +8397,13 @@
     {
       "cefr": "B2",
       "gloss": "dismissal, resignation",
+      "glossClean": "dismissal",
       "heritage": "standard",
       "ipa": null,
       "lemma": "звільнення",
       "lemmaId": "звільнення",
       "lemmaPlain": "звільнення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7568,11 +8414,13 @@
     {
       "cefr": "B2",
       "gloss": "to be resigning, to leave jobs repeatedly",
+      "glossClean": "to be resigning",
       "heritage": "standard",
       "ipa": null,
       "lemma": "звільнятися",
       "lemmaId": "звільнятися",
       "lemmaPlain": "звільнятися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7583,11 +8431,13 @@
     {
       "cefr": "B2",
       "gloss": "to be implemented",
+      "glossClean": "to be implemented",
       "heritage": "standard",
       "ipa": null,
       "lemma": "впроваджуватися",
       "lemmaId": "впроваджуватися",
       "lemmaPlain": "впроваджуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7598,11 +8448,13 @@
     {
       "cefr": "B2",
       "gloss": "academic style",
+      "glossClean": "academic style",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "науковий стиль",
       "lemmaId": "науковий-стиль",
       "lemmaPlain": "науковий стиль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7613,11 +8465,13 @@
     {
       "cefr": "B2",
       "gloss": "result of an action",
+      "glossClean": "result of an action",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "результат дії",
       "lemmaId": "результат-дії",
       "lemmaPlain": "результат дії",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7628,11 +8482,13 @@
     {
       "cefr": "B2",
       "gloss": "reform",
+      "glossClean": "reform",
       "heritage": "standard",
       "ipa": null,
       "lemma": "реформа",
       "lemmaId": "реформа",
       "lemmaPlain": "реформа",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -7672,11 +8528,13 @@
     {
       "cefr": "B2",
       "gloss": "to be developed",
+      "glossClean": "to be developed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розроблятися",
       "lemmaId": "розроблятися",
       "lemmaPlain": "розроблятися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7687,11 +8545,13 @@
     {
       "cefr": "B2",
       "gloss": "syntactic norm",
+      "glossClean": "syntactic norm",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "синтаксична норма",
       "lemmaId": "синтаксична-норма",
       "lemmaPlain": "синтаксична норма",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7702,11 +8562,13 @@
     {
       "cefr": "B2",
       "gloss": "to edit",
+      "glossClean": "to edit",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відредагувати",
       "lemmaId": "відредагувати",
       "lemmaPlain": "відредагувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7717,11 +8579,13 @@
     {
       "cefr": "B2",
       "gloss": "past participle",
+      "glossClean": "past participle",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "дієприкметник минулого часу",
       "lemmaId": "дієприкметник-минулого-часу",
       "lemmaPlain": "дієприкметник минулого часу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7732,11 +8596,13 @@
     {
       "cefr": "B2",
       "gloss": "forgotten",
+      "glossClean": "forgotten",
       "heritage": "standard",
       "ipa": null,
       "lemma": "забутий",
       "lemmaId": "забутий",
       "lemmaPlain": "забутий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7747,11 +8613,13 @@
     {
       "cefr": "B2",
       "gloss": "crumpled",
+      "glossClean": "crumpled",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зім'ятий",
       "lemmaId": "зім-ятий",
       "lemmaPlain": "зім'ятий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7762,11 +8630,13 @@
     {
       "cefr": "B2",
       "gloss": "conciseness",
+      "glossClean": "conciseness",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лаконічність",
       "lemmaId": "лаконічність",
       "lemmaPlain": "лаконічність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7777,11 +8647,13 @@
     {
       "cefr": "B2",
       "gloss": "literary modifier",
+      "glossClean": "literary modifier",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "художнє означення",
       "lemmaId": "художнє-означення",
       "lemmaPlain": "художнє означення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7792,11 +8664,13 @@
     {
       "cefr": "B2",
       "gloss": "nominal part of the predicate",
+      "glossClean": "nominal part of the predicate",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "іменна частина присудка",
       "lemmaId": "іменна-частина-присудка",
       "lemmaPlain": "іменна частина присудка",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -7807,11 +8681,13 @@
     {
       "cefr": "B2",
       "gloss": "anonymity, namelessness",
+      "glossClean": "anonymity",
       "heritage": "standard",
       "ipa": null,
       "lemma": "анонімність",
       "lemmaId": "анонімність",
       "lemmaPlain": "анонімність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7822,11 +8698,13 @@
     {
       "cefr": "B2",
       "gloss": "captive, prisoner taken in a raid",
+      "glossClean": "captive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бранець",
       "lemmaId": "бранець",
       "lemmaPlain": "бранець",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7837,11 +8715,13 @@
     {
       "cefr": "B2",
       "gloss": "galley (oared warship); a place of penal rowing",
+      "glossClean": "galley (oared warship)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "галера",
       "lemmaId": "галера",
       "lemmaPlain": "галера",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -7881,11 +8761,13 @@
     {
       "cefr": "B2",
       "gloss": "epic (as genre)",
+      "glossClean": "epic (as genre)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "епос",
       "lemmaId": "епос",
       "lemmaPlain": "епос",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -7896,11 +8778,13 @@
     {
       "cefr": "B2",
       "gloss": "self-sacrifice",
+      "glossClean": "self-sacrifice",
       "heritage": "standard",
       "ipa": null,
       "lemma": "жертовність",
       "lemmaId": "жертовність",
       "lemmaPlain": "жертовність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7911,11 +8795,13 @@
     {
       "cefr": "B2",
       "gloss": "cuckoo; symbol of a mother's lament and longing for home",
+      "glossClean": "cuckoo",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зозуля",
       "lemmaId": "зозуля",
       "lemmaPlain": "зозуля",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7926,11 +8812,13 @@
     {
       "cefr": "B2",
       "gloss": "galley; later, hard penal labour",
+      "glossClean": "galley",
       "heritage": "standard",
       "ipa": null,
       "lemma": "каторга",
       "lemmaId": "каторга",
       "lemmaPlain": "каторга",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -7970,11 +8858,13 @@
     {
       "cefr": "B2",
       "gloss": "raid, sudden military incursion",
+      "glossClean": "raid",
       "heritage": "standard",
       "ipa": null,
       "lemma": "набіг",
       "lemmaId": "набіг",
       "lemmaPlain": "набіг",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -7985,11 +8875,13 @@
     {
       "cefr": "B2",
       "gloss": "captivity, bondage",
+      "glossClean": "captivity",
       "heritage": "standard",
       "ipa": null,
       "lemma": "неволя",
       "lemmaId": "неволя",
       "lemmaPlain": "неволя",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -8029,11 +8921,13 @@
     {
       "cefr": "B2",
       "gloss": "captive, slave; one deprived of freedom and torn from the homeland",
+      "glossClean": "captive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "невільник",
       "lemmaId": "невільник",
       "lemmaPlain": "невільник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8044,11 +8938,13 @@
     {
       "cefr": "B2",
       "gloss": "psychologism; focus on inner emotional state",
+      "glossClean": "psychologism",
       "heritage": "standard",
       "ipa": null,
       "lemma": "психологізм",
       "lemmaId": "психологізм",
       "lemmaPlain": "психологізм",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8059,11 +8955,13 @@
     {
       "cefr": "B2",
       "gloss": "sycamore; symbol of misfortune, sorrow and death in a foreign land",
+      "glossClean": "sycamore",
       "heritage": "standard",
       "ipa": null,
       "lemma": "явір",
       "lemmaId": "явір",
       "lemmaPlain": "явір",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8074,11 +8972,13 @@
     {
       "cefr": "B2",
       "gloss": "janissary (Ottoman soldier)",
+      "glossClean": "janissary (Ottoman soldier)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "яничар",
       "lemmaId": "яничар",
       "lemmaPlain": "яничар",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8089,11 +8989,13 @@
     {
       "cefr": "B2",
       "gloss": "captives seized as living goods during raids (Turkic borrowing)",
+      "glossClean": "captives seized as living goods during raids (Turkic borrowing)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ясир",
       "lemmaId": "ясир",
       "lemmaPlain": "ясир",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8104,11 +9006,13 @@
     {
       "cefr": "B2",
       "gloss": "didukh (ceremonial sheaf)",
+      "glossClean": "didukh (ceremonial sheaf)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дідух",
       "lemmaId": "дідух",
       "lemmaPlain": "дідух",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8119,11 +9023,13 @@
     {
       "cefr": "B2",
       "gloss": "carolling (the rite of going house to house)",
+      "glossClean": "carolling (the rite of going house to house)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "колядування",
       "lemmaId": "колядування",
       "lemmaPlain": "колядування",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8134,11 +9040,13 @@
     {
       "cefr": "B2",
       "gloss": "ritual practice, body of rites",
+      "glossClean": "ritual practice",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обрядовість",
       "lemmaId": "обрядовість",
       "lemmaPlain": "обрядовість",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8149,11 +9057,13 @@
     {
       "cefr": "B2",
       "gloss": "fertility (of land)",
+      "glossClean": "fertility (of land)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "родючість",
       "lemmaId": "родючість",
       "lemmaPlain": "родючість",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8164,11 +9074,13 @@
     {
       "cefr": "B2",
       "gloss": "equinox",
+      "glossClean": "equinox",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рівнодення",
       "lemmaId": "рівнодення",
       "lemmaPlain": "рівнодення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8179,11 +9091,13 @@
     {
       "cefr": "B2",
       "gloss": "syncretism (coexistence of religious layers)",
+      "glossClean": "syncretism (coexistence of religious layers)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "синкретизм",
       "lemmaId": "синкретизм",
       "lemmaPlain": "синкретизм",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8194,11 +9108,13 @@
     {
       "cefr": "B2",
       "gloss": "solstice",
+      "glossClean": "solstice",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сонцестояння",
       "lemmaId": "сонцестояння",
       "lemmaPlain": "сонцестояння",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8209,11 +9125,13 @@
     {
       "cefr": "B2",
       "gloss": "cycle",
+      "glossClean": "cycle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "цикл",
       "lemmaId": "цикл",
       "lemmaPlain": "цикл",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8224,11 +9142,13 @@
     {
       "cefr": "B2",
       "gloss": "parallelism; repetition of similar syntactic constructions",
+      "glossClean": "parallelism",
       "heritage": "standard",
       "ipa": null,
       "lemma": "паралелізм",
       "lemmaId": "паралелізм",
       "lemmaPlain": "паралелізм",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8239,11 +9159,13 @@
     {
       "cefr": "B2",
       "gloss": "existence in everyday use; how a form lives among people",
+      "glossClean": "existence in everyday use",
       "heritage": "standard",
       "ipa": null,
       "lemma": "побутування",
       "lemmaId": "побутування",
       "lemmaPlain": "побутування",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8254,11 +9176,13 @@
     {
       "cefr": "B2",
       "gloss": "refrain; a repeated line returning after each verse",
+      "glossClean": "refrain",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рефрен",
       "lemmaId": "рефрен",
       "lemmaPlain": "рефрен",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8269,11 +9193,13 @@
     {
       "cefr": "B2",
       "gloss": "stylization; conscious imitation of another era's or genre's style",
+      "glossClean": "stylization",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стилізація",
       "lemmaId": "стилізація",
       "lemmaPlain": "стилізація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -8313,11 +9239,13 @@
     {
       "cefr": "B2",
       "gloss": "triad; here: host–hostess–children as a cosmic model",
+      "glossClean": "triad",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тріада",
       "lemmaId": "тріада",
       "lemmaPlain": "тріада",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -8357,11 +9285,13 @@
     {
       "cefr": "B2",
       "gloss": "veneration, honouring",
+      "glossClean": "veneration",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ушанування",
       "lemmaId": "ушанування",
       "lemmaPlain": "ушанування",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8372,11 +9302,13 @@
     {
       "cefr": "B2",
       "gloss": "funeral lament",
+      "glossClean": "funeral lament",
       "heritage": "standard",
       "ipa": null,
       "lemma": "голосіння",
       "lemmaId": "голосіння",
       "lemmaPlain": "голосіння",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8387,11 +9319,13 @@
     {
       "cefr": "B2",
       "gloss": "kobza (folk lute)",
+      "glossClean": "kobza (folk lute)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кобза",
       "lemmaId": "кобза",
       "lemmaPlain": "кобза",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -8431,11 +9365,13 @@
     {
       "cefr": "B2",
       "gloss": "ritual wedding bread",
+      "glossClean": "ritual wedding bread",
       "heritage": "standard",
       "ipa": null,
       "lemma": "коровай",
       "lemmaId": "коровай",
       "lemmaPlain": "коровай",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8446,11 +9382,13 @@
     {
       "cefr": "B2",
       "gloss": "lira (Ukrainian hurdy-gurdy)",
+      "glossClean": "lira (Ukrainian hurdy-gurdy)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ліра",
       "lemmaId": "ліра",
       "lemmaPlain": "ліра",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -8490,11 +9428,13 @@
     {
       "cefr": "B2",
       "gloss": "layering, stratification",
+      "glossClean": "layering",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нашарування",
       "lemmaId": "нашарування",
       "lemmaPlain": "нашарування",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8505,11 +9445,13 @@
     {
       "cefr": "B2",
       "gloss": "water spirit",
+      "glossClean": "water spirit",
       "heritage": "standard",
       "ipa": null,
       "lemma": "водяник",
       "lemmaId": "водяник",
       "lemmaPlain": "водяник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8520,11 +9462,13 @@
     {
       "cefr": "B2",
       "gloss": "divination, fortune-telling",
+      "glossClean": "divination",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ворожіння",
       "lemmaId": "ворожіння",
       "lemmaPlain": "ворожіння",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8535,11 +9479,13 @@
     {
       "cefr": "B2",
       "gloss": "house spirit, domovyk",
+      "glossClean": "house spirit",
       "heritage": "standard",
       "ipa": null,
       "lemma": "домовик",
       "lemmaId": "домовик",
       "lemmaPlain": "домовик",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8550,11 +9496,13 @@
     {
       "cefr": "B2",
       "gloss": "euphemism",
+      "glossClean": "euphemism",
       "heritage": "standard",
       "ipa": null,
       "lemma": "евфемізм",
       "lemmaId": "евфемізм",
       "lemmaPlain": "евфемізм",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8565,11 +9513,13 @@
     {
       "cefr": "B2",
       "gloss": "incantation, spell-formula",
+      "glossClean": "incantation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "замовляння",
       "lemmaId": "замовляння",
       "lemmaPlain": "замовляння",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8580,11 +9530,13 @@
     {
       "cefr": "B2",
       "gloss": "folk healer",
+      "glossClean": "folk healer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "знахар",
       "lemmaId": "знахар",
       "lemmaPlain": "знахар",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8595,11 +9547,13 @@
     {
       "cefr": "B2",
       "gloss": "forest spirit",
+      "glossClean": "forest spirit",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лісовик",
       "lemmaId": "лісовик",
       "lemmaPlain": "лісовик",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8610,11 +9564,13 @@
     {
       "cefr": "B2",
       "gloss": "mavka, forest nymph",
+      "glossClean": "mavka",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мавка",
       "lemmaId": "мавка",
       "lemmaPlain": "мавка",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8625,11 +9581,13 @@
     {
       "cefr": "B2",
       "gloss": "the dead one, corpse-revenant",
+      "glossClean": "the dead one",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мрець",
       "lemmaId": "мрець",
       "lemmaPlain": "мрець",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8640,11 +9598,13 @@
     {
       "cefr": "B2",
       "gloss": "mythology",
+      "glossClean": "mythology",
       "heritage": "standard",
       "ipa": null,
       "lemma": "міфологія",
       "lemmaId": "міфологія",
       "lemmaPlain": "міфологія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8655,11 +9615,13 @@
     {
       "cefr": "B2",
       "gloss": "pantheon",
+      "glossClean": "pantheon",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пантеон",
       "lemmaId": "пантеон",
       "lemmaPlain": "пантеон",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8670,11 +9632,13 @@
     {
       "cefr": "B2",
       "gloss": "shapeshifter",
+      "glossClean": "shapeshifter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перевертень",
       "lemmaId": "перевертень",
       "lemmaPlain": "перевертень",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8685,11 +9649,13 @@
     {
       "cefr": "B2",
       "gloss": "borderland, liminal zone",
+      "glossClean": "borderland",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пограниччя",
       "lemmaId": "пограниччя",
       "lemmaPlain": "пограниччя",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8700,11 +9666,13 @@
     {
       "cefr": "B2",
       "gloss": "ancestor",
+      "glossClean": "ancestor",
       "heritage": "standard",
       "ipa": null,
       "lemma": "предок",
       "lemmaId": "предок",
       "lemmaPlain": "предок",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8715,11 +9683,13 @@
     {
       "cefr": "B2",
       "gloss": "rusalka, water-and-field nymph",
+      "glossClean": "rusalka",
       "heritage": "standard",
       "ipa": null,
       "lemma": "русалка",
       "lemmaId": "русалка",
       "lemmaPlain": "русалка",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8730,11 +9700,13 @@
     {
       "cefr": "B2",
       "gloss": "upyr, undead vampire",
+      "glossClean": "upyr",
       "heritage": "standard",
       "ipa": null,
       "lemma": "упир",
       "lemmaId": "упир",
       "lemmaPlain": "упир",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8745,11 +9717,13 @@
     {
       "cefr": "B2",
       "gloss": "gradation (rising intensity)",
+      "glossClean": "gradation (rising intensity)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "градація",
       "lemmaId": "градація",
       "lemmaPlain": "градація",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8760,11 +9734,13 @@
     {
       "cefr": "B2",
       "gloss": "researcher, scholar",
+      "glossClean": "researcher",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дослідник",
       "lemmaId": "дослідник",
       "lemmaPlain": "дослідник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8775,11 +9751,13 @@
     {
       "cefr": "B2",
       "gloss": "ethnonym (name of a people)",
+      "glossClean": "ethnonym (name of a people)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "етнонім",
       "lemmaId": "етнонім",
       "lemmaPlain": "етнонім",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8790,11 +9768,13 @@
     {
       "cefr": "B2",
       "gloss": "incantatory (of a charm)",
+      "glossClean": "incantatory (of a charm)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "замовний",
       "lemmaId": "замовний",
       "lemmaPlain": "замовний",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8805,11 +9785,13 @@
     {
       "cefr": "B2",
       "gloss": "collector (of folklore)",
+      "glossClean": "collector (of folklore)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "збирач",
       "lemmaId": "збирач",
       "lemmaPlain": "збирач",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8820,11 +9802,13 @@
     {
       "cefr": "B2",
       "gloss": "magical",
+      "glossClean": "magical",
       "heritage": "standard",
       "ipa": null,
       "lemma": "магічний",
       "lemmaId": "магічний",
       "lemmaPlain": "магічний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8835,11 +9819,13 @@
     {
       "cefr": "B2",
       "gloss": "poetics",
+      "glossClean": "poetics",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поетика",
       "lemmaId": "поетика",
       "lemmaPlain": "поетика",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8850,11 +9836,13 @@
     {
       "cefr": "B2",
       "gloss": "verbal (of words)",
+      "glossClean": "verbal (of words)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "словесний",
       "lemmaId": "словесний",
       "lemmaPlain": "словесний",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8865,11 +9853,13 @@
     {
       "cefr": "B2",
       "gloss": "identity, sameness",
+      "glossClean": "identity",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тотожність",
       "lemmaId": "тотожність",
       "lemmaPlain": "тотожність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -8880,11 +9870,13 @@
     {
       "cefr": "B2",
       "gloss": "hetman",
+      "glossClean": "hetman",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гетьман",
       "lemmaId": "гетьман",
       "lemmaPlain": "гетьман",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8895,11 +9887,13 @@
     {
       "cefr": "B2",
       "gloss": "tithe; historical land unit",
+      "glossClean": "tithe",
       "heritage": "standard",
       "ipa": null,
       "lemma": "десятина",
       "lemmaId": "десятина",
       "lemmaPlain": "десятина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -8939,11 +9933,13 @@
     {
       "cefr": "B2",
       "gloss": "opryshok",
+      "glossClean": "opryshok",
       "heritage": "historism",
       "ipa": null,
       "lemma": "опришок",
       "lemmaId": "опришок",
       "lemmaPlain": "опришок",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -8955,10 +9951,10 @@
   "schema": "atlas-practice-lexemes",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 18566,
+    "gzipBytes": 20705,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 225166,
+    "rawBytes": 259282,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/public/lexicon/practice-lexemes.C1.json
+++ b/site/public/lexicon/practice-lexemes.C1.json
@@ -5,11 +5,13 @@
     {
       "cefr": "C1",
       "gloss": "drinking straw",
+      "glossClean": "drinking straw",
       "heritage": "standard",
       "ipa": null,
       "lemma": "соломинка",
       "lemmaId": "соломинка",
       "lemmaPlain": "соломинка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -49,11 +51,13 @@
     {
       "cefr": "C1",
       "gloss": "Canadian woman",
+      "glossClean": "Canadian woman",
       "heritage": "standard",
       "ipa": null,
       "lemma": "канадка",
       "lemmaId": "канадка",
       "lemmaPlain": "канадка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -64,11 +68,13 @@
     {
       "cefr": "C1",
       "gloss": "light blue",
+      "glossClean": "light blue",
       "heritage": "standard",
       "ipa": null,
       "lemma": "світло-синій",
       "lemmaId": "світло-синій",
       "lemmaPlain": "світло-синій",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -79,11 +85,13 @@
     {
       "cefr": "C1",
       "gloss": "dark green",
+      "glossClean": "dark green",
       "heritage": "standard",
       "ipa": null,
       "lemma": "темно-зелений",
       "lemmaId": "темно-зелений",
       "lemmaPlain": "темно-зелений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -94,11 +102,13 @@
     {
       "cefr": "C1",
       "gloss": "euphony; smooth sound flow",
+      "glossClean": "euphony",
       "heritage": "standard",
       "ipa": null,
       "lemma": "милозвучність",
       "lemmaId": "милозвучність",
       "lemmaPlain": "милозвучність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -109,11 +119,13 @@
     {
       "cefr": "C1",
       "gloss": "music",
+      "glossClean": "music",
       "heritage": "standard",
       "ipa": null,
       "lemma": "музика",
       "lemmaId": "музика",
       "lemmaPlain": "музика",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -124,11 +136,13 @@
     {
       "cefr": "C1",
       "gloss": "to perform shchedrivky",
+      "glossClean": "to perform shchedrivky",
       "heritage": "standard",
       "ipa": null,
       "lemma": "щедрувати",
       "lemmaId": "щедрувати",
       "lemmaPlain": "щедрувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -139,11 +153,13 @@
     {
       "cefr": "C1",
       "gloss": "to comb one's hair",
+      "glossClean": "to comb one's hair",
       "heritage": "standard",
       "ipa": null,
       "lemma": "причісуватися",
       "lemmaId": "причісуватися",
       "lemmaPlain": "причісуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -154,11 +170,13 @@
     {
       "cefr": "C1",
       "gloss": "short exercise routine",
+      "glossClean": "short exercise routine",
       "heritage": "standard",
       "ipa": null,
       "lemma": "руханка",
       "lemmaId": "руханка",
       "lemmaPlain": "руханка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -198,11 +216,13 @@
     {
       "cefr": "C1",
       "gloss": "apostrophe",
+      "glossClean": "apostrophe",
       "heritage": "standard",
       "ipa": null,
       "lemma": "апо́строф",
       "lemmaId": "апо-строф",
       "lemmaPlain": "апостроф",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -213,11 +233,13 @@
     {
       "cefr": "C1",
       "gloss": "loaf",
+      "glossClean": "loaf",
       "heritage": "standard",
       "ipa": null,
       "lemma": "буханка",
       "lemmaId": "буханка",
       "lemmaPlain": "буханка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -257,11 +279,13 @@
     {
       "cefr": "C1",
       "gloss": "small shop",
+      "glossClean": "small shop",
       "heritage": "standard",
       "ipa": null,
       "lemma": "крамниця",
       "lemmaId": "крамниця",
       "lemmaPlain": "крамниця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -301,11 +325,13 @@
     {
       "cefr": "C1",
       "gloss": "iotated",
+      "glossClean": "iotated",
       "heritage": "standard",
       "ipa": null,
       "lemma": "йото́ваний",
       "lemmaId": "йото-ваний",
       "lemmaPlain": "йотований",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -316,11 +342,13 @@
     {
       "cefr": "C1",
       "gloss": "separately",
+      "glossClean": "separately",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розді́льно",
       "lemmaId": "розді-льно",
       "lemmaPlain": "роздільно",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -331,11 +359,13 @@
     {
       "cefr": "C1",
       "gloss": "melody / intonation",
+      "glossClean": "melody / intonation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мелодика",
       "lemmaId": "мелодика",
       "lemmaPlain": "мелодика",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -346,11 +376,13 @@
     {
       "cefr": "C1",
       "gloss": "unstressed",
+      "glossClean": "unstressed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ненаголошений",
       "lemmaId": "ненаголошений",
       "lemmaPlain": "ненаголошений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -361,11 +393,13 @@
     {
       "cefr": "C1",
       "gloss": "you all study; are learning",
+      "glossClean": "you all study",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вивчаєте",
       "lemmaId": "вивчаєте",
       "lemmaPlain": "вивчаєте",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -376,11 +410,13 @@
     {
       "cefr": "C1",
       "gloss": "you walk",
+      "glossClean": "you walk",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гуляєш",
       "lemmaId": "гуляєш",
       "lemmaPlain": "гуляєш",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -391,11 +427,13 @@
     {
       "cefr": "C1",
       "gloss": "you learn; you study (plural/formal)",
+      "glossClean": "you learn",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вчите",
       "lemmaId": "вчите",
       "lemmaPlain": "вчите",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -406,11 +444,13 @@
     {
       "cefr": "C1",
       "gloss": "you learn; you study",
+      "glossClean": "you learn",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вчиш",
       "lemmaId": "вчиш",
       "lemmaPlain": "вчиш",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -421,11 +461,13 @@
     {
       "cefr": "C1",
       "gloss": "Canadian man",
+      "glossClean": "Canadian man",
       "heritage": "standard",
       "ipa": null,
       "lemma": "канадієць",
       "lemmaId": "канадієць",
       "lemmaPlain": "канадієць",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -436,11 +478,13 @@
     {
       "cefr": "C1",
       "gloss": "to treat with food",
+      "glossClean": "to treat with food",
       "heritage": "standard",
       "ipa": null,
       "lemma": "частувати",
       "lemmaId": "частувати",
       "lemmaPlain": "частувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -451,11 +495,13 @@
     {
       "cefr": "C1",
       "gloss": "concession",
+      "glossClean": "concession",
       "heritage": "standard",
       "ipa": null,
       "lemma": "допуст",
       "lemmaId": "допуст",
       "lemmaPlain": "допуст",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -466,11 +512,13 @@
     {
       "cefr": "C1",
       "gloss": "coordinating",
+      "glossClean": "coordinating",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сурядний",
       "lemmaId": "сурядний",
       "lemmaPlain": "сурядний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -481,11 +529,13 @@
     {
       "cefr": "C1",
       "gloss": "although, even though",
+      "glossClean": "although",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хоча",
       "lemmaId": "хоча",
       "lemmaPlain": "хоча",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -496,11 +546,13 @@
     {
       "cefr": "C1",
       "gloss": "self-check",
+      "glossClean": "self-check",
       "heritage": "standard",
       "ipa": null,
       "lemma": "самоперевірка",
       "lemmaId": "самоперевірка",
       "lemmaPlain": "самоперевірка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -540,11 +592,13 @@
     {
       "cefr": "C1",
       "gloss": "new information",
+      "glossClean": "new information",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рема",
       "lemmaId": "рема",
       "lemmaPlain": "рема",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -584,11 +638,13 @@
     {
       "cefr": "C1",
       "gloss": "master's program",
+      "glossClean": "master's program",
       "heritage": "standard",
       "ipa": null,
       "lemma": "магістратура",
       "lemmaId": "магістратура",
       "lemmaPlain": "магістратура",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -628,11 +684,13 @@
     {
       "cefr": "C1",
       "gloss": "euphony",
+      "glossClean": "euphony",
       "heritage": "standard",
       "ipa": null,
       "lemma": "евфонія",
       "lemmaId": "евфонія",
       "lemmaPlain": "евфонія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -643,11 +701,13 @@
     {
       "cefr": "C1",
       "gloss": "sticker",
+      "glossClean": "sticker",
       "heritage": "standard",
       "ipa": null,
       "lemma": "наліпка",
       "lemmaId": "наліпка",
       "lemmaPlain": "наліпка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -687,11 +747,13 @@
     {
       "cefr": "C1",
       "gloss": "let's check",
+      "glossClean": "let's check",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перевірмо",
       "lemmaId": "перевірмо",
       "lemmaPlain": "перевірмо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -702,11 +764,13 @@
     {
       "cefr": "C1",
       "gloss": "let's write",
+      "glossClean": "let's write",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пишімо",
       "lemmaId": "пишімо",
       "lemmaPlain": "пишімо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -717,11 +781,13 @@
     {
       "cefr": "C1",
       "gloss": "let's start",
+      "glossClean": "let's start",
       "heritage": "standard",
       "ipa": null,
       "lemma": "починаймо",
       "lemmaId": "починаймо",
       "lemmaPlain": "починаймо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -732,11 +798,13 @@
     {
       "cefr": "C1",
       "gloss": "just anywhere, in any random place",
+      "glossClean": "just anywhere",
       "heritage": "standard",
       "ipa": null,
       "lemma": "абиде",
       "lemmaId": "абиде",
       "lemmaPlain": "абиде",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -747,11 +815,13 @@
     {
       "cefr": "C1",
       "gloss": "dative case of абихто; to just anyone",
+      "glossClean": "dative case of абихто",
       "heritage": "standard",
       "ipa": null,
       "lemma": "абикому",
       "lemmaId": "абикому",
       "lemmaPlain": "абикому",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -762,11 +832,13 @@
     {
       "cefr": "C1",
       "gloss": "just anyone, any random person",
+      "glossClean": "just anyone",
       "heritage": "standard",
       "ipa": null,
       "lemma": "абихто",
       "lemmaId": "абихто",
       "lemmaPlain": "абихто",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -777,11 +849,13 @@
     {
       "cefr": "C1",
       "gloss": "brown-eyed",
+      "glossClean": "brown-eyed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кароокий",
       "lemmaId": "кароокий",
       "lemmaPlain": "кароокий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -792,11 +866,13 @@
     {
       "cefr": "C1",
       "gloss": "fair-haired",
+      "glossClean": "fair-haired",
       "heritage": "standard",
       "ipa": null,
       "lemma": "світловолосий",
       "lemmaId": "світловолосий",
       "lemmaPlain": "світловолосий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -807,11 +883,13 @@
     {
       "cefr": "C1",
       "gloss": "dark-haired",
+      "glossClean": "dark-haired",
       "heritage": "standard",
       "ipa": null,
       "lemma": "темноволосий",
       "lemmaId": "темноволосий",
       "lemmaPlain": "темноволосий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -822,11 +900,13 @@
     {
       "cefr": "C1",
       "gloss": "morpheme",
+      "glossClean": "morpheme",
       "heritage": "standard",
       "ipa": null,
       "lemma": "морфема",
       "lemmaId": "морфема",
       "lemmaPlain": "морфема",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -866,11 +946,13 @@
     {
       "cefr": "C1",
       "gloss": "morphology",
+      "glossClean": "morphology",
       "heritage": "standard",
       "ipa": null,
       "lemma": "морфологія",
       "lemmaId": "морфологія",
       "lemmaPlain": "морфологія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -881,11 +963,13 @@
     {
       "cefr": "C1",
       "gloss": "word formation",
+      "glossClean": "word formation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "словотвір",
       "lemmaId": "словотвір",
       "lemmaPlain": "словотвір",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -896,11 +980,13 @@
     {
       "cefr": "C1",
       "gloss": "sharing the same root",
+      "glossClean": "sharing the same root",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спільнокореневий",
       "lemmaId": "спільнокореневий",
       "lemmaPlain": "спільнокореневий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -911,11 +997,13 @@
     {
       "cefr": "C1",
       "gloss": "labial",
+      "glossClean": "labial",
       "heritage": "standard",
       "ipa": null,
       "lemma": "губний",
       "lemmaId": "губний",
       "lemmaPlain": "губний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -926,11 +1014,13 @@
     {
       "cefr": "C1",
       "gloss": "sound combination",
+      "glossClean": "sound combination",
       "heritage": "standard",
       "ipa": null,
       "lemma": "звукосполука",
       "lemmaId": "звукосполука",
       "lemmaPlain": "звукосполука",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -970,11 +1060,13 @@
     {
       "cefr": "C1",
       "gloss": "orthography, spelling rules",
+      "glossClean": "orthography",
       "heritage": "standard",
       "ipa": null,
       "lemma": "орфографія",
       "lemmaId": "орфографія",
       "lemmaPlain": "орфографія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -985,11 +1077,13 @@
     {
       "cefr": "C1",
       "gloss": "orthoepy, pronunciation rules",
+      "glossClean": "orthoepy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "орфоепія",
       "lemmaId": "орфоепія",
       "lemmaPlain": "орфоепія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1000,11 +1094,13 @@
     {
       "cefr": "C1",
       "gloss": "partially softened",
+      "glossClean": "partially softened",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пом'якшений",
       "lemmaId": "пом-якшений",
       "lemmaPlain": "пом'якшений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1015,11 +1111,13 @@
     {
       "cefr": "C1",
       "gloss": "sibilant, whistling consonant",
+      "glossClean": "sibilant",
       "heritage": "standard",
       "ipa": null,
       "lemma": "свистячий",
       "lemmaId": "свистячий",
       "lemmaPlain": "свистячий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1030,11 +1128,13 @@
     {
       "cefr": "C1",
       "gloss": "sonorant",
+      "glossClean": "sonorant",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сонорний",
       "lemmaId": "сонорний",
       "lemmaPlain": "сонорний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1045,11 +1145,13 @@
     {
       "cefr": "C1",
       "gloss": "transcription",
+      "glossClean": "transcription",
       "heritage": "standard",
       "ipa": null,
       "lemma": "транскрипція",
       "lemmaId": "транскрипція",
       "lemmaPlain": "транскрипція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1089,11 +1191,13 @@
     {
       "cefr": "C1",
       "gloss": "phoneme",
+      "glossClean": "phoneme",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фонема",
       "lemmaId": "фонема",
       "lemmaPlain": "фонема",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1133,11 +1237,13 @@
     {
       "cefr": "C1",
       "gloss": "hushing consonant",
+      "glossClean": "hushing consonant",
       "heritage": "standard",
       "ipa": null,
       "lemma": "шиплячий",
       "lemmaId": "шиплячий",
       "lemmaPlain": "шиплячий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1148,11 +1254,13 @@
     {
       "cefr": "C1",
       "gloss": "punctuation",
+      "glossClean": "punctuation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пунктуація",
       "lemmaId": "пунктуація",
       "lemmaPlain": "пунктуація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1163,11 +1271,13 @@
     {
       "cefr": "C1",
       "gloss": "metalanguage",
+      "glossClean": "metalanguage",
       "heritage": "standard",
       "ipa": null,
       "lemma": "метамова",
       "lemmaId": "метамова",
       "lemmaPlain": "метамова",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1207,11 +1317,13 @@
     {
       "cefr": "C1",
       "gloss": "to blossom",
+      "glossClean": "to blossom",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розквітати",
       "lemmaId": "розквітати",
       "lemmaPlain": "розквітати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1222,11 +1334,13 @@
     {
       "cefr": "C1",
       "gloss": "to melt",
+      "glossClean": "to melt",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розтанути",
       "lemmaId": "розтанути",
       "lemmaPlain": "розтанути",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1237,11 +1351,13 @@
     {
       "cefr": "C1",
       "gloss": "penguin",
+      "glossClean": "penguin",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пінгвін",
       "lemmaId": "пінгвін",
       "lemmaPlain": "пінгвін",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1252,11 +1368,13 @@
     {
       "cefr": "C1",
       "gloss": "to prefer",
+      "glossClean": "to prefer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "воліти",
       "lemmaId": "воліти",
       "lemmaPlain": "воліти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1267,11 +1385,13 @@
     {
       "cefr": "C1",
       "gloss": "garden bed",
+      "glossClean": "garden bed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "грядка",
       "lemmaId": "грядка",
       "lemmaPlain": "грядка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1311,11 +1431,13 @@
     {
       "cefr": "C1",
       "gloss": "to get wet",
+      "glossClean": "to get wet",
       "heritage": "standard",
       "ipa": null,
       "lemma": "змокнути",
       "lemmaId": "змокнути",
       "lemmaPlain": "змокнути",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1326,11 +1448,13 @@
     {
       "cefr": "C1",
       "gloss": "small parcel, book post",
+      "glossClean": "small parcel",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бандероль",
       "lemmaId": "бандероль",
       "lemmaPlain": "бандероль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -1370,11 +1494,13 @@
     {
       "cefr": "C1",
       "gloss": "I am proud, first-person form of гордитися",
+      "glossClean": "I am proud",
       "heritage": "standard",
       "ipa": null,
       "lemma": "горджуся",
       "lemmaId": "горджуся",
       "lemmaPlain": "горджуся",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1385,11 +1511,13 @@
     {
       "cefr": "C1",
       "gloss": "literal",
+      "glossClean": "literal",
       "heritage": "standard",
       "ipa": null,
       "lemma": "буквальний",
       "lemmaId": "буквальний",
       "lemmaPlain": "буквальний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1400,11 +1528,13 @@
     {
       "cefr": "C1",
       "gloss": "ellipsis",
+      "glossClean": "ellipsis",
       "heritage": "standard",
       "ipa": null,
       "lemma": "еліпсис",
       "lemmaId": "еліпсис",
       "lemmaPlain": "еліпсис",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1415,11 +1545,13 @@
     {
       "cefr": "C1",
       "gloss": "diminutive",
+      "glossClean": "diminutive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зменшувальний",
       "lemmaId": "зменшувальний",
       "lemmaPlain": "зменшувальний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1430,11 +1562,13 @@
     {
       "cefr": "C1",
       "gloss": "affectionate, diminutive",
+      "glossClean": "affectionate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пестливий",
       "lemmaId": "пестливий",
       "lemmaPlain": "пестливий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1445,11 +1579,13 @@
     {
       "cefr": "C1",
       "gloss": "trigger, cue",
+      "glossClean": "trigger",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тригер",
       "lemmaId": "тригер",
       "lemmaPlain": "тригер",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1460,11 +1596,13 @@
     {
       "cefr": "C1",
       "gloss": "emphatic",
+      "glossClean": "emphatic",
       "heritage": "standard",
       "ipa": null,
       "lemma": "емфатичний",
       "lemmaId": "емфатичний",
       "lemmaPlain": "емфатичний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1475,11 +1613,13 @@
     {
       "cefr": "C1",
       "gloss": "marked, emphasized",
+      "glossClean": "marked",
       "heritage": "standard",
       "ipa": null,
       "lemma": "маркований",
       "lemmaId": "маркований",
       "lemmaPlain": "маркований",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1490,11 +1630,13 @@
     {
       "cefr": "C1",
       "gloss": "absolutely white",
+      "glossClean": "absolutely white",
       "heritage": "standard",
       "ipa": null,
       "lemma": "білісінький",
       "lemmaId": "білісінький",
       "lemmaPlain": "білісінький",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1505,11 +1647,13 @@
     {
       "cefr": "C1",
       "gloss": "synonymic",
+      "glossClean": "synonymic",
       "heritage": "standard",
       "ipa": null,
       "lemma": "синонімічний",
       "lemmaId": "синонімічний",
       "lemmaPlain": "синонімічний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1520,11 +1664,13 @@
     {
       "cefr": "C1",
       "gloss": "the very best",
+      "glossClean": "the very best",
       "heritage": "standard",
       "ipa": null,
       "lemma": "щонайкращий",
       "lemmaId": "щонайкращий",
       "lemmaPlain": "щонайкращий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1535,11 +1681,13 @@
     {
       "cefr": "C1",
       "gloss": "as fast as possible",
+      "glossClean": "as fast as possible",
       "heritage": "standard",
       "ipa": null,
       "lemma": "якнайшвидший",
       "lemmaId": "якнайшвидший",
       "lemmaPlain": "якнайшвидший",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1550,11 +1698,13 @@
     {
       "cefr": "C1",
       "gloss": "just any, poor-quality",
+      "glossClean": "just any",
       "heritage": "standard",
       "ipa": null,
       "lemma": "абиякий",
       "lemmaId": "абиякий",
       "lemmaPlain": "абиякий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1565,11 +1715,13 @@
     {
       "cefr": "C1",
       "gloss": "prefixal-suffixal",
+      "glossClean": "prefixal-suffixal",
       "heritage": "standard",
       "ipa": null,
       "lemma": "суфіксально-префіксальний",
       "lemmaId": "суфіксально-префіксальний",
       "lemmaPlain": "суфіксально-префіксальний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1580,11 +1732,13 @@
     {
       "cefr": "C1",
       "gloss": "as well as possible, very best",
+      "glossClean": "as well as possible",
       "heritage": "standard",
       "ipa": null,
       "lemma": "щонайкраще",
       "lemmaId": "щонайкраще",
       "lemmaPlain": "щонайкраще",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1595,11 +1749,13 @@
     {
       "cefr": "C1",
       "gloss": "velar",
+      "glossClean": "velar",
       "heritage": "standard",
       "ipa": null,
       "lemma": "задньоязиковий",
       "lemmaId": "задньоязиковий",
       "lemmaPlain": "задньоязиковий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1610,11 +1766,13 @@
     {
       "cefr": "C1",
       "gloss": "unproductive",
+      "glossClean": "unproductive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "непродуктивний",
       "lemmaId": "непродуктивний",
       "lemmaPlain": "непродуктивний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1625,11 +1783,13 @@
     {
       "cefr": "C1",
       "gloss": "spelling pattern",
+      "glossClean": "spelling pattern",
       "heritage": "standard",
       "ipa": null,
       "lemma": "орфограма",
       "lemmaId": "орфограма",
       "lemmaPlain": "орфограма",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1640,11 +1800,13 @@
     {
       "cefr": "C1",
       "gloss": "palatalization",
+      "glossClean": "palatalization",
       "heritage": "standard",
       "ipa": null,
       "lemma": "палаталізація",
       "lemmaId": "палаталізація",
       "lemmaPlain": "палаталізація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1655,11 +1817,13 @@
     {
       "cefr": "C1",
       "gloss": "self-editing",
+      "glossClean": "self-editing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "саморедагування",
       "lemmaId": "саморедагування",
       "lemmaPlain": "саморедагування",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1670,11 +1834,13 @@
     {
       "cefr": "C1",
       "gloss": "affricate",
+      "glossClean": "affricate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "африката",
       "lemmaId": "африката",
       "lemmaPlain": "африката",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1685,11 +1851,13 @@
     {
       "cefr": "C1",
       "gloss": "morphophonology",
+      "glossClean": "morphophonology",
       "heritage": "standard",
       "ipa": null,
       "lemma": "морфонологія",
       "lemmaId": "морфонологія",
       "lemmaPlain": "морфонологія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1700,11 +1868,13 @@
     {
       "cefr": "C1",
       "gloss": "counterfactual",
+      "glossClean": "counterfactual",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "контрфактичний",
       "lemmaId": "контрфактичний",
       "lemmaPlain": "контрфактичний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1715,11 +1885,13 @@
     {
       "cefr": "C1",
       "gloss": "you will be writing, you will write habitually",
+      "glossClean": "you will be writing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "писатимеш",
       "lemmaId": "писатимеш",
       "lemmaPlain": "писатимеш",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1730,11 +1902,13 @@
     {
       "cefr": "C1",
       "gloss": "repeated",
+      "glossClean": "repeated",
       "heritage": "standard",
       "ipa": null,
       "lemma": "повторюваний",
       "lemmaId": "повторюваний",
       "lemmaPlain": "повторюваний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1745,11 +1919,13 @@
     {
       "cefr": "C1",
       "gloss": "to burn oneself",
+      "glossClean": "to burn oneself",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обпектися",
       "lemmaId": "обпектися",
       "lemmaPlain": "обпектися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1760,11 +1936,13 @@
     {
       "cefr": "C1",
       "gloss": "to finish washing",
+      "glossClean": "to finish washing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "домити",
       "lemmaId": "домити",
       "lemmaPlain": "домити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1775,11 +1953,13 @@
     {
       "cefr": "C1",
       "gloss": "mnemonic",
+      "glossClean": "mnemonic",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мнемоніка",
       "lemmaId": "мнемоніка",
       "lemmaPlain": "мнемоніка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1790,11 +1970,13 @@
     {
       "cefr": "C1",
       "gloss": "pragmatics; context-shaped meaning",
+      "glossClean": "pragmatics",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прагматика",
       "lemmaId": "прагматика",
       "lemmaPlain": "прагматика",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1805,11 +1987,13 @@
     {
       "cefr": "C1",
       "gloss": "single occurrence",
+      "glossClean": "single occurrence",
       "heritage": "standard",
       "ipa": null,
       "lemma": "однократність",
       "lemmaId": "однократність",
       "lemmaPlain": "однократність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1820,11 +2004,13 @@
     {
       "cefr": "C1",
       "gloss": "single-aspect",
+      "glossClean": "single-aspect",
       "heritage": "standard",
       "ipa": null,
       "lemma": "одновидовий",
       "lemmaId": "одновидовий",
       "lemmaPlain": "одновидовий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1835,11 +2021,13 @@
     {
       "cefr": "C1",
       "gloss": "impersonal",
+      "glossClean": "impersonal",
       "heritage": "standard",
       "ipa": null,
       "lemma": "безособовий",
       "lemmaId": "безособовий",
       "lemmaPlain": "безособовий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1850,11 +2038,13 @@
     {
       "cefr": "C1",
       "gloss": "turned gray",
+      "glossClean": "turned gray",
       "heritage": "standard",
       "ipa": null,
       "lemma": "посивілий",
       "lemmaId": "посивілий",
       "lemmaPlain": "посивілий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1865,11 +2055,13 @@
     {
       "cefr": "C1",
       "gloss": "turned blue",
+      "glossClean": "turned blue",
       "heritage": "standard",
       "ipa": null,
       "lemma": "посинілий",
       "lemmaId": "посинілий",
       "lemmaPlain": "посинілий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1880,11 +2072,13 @@
     {
       "cefr": "C1",
       "gloss": "postfix",
+      "glossClean": "postfix",
       "heritage": "standard",
       "ipa": null,
       "lemma": "постфікс",
       "lemmaId": "постфікс",
       "lemmaPlain": "постфікс",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1895,11 +2089,13 @@
     {
       "cefr": "C1",
       "gloss": "defective",
+      "glossClean": "defective",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бракований",
       "lemmaId": "бракований",
       "lemmaPlain": "бракований",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1910,11 +2106,13 @@
     {
       "cefr": "C1",
       "gloss": "prefix-suffix",
+      "glossClean": "prefix-suffix",
       "heritage": "standard",
       "ipa": null,
       "lemma": "префіксально-суфіксальний",
       "lemmaId": "префіксально-суфіксальний",
       "lemmaPlain": "префіксально-суфіксальний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1925,11 +2123,13 @@
     {
       "cefr": "C1",
       "gloss": "setting off",
+      "glossClean": "setting off",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вирушання",
       "lemmaId": "вирушання",
       "lemmaPlain": "вирушання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1940,11 +2140,13 @@
     {
       "cefr": "C1",
       "gloss": "multidirectional",
+      "glossClean": "multidirectional",
       "heritage": "standard",
       "ipa": null,
       "lemma": "різноспрямований",
       "lemmaId": "різноспрямований",
       "lemmaPlain": "різноспрямований",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1955,11 +2157,13 @@
     {
       "cefr": "C1",
       "gloss": "media text",
+      "glossClean": "media text",
       "heritage": "standard",
       "ipa": null,
       "lemma": "медіатекст",
       "lemmaId": "медіатекст",
       "lemmaPlain": "медіатекст",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1970,11 +2174,13 @@
     {
       "cefr": "C1",
       "gloss": "simultaneity",
+      "glossClean": "simultaneity",
       "heritage": "standard",
       "ipa": null,
       "lemma": "одночасність",
       "lemmaId": "одночасність",
       "lemmaPlain": "одночасність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -1985,11 +2191,13 @@
     {
       "cefr": "C1",
       "gloss": "paraphrasing",
+      "glossClean": "paraphrasing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перефразування",
       "lemmaId": "перефразування",
       "lemmaPlain": "перефразування",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2000,11 +2208,13 @@
     {
       "cefr": "C1",
       "gloss": "temporal non-simultaneity",
+      "glossClean": "temporal non-simultaneity",
       "heritage": "standard",
       "ipa": null,
       "lemma": "різночасність",
       "lemmaId": "різночасність",
       "lemmaPlain": "різночасність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2015,11 +2225,13 @@
     {
       "cefr": "C1",
       "gloss": "fact-checking",
+      "glossClean": "fact-checking",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фактчекінг",
       "lemmaId": "фактчекінг",
       "lemmaPlain": "фактчекінг",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2030,11 +2242,13 @@
     {
       "cefr": "C1",
       "gloss": "colon",
+      "glossClean": "colon",
       "heritage": "standard",
       "ipa": null,
       "lemma": "двокрапка",
       "lemmaId": "двокрапка",
       "lemmaPlain": "двокрапка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2074,11 +2288,13 @@
     {
       "cefr": "C1",
       "gloss": "to whiten",
+      "glossClean": "to whiten",
       "heritage": "standard",
       "ipa": null,
       "lemma": "білити",
       "lemmaId": "білити",
       "lemmaPlain": "білити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2089,11 +2305,13 @@
     {
       "cefr": "C1",
       "gloss": "to become white",
+      "glossClean": "to become white",
       "heritage": "standard",
       "ipa": null,
       "lemma": "біліти",
       "lemmaId": "біліти",
       "lemmaPlain": "біліти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2104,11 +2322,13 @@
     {
       "cefr": "C1",
       "gloss": "to ground",
+      "glossClean": "to ground",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заземлити",
       "lemmaId": "заземлити",
       "lemmaPlain": "заземлити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2119,11 +2339,13 @@
     {
       "cefr": "C1",
       "gloss": "to decolorize",
+      "glossClean": "to decolorize",
       "heritage": "standard",
       "ipa": null,
       "lemma": "знебарвити",
       "lemmaId": "знебарвити",
       "lemmaPlain": "знебарвити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2134,11 +2356,13 @@
     {
       "cefr": "C1",
       "gloss": "bureaucratese",
+      "glossClean": "bureaucratese",
       "heritage": "standard",
       "ipa": null,
       "lemma": "канцелярит",
       "lemmaId": "канцелярит",
       "lemmaPlain": "канцелярит",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2149,11 +2373,13 @@
     {
       "cefr": "C1",
       "gloss": "logging",
+      "glossClean": "logging",
       "heritage": "standard",
       "ipa": null,
       "lemma": "логування",
       "lemmaId": "логування",
       "lemmaPlain": "логування",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2164,11 +2390,13 @@
     {
       "cefr": "C1",
       "gloss": "to underestimate",
+      "glossClean": "to underestimate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "недооцінити",
       "lemmaId": "недооцінити",
       "lemmaPlain": "недооцінити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2179,11 +2407,13 @@
     {
       "cefr": "C1",
       "gloss": "to overload",
+      "glossClean": "to overload",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перевантажити",
       "lemmaId": "перевантажити",
       "lemmaPlain": "перевантажити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2194,11 +2424,13 @@
     {
       "cefr": "C1",
       "gloss": "to reinstall",
+      "glossClean": "to reinstall",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перевстановити",
       "lemmaId": "перевстановити",
       "lemmaPlain": "перевстановити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2209,11 +2441,13 @@
     {
       "cefr": "C1",
       "gloss": "to become exhausted",
+      "glossClean": "to become exhausted",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перевтомитися",
       "lemmaId": "перевтомитися",
       "lemmaPlain": "перевтомитися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2224,11 +2458,13 @@
     {
       "cefr": "C1",
       "gloss": "mutual exclusion",
+      "glossClean": "mutual exclusion",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "взаємовиключення",
       "lemmaId": "взаємовиключення",
       "lemmaPlain": "взаємовиключення",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2239,11 +2475,13 @@
     {
       "cefr": "C1",
       "gloss": "counterargument",
+      "glossClean": "counterargument",
       "heritage": "standard",
       "ipa": null,
       "lemma": "контраргумент",
       "lemmaId": "контраргумент",
       "lemmaPlain": "контраргумент",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2254,11 +2492,13 @@
     {
       "cefr": "C1",
       "gloss": "antecedent",
+      "glossClean": "antecedent",
       "heritage": "standard",
       "ipa": null,
       "lemma": "антецедент",
       "lemmaId": "антецедент",
       "lemmaPlain": "антецедент",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2269,11 +2509,13 @@
     {
       "cefr": "C1",
       "gloss": "postposition",
+      "glossClean": "postposition",
       "heritage": "standard",
       "ipa": null,
       "lemma": "постпозиція",
       "lemmaId": "постпозиція",
       "lemmaPlain": "постпозиція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2313,11 +2555,13 @@
     {
       "cefr": "C1",
       "gloss": "initial position, preposition of a clause",
+      "glossClean": "initial position",
       "heritage": "standard",
       "ipa": null,
       "lemma": "препозиція",
       "lemmaId": "препозиція",
       "lemmaPlain": "препозиція",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2357,11 +2601,13 @@
     {
       "cefr": "C1",
       "gloss": "self-diagnosis",
+      "glossClean": "self-diagnosis",
       "heritage": "standard",
       "ipa": null,
       "lemma": "самодіагностика",
       "lemmaId": "самодіагностика",
       "lemmaPlain": "самодіагностика",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2372,11 +2618,13 @@
     {
       "cefr": "C1",
       "gloss": "targeted, precise",
+      "glossClean": "targeted",
       "heritage": "standard",
       "ipa": null,
       "lemma": "точковий",
       "lemmaId": "точковий",
       "lemmaPlain": "точковий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2387,11 +2635,13 @@
     {
       "cefr": "C1",
       "gloss": "regret, pity",
+      "glossClean": "regret",
       "heritage": "standard",
       "ipa": null,
       "lemma": "жаль",
       "lemmaId": "жаль",
       "lemmaPlain": "жаль",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2402,11 +2652,13 @@
     {
       "cefr": "C1",
       "gloss": "to spread underneath",
+      "glossClean": "to spread underneath",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підстелити",
       "lemmaId": "підстелити",
       "lemmaPlain": "підстелити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2417,11 +2669,13 @@
     {
       "cefr": "C1",
       "gloss": "to vacuum",
+      "glossClean": "to vacuum",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "пилососити",
       "lemmaId": "пилососити",
       "lemmaPlain": "пилососити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2432,11 +2686,13 @@
     {
       "cefr": "C1",
       "gloss": "retake",
+      "glossClean": "retake",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перескладання",
       "lemmaId": "перескладання",
       "lemmaPlain": "перескладання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2447,11 +2703,13 @@
     {
       "cefr": "C1",
       "gloss": "first-year student",
+      "glossClean": "first-year student",
       "heritage": "standard",
       "ipa": null,
       "lemma": "першокурсник",
       "lemmaId": "першокурсник",
       "lemmaPlain": "першокурсник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2462,11 +2720,13 @@
     {
       "cefr": "C1",
       "gloss": "senior-year female student",
+      "glossClean": "senior-year female student",
       "heritage": "standard",
       "ipa": null,
       "lemma": "старшокурсниця",
       "lemmaId": "старшокурсниця",
       "lemmaPlain": "старшокурсниця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2477,11 +2737,13 @@
     {
       "cefr": "C1",
       "gloss": "to spread rapidly",
+      "glossClean": "to spread rapidly",
       "heritage": "standard",
       "ipa": null,
       "lemma": "облетіти",
       "lemmaId": "облетіти",
       "lemmaPlain": "облетіти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2492,11 +2754,13 @@
     {
       "cefr": "C1",
       "gloss": "reflexivity",
+      "glossClean": "reflexivity",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зворотність",
       "lemmaId": "зворотність",
       "lemmaPlain": "зворотність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2507,11 +2771,13 @@
     {
       "cefr": "C1",
       "gloss": "having done",
+      "glossClean": "having done",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зробивши",
       "lemmaId": "зробивши",
       "lemmaPlain": "зробивши",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2522,11 +2788,13 @@
     {
       "cefr": "C1",
       "gloss": "precedence",
+      "glossClean": "precedence",
       "heritage": "standard",
       "ipa": null,
       "lemma": "попередність",
       "lemmaId": "попередність",
       "lemmaPlain": "попередність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2537,11 +2805,13 @@
     {
       "cefr": "C1",
       "gloss": "having washed up",
+      "glossClean": "having washed up",
       "heritage": "standard",
       "ipa": null,
       "lemma": "умившись",
       "lemmaId": "умившись",
       "lemmaPlain": "умившись",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2552,11 +2822,13 @@
     {
       "cefr": "C1",
       "gloss": "painless",
+      "glossClean": "painless",
       "heritage": "standard",
       "ipa": null,
       "lemma": "безболісний",
       "lemmaId": "безболісний",
       "lemmaPlain": "безболісний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2567,11 +2839,13 @@
     {
       "cefr": "C1",
       "gloss": "asyndeton",
+      "glossClean": "asyndeton",
       "heritage": "standard",
       "ipa": null,
       "lemma": "асиндетон",
       "lemmaId": "асиндетон",
       "lemmaPlain": "асиндетон",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -2582,11 +2856,13 @@
     {
       "cefr": "C1",
       "gloss": "polysyndeton",
+      "glossClean": "polysyndeton",
       "heritage": "standard",
       "ipa": null,
       "lemma": "полісиндетон",
       "lemmaId": "полісиндетон",
       "lemmaPlain": "полісиндетон",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2597,11 +2873,13 @@
     {
       "cefr": "C1",
       "gloss": "adversative, contrastive",
+      "glossClean": "adversative",
       "heritage": "standard",
       "ipa": null,
       "lemma": "протиставний",
       "lemmaId": "протиставний",
       "lemmaPlain": "протиставний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2612,11 +2890,13 @@
     {
       "cefr": "C1",
       "gloss": "disjunctive, alternative",
+      "glossClean": "disjunctive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розділовий",
       "lemmaId": "розділовий",
       "lemmaPlain": "розділовий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2627,11 +2907,13 @@
     {
       "cefr": "C1",
       "gloss": "generalizing",
+      "glossClean": "generalizing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "узагальнювальний",
       "lemmaId": "узагальнювальний",
       "lemmaPlain": "узагальнювальний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2642,11 +2924,13 @@
     {
       "cefr": "C1",
       "gloss": "additive, connective",
+      "glossClean": "additive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "єднальний",
       "lemmaId": "єднальний",
       "lemmaPlain": "єднальний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2657,11 +2941,13 @@
     {
       "cefr": "C1",
       "gloss": "furnished",
+      "glossClean": "furnished",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вмебльована",
       "lemmaId": "вмебльована",
       "lemmaPlain": "вмебльована",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2672,11 +2958,13 @@
     {
       "cefr": "C1",
       "gloss": "furnished",
+      "glossClean": "furnished",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мебльована",
       "lemmaId": "мебльована",
       "lemmaPlain": "мебльована",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2687,11 +2975,13 @@
     {
       "cefr": "C1",
       "gloss": "newly built building",
+      "glossClean": "newly built building",
       "heritage": "standard",
       "ipa": null,
       "lemma": "новобудова",
       "lemmaId": "новобудова",
       "lemmaPlain": "новобудова",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2702,11 +2992,13 @@
     {
       "cefr": "C1",
       "gloss": "female tenant",
+      "glossClean": "female tenant",
       "heritage": "standard",
       "ipa": null,
       "lemma": "орендарка",
       "lemmaId": "орендарка",
       "lemmaPlain": "орендарка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2717,11 +3009,13 @@
     {
       "cefr": "C1",
       "gloss": "dishwasher",
+      "glossClean": "dishwasher",
       "heritage": "standard",
       "ipa": null,
       "lemma": "посудомийка",
       "lemmaId": "посудомийка",
       "lemmaPlain": "посудомийка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2732,11 +3026,13 @@
     {
       "cefr": "C1",
       "gloss": "plumber",
+      "glossClean": "plumber",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сантехнік",
       "lemmaId": "сантехнік",
       "lemmaPlain": "сантехнік",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2747,11 +3043,13 @@
     {
       "cefr": "C1",
       "gloss": "modern renovation",
+      "glossClean": "modern renovation",
       "heritage": "standard",
       "ipa": null,
       "lemma": "євроремонт",
       "lemmaId": "євроремонт",
       "lemmaPlain": "євроремонт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2762,11 +3060,13 @@
     {
       "cefr": "C1",
       "gloss": "let us protect",
+      "glossClean": "let us protect",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бережімо",
       "lemmaId": "бережімо",
       "lemmaPlain": "бережімо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2777,11 +3077,13 @@
     {
       "cefr": "C1",
       "gloss": "let us believe",
+      "glossClean": "let us believe",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вірмо",
       "lemmaId": "вірмо",
       "lemmaPlain": "вірмо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2792,11 +3094,13 @@
     {
       "cefr": "C1",
       "gloss": "bring in, carry in",
+      "glossClean": "bring in",
       "heritage": "standard",
       "ipa": null,
       "lemma": "занось",
       "lemmaId": "занось",
       "lemmaPlain": "занось",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2807,11 +3111,13 @@
     {
       "cefr": "C1",
       "gloss": "let us call",
+      "glossClean": "let us call",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кличмо",
       "lemmaId": "кличмо",
       "lemmaPlain": "кличмо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2822,11 +3128,13 @@
     {
       "cefr": "C1",
       "gloss": "let's discuss",
+      "glossClean": "let's discuss",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обговорімо",
       "lemmaId": "обговорімо",
       "lemmaPlain": "обговорімо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2837,11 +3145,13 @@
     {
       "cefr": "C1",
       "gloss": "let's put, let us place",
+      "glossClean": "let's put",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поставмо",
       "lemmaId": "поставмо",
       "lemmaPlain": "поставмо",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2852,11 +3162,13 @@
     {
       "cefr": "C1",
       "gloss": "let's hold on, let's stay together",
+      "glossClean": "let's hold on",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тримаймося",
       "lemmaId": "тримаймося",
       "lemmaPlain": "тримаймося",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2867,11 +3179,13 @@
     {
       "cefr": "C1",
       "gloss": "Cyrillic script",
+      "glossClean": "Cyrillic script",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кирилиця",
       "lemmaId": "кирилиця",
       "lemmaPlain": "кирилиця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2911,11 +3225,13 @@
     {
       "cefr": "C1",
       "gloss": "Latin script",
+      "glossClean": "Latin script",
       "heritage": "standard",
       "ipa": null,
       "lemma": "латиниця",
       "lemmaId": "латиниця",
       "lemmaPlain": "латиниця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -2955,11 +3271,13 @@
     {
       "cefr": "C1",
       "gloss": "banosh, Hutsul cornmeal dish",
+      "glossClean": "banosh",
       "heritage": "standard",
       "ipa": null,
       "lemma": "банош",
       "lemmaId": "банош",
       "lemmaPlain": "банош",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -2970,11 +3288,13 @@
     {
       "cefr": "C1",
       "gloss": "female tour guide",
+      "glossClean": "female tour guide",
       "heritage": "standard",
       "ipa": null,
       "lemma": "екскурсоводка",
       "lemmaId": "екскурсоводка",
       "lemmaPlain": "екскурсоводка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -2985,11 +3305,13 @@
     {
       "cefr": "C1",
       "gloss": "to sail or swim away; perfective",
+      "glossClean": "to sail or swim away",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відпливти",
       "lemmaId": "відпливти",
       "lemmaPlain": "відпливти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3000,11 +3322,13 @@
     {
       "cefr": "C1",
       "gloss": "to swim or sail all the way to habitually or in process",
+      "glossClean": "to swim or sail all the way to habitually or in process",
       "heritage": "standard",
       "ipa": null,
       "lemma": "допливати",
       "lemmaId": "допливати",
       "lemmaPlain": "допливати",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3015,11 +3339,13 @@
     {
       "cefr": "C1",
       "gloss": "to swim or sail all the way to; perfective",
+      "glossClean": "to swim or sail all the way to",
       "heritage": "standard",
       "ipa": null,
       "lemma": "доплисти",
       "lemmaId": "доплисти",
       "lemmaPlain": "доплисти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3030,11 +3356,13 @@
     {
       "cefr": "C1",
       "gloss": "to fly into; perfective",
+      "glossClean": "to fly into",
       "heritage": "standard",
       "ipa": null,
       "lemma": "залетіти",
       "lemmaId": "залетіти",
       "lemmaPlain": "залетіти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3045,11 +3373,13 @@
     {
       "cefr": "C1",
       "gloss": "to swim or sail into, beyond; perfective",
+      "glossClean": "to swim or sail into",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заплисти",
       "lemmaId": "заплисти",
       "lemmaPlain": "заплисти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3060,11 +3390,13 @@
     {
       "cefr": "C1",
       "gloss": "cabin on a ship",
+      "glossClean": "cabin on a ship",
       "heritage": "standard",
       "ipa": null,
       "lemma": "каюта",
       "lemmaId": "каюта",
       "lemmaPlain": "каюта",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3075,11 +3407,13 @@
     {
       "cefr": "C1",
       "gloss": "to swim or sail around; perfective",
+      "glossClean": "to swim or sail around",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обплисти",
       "lemmaId": "обплисти",
       "lemmaPlain": "обплисти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3090,11 +3424,13 @@
     {
       "cefr": "C1",
       "gloss": "you are swimming or sailing",
+      "glossClean": "you are swimming or sailing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пливеш",
       "lemmaId": "пливеш",
       "lemmaPlain": "пливеш",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3105,11 +3441,13 @@
     {
       "cefr": "C1",
       "gloss": "to arrive by water habitually or in process",
+      "glossClean": "to arrive by water habitually or in process",
       "heritage": "standard",
       "ipa": null,
       "lemma": "припливати",
       "lemmaId": "припливати",
       "lemmaPlain": "припливати",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3120,11 +3458,13 @@
     {
       "cefr": "C1",
       "gloss": "to arrive by water; perfective",
+      "glossClean": "to arrive by water",
       "heritage": "standard",
       "ipa": null,
       "lemma": "припливти",
       "lemmaId": "припливти",
       "lemmaPlain": "припливти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3135,11 +3475,13 @@
     {
       "cefr": "C1",
       "gloss": "to swim or sail past, through, or along; perfective",
+      "glossClean": "to swim or sail past",
       "heritage": "standard",
       "ipa": null,
       "lemma": "проплисти",
       "lemmaId": "проплисти",
       "lemmaPlain": "проплисти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3150,11 +3492,13 @@
     {
       "cefr": "C1",
       "gloss": "to fly up to, approach by air; perfective",
+      "glossClean": "to fly up to",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підлетіти",
       "lemmaId": "підлетіти",
       "lemmaPlain": "підлетіти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3165,11 +3509,13 @@
     {
       "cefr": "C1",
       "gloss": "to swim or sail up to; perfective",
+      "glossClean": "to swim or sail up to",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підплисти",
       "lemmaId": "підплисти",
       "lemmaPlain": "підплисти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3180,11 +3526,13 @@
     {
       "cefr": "C1",
       "gloss": "I will ride away, depart by vehicle",
+      "glossClean": "I will ride away",
       "heritage": "standard",
       "ipa": null,
       "lemma": "від'їду",
       "lemmaId": "від-їду",
       "lemmaPlain": "від'їду",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3195,11 +3543,13 @@
     {
       "cefr": "C1",
       "gloss": "to run away from, run aside; perfective",
+      "glossClean": "to run away from",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відбігти",
       "lemmaId": "відбігти",
       "lemmaPlain": "відбігти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3210,11 +3560,13 @@
     {
       "cefr": "C1",
       "gloss": "I will run out",
+      "glossClean": "I will run out",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вибіжу",
       "lemmaId": "вибіжу",
       "lemmaPlain": "вибіжу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3225,11 +3577,13 @@
     {
       "cefr": "C1",
       "gloss": "I will run in, I will pop in briefly",
+      "glossClean": "I will run in",
       "heritage": "standard",
       "ipa": null,
       "lemma": "забіжу",
       "lemmaId": "забіжу",
       "lemmaPlain": "забіжу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3240,11 +3594,13 @@
     {
       "cefr": "C1",
       "gloss": "I will carry in",
+      "glossClean": "I will carry in",
       "heritage": "standard",
       "ipa": null,
       "lemma": "занесу",
       "lemmaId": "занесу",
       "lemmaPlain": "занесу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3255,11 +3611,13 @@
     {
       "cefr": "C1",
       "gloss": "I will carry across, I will reschedule",
+      "glossClean": "I will carry across",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перенесу",
       "lemmaId": "перенесу",
       "lemmaPlain": "перенесу",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3270,11 +3628,13 @@
     {
       "cefr": "C1",
       "gloss": "I will cross by vehicle, I will relocate",
+      "glossClean": "I will cross by vehicle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "переїду",
       "lemmaId": "переїду",
       "lemmaPlain": "переїду",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3285,11 +3645,13 @@
     {
       "cefr": "C1",
       "gloss": "to run past habitually or in process",
+      "glossClean": "to run past habitually or in process",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пробігати",
       "lemmaId": "пробігати",
       "lemmaPlain": "пробігати",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3300,11 +3662,13 @@
     {
       "cefr": "C1",
       "gloss": "I will drive past or through",
+      "glossClean": "I will drive past or through",
       "heritage": "standard",
       "ipa": null,
       "lemma": "проїду",
       "lemmaId": "проїду",
       "lemmaPlain": "проїду",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3315,11 +3679,13 @@
     {
       "cefr": "C1",
       "gloss": "initiating event",
+      "glossClean": "initiating event",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зав'язка",
       "lemmaId": "зав-язка",
       "lemmaPlain": "зав'язка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3359,11 +3725,13 @@
     {
       "cefr": "C1",
       "gloss": "opening",
+      "glossClean": "opening",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зачин",
       "lemmaId": "зачин",
       "lemmaPlain": "зачин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3374,11 +3742,13 @@
     {
       "cefr": "C1",
       "gloss": "microtopic",
+      "glossClean": "microtopic",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мікротема",
       "lemmaId": "мікротема",
       "lemmaPlain": "мікротема",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3418,11 +3788,13 @@
     {
       "cefr": "C1",
       "gloss": "draft",
+      "glossClean": "draft",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чернетка",
       "lemmaId": "чернетка",
       "lemmaPlain": "чернетка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3462,11 +3834,13 @@
     {
       "cefr": "C1",
       "gloss": "badger",
+      "glossClean": "badger",
       "heritage": "standard",
       "ipa": null,
       "lemma": "борсук",
       "lemmaId": "борсук",
       "lemmaPlain": "борсук",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3477,11 +3851,13 @@
     {
       "cefr": "C1",
       "gloss": "bud",
+      "glossClean": "bud",
       "heritage": "standard",
       "ipa": null,
       "lemma": "брунька",
       "lemmaId": "брунька",
       "lemmaPlain": "брунька",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3521,11 +3897,13 @@
     {
       "cefr": "C1",
       "gloss": "downpour",
+      "glossClean": "downpour",
       "heritage": "standard",
       "ipa": null,
       "lemma": "злива",
       "lemmaId": "злива",
       "lemmaPlain": "злива",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3565,11 +3943,13 @@
     {
       "cefr": "C1",
       "gloss": "Russian-influenced form",
+      "glossClean": "Russian-influenced form",
       "heritage": "standard",
       "ipa": null,
       "lemma": "русизм",
       "lemmaId": "русизм",
       "lemmaPlain": "русизм",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3580,11 +3960,13 @@
     {
       "cefr": "C1",
       "gloss": "cooper, barrel maker",
+      "glossClean": "cooper",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бондар",
       "lemmaId": "бондар",
       "lemmaPlain": "бондар",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3595,11 +3977,13 @@
     {
       "cefr": "C1",
       "gloss": "stonecutter",
+      "glossClean": "stonecutter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "каменяр",
       "lemmaId": "каменяр",
       "lemmaPlain": "каменяр",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3610,11 +3994,13 @@
     {
       "cefr": "C1",
       "gloss": "belonging, membership",
+      "glossClean": "belonging",
       "heritage": "standard",
       "ipa": null,
       "lemma": "належність",
       "lemmaId": "належність",
       "lemmaPlain": "належність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3625,11 +4011,13 @@
     {
       "cefr": "C1",
       "gloss": "Ossetian man",
+      "glossClean": "Ossetian man",
       "heritage": "standard",
       "ipa": null,
       "lemma": "осетин",
       "lemmaId": "осетин",
       "lemmaPlain": "осетин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3640,11 +4028,13 @@
     {
       "cefr": "C1",
       "gloss": "punctuation rule",
+      "glossClean": "punctuation rule",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пунктограма",
       "lemmaId": "пунктограма",
       "lemmaPlain": "пунктограма",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -3684,11 +4074,13 @@
     {
       "cefr": "C1",
       "gloss": "tenacious, resilient",
+      "glossClean": "tenacious",
       "heritage": "standard",
       "ipa": null,
       "lemma": "живучий",
       "lemmaId": "живучий",
       "lemmaPlain": "живучий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3699,11 +4091,13 @@
     {
       "cefr": "C1",
       "gloss": "bankrupt",
+      "glossClean": "bankrupt",
       "heritage": "standard",
       "ipa": null,
       "lemma": "збанкрутілий",
       "lemmaId": "збанкрутілий",
       "lemmaPlain": "збанкрутілий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3714,11 +4108,13 @@
     {
       "cefr": "C1",
       "gloss": "wilted",
+      "glossClean": "wilted",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зів'ялий",
       "lemmaId": "зів-ялий",
       "lemmaPlain": "зів'ялий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3729,11 +4125,13 @@
     {
       "cefr": "C1",
       "gloss": "washing, cleaning",
+      "glossClean": "washing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мийний",
       "lemmaId": "мийний",
       "lemmaPlain": "мийний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3744,11 +4142,13 @@
     {
       "cefr": "C1",
       "gloss": "fallen, shed",
+      "glossClean": "fallen",
       "heritage": "standard",
       "ipa": null,
       "lemma": "опалий",
       "lemmaId": "опалий",
       "lemmaPlain": "опалий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3759,11 +4159,13 @@
     {
       "cefr": "C1",
       "gloss": "yellowed",
+      "glossClean": "yellowed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пожовклий",
       "lemmaId": "пожовклий",
       "lemmaPlain": "пожовклий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3774,11 +4176,13 @@
     {
       "cefr": "C1",
       "gloss": "blossomed",
+      "glossClean": "blossomed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "розквітлий",
       "lemmaId": "розквітлий",
       "lemmaPlain": "розквітлий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3789,11 +4193,13 @@
     {
       "cefr": "C1",
       "gloss": "driven, led",
+      "glossClean": "driven",
       "heritage": "standard",
       "ipa": null,
       "lemma": "воджений",
       "lemmaId": "воджений",
       "lemmaPlain": "воджений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3804,11 +4210,13 @@
     {
       "cefr": "C1",
       "gloss": "healed",
+      "glossClean": "healed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "загоєний",
       "lemmaId": "загоєний",
       "lemmaPlain": "загоєний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3819,11 +4227,13 @@
     {
       "cefr": "C1",
       "gloss": "twisted, screwed",
+      "glossClean": "twisted",
       "heritage": "standard",
       "ipa": null,
       "lemma": "закручений",
       "lemmaId": "закручений",
       "lemmaPlain": "закручений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3834,11 +4244,13 @@
     {
       "cefr": "C1",
       "gloss": "swept",
+      "glossClean": "swept",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заметений",
       "lemmaId": "заметений",
       "lemmaPlain": "заметений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3849,11 +4261,13 @@
     {
       "cefr": "C1",
       "gloss": "chopped, split",
+      "glossClean": "chopped",
       "heritage": "standard",
       "ipa": null,
       "lemma": "колотий",
       "lemmaId": "колотий",
       "lemmaPlain": "колотий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3864,11 +4278,13 @@
     {
       "cefr": "C1",
       "gloss": "worn, carried",
+      "glossClean": "worn",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ношений",
       "lemmaId": "ношений",
       "lemmaPlain": "ношений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3879,11 +4295,13 @@
     {
       "cefr": "C1",
       "gloss": "seen",
+      "glossClean": "seen",
       "heritage": "standard",
       "ipa": null,
       "lemma": "побачений",
       "lemmaId": "побачений",
       "lemmaPlain": "побачений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3894,11 +4312,13 @@
     {
       "cefr": "C1",
       "gloss": "has been restored",
+      "glossClean": "has been restored",
       "heritage": "standard",
       "ipa": null,
       "lemma": "відреставровано",
       "lemmaId": "відреставровано",
       "lemmaPlain": "відреставровано",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3909,11 +4329,13 @@
     {
       "cefr": "C1",
       "gloss": "is being repaired",
+      "glossClean": "is being repaired",
       "heritage": "standard",
       "ipa": null,
       "lemma": "лагодиться",
       "lemmaId": "лагодиться",
       "lemmaPlain": "лагодиться",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3924,11 +4346,13 @@
     {
       "cefr": "C1",
       "gloss": "has been painted",
+      "glossClean": "has been painted",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пофарбовано",
       "lemmaId": "пофарбовано",
       "lemmaPlain": "пофарбовано",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3939,11 +4363,13 @@
     {
       "cefr": "C1",
       "gloss": "has been designed",
+      "glossClean": "has been designed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спроєктовано",
       "lemmaId": "спроєктовано",
       "lemmaPlain": "спроєктовано",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3954,11 +4380,13 @@
     {
       "cefr": "C1",
       "gloss": "capricious",
+      "glossClean": "capricious",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вередливий",
       "lemmaId": "вередливий",
       "lemmaPlain": "вередливий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3969,11 +4397,13 @@
     {
       "cefr": "C1",
       "gloss": "envious",
+      "glossClean": "envious",
       "heritage": "standard",
       "ipa": null,
       "lemma": "заздрісний",
       "lemmaId": "заздрісний",
       "lemmaPlain": "заздрісний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3984,11 +4414,13 @@
     {
       "cefr": "C1",
       "gloss": "tactless",
+      "glossClean": "tactless",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нетактовний",
       "lemmaId": "нетактовний",
       "lemmaPlain": "нетактовний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3999,11 +4431,13 @@
     {
       "cefr": "C1",
       "gloss": "squat, short and stocky",
+      "glossClean": "squat",
       "heritage": "standard",
       "ipa": null,
       "lemma": "приземкуватий",
       "lemmaId": "приземкуватий",
       "lemmaPlain": "приземкуватий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4014,11 +4448,13 @@
     {
       "cefr": "C1",
       "gloss": "upland, highland",
+      "glossClean": "upland",
       "heritage": "standard",
       "ipa": null,
       "lemma": "височина",
       "lemmaId": "височина",
       "lemmaPlain": "височина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4058,11 +4494,13 @@
     {
       "cefr": "C1",
       "gloss": "lowland",
+      "glossClean": "lowland",
       "heritage": "standard",
       "ipa": null,
       "lemma": "низовина",
       "lemmaId": "низовина",
       "lemmaPlain": "низовина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4102,11 +4540,13 @@
     {
       "cefr": "C1",
       "gloss": "Lesia's",
+      "glossClean": "Lesia's",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Лесин",
       "lemmaId": "лесин",
       "lemmaPlain": "лесин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4117,11 +4557,13 @@
     {
       "cefr": "C1",
       "gloss": "Mariika's",
+      "glossClean": "Mariika's",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Марійчин",
       "lemmaId": "марійчин",
       "lemmaPlain": "марійчин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4132,11 +4574,13 @@
     {
       "cefr": "C1",
       "gloss": "Mariya's",
+      "glossClean": "Mariya's",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Маріїн",
       "lemmaId": "маріїн",
       "lemmaPlain": "маріїн",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4147,11 +4591,13 @@
     {
       "cefr": "C1",
       "gloss": "Natalka's",
+      "glossClean": "Natalka's",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Наталчин",
       "lemmaId": "наталчин",
       "lemmaPlain": "наталчин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4162,11 +4608,13 @@
     {
       "cefr": "C1",
       "gloss": "Oleksii's",
+      "glossClean": "Oleksii's",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Олексіїв",
       "lemmaId": "олексіїв",
       "lemmaPlain": "олексіїв",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4177,11 +4625,13 @@
     {
       "cefr": "C1",
       "gloss": "Olenka's",
+      "glossClean": "Olenka's",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Оленчин",
       "lemmaId": "оленчин",
       "lemmaPlain": "оленчин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4192,11 +4642,13 @@
     {
       "cefr": "C1",
       "gloss": "Olha's",
+      "glossClean": "Olha's",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Ольжин",
       "lemmaId": "ольжин",
       "lemmaPlain": "ольжин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4207,11 +4659,13 @@
     {
       "cefr": "C1",
       "gloss": "Serhii's",
+      "glossClean": "Serhii's",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Сергіїв",
       "lemmaId": "сергіїв",
       "lemmaPlain": "сергіїв",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4222,11 +4676,13 @@
     {
       "cefr": "C1",
       "gloss": "sister's",
+      "glossClean": "sister's",
       "heritage": "standard",
       "ipa": null,
       "lemma": "сестрин",
       "lemmaId": "сестрин",
       "lemmaPlain": "сестрин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4237,11 +4693,13 @@
     {
       "cefr": "C1",
       "gloss": "Sofiia's",
+      "glossClean": "Sofiia's",
       "heritage": "unknown",
       "ipa": null,
       "lemma": "Софіїн",
       "lemmaId": "софіїн",
       "lemmaPlain": "софіїн",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4252,11 +4710,13 @@
     {
       "cefr": "C1",
       "gloss": "aunt's",
+      "glossClean": "aunt's",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тітчин",
       "lemmaId": "тітчин",
       "lemmaPlain": "тітчин",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4267,11 +4727,13 @@
     {
       "cefr": "C1",
       "gloss": "self-assessment",
+      "glossClean": "self-assessment",
       "heritage": "standard",
       "ipa": null,
       "lemma": "самооцінювання",
       "lemmaId": "самооцінювання",
       "lemmaPlain": "самооцінювання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4282,11 +4744,13 @@
     {
       "cefr": "C1",
       "gloss": "transcript",
+      "glossClean": "transcript",
       "heritage": "standard",
       "ipa": null,
       "lemma": "транскрипт",
       "lemmaId": "транскрипт",
       "lemmaPlain": "транскрипт",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4297,11 +4761,13 @@
     {
       "cefr": "C1",
       "gloss": "alliteration",
+      "glossClean": "alliteration",
       "heritage": "standard",
       "ipa": null,
       "lemma": "алітерація",
       "lemmaId": "алітерація",
       "lemmaPlain": "алітерація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4341,11 +4807,13 @@
     {
       "cefr": "C1",
       "gloss": "hyperbole",
+      "glossClean": "hyperbole",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гіпербола",
       "lemmaId": "гіпербола",
       "lemmaPlain": "гіпербола",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4385,11 +4853,13 @@
     {
       "cefr": "C1",
       "gloss": "rhyme",
+      "glossClean": "rhyme",
       "heritage": "standard",
       "ipa": null,
       "lemma": "рима",
       "lemmaId": "рима",
       "lemmaPlain": "рима",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -4429,11 +4899,13 @@
     {
       "cefr": "C1",
       "gloss": "density",
+      "glossClean": "density",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ущільненість",
       "lemmaId": "ущільненість",
       "lemmaPlain": "ущільненість",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4444,11 +4916,13 @@
     {
       "cefr": "C1",
       "gloss": "to put on shoes",
+      "glossClean": "to put on shoes",
       "heritage": "standard",
       "ipa": null,
       "lemma": "взуватися",
       "lemmaId": "взуватися",
       "lemmaPlain": "взуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4459,11 +4933,13 @@
     {
       "cefr": "C1",
       "gloss": "to comb one's hair",
+      "glossClean": "to comb one's hair",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зачісуватися",
       "lemmaId": "зачісуватися",
       "lemmaPlain": "зачісуватися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4474,11 +4950,13 @@
     {
       "cefr": "C1",
       "gloss": "to wash, be washable",
+      "glossClean": "to wash",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пратися",
       "lemmaId": "пратися",
       "lemmaPlain": "пратися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4489,11 +4967,13 @@
     {
       "cefr": "C1",
       "gloss": "to read, be easy/hard to read",
+      "glossClean": "to read",
       "heritage": "standard",
       "ipa": null,
       "lemma": "читатися",
       "lemmaId": "читатися",
       "lemmaPlain": "читатися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4504,11 +4984,13 @@
     {
       "cefr": "C1",
       "gloss": "banush, Hutsul cornmeal dish",
+      "glossClean": "banush",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бануш",
       "lemmaId": "бануш",
       "lemmaPlain": "бануш",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4519,11 +5001,13 @@
     {
       "cefr": "C1",
       "gloss": "baked, roasted",
+      "glossClean": "baked",
       "heritage": "standard",
       "ipa": null,
       "lemma": "запечений",
       "lemmaId": "запечений",
       "lemmaPlain": "запечений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4534,11 +5018,13 @@
     {
       "cefr": "C1",
       "gloss": "stewed",
+      "glossClean": "stewed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "тушкований",
       "lemmaId": "тушкований",
       "lemmaPlain": "тушкований",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4549,11 +5035,13 @@
     {
       "cefr": "C1",
       "gloss": "more reliable",
+      "glossClean": "more reliable",
       "heritage": "standard",
       "ipa": null,
       "lemma": "надійніший",
       "lemmaId": "надійніший",
       "lemmaPlain": "надійніший",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4564,11 +5052,13 @@
     {
       "cefr": "C1",
       "gloss": "most advantageous",
+      "glossClean": "most advantageous",
       "heritage": "standard",
       "ipa": null,
       "lemma": "найвигідніший",
       "lemmaId": "найвигідніший",
       "lemmaPlain": "найвигідніший",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4579,11 +5069,13 @@
     {
       "cefr": "C1",
       "gloss": "female buyer, customer",
+      "glossClean": "female buyer",
       "heritage": "standard",
       "ipa": null,
       "lemma": "покупчиня",
       "lemmaId": "покупчиня",
       "lemmaPlain": "покупчиня",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4594,11 +5086,13 @@
     {
       "cefr": "C1",
       "gloss": "fine, small, poetic short form",
+      "glossClean": "fine",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дрібен",
       "lemmaId": "дрібен",
       "lemmaPlain": "дрібен",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4609,11 +5103,13 @@
     {
       "cefr": "C1",
       "gloss": "green, poetic short form",
+      "glossClean": "green",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зелен",
       "lemmaId": "зелен",
       "lemmaPlain": "зелен",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4624,11 +5120,13 @@
     {
       "cefr": "C1",
       "gloss": "beautiful, fair, poetic short form",
+      "glossClean": "beautiful",
       "heritage": "standard",
       "ipa": null,
       "lemma": "красен",
       "lemmaId": "красен",
       "lemmaPlain": "красен",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4639,11 +5137,13 @@
     {
       "cefr": "C1",
       "gloss": "folk-poetic",
+      "glossClean": "folk-poetic",
       "heritage": "standard",
       "ipa": null,
       "lemma": "народнопоетичний",
       "lemmaId": "народнопоетичний",
       "lemmaPlain": "народнопоетичний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4654,11 +5154,13 @@
     {
       "cefr": "C1",
       "gloss": "predicative",
+      "glossClean": "predicative",
       "heritage": "standard",
       "ipa": null,
       "lemma": "присудковий",
       "lemmaId": "присудковий",
       "lemmaPlain": "присудковий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4669,11 +5171,13 @@
     {
       "cefr": "C1",
       "gloss": "renowned, glorious, short form",
+      "glossClean": "renowned",
       "heritage": "standard",
       "ipa": null,
       "lemma": "славен",
       "lemmaId": "славен",
       "lemmaPlain": "славен",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4684,11 +5188,13 @@
     {
       "cefr": "C1",
       "gloss": "truncated",
+      "glossClean": "truncated",
       "heritage": "standard",
       "ipa": null,
       "lemma": "усічений",
       "lemmaId": "усічений",
       "lemmaPlain": "усічений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4699,11 +5205,13 @@
     {
       "cefr": "C1",
       "gloss": "to splash once",
+      "glossClean": "to splash once",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бризнути",
       "lemmaId": "бризнути",
       "lemmaPlain": "бризнути",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4714,11 +5222,13 @@
     {
       "cefr": "C1",
       "gloss": "wrist-related",
+      "glossClean": "wrist-related",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зап'ястний",
       "lemmaId": "зап-ястний",
       "lemmaPlain": "зап'ястний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4729,11 +5239,13 @@
     {
       "cefr": "C1",
       "gloss": "bony",
+      "glossClean": "bony",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кістлявий",
       "lemmaId": "кістлявий",
       "lemmaPlain": "кістлявий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4744,11 +5256,13 @@
     {
       "cefr": "C1",
       "gloss": "greasy, oily",
+      "glossClean": "greasy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "масний",
       "lemmaId": "масний",
       "lemmaPlain": "масний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4759,11 +5273,13 @@
     {
       "cefr": "C1",
       "gloss": "boastful",
+      "glossClean": "boastful",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хвастливий",
       "lemmaId": "хвастливий",
       "lemmaPlain": "хвастливий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4774,11 +5290,13 @@
     {
       "cefr": "C1",
       "gloss": "media literacy",
+      "glossClean": "media literacy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "медіаграмотність",
       "lemmaId": "медіаграмотність",
       "lemmaPlain": "медіаграмотність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4789,11 +5307,13 @@
     {
       "cefr": "C1",
       "gloss": "follower, subscriber",
+      "glossClean": "follower",
       "heritage": "standard",
       "ipa": null,
       "lemma": "підписник",
       "lemmaId": "підписник",
       "lemmaPlain": "підписник",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4804,11 +5324,13 @@
     {
       "cefr": "C1",
       "gloss": "in words",
+      "glossClean": "in words",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прописом",
       "lemmaId": "прописом",
       "lemmaPlain": "прописом",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4819,11 +5341,13 @@
     {
       "cefr": "C1",
       "gloss": "special edition",
+      "glossClean": "special edition",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спецвипуск",
       "lemmaId": "спецвипуск",
       "lemmaPlain": "спецвипуск",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4834,11 +5358,13 @@
     {
       "cefr": "C1",
       "gloss": "above-mentioned",
+      "glossClean": "above-mentioned",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вищезазначений",
       "lemmaId": "вищезазначений",
       "lemmaPlain": "вищезазначений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4849,11 +5375,13 @@
     {
       "cefr": "C1",
       "gloss": "bureaucratic expression",
+      "glossClean": "bureaucratic expression",
       "heritage": "standard",
       "ipa": null,
       "lemma": "канцеляризм",
       "lemmaId": "канцеляризм",
       "lemmaPlain": "канцеляризм",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4864,11 +5392,13 @@
     {
       "cefr": "C1",
       "gloss": "undersigned",
+      "glossClean": "undersigned",
       "heritage": "standard",
       "ipa": null,
       "lemma": "нижчепідписаний",
       "lemmaId": "нижчепідписаний",
       "lemmaPlain": "нижчепідписаний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4879,11 +5409,13 @@
     {
       "cefr": "C1",
       "gloss": "dialogic",
+      "glossClean": "dialogic",
       "heritage": "standard",
       "ipa": null,
       "lemma": "діалогічний",
       "lemmaId": "діалогічний",
       "lemmaPlain": "діалогічний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4894,11 +5426,13 @@
     {
       "cefr": "C1",
       "gloss": "spontaneity, ease",
+      "glossClean": "spontaneity",
       "heritage": "standard",
       "ipa": null,
       "lemma": "невимушеність",
       "lemmaId": "невимушеність",
       "lemmaPlain": "невимушеність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4909,11 +5443,13 @@
     {
       "cefr": "C1",
       "gloss": "to dehydrate; to remove water",
+      "glossClean": "to dehydrate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зневоднити",
       "lemmaId": "зневоднити",
       "lemmaPlain": "зневоднити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4924,11 +5460,13 @@
     {
       "cefr": "C1",
       "gloss": "to load; to burden",
+      "glossClean": "to load",
       "heritage": "standard",
       "ipa": null,
       "lemma": "навантажити",
       "lemmaId": "навантажити",
       "lemmaPlain": "навантажити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4939,11 +5477,13 @@
     {
       "cefr": "C1",
       "gloss": "to cook a lot; to prepare plenty",
+      "glossClean": "to cook a lot",
       "heritage": "standard",
       "ipa": null,
       "lemma": "наготувати",
       "lemmaId": "наготувати",
       "lemmaPlain": "наготувати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4954,11 +5494,13 @@
     {
       "cefr": "C1",
       "gloss": "to illuminate; to light up",
+      "glossClean": "to illuminate",
       "heritage": "standard",
       "ipa": null,
       "lemma": "освітлити",
       "lemmaId": "освітлити",
       "lemmaPlain": "освітлити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4969,11 +5511,13 @@
     {
       "cefr": "C1",
       "gloss": "to overload",
+      "glossClean": "to overload",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перенавантажити",
       "lemmaId": "перенавантажити",
       "lemmaPlain": "перенавантажити",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -4984,11 +5528,13 @@
     {
       "cefr": "C1",
       "gloss": "prefix (school synonym)",
+      "glossClean": "prefix (school synonym)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "приставка",
       "lemmaId": "приставка",
       "lemmaPlain": "приставка",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -4999,11 +5545,13 @@
     {
       "cefr": "C1",
       "gloss": "to whistle once",
+      "glossClean": "to whistle once",
       "heritage": "standard",
       "ipa": null,
       "lemma": "свиснути",
       "lemmaId": "свиснути",
       "lemmaPlain": "свиснути",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5014,11 +5562,13 @@
     {
       "cefr": "C1",
       "gloss": "to whistle",
+      "glossClean": "to whistle",
       "heritage": "standard",
       "ipa": null,
       "lemma": "свистіти",
       "lemmaId": "свистіти",
       "lemmaPlain": "свистіти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5029,11 +5579,13 @@
     {
       "cefr": "C1",
       "gloss": "to turn blue; to look blue",
+      "glossClean": "to turn blue",
       "heritage": "standard",
       "ipa": null,
       "lemma": "синіти",
       "lemmaId": "синіти",
       "lemmaPlain": "синіти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5044,11 +5596,13 @@
     {
       "cefr": "C1",
       "gloss": "to turn black; to look black",
+      "glossClean": "to turn black",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чорніти",
       "lemmaId": "чорніти",
       "lemmaPlain": "чорніти",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5059,11 +5613,13 @@
     {
       "cefr": "C1",
       "gloss": "zero-derived; without affix",
+      "glossClean": "zero-derived",
       "heritage": "standard",
       "ipa": null,
       "lemma": "безафіксний",
       "lemmaId": "безафіксний",
       "lemmaPlain": "безафіксний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5074,11 +5630,13 @@
     {
       "cefr": "C1",
       "gloss": "bookish; literary",
+      "glossClean": "bookish",
       "heritage": "standard",
       "ipa": null,
       "lemma": "книжний",
       "lemmaId": "книжний",
       "lemmaPlain": "книжний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5089,11 +5647,13 @@
     {
       "cefr": "C1",
       "gloss": "nominalization",
+      "glossClean": "nominalization",
       "heritage": "standard",
       "ipa": null,
       "lemma": "номіналізація",
       "lemmaId": "номіналізація",
       "lemmaPlain": "номіналізація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5104,11 +5664,13 @@
     {
       "cefr": "C1",
       "gloss": "doubled",
+      "glossClean": "doubled",
       "heritage": "standard",
       "ipa": null,
       "lemma": "подвоєний",
       "lemmaId": "подвоєний",
       "lemmaPlain": "подвоєний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5119,11 +5681,13 @@
     {
       "cefr": "C1",
       "gloss": "madam, lady",
+      "glossClean": "madam",
       "heritage": "standard",
       "ipa": null,
       "lemma": "добродійка",
       "lemmaId": "добродійка",
       "lemmaPlain": "добродійка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5134,11 +5698,13 @@
     {
       "cefr": "C1",
       "gloss": "rank, title",
+      "glossClean": "rank",
       "heritage": "standard",
       "ipa": null,
       "lemma": "звання",
       "lemmaId": "звання",
       "lemmaPlain": "звання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5149,11 +5715,13 @@
     {
       "cefr": "C1",
       "gloss": "coordinator (vocative)",
+      "glossClean": "coordinator (vocative)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "координаторе",
       "lemmaId": "координаторе",
       "lemmaPlain": "координаторе",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -5164,11 +5732,13 @@
     {
       "cefr": "C1",
       "gloss": "editor (female vocative)",
+      "glossClean": "editor (female vocative)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "редакторко",
       "lemmaId": "редакторко",
       "lemmaPlain": "редакторко",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -5179,11 +5749,13 @@
     {
       "cefr": "C1",
       "gloss": "anti-war",
+      "glossClean": "anti-war",
       "heritage": "standard",
       "ipa": null,
       "lemma": "антивоєнний",
       "lemmaId": "антивоєнний",
       "lemmaPlain": "антивоєнний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5194,11 +5766,13 @@
     {
       "cefr": "C1",
       "gloss": "cloudless",
+      "glossClean": "cloudless",
       "heritage": "standard",
       "ipa": null,
       "lemma": "безхмарний",
       "lemmaId": "безхмарний",
       "lemmaPlain": "безхмарний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5209,11 +5783,13 @@
     {
       "cefr": "C1",
       "gloss": "augmentative",
+      "glossClean": "augmentative",
       "heritage": "standard",
       "ipa": null,
       "lemma": "збільшувальний",
       "lemmaId": "збільшувальний",
       "lemmaPlain": "збільшувальний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5224,11 +5800,13 @@
     {
       "cefr": "C1",
       "gloss": "pre-holiday",
+      "glossClean": "pre-holiday",
       "heritage": "standard",
       "ipa": null,
       "lemma": "передсвятковий",
       "lemmaId": "передсвятковий",
       "lemmaPlain": "передсвятковий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5239,11 +5817,13 @@
     {
       "cefr": "C1",
       "gloss": "coastal, riverside",
+      "glossClean": "coastal",
       "heritage": "standard",
       "ipa": null,
       "lemma": "прибережний",
       "lemmaId": "прибережний",
       "lemmaPlain": "прибережний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5254,11 +5834,13 @@
     {
       "cefr": "C1",
       "gloss": "black-eyed",
+      "glossClean": "black-eyed",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чорноокий",
       "lemmaId": "чорноокий",
       "lemmaPlain": "чорноокий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5269,11 +5851,13 @@
     {
       "cefr": "C1",
       "gloss": "deverbal",
+      "glossClean": "deverbal",
       "heritage": "standard",
       "ipa": null,
       "lemma": "віддієслівний",
       "lemmaId": "віддієслівний",
       "lemmaPlain": "віддієслівний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5284,11 +5868,13 @@
     {
       "cefr": "C1",
       "gloss": "female baker",
+      "glossClean": "female baker",
       "heritage": "standard",
       "ipa": null,
       "lemma": "пекарка",
       "lemmaId": "пекарка",
       "lemmaPlain": "пекарка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5299,11 +5885,13 @@
     {
       "cefr": "C1",
       "gloss": "word-forming element",
+      "glossClean": "word-forming element",
       "heritage": "standard",
       "ipa": null,
       "lemma": "формант",
       "lemmaId": "формант",
       "lemmaPlain": "формант",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5314,11 +5902,13 @@
     {
       "cefr": "C1",
       "gloss": "non-standard",
+      "glossClean": "non-standard",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ненормативний",
       "lemmaId": "ненормативний",
       "lemmaPlain": "ненормативний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5329,11 +5919,13 @@
     {
       "cefr": "C1",
       "gloss": "baked",
+      "glossClean": "baked",
       "heritage": "standard",
       "ipa": null,
       "lemma": "спечений",
       "lemmaId": "спечений",
       "lemmaPlain": "спечений",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5344,11 +5936,13 @@
     {
       "cefr": "C1",
       "gloss": "erased, worn away",
+      "glossClean": "erased",
       "heritage": "standard",
       "ipa": null,
       "lemma": "стертий",
       "lemmaId": "стертий",
       "lemmaPlain": "стертий",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5359,11 +5953,13 @@
     {
       "cefr": "C1",
       "gloss": "agency; capacity to act as a subject",
+      "glossClean": "agency",
       "heritage": "standard",
       "ipa": null,
       "lemma": "агентність",
       "lemmaId": "агентність",
       "lemmaPlain": "агентність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5374,11 +5970,13 @@
     {
       "cefr": "C1",
       "gloss": "female captive",
+      "glossClean": "female captive",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бранка",
       "lemmaId": "бранка",
       "lemmaPlain": "бранка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5389,11 +5987,13 @@
     {
       "cefr": "C1",
       "gloss": "infidel, Muslim (archaic, in folk usage)",
+      "glossClean": "infidel",
       "heritage": "standard",
       "ipa": null,
       "lemma": "бусурман",
       "lemmaId": "бусурман",
       "lemmaPlain": "бусурман",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5404,11 +6004,13 @@
     {
       "cefr": "C1",
       "gloss": "victimhood, the condition of being a victim",
+      "glossClean": "victimhood",
       "heritage": "standard",
       "ipa": null,
       "lemma": "віктимність",
       "lemmaId": "віктимність",
       "lemmaPlain": "віктимність",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5419,11 +6021,13 @@
     {
       "cefr": "C1",
       "gloss": "apostasy, renunciation of one's faith",
+      "glossClean": "apostasy",
       "heritage": "standard",
       "ipa": null,
       "lemma": "віровідступництво",
       "lemmaId": "віровідступництво",
       "lemmaPlain": "віровідступництво",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5434,11 +6038,13 @@
     {
       "cefr": "C1",
       "gloss": "the heroic register, heroic dimension",
+      "glossClean": "the heroic register",
       "heritage": "standard",
       "ipa": null,
       "lemma": "героїка",
       "lemmaId": "героїка",
       "lemmaPlain": "героїка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5449,11 +6055,13 @@
     {
       "cefr": "C1",
       "gloss": "seafaring, navigation",
+      "glossClean": "seafaring",
       "heritage": "standard",
       "ipa": null,
       "lemma": "мореплавство",
       "lemmaId": "мореплавство",
       "lemmaPlain": "мореплавство",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5464,11 +6072,13 @@
     {
       "cefr": "C1",
       "gloss": "enslaver, oppressor",
+      "glossClean": "enslaver",
       "heritage": "standard",
       "ipa": null,
       "lemma": "поневолювач",
       "lemmaId": "поневолювач",
       "lemmaPlain": "поневолювач",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5479,11 +6089,13 @@
     {
       "cefr": "C1",
       "gloss": "a priest's daughter",
+      "glossClean": "a priest's daughter",
       "heritage": "standard",
       "ipa": null,
       "lemma": "попівна",
       "lemmaId": "попівна",
       "lemmaPlain": "попівна",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5494,11 +6106,13 @@
     {
       "cefr": "C1",
       "gloss": "to turn Turk, to convert to Islam (a betrayal of faith in folk view)",
+      "glossClean": "to turn Turk",
       "heritage": "standard",
       "ipa": null,
       "lemma": "потурчитися",
       "lemmaId": "потурчитися",
       "lemmaPlain": "потурчитися",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5509,11 +6123,13 @@
     {
       "cefr": "C1",
       "gloss": "slave trade",
+      "glossClean": "slave trade",
       "heritage": "standard",
       "ipa": null,
       "lemma": "работоргівля",
       "lemmaId": "работоргівля",
       "lemmaPlain": "работоргівля",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5524,11 +6140,13 @@
     {
       "cefr": "C1",
       "gloss": "renegade, one who has betrayed faith or side",
+      "glossClean": "renegade",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ренегат",
       "lemmaId": "ренегат",
       "lemmaPlain": "ренегат",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5539,11 +6157,13 @@
     {
       "cefr": "C1",
       "gloss": "dungeon, prison",
+      "glossClean": "dungeon",
       "heritage": "standard",
       "ipa": null,
       "lemma": "темниця",
       "lemmaId": "темниця",
       "lemmaPlain": "темниця",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5583,11 +6203,13 @@
     {
       "cefr": "C1",
       "gloss": "glorifying, laudatory",
+      "glossClean": "glorifying",
       "heritage": "standard",
       "ipa": null,
       "lemma": "величальний",
       "lemmaId": "величальний",
       "lemmaPlain": "величальний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5598,11 +6220,13 @@
     {
       "cefr": "C1",
       "gloss": "vesnianka (spring ritual song)",
+      "glossClean": "vesnianka (spring ritual song)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "веснянка",
       "lemmaId": "веснянка",
       "lemmaPlain": "веснянка",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -5613,11 +6237,13 @@
     {
       "cefr": "C1",
       "gloss": "hahilky (Galician spring songs)",
+      "glossClean": "hahilky (Galician spring songs)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гагілки",
       "lemmaId": "гагілки",
       "lemmaPlain": "гагілки",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -5628,11 +6254,13 @@
     {
       "cefr": "C1",
       "gloss": "giltse (decorated ritual treelet)",
+      "glossClean": "giltse (decorated ritual treelet)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "гільце",
       "lemmaId": "гільце",
       "lemmaPlain": "гільце",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -5643,11 +6271,13 @@
     {
       "cefr": "C1",
       "gloss": "decolonization",
+      "glossClean": "decolonization",
       "heritage": "standard",
       "ipa": null,
       "lemma": "деколонізація",
       "lemmaId": "деколонізація",
       "lemmaPlain": "деколонізація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5658,11 +6288,13 @@
     {
       "cefr": "C1",
       "gloss": "rite of starting the harvest",
+      "glossClean": "rite of starting the harvest",
       "heritage": "standard",
       "ipa": null,
       "lemma": "зажинки",
       "lemmaId": "зажинки",
       "lemmaPlain": "зажинки",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -5673,11 +6305,13 @@
     {
       "cefr": "C1",
       "gloss": "invocatory, summoning",
+      "glossClean": "invocatory",
       "heritage": "standard",
       "ipa": null,
       "lemma": "закликальний",
       "lemmaId": "закликальний",
       "lemmaPlain": "закликальний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5688,11 +6322,13 @@
     {
       "cefr": "C1",
       "gloss": "harvest-end rite",
+      "glossClean": "harvest-end rite",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обжинки",
       "lemmaId": "обжинки",
       "lemmaPlain": "обжинки",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5703,11 +6339,13 @@
     {
       "cefr": "C1",
       "gloss": "ritual (adjective)",
+      "glossClean": "ritual (adjective)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обрядовий",
       "lemmaId": "обрядовий",
       "lemmaPlain": "обрядовий",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -5718,11 +6356,13 @@
     {
       "cefr": "C1",
       "gloss": "ritual act",
+      "glossClean": "ritual act",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обрядодія",
       "lemmaId": "обрядодія",
       "lemmaPlain": "обрядодія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5762,11 +6402,13 @@
     {
       "cefr": "C1",
       "gloss": "performativity (text bound to action)",
+      "glossClean": "performativity (text bound to action)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перформативність",
       "lemmaId": "перформативність",
       "lemmaPlain": "перформативність",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -5777,11 +6419,13 @@
     {
       "cefr": "C1",
       "gloss": "ritual sowing of grain on New Year",
+      "glossClean": "ritual sowing of grain on New Year",
       "heritage": "standard",
       "ipa": null,
       "lemma": "посівання",
       "lemmaId": "посівання",
       "lemmaPlain": "посівання",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -5792,11 +6436,13 @@
     {
       "cefr": "C1",
       "gloss": "costumed (mummer)",
+      "glossClean": "costumed (mummer)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "ряджений",
       "lemmaId": "ряджений",
       "lemmaPlain": "ряджений",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -5807,11 +6453,13 @@
     {
       "cefr": "C1",
       "gloss": "syncretic",
+      "glossClean": "syncretic",
       "heritage": "standard",
       "ipa": null,
       "lemma": "синкретичний",
       "lemmaId": "синкретичний",
       "lemmaPlain": "синкретичний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5822,11 +6470,13 @@
     {
       "cefr": "C1",
       "gloss": "round dance with song",
+      "glossClean": "round dance with song",
       "heritage": "standard",
       "ipa": null,
       "lemma": "хоровод",
       "lemmaId": "хоровод",
       "lemmaPlain": "хоровод",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5837,11 +6487,13 @@
     {
       "cefr": "C1",
       "gloss": "autochthonous; of local, native origin (opposite of borrowed)",
+      "glossClean": "autochthonous",
       "heritage": "standard",
       "ipa": null,
       "lemma": "автохтонний",
       "lemmaId": "автохтонний",
       "lemmaPlain": "автохтонний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5852,11 +6504,13 @@
     {
       "cefr": "C1",
       "gloss": "glorification; the praising of the host in ritual song",
+      "glossClean": "glorification",
       "heritage": "standard",
       "ipa": null,
       "lemma": "величання",
       "lemmaId": "величання",
       "lemmaPlain": "величання",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5867,11 +6521,13 @@
     {
       "cefr": "C1",
       "gloss": "to glorify, extol (a host in song)",
+      "glossClean": "to glorify",
       "heritage": "standard",
       "ipa": null,
       "lemma": "величати",
       "lemmaId": "величати",
       "lemmaPlain": "величати",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5882,11 +6538,13 @@
     {
       "cefr": "C1",
       "gloss": "pre-Christian",
+      "glossClean": "pre-Christian",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дохристиянський",
       "lemmaId": "дохристиянський",
       "lemmaPlain": "дохристиянський",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5897,11 +6555,13 @@
     {
       "cefr": "C1",
       "gloss": "New Year rite of sprinkling grain on the floor for prosperity and harvest",
+      "glossClean": "New Year rite of sprinkling grain on the floor for prosperity and harvest",
       "heritage": "standard",
       "ipa": null,
       "lemma": "засівання",
       "lemmaId": "засівання",
       "lemmaPlain": "засівання",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -5912,11 +6572,13 @@
     {
       "cefr": "C1",
       "gloss": "cosmogonic; relating to the creation of the world",
+      "glossClean": "cosmogonic",
       "heritage": "standard",
       "ipa": null,
       "lemma": "космогонічний",
       "lemmaId": "космогонічний",
       "lemmaPlain": "космогонічний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5927,11 +6589,13 @@
     {
       "cefr": "C1",
       "gloss": "cosmogony; myth or account of the origin of the universe",
+      "glossClean": "cosmogony",
       "heritage": "standard",
       "ipa": null,
       "lemma": "космогонія",
       "lemmaId": "космогонія",
       "lemmaPlain": "космогонія",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
@@ -5971,11 +6635,13 @@
     {
       "cefr": "C1",
       "gloss": "solar; connected with the sun and the solar cult",
+      "glossClean": "solar",
       "heritage": "standard",
       "ipa": null,
       "lemma": "солярний",
       "lemmaId": "солярний",
       "lemmaPlain": "солярний",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -5986,11 +6652,13 @@
     {
       "cefr": "C1",
       "gloss": "Christianization",
+      "glossClean": "Christianization",
       "heritage": "standard",
       "ipa": null,
       "lemma": "християнізація",
       "lemmaId": "християнізація",
       "lemmaPlain": "християнізація",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6001,11 +6669,13 @@
     {
       "cefr": "C1",
       "gloss": "pagan; pre-Christian",
+      "glossClean": "pagan",
       "heritage": "standard",
       "ipa": null,
       "lemma": "язичницький",
       "lemmaId": "язичницький",
       "lemmaPlain": "язичницький",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6016,11 +6686,13 @@
     {
       "cefr": "C1",
       "gloss": "kobzar tradition",
+      "glossClean": "kobzar tradition",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кобзарство",
       "lemmaId": "кобзарство",
       "lemmaPlain": "кобзарство",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6031,11 +6703,13 @@
     {
       "cefr": "C1",
       "gloss": "sense of inferiority",
+      "glossClean": "sense of inferiority",
       "heritage": "standard",
       "ipa": null,
       "lemma": "меншовартість",
       "lemmaId": "меншовартість",
       "lemmaPlain": "меншовартість",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6046,11 +6720,13 @@
     {
       "cefr": "C1",
       "gloss": "recitative",
+      "glossClean": "recitative",
       "heritage": "standard",
       "ipa": null,
       "lemma": "речитатив",
       "lemmaId": "речитатив",
       "lemmaPlain": "речитатив",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6061,11 +6737,13 @@
     {
       "cefr": "C1",
       "gloss": "folkloristics, folklore studies",
+      "glossClean": "folkloristics",
       "heritage": "standard",
       "ipa": null,
       "lemma": "фольклористика",
       "lemmaId": "фольклористика",
       "lemmaPlain": "фольклористика",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6076,11 +6754,13 @@
     {
       "cefr": "C1",
       "gloss": "demonology (the system of beliefs about spirits)",
+      "glossClean": "demonology (the system of beliefs about spirits)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "демонологія",
       "lemmaId": "демонологія",
       "lemmaPlain": "демонологія",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6091,11 +6771,13 @@
     {
       "cefr": "C1",
       "gloss": "spirit",
+      "glossClean": "spirit",
       "heritage": "standard",
       "ipa": null,
       "lemma": "дух",
       "lemmaId": "дух",
       "lemmaPlain": "дух",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6106,11 +6788,13 @@
     {
       "cefr": "C1",
       "gloss": "niavka (Hutsul variant of мавка)",
+      "glossClean": "niavka (Hutsul variant of мавка)",
       "heritage": "authentic-archaism",
       "ipa": null,
       "lemma": "нявка",
       "lemmaId": "нявка",
       "lemmaPlain": "нявка",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6121,11 +6805,13 @@
     {
       "cefr": "C1",
       "gloss": "perelesnyk, seductive flying spirit",
+      "glossClean": "perelesnyk",
       "heritage": "standard",
       "ipa": null,
       "lemma": "перелесник",
       "lemmaId": "перелесник",
       "lemmaPlain": "перелесник",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6136,11 +6822,13 @@
     {
       "cefr": "C1",
       "gloss": "field spirit",
+      "glossClean": "field spirit",
       "heritage": "standard",
       "ipa": null,
       "lemma": "польовик",
       "lemmaId": "польовик",
       "lemmaPlain": "польовик",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6151,11 +6839,13 @@
     {
       "cefr": "C1",
       "gloss": "potercha, spirit of a dead unbaptized child",
+      "glossClean": "potercha",
       "heritage": "standard",
       "ipa": null,
       "lemma": "потерча",
       "lemmaId": "потерча",
       "lemmaPlain": "потерча",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6166,11 +6856,13 @@
     {
       "cefr": "C1",
       "gloss": "house spirit (synonym of домовик)",
+      "glossClean": "house spirit (synonym of домовик)",
       "heritage": "authentic-archaism",
       "ipa": null,
       "lemma": "хованець",
       "lemmaId": "хованець",
       "lemmaPlain": "хованець",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6181,11 +6873,13 @@
     {
       "cefr": "C1",
       "gloss": "chuhaister, Carpathian forest giant",
+      "glossClean": "chuhaister",
       "heritage": "standard",
       "ipa": null,
       "lemma": "чугайстер",
       "lemmaId": "чугайстер",
       "lemmaPlain": "чугайстер",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6196,11 +6890,13 @@
     {
       "cefr": "C1",
       "gloss": "ritual well-wishing, blessing",
+      "glossClean": "ritual well-wishing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "віншування",
       "lemmaId": "віншування",
       "lemmaPlain": "віншування",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6211,11 +6907,13 @@
     {
       "cefr": "C1",
       "gloss": "formulaic saying accompanying a minor action",
+      "glossClean": "formulaic saying accompanying a minor action",
       "heritage": "standard",
       "ipa": null,
       "lemma": "примовка",
       "lemmaId": "примовка",
       "lemmaPlain": "примовка",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6226,11 +6924,13 @@
     {
       "cefr": "C1",
       "gloss": "short charm; regional variant of примовка",
+      "glossClean": "short charm",
       "heritage": "authentic-archaism",
       "ipa": null,
       "lemma": "примівка",
       "lemmaId": "примівка",
       "lemmaPlain": "примівка",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6241,11 +6941,13 @@
     {
       "cefr": "C1",
       "gloss": "curse",
+      "glossClean": "curse",
       "heritage": "standard",
       "ipa": null,
       "lemma": "проклін",
       "lemmaId": "проклін",
       "lemmaPlain": "проклін",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6256,11 +6958,13 @@
     {
       "cefr": "C1",
       "gloss": "whisperer-healer (utters charms in a whisper)",
+      "glossClean": "whisperer-healer (utters charms in a whisper)",
       "heritage": "standard",
       "ipa": null,
       "lemma": "шептуха",
       "lemmaId": "шептуха",
       "lemmaPlain": "шептуха",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6271,11 +6975,13 @@
     {
       "cefr": "C1",
       "gloss": "archaic: word, speech",
+      "glossClean": "archaic: word",
       "heritage": "authentic-archaism",
       "ipa": null,
       "lemma": "глагол",
       "lemmaId": "глагол",
       "lemmaPlain": "глагол",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6286,11 +6992,13 @@
     {
       "cefr": "C1",
       "gloss": "regional: woman",
+      "glossClean": "regional: woman",
       "heritage": "standard",
       "ipa": null,
       "lemma": "кобіта",
       "lemmaId": "кобіта",
       "lemmaPlain": "кобіта",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -6302,10 +7010,10 @@
   "schema": "atlas-practice-lexemes",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 13508,
+    "gzipBytes": 15065,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 161042,
+    "rawBytes": 185807,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -125,7 +125,10 @@ function glossHeadword(entry: PracticeLexeme): string {
 
 function isPhraseGloss(label: string): boolean {
   const clean = label.replace(/\s+/g, ' ').trim();
-  const wordCount = clean ? clean.split(/\s+/).length : 0;
+  // Count alphanumeric tokens (ignoring standalone punctuation) to match the
+  // Python deck generator's `_meaning_label_word_count` regex exactly, so the
+  // served deck and this runtime guard never disagree on eligibility.
+  const wordCount = clean ? (clean.match(/[^\W_]+(?:[-'][^\W_]+)?/gu) || []).length : 0;
   return (
     !clean ||
     clean.length > MEANING_MC_MAX_CHARS ||
@@ -139,14 +142,8 @@ function isPhraseGloss(label: string): boolean {
 function isMeaningMcEligible(entry: PracticeLexeme): boolean {
   const label = glossLabel(entry);
   if (entry.meaningMcEligible === false) return false;
-  if (
-    entry.gloss.includes(';') ||
-    entry.gloss.includes('?') ||
-    entry.gloss.includes('(') ||
-    entry.gloss.includes(')')
-  ) {
-    return false;
-  }
+  // Judge the CLEAN first-sense label, not the raw multi-sense gloss: a word like
+  // "dog; hound" has a perfectly concise glossClean ("dog") and must stay eligible.
   if (isPhraseGloss(label)) return false;
   if (FUNCTION_GLOSS_HEADWORDS.has(glossHeadword(entry))) return false;
   if (entry.pos && FUNCTION_POS.has(entry.pos.toLocaleLowerCase('en-US'))) return false;
@@ -273,7 +270,7 @@ function orderedChoiceOptions(
 ): ChoiceOption[] {
   if (!isMeaningMcEligible(selection.lemma)) return [];
   const distractors = meaningDistractors(selection.lemma, deck, 3);
-  if (!distractors.length) return [];
+  if (distractors.length < 3) return [];
   const answer = polarity === 'word-to-meaning' ? glossLabel(selection.lemma) : selection.lemma.lemma;
   const options = [
     { label: answer, correct: true },
@@ -302,19 +299,19 @@ function meaningDistractors(
       isMeaningMcEligible(candidate) &&
       glossHeadword(candidate) !== answerHeadword,
   );
-  const samePos = candidates.filter((candidate) => candidate.pos === answer.pos);
-  const primary = samePos.length ? samePos : candidates;
-  const comparable = primary.filter(
-    (candidate) => Math.abs(glossLabel(candidate).length - answerLength) <= 12,
-  );
+  // PRIORITIZE same-POS + comparable gloss length via sort keys — never hard-filter
+  // the candidate pool down to a subset, which would starve distractors when a word
+  // has fewer than 3 same-POS peers even though hundreds of valid candidates exist.
   const seenLabels = new Set<string>();
-  return (comparable.length ? comparable : primary)
-    .sort(
-      (left, right) =>
-        Math.abs(glossLabel(left).length - answerLength) -
-          Math.abs(glossLabel(right).length - answerLength) ||
-        left.lemmaId.localeCompare(right.lemmaId),
-    )
+  return candidates
+    .sort((left, right) => {
+      const leftPos = left.pos === answer.pos ? 0 : 1;
+      const rightPos = right.pos === answer.pos ? 0 : 1;
+      if (leftPos !== rightPos) return leftPos - rightPos;
+      const leftLen = Math.abs(glossLabel(left).length - answerLength);
+      const rightLen = Math.abs(glossLabel(right).length - answerLength);
+      return leftLen - rightLen || left.lemmaId.localeCompare(right.lemmaId);
+    })
     .filter((entry) => {
       const key = glossLabel(entry).toLocaleLowerCase('en-US');
       if (seenLabels.has(key)) return false;
@@ -327,7 +324,7 @@ function meaningDistractors(
 function matchingPairs(selection: PracticeSelection, deck: PracticeDeckData) {
   if (!isMeaningMcEligible(selection.lemma)) return [];
   const distractors = meaningDistractors(selection.lemma, deck, 3);
-  if (!distractors.length) return [];
+  if (distractors.length < 3) return [];
   return [selection.lemma, ...distractors].map((entry) => ({
     left: entry.lemma,
     right: glossLabel(entry),

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -75,6 +75,84 @@ const HERITAGE_COLORS: Record<string, string> = {
   avoid: '#b91c1c',
 };
 
+const MEANING_MC_MAX_WORDS = 4;
+const MEANING_MC_MAX_CHARS = 32;
+const FUNCTION_POS = new Set([
+  'adp',
+  'conj',
+  'conjunction',
+  'det',
+  'determiner',
+  'interj',
+  'interjection',
+  'particle',
+  'prep',
+  'preposition',
+  'pron',
+  'pronoun',
+  'sconj',
+]);
+const FUNCTION_GLOSS_HEADWORDS = new Set([
+  'and',
+  'because',
+  'but',
+  'if',
+  'nor',
+  'or',
+  'than',
+  'that',
+  'though',
+  'unless',
+  'until',
+  'when',
+  'where',
+  'whether',
+  'while',
+  'yet',
+]);
+
+function cleanGloss(gloss: string): string {
+  return gloss.split(/[;,]/, 1)[0].replace(/\s+/g, ' ').trim();
+}
+
+function glossLabel(entry: PracticeLexeme): string {
+  return entry.glossClean?.trim() || cleanGloss(entry.gloss);
+}
+
+function glossHeadword(entry: PracticeLexeme): string {
+  return glossLabel(entry).toLocaleLowerCase('en-US').split(/\s+/)[0] ?? '';
+}
+
+function isPhraseGloss(label: string): boolean {
+  const clean = label.replace(/\s+/g, ' ').trim();
+  const wordCount = clean ? clean.split(/\s+/).length : 0;
+  return (
+    !clean ||
+    clean.length > MEANING_MC_MAX_CHARS ||
+    wordCount > MEANING_MC_MAX_WORDS ||
+    clean.includes('?') ||
+    clean.includes('(') ||
+    clean.includes(')')
+  );
+}
+
+function isMeaningMcEligible(entry: PracticeLexeme): boolean {
+  const label = glossLabel(entry);
+  if (entry.meaningMcEligible === false) return false;
+  if (
+    entry.gloss.includes(';') ||
+    entry.gloss.includes('?') ||
+    entry.gloss.includes('(') ||
+    entry.gloss.includes(')')
+  ) {
+    return false;
+  }
+  if (isPhraseGloss(label)) return false;
+  if (FUNCTION_GLOSS_HEADWORDS.has(glossHeadword(entry))) return false;
+  if (entry.pos && FUNCTION_POS.has(entry.pos.toLocaleLowerCase('en-US'))) return false;
+  return entry.meaningMcEligible ?? true;
+}
+
 function todayKey(date = new Date()): string {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');
@@ -145,10 +223,14 @@ function normalizeInitialDeck(initialDeck?: PracticeDeckData | PracticeLexeme[])
   const lexemes = initialDeck.map((entry) => {
     const legacy = entry as PracticeLexeme & { slug?: string; example?: string | null };
     const lemmaId = legacy.lemmaId ?? legacy.slug ?? legacy.lemma;
+    const glossClean = legacy.glossClean ?? cleanGloss(legacy.gloss);
+    const meaningMcEligible = legacy.meaningMcEligible ?? !isPhraseGloss(glossClean);
     return {
       ...entry,
       lemmaId,
       lemmaPlain: legacy.lemmaPlain ?? czNorm(legacy.lemma),
+      glossClean,
+      meaningMcEligible,
       severity: legacy.severity ?? null,
       paradigm: legacy.paradigm ?? { cases: {} },
     };
@@ -160,7 +242,7 @@ function normalizeInitialDeck(initialDeck?: PracticeDeckData | PracticeLexeme[])
       lemmaId: entry.lemmaId,
       lemma: entry.lemma,
       cefr: entry.cefr ?? 'A1',
-      modes: ['flashcards', 'matching', 'choice'],
+      modes: entry.meaningMcEligible ? ['flashcards', 'matching', 'choice'] : ['flashcards'],
       hasCloze: false,
       clozeIds: [],
       newOrder: index,
@@ -189,21 +271,14 @@ function orderedChoiceOptions(
   deck: PracticeDeckData,
   polarity: ChoicePolarity,
 ): ChoiceOption[] {
-  const sameBand = deck.lexemes.filter(
-    (candidate) =>
-      candidate.lemmaId !== selection.lemma.lemmaId &&
-      candidate.cefr === selection.lemma.cefr &&
-      candidate.gloss !== selection.lemma.gloss,
-  );
-  const distractors = sameBand
-    .sort((left, right) => left.lemmaId.localeCompare(right.lemmaId))
-    .slice(0, 3);
-  if (distractors.length < 3) return [];
-  const answer = polarity === 'word-to-meaning' ? selection.lemma.gloss : selection.lemma.lemma;
+  if (!isMeaningMcEligible(selection.lemma)) return [];
+  const distractors = meaningDistractors(selection.lemma, deck, 3);
+  if (!distractors.length) return [];
+  const answer = polarity === 'word-to-meaning' ? glossLabel(selection.lemma) : selection.lemma.lemma;
   const options = [
     { label: answer, correct: true },
     ...distractors.map((entry) => ({
-      label: polarity === 'word-to-meaning' ? entry.gloss : entry.lemma,
+      label: polarity === 'word-to-meaning' ? glossLabel(entry) : entry.lemma,
       correct: false,
     })),
   ];
@@ -213,20 +288,49 @@ function orderedChoiceOptions(
   return options;
 }
 
-function matchingPairs(selection: PracticeSelection, deck: PracticeDeckData) {
-  const distractors = deck.lexemes
-    .filter(
-      (candidate) =>
-        candidate.lemmaId !== selection.lemma.lemmaId &&
-        candidate.cefr === selection.lemma.cefr &&
-        candidate.gloss !== selection.lemma.gloss,
+function meaningDistractors(
+  answer: PracticeLexeme,
+  deck: PracticeDeckData,
+  limit: number,
+): PracticeLexeme[] {
+  const answerHeadword = glossHeadword(answer);
+  const answerLength = glossLabel(answer).length;
+  const candidates = deck.lexemes.filter(
+    (candidate) =>
+      candidate.lemmaId !== answer.lemmaId &&
+      candidate.cefr === answer.cefr &&
+      isMeaningMcEligible(candidate) &&
+      glossHeadword(candidate) !== answerHeadword,
+  );
+  const samePos = candidates.filter((candidate) => candidate.pos === answer.pos);
+  const primary = samePos.length ? samePos : candidates;
+  const comparable = primary.filter(
+    (candidate) => Math.abs(glossLabel(candidate).length - answerLength) <= 12,
+  );
+  const seenLabels = new Set<string>();
+  return (comparable.length ? comparable : primary)
+    .sort(
+      (left, right) =>
+        Math.abs(glossLabel(left).length - answerLength) -
+          Math.abs(glossLabel(right).length - answerLength) ||
+        left.lemmaId.localeCompare(right.lemmaId),
     )
-    .sort((left, right) => left.lemmaId.localeCompare(right.lemmaId))
-    .slice(0, 3);
-  if (distractors.length < 3) return [];
+    .filter((entry) => {
+      const key = glossLabel(entry).toLocaleLowerCase('en-US');
+      if (seenLabels.has(key)) return false;
+      seenLabels.add(key);
+      return true;
+    })
+    .slice(0, limit);
+}
+
+function matchingPairs(selection: PracticeSelection, deck: PracticeDeckData) {
+  if (!isMeaningMcEligible(selection.lemma)) return [];
+  const distractors = meaningDistractors(selection.lemma, deck, 3);
+  if (!distractors.length) return [];
   return [selection.lemma, ...distractors].map((entry) => ({
     left: entry.lemma,
-    right: entry.gloss,
+    right: glossLabel(entry),
   }));
 }
 
@@ -234,7 +338,7 @@ function choicePrompt(selection: PracticeSelection): string {
   if (selection.choicePolarity === 'word-to-meaning') {
     return `What does ${selection.lemma.lemma} mean?`;
   }
-  return `Which word means ${selection.lemma.gloss}?`;
+  return `Which word means ${glossLabel(selection.lemma)}?`;
 }
 
 function clozeParts(item: PracticeClozeItem): [string, string] {

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -36,6 +36,8 @@ export interface PracticeLexeme {
   lemmaPlain: string;
   ipa: string | null;
   gloss: string;
+  glossClean?: string;
+  meaningMcEligible?: boolean;
   pos: string | null;
   cefr: string | null;
   heritage: string | null;

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -284,6 +284,45 @@ describe('LexiconPractice', () => {
     }
   });
 
+  test('choice backfills distractors across POS when same-POS pool is too small', () => {
+    // The answer (a verb) has only ONE same-POS peer, but four other eligible words
+    // exist. The old strict-subset logic discarded the cross-POS pool and starved the
+    // distractor list (<3) -> the card could not render. It must now backfill to a
+    // full 4-option card.
+    const lexemes = [
+      lexeme('bachyty', 'бачити', 'to see', { nominative: 'бачити', accusative: 'бачити', locative: 'бачити' }, { pos: 'verb' }),
+      lexeme('ity', 'іти', 'to go', { nominative: 'іти', accusative: 'іти', locative: 'іти' }, { pos: 'verb' }),
+      lexeme('sad', 'сад', 'garden', { nominative: 'сад', accusative: 'сад', locative: 'саду' }),
+      lexeme('dim', 'дім', 'house', { nominative: 'дім', accusative: 'дім', locative: 'домі' }),
+      lexeme('lis', 'ліс', 'forest', { nominative: 'ліс', accusative: 'ліс', locative: 'лісі' }),
+    ];
+    const deck: PracticeDeckData = {
+      deckVersion: 'test-small-pos-pool',
+      level: 'A1',
+      lexemes,
+      index: lexemes.map((entry, index) => ({
+        lemmaId: entry.lemmaId,
+        lemma: entry.lemma,
+        cefr: 'A1',
+        modes: ['flashcards', 'matching', 'choice'],
+        hasCloze: false,
+        clozeIds: [],
+        newOrder: index,
+      })),
+      cloze: [],
+    };
+    render(<LexiconPractice initialDeck={deck} autoStart initialMode="choice" />);
+    const choice = screen.getByTestId('practice-choice');
+    const labels = within(choice)
+      .getAllByRole('button')
+      .map((button) => button.textContent ?? '');
+    // First card is the small-POS verb (newOrder 0). Without cross-POS backfill it
+    // would starve (<3 distractors) and not render; it must show a full 4-option set.
+    expect(labels).toHaveLength(4);
+    // The verb answer is present whichever polarity the selector picked.
+    expect(labels.some((label) => label === 'бачити' || label === 'to see')).toBe(true);
+  });
+
   test('cloze wrong-case answer records one case miss and leaves blank open', async () => {
     seedRecognitionMastery('knyha');
     const user = userEvent.setup();

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LexiconPractice from '@site/src/components/LexiconPractice';
 import {
@@ -18,6 +18,7 @@ function lexeme(
   lemma: string,
   gloss: string,
   forms: { nominative: string; accusative: string; locative: string },
+  overrides: Partial<PracticeLexeme> = {},
 ): PracticeLexeme {
   return {
     lemmaId,
@@ -36,6 +37,7 @@ function lexeme(
         locative: { singular: forms.locative },
       },
     },
+    ...overrides,
   };
 }
 
@@ -127,6 +129,71 @@ function sampleDeck(): PracticeDeckData {
   };
 }
 
+function wordToMeaningDeck(): PracticeDeckData {
+  const lexemes = [
+    lexeme('sady', 'сад', 'garden', {
+      nominative: 'сад',
+      accusative: 'сад',
+      locative: 'саду',
+    }),
+    lexeme('dimy', 'дім', 'house', {
+      nominative: 'дім',
+      accusative: 'дім',
+      locative: 'домі',
+    }),
+    lexeme('lisy', 'ліс', 'forest', {
+      nominative: 'ліс',
+      accusative: 'ліс',
+      locative: 'лісі',
+    }),
+    lexeme('rich', 'річка', 'river', {
+      nominative: 'річка',
+      accusative: 'річку',
+      locative: 'річці',
+    }),
+    lexeme(
+      'taxy',
+      'та',
+      'and; but; while',
+      {
+        nominative: 'та',
+        accusative: 'та',
+        locative: 'та',
+      },
+      { glossClean: 'and', meaningMcEligible: false, pos: 'conj' },
+    ),
+    lexeme(
+      'ityx',
+      'іти',
+      'to go',
+      {
+        nominative: 'іти',
+        accusative: 'іти',
+        locative: 'іти',
+      },
+      { pos: 'verb' },
+    ),
+  ];
+  return {
+    deckVersion: 'test-choice-clean-glosses',
+    level: 'A1',
+    lexemes,
+    index: lexemes.map((entry, index) => ({
+      lemmaId: entry.lemmaId,
+      lemma: entry.lemma,
+      cefr: 'A1',
+      modes:
+        entry.meaningMcEligible === false
+          ? ['flashcards']
+          : ['flashcards', 'matching', 'choice'],
+      hasCloze: false,
+      clozeIds: [],
+      newOrder: index,
+    })),
+    cloze: [],
+  };
+}
+
 function storedState() {
   return JSON.parse(localStorage.getItem(SRS_STORAGE_KEY) ?? '{}');
 }
@@ -196,6 +263,25 @@ describe('LexiconPractice', () => {
         rating: 'good',
       });
     });
+  });
+
+  test('choice mode shows only clean same-pos meaning labels', () => {
+    render(<LexiconPractice initialDeck={wordToMeaningDeck()} autoStart initialMode="choice" />);
+    const choice = screen.getByTestId('practice-choice');
+
+    expect(screen.getByText('What does сад mean?')).toBeInTheDocument();
+    const labels = within(choice)
+      .getAllByRole('button')
+      .map((button) => button.textContent ?? '');
+
+    expect(new Set(labels)).toEqual(new Set(['garden', 'house', 'forest', 'river']));
+    expect(labels).not.toContain('and');
+    expect(labels).not.toContain('and; but; while');
+    expect(labels).not.toContain('to go');
+    for (const label of labels) {
+      expect(label).not.toMatch(/[?(]/);
+      expect(label.trim().split(/\s+/)).toHaveLength(1);
+    }
   });
 
   test('cloze wrong-case answer records one case miss and leaves blank open', async () => {

--- a/tests/fixtures/lexicon-practice-manifest.json
+++ b/tests/fixtures/lexicon-practice-manifest.json
@@ -260,8 +260,44 @@
               }
             }
           }
-        }
       }
     }
-  ]
+  },
+  {
+    "lemma": "та",
+    "url_slug": "ta",
+    "gloss": "and; but; while",
+    "pos": "conj",
+    "primary_source": "course_vocab",
+    "course_usage": [
+      {
+        "track": "a1",
+        "slug": "connectors"
+      }
+    ],
+    "enrichment": {
+      "cefr": {
+        "level": "A1"
+      }
+    }
+  },
+  {
+    "lemma": "борщ",
+    "url_slug": "borshch",
+    "gloss": "borshch",
+    "pos": "noun",
+    "primary_source": "course_vocab",
+    "course_usage": [
+      {
+        "track": "a1",
+        "slug": "food"
+      }
+    ],
+    "enrichment": {
+      "cefr": {
+        "level": "A1"
+      }
+    }
+  }
+]
 }

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -46,9 +46,9 @@ def test_fixture_build_emits_sharded_schema() -> None:
     assert a1["lexemes"]["schema"] == "atlas-practice-lexemes"
     assert a1["cloze"]["schema"] == "atlas-practice-cloze"
     assert a1["index"]["fixtureNote"] == "fixture sample"
-    assert a1["index"]["counts"]["lexemes"] == 5
+    assert a1["index"]["counts"]["lexemes"] == 7
     assert a1["index"]["counts"]["cloze"] == 2
-    assert a1["index"]["counts"]["clozeCoverage"] == 0.4
+    assert a1["index"]["counts"]["clozeCoverage"] == 0.2857
 
     lexeme = next(item for item in a1["lexemes"]["lexemes"] if item["lemmaId"] == "knyha")
     assert lexeme["lemma"] == "книга"
@@ -76,9 +76,35 @@ def test_reviewed_allowlist_and_vesum_ambiguity_fail_closed() -> None:
 def test_manifest_cloze_fields_are_ignored_without_curated_sources() -> None:
     shards = _build(cloze_sources_path=None)
 
-    assert shards["A1"]["index"]["counts"]["lexemes"] == 5
+    assert shards["A1"]["index"]["counts"]["lexemes"] == 7
     assert shards["A1"]["index"]["counts"]["cloze"] == 0
     assert shards["A1"]["cloze"]["cloze"] == []
+
+
+def test_meaning_mc_eligibility_marks_clean_and_messy_glosses() -> None:
+    shards = _build()
+    a1 = shards["A1"]
+    lexemes = {item["lemmaId"]: item for item in a1["lexemes"]["lexemes"]}
+    index_items = {item["lemmaId"]: item for item in a1["index"]["items"]}
+
+    assert lexemes["knyha"]["glossClean"] == "book"
+    assert lexemes["knyha"]["meaningMcEligible"] is True
+    assert {"matching", "choice"}.issubset(set(index_items["knyha"]["modes"]))
+
+    assert lexemes["ta"]["glossClean"] == "and"
+    assert lexemes["ta"]["meaningMcEligible"] is False
+    assert index_items["ta"]["modes"] == ["flashcards"]
+
+    assert lexemes["borshch"]["glossClean"] == "borshch"
+    assert lexemes["borshch"]["meaningMcEligible"] is False
+    assert index_items["borshch"]["modes"] == ["flashcards"]
+
+
+def test_option_set_validator_rejects_phrase_labels() -> None:
+    cloze = json.loads(json.dumps(_build()["A1"]["cloze"]["cloze"][0]))
+    cloze["options"][1]["label"] = "and yours? formal"
+
+    assert "option labels must not be phrase glosses" in validate_option_set(cloze)
 
 
 def test_real_manifest_shapes_still_yield_recognition_lexemes() -> None:

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -107,6 +107,29 @@ def test_option_set_validator_rejects_phrase_labels() -> None:
     assert "option labels must not be phrase glosses" in validate_option_set(cloze)
 
 
+def test_multi_sense_gloss_first_sense_is_meaning_mc_eligible() -> None:
+    # A multi-sense content word ("forest; woods") has a clean concise first sense and
+    # must stay eligible for Choice/Matching. The raw-gloss `;` check used to over-exclude
+    # any multi-sense gloss even when its first sense was a perfect single-concept meaning.
+    entries = [
+        {
+            "lemma": "ліс",
+            "url_slug": "lis",
+            "gloss": "forest; woods",
+            "pos": "noun",
+            "primary_source": "course_vocab",
+            "cefr": "A1",
+        },
+    ]
+    shards = build_practice_shards(
+        entries, ReviewedSourceAllowlist.from_payload([]), JsonVesumVerifier({})
+    )
+    lexeme = shards["A1"]["lexemes"]["lexemes"][0]
+    assert lexeme["glossClean"] == "forest"
+    assert lexeme["meaningMcEligible"] is True
+    assert {"matching", "choice"}.issubset(set(shards["A1"]["index"]["items"][0]["modes"]))
+
+
 def test_real_manifest_shapes_still_yield_recognition_lexemes() -> None:
     entries = [
         {


### PR DESCRIPTION
## Summary
- Add per-lexeme `glossClean` and `meaningMcEligible` in the practice deck generator.
- Keep phrase/function/transliteration glosses out of generated Choice/Matching modes while preserving flashcards.
- Update Practice Hub Choice/Matching to use only eligible clean meanings, prefer same-POS distractors, and avoid shared gloss headwords.
- Extend fixtures and tests for messy phrase glosses, transliteration-only glosses, clean Choice labels, and same-POS distractors.

## Finalizer note
This PR intentionally does not regenerate or fabricate the real 39MB practice deck. The finalizer/orchestrator should regenerate the real Atlas practice deck from the hydrated manifest and render-verify `/lexicon/practice/`.

## #M-4 evidence

### Pytest
Command:
```bash
.venv/bin/python -m pytest tests/test_generate_practice_deck.py -q
```
Raw final line:
```text
============================== 12 passed in 0.35s ==============================
```

### Ruff
Command:
```bash
.venv/bin/ruff check scripts/audit/generate_practice_deck.py
```
Raw output:
```text
All checks passed!
```

### Vitest
Command:
```bash
cd site && npm test
```
Raw final lines:
```text
 Test Files  26 passed (26)
      Tests  384 passed (384)
   Start at  01:05:21
   Duration  38.92s (transform 985ms, setup 1.52s, import 4.31s, tests 41.67s, environment 9.57s)
```

### Site lint script
Command:
```bash
cd site && node -p "require('./package.json').scripts.lint || 'NO_LINT_SCRIPT'"
```
Raw output:
```text
NO_LINT_SCRIPT
```

### Agent trailer audit
Command:
```bash
.venv/bin/python scripts/audit/lint_agent_trailer.py
```
Raw output:
```text
Checking 1 commit(s) in origin/main..HEAD:

  ac1a000c8a  PASS  X-Agent: codex/practice-gloss-quality

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

### Git log
Command:
```bash
git log -1 --format=fuller
```
Raw output:
```text
commit ac1a000c8adcc2482383dc285cb6ea77bf903562
Author:     Krisztian oos <krisztian.koos@gmail.com>
AuthorDate: Thu Jun 25 01:07:15 2026 +0200
Commit:     Krisztian oos <krisztian.koos@gmail.com>
CommitDate: Thu Jun 25 01:07:15 2026 +0200

    fix(atlas): practice hub — clean meaning-MC glosses (only concise single-sense meanings Choice/Matching options)

    X-Agent: codex/practice-gloss-quality
```

### Push
Command:
```bash
git push -u origin $(git branch --show-current)
```
Raw output:
```text
ruff (lint)..............................................................Passed
gitleaks (secret scan)...................................................Passed
check yaml syntax........................................................Passed
block accidentally large files...........................................Passed
check merge conflicts...................................................Passed
fix end files............................................................Passed
trim trailing whitespace.................................................Passed
warn on commits missing an X-Agent trailer...............................Passed
remote: 
remote: Create pull request 'codex/practice-gloss-quality' on GitHub by visiting:
remote:      https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/new/codex/practice-gloss-quality
remote: 
To github.com:learn-ukrainian/learn-ukrainian.github.io.git
 * [new branch]          codex/practice-gloss-quality -> codex/practice-gloss-quality
branch 'codex/practice-gloss-quality' set up to track 'origin/codex/practice-gloss-quality'.
```
