### PR TITLE
docs(folk): istorychni-pisni reading catalog (rebuild research step 0)

### DIFF
--- a/docs/research/folk/istorychni-reading-catalog.md
+++ b/docs/research/folk/istorychni-reading-catalog.md
@@ -1,0 +1,162 @@
+# Reading Catalog: Історичні пісні (Historical Songs)
+
+This catalog details the historical songs (історичні пісні) taught in the Ukrainian literature school canon (Grades 5-8), verifying textbook attestation, public sources, and corpus availability.
+
+## Summary Table
+
+| Title (UA) | Title (EN) | Genre | Textbook Attestation | Hosting Decision | Text Identity Verified |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| Байда («В Цариграді на риночку…») | Baida ("In Constantinople on the Marketplace...") | Історична пісня | Grade 8 Literature (Zabolotnyi 2025, p. 9) | hosted | true |
+| «Зажурилась Україна» | "Ukraine is Grieving" | Історична пісня | Grade 8 Literature (Zabolotnyi 2025, p. 8) | hosted | true |
+| «Гей, не дивуйте, добрії люди» | "Hey, Do Not Wonder, Good People" | Історична пісня | Grade 8 Literature (Zabolotnyi 2025, p. 8) | hosted | true |
+| Морозенко («Ой Морозе, Морозенку…») | Morozenko ("Oh Moroz, Morozenko...") | Історична пісня | Grade 8 Literature (Zabolotnyi 2025, p. 12) | hosted | true |
+| Максим Залізняк («Максим козак Залізняк…») | Maksym Zalizniak ("Maksym the Cossack...") | Історична пісня | Grade 8 Literature (Zabolotnyi 2025, p. 8) | hosted | true |
+| Кармелюк («За Сибіром сонце сходить») | Karmeliuk ("Behind Siberia the Sun Rises") | Історична пісня | Grade 8 Literature (Zabolotnyi 2025, p. 8) | hosted | true |
+| «Чи не той то хміль» | "Is That Not the Hops" | Історична пісня | Grade 8 Literature (Zabolotnyi 2025, p. 14) | reading-needed | false |
+| Іван Сірко («Та, ой, як крикнув же козак Сірко») | Ivan Sirko ("Oh, As the Cossack Sirko Shouted") | Історична пісня | Grade 8 Literature (Zabolotnyi 2025, p. 8, 10) | reading-needed | false |
+| Довбуш («Ой попід гай зелененький») | Dovbush ("Oh, Under the Green Grove") | Історична пісня | Grade 8 Literature (Zabolotnyi 2025, p. 8) | reading-needed | false |
+
+---
+
+## Candidate Details
+
+### 1. Байда / Дмитро Вишневецький («В Цариграді на риночку…»)
+- **title**: Байда («В Цариграді на риночку…»)
+- **title_en**: Baida ("In Constantinople on the Marketplace...")
+- **author**: Народна творчість
+- **genre**: Історична пісня
+- **source_type**: primary
+- **textbook attestation**: Grade 8 Literature (Zabolotnyi 2025, page 9; Avramenko 2025, §16-17; also Grade 8 History: Schupak 2025, Gisem 2021, Hlibovska 2025, Galimov 2025)
+- **source_url**: https://www.ukrlib.com.ua/books/showit.php?tid=4747
+- **corpus verify result**: `40beaaff_c0000` (confidence: 1.0)
+- **license/public_domain**: Public Domain (folk)
+- **hosting_decision**: hosted
+- **text_identity_verified**: true
+- **notes**: Full verbatim text verified in `data/sources.db`. Protoype is Prince Dmytro Vyshnevetsky (founder of the first Zaporozhian Sich on Mala Khortytsia island, executed by the Ottoman Empire in 1653).
+
+### 2. «Зажурилась Україна»
+- **title**: «Зажурилась Україна»
+- **title_en**: "Ukraine is Grieving"
+- **author**: Народна творчість
+- **genre**: Історична пісня
+- **source_type**: primary
+- **textbook attestation**: Grade 8 Literature (Zabolotnyi 2025, page 8, 10; Avramenko 2025, §16-17)
+- **source_url**: https://www.ukrlib.com.ua/narod/book.php?id=3
+- **corpus verify result**: `1f7ae6ee_c0000` (confidence: 1.0)
+- **license/public_domain**: Public Domain (folk)
+- **hosting_decision**: hosted
+- **text_identity_verified**: true
+- **notes**: Full verbatim text verified in `data/sources.db`. Depicts the struggle against Turkish-Tatar raids (15th-16th c.) and calls all social layers to defend the homeland.
+
+### 3. «Гей, не дивуйте, добрії люди»
+- **title**: «Гей, не дивуйте, добрії люди»
+- **title_en**: "Hey, Do Not Wonder, Good People"
+- **author**: Народна творчість
+- **genre**: Історична пісня
+- **source_type**: primary
+- **textbook attestation**: Grade 8 Literature (Zabolotnyi 2025, page 8)
+- **source_url**: https://www.ukrlib.com.ua/narod/book.php?id=3
+- **corpus verify result**: `8028b13a_c0000` (confidence: 1.0)
+- **license/public_domain**: Public Domain (folk)
+- **hosting_decision**: hosted
+- **text_identity_verified**: true
+- **notes**: Full verbatim text verified in `data/sources.db`. Focuses on Maksym Kryvonis (Perebyinis) and Bohdan Khmelnytsky during the Khmelnytsky Uprising (1648).
+
+### 4. Морозенко («Ой Морозе, Морозенку…»)
+- **title**: Морозенко («Ой Морозе, Морозенку…»)
+- **title_en**: Morozenko ("Oh Moroz, Morozenko...")
+- **author**: Народна творчість
+- **genre**: Історична пісня
+- **source_type**: primary
+- **textbook attestation**: Grade 8 Literature (Zabolotnyi 2025, pages 12-14)
+- **source_url**: https://www.ukrlib.com.ua/narod/book.php?id=3
+- **corpus verify result**: `208e8198_c0001` (confidence: 1.0)
+- **license/public_domain**: Public Domain (folk)
+- **hosting_decision**: hosted
+- **text_identity_verified**: true
+- **notes**: Full verbatim text verified in `data/sources.db` (chrestomathy version). Prototype: Colonel Stanislav Mrozovytsky, close ally of Bohdan Khmelnytsky, killed in the Battle of Zbarazh (1649).
+
+### 5. Максим Залізняк («Максим козак Залізняк…»)
+- **title**: Максим Залізняк («Максим козак Залізняк…»)
+- **title_en**: Maksym Zalizniak ("Maksym the Cossack Zalizniak...")
+- **author**: Народна творчість
+- **genre**: Історична пісня
+- **source_type**: primary
+- **textbook attestation**: Grade 8 Literature (Zabolotnyi 2025, page 8; also Grade 8/9 History and Literature: Avramenko Grade 9, Hlibovska Grade 8, Schupak Grade 8)
+- **source_url**: https://www.ukrlib.com.ua/narod/book.php?id=3
+- **corpus verify result**: `83f36b8b_c0000` (confidence: 1.0)
+- **license/public_domain**: Public Domain (folk)
+- **hosting_decision**: hosted
+- **text_identity_verified**: true
+- **notes**: Full verbatim text verified in `data/sources.db`. Celebrates the leader of the Koliivщина uprising (1768).
+
+### 6. Кармелюк / «За Сибіром сонце сходить»
+- **title**: Кармелюк («За Сибіром сонце сходить»)
+- **title_en**: Karmeliuk ("Behind Siberia the Sun Rises")
+- **author**: Народна творчість
+- **genre**: Історична пісня
+- **source_type**: primary
+- **textbook attestation**: Grade 8 Literature (Zabolotnyi 2025, page 8; Grade 9 Literature: Mishchenko 2017)
+- **source_url**: https://www.ukrlib.com.ua/narod/book.php?id=3
+- **corpus verify result**: `ff912500_c0000` (confidence: 1.0)
+- **license/public_domain**: Public Domain (folk)
+- **hosting_decision**: hosted
+- **text_identity_verified**: true
+- **notes**: Full verbatim text verified in `data/sources.db`. Focuses on Ustim Karmeliuk, leader of the peasant movement in Podillia in the early 19th c.
+
+### 7. «Чи не той то хміль»
+- **title**: «Чи не той то хміль»
+- **title_en**: "Is That Not the Hops"
+- **author**: Народна творчість
+- **genre**: Історична пісня
+- **source_type**: primary
+- **textbook attestation**: Grade 8 Literature (Zabolotnyi 2025, pages 14-16)
+- **source_url**: https://www.ukrlib.com.ua/narod/book.php?id=3
+- **corpus verify result**: unknown
+- **license/public_domain**: Public Domain (folk)
+- **hosting_decision**: reading-needed
+- **text_identity_verified**: false
+- **notes**: Song is canonical (Grade 8 Literature Zabolotnyi 2025). The text is discussed in Hrushevsky (`5794da94_c2950`), but needs dedicated verbatim verification of the exact school-text edition for hosting.
+
+### 8. Іван Сірко («Та, ой, як крикнув же козак Сірко»)
+- **title**: Іван Сірко («Та, ой, як крикнув же козак Сірко»)
+- **title_en**: Ivan Sirko ("Oh, As the Cossack Sirko Shouted")
+- **author**: Народна творчість
+- **genre**: Історична пісня
+- **source_type**: primary
+- **textbook attestation**: Grade 8 Literature (Zabolotnyi 2025, page 8, 10; Avramenko 2025)
+- **source_url**: https://www.ukrlib.com.ua/narod/book.php?id=3
+- **corpus verify result**: unknown
+- **license/public_domain**: Public Domain (folk)
+- **hosting_decision**: reading-needed
+- **text_identity_verified**: false
+- **notes**: Taught in Grade 8. The song is canonical but its exact verbatim text needs separate retrieval/verification. Prototype: Otaman Ivan Sirko.
+
+### 9. Довбуш («Ой попід гай зелененький»)
+- **title**: Довбуш («Ой попід гай зелененький»)
+- **title_en**: Dovbush ("Oh, Under the Green Grove")
+- **author**: Народна творчість
+- **genre**: Історична пісня
+- **source_type**: primary
+- **textbook attestation**: Grade 8 Literature (Zabolotnyi 2025, page 8)
+- **source_url**: https://www.ukrlib.com.ua/narod/book.php?id=3
+- **corpus verify result**: unknown
+- **license/public_domain**: Public Domain (folk)
+- **hosting_decision**: reading-needed
+- **text_identity_verified**: false
+- **notes**: Mentioned in Grade 8 Zabolotnyi 2025. Prototype: Olexa Dovbush. Text is not present in local RAG database; needs online sourcing/retrieval.
+
+---
+
+## Preflight Summary Block
+
+```text
+Reading coverage:
+- hosted: 6
+- linked-only: 0
+- excerpt-only: 0
+- omit: 0
+- reading-needed: 3
+Primary source families checked: ukrlib-narod-dumy, wave4-hrushevsky-iur-t7-10
+Unresolved blockers: 3 songs (Чи не той то хміль, Іван Сірко, Довбуш) require verbatim text sourcing and verification to be marked ready for hosting.
+```


### PR DESCRIPTION
## What
The reading catalog for the `istorychni-pisni` rebuild (research step 0), produced by agy and reviewed by Claude (track driver). Adds `docs/research/folk/istorychni-reading-catalog.md`. Refs #3860.

Applies the locked sourcing chain: **textbook canon (safety/attestation) → corpus full text → public URL**.

## Review (Claude) — verified, with the key finding
- **All 9 songs carry Grade-8 school-canon attestation** (Zabolotnyi 2025 + others) → the OUTLINE/safety gate passes.
- **6 core songs `hosted`, full verbatim text CONFIRMED in `data/sources.db`** — I checked the chunks the catalog cites and they hold the **complete songs**, not fragments (Байда `40beaaff_c0000` = 1284 ch / full ПІСНЯ ПРО БАЙДУ; Морозенко `208e8198_c0001` = 2040 ch; Кармелюк `ff912500_c0000` = 1724 ch; etc.). The shipped pilot quoted **one line** from chunks that contained the whole song — the root of the "fragment not full song" defect.
- **Use the corpus's own per-song `source_url`** (authoritative ukrlib `narod/printout.php` pages, present in `literary_texts.source_url`) as the public citation — not the collection-page URLs the catalog currently lists, and never the chunk-id. (Minor; the rebuild pulls URLs from the corpus directly.)
- **3 enrichment songs** (Чи не той то хміль, Сірко, Довбуш) honestly marked `reading-needed` — not faked.

## For the rebuild
Host the FULL song per `:::primary-reading`, lesson quotes long excerpts, public ukrlib URL cited, internal chunk-ids stripped (now enforced by the merged chunk-id gate, #3868).

Track-driver PR — research doc; safe to merge.