### PR TITLE
docs(b2): persist M54-M58 LLM scores

### DIFF
--- a/docs/audits/b2-current-llm-scores-2026-06-28.md
+++ b/docs/audits/b2-current-llm-scores-2026-06-28.md
@@ -52,10 +52,15 @@ B2 M50 `questions-deliberative-rhetorical`,9/10,B+,Yes,Strong deliberative rheto
 B2 M51 `advanced-case-semantics`,9/10,B+,Yes,Strong advanced case-semantics module 10 workbook activities, 49 vocabulary items, final Agy/Claude Opus 4.6 review pass. Score held at 9 dense cross-case semantics non-blocking section-balance warnings.
 B2 M52 `pronoun-system-advanced`,9/10,B+,Yes,Strong advanced pronoun-system module 11 workbook activities, 31 vocabulary items, final Agy/Claude Opus 4.6 blocker fix and PASS re-review. Score held at 9 dense pronoun paradigms non-blocking target-form UA-GEC advisories.
 B2 M53 `checkpoint-cases-morphology`,9/10,B+,Yes,Strong B2.4 cases/morphology checkpoint 5 workbook and 5 inline activities, 30 vocabulary items, final Agy/Claude Opus 4.6 blocker fixes and PASS re-review. Score held at 9 compact synthesis non-blocking section-balance/UA-GEC advisories.
+B2 M54 `aspect-nuances-secondary-imperfectivization`,9/10,B+,Yes,Strong aspect nuance module 10 workbook activities, 40 vocabulary items, external review pass. Score held at 9 dense aspect semantics non-blocking redundancy/formulaic-style audit notes.
+B2 M55 `aspect-nuances-imperative-infinitive`,9/10,B+,Yes,Strong imperative/infinitive aspect module 10 workbook activities, 40 vocabulary items, external review pass. Score held at 9 conservative post-build polish risk and minor deterministic advisories.
+B2 M56 `pluperfect-tense`,9/10,B+,Yes,Strong pluperfect module 11 workbook activities, 40 vocabulary items, external review pass. Score held at 9 dense tense/register coverage and non-blocking deterministic style/UA-GEC advisories.
+B2 M57 `conditional-mood-particles`,9/10,B+,Yes,Strong conditional mood particles module 11 workbook activities, 40 vocabulary items, external review pass. Score held at 9 dense mood/particle coverage and minor deterministic advisories.
+B2 M58 `numeral-declension-time-dates`,9/10,B+,Yes,Strong numeral declension time/dates module 11 workbook activities, 40 vocabulary items, Agy/Gemini 3.1 Pro High re-review pass. Score held at 9 conservative post-fix human-polish reserve.
 
 Score,Count,Modules
 10/10,2,"M01, M08"
-9/10,50,"M02-M07, M09-M13, M15-M53"
+9/10,55,"M02-M07, M09-M13, M15-M58"
 8/10,1,M14
 
 Durable Report,Scope
@@ -70,6 +75,7 @@ Durable Report,Scope
 `docs/audits/b2-m43-m46-llm-score-report-2026-06-27.md`,M43-M46
 `docs/audits/b2-m47-m50-llm-score-report-2026-06-28.md`,M47-M50
 `docs/audits/b2-m51-m53-llm-score-report-2026-06-28.md`,M51-M53
+`docs/audits/b2-m54-m58-llm-score-report-2026-06-28.md`,M54-M58
 
 Module,Raw Word Count,Activities,Vocabulary
 M03 `b2-impersonal-passive`,4608,7 workbook / 4 inline,35
@@ -123,6 +129,11 @@ M50 `questions-deliberative-rhetorical`,4246,11 workbook / 0 inline,31
 M51 `advanced-case-semantics`,5124,10 workbook / 0 inline,49
 M52 `pronoun-system-advanced`,4403,11 workbook / 0 inline,31
 M53 `checkpoint-cases-morphology`,4957,5 workbook / 5 inline,30
+M54 `aspect-nuances-secondary-imperfectivization`,4973,10 workbook / 0 inline,40
+M55 `aspect-nuances-imperative-infinitive`,4317,10 workbook / 0 inline,40
+M56 `pluperfect-tense`,4636,11 workbook / 0 inline,40
+M57 `conditional-mood-particles`,4306,11 workbook / 0 inline,40
+M58 `numeral-declension-time-dates`,4246,11 workbook / 0 inline,40
 
 Score,Pass Count
 10/10,5/5 with no meaningful content polish
@@ -143,3 +154,4 @@ See `docs/audits/b2-m42-llm-score-report-2026-06-27.md`.,M42
 See `docs/audits/b2-m43-m46-llm-score-report-2026-06-27.md`.,M43-M46
 See `docs/audits/b2-m47-m50-llm-score-report-2026-06-28.md`.,M47-M50
 See `docs/audits/b2-m51-m53-llm-score-report-2026-06-28.md`.,M51-M53
+See `docs/audits/b2-m54-m58-llm-score-report-2026-06-28.md`.,M54-M58

--- a/docs/audits/b2-m54-m58-llm-score-report-2026-06-28.md
+++ b/docs/audits/b2-m54-m58-llm-score-report-2026-06-28.md
@@ -1,0 +1,27 @@
+Module,Score,Verdict,Deterministic Audit,Activity/Vocab Coverage,Ready Human Review?
+M54 `aspect-nuances-secondary-imperfectivization`,9/10,B+,PASS,10 workbook / 0 inline; 40 vocab,Yes
+M55 `aspect-nuances-imperative-infinitive`,9/10,B+,PASS,10 workbook / 0 inline; 40 vocab,Yes
+M56 `pluperfect-tense`,9/10,B+,PASS,11 workbook / 0 inline; 40 vocab,Yes
+M57 `conditional-mood-particles`,9/10,B+,PASS,11 workbook / 0 inline; 40 vocab,Yes
+M58 `numeral-declension-time-dates`,9/10,B+,PASS,11 workbook / 0 inline; 40 vocab,Yes
+
+Module,Notes
+M54 `aspect-nuances-secondary-imperfectivization`,Strong aspect nuance module 10 workbook activities and 40 vocabulary items, merged PR #3947 after external review pass. Score held at 9 for dense aspect semantics and non-blocking audit polish notes around redundancy/formulaic style.
+M55 `aspect-nuances-imperative-infinitive`,Strong imperative/infinitive aspect module 10 workbook activities and 40 vocabulary items, merged PR #3948 after external review pass. Score held at 9 for conservative post-build polish risk and minor deterministic advisory notes.
+M56 `pluperfect-tense`,Strong pluperfect module 11 workbook activities and 40 vocabulary items, merged PR #3950 after external review pass. Score held at 9 for dense tense/register coverage and non-blocking deterministic style/UA-GEC advisories.
+M57 `conditional-mood-particles`,Strong conditional mood particles module 11 workbook activities and 40 vocabulary items, merged PR #3951 after external review pass. Score held at 9 for dense mood/particle coverage and minor non-blocking deterministic advisory notes.
+M58 `numeral-declension-time-dates`,Strong numeral declension for time and dates module 11 workbook activities and 40 vocabulary items, merged PR #3953 after Agy/Gemini 3.1 Pro High re-review passed with 0 unresolved blockers. Score held at 9 for conservative post-fix human-polish reserve rather than content blockers.
+
+Score Rationale,Disposition
+Deterministic audit,All five modules passed deterministic module audit local validation.
+Validation,Activities vocabulary MDX generation deterministic audit diff check trailer lint and CI passed before merge.
+External review,Each module passed required external non-Codex review before merge; M58 model-answer blocker was fixed before merge and passed Agy/Gemini 3.1 Pro High re-review.
+Telemetry,Module-build telemetry persisted for PRs #3947 #3948 #3950 #3951 #3953 and M58 was updated to merged.
+Artifact hygiene,No status JSON generated audit report generated review report telemetry database linter config or `.python-version` files are included.
+
+Score,Pass Count
+10/10,5/5 no meaningful content polish
+9/10,5/5 non-blocking polish or unevenness
+8/10,4/5
+7/10,3/5
+6/10 or lower,0-2/5


### PR DESCRIPTION
## Scope
- Persist durable B2 M54-M58 LLM scores.
- Update the current B2 score snapshot through M58.
- No module content changes.

## Scores
- M54 `aspect-nuances-secondary-imperfectivization`: 9/10 B+
- M55 `aspect-nuances-imperative-infinitive`: 9/10 B+
- M56 `pluperfect-tense`: 9/10 B+
- M57 `conditional-mood-particles`: 9/10 B+
- M58 `numeral-declension-time-dates`: 9/10 B+

## Evidence
- M54-M58 content PRs merged: #3947, #3948, #3950, #3951, #3953.
- Deterministic audits passed for all five modules.
- Activities/vocabulary/MDX validation passed for all five modules.
- External non-Codex review passed for all five module PRs; M58 model-answer blocker was fixed and passed Agy/Gemini 3.1 Pro High re-review.
- Module-build telemetry persisted; M58 telemetry updated to `merged`.

## Validation / Hygiene
- PASS `git diff --check`
- PASS protected config/artifact guard
- PASS `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Changed files: 2 docs files under `docs/audits/`
- Forbidden generated artifacts included: no

## Independent Review
- Route/model: Agy / Gemini 3.1 Pro High
- Scope: read-only blocker review of score-only PR
- Disposition: PASS
- Unresolved findings: 0
- Notes: reviewer confirmed score rows are internally consistent, distribution is updated to 55 modules at 9/10 through M58, raw stats are present/plausible, scope is docs-only, and readiness wording stays at preview/human-review readiness.
