### PR TITLE
docs(agents): classify FOLK as seminar high-risk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,7 +342,7 @@ You will sometimes be invoked via `ab discuss` for design / framing / pedagogy /
 
 **When the orchestrator (Claude) emits a `## DECISION REQUIRED — ...` block, that's a Decision Card.** It means user input is needed. Don't try to resolve it on your side; the orchestrator routes it to inline chat / `docs/decisions/pending/` / GH issue depending on user availability.
 
-**High-risk-track override:** On sensitive tracks (HIST, BIO, ISTORIO, LIT, OES, RUTH), an `[AGREE]` consensus is suspect due to shared training-data biases. The orchestrator will override consensus by either force-emitting a Decision Card or injecting domain-specific bias checklists to provoke adversarial review.
+**High-risk-track override:** On sensitive tracks (FOLK, HIST, BIO, ISTORIO, LIT, OES, RUTH), an `[AGREE]` consensus is suspect due to shared training-data biases. The orchestrator will override consensus by either force-emitting a Decision Card or injecting domain-specific bias checklists to provoke adversarial review.
 
 **Pending decisions (`docs/decisions/pending/*.md`) are BLOCKING only for the scope declared in their `Scope` field.** If you're starting work in a worktree and that directory has files, surface them in your initial response and check the field before assuming a decision blocks your work.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -169,7 +169,7 @@ You will sometimes be invoked via `ab discuss` for design / framing / pedagogy /
 
 **When the orchestrator (Claude) emits a `## DECISION REQUIRED — ...` block, that's a Decision Card** routed to inline chat / `docs/decisions/pending/` / GH issue. Don't try to resolve it on Gemini's side.
 
-**High-risk-track override:** On sensitive tracks (HIST, BIO, ISTORIO, LIT, OES, RUTH), an `[AGREE]` consensus is suspect due to shared training-data biases. The orchestrator will override consensus by either force-emitting a Decision Card or injecting domain-specific bias checklists to provoke adversarial review.
+**High-risk-track override:** On sensitive tracks (FOLK, HIST, BIO, ISTORIO, LIT, OES, RUTH), an `[AGREE]` consensus is suspect due to shared training-data biases. The orchestrator will override consensus by either force-emitting a Decision Card or injecting domain-specific bias checklists to provoke adversarial review.
 
 **Pending decisions (`docs/decisions/pending/*.md`) are BLOCKING only for the scope declared in their `Scope` field.** Surface them before any new work that could invalidate them, and check the field before assuming a decision blocks your work.
 

--- a/agents_extensions/shared/NON-NEGOTIABLE-RULES.md
+++ b/agents_extensions/shared/NON-NEGOTIABLE-RULES.md
@@ -172,7 +172,7 @@ Read → Fix A → Audit → Read → Fix B → Audit → Read → Fix C → Aud
 
 Activities practice Ukrainian language skills, not subject knowledge.
 
-### 9a. Content-heavy modules (HIST, BIO, ISTORIO, LIT, RUTH, OES)
+### 9a. Content-heavy modules (FOLK, HIST, BIO, ISTORIO, LIT, RUTH, OES)
 
 **Golden Rule:** Can the learner answer without reading the Ukrainian text? If YES → rewrite it.
 

--- a/agents_extensions/shared/skills/content-review/content-review-prompt.md
+++ b/agents_extensions/shared/skills/content-review/content-review-prompt.md
@@ -26,7 +26,7 @@ Select the appropriate review tier based on level:
 |-------|------|-----------|
 | A1, A2 | Tier 1 (Beginner) | See `../plan-review/review-tiers/tier-1-beginner.md` |
 | B1, B2 | Tier 2 (Core) | See `../plan-review/review-tiers/tier-2-core.md` |
-| HIST, BIO, ISTORIO, LIT, OES, RUTH | Tier 3 (Seminar) | See `../plan-review/review-tiers/tier-3-seminar.md` |
+| FOLK, HIST, BIO, ISTORIO, LIT, OES, RUTH | Tier 3 (Seminar) | See `../plan-review/review-tiers/tier-3-seminar.md` |
 | C1, C2 | Tier 4 (Advanced) | See `../plan-review/review-tiers/tier-4-advanced.md` |
 
 Read the tier file and apply its rubrics alongside the checks below.
@@ -112,6 +112,14 @@ Read the activities YAML and check:
 - [ ] **Primary source accuracy** -- Verify text dating, genre, linguistic features using `mcp__sources__search_literary` with period filter.
 - [ ] **Not anachronistic** -- No modern features projected onto historical texts.
 
+### FOLK MODE
+
+- [ ] **FOLK framing hard gate** -- Apply `docs/folk-epic/FOLK-FRAMING-STANDARD.md`; any pagan-core / Christian-shell, occult-as-belief, magic-as-core, or demonology-as-belief framing is a blocker.
+- [ ] **No Soviet/Russian demonizing lens** -- Do not describe Ukrainian folk culture as primitive, backward, superstition, banditry, "Little Russian," or common-Russian inheritance except as explicitly marked hostile/historical framing.
+- [ ] **Source hygiene** -- Public learner pages cite public URLs only. Internal chunk IDs/source IDs must not appear in public-facing content.
+- [ ] **Primary readings** -- Hosted readings are full public texts where applicable, formatted as readings rather than blockquote noise, and lesson excerpts are source-faithful.
+- [ ] **Decolonization stance** -- Ukrainian cultural agency remains central without hagiography or romantic overclaiming.
+
 ---
 
 ## Output Format
@@ -120,7 +128,7 @@ Read the activities YAML and check:
 # Content Review: {slug}
 
 **Track:** {track} | **Sequence:** {sequence}
-**Mode:** core / history / biography / literary / oes-ruth
+**Mode:** core / folk / history / biography / literary / oes-ruth
 **Tier:** 1-beginner / 2-core / 3-seminar / 4-advanced
 **Pipeline:** PASS (words: X, target: Y)
 **Verdict:** A / B / C / F

--- a/agents_extensions/shared/skills/plan-review-seminar/SKILL.md
+++ b/agents_extensions/shared/skills/plan-review-seminar/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: plan-review-seminar
-description: Review SEMINAR track plans (HIST, BIO, ISTORIO, LIT, OES, RUTH) using Wikipedia + Literary RAG + VESUM. Finds factual errors, ghost sources, decolonization issues.
+description: Review SEMINAR track plans (FOLK, HIST, BIO, ISTORIO, LIT, OES, RUTH) using Wikipedia + Literary RAG + VESUM. Finds factual errors, ghost sources, decolonization issues.
 argument-hint: "<track> [modules: all | 1 | 5-10 | slug-name]"
 effort: xhigh
 ---
 
 # Plan Review (Seminar): $ARGUMENTS
 
-**Scope: HIST, BIO, ISTORIO, LIT (all subtracks), OES, RUTH only.** For core levels (A1-C2, PRO), use `/plan-review`.
+**Scope: FOLK, HIST, BIO, ISTORIO, LIT (all subtracks), OES, RUTH only.** For core levels (A1-C2, PRO), use `/plan-review`.
 
 ## Parse Arguments
 
@@ -25,7 +25,7 @@ Parse the arguments:
 
 **Plans directory**: `curriculum/l2-uk-en/plans/{track}/*.yaml`
 
-**Valid tracks**: hist, bio, istorio, lit, lit-drama, lit-essay, lit-doc, lit-crimea, lit-fantastika, lit-hist-fic, lit-humor, lit-war, lit-youth, oes, ruth
+**Valid tracks**: folk, hist, bio, istorio, lit, lit-drama, lit-essay, lit-doc, lit-crimea, lit-fantastika, lit-hist-fic, lit-humor, lit-war, lit-youth, oes, ruth
 
 ## Module Selection
 

--- a/agents_extensions/shared/skills/plan-review-seminar/plan-review-seminar-prompt.md
+++ b/agents_extensions/shared/skills/plan-review-seminar/plan-review-seminar-prompt.md
@@ -1,6 +1,6 @@
 # Plan Review Prompt — Seminar Tracks
 
-You are reviewing a Ukrainian language course plan YAML file for seminar tracks (HIST, BIO, ISTORIO, LIT and subtracks, OES, RUTH). Your job is to find errors, weaknesses, and gaps BEFORE content is built from this plan.
+You are reviewing a Ukrainian language course plan YAML file for seminar tracks (FOLK, HIST, BIO, ISTORIO, LIT and subtracks, OES, RUTH). Your job is to find errors, weaknesses, and gaps BEFORE content is built from this plan.
 
 **Key difference from core reviews:** Seminar tracks have NO State Standard mapping. Authority comes from external knowledge sources (Wikipedia, Literary RAG) and domain expertise, not government curriculum documents.
 
@@ -33,6 +33,7 @@ Read the plan YAML file, then systematically check every item below.
 
 | Track | target_words |
 |-------|-------------|
+| FOLK | 4000 |
 | HIST | 5000 |
 | ISTORIO | 5000 |
 | BIO | 5000 |
@@ -139,6 +140,16 @@ For every word in `vocabulary_hints.required` and `vocabulary_hints.recommended`
 
 ---
 
+#### FOLK (Folklore / Folk Culture)
+
+- [ ] Apply `docs/folk-epic/FOLK-FRAMING-STANDARD.md` as a hard gate.
+- [ ] No pagan-core / Christian-shell framing. Christian heritage is not a veneer over a hidden pagan essence.
+- [ ] No occult, demonology-as-belief, or magic-as-core explanatory frame in teacher prose.
+- [ ] Cosmogonic, demonological, or magic vocabulary appears only with source discipline and framing caveats, never as the module thesis.
+- [ ] No Soviet/Russian demonizing lens: Ukrainian folk culture is not primitive, backward, superstition, banditry, or "Little Russian" material.
+- [ ] Public learner sources use public URLs; internal corpus chunk IDs must not appear in public-facing or plan-facing learner surfaces.
+- [ ] Primary readings are school-canonical/public-source grounded where applicable, and hosted texts use the full public text rather than snippets.
+
 ## Output Format
 
 ```markdown
@@ -150,8 +161,8 @@ For every word in `vocabulary_hints.required` and `vocabulary_hints.recommended`
 ## Rule Compliance
 | Check | Status | Details |
 |-------|--------|---------|
-| word_target | PASS/FAIL | Plan: X, Config: 5000 |
-| section_budgets | PASS/FAIL | Sum = X vs target 5000 (+/-Z%) |
+| word_target | PASS/FAIL | Plan: X, Config: track target |
+| section_budgets | PASS/FAIL | Sum = X vs track target (+/-Z%) |
 | required_fields | PASS/FAIL | Missing: ... |
 | version_string | PASS/FAIL | ... |
 

--- a/agents_extensions/shared/skills/plan-review/SKILL.md
+++ b/agents_extensions/shared/skills/plan-review/SKILL.md
@@ -7,7 +7,7 @@ effort: xhigh
 
 # Plan Review (Core): $ARGUMENTS
 
-**Scope: A1, A2, B1, B2, C1, C2 only.** For seminar tracks (HIST, BIO, ISTORIO, LIT, OES, RUTH), use `/plan-review-seminar`.
+**Scope: A1, A2, B1, B2, C1, C2 only.** For seminar tracks (FOLK, HIST, BIO, ISTORIO, LIT, OES, RUTH), use `/plan-review-seminar`.
 
 ## Parse Arguments
 

--- a/agents_extensions/shared/skills/plan-review/review-tiers/tier-3-seminar.md
+++ b/agents_extensions/shared/skills/plan-review/review-tiers/tier-3-seminar.md
@@ -1,6 +1,6 @@
-# Tier 3: Seminar Modules (HIST, ISTORIO, BIO, LIT)
+# Tier 3: Seminar Modules (FOLK, HIST, ISTORIO, BIO, LIT, OES, RUTH)
 
-> **Target:** HIST (History), ISTORIO (History), BIO (Biography), LIT (Literature) tracks
+> **Target:** FOLK (Folk Culture), HIST (History), ISTORIO (History), BIO (Biography), LIT (Literature), OES, and RUTH tracks
 > **Pedagogy:** CBI (Content-Based Instruction)
 > **Immersion:** 98-100% Ukrainian
 > **Experience Goal:** A+ seminar lecture — memorable, engaging, transformative

--- a/docs/best-practices/agent-cooperation.html
+++ b/docs/best-practices/agent-cooperation.html
@@ -93,11 +93,11 @@
 
   h2 { font-size: 22px; margin-top: 48px; border-bottom: 1px solid var(--rule); padding-bottom: 8px; }
   h3 { font-size: 18px; margin-top: 32px; }
-  
+
   table { width: 100%; border-collapse: collapse; margin: 24px 0; font-family: var(--sans); font-size: 14px; }
   th { text-align: left; background: var(--surface-2); padding: 10px 12px; border: 1px solid var(--rule); }
   td { padding: 10px 12px; border: 1px solid var(--rule); vertical-align: top; }
-  
+
   .callout {
     padding: 16px;
     border-radius: 4px;
@@ -291,7 +291,7 @@ invoked through <code>scripts/agent_runtime/runner.invoke()</code>. This applies
 </code></pre>
 <h3>High-risk-track override (false-consensus failsafe)</h3>
 <p>When all participating agents share the same underlying bias on a topic (e.g., Russian-imperial framing on Ukrainian topics, Western centrism on decolonization), an <code>[AGREE]</code> consensus is NOT a green light. It is exactly when the Decision Card mechanism is most needed and most likely to be bypassed.</p>
-<p>For high-risk tracks — <strong>HIST, BIO, ISTORIO, LIT, OES, RUTH</strong> (all decolonization-sensitive seminar tracks where Russian/Soviet-imperial framings are most ingrained in training data) — the orchestrator MUST apply at least one of the following failsafe mechanisms:</p>
+<p>For high-risk tracks — <strong>FOLK, HIST, BIO, ISTORIO, LIT, OES, RUTH</strong> (all decolonization-sensitive seminar tracks where Russian/Soviet-imperial framings are most ingrained in training data) — the orchestrator MUST apply at least one of the following failsafe mechanisms:</p>
 <ul>
 <li><strong>Mechanism A (Force-emit Decision Card on <code>[AGREE]</code>):</strong> If <code>ab discuss</code> runs on a topic touching any high-risk track and converges with <code>[AGREE]</code>, the orchestrator emits a Decision Card anyway. The question is framed as &quot;agents converged on X — but consensus on this track is suspect; user should sanity-check.&quot; The user can quickly approve or override.</li>
 <li><strong>Mechanism B (Inject domain-specific bias checklist):</strong> For high-risk tracks, the <code>ab discuss</code> prompt is augmented with a short bias checklist explicitly provoking adversarial review on known bias vectors.

--- a/docs/best-practices/agent-cooperation.md
+++ b/docs/best-practices/agent-cooperation.md
@@ -306,7 +306,7 @@ Most `ab discuss` runs converge with `[AGREE]` — orchestrator just executes th
 
 When all participating agents share the same underlying bias on a topic (e.g., Russian-imperial framing on Ukrainian topics, Western centrism on decolonization), an `[AGREE]` consensus is NOT a green light. It is exactly when the Decision Card mechanism is most needed and most likely to be bypassed.
 
-For high-risk tracks — **HIST, BIO, ISTORIO, LIT, OES, RUTH** (all decolonization-sensitive seminar tracks where Russian/Soviet-imperial framings are most ingrained in training data) — the orchestrator MUST apply at least one of the following failsafe mechanisms:
+For high-risk tracks — **FOLK, HIST, BIO, ISTORIO, LIT, OES, RUTH** (all decolonization-sensitive seminar tracks where Russian/Soviet-imperial framings are most ingrained in training data) — the orchestrator MUST apply at least one of the following failsafe mechanisms:
 
 - **Mechanism A (Force-emit Decision Card on `[AGREE]`):** If `ab discuss` runs on a topic touching any high-risk track and converges with `[AGREE]`, the orchestrator emits a Decision Card anyway. The question is framed as "agents converged on X — but consensus on this track is suspect; user should sanity-check." The user can quickly approve or override.
 - **Mechanism B (Inject domain-specific bias checklist):** For high-risk tracks, the `ab discuss` prompt is augmented with a short bias checklist explicitly provoking adversarial review on known bias vectors.


### PR DESCRIPTION
## Summary
- Add FOLK to seminar plan/content review scopes.
- Add FOLK-specific framing/source hygiene checks to the active seminar/content review prompts.
- Add FOLK to high-risk-track guidance in AGENTS/GEMINI and agent-cooperation docs.

## Validation
- pre-commit hooks passed on commit.
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py passed.
- git diff --check passed before commit.

Note: targeted markdownlint currently reports existing style violations in these instruction docs; this PR does not reformat unrelated markdown.