### PR TITLE
fix(writer): pass folk framing to iterative writer

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -5806,6 +5806,7 @@ def run_llm_qg_with_corrections(
     use_generator: bool = False,
     obligation_checklist: Mapping[str, Any] | None = None,
     max_rounds: int | None = None,
+    framing_rules: str = "",
     corrector: Callable[[CorrectionContext], str | None] | None = None,
     python_qg_runner: Callable[[], dict[str, Any]] | None = None,
     invoker: Callable[..., Any] | None = None,
@@ -5926,6 +5927,7 @@ def run_llm_qg_with_corrections(
                 module_dir,
                 plan_path,
                 writer=writer,
+                framing_rules=framing_rules,
                 event_sink=event_sink,
             )
         else:
@@ -5969,6 +5971,7 @@ def run_python_qg_with_corrections(
     writer: str = "claude-tools",
     invoker: Callable[..., Any] | None = None,
     event_sink: Callable[..., None] | None = None,
+    framing_rules: str = "",
 ) -> dict[str, Any]:
     """Run Python QG with core legacy behavior and seminar best-round selection."""
     level = _python_qg_level_from_plan_path(plan_path)
@@ -5985,6 +5988,7 @@ def run_python_qg_with_corrections(
             writer=writer,
             invoker=invoker,
             event_sink=event_sink,
+            framing_rules=framing_rules,
             max_correction_rounds=python_qg_max_correction_rounds_for_level(level),
         )
     return _run_python_qg_with_legacy_single_shot_corrections(
@@ -6015,6 +6019,7 @@ def _run_python_qg_with_bounded_corrections(
     writer: str = "claude-tools",
     invoker: Callable[..., Any] | None = None,
     event_sink: Callable[..., None] | None = None,
+    framing_rules: str = "",
     max_correction_rounds: int = PYTHON_QG_SEMINAR_MAX_CORRECTION_ROUNDS,
 ) -> dict[str, Any]:
     """Run seminar Python QG with bounded corrections and restore the best round."""
@@ -6093,6 +6098,7 @@ def _run_python_qg_with_bounded_corrections(
                     writer=writer,
                     invoker=invoker,
                     section_attempts=iterative_section_attempts,
+                    framing_rules=framing_rules,
                 )
             )
         else:
@@ -11396,6 +11402,7 @@ def _apply_iterative_targeted_section_correction(
     invoke_fn: Callable[..., str] | None = None,
     section_attempts: dict[str, int] | None = None,
     max_attempts_per_section: int = ITERATIVE_SECTION_CORRECTION_RETRY_CAP,
+    framing_rules: str = "",
 ) -> tuple[bool, frozenset[str], dict[str, Any]]:
     sidecar = _load_iterative_sidecar(module_dir)
     if not sidecar:
@@ -11450,7 +11457,7 @@ def _apply_iterative_targeted_section_correction(
             },
         )
 
-    tasks = build_section_tasks(plan, "", [], framing_rules="")
+    tasks = build_section_tasks(plan, "", [], framing_rules=framing_rules)
     tasks_by_id = {task.section_id: task for task in tasks}
     artifacts_by_id = {artifact.section_id: artifact for artifact in artifacts}
     targets = _section_word_targets(plan)

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -916,6 +916,15 @@ def _plan_reading_section_map(plan: Mapping[str, Any]) -> Mapping[str, str] | No
     return None
 
 
+def _iterative_writer_framing_rules(plan: Mapping[str, Any], writer_mode: str) -> str:
+    if writer_mode != "iterative":
+        return ""
+    return linear_pipeline._seminar_folk_writer_rules(
+        str(plan.get("level", "")),
+        {"WORD_TARGET": plan.get("word_target", "")},
+    )
+
+
 def _iterative_writer_prompt_summary(result: Mapping[str, Any]) -> str:
     sidecar = result.get("sidecar", {})
     sections = sidecar.keys() if isinstance(sidecar, Mapping) else []
@@ -954,6 +963,7 @@ def _run_writer_mode(
     writer_cwd = PROJECT_ROOT if writer == "gemini-tools" else module_dir
     if writer_mode == "iterative":
         module_ref = f"{str(plan.get('level', '')).lower()}/{int(plan.get('sequence', 0))}"
+        framing_rules = _iterative_writer_framing_rules(plan, writer_mode)
         iterative_result = linear_pipeline.run_iterative_writer(
             plan,
             knowledge_packet,
@@ -964,6 +974,7 @@ def _run_writer_mode(
             implementation_map=implementation_map,
             obligation_checklist=obligation_checklist,
             reading_section_map=_plan_reading_section_map(plan),
+            framing_rules=framing_rules,
             cwd=writer_cwd,
             module=module_ref,
             tool_trace_path=module_dir / "writer_tool_calls.json",
@@ -1795,6 +1806,7 @@ def _run(args: argparse.Namespace) -> int:
         obligation_checklist: Mapping[str, Any] | None = None
         iterative_result: Mapping[str, Any] | None = None
         writer_mode = _writer_mode_from_env()
+        iterative_framing_rules = _iterative_writer_framing_rules(plan, writer_mode)
         if (
             resume_enabled
             and not force_rerun
@@ -1978,6 +1990,7 @@ def _run(args: argparse.Namespace) -> int:
                 module_dir,
                 plan_path,
                 writer=writer,
+                framing_rules=iterative_framing_rules,
             )
             linear_pipeline.write_json(module_dir / "python_qg.json", python_qg)
         _phase_done(
@@ -2130,6 +2143,7 @@ def _run(args: argparse.Namespace) -> int:
                     use_generator=use_generator,
                     obligation_checklist=obligation_checklist,
                     max_rounds=linear_pipeline.llm_qg_max_rounds_for_level(level),
+                    framing_rules=iterative_framing_rules,
                     event_sink=tracker.emit,
                     reviewer_samples=llm_qg_reviewer_samples,
                 )

--- a/tests/test_iterative_folk_reading_fences.py
+++ b/tests/test_iterative_folk_reading_fences.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from scripts.build import linear_pipeline, v7_build
+
+
+def _folk_plan() -> dict[str, Any]:
+    return {
+        "level": "folk",
+        "sequence": 1,
+        "module": 1,
+        "slug": "vesnianky-hayivky",
+        "title": "Веснянки й гаївки",
+        "word_target": 120,
+        "content_outline": [
+            {
+                "section": "Корпус і контекст",
+                "words": 80,
+                "points": ["Anchor the analysis in attested spring-song lines."],
+            },
+            {
+                "section": "Поетика",
+                "words": 40,
+                "points": ["Discuss formula and performance cues."],
+            },
+        ],
+        "readings": [
+            {
+                "reading_id": "vesnianky",
+                "title": "ВЕРБАТИМ примірники",
+                "text": "Ой весна, весна, днем красна... [S1]",
+            }
+        ],
+        "reading_section_map": {"vesnianky": "s1"},
+        "references": [{"id": "S1", "title": "Folk corpus"}],
+    }
+
+
+def _section_response(section_id: str, markdown: str) -> str:
+    metadata = {
+        "section_id": section_id,
+        "citations_used": [],
+        "primary_readings_used": [],
+        "vocab_candidates": [],
+        "activity_refs": [],
+        "self_check": {},
+    }
+    return (
+        f"````markdown file=section.md\n{markdown}\n````\n"
+        "```json file=section_artifact.json\n"
+        f"{json.dumps(metadata)}\n"
+        "```"
+    )
+
+
+def _write_iterative_module(module_dir: Path) -> None:
+    module_dir.mkdir(parents=True, exist_ok=True)
+    (module_dir / "module.md").write_text(
+        "## Корпус і контекст\n"
+        "one two three.\n"
+        "\n"
+        "## Поетика\n"
+        "alpha beta gamma delta.\n",
+        encoding="utf-8",
+    )
+    (module_dir / "iterative_writer_sidecar.json").write_text(
+        json.dumps(
+            {
+                "s1": {"line_start": 1, "line_end": 2},
+                "s2": {"line_start": 4, "line_end": 5},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_v7_iterative_writer_passes_folk_framing_rules(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, str] = {}
+
+    def fake_run_iterative_writer(*_args: Any, **kwargs: Any) -> dict[str, Any]:
+        captured["framing_rules"] = kwargs["framing_rules"]
+        return {"sidecar": {}}
+
+    monkeypatch.setattr(linear_pipeline, "run_iterative_writer", fake_run_iterative_writer)
+    monkeypatch.setattr(linear_pipeline, "iterative_result_to_writer_artifacts", lambda _result: {})
+    monkeypatch.setattr(linear_pipeline, "render_writer_artifacts_output", lambda _artifacts: "")
+
+    v7_build._run_writer_mode(
+        writer_mode="iterative",
+        plan=_folk_plan(),
+        plan_content="",
+        knowledge_packet="",
+        wiki_manifest={},
+        implementation_map={},
+        writer="codex",
+        module_dir=tmp_path,
+    )
+
+    assert captured["framing_rules"]
+    assert ":::primary-reading" in captured["framing_rules"]
+    assert "quote verbatim, never normalize archaic forms" in captured["framing_rules"]
+    assert v7_build._iterative_writer_framing_rules(_folk_plan(), "single_shot") == ""
+
+
+def test_iterative_folk_section_prompt_includes_primary_reading_rules() -> None:
+    plan = _folk_plan()
+    framing_rules = v7_build._iterative_writer_framing_rules(plan, "iterative")
+    tasks = linear_pipeline.build_section_tasks(
+        plan,
+        "knowledge packet",
+        plan["readings"],
+        reading_section_map=plan["reading_section_map"],
+        framing_rules=framing_rules,
+    )
+
+    prompt = linear_pipeline.render_section_writer_prompt(
+        plan=plan,
+        task=tasks[0],
+        knowledge_packet="knowledge packet",
+        readings=plan["readings"],
+    )
+
+    assert ":::primary-reading" in prompt
+    assert "quote verbatim" in prompt
+    assert "never normalize archaic forms" in prompt
+
+
+def test_targeted_correction_rebuilds_tasks_with_folk_framing_rules(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    plan = _folk_plan()
+    plan["content_outline"][1]["words"] = 4
+    framing_rules = v7_build._iterative_writer_framing_rules(plan, "iterative")
+    module_dir = tmp_path / "module"
+    _write_iterative_module(module_dir)
+    captured_rules: list[str] = []
+    prompts: list[str] = []
+    original_build_section_tasks = linear_pipeline.build_section_tasks
+
+    def spy_build_section_tasks(*args: Any, **kwargs: Any) -> list[linear_pipeline.SectionTask]:
+        captured_rules.append(kwargs.get("framing_rules", ""))
+        return original_build_section_tasks(*args, **kwargs)
+
+    def invoke_fn(prompt: str, writer: str, **_kwargs: Any) -> str:
+        assert writer == "codex"
+        prompts.append(prompt)
+        return _section_response(
+            "s1",
+            "one two three four five six seven eight nine ten eleven twelve.",
+        )
+
+    monkeypatch.setattr(linear_pipeline, "plan_check", lambda _path: plan)
+    monkeypatch.setattr(linear_pipeline, "build_section_tasks", spy_build_section_tasks)
+
+    handled, _unmatched, payload = linear_pipeline._apply_iterative_targeted_section_correction(
+        "word_count",
+        {"gates": {"word_count": {"passed": False, "count": 7, "target": 120}}},
+        module_dir=module_dir,
+        plan_path=tmp_path / "plan.yaml",
+        writer="codex",
+        invoke_fn=invoke_fn,
+        section_attempts={},
+        framing_rules=framing_rules,
+    )
+
+    assert handled is True
+    assert payload["selected_section_ids"] == ["s1"]
+    assert captured_rules == [framing_rules]
+    assert captured_rules[0]
+    assert ":::primary-reading" in prompts[0]
+    assert "never normalize archaic forms" in prompts[0]


### PR DESCRIPTION
Summary
- Compute seminar/FOLK framing rules for iterative writer mode in v7_build.py and pass them into run_iterative_writer.
- Thread the same framing rules through Python QG and LLM-QG correction paths so iterative targeted section rewrites rebuild tasks with primary-reading rules intact.
- Add offline tests for v7 framing propagation, rendered section prompts, and targeted correction task rebuilding.

Tests
- .venv/bin/python -m py_compile scripts/build/v7_build.py scripts/build/linear_pipeline.py tests/test_iterative_folk_reading_fences.py
- .venv/bin/python -m pytest -q tests/test_iterative_folk_reading_fences.py tests/test_iterative_overshoot_prompt.py tests/test_iterative_targeted_correction.py tests/test_iterative_activity_generation.py tests/test_iterative_vocab_merge.py tests/test_iterative_section_parse.py
- .venv/bin/ruff check scripts/build/v7_build.py scripts/build/linear_pipeline.py tests/test_iterative_folk_reading_fences.py
- .venv/bin/python scripts/audit/lint_agent_trailer.py

Notes
- Defense-in-depth VESUM hardening for primary-reading blocks is deferred as a follow-up; the current VESUM construction already has heritage-attestation stripping interactions, so I kept this PR to the required prompt/correction plumbing.