### PR TITLE
[codex] docs(b2): persist m32 m36 llm scores

### DIFF
--- a/docs/audits/b2-current-llm-scores-2026-06-27.md
+++ b/docs/audits/b2-current-llm-scores-2026-06-27.md
@@ -1,0 +1,101 @@
+Module,Current LLM Score,Verdict,Ready for Human Review?,Notes
+B2 M01 `passive-voice-system`,10/10,A,Yes,"Excellent B2 teaching arc, strong register control, no content blockers. Score carried forward from the 2026-06-24 durable score note."
+B2 M02 `past-passive-participles`,9/10,B+,Yes,Strong teaching arc and practice coverage. Score carried forward from the 2026-06-24 durable score note; optional activity-affordance/notation polish remains.
+B2 M03 `b2-impersonal-passive`,9/10,B+,Yes,Strong impersonal passive module after review fixes. Score held at 9 for non-blocking section-balance/formulaic-style audit notes.
+B2 M04 `dim-zhytlo`,9/10,B+,Yes,Strong housing/rental/repair communication module. Minor optional polish remains around section balance and deterministic UA-GEC false positives.
+B2 M05 `reflexive-passive`,9/10,B+,Yes,Strong reflexive-passive norm module. Review blocker on essay exemplar length was fixed before merge; residual audit notes are minor.
+B2 M06 `third-person-plural-passive`,9/10,B+,Yes,Strong 3rd-person-plural passive-alternative module. Dead/fabricated resource fallback was removed before merge; score held at 9 for section-balance warnings.
+B2 M07 `passive-in-context`,9/10,B+,Yes,Strong synthesis/context module. Review notes on worked-example coherence and exemplar length were fixed before merge; minor section-balance/resource notes remain.
+B2 M08 `pobut-shchodenne`,10/10,A,Yes,"Excellent everyday-life module with strong activity coverage, natural Ukrainian household negotiation, and no meaningful content blockers."
+B2 M09 `active-participles-present`,9/10,B+,Yes,Strong editorial grammar module. Score held at 9 because section balance remains uneven and deterministic audit still emits false-positive naturalness warnings.
+B2 M10 `checkpoint-passive-voice`,9/10,B+,Yes,High-quality passive-voice checkpoint. Score held at 9 for non-blocking collocation/translate-position/resource-polish notes.
+B2 M11 `active-participles-past`,9/10,B+,Yes,Strong advanced participle module after review fixes. Score held at 9 for normal post-build polish risk.
+B2 M12 `participles-vs-relative-clauses`,9/10,B+,Yes,Strong contrast module for participles and relative clauses. Review blocker on a padded quiz was fixed; score held at 9 for minor polish risk.
+B2 M13 `zdorovya-i-medytsyna`,9/10,B+,Yes,Strong health/medicine communication module after factual wording fixes. Score held at 9 for residual deterministic advisory warnings.
+B2 M14 `phrases-word-combinations`,8/10,B,Yes,Useful collocation and word-combination module after MDX and collocation blockers were fixed. Score held at 8 because cleanup required multiple passes and residual polish risk is higher.
+B2 M15 `predicate-types`,9/10,B+,Yes,Strong predicate-types module after render and activity consistency fixes. Score held at 9 for residual section-balance and deterministic advisory warnings.
+B2 M16 `secondary-sentence-members`,9/10,B+,Yes,Strong grammar-production module. Independent review blocker was stale-base MDX drift only; follow-up review found no blockers.
+B2 M17 `sport-i-dozvillia`,9/10,B+,Yes,Strong sport and leisure communication module with validated activity and vocabulary coverage. Independent review passed with no blockers.
+B2 M18 `b2-one-member-sentences`,9/10,B+,Yes,Strong one-member sentence module with 100% immersion and 96% richness. Independent review found no merge-blocking issues.
+B2 M19 `homogeneous-members`,9/10,B+,Yes,Strong homogeneous-members syntax module with 100% immersion and 96% richness. Independent review passed with no blockers.
+B2 M20 `detached-members`,9/10,B+,Yes,Strong detached-members module; audit passed at 4107/4000 words with 96% richness and 100% immersion. Independent review found no blockers.
+B2 M21 `checkpoint-syntax-i`,9/10,B+,Yes,Strong B2.1 syntax checkpoint; audit passed with 100% immersion and 99% richness. Score held at 9 for compact checkpoint scope and non-blocking section-balance warnings.
+B2 M22 `parenthetical-expressions`,9/10,B+,Yes,Strong parenthetical-expression module. Initial independent review blockers were fixed; follow-up review passed. Score held at 9 for non-blocking balance/recycling/advisory notes.
+B2 M23 `multi-clause-sentences`,9/10,B+,Yes,Strong multi-clause syntax module with 100% immersion and 99% richness. Independent review found no blockers; score held at 9 for conservative post-build polish risk.
+B2 M24 `kharchuvannia-i-kukhnia`,9/10,B+,Yes,Strong food and kitchen communication module with validated activity and vocabulary coverage. Score held at 9 for retained non-blocking section-balance warnings.
+B2 M25 `correlative-constructions`,9/10,B+,Yes,Strong correlative-constructions module with 99.6% immersion and 99% richness. Independent review passed with no blockers.
+B2 M26 `emphasis-and-inversion`,9/10,B+,Yes,Strong emphasis and inversion module with 100% immersion and 99% richness. Independent review passed; non-blocking activity nits were fixed before merge.
+B2 M27 `stylistic-connectors`,9/10,B+,Yes,Strong stylistic-connectors module. Initial independent blockers fixed before merge; final Agy/Gemini review passed. Score held at 9 for conservative post-fix polish risk.
+B2 M28 `kupivlia-i-servisy`,9/10,B+,Yes,Strong shopping/services communication module with validated activity and vocabulary coverage. Initial independent blocker fixed; final Agy/Gemini review passed.
+B2 M29 `complex-syntax-ellipsis-parcelling`,9/10,B+,Yes,Strong ellipsis/parcelling module. Agy/Claude Opus blocker review passed with no unresolved findings.
+B2 M30 `direct-indirect-speech`,9/10,B+,Yes,Strong direct/indirect speech module. Agy/Claude Opus blocker review passed with no unresolved findings.
+B2 M31 `checkpoint-syntax-ii`,9/10,B+,Yes,Strong Syntax II checkpoint with broad review coverage, 20 workbook activities, and passing deterministic audit. Agy/Claude Opus review passed; score held at 9 for checkpoint size and minor non-blocking notes.
+B2 M32 `phonetic-stylistic-devices`,9/10,B+,Yes,Strong phonetic stylistic devices module with 10 workbook activities, 38 vocabulary items, 99.8% richness, and final Agy/Claude Opus review pass. Score held at 9 for minor audit balance/repetition notes fixed enough for merge but worth human polish attention.
+B2 M33 `lexical-stylistic-devices`,9/10,B+,Yes,Strong lexical stylistic devices module with 10 workbook activities, 39 vocabulary items, 99.8% richness, and Agy/Claude Opus review pass. Score held at 9 for conservative post-build polish risk around dense trope coverage.
+B2 M34 `syntactic-stylistic-devices`,9/10,B+,Yes,Strong syntactic stylistic devices module with 11 workbook activities, 39 vocabulary items, 99.4% richness, and final Agy/Gemini review pass. Score held at 9 for minor audit UA-GEC/style advisories.
+B2 M35 `mistsia-i-oriientyry`,9/10,B+,Yes,Strong places and landmarks module with 11 workbook activities, 42 vocabulary items, 99.7% richness, and Agy/Claude Opus review pass. Score held at 9 for non-blocking review polish notes.
+B2 M36 `register-formal-informal`,9/10,B+,Yes,Strong formal/informal register module with 11 workbook activities, 42 vocabulary items, 96.3% richness, and Agy/Claude Opus review pass. Score held at 9 for lower cultural-anchor subscore and conservative post-build polish risk.
+
+Score,Count,Modules
+10/10,2,"M01, M08"
+9/10,33,"M02-M07, M09-M13, M15-M36"
+8/10,1,M14
+
+Durable Report,Scope
+`docs/audits/b2-m03-m10-llm-score-report-2026-06-25.md`,M03-M10
+`docs/audits/b2-m11-m15-llm-score-report-2026-06-25.md`,M11-M15
+`docs/audits/b2-m16-m21-llm-score-report-2026-06-25.md`,M16-M21
+`docs/audits/b2-m22-m26-llm-score-report-2026-06-26.md`,M22-M26
+`docs/audits/b2-m27-m31-llm-score-report-2026-06-26.md`,M27-M31
+`docs/audits/b2-m32-m36-llm-score-report-2026-06-27.md`,M32-M36
+
+Module,Raw Word Count,Activities,Vocabulary
+M03 `b2-impersonal-passive`,4608,7 workbook / 4 inline,35
+M04 `dim-zhytlo`,5224,10 workbook / 0 inline,94
+M05 `reflexive-passive`,4422,11 workbook / 0 inline,34
+M06 `third-person-plural-passive`,4779,11 workbook / 0 inline,43
+M07 `passive-in-context`,4751,10 workbook / 0 inline,36
+M08 `pobut-shchodenne`,5047,12 workbook / 0 inline,55
+M09 `active-participles-present`,5428,10 workbook / 0 inline,40
+M10 `checkpoint-passive-voice`,4671,5 workbook / 5 inline,30
+M11 `active-participles-past`,4736,11 workbook / 0 inline,30
+M12 `participles-vs-relative-clauses`,4383,10 workbook / 0 inline,45
+M13 `zdorovya-i-medytsyna`,4123,10 workbook / 0 inline,40
+M14 `phrases-word-combinations`,5696,11 workbook / 5 inline,42
+M15 `predicate-types`,5645,10 workbook / 5 inline,32
+M16 `secondary-sentence-members`,5396,12 workbook / 0 inline,32
+M17 `sport-i-dozvillia`,4153,10 workbook / 0 inline,32
+M18 `b2-one-member-sentences`,4430,10 workbook / 0 inline,32
+M19 `homogeneous-members`,4569,10 workbook / 0 inline,32
+M20 `detached-members`,4267,11 workbook / 0 inline,32
+M21 `checkpoint-syntax-i`,4334,10 workbook / 0 inline,20
+M22 `parenthetical-expressions`,5509,10 workbook / 0 inline,32
+M23 `multi-clause-sentences`,5881,11 workbook / 0 inline,30
+M24 `kharchuvannia-i-kukhnia`,4753,11 workbook / 0 inline,43
+M25 `correlative-constructions`,4822,10 workbook / 0 inline,35
+M26 `emphasis-and-inversion`,4633,11 workbook / 0 inline,38
+M27 `stylistic-connectors`,5212,10 workbook / 0 inline,32
+M28 `kupivlia-i-servisy`,6004,10 workbook / 0 inline,46
+M29 `complex-syntax-ellipsis-parcelling`,4686,10 workbook / 0 inline,45
+M30 `direct-indirect-speech`,4683,12 workbook / 0 inline,46
+M31 `checkpoint-syntax-ii`,7247,20 workbook / 0 inline,35
+M32 `phonetic-stylistic-devices`,5367,10 workbook / 0 inline,38
+M33 `lexical-stylistic-devices`,5421,10 workbook / 0 inline,39
+M34 `syntactic-stylistic-devices`,4904,11 workbook / 0 inline,39
+M35 `mistsia-i-oriientyry`,4798,11 workbook / 0 inline,42
+M36 `register-formal-informal`,4663,11 workbook / 0 inline,42
+
+Score,Pass Count
+10/10,5/5 with no meaningful content polish
+9/10,5/5 with non-blocking polish or unevenness
+8/10,4/5
+7/10,3/5
+6/10 or lower,0-2/5
+
+Independent Review Evidence,Scope
+See `docs/audits/b2-m03-m10-llm-score-report-2026-06-25.md`.,M03-M10
+See `docs/audits/b2-m11-m15-llm-score-report-2026-06-25.md`.,M11-M15
+See `docs/audits/b2-m16-m21-llm-score-report-2026-06-25.md`.,M16-M21
+See `docs/audits/b2-m22-m26-llm-score-report-2026-06-26.md`.,M22-M26
+See `docs/audits/b2-m27-m31-llm-score-report-2026-06-26.md`.,M27-M31
+See `docs/audits/b2-m32-m36-llm-score-report-2026-06-27.md`.,M32-M36

--- a/docs/audits/b2-m32-m36-llm-score-report-2026-06-27.md
+++ b/docs/audits/b2-m32-m36-llm-score-report-2026-06-27.md
@@ -1,0 +1,27 @@
+Module,Score,Verdict,Deterministic Audit,Activity/Vocab Coverage,Ready Human Review?
+M32 `phonetic-stylistic-devices`,9/10,B+,PASS,10 workbook / 0 inline; 38 vocab,Yes
+M33 `lexical-stylistic-devices`,9/10,B+,PASS,10 workbook / 0 inline; 39 vocab,Yes
+M34 `syntactic-stylistic-devices`,9/10,B+,PASS,11 workbook / 0 inline; 39 vocab,Yes
+M35 `mistsia-i-oriientyry`,9/10,B+,PASS,11 workbook / 0 inline; 42 vocab,Yes
+M36 `register-formal-informal`,9/10,B+,PASS,11 workbook / 0 inline; 42 vocab,Yes
+
+Module,Notes
+M32 `phonetic-stylistic-devices`,Strong phonetic stylistic devices module 5367 raw words, 10 workbook activities, 38 vocabulary items, 99.8% richness. Initial Agy/Claude Opus review blockers fixed before merge; follow-up passed with no unresolved blockers. Score held at 9 for minor audit balance/repetition notes and conservative post-fix polish risk.
+M33 `lexical-stylistic-devices`,Strong lexical stylistic devices module 5421 raw words, 10 workbook activities, 39 vocabulary items, 99.8% richness. Agy/Claude Opus review passed with no unresolved blockers. Score held at 9 for conservative post-build polish risk around dense trope coverage.
+M34 `syntactic-stylistic-devices`,Strong syntactic stylistic devices module 4904 raw words, 11 workbook activities, 39 vocabulary items, 99.4% richness. Final Agy/Gemini review passed after three initial blockers were fixed. Score held at 9 for minor audit UA-GEC/style advisories.
+M35 `mistsia-i-oriientyry`,Strong places and landmarks module 4798 raw words, 11 workbook activities, 42 vocabulary items, 99.7% richness. Agy/Claude Opus review passed with no blockers. Score held at 9 for non-blocking review polish notes.
+M36 `register-formal-informal`,Strong formal/informal register module 4663 raw words, 11 workbook activities, 42 vocabulary items, 96.3% richness. Agy/Claude Opus review passed with no blockers. Score held at 9 for lower cultural-anchor subscore and conservative post-build polish risk.
+
+Module,Independent Review Route,Disposition
+M32 `phonetic-stylistic-devices`,Agy -> Claude Opus 4.6 Thinking blocker review,PASS after fixes; no unresolved blockers.
+M33 `lexical-stylistic-devices`,Agy -> Claude Opus 4.6 Thinking blocker review,PASS; no unresolved blockers.
+M34 `syntactic-stylistic-devices`,Agy -> Gemini 3.1 Pro High fallback blocker review,PASS after fixes; no unresolved blockers.
+M35 `mistsia-i-oriientyry`,Agy -> Claude Opus 4.6 Thinking blocker review,PASS; no blockers.
+M36 `register-formal-informal`,Agy -> Claude Opus 4.6 Thinking blocker review,PASS; no blockers.
+
+Module,PR,Merge Commit,Telemetry Run
+M32 `phonetic-stylistic-devices`,#3878,`d3aadfb1ace35c782a7dbb7697704be2e5820077`,`b2-phonetic-stylistic-devices-codex-b2-m32-phonetic-stylistic-devices-20260626`
+M33 `lexical-stylistic-devices`,#3881,`ae1a6d5833769ad530ebea91515c0de77b8d7f0f`,`b2-lexical-stylistic-devices-codex-b2-m33-lexical-stylistic-devices-20260626`
+M34 `syntactic-stylistic-devices`,#3883,`5c54e1d8f54c91bcc53f0681f50dfa648a57a031`,`b2-syntactic-stylistic-devices-codex-b2-m34-syntactic-stylistic-devices-20260626`
+M35 `mistsia-i-oriientyry`,#3885,`3b58e02cfecb51383be093db78e19af062aa1fb0`,`b2-m35-pr3885`
+M36 `register-formal-informal`,#3888,`61b4e3da141839625118919e3b4050b939f715a2`,`b2-m36-pr3888`


### PR DESCRIPTION
## Changed
- Added the 2026-06-27 current B2 LLM score snapshot including M32-M36.
- Added a durable M32-M36 score report with scores, metrics, review routes, PRs, merge commits, and telemetry run ids.

## Why
- Persist the completed M32-M36 scoring decisions after the modules were merged.
- Keep the current B2 score snapshot linked to the durable batch report.

## Validation
- `git diff --check`
- Commit hooks on commit and push
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Scope
Docs-only score persistence. No generated `status/`, `audit/`, `review/`, `.cache/`, or telemetry database files included.