### PR TITLE
fix(atlas): fill cached Slovnyk translations

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -3317,6 +3317,7 @@ _SLOVNYK_UKRENG_PREFIX_LABELS = {
     "мед",
     "мет",
     "мін",
+    "мн",
     "мор",
     "муз",
     "перен",
@@ -3343,6 +3344,7 @@ def _ukreng_prefix_is_label(prefix: str) -> bool:
 def _clean_ukreng_gloss(candidate: str) -> str | None:
     cleaned = clean_html_entities(candidate)
     cleaned = re.sub(r"\b(?:also|fig|figurative|literally|lit)\.?\b", " ", cleaned, flags=re.IGNORECASE)
+    cleaned = re.sub(r"\(\s*(?:pl|sg|plural|singular)\.?\s*\)", " ", cleaned, flags=re.IGNORECASE)
     cleaned = re.sub(r"\s+", " ", cleaned).strip(" \t\r\n.,;:!?()[]{}«»\"“”")
     cleaned = re.sub(r"^(?:to|a|an|the)\s+", "", cleaned, flags=re.IGNORECASE)
     if not cleaned or not _LATIN_RE.search(cleaned) or re.search(r"[А-Яа-яЄєІіЇїҐґ]", cleaned):

--- a/scripts/lexicon/reenrich_thin_manifest_entries.py
+++ b/scripts/lexicon/reenrich_thin_manifest_entries.py
@@ -98,30 +98,44 @@ def _translation_for_entry(
     conn: sqlite3.Connection,
     entry: dict[str, Any],
     kaikki_lookup: dict[str, dict[str, Any]],
+    *,
+    cached_slovnyk_only: bool = False,
 ) -> dict[str, object] | None:
     lemma = str(entry.get("lemma") or "")
     entry_pos = entry.get("pos")
     gloss_hints = enrich_manifest._surface_gloss_hints(entry)
+    slovnyk_cache = enrich_manifest._slovnyk_cache(lemma)
+    if cached_slovnyk_only and not enrich_manifest._cache_has_lookup(
+        slovnyk_cache,
+        enrich_manifest._SLOVNYK_UKRENG_SLUG,
+    ):
+        slovnyk_cache = None
     translation = enrich_manifest._translation(
         conn,
         lemma,
         kaikki_lookup,
         entry_pos=entry_pos,
         gloss_hints=gloss_hints,
-        slovnyk_cache=enrich_manifest._slovnyk_cache(lemma),
+        slovnyk_cache=slovnyk_cache,
     )
     if translation:
         return translation
     fallback_base = enrich_manifest._base_lookup_for_entry(lemma, entry_pos)
     if not fallback_base:
         return None
+    fallback_cache = enrich_manifest._slovnyk_cache(fallback_base)
+    if cached_slovnyk_only and not enrich_manifest._cache_has_lookup(
+        fallback_cache,
+        enrich_manifest._SLOVNYK_UKRENG_SLUG,
+    ):
+        fallback_cache = None
     translation = enrich_manifest._translation(
         conn,
         fallback_base,
         kaikki_lookup,
         entry_pos=entry_pos,
         gloss_hints=gloss_hints,
-        slovnyk_cache=enrich_manifest._slovnyk_cache(fallback_base),
+        slovnyk_cache=fallback_cache,
     )
     if not translation:
         return None
@@ -132,8 +146,15 @@ def _reenrich_translation_only(
     conn: sqlite3.Connection,
     entry: dict[str, Any],
     kaikki_lookup: dict[str, dict[str, Any]],
+    *,
+    cached_slovnyk_only: bool = False,
 ) -> None:
-    translation = _translation_for_entry(conn, entry, kaikki_lookup)
+    translation = _translation_for_entry(
+        conn,
+        entry,
+        kaikki_lookup,
+        cached_slovnyk_only=cached_slovnyk_only,
+    )
     if not translation:
         return
     enrichment = entry.setdefault("enrichment", {})
@@ -159,6 +180,24 @@ def _reenrich_full_entry(
     )
 
 
+def _has_translation(entry: dict[str, Any]) -> bool:
+    enrichment = entry.get("enrichment")
+    if not isinstance(enrichment, dict):
+        return False
+    translation = enrichment.get("translation")
+    if not isinstance(translation, dict):
+        return False
+    terms = translation.get("en")
+    return isinstance(terms, list) and any(str(term).strip() for term in terms)
+
+
+def missing_translation_entries(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    entries = manifest.get("entries")
+    if not isinstance(entries, list):
+        return []
+    return [entry for entry in entries if isinstance(entry, dict) and not _has_translation(entry)]
+
+
 def reenrich_thin_entries(
     manifest: dict[str, Any],
     *,
@@ -167,8 +206,15 @@ def reenrich_thin_entries(
     limit: int | None = None,
     full_entry: bool = False,
     refresh_wiki: bool = False,
+    target: str = "missing-anchor",
+    cached_slovnyk_only: bool = False,
 ) -> dict[str, Any]:
-    targets = thin_old_gate_entries(manifest)
+    if target == "missing-translation":
+        targets = missing_translation_entries(manifest)
+    elif target == "missing-anchor":
+        targets = thin_old_gate_entries(manifest)
+    else:
+        raise ValueError(f"unsupported re-enrichment target: {target}")
     if limit is not None:
         targets = targets[:limit]
 
@@ -179,12 +225,14 @@ def reenrich_thin_entries(
 
     changed = 0
     gained_anchor = 0
+    filled_translation = 0
     try:
         for entry in targets:
             enrichment = entry.get("enrichment") if isinstance(entry.get("enrichment"), dict) else {}
             existing_cefr = enrichment.get("cefr") if isinstance(enrichment, dict) else None
             existing_wiki_reference = entry.get("wiki_reference")
             had_anchor = has_learner_english_anchor(entry)
+            had_translation = _has_translation(entry)
             before = json.dumps(entry, ensure_ascii=False, sort_keys=True)
             if full_entry:
                 _reenrich_full_entry(
@@ -194,7 +242,12 @@ def reenrich_thin_entries(
                     has_sum11_flags=has_sum11_flags,
                 )
             else:
-                _reenrich_translation_only(conn, entry, kaikki_lookup)
+                _reenrich_translation_only(
+                    conn,
+                    entry,
+                    kaikki_lookup,
+                    cached_slovnyk_only=cached_slovnyk_only,
+                )
             _preserve_existing_metadata(
                 entry,
                 existing_cefr=existing_cefr if isinstance(existing_cefr, dict) else None,
@@ -207,13 +260,17 @@ def reenrich_thin_entries(
                 changed += 1
             if not had_anchor and has_learner_english_anchor(entry):
                 gained_anchor += 1
+            if not had_translation and _has_translation(entry):
+                filled_translation += 1
     finally:
         enrich_manifest._wiki_reference = original_wiki_reference
 
     remaining = thin_old_gate_entries(manifest)
     return {
+        "target": target,
         "targets": len(targets),
         "changed": changed,
+        "filled_translation": filled_translation,
         "gained_english_anchor": gained_anchor,
         "remaining_old_gate_no_english_anchor": len(remaining),
     }
@@ -237,6 +294,20 @@ def main() -> int:
         action="store_true",
         help="Run full enrich_entry for each target. Default only recomputes translation anchors.",
     )
+    parser.add_argument(
+        "--target",
+        choices=("missing-anchor", "missing-translation"),
+        default="missing-anchor",
+        help=(
+            "Select entries to re-enrich. Default keeps the old gate repair behavior; "
+            "missing-translation fills sourced translation cards where deterministic sources exist."
+        ),
+    )
+    parser.add_argument(
+        "--cached-slovnyk-only",
+        action="store_true",
+        help="Use existing Slovnyk.me Ukrainian-English cache rows only; do not live-fetch missing Slovnyk entries.",
+    )
     parser.add_argument("--refresh-wiki", action="store_true")
     parser.add_argument("--write", action="store_true")
     args = parser.parse_args()
@@ -255,6 +326,8 @@ def main() -> int:
             limit=args.limit,
             full_entry=args.full_entry,
             refresh_wiki=args.refresh_wiki,
+            target=args.target,
+            cached_slovnyk_only=args.cached_slovnyk_only,
         )
 
     print(json.dumps(summary, ensure_ascii=False, indent=2))

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "55ed8a2cf2321409a9d1cc2e08fa09b2664cab21d755d49b0bc9b0f9987bef13",
+  "fingerprint": "59ab270398e4722123112e2a5b08763cac46a519334acc040de0facd92a28885",
   "inputs": {
     "lexicon_code": [
       {
@@ -44,7 +44,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "50bc29950b67731ac2b5ac066dda363a6871b9ed5035f0514a552ee812660bb5"
+        "sha256": "8822ed30fc2079358826311e3ec4feecd82d427705a6c2a2c3fae9019c3a9f1c"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",
@@ -100,7 +100,7 @@
       },
       {
         "path": "scripts/lexicon/reenrich_thin_manifest_entries.py",
-        "sha256": "f06d909cb48898186eaa614163f8ce9271b599f2d264f4a492968ac0b715344e"
+        "sha256": "28c72082c388ae5b301acc006eeed4e585c9fbbda48b805d1ff543d31862745d"
       },
       {
         "path": "scripts/lexicon/repair_plural_noun_aliases.py",

--- a/site/src/data/lexicon-manifest.pointer.json
+++ b/site/src/data/lexicon-manifest.pointer.json
@@ -2,12 +2,12 @@
   "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest.json.gz",
   "release_tag": "atlas-manifest",
   "manifest_version": "0.1",
-  "manifest_fingerprint": "55ed8a2cf2321409a9d1cc2e08fa09b2664cab21d755d49b0bc9b0f9987bef13",
+  "manifest_fingerprint": "59ab270398e4722123112e2a5b08763cac46a519334acc040de0facd92a28885",
   "fingerprint_schema_version": 1,
   "generated_at": "2026-06-27T13:55:58+00:00",
-  "gz_sha256": "3ab8ea34ecc056f5c7d4755ed268b1669de9d8a30e5691aedf6f2c7e954f8574",
-  "json_sha256": "c71b2e223e9eaeaea7d9dd1594f38adc13daac9b6d88c61c260511b9f1fffee7",
-  "gz_bytes": 6092735,
-  "json_bytes": 44388233,
+  "gz_sha256": "feb7e40f86ca8be4896dc820a2ec6811953da1ebed11e3b9a9ad7763edb66ef0",
+  "json_sha256": "0e4038776eb980ea9655a3a95552a6ec11bd20ce8ec353e5ab147bcbbecf1f01",
+  "gz_bytes": 6098528,
+  "json_bytes": 44427989,
   "note": "Pins GitHub Release asset manifest for #3659; hydrate it build time instead committing raw JSON."
 }

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -2098,6 +2098,35 @@ def test_translation_uses_slovnyk_ukreng_after_source_misses(monkeypatch) -> Non
     }
 
 
+def test_translation_parses_slovnyk_ukreng_plural_label(monkeypatch) -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
+    monkeypatch.setattr(enrich_manifest_module, "_DMKLINGER_INDEX", None)
+    monkeypatch.setattr(enrich_manifest_module, "_BALLA_REVERSE_INDEX", {})
+    cache = {
+        "lookups": {
+            "ukreng": {
+                "dictionary_slug": "ukreng",
+                "dictionary_label": "Українсько-англійський словник",
+                "word": "бризки",
+                "source_url": "https://slovnyk.me/dict/ukreng/бризки",
+                "text": (
+                    "бризки мн. splashes ( pl. ), spray ( sg. ); "
+                    "( розплавленого металу ) sparks ( pl. ); "
+                    "( дощу ) fine drops of rain "
+                    "Джерело: Українсько-англійський словник на Slovnyk.me"
+                ),
+            }
+        }
+    }
+
+    assert _translation(conn, "бризки", {}, slovnyk_cache=cache) == {
+        "en": ["splashes", "spray"],
+        "source": _SLOVNYK_UKRENG_SOURCE,
+        "source_url": "https://slovnyk.me/dict/ukreng/бризки",
+    }
+
+
 def test_translation_prefers_kaikki_over_curated_learner_gloss(monkeypatch) -> None:
     conn = sqlite3.connect(":memory:")
     conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")

--- a/tests/test_reenrich_thin_manifest_entries.py
+++ b/tests/test_reenrich_thin_manifest_entries.py
@@ -4,6 +4,7 @@ from scripts.lexicon import enrich_manifest
 from scripts.lexicon.reenrich_thin_manifest_entries import (
     _preserve_existing_metadata,
     _reenrich_translation_only,
+    reenrich_thin_entries,
 )
 
 
@@ -69,3 +70,89 @@ def test_preserve_existing_metadata_restores_cefr_and_wiki_reference() -> None:
     }
     assert entry["enrichment"]["sources"] == ["estimated (GRAC frequency)", "fixture source"]
     assert entry["wiki_reference"] == {"wikipedia": {"title": "Помішувати"}}
+
+
+def test_missing_translation_target_fills_only_entries_without_translation(monkeypatch) -> None:
+    manifest = {
+        "entries": [
+            {
+                "lemma": "бризки",
+                "gloss": "splashes",
+                "enrichment": {"stress": {"form": "бри́зки", "source": "fixture"}},
+            },
+            {
+                "lemma": "вершки",
+                "gloss": "cream",
+                "enrichment": {
+                    "translation": {"en": ["cream"], "source": "existing source"},
+                    "sources": ["existing source"],
+                },
+            },
+        ],
+    }
+    seen: list[str] = []
+
+    def fake_translation(conn, lemma, kaikki_lookup, *, entry_pos=None, gloss_hints=None, slovnyk_cache=None):
+        seen.append(lemma)
+        return {"en": ["splashes"], "source": "slovnyk.me: Українсько-англійський словник"}
+
+    monkeypatch.setattr(enrich_manifest, "_translation", fake_translation)
+    monkeypatch.setattr(enrich_manifest, "_base_lookup_for_entry", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_slovnyk_cache", lambda lemma: {})
+
+    with sqlite3.connect(":memory:") as conn:
+        summary = reenrich_thin_entries(
+            manifest,
+            conn=conn,
+            kaikki_lookup={},
+            target="missing-translation",
+        )
+
+    assert seen == ["бризки"]
+    assert summary["target"] == "missing-translation"
+    assert summary["targets"] == 1
+    assert summary["filled_translation"] == 1
+    assert manifest["entries"][0]["enrichment"]["translation"] == {
+        "en": ["splashes"],
+        "source": "slovnyk.me: Українсько-англійський словник",
+    }
+    assert manifest["entries"][1]["enrichment"]["translation"] == {
+        "en": ["cream"],
+        "source": "existing source",
+    }
+
+
+def test_cached_slovnyk_only_skips_uncached_slovnyk_lookup(monkeypatch) -> None:
+    entry = {"lemma": "невідоме", "enrichment": {}}
+
+    def fake_translation(conn, lemma, kaikki_lookup, *, entry_pos=None, gloss_hints=None, slovnyk_cache=None):
+        assert slovnyk_cache is None
+        return None
+
+    monkeypatch.setattr(enrich_manifest, "_translation", fake_translation)
+    monkeypatch.setattr(enrich_manifest, "_base_lookup_for_entry", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest, "_slovnyk_cache", lambda lemma: {})
+
+    with sqlite3.connect(":memory:") as conn:
+        _reenrich_translation_only(conn, entry, {}, cached_slovnyk_only=True)
+
+    assert "translation" not in entry["enrichment"]
+
+
+def test_cached_slovnyk_only_does_not_live_fetch_missing_ukreng(monkeypatch) -> None:
+    entry = {"lemma": "бризки", "gloss": "splashes", "enrichment": {}}
+
+    def fail_fetch(*args, **kwargs):
+        raise AssertionError("cached-only mode must not live-fetch Slovnyk")
+
+    monkeypatch.setattr(enrich_manifest, "_DMKLINGER_INDEX", None)
+    monkeypatch.setattr(enrich_manifest, "_BALLA_REVERSE_INDEX", {})
+    monkeypatch.setattr(enrich_manifest, "_slovnyk_cache", lambda lemma: {"lookups": {}})
+    monkeypatch.setattr(enrich_manifest, "_fetch_slovnyk_entry", fail_fetch)
+    monkeypatch.setattr(enrich_manifest, "_base_lookup_for_entry", lambda *args, **kwargs: None)
+
+    with sqlite3.connect(":memory:") as conn:
+        conn.execute("CREATE TABLE dmklinger_uk_en (word TEXT, pos TEXT, translations TEXT)")
+        _reenrich_translation_only(conn, entry, {}, cached_slovnyk_only=True)
+
+    assert "translation" not in entry["enrichment"]


### PR DESCRIPTION
## Summary
- add a `missing-translation` target to the Atlas re-enrichment utility
- add `--cached-slovnyk-only` so source fills can use existing Slovnyk.me Ukrainian-English cache rows without live-fetching thousands of misses
- parse Slovnyk `ukreng` plural label `мн.` and clean `(pl.)` / `(sg.)` labels, fixing the concrete `бризки` translation source
- refresh the manifest pointer after filling 96 cached translation cards total; `бризки` now has `splashes` / `spray` from Slovnyk.me

## Verification
- `.venv/bin/python -m pytest tests/test_reenrich_thin_manifest_entries.py tests/test_lexicon_enrich_manifest.py tests/test_audit_atlas_poc_richness.py -q`
- `npm --prefix site run test -- --run tests/unit/lexicon-search.test.ts`
- `npm --prefix site run build`
- `.venv/bin/python -m scripts.audit.audit_atlas_poc_richness --local --format json --limit 5` -> search_no_visible_gloss=0, old_gate_no_english_anchor=0, poc_thin_pages=786
- `.venv/bin/python -m scripts.lexicon.publish_manifest --dry-run` -> fingerprint `59ab270398e4722123112e2a5b08763cac46a519334acc040de0facd92a28885`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Notes
- Published matching `atlas-manifest` release asset fingerprint `59ab270398e4722123112e2a5b08763cac46a519334acc040de0facd92a28885` before PR creation so CI can hydrate the committed pointer.
- This intentionally does not fabricate translations from course glosses. Remaining missing translation cards need either uncached live source passes with progress/checkpointing or genuinely have no deterministic source yet.
