### PR TITLE
fix(folk): clean stub plans for 4 unpublished modules — unblock main (Curriculum Plans red)

### DIFF
--- a/curriculum/l2-uk-en/plans/folk/dumy-nevilnytski-lytsarski.yaml
+++ b/curriculum/l2-uk-en/plans/folk/dumy-nevilnytski-lytsarski.yaml
@@ -1,0 +1,26 @@
+module: folk-010
+level: FOLK
+sequence: 10
+slug: dumy-nevilnytski-lytsarski
+title: "Невільницькі та лицарські думи: Плач і героїка"
+subtitle: "Captivity and Knightly Dumas — заглушка (перебудовується, #3879)"
+version: 1
+status: stub
+word_target: 4000
+objectives:
+  - 'Заглушка — чисті цілі регенеруються в базовій перебудові (#3879).'
+content_outline:
+  - section: 'Заглушка, частина 1 (#3879)'
+    words: 2000
+    points:
+      - 'Заглушка — план регенерується в базовій перебудові фольклору (#3879)'
+  - section: 'Заглушка, частина 2 (#3879)'
+    words: 2000
+    points:
+      - 'Заглушка — план регенерується в базовій перебудові фольклору (#3879)'
+references:
+  - title: 'Заглушка — джерела регенеруються в базовій перебудові (#3879)'
+note: >-
+  Outline placeholder. Built module + poisoned plan content removed in PR #3867. Full clean
+  base (dossier -> wiki -> plan -> module) regenerated base-first in the folk rebuild (#3879).
+  Not built, not published. All placeholder text carries zero framing/readings/chunk-ids.

--- a/curriculum/l2-uk-en/plans/folk/kalendarna-obriadovist-zvychai.yaml
+++ b/curriculum/l2-uk-en/plans/folk/kalendarna-obriadovist-zvychai.yaml
@@ -1,0 +1,26 @@
+module: folk-002
+level: FOLK
+sequence: 2
+slug: kalendarna-obriadovist-zvychai
+title: "Календарна обрядовість і звичаї"
+subtitle: "Calendar Rites and Customs — заглушка (перебудовується, #3879)"
+version: 1
+status: stub
+word_target: 4000
+objectives:
+  - 'Заглушка — чисті цілі регенеруються в базовій перебудові (#3879).'
+content_outline:
+  - section: 'Заглушка, частина 1 (#3879)'
+    words: 2000
+    points:
+      - 'Заглушка — план регенерується в базовій перебудові фольклору (#3879)'
+  - section: 'Заглушка, частина 2 (#3879)'
+    words: 2000
+    points:
+      - 'Заглушка — план регенерується в базовій перебудові фольклору (#3879)'
+references:
+  - title: 'Заглушка — джерела регенеруються в базовій перебудові (#3879)'
+note: >-
+  Outline placeholder. Built module + poisoned plan content removed in PR #3867. Full clean
+  base (dossier -> wiki -> plan -> module) regenerated base-first in the folk rebuild (#3879).
+  Not built, not published. All placeholder text carries zero framing/readings/chunk-ids.

--- a/curriculum/l2-uk-en/plans/folk/koliadky-shchedrivky.yaml
+++ b/curriculum/l2-uk-en/plans/folk/koliadky-shchedrivky.yaml
@@ -1,0 +1,26 @@
+module: folk-003
+level: FOLK
+sequence: 3
+slug: koliadky-shchedrivky
+title: "Колядки та щедрівки: різдвяна величальна традиція"
+subtitle: "Carols and Shchedrivky — заглушка (перебудовується, #3879)"
+version: 1
+status: stub
+word_target: 4000
+objectives:
+  - 'Заглушка — чисті цілі регенеруються в базовій перебудові (#3879).'
+content_outline:
+  - section: 'Заглушка, частина 1 (#3879)'
+    words: 2000
+    points:
+      - 'Заглушка — план регенерується в базовій перебудові фольклору (#3879)'
+  - section: 'Заглушка, частина 2 (#3879)'
+    words: 2000
+    points:
+      - 'Заглушка — план регенерується в базовій перебудові фольклору (#3879)'
+references:
+  - title: 'Заглушка — джерела регенеруються в базовій перебудові (#3879)'
+note: >-
+  Outline placeholder. Built module + poisoned plan content removed in PR #3867. Full clean
+  base (dossier -> wiki -> plan -> module) regenerated base-first in the folk rebuild (#3879).
+  Not built, not published. All placeholder text carries zero framing/readings/chunk-ids.

--- a/curriculum/l2-uk-en/plans/folk/narodna-kultura-yak-systema.yaml
+++ b/curriculum/l2-uk-en/plans/folk/narodna-kultura-yak-systema.yaml
@@ -1,0 +1,26 @@
+module: folk-001
+level: FOLK
+sequence: 1
+slug: narodna-kultura-yak-systema
+title: "Народна культура як система"
+subtitle: "Folk Culture as a System — заглушка (перебудовується, #3879)"
+version: 1
+status: stub
+word_target: 4000
+objectives:
+  - 'Заглушка — чисті цілі регенеруються в базовій перебудові (#3879).'
+content_outline:
+  - section: 'Заглушка, частина 1 (#3879)'
+    words: 2000
+    points:
+      - 'Заглушка — план регенерується в базовій перебудові фольклору (#3879)'
+  - section: 'Заглушка, частина 2 (#3879)'
+    words: 2000
+    points:
+      - 'Заглушка — план регенерується в базовій перебудові фольклору (#3879)'
+references:
+  - title: 'Заглушка — джерела регенеруються в базовій перебудові (#3879)'
+note: >-
+  Outline placeholder. Built module + poisoned plan content removed in PR #3867. Full clean
+  base (dossier -> wiki -> plan -> module) regenerated base-first in the folk rebuild (#3879).
+  Not built, not published. All placeholder text carries zero framing/readings/chunk-ids.


### PR DESCRIPTION
## Why
Main is **red** on the `Curriculum Plans` CI check (`validate_plan_ordering`): PR #3867 deleted 4 folk modules' plan files but left them in `curriculum.yaml` → 4 "MISSING plan file" errors → **every curriculum-touching PR is blocked** (e.g. #3878). Another #3867 cleanup miss (same family as the test regression #3872 and the CI-filter gap #3877).

## What
Restoring the old plans was **rejected — they are poisoned** (космогонія/світове дерево, «християнська оболонка», магічна функція = заклинання, продукувальна магія, + internal chunk-ids). Instead, the 4 (`narodna-kultura-yak-systema`, `kalendarna-obriadovist-zvychai`, `koliadky-shchedrivky`, `dumy-nevilnytski-lytsarski`) get **clean minimal stub plans** — meta only (`module`/`level`/`sequence`/`slug`/`title`/`status: stub`), zero framing, zero readings — matching how the other unbuilt folk modules sit in the outline. The full clean base (dossier→wiki→plan→module) is regenerated **base-first** in the folk rebuild (#3879, STEP 0).

## Verification
- `validate_plan_ordering.py` → **0 errors, 0 warnings** across 20 tracks.
- Contamination grep on the 4 stubs → **0**.
- This PR touches `curriculum/**`, so (per #3877) it runs the **full pytest** — the comprehensive check that the earlier deletion skipped.

Track-driver PR. Refs #3867, #3879.