### PR TITLE
feat(atlas): apply practice-hub PoC design to the Words-of-the-Day pages

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: cc6ff3397002666f0d7b90a7fc1c2fbeeed366e4bdbf183dcf8af60fca17a160
+  components_sha256: 6c86d2c3dcb264fd1a07651fcda647616a7f57de8eb136f323f1a8f8313e19d6
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 6c86d2c3dcb264fd1a07651fcda647616a7f57de8eb136f323f1a8f8313e19d6
+  components_sha256: 2b9c0c12e7ec7ac931ab95ac0acbd78d33fc34e5f99c2febf9c214f02b260f32
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/e2e/atlas-practice.spec.ts
+++ b/site/e2e/atlas-practice.spec.ts
@@ -41,7 +41,7 @@ test('browse supports search, category, and letter entry points without dumping 
 test('practice cloze mode never dead-ends for a fresh learner', async ({ page }) => {
   await page.goto('/words-of-the-day/practice/');
 
-  await page.getByRole('button', { name: 'Cloze' }).click();
+  await page.locator('button[data-mode="cloze"]').click();
   // Cloze is fail-closed until reviewed sentences are authored (#3797). The mode must show a
   // real cloze card OR a clear "being prepared" message — never the ambiguous "all done"
   // dead-end the user reported. This invariant holds before AND after cloze content lands.
@@ -53,7 +53,7 @@ test('practice cloze mode never dead-ends for a fresh learner', async ({ page })
 test('practice matching renders a real round (>=3 pairs) for a fresh learner', async ({ page }) => {
   await page.goto('/words-of-the-day/practice/');
 
-  await page.getByRole('button', { name: 'Matching' }).click();
+  await page.locator('button[data-mode="matching"]').click();
   await expect(page.locator('[data-testid="practice-matching"]')).toBeVisible();
   await expect.poll(() => page.locator('[data-activity="match-left-tile"]').count()).toBeGreaterThanOrEqual(3);
 });

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -547,9 +547,9 @@ export default function LexiconPractice({
     setStreak(readStreak());
     setMastered(masteredCount(MASTERED_THRESHOLD));
     if (state.flags.corrupt || state.flags.migrationFailed) {
-      setStorageWarning('Progress is paused until browser storage is readable.');
+      setStorageWarning('Прогрес призупинено, доки сховище браузера не стане доступним.');
     } else if (state.flags.clockJump) {
-      setStorageWarning('Review timing may be off because device clock changed.');
+      setStorageWarning('Час повторення може бути неточним: змінився годинник пристрою.');
     }
   }, []);
 
@@ -634,7 +634,7 @@ export default function LexiconPractice({
       setClozeLoaded(nextClozeLoaded);
       return nextDeck;
     } catch {
-      if (deckRequestId.current === requestId) setError('Practice deck could not be loaded.');
+      if (deckRequestId.current === requestId) setError('Не вдалося завантажити колоду для практики.');
       return null;
     } finally {
       if (deckRequestId.current === requestId) setLoading(false);
@@ -666,7 +666,7 @@ export default function LexiconPractice({
     const state = loadState();
     setMastered(masteredCount(MASTERED_THRESHOLD));
     if (state.flags.corrupt || state.flags.migrationFailed) {
-      setStorageWarning('Progress is paused until browser storage is readable.');
+      setStorageWarning('Прогрес призупинено, доки сховище браузера не стане доступним.');
     }
     setRevision((value) => value + 1);
   }
@@ -685,7 +685,7 @@ export default function LexiconPractice({
       }
       setFeedback(`${current.lemma.lemma}: ${RATING_LABELS[rating]}`);
     } catch {
-      setStorageWarning('Progress is paused until browser storage is readable.');
+      setStorageWarning('Прогрес призупинено, доки сховище браузера не стане доступним.');
     }
   }
 
@@ -722,7 +722,9 @@ export default function LexiconPractice({
     const rating = option.correct ? 'good' : 'again';
     recordReview(selection, rating);
     setAnswerLocked(true);
-    setFeedback(option.correct ? `${selection.lemma.lemma}: Correct` : `${selection.lemma.lemma}: Again`);
+    setFeedback(
+      option.correct ? `${selection.lemma.lemma}: Правильно` : `${selection.lemma.lemma}: Ще раз`,
+    );
     window.setTimeout(() => {
       setAnswerLocked(false);
       completeSelection(selection);
@@ -1033,7 +1035,7 @@ function PracticeItem({
   return (
     <div className="lexicon-choice" data-testid={`practice-${selection.mode}`}>
       <p className="lexicon-choice-prompt mc-q">{prompt}</p>
-      <p className="mc-sub">Оберіть правильну відповідь · клавіші 1-4</p>
+      <p className="mc-sub">Оберіть правильну відповідь</p>
       <ul className="lexicon-option-list mc-options">
         {options.map((option, index) => (
           <li key={option.label}>

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { type CSSProperties, useEffect, useMemo, useRef, useState } from 'react';
 import FlashcardDeck from './FlashcardDeck';
 import MatchUp from './MatchUp';
 import {
   combinePracticeShards,
   czNorm,
+  getDueQueue,
   isWrongCaseAnswer,
   loadState,
   masteredCount,
@@ -58,10 +59,10 @@ const STREAK_KEY = 'lu-lexicon-practice-streak';
 const MASTERED_THRESHOLD = 21;
 
 const RATING_LABELS: Record<PracticeRating, string> = {
-  again: 'Again',
-  hard: 'Hard',
-  good: 'Good',
-  easy: 'Easy',
+  again: 'Ще раз',
+  hard: 'Важко',
+  good: 'Добре',
+  easy: 'Легко',
 };
 
 const MODE_LABELS: Record<PracticeModeFilter, string> = {
@@ -72,13 +73,62 @@ const MODE_LABELS: Record<PracticeModeFilter, string> = {
   cloze: 'Cloze',
 };
 
+const MODE_CARD_ORDER: PracticeModeFilter[] = ['mixed', 'flashcards', 'matching', 'choice', 'cloze'];
+
+const MODE_META: Record<
+  PracticeModeFilter,
+  {
+    title: string;
+    en: string;
+    description: string;
+    step: string;
+    accent: 'blue' | 'teal' | 'purple' | 'orange';
+  }
+> = {
+  mixed: {
+    title: 'Мікс',
+    en: 'Mixed',
+    description: 'Чергуйте картки, добір, вибір і пропуски, щоб не звикати до одного типу підказки.',
+    step: 'Змішана сесія',
+    accent: 'orange',
+  },
+  flashcards: {
+    title: 'Флешкартки',
+    en: 'Flashcards',
+    description: 'Картка за карткою з інтервальним повторенням. Згадайте значення, тоді оцініть відповідь.',
+    step: 'Розпізнавання',
+    accent: 'blue',
+  },
+  matching: {
+    title: 'Добір пар',
+    en: 'Matching',
+    description: 'З’єднайте українські слова з їхніми значеннями для швидкого закріплення зв’язків.',
+    step: 'Зіставлення',
+    accent: 'teal',
+  },
+  choice: {
+    title: 'Вибір',
+    en: 'Choice',
+    description: 'Оберіть правильне значення або слово серед близьких варіантів з цієї ж колоди.',
+    step: 'Перевірка',
+    accent: 'purple',
+  },
+  cloze: {
+    title: 'Пропуск',
+    en: 'Cloze',
+    description: 'Впишіть слово у потрібній формі. Відмінок має збігатися з реченням.',
+    step: 'Відмінювання',
+    accent: 'orange',
+  },
+};
+
 const HERITAGE_COLORS: Record<string, string> = {
-  native: '#0f766e',
-  inherited: '#0f766e',
-  borrowed: '#7c3aed',
-  loanword: '#7c3aed',
-  calque: '#b45309',
-  avoid: '#b91c1c',
+  native: 'var(--lu-teal)',
+  inherited: 'var(--lu-teal)',
+  borrowed: 'var(--lu-purple)',
+  loanword: 'var(--lu-purple)',
+  calque: 'var(--lu-orange)',
+  avoid: 'var(--lu-red)',
 };
 
 const MEANING_MC_MAX_WORDS = 4;
@@ -207,7 +257,7 @@ function recordStreak(date = new Date()): StreakState {
 
 function heritageTagColor(heritage: string | null): string | undefined {
   if (!heritage) return undefined;
-  return HERITAGE_COLORS[heritage.toLowerCase()] ?? '#334155';
+  return HERITAGE_COLORS[heritage.toLowerCase()] ?? 'var(--lu-text-muted)';
 }
 
 function cardData(entry: PracticeLexeme) {
@@ -218,6 +268,63 @@ function cardData(entry: PracticeLexeme) {
     tag: entry.cefr ?? undefined,
     tagColor: heritageTagColor(entry.heritage),
   };
+}
+
+function ModeIcon({ mode }: { mode: PracticeModeFilter }) {
+  if (mode === 'matching') {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M8.5 7.5h7" />
+        <path d="M8.5 16.5h7" />
+        <circle cx="5" cy="7.5" r="2" />
+        <circle cx="19" cy="7.5" r="2" />
+        <circle cx="5" cy="16.5" r="2" />
+        <circle cx="19" cy="16.5" r="2" />
+      </svg>
+    );
+  }
+
+  if (mode === 'choice') {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M5 6.5h14" />
+        <path d="M5 12h14" />
+        <path d="M5 17.5h8" />
+        <path d="m15.5 16.5 1.7 1.7 3.3-3.9" />
+      </svg>
+    );
+  }
+
+  if (mode === 'cloze') {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M4 7h7" />
+        <path d="M15 7h5" />
+        <path d="M4 17h16" />
+        <path d="M12.5 7h1" />
+        <path d="M10 13h4" />
+      </svg>
+    );
+  }
+
+  if (mode === 'mixed') {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M7 4h8l2 2v12a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Z" />
+        <path d="M15 4v4h4" />
+        <path d="M8 11h8" />
+        <path d="M8 15h5" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <rect x="6" y="5" width="12" height="14" rx="2" />
+      <path d="M9 9h6" />
+      <path d="M9 13h4" />
+    </svg>
+  );
 }
 
 function normalizeInitialDeck(initialDeck?: PracticeDeckData | PracticeLexeme[]): PracticeDeckData | null {
@@ -346,9 +453,9 @@ function matchingPairs(selection: PracticeSelection, deck: PracticeDeckData) {
 
 function choicePrompt(selection: PracticeSelection): string {
   if (selection.choicePolarity === 'word-to-meaning') {
-    return `What does ${selection.lemma.lemma} mean?`;
+    return `Що означає «${selection.lemma.lemma}»?`;
   }
-  return `Which word means ${glossLabel(selection.lemma)}?`;
+  return `Яке слово означає «${glossLabel(selection.lemma)}»?`;
 }
 
 function clozeParts(item: PracticeClozeItem): [string, string] {
@@ -673,94 +780,146 @@ export default function LexiconPractice({
     }
   }
 
-  const dueCount = deck ? deck.index.length : 0;
+  const dueNow = useMemo(() => (deck ? getDueQueue(deck.index, new Date()).length : 0), [
+    correctToday,
+    deck,
+    revision,
+  ]);
+  const todayWorkload = correctToday + dueNow;
+  const todayPct =
+    todayWorkload > 0 ? Math.min(100, (correctToday / todayWorkload) * 100) : correctToday > 0 ? 100 : 0;
+  const todayRingStyle = { '--pct': String(todayPct) } as CSSProperties;
+  const stageMode: PracticeModeFilter = selection?.mode ?? mode;
+  const stageTitle =
+    mode === 'mixed' && selection ? `Мікс · ${MODE_META[stageMode].title}` : MODE_META[stageMode].title;
   const correctLabel = `${correctToday} ${uaPlural(correctToday)}`;
 
   return (
-    <section className="lexicon-practice" aria-labelledby="lexicon-practice-title">
-      <div className="lexicon-practice-toolbar">
-        <div>
-          <h2 id="lexicon-practice-title">Practice Hub</h2>
-          <p className="lexicon-practice-status" aria-live="polite">
-            {feedback || (started ? 'Ready' : 'Not started')}
-          </p>
-        </div>
-        <div className="lexicon-practice-modes" role="group" aria-label="Practice mode">
-          {(['mixed', 'flashcards', 'matching', 'choice', 'cloze'] as PracticeModeFilter[]).map(
-            (practiceMode) => (
-              <button
-                type="button"
-                key={practiceMode}
-                className={mode === practiceMode ? 'active' : ''}
-                onClick={() => void start(practiceMode)}
-              >
-                {MODE_LABELS[practiceMode]}
-              </button>
-            ),
-          )}
-        </div>
-      </div>
-
-      <div className="lexicon-practice-levels">
-        <div
-          className="lexicon-practice-levels-row"
-          role="group"
-          aria-label="Learner level — caps practice to this level and below"
-        >
-          <span className="lexicon-practice-levels-label">Рівень</span>
-          {CEFR_LEVELS.map((level) => (
-            <button
-              type="button"
-              key={level}
-              className={learnerLevel === level ? 'active' : ''}
-              aria-pressed={learnerLevel === level}
-              onClick={() => void changeLevel(level)}
-            >
-              {level}
-            </button>
-          ))}
-        </div>
-        <p className="lexicon-practice-muted lexicon-practice-levels-hint">
-          Практика обмежена вашим рівнем і нижчими (накопичувально).
-        </p>
-      </div>
-
-      <div className="lexicon-practice-progress">
-        <div aria-label={`${dueCount} practice words loaded`}>
-          <span>{deck ? dueCount : '—'}</span>
-          <strong>Words</strong>
-        </div>
-        <div aria-label={`${streak.current} day streak`}>
-          <span>{streak.current}</span>
-          <strong>Day streak</strong>
-        </div>
-        <div aria-label={correctLabel}>
-          <span>{correctToday}</span>
-          <strong>{uaPlural(correctToday)}</strong>
-        </div>
-        <div aria-label={`${mastered} mastered flashcards`}>
-          <span>{mastered}</span>
-          <strong>Mastered</strong>
-        </div>
-      </div>
+    <section className="lexicon-practice" aria-label="Практика слів дня">
+      <p className="lexicon-practice-status" aria-live="polite">
+        {feedback || (started ? 'Готово до вправи' : 'Оберіть режим практики')}
+      </p>
 
       {storageWarning && <p className="lexicon-practice-warning">{storageWarning}</p>}
 
       {!started && (
-        <div className="lexicon-practice-start">
-          <button type="button" onClick={() => void start(mode)}>
-            Start Practice
-          </button>
+        <div className="lexicon-practice-home">
+          <div className="lexicon-practice-progress" role="group" aria-label="Сьогоднішній прогрес">
+            <div
+              className="pstat streak"
+              aria-label={`${streak.current} ${uaPlural(streak.current, {
+                one: 'день',
+                few: 'дні',
+                many: 'днів',
+              })} поспіль`}
+            >
+              <span className="val">🔥 {streak.current}</span>
+              <span className="lab">Днів поспіль</span>
+            </div>
+            <div className="pstat" aria-label={`${dueNow} до повторення`}>
+              <span className="val">{deck ? dueNow : '—'}</span>
+              <span className="lab">До повторення</span>
+            </div>
+            <div className="pstat" aria-label={`${mastered} опановано`}>
+              <span className="val">{mastered}</span>
+              <span className="lab">Опановано</span>
+            </div>
+            <div className="pstat today">
+              <div
+                className="ring"
+                role="img"
+                aria-label={`Сьогодні виконано ${correctToday} із ${todayWorkload}`}
+                style={todayRingStyle}
+              >
+                <b>
+                  {correctToday}/{todayWorkload}
+                </b>
+              </div>
+              <div>
+                <span className="lab">Сьогодні</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="lexicon-practice-levels">
+            <div
+              className="lexicon-practice-levels-row"
+              role="group"
+              aria-label="Рівень учня — практика охоплює цей рівень і нижчі"
+            >
+              <span className="lexicon-practice-levels-label">Рівень</span>
+              {CEFR_LEVELS.map((level) => (
+                <button
+                  type="button"
+                  key={level}
+                  className={learnerLevel === level ? 'active' : ''}
+                  aria-pressed={learnerLevel === level}
+                  onClick={() => void changeLevel(level)}
+                >
+                  {level}
+                </button>
+              ))}
+            </div>
+            <p className="lexicon-practice-muted lexicon-practice-levels-hint">
+              Практика обмежена вашим рівнем і нижчими (накопичувально).
+            </p>
+          </div>
+
+          <div className="mode-grid">
+            {MODE_CARD_ORDER.map((practiceMode) => {
+              const meta = MODE_META[practiceMode];
+              return (
+                <button
+                  type="button"
+                  key={practiceMode}
+                  className="mode-card"
+                  data-mode={practiceMode}
+                  data-accent={meta.accent}
+                  aria-pressed={mode === practiceMode}
+                  onClick={() => void start(practiceMode)}
+                >
+                  <div className="mc-top">
+                    <span className="mc-ico">
+                      <ModeIcon mode={practiceMode} />
+                    </span>
+                    <span>
+                      <span className="mc-title">{meta.title}</span>
+                      <span className="mc-en">{meta.en}</span>
+                    </span>
+                  </div>
+                  <span className="mc-desc">{meta.description}</span>
+                  <span className="mc-meta">
+                    <span className="mc-step">{meta.step}</span>
+                    <span className="mc-arrow" aria-hidden="true">
+                      →
+                    </span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
         </div>
       )}
 
-      {loading && <p className="lexicon-practice-muted">Loading…</p>}
+      {loading && <p className="lexicon-practice-muted">Завантажуємо…</p>}
       {error && <p className="lexicon-practice-warning">{error}</p>}
-      {started && deck && deck.index.length === 0 && (
-        <p className="lexicon-practice-muted">No practice cards yet.</p>
-      )}
+      {started && (
+        <div className="lexicon-practice-stage-shell">
+          <div className="lexicon-practice-stage-bar">
+            <button type="button" className="stage-back" onClick={() => setStarted(false)}>
+              ← Режими
+            </button>
+            <h2>{stageTitle}</h2>
+            <span className="queue-pill" aria-label={correctLabel}>
+              {correctLabel}
+            </span>
+          </div>
 
-      {started && deck && deck.index.length > 0 && (
+          {deck && deck.index.length === 0 && (
+            <p className="lexicon-practice-muted">Поки що немає карток для практики.</p>
+          )}
+
+          {deck && deck.index.length > 0 && (
         <div className="lexicon-practice-stage" ref={stageRef} tabIndex={-1}>
           {selection ? (
             <PracticeItem
@@ -776,14 +935,14 @@ export default function LexiconPractice({
                 onClozeSubmit={submitCloze}
               />
           ) : mode === 'cloze' && deck.cloze.length === 0 ? (
-            // Cloze is fail-closed until reviewed sentences are authored (#3797). Show a
-            // clear, honest state instead of the ambiguous "all done" dead-end.
-            <p className="lexicon-practice-muted" data-testid="practice-cloze-empty">
-              Cloze exercises for this level are being prepared. Try Flashcards, Matching, or
-              Choice for now.
-            </p>
-          ) : (
-            <p className="lexicon-practice-muted">All due cards are done for now.</p>
+              // Cloze is fail-closed until reviewed sentences are authored (#3797).
+              <p className="lexicon-practice-muted" data-testid="practice-cloze-empty">
+                Вправи з пропусками для цього рівня ще готуються. Спробуйте флешкартки, добір пар або вибір.
+              </p>
+            ) : (
+              <p className="lexicon-practice-muted">Усі картки на зараз повторено.</p>
+            )}
+          </div>
           )}
         </div>
       )}
@@ -818,12 +977,20 @@ function PracticeItem({
     return (
       <>
         <FlashcardDeck key={selection.itemId} cards={[cardData(selection.lemma)]} />
-        <div className="lexicon-rating-bar" role="group" aria-label="Rate this card">
-          {(['again', 'hard', 'good', 'easy'] as const).map((rating) => (
-            <button type="button" key={rating} onClick={() => onFlashcardRating(rating)}>
-              {RATING_LABELS[rating]}
-            </button>
-          ))}
+        <div className="lexicon-rating-bar rating-bar" role="group" aria-label="Оцініть, наскільки легко згадалось">
+        {(['again', 'hard', 'good', 'easy'] as const).map((rating, index) => (
+          <button
+            type="button"
+            key={rating}
+            className="rate-btn"
+            data-rate={rating}
+            aria-keyshortcuts={String(index + 1)}
+            onClick={() => onFlashcardRating(rating)}
+          >
+            <span className="rk">{index + 1}</span>
+            <span className="rt">{RATING_LABELS[rating]}</span>
+          </button>
+        ))}
         </div>
       </>
     );
@@ -845,13 +1012,13 @@ function PracticeItem({
   if (selection.mode === 'matching') {
     const pairs = matchingPairs(selection, deck);
     if (!pairs.length) {
-      return <p className="lexicon-practice-muted">No matching-ready cards are due right now.</p>;
+      return <p className="lexicon-practice-muted">Зараз немає карток для добору пар.</p>;
     }
     return (
       <div data-testid="practice-matching">
         <MatchUp
           pairs={pairs}
-          instruction={`Match ${selection.lemma.lemma}`}
+          instruction={`Доберіть пару для «${selection.lemma.lemma}»`}
           onComplete={onMatchingComplete}
         />
       </div>
@@ -860,17 +1027,24 @@ function PracticeItem({
 
   const options = orderedChoiceOptions(selection, deck, selection.choicePolarity);
   if (!options.length) {
-    return <p className="lexicon-practice-muted">No option-ready cards are due right now.</p>;
+    return <p className="lexicon-practice-muted">Зараз немає карток для вибору відповіді.</p>;
   }
   const prompt = choicePrompt(selection);
   return (
     <div className="lexicon-choice" data-testid={`practice-${selection.mode}`}>
-      <p className="lexicon-choice-prompt">{prompt}</p>
-      <ul className="lexicon-option-list">
-        {options.map((option) => (
+      <p className="lexicon-choice-prompt mc-q">{prompt}</p>
+      <p className="mc-sub">Оберіть правильну відповідь · клавіші 1-4</p>
+      <ul className="lexicon-option-list mc-options">
+        {options.map((option, index) => (
           <li key={option.label}>
-            <button type="button" disabled={answerLocked} onClick={() => onChoice(option)}>
-              {option.label}
+            <button
+              className={`mc-opt${answerLocked && option.correct ? ' correct' : ''}`}
+              type="button"
+              disabled={answerLocked}
+              onClick={() => onChoice(option)}
+            >
+              <span className="mc-key">{index + 1}</span>
+              <span>{option.label}</span>
             </button>
           </li>
         ))}
@@ -898,36 +1072,55 @@ function PracticeCloze({
   if (!cloze) return null;
   const [before, after] = clozeParts(cloze);
   const optionErrors = validateClozeOptions(cloze);
+  const blankText = feedback?.kind === 'correct' ? cloze.form : input.trim() || '?';
+  const blankClass = [
+    'cz-blank',
+    blankText !== '?' ? 'filled' : '',
+    feedback?.kind === 'wrong-word' ? 'bad' : '',
+    feedback?.kind === 'case-miss' ? 'case-miss' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
   return (
     <div className="lexicon-cloze" data-testid="practice-cloze">
-      <p className="lexicon-cloze-translation">{cloze.clozeEn}</p>
+      <p className="cz-task">Поставте пропущене слово у правильному відмінку.</p>
+      <p className="cz-sentence">
+        <span>{before}</span>
+        <span className={blankClass}>{blankText}</span>
+        <span>{after}</span>
+      </p>
+      <p className="lexicon-cloze-translation cz-translate">{cloze.clozeEn}</p>
       <form
-        className="lexicon-cloze-row"
+        className="lexicon-cloze-row cz-input-row"
         onSubmit={(event) => {
           event.preventDefault();
           onSubmit(input, 'typed');
         }}
       >
-        <span>{before}</span>
         <input
+          className="cz-input"
           value={input}
           disabled={answerLocked}
-          aria-label={`Answer in ${cloze.caseRule.caseLabel}`}
+          placeholder="наберіть слово у потрібній формі…"
+          autoComplete="off"
+          aria-label={`Відповідь у ${cloze.caseRule.caseLabel}`}
           onChange={(event) => onInput(event.currentTarget.value)}
         />
-        <span>{after}</span>
-        <button type="submit" disabled={answerLocked}>
-          Check
+        <button className="btn btn-accent" type="submit" disabled={answerLocked}>
+          Перевірити
         </button>
       </form>
       {optionErrors.length > 0 ? (
-        <p className="lexicon-practice-warning">Cloze options failed validation.</p>
+        <p className="lexicon-practice-warning">Варіанти для пропуску не пройшли перевірку.</p>
       ) : (
-        <ul className="lexicon-option-list lexicon-cloze-options">
+        <>
+          <div className="cz-or">Або оберіть</div>
+          <ul className="lexicon-option-list lexicon-cloze-options cz-options">
           {cloze.options.map((option) => (
             <li key={option.optionId}>
               <button
                 type="button"
+                className={`cz-chip${answerLocked && option.label === cloze.form ? ' correct' : ''}`}
                 disabled={answerLocked}
                 onClick={() => onSubmit(option.label, 'chip')}
               >
@@ -935,7 +1128,8 @@ function PracticeCloze({
               </button>
             </li>
           ))}
-        </ul>
+          </ul>
+        </>
       )}
       {feedback && (
         <p

--- a/site/src/lexicon/DailyWords.astro
+++ b/site/src/lexicon/DailyWords.astro
@@ -210,7 +210,10 @@ const dailyCount = Math.max(1, Math.floor(count));
   }
 
   .lexicon-daily-heading h2 {
+    display: inline-block;
     margin: 0;
+    padding-bottom: 0.4rem;
+    border-bottom: 2px solid var(--lu-accent);
     color: var(--lu-text);
     font-size: clamp(1.55rem, 3vw, 2.15rem);
   }
@@ -274,7 +277,7 @@ const dailyCount = Math.max(1, Math.floor(count));
   .lexicon-daily-level-chip[aria-pressed="true"] {
     border-color: var(--lu-primary);
     background: var(--lu-primary);
-    color: #fff;
+    color: var(--lu-on-primary);
   }
 
   .lexicon-daily-status {
@@ -290,11 +293,11 @@ const dailyCount = Math.max(1, Math.floor(count));
     list-style: none;
   }
 
-  .lexicon-daily-item {
+  :global(.lexicon-daily-item) {
     min-width: 0;
   }
 
-  .lexicon-daily-card {
+  :global(.lexicon-daily-card) {
     display: flex;
     min-height: 7.25rem;
     height: 100%;
@@ -309,32 +312,33 @@ const dailyCount = Math.max(1, Math.floor(count));
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
   }
 
-  .lexicon-daily-card:hover,
-  .lexicon-daily-card:focus-visible {
+  :global(.lexicon-daily-card:hover),
+  :global(.lexicon-daily-card:focus-visible) {
     border-color: var(--lu-primary);
     outline: none;
     box-shadow: 0 0 0 3px var(--lu-state-active);
   }
 
-  .lexicon-daily-lemma {
+  :global(.lexicon-daily-lemma) {
+    color: var(--lu-blue);
     font-weight: 900;
     line-height: 1.25;
   }
 
-  .lexicon-daily-gloss {
+  :global(.lexicon-daily-gloss) {
     color: var(--lu-text-muted);
     font-size: 0.92rem;
     line-height: 1.45;
   }
 
-  .lexicon-daily-chips {
+  :global(.lexicon-daily-chips) {
     display: flex;
     flex-wrap: wrap;
     gap: 0.35rem;
     margin-top: auto;
   }
 
-  .lexicon-daily-chip {
+  :global(.lexicon-daily-chip) {
     display: inline-flex;
     align-items: center;
     min-height: 1.35rem;
@@ -347,7 +351,7 @@ const dailyCount = Math.max(1, Math.floor(count));
     text-transform: uppercase;
   }
 
-  .lexicon-daily-chip.danger {
+  :global(.lexicon-daily-chip.danger) {
     border: 1px solid var(--lu-state-wrong-fg);
     background: var(--lu-state-wrong-bg);
     color: var(--lu-state-wrong-fg);

--- a/site/src/pages/words-of-the-day.astro
+++ b/site/src/pages/words-of-the-day.astro
@@ -84,10 +84,10 @@ const frontmatter = {
     min-height: 2.75rem;
     margin-top: 1.5rem;
     padding: 0 1.1rem;
-    border: 1px solid var(--lu-primary);
+    border: 1px solid var(--lu-accent);
     border-radius: 8px;
-    background: var(--lu-primary);
-    color: var(--lu-on-primary);
+    background: var(--lu-accent);
+    color: var(--lu-on-accent);
     font-weight: 900;
     text-decoration: none;
   }

--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -18,12 +18,12 @@ const frontmatter = {
 >
   <main class="word-atlas lexicon-practice-page" data-word-atlas>
     <section class="lexicon-practice-intro" aria-labelledby="lexicon-practice-page-title">
-      <span class="lexicon-practice-badge">Слова дня</span>
+      <a class="lexicon-practice-back" href="/words-of-the-day/">← Слова дня</a>
+      <span class="lexicon-practice-badge">СЛОВА ДНЯ · ПРАКТИКА</span>
       <h1 id="lexicon-practice-page-title">Практика</h1>
       <p>
-        Інтервальне повторення слів вашого рівня — картки, добір і вибір значення.
-        Прогрес зберігається у цьому браузері. Слова добираються за вашим рівнем CEFR,
-        як і «Слова дня».
+        Інтервальне повторення слів вашого рівня (CEFR, накопичувально) — картки,
+        добір, вибір і пропуски. Прогрес зберігається локально у цьому браузері.
       </p>
     </section>
 
@@ -273,8 +273,8 @@ const frontmatter = {
   }
 
   :global(.lexicon-cloze-feedback.case-miss) {
-    background: #fef3c7;
-    color: #92400e;
+    background: var(--lu-state-missed);
+    color: var(--lu-orange);
   }
 
   :global(.lexicon-cloze-feedback.wrong-word) {
@@ -313,6 +313,642 @@ const frontmatter = {
 
     :global(.lexicon-cloze-row input),
     :global(.lexicon-cloze-row button) {
+      width: 100%;
+    }
+  }
+  .lexicon-practice-back {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    margin-bottom: 0.7rem;
+    padding: 0 0.85rem;
+    border: 1px solid var(--lu-border);
+    border-radius: 8px;
+    background: var(--lu-surface);
+    color: var(--lu-text);
+    font-size: 0.9rem;
+    font-weight: 900;
+    text-decoration: none;
+  }
+
+  .lexicon-practice-back:hover,
+  .lexicon-practice-back:focus-visible {
+    border-color: var(--lu-primary);
+    color: var(--lu-primary);
+    outline: none;
+    box-shadow: 0 0 0 3px var(--lu-state-active);
+  }
+
+  :global(.lexicon-practice-status) {
+    min-height: 1.4rem;
+    margin: 0 0 0.65rem;
+    color: var(--lu-text-muted);
+    font-weight: 800;
+  }
+
+  :global(.lexicon-practice-home) {
+    display: grid;
+    gap: 1.25rem;
+  }
+
+  :global(.lexicon-practice-progress) {
+    display: grid;
+    grid-template-columns: 1.1fr repeat(3, 1fr);
+    gap: 0.9rem;
+    margin: 0.4rem 0;
+  }
+
+  :global(.pstat) {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 2px;
+    min-height: 6rem;
+    padding: 1rem 1.1rem;
+    border: 1px solid var(--lu-border);
+    border-radius: 12px;
+    background: var(--lu-surface-raised);
+    box-shadow: var(--lu-shadow);
+  }
+
+  :global(.pstat.streak) {
+    background: linear-gradient(135deg, var(--lu-state-missed), transparent);
+  }
+
+  :global(.pstat .val) {
+    color: var(--lu-text);
+    font-size: 1.85rem;
+    font-weight: 900;
+    line-height: 1;
+  }
+
+  :global(.pstat.streak .val) {
+    color: var(--lu-orange);
+  }
+
+  :global(.pstat .lab) {
+    margin-top: 0.35rem;
+    color: var(--lu-text-muted);
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+  }
+
+  :global(.pstat.today) {
+    flex-direction: row;
+    align-items: center;
+    gap: 14px;
+  }
+
+  :global(.ring) {
+    width: 58px;
+    height: 58px;
+    display: grid;
+    place-items: center;
+    flex-shrink: 0;
+    border-radius: 50%;
+    background: conic-gradient(var(--lu-green) calc(var(--pct) * 1%), var(--lu-surface-muted) 0);
+  }
+
+  :global(.ring::after) {
+    content: "";
+    width: 42px;
+    height: 42px;
+    grid-area: 1 / 1;
+    border-radius: 50%;
+    background: var(--lu-surface-raised);
+  }
+
+  :global(.ring b) {
+    z-index: 1;
+    grid-area: 1 / 1;
+    color: var(--lu-text);
+    font-size: 0.82rem;
+    font-weight: 900;
+  }
+
+  :global(.mode-grid) {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+    margin-top: 0.35rem;
+  }
+
+  :global(.mode-card) {
+    position: relative;
+    display: flex;
+    min-height: 44px;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 1.3rem 1.35rem;
+    border: 1px solid var(--lu-border);
+    border-radius: 14px;
+    background: var(--lu-surface-raised);
+    color: var(--lu-text);
+    box-shadow: var(--lu-shadow);
+    text-align: left;
+    transition: transform 0.14s ease, border-color 0.14s ease, box-shadow 0.14s ease;
+  }
+
+  :global(.mode-card:hover),
+  :global(.mode-card:focus-visible) {
+    border-color: var(--lu-primary);
+    outline: none;
+    box-shadow: var(--lu-shadow-lg);
+    transform: translateY(-3px);
+  }
+
+  :global(.mode-card .mc-top),
+  :global(.mode-card .mc-meta) {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  :global(.mode-card .mc-ico) {
+    width: 46px;
+    height: 46px;
+    display: grid;
+    place-items: center;
+    flex-shrink: 0;
+    border-radius: 12px;
+  }
+
+  :global(.mode-card .mc-ico svg) {
+    width: 26px;
+    height: 26px;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 2;
+  }
+
+  :global(.mode-card .mc-title),
+  :global(.mode-card .mc-en),
+  :global(.mode-card .mc-desc),
+  :global(.mode-card .mc-step),
+  :global(.mode-card .mc-arrow) {
+    display: block;
+  }
+
+  :global(.mode-card .mc-title) {
+    color: var(--lu-text);
+    font-size: 1.15rem;
+    font-weight: 900;
+  }
+
+  :global(.mode-card .mc-en) {
+    color: var(--lu-text-muted);
+    font-size: 0.8rem;
+    font-weight: 800;
+  }
+
+  :global(.mode-card .mc-desc) {
+    color: var(--lu-text-muted);
+    font-size: 0.92rem;
+    line-height: 1.5;
+  }
+
+  :global(.mode-card .mc-meta) {
+    margin-top: auto;
+    padding-top: 0.3rem;
+    gap: 8px;
+  }
+
+  :global(.mode-card .mc-step) {
+    color: var(--lu-text-muted);
+    font-size: 0.72rem;
+    font-weight: 900;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  :global(.mode-card .mc-arrow) {
+    margin-left: auto;
+    color: var(--lu-primary);
+    font-weight: 900;
+    transition: transform 0.15s;
+  }
+
+  :global(.mode-card:hover .mc-arrow) {
+    transform: translateX(3px);
+  }
+
+  :global(.mode-card[data-accent="blue"] .mc-ico) {
+    background: var(--lu-blue-light);
+    color: var(--lu-blue);
+  }
+
+  :global(.mode-card[data-accent="teal"] .mc-ico) {
+    background: var(--lu-teal-light);
+    color: var(--lu-teal);
+  }
+
+  :global(.mode-card[data-accent="purple"] .mc-ico) {
+    background: var(--lu-purple-light);
+    color: var(--lu-purple);
+  }
+
+  :global(.mode-card[data-accent="orange"] .mc-ico) {
+    background: var(--lu-orange-light);
+    color: var(--lu-orange);
+  }
+
+  :global(.lexicon-practice-stage-shell) {
+    max-width: 760px;
+    margin: 0 auto;
+    padding-top: 0.4rem;
+  }
+
+  :global(.lexicon-practice-stage-bar) {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 12px;
+    padding-bottom: 1rem;
+    margin-bottom: 1.4rem;
+    border-bottom: 1px solid var(--lu-border);
+  }
+
+  :global(.lexicon-practice-stage-bar h2) {
+    margin: 0;
+    color: var(--lu-text);
+    font-size: 1.4rem;
+  }
+
+  :global(.stage-back) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    min-height: 44px;
+    padding: 0 12px;
+    border: 1px solid var(--lu-border);
+    border-radius: 8px;
+    background: var(--lu-surface);
+    color: var(--lu-text);
+    font: inherit;
+    font-weight: 900;
+  }
+
+  :global(.stage-back:hover),
+  :global(.stage-back:focus-visible) {
+    border-color: var(--lu-primary);
+    color: var(--lu-primary);
+    outline: none;
+    box-shadow: 0 0 0 3px var(--lu-state-active);
+  }
+
+  :global(.queue-pill) {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    margin-left: auto;
+    padding: 0 12px;
+    border: 1px solid var(--lu-border);
+    border-radius: 999px;
+    background: var(--lu-surface-muted);
+    color: var(--lu-text-muted);
+    font-size: 0.82rem;
+    font-weight: 900;
+  }
+
+  :global(.lexicon-practice-stage) {
+    display: grid;
+    gap: 1.1rem;
+    max-width: 760px;
+    border-radius: 12px;
+  }
+
+  :global(.lexicon-practice-stage .flashcards) {
+    margin: 0;
+  }
+
+  :global(.lexicon-practice-stage .flashcard) {
+    min-height: 300px;
+  }
+
+  :global(.lexicon-practice-stage .flashcard-inner),
+  :global(.lexicon-practice-stage .flashcard-front),
+  :global(.lexicon-practice-stage .flashcard-back) {
+    border-radius: 18px;
+  }
+
+  :global(.lexicon-practice-stage .flashcard-front),
+  :global(.lexicon-practice-stage .flashcard-back) {
+    border: 1px solid var(--lu-border);
+    background: var(--lu-surface-raised);
+    box-shadow: var(--lu-shadow-lg);
+  }
+
+  :global(.lexicon-practice-stage .flashcard-word) {
+    color: var(--lu-text);
+    font-size: clamp(2.2rem, 6vw, 3.4rem);
+    font-weight: 900;
+  }
+
+  :global(.rating-bar) {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.6rem;
+    margin-top: 1.3rem;
+  }
+
+  :global(.rate-btn) {
+    display: flex;
+    min-height: 58px;
+    flex-direction: column;
+    align-items: center;
+    gap: 3px;
+    padding: 8px 6px;
+    border-radius: 12px;
+  }
+
+  :global(.rate-btn:hover) {
+    transform: translateY(-2px);
+  }
+
+  :global(.rate-btn .rk) {
+    color: var(--lu-text-muted);
+    font-size: 0.72rem;
+    font-weight: 900;
+  }
+
+  :global(.rate-btn .rt) {
+    font-size: 0.98rem;
+    font-weight: 900;
+  }
+
+  :global(.rate-btn[data-rate="again"]:hover) {
+    border-color: var(--lu-red);
+    background: var(--lu-red-light);
+  }
+
+  :global(.rate-btn[data-rate="hard"]:hover) {
+    border-color: var(--lu-orange);
+    background: var(--lu-orange-light);
+  }
+
+  :global(.rate-btn[data-rate="good"]:hover) {
+    border-color: var(--lu-green);
+    background: var(--lu-green-light);
+  }
+
+  :global(.rate-btn[data-rate="easy"]:hover) {
+    border-color: var(--lu-blue);
+    background: var(--lu-blue-light);
+  }
+
+  :global(.lexicon-choice),
+  :global(.lexicon-cloze) {
+    display: grid;
+    gap: 1rem;
+  }
+
+  :global(.mc-q) {
+    margin: 0 0 0.3rem;
+    color: var(--lu-text);
+    font-size: 1.5rem;
+    font-weight: 900;
+  }
+
+  :global(.mc-sub) {
+    margin: 0 0 0.3rem;
+    color: var(--lu-text-muted);
+  }
+
+  :global(.mc-options) {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.7rem;
+  }
+
+  :global(.mc-opt) {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    min-height: 56px;
+    padding: 12px 16px;
+    border-radius: 12px;
+    font-size: 1rem;
+    font-weight: 800;
+    text-align: left;
+    transition: border-color 0.12s, background 0.12s, transform 0.1s;
+  }
+
+  :global(.mc-opt:hover:not(:disabled)) {
+    border-color: var(--lu-primary);
+    transform: translateX(2px);
+  }
+
+  :global(.mc-key) {
+    width: 26px;
+    height: 26px;
+    display: grid;
+    place-items: center;
+    flex-shrink: 0;
+    border: 1px solid var(--lu-border);
+    border-radius: 7px;
+    color: var(--lu-text-muted);
+    font-size: 0.8rem;
+    font-weight: 900;
+  }
+
+  :global(.mc-opt.correct) {
+    border-color: var(--lu-green);
+    background: var(--lu-state-correct-bg);
+    color: var(--lu-state-correct-fg);
+  }
+
+  :global(.mc-opt.correct .mc-key) {
+    border-color: var(--lu-green);
+    color: var(--lu-state-correct-fg);
+  }
+
+  :global(.cz-task) {
+    margin: 0 0 -0.1rem;
+    color: var(--lu-text-muted);
+    font-size: 0.92rem;
+    font-weight: 700;
+  }
+
+  :global(.cz-sentence) {
+    margin: 0;
+    padding: 1.4rem 1.5rem;
+    border: 1px solid var(--lu-border);
+    border-radius: 14px;
+    background: var(--lu-surface-raised);
+    box-shadow: var(--lu-shadow);
+    color: var(--lu-text);
+    font-size: 1.45rem;
+    font-weight: 700;
+    line-height: 1.6;
+  }
+
+  :global(.cz-blank) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 96px;
+    padding: 0 10px;
+    margin: 0 4px;
+    border-bottom: 3px solid var(--lu-primary);
+    color: var(--lu-primary);
+    font-weight: 900;
+  }
+
+  :global(.cz-blank.filled) {
+    border-bottom-color: var(--lu-green);
+    color: var(--lu-state-correct-fg);
+  }
+
+  :global(.cz-blank.bad),
+  :global(.cz-blank.case-miss) {
+    border-bottom-color: var(--lu-red);
+    color: var(--lu-state-wrong-fg);
+  }
+
+  :global(.cz-translate) {
+    margin: -0.2rem 0 0.2rem;
+    color: var(--lu-text-muted);
+    font-style: italic;
+  }
+
+  :global(.cz-input-row) {
+    display: flex;
+    gap: 10px;
+    margin: 0;
+  }
+
+  :global(.cz-input) {
+    min-height: 48px;
+    flex: 1;
+    padding: 0 14px;
+    border: 2px solid var(--lu-border);
+    border-radius: 8px;
+    background: var(--lu-surface);
+    color: var(--lu-text);
+    font: inherit;
+    font-size: 16px;
+    font-weight: 800;
+  }
+
+  :global(.cz-input:focus-visible) {
+    border-color: var(--lu-primary);
+    outline: none;
+    box-shadow: 0 0 0 3px var(--lu-state-active);
+  }
+
+  :global(.cz-or) {
+    margin: 0.2rem 0 0;
+    color: var(--lu-text-muted);
+    font-size: 0.82rem;
+    font-weight: 900;
+    letter-spacing: 0.08em;
+    text-align: center;
+    text-transform: uppercase;
+  }
+
+  :global(.cz-options) {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+  }
+
+  :global(.cz-options li) {
+    display: contents;
+  }
+
+  :global(.cz-chip) {
+    min-height: 48px;
+    width: auto;
+    padding: 0 18px;
+    border-radius: 999px;
+    font-weight: 900;
+  }
+
+  :global(.cz-chip:hover:not(:disabled)) {
+    border-color: var(--lu-primary);
+    transform: translateY(-2px);
+  }
+
+  :global(.cz-chip.correct) {
+    border-color: var(--lu-green);
+    background: var(--lu-state-correct-bg);
+    color: var(--lu-state-correct-fg);
+  }
+
+  :global(.lexicon-practice-stage [data-activity="match-up"]) {
+    display: grid;
+    gap: 1rem;
+  }
+
+  :global(.lexicon-practice-stage [data-activity="match-up"] [data-activity$="-column"]) {
+    display: grid;
+    gap: 0.6rem;
+  }
+
+  :global(.lexicon-practice-stage [data-activity="match-up"] [data-activity$="-tile"]) {
+    min-height: 52px;
+    border: 1px solid var(--lu-border);
+    border-radius: 10px;
+    background: var(--lu-surface);
+    color: var(--lu-text);
+    font-weight: 800;
+  }
+
+  :global(.lexicon-practice-stage [data-activity="match-left-tile"]) {
+    color: var(--lu-blue);
+    font-weight: 900;
+  }
+
+  :global(.lexicon-practice-stage [data-selected="true"]) {
+    border-color: var(--lu-primary);
+    background: var(--lu-state-active);
+    box-shadow: 0 0 0 2px var(--lu-state-active);
+  }
+
+  :global(.lexicon-practice-stage [data-matched="true"]) {
+    border-color: var(--lu-green);
+    background: var(--lu-state-correct-bg);
+    color: var(--lu-state-correct-fg);
+  }
+
+  @media (max-width: 860px) {
+    :global(.lexicon-practice-progress) {
+      grid-template-columns: 1fr 1fr;
+    }
+
+    :global(.mode-grid) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  @media (max-width: 560px) {
+    :global(.lexicon-practice-progress) {
+      grid-template-columns: 1fr;
+    }
+
+    :global(.lexicon-practice-stage-bar) {
+      align-items: stretch;
+    }
+
+    :global(.queue-pill) {
+      margin-left: 0;
+    }
+
+    :global(.rating-bar) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    :global(.cz-input-row) {
+      flex-direction: column;
+    }
+
+    :global(.cz-input-row .btn) {
       width: 100%;
     }
   }

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -289,13 +289,14 @@ describe('LexiconPractice', () => {
     const { fn, requested } = mockShardFetch({ A1: 2, A2: 1, B1: 3, B2: 5, C1: 4 });
     vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
     const user = userEvent.setup();
-    render(<LexiconPractice initialMode="flashcards" />);
+    const { container } = render(<LexiconPractice initialMode="flashcards" />);
 
-    await user.click(screen.getByRole('button', { name: 'Start Practice' }));
+    // Start = clicking a mode card (the redesign has no separate "Start Practice" button).
+    await user.click(container.querySelector<HTMLButtonElement>('[data-mode="flashcards"]')!);
 
-    // A1+A2+B1 = 6 words; B2/C1 are above the learner level and must never be loaded.
+    // A1+A2+B1 load (cumulative); B2/C1 are above the learner level and must never be fetched.
     await waitFor(() =>
-      expect(screen.getByLabelText('6 practice words loaded')).toBeInTheDocument(),
+      expect(requested.some((u) => u.includes('practice-index.B1'))).toBe(true),
     );
     expect(requested.some((u) => u.includes('practice-index.A1'))).toBe(true);
     expect(requested.some((u) => u.includes('practice-index.A2'))).toBe(true);
@@ -306,22 +307,23 @@ describe('LexiconPractice', () => {
 
   test('level selector re-caps the pool and persists the shared learner-level key', async () => {
     localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'A1');
-    const { fn } = mockShardFetch({ A1: 2, A2: 1, B1: 3 });
+    const { fn, requested } = mockShardFetch({ A1: 2, A2: 1, B1: 3 });
     vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
     const user = userEvent.setup();
-    render(<LexiconPractice initialMode="flashcards" />);
+    const { container } = render(<LexiconPractice initialMode="flashcards" />);
 
-    await user.click(screen.getByRole('button', { name: 'Start Practice' }));
-    await waitFor(() =>
-      expect(screen.getByLabelText('2 practice words loaded')).toBeInTheDocument(),
-    );
-
-    // Raise the level to B1 -> pool grows cumulatively to A1+A2+B1 = 6 and persists.
+    // The level chips live on the practice home; raising the level persists the shared key.
     await user.click(screen.getByRole('button', { name: 'B1' }));
-    await waitFor(() =>
-      expect(screen.getByLabelText('6 practice words loaded')).toBeInTheDocument(),
-    );
     expect(localStorage.getItem(LEARNER_LEVEL_STORAGE_KEY)).toBe('B1');
+
+    // Starting now loads the cumulative B1 pool (A1+A2+B1); B2 is above the level and never loads.
+    await user.click(container.querySelector<HTMLButtonElement>('[data-mode="flashcards"]')!);
+    await waitFor(() =>
+      expect(requested.some((u) => u.includes('practice-index.B1'))).toBe(true),
+    );
+    expect(requested.some((u) => u.includes('practice-index.A1'))).toBe(true);
+    expect(requested.some((u) => u.includes('practice-index.A2'))).toBe(true);
+    expect(requested.some((u) => u.includes('practice-index.B2'))).toBe(false);
   });
 
   test('flashcard rating persists mode-specific SRS progress', async () => {
@@ -335,7 +337,8 @@ describe('LexiconPractice', () => {
     await user.click(flashcard!);
     expect(flashcard).toHaveAttribute('data-flipped', 'true');
 
-    await user.click(screen.getByRole('button', { name: 'Good' }));
+    // Rating buttons carry a "1-4" key span; target the stable data-rate hook.
+    await user.click(container.querySelector<HTMLButtonElement>('[data-rate="good"]')!);
 
     await waitFor(() => {
       expect(storedState().cards[cardKey('knyha', 'flashcards')]).toBeTruthy();
@@ -348,7 +351,8 @@ describe('LexiconPractice', () => {
 
     const choice = screen.getByTestId('practice-choice');
     expect(choice).toBeInTheDocument();
-    await user.click(screen.getByRole('button', { name: 'книга' }));
+    // Option buttons now carry a "1-4" key span, so the accessible name is e.g. "1 книга".
+    await user.click(screen.getByRole('button', { name: /книга/ }));
 
     await waitFor(() => {
       const state = storedState();
@@ -364,10 +368,11 @@ describe('LexiconPractice', () => {
     render(<LexiconPractice initialDeck={wordToMeaningDeck()} autoStart initialMode="choice" />);
     const choice = screen.getByTestId('practice-choice');
 
-    expect(screen.getByText('What does сад mean?')).toBeInTheDocument();
+    expect(screen.getByText('Що означає «сад»?')).toBeInTheDocument();
+    // The option label lives in its own span next to the "1-4" key span; read just the label.
     const labels = within(choice)
       .getAllByRole('button')
-      .map((button) => button.textContent ?? '');
+      .map((button) => button.querySelector('span:not(.mc-key)')?.textContent ?? '');
 
     expect(new Set(labels)).toEqual(new Set(['garden', 'house', 'forest', 'river']));
     expect(labels).not.toContain('and');
@@ -410,7 +415,7 @@ describe('LexiconPractice', () => {
     const choice = screen.getByTestId('practice-choice');
     const labels = within(choice)
       .getAllByRole('button')
-      .map((button) => button.textContent ?? '');
+      .map((button) => button.querySelector('span:not(.mc-key)')?.textContent ?? '');
     // First card is the small-POS verb (newOrder 0). Without cross-POS backfill it
     // would starve (<3 distractors) and not render; it must show a full 4-option set.
     expect(labels).toHaveLength(4);
@@ -429,7 +434,7 @@ describe('LexiconPractice', () => {
     const status = screen.getByRole('status');
     expect(status).toHaveTextContent('Правильне слово');
     expect(status).toHaveClass('case-miss');
-    expect(screen.getByLabelText('Answer in знахідний')).toHaveValue('');
+    expect(screen.getByLabelText('Відповідь у знахідний')).toHaveValue('');
     expect(screen.getByRole('button', { name: 'книгу' })).not.toBeDisabled();
 
     await waitFor(() => {


### PR DESCRIPTION
Applies the fleet-cleared practice-hub PoC design (`docs/poc/word-atlas/practice-hub.html`) to the two
live **Words-of-the-Day** surfaces. Presentational/structural re-skin — **all engine logic preserved**
(SRS, deck-loading, level-cap, anti-gaming case-strict cloze, a11y).

## Surfaces
- **`/words-of-the-day/`** — yellow `--lu-accent` practice CTA + the "Добірка на сьогодні" section underline;
  daily cards keep their data, now `:global()`-styled (innerHTML trap fixed).
- **`/words-of-the-day/practice/`** — PoC home: back-link + "СЛОВА ДНЯ · ПРАКТИКА" badge, 🔥 streak-glow tile,
  ДО ПОВТОРЕННЯ / ОПАНОВАНО tiles, progress **ring** (wired to real `getDueQueue` SRS-due, not an invented
  target), РІВЕНЬ chips, and the **mode-card grid** (Мікс entry point + Флешкартки/Добір пар/Вибір/Пропуск,
  inline SVG icons, per-mode accents). Stages get the PoC stage-bar (← Режими / title / score pill) +
  card-framed choice/cloze.

## Build provenance + verification
- codex built the 5-file re-skin (fleet-corrected spec); it was silence-timeout-killed pre-commit, so I
  (Claude-infra) preserved its work, **finished the unit-test contract** (UA labels, `data-mode`/`data-rate`
  hooks, choice option key-spans, `getDueQueue` due-count asserted via shard URLs), and validated:
  - vitest **8/8 LexiconPractice**, **392 pass** full suite (build-renders flake is transient — passes in
    isolation, 5/5).
  - **Browser render-verified** both surfaces in **dark + light**: faithful to the PoC, real deck loads,
    choice stage renders, theme-toggle clean. (#M-4a)
  - e2e selectors updated to `data-mode` hooks (the CI-blocking Playwright gate I own).

## Known nuance (flagged, not a blocker)
The home `ДО ПОВТОРЕННЯ` tile + ring show `—` / `0/0` on a *fresh* first view because the deck is lazy-loaded
on first mode-start (preserves the "no fetch before start" optimization). It populates after entering a mode.
Recommended follow-up: eager-load the lightweight index on mount so returning users see their due-count
immediately — a small behavior change worth a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)