### PR TITLE
fix(runtime): use composite silence watchdog

### DIFF
--- a/docs/architecture/adr/adr-009-dispatch-timeout-unification-and-liveness.md
+++ b/docs/architecture/adr/adr-009-dispatch-timeout-unification-and-liveness.md
@@ -84,6 +84,24 @@ scripts/ai_llm/fallback.py                 effective_timeout defaults to _ONE_DA
 - **Monitor**: `/api/delegate/active` already exposes `last_activity` + `started_at` per dispatch. When #1520 Phase 3 lands, this surface extends to probe state.
 - **Revisit trigger**: if a real CLI bug causes a 24h-leak incident, OR if #1520 Phase 2 (watchdog integration) ships, this ADR is candidate for supersede. The next ADR should explain which half of "24h ceiling + composite probe" is authoritative.
 
+## 2026-06-27 amendment (#3875)
+
+User sign-off on 2026-06-27 amends ADR-009 for explicit
+`stdout_silence_timeout` / `--silence-timeout` use. The runtime may kill before
+`hard_timeout` only when the dispatch has no composite watchdog activity within
+the configured silence window.
+
+Composite watchdog activity is ANY of:
+
+- stdout/stderr lines drained by the watchdog;
+- liveness-file mtime changes reported by the adapter;
+- process-tree CPU/disk activity from the agent CLI or descendants.
+
+This is not a return to single-signal stall detection. Stdout silence alone is
+insufficient to kill a dispatch, and merely having a live sleeping process is
+insufficient to keep it alive. The hard timeout remains the wall-clock leak
+guard.
+
 ## History
 
 | Date | Event |
@@ -93,4 +111,5 @@ scripts/ai_llm/fallback.py                 effective_timeout defaults to _ONE_DA
 | 2026-04-24 | `a1/sounds-letters-and-hello` SKELETON fails at 300s; user flags the clock-based design |
 | 2026-04-24 | Architecture discussion on bridge thread `0f94b8c0`; Codex and Gemini converge (after round-2 corrections) on this design |
 | 2026-04-24 | `fa8b4ee0c1` commits the unification; this ADR codifies it |
+| 2026-06-27 | #3875 amends explicit silence timeout to use composite watchdog activity, not stdout alone |
 | TBD | #1520 Phase 2 lands composite probes → this ADR candidate for supersede |

--- a/docs/best-practices/agent-bridge.html
+++ b/docs/best-practices/agent-bridge.html
@@ -233,21 +233,20 @@ delegate worker.</p>
 <h2>Silence-timeout vs hard-timeout</h2>
 <p><code>delegate.py dispatch</code> has two watchdogs with different jobs.
 <code>--hard-timeout</code> is the absolute wall-clock fallback for the worker.
-<code>--silence-timeout</code> is narrower: it kills the agent CLI when no stdout
-line arrives within the configured window, then marks the task
+<code>--silence-timeout</code> is narrower: it kills the agent CLI when no watchdog
+activity arrives within the configured window, then marks the task
 <code>status=&quot;timeout&quot;</code>.</p>
-<p>The default silence timeout is 1800 seconds. This is intentionally
-longer than the old 600-second watchdog because substantive Codex
-dispatches can be quiet for more than 10 minutes during thinking
-phases, multi-file refactors, or long test runs. The #1725
-<code>1725-verbatim-quoting</code> dispatch was killed after 12 minutes of stdout
-silence with most work already complete and the last phase still
-salvageable; that is the failure mode this default avoids.</p>
-<p>Use <code>--silence-timeout 600</code> when you want the tighter 10-minute
-operator watchdog. OAuth or CLI hangs should still show up within
-minutes, while the hard timeout remains the final wall-clock cap.
-Use <code>--silence-timeout 0</code> only when stdout silence is expected and the
-hard timeout alone is acceptable.</p>
+<p>Watchdog activity includes stdout/stderr lines, liveness-file mtime
+updates, and process-tree CPU/disk activity. This keeps quiet but active
+build/test/enrich subprocess phases alive while still killing fully idle
+poll-loop hangs before the hard timeout.</p>
+<p>The default silence timeout is 3600 seconds. Do not lower it merely
+because wrapper stdout is expected to be quiet; that recreates the
+stdout-only false-kill shape from #3875. Use a shorter value only for a
+known protocol where all legitimate work emits frequent watchdog
+activity.</p>
+<p>Use <code>--silence-timeout 0</code> only when the hard timeout alone is acceptable
+and you have another way to detect parked sessions.</p>
 <h2>When to use channels vs <code>ask-*</code></h2>
 <p>| Situation | Use |
 | --- | --- |

--- a/docs/best-practices/agent-bridge.md
+++ b/docs/best-practices/agent-bridge.md
@@ -174,23 +174,23 @@ delegate worker.
 
 `delegate.py dispatch` has two watchdogs with different jobs.
 `--hard-timeout` is the absolute wall-clock fallback for the worker.
-`--silence-timeout` is narrower: it kills the agent CLI when no stdout
-line arrives within the configured window, then marks the task
+`--silence-timeout` is narrower: it kills the agent CLI when no watchdog
+activity arrives within the configured window, then marks the task
 `status="timeout"`.
 
-The default silence timeout is 1800 seconds. This is intentionally
-longer than the old 600-second watchdog because substantive Codex
-dispatches can be quiet for more than 10 minutes during thinking
-phases, multi-file refactors, or long test runs. The #1725
-`1725-verbatim-quoting` dispatch was killed after 12 minutes of stdout
-silence with most work already complete and the last phase still
-salvageable; that is the failure mode this default avoids.
+Watchdog activity includes stdout/stderr lines, liveness-file mtime
+updates, and process-tree CPU/disk activity. This keeps quiet but active
+build/test/enrich subprocess phases alive while still killing fully idle
+poll-loop hangs before the hard timeout.
 
-Use `--silence-timeout 600` when you want the tighter 10-minute
-operator watchdog. OAuth or CLI hangs should still show up within
-minutes, while the hard timeout remains the final wall-clock cap.
-Use `--silence-timeout 0` only when stdout silence is expected and the
-hard timeout alone is acceptable.
+The default silence timeout is 3600 seconds. Do not lower it merely
+because wrapper stdout is expected to be quiet; that recreates the
+stdout-only false-kill shape from #3875. Use a shorter value only for a
+known protocol where all legitimate work emits frequent watchdog
+activity.
+
+Use `--silence-timeout 0` only when the hard timeout alone is acceptable
+and you have another way to detect parked sessions.
 
 ## When to use channels vs `ask-*`
 

--- a/docs/bug-autopsies/codex-dispatch-stall.md
+++ b/docs/bug-autopsies/codex-dispatch-stall.md
@@ -22,16 +22,16 @@ Two compounding causes:
 2. **`--silence-timeout=0` removed the backstop.** The first run (`atlas-finalize-all`) was dispatched with
    `--silence-timeout 0` (the brief said "long + silent by nature"), so the runtime never killed the silent
    poll-loop — it ran ~75 min until the hard timeout. The later two runs used a non-zero
-   `--silence-timeout 2700`, which **caught the stall cleanly** (`status: timeout` after 45 min idle) because
-   codex's wrapper-stdout IS silent during the hang.
+   `--silence-timeout 2700`, which **caught the stall cleanly** (`status: timeout` after 45 min idle).
 
 A secondary failure mode: while working the pre-submit checklist, codex **over-reaches** — `kaikki-ipa-etym-wiring`
 "helpfully" rewrote `sys.executable → .venv/bin/python` in **5 unrelated test files** to satisfy the
 "no `sys.executable`" checklist item, violating "every changed file is directly related to the task."
 
 ## Prevention
-- **Always set a non-zero `--silence-timeout`** on long codex dispatches (e.g. 2700s). Codex's wrapper-stdout
-  is silent during the poll-loop hang, so the silence timeout is the reliable catch. Never `--silence-timeout 0`.
+- **Keep a non-zero `--silence-timeout`** on long codex dispatches. Since #3875 it keys off composite watchdog
+  activity, not stdout alone, so active child subprocesses stay alive while a parked poll-loop still times out.
+  Use `--silence-timeout 0` only when hard-timeout-only behavior is intentional and separately monitored.
 - **Brief instruction:** tell codex to run regenerations as FOREGROUND blocking commands with an explicit
   `timeout`, NOT in a backgrounded interactive shell it polls.
 - **Finalize-the-zombie** (orchestrator playbook when a codex dispatch reads `running` but pid is dead /

--- a/docs/decisions/2026-06-14-autonomous-codex-dispatch-narrow-class.md
+++ b/docs/decisions/2026-06-14-autonomous-codex-dispatch-narrow-class.md
@@ -97,7 +97,7 @@ Reasoning:
 
 1. Poller sees label.
 2. Generates brief from issue body using a fixed template (cwd warning, numbered steps, evidence requirements, anti-fabrication preamble per `deterministic-over-hallucination.md`).
-3. Dispatches Codex with `--mode danger --worktree --silence-timeout 1800`.
+3. Dispatches Codex with `--mode danger --worktree --silence-timeout 3600`.
 4. Codex works to completion, pushes branch, opens PR, comments on the issue.
 5. Poller reconciles: if PR has `symphony` label and CI green → auto-merge after 24h (or human-merge if I'm awake).
 6. If CI red or stalls → marks issue with `agent:codex-needs-orchestrator`, removes auto-label, re-queues for human attention.

--- a/scripts/agent_runtime/errors.py
+++ b/scripts/agent_runtime/errors.py
@@ -60,8 +60,9 @@ class AgentTimeoutError(AgentRuntimeError):
 class AgentStalledError(AgentRuntimeError):
     """Agent produced no activity for longer than ``stall_timeout``.
 
-    Distinct from AgentTimeoutError. Raised when the last observed activity
-    (stdout line OR liveness file mtime bump) is older than ``stall_timeout``.
+    Distinct from AgentTimeoutError. Raised when the last observed activity is
+    older than ``stall_timeout``. Activity includes watchdog-observed
+    stdout/stderr, liveness files, and process-tree CPU/disk work.
     The agent might have been alive earlier but is now genuinely stuck —
     waiting for input, deadlocked, or the provider dropped the connection.
 

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -1005,6 +1005,9 @@ def _execute_invocation_plan(
             list(liveness_paths),
             stdout_master_fd=stdout_master_fd,
             stderr_master_fd=stderr_master_fd,
+            track_process_activity=bool(
+                stdout_silence_timeout is not None and stdout_silence_timeout > 0
+            ),
         )
         mcp_observer = _McpRuntimeObserver.from_tool_config(
             agent_name=agent_name,
@@ -1659,13 +1662,14 @@ def invoke(
             successful long-running calls were killed as false-positive
             stalls. See watchdog.py::should_kill() docstring for the
             full incident chain. hard_timeout is the only safety net now.
-        stdout_silence_timeout: Optional per-call stdout silence watchdog in
-            seconds. Disabled by default. Use only for protocols where stdout
-            bytes are the authoritative liveness signal.
+        stdout_silence_timeout: Optional per-call composite silence watchdog in
+            seconds. Disabled by default. Uses stdout/stderr, liveness-file
+            updates, and process-tree CPU/disk activity.
         initial_response_timeout: Optional startup probe in seconds. When set,
             the runtime kills the subprocess if it produces no stdout/stderr
             or liveness-file activity within this window (#2071). Distinct
-            from ``stdout_silence_timeout``, which only watches stdout lines.
+            from ``stdout_silence_timeout``, which watches composite activity
+            after startup.
         event_sink: Optional ``event_sink(event_name, **fields)`` callback for
             dispatch JSONL observability events.
         effort: Cross-agent reasoning/effort level. First-class peer of

--- a/scripts/agent_runtime/watchdog.py
+++ b/scripts/agent_runtime/watchdog.py
@@ -13,18 +13,19 @@ string of production incidents. The module now does three things:
 
 2. **Liveness-file mtime poller** — updates
    ``WatchdogState.last_activity`` for observability (emitted into
-   usage records) but never drives kill decisions. Stall detection
-   as a kill condition was unreliable because every CLI version
-   bump broke a different mtime signal; see ``should_kill`` for
-   the full story.
+   usage records) and to suppress explicitly requested silence kills.
 
-3. **Hard-timeout kill** — the default kill condition.
+3. **Process-tree activity poller** — updates ``last_activity`` while the
+   agent CLI or descendants are measurably doing CPU/disk work. This prevents
+   stdout-only false kills during quiet build/test/enrich subprocess phases.
+
+4. **Hard-timeout kill** — the default kill condition.
    Triggers ``AgentTimeoutError`` when ``now - start_time >
    hard_timeout``. Default hard_timeout is 1h.
 
-Callers may opt in to a separate stdout-silence timeout for workflows where
-the stdout pipe is the protocol liveness signal. It remains disabled by
-default so normal agent dispatch keeps ADR-009's hard-timeout behavior.
+Callers may opt in to a separate silence timeout. It now keys off composite
+watchdog activity (stdout/stderr, liveness-file mtime, process-tree CPU/disk
+activity), not stdout alone.
 
 Issue: #1184
 """
@@ -41,10 +42,18 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import psutil
+
 # Poll interval for the mtime fallback thread. 5s is a good balance — fast
 # enough to extend the stall clock promptly, slow enough that the overhead
 # is negligible (at most 5 stat calls per 5s = ~1 per second).
 _MTIME_POLL_INTERVAL_S = 5.0
+
+# Optional silence-timeout backstop should not fire while the subprocess tree is
+# demonstrably doing work. Poll slowly; stdout/stderr/liveness file events remain
+# the primary cheap signals.
+_PROCESS_ACTIVITY_POLL_INTERVAL_S = 5.0
+_PROCESS_ACTIVITY_MIN_CPU_SECONDS = 0.05
 
 # Maximum number of liveness paths to poll. Adapters returning more than
 # this many paths will only have the first _MAX_LIVENESS_PATHS polled.
@@ -80,10 +89,11 @@ class WatchdogState:
     Fields:
         start_time: monotonic timestamp when the subprocess was spawned.
         last_activity: monotonic timestamp of the most recent observed
-            activity (stdout line or liveness file mtime bump).
+            activity (stdout/stderr line, liveness file mtime bump, or
+            process-tree CPU/disk activity).
         last_stdout_activity: monotonic timestamp of the most recent stdout
-            line. Unlike ``last_activity``, stderr and liveness files never
-            update this field.
+            line. Unlike ``last_activity``, stderr, liveness files, and
+            process-tree activity never update this field.
         stop: Set to True by the main thread when the watchdog should exit.
         stdout_lines: Accumulated stdout lines captured by the streamer.
             The runner reads this on normal termination to build the final
@@ -281,12 +291,122 @@ def _mtime_poller(paths: Iterable[Path], state: WatchdogState) -> None:
                 baseline_mtimes[p] = current
 
 
+def _process_io_snapshot(process: psutil.Process) -> tuple[int, int, int, int] | None:
+    """Return cheap cumulative I/O counters when the platform exposes them."""
+    try:
+        counters = process.io_counters()
+    except (AttributeError, NotImplementedError, psutil.Error):
+        return None
+    return (
+        int(getattr(counters, "read_count", 0)),
+        int(getattr(counters, "write_count", 0)),
+        int(getattr(counters, "read_bytes", 0)),
+        int(getattr(counters, "write_bytes", 0)),
+    )
+
+
+def _process_cpu_seconds(process: psutil.Process) -> float | None:
+    """Return cumulative user+system CPU seconds for one process."""
+    try:
+        cpu_times = process.cpu_times()
+    except (AttributeError, psutil.Error):
+        return None
+    return float(getattr(cpu_times, "user", 0.0)) + float(
+        getattr(cpu_times, "system", 0.0)
+    )
+
+
+def _process_tree_has_activity(
+    proc: subprocess.Popen,
+    primed_pids: set[int],
+    cpu_baselines: dict[int, float],
+    io_baselines: dict[int, tuple[int, int, int, int]],
+) -> bool:
+    """Return True when proc or descendants are measurably doing CPU/disk work."""
+    try:
+        root = psutil.Process(proc.pid)
+        processes = [root, *root.children(recursive=True)]
+    except psutil.Error:
+        return False
+
+    active = False
+    for process in processes:
+        try:
+            cpu_seconds = _process_cpu_seconds(process)
+            io_snapshot = _process_io_snapshot(process)
+        except psutil.Error:
+            continue
+
+        if process.pid not in primed_pids:
+            primed_pids.add(process.pid)
+            if cpu_seconds is not None:
+                cpu_baselines[process.pid] = cpu_seconds
+            if io_snapshot is not None:
+                io_baselines[process.pid] = io_snapshot
+            continue
+
+        if cpu_seconds is not None:
+            previous_cpu = cpu_baselines.get(process.pid)
+            cpu_baselines[process.pid] = cpu_seconds
+            if (
+                previous_cpu is not None
+                and cpu_seconds - previous_cpu >= _PROCESS_ACTIVITY_MIN_CPU_SECONDS
+            ):
+                active = True
+
+        if io_snapshot is not None:
+            previous = io_baselines.get(process.pid)
+            io_baselines[process.pid] = io_snapshot
+            if previous is not None and io_snapshot != previous:
+                active = True
+
+    live_pids = {process.pid for process in processes}
+    primed_pids.intersection_update(live_pids)
+    for pid in list(cpu_baselines):
+        if pid not in live_pids:
+            cpu_baselines.pop(pid, None)
+    for pid in list(io_baselines):
+        if pid not in live_pids:
+            io_baselines.pop(pid, None)
+
+    return active
+
+
+def _sleep_until_stop(state: WatchdogState, duration_s: float) -> None:
+    deadline = time.monotonic() + duration_s
+    while not state.stop:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        time.sleep(min(0.1, remaining))
+
+
+def _process_activity_poller(proc: subprocess.Popen, state: WatchdogState) -> None:
+    """Refresh last_activity while the subprocess tree is doing CPU/disk work."""
+    primed_pids: set[int] = set()
+    cpu_baselines: dict[int, float] = {}
+    io_baselines: dict[int, tuple[int, int, int, int]] = {}
+
+    while not state.stop:
+        if proc.poll() is not None:
+            return
+        if _process_tree_has_activity(
+            proc,
+            primed_pids,
+            cpu_baselines,
+            io_baselines,
+        ):
+            state.last_activity = time.monotonic()
+        _sleep_until_stop(state, _PROCESS_ACTIVITY_POLL_INTERVAL_S)
+
+
 def start_watchdog(
     proc: subprocess.Popen,
     liveness_paths: Iterable[Path] = (),
     *,
     stdout_master_fd: int | None = None,
     stderr_master_fd: int | None = None,
+    track_process_activity: bool = False,
 ) -> tuple[WatchdogState, list[threading.Thread]]:
     """Start the stdout streamer + mtime poller threads for a running subprocess.
 
@@ -301,6 +421,8 @@ def start_watchdog(
             ``_spawn_pty_subprocess`` in runner.py (#2071).
         stderr_master_fd: PTY master fd for the child's stderr. Same
             semantics as ``stdout_master_fd``.
+        track_process_activity: When True, poll process-tree CPU/disk activity
+            and refresh ``last_activity`` while the process tree is doing work.
 
     When the fd kwargs are ``None`` the watchdog falls back to the
     legacy pipe-mode streamers — exercised by the ``DELEGATE_DISABLE_PTY``
@@ -375,6 +497,19 @@ def start_watchdog(
         )
         t_mtime.start()
         threads.append(t_mtime)
+
+    if track_process_activity:
+        # Layer 3: process-tree activity poller. This only keeps an explicit
+        # silence timeout alive while the agent CLI or its children are actually
+        # doing CPU/disk work; mere process existence still times out.
+        t_process = threading.Thread(
+            target=_process_activity_poller,
+            args=(proc, state),
+            name=f"watchdog-process-{proc.pid}",
+            daemon=True,
+        )
+        t_process.start()
+        threads.append(t_process)
 
     return state, threads
 
@@ -466,8 +601,9 @@ def should_kill(
         "initial_response_timeout" if the caller enabled startup probing and
         the subprocess produced no stdout/stderr/liveness activity within that
         window (#2071 startup hangs with response_chars=0).
-        "stdout_silence_timeout" if the caller explicitly enabled stdout
-        silence detection and no stdout line has arrived within that window.
+        "stdout_silence_timeout" if the caller explicitly enabled silence
+        detection and no stdout/stderr/liveness/process-tree activity has
+        arrived within that window.
 
     ``stall_timeout`` is accepted for backward compatibility with callers but
     is NOT used as a kill condition. Deleting stall detection from the kill
@@ -488,11 +624,11 @@ def should_kill(
        place with a different convention, and tracking each one
        individually is whack-a-mole with no ground truth.
 
-    The mtime poller still runs for observability (via the WatchdogState
-    last_activity field, which the runner reads for usage records), but
-    the kill decision now relies solely on hard_timeout as the safety net.
-    A legitimately long-running task will be allowed to complete; a truly
-    runaway process still gets killed by hard_timeout.
+    Mtime and process-tree pollers are allowed to suppress an explicitly
+    requested silence timeout because that timeout is a hang backstop, not a
+    stdout-only productivity heuristic. This preserves ADR-009's "no single
+    fragile signal kills productive work" rule while still catching fully quiet
+    hangs before hard_timeout.
 
     See #1184 for the full incident chain.
     """
@@ -510,7 +646,7 @@ def should_kill(
     if (
         stdout_silence_timeout is not None
         and stdout_silence_timeout > 0
-        and (now - state.last_stdout_activity) > stdout_silence_timeout
+        and (now - state.last_activity) > stdout_silence_timeout
     ):
         return "stdout_silence_timeout"
     return None

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -165,13 +165,10 @@ def _inject_gh_token_for_agent(worker_env: dict[str, str], agent: str) -> None:
 
 
 DEFAULT_HARD_TIMEOUT_S = 7200
-# Bumped 1800 -> 3600 on 2026-05-18 after kubedojo-artifacts Codex dispatch
-# timed out at exactly 1800s with worktree_dirty_on_exit=true and
-# response_chars=0 — i.e. the agent was actively making file changes but
-# its stream-json output was block-buffered by libc (non-TTY stdout) and
-# never reached the watchdog. Until #2071 PTY-wrapping lands, the looser
-# silence window is the stopgap. See watchdog.py:323-332 for the historical
-# Gemini block-buffering incident chain (#1184).
+# Silence timeout is a composite hang backstop: stdout/stderr, liveness-file
+# updates, and process-tree CPU/disk activity all keep it alive. Do not lower it
+# for build/test/enrich jobs merely because wrapper stdout is expected to be
+# quiet; that recreates the false-kill shape from #3875.
 DEFAULT_SILENCE_TIMEOUT_S = 3600
 # Fail fast when Codex (or any agent) never produces stdout/stderr/liveness
 # activity at startup — distinct from the long silence window above (#2071).
@@ -2071,8 +2068,8 @@ def build_parser() -> argparse.ArgumentParser:
             "  Persists task state under batch_state/tasks/ and streams worker output to task-owned logs.\n\n"
             "Timeouts:\n"
             "  --hard-timeout is the absolute wall-clock fallback for the worker.\n"
-            "  --silence-timeout kills the agent CLI earlier when no stdout line arrives within the window.\n"
-            "    Default is 1800s to tolerate long Codex thinking/test phases; pass 600 for a tighter watchdog; 0 disables it.\n\n"
+            "  --silence-timeout kills the agent CLI earlier when no watchdog activity arrives within the window.\n"
+            f"    Default is {DEFAULT_SILENCE_TIMEOUT_S}s to tolerate quiet build/test phases; 0 disables it.\n\n"
             "  --max-budget-usd caps Claude Code API spend for this dispatch when set; omitted means no dollar cap.\n\n"
             "Exit codes:\n"
             "  0 on successful command completion; non-zero on CLI misuse or worker/task failures.\n\n"
@@ -2196,11 +2193,11 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="SECS",
         default=DEFAULT_SILENCE_TIMEOUT_S,
         help=(
-            "Seconds without a subprocess stdout line before killing the agent "
+            "Seconds without subprocess watchdog activity before killing the agent "
             "CLI and marking the task status='timeout' "
             f"(default: {DEFAULT_SILENCE_TIMEOUT_S}s; 0 disables). "
-            "The default tolerates long Codex thinking/test phases; pass 600 "
-            "for a tighter watchdog. --hard-timeout still applies as the "
+            "Watchdog activity includes stdout/stderr, liveness-file updates, "
+            "and process-tree CPU/disk activity. --hard-timeout still applies as the "
             "absolute wall-clock fallback."
         ),
     )
@@ -2213,8 +2210,8 @@ def build_parser() -> argparse.ArgumentParser:
             "Startup probe: kill the agent CLI if it produces no "
             "stdout/stderr/liveness activity within this many seconds "
             f"(default: {DEFAULT_INITIAL_RESPONSE_TIMEOUT_S}; 0 disables). "
-            "Distinct from --silence-timeout, which only watches stdout "
-            "lines after startup (#2071)."
+            "Distinct from --silence-timeout, which watches composite "
+            "activity after startup (#2071, #3875)."
         ),
     )
     d.add_argument(

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -23,6 +23,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -120,6 +121,7 @@ from agent_runtime.runner import (
 from agent_runtime.usage import _reset_rate_limit_cache_for_tests
 from agent_runtime.watchdog import (
     WatchdogState,
+    _process_tree_has_activity,
     should_kill,
     start_watchdog,
     stop_watchdog,
@@ -2174,6 +2176,90 @@ def test_should_kill_detects_hard_timeout():
     state = WatchdogState(start_time=now - 4000, last_activity=now)
     # Started 4000s ago, hard_timeout 3600s → hard_timeout
     assert should_kill(state, stall_timeout=180, hard_timeout=3600) == "hard_timeout"
+
+
+def test_should_kill_silence_timeout_accepts_liveness_activity():
+    """Silence timeout is a hang backstop, not a stdout-only heuristic."""
+    now = time.monotonic()
+    state = WatchdogState(
+        start_time=now - 2400,
+        last_activity=now,
+        last_stdout_activity=now - 2400,
+    )
+
+    assert (
+        should_kill(
+            state,
+            stall_timeout=180,
+            hard_timeout=3600,
+            stdout_silence_timeout=1800,
+        )
+        is None
+    )
+
+
+def test_should_kill_silence_timeout_kills_fully_silent_process():
+    now = time.monotonic()
+    state = WatchdogState(
+        start_time=now - 2400,
+        last_activity=now - 2400,
+        last_stdout_activity=now - 2400,
+    )
+
+    assert (
+        should_kill(
+            state,
+            stall_timeout=180,
+            hard_timeout=3600,
+            stdout_silence_timeout=1800,
+        )
+        == "stdout_silence_timeout"
+    )
+
+
+def test_process_tree_has_activity_tracks_descendant_cpu(monkeypatch):
+    """CPU baselines survive fresh psutil.Process wrappers across polls."""
+
+    class FakeProcess:
+        def __init__(self, pid, cpu_seconds, children=()):
+            self.pid = pid
+            self._cpu_seconds = cpu_seconds
+            self._children = list(children)
+
+        def cpu_times(self):
+            return SimpleNamespace(user=self._cpu_seconds, system=0.0)
+
+        def io_counters(self):
+            raise AttributeError("not available on this platform")
+
+        def children(self, recursive=False):
+            assert recursive is True
+            return list(self._children)
+
+    import agent_runtime.watchdog as watchdog_module
+
+    samples = iter([(0.0, 0.0), (0.0, 0.10)])
+
+    def fake_process(_pid):
+        root_cpu, child_cpu = next(samples)
+        child = FakeProcess(pid=456, cpu_seconds=child_cpu)
+        return FakeProcess(pid=123, cpu_seconds=root_cpu, children=[child])
+
+    monkeypatch.setattr(watchdog_module.psutil, "Process", fake_process)
+
+    primed_pids: set[int] = set()
+    cpu_baselines: dict[int, float] = {}
+    io_baselines: dict[int, tuple[int, int, int, int]] = {}
+    proc = SimpleNamespace(pid=123)
+
+    assert (
+        _process_tree_has_activity(proc, primed_pids, cpu_baselines, io_baselines)
+        is False
+    )
+    assert (
+        _process_tree_has_activity(proc, primed_pids, cpu_baselines, io_baselines)
+        is True
+    )
 
 
 def test_tail_liveness_skips_binary_sqlite(tmp_path):

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -167,7 +167,7 @@ def test_dispatch_help_documents_timeout_interaction(capsys):
     assert "--hard-timeout" in captured.out
     assert "--silence-timeout" in captured.out
     assert "3600s" in captured.out
-    assert "pass 600" in captured.out
+    assert "watchdog activity" in captured.out
     assert "fallback" in captured.out
     assert "0 disables" in captured.out
 


### PR DESCRIPTION
## Summary
- Make explicit silence timeout use composite watchdog activity instead of stdout-only silence.
- Add process-tree CPU/disk activity tracking for quiet child subprocess phases.
- Amend ADR-009 and refresh operator guidance for #3875.

## Review
- Local Gemini review found the psutil cpu_percent re-instantiation bug; challenge round kept all findings.
- Fixed by switching to cumulative cpu_times baselines and updating the regression test to recreate psutil wrappers.
- Gemini re-review was attempted after the fix but the Gemini CLI returned an IneligibleTierError.

## Validation
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check --fix scripts/agent_runtime/errors.py scripts/agent_runtime/runner.py scripts/agent_runtime/watchdog.py scripts/delegate.py tests/test_agent_runtime.py tests/test_delegate.py
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_agent_runtime.py tests/test_delegate.py tests/agent_runtime/test_pty_subprocess_wrap.py
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py
- git diff --check origin/main..HEAD
- pre-commit hook on commit and push passed