### PR TITLE
fix(atlas): retry stale manifest release downloads

### DIFF
--- a/scripts/lexicon/manifest_io.py
+++ b/scripts/lexicon/manifest_io.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import gzip
 import hashlib
+import http.client
 import json
 import os
+import urllib.error
+import urllib.parse
 import urllib.request
 from contextlib import suppress
 from pathlib import Path
@@ -26,6 +29,7 @@ REQUIRED_POINTER_KEYS = (
     "gz_bytes",
     "json_bytes",
 )
+DOWNLOAD_ATTEMPTS = 3
 
 
 def _sha256(data: bytes) -> str:
@@ -75,21 +79,67 @@ def _write_atomic(path: Path, data: bytes) -> None:
             tmp_path.unlink()
 
 
-def _download(pointer: dict[str, Any]) -> bytes:
-    with urllib.request.urlopen(pointer["asset_url"], timeout=60) as response:
+def _download_url(pointer: dict[str, Any], attempt: int) -> str:
+    asset_url = pointer["asset_url"]
+    if attempt == 0:
+        return asset_url
+
+    split = urllib.parse.urlsplit(asset_url)
+    query = urllib.parse.parse_qsl(split.query, keep_blank_values=True)
+    query.extend(
+        [
+            ("atlas_manifest_sha256", pointer["gz_sha256"]),
+            ("atlas_manifest_attempt", str(attempt)),
+        ]
+    )
+    return urllib.parse.urlunsplit(split._replace(query=urllib.parse.urlencode(query)))
+
+
+def _download(pointer: dict[str, Any], *, attempt: int = 0) -> bytes:
+    request = urllib.request.Request(
+        _download_url(pointer, attempt),
+        headers={
+            "Accept": "application/gzip, application/octet-stream;q=0.9, */*;q=0.1",
+            "Cache-Control": "no-cache",
+            "Pragma": "no-cache",
+            "User-Agent": "learn-ukrainian-atlas-manifest-hydrate/1.0",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
         return response.read()
 
 
 def _hydrate(path: Path, pointer: dict[str, Any]) -> dict[str, Any]:
-    gz_bytes = _download(pointer)
-    gz_sha = _sha256(gz_bytes)
-    if gz_sha != pointer["gz_sha256"]:
+    gz_bytes: bytes | None = None
+    gz_sha = ""
+    last_error: BaseException | None = None
+    last_failure = ""
+    for attempt in range(DOWNLOAD_ATTEMPTS):
+        try:
+            gz_bytes = _download(pointer, attempt=attempt)
+        except (OSError, urllib.error.URLError, http.client.HTTPException) as exc:
+            last_error = exc
+            last_failure = "error"
+            continue
+        gz_sha = _sha256(gz_bytes)
+        if gz_sha == pointer["gz_sha256"]:
+            break
+        last_failure = "mismatch"
+    else:
+        if last_error is not None and last_failure == "error":
+            raise ValueError(
+                "failed to download Atlas manifest release asset "
+                f"after {DOWNLOAD_ATTEMPTS} attempts: {last_error}. "
+                f"Manual recovery command: {RECOVERY_COMMAND}"
+            ) from last_error
         raise ValueError(
             "gz sha256 mismatch: "
-            f"expected {pointer['gz_sha256']}, got {gz_sha}. "
+            f"expected {pointer['gz_sha256']}, got {gz_sha} "
+            f"after {DOWNLOAD_ATTEMPTS} download attempts. "
             f"Manual recovery command: {RECOVERY_COMMAND}"
         )
 
+    assert gz_bytes is not None
     json_bytes = gzip.decompress(gz_bytes)
     json_sha = _sha256(json_bytes)
     if json_sha != pointer["json_sha256"]:

--- a/site/scripts/hydrate-manifest.mjs
+++ b/site/scripts/hydrate-manifest.mjs
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { gunzipSync } from "node:zlib";
 
 const RECOVERY_COMMAND =
@@ -27,6 +27,7 @@ const fingerprintPath = resolve(repoRoot, "site/src/data/lexicon-manifest.finger
 const manifestPath = resolve(repoRoot, "site/src/data/lexicon-manifest.json");
 const tempPath = `${manifestPath}.tmp`;
 const allowStalePointer = process.env.ATLAS_MANIFEST_ALLOW_STALE_POINTER === "1";
+const DOWNLOAD_ATTEMPTS = 3;
 
 function sha256(data) {
   return createHash("sha256").update(data).digest("hex");
@@ -100,6 +101,58 @@ function parseManifest(jsonBytes, pointer, sourceLabel) {
   return manifest;
 }
 
+function downloadUrl(pointer, attempt) {
+  if (attempt === 0) return pointer.asset_url;
+
+  const url = new URL(pointer.asset_url);
+  url.searchParams.set("atlas_manifest_sha256", pointer.gz_sha256);
+  url.searchParams.set("atlas_manifest_attempt", String(attempt));
+  return url.toString();
+}
+
+async function downloadGzip(pointer) {
+  let gzBytes = null;
+  let actualGzSha = "";
+  let lastError = null;
+  let lastFailure = "";
+
+  for (let attempt = 0; attempt < DOWNLOAD_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await fetch(downloadUrl(pointer, attempt), {
+        cache: "no-store",
+        headers: {
+          Accept: "application/gzip, application/octet-stream;q=0.9, */*;q=0.1",
+          "Cache-Control": "no-cache",
+          Pragma: "no-cache",
+          "User-Agent": "learn-ukrainian-atlas-manifest-hydrate/1.0",
+        },
+      });
+      if (!response.ok) {
+        throw new Error(`fetch failed: ${response.status} ${response.statusText}`);
+      }
+
+      gzBytes = Buffer.from(await response.arrayBuffer());
+      actualGzSha = sha256(gzBytes);
+      if (actualGzSha === pointer.gz_sha256) return gzBytes;
+      lastFailure = "mismatch";
+    } catch (error) {
+      lastError = error;
+      lastFailure = "error";
+    }
+  }
+
+  if (lastError !== null && lastFailure === "error") {
+    const message = lastError instanceof Error ? lastError.message : String(lastError);
+    throw new Error(
+      `failed to download Atlas manifest release asset after ${DOWNLOAD_ATTEMPTS} attempts: ${message}\n${recoveryMessage()}`,
+    );
+  }
+
+  throw new Error(
+    `gz sha mismatch: expected ${pointer.gz_sha256}, got ${actualGzSha} after ${DOWNLOAD_ATTEMPTS} download attempts`,
+  );
+}
+
 async function alreadyHydrated(pointer) {
   if (!existsSync(manifestPath)) return false;
 
@@ -119,16 +172,7 @@ async function hydrate() {
     return;
   }
 
-  const response = await fetch(pointer.asset_url);
-  if (!response.ok) {
-    throw new Error(`fetch failed: ${response.status} ${response.statusText}\n${recoveryMessage()}`);
-  }
-
-  const gzBytes = Buffer.from(await response.arrayBuffer());
-  const actualGzSha = sha256(gzBytes);
-  if (actualGzSha !== pointer.gz_sha256) {
-    throw new Error(`gz sha mismatch: expected ${pointer.gz_sha256}, got ${actualGzSha}`);
-  }
+  const gzBytes = await downloadGzip(pointer);
   if (gzBytes.length !== pointer.gz_bytes) {
     throw new Error(`gz size mismatch: expected ${pointer.gz_bytes}, got ${gzBytes.length}`);
   }
@@ -148,8 +192,12 @@ async function hydrate() {
   console.log(`✓ hydrated manifest ${mb(jsonBytes.length)} from ${mb(gzBytes.length)} release asset`);
 }
 
-hydrate().catch(async (error) => {
-  await unlink(tempPath).catch(() => {});
-  console.error(`Failed to hydrate lexicon manifest: ${error.message}`);
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  hydrate().catch(async (error) => {
+    await unlink(tempPath).catch(() => {});
+    console.error(`Failed to hydrate lexicon manifest: ${error.message}`);
+    process.exit(1);
+  });
+}
+
+export { downloadGzip, downloadUrl };

--- a/site/tests/unit/hydrate-manifest.test.ts
+++ b/site/tests/unit/hydrate-manifest.test.ts
@@ -1,0 +1,95 @@
+import { createHash } from 'node:crypto';
+import { gzipSync } from 'node:zlib';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { downloadGzip, downloadUrl } from '../../scripts/hydrate-manifest.mjs';
+
+function sha256(data: Buffer): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+function pointerFor(gzBytes: Buffer) {
+  return {
+    asset_url: 'https://example.test/lexicon-manifest.json.gz',
+    gz_sha256: sha256(gzBytes),
+  };
+}
+
+function okResponse(gzBytes: Buffer) {
+  return {
+    ok: true,
+    arrayBuffer: async () =>
+      gzBytes.buffer.slice(gzBytes.byteOffset, gzBytes.byteOffset + gzBytes.byteLength),
+  };
+}
+
+describe('hydrate manifest release download', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('adds deterministic cache-busting query parameters after first attempt', () => {
+    const gzBytes = gzipSync(Buffer.from('{"entries":[]}'));
+    const pointer = pointerFor(gzBytes);
+
+    expect(downloadUrl(pointer, 0)).toBe('https://example.test/lexicon-manifest.json.gz');
+    expect(downloadUrl(pointer, 1)).toBe(
+      `https://example.test/lexicon-manifest.json.gz?atlas_manifest_sha256=${sha256(
+        gzBytes,
+      )}&atlas_manifest_attempt=1`,
+    );
+  });
+
+  test('retries stale gzip responses with cache-busting URL', async () => {
+    const gzBytes = gzipSync(Buffer.from('{"entries":[{"lemma":"новий"}]}'));
+    const staleGzBytes = gzipSync(Buffer.from('{"entries":[{"lemma":"старий"}]}'));
+    const pointer = pointerFor(gzBytes);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(okResponse(staleGzBytes))
+      .mockResolvedValueOnce(okResponse(gzBytes));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(downloadGzip(pointer)).resolves.toEqual(gzBytes);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('atlas_manifest_sha256='),
+      expect.objectContaining({ cache: 'no-store' }),
+    );
+  });
+
+  test('retries transient fetch failures with cache-busting URL', async () => {
+    const gzBytes = gzipSync(Buffer.from('{"entries":[{"lemma":"мережа"}]}'));
+    const pointer = pointerFor(gzBytes);
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('temporary edge failure'))
+      .mockResolvedValueOnce(okResponse(gzBytes));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(downloadGzip(pointer)).resolves.toEqual(gzBytes);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('atlas_manifest_attempt=1'),
+      expect.objectContaining({ cache: 'no-store' }),
+    );
+  });
+
+  test('reports final fetch failure after prior stale gzip response', async () => {
+    const gzBytes = gzipSync(Buffer.from('{"entries":[{"lemma":"збій"}]}'));
+    const staleGzBytes = gzipSync(Buffer.from('{"entries":[{"lemma":"старий"}]}'));
+    const pointer = pointerFor(gzBytes);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(okResponse(staleGzBytes))
+      .mockRejectedValueOnce(new Error('temporary edge failure'))
+      .mockRejectedValueOnce(new Error('late edge failure'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(downloadGzip(pointer)).rejects.toThrow(
+      'failed to download Atlas manifest release asset after 3 attempts: late edge failure',
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/test_manifest_io.py
+++ b/tests/test_manifest_io.py
@@ -47,6 +47,10 @@ def _pin_defaults(monkeypatch: pytest.MonkeyPatch, manifest_path: Path, pointer_
     monkeypatch.setattr(manifest_io, "DEFAULT_POINTER", pointer_path)
 
 
+def _request_url(request: object) -> str:
+    return getattr(request, "full_url", str(request))
+
+
 def test_load_manifest_returns_matching_local_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     payload = {"entries": [{"lemma": "дім"}], "enrichment_generated": True}
     json_bytes = _json_bytes(payload)
@@ -77,8 +81,8 @@ def test_load_manifest_fetches_decompresses_and_writes_when_absent(
     _write_pointer(pointer_path, json_bytes=json_bytes, gz_bytes=gz_bytes)
     _pin_defaults(monkeypatch, manifest_path, pointer_path)
 
-    def fake_urlopen(url: str, timeout: int):
-        assert url == "https://example.test/lexicon-manifest.json.gz"
+    def fake_urlopen(request: object, timeout: int):
+        assert _request_url(request) == "https://example.test/lexicon-manifest.json.gz"
         assert timeout == 60
         return io.BytesIO(gz_bytes)
 
@@ -100,7 +104,7 @@ def test_load_manifest_raises_on_gz_sha256_mismatch(
     _write_pointer(pointer_path, json_bytes=json_bytes, gz_bytes=gz_bytes, gz_sha256="0" * 64)
     _pin_defaults(monkeypatch, manifest_path, pointer_path)
 
-    def fake_urlopen(url: str, timeout: int):
+    def fake_urlopen(request: object, timeout: int):
         return io.BytesIO(gz_bytes)
 
     monkeypatch.setattr(manifest_io.urllib.request, "urlopen", fake_urlopen)
@@ -109,4 +113,97 @@ def test_load_manifest_raises_on_gz_sha256_mismatch(
         manifest_io.load_manifest(path=manifest_path)
 
     assert "gh release download atlas-manifest" in str(excinfo.value)
+    assert not manifest_path.exists()
+
+
+def test_load_manifest_retries_gz_sha256_mismatch_with_cache_bust(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {"entries": [{"lemma": "повтор"}], "enrichment_generated": True}
+    json_bytes = _json_bytes(payload)
+    gz_bytes = gzip.compress(json_bytes)
+    stale_gz_bytes = gzip.compress(_json_bytes({"entries": [{"lemma": "старий"}]}))
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    pointer_path = tmp_path / "lexicon-manifest.pointer.json"
+    _write_pointer(pointer_path, json_bytes=json_bytes, gz_bytes=gz_bytes)
+    _pin_defaults(monkeypatch, manifest_path, pointer_path)
+    urls: list[str] = []
+
+    def fake_urlopen(request: object, timeout: int):
+        assert timeout == 60
+        urls.append(_request_url(request))
+        return io.BytesIO(stale_gz_bytes if len(urls) == 1 else gz_bytes)
+
+    monkeypatch.setattr(manifest_io.urllib.request, "urlopen", fake_urlopen)
+
+    assert manifest_io.load_manifest(path=manifest_path) == payload
+    assert manifest_path.read_bytes() == json_bytes
+    assert urls == [
+        "https://example.test/lexicon-manifest.json.gz",
+        (
+            "https://example.test/lexicon-manifest.json.gz"
+            f"?atlas_manifest_sha256={_sha256(gz_bytes)}&atlas_manifest_attempt=1"
+        ),
+    ]
+
+
+def test_load_manifest_retries_transient_download_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {"entries": [{"lemma": "мережа"}], "enrichment_generated": True}
+    json_bytes = _json_bytes(payload)
+    gz_bytes = gzip.compress(json_bytes)
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    pointer_path = tmp_path / "lexicon-manifest.pointer.json"
+    _write_pointer(pointer_path, json_bytes=json_bytes, gz_bytes=gz_bytes)
+    _pin_defaults(monkeypatch, manifest_path, pointer_path)
+    urls: list[str] = []
+
+    def fake_urlopen(request: object, timeout: int):
+        assert timeout == 60
+        urls.append(_request_url(request))
+        if len(urls) == 1:
+            raise manifest_io.urllib.error.URLError("temporary release edge failure")
+        return io.BytesIO(gz_bytes)
+
+    monkeypatch.setattr(manifest_io.urllib.request, "urlopen", fake_urlopen)
+
+    assert manifest_io.load_manifest(path=manifest_path) == payload
+    assert manifest_path.read_bytes() == json_bytes
+    assert urls[1] == (
+        "https://example.test/lexicon-manifest.json.gz"
+        f"?atlas_manifest_sha256={_sha256(gz_bytes)}&atlas_manifest_attempt=1"
+    )
+
+
+def test_load_manifest_reports_final_download_error_after_prior_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {"entries": [{"lemma": "збій"}], "enrichment_generated": True}
+    json_bytes = _json_bytes(payload)
+    gz_bytes = gzip.compress(json_bytes)
+    stale_gz_bytes = gzip.compress(_json_bytes({"entries": [{"lemma": "старий"}]}))
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    pointer_path = tmp_path / "lexicon-manifest.pointer.json"
+    _write_pointer(pointer_path, json_bytes=json_bytes, gz_bytes=gz_bytes)
+    _pin_defaults(monkeypatch, manifest_path, pointer_path)
+    urls: list[str] = []
+
+    def fake_urlopen(request: object, timeout: int):
+        assert timeout == 60
+        urls.append(_request_url(request))
+        if len(urls) == 1:
+            return io.BytesIO(stale_gz_bytes)
+        raise manifest_io.http.client.IncompleteRead(b"partial")
+
+    monkeypatch.setattr(manifest_io.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(ValueError, match="failed to download Atlas manifest") as excinfo:
+        manifest_io.load_manifest(path=manifest_path)
+
+    assert "IncompleteRead" in str(excinfo.value)
+    assert "gz sha256 mismatch" not in str(excinfo.value)
     assert not manifest_path.exists()


### PR DESCRIPTION
## Summary
- retry Atlas manifest release downloads across stale gzip, transient HTTP/network failures, and Python incomplete reads
- add deterministic SHA-keyed cache-busting on retry for Python and Node hydrate paths
- add Python and Vitest coverage for stale release responses, transient failures, and mixed failure reporting

## Verification
- .venv/bin/python -m pytest tests/test_manifest_io.py tests/test_atlas_conformance.py::test_real_lexicon_manifest_conforms_to_atlas_gates -q
- npm --prefix site run test -- --run tests/unit/hydrate-manifest.test.ts
- .venv/bin/ruff check scripts/lexicon/manifest_io.py tests/test_manifest_io.py
- node --check site/scripts/hydrate-manifest.mjs
- npm --prefix site run build
- .venv/bin/python scripts/audit/lint_agent_trailer.py
- Agy/Gemini 3.1 Pro High independent blocker review: PASS

Follow-up for #3675 / #3909 main CI release-asset cache mismatch.