### PR TITLE
fix(atlas): add learner gloss fallback for interjections

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -294,6 +294,14 @@ _BALLA_LOOKUPS: dict[str, tuple[str, ...]] = {
     "чудово": ("wonderful", "great", "fine"),
 }
 
+# Transparent learner-facing glosses for common particles/interjections where
+# the Ukrainian dictionaries have exact definition cards but the local bilingual
+# and Kaikki/Wiktionary sources have no English row. Keep this small and
+# high-confidence; never pretend these are dictionary imports.
+_CURATED_LEARNER_TRANSLATIONS: dict[str, tuple[str, ...]] = {
+    "ого": ("wow", "whoa"),
+}
+
 _BLOCKED_SYNONYMS = {
     "java",
     "ma",
@@ -3033,7 +3041,18 @@ def _translation(
                 if pos:
                     block["pos"] = pos
                 return block
-    return _kaikki_translation(kaikki_lookup or {}, lemma)
+    kaikki_translation = _kaikki_translation(kaikki_lookup or {}, lemma)
+    if kaikki_translation:
+        return kaikki_translation
+
+    for variant in _split_lemma_variants(lemma):
+        curated = _CURATED_LEARNER_TRANSLATIONS.get(_lookup_key(variant).casefold())
+        if curated:
+            return {
+                "en": list(curated),
+                "source": "curated learner gloss",
+            }
+    return None
 
 
 def _fts_phrase(term: str) -> str:

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "0b96e64555f5fcee3491b408c85de324ae601b13d0852002ea98a102473a5fba",
+  "fingerprint": "755a63dca45dba1a7537b6257791e6be35520345e6e03432a79152683b351f0a",
   "inputs": {
     "lexicon_code": [
       {
@@ -44,7 +44,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "eb0cd72cc301b21b95f19a58569dd48be804323c741f3776838af7899757abe8"
+        "sha256": "bb42e88f1734f30d2ca41b00efed841029634baa97a2fb44e5878f9dbadc595f"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/site/src/data/lexicon-manifest.pointer.json
+++ b/site/src/data/lexicon-manifest.pointer.json
@@ -2,12 +2,12 @@
   "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest.json.gz",
   "release_tag": "atlas-manifest",
   "manifest_version": "0.1",
-  "manifest_fingerprint": "0b96e64555f5fcee3491b408c85de324ae601b13d0852002ea98a102473a5fba",
+  "manifest_fingerprint": "755a63dca45dba1a7537b6257791e6be35520345e6e03432a79152683b351f0a",
   "fingerprint_schema_version": 1,
   "generated_at": "2026-06-27T00:33:09+00:00",
-  "gz_sha256": "5d6dc04f076074315d1df20569fccd54dad51bb0ffb1ae5ee33d89dd00f4f9c9",
-  "json_sha256": "d97f4bf22c35b0b93ec11a7377b7b0228c73b8ffff171571627364704a38fbd1",
-  "gz_bytes": 14746668,
-  "json_bytes": 109042047,
+  "gz_sha256": "df84e182bf23ab0eaa289f94d6d823413a7b22f534612af99c0f90b5a8f42e07",
+  "json_sha256": "35b8f660a42780e35c80fa639133ab281355598ae7213bbd9fef7ec68b24214f",
+  "gz_bytes": 14746673,
+  "json_bytes": 109042231,
   "note": "Pins GitHub Release asset manifest for #3659; hydrate it build time instead committing raw JSON."
 }

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -1923,6 +1923,28 @@ def test_translation_returns_none_when_lemma_absent(monkeypatch) -> None:
     assert _translation(conn, "неіснуючеслово") is None
 
 
+def test_translation_uses_curated_learner_gloss_after_source_misses(monkeypatch) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
+    monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
+
+    assert _translation(conn, "ого", {}) == {
+        "en": ["wow", "whoa"],
+        "source": "curated learner gloss",
+    }
+
+
+def test_translation_prefers_kaikki_over_curated_learner_gloss(monkeypatch) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
+    monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
+
+    assert _translation(conn, "ого", {"ого": {"glosses": ["oh wow"]}}) == {
+        "en": ["oh wow"],
+        "source": KAIKKI_SOURCE,
+    }
+
+
 def test_wiki_reference_success(monkeypatch, tmp_path) -> None:
     fake_wiki_data = {
         "title": "Україна",


### PR DESCRIPTION
## Summary
- Add a transparent curated learner-gloss fallback for common interjections/particles that have Ukrainian definition cards but no local bilingual or Kaikki/Wiktionary English row.
- Apply the fallback to `ого`, producing `wow` / `whoa` in the Atlas translation section.
- Publish a PR-scoped Atlas manifest asset and update the pointer/fingerprint for CI validation.

## Root Cause
`/lexicon/ого/` was technically enriched because it had stress, CEFR, morphology, VESUM, ВТС/СУМ-20 definitions, and literary attestation. For an English learner it was still thin because the translation source path missed the interjection: no dmklinger row and no Kaikki/Wiktionary lookup entry.

## Validation
- `python -m pytest tests/test_lexicon_enrich_manifest.py -q` — 74 passed
- `python -m ruff check scripts/lexicon/enrich_manifest.py tests/test_lexicon_enrich_manifest.py` — passed
- `python scripts/lexicon/verify_manifest.py` — clean, 0 §8 violations
- `python scripts/audit/check_atlas_manifest_enrichment.py` — OK, 10053/10864 enriched (92.5%)
- `node site/scripts/hydrate-manifest.mjs` — manifest already hydrated from staged pointer
- `npm --prefix site run build` — 11173 pages built
- Generated `site/dist/lexicon/ого/index.html` contains `Переклад`, `wow`, `whoa`, and source `curated learner gloss`.

## Notes
This does not fabricate dictionary provenance: the fallback is explicitly labelled `curated learner gloss` and is only used after the normal dictionary/Wiktionary translation sources miss.
