### PR TITLE
fix(lexicon): skip garbled ESUM etymology fallback

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -70,6 +70,7 @@ from scripts.lexicon.calque_corrections import (
 )
 from scripts.lexicon.esum_garbled import (
     garbled_esum_entry,
+    has_mojibake_marker,
     strip_garbled_tail,
     trim_curated_goroh_text,
 )
@@ -2658,6 +2659,8 @@ def _esum_etymology(conn: sqlite3.Connection, lemma: str) -> dict | None:
     if garbled_esum_entry(word):
         text = clean_html_entities(strip_garbled_tail(text, word))
         cite += " (garbled tail stripped)"
+    elif has_mojibake_marker(text):
+        return None
     if not text:
         return None
     return {"text": text, "source": cite}

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -2659,7 +2659,7 @@ def _esum_etymology(conn: sqlite3.Connection, lemma: str) -> dict | None:
     if garbled_esum_entry(word):
         text = clean_html_entities(strip_garbled_tail(text, word))
         cite += " (garbled tail stripped)"
-    elif has_mojibake_marker(text):
+    if has_mojibake_marker(text):
         return None
     if not text:
         return None

--- a/scripts/wiki/sources_db.py
+++ b/scripts/wiki/sources_db.py
@@ -28,6 +28,7 @@ import yaml
 
 from scripts.lexicon.esum_garbled import (
     garbled_esum_entry,
+    has_mojibake_marker,
     strip_garbled_tail,
     trim_curated_goroh_text,
 )
@@ -1470,6 +1471,8 @@ def _clean_garbled_esum_results(conn: sqlite3.Connection, rows: list[dict]) -> l
     for row in rows:
         lemma = str(row.get("lemma") or "")
         if not garbled_esum_entry(lemma):
+            if has_mojibake_marker(str(row.get("etymology_text") or "")):
+                continue
             cleaned.append(row)
             continue
         item = dict(row)
@@ -1478,6 +1481,8 @@ def _clean_garbled_esum_results(conn: sqlite3.Connection, rows: list[dict]) -> l
             item.update(override)
         else:
             item["etymology_text"] = strip_garbled_tail(str(item.get("etymology_text") or ""), lemma)
+            if has_mojibake_marker(str(item.get("etymology_text") or "")):
+                continue
             item["source"] = f"{item.get('source') or 'ЕСУМ'} (garbled tail stripped)"
         cleaned.append(item)
     return cleaned

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "6124457f52ca626a5c37fb0cc0b829e74ea0bde33afd8a971f2d4b7ce0227498",
+  "fingerprint": "bd53914a6c6646175f234a9b0517a4c10417b579d7945fc5e5da734bb17db9ca",
   "inputs": {
     "lexicon_code": [
       {
@@ -44,7 +44,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "f2d5b5072e76b2070a22b2ede619084e286dabd25138d3c50c9f10b819637b64"
+        "sha256": "de1c6eddd345a8c9872b948e729a2b1a77c1e131bacb03712ba04feddfa7c936"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "bd53914a6c6646175f234a9b0517a4c10417b579d7945fc5e5da734bb17db9ca",
+  "fingerprint": "f025cfc14420caa8a6cfd6acc6d7d4819159f39945d6f77d7df6ddab9c22bdd9",
   "inputs": {
     "lexicon_code": [
       {
@@ -44,7 +44,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "de1c6eddd345a8c9872b948e729a2b1a77c1e131bacb03712ba04feddfa7c936"
+        "sha256": "2fdd10bea8faf8d7d4f8fce29c099e06bb688e41edf2dedc9d7d858482fe6ad7"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/site/src/data/lexicon-manifest.pointer.json
+++ b/site/src/data/lexicon-manifest.pointer.json
@@ -2,12 +2,12 @@
   "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest.json.gz",
   "release_tag": "atlas-manifest",
   "manifest_version": "0.1",
-  "manifest_fingerprint": "6124457f52ca626a5c37fb0cc0b829e74ea0bde33afd8a971f2d4b7ce0227498",
+  "manifest_fingerprint": "f025cfc14420caa8a6cfd6acc6d7d4819159f39945d6f77d7df6ddab9c22bdd9",
   "fingerprint_schema_version": 1,
-  "generated_at": "2026-06-27T00:33:09+00:00",
-  "gz_sha256": "9935b96c9de13e905f7b70c2a4931e65a812adbef29c57e2f9818056ccbe1612",
-  "json_sha256": "76cabfa730a2d9d10b4278832eed852352489c9740c2e97545e0223fa7db349b",
-  "gz_bytes": 14739517,
-  "json_bytes": 109042452,
+  "generated_at": "2026-06-27T13:55:58+00:00",
+  "gz_sha256": "454e56e861330e4a0e8e3ca3517e51e16636b6e421e528234b7ed5eab6f553c0",
+  "json_sha256": "bee5b8b37e8f66a863ca8a40ede9aff96cc408dec4e6d39ebb185e25c99837fb",
+  "gz_bytes": 6096174,
+  "json_bytes": 44410784,
   "note": "Pins GitHub Release asset manifest for #3659; hydrate it build time instead committing raw JSON."
 }

--- a/tests/test_esum_garbled_etymologies.py
+++ b/tests/test_esum_garbled_etymologies.py
@@ -16,6 +16,8 @@ GARBLED_BAZHANNIA = (
     "[бажання, «потреба; лит. разахотіти», нужда, злидні», "
     "іє. \"пац-, Зпоц-, \"пй- «стомлювати(ся)». -- Эндзелин РФВ 68"
 )
+GARBLED_ASPIRANT = "аспірант; фр. азрігапі; \\Уа1йе--НоГт. II 575; Веліа[ Е55) tail"
+CLEAN_ESUM = "чистий ЕСУМ ряд без OCR-гарблення."
 
 
 def _build_sources_db(path) -> None:
@@ -112,6 +114,67 @@ def test_curated_goroh_override_cleans_search_esum(tmp_path) -> None:
     assert not has_mojibake_marker(hits[0]["etymology_text"])
 
 
+def test_uncurated_garbled_esum_row_is_filtered_from_search(tmp_path) -> None:
+    db_path = tmp_path / "sources.db"
+    _build_sources_db(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO esum_etymology_meta
+            (id, lemma, vol, page, etymology_text)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (3, "аспірант", 1, 92, GARBLED_ASPIRANT),
+        )
+        conn.execute(
+            """
+            INSERT INTO esum_etymology(rowid, lemma, etymology_text, cognates, vol, page)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (3, "аспірант", GARBLED_ASPIRANT, "[]", 1, 92),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert not is_garbled_esum_lemma("аспірант")
+    assert search_esum("аспірант", limit=3, db_path=db_path) == []
+
+
+def test_uncurated_clean_esum_row_still_surfaces(tmp_path) -> None:
+    db_path = tmp_path / "sources.db"
+    _build_sources_db(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO esum_etymology_meta
+            (id, lemma, vol, page, etymology_text)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (3, "весна", 1, 92, CLEAN_ESUM),
+        )
+        conn.execute(
+            """
+            INSERT INTO esum_etymology(rowid, lemma, etymology_text, cognates, vol, page)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (3, "весна", CLEAN_ESUM, "[]", 1, 92),
+        )
+        conn.commit()
+
+        etymology = _source_etymology(conn, "весна", {})
+    finally:
+        conn.close()
+
+    assert not is_garbled_esum_lemma("весна")
+    assert etymology == {"text": CLEAN_ESUM, "source": "ЕСУМ, т. 1, с. 92"}
+    hits = search_esum("весна", limit=3, db_path=db_path)
+    assert [hit["lemma"] for hit in hits] == ["весна"]
+    assert hits[0]["etymology_text"] == CLEAN_ESUM
+
+
 def test_strip_only_curated_entry_drops_garbled_tail(tmp_path) -> None:
     db_path = tmp_path / "sources.db"
     _build_sources_db(db_path)
@@ -166,7 +229,7 @@ def test_uncurated_garbled_esum_row_falls_back_to_wiktionary(tmp_path) -> None:
             (
                 1,
                 "аспірант",
-                "аспірант; фр. азрігапі; \\Уа1йе--НоГт. II 575; Веліа[ Е55) tail",
+                GARBLED_ASPIRANT,
                 "[]",
                 1,
                 92,

--- a/tests/test_esum_garbled_etymologies.py
+++ b/tests/test_esum_garbled_etymologies.py
@@ -130,3 +130,69 @@ def test_strip_only_curated_entry_drops_garbled_tail(tmp_path) -> None:
     hits = search_esum("бажання", limit=3, db_path=db_path)
     assert hits[0]["etymology_text"] == etymology["text"]
     assert not has_mojibake_marker(hits[0]["etymology_text"])
+
+
+def test_uncurated_garbled_esum_row_falls_back_to_wiktionary(tmp_path) -> None:
+    db_path = tmp_path / "sources.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE goroh_etymology (
+                requested_lemma TEXT PRIMARY KEY,
+                headword TEXT NOT NULL DEFAULT '',
+                etymology_text TEXT NOT NULL DEFAULT '',
+                source_url TEXT NOT NULL DEFAULT '',
+                retrieved_at TEXT NOT NULL DEFAULT '',
+                content_hash TEXT NOT NULL DEFAULT ''
+            );
+
+            CREATE VIRTUAL TABLE esum_etymology
+            USING fts5(lemma, etymology_text, cognates, vol UNINDEXED, page UNINDEXED);
+
+            CREATE TABLE wiktionary_etymology (
+                requested_lemma TEXT PRIMARY KEY,
+                headword TEXT NOT NULL DEFAULT '',
+                etymology_text TEXT NOT NULL DEFAULT '',
+                source_url TEXT NOT NULL DEFAULT ''
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO esum_etymology(rowid, lemma, etymology_text, cognates, vol, page)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                1,
+                "аспірант",
+                "аспірант; фр. азрігапі; \\Уа1йе--НоГт. II 575; Веліа[ Е55) tail",
+                "[]",
+                1,
+                92,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO wiktionary_etymology
+            (requested_lemma, headword, etymology_text, source_url)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                "аспірант",
+                "аспірант",
+                "Від французького aspirant, далі від латинського aspirans.",
+                "https://example.test/aspirant",
+            ),
+        )
+        conn.commit()
+
+        etymology = _source_etymology(conn, "аспірант", {})
+    finally:
+        conn.close()
+
+    assert not is_garbled_esum_lemma("аспірант")
+    assert etymology is not None
+    assert etymology["source"] == "Вікісловник (uk.wiktionary)"
+    assert etymology["text"] == "Від французького aspirant, далі від латинського aspirans."
+    assert not has_mojibake_marker(etymology["text"])

--- a/tests/test_esum_garbled_etymologies.py
+++ b/tests/test_esum_garbled_etymologies.py
@@ -102,6 +102,21 @@ def test_curated_goroh_override_cleans_manifest_etymology(tmp_path) -> None:
     assert not has_mojibake_marker(etymology["text"])
 
 
+def test_curated_entry_with_unstripped_marker_is_dropped_from_manifest(tmp_path) -> None:
+    db_path = tmp_path / "sources.db"
+    _build_sources_db(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("DELETE FROM goroh_etymology WHERE requested_lemma = ?", ("варіант",))
+        conn.commit()
+        etymology = _source_etymology(conn, "варіант", {})
+    finally:
+        conn.close()
+
+    assert is_garbled_esum_lemma("варіант")
+    assert etymology is None
+
+
 def test_curated_goroh_override_cleans_search_esum(tmp_path) -> None:
     db_path = tmp_path / "sources.db"
     _build_sources_db(db_path)


### PR DESCRIPTION
## Summary

Fixes #3406.

- Skip uncurated ЕСУМ etymology rows that contain the existing high-confidence mojibake markers.
- Preserve curated cleanup behavior: known bad rows can still use Горох replacement or strip-only tails.
- Add a regression test proving a bad uncurated ЕСУМ row falls through to clean Wiktionary data.
- Refresh the Atlas manifest fingerprint sidecar required by the freshness gate.

## Validation

- `ruff check scripts/lexicon/enrich_manifest.py tests/test_esum_garbled_etymologies.py`
- `pytest tests/test_esum_garbled_etymologies.py tests/ingest/test_esum_noise_filters.py tests/etymology/test_recover_latin_cognates.py -q`
- `python scripts/lexicon/check_manifest_freshness.py`
- `python scripts/audit/lint_agent_trailer.py`
- Local Gemini code review returned LGTM; I applied its minor test cleanup suggestion.

## Notes

This intentionally does not introduce a broad Latin-in-Cyrillic classifier. It only reuses the existing curated high-confidence mojibake marker set, matching the caution from #2882.
