### PR TITLE
feat(audit): add folk publish safety gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -498,6 +498,14 @@ jobs:
         run: |
           .venv/bin/python scripts/audit/check_mdx_forward_parity.py --changed-vs-base origin/main
 
+      - name: Check internal IDs are not published
+        run: |
+          .venv/bin/python scripts/audit/check_no_internal_ids.py --changed-vs-base origin/main
+
+      - name: Check locked modules are not published
+        run: |
+          .venv/bin/python scripts/audit/check_locked_module_not_published.py --changed-vs-base origin/main
+
   mdx-generation-drift:
     name: MDX Generation Drift
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -137,6 +137,27 @@ repos:
           /.*\.(md|ya?ml)$
         stages: [pre-commit]
 
+      - id: check-no-internal-ids
+        name: check no internal IDs in published seminar MDX
+        entry: bash scripts/pre_commit/project_python.sh scripts/audit/check_no_internal_ids.py --files
+        language: system
+        files: >-
+          (?x)^site/src/content/
+          (
+            docs/(folk|hist|istorio|bio|lit|lit-essay|lit-hist-fic|lit-fantastika|
+            lit-war|lit-humor|lit-youth|lit-doc|lit-drama|lit-crimea|oes|ruth)/.*\.mdx|
+            readings/.*\.mdx
+          )$
+        stages: [pre-commit]
+      - id: check-locked-module-not-published
+        name: check locked modules are not published
+        entry: bash scripts/pre_commit/project_python.sh scripts/audit/check_locked_module_not_published.py --files
+        language: system
+        files: >-
+          (?x)^site/src/content/docs/
+          (folk|hist|istorio|bio|lit|lit-essay|lit-hist-fic|lit-fantastika|
+          lit-war|lit-humor|lit-youth|lit-doc|lit-drama|lit-crimea|oes|ruth)/.*\.mdx$
+        stages: [pre-commit]
       - id: lesson-schema-drift
         name: lesson schema drift gate
         entry: >-

--- a/scripts/audit/check_locked_module_not_published.py
+++ b/scripts/audit/check_locked_module_not_published.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Block locked/todo/planned seminar modules from being served as live MDX."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DOCS_DIR = PROJECT_ROOT / "site" / "src" / "content" / "docs"
+
+SEMINAR_DOC_TRACKS = {
+    "bio",
+    "folk",
+    "hist",
+    "istorio",
+    "lit",
+    "lit-crimea",
+    "lit-doc",
+    "lit-drama",
+    "lit-essay",
+    "lit-fantastika",
+    "lit-hist-fic",
+    "lit-humor",
+    "lit-war",
+    "lit-youth",
+    "oes",
+    "ruth",
+}
+NON_PUBLISHED_STATUSES = {"locked", "planned", "todo"}
+MODULE_OBJECT_RE = re.compile(r"\{[^{}]*\}", re.DOTALL)
+PROP_RE = re.compile(r"""\b(?P<name>slug|status)\s*:\s*["'](?P<value>[^"']+)["']""")
+DRAFT_TRUE_RE = re.compile(r"^draft:\s*true\s*(?:#.*)?$", re.IGNORECASE)
+
+
+@dataclass(frozen=True, order=True)
+class ModuleStatus:
+    track: str
+    slug: str
+    status: str
+    index_path: Path
+    line_no: int
+
+
+@dataclass(frozen=True, order=True)
+class ModuleTarget:
+    track: str
+    slug: str
+
+
+@dataclass(frozen=True, order=True)
+class CheckScope:
+    tracks: frozenset[str]
+    modules: frozenset[ModuleTarget]
+
+
+@dataclass(frozen=True, order=True)
+class Finding:
+    module: ModuleStatus
+    mdx_path: Path
+
+    def format(self) -> str:
+        module = self.module
+        return (
+            f"{display_path(self.mdx_path)}:1: {module.track}/{module.slug} is "
+            f"{module.status!r} in {display_path(module.index_path)}:{module.line_no} "
+            "but its MDX page is published; add draft: true or remove the page"
+        )
+
+
+def display_path(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(PROJECT_ROOT.resolve()).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _as_absolute_path(path: Path) -> Path:
+    if path.is_absolute():
+        return path
+    return PROJECT_ROOT / path
+
+
+def _repo_relative(path: Path) -> Path | None:
+    try:
+        return _as_absolute_path(path).resolve().relative_to(PROJECT_ROOT.resolve())
+    except ValueError:
+        return None
+
+
+def parse_landing_modules(index_path: Path, track: str) -> dict[str, ModuleStatus]:
+    if not index_path.is_file():
+        return {}
+
+    text = index_path.read_text(encoding="utf-8")
+    modules: dict[str, ModuleStatus] = {}
+    for object_match in MODULE_OBJECT_RE.finditer(text):
+        props = {match.group("name"): match.group("value") for match in PROP_RE.finditer(object_match.group(0))}
+        slug = props.get("slug")
+        status = props.get("status")
+        if slug is None or status is None:
+            continue
+        modules[slug] = ModuleStatus(
+            track=track,
+            slug=slug,
+            status=status,
+            index_path=index_path,
+            line_no=text.count("\n", 0, object_match.start()) + 1,
+        )
+    return modules
+
+
+def has_draft_true(path: Path) -> bool:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0].strip() != "---":
+        return False
+    for line in lines[1:]:
+        stripped = line.strip()
+        if stripped == "---":
+            return False
+        if DRAFT_TRUE_RE.match(stripped):
+            return True
+    return False
+
+
+def _module_path(docs_dir: Path, module: ModuleStatus | ModuleTarget) -> Path:
+    return docs_dir / module.track / f"{module.slug}.mdx"
+
+
+def _check_module(module: ModuleStatus, docs_dir: Path) -> Finding | None:
+    if module.status not in NON_PUBLISHED_STATUSES:
+        return None
+    mdx_path = _module_path(docs_dir, module)
+    if not mdx_path.is_file():
+        return None
+    if has_draft_true(mdx_path):
+        return None
+    return Finding(module=module, mdx_path=mdx_path)
+
+
+def check_scope(scope: CheckScope, *, docs_dir: Path = DOCS_DIR) -> list[Finding]:
+    findings_by_module: dict[tuple[str, str], Finding] = {}
+    tracks = set(scope.tracks)
+    tracks.update(module.track for module in scope.modules)
+
+    modules_by_track = {
+        track: parse_landing_modules(docs_dir / track / "index.mdx", track)
+        for track in tracks
+        if track in SEMINAR_DOC_TRACKS
+    }
+
+    for track in scope.tracks:
+        for module in modules_by_track.get(track, {}).values():
+            finding = _check_module(module, docs_dir)
+            if finding is not None:
+                findings_by_module[(module.track, module.slug)] = finding
+
+    for target in scope.modules:
+        module = modules_by_track.get(target.track, {}).get(target.slug)
+        if module is None:
+            continue
+        finding = _check_module(module, docs_dir)
+        if finding is not None:
+            findings_by_module[(module.track, module.slug)] = finding
+
+    return sorted(findings_by_module.values())
+
+
+def affected_scope(paths: list[Path]) -> CheckScope:
+    tracks: set[str] = set()
+    modules: set[ModuleTarget] = set()
+
+    for raw_path in paths:
+        rel_path = _repo_relative(raw_path)
+        if rel_path is None or rel_path.suffix.lower() != ".mdx":
+            continue
+
+        parts = rel_path.parts
+        if len(parts) != 6 or parts[:4] != ("site", "src", "content", "docs"):
+            continue
+
+        track = parts[4]
+        if track not in SEMINAR_DOC_TRACKS:
+            continue
+        if parts[5] == "index.mdx":
+            tracks.add(track)
+            continue
+        modules.add(ModuleTarget(track=track, slug=Path(parts[5]).stem))
+
+    return CheckScope(tracks=frozenset(tracks), modules=frozenset(modules))
+
+
+def _git_output(args: list[str]) -> str:
+    return subprocess.check_output(["git", *args], cwd=PROJECT_ROOT, text=True)
+
+
+def get_changed_files(base: str) -> list[Path]:
+    merge_base = _git_output(["merge-base", base, "HEAD"]).strip()
+    output = _git_output(["diff", "--name-only", f"{merge_base}...HEAD"])
+    return [PROJECT_ROOT / line for line in output.splitlines() if line]
+
+
+def get_local_changed_files(*, cached: bool = False) -> list[Path]:
+    cmd = ["diff", "--name-only"]
+    if cached:
+        cmd.append("--cached")
+    output = _git_output(cmd)
+    return [PROJECT_ROOT / line for line in output.splitlines() if line]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Check locked/todo/planned seminar modules are not published.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--changed-vs-base", metavar="BASE", help="Compare against base branch, e.g. origin/main")
+    group.add_argument("--files", nargs="+", type=Path, help="Scan explicit files, e.g. from pre-commit")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.changed_vs_base:
+        raw_paths = [
+            *get_changed_files(args.changed_vs_base),
+            *get_local_changed_files(),
+            *get_local_changed_files(cached=True),
+        ]
+    else:
+        raw_paths = args.files
+
+    scope = affected_scope(raw_paths)
+    if not scope.tracks and not scope.modules:
+        print("0 findings: no changed seminar docs require locked-module publish check.")
+        return 0
+
+    findings = check_scope(scope)
+    if not findings:
+        checked_count = len(scope.tracks) + len(scope.modules)
+        print(f"0 findings: no locked/todo/planned modules published in {checked_count} changed scope(s).")
+        return 0
+
+    for finding in findings:
+        print(finding.format())
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/check_no_internal_ids.py
+++ b/scripts/audit/check_no_internal_ids.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Block internal corpus/source IDs from published seminar MDX."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DOCS_DIR = PROJECT_ROOT / "site" / "src" / "content" / "docs"
+READINGS_DIR = PROJECT_ROOT / "site" / "src" / "content" / "readings"
+
+SEMINAR_DOC_TRACKS = {
+    "bio",
+    "folk",
+    "hist",
+    "istorio",
+    "lit",
+    "lit-crimea",
+    "lit-doc",
+    "lit-drama",
+    "lit-essay",
+    "lit-fantastika",
+    "lit-hist-fic",
+    "lit-humor",
+    "lit-war",
+    "lit-youth",
+    "oes",
+    "ruth",
+}
+
+INTERNAL_ID_PATTERNS = (
+    ("corpus chunk id", re.compile(r"\b[0-9a-f]{8}_c[0-9]{4}\b")),
+    ("source section id", re.compile(r"\bS[0-9]{3,4}\b")),
+)
+
+
+@dataclass(frozen=True, order=True)
+class Finding:
+    path: Path
+    line_no: int
+    column_no: int
+    kind: str
+    value: str
+
+    def format(self) -> str:
+        return (
+            f"{display_path(self.path)}:{self.line_no}:{self.column_no}: "
+            f"internal {self.kind} leaked: {self.value}"
+        )
+
+
+def display_path(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(PROJECT_ROOT.resolve()).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _as_absolute_path(path: Path) -> Path:
+    if path.is_absolute():
+        return path
+    return PROJECT_ROOT / path
+
+
+def _repo_relative(path: Path) -> Path | None:
+    try:
+        return _as_absolute_path(path).resolve().relative_to(PROJECT_ROOT.resolve())
+    except ValueError:
+        return None
+
+
+def is_published_seminar_mdx(path: Path, *, allow_external: bool = False) -> bool:
+    if path.suffix.lower() != ".mdx":
+        return False
+
+    rel_path = _repo_relative(path)
+    if rel_path is None:
+        return allow_external
+
+    parts = rel_path.parts
+    if len(parts) >= 5 and parts[:4] == ("site", "src", "content", "readings"):
+        return True
+    if len(parts) >= 6 and parts[:4] == ("site", "src", "content", "docs"):
+        return parts[4] in SEMINAR_DOC_TRACKS
+    return False
+
+
+def _dedupe(paths: list[Path]) -> list[Path]:
+    seen: set[Path] = set()
+    unique_paths: list[Path] = []
+    for path in paths:
+        normalized = path.resolve()
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        unique_paths.append(path)
+    return unique_paths
+
+
+def scan_candidates(paths: list[Path], *, allow_external: bool = False) -> list[Path]:
+    candidates: list[Path] = []
+    for raw_path in paths:
+        path = _as_absolute_path(raw_path)
+        if not path.is_file():
+            continue
+        if is_published_seminar_mdx(path, allow_external=allow_external):
+            candidates.append(path)
+    return _dedupe(candidates)
+
+
+def scan_file(path: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    text = path.read_text(encoding="utf-8")
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        for kind, pattern in INTERNAL_ID_PATTERNS:
+            for match in pattern.finditer(line):
+                findings.append(
+                    Finding(
+                        path=path,
+                        line_no=line_no,
+                        column_no=match.start() + 1,
+                        kind=kind,
+                        value=match.group(0),
+                    )
+                )
+    return findings
+
+
+def scan_files(paths: list[Path]) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in paths:
+        findings.extend(scan_file(path))
+    return sorted(findings)
+
+
+def _git_output(args: list[str]) -> str:
+    return subprocess.check_output(["git", *args], cwd=PROJECT_ROOT, text=True)
+
+
+def get_changed_files(base: str) -> list[Path]:
+    merge_base = _git_output(["merge-base", base, "HEAD"]).strip()
+    output = _git_output(["diff", "--name-only", f"{merge_base}...HEAD"])
+    return [PROJECT_ROOT / line for line in output.splitlines() if line]
+
+
+def get_local_changed_files(*, cached: bool = False) -> list[Path]:
+    cmd = ["diff", "--name-only"]
+    if cached:
+        cmd.append("--cached")
+    output = _git_output(cmd)
+    return [PROJECT_ROOT / line for line in output.splitlines() if line]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Check published seminar/readings MDX for internal source IDs.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--changed-vs-base", metavar="BASE", help="Compare against base branch, e.g. origin/main")
+    group.add_argument("--files", nargs="+", type=Path, help="Scan explicit files, e.g. from pre-commit")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.changed_vs_base:
+        raw_paths = [
+            *get_changed_files(args.changed_vs_base),
+            *get_local_changed_files(),
+            *get_local_changed_files(cached=True),
+        ]
+        candidates = scan_candidates(raw_paths)
+    else:
+        candidates = scan_candidates(args.files, allow_external=True)
+
+    if not candidates:
+        print("0 findings: no published seminar/readings MDX files to scan.")
+        return 0
+
+    findings = scan_files(candidates)
+    if not findings:
+        print(f"0 findings: no internal IDs in {len(candidates)} published seminar/readings MDX file(s).")
+        return 0
+
+    for finding in findings:
+        print(finding.format())
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_locked_module_not_published.py
+++ b/tests/test_check_locked_module_not_published.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+from scripts.audit import check_locked_module_not_published
+
+
+def _write_track_fixture(tmp_path: Path, *, locked_frontmatter: str) -> Path:
+    docs_dir = tmp_path / "docs"
+    track_dir = docs_dir / "folk"
+    track_dir.mkdir(parents=True)
+    (track_dir / "index.mdx").write_text(
+        """---
+title: Folk
+---
+
+<LevelLanding
+  modules={[
+        { num: 1, slug: "active-module", title: "Active", sub: "Active", status: "active" },
+        { num: 2, slug: "locked-module", title: "Locked", sub: "Locked", status: "locked" },
+  ]}
+/>
+""",
+        encoding="utf-8",
+    )
+    (track_dir / "active-module.mdx").write_text("---\ntitle: Active\n---\n\nLive.\n", encoding="utf-8")
+    (track_dir / "locked-module.mdx").write_text(locked_frontmatter + "\n\nLocked body.\n", encoding="utf-8")
+    return docs_dir
+
+
+def test_locked_module_with_draft_true_has_no_findings(tmp_path: Path) -> None:
+    docs_dir = _write_track_fixture(tmp_path, locked_frontmatter="---\ntitle: Locked\ndraft: true\n---")
+    scope = check_locked_module_not_published.CheckScope(tracks=frozenset({"folk"}), modules=frozenset())
+
+    assert check_locked_module_not_published.check_scope(scope, docs_dir=docs_dir) == []
+
+
+def test_locked_module_without_draft_true_is_reported(tmp_path: Path) -> None:
+    docs_dir = _write_track_fixture(tmp_path, locked_frontmatter="---\ntitle: Locked\n---")
+    scope = check_locked_module_not_published.CheckScope(tracks=frozenset({"folk"}), modules=frozenset())
+
+    findings = check_locked_module_not_published.check_scope(scope, docs_dir=docs_dir)
+
+    assert len(findings) == 1
+    assert findings[0].module.slug == "locked-module"
+    assert findings[0].module.status == "locked"
+    assert findings[0].mdx_path == docs_dir / "folk" / "locked-module.mdx"
+
+
+def test_locked_module_finding_prints_mdx_file_line(tmp_path: Path) -> None:
+    docs_dir = _write_track_fixture(tmp_path, locked_frontmatter="---\ntitle: Locked\n---")
+    scope = check_locked_module_not_published.CheckScope(
+        tracks=frozenset(),
+        modules=frozenset({check_locked_module_not_published.ModuleTarget("folk", "locked-module")}),
+    )
+
+    finding = check_locked_module_not_published.check_scope(scope, docs_dir=docs_dir)[0]
+
+    assert str(docs_dir / "folk" / "locked-module.mdx") in finding.format()
+    assert ":1: folk/locked-module is 'locked'" in finding.format()
+
+
+def test_affected_scope_checks_index_tracks_and_module_pages() -> None:
+    paths = [
+        Path("site/src/content/docs/folk/index.mdx"),
+        Path("site/src/content/docs/folk/locked-module.mdx"),
+        Path("site/src/content/docs/a1/core-module.mdx"),
+    ]
+
+    scope = check_locked_module_not_published.affected_scope(paths)
+
+    assert scope.tracks == frozenset({"folk"})
+    assert scope.modules == frozenset({check_locked_module_not_published.ModuleTarget("folk", "locked-module")})

--- a/tests/test_check_no_internal_ids.py
+++ b/tests/test_check_no_internal_ids.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+from scripts.audit import check_no_internal_ids
+
+
+def test_clean_fixture_has_no_findings(tmp_path: Path) -> None:
+    clean = tmp_path / "clean.mdx"
+    clean.write_text(
+        "---\ntitle: Clean\n---\n\nA public source URL is fine: https://www.ukrlib.com.ua/demo/\n",
+        encoding="utf-8",
+    )
+
+    assert check_no_internal_ids.scan_files([clean]) == []
+
+
+def test_violating_fixture_reports_chunk_and_section_ids(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.mdx"
+    bad.write_text(
+        "---\ntitle: Bad\n---\n\ntruthSource={`5794da94_c0817`}\nSource section S4433 leaked.\n",
+        encoding="utf-8",
+    )
+
+    findings = check_no_internal_ids.scan_files([bad])
+
+    assert [(finding.line_no, finding.value) for finding in findings] == [
+        (5, "5794da94_c0817"),
+        (6, "S4433"),
+    ]
+
+
+def test_main_files_mode_prints_file_line_on_violation(tmp_path: Path, capsys) -> None:
+    bad = tmp_path / "bad.mdx"
+    bad.write_text("Visible leak 40beaaff_c0000.\n", encoding="utf-8")
+
+    exit_code = check_no_internal_ids.main(["--files", str(bad)])
+
+    output = capsys.readouterr().out
+    assert exit_code == 1
+    assert f"{bad}:1:14: internal corpus chunk id leaked: 40beaaff_c0000\n" == output
+
+
+def test_non_mdx_explicit_file_is_ignored(tmp_path: Path, capsys) -> None:
+    note = tmp_path / "note.txt"
+    note.write_text("Internal-looking text 40beaaff_c0000 outside MDX.\n", encoding="utf-8")
+
+    exit_code = check_no_internal_ids.main(["--files", str(note)])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert output == "0 findings: no published seminar/readings MDX files to scan.\n"


### PR DESCRIPTION
## Summary
- Add a changed-file gate for internal corpus chunk IDs and source section IDs in published seminar/readings MDX.
- Add a changed-file gate that blocks locked/todo/planned seminar modules from being served without draft: true.
- Wire both gates into pre-commit and the MDX parity CI job.

## Notes
- References #3860.
- PR #3867 is still open, so the locked-module gate intentionally runs on changed seminar docs; running it against the current folk index reports the four stale locked pages from that cleanup PR.
- The whole-site ID control scan found existing chunk-ID debt beyond istorychni-pisni, so the internal-ID gate is also changed-file scoped to avoid blocking unrelated PRs while still blocking new or touched leaks.

## Validation
- .venv/bin/python -m pytest tests/test_check_no_internal_ids.py tests/test_check_locked_module_not_published.py -q
- .venv/bin/ruff check scripts/audit/check_no_internal_ids.py scripts/audit/check_locked_module_not_published.py
- .venv/bin/python scripts/audit/check_no_internal_ids.py --files site/src/content/docs/folk/index.mdx
- .venv/bin/python scripts/audit/check_no_internal_ids.py --files site/src/content/docs/folk/koliadky-shchedrivky.mdx
- .venv/bin/python scripts/audit/check_locked_module_not_published.py --files site/src/content/docs/folk/istorychni-pisni.mdx
- .venv/bin/python scripts/audit/check_locked_module_not_published.py --files site/src/content/docs/folk/index.mdx