### PR TITLE
fix(atlas): allow current VESUM gap terms

### DIFF
--- a/scripts/audit/validate_atlas_conformance.py
+++ b/scripts/audit/validate_atlas_conformance.py
@@ -64,6 +64,7 @@ FRESHNESS_DATE_KEYS = (
 APOSTROPHE_TRANSLATION = str.maketrans({"’": "'", "ʼ": "'", "`": "'", "′": "'"})
 STRESS_MARKS = {"\u0301", "\u0300", "\u0341"}
 WORD_TOKEN_RE = re.compile(r"[A-Za-zА-Яа-яЄєІіЇїҐґ0-9'’ʼ-]+")
+DELIMITED_LEMMA_RE = re.compile(r"\.\.\.|/")
 DATE_PREFIX_RE = re.compile(r"^\d{4}-\d{2}-\d{2}(?:$|[T ])")
 IPA_RE = re.compile(r"^(?:\[[^\[\]]+\]|/[^/]+/)$")
 
@@ -298,6 +299,16 @@ def _is_genuine_multi_word(value: str) -> bool:
     return len(WORD_TOKEN_RE.findall(value)) >= 2
 
 
+def _has_vesum_backed_delimited_components(value: str, vesum: Any) -> bool:
+    """Accept compact pair heads like ``не/ні`` when each component is in VESUM."""
+    if not DELIMITED_LEMMA_RE.search(value):
+        return False
+    components = [component.strip() for component in DELIMITED_LEMMA_RE.split(value)]
+    return len(components) >= 2 and all(
+        component and _vesum_has_entry(vesum, component) for component in components
+    )
+
+
 # OFFLINE FALLBACK for the VESUM-gap class (#3211): the primary mechanism is now the
 # live ``HeritageLemmaLookup`` (Грінченко/ЕСУМ via sources.db), which self-heals on any
 # VESUM-gap-but-attested word. This curated allowlist is consulted ONLY when the heritage
@@ -334,6 +345,25 @@ _MODERN_TECHNICAL_LEMMAS: frozenset[str] = frozenset(
         # контрфактичний — counterfactual; standard grammar metalanguage for unreal
         # conditionals. Taught in b1/conditionals-unreal; modern term, not in СУМ-11.
         "контрфактичний",
+        # Current course/Atlas standard terms absent from VESUM and the historical
+        # heritage corpus. Keep these narrow: each is constrained by real
+        # course_usage in the hydrated manifest and is rechecked by other §8 gates.
+        "бездіячевий",
+        "джерельність",
+        "дієслово-зв'язка",
+        "катафора",
+        "масмедіа",
+        "медіаманіпулювання",
+        "неозначено-особове",
+        "означено-особове",
+        "онлайн-оплата",
+        "офіційно-діловий",
+        "поломка",
+        "симплока",
+        "топікалізація",
+        "узагальнено-особове",
+        "цільнозерновий",
+        "інтерстилістика",
     }
 )
 
@@ -395,6 +425,8 @@ def _check_lemma_in_vesum(
         # false-positive storm, not enforcement.
         return
     if _vesum_has_entry(vesum, lemma):
+        return
+    if _has_vesum_backed_delimited_components(raw_lemma, vesum):
         return
 
     # VESUM missed. A miss is necessary-but-not-sufficient evidence of invalidity — VESUM
@@ -861,13 +893,18 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Validate Word Atlas manifest conformance gates")
     parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     parser.add_argument("--vesum", type=Path, default=DEFAULT_VESUM)
+    parser.add_argument("--heritage", type=Path, default=DEFAULT_SOURCES_DB)
     parser.add_argument("--curriculum", type=Path, default=DEFAULT_CURRICULUM)
     args = parser.parse_args(argv)
 
     manifest = _load_json(args.manifest)
     curriculum = _load_yaml(args.curriculum)
-    with VesumLemmaLookup(args.vesum) as vesum:
-        violations = validate(manifest, vesum=vesum, curriculum=curriculum)
+    heritage = args.heritage if args.heritage.exists() else None
+    if args.vesum.exists():
+        with VesumLemmaLookup(args.vesum) as vesum:
+            violations = validate(manifest, vesum=vesum, curriculum=curriculum, heritage=heritage)
+    else:
+        violations = validate(manifest, vesum=None, curriculum=curriculum, heritage=heritage)
 
     _print_violations(violations)
     return 1 if violations else 0

--- a/tests/test_atlas_conformance.py
+++ b/tests/test_atlas_conformance.py
@@ -57,15 +57,16 @@ def _gates_for(
 def test_real_lexicon_manifest_conforms_to_atlas_gates():
     manifest = load_manifest(MANIFEST_PATH)
     curriculum = yaml.safe_load(CURRICULUM_PATH.read_text(encoding="utf-8"))
+    heritage = SOURCES_PATH if SOURCES_PATH.exists() else None
 
     if VESUM_PATH.exists():
         # Local dev: full enforcement incl. lemma↔VESUM membership.
         with VesumLemmaLookup(VESUM_PATH) as vesum:
-            violations = validate(manifest, vesum=vesum, curriculum=curriculum)
+            violations = validate(manifest, vesum=vesum, curriculum=curriculum, heritage=heritage)
     else:
         # CI lacks the 967MB gitignored data/vesum.db → vesum=None skips ONLY the
         # lemma_in_vesum gate; every other §8 gate still enforces on the real manifest.
-        violations = validate(manifest, vesum=None, curriculum=curriculum)
+        violations = validate(manifest, vesum=None, curriculum=curriculum, heritage=heritage)
 
     assert violations == []
 
@@ -131,10 +132,28 @@ def test_lemma_in_vesum_exempts_modern_technical_term_in_both_modes():
     # from the HISTORICAL heritage corpus. The live heritage lookup cannot self-heal them,
     # so the curated modern-technical allowlist must exempt them in BOTH modes — including
     # the live-heritage mode (heritage present but NOT attesting), which was the failing case.
-    for lemma, pos in (("морфонеміка", "noun"), ("контрфактичний", "adjective")):
+    for lemma, pos in (
+        ("морфонеміка", "noun"),
+        ("контрфактичний", "adjective"),
+        ("топікалізація", "noun"),
+        ("цільнозерновий", "adjective"),
+    ):
         entry = _entry(lemma=lemma, url_slug=lemma, pos=pos)
         assert _gates_for(entry, vesum=set()) == []  # offline mode (no heritage source)
         assert _gates_for(entry, vesum=set(), heritage=set()) == []  # live mode, not attested
+
+
+def test_lemma_in_vesum_exempts_delimited_heads_when_each_component_is_known():
+    entry = _entry(lemma="не/ні", url_slug="не-ні", pos="particle pair")
+    assert _gates_for(entry, vesum={"не", "ні"}, heritage=set()) == []
+
+    entry = _entry(lemma="доти...доки", url_slug="доти-доки", pos="correlative conjunction")
+    assert _gates_for(entry, vesum={"доти", "доки"}, heritage=set()) == []
+
+
+def test_lemma_in_vesum_flags_delimited_heads_with_unknown_component():
+    entry = _entry(lemma="не/зызыжщ", url_slug="не-зызыжщ", pos="particle pair")
+    assert _gates_for(entry, vesum={"не"}, heritage=set()) == ["lemma_in_vesum"]
 
 
 def test_lemma_in_vesum_flags_when_absent_from_both_vesum_and_heritage():


### PR DESCRIPTION
## Summary
- allow Atlas conformance for compact delimiter heads when each component is VESUM-backed (`не/ні`, `доти...доки`)
- extend the curated contemporary VESUM-gap term list for current course vocabulary that is absent from VESUM and historical heritage sources
- wire `data/sources.db`/`--heritage` into the real-manifest test and CLI so live heritage fallback is exercised when available

Note: the mutable `atlas-manifest` GitHub Release asset was restored out-of-band to the existing main-committed pointer hash `3ab8ea34ecc056f5c7d4755ed268b1669de9d8a30e5691aedf6f2c7e954f8574`. This PR does not change pointer/fingerprint files.

## Verification
- `gh release view atlas-manifest --json assets` reports `sha256:3ab8ea34ecc056f5c7d4755ed268b1669de9d8a30e5691aedf6f2c7e954f8574`
- `.venv/bin/python scripts/lexicon/check_manifest_freshness.py` (OK)
- `.venv/bin/python -m pytest tests/test_atlas_conformance.py -q` (30 passed, 1 skipped)
- `.venv/bin/python scripts/audit/validate_atlas_conformance.py --manifest site/src/data/lexicon-manifest.json --vesum /Users/krisztiankoos/projects/learn-ukrainian/data/vesum.db --heritage /Users/krisztiankoos/projects/learn-ukrainian/data/sources.db --curriculum curriculum/l2-uk-en/curriculum.yaml` (0 violations)
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## External Review
- Agy/Gemini 3.1 Pro High initial review found heritage wiring blockers; fixed.
- Agy/Gemini 3.1 Pro High follow-up review passed after wiring fixes.
