### PR TITLE
fix(b2): unblock B2.4 preflight source shapes

### DIFF
--- a/scripts/audit/wiki_completeness_gate.py
+++ b/scripts/audit/wiki_completeness_gate.py
@@ -61,12 +61,15 @@ SEMINAR_SECTION_HEADING_RES = {
 }
 
 METHODOLOGY_HEADING_RE = re.compile(r"^##\s+Методичний\s+підхід\b", re.IGNORECASE)
+B2_SCHOOL_METHOD_HEADING_RE = re.compile(r"^##\s+Як\s+це\s+пояснюють\s+у\s+школі\b", re.IGNORECASE)
 DECOLONIZATION_HEADING_RE = re.compile(r"^##\s+Деколонізаційні\s+застереження\b", re.IGNORECASE)
 TEXTBOOK_EXAMPLES_HEADING_RE = re.compile(r"^##\s+Приклади\s+з\s+підручників\b", re.IGNORECASE)
+EXERCISE_RECOMMENDATIONS_HEADING_RE = re.compile(r"^##\s+Рекомендації\s+для\s+вправ\b", re.IGNORECASE)
 ANY_H2_RE = re.compile(r"^##\s+\S")
 SOURCE_REF_RE = re.compile(r"\[S(?P<num>\d+)\]")
 BAD_MARKER_RE = re.compile(r"<!--\s*bad\s*-->(?P<body>.*?)<!--\s*/bad\s*-->", re.IGNORECASE | re.DOTALL)
 GUILLEMET_NEGATED_PAIR_RE = re.compile(r"«[^»\n]{1,120}»\s*\(\s*не\s+«[^»\n]{1,120}»\s*\)", re.IGNORECASE)
+LEGACY_PHASE_RE = re.compile(r"^\s*(?:[-*]\s*)?(?:\*\*)?Фаза\s+\d+\s*[:.]", re.IGNORECASE)
 UKRAINIAN_RE = re.compile(r"[А-Яа-яІіЇїЄєҐґ]")
 
 CHECK_TITLES = {
@@ -80,6 +83,8 @@ CHECK_TITLES = {
     "chunk_citations_spot_check": "chunk_citations_spot_check",
     "seminar_sections": "seminar_sections",
     "distinct_sources": "distinct_sources",
+    "exercise_progression": "Рекомендації для вправ",
+    "decolonization_guidance": "Деколонізаційні застереження",
     "citation_resolution": "citation_resolution",
     "source_ref_resolution": "source_ref_resolution",
     "all_chunk_verify_quote": "all_chunk_verify_quote",
@@ -100,6 +105,16 @@ SEMINAR_CHECK_ORDER = (
     "citation_resolution",
     "source_ref_resolution",
     "all_chunk_verify_quote",
+)
+B2_SOURCE_READINESS_CHECK_ORDER = (
+    "methodology",
+    "exercise_progression",
+    "l2_errors",
+    "decolonization_guidance",
+    "distinct_sources",
+    "citation_resolution",
+    "source_ref_resolution",
+    "chunk_citations_spot_check",
 )
 
 
@@ -125,6 +140,16 @@ def thresholds_for_level(level: str) -> dict[str, Any]:
             "textbook_exercises": 3,
             "distractor_inventory": 6,
             "chunk_citations_spot_check": 3,
+        }
+    if level_key == "b2":
+        return {
+            "exercise_progression": 3,
+            "l2_errors": 3,
+            "decolonization_guidance": 2,
+            "min_distinct_sources": 3,
+            "citations_resolve": 100,
+            "source_refs_resolve": 100,
+            "chunk_citations_spot_check": 5,
         }
     return {
         "sequence_steps": 5,
@@ -171,6 +196,17 @@ def check_wiki_completeness(
             path,
             level=level_key,
             slug=slug_value,
+            thresholds=thresholds,
+            verify_quote_fn=verify_quote_fn,
+        )
+    if level_key == "b2":
+        return _check_b2_source_readiness(
+            text,
+            lines,
+            path,
+            level=level_key,
+            slug=slug_value,
+            manifest=manifest,
             thresholds=thresholds,
             verify_quote_fn=verify_quote_fn,
         )
@@ -274,6 +310,76 @@ def _check_seminar_completeness(
     }
 
     failed = [name for name in SEMINAR_CHECK_ORDER if checks[name]["verdict"] == "FAIL"]
+    return {
+        "verdict": "FAIL" if failed else "PASS",
+        "level": level,
+        "slug": slug,
+        "checks": checks,
+        "diagnostic": _diagnostic(failed[0], checks[failed[0]]) if failed else "Wiki completeness gate passed.",
+    }
+
+
+def _check_b2_source_readiness(
+    wiki_text: str,
+    lines: list[str],
+    wiki_path: Path,
+    *,
+    level: str,
+    slug: str,
+    manifest: Mapping[str, Any],
+    thresholds: Mapping[str, Any],
+    verify_quote_fn: Callable[[str, str, Mapping[str, Any]], Mapping[str, Any] | bool] | None,
+) -> dict[str, Any]:
+    """Validate locked B2 wiki articles against source-readiness, not compile schema."""
+    methodology_text = _section_text(lines, METHODOLOGY_HEADING_RE) or _section_text(
+        lines,
+        B2_SCHOOL_METHOD_HEADING_RE,
+    )
+    decolonization_text = _section_text(lines, DECOLONIZATION_HEADING_RE)
+    citations = _ordered_source_ids(wiki_text)
+    sources = _load_source_registry(wiki_path)
+
+    checks = {
+        "methodology": _section_presence_check(methodology_text, "B2 school-method section non-empty."),
+        "exercise_progression": _minimum_check(
+            _count_b2_exercise_progression(lines, manifest),
+            int(thresholds["exercise_progression"]),
+            "formal sequence step(s) or legacy exercise phase(s) found.",
+        ),
+        "l2_errors": _minimum_check(
+            len(manifest.get("l2_errors", [])),
+            int(thresholds["l2_errors"]),
+            "L2 error table row(s) found.",
+        ),
+        "decolonization_guidance": _minimum_check(
+            len(manifest.get("decolonization_bans", [])) or int(bool(decolonization_text.strip())),
+            int(thresholds["decolonization_guidance"]),
+            "decolonization guidance item(s) found.",
+        ),
+        "distinct_sources": _minimum_check(
+            len(sources),
+            int(thresholds["min_distinct_sources"]),
+            "source registry entry/entries found.",
+        ),
+        "citation_resolution": _citation_resolution_check(
+            citations,
+            sources,
+            int(thresholds["citations_resolve"]),
+        ),
+        "source_ref_resolution": _source_ref_resolution_check(
+            citations,
+            sources,
+            int(thresholds["source_refs_resolve"]),
+        ),
+        "chunk_citations_spot_check": _chunk_citation_check(
+            wiki_text,
+            wiki_path,
+            int(thresholds["chunk_citations_spot_check"]),
+            verify_quote_fn=verify_quote_fn,
+        ),
+    }
+
+    failed = [name for name in B2_SOURCE_READINESS_CHECK_ORDER if checks[name]["verdict"] == "FAIL"]
     return {
         "verdict": "FAIL" if failed else "PASS",
         "level": level,
@@ -476,6 +582,17 @@ def _section_text(lines: list[str], heading_re: re.Pattern[str]) -> str:
             end = index
             break
     return "\n".join(lines[start + 1 : end]).strip()
+
+
+def _count_b2_exercise_progression(lines: list[str], manifest: Mapping[str, Any]) -> int:
+    formal_steps = manifest.get("sequence_steps", [])
+    if isinstance(formal_steps, list) and formal_steps:
+        return len(formal_steps)
+
+    section_text = _section_text(lines, EXERCISE_RECOMMENDATIONS_HEADING_RE)
+    if not section_text:
+        return 0
+    return sum(1 for line in section_text.splitlines() if LEGACY_PHASE_RE.search(line))
 
 
 def _count_decolonization_pairs(section_text: str) -> int:

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -1005,10 +1005,83 @@ def plan_path_for(level: str, slug: str) -> Path:
     return PROJECT_ROOT / "curriculum" / "l2-uk-en" / "plans" / level / f"{slug}.yaml"
 
 
+def _legacy_section_points(section: Mapping[str, Any]) -> list[str]:
+    """Return writer points for legacy B2 plan sections without mutating plans."""
+    raw_subsections = section.get("subsections")
+    points: list[str] = []
+    if isinstance(raw_subsections, str):
+        points.extend(
+            part.strip()
+            for part in re.split(r"\s+-\s+|\n+", raw_subsections)
+            if part.strip()
+        )
+    elif isinstance(raw_subsections, list):
+        points.extend(str(part).strip() for part in raw_subsections if str(part).strip())
+
+    raw_concepts = section.get("key_concepts")
+    if isinstance(raw_concepts, list):
+        concepts = [str(concept).strip() for concept in raw_concepts if str(concept).strip()]
+        if concepts:
+            points.append("Ключові поняття: " + ", ".join(concepts))
+
+    return points
+
+
+def _legacy_reference_title(reference: Any) -> str | None:
+    if isinstance(reference, str):
+        return reference.strip() or None
+    if isinstance(reference, Mapping):
+        for key in ("source", "title", "file", "topic"):
+            value = reference.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        if len(reference) == 1:
+            key, value = next(iter(reference.items()))
+            key_text = str(key).strip()
+            value_text = str(value).strip()
+            if key_text and value_text:
+                return f"{key_text}: {value_text}"
+            if key_text:
+                return key_text
+    return None
+
+
+def _normalize_legacy_plan_shape(plan: dict[str, Any]) -> None:
+    """Normalize locked legacy B2 plan fields into the V7 in-memory contract."""
+    if str(plan.get("level") or "").strip().casefold() != "b2":
+        return
+
+    sections = plan.get("content_outline")
+    if isinstance(sections, list):
+        for section in sections:
+            if not isinstance(section, dict):
+                continue
+            points = section.get("points")
+            if isinstance(points, list) and all(isinstance(point, str) for point in points):
+                continue
+            legacy_points = _legacy_section_points(section)
+            if legacy_points:
+                section["points"] = legacy_points
+
+    references = plan.get("references")
+    if isinstance(references, list):
+        for index, reference in enumerate(references):
+            if isinstance(reference, str):
+                title = _legacy_reference_title(reference)
+                if title:
+                    references[index] = {"title": title}
+                continue
+            if isinstance(reference, dict) and not reference.get("title"):
+                title = _legacy_reference_title(reference)
+                if title:
+                    reference["title"] = title
+
+
 def load_plan(plan_path: Path) -> dict[str, Any]:
     data = load_yaml(plan_path)
     if not isinstance(data, dict):
         raise LinearPipelineError(f"Plan must be a mapping: {plan_path}")
+    _normalize_legacy_plan_shape(data)
     return data
 
 

--- a/tests/audit/test_b2_source_readiness_gate.py
+++ b/tests/audit/test_b2_source_readiness_gate.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from scripts.audit.wiki_completeness_gate import check_wiki_completeness
+
+
+def _write_sources(wiki_path: Path, count: int = 5) -> None:
+    wiki_path.with_suffix(".sources.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "sources": [
+                    {
+                        "id": f"S{index}",
+                        "file": f"chunk-{index}",
+                        "type": "textbook",
+                        "title": f"Source {index}",
+                    }
+                    for index in range(1, count + 1)
+                ]
+            },
+            allow_unicode=True,
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_b2_legacy_wiki_uses_source_readiness_not_compile_schema(tmp_path: Path) -> None:
+    wiki = tmp_path / "legacy-b2.md"
+    wiki.write_text(
+        """
+# Граматика B2: Legacy
+<!-- wiki-meta slug: legacy-b2 domain: grammar/b2 tracks: [b2] -->
+
+## Як це пояснюють у школі
+
+Шкільний підхід подає тему через функцію в тексті й поступове редагування [S1].
+
+## Типові помилки L2 (англомовні учні)
+
+| Помилково | Правильно | Чому |
+| --- | --- | --- |
+| Хиба 1. | Норма 1. | Пояснення [S2]. |
+| Хиба 2. | Норма 2. | Пояснення [S3]. |
+| Хиба 3. | Норма 3. | Пояснення [S4]. |
+
+## Деколонізаційні застереження
+
+Не переносити російську модель керування на українські конструкції [S3].
+
+Не подавати суржикові варіанти як нейтральну норму [S4].
+
+## Природні приклади
+
+Перший приклад показує норму [S5].
+
+## Рекомендації для вправ
+
+**Фаза 1: Розпізнавання.** Учень знаходить форму в тексті [S1].
+
+**Фаза 2: Керована трансформація.** Учень перебудовує речення [S2].
+
+**Фаза 3: Продукція.** Учень пише власний короткий текст [S5].
+""".strip(),
+        encoding="utf-8",
+    )
+    _write_sources(wiki)
+
+    report = check_wiki_completeness(wiki, level="b2", slug="legacy-b2")
+
+    assert report["verdict"] == "PASS"
+    assert "vocabulary_minimum" not in report["checks"]
+    assert "textbook_exercises" not in report["checks"]
+    assert "decolonization_pairs" not in report["checks"]
+    assert report["checks"]["exercise_progression"]["actual"] == 3
+    assert report["checks"]["decolonization_guidance"]["actual"] == 2

--- a/tests/build/test_legacy_b2_plan_normalization.py
+++ b/tests/build/test_legacy_b2_plan_normalization.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.build.linear_pipeline import load_plan, validate_plan
+
+
+def test_load_plan_normalizes_legacy_b2_subsections_and_references(tmp_path: Path) -> None:
+    plan_path = tmp_path / "legacy-b2.yaml"
+    plan_path.write_text(
+        """
+module: b2-999
+level: B2
+sequence: 999
+slug: legacy-b2
+title: Legacy B2
+subtitle: Legacy section shape
+word_target: 4000
+content_outline:
+  - section: Legacy Section
+    words: 800
+    subsections: First teaching point - Second teaching point
+    key_concepts:
+      - регістр
+      - доречність
+references:
+  - source: Test textbook
+    pages: 10-12
+    topic: Test topic
+  - State Standard 2024: B2 source reference
+""".strip(),
+        encoding="utf-8",
+    )
+
+    plan = load_plan(plan_path)
+
+    validate_plan(plan)
+    section = plan["content_outline"][0]
+    assert section["points"] == [
+        "First teaching point",
+        "Second teaching point",
+        "Ключові поняття: регістр, доречність",
+    ]
+    assert plan["references"][0]["title"] == "Test textbook"
+    assert plan["references"][1]["title"] == "State Standard 2024: B2 source reference"


### PR DESCRIPTION
## Scope

Preflight remediation only for B2.4 production blockers. PR does not build or publish B2.4 module content.

## Root Cause

Plan-shape failure: locked B2 core plans include legacy `content_outline[].subsections`, `key_concepts`, plain-string references, and one-key YAML reference mappings. V7 `validate_plan()` only accepted `points` arrays and `references[].title`, so dry-runs stopped before source-readiness.

Wiki completeness failure: the clean gate applied newer core compile-schema checks to locked B2 wiki articles. The B2 source corpus has source-backed school-method sections (`Як це пояснюють у школі`), L2 errors, decolonization guidance, source registries, citations, natural examples, and exercise phases, but not the newer `Словниковий мінімум` / `Приклади з підручників` inventories.

## Changes

- Normalize locked B2 plan shapes in memory inside `scripts/build/linear_pipeline.py`; source plans remain unchanged.
- Route B2 wiki checks through a B2 source-readiness gate in `scripts/audit/wiki_completeness_gate.py`.
- Add focused regression tests for legacy B2 plan normalization and B2 source-readiness behavior.

## Validation

- `.venv/bin/pytest tests/build/test_legacy_b2_plan_normalization.py tests/audit/test_b2_source_readiness_gate.py tests/audit/test_wiki_completeness_gate.py tests/test_atlas_conformance.py::test_real_lexicon_manifest_conforms_to_atlas_gates -q` -> 18 passed.
- `.venv/bin/ruff check scripts/build/linear_pipeline.py scripts/audit/wiki_completeness_gate.py tests/build/test_legacy_b2_plan_normalization.py tests/audit/test_b2_source_readiness_gate.py` -> passed.
- `.venv/bin/python -m py_compile scripts/build/linear_pipeline.py scripts/audit/wiki_completeness_gate.py tests/build/test_legacy_b2_plan_normalization.py tests/audit/test_b2_source_readiness_gate.py` -> passed.
- `git diff --check` -> passed.
- Protected config/artifact/sys.executable guard -> passed.
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` -> passed.
- B2.4 dry-run sweep M43-M53 with `.venv/bin/python scripts/build/v7_build.py b2 <slug> --dry-run` -> all 11 passed; generated `wiki_completeness_gate.json` dry-run output directories removed before push.
- GitHub CI -> passed after rerunning `Test (pytest)` once the unrelated atlas release asset was restored to match `main`.

## External Review

- Route: Agy -> Claude Opus 4.6 (Thinking).
- First response was policy-only and treated as insufficient.
- Second strict review verdict: PASS.
- Blockers: none.
- Non-blocking notes: optional comment around `decolonization_guidance` fallback logic; optional non-B2 passthrough test.
- Unresolved findings: 0.

## Atlas CI Note

The first rebased CI attempt failed in `tests/test_atlas_conformance.py::test_real_lexicon_manifest_conforms_to_atlas_gates` while draft PR #3910 temporarily clobbered the shared mutable `atlas-manifest` GitHub Release asset. This matched the known release-pointer race documented in `docs/bug-autopsies/2026-06-26-atlas-hydrate-clobber.md` and was unrelated to the B2.4 remediation diff. After the asset was restored to the `main` pointer hash (`d2470205a0691a813e61cab9af911d90b01fe9d3f36cc6342922f8ef0b45aad2`), rerunning the failed pytest job passed.

## Production Resume Decision

B2.4 preflight blockers are remediated: all M43-M53 dry-runs pass and no B2.4 module content was built. B2.4 production may resume after this PR merges.