### PR TITLE
[codex] Gate static Word Day practice assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,9 +160,15 @@ jobs:
             atlas:
               - '.github/workflows/ci.yml'
               - 'scripts/lexicon/*.py'
+              - 'scripts/audit/check_static_practice_assets.py'
+              - 'scripts/audit/generate_daily_pool.py'
+              - 'scripts/audit/generate_practice_deck.py'
               - 'curriculum/l2-uk-en/**/vocabulary.yaml'
+              - 'site/public/lexicon/practice-*.json'
+              - 'site/src/data/lexicon-daily-pool.json'
               - 'site/src/data/lexicon-manifest.json'
               - 'site/src/data/lexicon-manifest.fingerprint.json'
+              - 'site/src/data/lexicon-practice-reviewed-sources.json'
             postmortems:
               - '.github/workflows/ci.yml'
               - 'docs/bug-autopsies/**'
@@ -201,6 +207,9 @@ jobs:
       # an empty Atlas while the fingerprint/freshness gate above stays green. Blocks it.
       - name: Block thin/un-enriched Atlas manifest (#3658)
         run: python scripts/audit/check_atlas_manifest_enrichment.py
+
+      - name: Check static Word Day / practice assets (#3935)
+        run: python scripts/audit/check_static_practice_assets.py
 
       # Diff-scoped + advisory (#3150): only flags modules whose vocabulary.yaml changed
       # in THIS PR (no cross-PR coupling on the merge-train), and never blocks merge — a

--- a/scripts/audit/check_static_practice_assets.py
+++ b/scripts/audit/check_static_practice_assets.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""Check static Word of the Day and practice assets.
+
+The public practice page must work without backend/API/DB services. This audit
+validates the committed static files that page fetches: the daily pool and the
+per-level practice index, lexeme, and cloze shards.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+DEFAULT_DAILY_POOL = Path("site/src/data/lexicon-daily-pool.json")
+DEFAULT_PRACTICE_DIR = Path("site/public/lexicon")
+DEFAULT_REVIEWED_SOURCES = Path("site/src/data/lexicon-practice-reviewed-sources.json")
+DEFAULT_LEVELS = ("A1", "A2", "B1", "B2", "C1")
+DAILY_CEFR_LEVELS = {"A1", "A2", "B1"}
+PRACTICE_MODES = {"flashcards", "matching", "choice", "cloze"}
+EXPECTED_SCHEMAS = {
+    "index": "atlas-practice-index",
+    "lexemes": "atlas-practice-lexemes",
+    "cloze": "atlas-practice-cloze",
+}
+
+
+def _read_json(path: Path, errors: list[str]) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        errors.append(f"{path}: missing")
+    except json.JSONDecodeError as exc:
+        errors.append(f"{path}: invalid JSON at line {exc.lineno} column {exc.colno}: {exc.msg}")
+    return None
+
+
+def _has_text(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _reviewed_source_keys(path: Path, errors: list[str]) -> set[tuple[str, str]]:
+    payload = _read_json(path, errors)
+    rows = payload.get("reviewed") if isinstance(payload, dict) else payload
+    if not isinstance(rows, list):
+        errors.append(f"{path}: reviewed sources must be a list or an object with a reviewed list")
+        return set()
+
+    reviewed: set[tuple[str, str]] = set()
+    for index, row in enumerate(rows):
+        if isinstance(row, str):
+            if _has_text(row):
+                reviewed.add(("reviewed", row.strip()))
+            else:
+                errors.append(f"{path}: reviewed[{index}] is empty")
+        elif isinstance(row, dict):
+            status = str(row.get("status") or "reviewed").strip()
+            source_path = str(row.get("path") or "").strip()
+            if not source_path:
+                errors.append(f"{path}: reviewed[{index}] missing path")
+                continue
+            reviewed.add((status, source_path))
+        else:
+            errors.append(f"{path}: reviewed[{index}] must be string or object")
+    return reviewed
+
+
+def _check_daily_pool(path: Path, min_size: int, errors: list[str]) -> dict[str, Any]:
+    payload = _read_json(path, errors)
+    if not isinstance(payload, list):
+        errors.append(f"{path}: daily pool must be a list")
+        return {"count": 0, "by_cefr": {}, "by_kind": {}}
+
+    if len(payload) < min_size:
+        errors.append(f"{path}: daily pool has {len(payload)} entries, expected at least {min_size}")
+
+    slugs: set[str] = set()
+    by_cefr: Counter[str] = Counter()
+    by_kind: Counter[str] = Counter()
+    for index, item in enumerate(payload):
+        prefix = f"{path}: item[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+
+        lemma = item.get("lemma")
+        slug = item.get("slug")
+        gloss = item.get("gloss")
+        kind = item.get("k")
+        cefr = item.get("cefr")
+        if not _has_text(lemma):
+            errors.append(f"{prefix} missing lemma")
+        if not _has_text(slug):
+            errors.append(f"{prefix} missing slug")
+        elif slug in slugs:
+            errors.append(f"{prefix} duplicate slug {slug!r}")
+        else:
+            slugs.add(slug)
+        if not _has_text(gloss):
+            errors.append(f"{prefix} missing learner gloss")
+        if not _has_text(kind):
+            errors.append(f"{prefix} missing source kind k")
+        else:
+            by_kind[str(kind)] += 1
+
+        if _has_text(cefr):
+            by_cefr[str(cefr)] += 1
+        elif kind != "avoid":
+            errors.append(f"{prefix} missing CEFR for non-avoid daily word")
+
+        if _has_text(cefr) and cefr not in DAILY_CEFR_LEVELS:
+            errors.append(f"{prefix} CEFR {cefr!r} outside daily levels {sorted(DAILY_CEFR_LEVELS)}")
+        if kind == "avoid" and isinstance(gloss, str) and not gloss.casefold().startswith("avoid:"):
+            errors.append(f"{prefix} avoid item gloss must start with 'avoid:'")
+
+    return {
+        "count": len(payload),
+        "by_cefr": dict(by_cefr.most_common()),
+        "by_kind": dict(by_kind.most_common()),
+    }
+
+
+def _size_budget_ok(path: Path, payload: dict[str, Any], errors: list[str]) -> None:
+    size_budget = payload.get("sizeBudget")
+    if not isinstance(size_budget, dict):
+        errors.append(f"{path}: missing sizeBudget")
+        return
+    if size_budget.get("ok") is not True:
+        errors.append(f"{path}: sizeBudget.ok is not true")
+    for used_key, limit_key in (("rawBytes", "rawLimitBytes"), ("gzipBytes", "gzipLimitBytes")):
+        used = size_budget.get(used_key)
+        limit = size_budget.get(limit_key)
+        if not isinstance(used, int) or not isinstance(limit, int):
+            errors.append(f"{path}: sizeBudget missing integer {used_key}/{limit_key}")
+        elif used > limit:
+            errors.append(f"{path}: {used_key} {used} exceeds {limit_key} {limit}")
+
+
+def _check_shard_meta(path: Path, payload: Any, *, level: str, kind: str, errors: list[str]) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        errors.append(f"{path}: shard must be an object")
+        return {}
+
+    expected_schema = EXPECTED_SCHEMAS[kind]
+    if payload.get("schema") != expected_schema:
+        errors.append(f"{path}: schema {payload.get('schema')!r} != {expected_schema!r}")
+    if payload.get("schemaVersion") != 1:
+        errors.append(f"{path}: schemaVersion must be 1")
+    if payload.get("level") != level:
+        errors.append(f"{path}: level {payload.get('level')!r} != {level!r}")
+    if not _has_text(payload.get("deckVersion")):
+        errors.append(f"{path}: missing deckVersion")
+    _size_budget_ok(path, payload, errors)
+    return payload
+
+
+def _check_cloze_item(
+    path: Path,
+    item: Any,
+    *,
+    index: int,
+    level: str,
+    lexeme_ids: set[str],
+    index_cloze_ids: set[str],
+    reviewed: set[tuple[str, str]],
+    errors: list[str],
+) -> None:
+    prefix = f"{path}: cloze[{index}]"
+    if not isinstance(item, dict):
+        errors.append(f"{prefix} must be an object")
+        return
+
+    cloze_id = item.get("clozeId")
+    lemma_id = item.get("lemmaId")
+    sentence = item.get("sentence")
+    form = item.get("form")
+    if not _has_text(cloze_id):
+        errors.append(f"{prefix} missing clozeId")
+    elif cloze_id not in index_cloze_ids:
+        errors.append(f"{prefix} {cloze_id!r} not referenced by {level} index shard")
+    if not _has_text(lemma_id):
+        errors.append(f"{prefix} missing lemmaId")
+    elif lemma_id not in lexeme_ids:
+        errors.append(f"{prefix} lemmaId {lemma_id!r} missing from {level} lexeme shard")
+    if not (_has_text(sentence) and "___" in sentence):
+        errors.append(f"{prefix} sentence must contain ___ blank")
+    if not _has_text(form):
+        errors.append(f"{prefix} missing target form")
+    if not isinstance(item.get("caseRule"), dict):
+        errors.append(f"{prefix} missing caseRule")
+
+    options = item.get("options")
+    if not isinstance(options, list) or len(options) < 4:
+        errors.append(f"{prefix} must have at least 4 options")
+    else:
+        answer_count = sum(1 for option in options if isinstance(option, dict) and option.get("kind") == "answer")
+        if answer_count != 1:
+            errors.append(f"{prefix} must have exactly one answer option")
+
+    provenance = item.get("provenance")
+    status = provenance.get("status") if isinstance(provenance, dict) else None
+    source_path = provenance.get("path") if isinstance(provenance, dict) else None
+    key = (str(status or "").strip(), str(source_path or "").strip())
+    if key not in reviewed:
+        errors.append(f"{prefix} provenance {key!r} is not in reviewed source allowlist")
+
+
+def _check_level(
+    practice_dir: Path,
+    level: str,
+    min_lexemes: int,
+    reviewed: set[tuple[str, str]],
+    errors: list[str],
+) -> dict[str, Any]:
+    paths = {
+        "index": practice_dir / f"practice-index.{level}.json",
+        "lexemes": practice_dir / f"practice-lexemes.{level}.json",
+        "cloze": practice_dir / f"practice-cloze.{level}.json",
+    }
+    shards = {
+        kind: _check_shard_meta(
+            path,
+            _read_json(path, errors),
+            level=level,
+            kind=kind,
+            errors=errors,
+        )
+        for kind, path in paths.items()
+    }
+
+    index_items = shards["index"].get("items")
+    lexemes = shards["lexemes"].get("lexemes")
+    cloze_items = shards["cloze"].get("cloze")
+    if not isinstance(index_items, list):
+        errors.append(f"{paths['index']}: items must be a list")
+        index_items = []
+    if not isinstance(lexemes, list):
+        errors.append(f"{paths['lexemes']}: lexemes must be a list")
+        lexemes = []
+    if not isinstance(cloze_items, list):
+        errors.append(f"{paths['cloze']}: cloze must be a list")
+        cloze_items = []
+
+    if len(index_items) < min_lexemes:
+        errors.append(f"{paths['index']}: {len(index_items)} items, expected at least {min_lexemes}")
+    if len(lexemes) < min_lexemes:
+        errors.append(f"{paths['lexemes']}: {len(lexemes)} lexemes, expected at least {min_lexemes}")
+
+    versions = {str(shard.get("deckVersion")) for shard in shards.values() if shard.get("deckVersion")}
+    if len(versions) > 1:
+        errors.append(f"{practice_dir}: {level} shard deckVersion mismatch: {sorted(versions)}")
+
+    lexeme_by_id = {str(item.get("lemmaId")): item for item in lexemes if isinstance(item, dict)}
+    if len(lexeme_by_id) != len(lexemes):
+        errors.append(f"{paths['lexemes']}: duplicate or invalid lemmaId values")
+
+    index_cloze_ids: set[str] = set()
+    for index, item in enumerate(index_items):
+        prefix = f"{paths['index']}: items[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+        lemma_id = item.get("lemmaId")
+        if not _has_text(lemma_id):
+            errors.append(f"{prefix} missing lemmaId")
+        elif str(lemma_id) not in lexeme_by_id:
+            errors.append(f"{prefix} lemmaId {lemma_id!r} missing from lexeme shard")
+        if item.get("cefr") != level:
+            errors.append(f"{prefix} cefr {item.get('cefr')!r} != {level!r}")
+        modes = item.get("modes")
+        if not isinstance(modes, list) or "flashcards" not in modes:
+            errors.append(f"{prefix} modes must include flashcards")
+            modes = modes if isinstance(modes, list) else []
+        unknown_modes = sorted({mode for mode in modes if mode not in PRACTICE_MODES})
+        if unknown_modes:
+            errors.append(f"{prefix} unknown modes: {unknown_modes}")
+        cloze_ids = item.get("clozeIds")
+        if not isinstance(cloze_ids, list):
+            errors.append(f"{prefix} clozeIds must be a list")
+            cloze_ids = []
+        index_cloze_ids.update(str(cloze_id) for cloze_id in cloze_ids if _has_text(cloze_id))
+        has_cloze = bool(cloze_ids)
+        if item.get("hasCloze") is not has_cloze:
+            errors.append(f"{prefix} hasCloze does not match clozeIds")
+        if ("cloze" in modes) != has_cloze:
+            errors.append(f"{prefix} cloze mode does not match clozeIds")
+
+    for index, lexeme in enumerate(lexemes):
+        prefix = f"{paths['lexemes']}: lexemes[{index}]"
+        if not isinstance(lexeme, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+        for field in ("lemmaId", "lemma", "lemmaPlain", "gloss"):
+            if not _has_text(lexeme.get(field)):
+                errors.append(f"{prefix} missing {field}")
+        if lexeme.get("cefr") != level:
+            errors.append(f"{prefix} cefr {lexeme.get('cefr')!r} != {level!r}")
+
+    for index, item in enumerate(cloze_items):
+        _check_cloze_item(
+            paths["cloze"],
+            item,
+            index=index,
+            level=level,
+            lexeme_ids=set(lexeme_by_id),
+            index_cloze_ids=index_cloze_ids,
+            reviewed=reviewed,
+            errors=errors,
+        )
+
+    counts = shards["index"].get("counts")
+    if not isinstance(counts, dict):
+        errors.append(f"{paths['index']}: missing counts")
+        counts = {}
+    expected_cloze_lexemes = len({item.get("lemmaId") for item in cloze_items if isinstance(item, dict)})
+    expected_coverage = round(expected_cloze_lexemes / len(lexemes), 4) if lexemes else 0.0
+    expected_counts = {
+        "lexemes": len(lexemes),
+        "cloze": len(cloze_items),
+        "clozeEligibleLexemes": expected_cloze_lexemes,
+        "clozeCoverage": expected_coverage,
+    }
+    for key, expected in expected_counts.items():
+        if counts.get(key) != expected:
+            errors.append(f"{paths['index']}: counts.{key} {counts.get(key)!r} != {expected!r}")
+
+    return {
+        "index": len(index_items),
+        "lexemes": len(lexemes),
+        "cloze": len(cloze_items),
+        "deck_versions": sorted(versions),
+    }
+
+
+def check_assets(
+    *,
+    daily_pool: Path = DEFAULT_DAILY_POOL,
+    practice_dir: Path = DEFAULT_PRACTICE_DIR,
+    reviewed_sources: Path = DEFAULT_REVIEWED_SOURCES,
+    levels: tuple[str, ...] = DEFAULT_LEVELS,
+    min_daily_pool_size: int = 250,
+    min_practice_lexemes_per_level: int = 25,
+) -> dict[str, Any]:
+    errors: list[str] = []
+    daily = _check_daily_pool(daily_pool, min_daily_pool_size, errors)
+    reviewed = _reviewed_source_keys(reviewed_sources, errors)
+    practice = {
+        level: _check_level(practice_dir, level, min_practice_lexemes_per_level, reviewed, errors)
+        for level in levels
+    }
+
+    deck_versions = {
+        version
+        for row in practice.values()
+        for version in row.get("deck_versions", [])
+        if version
+    }
+    if len(deck_versions) > 1:
+        errors.append(f"{practice_dir}: cross-level deckVersion mismatch: {sorted(deck_versions)}")
+
+    total_cloze = sum(int(row["cloze"]) for row in practice.values())
+    if total_cloze and not reviewed:
+        errors.append(f"{reviewed_sources}: cloze shards are nonempty but reviewed allowlist is empty")
+
+    return {
+        "ok": not errors,
+        "errors": errors,
+        "daily": daily,
+        "practice": practice,
+        "reviewed_sources": len(reviewed),
+        "total_cloze": total_cloze,
+        "deck_versions": sorted(deck_versions),
+    }
+
+
+def _parse_levels(raw: str) -> tuple[str, ...]:
+    levels = tuple(level.strip().upper() for level in raw.split(",") if level.strip())
+    if not levels:
+        raise argparse.ArgumentTypeError("levels must contain at least one CEFR level")
+    return levels
+
+
+def _print_summary(summary: dict[str, Any]) -> None:
+    print(
+        "Static practice assets: "
+        f"{summary['daily']['count']} daily words, "
+        f"{sum(row['lexemes'] for row in summary['practice'].values())} practice lexemes, "
+        f"{summary['total_cloze']} cloze items."
+    )
+    print(f"Deck versions: {', '.join(summary['deck_versions']) or 'none'}")
+    print(f"Reviewed cloze source allowlist rows: {summary['reviewed_sources']}")
+    for level, row in summary["practice"].items():
+        print(
+            f"  {level}: index={row['index']} lexemes={row['lexemes']} "
+            f"cloze={row['cloze']}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--daily-pool", type=Path, default=DEFAULT_DAILY_POOL)
+    parser.add_argument("--practice-dir", type=Path, default=DEFAULT_PRACTICE_DIR)
+    parser.add_argument("--reviewed-sources", type=Path, default=DEFAULT_REVIEWED_SOURCES)
+    parser.add_argument("--levels", type=_parse_levels, default=DEFAULT_LEVELS)
+    parser.add_argument("--min-daily-pool-size", type=int, default=250)
+    parser.add_argument("--min-practice-lexemes-per-level", type=int, default=25)
+    parser.add_argument("--format", choices=("summary", "json"), default="summary")
+    args = parser.parse_args(argv)
+
+    summary = check_assets(
+        daily_pool=args.daily_pool,
+        practice_dir=args.practice_dir,
+        reviewed_sources=args.reviewed_sources,
+        levels=args.levels,
+        min_daily_pool_size=args.min_daily_pool_size,
+        min_practice_lexemes_per_level=args.min_practice_lexemes_per_level,
+    )
+
+    if args.format == "json":
+        print(json.dumps(summary, ensure_ascii=False, indent=2))
+    else:
+        _print_summary(summary)
+        if summary["errors"]:
+            print("Static practice asset gate failed:")
+            for error in summary["errors"]:
+                print(f"- {error}")
+    return 0 if summary["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_static_practice_assets.py
+++ b/tests/test_check_static_practice_assets.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from scripts.audit.check_static_practice_assets import check_assets
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+def _budget() -> dict[str, int | bool]:
+    return {
+        "rawBytes": 100,
+        "gzipBytes": 80,
+        "rawLimitBytes": 550_000,
+        "gzipLimitBytes": 140_000,
+        "ok": True,
+    }
+
+
+def _write_daily_pool(path: Path) -> None:
+    _write_json(
+        path,
+        [
+            {
+                "lemma": "дім",
+                "slug": "дім",
+                "gloss": "house",
+                "k": "vyv",
+                "cefr": "A1",
+                "weight": 3,
+            },
+            {
+                "lemma": "авось",
+                "slug": "авось",
+                "gloss": "avoid: ану ж",
+                "k": "avoid",
+                "weight": 2,
+            },
+        ],
+    )
+
+
+def _write_reviewed_sources(path: Path, *, reviewed: bool = False) -> None:
+    rows = (
+        [{"status": "reviewed", "path": "curriculum/l2-uk-en/a1/vocabulary/home.yaml"}]
+        if reviewed
+        else []
+    )
+    _write_json(path, {"reviewed": rows})
+
+
+def _write_level(practice_dir: Path, *, level: str = "A1", with_cloze: bool = False) -> None:
+    deck_version = "atlas-practice-v1-test"
+    cloze_id = "dim-cloze-1"
+    modes = ["flashcards", "matching", "choice"]
+    cloze_ids: list[str] = []
+    cloze_rows: list[dict[str, object]] = []
+    if with_cloze:
+        modes.append("cloze")
+        cloze_ids = [cloze_id]
+        cloze_rows = [
+            {
+                "clozeId": cloze_id,
+                "lemmaId": "dim",
+                "sentenceFrameId": "home-1",
+                "sentence": "Я живу у ___.",
+                "blankCase": "locative",
+                "form": "домі",
+                "caseRule": {"caseLabel": "місцевий", "feedback": "у + місцевий"},
+                "clozeEn": "I live in a house.",
+                "options": [
+                    {"label": "домі", "kind": "answer", "case": "locative", "lemmaId": "dim"},
+                    {"label": "місті", "kind": "decoy", "case": "locative", "lemmaId": "misto"},
+                    {"label": "школі", "kind": "decoy", "case": "locative", "lemmaId": "shkola"},
+                    {"label": "кімнаті", "kind": "decoy", "case": "locative", "lemmaId": "kimnata"},
+                ],
+                "provenance": {
+                    "status": "reviewed",
+                    "path": "curriculum/l2-uk-en/a1/vocabulary/home.yaml",
+                },
+            }
+        ]
+
+    _write_json(
+        practice_dir / f"practice-index.{level}.json",
+        {
+            "schema": "atlas-practice-index",
+            "schemaVersion": 1,
+            "deckVersion": deck_version,
+            "level": level,
+            "source": "fixture",
+            "sizeBudget": _budget(),
+            "counts": {
+                "lexemes": 1,
+                "cloze": len(cloze_rows),
+                "clozeEligibleLexemes": 1 if with_cloze else 0,
+                "clozeCoverage": 1.0 if with_cloze else 0.0,
+            },
+            "items": [
+                {
+                    "lemmaId": "dim",
+                    "lemma": "дім",
+                    "cefr": level,
+                    "modes": modes,
+                    "hasCloze": bool(cloze_ids),
+                    "clozeIds": cloze_ids,
+                    "newOrder": 0,
+                }
+            ],
+        },
+    )
+    _write_json(
+        practice_dir / f"practice-lexemes.{level}.json",
+        {
+            "schema": "atlas-practice-lexemes",
+            "schemaVersion": 1,
+            "deckVersion": deck_version,
+            "level": level,
+            "source": "fixture",
+            "sizeBudget": _budget(),
+            "lexemes": [
+                {
+                    "lemmaId": "dim",
+                    "lemma": "дім",
+                    "lemmaPlain": "дім",
+                    "ipa": None,
+                    "gloss": "house",
+                    "pos": "noun",
+                    "cefr": level,
+                    "heritage": None,
+                    "severity": None,
+                    "paradigm": {"cases": {}},
+                }
+            ],
+        },
+    )
+    _write_json(
+        practice_dir / f"practice-cloze.{level}.json",
+        {
+            "schema": "atlas-practice-cloze",
+            "schemaVersion": 1,
+            "deckVersion": deck_version,
+            "level": level,
+            "source": "fixture",
+            "sizeBudget": _budget(),
+            "cloze": cloze_rows,
+        },
+    )
+
+
+def _fixture_paths(tmp_path: Path) -> tuple[Path, Path, Path]:
+    daily_pool = tmp_path / "lexicon-daily-pool.json"
+    practice_dir = tmp_path / "lexicon"
+    reviewed_sources = tmp_path / "lexicon-practice-reviewed-sources.json"
+    _write_daily_pool(daily_pool)
+    _write_reviewed_sources(reviewed_sources)
+    _write_level(practice_dir)
+    return daily_pool, practice_dir, reviewed_sources
+
+
+def test_check_assets_accepts_static_fallback_assets(tmp_path: Path) -> None:
+    daily_pool, practice_dir, reviewed_sources = _fixture_paths(tmp_path)
+
+    summary = check_assets(
+        daily_pool=daily_pool,
+        practice_dir=practice_dir,
+        reviewed_sources=reviewed_sources,
+        levels=("A1",),
+        min_daily_pool_size=2,
+        min_practice_lexemes_per_level=1,
+    )
+
+    assert summary["ok"] is True
+    assert summary["daily"]["count"] == 2
+    assert summary["practice"]["A1"]["lexemes"] == 1
+    assert summary["total_cloze"] == 0
+
+
+def test_check_assets_fails_closed_for_unallowlisted_cloze(tmp_path: Path) -> None:
+    daily_pool = tmp_path / "lexicon-daily-pool.json"
+    practice_dir = tmp_path / "lexicon"
+    reviewed_sources = tmp_path / "lexicon-practice-reviewed-sources.json"
+    _write_daily_pool(daily_pool)
+    _write_reviewed_sources(reviewed_sources)
+    _write_level(practice_dir, with_cloze=True)
+
+    summary = check_assets(
+        daily_pool=daily_pool,
+        practice_dir=practice_dir,
+        reviewed_sources=reviewed_sources,
+        levels=("A1",),
+        min_daily_pool_size=2,
+        min_practice_lexemes_per_level=1,
+    )
+
+    assert summary["ok"] is False
+    assert summary["total_cloze"] == 1
+    assert any("not in reviewed source allowlist" in error for error in summary["errors"])
+    assert any("reviewed allowlist is empty" in error for error in summary["errors"])
+
+
+def test_check_assets_accepts_allowlisted_cloze(tmp_path: Path) -> None:
+    daily_pool = tmp_path / "lexicon-daily-pool.json"
+    practice_dir = tmp_path / "lexicon"
+    reviewed_sources = tmp_path / "lexicon-practice-reviewed-sources.json"
+    _write_daily_pool(daily_pool)
+    _write_reviewed_sources(reviewed_sources, reviewed=True)
+    _write_level(practice_dir, with_cloze=True)
+
+    summary = check_assets(
+        daily_pool=daily_pool,
+        practice_dir=practice_dir,
+        reviewed_sources=reviewed_sources,
+        levels=("A1",),
+        min_daily_pool_size=2,
+        min_practice_lexemes_per_level=1,
+    )
+
+    assert summary["ok"] is True
+    assert summary["reviewed_sources"] == 1
+    assert summary["total_cloze"] == 1
+
+
+def test_check_assets_reports_bad_daily_pool_rows(tmp_path: Path) -> None:
+    daily_pool, practice_dir, reviewed_sources = _fixture_paths(tmp_path)
+    _write_json(
+        daily_pool,
+        [
+            {
+                "lemma": "дім",
+                "slug": "дім",
+                "gloss": "house",
+                "k": "vyv",
+                "cefr": "B2",
+            },
+            {
+                "lemma": "інший",
+                "slug": "дім",
+                "gloss": "",
+                "k": "vyv",
+            },
+        ],
+    )
+
+    summary = check_assets(
+        daily_pool=daily_pool,
+        practice_dir=practice_dir,
+        reviewed_sources=reviewed_sources,
+        levels=("A1",),
+        min_daily_pool_size=2,
+        min_practice_lexemes_per_level=1,
+    )
+
+    assert summary["ok"] is False
+    assert any("outside daily levels" in error for error in summary["errors"])
+    assert any("duplicate slug" in error for error in summary["errors"])
+    assert any("missing learner gloss" in error for error in summary["errors"])
+    assert any("missing CEFR for non-avoid" in error for error in summary["errors"])
+
+
+def test_check_assets_reports_schema_and_index_inconsistencies(tmp_path: Path) -> None:
+    daily_pool, practice_dir, reviewed_sources = _fixture_paths(tmp_path)
+    index_path = practice_dir / "practice-index.A1.json"
+    index_payload = json.loads(index_path.read_text(encoding="utf-8"))
+    index_payload["schema"] = "wrong-schema"
+    index_payload["items"][0]["hasCloze"] = True
+    index_payload["items"][0]["modes"] = ["flashcards", "made-up-mode"]
+    index_payload["counts"]["lexemes"] = 99
+    _write_json(index_path, index_payload)
+
+    summary = check_assets(
+        daily_pool=daily_pool,
+        practice_dir=practice_dir,
+        reviewed_sources=reviewed_sources,
+        levels=("A1",),
+        min_daily_pool_size=2,
+        min_practice_lexemes_per_level=1,
+    )
+
+    assert summary["ok"] is False
+    assert any("wrong-schema" in error for error in summary["errors"])
+    assert any("unknown modes" in error for error in summary["errors"])
+    assert any("hasCloze does not match clozeIds" in error for error in summary["errors"])
+    assert any("counts.lexemes" in error for error in summary["errors"])
+
+
+def test_cli_reports_missing_static_shard(tmp_path: Path) -> None:
+    daily_pool, practice_dir, reviewed_sources = _fixture_paths(tmp_path)
+    (practice_dir / "practice-lexemes.A1.json").unlink()
+
+    result = subprocess.run(
+        [
+            ".venv/bin/python",
+            "scripts/audit/check_static_practice_assets.py",
+            "--daily-pool",
+            str(daily_pool),
+            "--practice-dir",
+            str(practice_dir),
+            "--reviewed-sources",
+            str(reviewed_sources),
+            "--levels",
+            "A1",
+            "--min-daily-pool-size",
+            "2",
+            "--min-practice-lexemes-per-level",
+            "1",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "practice-lexemes.A1.json: missing" in result.stdout


### PR DESCRIPTION
## Summary

Refs #3935.

This adds a deterministic health gate for the static Word of the Day / Daily Practice assets that the public site serves without backend/API/DB services.

## Changed

- Added `scripts/audit/check_static_practice_assets.py`.
- Validates `lexicon-daily-pool.json` is present, parseable, nonempty, has learner glosses, has stable slugs, and keeps normal daily words inside early CEFR levels.
- Validates each committed practice shard set under `site/public/lexicon/` has matching schemas, level, deck versions, size-budget metadata, nonempty recognition decks, valid index/lexeme cross references, and accurate counts.
- Keeps cloze fail-closed by requiring every cloze item provenance to appear in `lexicon-practice-reviewed-sources.json`; current production state remains `0` cloze items with an empty reviewed allowlist.
- Wires the checker into the existing Atlas freshness CI path and extends the path filter to cover daily pool, practice shards, reviewed-source allowlist, and the relevant generators.
- Adds focused tests for happy path, missing shard failure, unallowlisted/allowlisted cloze, bad daily pool rows, and index/schema/count inconsistencies.

## Current Static Baseline

`check_static_practice_assets.py` on committed assets reports:

- `300` daily words.
- `4123` practice lexemes.
- `0` cloze items.
- one deck version: `atlas-practice-v1-9cf4a4d7319d19ce`.
- A1 `1114`, A2 `1082`, B1 `1119`, B2 `469`, C1 `339` lexemes.

## Validation

- `.venv/bin/ruff check scripts/audit/check_static_practice_assets.py tests/test_check_static_practice_assets.py`
- `.venv/bin/python -m pytest tests/test_check_static_practice_assets.py tests/test_generate_daily_pool.py tests/test_generate_practice_deck.py -q`
- `.venv/bin/python scripts/audit/check_static_practice_assets.py`
- `.venv/bin/python scripts/audit/check_static_practice_assets.py --format json | .venv/bin/python -m json.tool >/dev/null`
- `.venv/bin/pre-commit run check-yaml --files .github/workflows/ci.yml`
- YAML parse via PyYAML
- `npm test -- --run tests/unit/lexicon-daily.test.ts tests/unit/LexiconPractice.test.tsx` from `site/`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- pre-commit hooks during commit and push

Read-only subagent review found no blockers; its low-severity coverage recommendation was addressed with additional negative tests. Gemini bridge review was attempted but unavailable due the local Gemini Code Assist tier/auth error.