### PR TITLE
docs(b2): persist m51-m53 scores

### DIFF
--- a/docs/audits/b2-current-llm-scores-2026-06-28.md
+++ b/docs/audits/b2-current-llm-scores-2026-06-28.md
@@ -49,10 +49,13 @@ B2 M47 `genitive-advanced`,9/10,B+,Yes,Strong advanced genitive module 12 workbo
 B2 M48 `dative-advanced`,9/10,B+,Yes,Strong advanced dative module 12 workbook activities, 41 vocabulary items, independent review pass. Score held at 9 dense dative semantics and register coverage human-polish reserve.
 B2 M49 `instrumental-advanced`,9/10,B+,Yes,Strong advanced instrumental module 10 workbook activities, 31 vocabulary items, final Agy/Claude Opus 4.6 review pass. Score held at 9 dense instrumental semantics non-blocking polish risk.
 B2 M50 `questions-deliberative-rhetorical`,9/10,B+,Yes,Strong deliberative rhetorical embedded-questions module 11 workbook activities, 31 vocabulary items, final Agy/Claude Opus 4.6 review pass. Score held at 9 dense punctuation/register coverage non-blocking polish risk.
+B2 M51 `advanced-case-semantics`,9/10,B+,Yes,Strong advanced case-semantics module 10 workbook activities, 49 vocabulary items, final Agy/Claude Opus 4.6 review pass. Score held at 9 dense cross-case semantics non-blocking section-balance warnings.
+B2 M52 `pronoun-system-advanced`,9/10,B+,Yes,Strong advanced pronoun-system module 11 workbook activities, 31 vocabulary items, final Agy/Claude Opus 4.6 blocker fix and PASS re-review. Score held at 9 dense pronoun paradigms non-blocking target-form UA-GEC advisories.
+B2 M53 `checkpoint-cases-morphology`,9/10,B+,Yes,Strong B2.4 cases/morphology checkpoint 5 workbook and 5 inline activities, 30 vocabulary items, final Agy/Claude Opus 4.6 blocker fixes and PASS re-review. Score held at 9 compact synthesis non-blocking section-balance/UA-GEC advisories.
 
 Score,Count,Modules
 10/10,2,"M01, M08"
-9/10,47,"M02-M07, M09-M13, M15-M50"
+9/10,50,"M02-M07, M09-M13, M15-M53"
 8/10,1,M14
 
 Durable Report,Scope
@@ -66,6 +69,7 @@ Durable Report,Scope
 `docs/audits/b2-m42-llm-score-report-2026-06-27.md`,M42
 `docs/audits/b2-m43-m46-llm-score-report-2026-06-27.md`,M43-M46
 `docs/audits/b2-m47-m50-llm-score-report-2026-06-28.md`,M47-M50
+`docs/audits/b2-m51-m53-llm-score-report-2026-06-28.md`,M51-M53
 
 Module,Raw Word Count,Activities,Vocabulary
 M03 `b2-impersonal-passive`,4608,7 workbook / 4 inline,35
@@ -116,6 +120,9 @@ M47 `genitive-advanced`,4537,12 workbook / 0 inline,41
 M48 `dative-advanced`,4418,12 workbook / 0 inline,41
 M49 `instrumental-advanced`,4293,10 workbook / 0 inline,31
 M50 `questions-deliberative-rhetorical`,4246,11 workbook / 0 inline,31
+M51 `advanced-case-semantics`,5124,10 workbook / 0 inline,49
+M52 `pronoun-system-advanced`,4403,11 workbook / 0 inline,31
+M53 `checkpoint-cases-morphology`,4957,5 workbook / 5 inline,30
 
 Score,Pass Count
 10/10,5/5 with no meaningful content polish
@@ -135,3 +142,4 @@ See `docs/audits/b2-m37-m41-llm-score-report-2026-06-27.md`.,M37-M41
 See `docs/audits/b2-m42-llm-score-report-2026-06-27.md`.,M42
 See `docs/audits/b2-m43-m46-llm-score-report-2026-06-27.md`.,M43-M46
 See `docs/audits/b2-m47-m50-llm-score-report-2026-06-28.md`.,M47-M50
+See `docs/audits/b2-m51-m53-llm-score-report-2026-06-28.md`.,M51-M53

--- a/docs/audits/b2-m51-m53-llm-score-report-2026-06-28.md
+++ b/docs/audits/b2-m51-m53-llm-score-report-2026-06-28.md
@@ -1,0 +1,20 @@
+Module,Score,Verdict,Deterministic Audit,Activity/Vocab Coverage,Ready Human Review?
+M51 `advanced-case-semantics`,9/10,B+,PASS,10 workbook / 0 inline; 49 vocab,Yes
+M52 `pronoun-system-advanced`,9/10,B+,PASS,11 workbook / 0 inline; 31 vocab,Yes
+M53 `checkpoint-cases-morphology`,9/10,B+,PASS,5 workbook / 5 inline; 30 vocab,Yes
+
+Module,Notes
+M51 `advanced-case-semantics`,Strong advanced case-semantics module 10 workbook activities and 49 vocabulary items, merged PR #3942 after Agy/Claude Opus 4.6 PASS review. Score held at 9 due dense cross-case semantics and non-blocking section-balance warnings.
+M52 `pronoun-system-advanced`,Strong advanced pronoun-system module 11 workbook activities and 31 vocabulary items, merged PR #3943 after Agy/Claude Opus 4.6 blocker fix and PASS re-review. Score held at 9 due dense pronoun paradigms and non-blocking UA-GEC false positives for target forms.
+M53 `checkpoint-cases-morphology`,Strong B2.4 cases/morphology checkpoint 5 workbook and 5 inline activities with 30 vocabulary items, merged PR #3944 after Agy/Claude Opus 4.6 blocker fixes and PASS re-review. Score held at 9 due compact checkpoint synthesis and non-blocking section-balance/UA-GEC advisories.
+
+Score Rationale,Disposition
+Deterministic audit,All three modules passed deterministic module audit after local validation.
+Validation,Activities, vocabulary, MDX generation, markdownlint, MDX drift/parity where applicable, diff check, and trailer lint passed before merge.
+External review,Each module had external independent Agy/Claude Opus 4.6 review; M52 and M53 blockers were fixed before merge.
+Telemetry,Module-build telemetry persisted for PRs #3942, #3943, and #3944 with `swarm_used: true` and thin-swarm notes.
+
+Module,Raw Word Count,Activities,Vocabulary
+M51 `advanced-case-semantics`,5124,10 workbook / 0 inline,49
+M52 `pronoun-system-advanced`,4403,11 workbook / 0 inline,31
+M53 `checkpoint-cases-morphology`,4957,5 workbook / 5 inline,30


### PR DESCRIPTION
## Summary
- Adds durable B2 M51-M53 LLM score report under docs/audits.
- Updates the current B2 score snapshot with M51-M53 rows, raw counts, durable-report link, and review evidence.

## Validation
- npx markdownlint-cli2 docs/audits/b2-current-llm-scores-2026-06-28.md docs/audits/b2-m51-m53-llm-score-report-2026-06-28.md
- git diff --check
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py

## External Review
VERDICT: PASS. Blank-line blocker fixed and re-reviewed.