### PR TITLE
feat(gate): per-module plan-declared vesum_exemptions for seminar/folk

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -9912,9 +9912,17 @@ def _foreign_proper_noun_attestation_urls(row: Mapping[str, Any]) -> list[str]:
     return []
 
 
+_UK_WIKI_ARTICLE_PREFIX = "https://uk.wikipedia.org/wiki/"
+
+
 def _foreign_proper_noun_attestation_is_valid(row: Mapping[str, Any]) -> bool:
+    # Require a non-empty article slug after the prefix: the degenerate
+    # "https://uk.wikipedia.org/wiki/" (no article) must NOT validate, so a
+    # plan-declared foreign_cultural_terms exemption cannot be blessed with a
+    # placeholder URL that points at no real page.
     return any(
-        url.startswith("https://uk.wikipedia.org/wiki/")
+        url.startswith(_UK_WIKI_ARTICLE_PREFIX)
+        and url[len(_UK_WIKI_ARTICLE_PREFIX) :].strip("/").strip() != ""
         for url in _foreign_proper_noun_attestation_urls(row)
     )
 
@@ -10017,6 +10025,14 @@ def _span_surface_lc(span_texts: Iterable[str]) -> set[str]:
 
 _BACKTICK_SPAN_RE = re.compile(r"`([^`]*)`")
 
+# A legitimate inline «…» citation in seminar/folk prose is short (the longest
+# across all shipped folk modules is ~65 chars; verbatim verse lives in stripped
+# :::primary-reading fences, not inline guillemets). An unbalanced «  paired with
+# a far-later » by the stack below would otherwise yield a runaway span that
+# falsely marks an un-quoted token as quoted (→ a false exemption). Bounding the
+# span length cleanly separates real citations from such parse artifacts.
+_MAX_GUILLEMET_SPAN_CHARS = 200
+
 
 def _guillemet_span_texts(module_text: str) -> list[str]:
     spans: list[str] = []
@@ -10025,7 +10041,9 @@ def _guillemet_span_texts(module_text: str) -> list[str]:
         if char == "«":
             starts.append(index + 1)
         elif char == "»" and starts:
-            spans.append(module_text[starts.pop() : index])
+            start = starts.pop()
+            if index - start <= _MAX_GUILLEMET_SPAN_CHARS:
+                spans.append(module_text[start:index])
     return spans
 
 

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -24,7 +24,7 @@ import tempfile
 import unicodedata
 import urllib.parse
 import xml.etree.ElementTree as ET
-from collections.abc import Callable, Collection, Mapping, Sequence
+from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
@@ -8416,6 +8416,7 @@ def run_python_qg(
             verify_words_fn=verify_words_fn,
             level=level,
             ignored_missing_surfaces=ignored_vesum_missing_surfaces,
+            plan_vesum_exemptions=plan.get("vesum_exemptions"),
         ),
     )
     record(
@@ -9997,6 +9998,165 @@ def _resolve_foreign_proper_noun_attested_missing(
     return attested
 
 
+_PLAN_VESUM_EXEMPTION_CATEGORIES: tuple[str, ...] = (
+    "foreign_cultural_terms",
+    "quoted_critical_terms",
+    "corpus_attested_quotes",
+)
+
+
+def _span_surface_lc(span_texts: Iterable[str]) -> set[str]:
+    surfaces: set[str] = set()
+    for span_text in span_texts:
+        for word in _iter_vesum_word_surfaces(_normalize_for_vesum(span_text)):
+            normalized = _normalize_for_vesum(word).lower()
+            if normalized:
+                surfaces.add(normalized)
+    return surfaces
+
+
+_BACKTICK_SPAN_RE = re.compile(r"`([^`]*)`")
+
+
+def _guillemet_span_texts(module_text: str) -> list[str]:
+    spans: list[str] = []
+    starts: list[int] = []
+    for index, char in enumerate(module_text):
+        if char == "«":
+            starts.append(index + 1)
+        elif char == "»" and starts:
+            spans.append(module_text[starts.pop() : index])
+    return spans
+
+
+def _backtick_span_texts(module_text: str) -> list[str]:
+    return [match.group(1) for match in _BACKTICK_SPAN_RE.finditer(module_text)]
+
+
+def _quoted_surface_lc(module_text: str) -> set[str]:
+    """Return normalized-lowercase surfaces quoted in guillemets or backticks."""
+    return _span_surface_lc(_guillemet_span_texts(module_text)) | _span_surface_lc(
+        _backtick_span_texts(module_text)
+    )
+
+
+def _guillemet_surface_lc(module_text: str) -> set[str]:
+    return _span_surface_lc(_guillemet_span_texts(module_text))
+
+
+def _plan_vesum_exemption_surfaces_lc(
+    category: str,
+    entry: Mapping[str, Any],
+    index: int,
+) -> set[str]:
+    term = entry.get("term")
+    if not isinstance(term, str) or not term.strip():
+        raise ValueError(f"vesum_exemptions.{category}[{index}] missing non-empty term")
+
+    forms = entry.get("forms")
+    if not isinstance(forms, list):
+        raise ValueError(f"vesum_exemptions.{category}[{index}] missing forms list")
+
+    rationale = entry.get("rationale")
+    if not isinstance(rationale, str) or not rationale.strip():
+        raise ValueError(
+            f"vesum_exemptions.{category}[{index}] missing non-empty rationale"
+        )
+
+    if category == "foreign_cultural_terms":
+        wikipedia_url = entry.get("wikipedia_url")
+        if (
+            not isinstance(wikipedia_url, str)
+            or not wikipedia_url.strip()
+            or not _foreign_proper_noun_attestation_is_valid(entry)
+        ):
+            raise ValueError(
+                f"vesum_exemptions.{category}[{index}] "
+                "missing valid uk.wikipedia.org wikipedia_url"
+            )
+
+    if category == "corpus_attested_quotes":
+        source_chunk = entry.get("source_chunk")
+        if not isinstance(source_chunk, str) or not source_chunk.strip():
+            raise ValueError(
+                f"vesum_exemptions.{category}[{index}] missing non-empty source_chunk"
+            )
+
+    surfaces = {_normalize_for_vesum(term).lower()}
+    for form_index, form in enumerate(forms):
+        if not isinstance(form, str):
+            raise ValueError(
+                f"vesum_exemptions.{category}[{index}].forms[{form_index}] must be string"
+            )
+        normalized = _normalize_for_vesum(form).lower()
+        if not normalized:
+            raise ValueError(
+                f"vesum_exemptions.{category}[{index}].forms[{form_index}] is empty"
+            )
+        surfaces.add(normalized)
+    if "" in surfaces:
+        raise ValueError(f"vesum_exemptions.{category}[{index}] has empty term")
+    return surfaces
+
+
+def _resolve_plan_declared_vesum_exemptions(
+    missing_lc: set[str],
+    unchecked_pairs: Sequence[tuple[str, str, str]],
+    module_text: str,
+    plan_vesum_exemptions: Mapping[str, Any] | None,
+) -> tuple[set[str], dict[str, list[str]]]:
+    if plan_vesum_exemptions is None:
+        return set(), {category: [] for category in _PLAN_VESUM_EXEMPTION_CATEGORIES}
+    if not isinstance(plan_vesum_exemptions, Mapping):
+        raise ValueError("vesum_exemptions must be a mapping")
+
+    unknown_categories = sorted(
+        set(plan_vesum_exemptions) - set(_PLAN_VESUM_EXEMPTION_CATEGORIES)
+    )
+    if unknown_categories:
+        raise ValueError(
+            "vesum_exemptions contains unknown categories: "
+            + ", ".join(unknown_categories)
+        )
+
+    quoted_lc: set[str] | None = None
+    guillemet_lc: set[str] | None = None
+    by_category_lc: dict[str, set[str]] = {
+        category: set() for category in _PLAN_VESUM_EXEMPTION_CATEGORIES
+    }
+
+    for category in _PLAN_VESUM_EXEMPTION_CATEGORIES:
+        rows = plan_vesum_exemptions.get(category, [])
+        if not isinstance(rows, list):
+            raise ValueError(f"vesum_exemptions.{category} must be a list")
+        for index, row in enumerate(rows):
+            if not isinstance(row, Mapping):
+                raise ValueError(f"vesum_exemptions.{category}[{index}] must be a mapping")
+            declared_lc = _plan_vesum_exemption_surfaces_lc(category, row, index)
+            candidates = declared_lc & missing_lc
+            if category == "quoted_critical_terms":
+                if guillemet_lc is None:
+                    guillemet_lc = _guillemet_surface_lc(module_text)
+                candidates &= guillemet_lc
+            elif category == "corpus_attested_quotes":
+                if quoted_lc is None:
+                    quoted_lc = _quoted_surface_lc(module_text)
+                candidates &= quoted_lc
+            by_category_lc[category].update(candidates)
+
+    exempted_lc = set().union(*by_category_lc.values())
+    by_category_words: dict[str, list[str]] = {}
+    for category, category_lc in by_category_lc.items():
+        by_category_words[category] = sorted(
+            {
+                surface
+                for surface, lower, _original in unchecked_pairs
+                if lower in category_lc
+            }
+        )
+    return exempted_lc, by_category_words
+
+
 _HERITAGE_AUTHENTIC_CLASSIFICATIONS = frozenset(
     {"authentic-archaism", "dialect", "historism", "borrowing", "standard"}
 )
@@ -10207,6 +10367,7 @@ def _vesum_gate(
     verify_words_fn: Callable[[list[str]], dict[str, list[dict[str, Any]]]] | None,
     level: str | None = None,
     ignored_missing_surfaces: Collection[str] = (),
+    plan_vesum_exemptions: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Verify Ukrainian words against VESUM, walking artifacts structurally.
 
@@ -10460,7 +10621,28 @@ def _vesum_gate(
                 "error": str(exc),
                 "checked": len(unchecked_pairs),
             }
-        missing_lc -= heritage_attested_lc
+    missing_lc -= heritage_attested_lc
+    plan_exempted_lc: set[str] = set()
+    plan_exempted_by_category: dict[str, list[str]] = {
+        category: [] for category in _PLAN_VESUM_EXEMPTION_CATEGORIES
+    }
+    if _vesum_heritage_attestation_enabled(level) and plan_vesum_exemptions is not None:
+        try:
+            plan_exempted_lc, plan_exempted_by_category = (
+                _resolve_plan_declared_vesum_exemptions(
+                    missing_lc,
+                    unchecked_pairs,
+                    module_text,
+                    plan_vesum_exemptions,
+                )
+            )
+        except Exception as exc:
+            return {
+                "passed": False,
+                "error": str(exc),
+                "checked": len(unchecked_pairs),
+            }
+    missing_lc -= plan_exempted_lc
     missing = sorted(
         {
             surface
@@ -10474,6 +10656,9 @@ def _vesum_gate(
     )
     foreign_proper_attested_words = sorted(
         {surface for surface, lower, _original in unchecked_pairs if lower in foreign_proper_attested_lc}
+    )
+    plan_exempted_words = sorted(
+        {surface for words in plan_exempted_by_category.values() for surface in words}
     )
     ignored_missing_lc = _vesum_missing_exclusion_keys(
         ignored_missing_surfaces,
@@ -10489,6 +10674,11 @@ def _vesum_gate(
         "heritage_attested_words": heritage_attested_words[:100],
         "foreign_proper_noun_attested": len(foreign_proper_attested_words),
         "foreign_proper_noun_attested_words": foreign_proper_attested_words[:100],
+        "plan_exempted": len(plan_exempted_words),
+        "plan_exempted_words": plan_exempted_words[:100],
+        "plan_exempted_by_category": {
+            category: words[:100] for category, words in plan_exempted_by_category.items()
+        },
         "missing": missing[:100],
         "missing_count": len(missing),
     }

--- a/tests/test_vesum_plan_exemptions.py
+++ b/tests/test_vesum_plan_exemptions.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from scripts.build import linear_pipeline
+
+
+def _rejecting_verifier(
+    missing_surfaces: set[str],
+) -> Callable[[list[str]], dict[str, list[dict[str, str]]]]:
+    missing_lc = {
+        linear_pipeline._normalize_for_vesum(surface).lower()
+        for surface in missing_surfaces
+    }
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        return {
+            word: (
+                []
+                if linear_pipeline._normalize_for_vesum(word).lower() in missing_lc
+                else [{"lemma": word}]
+            )
+            for word in words
+        }
+
+    return verify_words
+
+
+def _disable_existing_attestations(monkeypatch: pytest.MonkeyPatch) -> None:
+    def no_attested_missing(
+        missing_lc: set[str],
+        unchecked_pairs: list[tuple[str, str, str]],
+    ) -> set[str]:
+        return set()
+
+    monkeypatch.setattr(
+        linear_pipeline,
+        "_resolve_foreign_proper_noun_attested_missing",
+        no_attested_missing,
+    )
+    monkeypatch.setattr(
+        linear_pipeline,
+        "_resolve_folk_heritage_attested_missing",
+        no_attested_missing,
+    )
+
+
+def _gate(
+    text: str,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    missing_surfaces: set[str],
+    plan: dict[str, Any] | None = None,
+    level: str = "folk",
+) -> dict[str, Any]:
+    _disable_existing_attestations(monkeypatch)
+    return linear_pipeline._vesum_gate(
+        module_text=text,
+        activities=[],
+        vocabulary=[],
+        resources=[],
+        verify_words_fn=_rejecting_verifier(missing_surfaces),
+        level=level,
+        plan_vesum_exemptions=plan,
+    )
+
+
+def test_foreign_cultural_terms_exempt_titlecase_and_lowercase_hanami(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = {
+        "foreign_cultural_terms": [
+            {
+                "term": "Белтейн",
+                "forms": ["Белтейн", "Белтейном"],
+                "wikipedia_url": "https://uk.wikipedia.org/wiki/Белтейн",
+                "rationale": "кельтське весняне свято",
+            },
+            {
+                "term": "ханамі",
+                "forms": ["ханамі"],
+                "wikipedia_url": "https://uk.wikipedia.org/wiki/Ханамі",
+                "rationale": "японський звичай милування квітами",
+            },
+        ]
+    }
+
+    gate = _gate(
+        "Белтейн Белтейном ханамі",
+        monkeypatch,
+        missing_surfaces={"Белтейн", "Белтейном", "ханамі"},
+        plan=plan,
+    )
+
+    assert gate["passed"] is True
+    assert gate["missing"] == []
+    assert gate["plan_exempted"] == 3
+    assert set(gate["plan_exempted_by_category"]["foreign_cultural_terms"]) == {
+        "Белтейн",
+        "Белтейном",
+        "ханамі",
+    }
+
+
+def test_foreign_cultural_terms_fail_closed_without_valid_ukwiki_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = {
+        "foreign_cultural_terms": [
+            {
+                "term": "Белтейн",
+                "forms": ["Белтейн"],
+                "wikipedia_url": "https://example.invalid/Белтейн",
+                "rationale": "кельтське весняне свято",
+            }
+        ]
+    }
+
+    gate = _gate(
+        "Белтейн",
+        monkeypatch,
+        missing_surfaces={"Белтейн"},
+        plan=plan,
+    )
+
+    assert gate["passed"] is False
+    assert "wikipedia_url" in str(gate["error"])
+
+
+def test_quoted_critical_terms_require_guillemet_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = {
+        "quoted_critical_terms": [
+            {
+                "term": "общеславянська",
+                "forms": ["общеславянської"],
+                "rationale": "імперський термін, цитований для критики",
+            }
+        ]
+    }
+
+    quoted_gate = _gate(
+        "Термін «общеславянської» тут критикуємо.",
+        monkeypatch,
+        missing_surfaces={"общеславянської"},
+        plan=plan,
+    )
+    unquoted_gate = _gate(
+        "Термін общеславянської тут критикуємо.",
+        monkeypatch,
+        missing_surfaces={"общеславянської"},
+        plan=plan,
+    )
+
+    assert quoted_gate["passed"] is True
+    assert quoted_gate["missing"] == []
+    assert quoted_gate["plan_exempted_by_category"]["quoted_critical_terms"] == [
+        "общеславянської"
+    ]
+    assert unquoted_gate["passed"] is False
+    assert unquoted_gate["missing"] == ["общеславянської"]
+    assert unquoted_gate["plan_exempted"] == 0
+
+
+def test_corpus_attested_quotes_accept_guillemet_or_backtick_and_require_source_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = {
+        "corpus_attested_quotes": [
+            {
+                "term": "жаворонку",
+                "forms": ["жаворонку"],
+                "source_chunk": "da46aa92_c0284",
+                "rationale": "вербатим із цитованої веснянки",
+            }
+        ]
+    }
+
+    guillemet_gate = _gate(
+        "Порівнюємо жаворонку: «жаворонку».",
+        monkeypatch,
+        missing_surfaces={"жаворонку"},
+        plan=plan,
+    )
+    backtick_gate = _gate(
+        "Порівнюємо жаворонку (`жаворонку`).",
+        monkeypatch,
+        missing_surfaces={"жаворонку"},
+        plan=plan,
+    )
+    bad_gate = _gate(
+        "Порівнюємо жаворонку: «жаворонку».",
+        monkeypatch,
+        missing_surfaces={"жаворонку"},
+        plan={
+            "corpus_attested_quotes": [
+                {
+                    "term": "жаворонку",
+                    "forms": ["жаворонку"],
+                    "rationale": "вербатим із цитованої веснянки",
+                }
+            ]
+        },
+    )
+
+    assert guillemet_gate["passed"] is True
+    assert guillemet_gate["missing"] == []
+    assert backtick_gate["passed"] is True
+    assert backtick_gate["missing"] == []
+    assert bad_gate["passed"] is False
+    assert "source_chunk" in str(bad_gate["error"])
+
+
+def test_plan_exemption_entry_requires_non_empty_rationale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gate = _gate(
+        "Белтейн",
+        monkeypatch,
+        missing_surfaces={"Белтейн"},
+        plan={
+            "foreign_cultural_terms": [
+                {
+                    "term": "Белтейн",
+                    "forms": ["Белтейн"],
+                    "wikipedia_url": "https://uk.wikipedia.org/wiki/Белтейн",
+                    "rationale": "   ",
+                }
+            ]
+        },
+    )
+
+    assert gate["passed"] is False
+    assert "rationale" in str(gate["error"])
+
+
+def test_core_level_ignores_plan_vesum_exemptions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gate = _gate(
+        "ханамі",
+        monkeypatch,
+        missing_surfaces={"ханамі"},
+        level="a1",
+        plan={
+            "foreign_cultural_terms": [
+                {
+                    "term": "ханамі",
+                    "forms": ["ханамі"],
+                    "wikipedia_url": "https://uk.wikipedia.org/wiki/Ханамі",
+                    "rationale": "японський звичай милування квітами",
+                }
+            ]
+        },
+    )
+
+    assert gate["passed"] is False
+    assert gate["missing"] == ["ханамі"]
+    assert gate["plan_exempted"] == 0
+
+
+def test_undeclared_real_misspelling_stays_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gate = _gate(
+        "ханамі музеїфікація",
+        monkeypatch,
+        missing_surfaces={"ханамі", "музеїфікація"},
+        plan={
+            "foreign_cultural_terms": [
+                {
+                    "term": "ханамі",
+                    "forms": ["ханамі"],
+                    "wikipedia_url": "https://uk.wikipedia.org/wiki/Ханамі",
+                    "rationale": "японський звичай милування квітами",
+                }
+            ]
+        },
+    )
+
+    assert gate["passed"] is False
+    assert gate["missing"] == ["музеїфікація"]
+    assert gate["plan_exempted_words"] == ["ханамі"]
+
+
+def test_plan_exemption_report_shape_by_category(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gate = _gate(
+        "Белтейн. Термін «общеславянської» критикуємо. Жаворонку поруч: `жаворонку`.",
+        monkeypatch,
+        missing_surfaces={"Белтейн", "общеславянської", "Жаворонку"},
+        plan={
+            "foreign_cultural_terms": [
+                {
+                    "term": "Белтейн",
+                    "forms": ["Белтейн"],
+                    "wikipedia_url": "https://uk.wikipedia.org/wiki/Белтейн",
+                    "rationale": "кельтське весняне свято",
+                }
+            ],
+            "quoted_critical_terms": [
+                {
+                    "term": "общеславянська",
+                    "forms": ["общеславянської"],
+                    "rationale": "імперський термін, цитований для критики",
+                }
+            ],
+            "corpus_attested_quotes": [
+                {
+                    "term": "жаворонку",
+                    "forms": ["жаворонку"],
+                    "source_chunk": "da46aa92_c0284",
+                    "rationale": "вербатим із цитованої веснянки",
+                }
+            ],
+        },
+    )
+
+    assert gate["passed"] is True
+    assert gate["plan_exempted"] == 3
+    assert gate["plan_exempted_words"] == [
+        "Белтейн",
+        "Жаворонку",
+        "общеславянської",
+    ]
+    assert gate["plan_exempted_by_category"] == {
+        "foreign_cultural_terms": ["Белтейн"],
+        "quoted_critical_terms": ["общеславянської"],
+        "corpus_attested_quotes": ["Жаворонку"],
+    }

--- a/tests/test_vesum_plan_exemptions.py
+++ b/tests/test_vesum_plan_exemptions.py
@@ -333,3 +333,108 @@ def test_plan_exemption_report_shape_by_category(
         "quoted_critical_terms": ["общеславянської"],
         "corpus_attested_quotes": ["Жаворонку"],
     }
+
+
+def test_quoted_critical_terms_backtick_context_is_not_enough(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # quoted_critical_terms is guarded by GUILLEMET context ONLY. A surface that
+    # is missing (because it occurs in plain prose) and is ALSO shown in backticks
+    # — but never in «…» — must NOT be exempted. (Backtick-only text is stripped
+    # from VESUM input, so the prose occurrence is what makes it missing.)
+    plan = {
+        "quoted_critical_terms": [
+            {
+                "term": "общеславянська",
+                "forms": ["общеславянської"],
+                "rationale": "імперський термін, цитований для критики",
+            }
+        ]
+    }
+    gate = _gate(
+        "Термін общеславянської у прозі, а також `общеславянської` у бектиках.",
+        monkeypatch,
+        missing_surfaces={"общеславянської"},
+        plan=plan,
+    )
+    assert gate["passed"] is False
+    assert gate["missing"] == ["общеславянської"]
+    assert gate["plan_exempted"] == 0
+
+
+def test_foreign_cultural_degenerate_ukwiki_url_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The empty-article URL "https://uk.wikipedia.org/wiki/" must NOT validate.
+    gate = _gate(
+        "Белтейн",
+        monkeypatch,
+        missing_surfaces={"Белтейн"},
+        plan={
+            "foreign_cultural_terms": [
+                {
+                    "term": "Белтейн",
+                    "forms": ["Белтейн"],
+                    "wikipedia_url": "https://uk.wikipedia.org/wiki/",
+                    "rationale": "кельтське весняне свято",
+                }
+            ]
+        },
+    )
+    assert gate["passed"] is False
+    assert "wikipedia_url" in str(gate["error"])
+
+
+def test_runaway_unbalanced_guillemet_span_does_not_exempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An unbalanced « paired with a far-later » would otherwise yield a runaway
+    # span (> _MAX_GUILLEMET_SPAN_CHARS) that falsely marks an un-quoted declared
+    # token as quoted. The span bound must drop it, leaving the token missing.
+    filler = "слово " * 60  # ~300 chars between the stray « and the real »
+    text = f"Початок « {filler} жаворонку далі правильна цитата»."
+    plan = {
+        "corpus_attested_quotes": [
+            {
+                "term": "жаворонку",
+                "forms": ["жаворонку"],
+                "source_chunk": "da46aa92_c0284",
+                "rationale": "вербатим із цитованої веснянки",
+            }
+        ]
+    }
+    gate = _gate(
+        text,
+        monkeypatch,
+        missing_surfaces={"жаворонку"},
+        plan=plan,
+    )
+    assert gate["passed"] is False
+    assert "жаворонку" in gate["missing"]
+    assert gate["plan_exempted"] == 0
+
+
+def test_empty_forms_list_exempts_only_the_term(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # forms: [] is valid and exempts only the term surface itself, not arbitrary
+    # inflections.
+    plan = {
+        "foreign_cultural_terms": [
+            {
+                "term": "ханамі",
+                "forms": [],
+                "wikipedia_url": "https://uk.wikipedia.org/wiki/Милування_квітами",
+                "rationale": "японський звичай милування квітами",
+            }
+        ]
+    }
+    gate = _gate(
+        "ханамі ханамікою",
+        monkeypatch,
+        missing_surfaces={"ханамі", "ханамікою"},
+        plan=plan,
+    )
+    assert gate["passed"] is False
+    assert gate["missing"] == ["ханамікою"]
+    assert gate["plan_exempted_words"] == ["ханамі"]


### PR DESCRIPTION
## What
Adds a per-module, **plan-declared `vesum_exemptions:` allowlist** to the `vesum_verified`
gate (`scripts/build/linear_pipeline.py`), honored **only for SEMINAR_LEVELS**. Lets legitimate
seminar/folk vocabulary pass without weakening the gate against real russianisms/misspellings.

Three categories, each entry **requires a non-empty `rationale`** (fail-closed on malformed):
- `foreign_cultural_terms` — requires a valid `https://uk.wikipedia.org/wiki/<article>` URL; exempts
  declared surfaces (no quote requirement; fixes lowercase foreign terms the title-case-only global
  mechanism can't handle, e.g. `ханамі`).
- `quoted_critical_terms` — exempts a declared surface **only when it appears inside «…»** in prose
  (the integrity guard: you cannot bless an un-quoted russianism). For decolonial quoted-for-criticism
  imperial terms, e.g. «общеславянська».
- `corpus_attested_quotes` — requires a `source_chunk`; exempts **only when the surface is quoted**
  («…» or `` `backtick` ``). For folk forms the writer analyzes in prose that are verbatim in the
  module's cited readings (e.g. `жаворонку`, `васильочок`).

Report extended with `plan_exempted` / `plan_exempted_words` / `plan_exempted_by_category` so each
exemption records *why* it was granted. A plan with no `vesum_exemptions` block behaves **identically**
to today (purely additive + opt-in; zero blast radius for existing modules). Real misspellings stay
failing by design (not declared).

## Why
The first pipeline-built folk module (`vesnianky-hayivky`) was blocked by `vesum_verified` over-flagging
17 *legitimate, planned* tokens (foreign festival names, a decolonial quoted-for-criticism term, and
corpus-attested folk forms) — NOT a content defect. Design adversarially reviewed by codex
(`vesum-seminar-calibration-design`): **do not blanket-exempt «…» spans** — exempt only on an explicit,
declared, rationale-bearing evidence class, scoped to the module.

## Verification
- New `tests/test_vesum_plan_exemptions.py` — 12 tests (lowercase-foreign exempt; un-quoted russianism
  stays failing; real misspelling stays failing; CORE level ignores the block; fail-closed on malformed;
  report shape; off-seat hardening cases).
- Regression slice (94+ tests: vesum/heritage/foreign-proper/no-rewrite-contract/reading-coverage) — green.
- Adversarial probes confirm the «…»/backtick quote guards hold (declared-but-unquoted token still fails).
- **Off-seat code review (deepseek-v4-pro)** confirmed core integrity (quote guards, ordering, SEMINAR
  scope, fail-closed coverage all correct) and surfaced two real edge cases now hardened in the 2nd commit:
  (F1) reject the degenerate empty `…/wiki/` URL; (F2) bound guillemet spans to 200 chars so an unbalanced
  «  can't produce a runaway false-quote span.

NO auto-merge requested in the dispatch; opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
