### PR TITLE
docs(b2): persist M03-M10 LLM scores

### DIFF
--- a/docs/audits/b2-current-llm-scores-2026-06-25.md
+++ b/docs/audits/b2-current-llm-scores-2026-06-25.md
@@ -2,34 +2,55 @@
 
 Date: 2026-06-25
 Auditor: codex/gpt-5
-Branch: `codex/b2-m04-m08-m09-audit-scores`
-Scope: currently active B2 preview modules on `origin/main`: M01, M02, M04, M08, M09.
+Branch: `codex/b2-m03-m10-llm-scores`
+Scope: active B2 preview modules on `origin/main` after PRs #3812, #3813, #3814, #3815, and #3817 merged.
 
-This durable score note supersedes `docs/audits/b2-current-llm-scores-2026-06-24.md` for current B2 active-module status. It intentionally does not persist generated files under `curriculum/l2-uk-en/**/status/`, `curriculum/l2-uk-en/**/audit/`, or `curriculum/l2-uk-en/**/review/`.
+This durable score note supersedes `docs/audits/b2-current-llm-scores-2026-06-24.md` and the earlier 2026-06-25 M04/M08/M09-only snapshot. It intentionally does not persist generated files under `curriculum/l2-uk-en/**/status/`, `curriculum/l2-uk-en/**/audit/`, or `curriculum/l2-uk-en/**/review/`.
 
 ## Summary
 
 | Module | Current LLM Score | Verdict | Ready for Human Review? | Notes |
 | --- | ---: | --- | --- | --- |
-| B2 M01 `passive-voice-system` | 10/10 | A | Yes | Excellent B2 teaching arc, strong register control, no content blockers. Score carried forward from 2026-06-24 durable score note. |
-| B2 M02 `past-passive-participles` | 9/10 | B | Yes | Strong teaching arc and practice coverage. Score carried forward from 2026-06-24 durable score note; optional activity-affordance/notation polish remains. |
-| B2 M04 `dim-zhytlo` | 9/10 | B+ | Yes | Strong housing/rental/repair communication module. Minor optional polish around section balance and residual deterministic false-positive naturalness warning. |
-| B2 M08 `pobut-shchodenne` | 10/10 | A | Yes | Excellent everyday-life module with strong activity coverage, natural Ukrainian household negotiation, and no meaningful content issue found. |
-| B2 M09 `active-participles-present` | 9/10 | B+ | Yes | Strong editorial grammar module. Score held at 9 due section imbalance and residual deterministic false-positive warnings despite clean source inspection. |
+| B2 M01 `passive-voice-system` | 10/10 | A | Yes | Excellent B2 teaching arc, strong register control, no content blockers. Score carried forward from the 2026-06-24 durable score note. |
+| B2 M02 `past-passive-participles` | 9/10 | B+ | Yes | Strong teaching arc and practice coverage. Score carried forward from the 2026-06-24 durable score note; optional activity-affordance/notation polish remains. |
+| B2 M03 `b2-impersonal-passive` | 9/10 | B+ | Yes | Strong impersonal passive module after review fixes. Score held at 9 for non-blocking section-balance/formulaic-style audit notes. |
+| B2 M04 `dim-zhytlo` | 9/10 | B+ | Yes | Strong housing/rental/repair communication module. Minor optional polish remains around section balance and a deterministic UA-GEC false-positive family. |
+| B2 M05 `reflexive-passive` | 9/10 | B+ | Yes | Strong reflexive-passive norm module. Review blocker on essay exemplar length was fixed before merge; residual audit notes are minor. |
+| B2 M06 `third-person-plural-passive` | 9/10 | B+ | Yes | Strong 3rd-person-plural passive-alternative module. Dead/fabricated resource fallback was removed before merge; score held at 9 for section-balance warnings. |
+| B2 M07 `passive-in-context` | 9/10 | B+ | Yes | Strong synthesis/context module. Review notes on worked-example coherence and exemplar length were fixed before merge; minor section-balance/resource notes remain. |
+| B2 M08 `pobut-shchodenne` | 10/10 | A | Yes | Excellent everyday-life module with strong activity coverage, natural Ukrainian household negotiation, and no meaningful content blockers. |
+| B2 M09 `active-participles-present` | 9/10 | B+ | Yes | Strong editorial grammar module. Score held at 9 because section balance remains uneven and deterministic audit still emits false-positive naturalness warnings. |
+| B2 M10 `checkpoint-passive-voice` | 9/10 | B+ | Yes | High-quality passive-voice checkpoint. Score held at 9 for non-blocking collocation/translate-position/resource-polish notes. |
 
-## Deterministic Audit Evidence
+## M03-M10 Report
 
-| Module | Audit Result | Words | Activities | Vocabulary | Immersion | Richness |
-| --- | --- | ---: | ---: | ---: | ---: | ---: |
-| B2 M01 `passive-voice-system` | PASS | 4599/4000 | 11 workbook / 0 inline | 37/25 | 99.8% | 99% |
-| B2 M02 `past-passive-participles` | PASS | 4623/4000 | 11 workbook / 0 inline | 40/25 | 99.9% | 99% |
-| B2 M04 `dim-zhytlo` | PASS | 4882/4000 | 10 workbook / 0 inline | 94/25 | 100.0% | 96% |
-| B2 M08 `pobut-shchodenne` | PASS | 4263/4000 | 12 workbook / 0 inline | 55/25 | 99.9% | 99% |
-| B2 M09 `active-participles-present` | PASS | 4808/4000 | 10 workbook / 0 inline | 40/25 | 100.0% | 99% |
+| Module | Score | Grade | Deterministic Audit | Activity/Vocab Coverage | Independent Review | Disposition |
+| --- | ---: | --- | --- | --- | --- | --- |
+| M03 `b2-impersonal-passive` | 9/10 | B+ | PASS | 7 workbook / 4 inline; 35 vocab | PR #3812 Claude Opus 4.8 | Initial blockers fixed; mergeable; merged. |
+| M04 `dim-zhytlo` | 9/10 | B+ | PASS | 10 workbook / 0 inline; 94 vocab | PR #3803 Claude Opus 4.8 | Mergeable; one wording nit fixed before merge. |
+| M05 `reflexive-passive` | 9/10 | B+ | PASS | 11 workbook / 0 inline; 34 vocab | PR #3813 Claude Opus 4.8 | Essay model-answer blocker fixed; mergeable; merged. |
+| M06 `third-person-plural-passive` | 9/10 | B+ | PASS | 11 workbook / 0 inline; 43 vocab | PR #3814 Claude Opus 4.8 | Dead/fabricated resource link fixed; mergeable; merged. |
+| M07 `passive-in-context` | 9/10 | B+ | PASS | 10 workbook / 0 inline; 36 vocab | PR #3815 Claude Opus 4.8 | Non-blocking review notes fixed; mergeable; merged. |
+| M08 `pobut-shchodenne` | 10/10 | A | PASS | 12 workbook / 0 inline; 55 vocab | PR #3801 Claude Opus 4.8 | Mergeable; no blockers. |
+| M09 `active-participles-present` | 9/10 | B+ | PASS | 10 workbook / 0 inline; 40 vocab | PR #3805 Claude Opus 4.8 | Mergeable; one morphology-table nit fixed before merge. |
+| M10 `checkpoint-passive-voice` | 9/10 | B+ | PASS | 5 workbook / 5 inline; 30 vocab | PR #3817 Claude Opus 4.8 | Mergeable; no blockers; non-blocking polish deferred. |
+
+## Current Raw Stats
+
+| Module | Raw Word Count | Activities | Vocabulary |
+| --- | ---: | --- | ---: |
+| M03 `b2-impersonal-passive` | 4608 | 7 workbook / 4 inline | 35 |
+| M04 `dim-zhytlo` | 5224 | 10 workbook / 0 inline | 94 |
+| M05 `reflexive-passive` | 4422 | 11 workbook / 0 inline | 34 |
+| M06 `third-person-plural-passive` | 4779 | 11 workbook / 0 inline | 43 |
+| M07 `passive-in-context` | 4751 | 10 workbook / 0 inline | 36 |
+| M08 `pobut-shchodenne` | 5047 | 12 workbook / 0 inline | 55 |
+| M09 `active-participles-present` | 5428 | 10 workbook / 0 inline | 40 |
+| M10 `checkpoint-passive-voice` | 4671 | 5 workbook / 5 inline | 30 |
 
 ## Scoring Method
 
-B2 uses the Tier 2 Core rubric. LLM score here is the content-review `Lesson Quality Score`, grounded in the Tier 2 "Did I Learn?" test:
+B2 uses the Tier 2 Core rubric. The LLM score here is the content-review `Lesson Quality Score`, grounded in the Tier 2 "Did I Learn?" test:
 
 | Pass Count | Score |
 | ---: | ---: |
@@ -39,52 +60,24 @@ B2 uses the Tier 2 Core rubric. LLM score here is the content-review `Lesson Qua
 | 3/5 | 7/10 |
 | 0-2/5 | 6/10 or lower |
 
-## Score Notes For New Modules
-
-### B2 M04: `dim-zhytlo`
-
-**Lesson Quality Score:** 9/10
-**Verdict:** B+
-**Human-review readiness:** ready
-
-All five Tier 2 checks pass. The score is 9 rather than 10 because the module still has uneven section balance and one residual deterministic UA-GEC false-positive family. No blocker or required fix was found.
-
-### B2 M08: `pobut-shchodenne`
-
-**Lesson Quality Score:** 10/10
-**Verdict:** A
-**Human-review readiness:** ready
-
-All five Tier 2 checks pass with strong deterministic audit metrics and no meaningful content issue. The module is ready for human review without required polish.
-
-### B2 M09: `active-participles-present`
-
-**Lesson Quality Score:** 9/10
-**Verdict:** B+
-**Human-review readiness:** ready
-
-All five Tier 2 checks pass. The module is strong and correctly teaches active present participles as recognition/editorial replacement rather than productive morphology. The score is 9 rather than 10 because section balance remains uneven and deterministic audit still emits false-positive warnings after source inspection.
-
-## Validation Commands Run For 2026-06-25 Additions
-
-```bash
-.venv/bin/python scripts/validate_activities.py l2-uk-en b2 4
-.venv/bin/python scripts/validate_activities.py l2-uk-en b2 8
-.venv/bin/python scripts/validate_activities.py l2-uk-en b2 9
-.venv/bin/python scripts/validate_vocab_yaml.py curriculum/l2-uk-en/b2/dim-zhytlo/vocabulary.yaml
-.venv/bin/python scripts/validate_vocab_yaml.py curriculum/l2-uk-en/b2/pobut-shchodenne/vocabulary.yaml
-.venv/bin/python scripts/validate_vocab_yaml.py curriculum/l2-uk-en/b2/active-participles-present/vocabulary.yaml
-.venv/bin/python scripts/audit_module.py --skip-review curriculum/l2-uk-en/b2/dim-zhytlo/module.md
-.venv/bin/python scripts/audit_module.py --skip-review curriculum/l2-uk-en/b2/pobut-shchodenne/module.md
-.venv/bin/python scripts/audit_module.py --skip-review curriculum/l2-uk-en/b2/active-participles-present/module.md
-```
-
-All commands completed successfully. Local generated audit/status/cache outputs were removed before staging.
+All M03-M10 modules pass the five Tier 2 teaching checks. Scores below 10 reflect non-blocking polish, section-balance warnings, or review notes, not deployment blockers.
 
 ## Review Evidence
 
-| Module | Independent Review | Disposition |
+| Module | Independent Review | Result |
 | --- | --- | --- |
+| M03 `b2-impersonal-passive` | Claude Opus 4.8 PR #3812 blocker review + re-review | Initial blockers fixed; final disposition mergeable. |
 | M04 `dim-zhytlo` | Claude Opus 4.8 PR #3803 blocker review | Mergeable, 0 blockers; one wording nit addressed before merge. |
+| M05 `reflexive-passive` | Claude Opus 4.8 PR #3813 blocker review + final verdict | Initial essay-length blocker fixed; final disposition mergeable. |
+| M06 `third-person-plural-passive` | Claude Opus 4.8 PR #3814 blocker review + re-review | Dead resource link blocker fixed; final disposition mergeable. |
+| M07 `passive-in-context` | Claude Opus 4.8 PR #3815 blocker review + re-review | Mergeable; non-blocking exemplar/coherence notes fixed before merge. |
 | M08 `pobut-shchodenne` | Claude Opus 4.8 PR #3801 blocker review | Mergeable, 0 blockers. |
 | M09 `active-participles-present` | Claude Opus 4.8 PR #3805 blocker review | Mergeable, 0 blockers; one morphology-table nit addressed before merge. |
+| M10 `checkpoint-passive-voice` | Claude Opus 4.8 PR #3817 blocker review | Mergeable, 0 blockers; non-blocking polish deferred. |
+
+## Artifact Hygiene
+
+- No generated `curriculum/l2-uk-en/**/status/*.json` files persisted.
+- No generated `curriculum/l2-uk-en/**/audit/*-review.md` or `review/*-review.md` files persisted.
+- No telemetry database files persisted.
+- `.python-version`, `.yamllint`, and `.markdownlint.json` unchanged.

--- a/docs/audits/b2-m03-m10-llm-score-report-2026-06-25.md
+++ b/docs/audits/b2-m03-m10-llm-score-report-2026-06-25.md
@@ -1,0 +1,36 @@
+# B2 M03-M10 LLM Score Report
+
+Date: 2026-06-25
+Scope: B2 modules 3 through 10 on `origin/main` after M10 merge.
+
+## Final Scores
+
+| # | Slug | Score | Grade | Human Review |
+| ---: | --- | ---: | --- | --- |
+| 3 | `b2-impersonal-passive` | 9/10 | B+ | Ready |
+| 4 | `dim-zhytlo` | 9/10 | B+ | Ready |
+| 5 | `reflexive-passive` | 9/10 | B+ | Ready |
+| 6 | `third-person-plural-passive` | 9/10 | B+ | Ready |
+| 7 | `passive-in-context` | 9/10 | B+ | Ready |
+| 8 | `pobut-shchodenne` | 10/10 | A | Ready |
+| 9 | `active-participles-present` | 9/10 | B+ | Ready |
+| 10 | `checkpoint-passive-voice` | 9/10 | B+ | Ready |
+
+## Bottom Line
+
+All M03-M10 modules are active, audit-passing, independently reviewed, and ready for human review in B2 preview. M08 is the only 10/10 in this span. The rest are 9/10 because they have non-blocking polish or section-balance notes, not blockers.
+
+## Notes By Module
+
+- M03 `b2-impersonal-passive`: blockers fixed before merge; strong `-но/-то` teaching, authentic proverb, minor audit polish remains.
+- M04 `dim-zhytlo`: strong housing communication module; minor section-balance/UA-GEC false-positive polish remains.
+- M05 `reflexive-passive`: blocker on essay exemplar length fixed; strong norm-focused reflexive-passive teaching.
+- M06 `third-person-plural-passive`: blocker on fabricated/dead resource link fixed; strong indefinite-personal strategy teaching.
+- M07 `passive-in-context`: review notes on worked example and exemplar length fixed; strong synthesis module.
+- M08 `pobut-shchodenne`: no meaningful content issue found; excellent everyday-life module.
+- M09 `active-participles-present`: strong editorial grammar module; score held for section-balance and deterministic false-positive warnings.
+- M10 `checkpoint-passive-voice`: high-quality checkpoint; non-blocking collocation/position-bias/resource-polish notes deferred.
+
+## Persistence
+
+The comprehensive current snapshot is persisted in `docs/audits/b2-current-llm-scores-2026-06-25.md`.


### PR DESCRIPTION
## Scope
- Persist current B2 LLM scores for M03-M10.
- Update the durable current score snapshot to cover all active B2 preview modules.
- Add a focused M03-M10 score report requested for orchestration.

## Scores
- M03 `b2-impersonal-passive`: 9/10
- M04 `dim-zhytlo`: 9/10
- M05 `reflexive-passive`: 9/10
- M06 `third-person-plural-passive`: 9/10
- M07 `passive-in-context`: 9/10
- M08 `pobut-shchodenne`: 10/10
- M09 `active-participles-present`: 9/10
- M10 `checkpoint-passive-voice`: 9/10

## Validation / Hygiene
- PASS `git diff --cached --check`
- PASS `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Touched files: 2 docs files under `docs/audits/`
- No generated curriculum `status/`, `audit/`, or `review/` artifacts.
- `.python-version`, `.yamllint`, `.markdownlint.json` unchanged.

## Review
- Independent review: Claude Opus 4.8 read-only review on 2026-06-25.
- Disposition: MERGEABLE, blockers none.
- Scope confirmed: exactly 2 docs files under `docs/audits/`; no generated curriculum artifacts, telemetry DB, or protected config files.
- Non-blocking notes: carried-forward M02 grade label is normalized from `B` to `B+` while the 9/10 score is unchanged; exact numeric scores are persisted from content-review scoring rather than re-derived solely from visible PR threads.
