### PR TITLE
ci(atlas): gate learner anchors and POC richness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,8 @@ jobs:
               - 'scripts/build/generate_lesson_schema.py'
             atlas:
               - '.github/workflows/ci.yml'
+              - 'scripts/audit/audit_atlas_poc_richness.py'
+              - 'scripts/audit/check_atlas_manifest_enrichment.py'
               - 'scripts/lexicon/*.py'
               - 'curriculum/l2-uk-en/**/vocabulary.yaml'
               - 'site/src/data/lexicon-manifest.json'
@@ -191,16 +193,29 @@ jobs:
           key: lexicon-manifest-${{ hashFiles('site/src/data/lexicon-manifest.pointer.json') }}
 
       - name: Install YAML parser
-        run: pip install PyYAML
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install PyYAML
 
       - name: Check DB-free Atlas manifest freshness
-        run: python scripts/lexicon/check_manifest_freshness.py
+        run: .venv/bin/python scripts/lexicon/check_manifest_freshness.py
 
       # Root-cause guard for the #3631 empty-atlas regression: a manifest committed
       # without enrichment (enrichment_generated False / ~0 enriched entries) renders
       # an empty Atlas while the fingerprint/freshness gate above stays green. Blocks it.
       - name: Block thin/un-enriched Atlas manifest (#3658)
-        run: python scripts/audit/check_atlas_manifest_enrichment.py
+        run: .venv/bin/python scripts/audit/check_atlas_manifest_enrichment.py
+
+      # Learner-facing static Atlas gate (#3930): no missing English anchors in
+      # search suggestions, and the current thin-page count must not regress
+      # above the release-asset baseline until #3931/#3933/#3934 reduce it.
+      - name: Gate Atlas POC richness and learner anchors (#3930)
+        run: |
+          .venv/bin/python scripts/audit/audit_atlas_poc_richness.py \
+            --max-search-no-visible-gloss 0 \
+            --max-old-gate-no-english-anchor 0 \
+            --max-poc-thin-pages 786
 
       # Diff-scoped + advisory (#3150): only flags modules whose vocabulary.yaml changed
       # in THIS PR (no cross-PR coupling on the merge-train), and never blocks merge — a
@@ -210,7 +225,7 @@ jobs:
         continue-on-error: true
         run: |
           git fetch --no-tags --quiet origin main || true
-          python scripts/lexicon/check_manifest_vocabulary_coverage.py --changed-only --base origin/main
+          .venv/bin/python scripts/lexicon/check_manifest_vocabulary_coverage.py --changed-only --base origin/main
 
   lint:
     name: Lint (ruff)

--- a/scripts/audit/audit_atlas_poc_richness.py
+++ b/scripts/audit/audit_atlas_poc_richness.py
@@ -22,16 +22,16 @@ ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MANIFEST = ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
 
 SCRIPT_DIR = Path(__file__).resolve().parent
-if str(SCRIPT_DIR) in sys.path:
-    sys.path.remove(str(SCRIPT_DIR))
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
 
-from scripts.audit.audit_atlas_thin_enriched import (
+from audit_atlas_thin_enriched import (
     has_learner_english_anchor,
     old_gate_enriched,
 )
-from scripts.audit.generate_search_index import _search_row
+
 from scripts.lexicon.manifest_io import load_manifest
 
 RICH_SECTION_ORDER = (
@@ -133,9 +133,28 @@ def rendered_sections(entry: dict[str, Any]) -> set[str]:
     return sections
 
 
+def _is_static_search_entry(entry: dict[str, Any]) -> bool:
+    return bool(entry.get("lemma")) and bool(entry.get("url_slug")) and entry.get("pos") != "grammar term"
+
+
+def _static_search_gloss(entry: dict[str, Any]) -> str | None:
+    if _nonempty_string(entry.get("gloss")):
+        return str(entry["gloss"])
+    enrichment = entry.get("enrichment")
+    if not isinstance(enrichment, dict):
+        return None
+    translation = enrichment.get("translation")
+    if not isinstance(translation, dict):
+        return None
+    terms = translation.get("en")
+    if not isinstance(terms, list):
+        return None
+    visible = [str(term).strip() for term in terms if _nonempty_string(term)]
+    return "; ".join(visible[:3]) if visible else None
+
+
 def search_has_visible_gloss(entry: dict[str, Any]) -> bool:
-    row = _search_row(entry)
-    return bool(row and _nonempty_string(row.get("g")))
+    return _is_static_search_entry(entry) and _nonempty_string(_static_search_gloss(entry))
 
 
 def _entry_cefr(entry: dict[str, Any]) -> str | None:
@@ -169,7 +188,7 @@ def audit_manifest(
     sample_limit: int = 25,
 ) -> dict[str, Any]:
     entries = [entry for entry in manifest.get("entries", []) if isinstance(entry, dict)]
-    search_entries = [entry for entry in entries if _search_row(entry)]
+    search_entries = [entry for entry in entries if _is_static_search_entry(entry)]
     old_enriched = [entry for entry in search_entries if old_gate_enriched(entry)]
 
     search_no_gloss: list[dict[str, Any]] = []
@@ -265,6 +284,20 @@ def _print_tsv(summary: dict[str, Any]) -> None:
             )
 
 
+def _max_failures(summary: dict[str, Any], limits: dict[str, int | None]) -> list[str]:
+    failures: list[str] = []
+    for key, limit in limits.items():
+        if limit is None:
+            continue
+        if limit < 0:
+            failures.append(f"{key}: max must be non-negative, got {limit}")
+            continue
+        count = int(summary[key])
+        if count > limit:
+            failures.append(f"{key}: {count} exceeds max {limit}")
+    return failures
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
@@ -277,6 +310,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--limit", type=int, default=25)
     parser.add_argument("--format", choices=("summary", "json", "tsv"), default="summary")
     parser.add_argument("--fail-if-any", action="store_true")
+    parser.add_argument("--max-search-no-visible-gloss", type=int, default=None)
+    parser.add_argument("--max-old-gate-no-english-anchor", type=int, default=None)
+    parser.add_argument("--max-poc-thin-pages", type=int, default=None)
     args = parser.parse_args(argv)
 
     manifest = _read_local_manifest(args.manifest) if args.local else load_manifest(args.manifest)
@@ -293,12 +329,28 @@ def main(argv: list[str] | None = None) -> int:
     else:
         _print_summary(summary)
 
+    failures = _max_failures(
+        summary,
+        {
+            "search_no_visible_gloss": args.max_search_no_visible_gloss,
+            "old_gate_no_english_anchor": args.max_old_gate_no_english_anchor,
+            "poc_thin_pages": args.max_poc_thin_pages,
+        },
+    )
+
     if args.fail_if_any and (
         summary["search_no_visible_gloss"]
         or summary["old_gate_no_english_anchor"]
         or summary["poc_thin_pages"]
     ):
+        failures.append("--fail-if-any matched at least one non-zero audit bucket")
+
+    if failures:
+        print("Atlas POC richness gate failed:")
+        for failure in failures:
+            print(f"- {failure}")
         return 1
+
     return 0
 
 

--- a/tests/test_audit_atlas_poc_richness.py
+++ b/tests/test_audit_atlas_poc_richness.py
@@ -114,6 +114,76 @@ def test_audit_cli_runs_as_direct_script(tmp_path) -> None:
     assert json.loads(result.stdout)["total_entries"] == 1
 
 
+def test_audit_cli_enforces_explicit_max_counts(tmp_path) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "entries": [
+                    _entry(
+                        lemma="тонкий",
+                        url_slug="тонкий",
+                        gloss=None,
+                        pos="adjective",
+                        enrichment={
+                            "definition_cards": [
+                                {
+                                    "id": "vts-main",
+                                    "source": "ВТС",
+                                    "definitions": ["Без товщини."],
+                                }
+                            ],
+                            "morphology": {
+                                "pos": "adjective",
+                                "form_count": 1,
+                                "forms": [{"form": "тонкий", "label": "прикметник"}],
+                                "source": "VESUM",
+                            },
+                        },
+                    )
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    blocked = subprocess.run(
+        [
+            ".venv/bin/python",
+            "scripts/audit/audit_atlas_poc_richness.py",
+            "--manifest",
+            str(manifest_path),
+            "--local",
+            "--max-search-no-visible-gloss",
+            "0",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert blocked.returncode == 1
+    assert "search_no_visible_gloss: 1 exceeds max 0" in blocked.stdout
+
+    subprocess.run(
+        [
+            ".venv/bin/python",
+            "scripts/audit/audit_atlas_poc_richness.py",
+            "--manifest",
+            str(manifest_path),
+            "--local",
+            "--max-search-no-visible-gloss",
+            "1",
+            "--max-old-gate-no-english-anchor",
+            "1",
+            "--max-poc-thin-pages",
+            "1",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
 def test_audit_separates_search_gloss_and_poc_thin_failures() -> None:
     ogo_like = _entry(
         lemma="ого",


### PR DESCRIPTION
## Summary
- Adds explicit max-count gates to `audit_atlas_poc_richness.py` so CI can block missing English learner anchors while ratcheting current POC-thin pages.
- Wires the Atlas freshness job to run through `.venv/bin/python`, include the new audit in path filtering, and enforce the current static baseline: 0 search rows without visible English gloss, 0 old-gate entries without an English anchor, and no increase above 786 POC-thin pages.
- Adds CLI regression coverage for the new max-count gate behavior.

## Static/public behavior
The public static Atlas remains backend-free. The new CI gate hydrates the release-pinned static manifest, blocks regressions in learner-visible search anchors, and prevents the current thin-page count from growing while follow-up source-gap/source-intake issues reduce it.

## Validation
- `.venv/bin/python -m pytest tests/test_audit_atlas_poc_richness.py tests/test_audit_atlas_thin_enriched.py -q`
- `.venv/bin/ruff check --fix scripts/audit/audit_atlas_poc_richness.py tests/test_audit_atlas_poc_richness.py`
- `.venv/bin/python scripts/audit/audit_atlas_poc_richness.py --max-search-no-visible-gloss 0 --max-old-gate-no-english-anchor 0 --max-poc-thin-pages 786`
- `.venv/bin/python scripts/audit/check_atlas_manifest_enrichment.py`
- `.venv/bin/python scripts/lexicon/check_manifest_freshness.py`
- `.venv/bin/python - <<'PY'` YAML parse for `.github/workflows/ci.yml`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

Notes: local `actionlint` is not installed. Gemini local-code-review bridge was attempted but unavailable due Gemini CLI auth/tier error; no Claude-derived review output was used.

Closes #3930.
