### PR TITLE
[codex] Audit thin enriched Atlas entries

### DIFF
--- a/scripts/audit/audit_atlas_thin_enriched.py
+++ b/scripts/audit/audit_atlas_thin_enriched.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Report Atlas entries that pass the old enrichment gate but lack English anchors.
+
+The legacy gate only checks for any ``enrichment`` block. That catches empty-manifest
+regressions, but it also treats pages with Ukrainian-only cards as learner-ready. This
+audit keeps that broader gate intact and identifies the narrower class that needs
+targeted re-enrichment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
+
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.lexicon.build_kaikki_lookup import KAIKKI_SOURCE
+from scripts.lexicon.manifest_io import load_manifest
+
+
+def old_gate_enriched(entry: dict[str, Any]) -> bool:
+    """Return the legacy enrichment-gate predicate."""
+    return bool(entry.get("enrichment"))
+
+
+def _has_nonempty_string(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _has_nonempty_list(value: object) -> bool:
+    return isinstance(value, list) and any(_has_nonempty_string(item) for item in value)
+
+
+def has_learner_english_anchor(entry: dict[str, Any]) -> bool:
+    """Return True when an entry has a learner-facing English meaning anchor."""
+    if _has_nonempty_string(entry.get("gloss")):
+        return True
+
+    enrichment = entry.get("enrichment")
+    if not isinstance(enrichment, dict):
+        return False
+
+    translation = enrichment.get("translation")
+    if isinstance(translation, dict) and _has_nonempty_list(translation.get("en")):
+        return True
+
+    meaning = enrichment.get("meaning")
+    if not isinstance(meaning, dict):
+        return False
+    if meaning.get("source") != KAIKKI_SOURCE:
+        return False
+    return _has_nonempty_list(meaning.get("definitions"))
+
+
+def thin_old_gate_entries(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    """Entries counted enriched by the old gate but lacking an English anchor."""
+    entries = manifest.get("entries", [])
+    if not isinstance(entries, list):
+        return []
+    return [
+        entry
+        for entry in entries
+        if isinstance(entry, dict)
+        and old_gate_enriched(entry)
+        and not has_learner_english_anchor(entry)
+    ]
+
+
+def _entry_cefr(entry: dict[str, Any]) -> str:
+    enrichment = entry.get("enrichment")
+    if isinstance(enrichment, dict):
+        cefr = enrichment.get("cefr")
+        if isinstance(cefr, dict):
+            level = cefr.get("level")
+            if isinstance(level, str):
+                return level.upper()
+    level = entry.get("cefr")
+    return str(level or "").upper()
+
+
+def _entry_row(entry: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "lemma": entry.get("lemma"),
+        "pos": entry.get("pos"),
+        "primary_source": entry.get("primary_source") or "unknown",
+        "cefr": _entry_cefr(entry) or None,
+        "course_usage": entry.get("course_usage") or [],
+    }
+
+
+def summarize_manifest(manifest: dict[str, Any], *, sample_limit: int = 50) -> dict[str, Any]:
+    entries = [entry for entry in manifest.get("entries", []) if isinstance(entry, dict)]
+    old_enriched = [entry for entry in entries if old_gate_enriched(entry)]
+    thin = [entry for entry in old_enriched if not has_learner_english_anchor(entry)]
+    by_source = Counter(str(entry.get("primary_source") or "unknown") for entry in thin)
+    by_pos = Counter(str(entry.get("pos") or "unknown") for entry in thin)
+    course_used = [entry for entry in thin if entry.get("course_usage")]
+    beginner = [entry for entry in thin if _entry_cefr(entry) in {"A1", "A2"}]
+
+    return {
+        "total_entries": len(entries),
+        "old_gate_enriched": len(old_enriched),
+        "old_gate_no_english_anchor": len(thin),
+        "course_used_no_english_anchor": len(course_used),
+        "beginner_cefr_no_english_anchor": len(beginner),
+        "by_primary_source": dict(by_source.most_common()),
+        "by_pos": dict(by_pos.most_common()),
+        "samples": [_entry_row(entry) for entry in thin[:sample_limit]],
+    }
+
+
+def _print_summary(summary: dict[str, Any]) -> None:
+    old_gate = int(summary["old_gate_enriched"])
+    thin = int(summary["old_gate_no_english_anchor"])
+    ratio = thin / old_gate if old_gate else 0.0
+    print(
+        "Atlas old-gate/no-English-anchor audit: "
+        f"{thin}/{old_gate} old-gate-enriched entries ({ratio:.1%})."
+    )
+    print(f"Course-used no-English entries: {summary['course_used_no_english_anchor']}")
+    print(f"Beginner CEFR no-English entries: {summary['beginner_cefr_no_english_anchor']}")
+    print("Top primary sources:")
+    for source, count in list(summary["by_primary_source"].items())[:10]:
+        print(f"  {source}: {count}")
+    print("Top POS buckets:")
+    for pos, count in list(summary["by_pos"].items())[:10]:
+        print(f"  {pos}: {count}")
+    if summary["samples"]:
+        print("Samples:")
+        for entry in summary["samples"]:
+            usage = entry["course_usage"]
+            usage_label = f" course_usage={len(usage)}" if usage else ""
+            print(
+                f"  {entry['lemma']} pos={entry['pos'] or 'unknown'} "
+                f"cefr={entry['cefr'] or 'unknown'} source={entry['primary_source']}"
+                f"{usage_label}"
+            )
+
+
+def _print_tsv(rows: list[dict[str, Any]]) -> None:
+    print("lemma\tpos\tcefr\tprimary_source\tcourse_usage_count")
+    for row in rows:
+        print(
+            f"{row['lemma']}\t{row['pos'] or ''}\t{row['cefr'] or ''}\t"
+            f"{row['primary_source']}\t{len(row['course_usage'])}"
+        )
+
+
+def _read_local_manifest(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Audit old-gate-enriched Atlas entries that lack learner English anchors."
+    )
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument(
+        "--local",
+        action="store_true",
+        help="Read the manifest path directly instead of hydrating the canonical release asset.",
+    )
+    parser.add_argument("--format", choices=("summary", "json", "tsv"), default="summary")
+    parser.add_argument("--limit", type=int, default=50, help="Sample/output row limit.")
+    parser.add_argument("--fail-if-any", action="store_true")
+    args = parser.parse_args()
+
+    manifest_path = args.manifest if args.manifest.is_absolute() else ROOT / args.manifest
+    manifest = _read_local_manifest(manifest_path) if args.local else load_manifest(manifest_path)
+    summary = summarize_manifest(manifest, sample_limit=args.limit)
+
+    if args.format == "json":
+        print(json.dumps(summary, ensure_ascii=False, indent=2))
+    elif args.format == "tsv":
+        _print_tsv(summary["samples"])
+    else:
+        _print_summary(summary)
+
+    return 1 if args.fail_if_any and summary["old_gate_no_english_anchor"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -302,6 +302,67 @@ _CURATED_LEARNER_TRANSLATIONS: dict[str, tuple[str, ...]] = {
     "ого": ("wow", "whoa"),
 }
 
+_BALLA_REVERSE_SOURCE = "Балла EN→UK reverse exact"
+_BALLA_REVERSE_MAX_HEADWORDS = 1
+_BALLA_REVERSE_UKRAINIAN_TOKEN_RE = re.compile(r"[А-Яа-яЄєІіЇїҐґ][А-Яа-яЄєІіЇїҐґ'’ʼ-]*")
+_BALLA_REVERSE_SURFACE_GLOSS_RE = re.compile(r"surface gloss='([^']+)'")
+_BALLA_REVERSE_SOURCE_POS_RE = re.compile(r"pos='([^']+)'")
+_BALLA_REVERSE_HINT_SPLIT_RE = re.compile(r"[,;/]")
+_BALLA_REVERSE_LEADING_LABEL_RE = re.compile(
+    r"^\s*(?:\d+\.?\s*)?(?:(?:n|v|adj|adv|prep|pron|conj|interj|num|part|abbr)\.?\s+)+",
+    flags=re.IGNORECASE,
+)
+_BALLA_REVERSE_HEADWORD_RE = re.compile(r"[a-z][a-z -]{1,39}", flags=re.IGNORECASE)
+_BALLA_REVERSE_STOP_TOKENS = {
+    "а",
+    "або",
+    "без",
+    "біля",
+    "в",
+    "від",
+    "до",
+    "за",
+    "з",
+    "зі",
+    "із",
+    "на",
+    "над",
+    "не",
+    "під",
+    "по",
+    "при",
+    "про",
+    "та",
+    "у",
+    "чи",
+    "як",
+    "амер",
+    "англ",
+    "бот",
+    "буд",
+    "військ",
+    "грам",
+    "див",
+    "зоол",
+    "іст",
+    "книжн",
+    "лінгв",
+    "мед",
+    "мін",
+    "мор",
+    "муз",
+    "перен",
+    "поет",
+    "розм",
+    "спорт",
+    "тех",
+    "тж",
+    "фіз",
+    "хім",
+    "церк",
+    "юр",
+}
+
 _BLOCKED_SYNONYMS = {
     "java",
     "ma",
@@ -2972,6 +3033,158 @@ def _parse_translations(raw: object) -> list[str]:
     return out
 
 
+_BALLA_REVERSE_INDEX: dict[int, dict[str, list[tuple[str, str | None]]]] = {}
+
+
+def _balla_reverse_headword(word: object) -> str | None:
+    headword = re.sub(r"\s+", " ", clean_html_entities(str(word or "")).strip()).casefold()
+    if not headword or "~" in headword:
+        return None
+    if not _BALLA_REVERSE_HEADWORD_RE.fullmatch(headword):
+        return None
+    return headword
+
+
+def _balla_reverse_definition_segments(definition: object) -> list[str]:
+    text = clean_html_entities(str(definition or ""))
+    text = re.sub(r"\([^)]*\)", " ", text)
+    segments: list[str] = []
+    for segment in re.split(r"\[m\d+\]|\d+\)|[;,]", text):
+        cleaned = _BALLA_REVERSE_LEADING_LABEL_RE.sub("", segment).strip()
+        if not cleaned or "—" in cleaned or "~" in cleaned or _LATIN_RE.search(cleaned):
+            continue
+        segments.append(cleaned)
+    return segments
+
+
+def _balla_reverse_candidate_keys(token: str) -> list[tuple[str, str | None]]:
+    key = _lookup_key(token)
+    if len(key) < 3 or key in _BALLA_REVERSE_STOP_TOKENS:
+        return []
+    analyses = _vesum_word_analyses(token)
+    if not analyses:
+        return [(key, None)]
+    out: list[tuple[str, str | None]] = []
+    seen: set[tuple[str, str | None]] = set()
+    for lemma, pos in analyses:
+        lemma_key = _lookup_key(lemma)
+        if len(lemma_key) < 3 or lemma_key in _BALLA_REVERSE_STOP_TOKENS:
+            continue
+        item = (lemma_key, pos or None)
+        if item not in seen:
+            seen.add(item)
+            out.append(item)
+    return out
+
+
+def _load_balla_reverse_index(conn: sqlite3.Connection) -> dict[str, list[tuple[str, str | None]]]:
+    cache_key = id(conn)
+    cached = _BALLA_REVERSE_INDEX.get(cache_key)
+    if cached is not None:
+        return cached
+    index: dict[str, list[tuple[str, str | None]]] = {}
+    seen: set[tuple[str, str, str | None]] = set()
+    try:
+        rows = conn.execute("SELECT word, definition FROM balla_en_uk ORDER BY word").fetchall()
+    except sqlite3.OperationalError as exc:
+        if _missing_table(exc):
+            _BALLA_REVERSE_INDEX[cache_key] = {}
+            return {}
+        raise
+    for word, definition in rows:
+        headword = _balla_reverse_headword(word)
+        if not headword:
+            continue
+        for segment in _balla_reverse_definition_segments(definition):
+            tokens = _BALLA_REVERSE_UKRAINIAN_TOKEN_RE.findall(segment)
+            if len(tokens) != 1:
+                continue
+            for key, pos in _balla_reverse_candidate_keys(tokens[0]):
+                seen_key = (key, headword, pos)
+                if seen_key in seen:
+                    continue
+                seen.add(seen_key)
+                index.setdefault(key, []).append((headword, pos))
+    _BALLA_REVERSE_INDEX[cache_key] = index
+    return index
+
+
+def _balla_reverse_hint_keys(gloss_hints: object) -> set[str]:
+    if not isinstance(gloss_hints, set | list | tuple):
+        return set()
+    out: set[str] = set()
+    for hint in gloss_hints:
+        for part in _BALLA_REVERSE_HINT_SPLIT_RE.split(str(hint or "")):
+            cleaned = clean_html_entities(part).strip().casefold()
+            cleaned = re.sub(r"^(?:to|a|an|the)\s+", "", cleaned)
+            cleaned = re.sub(r"\s+", " ", cleaned)
+            if _BALLA_REVERSE_HEADWORD_RE.fullmatch(cleaned):
+                out.add(cleaned)
+    return out
+
+
+def _surface_gloss_hints(entry: dict[str, Any]) -> set[str]:
+    hints: set[str] = set()
+    if isinstance(entry.get("gloss"), str) and entry["gloss"].strip():
+        hints.add(str(entry["gloss"]))
+    normalizations = entry.get("atlas_normalizations")
+    if not isinstance(normalizations, list):
+        return hints
+    for normalization in normalizations:
+        if not isinstance(normalization, dict):
+            continue
+        reason = str(normalization.get("reason") or "")
+        pos_match = _BALLA_REVERSE_SOURCE_POS_RE.search(reason)
+        source_pos = pos_match.group(1).casefold() if pos_match else ""
+        if source_pos.startswith("noun"):
+            continue
+        hints.update(match.group(1) for match in _BALLA_REVERSE_SURFACE_GLOSS_RE.finditer(reason))
+    return hints
+
+
+def _balla_reverse_translation(
+    conn: sqlite3.Connection,
+    lemma: str,
+    *,
+    entry_pos: object = None,
+    gloss_hints: object = None,
+) -> dict[str, object] | None:
+    allowed_headwords = _balla_reverse_hint_keys(gloss_hints)
+    if not allowed_headwords:
+        return None
+    target_pos = _MANIFEST_POS_TO_VESUM_POS.get(_lookup_key(str(entry_pos or "")))
+    target_keys = {_lookup_key(variant) for variant in _split_lemma_variants(lemma)}
+    target_keys = {key for key in target_keys if key}
+    if not target_keys:
+        return None
+
+    index = _load_balla_reverse_index(conn)
+    english: list[str] = []
+    seen: set[str] = set()
+    for key in sorted(target_keys):
+        for headword, vesum_pos in index.get(key, []):
+            if headword not in allowed_headwords:
+                continue
+            if target_pos and vesum_pos and vesum_pos != target_pos:
+                continue
+            if headword in seen:
+                continue
+            seen.add(headword)
+            english.append(headword)
+            if len(english) > _BALLA_REVERSE_MAX_HEADWORDS:
+                return None
+    if not english:
+        return None
+    return {
+        "en": english,
+        "source": _BALLA_REVERSE_SOURCE,
+        "note": (
+            "Reverse lookup from an exact Ukrainian token in Балла EN→UK, "
+            "validated by the source learner gloss; skipped when ambiguous."
+        ),
+    }
+
+
 _DMKLINGER_INDEX: dict[str, list[tuple[str, str]]] | None = None
 
 
@@ -3010,14 +3223,18 @@ def _translation(
     conn: sqlite3.Connection,
     lemma: str,
     kaikki_lookup: dict[str, dict[str, Any]] | None = None,
+    *,
+    entry_pos: object = None,
+    gloss_hints: object = None,
 ) -> dict[str, object] | None:
     """English translations for a Ukrainian lemma (Переклад, §11).
 
     Primary source is the dmklinger UK→EN dictionary (`dmklinger_uk_en`) — a curated
-    bilingual dictionary, preferred for precision. Балла is EN→UK only — no clean
-    reverse — so it is intentionally NOT used here. When dmklinger has no entry, fall
+    bilingual dictionary, preferred for precision. When dmklinger has no entry, fall
     back to Wiktionary/kaikki translation glosses (form-of/misspelling meta-glosses are
-    stripped at build time). Returns up to six glosses.
+    stripped at build time). Балла is EN→UK only, so reverse lookup is used only when an
+    exact Ukrainian token resolves to one unique English headword that matches an
+    existing learner-gloss hint from the source entry. Returns up to six glosses.
     """
     index = _load_dmklinger_index(conn)
     if index:
@@ -3044,6 +3261,14 @@ def _translation(
     kaikki_translation = _kaikki_translation(kaikki_lookup or {}, lemma)
     if kaikki_translation:
         return kaikki_translation
+    balla_translation = _balla_reverse_translation(
+        conn,
+        lemma,
+        entry_pos=entry_pos,
+        gloss_hints=gloss_hints,
+    )
+    if balla_translation:
+        return balla_translation
 
     for variant in _split_lemma_variants(lemma):
         curated = _CURATED_LEARNER_TRANSLATIONS.get(_lookup_key(variant).casefold())
@@ -3259,6 +3484,7 @@ def enrich_entry(entry, conn, kaikki_lookup, *, has_sum11_flags) -> bool:
     lemma = entry["lemma"]
     base = _base_lemma(lemma)
     entry_pos = entry.get("pos")
+    gloss_hints = _surface_gloss_hints(entry)
     fallback_base = _base_lookup_for_entry(lemma, entry_pos)
     slovnyk_cache = _slovnyk_cache(lemma)
     definition_cards = _definition_cards(
@@ -3365,9 +3591,21 @@ def enrich_entry(entry, conn, kaikki_lookup, *, has_sum11_flags) -> bool:
     literary = _literary_attestation(conn, lemma)
     if literary:
         block["literary_attestation"] = literary
-    translation = _translation(conn, lemma, kaikki_lookup)
+    translation = _translation(
+        conn,
+        lemma,
+        kaikki_lookup,
+        entry_pos=entry_pos,
+        gloss_hints=gloss_hints,
+    )
     if not translation and fallback_base:
-        translation = _translation(conn, fallback_base, kaikki_lookup)
+        translation = _translation(
+            conn,
+            fallback_base,
+            kaikki_lookup,
+            entry_pos=entry_pos,
+            gloss_hints=gloss_hints,
+        )
         if translation:
             translation = _with_base_source_label(translation, fallback_base)
     if translation:

--- a/scripts/lexicon/reenrich_thin_manifest_entries.py
+++ b/scripts/lexicon/reenrich_thin_manifest_entries.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Re-enrich Atlas entries that passed the old gate but lack English anchors."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
+
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.audit.audit_atlas_thin_enriched import (
+    has_learner_english_anchor,
+    thin_old_gate_entries,
+)
+from scripts.lexicon import enrich_manifest
+from scripts.lexicon.manifest_io import load_manifest
+from scripts.lexicon.publish_manifest import (
+    DEFAULT_GZIP,
+    DEFAULT_POINTER,
+    build_pointer_payload,
+    gzip_manifest,
+    write_pointer,
+)
+
+
+def _load_kaikki_lookup(path: Path) -> dict[str, dict[str, Any]]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_manifest(path: Path, manifest: dict[str, Any]) -> None:
+    path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _read_local_manifest(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def _refresh_manifest_fingerprint(manifest: dict[str, Any]) -> None:
+    fingerprint_payload = enrich_manifest.write_fingerprint(enrich_manifest.DEFAULT_FINGERPRINT, root=ROOT)
+    manifest["manifest_fingerprint"] = {
+        "schema_version": fingerprint_payload["schema_version"],
+        "fingerprint": fingerprint_payload["fingerprint"],
+    }
+
+
+def _write_default_release_pointer(manifest_path: Path) -> dict[str, Any] | None:
+    if manifest_path.resolve() != DEFAULT_MANIFEST.resolve():
+        return None
+    gzip_manifest(manifest_path, DEFAULT_GZIP)
+    pointer = build_pointer_payload(manifest_path=manifest_path, gzip_path=DEFAULT_GZIP)
+    write_pointer(DEFAULT_POINTER, pointer)
+    return pointer
+
+
+def _preserve_existing_metadata(
+    entry: dict[str, Any],
+    *,
+    existing_cefr: dict[str, Any] | None,
+    existing_wiki_reference: dict[str, Any] | None,
+) -> None:
+    enrichment = entry.get("enrichment")
+    if isinstance(enrichment, dict) and existing_cefr and "cefr" not in enrichment:
+        enrichment["cefr"] = existing_cefr
+        sources = set(enrichment.get("sources") or [])
+        source = existing_cefr.get("source")
+        if source:
+            sources.add(str(source))
+        if sources:
+            enrichment["sources"] = sorted(sources)
+    if existing_wiki_reference and "wiki_reference" not in entry:
+        entry["wiki_reference"] = existing_wiki_reference
+
+
+def _add_source(enrichment: dict[str, Any], source: object) -> None:
+    if not source:
+        return
+    sources = set(enrichment.get("sources") or [])
+    sources.add(str(source))
+    enrichment["sources"] = sorted(sources)
+
+
+def _translation_for_entry(
+    conn: sqlite3.Connection,
+    entry: dict[str, Any],
+    kaikki_lookup: dict[str, dict[str, Any]],
+) -> dict[str, object] | None:
+    lemma = str(entry.get("lemma") or "")
+    entry_pos = entry.get("pos")
+    gloss_hints = enrich_manifest._surface_gloss_hints(entry)
+    translation = enrich_manifest._translation(
+        conn,
+        lemma,
+        kaikki_lookup,
+        entry_pos=entry_pos,
+        gloss_hints=gloss_hints,
+    )
+    if translation:
+        return translation
+    fallback_base = enrich_manifest._base_lookup_for_entry(lemma, entry_pos)
+    if not fallback_base:
+        return None
+    translation = enrich_manifest._translation(
+        conn,
+        fallback_base,
+        kaikki_lookup,
+        entry_pos=entry_pos,
+        gloss_hints=gloss_hints,
+    )
+    if not translation:
+        return None
+    return enrich_manifest._with_base_source_label(translation, fallback_base)
+
+
+def _reenrich_translation_only(
+    conn: sqlite3.Connection,
+    entry: dict[str, Any],
+    kaikki_lookup: dict[str, dict[str, Any]],
+) -> None:
+    translation = _translation_for_entry(conn, entry, kaikki_lookup)
+    if not translation:
+        return
+    enrichment = entry.setdefault("enrichment", {})
+    if not isinstance(enrichment, dict):
+        enrichment = {}
+        entry["enrichment"] = enrichment
+    enrichment["translation"] = translation
+    _add_source(enrichment, translation.get("source"))
+
+
+def _reenrich_full_entry(
+    conn: sqlite3.Connection,
+    entry: dict[str, Any],
+    kaikki_lookup: dict[str, dict[str, Any]],
+    *,
+    has_sum11_flags: bool,
+) -> None:
+    enrich_manifest.enrich_entry(
+        entry,
+        conn,
+        kaikki_lookup,
+        has_sum11_flags=has_sum11_flags,
+    )
+
+
+def reenrich_thin_entries(
+    manifest: dict[str, Any],
+    *,
+    conn: sqlite3.Connection,
+    kaikki_lookup: dict[str, dict[str, Any]],
+    limit: int | None = None,
+    full_entry: bool = False,
+    refresh_wiki: bool = False,
+) -> dict[str, Any]:
+    targets = thin_old_gate_entries(manifest)
+    if limit is not None:
+        targets = targets[:limit]
+
+    has_sum11_flags = enrich_manifest._sum11_has_flag_columns(conn)
+    original_wiki_reference = enrich_manifest._wiki_reference
+    if not refresh_wiki:
+        enrich_manifest._wiki_reference = lambda *args, **kwargs: None
+
+    changed = 0
+    gained_anchor = 0
+    try:
+        for entry in targets:
+            enrichment = entry.get("enrichment") if isinstance(entry.get("enrichment"), dict) else {}
+            existing_cefr = enrichment.get("cefr") if isinstance(enrichment, dict) else None
+            existing_wiki_reference = entry.get("wiki_reference")
+            had_anchor = has_learner_english_anchor(entry)
+            before = json.dumps(entry, ensure_ascii=False, sort_keys=True)
+            if full_entry:
+                _reenrich_full_entry(
+                    conn,
+                    entry,
+                    kaikki_lookup,
+                    has_sum11_flags=has_sum11_flags,
+                )
+            else:
+                _reenrich_translation_only(conn, entry, kaikki_lookup)
+            _preserve_existing_metadata(
+                entry,
+                existing_cefr=existing_cefr if isinstance(existing_cefr, dict) else None,
+                existing_wiki_reference=(
+                    existing_wiki_reference if isinstance(existing_wiki_reference, dict) else None
+                ),
+            )
+            after = json.dumps(entry, ensure_ascii=False, sort_keys=True)
+            if after != before:
+                changed += 1
+            if not had_anchor and has_learner_english_anchor(entry):
+                gained_anchor += 1
+    finally:
+        enrich_manifest._wiki_reference = original_wiki_reference
+
+    remaining = thin_old_gate_entries(manifest)
+    return {
+        "targets": len(targets),
+        "changed": changed,
+        "gained_english_anchor": gained_anchor,
+        "remaining_old_gate_no_english_anchor": len(remaining),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Re-enrich old-gate-enriched Atlas entries missing learner English anchors."
+    )
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument(
+        "--local",
+        action="store_true",
+        help="Read manifest path directly instead of hydrating the canonical release asset.",
+    )
+    parser.add_argument("--sources-db", type=Path, default=enrich_manifest.SOURCES_DB)
+    parser.add_argument("--kaikki-lookup", type=Path, default=enrich_manifest.KAIKKI_LOOKUP)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument(
+        "--full-entry",
+        action="store_true",
+        help="Run full enrich_entry for each target. Default only recomputes translation anchors.",
+    )
+    parser.add_argument("--refresh-wiki", action="store_true")
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args()
+
+    manifest_path = args.manifest if args.manifest.is_absolute() else ROOT / args.manifest
+    sources_db = args.sources_db if args.sources_db.is_absolute() else ROOT / args.sources_db
+    kaikki_path = args.kaikki_lookup if args.kaikki_lookup.is_absolute() else ROOT / args.kaikki_lookup
+
+    manifest = _read_local_manifest(manifest_path) if args.local else load_manifest(manifest_path)
+    kaikki_lookup = _load_kaikki_lookup(kaikki_path)
+    with sqlite3.connect(sources_db) as conn:
+        summary = reenrich_thin_entries(
+            manifest,
+            conn=conn,
+            kaikki_lookup=kaikki_lookup,
+            limit=args.limit,
+            full_entry=args.full_entry,
+            refresh_wiki=args.refresh_wiki,
+        )
+
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    if args.write:
+        _refresh_manifest_fingerprint(manifest)
+        _write_manifest(manifest_path, manifest)
+        pointer = _write_default_release_pointer(manifest_path)
+        if pointer:
+            print(
+                "Updated local atlas-manifest pointer "
+                f"{pointer['manifest_fingerprint']} {pointer['json_sha256']}"
+            )
+    else:
+        print("Dry run only; pass --write to update the manifest.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "755a63dca45dba1a7537b6257791e6be35520345e6e03432a79152683b351f0a",
+  "fingerprint": "8e409ae0e414ae2b15c8d761d7027a5b37ad3b0d267bb4811ac045c306f9583e",
   "inputs": {
     "lexicon_code": [
       {
@@ -44,7 +44,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "bb42e88f1734f30d2ca41b00efed841029634baa97a2fb44e5878f9dbadc595f"
+        "sha256": "403a2de64076d2517ebd9afa6da6b6105b983c9a3b164dbc114fc4ad1b409e60"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",
@@ -95,6 +95,10 @@
         "sha256": "3aac9e0942366c3a6d50ed2590a6b92c600f7064d458f2fe92bae1f3d42814f7"
       },
       {
+        "path": "scripts/lexicon/reenrich_thin_manifest_entries.py",
+        "sha256": "90ebbe4d39e44420a4d8c82f0dc562c6927ad6b4663d434be07511a0e020cfa4"
+      },
+      {
         "path": "scripts/lexicon/verify_manifest.py",
         "sha256": "e128d60f2c72ca44fdc550fb99436adc27481d59b9877f22480f67a988ae3059"
       }
@@ -103,6 +107,6 @@
   "schema_version": 1,
   "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
   "stats": {
-    "lexicon_code_files": 24
+    "lexicon_code_files": 25
   }
 }

--- a/site/src/data/lexicon-manifest.pointer.json
+++ b/site/src/data/lexicon-manifest.pointer.json
@@ -2,12 +2,12 @@
   "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest.json.gz",
   "release_tag": "atlas-manifest",
   "manifest_version": "0.1",
-  "manifest_fingerprint": "755a63dca45dba1a7537b6257791e6be35520345e6e03432a79152683b351f0a",
+  "manifest_fingerprint": "8e409ae0e414ae2b15c8d761d7027a5b37ad3b0d267bb4811ac045c306f9583e",
   "fingerprint_schema_version": 1,
   "generated_at": "2026-06-27T00:33:09+00:00",
-  "gz_sha256": "df84e182bf23ab0eaa289f94d6d823413a7b22f534612af99c0f90b5a8f42e07",
-  "json_sha256": "35b8f660a42780e35c80fa639133ab281355598ae7213bbd9fef7ec68b24214f",
-  "gz_bytes": 14746673,
-  "json_bytes": 109042231,
+  "gz_sha256": "d2470205a0691a813e61cab9af911d90b01fe9d3f36cc6342922f8ef0b45aad2",
+  "json_sha256": "fd967fe2bff0feaca9634fa7899890ab2bc28f96674fb8851a91b9f8296ec8ee",
+  "gz_bytes": 14746767,
+  "json_bytes": 109042570,
   "note": "Pins GitHub Release asset manifest for #3659; hydrate it build time instead committing raw JSON."
 }

--- a/tests/test_audit_atlas_thin_enriched.py
+++ b/tests/test_audit_atlas_thin_enriched.py
@@ -1,0 +1,76 @@
+from scripts.audit.audit_atlas_thin_enriched import (
+    has_learner_english_anchor,
+    summarize_manifest,
+    thin_old_gate_entries,
+)
+from scripts.lexicon.build_kaikki_lookup import KAIKKI_SOURCE
+
+
+def test_has_learner_english_anchor_accepts_supported_anchor_shapes() -> None:
+    assert has_learner_english_anchor({"gloss": "wow"})
+    assert has_learner_english_anchor({"enrichment": {"translation": {"en": ["stir"]}}})
+    assert has_learner_english_anchor(
+        {
+            "enrichment": {
+                "meaning": {
+                    "definitions": ["alphabet"],
+                    "source": KAIKKI_SOURCE,
+                }
+            }
+        }
+    )
+
+
+def test_has_learner_english_anchor_rejects_ukrainian_only_enrichment() -> None:
+    assert not has_learner_english_anchor(
+        {
+            "enrichment": {
+                "definition_cards": [
+                    {
+                        "source": "СУМ-20",
+                        "definitions": ["помішувати: перемішувати ложкою."],
+                    }
+                ]
+            }
+        }
+    )
+    assert not has_learner_english_anchor(
+        {
+            "enrichment": {
+                "meaning": {
+                    "definitions": ["помішувати, перемішувати"],
+                    "source": "Вікісловник",
+                }
+            }
+        }
+    )
+
+
+def test_thin_old_gate_entries_reports_old_gate_false_positive() -> None:
+    manifest = {
+        "entries": [
+            {
+                "lemma": "помішувати",
+                "pos": "verb",
+                "primary_source": "built_vocabulary_normalized",
+                "course_usage": [{"track": "a2"}],
+                "enrichment": {"stress": {"form": "помі́шувати"}},
+            },
+            {
+                "lemma": "ого",
+                "pos": "intj",
+                "primary_source": "content_lexicon_grow",
+                "enrichment": {"translation": {"en": ["wow"]}},
+            },
+            {"lemma": "pluralia tantum", "gloss": "plural-only nouns"},
+        ]
+    }
+
+    thin = thin_old_gate_entries(manifest)
+    summary = summarize_manifest(manifest)
+
+    assert [entry["lemma"] for entry in thin] == ["помішувати"]
+    assert summary["old_gate_enriched"] == 2
+    assert summary["old_gate_no_english_anchor"] == 1
+    assert summary["course_used_no_english_anchor"] == 1
+    assert summary["by_primary_source"] == {"built_vocabulary_normalized": 1}

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -7,6 +7,7 @@ import pytest
 
 from scripts.lexicon import enrich_manifest as enrich_manifest_module
 from scripts.lexicon.enrich_manifest import (
+    _BALLA_REVERSE_SOURCE,
     _DROP_ANTONYM_LEMMAS,
     _WRONG_ANTONYMS,
     _WRONG_SENSE_SYNONYMS,
@@ -38,6 +39,7 @@ from scripts.lexicon.enrich_manifest import (
     _sense_correct_synonyms,
     _slovnyk_cache,
     _SlovnykTransientError,
+    _surface_gloss_hints,
     _synonyms_slovnyk,
     _translation,
     _warning_slovnyk,
@@ -1317,7 +1319,7 @@ def test_enrich_entry_uses_pos_matched_base_translation_fallback(monkeypatch) ->
     monkeypatch.setattr(enrich_manifest_module, "_wiki_reference", none)
     monkeypatch.setattr(enrich_manifest_module, "_base_lookup_for_entry", lambda lemma, pos: "бачити")
 
-    def fake_translation(conn, lemma: str, kaikki_lookup):
+    def fake_translation(conn, lemma: str, kaikki_lookup, **kwargs):
         if lemma == "бачити":
             return {"en": ["to see"], "source": "fixture"}
         return None
@@ -1919,14 +1921,132 @@ def test_translation_returns_none_when_lemma_absent(monkeypatch) -> None:
     conn = sqlite3.connect(":memory:")
     conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
     monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
+    monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
 
     assert _translation(conn, "неіснуючеслово") is None
+
+
+def test_translation_uses_unambiguous_reverse_balla_after_source_misses(monkeypatch) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
+    conn.execute("CREATE TABLE balla_en_uk (word TEXT, definition TEXT, text TEXT)")
+    conn.execute(
+        "INSERT INTO balla_en_uk (word, definition, text) VALUES (?, ?, ?)",
+        ("stir", "v 1) мішати, помішувати, розмішувати; збовтувати", ""),
+    )
+    monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
+    monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+    _patch_vesum_analyses(monkeypatch, {"помішувати": "verb"})
+
+    assert _translation(conn, "помішувати", {}, entry_pos="verb") is None
+    assert _translation(conn, "помішувати", {}, entry_pos="verb", gloss_hints={"stir"}) == {
+        "en": ["stir"],
+        "source": _BALLA_REVERSE_SOURCE,
+        "note": (
+            "Reverse lookup from an exact Ukrainian token in Балла EN→UK, "
+            "validated by the source learner gloss; skipped when ambiguous."
+        ),
+    }
+
+
+def test_translation_skips_ambiguous_reverse_balla(monkeypatch) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
+    conn.execute("CREATE TABLE balla_en_uk (word TEXT, definition TEXT, text TEXT)")
+    conn.executemany(
+        "INSERT INTO balla_en_uk (word, definition, text) VALUES (?, ?, ?)",
+        [
+            ("mix", "v змішувати, помішувати", ""),
+            ("stir", "v мішати, помішувати", ""),
+        ],
+    )
+    monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
+    monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+    _patch_vesum_analyses(monkeypatch, {"помішувати": "verb"})
+
+    assert (
+        _translation(conn, "помішувати", {}, entry_pos="verb", gloss_hints={"mix", "stir"})
+        is None
+    )
+
+
+def test_translation_prefers_kaikki_over_reverse_balla(monkeypatch) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
+    conn.execute("CREATE TABLE balla_en_uk (word TEXT, definition TEXT, text TEXT)")
+    conn.execute(
+        "INSERT INTO balla_en_uk (word, definition, text) VALUES (?, ?, ?)",
+        ("stir", "v помішувати", ""),
+    )
+    monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
+    monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+    _patch_vesum_analyses(monkeypatch, {"помішувати": "verb"})
+
+    assert _translation(conn, "помішувати", {"помішувати": {"glosses": ["to stir"]}}) == {
+        "en": ["to stir"],
+        "source": KAIKKI_SOURCE,
+    }
+
+
+def test_translation_reverse_balla_ignores_example_sentences(monkeypatch) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
+    conn.execute("CREATE TABLE balla_en_uk (word TEXT, definition TEXT, text TEXT)")
+    conn.execute(
+        "INSERT INTO balla_en_uk (word, definition, text) VALUES (?, ?, ?)",
+        ("dash", "v he ~ed the book on the floor — він шпурнув книгу додолу", ""),
+    )
+    monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
+    monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+    _patch_vesum_analyses(monkeypatch, {"книга": "noun"})
+
+    assert _translation(conn, "книга", {}, entry_pos="noun", gloss_hints={"dash"}) is None
+
+
+def test_translation_reverse_balla_requires_single_token_segment(monkeypatch) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
+    conn.execute("CREATE TABLE balla_en_uk (word TEXT, definition TEXT, text TEXT)")
+    conn.execute(
+        "INSERT INTO balla_en_uk (word, definition, text) VALUES (?, ?, ?)",
+        ("home", "n 1) дім 2) порт базування", ""),
+    )
+    monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
+    monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+    _patch_vesum_analyses(monkeypatch, {"базування": "noun", "дім": "noun"})
+
+    assert _translation(conn, "базування", {}, entry_pos="noun", gloss_hints={"home"}) is None
+    assert _translation(conn, "дім", {}, entry_pos="noun", gloss_hints={"home"}) == {
+        "en": ["home"],
+        "source": _BALLA_REVERSE_SOURCE,
+        "note": (
+            "Reverse lookup from an exact Ukrainian token in Балла EN→UK, "
+            "validated by the source learner gloss; skipped when ambiguous."
+        ),
+    }
+
+
+def test_surface_gloss_hints_skip_noun_normalization() -> None:
+    entry = {
+        "lemma": "вершок",
+        "atlas_normalizations": [
+            {
+                "reason": (
+                    "VESUM: inflected surface «вершки» (surface gloss='cream', "
+                    "pos='noun:pl') folded into a NEWLY-CREATED lemma page «вершок»."
+                )
+            }
+        ],
+    }
+
+    assert _surface_gloss_hints(entry) == set()
 
 
 def test_translation_uses_curated_learner_gloss_after_source_misses(monkeypatch) -> None:
     conn = sqlite3.connect(":memory:")
     conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
     monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
+    monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
 
     assert _translation(conn, "ого", {}) == {
         "en": ["wow", "whoa"],
@@ -1938,6 +2058,7 @@ def test_translation_prefers_kaikki_over_curated_learner_gloss(monkeypatch) -> N
     conn = sqlite3.connect(":memory:")
     conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
     monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
+    monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
 
     assert _translation(conn, "ого", {"ого": {"glosses": ["oh wow"]}}) == {
         "en": ["oh wow"],

--- a/tests/test_reenrich_thin_manifest_entries.py
+++ b/tests/test_reenrich_thin_manifest_entries.py
@@ -1,0 +1,69 @@
+import sqlite3
+
+from scripts.lexicon import enrich_manifest
+from scripts.lexicon.reenrich_thin_manifest_entries import (
+    _preserve_existing_metadata,
+    _reenrich_translation_only,
+)
+
+
+def test_reenrich_translation_only_preserves_existing_enrichment(monkeypatch) -> None:
+    entry = {
+        "lemma": "помішувати",
+        "enrichment": {
+            "stress": {"form": "помі́шувати", "source": "ukrainian-word-stress"},
+            "cefr": {"level": "C1", "source": "estimated (GRAC frequency)"},
+            "sources": ["VESUM"],
+        },
+        "atlas_normalizations": [
+            {
+                "reason": (
+                    "VESUM: inflected surface «помішуйте» (surface gloss='stir', "
+                    "pos='imperative') folded into a NEWLY-CREATED lemma page «помішувати»."
+                )
+            }
+        ],
+    }
+
+    def fake_translation(conn, lemma, kaikki_lookup, *, entry_pos=None, gloss_hints=None):
+        assert gloss_hints == {"stir"}
+        return {"en": ["stir"], "source": "fixture source"}
+
+    monkeypatch.setattr(enrich_manifest, "_translation", fake_translation)
+    monkeypatch.setattr(enrich_manifest, "_base_lookup_for_entry", lambda *args, **kwargs: None)
+
+    with sqlite3.connect(":memory:") as conn:
+        _reenrich_translation_only(conn, entry, {})
+
+    assert entry["enrichment"]["translation"] == {"en": ["stir"], "source": "fixture source"}
+    assert entry["enrichment"]["stress"] == {
+        "form": "помі́шувати",
+        "source": "ukrainian-word-stress",
+    }
+    assert entry["enrichment"]["cefr"] == {
+        "level": "C1",
+        "source": "estimated (GRAC frequency)",
+    }
+    assert entry["enrichment"]["sources"] == ["VESUM", "fixture source"]
+
+
+def test_preserve_existing_metadata_restores_cefr_and_wiki_reference() -> None:
+    entry = {
+        "enrichment": {
+            "translation": {"en": ["stir"], "source": "fixture source"},
+            "sources": ["fixture source"],
+        }
+    }
+
+    _preserve_existing_metadata(
+        entry,
+        existing_cefr={"level": "B1", "source": "estimated (GRAC frequency)"},
+        existing_wiki_reference={"wikipedia": {"title": "Помішувати"}},
+    )
+
+    assert entry["enrichment"]["cefr"] == {
+        "level": "B1",
+        "source": "estimated (GRAC frequency)",
+    }
+    assert entry["enrichment"]["sources"] == ["estimated (GRAC frequency)", "fixture source"]
+    assert entry["wiki_reference"] == {"wikipedia": {"title": "Помішувати"}}


### PR DESCRIPTION
## Summary

- Adds a DB-free audit for old-gate-enriched Atlas entries that still lack learner English anchors.
- Adds a targeted re-enricher for those entries, defaulting to translation-only updates so it does not refetch Slovnyk or clobber unrelated enrichment.
- Adds conservative reverse Balla EN→UK support only when the English headword is validated by an existing source learner gloss hint; this recovers `помішувати → stir` while avoiding unsafe cases like `вершок → cream`.
- Updates the Atlas manifest pointer/fingerprint and uploads the matching canonical `atlas-manifest` release asset.

## Root Cause

The old enrichment gate only counted the presence of any `enrichment` block. That let Ukrainian-only pages pass as enriched even when they had no learner-facing English anchor. Broad reverse lookup from Balla is unsafe, so the fix adds an audit and a tightly validated fallback instead of blanket reverse matching.

## Validation

- `.venv/bin/python -m pytest tests/test_lexicon_enrich_manifest.py tests/test_audit_atlas_thin_enriched.py tests/test_reenrich_thin_manifest_entries.py -q` — 86 passed
- `.venv/bin/ruff check scripts/lexicon/enrich_manifest.py scripts/audit/audit_atlas_thin_enriched.py scripts/lexicon/reenrich_thin_manifest_entries.py tests/test_lexicon_enrich_manifest.py tests/test_audit_atlas_thin_enriched.py tests/test_reenrich_thin_manifest_entries.py`
- `.venv/bin/python -m scripts.audit.check_atlas_manifest_enrichment`
- `.venv/bin/python -m scripts.audit.audit_atlas_thin_enriched --local --limit 5`
- `.venv/bin/python -m scripts.lexicon.publish_manifest --dry-run`
- `npm --prefix site run build` — completed, 11173 pages built
- Render text check: `/lexicon/помішувати/` contains `stir` with `Балла EN→UK reverse exact`; `/lexicon/вершок/` contains no `cream`/reverse-Balla gloss
- Public release asset hash verified from `https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest.json.gz`
- Independent review: Agy with Gemini 3.1 Pro High; follow-up review found no remaining blocking issues
