### PR TITLE
test(folk): decouple tests from deleted modules

### DIFF
--- a/tests/test_citation_resolve.py
+++ b/tests/test_citation_resolve.py
@@ -173,11 +173,23 @@ def test_quoted_title_with_no_plan_match_still_rejected() -> None:
 
 
 def test_koliadky_author_prefixed_plan_references_resolve_by_containment() -> None:
-    plan_path = (
-        linear_pipeline.PROJECT_ROOT
-        / "curriculum/l2-uk-en/plans/folk/koliadky-shchedrivky.yaml"
-    )
-    plan = yaml.safe_load(plan_path.read_text("utf-8"))
+    plan = {
+        "references": [
+            {"title": "Слов'янська міфологія", "author": "Костомаров М."},
+            {"title": "Нарис історії культури України", "author": "Попович М."},
+            {
+                "title": "Історія української літератури",
+                "author": "Чижевський Д.",
+            },
+            {
+                "title": (
+                    "Праці етнографічно-статистичної експедиції "
+                    "в Західно-Руський край"
+                ),
+                "author": "Чубинський П.",
+            },
+        ]
+    }
     resources = [
         {"source_ref": "Костомаров М. «Слов'янська міфологія»"},
         {"source_ref": "Попович М. «Нарис історії культури України»"},

--- a/tests/test_llm_qg_api.py
+++ b/tests/test_llm_qg_api.py
@@ -2,26 +2,86 @@
 
 from __future__ import annotations
 
+import json
+
+import pytest
 from fastapi.testclient import TestClient
 
 import scripts.api.main as api_main
+import scripts.api.state_compute as state_compute
 import scripts.api.state_router as state_router
 
 client = TestClient(api_main.app, raise_server_exceptions=False)
+
+_FOLK_LLM_QG_SLUGS = [
+    (1, "fixture-folk-llm-qg-1"),
+    (2, "fixture-folk-llm-qg-2"),
+    (3, "fixture-folk-llm-qg-3"),
+    (4, "fixture-folk-llm-qg-4"),
+]
+
+_DIMENSIONS = ("accuracy", "source", "pedagogy", "language", "culture")
+
+
+@pytest.fixture
+def folk_llm_qg_fixture(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    curriculum_root = tmp_path / "curriculum"
+    track_dir = curriculum_root / "folk"
+    router_get_plan_slugs = state_router.get_plan_slugs
+    compute_get_plan_slugs = state_compute.get_plan_slugs
+
+    for index, (_, slug) in enumerate(_FOLK_LLM_QG_SLUGS, start=1):
+        module_dir = track_dir / slug
+        module_dir.mkdir(parents=True)
+        dimensions = {
+            name: {
+                "score": 8.0 + (index / 10),
+                "evidence": f"{slug}:{name}",
+            }
+            for name in _DIMENSIONS
+        }
+        payload = {
+            "aggregate": {
+                "verdict": "PASS",
+                "terminal_verdict": "PASS",
+                "min_score": 8.0 + (index / 10),
+                "min_dim": "accuracy",
+                "failing_dims": [],
+                "warning_dims": [],
+            },
+            "dimensions": dimensions,
+        }
+        (module_dir / "llm_qg.json").write_text(
+            json.dumps(payload, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+    def fake_get_plan_slugs(track_id: str) -> list[tuple[int, str]]:
+        if track_id == "folk":
+            return _FOLK_LLM_QG_SLUGS
+        return router_get_plan_slugs(track_id)
+
+    def fake_compute_get_plan_slugs(track_id: str) -> list[tuple[int, str]]:
+        if track_id == "folk":
+            return _FOLK_LLM_QG_SLUGS
+        return compute_get_plan_slugs(track_id)
+
+    monkeypatch.setattr(state_router, "CURRICULUM_ROOT", curriculum_root)
+    monkeypatch.setattr(state_compute, "CURRICULUM_ROOT", curriculum_root)
+    monkeypatch.setattr(state_router, "get_plan_slugs", fake_get_plan_slugs)
+    monkeypatch.setattr(state_compute, "get_plan_slugs", fake_compute_get_plan_slugs)
 
 
 def _folk_scored_module(body: dict) -> dict:
     return next(module for module in body["modules"] if module["has_llm_qg"])
 
 
-def test_folk_llm_qg_track_returns_scored_modules():
+def test_folk_llm_qg_track_returns_scored_modules(folk_llm_qg_fixture):
     resp = client.get("/api/state/llm-qg/folk")
     body = resp.json()
 
     assert resp.status_code == 200
     assert body["track"] == "folk"
-    # 4 built+scored folk modules after the 2026-06-25 folk reset cut (was 6; cut
-    # narodni-viruvannia-mifolohiia-demonolohiia + zamovliannia-zaklynannia-prymovky).
     assert body["summary"]["scored"] >= 4
     assert body["summary"]["total"] == len(state_router.get_plan_slugs("folk"))
     assert len(body["modules"]) == body["summary"]["total"]
@@ -53,7 +113,7 @@ def test_llm_qg_unknown_track_returns_404():
     assert resp.json() == {"error": "Track 'no-such-track' not found"}
 
 
-def test_llm_qg_verbose_includes_evidence_default_omits_it():
+def test_llm_qg_verbose_includes_evidence_default_omits_it(folk_llm_qg_fixture):
     compact = _folk_scored_module(client.get("/api/state/llm-qg/folk").json())
     verbose = _folk_scored_module(client.get("/api/state/llm-qg/folk?verbose=true").json())
 
@@ -65,7 +125,7 @@ def test_llm_qg_verbose_includes_evidence_default_omits_it():
     assert "evidence" in verbose_dim
 
 
-def test_module_slug_compact_projection_includes_llm_qg_block():
+def test_module_slug_compact_projection_includes_llm_qg_block(folk_llm_qg_fixture):
     track = client.get("/api/state/llm-qg/folk").json()
     slug = _folk_scored_module(track)["slug"]
 

--- a/tests/test_reading_coverage_gate.py
+++ b/tests/test_reading_coverage_gate.py
@@ -8,8 +8,6 @@ import yaml
 
 from scripts.build.linear_pipeline import PYTHON_QG_GATE_ORDER, _reading_coverage_gate
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-
 
 def _run_fixture_gate(tmp_path: Path, plan: dict[str, Any], module_text: str) -> dict[str, Any]:
     plan_path = tmp_path / "plan.yaml"
@@ -165,22 +163,73 @@ def test_non_seminar_level_is_skipped(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    ("slug", "expect_floor_warning"),
+    ("plan", "module_text", "expect_floor_warning"),
     [
-        ("koliadky-shchedrivky", False),
-        ("kalendarna-obriadovist-zvychai", False),
-        ("narodna-kultura-yak-systema", False),
-        ("dumy-nevilnytski-lytsarski", False),
-        # narodni-viruvannia-mifolohiia-demonolohiia + zamovliannia-zaklynannia-prymovky CUT 2026-06-25
-        # (folk reset — see FOLK-FRAMING-STANDARD.md; modules removed from the track).
+        pytest.param(
+            {
+                "level": "folk",
+                "readings": [
+                    {
+                        "title": "«Ой весна»",
+                        "hosting": "host",
+                        "reading_slug": "oi-vesna",
+                    },
+                ],
+            },
+            _module_with_four_blocks("«Ой весна»"),
+            False,
+            id="hosted-title-attribution",
+        ),
+        pytest.param(
+            {
+                "level": "folk",
+                "readings": [
+                    {
+                        "title": "«Гей, соколи»",
+                        "hosting": "hosted",
+                        "reading_slug": "hei-sokoly",
+                    },
+                ],
+            },
+            _module_with_four_blocks("«Гей, соколи»"),
+            False,
+            id="hosted-alias-attribution",
+        ),
+        pytest.param(
+            {
+                "level": "folk",
+                "readings": [
+                    {
+                        "title": "«Дума про втечу трьох братів з Азова»",
+                        "hosting": "host",
+                        "reading_slug": "duma-pro-vtechu-trokh-brativ-z-azova",
+                    },
+                ],
+            },
+            _module_with_four_blocks("«Дума про втечу трьох братів з Азова»"),
+            False,
+            id="long-hosted-title-attribution",
+        ),
+        pytest.param(
+            {
+                "level": "folk",
+                "readings": [
+                    {
+                        "title": "«Щедрий вечір»",
+                        "hosting": "host",
+                        "reading_slug": "shchedryi-vechir",
+                    },
+                ],
+            },
+            _module_with_four_blocks("«Щедрий вечір»"),
+            False,
+            id="hosted-title-no-floor-warning",
+        ),
     ],
 )
-def test_real_built_folk_modules_all_pass_reading_coverage(slug: str, expect_floor_warning: bool) -> None:
-    plan_path = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "plans" / "folk" / f"{slug}.yaml"
-    module_path = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "folk" / slug / "module.md"
-    plan = yaml.safe_load(plan_path.read_text(encoding="utf-8"))
-    module_text = module_path.read_text(encoding="utf-8")
-
+def test_fixture_folk_modules_all_pass_reading_coverage(
+    plan: dict[str, Any], module_text: str, expect_floor_warning: bool
+) -> None:
     result = _reading_coverage_gate(module_text, plan)
 
     assert result["passed"] is True


### PR DESCRIPTION
## Summary

- Replace the deleted `koliadky-shchedrivky` plan read in citation resolution tests with an inline synthetic plan containing the exact author-prefixed references under test.
- Add a deterministic temporary folk llm-qg fixture so scored API tests no longer depend on whichever folk modules are currently built.
- Replace the reading-coverage parametrization that read the four deleted folk modules with inline folk reading-coverage cases.

## Root Cause

PR #3867 intentionally unpublished four poisoned, unre-built folk modules. Several tests still treated those modules and their generated artifacts as stable fixtures.

## Validation

- `.venv/bin/python -m pytest tests/test_citation_resolve.py tests/test_llm_qg_api.py -q`
  - `============================== 39 passed in 0.92s ==============================`
- `.venv/bin/python -m pytest tests/test_citation_resolve.py tests/test_llm_qg_api.py tests/test_reading_coverage_gate.py -q`
  - `============================== 51 passed in 0.97s ==============================`
- `.venv/bin/ruff check tests/test_citation_resolve.py tests/test_llm_qg_api.py tests/test_reading_coverage_gate.py`
  - `All checks passed!`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
  - `✅ All 1 non-skipped commit(s) carry an X-Agent trailer.`
- Full suite, with ignored local runtime symlinks for external article JSONL, Diasporiana JSONL, and embed venv restored from the main checkout:
  - `= 1 failed, 9093 passed, 129 skipped, 11 xfailed, 3 warnings in 689.34s (0:11:29) =`
  - Remaining failure is unrelated to #3867: `tests/test_atlas_conformance.py::test_real_lexicon_manifest_conforms_to_atlas_gates` reports four lexicon manifest entries absent from local VESUM/heritage data (`доти...доки`, `масмедіа`, `медіаманіпулювання`, `не/ні`).

Refs #3867.
