### PR TITLE
feat(atlas): eager-load WoD practice due-count on mount (#3876)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 2b9c0c12e7ec7ac931ab95ac0acbd78d33fc34e5f99c2febf9c214f02b260f32
+  components_sha256: 7345fa0182480f923dd078f62834d7f3418680a41aadce9e325fc43006c17e52
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -15,6 +15,7 @@ import {
   type ChoicePolarity,
   type PracticeClozeItem,
   type PracticeDeckData,
+  type PracticeIndexItem,
   type PracticeIndexShard,
   type PracticeLexeme,
   type PracticeLexemeShard,
@@ -538,6 +539,9 @@ export default function LexiconPractice({
   const [clozeInput, setClozeInput] = useState('');
   const [clozeFeedback, setClozeFeedback] = useState<ClozeFeedback | null>(null);
   const [clozeAttemptRecorded, setClozeAttemptRecorded] = useState(false);
+  // Lightweight per-level index used to show the due-count on the home BEFORE a mode
+  // is started. Superseded by `deck.index` once a full deck loads.
+  const [dueIndex, setDueIndex] = useState<PracticeIndexItem[] | null>(null);
   const stageRef = useRef<HTMLDivElement | null>(null);
   // Monotonic id so a slow earlier deck fetch can't overwrite a newer one (rapid level switches).
   const deckRequestId = useRef(0);
@@ -552,6 +556,39 @@ export default function LexiconPractice({
       setStorageWarning('Час повторення може бути неточним: змінився годинник пристрою.');
     }
   }, []);
+
+  // Eager-load ONLY the lightweight per-level index shards on mount (and on a
+  // pre-session level change) so the «До повторення» tile + today ring reflect the
+  // learner's real SRS due-count immediately — the most motivating number on the
+  // home, and the reason a returning learner opens this page. The heavy
+  // lexeme/cloze shards stay lazy until a mode actually starts (ensureDeck). Once a
+  // full deck is loaded its own `index` supersedes this. The `cancelled` flag drops
+  // a stale fetch when the learner switches level before it resolves.
+  useEffect(() => {
+    if (deck) {
+      setDueIndex(null);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const batches = await Promise.all(
+          levelsUpTo(learnerLevel).map(async (shardLevel) => {
+            const response = await fetch(`${shardBaseUrl}/practice-index.${shardLevel}.json`);
+            if (!response.ok) return [];
+            const shard = (await response.json()) as PracticeIndexShard;
+            return shard.items ?? [];
+          }),
+        );
+        if (!cancelled) setDueIndex(batches.flat());
+      } catch {
+        if (!cancelled) setDueIndex(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [deck, learnerLevel, shardBaseUrl]);
 
   const selection = useMemo(() => {
     if (!deck) return null;
@@ -782,11 +819,12 @@ export default function LexiconPractice({
     }
   }
 
-  const dueNow = useMemo(() => (deck ? getDueQueue(deck.index, new Date()).length : 0), [
-    correctToday,
-    deck,
-    revision,
-  ]);
+  // Prefer the full deck's index once loaded; otherwise fall back to the eager
+  // index so the due-count is live on the home before any mode starts.
+  const dueNow = useMemo(() => {
+    const entries = deck ? deck.index : dueIndex;
+    return entries ? getDueQueue(entries, new Date()).length : 0;
+  }, [correctToday, deck, dueIndex, revision]);
   const todayWorkload = correctToday + dueNow;
   const todayPct =
     todayWorkload > 0 ? Math.min(100, (correctToday / todayWorkload) * 100) : correctToday > 0 ? 100 : 0;
@@ -819,7 +857,7 @@ export default function LexiconPractice({
               <span className="lab">Днів поспіль</span>
             </div>
             <div className="pstat" aria-label={`${dueNow} до повторення`}>
-              <span className="val">{deck ? dueNow : '—'}</span>
+              <span className="val">{deck || dueIndex ? dueNow : '—'}</span>
               <span className="lab">До повторення</span>
             </div>
             <div className="pstat" aria-label={`${mastered} опановано`}>

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -276,12 +276,33 @@ beforeEach(() => {
 });
 
 describe('LexiconPractice', () => {
-  test('does not fetch deck before start mode action', () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+  test('eager-loads only the index (not lexemes/cloze) before a mode starts', async () => {
+    const { fn, requested } = mockShardFetch({ A1: 2 });
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
 
     render(<LexiconPractice />);
 
-    expect(fetchSpy).not.toHaveBeenCalled();
+    // The due-count tile eager-loads the lightweight index on mount so a returning
+    // learner sees their SRS due-count immediately...
+    await waitFor(() =>
+      expect(requested.some((u) => u.includes('practice-index.A1'))).toBe(true),
+    );
+    // ...while the heavy lexeme/cloze shards stay lazy until a mode actually starts.
+    expect(requested.some((u) => u.includes('practice-lexemes'))).toBe(false);
+    expect(requested.some((u) => u.includes('practice-cloze'))).toBe(false);
+  });
+
+  test('shows the real SRS due-count on the home before any mode starts', async () => {
+    const { fn } = mockShardFetch({ A1: 3 });
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
+
+    render(<LexiconPractice />);
+
+    // Three never-reviewed A1 cards are all due → the «До повторення» tile shows 3
+    // on mount (not the placeholder '—'), without entering a mode first.
+    await waitFor(() =>
+      expect(screen.getByLabelText('3 до повторення')).toBeInTheDocument(),
+    );
   });
 
   test('caps the practice pool at the learner level (cumulative, never higher levels)', async () => {


### PR DESCRIPTION
## What
Eager-load the WoD practice **due-count** on mount so the `/words-of-the-day/practice/`
home shows the learner's real SRS due-count immediately, instead of `—` / `0/0`. Closes #3876
(PR #3874 follow-up, the recommended fleet diff-review item).

## Why
After the #3874 redesign the home showed **«До повторення» `—`** and the today ring **`0/0`**
on a fresh view, because the deck (index + lexemes) loaded lazily only on first mode-start. For a
**returning** learner the SRS due-count is the most motivating number and the reason they open the
page — it should be visible on landing.

## How (minimal blast radius)
- New `dueIndex` state + a mount/level effect that fetches **only** the lightweight per-level
  `practice-index.*.json` shards (not the heavy `practice-lexemes`/`practice-cloze`) and drives the
  due tile + today ring via `getDueQueue`.
- The race-guarded `ensureDeck` is **untouched**; an idiomatic `cancelled` flag drops a stale index
  fetch on rapid level switches. Once a full deck loads, its own `index` supersedes `dueIndex`.

## Tests
- Rewrote `does not fetch deck before start` → **`eager-loads only the index (not lexemes/cloze)
  before a mode starts`** (per the issue's requested test change).
- Added a **load-bearing** test: the real SRS due-count renders on the home before any mode starts.
- Full site vitest: **394 passed**. `astro check` clean for the changed files.

## Render-verified (#M-4a, real browser)
- Home, fresh: «До повторення» = **1079** (A1 pool, all never-reviewed = due), ring **0/1079** — no `—`.
- Switch to B1 on the home (no mode start): due-count → **3081** (A1+A2+B1 cumulative), live, race-safe.
- Persisted level eager-loads on reload; starting a mode still renders a real card; **0 console errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
