### PR TITLE
[codex] readings-first hosted readings from plan

### DIFF
--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -30,6 +30,7 @@ from scripts.build.phases.implementation_map import (
 )
 from scripts.common.thresholds import QG_DIMS, terminal_dims_for
 from scripts.orchestration import reap_worktrees
+from scripts.readings.generate_readings import GenerationSummary, generate_from_plan
 
 DEFAULT_WRITER_TIMEOUT_S = 1800
 FETCH_TIMEOUT_S = 30
@@ -1484,6 +1485,49 @@ def _run_stress_annotation_for_level(module_dir: Path, level: str) -> dict[str, 
     return linear_pipeline.run_stress_annotation(module_dir)
 
 
+def _run_readings_prebuild_phase(
+    *,
+    level: str,
+    slug: str,
+    plan_path: Path,
+    output_dir: Path,
+    sources_db: Path,
+    dry_run: bool,
+    event_sink: Callable[..., None] = emit_event,
+) -> GenerationSummary | None:
+    if level.lower() not in SEMINAR_LEVELS:
+        return None
+
+    summary = generate_from_plan(
+        plan_path,
+        output_dir=output_dir,
+        sources_db=sources_db,
+        dry_run=dry_run,
+    )
+    for item in (*summary.written, *summary.existing):
+        event_sink(
+            "reading_generated",
+            level=level,
+            slug=slug,
+            reading_slug=item.slug,
+            action=item.action,
+            path=item.path.as_posix(),
+            source_chunk_id=item.source_chunk_id,
+            dry_run=dry_run,
+        )
+    for item in summary.skipped:
+        event_sink(
+            "reading_skipped",
+            level=level,
+            slug=slug,
+            reading_slug=item.slug,
+            title=item.title,
+            reason=item.reason,
+            dry_run=dry_run,
+        )
+    return summary
+
+
 def _run(args: argparse.Namespace) -> int:
     level = args.level.lower()
     slug = args.slug
@@ -1526,6 +1570,31 @@ def _run(args: argparse.Namespace) -> int:
             slug=slug,
             event_sink=tracker.emit,
             archive=archive,
+        )
+
+        phase = "readings"
+        _phase_started(archive, phase)
+        started_at = time.monotonic()
+        readings_summary = _run_readings_prebuild_phase(
+            level=level,
+            slug=slug,
+            plan_path=plan_path,
+            output_dir=PROJECT_ROOT / "site" / "src" / "content" / "readings",
+            sources_db=PROJECT_ROOT / "data" / "sources.db",
+            dry_run=args.dry_run,
+            event_sink=tracker.emit,
+        )
+        _phase_done(
+            phase,
+            started_at,
+            level=level,
+            slug=slug,
+            event_sink=tracker.emit,
+            archive=archive,
+            readings_written=len(readings_summary.written) if readings_summary else 0,
+            readings_existing=len(readings_summary.existing) if readings_summary else 0,
+            readings_skipped=len(readings_summary.skipped) if readings_summary else 0,
+            skipped="non-seminar" if readings_summary is None else None,
         )
 
         phase = "knowledge_packet"

--- a/scripts/readings/generate_readings.py
+++ b/scripts/readings/generate_readings.py
@@ -42,6 +42,8 @@ _ATTRIBUTION_RE = re.compile(
     r"^—\s*(?P<author>[^,\n]+),\s*«(?P<title>[^»]+)»(?:\s*\((?P<note>[^)\n]+)\))?",
     re.MULTILINE,
 )
+_PLAN_SOURCE_CHUNK_RE = re.compile(r"\bchunk\s+([0-9a-f]+_c\d+)\b", re.IGNORECASE)
+_PLAN_TITLE_STRIP_CHARS = " \t\r\n«»“”„\"'`"
 _STRESS_RE = re.compile("[\u0300\u0301]")
 _NON_WORD_RE = re.compile(r"[^\w]+", re.UNICODE)
 
@@ -101,6 +103,7 @@ class ResolvedReading:
     study_links: str | None = None
     taught_in: tuple[str, ...] = ()
     source_chunk_ids: tuple[str, ...] = ()
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -388,6 +391,100 @@ def generate_from_demand(
     return GenerationSummary(tuple(written), tuple(skipped), tuple(existing))
 
 
+def generate_from_plan(
+    plan_path: Path,
+    *,
+    output_dir: Path = READINGS_ROOT,
+    sources_db: Path = SOURCES_DB,
+    dry_run: bool = False,
+    quote_verifier: QuoteVerifier | None = None,
+) -> GenerationSummary:
+    """Generate hosted reading MDX files from one plan's readings block."""
+    verifier = quote_verifier or verify_candidate_against_corpus
+    output_dir.mkdir(parents=True, exist_ok=True)
+    raw_plan = yaml.safe_load(plan_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(raw_plan, dict):
+        return GenerationSummary((), (SkippedReading(plan_path.stem, None, "plan is not a mapping"),), ())
+
+    readings = raw_plan.get("readings")
+    if not isinstance(readings, list):
+        return GenerationSummary((), (), ())
+
+    level = str(raw_plan.get("level") or plan_path.parent.name).strip().lower()
+    module_slug = str(raw_plan.get("slug") or plan_path.stem).strip()
+    study_links = _study_link_from_plan(raw_plan, plan_path, level=level, slug=module_slug)
+    lookup = CorpusLookup(sources_db)
+    hosted_values = _hosted_reading_values()
+    resolved_by_slug: dict[str, ResolvedReading] = {}
+    skipped: list[SkippedReading] = []
+
+    for entry in readings:
+        if not isinstance(entry, dict):
+            continue
+        hosting = str(entry.get("hosting") or "").strip().casefold()
+        if hosting not in hosted_values:
+            continue
+
+        raw_title = str(entry.get("title") or "").strip()
+        slug = str(entry.get("reading_slug") or "").strip()
+        if not slug:
+            skipped.append(SkippedReading(raw_title or "<untitled>", None, "missing reading_slug"))
+            continue
+        if not raw_title:
+            skipped.append(SkippedReading("<untitled>", slug, "missing title"))
+            continue
+
+        source = str(entry.get("source") or "").strip()
+        source_chunk_id = _source_chunk_id(source)
+        candidate_title = _plan_candidate_title(raw_title)
+        candidate = PrimaryReadingCandidate(
+            module_dir=plan_path.parent,
+            track=level,
+            slug=module_slug,
+            author=_plan_entry_author(entry),
+            title=candidate_title,
+            note=str(entry.get("genre") or "").strip(),
+            quote_lines=(candidate_title,),
+        )
+        hints = _plan_resource_hints(candidate, source, source_chunk_id, raw_title)
+        corpus = lookup.resolve(candidate, hints)
+        if corpus is None:
+            skipped.append(SkippedReading(raw_title, slug, "no matching corpus text"))
+            continue
+        rights_corpus = _plan_rights_corpus(candidate, corpus, entry)
+        if not is_public_domain(rights_corpus, track=candidate.track):
+            skipped.append(SkippedReading(raw_title, slug, "corpus row is not public-domain"))
+            continue
+        verdict = verifier(candidate, corpus)
+        if not verdict.matched:
+            skipped.append(
+                SkippedReading(
+                    raw_title,
+                    slug,
+                    f"quote verification failed: {verdict.detail}",
+                )
+            )
+            continue
+
+        resolved_by_slug[slug] = ResolvedReading(
+            candidate=candidate,
+            corpus=corpus,
+            slug=slug,
+            tracks={level} if level else set(),
+            study_links=study_links,
+            taught_in=(module_slug,) if module_slug else (),
+            source_chunk_ids=(source_chunk_id or corpus.chunk_id,),
+            metadata=_plan_reading_metadata(entry),
+        )
+
+    written, existing = _write_resolved_readings(
+        resolved_by_slug,
+        output_dir=output_dir,
+        dry_run=dry_run,
+    )
+    return GenerationSummary(tuple(written), tuple(skipped), tuple(existing))
+
+
 def _write_resolved_readings(
     resolved_by_slug: dict[str, ResolvedReading],
     *,
@@ -479,11 +576,12 @@ class CorpusLookup:
                    language_period, source_file, source_url, text
             FROM literary_texts
         """
-        title_like = f"%{candidate.title}%"
-        add(
-            f"{select} WHERE author = ? AND (work LIKE ? OR text LIKE ?) LIMIT 25",
-            (candidate.author, title_like, title_like),
-        )
+        for title_variant in _title_lookup_variants(candidate.title):
+            title_like = f"%{title_variant}%"
+            add(
+                f"{select} WHERE author = ? AND (work LIKE ? OR text LIKE ?) LIMIT 25",
+                (candidate.author, title_like, title_like),
+            )
         first_line = next((line for line in candidate.quote_lines if line.strip()), "")
         if first_line:
             add(
@@ -638,6 +736,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("module_dirs", nargs="*", type=Path, help="Folk module directories to scan")
     parser.add_argument("--all-folk", action="store_true", help="Scan all built folk modules")
     parser.add_argument("--from-demand", action="store_true", help="Generate from primary-text demand manifest")
+    parser.add_argument("--from-plan", type=Path, help="Generate hosted readings from a single plan YAML")
     parser.add_argument("--track", help="Only scan one plans track when using --from-demand")
     parser.add_argument("--plans-dir", type=Path, default=DEFAULT_PLANS_DIR)
     parser.add_argument("--output-dir", type=Path, default=READINGS_ROOT)
@@ -650,7 +749,16 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
-    if args.from_demand:
+    if args.from_plan:
+        if args.from_demand or args.module_dirs or args.all_folk or args.track:
+            parser.error("--from-plan cannot be combined with other generation modes or --track")
+        summary = generate_from_plan(
+            args.from_plan,
+            output_dir=args.output_dir,
+            sources_db=args.sources_db,
+            dry_run=args.dry_run,
+        )
+    elif args.from_demand:
         if args.module_dirs or args.all_folk:
             parser.error("--from-demand cannot be combined with folk module dirs or --all-folk")
         summary = generate_from_demand(
@@ -697,6 +805,93 @@ def _dedupe_candidates(candidates: Sequence[PrimaryReadingCandidate]) -> list[Pr
         if existing is None or len(candidate.quote_lines) > len(existing.quote_lines):
             by_key[candidate.work_key] = candidate
     return list(by_key.values())
+
+
+def _hosted_reading_values() -> set[str]:
+    try:
+        from scripts.build.linear_pipeline import _HOSTED_READING_VALUES
+    except (ImportError, AttributeError):
+        return {"host", "hosted"}
+    return {str(value).strip().casefold() for value in _HOSTED_READING_VALUES}
+
+
+def _source_chunk_id(source: str) -> str | None:
+    match = _PLAN_SOURCE_CHUNK_RE.search(source)
+    return match.group(1) if match else None
+
+
+def _plan_candidate_title(title: str) -> str:
+    return title.strip(_PLAN_TITLE_STRIP_CHARS) or title.strip()
+
+
+def _plan_entry_author(entry: dict[str, Any]) -> str:
+    explicit = str(entry.get("author") or "").strip()
+    if explicit:
+        return explicit
+    source = str(entry.get("source") or "").strip()
+    source_author = source.split(";", 1)[0].strip()
+    return source_author or "Народна творчість"
+
+
+def _plan_resource_hints(
+    candidate: PrimaryReadingCandidate,
+    source: str,
+    source_chunk_id: str | None,
+    raw_title: str,
+) -> list[ResourceHint]:
+    if not source_chunk_id:
+        return []
+    return [
+        ResourceHint(
+            title=candidate.title,
+            source_ref=source,
+            role="plan-reading",
+            notes=raw_title,
+            packet_chunk_id=source_chunk_id,
+        )
+    ]
+
+
+def _plan_reading_metadata(entry: dict[str, Any]) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    for key in ("title", "title_en", "genre", "source"):
+        value = str(entry.get(key) or "").strip()
+        if value:
+            metadata[key] = value
+    return metadata
+
+
+def _plan_rights_corpus(
+    candidate: PrimaryReadingCandidate,
+    corpus: CorpusText,
+    entry: dict[str, Any],
+) -> CorpusText:
+    license_value = str(entry.get("license") or "").strip().casefold().replace("-", "_")
+    if license_value != "public_domain":
+        return corpus
+    return CorpusText(
+        chunk_id=corpus.chunk_id,
+        author=candidate.author or corpus.author,
+        work=candidate.title or corpus.work,
+        work_id=corpus.work_id,
+        year=corpus.year,
+        genre=corpus.genre,
+        language_period=corpus.language_period,
+        source_file=corpus.source_file,
+        source_url=corpus.source_url,
+        text=corpus.text,
+    )
+
+
+def _study_link_from_plan(plan: dict[str, Any], plan_path: Path, *, level: str, slug: str) -> str:
+    title = str(plan.get("title") or plan_path.stem).strip()
+    return f"[{_track_label(level)} · «{title}»](/{level}/{slug}/)"
+
+
+def _title_lookup_variants(title: str) -> list[str]:
+    quoted = re.findall(r"«([^»]+)»", title)
+    stripped = title.strip(_PLAN_TITLE_STRIP_CHARS)
+    return _ordered_unique([title, stripped, *quoted])
 
 
 def _quote_lines(block: str) -> Iterable[str]:
@@ -902,6 +1097,7 @@ def _metadata_for(resolved: ResolvedReading) -> dict[str, Any]:
     corpus = resolved.corpus
     slug = resolved.slug
     curated = dict(CURATED_METADATA.get(slug, {}))
+    curated.update(resolved.metadata)
     genre = curated.get("genre") or _genre_from_note(candidate.note) or _genre_from_corpus(corpus.genre)
     source_file = corpus.source_file or "corpus"
     metadata = {

--- a/tests/build/test_v7_build_mdx_terminal.py
+++ b/tests/build/test_v7_build_mdx_terminal.py
@@ -93,6 +93,11 @@ def _install_pass_fixture(
         lambda **_: {"passed": True, "coverage_pct": 1.0},
     )
     monkeypatch.setattr(
+        v7_build.linear_pipeline,
+        "run_ulp_fidelity_with_correction",
+        lambda *_args, **_kwargs: {"passed": True, "failed_checks": []},
+    )
+    monkeypatch.setattr(
         v7_build,
         "_run_wiki_coverage_review",
         lambda **_: {"overall_verdict": "PASS", "verdicts": []},

--- a/tests/test_generate_readings_from_plan.py
+++ b/tests/test_generate_readings_from_plan.py
@@ -1,0 +1,426 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.build import v7_build
+from scripts.readings.generate_readings import (
+    CorpusText,
+    GenerationSummary,
+    PrimaryReadingCandidate,
+    SkippedReading,
+    VerificationResult,
+    WrittenReading,
+    generate_from_plan,
+)
+
+SPRING_TEXT = """ОЙ ВЕСНА, ВЕСНА, ТИ КРАСНА
+
+Ой весна, весна, ти красна,
+
+Що ти нам, весно, принесла?"""
+
+HINTED_TEXT = """ОЙ ВИЛИНЬ, ВИЛИНЬ, ГОГОЛЮ
+
+Ой вилинь, вилинь, гоголю,
+
+Винеси літо з собою."""
+
+
+def test_generate_from_plan_writes_plan_reading_slug(tmp_path: Path) -> None:
+    plan_path = _write_plan(
+        tmp_path,
+        [
+            _reading_entry(
+                title="«Ой весна, весна, ти красна»",
+                source="Народна творчість; корпус ukrlib-narod-dumy",
+                reading_slug="plan-curated-vesna-slug",
+            )
+        ],
+    )
+    db_path = _write_sources_db(
+        tmp_path,
+        [
+            _corpus_row(
+                chunk_id="2df42ee0_c0000",
+                work="Народна творчість. Ой весна, весна, ти красна",
+                text=SPRING_TEXT,
+            )
+        ],
+    )
+    output_dir = tmp_path / "readings"
+
+    summary = generate_from_plan(plan_path, output_dir=output_dir, sources_db=db_path)
+
+    assert [item.slug for item in summary.written] == ["plan-curated-vesna-slug"]
+    assert (output_dir / "plan-curated-vesna-slug.mdx").exists()
+    assert not (output_dir / "vesnianka-oi-vesna-vesna-ty-krasna.mdx").exists()
+
+
+def test_generate_from_plan_uses_source_chunk_as_lookup_hint(tmp_path: Path) -> None:
+    plan_path = _write_plan(
+        tmp_path,
+        [
+            _reading_entry(
+                title="«Ой вилинь, вилинь, гоголю»",
+                source="Народна творчість; запис Грушевського; корпус chunk da46aa92_c0284",
+                reading_slug="vesnianka-oi-vylyn-hoholu",
+            )
+        ],
+    )
+    db_path = _write_sources_db(
+        tmp_path,
+        [
+            _corpus_row(
+                chunk_id="da46aa92_c0284",
+                work="Unrelated corpus work title",
+                text=HINTED_TEXT,
+            )
+        ],
+    )
+
+    summary = generate_from_plan(plan_path, output_dir=tmp_path / "readings", sources_db=db_path)
+
+    assert [item.source_chunk_id for item in summary.written] == ["da46aa92_c0284"]
+    assert summary.skipped == ()
+
+
+def test_generate_from_plan_skips_without_fabricating(tmp_path: Path) -> None:
+    modern_plan = _write_plan(
+        tmp_path / "modern",
+        [
+            _reading_entry(
+                title="«Сучасний текст»",
+                source="Сучасний автор; корпус chunk deadbeef_c0001",
+                reading_slug="modern-text",
+            )
+        ],
+    )
+    modern_db = _write_sources_db(
+        tmp_path / "modern",
+        [
+            _corpus_row(
+                chunk_id="deadbeef_c0001",
+                author="Сучасний автор",
+                work="Сучасний текст",
+                year=2020,
+                source_file="modern-source",
+                text="Сучасний текст\n\nрядок",
+            )
+        ],
+    )
+    modern_output = tmp_path / "modern" / "readings"
+
+    modern_summary = generate_from_plan(modern_plan, output_dir=modern_output, sources_db=modern_db)
+
+    assert modern_summary.written == ()
+    assert modern_summary.skipped[0].reason == "corpus row is not public-domain"
+    assert not (modern_output / "modern-text.mdx").exists()
+
+    verify_plan = _write_plan(
+        tmp_path / "verify",
+        [
+            _reading_entry(
+                title="«Ой весна, весна, ти красна»",
+                source="Народна творчість; корпус chunk feedface_c0002",
+                reading_slug="verify-fail",
+            )
+        ],
+    )
+    verify_db = _write_sources_db(
+        tmp_path / "verify",
+        [
+            _corpus_row(
+                chunk_id="feedface_c0002",
+                work="Ой весна, весна, ти красна",
+                text=SPRING_TEXT,
+            )
+        ],
+    )
+
+    def fail_verifier(
+        _candidate: PrimaryReadingCandidate,
+        _corpus: CorpusText,
+    ) -> VerificationResult:
+        return VerificationResult(False, 0.0, "forced failure")
+
+    verify_summary = generate_from_plan(
+        verify_plan,
+        output_dir=tmp_path / "verify" / "readings",
+        sources_db=verify_db,
+        quote_verifier=fail_verifier,
+    )
+
+    assert verify_summary.written == ()
+    assert verify_summary.skipped[0].reason == "quote verification failed: forced failure"
+    assert not (tmp_path / "verify" / "readings" / "verify-fail.mdx").exists()
+
+    missing_plan = _write_plan(
+        tmp_path / "missing",
+        [
+            _reading_entry(
+                title="«Немає в корпусі»",
+                source="Народна творчість; корпус chunk abcdef12_c0001",
+                reading_slug="missing-corpus",
+            )
+        ],
+    )
+    missing_summary = generate_from_plan(
+        missing_plan,
+        output_dir=tmp_path / "missing" / "readings",
+        sources_db=tmp_path / "missing" / "sources.db",
+    )
+
+    assert missing_summary.written == ()
+    assert missing_summary.skipped[0].reason == "no matching corpus text"
+    assert not (tmp_path / "missing" / "readings" / "missing-corpus.mdx").exists()
+
+
+def test_generate_from_plan_is_idempotent_and_preserves_hand_authored(tmp_path: Path) -> None:
+    plan_path = _write_plan(
+        tmp_path,
+        [
+            _reading_entry(
+                title="«Ой весна, весна, ти красна»",
+                source="Народна творчість; корпус chunk 2df42ee0_c0000",
+                reading_slug="vesna-idempotent",
+            )
+        ],
+    )
+    db_path = _write_sources_db(
+        tmp_path,
+        [
+            _corpus_row(
+                chunk_id="2df42ee0_c0000",
+                work="Ой весна, весна, ти красна",
+                text=SPRING_TEXT,
+            )
+        ],
+    )
+    output_dir = tmp_path / "readings"
+
+    first = generate_from_plan(plan_path, output_dir=output_dir, sources_db=db_path)
+    second = generate_from_plan(plan_path, output_dir=output_dir, sources_db=db_path)
+
+    assert [item.action for item in first.written] == ["created"]
+    assert second.written == ()
+    assert [item.action for item in second.existing] == ["unchanged"]
+
+    hand_output = tmp_path / "hand-authored"
+    hand_output.mkdir()
+    hand_path = hand_output / "vesna-idempotent.mdx"
+    hand_path.write_text("---\ntitle: Hand authored\n---\n", encoding="utf-8")
+
+    hand_summary = generate_from_plan(plan_path, output_dir=hand_output, sources_db=db_path)
+
+    assert hand_summary.written == ()
+    assert [item.action for item in hand_summary.existing] == ["existing-hand-authored"]
+    assert hand_path.read_text(encoding="utf-8") == "---\ntitle: Hand authored\n---\n"
+
+
+def test_readings_prebuild_phase_core_level_is_noop(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    called = False
+
+    def fake_generate_from_plan(*_args: Any, **_kwargs: Any) -> GenerationSummary:
+        nonlocal called
+        called = True
+        return GenerationSummary((), (), ())
+
+    monkeypatch.setattr(v7_build, "generate_from_plan", fake_generate_from_plan)
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    summary = v7_build._run_readings_prebuild_phase(
+        level="a1",
+        slug="core-fixture",
+        plan_path=tmp_path / "plan.yaml",
+        output_dir=tmp_path / "readings",
+        sources_db=tmp_path / "sources.db",
+        dry_run=False,
+        event_sink=lambda event, **fields: events.append((event, fields)),
+    )
+
+    assert summary is None
+    assert called is False
+    assert events == []
+
+
+def test_readings_prebuild_phase_emits_generation_and_skip_events(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    generated = WrittenReading(
+        slug="hosted-reading",
+        path=tmp_path / "readings" / "hosted-reading.mdx",
+        action="created",
+        source_chunk_id="2df42ee0_c0000",
+    )
+    skipped = SkippedReading("Missing", "missing-reading", "no matching corpus text")
+    fake_summary = GenerationSummary((generated,), (skipped,), ())
+    calls: list[dict[str, Any]] = []
+
+    def fake_generate_from_plan(*args: Any, **kwargs: Any) -> GenerationSummary:
+        calls.append({"args": args, "kwargs": kwargs})
+        return fake_summary
+
+    monkeypatch.setattr(v7_build, "generate_from_plan", fake_generate_from_plan)
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    summary = v7_build._run_readings_prebuild_phase(
+        level="folk",
+        slug="seminar-fixture",
+        plan_path=tmp_path / "plan.yaml",
+        output_dir=tmp_path / "readings",
+        sources_db=tmp_path / "sources.db",
+        dry_run=True,
+        event_sink=lambda event, **fields: events.append((event, fields)),
+    )
+
+    assert summary == fake_summary
+    assert calls[0]["args"] == (tmp_path / "plan.yaml",)
+    assert calls[0]["kwargs"]["dry_run"] is True
+    assert [event for event, _fields in events] == ["reading_generated", "reading_skipped"]
+    assert events[0][1]["reading_slug"] == "hosted-reading"
+    assert events[1][1]["reason"] == "no matching corpus text"
+
+
+def test_generated_plan_reading_has_required_schema_fields(tmp_path: Path) -> None:
+    plan_path = _write_plan(
+        tmp_path,
+        [
+            _reading_entry(
+                title="«Ой весна, весна, ти красна»",
+                title_en="Oh spring, spring, you beautiful one",
+                genre="Веснянка",
+                source="Народна творчість; корпус chunk 2df42ee0_c0000",
+                reading_slug="schema-vesna",
+            )
+        ],
+    )
+    db_path = _write_sources_db(
+        tmp_path,
+        [
+            _corpus_row(
+                chunk_id="2df42ee0_c0000",
+                work="Ой весна, весна, ти красна",
+                text=SPRING_TEXT,
+            )
+        ],
+    )
+    output_dir = tmp_path / "readings"
+
+    generate_from_plan(plan_path, output_dir=output_dir, sources_db=db_path)
+    mdx = (output_dir / "schema-vesna.mdx").read_text(encoding="utf-8")
+    frontmatter = yaml.safe_load(mdx.split("---", 2)[1])
+    body = mdx.split("---", 2)[2]
+
+    assert frontmatter["title"] == "«Ой весна, весна, ти красна»"
+    assert frontmatter["title_en"] == "Oh spring, spring, you beautiful one"
+    assert frontmatter["genre"] == "Веснянка"
+    assert frontmatter["tracks"] == ["folk"]
+    assert frontmatter["public_domain"] is True
+    assert "<PrimaryReading>" in body
+    assert "Ой весна, весна, ти красна" in body
+
+
+def _reading_entry(
+    *,
+    title: str,
+    source: str,
+    reading_slug: str,
+    title_en: str = "Fixture reading",
+    genre: str = "Веснянка",
+) -> dict[str, str]:
+    return {
+        "title": title,
+        "title_en": title_en,
+        "genre": genre,
+        "source": source,
+        "license": "public_domain",
+        "hosting": "host",
+        "reading_slug": reading_slug,
+    }
+
+
+def _write_plan(tmp_path: Path, readings: list[dict[str, str]]) -> Path:
+    plan_dir = tmp_path / "curriculum" / "l2-uk-en" / "plans" / "folk"
+    plan_dir.mkdir(parents=True, exist_ok=True)
+    plan_path = plan_dir / "fixture-module.yaml"
+    plan_path.write_text(
+        yaml.safe_dump(
+            {
+                "level": "folk",
+                "slug": "fixture-module",
+                "sequence": 1,
+                "title": "Fixture Module",
+                "readings": readings,
+            },
+            allow_unicode=True,
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return plan_path
+
+
+def _write_sources_db(tmp_path: Path, rows: list[tuple[Any, ...]] | None = None) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    db_path = tmp_path / "sources.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE literary_texts (
+            chunk_id TEXT,
+            author TEXT,
+            work TEXT,
+            work_id TEXT,
+            year INTEGER,
+            genre TEXT,
+            language_period TEXT,
+            source_file TEXT,
+            source_url TEXT,
+            text TEXT
+        )
+        """
+    )
+    conn.executemany(
+        """
+        INSERT INTO literary_texts (
+            chunk_id, author, work, work_id, year, genre,
+            language_period, source_file, source_url, text
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        rows or [],
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _corpus_row(
+    *,
+    chunk_id: str,
+    work: str,
+    text: str,
+    author: str = "Народна творчість",
+    year: int = 1600,
+    source_file: str = "ukrlib-narod-dumy",
+) -> tuple[Any, ...]:
+    return (
+        chunk_id,
+        author,
+        work,
+        f"{chunk_id}_work",
+        year,
+        "song",
+        "middle_ukrainian",
+        source_file,
+        "https://example.test/source",
+        text,
+    )


### PR DESCRIPTION
## What

- Add `generate_from_plan` and `--from-plan PLAN_PATH` to generate hosted readings from a plan `readings:` block.
- Preserve `reading_slug` exactly as the output slug while reusing `CorpusLookup`, `verify_candidate_against_corpus`, `is_public_domain`, `ResolvedReading`, `render_reading`, and `_write_resolved_readings`.
- Wire a `readings` pre-build phase in `v7_build.py` before writer work, with `reading_generated`, `reading_skipped`, and `phase_done` telemetry.
- Add focused plan-generation tests and keep the existing readings/v7 build slices green.

## Why

Hosted readings referenced by seminar `:::primary-reading` blocks need to exist before module build gates run. This moves reading generation into the build pipeline so future seminar builds get the hosted `/readings/<slug>.mdx` files automatically instead of relying on a manual step.

## #M-4 Evidence

| Claim | Evidence |
|---|---|
| slug==plan reading_slug | `tests/test_generate_readings_from_plan.py::test_generate_from_plan_writes_plan_reading_slug PASSED [ 14%]` |
| skip-not-fabricate on non-PD/verify-fail | `tests/test_generate_readings_from_plan.py::test_generate_from_plan_skips_without_fabricating PASSED [ 42%]` |
| idempotent + hand-authored protected | `tests/test_generate_readings_from_plan.py::test_generate_from_plan_is_idempotent_and_preserves_hand_authored PASSED [ 57%]` |
| CORE no-op | `tests/test_generate_readings_from_plan.py::test_readings_prebuild_phase_core_level_is_noop PASSED [ 71%]` |
| pre-build phase wired | `tests/test_generate_readings_from_plan.py::test_readings_prebuild_phase_emits_generation_and_skip_events PASSED [ 85%]`; dry run: `Written: 5`, `Skipped: 0` for `vesnianky-hayivky.yaml` |
| no regression | `.venv/bin/python -m pytest tests/test_generate_readings.py tests/test_generate_readings_demand.py tests/test_generate_readings_from_plan.py -q` -> `14 passed in 0.60s`; `.venv/bin/python -m pytest tests/build/test_v7_build_*.py tests/test_v7_build_*.py -q` -> `52 passed in 6.56s` |
| lint | `.venv/bin/ruff check scripts/readings/generate_readings.py scripts/build/v7_build.py tests/test_generate_readings_from_plan.py tests/build/test_v7_build_mdx_terminal.py` -> `All checks passed!` |

## Additional checks

- `git diff --cached --check` passed before commit.
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` passed for `64156ac37d`.
- Push preflight hooks passed, including X-Agent trailer check.
