### PR TITLE
[codex] Route ask-gemini through agy

### DIFF
--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -28,7 +28,12 @@ from ._dispatch_wrappers import (
     handle_dispatch_fix,
     handle_review_deep,
 )
-from ._gemini import ask_gemini, converse_gemini, process_and_respond
+from ._gemini import (
+    AGY_GEMINI_DEFAULT_MODEL,
+    agy_model_for_gemini,
+    converse_gemini,
+    process_and_respond,
+)
 from ._grok_build import (
     GROK_BUILD_DEFAULT_MODEL,
     ask_grok_build,
@@ -519,20 +524,32 @@ def _build_parser() -> argparse.ArgumentParser:
                                   help="Prepend docs/review-protocol.md")
 
     # ask-gemini
-    ask_gemini_parser = subparsers.add_parser("ask-gemini", help="Send message AND invoke Gemini (one-step)")
+    ask_gemini_parser = subparsers.add_parser(
+        "ask-gemini",
+        help="Send message AND invoke Agy with a Gemini-family model (one-step)",
+    )
     ask_gemini_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
     ask_gemini_parser.add_argument("--task-id", required=True, help="Task ID (required for session tracking)")
     ask_gemini_parser.add_argument("--type", default="query", help="Message type (default: query)")
     ask_gemini_parser.add_argument("--data", help="Path to data file to attach")
     ask_gemini_parser.add_argument(
-        "--model", default=GEMINI_DEFAULT_MODEL, help="Gemini model to use"
+        "--model",
+        default=AGY_GEMINI_DEFAULT_MODEL,
+        help=(
+            "Gemini/Agy model to use; legacy Gemini CLI slugs are mapped to "
+            "Agy runtime slugs, then the runtime passes the matching `agy models` label"
+        ),
     )
     ask_gemini_parser.add_argument("--from-model", dest="from_model",
                                    help="Exact sender model ID")
     ask_gemini_parser.add_argument("--from", dest="from_llm",
                                    help="Sender agent family. Default: inferred from environment")
-    ask_gemini_parser.add_argument("--async", dest="async_mode", action="store_true",
-                                   help="Queue only, don't invoke Gemini CLI")
+    ask_gemini_parser.add_argument(
+        "--async",
+        dest="async_mode",
+        action="store_true",
+        help="Compatibility flag; ask-gemini now runs through synchronous Agy",
+    )
     ask_gemini_parser.add_argument("--stdout-only", dest="stdout_only", action="store_true",
                                    help="Print Gemini's response body to stdout for the "
                                         "caller to parse; a thin summary still goes to the "
@@ -577,7 +594,10 @@ def _build_parser() -> argparse.ArgumentParser:
     ask_agy_parser.add_argument("--from-model", dest="from_model",
                                 help="Exact sender model ID")
     ask_agy_parser.add_argument("--to-model", dest="to_model",
-                                help="Target Agy model ID (default: gemini-3.5-flash-high)")
+                                help=(
+                                    "Target Agy model slug or `agy models` display label "
+                                    "(default: gemini-3.5-flash-high)"
+                                ))
     ask_agy_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true",
                                 help="Run sync without timeout")
     ask_agy_parser.add_argument("--review", action="store_true",
@@ -1185,19 +1205,40 @@ def _handle_ask_gemini(args):
     content = sys.stdin.read() if args.content == "-" else args.content
     kwargs = {"review": True} if getattr(args, "review", False) else {}
     from_llm = _resolve_from_llm(args)
-    ask_gemini(content, args.task_id, args.type, data, args.model,
-               from_llm,
-               getattr(args, 'from_model', None),
-               getattr(args, 'async_mode', False),
-               getattr(args, 'stdout_only', False),
-               getattr(args, 'output_path', None),
-               getattr(args, 'extract', None),
-               getattr(args, 'skip_model_check', False),
-               getattr(args, 'allow_write', False),
-               getattr(args, 'delimiters', None),
-               getattr(args, 'no_github', False),
-               getattr(args, 'auth', None),
-               **kwargs)
+    target_model = agy_model_for_gemini(args.model)
+    ignored_flags = [
+        name
+        for name, enabled in (
+            ("--async", getattr(args, "async_mode", False)),
+            ("--stdout-only", getattr(args, "stdout_only", False)),
+            ("--output-path", bool(getattr(args, "output_path", None))),
+            ("--extract", bool(getattr(args, "extract", None))),
+            ("--skip-model-check", getattr(args, "skip_model_check", False)),
+            ("--allow-write", getattr(args, "allow_write", False)),
+            ("--delimiters", bool(getattr(args, "delimiters", None))),
+            ("--no-github", getattr(args, "no_github", False)),
+            ("--auth", bool(getattr(args, "auth", None))),
+        )
+        if enabled
+    ]
+    if ignored_flags:
+        print(
+            "ℹ️ ask-gemini now routes through Agy; ignored Gemini CLI flags: "
+            + ", ".join(ignored_flags)
+        )
+    print(f"ℹ️ ask-gemini routes through Agy with model {target_model}")
+    ask_agy(
+        content,
+        args.task_id,
+        args.type,
+        data,
+        False,
+        from_llm,
+        getattr(args, "from_model", None),
+        target_model,
+        False,
+        **kwargs,
+    )
 
 
 def main():

--- a/scripts/ai_agent_bridge/_gemini.py
+++ b/scripts/ai_agent_bridge/_gemini.py
@@ -54,6 +54,29 @@ from ._messaging import (
 from ._model import _detect_model_error
 from ._prompts import build_gemini_prompt
 
+AGY_GEMINI_DEFAULT_MODEL = "gemini-3.1-pro-high"
+_AGY_GEMINI_MODEL_ALIASES = {
+    "auto": AGY_GEMINI_DEFAULT_MODEL,
+    "gemini-3.1-pro-preview": "gemini-3.1-pro-high",
+    "gemini-3-pro-preview": "gemini-3.1-pro-high",
+    "gemini-3.0-pro-preview": "gemini-3.1-pro-high",
+    "gemini-3-flash-preview": "gemini-3.5-flash-high",
+    "gemini-3.0-flash-preview": "gemini-3.5-flash-high",
+    "gemini-3.1-flash-lite-preview": "gemini-3.5-flash-high",
+}
+
+
+def agy_model_for_gemini(model: str | None) -> str:
+    """Map legacy Gemini CLI model slugs onto Agy runtime slugs.
+
+    The Agy runtime adapter translates these slugs to the display labels printed
+    by ``agy models`` immediately before invoking ``agy --model``.
+    """
+    if not model:
+        return AGY_GEMINI_DEFAULT_MODEL
+    normalized = model.strip()
+    return _AGY_GEMINI_MODEL_ALIASES.get(normalized, normalized)
+
 
 def converse_gemini(content: str, task_id: str, model: str = "gemini-3.1-pro-preview",
                     skip_github: bool = False, auth_mode: str | None = None):

--- a/tests/test_gemini_bridge.py
+++ b/tests/test_gemini_bridge.py
@@ -8,11 +8,12 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
+from agent_runtime.adapters.agy import AgyAdapter
 from agent_runtime.errors import RateLimitedError
 from agent_runtime.result import Result
 from ai_agent_bridge._cli import _handle_ask_gemini
 from ai_agent_bridge._db import get_db, init_db
-from ai_agent_bridge._gemini import _run_gemini_sync
+from ai_agent_bridge._gemini import _run_gemini_sync, agy_model_for_gemini
 from ai_agent_bridge._messaging import send_message
 from batch_gemini_config import FALLBACK_MODEL, PRO_MODEL
 
@@ -175,14 +176,15 @@ def test_run_gemini_sync_passes_auth_mode_to_runtime(
     assert mock_invoke.call_args.kwargs["tool_config"] == {"auth_mode": "subscription"}
 
 
-def test_handle_ask_gemini_passes_auth_mode(monkeypatch):
+def test_handle_ask_gemini_routes_through_agy_with_model_mapping(monkeypatch):
     captured: dict[str, object] = {}
 
-    def _fake_ask_gemini(*args):
+    def _fake_ask_agy(*args, **kwargs):
         captured["args"] = args
+        captured["kwargs"] = kwargs
         return 123
 
-    monkeypatch.setattr("ai_agent_bridge._cli.ask_gemini", _fake_ask_gemini)
+    monkeypatch.setattr("ai_agent_bridge._cli.ask_agy", _fake_ask_agy)
 
     class _Args:
         content = "hello"
@@ -199,8 +201,59 @@ def test_handle_ask_gemini_passes_auth_mode(monkeypatch):
         skip_model_check = False
         allow_write = False
         delimiters = None
-        no_github = True
-        auth = "api-key"
+        no_github = False
+        auth = None
+        review = True
 
     _handle_ask_gemini(_Args())
-    assert captured["args"][-1] == "api-key"
+    assert captured["args"] == (
+        "hello",
+        "task-1",
+        "query",
+        None,
+        False,
+        "claude",
+        None,
+        "gemini-3.1-pro-high",
+        False,
+    )
+    assert captured["kwargs"] == {"review": True}
+
+
+def test_legacy_gemini_model_resolves_to_agy_display_label():
+    target_model = agy_model_for_gemini(PRO_MODEL)
+
+    assert target_model == "gemini-3.1-pro-high"
+    assert AgyAdapter()._resolve_model_flag(target_model) == "Gemini 3.1 Pro (High)"
+
+
+def test_handle_ask_gemini_accepts_agy_model_name(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def _fake_ask_agy(*args, **_kwargs):
+        captured["args"] = args
+        return 123
+
+    monkeypatch.setattr("ai_agent_bridge._cli.ask_agy", _fake_ask_agy)
+
+    class _Args:
+        content = "hello"
+        task_id = "task-1"
+        type = "query"
+        data = None
+        model = "gemini-3.5-flash-high"
+        from_llm = "claude"
+        from_model = None
+        async_mode = False
+        stdout_only = False
+        output_path = None
+        extract = None
+        skip_model_check = False
+        allow_write = False
+        delimiters = None
+        no_github = False
+        auth = None
+        review = False
+
+    _handle_ask_gemini(_Args())
+    assert captured["args"][7] == "gemini-3.5-flash-high"


### PR DESCRIPTION
Closes #3957.

## Summary
- route `ask-gemini` through `ask_agy` so stale Gemini CLI / Code Assist auth paths are no longer used
- map legacy Gemini CLI model names such as `gemini-3.1-pro-preview` to AGY runtime slugs such as `gemini-3.1-pro-high`
- document that the AGY adapter converts those slugs to the actual `agy models` display labels, e.g. `Gemini 3.1 Pro (High)`
- keep obsolete Gemini CLI-only flags accepted as compatibility no-ops with a warning

## Validation
- `.venv/bin/python -m py_compile scripts/ai_agent_bridge/_cli.py scripts/ai_agent_bridge/_gemini.py tests/test_gemini_bridge.py`
- `.venv/bin/ruff check scripts/ai_agent_bridge/_cli.py scripts/ai_agent_bridge/_gemini.py tests/test_gemini_bridge.py`
- `.venv/bin/python -m pytest tests/test_gemini_bridge.py tests/test_bridge_inbox_cli.py tests/ai_agent_bridge/test_agy_model_selection.py -q`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

No live AGY review call was run for this bridge patch; routing and model selection are covered by mocked bridge tests plus the AGY adapter model-selection regression test.