### PR TITLE
fix(ci): run pytest when content tests' inputs change (closes #3873)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,12 @@ jobs:
     outputs:
       # code = any high-signal source/config change. Used by the broad secret scan.
       code: ${{ steps.filter.outputs.code }}
-      # python = Python/test paths only. Gates pytest + ruff/radon/root guards.
-      # Deliberately EXCLUDES site/** so content/MDX PRs do NOT run pytest.
+      # python = Python/test paths PLUS the curriculum/site content that tests
+      # read at runtime. Gates pytest + ruff/radon/root guards. curriculum/l2-uk-en/**
+      # and site/src/content/** are INCLUDED because content-reading tests
+      # (citation_resolve, llm_qg_api, reading_coverage, reading_links, parity, ...)
+      # load those files at runtime — excluding them let a content-deletion PR
+      # (#3867) skip pytest entirely and ship a regression to main (root cause: #3873).
       python: ${{ steps.filter.outputs.python }}
       # frontend = generated site inputs/outputs. Gates the build/vitest job plus
       # MDX source/drift checks, so curriculum source edits cannot leave stale
@@ -115,6 +119,12 @@ jobs:
               - 'pyproject.toml'
               - 'scripts/**/*.py'
               - 'tests/**/*.py'
+              # Content that python tests read at runtime — a deletion/edit here
+              # must run pytest, else a content regression reaches main unguarded
+              # (this is the #3873 root cause: #3867 deleted curriculum files,
+              # python filter was false, pytest skipped, 4 tests broke on main).
+              - 'curriculum/l2-uk-en/**'
+              - 'site/src/content/**'
             frontend:
               - '.github/workflows/ci.yml'
               - 'site/**'


### PR DESCRIPTION
## Root cause (#3873)
The `Test (pytest)` job's body is gated by the `python` paths-filter, which listed `scripts/**/*.py` + `tests/**/*.py` but **not** the curriculum/site content that many tests read at runtime. So a content-only / deletion PR → `python=false` → **pytest body skips** while the required check still reports pass.

Evidence: PR #3867 (deleted 4 folk module dirs + plans) showed `Test (pytest) pass` in **4 seconds**, merged, and main then went red on 4 tests that load those files (`test_citation_resolve`, `test_llm_qg_api` ×3, `test_reading_coverage_gate`). The regression-fix PR #3872 — which changed `.py` files — ran pytest for **5m41s**.

## Fix
Add to the `python` filter:
```
- 'curriculum/l2-uk-en/**'
- 'site/src/content/**'
```
Now any change to content the python tests load at runtime runs the suite, so a deletion can't slip a regression past the required check. Comment updated to record why.

## Tradeoff (called out, per "no silent caps")
Content/module-build PRs now run the full pytest (~5–6m) instead of skipping it. That is the **correct** behavior for a required gate (content tests should run when content changes). If CI minutes become a concern, the follow-up optimization is a surgical content-dependent test subset rather than the full suite — noted, not done here.

## Verification
- `ci.yml` is valid YAML; pre-commit clean. The `actionlint` + `Test (pytest)` CI jobs validate the rest.
- This PR edits `ci.yml` (already in the filter) so its own pytest runs — proving the suite is green with the change. (A curriculum-only trigger can't be exercised from this PR, but `dorny/paths-filter` glob-matches the added paths deterministically.)

Closes #3873. Track-driver infra PR (#0.2).