### PR TITLE
fix(atlas): accent-insensitive lexicon search (strip U+0301)

### DIFF
--- a/site/src/lib/lexicon/search.ts
+++ b/site/src/lib/lexicon/search.ts
@@ -19,7 +19,13 @@ const ESCAPE_MAP: Record<string, string> = {
 };
 
 function normalizeText(value: string): string {
-  return value.normalize("NFC").toLocaleLowerCase("uk-UA");
+  // NFC first (composes e.g. Latin "é" → "é"), then strip any *residual*
+  // combining acute (U+0301). Ukrainian stressed Cyrillic vowels have no
+  // precomposed form, so NFC leaves their stress mark standalone and this removes
+  // it (на́голос → наголос) for accent-insensitive search — while precomposed Latin
+  // accents and, crucially, the breve composing й (и+U+0306) and the diaeresis
+  // composing ї (і+U+0308) are left intact.
+  return value.normalize("NFC").replace(/\u0301/g, "").toLocaleLowerCase("uk-UA");
 }
 
 function escapeHtml(value: string): string {

--- a/site/tests/unit/lexicon-search.test.ts
+++ b/site/tests/unit/lexicon-search.test.ts
@@ -15,6 +15,24 @@ describe('lexicon search helpers', () => {
     expect(normalize('e\u0301')).toBe('é');
   });
 
+  test('strips Ukrainian stress accents while preserving й, ї, and Latin accents', () => {
+    // Cyrillic stress marks (U+0301) are stripped so plain typing matches accented lemmas.
+    expect(normalize('на́голос')).toBe('наголос');
+    expect(normalize('авантю́рний')).toBe('авантюрний');
+    // The breve composing й (и+U+0306) and diaeresis composing ї (і+U+0308) survive NFC + strip.
+    expect(normalize('й')).toBe('й');
+    expect(normalize('ї')).toBe('ї');
+    // Precomposed Latin accents are untouched (regression guard for the NFC behavior).
+    expect(normalize('é')).toBe('é');
+  });
+
+  test('finds a stress-accented lemma by a plain (unaccented) query', () => {
+    const accented: SearchRow[] = [
+      { l: 'авантю́рний', s: 'avantiurnyi', g: 'adventurous', r: 'avantiurnyi', k: 'vyv' },
+    ];
+    expect(rankMatches(accented, 'авантюрний').map((row) => row.l)).toEqual(['авантю́рний']);
+  });
+
   test('matches Cyrillic lemma prefixes', () => {
     expect(rankMatches(rows, 'офі', 3).map((row) => row.l)).toEqual(['офіс', 'офісний', 'офіціант']);
   });


### PR DESCRIPTION
## What
Make Atlas lexicon **search accent-insensitive** so stress-accented lemmas are findable by plain typing.

## Why
~20% of Atlas lemmas (940 pre-existing + the doc-import #3886's adjectives) carry a combining acute **U+0301** in the lemma key (stress marks: `на́голос`, `авантю́рний`). `search.ts normalizeText` did NFC + lowercase only → the indexed lemma kept the accent → a plain query (`наголос`) never matched. Those entries were effectively unfindable. Surfaced + flagged by the personal-doc import (#3886).

## How
After NFC, strip residual **U+0301**. Ukrainian stressed Cyrillic vowels have no precomposed form, so NFC leaves the stress mark standalone and this removes it — while precomposed Latin accents (`é`) and, critically, the **breve composing й (и+U+0306)** and **diaeresis composing ї (і+U+0308)** stay intact (those compose under NFC, leaving no standalone U+0301).

```ts
value.normalize("NFC").replace(/́/g, "").toLocaleLowerCase("uk-UA")
```

## Tests (9 pass)
- stress strip (`на́голос`→`наголос`, `авантю́рний`→`авантюрний`)
- **й/ї preserved** (и+U+0306→й, і+U+0308→ї)
- **Latin-é regression guard** (existing NFC behavior intact)
- a plain query finds an accented lemma

## Review
The U+0301-only approach was explicitly endorsed by agy (independent family) in the #3886 review ("the exact right fix — preserves the breve for й and the diaeresis for ї"); this PR implements it with tests covering exactly those cases. No manifest/asset change → clean CI.

Whole-Atlas findability fix; deeper data cleanup (why enrich stores accented lemma keys) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
