### PR TITLE
[codex] Persist B2 M27-M31 scores

### DIFF
--- a/docs/audits/b2-current-llm-scores-2026-06-26.md
+++ b/docs/audits/b2-current-llm-scores-2026-06-26.md
@@ -25,10 +25,15 @@ B2 M23 `multi-clause-sentences`,9/10,B+,Yes,Strong multi-clause syntax module wi
 B2 M24 `kharchuvannia-i-kukhnia`,9/10,B+,Yes,Strong food and kitchen communication module with validated activity and vocabulary coverage. Score held at 9 for retained non-blocking section-balance warnings.
 B2 M25 `correlative-constructions`,9/10,B+,Yes,Strong correlative-constructions module with 99.6% immersion and 99% richness. Independent review passed with no blockers.
 B2 M26 `emphasis-and-inversion`,9/10,B+,Yes,Strong emphasis and inversion module with 100% immersion and 99% richness. Independent review passed; non-blocking activity nits were fixed before merge.
+B2 M27 `stylistic-connectors`,9/10,B+,Yes,Strong stylistic-connectors module. Initial independent blockers fixed before merge; final Agy/Gemini review passed. Score held at 9 for conservative post-fix polish risk.
+B2 M28 `kupivlia-i-servisy`,9/10,B+,Yes,Strong shopping/services communication module with validated activity and vocabulary coverage. Initial independent blocker fixed; final Agy/Gemini review passed.
+B2 M29 `complex-syntax-ellipsis-parcelling`,9/10,B+,Yes,Strong ellipsis/parcelling module. Agy/Claude Opus blocker review passed with no unresolved findings.
+B2 M30 `direct-indirect-speech`,9/10,B+,Yes,Strong direct/indirect speech module. Agy/Claude Opus blocker review passed with no unresolved findings.
+B2 M31 `checkpoint-syntax-ii`,9/10,B+,Yes,Strong Syntax II checkpoint with broad review coverage, 20 workbook activities, and passing deterministic audit. Agy/Claude Opus review passed; score held at 9 for checkpoint size and minor non-blocking notes.
 
 Score,Count,Modules
 10/10,2,"M01, M08"
-9/10,23,"M02-M07, M09-M13, M15-M26"
+9/10,28,"M02-M07, M09-M13, M15-M31"
 8/10,1,M14
 
 Durable Report,Scope
@@ -36,6 +41,7 @@ Durable Report,Scope
 `docs/audits/b2-m11-m15-llm-score-report-2026-06-25.md`,M11-M15
 `docs/audits/b2-m16-m21-llm-score-report-2026-06-25.md`,M16-M21
 `docs/audits/b2-m22-m26-llm-score-report-2026-06-26.md`,M22-M26
+`docs/audits/b2-m27-m31-llm-score-report-2026-06-26.md`,M27-M31
 
 Module,Raw Word Count,Activities,Vocabulary
 M03 `b2-impersonal-passive`,4608,7 workbook / 4 inline,35
@@ -62,6 +68,11 @@ M23 `multi-clause-sentences`,5881,11 workbook / 0 inline,30
 M24 `kharchuvannia-i-kukhnia`,4753,11 workbook / 0 inline,43
 M25 `correlative-constructions`,4822,10 workbook / 0 inline,35
 M26 `emphasis-and-inversion`,4633,11 workbook / 0 inline,38
+M27 `stylistic-connectors`,5212,10 workbook / 0 inline,32
+M28 `kupivlia-i-servisy`,6004,10 workbook / 0 inline,46
+M29 `complex-syntax-ellipsis-parcelling`,4686,10 workbook / 0 inline,45
+M30 `direct-indirect-speech`,4683,12 workbook / 0 inline,46
+M31 `checkpoint-syntax-ii`,7247,20 workbook / 0 inline,35
 
 Score,Pass Count
 10/10,5/5 with no meaningful content polish
@@ -75,3 +86,4 @@ See `docs/audits/b2-m03-m10-llm-score-report-2026-06-25.md`.,M03-M10
 See `docs/audits/b2-m11-m15-llm-score-report-2026-06-25.md`.,M11-M15
 See `docs/audits/b2-m16-m21-llm-score-report-2026-06-25.md`.,M16-M21
 See `docs/audits/b2-m22-m26-llm-score-report-2026-06-26.md`.,M22-M26
+See `docs/audits/b2-m27-m31-llm-score-report-2026-06-26.md`.,M27-M31

--- a/docs/audits/b2-m27-m31-llm-score-report-2026-06-26.md
+++ b/docs/audits/b2-m27-m31-llm-score-report-2026-06-26.md
@@ -1,0 +1,34 @@
+Module,Score,Verdict,Deterministic Audit,Activity/Vocab Coverage,Ready Human Review?
+M27 `stylistic-connectors`,9/10,B+,PASS,10 workbook / 0 inline; 32 vocab,Yes
+M28 `kupivlia-i-servisy`,9/10,B+,PASS,10 workbook / 0 inline; 46 vocab,Yes
+M29 `complex-syntax-ellipsis-parcelling`,9/10,B+,PASS,10 workbook / 0 inline; 45 vocab,Yes
+M30 `direct-indirect-speech`,9/10,B+,PASS,12 workbook / 0 inline; 46 vocab,Yes
+M31 `checkpoint-syntax-ii`,9/10,B+,PASS,20 workbook / 0 inline; 35 vocab,Yes
+
+Module,Notes
+M27 `stylistic-connectors`,Strong stylistic-connectors module with validated activity coverage and 100.0% immersion. Initial independent blockers were fixed before merge; final Agy/Gemini review passed. Score held at 9 for conservative post-fix polish risk and the 32/35 vocabulary soft-target note.
+M28 `kupivlia-i-servisy`,Strong shopping/services communication module with 5787/4000 audit words, 46 vocabulary items, and validated consumer-service practice. Initial Agy/Gemini blocker was fixed; follow-up review passed. Score held at 9 for conservative post-build polish risk.
+M29 `complex-syntax-ellipsis-parcelling`,Strong ellipsis/parcelling module with 4283/4000 audit words, 100.0% immersion, and 99% richness. Agy/Claude Opus blocker review passed with no unresolved findings. Score held at 9 for conservative advanced-syntax polish risk.
+M30 `direct-indirect-speech`,Strong direct/indirect speech module with 12 workbook activities, 46 vocabulary items, and 96% richness. Agy/Claude Opus blocker review passed with no unresolved findings. Score held at 9 for conservative punctuation/transformation polish risk.
+M31 `checkpoint-syntax-ii`,Strong Syntax II checkpoint with broad review coverage, 20 workbook activities, 6995/4000 audit words, and 99.9% immersion. Agy/Claude Opus review passed with no unresolved findings. Score held at 9 for checkpoint size and minor non-blocking notes.
+
+Module,Raw Word Count,Activities,Vocabulary,Audit Words,Immersion,Richness
+M27 `stylistic-connectors`,5212,10 workbook / 0 inline,32,4880/4000,100.0%,99%
+M28 `kupivlia-i-servisy`,6004,10 workbook / 0 inline,46,5787/4000,100.0%,97%
+M29 `complex-syntax-ellipsis-parcelling`,4686,10 workbook / 0 inline,45,4283/4000,100.0%,99%
+M30 `direct-indirect-speech`,4683,12 workbook / 0 inline,46,4131/4000,100.0%,96%
+M31 `checkpoint-syntax-ii`,7247,20 workbook / 0 inline,35,6995/4000,99.9%,99%
+
+Module,Reviewer,Result
+M27 `stylistic-connectors`,Agy -> Claude Opus 4.6 initial review; Agy -> Gemini 3.1 Pro High final review,Initial two blockers fixed before merge; final PASS no unresolved blockers.
+M28 `kupivlia-i-servisy`,Agy -> Gemini 3.1 Pro High initial and follow-up review,Initial one blocker fixed before merge; follow-up PASS no unresolved blockers.
+M29 `complex-syntax-ellipsis-parcelling`,Agy -> Claude Opus 4.6 Thinking blocker review,PASS; no unresolved findings.
+M30 `direct-indirect-speech`,Agy -> Claude Opus 4.6 Thinking blocker review,PASS; no unresolved findings.
+M31 `checkpoint-syntax-ii`,Agy -> Claude Opus 4.6 Thinking blocker review,PASS; no unresolved findings.
+
+Module,PR,Merge Commit,Telemetry Run
+M27 `stylistic-connectors`,#3861,`603c49861af56d8d813d79f4d1e1747a6f58060b`,`b2-stylistic-connectors-codex-b2-m27-stylistic-connectors-20260626`
+M28 `kupivlia-i-servisy`,#3862,`6836ffd7e38b96506f6dd986b7ffae8e5e489236`,`b2-kupivlia-i-servisy-codex-b2-m28-kupivlia-i-servisy-20260626`
+M29 `complex-syntax-ellipsis-parcelling`,#3863,`56c98bdc2a473ee626e425a33f160bb63e0933ad`,`b2-complex-syntax-ellipsis-parcelling-codex-b2-m29-ellipsis-parcelling-20260626`
+M30 `direct-indirect-speech`,#3864,`844928f4e75fbec3e54f5c3ee551c987d2290e60`,`b2-direct-indirect-speech-codex-b2-m30-direct-indirect-speech-20260626`
+M31 `checkpoint-syntax-ii`,#3865,`c664961c01c22ce0a0c36a1cc1196d77f311dd70`,`b2-checkpoint-syntax-ii-codex-b2-m31-checkpoint-syntax-ii-20260626`


### PR DESCRIPTION
## Scope

- Persist B2 M27-M31 score decisions in the current score ledger.
- Add the durable M27-M31 LLM score report with raw counts, deterministic audit metrics, independent review evidence, PR links, merge commits, and telemetry run IDs.
- Keep the score PR docs-only under `docs/audits/`; no module content or generated artifacts are included.

## Score Summary

All five modules are recorded as `9/10`, `B+`, ready for human review:

- M27 `stylistic-connectors`
- M28 `kupivlia-i-servisy`
- M29 `complex-syntax-ellipsis-parcelling`
- M30 `direct-indirect-speech`
- M31 `checkpoint-syntax-ii`

## Validation

- `.venv/bin/python scripts/audit_module.py --skip-review curriculum/l2-uk-en/b2/{stylistic-connectors,kupivlia-i-servisy,complex-syntax-ellipsis-parcelling,direct-indirect-speech,checkpoint-syntax-ii}/module.md` equivalent per-module reruns: PASS for all five.
- `git diff --cached --check`: PASS before commit.
- Protected config guard for `.python-version`, `.yamllint`, `.markdownlint.json`: PASS.
- Generated artifact guard for `status/*.json`, `audit/*-review.md`, `review/*-review.md`, `docs/*-STATUS.md`, and `data/telemetry/**`: PASS.
- `sys.executable` guard on changed files: PASS.
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`: PASS.
- Commit/push hooks: PASS.

## Review Notes

This PR only persists scores for already merged module PRs #3861-#3865. Module-level independent reviews were completed before those module merges; this score PR still needs the final external blocker review gate before merge.