### PR TITLE
feat(readings): source hosted readings from curated plan text

### DIFF
--- a/scripts/readings/generate_readings.py
+++ b/scripts/readings/generate_readings.py
@@ -43,6 +43,18 @@ _ATTRIBUTION_RE = re.compile(
     re.MULTILINE,
 )
 _PLAN_SOURCE_CHUNK_RE = re.compile(r"\bchunk\s+([0-9a-f]+_c\d+)\b", re.IGNORECASE)
+_APOSTROPHE_TRANSLATION = str.maketrans(
+    {
+        "\u02bc": "'",
+        "\u02bb": "'",
+        "\u2018": "'",
+        "\u2019": "'",
+        "`": "'",
+    }
+)
+_STRESS_MARKS = {"\u0300", "\u0301", "\u0341"}
+_DOUBLE_QUOTE_CHARS_RE = re.compile(r'[«»“”„‟"]')
+_HYPHENATED_LINE_BREAK_RE = re.compile(r"(?<=\w)[\-\u2010\u2011\u2012]\s+(?=\w)")
 _PLAN_TITLE_STRIP_CHARS = " \t\r\n«»“”„\"'`"
 _STRESS_RE = re.compile("[\u0300\u0301]")
 _NON_WORD_RE = re.compile(r"[^\w]+", re.UNICODE)
@@ -103,6 +115,8 @@ class ResolvedReading:
     study_links: str | None = None
     taught_in: tuple[str, ...] = ()
     source_chunk_ids: tuple[str, ...] = ()
+    body_text: str | None = None
+    text_match: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
@@ -112,6 +126,7 @@ class WrittenReading:
     path: Path
     action: str
     source_chunk_id: str
+    text_match: str | None = None
 
 
 @dataclass(frozen=True)
@@ -400,7 +415,7 @@ def generate_from_plan(
     quote_verifier: QuoteVerifier | None = None,
 ) -> GenerationSummary:
     """Generate hosted reading MDX files from one plan's readings block."""
-    verifier = quote_verifier or verify_candidate_against_corpus
+    _ = quote_verifier
     output_dir.mkdir(parents=True, exist_ok=True)
     raw_plan = yaml.safe_load(plan_path.read_text(encoding="utf-8")) or {}
     if not isinstance(raw_plan, dict):
@@ -414,6 +429,7 @@ def generate_from_plan(
     module_slug = str(raw_plan.get("slug") or plan_path.stem).strip()
     study_links = _study_link_from_plan(raw_plan, plan_path, level=level, slug=module_slug)
     lookup = CorpusLookup(sources_db)
+    chunk_rows: dict[str, sqlite3.Row] | None = None
     hosted_values = _hosted_reading_values()
     resolved_by_slug: dict[str, ResolvedReading] = {}
     skipped: list[SkippedReading] = []
@@ -433,6 +449,13 @@ def generate_from_plan(
         if not raw_title:
             skipped.append(SkippedReading("<untitled>", slug, "missing title"))
             continue
+        if "text" not in entry or entry.get("text") is None:
+            skipped.append(SkippedReading(raw_title, slug, "no curated text: field"))
+            continue
+        curated_text = _normalize_curated_text(str(entry.get("text") or ""))
+        if not curated_text:
+            skipped.append(SkippedReading(raw_title, slug, "no curated text: field"))
+            continue
 
         source = str(entry.get("source") or "").strip()
         source_chunk_id = _source_chunk_id(source)
@@ -447,7 +470,12 @@ def generate_from_plan(
             quote_lines=(candidate_title,),
         )
         hints = _plan_resource_hints(candidate, source, source_chunk_id, raw_title)
-        corpus = lookup.resolve(candidate, hints)
+        if source_chunk_id:
+            if chunk_rows is None:
+                chunk_rows = _load_corpus_chunk_rows(sources_db) if sources_db.exists() else {}
+            corpus = _read_corpus_chunks(chunk_rows, (source_chunk_id,))
+        else:
+            corpus = lookup.resolve(candidate, hints)
         if corpus is None:
             skipped.append(SkippedReading(raw_title, slug, "no matching corpus text"))
             continue
@@ -455,13 +483,13 @@ def generate_from_plan(
         if not is_public_domain(rights_corpus, track=candidate.track):
             skipped.append(SkippedReading(raw_title, slug, "corpus row is not public-domain"))
             continue
-        verdict = verifier(candidate, corpus)
-        if not verdict.matched:
+        text_match = _curated_text_match(curated_text, corpus)
+        if text_match is None:
             skipped.append(
                 SkippedReading(
                     raw_title,
                     slug,
-                    f"quote verification failed: {verdict.detail}",
+                    f"curated text not attested in corpus chunk {source_chunk_id or corpus.chunk_id}",
                 )
             )
             continue
@@ -474,6 +502,8 @@ def generate_from_plan(
             study_links=study_links,
             taught_in=(module_slug,) if module_slug else (),
             source_chunk_ids=(source_chunk_id or corpus.chunk_id,),
+            body_text=curated_text,
+            text_match=text_match,
             metadata=_plan_reading_metadata(entry),
         )
 
@@ -499,19 +529,29 @@ def _write_resolved_readings(
         if path.exists():
             current = path.read_text(encoding="utf-8")
             if GENERATED_MARKER not in current:
-                existing.append(WrittenReading(slug, path, "existing-hand-authored", resolved.corpus.chunk_id))
+                existing.append(
+                    WrittenReading(
+                        slug,
+                        path,
+                        "existing-hand-authored",
+                        resolved.corpus.chunk_id,
+                        resolved.text_match,
+                    )
+                )
                 continue
             if current == rendered:
-                existing.append(WrittenReading(slug, path, "unchanged", resolved.corpus.chunk_id))
+                existing.append(
+                    WrittenReading(slug, path, "unchanged", resolved.corpus.chunk_id, resolved.text_match)
+                )
                 continue
             if not dry_run:
                 path.write_text(rendered, encoding="utf-8")
-            written.append(WrittenReading(slug, path, "updated", resolved.corpus.chunk_id))
+            written.append(WrittenReading(slug, path, "updated", resolved.corpus.chunk_id, resolved.text_match))
             continue
 
         if not dry_run:
             path.write_text(rendered, encoding="utf-8")
-        written.append(WrittenReading(slug, path, "created", resolved.corpus.chunk_id))
+        written.append(WrittenReading(slug, path, "created", resolved.corpus.chunk_id, resolved.text_match))
     return written, existing
 
 
@@ -668,8 +708,9 @@ def render_reading(resolved: ResolvedReading) -> str:
     metadata = _metadata_for(resolved)
     tracks = sorted(resolved.tracks)
     study_links = resolved.study_links or _study_links(resolved.module_dirs)
-    body_text = _display_text(corpus.text, candidate.title)
+    body_text = resolved.body_text if resolved.body_text is not None else _display_text(corpus.text, candidate.title)
     quote = _blockquote(body_text)
+    attribution = _attribution(candidate) if resolved.body_text is not None else None
     intro_template = metadata.pop("intro", None)
     if intro_template:
         intro = intro_template.format(links=study_links)
@@ -690,6 +731,7 @@ def render_reading(resolved: ResolvedReading) -> str:
         "<PrimaryReading>",
         "",
         quote,
+        *(["", attribution] if attribution else []),
         "",
         "</PrimaryReading>",
         "",
@@ -1004,7 +1046,7 @@ def _load_corpus_chunk_rows(db_path: Path) -> dict[str, sqlite3.Row]:
             SELECT chunk_id, author, work, work_id, year, genre, language_period,
                    source_file, source_url, text
             FROM literary_texts
-            ORDER BY chunk_id, id
+            ORDER BY chunk_id, rowid
             """
         ).fetchall()
     for row in rows:
@@ -1047,6 +1089,37 @@ def _chunk_id_label(chunk_ids: Sequence[Any]) -> str:
     if len(values) <= 1:
         return values[0] if values else ""
     return f"{values[0]}-{values[-1]}"
+
+
+def _normalize_curated_text(raw_text: str) -> str:
+    lines = raw_text.replace("\r\n", "\n").replace("\r", "\n").splitlines()
+    while lines and not lines[0].strip():
+        lines.pop(0)
+    while lines and not lines[-1].strip():
+        lines.pop()
+    return "\n".join(line.rstrip() for line in lines)
+
+
+def _curated_text_match(curated_text: str, corpus: CorpusText) -> str | None:
+    corpus_text = corpus.text.replace("\r\n", "\n").replace("\r", "\n")
+    if curated_text and curated_text in corpus_text:
+        return "exact"
+
+    normalized_curated = _normalize_for_quote_match(curated_text)
+    normalized_corpus = _normalize_for_quote_match(corpus.text)
+    if normalized_curated and normalized_curated in normalized_corpus:
+        return "normalized"
+    return None
+
+
+def _normalize_for_quote_match(text: str) -> str:
+    text = text.replace("\r\n", "\n").replace("\r", "\n").translate(_APOSTROPHE_TRANSLATION)
+    decomposed = unicodedata.normalize("NFD", text)
+    without_stress = "".join(char for char in decomposed if char not in _STRESS_MARKS)
+    text = unicodedata.normalize("NFC", without_stress).replace("\u00ad", "")
+    text = _DOUBLE_QUOTE_CHARS_RE.sub("", text)
+    text = _HYPHENATED_LINE_BREAK_RE.sub("", text)
+    return re.sub(r"\s+", " ", text).strip()
 
 
 def _verify_rendered_text_attested(corpus: CorpusText, candidate_title: str) -> VerificationResult:
@@ -1122,6 +1195,8 @@ def _metadata_for(resolved: ResolvedReading) -> dict[str, Any]:
         metadata["taught_in"] = list(resolved.taught_in)
     if resolved.source_chunk_ids:
         metadata["source_chunk_ids"] = list(resolved.source_chunk_ids)
+    if resolved.text_match:
+        metadata["text_match"] = resolved.text_match
     return metadata
 
 
@@ -1137,6 +1212,7 @@ def _frontmatter(metadata: dict[str, Any], tracks: Sequence[str]) -> list[str]:
         "tracks",
         "taught_in",
         "source_chunk_ids",
+        "text_match",
         "excerpt",
         "source",
         "public_domain",
@@ -1187,6 +1263,11 @@ def _looks_like_title_line(line: str, candidate_title: str) -> bool:
 
 def _blockquote(text: str) -> str:
     return "\n".join(f"> {line}" if line else ">" for line in text.splitlines())
+
+
+def _attribution(candidate: PrimaryReadingCandidate) -> str:
+    note = f" ({candidate.note})" if candidate.note else ""
+    return f"— {candidate.author}, «{candidate.title}»{note}"
 
 
 def _study_links(module_dirs: Sequence[Path]) -> str:

--- a/tests/test_generate_readings_from_plan.py
+++ b/tests/test_generate_readings_from_plan.py
@@ -8,11 +8,8 @@ import yaml
 
 from scripts.build import v7_build
 from scripts.readings.generate_readings import (
-    CorpusText,
     GenerationSummary,
-    PrimaryReadingCandidate,
     SkippedReading,
-    VerificationResult,
     WrittenReading,
     generate_from_plan,
 )
@@ -29,15 +26,27 @@ HINTED_TEXT = """ОЙ ВИЛИНЬ, ВИЛИНЬ, ГОГОЛЮ
 
 Винеси літо з собою."""
 
+SPRING_CURATED_TEXT = """Ой весна, весна, ти красна,
 
-def test_generate_from_plan_writes_plan_reading_slug(tmp_path: Path) -> None:
+Що ти нам, весно, принесла?"""
+
+NORMALIZED_CURATED_TEXT = """Ой в полі з'явилася зірка
+В небі ясная"""
+
+NORMALIZED_CORPUS_TEXT = """Ой в полі зʼяви́лася   зірка
+
+В небі ясная"""
+
+
+def test_generate_from_plan_writes_curated_text_body_and_plan_slug(tmp_path: Path) -> None:
     plan_path = _write_plan(
         tmp_path,
         [
             _reading_entry(
                 title="«Ой весна, весна, ти красна»",
-                source="Народна творчість; корпус ukrlib-narod-dumy",
+                source="Народна творчість; корпус ukrlib-narod-dumy, chunk 2df42ee0_c0000",
                 reading_slug="plan-curated-vesna-slug",
+                text=SPRING_CURATED_TEXT,
             )
         ],
     )
@@ -56,8 +65,16 @@ def test_generate_from_plan_writes_plan_reading_slug(tmp_path: Path) -> None:
     summary = generate_from_plan(plan_path, output_dir=output_dir, sources_db=db_path)
 
     assert [item.slug for item in summary.written] == ["plan-curated-vesna-slug"]
-    assert (output_dir / "plan-curated-vesna-slug.mdx").exists()
+    rendered_path = output_dir / "plan-curated-vesna-slug.mdx"
+    rendered = rendered_path.read_text(encoding="utf-8")
+    assert rendered_path.exists()
     assert not (output_dir / "vesnianka-oi-vesna-vesna-ty-krasna.mdx").exists()
+    assert "> Ой весна, весна, ти красна," in rendered
+    assert "> Що ти нам, весно, принесла?" in rendered
+    assert "ОЙ ВЕСНА, ВЕСНА, ТИ КРАСНА" not in rendered
+    assert "source_chunk_ids: [\"2df42ee0_c0000\"]" in rendered
+    assert "text_match: \"exact\"" in rendered
+    assert "— Народна творчість, «Ой весна, весна, ти красна» (Веснянка)" in rendered
 
 
 def test_generate_from_plan_uses_source_chunk_as_lookup_hint(tmp_path: Path) -> None:
@@ -68,6 +85,9 @@ def test_generate_from_plan_uses_source_chunk_as_lookup_hint(tmp_path: Path) -> 
                 title="«Ой вилинь, вилинь, гоголю»",
                 source="Народна творчість; запис Грушевського; корпус chunk da46aa92_c0284",
                 reading_slug="vesnianka-oi-vylyn-hoholu",
+                text="""Ой вилинь, вилинь, гоголю,
+
+Винеси літо з собою.""",
             )
         ],
     )
@@ -88,7 +108,7 @@ def test_generate_from_plan_uses_source_chunk_as_lookup_hint(tmp_path: Path) -> 
     assert summary.skipped == ()
 
 
-def test_generate_from_plan_skips_without_fabricating(tmp_path: Path) -> None:
+def test_generate_from_plan_skips_non_public_domain_without_writing(tmp_path: Path) -> None:
     modern_plan = _write_plan(
         tmp_path / "modern",
         [
@@ -96,6 +116,7 @@ def test_generate_from_plan_skips_without_fabricating(tmp_path: Path) -> None:
                 title="«Сучасний текст»",
                 source="Сучасний автор; корпус chunk deadbeef_c0001",
                 reading_slug="modern-text",
+                text="Сучасний текст\n\nрядок",
             )
         ],
     )
@@ -120,18 +141,21 @@ def test_generate_from_plan_skips_without_fabricating(tmp_path: Path) -> None:
     assert modern_summary.skipped[0].reason == "corpus row is not public-domain"
     assert not (modern_output / "modern-text.mdx").exists()
 
-    verify_plan = _write_plan(
-        tmp_path / "verify",
+
+def test_generate_from_plan_skips_unattested_curated_text_without_writing(tmp_path: Path) -> None:
+    drift_plan = _write_plan(
+        tmp_path,
         [
             _reading_entry(
                 title="«Ой весна, весна, ти красна»",
                 source="Народна творчість; корпус chunk feedface_c0002",
-                reading_slug="verify-fail",
+                reading_slug="curated-drift",
+                text="Цього рядка немає в корпусному чанку.",
             )
         ],
     )
-    verify_db = _write_sources_db(
-        tmp_path / "verify",
+    drift_db = _write_sources_db(
+        tmp_path,
         [
             _corpus_row(
                 chunk_id="feedface_c0002",
@@ -140,43 +164,108 @@ def test_generate_from_plan_skips_without_fabricating(tmp_path: Path) -> None:
             )
         ],
     )
+    output_dir = tmp_path / "readings"
 
-    def fail_verifier(
-        _candidate: PrimaryReadingCandidate,
-        _corpus: CorpusText,
-    ) -> VerificationResult:
-        return VerificationResult(False, 0.0, "forced failure")
-
-    verify_summary = generate_from_plan(
-        verify_plan,
-        output_dir=tmp_path / "verify" / "readings",
-        sources_db=verify_db,
-        quote_verifier=fail_verifier,
+    drift_summary = generate_from_plan(
+        drift_plan,
+        output_dir=output_dir,
+        sources_db=drift_db,
     )
 
-    assert verify_summary.written == ()
-    assert verify_summary.skipped[0].reason == "quote verification failed: forced failure"
-    assert not (tmp_path / "verify" / "readings" / "verify-fail.mdx").exists()
+    assert drift_summary.written == ()
+    assert (
+        drift_summary.skipped[0].reason
+        == "curated text not attested in corpus chunk feedface_c0002"
+    )
+    assert not (output_dir / "curated-drift.mdx").exists()
 
+
+def test_generate_from_plan_skips_missing_curated_text_without_chunk_dump(tmp_path: Path) -> None:
+    no_text_plan = _write_plan(
+        tmp_path,
+        [
+            _reading_entry(
+                title="«Ой весна, весна, ти красна»",
+                source="Народна творчість; корпус chunk 2df42ee0_c0000",
+                reading_slug="no-curated-text",
+            )
+        ],
+    )
+    no_text_db = _write_sources_db(
+        tmp_path,
+        [
+            _corpus_row(
+                chunk_id="2df42ee0_c0000",
+                work="Ой весна, весна, ти красна",
+                text=SPRING_TEXT,
+            )
+        ],
+    )
+    no_text_output = tmp_path / "readings"
+
+    no_text_summary = generate_from_plan(no_text_plan, output_dir=no_text_output, sources_db=no_text_db)
+
+    assert no_text_summary.written == ()
+    assert no_text_summary.skipped[0].reason == "no curated text: field"
+    assert not (no_text_output / "no-curated-text.mdx").exists()
+
+
+def test_generate_from_plan_skips_missing_corpus_without_writing(tmp_path: Path) -> None:
     missing_plan = _write_plan(
-        tmp_path / "missing",
+        tmp_path,
         [
             _reading_entry(
                 title="«Немає в корпусі»",
                 source="Народна творчість; корпус chunk abcdef12_c0001",
                 reading_slug="missing-corpus",
+                text="Немає в корпусі",
             )
         ],
     )
+    output_dir = tmp_path / "readings"
+
     missing_summary = generate_from_plan(
         missing_plan,
-        output_dir=tmp_path / "missing" / "readings",
-        sources_db=tmp_path / "missing" / "sources.db",
+        output_dir=output_dir,
+        sources_db=tmp_path / "sources.db",
     )
 
     assert missing_summary.written == ()
     assert missing_summary.skipped[0].reason == "no matching corpus text"
-    assert not (tmp_path / "missing" / "readings" / "missing-corpus.mdx").exists()
+    assert not (output_dir / "missing-corpus.mdx").exists()
+
+
+def test_generate_from_plan_accepts_normalized_curated_text_match(tmp_path: Path) -> None:
+    plan_path = _write_plan(
+        tmp_path,
+        [
+            _reading_entry(
+                title="«Ой в полі з'явилася зірка»",
+                source="Народна творчість; корпус chunk abc12345_c0000",
+                reading_slug="normalized-only-match",
+                text=NORMALIZED_CURATED_TEXT,
+            )
+        ],
+    )
+    db_path = _write_sources_db(
+        tmp_path,
+        [
+            _corpus_row(
+                chunk_id="abc12345_c0000",
+                work="Ой в полі з'явилася зірка",
+                text=NORMALIZED_CORPUS_TEXT,
+            )
+        ],
+    )
+    output_dir = tmp_path / "readings"
+
+    summary = generate_from_plan(plan_path, output_dir=output_dir, sources_db=db_path)
+
+    assert [item.text_match for item in summary.written] == ["normalized"]
+    rendered = (output_dir / "normalized-only-match.mdx").read_text(encoding="utf-8")
+    assert "text_match: \"normalized\"" in rendered
+    assert "> Ой в полі з'явилася зірка" in rendered
+    assert "зʼяви́лася" not in rendered
 
 
 def test_generate_from_plan_is_idempotent_and_preserves_hand_authored(tmp_path: Path) -> None:
@@ -187,6 +276,7 @@ def test_generate_from_plan_is_idempotent_and_preserves_hand_authored(tmp_path: 
                 title="«Ой весна, весна, ти красна»",
                 source="Народна творчість; корпус chunk 2df42ee0_c0000",
                 reading_slug="vesna-idempotent",
+                text=SPRING_CURATED_TEXT,
             )
         ],
     )
@@ -299,6 +389,7 @@ def test_generated_plan_reading_has_required_schema_fields(tmp_path: Path) -> No
                 genre="Веснянка",
                 source="Народна творчість; корпус chunk 2df42ee0_c0000",
                 reading_slug="schema-vesna",
+                text=SPRING_CURATED_TEXT,
             )
         ],
     )
@@ -323,6 +414,8 @@ def test_generated_plan_reading_has_required_schema_fields(tmp_path: Path) -> No
     assert frontmatter["title_en"] == "Oh spring, spring, you beautiful one"
     assert frontmatter["genre"] == "Веснянка"
     assert frontmatter["tracks"] == ["folk"]
+    assert frontmatter["source_chunk_ids"] == ["2df42ee0_c0000"]
+    assert frontmatter["text_match"] == "exact"
     assert frontmatter["public_domain"] is True
     assert "<PrimaryReading>" in body
     assert "Ой весна, весна, ти красна" in body
@@ -335,8 +428,9 @@ def _reading_entry(
     reading_slug: str,
     title_en: str = "Fixture reading",
     genre: str = "Веснянка",
-) -> dict[str, str]:
-    return {
+    text: str | None = None,
+) -> dict[str, Any]:
+    entry: dict[str, Any] = {
         "title": title,
         "title_en": title_en,
         "genre": genre,
@@ -345,9 +439,12 @@ def _reading_entry(
         "hosting": "host",
         "reading_slug": reading_slug,
     }
+    if text is not None:
+        entry["text"] = text
+    return entry
 
 
-def _write_plan(tmp_path: Path, readings: list[dict[str, str]]) -> Path:
+def _write_plan(tmp_path: Path, readings: list[dict[str, Any]]) -> Path:
     plan_dir = tmp_path / "curriculum" / "l2-uk-en" / "plans" / "folk"
     plan_dir.mkdir(parents=True, exist_ok=True)
     plan_path = plan_dir / "fixture-module.yaml"


### PR DESCRIPTION
## Summary
- `generate_from_plan` now requires hosted plan readings to provide curated `text:` and renders that text instead of dumping the corpus chunk.
- Curated text is verified against the declared `source` chunk with an exact/normalized contiguous-substring check before anything is written.
- Generated frontmatter records `source_chunk_ids` and `text_match`; unattested or missing text skips loudly without creating an MDX file.

## Root Cause
Hosted folk verses are embedded inside scholarly corpus chunks, so the old `_display_text(corpus.text, ...)` fallback produced readings with prose, footnotes, and the verse buried inside. These readings are editorial artifacts and need curated text in the plan, verified against the corpus chunk.

## #M-4 Evidence
| Claim | Evidence |
|---|---|
| curated text hosted, not chunk dump | `tests/test_generate_readings_from_plan.py::test_generate_from_plan_writes_curated_text_body_and_plan_slug PASSED [  9%]` plus rendered snippet:<br><br>`source_chunk_ids: ["2df42ee0_c0000"]`<br>`text_match: "exact"`<br>`<PrimaryReading>`<br>`> Ой весна, весна, ти красна,`<br>`>`<br>`> Що ти нам, весно, принесла?`<br>`— Народна творчість, «Ой весна, весна, ти красна» (Веснянка)` |
| drift fails loud (no write) | `tests/test_generate_readings_from_plan.py::test_generate_from_plan_skips_unattested_curated_text_without_writing PASSED [ 36%]` |
| no-text → skip not dump | `tests/test_generate_readings_from_plan.py::test_generate_from_plan_skips_missing_curated_text_without_chunk_dump PASSED [ 45%]` |
| normalization match defined | `tests/test_generate_readings_from_plan.py::test_generate_from_plan_accepts_normalized_curated_text_match PASSED [ 63%]` |
| no regression | `============================== 18 passed in 0.59s ==============================` |
| lint | `All checks passed!` from `.venv/bin/ruff check scripts/readings/generate_readings.py tests/test_generate_readings_from_plan.py` |

## Validation
- `.venv/bin/python -m pytest tests/test_generate_readings_from_plan.py -vv`
- `.venv/bin/python -m pytest tests/test_generate_readings*.py -q`
- `.venv/bin/ruff check scripts/readings/generate_readings.py tests/test_generate_readings_from_plan.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `git diff --check HEAD~1..HEAD`

Note: full-repo `.venv/bin/ruff check` currently reports pre-existing unrelated lint failures under `docs/reports/` and `plans/`; changed-file ruff is clean.
