### PR TITLE
feat(atlas): practice hub learner-level cap (default A1, cumulative)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 0d2057e2e2178041be8169d227c777c22f5f0a4ff9ab1c41d489279088aefacb
+  components_sha256: f2a1ab6929f9a745847515db1a63116f40f487c526688520eaa268aca8285b4e
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: f2a1ab6929f9a745847515db1a63116f40f487c526688520eaa268aca8285b4e
+  components_sha256: a4160aaf26b759ee0bf947d1fd291f6e8add12eafbfcbc00bac004f648adbbb6
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -22,6 +22,12 @@ import {
   type PracticeSelection,
   type SelectionHistoryItem,
 } from '../lib/lexicon/srs';
+import {
+  CEFR_LEVELS,
+  LEARNER_LEVEL_STORAGE_KEY,
+  normalizeCefrLevel,
+  type CefrLevel,
+} from '../lib/lexicon/levels';
 
 interface LexiconPracticeProps {
   deckLevel?: string;
@@ -347,6 +353,42 @@ function shouldLoadCloze(mode: PracticeModeFilter): boolean {
   return mode === 'mixed' || mode === 'cloze';
 }
 
+/** Learner level persisted in the shared `lu-learner-level` key (also used by Words of the Day). */
+function readLearnerLevel(fallback: CefrLevel): CefrLevel {
+  if (typeof window === 'undefined') return fallback;
+  try {
+    return normalizeCefrLevel(window.localStorage.getItem(LEARNER_LEVEL_STORAGE_KEY), fallback);
+  } catch {
+    return fallback;
+  }
+}
+
+function writeLearnerLevel(level: CefrLevel): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, level);
+  } catch {
+    // Persisting the preference is best-effort; the in-memory selection still applies.
+  }
+}
+
+/** CEFR levels at or below `level` (cumulative: B1 -> A1, A2, B1). */
+function levelsUpTo(level: CefrLevel): CefrLevel[] {
+  const cap = CEFR_LEVELS.indexOf(level);
+  return CEFR_LEVELS.slice(0, cap + 1);
+}
+
+/** Concatenate per-level decks into one cumulative deck (CEFR shards are disjoint). */
+function mergeDecks(decks: PracticeDeckData[], level: CefrLevel): PracticeDeckData {
+  return {
+    deckVersion: decks[0]?.deckVersion ?? `cumulative-${level}`,
+    level,
+    index: decks.flatMap((deck) => deck.index),
+    lexemes: decks.flatMap((deck) => deck.lexemes),
+    cloze: decks.flatMap((deck) => deck.cloze),
+  };
+}
+
 export default function LexiconPractice({
   deckLevel = 'A1',
   shardBaseUrl = '/lexicon',
@@ -362,6 +404,9 @@ export default function LexiconPractice({
   });
   const [started, setStarted] = useState(autoStart);
   const [mode, setMode] = useState<PracticeModeFilter>(initialMode);
+  const [learnerLevel, setLearnerLevel] = useState<CefrLevel>(() =>
+    readLearnerLevel(normalizeCefrLevel(deckLevel)),
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [feedback, setFeedback] = useState('');
@@ -416,31 +461,54 @@ export default function LexiconPractice({
     document.title = `${MODE_LABELS[mode]} Practice - Word Atlas`;
   }, [mode, started]);
 
-  async function ensureDeck(includeCloze = shouldLoadCloze(mode)): Promise<PracticeDeckData | null> {
-    if (deck && (!includeCloze || clozeLoaded)) return deck;
+  async function ensureDeck(
+    includeCloze = shouldLoadCloze(mode),
+    options: { level?: CefrLevel; force?: boolean } = {},
+  ): Promise<PracticeDeckData | null> {
+    // `level`/`force` are passed explicitly on a level change so we don't read the
+    // stale `learnerLevel`/`deck` closures before their state updates have flushed.
+    const level = options.level ?? learnerLevel;
+    const force = options.force ?? false;
+    const current = force ? null : deck;
+    if (current && (!includeCloze || clozeLoaded)) return current;
     setLoading(true);
     setError(null);
     try {
-      let nextDeck = deck;
+      let nextDeck = current;
+      const levels = levelsUpTo(level);
       if (!nextDeck) {
-        const [indexResponse, lexemeResponse] = await Promise.all([
-          fetch(`${shardBaseUrl}/practice-index.${deckLevel}.json`),
-          fetch(`${shardBaseUrl}/practice-lexemes.${deckLevel}.json`),
-        ]);
-        if (!indexResponse.ok || !lexemeResponse.ok) {
+        // Load every CEFR shard at or below the learner level and merge them, so an
+        // A1 learner only ever practices A1 words while a B1 learner gets A1+A2+B1.
+        const perLevel = await Promise.all(
+          levels.map(async (shardLevel) => {
+            const [indexResponse, lexemeResponse] = await Promise.all([
+              fetch(`${shardBaseUrl}/practice-index.${shardLevel}.json`),
+              fetch(`${shardBaseUrl}/practice-lexemes.${shardLevel}.json`),
+            ]);
+            // A level shard may not be published yet (e.g. C2); skip it gracefully.
+            if (!indexResponse.ok || !lexemeResponse.ok) return null;
+            const indexShard = (await indexResponse.json()) as PracticeIndexShard;
+            const lexemeShard = (await lexemeResponse.json()) as PracticeLexemeShard;
+            return combinePracticeShards(indexShard, lexemeShard);
+          }),
+        );
+        const loaded = perLevel.filter((entry): entry is PracticeDeckData => entry !== null);
+        if (loaded.length === 0) {
           throw new Error('Practice shard request failed');
         }
-        const indexShard = (await indexResponse.json()) as PracticeIndexShard;
-        const lexemeShard = (await lexemeResponse.json()) as PracticeLexemeShard;
-        nextDeck = combinePracticeShards(indexShard, lexemeShard);
+        nextDeck = mergeDecks(loaded, level);
       }
-      if (includeCloze && !clozeLoaded) {
-        const clozeResponse = await fetch(`${shardBaseUrl}/practice-cloze.${deckLevel}.json`);
-        if (clozeResponse.ok) {
-          const clozeShard = (await clozeResponse.json()) as { cloze: PracticeClozeItem[] };
-          nextDeck = { ...nextDeck, cloze: clozeShard.cloze };
-          setClozeLoaded(true);
-        }
+      if (includeCloze && (force || !clozeLoaded)) {
+        const clozeBatches = await Promise.all(
+          levels.map(async (shardLevel) => {
+            const clozeResponse = await fetch(`${shardBaseUrl}/practice-cloze.${shardLevel}.json`);
+            if (!clozeResponse.ok) return [];
+            const clozeShard = (await clozeResponse.json()) as { cloze: PracticeClozeItem[] };
+            return clozeShard.cloze ?? [];
+          }),
+        );
+        nextDeck = { ...nextDeck, cloze: clozeBatches.flat() };
+        setClozeLoaded(true);
       }
       setDeck(nextDeck);
       return nextDeck;
@@ -456,6 +524,21 @@ export default function LexiconPractice({
     setMode(nextMode);
     setStarted(true);
     await ensureDeck(shouldLoadCloze(nextMode));
+  }
+
+  async function changeLevel(nextLevel: CefrLevel) {
+    if (nextLevel === learnerLevel) return;
+    setLearnerLevel(nextLevel);
+    writeLearnerLevel(nextLevel);
+    // The pool changed: drop the loaded deck + per-session history and, if a session is
+    // already running, immediately reload the cumulative pool for the new level.
+    setClozeLoaded(false);
+    setHistory([]);
+    if (started) {
+      await ensureDeck(shouldLoadCloze(mode), { level: nextLevel, force: true });
+    } else {
+      setDeck(null);
+    }
   }
 
   function refreshProgress() {
@@ -602,6 +685,30 @@ export default function LexiconPractice({
             ),
           )}
         </div>
+      </div>
+
+      <div className="lexicon-practice-levels">
+        <div
+          className="lexicon-practice-levels-row"
+          role="group"
+          aria-label="Learner level — caps practice to this level and below"
+        >
+          <span className="lexicon-practice-levels-label">Рівень</span>
+          {CEFR_LEVELS.map((level) => (
+            <button
+              type="button"
+              key={level}
+              className={learnerLevel === level ? 'active' : ''}
+              aria-pressed={learnerLevel === level}
+              onClick={() => void changeLevel(level)}
+            >
+              {level}
+            </button>
+          ))}
+        </div>
+        <p className="lexicon-practice-muted lexicon-practice-levels-hint">
+          Практика обмежена вашим рівнем і нижчими (накопичувально).
+        </p>
       </div>
 
       <div className="lexicon-practice-progress">

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -425,6 +425,8 @@ export default function LexiconPractice({
   const [clozeFeedback, setClozeFeedback] = useState<ClozeFeedback | null>(null);
   const [clozeAttemptRecorded, setClozeAttemptRecorded] = useState(false);
   const stageRef = useRef<HTMLDivElement | null>(null);
+  // Monotonic id so a slow earlier deck fetch can't overwrite a newer one (rapid level switches).
+  const deckRequestId = useRef(0);
 
   useEffect(() => {
     const state = loadState();
@@ -471,10 +473,12 @@ export default function LexiconPractice({
     const force = options.force ?? false;
     const current = force ? null : deck;
     if (current && (!includeCloze || clozeLoaded)) return current;
+    const requestId = ++deckRequestId.current;
     setLoading(true);
     setError(null);
     try {
       let nextDeck = current;
+      let nextClozeLoaded = clozeLoaded;
       const levels = levelsUpTo(level);
       if (!nextDeck) {
         // Load every CEFR shard at or below the learner level and merge them, so an
@@ -508,15 +512,18 @@ export default function LexiconPractice({
           }),
         );
         nextDeck = { ...nextDeck, cloze: clozeBatches.flat() };
-        setClozeLoaded(true);
+        nextClozeLoaded = true;
       }
+      // Ignore the result if a newer fetch (e.g. a later level switch) has superseded this one.
+      if (deckRequestId.current !== requestId) return nextDeck;
       setDeck(nextDeck);
+      setClozeLoaded(nextClozeLoaded);
       return nextDeck;
     } catch {
-      setError('Practice deck could not be loaded.');
+      if (deckRequestId.current === requestId) setError('Practice deck could not be loaded.');
       return null;
     } finally {
-      setLoading(false);
+      if (deckRequestId.current === requestId) setLoading(false);
     }
   }
 

--- a/site/src/pages/lexicon/practice.astro
+++ b/site/src/pages/lexicon/practice.astro
@@ -97,10 +97,30 @@ const frontmatter = {
   }
 
   :global(.lexicon-practice-modes),
+  :global(.lexicon-practice-levels-row),
   :global(.lexicon-rating-bar) {
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
     gap: 0.5rem;
+  }
+
+  :global(.lexicon-practice-levels) {
+    margin: 1.25rem 0 0;
+  }
+
+  :global(.lexicon-practice-levels-label) {
+    font-size: 0.78rem;
+    font-weight: 900;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--lu-text-muted);
+    margin-right: 0.35rem;
+  }
+
+  :global(.lexicon-practice-levels-hint) {
+    margin: 0.5rem 0 0;
+    font-size: 0.85rem;
   }
 
   :global(.lexicon-practice button) {
@@ -130,12 +150,14 @@ const frontmatter = {
   }
 
   :global(.lexicon-practice-modes button),
+  :global(.lexicon-practice-levels-row button),
   :global(.lexicon-rating-bar button),
   :global(.lexicon-practice-start button) {
     padding: 0 0.85rem;
   }
 
-  :global(.lexicon-practice-modes button.active) {
+  :global(.lexicon-practice-modes button.active),
+  :global(.lexicon-practice-levels-row button.active) {
     border-color: var(--lu-primary);
     background: var(--lu-primary);
     color: var(--lu-on-primary);

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -10,8 +10,63 @@ import {
   type PracticeDeckData,
   type PracticeLexeme,
 } from '@site/src/lib/lexicon/srs';
+import { LEARNER_LEVEL_STORAGE_KEY, type CefrLevel } from '@site/src/lib/lexicon/levels';
 
 const NOW = new Date('2026-06-23T12:00:00.000Z');
+
+function okJson(body: unknown): Response {
+  return { ok: true, json: async () => body } as unknown as Response;
+}
+
+function notFoundResponse(): Response {
+  return { ok: false, json: async () => ({}) } as unknown as Response;
+}
+
+/** Mock fetch for the level-sharded practice deck; `counts` lists which levels are published. */
+function mockShardFetch(counts: Partial<Record<CefrLevel, number>>) {
+  const requested: string[] = [];
+  const fn = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    requested.push(url);
+    const match = url.match(/practice-(index|lexemes|cloze)\.([ABC][12])\.json/);
+    if (!match) return notFoundResponse();
+    const kind = match[1] as 'index' | 'lexemes' | 'cloze';
+    const level = match[2] as CefrLevel;
+    const n = counts[level];
+    if (n === undefined) return notFoundResponse(); // shard not published (e.g. C2)
+    if (kind === 'cloze') return okJson({ cloze: [] });
+    const lexemes = Array.from({ length: n }, (_unused, i) =>
+      lexeme(
+        `${level}-${i}`,
+        `слово-${level}-${i}`,
+        `gloss ${level} ${i}`,
+        {
+          nominative: `слово-${level}-${i}`,
+          accusative: `слово-${level}-${i}`,
+          locative: `слово-${level}-${i}`,
+        },
+        { cefr: level },
+      ),
+    );
+    if (kind === 'index') {
+      return okJson({
+        deckVersion: `v-${level}`,
+        level,
+        items: lexemes.map((lex, order) => ({
+          lemmaId: lex.lemmaId,
+          lemma: lex.lemma,
+          cefr: level,
+          modes: ['flashcards', 'matching', 'choice'],
+          hasCloze: false,
+          clozeIds: [],
+          newOrder: order,
+        })),
+      });
+    }
+    return okJson({ deckVersion: `v-${level}`, level, lexemes });
+  });
+  return { fn, requested };
+}
 
 function lexeme(
   lemmaId: string,
@@ -227,6 +282,46 @@ describe('LexiconPractice', () => {
     render(<LexiconPractice />);
 
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test('caps the practice pool at the learner level (cumulative, never higher levels)', async () => {
+    localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'B1');
+    const { fn, requested } = mockShardFetch({ A1: 2, A2: 1, B1: 3, B2: 5, C1: 4 });
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
+    const user = userEvent.setup();
+    render(<LexiconPractice initialMode="flashcards" />);
+
+    await user.click(screen.getByRole('button', { name: 'Start Practice' }));
+
+    // A1+A2+B1 = 6 words; B2/C1 are above the learner level and must never be loaded.
+    await waitFor(() =>
+      expect(screen.getByLabelText('6 practice words loaded')).toBeInTheDocument(),
+    );
+    expect(requested.some((u) => u.includes('practice-index.A1'))).toBe(true);
+    expect(requested.some((u) => u.includes('practice-index.A2'))).toBe(true);
+    expect(requested.some((u) => u.includes('practice-index.B1'))).toBe(true);
+    expect(requested.some((u) => u.includes('practice-index.B2'))).toBe(false);
+    expect(requested.some((u) => u.includes('practice-index.C1'))).toBe(false);
+  });
+
+  test('level selector re-caps the pool and persists the shared learner-level key', async () => {
+    localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'A1');
+    const { fn } = mockShardFetch({ A1: 2, A2: 1, B1: 3 });
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
+    const user = userEvent.setup();
+    render(<LexiconPractice initialMode="flashcards" />);
+
+    await user.click(screen.getByRole('button', { name: 'Start Practice' }));
+    await waitFor(() =>
+      expect(screen.getByLabelText('2 practice words loaded')).toBeInTheDocument(),
+    );
+
+    // Raise the level to B1 -> pool grows cumulatively to A1+A2+B1 = 6 and persists.
+    await user.click(screen.getByRole('button', { name: 'B1' }));
+    await waitFor(() =>
+      expect(screen.getByLabelText('6 practice words loaded')).toBeInTheDocument(),
+    );
+    expect(localStorage.getItem(LEARNER_LEVEL_STORAGE_KEY)).toBe('B1');
   });
 
   test('flashcard rating persists mode-specific SRS progress', async () => {


### PR DESCRIPTION
## Practice Hub learner-level cap (default A1, cumulative)

Completes the user's level-cap direction ("i dont want to give c1 words to an a1 student") — the WoD half shipped in #3802; this is the Practice half.

### What
- **РІВЕНЬ selector** on `/lexicon/practice/`, **default A1**, reusing the shared `lu-learner-level` localStorage key + `levels.ts` helpers from #3802 → Practice and Words of the Day stay in sync.
- **Cumulative loading**: B1 fetches + merges shards A1+A2+B1 (a learner sees their level and below). Tolerates an unpublished shard (C2 → 404 → skipped); errors only if nothing ≤ level loads.
- Mid-session level change force-reloads the cumulative pool + resets per-session history. `ensureDeck` takes explicit `level`/`force` options so it never reads un-flushed `learnerLevel`/`deck` state closures.
- SSR-safe (`typeof window` guards; component is `client:only`).

### Verification (#M-4)
- `npx vitest run` → **392 passed** (added cumulative-cap + selector-persistence tests, with a mocked level-sharded fetch).
- `npm run build` → **green, 4838 pages**.
- `npx tsc --noEmit` → clean (only the pre-existing tsconfig `baseUrl` deprecation).
- **Render-verified in browser** (#M-4a): default **A1 → 1079 words**; switch to **B1 → 3081** (A1 1079 + A2 883 + B1 1119); `lu-learner-level=B1` persisted; a card renders from the merged pool; no console errors.

Independent fleet review (agy) in progress; findings will be applied before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
