### PR TITLE
[codex] fix iterative scaffolding leaks

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -9969,6 +9969,18 @@ def render_section_writer_prompt(
         "plan title as an H2.",
         "- Start `markdown` with the section body. In-body subheadings are "
         "allowed after body text when useful.",
+        *(
+            [
+                "- `[S#]`/`[С#]` source markers, Knowledge Packet anchors, "
+                "`truth_source:`, `self_check:`, section ids, ledger notes, "
+                "`knowledge_packet`, `implementation_map`, and `wiki_manifest` "
+                "names are internal scaffolding. Never print them in published "
+                "`section.md` prose or primary-reading blocks; use natural "
+                "attribution instead.",
+            ]
+            if str(plan.get("level", "")).lower() in SEMINAR_LEVELS
+            else []
+        ),
         "",
         "## Points To Cover",
         point_lines,
@@ -11014,6 +11026,17 @@ def _artifact_sidecar_entry(
 
 
 _ITERATIVE_LEADING_SECTION_HEADING_RE = re.compile(r"^\s{0,3}#{1,3}(?:\s+|$)")
+_ITERATIVE_SCAFFOLDING_SOURCE_MARKER_RE = re.compile(
+    r"\[[SС]\d+(?:\s*,\s*[SС]\d+)*\]"
+)
+_ITERATIVE_SCAFFOLDING_FIELD_LINE_RE = re.compile(
+    r"^\s*(?:"
+    r"truth_source|claim_source|self_check|section_id|ledger|"
+    r"knowledge_packet|implementation_map|wiki_manifest|"
+    r"citations_used|primary_readings_used|vocab_candidates|activity_refs"
+    r")\s*:\s*.*$",
+    re.IGNORECASE,
+)
 
 
 def _strip_leading_iterative_section_headings(markdown: str) -> str:
@@ -11038,6 +11061,31 @@ def _canonical_iterative_section_markdown(markdown: str, title: str) -> str:
     return f"{heading}\n\n{body}"
 
 
+def _strip_iterative_scaffolding_leaks(markdown: str) -> str:
+    cleaned_lines: list[str] = []
+    in_primary_reading = False
+
+    for line in markdown.splitlines(keepends=True):
+        stripped = line.strip()
+        if stripped.startswith(":::primary-reading"):
+            in_primary_reading = True
+            cleaned_lines.append(line)
+            continue
+        if in_primary_reading:
+            cleaned_lines.append(line)
+            if stripped == ":::":
+                in_primary_reading = False
+            continue
+        if _ITERATIVE_SCAFFOLDING_FIELD_LINE_RE.match(line):
+            continue
+        clean_line = _ITERATIVE_SCAFFOLDING_SOURCE_MARKER_RE.sub("", line)
+        clean_line = re.sub(r"\s+([,.;:!?])", r"\1", clean_line)
+        clean_line = re.sub(r" {2,}", " ", clean_line)
+        cleaned_lines.append(clean_line)
+
+    return "".join(cleaned_lines)
+
+
 def assemble_iterative(
     artifacts: Sequence[SectionArtifact],
     plan: Mapping[str, Any],
@@ -11059,6 +11107,8 @@ def assemble_iterative(
             artifact.markdown,
             section_title,
         )
+        if str(plan.get("level", "")).lower() in SEMINAR_LEVELS:
+            section_markdown = _strip_iterative_scaffolding_leaks(section_markdown)
         section_lines = section_markdown.splitlines() or [""]
         line_start = next_line
         line_end = line_start + len(section_lines) - 1

--- a/tests/test_iterative_scaffolding_leak.py
+++ b/tests/test_iterative_scaffolding_leak.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from typing import Any
+
+from scripts.build import linear_pipeline
+
+
+def _plan() -> dict[str, Any]:
+    return {
+        "level": "folk",
+        "sequence": 1,
+        "module": 1,
+        "slug": "vesnianky-hayivky",
+        "title": "Веснянки й гаївки",
+        "content_outline": [
+            {
+                "section": "Корпус і контекст",
+                "words": 20,
+                "points": ["Anchor analysis in attested spring-song lines."],
+            }
+        ],
+    }
+
+
+def _artifact(markdown: str) -> linear_pipeline.SectionArtifact:
+    return linear_pipeline.SectionArtifact(
+        section_id="s1",
+        markdown=markdown,
+        citations_used=[],
+        primary_readings_used=[],
+        vocab_candidates=[],
+        activity_refs=[],
+        self_check={},
+    )
+
+
+def test_assemble_iterative_strips_source_markers_and_metadata_lines() -> None:
+    result = linear_pipeline.assemble_iterative(
+        [
+            _artifact(
+                "\n".join(
+                    [
+                        "Веснянкова строфа подана як корпусний приклад [S4].",
+                        'truth_source: "Сучасна фольклористика; vesnianky-hayivky.md [S4]"',
+                        "У прозі лишається природна атрибуція до корпусу.",
+                    ]
+                )
+            )
+        ],
+        _plan(),
+        activities=[],
+    )
+
+    module_md = str(result["module_md"])
+
+    assert "[S4]" not in module_md
+    assert "truth_source:" not in module_md
+    assert "Веснянкова строфа подана як корпусний приклад." in module_md
+    assert "У прозі лишається природна атрибуція до корпусу." in module_md
+    assert linear_pipeline._scaffolding_leak_gate(module_md)["passed"] is True
+
+
+def test_assemble_iterative_preserves_primary_reading_blocks_verbatim() -> None:
+    primary_reading = "\n".join(
+        [
+            ":::primary-reading",
+            "> Ой весна, весна, днем красна... [S4]",
+            'truth_source: "kept because this line is inside the quoted block"',
+            ":::",
+        ]
+    )
+
+    result = linear_pipeline.assemble_iterative(
+        [_artifact(f"Пояснення має зайвий маркер [S3].\n\n{primary_reading}")],
+        _plan(),
+        activities=[],
+    )
+
+    module_md = str(result["module_md"])
+
+    assert primary_reading in module_md
+    assert "Пояснення має зайвий маркер." in module_md
+
+
+def test_assemble_iterative_leaves_core_sections_unchanged() -> None:
+    plan = _plan()
+    plan["level"] = "a1"
+
+    result = linear_pipeline.assemble_iterative(
+        [
+            _artifact(
+                "\n".join(
+                    [
+                        "Core prose keeps its prior assembly behavior [S4].",
+                        'truth_source: "unchanged outside seminar/FOLK"',
+                    ]
+                )
+            )
+        ],
+        plan,
+        activities=[],
+    )
+
+    module_md = str(result["module_md"])
+
+    assert "[S4]" in module_md
+    assert 'truth_source: "unchanged outside seminar/FOLK"' in module_md
+
+
+def test_render_section_writer_prompt_marks_scaffolding_internal() -> None:
+    task = linear_pipeline.SectionTask(
+        section_id="s1",
+        title="Корпус і контекст",
+        word_budget=20,
+        points=["Anchor analysis in attested spring-song lines."],
+        assigned_readings=[],
+        knowledge_slice="",
+        framing_rules=":::primary-reading\n> Ой весна... [S4]\n:::",
+        ledger=linear_pipeline.Ledger(),
+    )
+
+    prompt = linear_pipeline.render_section_writer_prompt(
+        plan=_plan(),
+        task=task,
+        knowledge_packet="",
+        readings=[],
+    )
+
+    assert "[S#]`/`[С#]` source markers" in prompt
+    assert "Never print them in published `section.md` prose" in prompt
+    assert "`truth_source:`" in prompt
+
+
+def test_render_section_writer_prompt_leaves_core_prompt_unchanged() -> None:
+    plan = _plan()
+    plan["level"] = "a1"
+    task = linear_pipeline.SectionTask(
+        section_id="s1",
+        title="Корпус і контекст",
+        word_budget=20,
+        points=["Anchor analysis in attested spring-song lines."],
+        assigned_readings=[],
+        knowledge_slice="",
+        framing_rules="",
+        ledger=linear_pipeline.Ledger(),
+    )
+
+    prompt = linear_pipeline.render_section_writer_prompt(
+        plan=plan,
+        task=task,
+        knowledge_packet="",
+        readings=[],
+    )
+
+    assert "[S#]`/`[С#]` source markers" not in prompt


### PR DESCRIPTION
## What changed
- Added an explicit seminar/FOLK-only iterative section-writer rule that `[S#]` / `[С#]` source markers and sidecar-style fields are internal scaffolding, not published module text.
- Added an `assemble_iterative` safety net for seminar/FOLK plans that strips leaked source markers and bare scaffold metadata-field lines from assembled section prose.
- Preserved `:::primary-reading` blocks verbatim in the safety net so citation/reading-sensitive quoted content is not mutated by assembly.
- Added regression coverage for leaked prose markers, leaked `truth_source:` lines, primary-reading preservation, prompt discipline, and CORE non-seminar unchanged behavior.

## Why
PR #3807 started passing seminar/FOLK framing rules into the iterative writer. Those rules include dossier examples with internal `[S#]` source tags, and the iterative path lacked the single-shot prompt discipline that keeps writer scaffolding out of published prose.

## Validation
- `.venv/bin/python -m py_compile scripts/build/linear_pipeline.py tests/test_iterative_scaffolding_leak.py` → `py_compile_exit:0`
- `.venv/bin/python -m pytest tests/test_iterative_scaffolding_leak.py tests/test_iterative_folk_reading_fences.py tests/test_iterative_overshoot_prompt.py tests/test_iterative_targeted_correction.py tests/test_iterative_section_parse.py tests/test_reading_coverage_gate.py tests/test_citation_matcher.py tests/test_citation_resolve.py tests/test_citation_resolution_gate.py tests/test_citation_whitespace.py tests/test_citation_resolution_invariant.py tests/test_wiki_compile_citation_alignment.py tests/test_citation_check.py -q` → `221 passed in 9.05s`
- `.venv/bin/ruff check scripts/build/linear_pipeline.py tests/test_iterative_scaffolding_leak.py` → `All checks passed!`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` → `All 11 non-skipped commit(s) carry an X-Agent trailer.`

No real `v7_build.py` build was run per dispatch brief.
