### PR TITLE
[codex] Add deterministic module range status API

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -350,6 +350,54 @@ Returns only tracks that have activity. Use during overnight builds for a single
 
 ---
 
+### `GET /api/state/module-range/{track}`
+
+Deterministic committed-file status for a module number range. Use this for
+questions like "what is left for B2 M32-M41?" without spending model context on
+manual repo scans.
+
+With `MONITOR_API_BASE` set to the monitor host:
+
+```bash
+curl -s "${MONITOR_API_BASE}/api/state/module-range/b2?start=32&end=41" | .venv/bin/python -m json.tool
+```
+
+The endpoint checks committed source files, generated MDX, and durable score
+docs. It intentionally does not depend on `status/*.json`, `audit/*-review.md`,
+or local orchestration artifacts because those are runtime state and are not
+committed.
+
+Returns:
+```json
+{
+  "track": "b2",
+  "range": {"start": 32, "end": 41},
+  "total": 10,
+  "complete": 10,
+  "content_complete": 10,
+  "score_persisted": 10,
+  "incomplete": 0,
+  "remaining": [],
+  "modules": [
+    {
+      "num": 32,
+      "slug": "phonetic-stylistic-devices",
+      "status": "complete",
+      "complete": true,
+      "content_complete": true,
+      "score_persisted": true,
+      "files": {"module": true, "activities": true, "vocabulary": true, "mdx": true},
+      "missing_files": [],
+      "missing": []
+    }
+  ],
+  "deterministic": true,
+  "source": "fs:plans+content+mdx+score-docs"
+}
+```
+
+---
+
 ### `GET /api/state/build-stats/{track}`
 
 V6 build attempt history from `build-stats.jsonl`. Each V6 build appends a line to this file; this endpoint reads and summarizes it.

--- a/scripts/api/state_build.py
+++ b/scripts/api/state_build.py
@@ -6,13 +6,14 @@ aggregation. All functions are sync and designed for asyncio.to_thread().
 
 import json
 from datetime import UTC, datetime
+from pathlib import Path
 
 try:
     from path_safety import safe_join  # scripts/ on sys.path (test sys.path-hack)
 except ImportError:
     from ..path_safety import safe_join  # scripts.api package import (production)
 
-from .config import CURRICULUM_ROOT, LEVELS
+from .config import CURRICULUM_ROOT, LEVELS, PROJECT_ROOT
 from .state_compute import _compute_shippable, _get_review_score
 from .state_helpers import (
     PLANS_ROOT,
@@ -153,6 +154,121 @@ def compute_build_status_all() -> dict:
         }
 
     return {"generated_at": datetime.now(UTC).isoformat(), "tracks": tracks}
+
+
+def _score_docs_text(track_id: str) -> str:
+    """Return concatenated durable score docs text for a track."""
+    docs_dir = safe_join(PROJECT_ROOT, "docs", "audits")
+    if not docs_dir.exists():
+        return ""
+    chunks: list[str] = []
+    track_prefix = track_id.lower()
+    for path in sorted(docs_dir.glob("*llm-score*.md")):
+        if not path.name.lower().startswith(track_prefix):
+            continue
+        chunks.append(path.read_text(encoding="utf-8"))
+    return "\n".join(chunks)
+
+
+def _module_score_persisted(score_text: str, num: int, slug: str) -> bool:
+    """Return whether durable score docs mention this module number and slug."""
+    return f"M{num:02d} `{slug}`" in score_text or f"M{num} `{slug}`" in score_text
+
+
+def _module_range_entry(
+    track_dir: Path,
+    mdx_dir: Path,
+    score_text: str,
+    num: int,
+    slug: str,
+) -> dict:
+    """Return deterministic status for one module in a range."""
+    module_dir = track_dir / slug
+    paths = {
+        "module": module_dir / "module.md",
+        "activities": module_dir / "activities.yaml",
+        "vocabulary": module_dir / "vocabulary.yaml",
+        "mdx": mdx_dir / f"{slug}.mdx",
+    }
+    files = {key: path.exists() for key, path in paths.items()}
+    missing_files = [key for key, exists in files.items() if not exists]
+    content_complete = not missing_files
+    score_persisted = _module_score_persisted(score_text, num, slug)
+    complete = content_complete and score_persisted
+    missing = [*missing_files]
+    if not score_persisted:
+        missing.append("score")
+    if complete:
+        status = "complete"
+    elif any(files.values()) or score_persisted:
+        status = "partial"
+    else:
+        status = "missing"
+    return {
+        "num": num,
+        "slug": slug,
+        "status": status,
+        "complete": complete,
+        "content_complete": content_complete,
+        "score_persisted": score_persisted,
+        "files": files,
+        "missing_files": missing_files,
+        "missing": missing,
+    }
+
+
+def compute_module_range_status(
+    track_id: str,
+    level_cfg: dict,
+    *,
+    start: int,
+    end: int,
+) -> dict:
+    """Compute deterministic committed-file status for a module number range.
+
+    This does not read generated audit/status artifacts because those are local
+    runtime state and must not be committed. It answers orchestration questions
+    like "what is left for B2 M32-M41?" from source files, generated MDX, and
+    durable score docs.
+    """
+    if start <= 0 or end <= 0:
+        raise ValueError("start and end must be positive")
+    if end < start:
+        raise ValueError("end must be greater than or equal to start")
+
+    plan_slugs = get_plan_slugs(track_id)
+    selected = [(num, slug) for num, slug in plan_slugs if start <= num <= end]
+    track_dir = CURRICULUM_ROOT / level_cfg["path"]
+    mdx_dir = safe_join(PROJECT_ROOT, "site", "src", "content", "docs", track_id)
+    score_text = _score_docs_text(track_id)
+
+    modules = [
+        _module_range_entry(track_dir, mdx_dir, score_text, num, slug)
+        for num, slug in selected
+    ]
+
+    total = len(modules)
+    complete_count = sum(1 for module in modules if module["complete"])
+    content_complete_count = sum(1 for module in modules if module["content_complete"])
+    score_persisted_count = sum(1 for module in modules if module["score_persisted"])
+    incomplete = [module for module in modules if not module["complete"]]
+    return {
+        "track": track_id,
+        "range": {"start": start, "end": end},
+        "total": total,
+        "complete": complete_count,
+        "content_complete": content_complete_count,
+        "score_persisted": score_persisted_count,
+        "incomplete": len(incomplete),
+        "remaining": [
+            {"num": module["num"], "slug": module["slug"], "missing": module["missing"]}
+            for module in incomplete
+        ],
+        "modules": modules,
+        "deterministic": True,
+        "source": "fs:plans+content+mdx+score-docs",
+        "generated_at": datetime.now(UTC).isoformat(),
+    }
 
 
 def compute_track_health(track_id: str, level_cfg: dict) -> dict:

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -9,6 +9,7 @@ Endpoints:
   GET /api/state/weak-points          Modules with quality issues
   GET /api/state/build-status/{track}  Compact live build progress (one call)
   GET /api/state/build-status          All-tracks build progress summary
+  GET /api/state/module-range/{track}  Deterministic committed-file status for a module range
   GET /api/state/module/{track}/{num}  Single module deep-dive with comms
   GET /api/state/final-reviews/{track} Phase F results aggregated per track
   GET /api/state/failing              Modules with audit/phase failures
@@ -49,6 +50,7 @@ from .state_build import (
     compute_build_status_all,
     compute_build_status_track,
     compute_enrichment_status,
+    compute_module_range_status,
     compute_track_health,
 )
 from .state_compute import (
@@ -944,6 +946,36 @@ async def build_status_all():
         return cached
     result = await asyncio.to_thread(compute_build_status_all)
     cache_set("build_status_all", result)
+    return result
+
+
+@router.get("/module-range/{track_id}")
+async def module_range_status(
+    track_id: str,
+    start: int = Query(..., ge=1),
+    end: int = Query(..., ge=1),
+):
+    """Deterministic committed-file status for a module number range."""
+    level_cfg = next((l for l in LEVELS if l["id"] == track_id), None)
+    if not level_cfg:
+        return JSONResponse(status_code=404, content={"error": f"Track '{track_id}' not found"})
+    if end < start:
+        return JSONResponse(
+            status_code=422,
+            content={"error": "end must be greater than or equal to start"},
+        )
+    cache_key = f"module_range_{track_id}_{start}_{end}"
+    cached = cache_get(cache_key, ttl=30.0)
+    if cached is not None:
+        return cached
+    result = await asyncio.to_thread(
+        compute_module_range_status,
+        track_id,
+        level_cfg,
+        start=start,
+        end=end,
+    )
+    cache_set(cache_key, result)
     return result
 
 

--- a/tests/test_api_module_range_status.py
+++ b/tests/test_api_module_range_status.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from scripts.api import state_build, state_router
+from scripts.api.main import app
+
+
+def _write_module_files(root: Path, slug: str) -> None:
+    module_dir = root / "curriculum" / "l2-uk-en" / "b2" / slug
+    module_dir.mkdir(parents=True, exist_ok=True)
+    (module_dir / "module.md").write_text("# Module\n", encoding="utf-8")
+    (module_dir / "activities.yaml").write_text("version: '1.0'\n", encoding="utf-8")
+    (module_dir / "vocabulary.yaml").write_text("[]\n", encoding="utf-8")
+
+    mdx_dir = root / "site" / "src" / "content" / "docs" / "b2"
+    mdx_dir.mkdir(parents=True, exist_ok=True)
+    (mdx_dir / f"{slug}.mdx").write_text("---\ntitle: Module\n---\n", encoding="utf-8")
+
+
+def test_compute_module_range_status_reports_complete_and_remaining(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(state_build, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(state_build, "CURRICULUM_ROOT", tmp_path / "curriculum" / "l2-uk-en")
+    monkeypatch.setattr(
+        state_build,
+        "get_plan_slugs",
+        lambda track_id: [(32, "m32"), (33, "m33"), (34, "m34")],
+    )
+
+    _write_module_files(tmp_path, "m32")
+    _write_module_files(tmp_path, "m33")
+    score_dir = tmp_path / "docs" / "audits"
+    score_dir.mkdir(parents=True)
+    (score_dir / "b2-current-llm-scores-test.md").write_text(
+        "B2 M32 `m32`,9/10,B+,Yes,done\n",
+        encoding="utf-8",
+    )
+    (score_dir / "a1-current-llm-scores-test.md").write_text(
+        "A1 M33 `m33`,9/10,B+,Yes,wrong track\n",
+        encoding="utf-8",
+    )
+
+    result = state_build.compute_module_range_status(
+        "b2",
+        {"path": "b2"},
+        start=32,
+        end=34,
+    )
+
+    assert result["deterministic"] is True
+    assert result["total"] == 3
+    assert result["complete"] == 1
+    assert result["content_complete"] == 2
+    assert result["score_persisted"] == 1
+    assert result["incomplete"] == 2
+    assert result["remaining"] == [
+        {"num": 33, "slug": "m33", "missing": ["score"]},
+        {
+            "num": 34,
+            "slug": "m34",
+            "missing": ["module", "activities", "vocabulary", "mdx", "score"],
+        },
+    ]
+    assert result["modules"][0]["status"] == "complete"
+    assert result["modules"][1]["status"] == "partial"
+    assert result["modules"][2]["status"] == "missing"
+
+
+def test_compute_module_range_status_accepts_unpadded_score_module_numbers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(state_build, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(state_build, "CURRICULUM_ROOT", tmp_path / "curriculum" / "l2-uk-en")
+    monkeypatch.setattr(state_build, "get_plan_slugs", lambda track_id: [(7, "m7")])
+
+    _write_module_files(tmp_path, "m7")
+    score_dir = tmp_path / "docs" / "audits"
+    score_dir.mkdir(parents=True)
+    (score_dir / "b2-current-llm-scores-test.md").write_text(
+        "B2 M7 `m7`,9/10,B+,Yes,done\n",
+        encoding="utf-8",
+    )
+
+    result = state_build.compute_module_range_status(
+        "b2",
+        {"path": "b2"},
+        start=7,
+        end=7,
+    )
+
+    assert result["complete"] == 1
+    assert result["remaining"] == []
+
+
+def test_compute_module_range_status_rejects_invalid_ranges() -> None:
+    with pytest.raises(ValueError, match="positive"):
+        state_build.compute_module_range_status("b2", {"path": "b2"}, start=0, end=1)
+
+    with pytest.raises(ValueError, match="greater than or equal"):
+        state_build.compute_module_range_status("b2", {"path": "b2"}, start=2, end=1)
+
+
+def test_module_range_status_route_returns_computed_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "track": "b2",
+        "range": {"start": 32, "end": 41},
+        "total": 10,
+        "complete": 10,
+        "content_complete": 10,
+        "score_persisted": 10,
+        "incomplete": 0,
+        "remaining": [],
+        "modules": [],
+        "deterministic": True,
+        "source": "test",
+    }
+    calls: list[tuple[str, str, int, int]] = []
+
+    def fake_compute(
+        track_id: str,
+        level_cfg: dict,
+        *,
+        start: int,
+        end: int,
+    ) -> dict:
+        calls.append((track_id, level_cfg["path"], start, end))
+        return payload
+
+    state_router.cache_invalidate("module_range_b2_32_41")
+    monkeypatch.setattr(state_router, "compute_module_range_status", fake_compute)
+    client = TestClient(app)
+
+    response = client.get("/api/state/module-range/b2?start=32&end=41")
+
+    assert response.status_code == 200
+    assert response.json() == payload
+    assert calls == [("b2", "b2", 32, 41)]
+
+
+def test_module_range_status_route_rejects_inverted_range() -> None:
+    client = TestClient(app)
+
+    response = client.get("/api/state/module-range/b2?start=41&end=32")
+
+    assert response.status_code == 422
+    assert response.json() == {"error": "end must be greater than or equal to start"}


### PR DESCRIPTION
## Summary

Adds a deterministic module-range status endpoint for orchestration checks such as B2 M32-M41. The endpoint reads plan order, module source files, generated MDX, and durable score docs, and intentionally avoids generated status/audit/review artifacts.

## Changes

- Add `GET /api/state/module-range/{track}?start=N&end=M`.
- Report total, complete, content-complete, score-persisted, incomplete, remaining, and per-module missing fields.
- Filter score docs by track prefix before checking `MNN `slug`` markers.
- Document the endpoint in `docs/MONITOR-API.md`.
- Add unit and route coverage for complete, partial, missing, invalid range, and API route behavior.

## Validation

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check --fix scripts/api/state_build.py scripts/api/state_router.py tests/test_api_module_range_status.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_api_module_range_status.py -v` (5 passed)
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m py_compile scripts/api/state_build.py scripts/api/state_router.py tests/test_api_module_range_status.py`
- `git diff --check`
- TestClient probe: `/api/state/module-range/b2?start=32&end=41` returned `total=10`, `complete=10`, `content_complete=10`, `score_persisted=10`, `remaining=[]`.
- `scripts/audit/lint_agent_trailer.py` passed.

## Independent Review

- Agy/Gemini 3.1 Pro High review: PASS, no blockers.
- One minor finding flagged a route test that depended on live B2 M32-M41 repo state. Fixed by monkeypatching the route compute function and asserting the endpoint returns the computed payload.