### PR TITLE
fix: retire Gemini CLI bridge route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,28 @@ This project runs **locally with pyenv**, NOT in Docker. Do not use:
 - `/app/curriculum/...` — use relative paths or real local paths
 - `localhost:8765` — use relative URLs (`/api/...`)
 
+### 13. Use Current Agent Tooling
+
+Gemini CLI and Gemini Code Assist are not supported or restorable routes for
+this project. For Gemini-family work, use AGY through the project bridge or
+dispatch runtime.
+
+Do not tell agents to run bare `ab ...` commands. On the user's machine `ab`
+resolves to ApacheBench (`/usr/sbin/ab`), so bare `ab ask-*`, `ab post`, and
+`ab discuss` instructions are brittle. Use explicit project entry points:
+
+```bash
+.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy - \
+  --task-id review-123 \
+  --to-model gemini-3.1-pro-high
+
+scripts/delegate.py dispatch --agent agy --brief docs/dispatch-briefs/task.md --worktree
+```
+
+Direct `agy --model` calls use display labels from `agy models`, such as
+`Gemini 3.1 Pro (High)` and `Gemini 3.5 Flash (High)`. The bridge/runtime may
+map slugs such as `gemini-3.1-pro-high` to those labels.
+
 ---
 
 ## Economical Multi-Agent Delegation
@@ -255,7 +277,7 @@ Cost controls:
 - Do not spawn a subagent for work the main agent can finish faster than delegation overhead.
 - Keep routine delegation to one to three subagents at a time unless the user explicitly asks for a larger sweep.
 - Do not let subagents read secrets, source `.envrc`, call `gh`, request reviews, or merge PRs.
-- Do not delegate independent review requirement. Internal GPT helper swarms and Codex self-review do not satisfy the external gate. Request one read-only review through an independent non-Codex route and treat unresolved blockers as blockers. Current lanes: Hermes -> DeepSeek 4 Pro; Agy -> Gemini models and Claude Opus 4.6 when available; Cursor -> non-Codex models including Composer 2.5. If Claude main provider is unavailable before Monday, June 29, 2026 09:00 Budapest local time, do not block on Claude; use another independent non-Codex route.
+- Do not delegate independent review requirement. Internal GPT helper swarms Codex self-review do not satisfy external gate. Request one read-only review through an independent non-Codex route and treat unresolved findings as blockers. Current lanes: Hermes -> DeepSeek 4 Pro; Agy -> Gemini models with Claude Opus 4.6 available; Cursor -> non-Codex models including Composer 2.5. If Claude main provider is unavailable before Monday, June 29, 2026 09:00 Budapest local time, do not block on Claude; use another independent non-Codex route. If AGY is used as that route, call it through the explicit bridge, example `printf '%s\n' "<review prompt>" | .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy - --task-id review-<id> --to-model gemini-3.1-pro-high --review`.
 
 Module-build PRs must persist token telemetry through
 `POST /api/telemetry/module-builds` and include the same summary in the PR body
@@ -333,9 +355,9 @@ curriculum/l2-uk-en/
 
 ## Multi-Agent Deliberation Protocol (added 2026-05-02 — issue #1639)
 
-You will sometimes be invoked via `ab discuss` for design / framing / pedagogy / architecture decisions. **This is NOT a quorum** — Claude/Gemini/Codex have correlated training-data priors. What we DO get from deliberation: more angles, adversarial pressure, written record.
+You will sometimes be invoked via `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss` for design / framing / pedagogy / architecture decisions. **This is NOT a quorum** — Claude/AGY/Codex have correlated training-data priors. What we DO get from deliberation: more angles, adversarial pressure, written record.
 
-**When you participate in `ab discuss`:**
+**When you participate in multi-agent discussion through `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss`:**
 
 1. **End with `[AGREE]`** if you genuinely agree with the prior round's converging position. This short-circuits the discussion.
 2. **Surface options with explicit labels** — Option A / Option B / Option C. Don't bury alternatives in prose.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@
 
 > **Status**: `curriculum/l2-uk-en/{level}/status/{slug}.json` | Update: `.venv/bin/python scripts/audit_module.py {path}`
 
-> **Cross-session Memory**: Built-in auto-memory at `~/.claude/projects/.../memory/MEMORY.md`. Inter-agent comms via `scripts/ai_agent_bridge/__main__.py`; Headroom is also available as the `headroom` MCP server for compressed handoffs, retrieval, stats, and shared proxy memory.
+> **Cross-session Memory**: Built-in auto-memory at `~/.claude/projects/.../memory/MEMORY.md`. Inter-agent comms via `.venv/bin/python scripts/ai_agent_bridge/__main__.py`; Headroom is also available as the `headroom` MCP server for compressed handoffs, retrieval, stats, and shared proxy memory. Gemini-family work routes through AGY, not Gemini CLI or Gemini Code Assist; see `docs/guardrails/agent-fleet-tooling.md`.
 
 > **Default subagent**: Always use `subagent_type: "curriculum-orchestrator"` when spawning agents for curriculum orchestration work.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,8 @@
 # GEMINI.md — Yellow Team Context
 
-> **Provider boundary:** Shared repository invariants live in `AGENTS.md`. Gemini/Agy agents should read `AGENTS.md` plus this Gemini-specific context; Codex prompts should not read this file as runtime instructions.
+> **Provider boundary:** Shared repository invariants live in `AGENTS.md`. Gemini/Agy agents should read `AGENTS.md` plus Gemini-specific context; Codex prompts should not read this file for runtime instructions.
+
+> **Current tooling note:** Gemini CLI and Gemini Code Assist are unsupported for this project. Gemini-family work now routes through AGY via `.venv/bin/python scripts/ai_agent_bridge/__main__.py ...` or `scripts/delegate.py dispatch --agent agy ...`. See `docs/guardrails/agent-fleet-tooling.md`.
 
 ## Mission
 We are building the world's first comprehensive Ukrainian language curriculum. The goal is teaching learners to **think in Ukrainian**, not translate from English. Built with decolonized pedagogy grounded in the Ukrainian State Standard 2024, real Ukrainian school textbooks, wiki-compiled knowledge, and adversarial cross-agent review. Quality over quantity. 5 excellent modules beat 55 mediocre ones.
@@ -164,9 +166,9 @@ data/
 
 ## Multi-Agent Deliberation Protocol (added 2026-05-02 — issue #1639)
 
-You will sometimes be invoked via `ab discuss` for design / framing / pedagogy / architecture decisions. **This is NOT a quorum** — Claude/Gemini/Codex have correlated training-data priors. What we DO get from deliberation: more angles, adversarial pressure, written record.
+You will sometimes be invoked via `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss` for design / framing / pedagogy / architecture decisions. **This is NOT a quorum** — Claude/AGY/Codex have correlated training-data priors. What we DO get from deliberation: more angles, adversarial pressure, written record.
 
-**When you participate in `ab discuss`:**
+**When you participate in `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss`:**
 
 1. **End with `[AGREE]`** if you genuinely agree with the prior round's converging position. This short-circuits the discussion.
 2. **Surface options with explicit labels** — Option A / Option B / Option C. Don't bury alternatives in prose.

--- a/docs/RUNBOOK-BUILD.md
+++ b/docs/RUNBOOK-BUILD.md
@@ -65,24 +65,12 @@ V7 is single-module per invocation (no `--range`). To run a batch, use standard 
   --writer gemini-tools --reviewer gemini-tools
 ```
 
-### Gemini Auth Mode
+### AGY Route
 
-```bash
-# Auto (default): preserve current environment behavior
-.venv/bin/python scripts/build/v7_build.py a1 m01-alphabet --worktree --writer gemini-tools
-
-# Subscription / OAuth: strip GEMINI_API_KEY and GOOGLE_API_KEY for this run
-GEMINI_AUTH_MODE=subscription \
-  .venv/bin/python scripts/build/v7_build.py a1 m01-alphabet --worktree --writer gemini-tools
-
-# API key: preserve key env vars explicitly
-GEMINI_AUTH_MODE=api \
-  GEMINI_API_KEY=... \
-  .venv/bin/python scripts/build/v7_build.py a1 m01-alphabet --worktree --writer gemini-tools
-```
-
-`GEMINI_AUTH_MODE=subscription|api|auto` only affects Gemini CLI launches.
-Claude and Codex paths ignore it.
+Gemini CLI auth modes are legacy-only and are not supported for current
+project work. Route Gemini-family review or Q&A through AGY via
+`ai_agent_bridge`. Use `scripts/delegate.py dispatch --agent agy` for
+dispatched execution.
 
 ### Resume (continue from where it stopped)
 

--- a/docs/RUNBOOK-BUILD.md
+++ b/docs/RUNBOOK-BUILD.md
@@ -97,7 +97,7 @@ dispatched execution.
 ## Important Flags
 
 | Flag | What it does |
-|------|-------------|
+| --- | --- |
 | `--resume` | Skip completed phases (reads state.json) |
 | `--step publish --resume` | Audit → heal → publish only (cheapest resume) |
 | `--step review --resume` | Re-review only |
@@ -138,7 +138,7 @@ done
 ## Module Counts (from curriculum.yaml)
 
 | Level | Modules | Plans | Wikis |
-|-------|---------|-------|-------|
+| --- | --- | --- | --- |
 | A1 | 55 | 55 | 55 ✅ |
 | A2 | 69 | 69 | 69 ✅ |
 | B1 | 94 | 100 | 100 ✅ |

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -385,7 +385,7 @@ Additional audit guardrails:
   --mode danger
 ```
 
-Fire-and-forget **execution** with status polling and completion artifacts. This is the right tool when you need another agent to write code, run commands, and commit — not to hold a conversation. For discussion, reviews, or Q&A see [Inter-Agent Communication](#inter-agent-communication) below (`ab` channel bridge, `ask-*`).
+Fire-and-forget **execution** with status polling and completion artifacts. This is the right tool when you need another agent to write code, run commands, and commit — not to hold a conversation. For discussion, reviews, or Q&A see [Inter-Agent Communication](#inter-agent-communication) below (`ai_agent_bridge` channel bridge, `ask-*`).
 
 For write-capable delegation, prefer `--worktree`. `delegate.py` creates the worktree if missing and records its path in the task state. `--mode danger` now requires `--worktree` so background agents cannot switch branches in the main checkout by accident.
 
@@ -871,7 +871,7 @@ The Monitor API exposes the same read-only JSON at `/api/decisions/lineage`.
 Claude, Gemini, and Codex coordinate through three distinct primitives. Pick the right one for the job.
 
 > **Authoritative sources:**
-> - [`docs/best-practices/agent-bridge.md`](best-practices/agent-bridge.md) — channel bridge mechanics, pinned context, include chains, `ab discuss`
+> - [`docs/best-practices/agent-bridge.md`](best-practices/agent-bridge.md) — channel bridge mechanics, pinned context, include chains, bridge `discuss`
 > - [`docs/best-practices/agent-cooperation.md`](best-practices/agent-cooperation.md) — agent roles, Green Team protocol, review discipline
 >
 > This section is a quick-reference index. For anything more than the examples below, read the authoritative docs.
@@ -880,8 +880,8 @@ Claude, Gemini, and Codex coordinate through three distinct primitives. Pick the
 
 | Need | Tool | Write access? |
 |---|---|---|
-| Sustained topic-scoped discussion, multi-turn, pinned context | **`ab post` / `ab discuss`** (channel bridge) | No (Q&A only) |
-| One-off drive-by question to another agent | **`ask-claude` / `ask-gemini` / `ask-codex`** | No by default; opt-in via `--allow-write` |
+| Sustained topic-scoped discussion, multi-turn, pinned context | **`ai_agent_bridge post` / `ai_agent_bridge discuss`** (channel bridge) | No (Q&A only) |
+| One-off drive-by question to another agent | **`ask-claude` / `ask-agy` / `ask-codex`** | No by default; opt-in via `--allow-write` |
 | Fire-and-forget execution — run code, commit, push | **`scripts/delegate.py dispatch`** | Yes |
 | Watch a long-running process (builds, reviews) emit events — **Claude only** | **`Monitor` tool** (Claude Code built-in) | N/A |
 | Watch a long-running process — **Gemini / Codex** | Shell-poll the Monitor API | N/A |
@@ -889,7 +889,7 @@ Claude, Gemini, and Codex coordinate through three distinct primitives. Pick the
 
 **Rules of thumb:**
 - Channel-first for anything >1 turn. The pinned `context.md` eliminates re-pasting project setup on every round.
-- `ask-*` is not deprecated — use it for genuine one-shots.
+- `ask-*` is not deprecated for genuine one-shots. `ask-gemini` is retired; use `ask-agy` for Gemini-family one-shots.
 - `ai_agent_bridge` is for **communication**. `delegate.py dispatch` is for **execution**. Don't confuse them.
 - Never run a polling loop to check a background task — use `Monitor` or the bash `run_in_background` completion notification.
 
@@ -899,44 +899,38 @@ Channels are topic-scoped threads with auto-prepended pinned context and a Monit
 
 Seeded channels: `shared`, `pipeline`, `content`, `architecture`, `reviews`. `shared` is included by all others.
 
-Set up the `ab` shorthand once (the bridge ships no wrapper, and system `/usr/sbin/ab` is Apache Bench):
-
-```bash
-alias ab='.venv/bin/python scripts/ai_agent_bridge/__main__.py'
-```
-
-Then:
+Use the explicit bridge path. Do not rely on `ab`; on some machines it resolves to ApacheBench.
 
 ```bash
 # Inspect
-ab channel list
-ab channel info pipeline
-ab channel tail reviews -n 20
-ab channel tail reviews --thread THREAD_ID
+.venv/bin/python scripts/ai_agent_bridge/__main__.py channel list
+.venv/bin/python scripts/ai_agent_bridge/__main__.py channel info pipeline
+.venv/bin/python scripts/ai_agent_bridge/__main__.py channel tail reviews -n 20
+.venv/bin/python scripts/ai_agent_bridge/__main__.py channel tail reviews --thread THREAD_ID
 
 # Create a new topic-scoped channel
-ab channel new mytopic --include shared --agents claude,gemini,codex
+.venv/bin/python scripts/ai_agent_bridge/__main__.py channel new mytopic --include shared --agents claude,agy,codex
 
 # Post — short form (one recipient)
-ab p reviews gemini "Review the heal-loop changes in scripts/build/linear_pipeline.py"
+.venv/bin/python scripts/ai_agent_bridge/__main__.py p reviews agy "Review the heal-loop changes in scripts/build/linear_pipeline.py"
 
 # Post — long form (multi-recipient, threading)
-ab post reviews "Adversarial review of #1299 docs patch" --to gemini,codex --parent MSG_ID
+.venv/bin/python scripts/ai_agent_bridge/__main__.py post reviews "Adversarial review of #1299 docs patch" --to agy,codex --parent MSG_ID
 
 # Multi-agent bounded discussion (parallel rounds, short-circuits on [AGREE])
-ab discuss architecture "Should we extract the V6 god object?" \
-    --with claude,gemini,codex --max-rounds 2
+.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss architecture "Should we extract the V6 god object?" \
+    --with claude,agy,codex --max-rounds 2
 
-# Drain incoming channel deliveries (REQUIRED for headless Gemini/Codex;
+# Drain incoming channel deliveries (REQUIRED for headless AGY/Codex;
 # Claude Code drains automatically via OS-level watchers)
-ab sync gemini --auth subscription
-ab sync --all
+.venv/bin/python scripts/ai_agent_bridge/__main__.py sync agy
+.venv/bin/python scripts/ai_agent_bridge/__main__.py sync --all
 ```
 
 **Reading messages — critical distinction:**
 
-- `ab sync <agent>` drains the **channel deliveries queue** — this is how Gemini and Codex actually receive channel posts when running headless.
-- `ab inbox` (in the Legacy broker section below) reads the **old 1:1 message queue ONLY**. It does NOT show channel messages. If you expected channel posts and `ab inbox` is empty, run `ab sync` instead.
+- `sync <agent>` drains the **channel deliveries queue** — this is how AGY and Codex actually receive channel posts when running headless.
+- `inbox` (in the Legacy broker section below) reads the **old 1:1 message queue ONLY**. It does NOT show channel messages. If you expected channel posts and `inbox` is empty, run `sync` instead.
 
 Web dashboard at `http://localhost:8765/channels.html` (localhost-only, read + post).
 
@@ -946,58 +940,54 @@ Fire a single query at one agent. Each recipient has its own model flag and defa
 
 | Recipient | Flag | Recommended value |
 |---|---|---|
-| Gemini | `--model`, `--auth` | `gemini-3.1-pro-preview`, `subscription` |
+| AGY | `--to-model` | `gemini-3.1-pro-high` or display label from `agy models`, e.g. `Gemini 3.1 Pro (High)` |
 | Codex | `--model` | omit unless overriding (defaults to `gpt-5.5` via runtime config) |
 | Claude | `--to-model` | omit (auto-selects per active session); override only when routing to a specific Opus/Sonnet tier |
 
 ```bash
-# Gemini — adversarial review
-ab ask-gemini "Adversarial review for #NNN. Read {path}." \
+# AGY — Gemini-family adversarial review
+.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy "Adversarial review for #NNN. Read {path}." \
   --task-id issue-NNN \
-  --model gemini-3.1-pro-preview \
-  --auth subscription
+  --to-model gemini-3.1-pro-high
 
 # Codex — quick question
-ab ask-codex "Review posted on #1177. Please read and respond." \
+.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-codex "Review posted on #1177. Please read and respond." \
   --task-id issue-1177
 
-# Claude — routed from Gemini/Codex or a script
-ab ask-claude "Please verify the stress marks in curriculum/l2-uk-en/a1/hello.md" \
-  --task-id stress-verify-hello --from gemini
+# Claude — routed from AGY/Codex or a script
+.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-claude "Please verify the stress marks in curriculum/l2-uk-en/a1/hello.md" \
+  --task-id stress-verify-hello --from agy
 
-# Gemini with skill activation + write access
-ab ask-gemini "Activate skill final-review. ..." \
+# AGY with skill activation + write access
+.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy "Activate skill final-review. ..." \
   --task-id fr-{slug} --allow-write \
   --delimiters FINAL_REVIEW,FRICTION \
-  --model gemini-3.1-pro-preview \
-  --auth subscription
+  --to-model gemini-3.1-pro-high
 ```
 
-Gemini auth examples:
+AGY examples:
 
 ```bash
-# Default: subscription/OAuth-backed bridge call
-ab ask-gemini "Review #NNN." \
+# Default: AGY bridge call
+.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy "Review #NNN." \
   --task-id issue-NNN \
-  --model gemini-3.1-pro-preview \
-  --auth subscription
+  --to-model gemini-3.1-pro-high
 
-# Explicit API-key-backed one-off
-ab ask-gemini "Quick one-off check." \
-  --task-id adhoc-gemini-check \
-  --model gemini-3.1-pro-preview \
-  --auth api-key
+# Fast AGY one-off
+.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy "Quick one-off check." \
+  --task-id adhoc-agy-check \
+  --to-model gemini-3.5-flash-high
 
-# Drain Gemini's channel inbox explicitly via subscription auth
-ab inbox run gemini --auth subscription
-ab sync gemini --auth subscription
+# Drain AGY channel inbox explicitly
+.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox run agy
+.venv/bin/python scripts/ai_agent_bridge/__main__.py sync agy
 ```
 
-> **Note.** You rarely call `ask-claude` from inside a Claude session — you already *are* Claude. It's the return path for Gemini/Codex or for scripts routing work to Claude.
+> **Note.** You rarely call `ask-claude` from inside a Claude session — you already *are* Claude. It's the return path for AGY/Codex or for scripts routing work to Claude.
 
 ### Execution via `delegate.py dispatch`
 
-For write-access work (implement, commit, push). See [Delegate to background workers](#delegate-to-background-workers) above for the full command. **Not** a comms tool — use `ab` or `ask-*` to discuss, `delegate.py` to have the work done.
+For write-access work (implement, commit, push). See [Delegate to background workers](#delegate-to-background-workers) above for the full command. **Not** a comms tool — use `ai_agent_bridge` or `ask-*` to discuss, `delegate.py` to have the work done.
 
 When the delegated task may edit files or run git commands:
 
@@ -1017,7 +1007,7 @@ Use `delegate.py status-or-fail <task-id>` before reporting async task state fro
 
 Two event surfaces, split by agent:
 
-- **Claude Code** has a built-in `Monitor` tool that streams stdout events as notifications with ~zero context cost. Use it to watch `v7_build.py` JSONL events, `ab channel watch --event-stream`, or any long-running command. Invoke the tool directly — do **not** wrap it in a shell poll loop.
+- **Claude Code** has a built-in `Monitor` tool that streams stdout events as notifications with ~zero context cost. Use it to watch `v7_build.py` JSONL events, `.venv/bin/python scripts/ai_agent_bridge/__main__.py channel watch --event-stream`, or any long-running command. Invoke the tool directly — do **not** wrap it in a shell poll loop.
 - **Gemini / Codex** (headless) do not have `Monitor`. Poll the Monitor API via `curl` when they need to check state.
 
 State queries (all agents):
@@ -1048,8 +1038,8 @@ Defaults:
 ### Usage telemetry
 
 ```bash
-ab codex-usage --window 5h
-ab codex-usage --window 24h --entrypoint bridge --json
+.venv/bin/python scripts/ai_agent_bridge/__main__.py codex-usage --window 5h
+.venv/bin/python scripts/ai_agent_bridge/__main__.py codex-usage --window 24h --entrypoint bridge --json
 ```
 
 Reads recent `batch_state/api_usage/usage_codex-*.jsonl` records, groups by outcome and entrypoint, lists recent rate-limit events, and reports whether `gpt-5.5` currently has bridge headroom.
@@ -1058,18 +1048,15 @@ Reads recent `batch_state/api_usage/usage_codex-*.jsonl` records, groups by outc
 
 The original 1:1 broker (separate from channels) is still available for low-level inspection and legacy flows. Prefer channels for new work.
 
-> **Do not confuse with channel draining.** `ab inbox` reads **only** the legacy 1:1 queue. Channel deliveries require `ab sync <agent>` (see Channel bridge above). An empty `ab inbox` does NOT mean you have no channel messages.
+> **Do not confuse with channel draining.** `inbox` reads **only** the legacy 1:1 queue. Channel deliveries require `sync <agent>` (see Channel bridge above). An empty `inbox` does NOT mean you have no channel messages.
 
 ```bash
-ab inbox
-ab inbox --for codex
-ab read <message_id>
-ab conversation <task_id>
-ab send "Your message" --type query --task-id my-task
-ab process <message_id> --model gemini-3.1-pro-preview
-ab interactive
-ab converse "Let's plan the A1/1 build" --task-id a1-1-planning \
-  --model gemini-3.1-pro-preview
+.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox
+.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox --for codex
+.venv/bin/python scripts/ai_agent_bridge/__main__.py read <message_id>
+.venv/bin/python scripts/ai_agent_bridge/__main__.py conversation <task_id>
+.venv/bin/python scripts/ai_agent_bridge/__main__.py send "Your message" --type query --task-id my-task
+.venv/bin/python scripts/ai_agent_bridge/__main__.py interactive
 ```
 
 | Message type | Purpose |

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -47,7 +47,7 @@ Session hooks live in `claude_extensions/hooks/` and deploy to `.claude/hooks/`.
 Runs on every session start, new or resumed.
 
 | # | Check | Severity | Details |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | 1 | Python venv | ISSUE | `.venv/bin/python` exists and is 3.12.x |
 | 2 | Env vars | ISSUE | `CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS` is set |
 | 3 | Message broker | INFO | SQLite DB for agent communication exists |
@@ -280,7 +280,7 @@ PID/lock/port bookkeeping — **always use it instead of ad-hoc `npm run dev`,
 servers.
 
 | Service | Port | What it is |
-|---|---|---|
+| --- | --- | --- |
 | `sources` | 8766 | MCP Sources Server (SQLite FTS5 — textbooks, dicts, literary, Wikipedia). Legacy alias: `rag`. |
 | `api` | 8765 | API / Monitor dashboard (FastAPI) — the `/api/orient` etc. cold-start endpoints. |
 | `astro` | **4321** | **Astro Course UI dev server** — the local site. Alias: `starlight`. |
@@ -311,7 +311,7 @@ of a second server:
 ### Key Files
 
 | File | Purpose |
-|---|---|
+| --- | --- |
 | `scripts/wiki/compile.py` | Wiki compiler CLI |
 | `scripts/wiki/compiler.py` | Compilation logic |
 | `scripts/wiki/enrichment.py` | Source enrichment pipeline |
@@ -330,7 +330,7 @@ of a second server:
 ## Related Documentation
 
 | Document | Purpose |
-|---|---|
+| --- | --- |
 | `.claude/rules/workflow.md` | Core workflow rules for agent sessions |
 | `.claude/rules/pipeline.md` | Build and validation workflow guidance |
 | `.claude/rules/rag-and-dictionaries.md` | MCP sources and dictionary lookup rules |
@@ -396,7 +396,7 @@ For write-capable delegation, prefer `--worktree`. `delegate.py` creates the wor
 Use two entry points depending on the job:
 
 | Need | Entry point |
-|---|---|
+| --- | --- |
 | Full module build | `.venv/bin/python scripts/build/v7_build.py {level} {slug} --worktree` |
 | Validate existing content | `npm run audit`, `npm run pipeline`, `npm run generate:json` |
 
@@ -511,7 +511,7 @@ Use this before content generation to verify plan files still match `scripts/aud
 ## Scripts Quick Reference
 
 | Script | Purpose | Command |
-|---|---|---|
+| --- | --- | --- |
 | `scripts/build/v7_build.py` | End-to-end module build | `.venv/bin/python scripts/build/v7_build.py a1 m01-alphabet --worktree` |
 | `scripts/audit_level.py` | Audit a level, module, or range | `npm run audit -- b1 1-10` |
 | `scripts/audit_module.py` | Audit a single module file | `.venv/bin/python scripts/audit_module.py <file>` |
@@ -792,7 +792,7 @@ The consultation loop proposes prompt or template changes for human review.
 Queue locations:
 
 | Path | Purpose |
-|---|---|
+| --- | --- |
 | `claude_extensions/consultation-queue/*.yaml` | Pending proposals |
 | `claude_extensions/consultation-queue/applied/` | Approved proposals |
 | `claude_extensions/consultation-queue/rejected/` | Rejected proposals |
@@ -858,7 +858,7 @@ The Monitor API exposes the same read-only JSON at `/api/decisions/lineage`.
 ## Dashboards
 
 | Entry | Purpose |
-|---|---|
+| --- | --- |
 | `scripts/generate_dashboard_data.py` | Aggregate audit cache into dashboard data |
 | `scripts/build_dashboards.py` | Build HTML dashboards with embedded data |
 | `npm run dashboards:data` | Regenerate `dashboards/data/status.json` |
@@ -879,7 +879,7 @@ Claude, Gemini, and Codex coordinate through three distinct primitives. Pick the
 ### When to use which tool
 
 | Need | Tool | Write access? |
-|---|---|---|
+| --- | --- | --- |
 | Sustained topic-scoped discussion, multi-turn, pinned context | **`ai_agent_bridge post` / `ai_agent_bridge discuss`** (channel bridge) | No (Q&A only) |
 | One-off drive-by question to another agent | **`ask-claude` / `ask-agy` / `ask-codex`** | No by default; opt-in via `--allow-write` |
 | Fire-and-forget execution — run code, commit, push | **`scripts/delegate.py dispatch`** | Yes |
@@ -939,7 +939,7 @@ Web dashboard at `http://localhost:8765/channels.html` (localhost-only, read + p
 Fire a single query at one agent. Each recipient has its own model flag and defaults — do not assume they are interchangeable.
 
 | Recipient | Flag | Recommended value |
-|---|---|---|
+| --- | --- | --- |
 | AGY | `--to-model` | `gemini-3.1-pro-high` or display label from `agy models`, e.g. `Gemini 3.1 Pro (High)` |
 | Codex | `--model` | omit unless overriding (defaults to `gpt-5.5` via runtime config) |
 | Claude | `--to-model` | omit (auto-selects per active session); override only when routing to a specific Opus/Sonnet tier |
@@ -1060,7 +1060,7 @@ The original 1:1 broker (separate from channels) is still available for low-leve
 ```
 
 | Message type | Purpose |
-|---|---|
+| --- | --- |
 | `query` | Ask another agent a question |
 | `response` | Return an answer |
 | `request` | Request work |
@@ -1080,12 +1080,12 @@ The original 1:1 broker (separate from channels) is still available for low-leve
 ## Common Workflows
 
 | Workflow | Command |
-|---|---|
+| --- | --- |
 | Build one module | `/module {level} {num}` |
 | Full seminar rebuild | `/full-rebuild {track} {slug}` |
 | Full core rebuild | `/full-rebuild-core {level} {num}` |
 | Full v7 build via script | `.venv/bin/python scripts/build/v7_build.py {level} {slug} --worktree` |
-| Audit a module or range | `npm run audit -- {level} {num|range}` |
+| Audit a module or range | `npm run audit -- {level} {num\|range}` |
 | Run technical validation | `npm run pipeline l2-uk-en {level} {num}` |
 | Generate app JSON | `npm run generate:json l2-uk-en {level} {num}` |
 | Sync landing pages | `npm run sync:landing` |

--- a/docs/agent-bridge-setup-guide.md
+++ b/docs/agent-bridge-setup-guide.md
@@ -40,23 +40,23 @@ export AB_WAKE_DIR="${AB_REPO_ROOT}/.agent/wake"
 Create your base channels. It is recommended to create a `shared` channel for global context, and include it in topic-specific channels.
 ```bash
 # Create the global shared channel
-ab channel new shared
+.venv/bin/python scripts/ai_agent_bridge/__main__.py channel new shared
 
 # Create a topic channel and include shared context
-ab channel new ops --include shared
+.venv/bin/python scripts/ai_agent_bridge/__main__.py channel new ops --include shared
 ```
 
 ### Step 3.4: Test the Setup
 Verify the bridge is functioning correctly:
 ```bash
 # List available channels
-ab channel list
+.venv/bin/python scripts/ai_agent_bridge/__main__.py channel list
 
 # Post a test message
-ab post ops "Initialization test" --to claude
+.venv/bin/python scripts/ai_agent_bridge/__main__.py post ops "Initialization test" --to claude
 
 # Check the inbox queue
-ab inbox show
+.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox show claude
 ```
 
 ## 4. Environment Variable Reference
@@ -71,22 +71,23 @@ The bridge is fully configurable via `AB_*` environment variables to support por
 | `AB_CONTEXT_DIR` | `{AB_REPO_ROOT}/docs/agent-channels` | Directory containing channel `context.md` files. |
 | `AB_WAKE_DIR` | `{AB_REPO_ROOT}/.agent/wake` | Directory for OS-level wake files for the inbox worker. |
 | `AB_MONITOR_URL` | `http://localhost:8765/api/state/summary` | URL for the Monitor API. Set to `""` to disable snapshot injection. |
-| `AB_GEMINI_MODEL` | `batch_gemini_config.FLASH_MODEL` / `gemini-2.0-flash` | Default Gemini model to invoke. |
+| `AB_GEMINI_MODEL` | Legacy only | Gemini CLI is unsupported for current project work; use AGY through bridge/runtime instead. |
 | `AB_PIPELINE_ENV_KEY` | `LEARN_UKRAINIAN_PIPELINE` | Env var key to suppress inbox hooks during pipeline runs. |
 
 ## 5. CLI Quick Reference
 
-The bridge is managed via the `ab` command line interface (typically aliased to `python -m ai_agent_bridge`).
+Bridge commands should use the explicit project entry point. Avoid bare `ab ...`
+examples because `ab` resolves to ApacheBench on the user's machine.
 
-- **`ab channel ...`**: Manage channels.
-  - `ab channel new <name> [--include <other>]`: Create a new channel.
-  - `ab channel list`: List all channels.
-  - `ab channel context <name> --edit`: Edit the pinned context for a channel.
-- **`ab post <channel> "<message>"`**: Send a message to a channel. Use `--to <agent1,agent2>` to specify recipients, or `--parent <id>` to reply to a thread.
-- **`ab discuss <channel> "<topic>"`**: Start a bounded multi-agent debate. Use `--with <agents>` and `--max-rounds <N>`.
-- **`ab inbox show`**: View pending messages waiting for agents.
-- **`ab inbox run <agent> [--until-idle]`**: Run the inbox worker to process messages for a specific agent.
-- **`ab sync <agent>`**: Manually drain the queue and sync messages for an agent (alternative to `inbox run`).
+- **`.venv/bin/python scripts/ai_agent_bridge/__main__.py channel ...`**: Manage channels.
+  - `.venv/bin/python scripts/ai_agent_bridge/__main__.py channel new <name> [--include <other>]`: Create a new channel.
+  - `.venv/bin/python scripts/ai_agent_bridge/__main__.py channel list`: List all channels.
+  - `.venv/bin/python scripts/ai_agent_bridge/__main__.py channel context <name> --edit`: Edit the pinned context for a channel.
+- **`.venv/bin/python scripts/ai_agent_bridge/__main__.py post <channel> "<message>"`**: Send a message to a channel. Use `--to <agent1,agent2>` to specify recipients, or `--parent <id>` to reply to a thread.
+- **`.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss <channel> "<topic>"`**: Start a bounded multi-agent debate. Use `--with <agents>` and `--max-rounds <N>`.
+- **`.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox show <agent>`**: View pending messages waiting for agents.
+- **`.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox run <agent> [--until-idle]`**: Run the inbox worker to process messages for a specific agent.
+- **`.venv/bin/python scripts/ai_agent_bridge/__main__.py sync <agent>`**: Manually drain the queue and sync messages for an agent (alternative to `inbox run`).
 
 ## 6. Architecture Diagram
 
@@ -94,12 +95,12 @@ The flow of a message through the Agent Bridge:
 
 ```mermaid
 graph TD
-    A[Human/Agent Post] -->|ab post| B(Channel)
+    A[Human/Agent Post] -->|bridge post| B(Channel)
     B -->|Context + Snapshot + History| C[(SQLite DB: channel_messages)]
     C -->|Generate Routes| D[(SQLite DB: deliveries)]
     D -->|Wake Hint| E[Wake File (.agent/wake/)]
-    E -.->|File Event| F[Inbox Worker (ab inbox run)]
+    E -.->|File Event| F[Inbox Worker]
     D -->|Poll / Lease| F
-    F -->|Assemble Prompt| G[Agent Invoke (Claude/Gemini)]
+    F -->|Assemble Prompt| G[Agent Invoke]
     G -->|Reply| B
 ```

--- a/docs/agent-channels/shared/context.md
+++ b/docs/agent-channels/shared/context.md
@@ -90,12 +90,12 @@ Communication protocol:
 - **Tests:** `.venv/bin/pytest` — colocated in `tests/`
 - **Lint:** `.venv/bin/ruff check` — pre-commit hook enforced
 - **Bridge CLI:** `scripts/ai_agent_bridge/__main__.py` — for agent delegations
-- **Channel bridge (#1190):** `ab channel`, `ab p`, `ab post`, `ab discuss`
+- **Channel bridge (#1190):** `.venv/bin/python scripts/ai_agent_bridge/__main__.py channel`, `p`, `post`, `discuss`
 - **GH issues as memory:** reference issue numbers in commits, close when all ACs met
 
 ## Multi-agent deliberation protocol (2026-05-02 onward)
 
-`ab discuss` is the tool for design / framing / architecture / pedagogy decisions where any single agent reasoning alone has a known failure mode. **It is NOT a quorum** — Claude/Gemini/Codex have correlated training-data priors (e.g., Russian-imperial framings show up in all three). What it gives us: more angles per decision, adversarial pressure, and a written deliberation record.
+`.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss` is the tool for design / framing / architecture / pedagogy decisions where any single agent reasoning alone has a known failure mode. **It is NOT a quorum** — Claude/AGY/Codex have correlated training-data priors (e.g., Russian-imperial framings show up in all three). What it gives us: more angles per decision, adversarial pressure, and a written deliberation record.
 
 **When you (any agent) participate in a discussion:**
 

--- a/docs/agents/AGENT-CAPABILITY-MATRIX.md
+++ b/docs/agents/AGENT-CAPABILITY-MATRIX.md
@@ -35,10 +35,10 @@ on 4 of those roles. Headline recommendations:
 
 | # | Family | CLI | Production models | Surface where they live |
 |---|---|---|---|---|
-| 1 | **Claude** | `claude` (Code), `claude` (Desktop) | `claude-sonnet-4.6` (default), `claude-opus-4.7` (xhigh) | `delegate.py --agent claude` (until 2026-06-15 cutoff); `ab ask-claude`; inline orchestrator |
-| 2 | **Codex** | `codex` (CLI), `codex` (Desktop) | `gpt-5.5` (xhigh) | `delegate.py --agent codex`; `ab ask-codex`; Codex Desktop UI |
-| 3 | **Gemini** | `gemini` | `gemini-3.1-pro-preview` (deep), `gemini-3.0-flash-preview` (routine), Gemini Vision (OCR) | `delegate.py --agent gemini`; `ab ask-gemini --model gemini-3.0-flash-preview` for routine, `--model gemini-3.1-pro-preview` for deep |
-| 4 | **Grok** | `hermes -m grok-4.3` | `grok-4.3` | `delegate.py --agent grok`; `ab ask-grok`; uses `hermes_grok.py` adapter |
+| 1 | **Claude** | `claude` (Code), `claude` (Desktop) | `claude-sonnet-4.6` (default), `claude-opus-4.7` (xhigh) | `scripts/delegate.py dispatch --agent claude`; `.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-claude`; inline orchestrator |
+| 2 | **Codex** | `codex` (CLI), `codex` (Desktop) | `gpt-5.5` (xhigh) | `scripts/delegate.py dispatch --agent codex`; `.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-codex`; Codex Desktop UI |
+| 3 | **AGY** | `agy` | `Gemini 3.1 Pro (High)` (deep), `Gemini 3.5 Flash (High)` (routine) | `scripts/delegate.py dispatch --agent agy`; `.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy --to-model gemini-3.1-pro-high` |
+| 4 | **Grok** | `hermes -m grok-4.3` | `grok-4.3` | `scripts/delegate.py dispatch --agent grok`; `.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-grok`; uses `hermes_grok.py` adapter |
 | 5 | **DeepSeek v4** | `hermes -z PROMPT -m deepseek-v4-pro\|flash` | `deepseek-v4-pro` (default), `deepseek-v4-flash` (lighter) | LIVE LANE — adapter `scripts/agent_runtime/adapters/hermes_deepseek.py` SHIPPED PR #2107 (2026-05-17, SHA `84ef22455e`). `delegate.py dispatch --agent deepseek` end-to-end smoke validated; first real-world write-mode dispatch landed PR #2112 (artifacts MD support, +192 lines + 10 tests, pytest green). REVERSED from opencode after 33% empty-output flake. Hermes wires `sources` MCP into the model session; model proactively verifies vocab via VESUM + CEFR. |
 | ~~6~~ | ~~Mistral~~ | ~~vibe -p~~ | — | **REMOVED 2026-05-17 (user-cancelled subscription)**. DeepSeek-flash via hermes covers the lane. |
 | 7 | **Gemma local** | REMOVED | `gemma-local` | REMOVED — per user direction 2026-05-17. See PR removing gemma-local. |
@@ -227,7 +227,7 @@ prior audits**, **(I)nferred from architecture**.
 | **Architect** | Claude-Opus-xhigh (H) | DeepSeek-pro-max (E) | Opus xhigh for ADRs/decision cards (post-2026-06-15: Opus dispatches dropped → DeepSeek-pro-max takes lead). Pro's grep-then-design pattern is encouraging. |
 | **Coding** | Codex gpt-5.5 (H) | DeepSeek-pro-max (E) | Codex remains incumbent — production-shipped 20+ PRs this month. DeepSeek-pro-max competitive on small tasks; needs validation on cross-file work. |
 | **Code Review** | Codex (H) + DeepSeek-flash (E) | Gemini-3.1-pro (H) | DeepSeek-flash had the highest signal density tonight. Use it as cheap second-opinion alongside Codex on PR reviews. |
-| **Content Writing** | Claude (until 2026-06-15) / Gemini (after) | DeepSeek-flash (E), Mistral medium-3.5 (E) | Per ADR `2026-05-06-writer-selection-codex-gpt55.md` REVISED → claude-tools. Post-June-15: Gemini default. Flash beat Mistral on format compliance + speaker labels in the A1 dialogue test. Pro-max UNUSABLE here (returned empty). NOT yet tested on full V7-module-scale output. |
+| **Content Writing** | Claude / AGY | DeepSeek-flash (E) | Gemini CLI is unsupported; AGY is the Gemini-family route. Use `scripts/delegate.py dispatch --agent agy` for dispatched content work. |
 | **Content Review** | Claude-Opus-xhigh (H) + Codex (H, green-team) | Gemini-3.1-pro (H), DeepSeek-flash (E) | xhigh-effort review on Opus is gold standard. **DeepSeek-flash is the strongest new entrant — caught the planted Russianism + sharp pedagogical critique + zero false positives.** Mistral medium-3.5 NOT trustworthy for content review without a verifier (produced false positive on `-ся/-сь`). |
 | **Linguistic Verification** | inline Claude with `mcp__sources__*` | DeepSeek-pro / DeepSeek-flash (E) | Sources MCP must run in-process (Claude Code). For OUT-OF-PROCESS verification: DeepSeek (either variant) — both passed `на протязі`. **NEVER devstral-small** (contamination). |
 | **OCR / Vision** | **Gemini Vision** via `scripts/etymology/bulk_ocr_gemini.py` (gemini-2.5-flash default, 691-page ESUM Phase 2 track record) | Apple Vision (untested, on-device option if budget tight) | Mistral OCR was on the list — cancelled with the subscription 2026-05-17. The credential-loader pattern (`scripts/ocr/_credentials.py`) stays for future API key needs. |
@@ -319,10 +319,10 @@ scripts/delegate.py dispatch --agent claude --model claude-opus-4-7 --effort xhi
 scripts/delegate.py dispatch --agent codex --model gpt-5.5 --effort xhigh \
   --brief docs/dispatch-briefs/foo.md
 
-# Gemini (default flash for routine; pro for deep)
-scripts/ai_agent_bridge/__main__.py ask-gemini --model gemini-3.0-flash-preview "QUESTION"
-scripts/ai_agent_bridge/__main__.py ask-gemini --model gemini-3.1-pro-preview  "DEEP QUESTION"
-scripts/delegate.py dispatch --agent gemini --brief docs/dispatch-briefs/foo.md
+# AGY (Gemini-family route; direct agy --model uses display labels)
+.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy "QUESTION" --task-id agy-question --to-model gemini-3.5-flash-high
+.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy "DEEP QUESTION" --task-id agy-deep-question --to-model gemini-3.1-pro-high
+scripts/delegate.py dispatch --agent agy --brief docs/dispatch-briefs/foo.md
 
 # Grok (via hermes)
 hermes -z "QUESTION" -m grok-4.3

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -107,7 +107,7 @@ plans/{level}/{slug}.yaml    →  Source of truth (reviewed before lock)
 
 | Tool | Command | Purpose |
 |------|---------|---------|
-| **One-shot** | `ask-gemini "msg" --task-id issue-N` | Reviews, simple requests |
+| **One-shot** | `.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy "msg" --task-id issue-N` | Gemini-family reviews, simple requests |
 | **Multi-turn** | `converse "msg" --task-id "topic"` | Co-design, planning, iteration |
 | **Builder Notes** | `===BUILDER_NOTES_START===` | Structured handoff after builds |
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -44,7 +44,7 @@ Learn Ukrainian is an AI-powered content factory that generates Ukrainian langua
 ## Pipeline Phases (v5)
 
 | # | Phase | Agent | Purpose | Pre-conditions |
-|---|-------|-------|---------|----------------|
+| --- | --- | --- | --- | --- |
 | 1 | **research** | Gemini | Web research, textbook search, meta outline | Plan exists |
 | 2 | **discover** | Gemini | YouTube discovery (non-blocking) | — |
 | 3 | **content** | Gemini | Lesson prose + vocabulary | Preflight passes, learner state injected |
@@ -58,7 +58,7 @@ Learn Ukrainian is an AI-powered content factory that generates Ukrainian langua
 ### Pre-Content Gates (run before content phase)
 
 | Gate | Script | What it checks |
-|------|--------|----------------|
+| --- | --- | --- |
 | **Preflight** | `pipeline/prompt_preflight.py` | Gemini reviews its own prompt for contradictions. Auto-fixes HIGH issues. |
 | **Semantic Russianisms** | `pipeline/semantic_russianisms.py` | Catches words in plan with Russian meanings (e.g., лук=onion → цибуля) |
 | **Learner State** | `pipeline/learner_state.py` | Injects cumulative vocabulary + grammar from all previous modules |
@@ -66,7 +66,7 @@ Learn Ukrainian is an AI-powered content factory that generates Ukrainian langua
 ### Content Phase Enhancements
 
 | Feature | What it does |
-|---------|-------------|
+| --- | --- |
 | **Builder Notes** | Gemini outputs structured YAML (deviations, frictions, unverified terms) |
 | **Prompt restructuring** | Goal → Context → Outline → Guidelines → Constraints (not constraints-first) |
 | **Split mode** | Content and activities are separate phases (default), not one pass |
@@ -80,7 +80,7 @@ plans/{level}/{slug}.yaml    →  Source of truth (reviewed before lock)
 ```
 
 | Layer | Location | Owner | Lifecycle |
-|-------|----------|-------|-----------|
+| --- | --- | --- | --- |
 | **Plans** | `curriculum/l2-uk-en/plans/` | Human + LLM (reviewed) | DRAFT → REVIEWED → LOCKED |
 | **Build** | `curriculum/l2-uk-en/{level}/` | Gemini | Rebuilt by pipeline |
 | **Status** | `curriculum/l2-uk-en/{level}/status/` | Audit system | Auto-generated |
@@ -106,7 +106,7 @@ plans/{level}/{slug}.yaml    →  Source of truth (reviewed before lock)
 ### Cooperation Tooling
 
 | Tool | Command | Purpose |
-|------|---------|---------|
+| --- | --- | --- |
 | **One-shot** | `.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy "msg" --task-id issue-N` | Gemini-family reviews, simple requests |
 | **Multi-turn** | `converse "msg" --task-id "topic"` | Co-design, planning, iteration |
 | **Builder Notes** | `===BUILDER_NOTES_START===` | Structured handoff after builds |
@@ -116,6 +116,7 @@ The bridge is NOT an MCP tool. It uses SQLite broker DB + subprocess spawning. C
 ## Subsystems
 
 ### 1. Pipeline (`scripts/build/pipeline_v5.py` + `scripts/pipeline/`)
+
 **~11K LOC** | Entry: `scripts/build_module_v5.py`
 
 Supporting modules:
@@ -130,13 +131,15 @@ Supporting modules:
 - `pipeline_lib.py` — Shared utilities
 
 ### 2. Audit System (`scripts/audit/`)
+
 **~23K LOC** | Entry: `scripts/audit_module.py` | 34 check modules
 
 ### 3. RAG System (`scripts/rag/` + `.mcp/servers/sources/`)
+
 **~8K LOC** | MCP server at port 8766
 
 | Source | MCP Tool |
-|--------|----------|
+| --- | --- |
 | Textbooks (1.2K chunks) | `search_text` |
 | Literary sources | `search_literary` |
 | VESUM (415K lemmas) | `verify_word`, `verify_lemma` |
@@ -147,12 +150,15 @@ Supporting modules:
 | ULIF paradigms | `query_ulif` |
 
 ### 4. API Server (`scripts/api/`)
+
 **~6K LOC** | FastAPI + WebSocket | Port 8765
 
 ### 5. Agent Bridge (`scripts/ai_agent_bridge/`)
+
 **~2K LOC** | Claude↔Gemini communication via subprocess + SQLite broker
 
 ### 6. Prompt Templates (`claude_extensions/phases/gemini/`)
+
 **~54 files** | Phase-specific prompts injected during pipeline execution
 
 Key templates:
@@ -162,23 +168,27 @@ Key templates:
 - `review-repair.md` — Claude D.2 fix
 
 ### 7. Batch Operations, Scoring, Code Generation, Playgrounds
+
 See `docs/SCRIPTS.md` for full reference.
 
 ## Curriculum Tracks
 
 ### Core Language: `l2-uk-en` (A1→C2)
+
 Ukrainian for English-speaking teens and adults.
 
 ### Seminar Tracks (B2–C1)
+
 HIST, BIO, ISTORIO, LIT, OES, RUTH — history, literature, biography.
 
 ### Secondary: `l2-uk-direct` (A1→B2)
+
 L1-agnostic Ukrainian. Separate schemas, no English.
 
 ## Quality Systems
 
 | System | Type | Entry Point |
-|--------|------|-------------|
+| --- | --- | --- |
 | Audit (34 gates) | Deterministic | `scripts/audit_module.py` |
 | VESUM morphology | Dictionary | `audit/checks/morphological_validator.py` |
 | Russicism detection | Rule-based | Part of validate phase |
@@ -203,7 +213,7 @@ L1-agnostic Ukrainian. Separate schemas, no English.
 ## Related Documentation
 
 | Topic | Location |
-|-------|----------|
+| --- | --- |
 | Pipeline commands | `docs/SCRIPTS.md` |
 | Agent cooperation | `docs/best-practices/agent-cooperation.md` |
 | Cooperation protocol | `docs/CLAUDE-GEMINI-COOPERATION.md` |

--- a/docs/architecture/system-topology.md
+++ b/docs/architecture/system-topology.md
@@ -8,7 +8,7 @@ How the learn-ukrainian subsystems fit together. Reference diagram for new engin
 graph TB
     subgraph Agents["Agent Layer"]
         Claude[Claude Code / API]
-        Gemini[Gemini CLI]
+        Gemini[AGY]
         Codex[Codex CLI]
     end
 
@@ -19,7 +19,7 @@ graph TB
     end
 
     subgraph Bridge["scripts/ai_agent_bridge/"]
-        BridgeCLI[ask-claude<br/>ask-gemini<br/>ask-codex<br/>codex-usage]
+        BridgeCLI[ask-claude<br/>ask-agy<br/>ask-codex<br/>codex-usage]
         MsgBroker[(message_broker.db<br/>SQLite)]
     end
 

--- a/docs/architecture/system-topology.md
+++ b/docs/architecture/system-topology.md
@@ -179,7 +179,7 @@ user → compile.py --track hist --slug kyivan-rus
 ## Key files
 
 | Path | Purpose |
-|------|---------|
+| --- | --- |
 | `scripts/build/v7_build.py` | The one pipeline entry point |
 | `scripts/agent_runtime/runner.py` | The one LLM dispatch function |
 | `scripts/api/main.py` | The one API server |

--- a/docs/best-practices/agent-activity-matrix.md
+++ b/docs/best-practices/agent-activity-matrix.md
@@ -28,10 +28,10 @@ Each cell carries:
 |---|---|---|---|---|
 | **Claude** ⭐ | Opus 4.8 (orchestrator inline + headless dispatch + Q&A); Sonnet 4.x (mid-tier headless); Haiku (cheap Explore subagent grep/read) | Anthropic API (interactive weekly cap, doubled until ~mid-July 2026 promo) + `delegate.py --agent claude` headless | Metered; interactive cap shared with user sessions | **TOP-PRIORITY lane.** Dispatch lane **AVAILABLE** (the planned post-2026-06-15 sunset was CANCELLED). Architecture, V7 writer (claude-tools), hard-bug reasoning, adversarial review (**inline only — never `claude -p`/`--agent claude` subagent for the Claude review seat**). Cap 2 in-flight. |
 | **Codex** ⭐ | gpt-5.5 (default) | OpenAI via Codex CLI | $1000/wk bucket (metered) | **TOP-PRIORITY lane.** Novel impl, cross-file patterns, hard debug, primary V7 reviewer + novel-architecture code review. Cap 2 in-flight. |
-| **agy** | Gemini-family (Antigravity CLI; **replaced gemini-cli 2026-06-08**) | `delegate.py --agent agy` / `ab ask-agy` | **METERED** (corrected 2026-06-19 — NOT unmetered; route by fit/cost, not as a free default) | Support lane: existing scripts, ingestion, fixtures/migrations, docs-near-code, wiki writing; §7/factual cleared 2026-06-13. Cap 2 in-flight. |
+| **agy** | Gemini-family (Antigravity CLI; **replaced gemini-cli 2026-06-08**) | `scripts/delegate.py dispatch --agent agy` / `.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy` | **METERED** (corrected 2026-06-19 — NOT unmetered; route by fit/cost, not as a free default) | Support lane: existing scripts, ingestion, fixtures/migrations, docs-near-code, wiki writing; §7/factual cleared 2026-06-13. Cap 2 in-flight. |
 | **DeepSeek** | deepseek-v4-pro (content review + VESUM via `sources` MCP); deepseek-v4-flash (cheap PR code review) | `delegate.py --agent deepseek` (Hermes adapter) | Cheap | **Off-seat REVIEW lane — use it, don't review inline.** Primary PR-diff + content review. |
-| **Grok** | **grok-build** via native grok CLI (`delegate.py --agent grok-build`, **file-editing dispatch**, validated 2026-06-14 — prefer over grok-4.3); **grok-4.\*** via Hermes (`ab ask-grok`, one-shot/discuss) | native grok CLI / Hermes (xai-oauth) | Cheap | **Active — use both.** grok-build is a real writer/fixer dispatch lane (V7 grok-tools writer); grok-4.\* for one-shot Q&A/discuss. |
-| **cursor** | cursor-agent | `delegate.py --agent cursor` / `ab ask-cursor` | Metered | Valid writer/fixer dispatch lane (integrated 2026-05-24). |
+| **Grok** | **grok-build** via native grok CLI (`scripts/delegate.py dispatch --agent grok-build`, **file-editing dispatch**, validated 2026-06-14 — prefer over grok-4.3); **grok-4.\*** via Hermes (`.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-grok`, one-shot/discuss) | native grok CLI / Hermes (xai-oauth) | Cheap | **Active — use both.** grok-build is a real writer/fixer dispatch lane (V7 grok-tools writer); grok-4.\* for one-shot Q&A/discuss. |
+| **cursor** | cursor-agent | `scripts/delegate.py dispatch --agent cursor` / `.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-cursor` | Metered | Valid writer/fixer dispatch lane (integrated 2026-05-24). |
 | **Qwen** | — | — | — | ❌ **EXCLUDED** — too expensive (user 2026-05-29). Adapter exists but **do not route to it.** |
 
 **Sub-agents (children of the orchestrator session, not separate dispatches):**
@@ -50,7 +50,7 @@ The rest of this doc is *task → agent*. This section is the **inverse — *fre
   - **Codex / Claude (top-priority):** the hardest open work first — novel impl, cross-file refactors, architecture, V7 module building/review, hard debugging. Don't burn these on mechanical work a cheaper lane can do.
   - **agy / cursor / grok-build:** mechanical-with-judgment — running scripts, fixtures/migrations, docs-near-code, wiki/content writing, schema edits, bounded refactors.
   - **DeepSeek:** any open PR diff or content+VESUM review — route reviews here off-seat; don't review inline.
-  - **grok-4.\* / hermes / opencode (`ab ask-*`):** one-shot Q&A, second opinions, quick research with no commit.
+  - **grok-4.\* / hermes / opencode (explicit `.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-*`):** one-shot Q&A, second opinions, quick research with no commit.
   - **Explore (Haiku subagent):** search/grep fan-out.
 - **Where "next work" comes from:** the active track handoff's NEXT-ACTIONS, open GH issues, and the build/review queue. If nothing genuinely fits a free lane, log it and leave it idle — do **not** manufacture busywork (quality > utilization).
 - **Quality gate, not just utilization:** gates passing ≠ shippable (#M-11). Anything a support lane produces gets a strong-model (Codex/Claude) or cross-model (DeepSeek) review before it ships. "Keep the lane busy" never lowers the bar.
@@ -118,7 +118,7 @@ New evidence from judge-calibration bakeoffs (per `audit/INDEX-bakeoff-evidence.
 | Slot | Agent | F1 / accuracy | Last verified | Evidence |
 |---|---|---|---|---|
 | **Primary** | Claude Opus 4.7 | **F1=86%, 100% case accuracy** on 12-case Russianism set | 2026-05-15 | `audit/2026-05-15-russianism-judge-calibration/REPORT.md` |
-| Runner-up 1 | Gemini-3.1-pro-preview | F1=84% (greeting-FP issue) | 2026-05-15 | same; H2 won at 2026-05-17 — `audit/2026-05-17-judge-calibration-h2/COMPARISON.md` |
+| Runner-up 1 | AGY Gemini 3.1 Pro (High) | F1=84% (greeting-FP issue) | 2026-05-15 | same; H2 won at 2026-05-17 — `audit/2026-05-17-judge-calibration-h2/COMPARISON.md` |
 | Runner-up 2 | GPT-5.5 (Codex) | high precision, lower recall (conservative) | 2026-05-15 | same |
 | Runner-up 3 | Grok-4.3 | F1=77% (middle of pack) | 2026-05-15 | `audit/2026-05-15-grok-4.3-judge-calibration/REPORT.md` |
 
@@ -159,7 +159,7 @@ New evidence from judge-calibration bakeoffs (per `audit/INDEX-bakeoff-evidence.
 
 | Slot | Agent | Score | Last verified | Evidence | Notes |
 |---|---|---|---|---|---|
-| **Primary** | Gemini (gemini-3.0-flash-preview) | unmetered; routine pattern-application across multiple files | 2026-05-13 | MEMORY #M-0 reframe | "default for routine: running existing scripts, ingestion runs, tests/migrations/fixtures, docs-near-code" |
+| **Primary** | AGY Gemini 3.5 Flash (High) | metered; routine pattern-application across multiple files | 2026-05-13 | MEMORY #M-0 reframe | "default for routine: running existing scripts, ingestion runs, tests/migrations/fixtures, docs-near-code" |
 | Runner-up | Codex | tighter on edge-cases; better for high-uncertainty refactors | 2026-05-12 | various recent merges (#2121, #2123) | Costs Codex quota; reserve for cases where Gemini's pattern-match might miss. |
 
 **Known weakness (Gemini for mechanical):** ambiguous cross-file architectural rewrites; security/concurrency bugs; GH/rebase/auth-heavy work; mass mechanical pattern-application that requires nuanced judgment. For those → Codex.
@@ -203,9 +203,9 @@ New evidence from judge-calibration bakeoffs (per `audit/INDEX-bakeoff-evidence.
 
 | Slot | Agent | Score | Last verified | Evidence | Notes |
 |---|---|---|---|---|---|
-| **Primary (routine)** | Gemini-3.0-flash via `ab ask-gemini` | unmetered; fast | ongoing | `scripts/ai_agent_bridge/__main__.py` | Default for low-stakes one-shot. |
-| **Primary (deep)** | Gemini-3.1-pro via `ab ask-gemini --model gemini-3.1-pro-preview` | qualitative | ongoing | same | When deep reasoning needed and Codex/Claude not on the question. |
-| Runner-up 1 | Codex via `ab ask-codex` | high-judgment one-shot | ongoing | same | For implementation-y questions. |
+| **Primary (routine)** | AGY Gemini 3.5 Flash (High) via `.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy --to-model gemini-3.5-flash-high` | metered; fast | ongoing | `scripts/ai_agent_bridge/__main__.py` | Default for low-stakes one-shot. |
+| **Primary (deep)** | AGY Gemini 3.1 Pro (High) via `.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy --to-model gemini-3.1-pro-high` | qualitative | ongoing | same | When deep reasoning needed and Codex/Claude not on the question. |
+| Runner-up 1 | Codex via `.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-codex` | high-judgment one-shot | ongoing | same | For implementation-y questions. |
 | Runner-up 2 | Claude inline | when orchestrator IS Claude | ongoing | same | The Q&A is me; no round-trip. |
 
 ---
@@ -235,15 +235,15 @@ New evidence from judge-calibration bakeoffs (per `audit/INDEX-bakeoff-evidence.
 |---|---|
 | V7 module writing | `.venv/bin/python scripts/build/v7_build.py {level} {slug} --worktree --writer claude-tools` (default writer omitted) |
 | Wiki article writing | `.venv/bin/python scripts/wiki/compile.py --writer gemini` (default) |
-| Code dispatch (mechanical) | `.venv/bin/python scripts/delegate.py dispatch --agent gemini --task-id X --mode danger --worktree --prompt-file BRIEF` |
+| Code dispatch (mechanical) | `.venv/bin/python scripts/delegate.py dispatch --agent agy --task-id X --mode danger --worktree --prompt-file BRIEF` |
 | Code dispatch (novel) | `.venv/bin/python scripts/delegate.py dispatch --agent codex --model gpt-5.5 --effort xhigh --mode danger --worktree --silence-timeout 3600 --task-id X --prompt-file BRIEF` |
 | Adversarial review (pre-June-15) | `.venv/bin/python scripts/delegate.py dispatch --agent claude --mode read-only --model claude-opus-4-7 --effort xhigh --task-id X --prompt-file BRIEF` |
 | Adversarial review (post-June-15) | `.venv/bin/python scripts/delegate.py dispatch --agent codex --effort xhigh --mode read-only ...` per substitutions YAML |
 | Code review (PR diff) | `.venv/bin/python scripts/delegate.py dispatch --agent deepseek --model deepseek-v4-flash --task-id review-{PR} --prompt-file ...` |
 | Content review (load-bearing, VESUM) | `.venv/bin/python scripts/delegate.py dispatch --agent deepseek --model deepseek-v4-pro --task-id review-content-X --prompt-file ...` |
-| Q&A (routine) | `.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-gemini "PROMPT"` |
-| Q&A (deep) | `.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-gemini --model gemini-3.1-pro-preview "PROMPT"` |
-| Discuss (multi-agent) | `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss CHANNEL "TOPIC" --with codex,claude,gemini` |
+| Q&A (routine) | `.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy "PROMPT" --task-id agy-question --to-model gemini-3.5-flash-high` |
+| Q&A (deep) | `.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy "PROMPT" --task-id agy-deep-question --to-model gemini-3.1-pro-high` |
+| Discuss (multi-agent) | `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss CHANNEL "TOPIC" --with codex,claude,agy` |
 | Search / locate | `Agent(subagent_type="Explore", model="haiku", description="...", prompt="...")` |
 | Status check (state) | `curl -s http://localhost:8765/api/state/...` |
 
@@ -254,7 +254,7 @@ New evidence from judge-calibration bakeoffs (per `audit/INDEX-bakeoff-evidence.
 The matrix updates when bakeoff signal flips a champion. The protocol:
 
 1. **Operator initiates** a challenge on one task-type cell. Says: *"Cell 4.X primary is currently $AGENT. We want to test whether $CHALLENGER can do better with $PROPOSED_CHANGES (prompt / context / harness)."*
-2. **Challenger receives a structured request** via `ab discuss`:
+2. **Challenger receives a structured request** via `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss`:
    ```
    You are the candidate. The current primary on task type X is $PRIMARY with score $S, last verified $D. We are open to promoting you IF you can show > $S on the same eval set. You may propose ONE OF: (a) prompt change, (b) added context, (c) harness change. State your proposal in 5 lines max + the smallest viable bakeoff that would prove it. If you are not confident, respond DECLINE.
    ```
@@ -313,7 +313,7 @@ Listed by priority for next-session fill:
 | Rank | Model | F1 | Precision | Recall | Case acc | Cost | Notes |
 |---|---|---:|---:|---:|---:|---|---|
 | 1 ✅ | Claude Opus 4.7 | **86%** | 79% | 94% | 100% | $$$ | Primary. Highest recall in the field. |
-| 2 ✅ | Gemini-3.1-pro-preview | **84%** | 81% | 87% | 92% | 0$ | Greeting-FP issue. |
+| 2 ✅ | AGY Gemini 3.1 Pro (High) | **84%** | 81% | 87% | 92% | 0$ | Greeting-FP issue. |
 | 3 ✅ | GPT-5.5 (Codex) | **78%** | 90% | 69% | 83% | $$ | Conservative, high precision. |
 | 4 ✅ | Grok-4.3 | **77%** | — | — | — | $ | Middle of pack (2026-05-15 calibration). |
 | 5 ✅ | Qwen-3.6-plus | **69%** | 90% | 56% | 92% | $ | **NEW 2026-05-19 (`audit/2026-05-19-qwen-3.6-judge-calibration/`).** Most conservative judge in the field — ties Codex on precision but lowest recall (misses ~half of sev≥2 issues). 1 spurious flag on `cal_clean_with_lure`. NOT primary; viable as cheap second-opinion screen where precision matters more than recall. |
@@ -371,9 +371,9 @@ Listed by priority for next-session fill:
 
 | Rank routine | Model | Cost |
 |---|---|---|
-| 1 ✅ | Gemini-3.0-flash (`ab ask-gemini`) | 0$ |
-| 1 deep ✅ | Gemini-3.1-pro-preview | 0$ |
-| 2 ✅ | Codex GPT-5.5 (`ab ask-codex`) | $$ |
+| 1 ✅ | AGY Gemini 3.5 Flash (High) | metered |
+| 1 deep ✅ | AGY Gemini 3.1 Pro (High) | metered |
+| 2 ✅ | Codex GPT-5.5 (`.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-codex`) | $$ |
 | ❓ | Qwen-3.6-plus | $ |
 
 ### 8.10 The Chinese-model question (user-asked)

--- a/docs/best-practices/agent-bridge.md
+++ b/docs/best-practices/agent-bridge.md
@@ -1,17 +1,17 @@
 # Agent Bridge — Channel Communication
 
-The agent bridge is how Claude, Gemini, and Codex (and you, the
+The agent bridge is how Claude, AGY, and Codex (and you, the
 human) communicate across invocations. The new **channel bridge**
 (added in #1190) replaces the old 1:1 `ask-*` pattern with topic-
 scoped channels, pinned context, and character-budget history
 truncation — the token waste from re-explaining project setup on
 every delegation drops from ~15KB to ~6KB per post.
 
-> **Note on the legacy `ask-*` commands.** They still work and are
-> the simplest way to fire a one-shot delegation with no history
-> tracking. They're **not deprecated** and won't be. Channels are
-> the right primitive for sustained, topic-scoped conversations;
-> `ask-*` is the right primitive for one-off questions. Use both.
+> **Current tooling note.** Use `.venv/bin/python
+> scripts/ai_agent_bridge/__main__.py ...` for bridge commands. Do not use
+> bare `ab ...` examples; `ab` resolves to ApacheBench on the user's machine.
+> Gemini CLI and Gemini Code Assist are unsupported. Use AGY for
+> Gemini-family work.
 
 ## Mental model
 
@@ -43,29 +43,33 @@ the thread_id and get `round_index = parent.round_index + 1`.
 
 ## Discussion vs execution
 
-`ab discuss` is deliberation, not implementation. The bridge invokes
+`.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss` is
+deliberation, not implementation. The bridge invokes
 participants in read-only mode, passes the `AB_DISCUSS_READONLY=1`
 contract through the adapter layer, and fails the round if the git
 working tree changes while participants are running. A failed round
 posts a loud system warning into the thread before returning non-zero,
 including `READ_ONLY_VIOLATION: <agent>` for the agent family that must
 be treated as the write source. Filesystem writes during discussion are
-a hard stop; dispatch the work as a separate `delegate.py dispatch`
+a hard stop; dispatch the work as a separate `scripts/delegate.py dispatch`
 brief.
 
-`ab post` creates channel messages and delivery rows. Its default
+`.venv/bin/python scripts/ai_agent_bridge/__main__.py post` creates channel
+messages and delivery rows. Its default
 delivery mode is read-only, and the inbox worker applies the same
 discussion read-only adapter contract to those default deliveries. Use
 write-capable modes only when the post is explicitly an execution
 request. Implementation work that needs file edits, commits, pushes, or
-a PR should normally go through `delegate.py dispatch` or
-`ab dispatch-fix`, not through discussion.
+a PR should normally go through `scripts/delegate.py dispatch` or
+`.venv/bin/python scripts/ai_agent_bridge/__main__.py dispatch-fix`, not
+through discussion.
 
 Current adapter policy for discussion calls:
 
 - Codex: `read-only` maps to `codex exec -s read-only`.
-- Gemini: discussion calls add `--approval-mode plan`; plain read-only
-  CLI defaults were not enough in trusted workspaces.
+- AGY: discussion calls route through the AGY adapter. Direct `agy --model`
+  uses display labels such as `Gemini 3.1 Pro (High)`; bridge/runtime calls
+  may pass slugs such as `gemini-3.1-pro-high` for adapter mapping.
 - Claude: discussion calls restrict built-in tools to read/list/search
   tools. They do not use Claude plan mode because discussion replies are
   comments, not implementation plans; the restricted tool list plus the
@@ -78,20 +82,20 @@ Current adapter policy for discussion calls:
 
 ```bash
 # Channel management
-ab channel new pipeline --include shared --agents claude,gemini,codex
-ab channel list
-ab channel info pipeline
-ab channel context pipeline --edit     # opens $EDITOR on context.md
-ab channel tail pipeline -n 20         # last 20 messages
-ab channel tail pipeline --thread ABC  # full thread
+.venv/bin/python scripts/ai_agent_bridge/__main__.py channel new pipeline --include shared --agents claude,agy,codex
+.venv/bin/python scripts/ai_agent_bridge/__main__.py channel list
+.venv/bin/python scripts/ai_agent_bridge/__main__.py channel info pipeline
+.venv/bin/python scripts/ai_agent_bridge/__main__.py channel context pipeline --edit
+.venv/bin/python scripts/ai_agent_bridge/__main__.py channel tail pipeline -n 20
+.venv/bin/python scripts/ai_agent_bridge/__main__.py channel tail pipeline --thread ABC
 
 # Posting (short + long form)
-ab p pipeline gemini "quick question about X"
-ab post pipeline "full form with --to options" --to gemini,codex
-ab post pipeline "reply" --parent MESSAGE_ID
+.venv/bin/python scripts/ai_agent_bridge/__main__.py p pipeline agy "quick question about X"
+.venv/bin/python scripts/ai_agent_bridge/__main__.py post pipeline "full form with --to options" --to agy,codex
+.venv/bin/python scripts/ai_agent_bridge/__main__.py post pipeline "reply" --parent MESSAGE_ID
 
 # Multi-agent discussion (B.4)
-ab discuss architecture "should we refactor X?" --with claude,gemini,codex --max-rounds 2
+.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss architecture "should we refactor X?" --with claude,agy,codex --max-rounds 2
 ```
 
 ## Desktop Participation
@@ -106,38 +110,38 @@ the Desktop session.
 Orchestrator dispatch to Codex Desktop:
 
 ```bash
-ab post desktop-tasks "<brief>" --to codex-desktop --from-agent claude
+.venv/bin/python scripts/ai_agent_bridge/__main__.py post desktop-tasks "<brief>" --to codex-desktop --from-agent claude
 ```
 
 Codex Desktop watches the task channel from its own session:
 
 ```bash
-ab channel tail desktop-tasks --follow
+.venv/bin/python scripts/ai_agent_bridge/__main__.py channel tail desktop-tasks --follow
 ```
 
 Codex Desktop can also pull its pending inbox:
 
 ```bash
-ab inbox show codex-desktop
+.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox show codex-desktop
 ```
 
-### Explicit ack: `ab inbox ack <delivery_id>`
+### Explicit ack: `.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox ack <delivery_id>`
 
 When an external worker processes a delivery without going through
-`ab inbox run`, ack it explicitly:
+`.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox run`, ack it explicitly:
 
 ```bash
-ab inbox ack <delivery_id> [--error "processed by <thing>"]
+.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox ack <delivery_id> [--error "processed by <thing>"]
 ```
 
 Without an explicit ack, deliveries stay `pending` forever and the inbox
-warning recurs. `ab discuss` acks its own deliveries on round convergence
+warning recurs. Bridge discussion acks its own deliveries on round convergence
 automatically, so no manual intervention is needed for that path.
 
 Codex Desktop posts replies with its own sender identity:
 
 ```bash
-ab post desktop-tasks "<status>" --from-agent codex-desktop
+.venv/bin/python scripts/ai_agent_bridge/__main__.py post desktop-tasks "<status>" --from-agent codex-desktop
 ```
 
 Limitation: this MVP stores a flat sender/recipient string. The pending
@@ -150,15 +154,15 @@ SSE replay, and attachments.
 Use these wrappers when the task needs the project-standard model/mode
 assignment enforced by tooling instead of memory.
 
-`ab dispatch-fix <issue-or-task-id> [--brief-file PATH]` dispatches a
+`.venv/bin/python scripts/ai_agent_bridge/__main__.py dispatch-fix <issue-or-task-id> [--brief-file PATH]` dispatches a
 Codex worktree implementation run for "fix this and ship a PR" tasks.
-It hardcodes `delegate.py dispatch --agent codex --mode danger
+It hardcodes `scripts/delegate.py dispatch --agent codex --mode danger
 --worktree --base origin/main --effort high`, and every generated
 brief includes the commit, push, and PR checklist. If `--brief-file`
 is omitted, the wrapper builds `/tmp/dispatch-fix-<task-id>.md` from
 `gh issue view <issue> --json title,body`.
 
-`ab review-deep <PR-or-path> [--effort xhigh]` dispatches an
+`.venv/bin/python scripts/ai_agent_bridge/__main__.py review-deep <PR-or-path> [--effort xhigh]` dispatches an
 adversarial Claude review run. It hardcodes `--agent claude --mode
 read-only --model claude-opus-4-7 --effort xhigh` unless an explicit
 effort override is passed, then builds a review prompt from either
@@ -172,7 +176,7 @@ delegate worker.
 
 ## Silence-timeout vs hard-timeout
 
-`delegate.py dispatch` has two watchdogs with different jobs.
+`scripts/delegate.py dispatch` has two watchdogs with different jobs.
 `--hard-timeout` is the absolute wall-clock fallback for the worker.
 `--silence-timeout` is narrower: it kills the agent CLI when no watchdog
 activity arrives within the configured window, then marks the task
@@ -196,11 +200,11 @@ and you have another way to detect parked sessions.
 
 | Situation | Use |
 | --- | --- |
-| One-off question, no history needed | `ask-claude/gemini/codex` |
-| Sustained discussion on a topic | `ab post` to a channel |
-| Need a 2-3 agent debate on a design | `ab discuss` |
+| One-off question, no history needed | `.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy ...` / `ask-claude` / `ask-codex` |
+| Sustained discussion on a topic | `.venv/bin/python scripts/ai_agent_bridge/__main__.py post` to a channel |
+| Need a 2-3 agent debate on a design | `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss` |
 | Sharing context across many delegations | Pin it in `docs/agent-channels/{topic}/context.md` |
-| Code review with adversarial feedback | `ab post reviews ...` |
+| Code review with adversarial feedback | `.venv/bin/python scripts/ai_agent_bridge/__main__.py post reviews ...` |
 | Want the post visible in the dashboard | Channels only (the legacy `messages` table has its own UI) |
 
 ## The hygiene rule
@@ -210,10 +214,10 @@ agent.** Per channel conventions:
 
 1. Write code → stage with `git add`
 2. `git diff --cached > /tmp/diff.txt`
-3. `ab post reviews "Review request for #NNN" --to gemini` (or ask-gemini with the diff attached)
+3. `.venv/bin/python scripts/ai_agent_bridge/__main__.py post reviews "Review request for #NNN" --to agy`
 4. Apply feedback or argue back in writing
 5. Commit only after the review is CLEAN or BLOCKING is resolved
-6. Commit message includes `Reviewed-By: gemini-3.1-pro-preview (task-id)` trailer
+6. Commit message includes `Reviewed-By: AGY Gemini 3.1 Pro (High) (task-id)` trailer
 
 This rule is non-negotiable. Bypassing it was the #1 reason review
 quality degraded on earlier commits.
@@ -310,7 +314,7 @@ of repeated context avoided** on this one issue alone — and the
 savings grow roughly linearly with round count.
 
 **Compound wins on multi-round debates:** the same trick applies to
-`ab discuss` round 2+. When an agent is handed their own prior
+`.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss` round 2+. When an agent is handed their own prior
 response via `_channels.build_agent_prompt` it doesn't need to be
 re-typed. The B.2 prompt assembler caps history at 5KB (configurable
 via `DEFAULT_MAX_HISTORY_CHARS`), so even a 4-round, 4-agent
@@ -392,7 +396,7 @@ If `context.md` for a channel goes stale (the rules no longer match
 reality), fix it immediately:
 
 ```bash
-ab channel context pipeline --edit
+.venv/bin/python scripts/ai_agent_bridge/__main__.py channel context pipeline --edit
 ```
 
 This bumps the sha256, and the next post will record the new rev.
@@ -415,12 +419,12 @@ Who writes:
 Who reads:
 
 - Any external watcher you configure locally
-- `ab sync` if you prefer manual draining instead of OS integration
+- `.venv/bin/python scripts/ai_agent_bridge/__main__.py sync` if you prefer manual draining instead of OS integration
 
 Recommended mental model:
 
 - The SQLite `deliveries` table is the source of truth
-- Wake files are only a nudge to run `ab inbox run <agent>`
+- Wake files are only a nudge to run `.venv/bin/python scripts/ai_agent_bridge/__main__.py inbox run <agent>`
 - Missing a wake is safe because the work is still pending in SQLite
 
 Example launchd `.plist` (`docs/examples/learn-ukrainian.codex-inbox.plist`):
@@ -465,8 +469,8 @@ ExecStart=%h/projects/learn-ukrainian/.venv/bin/python scripts/ai_agent_bridge/_
 If you do not want OS-level watchers, use the manual fallback:
 
 ```bash
-ab sync claude
-ab sync --all
+.venv/bin/python scripts/ai_agent_bridge/__main__.py sync claude
+.venv/bin/python scripts/ai_agent_bridge/__main__.py sync --all
 ```
 
 That path reads the same `deliveries` queue and drains it on demand.

--- a/docs/best-practices/agent-cooperation.md
+++ b/docs/best-practices/agent-cooperation.md
@@ -90,7 +90,7 @@ low-noise surfaces:
 2. **GitHub PRs carry deliverables.** Track orchestrators open PRs with clear
    scope, validation, active dispatch ids, and blockers. The main orchestrator
    reads the PR instead of scraping private chat context.
-3. **Bridge messages are pings, not payloads.** Use `ab p` / channel posts only
+3. **Bridge messages are pings, not payloads.** Use `.venv/bin/python scripts/ai_agent_bridge/__main__.py p` / channel posts only
    to point to the PR, issue, or handoff section that changed.
 4. **Main only interrupts for repo-wide risk.** Examples: generated artifacts in
    diff, `.python-version`/linter config changes, merge conflicts, failing
@@ -151,7 +151,7 @@ change.
 As of #1184 (April 2026), all three agents (Claude, Gemini, Codex) are
 invoked through `scripts/agent_runtime/runner.invoke()`. This applies to:
 
-- `scripts/ai_agent_bridge/` — bridge messaging (`ask-gemini`, `ask-codex`, `process-claude`, etc.)
+- `scripts/ai_agent_bridge/` — bridge messaging (`ask-agy`, `ask-codex`, `process-claude`, etc.)
 - `scripts/build/dispatch.py` — pipeline phase dispatch (`skeleton`, `write`, `review`, etc.)
 - `scripts/delegate.py` (future) — ad-hoc coding task delegation
 - `scripts/consult.py` (future) — multi-agent consultation
@@ -166,10 +166,10 @@ Full guide: [`docs/agent-runtime-guide.md`](../agent-runtime-guide.md).
 - **CC 2.1.119+: `--agent <name>` honors agent definition's `permissionMode` for built-in agents.** We pass `--mode danger` explicitly on every dispatch, so this is a no-op for us. Don't remove the explicit `--mode danger` and expect the agent definition to carry it — not every dispatch target is a built-in agent.
 - **CC 2.1.119+: `Agent` tool with `isolation: "worktree"` no longer reuses stale worktrees from prior sessions.** Until this fix we avoided the built-in Agent-tool isolation and hand-rolled `git worktree add` (see `.claude/rules/delegate-must-use-worktree.md`). The hand-rolled pattern is still correct — it survives across sessions, shows up in `git worktree list`, and matches our dispatch conventions — but the Agent-tool built-in is now a safe alternative for short-lived, same-session isolation.
 
-### Direct dispatch (ask-gemini / ask-codex)
+### Direct dispatch (ask-agy / ask-codex)
 For requests needing immediate response:
 ```bash
-.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-gemini \
+.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy \
   "Review posted on #559. Please read and respond." \
   --task-id issue-559
 
@@ -191,50 +191,42 @@ For iterative co-design, planning, or prompt optimization:
   "Good points. What about the dialogue examples?" \
   --task-id "a1-1-planning"
 ```
-Each turn includes full conversation history. Oldest messages truncated first if history exceeds 30K chars. Use `--model gemini-3.1-pro-preview` for design conversations.
+Each turn includes full conversation history. Oldest messages truncated first if history exceeds 30K chars. Use AGY via `ask-agy` for current Gemini-family design questions.
 
 ### How the bridge works (architecture)
 The bridge is **not** an MCP tool. MCP is one-directional (client→server). The bridge uses a different architecture:
 
 1. **SQLite broker DB** (`data/broker.db`) — shared message queue
-2. **CLI wrapper** spawns the target agent CLI (`gemini`, `claude`, or `codex`) as a subprocess with the message as prompt
+2. **CLI wrapper** spawns the target agent CLI (`agy`, `claude`, or `codex`) as a subprocess with the message as prompt
 3. The target agent runs, output is captured and stored back in the broker DB
 4. Reviews auto-posted to GitHub issues (when task_id matches `issue-NNN`)
 
-This means the broker can route among Claude, Gemini, and Codex. In practice, GitHub remains the source of truth and broker messages should stay short.
+This means the broker can route among Claude, AGY, and Codex. In practice, GitHub remains the source of truth and broker messages should stay short.
 
-### Automatic Review Persistence
+### Review Persistence
 
-Reviews dispatched via `ask-gemini` are automatically posted to GitHub:
-
-| task_id pattern | Behavior |
-|-----------------|----------|
-| `issue-NNN` / `gh-NNN` | Posted as comment on issue #NNN |
-| Any other value | New issue created with `review-result` label |
-| None | New issue created titled `Review: {timestamp}` |
-
-Reviews >65K chars are split into multiple comments. To skip: `--no-github`.
-
-Only applies to **standard mode** (not `--stdout-only` or `--output-path`).
+Gemini CLI review auto-posting is legacy behavior and is not a current route.
+For current Gemini-family review, use AGY via the bridge and record the review
+result in the PR body or GitHub issue explicitly.
 
 ### Passive notification (MCP send_message)
-For non-blocking FYI messages Gemini sees at next session start:
+For non-blocking FYI messages AGY sees at next session start:
 ```python
 mcp__message-broker__send_message(
-    to="gemini", content="FYI: bio Phase A complete. See #560.",
+    to="agy", content="FYI: bio Phase A complete. See #560.",
     from_llm="claude", message_type="context"
 )
 ```
 
 ---
 
-## Multi-Agent Deliberation (`ab discuss`)
+## Multi-Agent Deliberation (`.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss`)
 
-**This section was added 2026-05-02 after recognizing systematic underutilization** of `ab discuss` for design/framing/architecture decisions. We were defaulting to single-shot Gemini reviews and Claude-alone-reasoning where distributed deliberation would have caught more.
+**This section was added 2026-05-02 after recognizing systematic underutilization** of `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss` for design/framing/architecture decisions. We were defaulting to single-shot AGY reviews and Claude-alone-reasoning where distributed deliberation would have caught more.
 
-### What `ab discuss` is — and isn't
+### What `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss` is — and isn't
 
-`ab discuss` runs bounded rounds (default 2, max 4) of parallel agent responses on a topic, short-circuiting when all agents end with `[AGREE]`. Transcript lands in the named channel with `parent_id` threading.
+`.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss` runs bounded rounds (default 2, max 4) of parallel agent responses on a topic, short-circuiting when all agents end with `[AGREE]`. Transcript lands in the named channel with `parent_id` threading.
 
 **It is NOT a quorum mechanism.** Three agents don't form an independent jury — Claude/Gemini/Codex all trained on overlapping internet corpora and have **correlated blind spots** (e.g., Russian-imperial framings show up in all three model families' priors). Math-voting on agent agreement isn't trustworthy.
 
@@ -245,7 +237,7 @@ mcp__message-broker__send_message(
 
 ### When to use which tool
 
-| Use `ab discuss` | Use `ask-gemini` (single-shot) | Don't use either |
+| Use `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss` | Use bridge `ask-agy` (single-shot) | Don't use either |
 |---|---|---|
 | Architectural trade-offs (e.g., module_type categories, retrieval strategy) | Mechanical PR review with green CI | Trivial fixes (delete leftover file) |
 | Pedagogy/framing decisions (POC scope, anchor choice, decolonization audits) | Adversarial review of a single PR | Implementation tasks (Codex codes alone) |
@@ -255,22 +247,22 @@ mcp__message-broker__send_message(
 
 ### Budget angle
 
-- `ab discuss --with gemini,codex` (Claude excluded) is FREE for orchestrator — Gemini subscription unmetered, Codex on OpenAI subscription. Use aggressively when Anthropic budget is tight.
-- `ab discuss --with claude,gemini,codex` burns Anthropic per round per Claude turn. Reserve for foundational decisions where Claude's voice as architect/reviewer matters (architecture, pedagogy framing, decision arbitration).
+- `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss ... --with agy,codex` (Claude excluded) avoids Anthropic spend; AGY itself is metered. Use when AGY/Codex perspectives are enough.
+- `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss ... --with claude,agy,codex` burns Anthropic per round per Claude turn. Reserve for foundational decisions where Claude's voice as architect/reviewer matters (architecture, pedagogy framing, decision arbitration).
 
 ### Concrete example — what we missed today (2026-05-02)
 
 When proposing the POC anchor module, Claude reasoned alone and offered A1/M10 colors as a "neutral steady-state baseline." User had to catch the Russian-imperial-propaganda angle on colors that invalidated "neutral." If we had run:
 
 ```bash
-ab discuss content "POC anchor module choice — M10 colors vs M20 my-morning, considering decolonization sensitivity in A1" --with claude,gemini,codex --max-rounds 2
+.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss content "POC anchor module choice — M10 colors vs M20 my-morning, considering decolonization sensitivity in A1" --with claude,agy,codex --max-rounds 2
 ```
 
 …Gemini or Codex might have surfaced the colors angle independently. The deliberation transcript would also exist as a referenceable record on the `content` channel, not buried in a Claude session that compaction would eventually destroy. **Pattern: when picking among options that touch decolonization, framing, or pedagogy — discuss, don't decide alone.**
 
-### Decision Card pattern (when `ab discuss` surfaces a CHOICE)
+### Decision Card pattern (when `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss` surfaces a CHOICE)
 
-Most `ab discuss` runs converge with `[AGREE]` — orchestrator just executes the consensus. But when discussion surfaces **disagreement OR multi-option output**, the orchestrator MUST emit a structured Decision Card so the user can override or approve. Don't bury decisions in transcript noise.
+Most `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss` runs converge with `[AGREE]` — orchestrator just executes the consensus. But when discussion surfaces **disagreement OR multi-option output**, the orchestrator MUST emit a structured Decision Card so the user can override or approve. Don't bury decisions in transcript noise.
 
 **Template:**
 
@@ -308,11 +300,11 @@ When all participating agents share the same underlying bias on a topic (e.g., R
 
 For high-risk tracks — **FOLK, HIST, BIO, ISTORIO, LIT, OES, RUTH** (all decolonization-sensitive seminar tracks where Russian/Soviet-imperial framings are most ingrained in training data) — the orchestrator MUST apply at least one of the following failsafe mechanisms:
 
-- **Mechanism A (Force-emit Decision Card on `[AGREE]`):** If `ab discuss` runs on a topic touching any high-risk track and converges with `[AGREE]`, the orchestrator emits a Decision Card anyway. The question is framed as "agents converged on X — but consensus on this track is suspect; user should sanity-check." The user can quickly approve or override.
-- **Mechanism B (Inject domain-specific bias checklist):** For high-risk tracks, the `ab discuss` prompt is augmented with a short bias checklist explicitly provoking adversarial review on known bias vectors.
+- **Mechanism A (Force-emit Decision Card on `[AGREE]`):** If `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss` runs on a topic touching any high-risk track and converges with `[AGREE]`, the orchestrator emits a Decision Card anyway. The question is framed as "agents converged on X — but consensus on this track is suspect; user should sanity-check." The user can quickly approve or override.
+- **Mechanism B (Inject domain-specific bias checklist):** For high-risk tracks, the `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss` prompt is augmented with a short bias checklist explicitly provoking adversarial review on known bias vectors.
   - *Example for HIST:* "Did you check the proposed framing against canonical decolonized sources? Bulgakov-as-Ukrainian, Gogol-as-Ukrainian, Akhmatova-as-Ukrainian, etc., are the 'Kyiv-born equals Ukrainian writer' trap — flag if you see it. Did you check whether the historical actor is being framed in Russian-imperial categories versus Ukrainian native categories?"
 
-**Recommendation:** Prefer **Mechanism B** (proactive — catches bias during discussion) for any new `ab discuss` on high-risk tracks. Fall back to **Mechanism A** (reactive — emit card on consensus) when no domain-specific checklist exists yet for that track.
+**Recommendation:** Prefer **Mechanism B** (proactive — catches bias during discussion) for any new `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss` on high-risk tracks. Fall back to **Mechanism A** (reactive — emit card on consensus) when no domain-specific checklist exists yet for that track.
 
 **Pattern:** Consensus on high-risk tracks is a SIGNAL TO CHECK, not a signal to proceed.
 
@@ -345,7 +337,7 @@ The bridge runs a citation-provenance check on every channel post and reply befo
 
 **Annotate-mode, not block-mode.** The check never refuses a post — it surfaces the doubt. This keeps the cost of a false-positive low (the channel still flows; reviewers see the marker and can dismiss it) and the cost of a true-positive a clear breadcrumb for downstream consumers (reviewer prompts, content modules, students never inherit a forged citation).
 
-**Why this exists.** On 2026-05-05, two `ab discuss` runs hours apart on собака gender produced the same fabricated Антоненко-Давидович citation ("Антоненко-Давидович categorizes feminine собака as a calque/Russianism") in Gemini's reply. АД has no entry on собака per `mcp__sources__search_style_guide`; the model's prior was the bug, not the source. The deliberation-protocol fix (commit `872d8376b0`) blocked round-1 short-circuit so a single round of cross-agent comparison happens — but if a fabrication had survived two rounds of `[AGREE]`, it would have shipped to curriculum. This check closes that gap.
+**Why this exists.** On 2026-05-05, two `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss` runs hours apart on собака gender produced the same fabricated Антоненко-Давидович citation ("Антоненко-Давидович categorizes feminine собака as a calque/Russianism") in Gemini's reply. АД has no entry on собака per `mcp__sources__search_style_guide`; the model's prior was the bug, not the source. The deliberation-protocol fix (commit `872d8376b0`) blocked round-1 short-circuit so a single round of cross-agent comparison happens — but if a fabrication had survived two rounds of `[AGREE]`, it would have shipped to curriculum. This check closes that gap.
 
 **Detection scope (v1):** verbatim source-name match (with permissive inflection across Cyrillic case endings) + headword extraction from the local window (italicized, code-fenced, quoted, or "іменник X" / "слово X" patterns). Multi-pattern same-source mentions within ~200 chars are de-duplicated to one citation. Out of scope (deferred): fuzzy-match of quoted text against source body content; LLM-based attribution detection; block-mode rejection. The v1 catches outright fabrication where the headword does not exist anywhere in the source corpus.
 
@@ -486,11 +478,11 @@ Use Gemini's skill files instead of verbose prompts. Each skill encodes the full
 
 ```bash
 # Seminar track rebuild
-.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-gemini "/full-rebuild-bio 5" \
+.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy "/full-rebuild-bio 5" \
   --task-id rebuild-bio-5
 
 # Core track rebuild
-.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-gemini "/full-rebuild-core-a a1 3" \
+.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy "/full-rebuild-core-a a1 3" \
   --task-id rebuild-a1-3
 ```
 
@@ -523,28 +515,17 @@ research = _extract_delimiter(output, "===RESEARCH_START===", "===RESEARCH_END==
 
 Never parse Gemini's prose output for structured data.
 
-### Gemini CLI Auth and Prompt Passing
+### AGY Model Names
 
-As of 2026-05-05 (#1709/#1710), the runtime invokes Gemini CLI with `-p`
-instead of piping prompts on stdin. Gemini CLI v0.40.1 treats non-TTY stdin as
-REPL input and can ignore or hang on piped prompts. Small prompts are passed
-inline with `-p PROMPT`; prompts over 100K chars use the verified file-reference
-form `-p @PATH`.
+Gemini CLI and Gemini Code Assist are unsupported for current project work.
+For Gemini-family review or support, use AGY through
+`.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy ...` or
+`scripts/delegate.py dispatch --agent agy ...`.
 
-For write-mode runtime calls, keep `--approval-mode=yolo` and include
-`--skip-trust`; Gemini CLI v0.40.1 otherwise downgrades approval mode in
-untrusted output directories such as `/tmp` and exits before writing.
-
-Gemini auth precedence is API first, then subscription/OAuth fallback:
-
-- `GEMINI_AUTH_MODE=api` forces API mode and fails fast if no Gemini API key is
-  configured.
-- `GEMINI_AUTH_MODE=subscription` or `oauth` forces subscription/OAuth mode and
-  strips Gemini API env vars from the subprocess.
-- With no override, `GEMINI_API_KEY` or `GOOGLE_API_KEY` selects API mode.
-- With no override and no API key, subscription/OAuth remains the default.
-- The fallback ladder starts on API rungs when API keys are available, then
-  transitions to subscription/OAuth rungs on rate limit or capacity failures.
+Direct `agy --model` calls use display labels from `agy models`, such as
+`Gemini 3.1 Pro (High)` and `Gemini 3.5 Flash (High)`. The bridge and runtime
+may accept slugs such as `gemini-3.1-pro-high` and map them to AGY display
+labels before invoking AGY.
 
 ---
 

--- a/docs/best-practices/api-ui-improvements-proposal.md
+++ b/docs/best-practices/api-ui-improvements-proposal.md
@@ -206,7 +206,7 @@ All phases plug into EPIC #1814 (HTML artifact serving + nav UI). The `/dashboar
 3. **Cache-friendly.** Existing endpoints use TTL caching (per-section). New endpoints follow same pattern.
 4. **Kubedojo aesthetic** for HTML — already adopted, consistent.
 5. **Agents read first, humans read second.** When designing a new endpoint, write the JSON shape FIRST (because agent routing depends on it), then derive the HTML view.
-6. **No interactive forms in v1.** Read-only views only. Bakeoff firings, promote-protocol acceptances, etc. happen via CLI (`delegate.py`, `ab discuss`) — the dashboard *shows* state but doesn't *change* it.
+6. **No interactive forms in v1.** Read-only views only. Bakeoff firings, promote-protocol acceptances, etc. happen via CLI (`scripts/delegate.py dispatch`, `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss`) — the dashboard *shows* state but doesn't *change* it.
 
 ---
 

--- a/docs/best-practices/harness-engineering.md
+++ b/docs/best-practices/harness-engineering.md
@@ -173,7 +173,7 @@ We have already been doing harness engineering for ~6 months. The OpenAI posts g
 | Per-worktree isolated runs | `delegate.py dispatch --worktree` (mandatory per #M0 dispatch routing) |
 | Bug autopsies / continuous GC | `docs/bug-autopsies/INDEX.md`, MEMORY trim cadence, ADR hygiene flags |
 | Repo as only state | Decisions, comms, channel history all in-repo or DB-served |
-| Multi-agent feedback loops | `ab discuss` channels, dispatch with cross-agent code review |
+| Multi-agent feedback loops | `.venv/bin/python scripts/ai_agent_bridge/__main__.py discuss` channels, dispatch with cross-agent code review |
 | Two-tier handoffs | brief.md + .html (epic #1865 item #1, shipped 2026-05-11) |
 | Objectives over rigid state transitions | `/goal` rule (#1884, shipped 2026-05-12) |
 
@@ -223,5 +223,5 @@ Our project is **education** where:
 - [OpenAI: "An open-source spec for Codex orchestration: Symphony"](https://openai.com/index/open-source-codex-orchestration-symphony/) — the orchestration follow-up.
 - [openai/symphony on GitHub](https://github.com/openai/symphony) — `SPEC.md` (~2,200 lines, RFC-2119) + Elixir reference implementation.
 - This project: `claude_extensions/rules/goal-driven-runs.md` — our `/goal` rule, independently convergent on Symphony's "objectives over transitions" lesson.
-- This project: `docs/best-practices/agent-cooperation.md` — multi-agent deliberation protocol (`ab discuss`, Decision Card pattern).
+- This project: `docs/best-practices/agent-cooperation.md` — multi-agent deliberation protocol (bridge `discuss`, Decision Card pattern).
 - This project: `docs/best-practices/context-engineering.md` — the layer below harness engineering.

--- a/docs/best-practices/hermes-usage.md
+++ b/docs/best-practices/hermes-usage.md
@@ -229,7 +229,7 @@ Total config: **514 lines, 31 top-level keys.** We've meaningfully configured ~3
 | `hermes -z "$(cat brief.md)" -m claude-opus-4-7` | One-shot with Claude (broken — #2036) | SOUL.md slot #1 ✅ |
 | `--writer grok-tools` in V7 (our adapter calls `hermes -z`) | V7 module writer phase | SOUL.md slot #1 ✅ |
 | `--reviewer grok-tools` in V7 | V7 reviewer phase | SOUL.md slot #1 ✅ |
-| `ab ask-grok` (not yet implemented) | Q&A via hermes | SOUL.md slot #1 ✅ when added |
+| `.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-grok` | Q&A via hermes | SOUL.md slot #1 ✅ when added |
 | `hermes chat` (interactive) | Manual TUI session | SOUL.md slot #1 + `/personality` overlay |
 | `--ignore-rules` flag | Skip SOUL.md + AGENTS.md + memory | ❌ NO persona |
 | `hermes cron …` | Scheduled hermes runs | SOUL.md slot #1 ✅ |

--- a/docs/best-practices/issue-tracking.md
+++ b/docs/best-practices/issue-tracking.md
@@ -160,9 +160,10 @@ When handing off to another agent:
 # Post content on the issue
 gh issue comment {N} --body "[full review/spec/request]"
 
-# Ping Gemini
-.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-gemini \
-  "New task posted on #N. Please read and start." --task-id issue-N
+# Ping AGY
+.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy \
+  "New task posted on #N. Please read and start." \
+  --task-id issue-N --to-model gemini-3.5-flash-high
 
 # Ping Codex
 .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-codex \

--- a/docs/best-practices/wiki-plan-review-and-lock.md
+++ b/docs/best-practices/wiki-plan-review-and-lock.md
@@ -148,12 +148,12 @@ The most common failure mode at scale is **wiki-plan drift**: wiki says one thin
 
 ---
 
-## AC-4 — Adversarial review (Gemini) before PR
+## AC-4 — Adversarial review (AGY) before PR
 
-Spawn Gemini via the bridge:
+Spawn AGY via the bridge:
 
 ```bash
-.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-gemini \
+.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy \
   "Adversarial review of #<N> review-and-lock for <slug> wiki + plan. \
    Read the diff. Look for: \
    (1) wiki fixes that introduce NEW gaps while closing documented ones, \
@@ -161,7 +161,7 @@ Spawn Gemini via the bridge:
    (3) plan-review checklist missing categories that the latest systemic audit would have caught, \
    (4) this rubric doc drifting from what was actually applied (worked example must match rubric step-for-step), \
    (5) hallucinated vocab not verifiable in VESUM." \
-  --task-id <N>-review --model gemini-3.1-pro-preview
+  --task-id <N>-review --to-model gemini-3.1-pro-high
 ```
 
 Address findings. If non-trivial, a second round is expected — don't short-circuit.

--- a/docs/design/agent-runtime.md
+++ b/docs/design/agent-runtime.md
@@ -317,7 +317,7 @@ Two complementary signals feed one `last_activity` clock:
 **Discovered session file paths per agent:**
 
 | Agent | Path pattern | Update cadence |
-|---|---|---|
+| --- | --- | --- |
 | Gemini | `~/.gemini/tmp/learn-ukrainian/chats/session-<ts>-<hash>.json` | mtime bumps per message + tool call |
 | Codex | `~/.codex/logs_1.sqlite` and the `-o <file>` passed on the command line | continuous during `codex exec` |
 | Claude | `~/.claude/projects/-Users-krisztiankoos-projects-learn-ukrainian/<session>.jsonl` | one line appended per tool call / message |
@@ -388,9 +388,11 @@ Revised order based on Codex and Gemini reviews (both correct in different ways 
 ## 6. Design decisions
 
 ### 6.1 Protocol vs ABC
+
 Use `typing.Protocol` (structural). Lighter than ABC, no runtime overhead, supports `mypy --strict`. Both reviewers agreed.
 
 ### 6.2 Mode vocabulary — `{"read-only", "workspace-write", "danger"}`
+
 Keep these names. They already match the shape the code uses (`_codex.py:16`, `dispatch.py:46`). Gemini said "excellent," Codex agreed with the caveat that `supported_modes` must be real and the runner must reject unsupported modes explicitly. Runner raises `ValueError` if `mode not in adapter.supported_modes`.
 
 ### 6.3 Session resume policy — data-driven
@@ -403,7 +405,7 @@ Keep these names. They already match the shape the code uses (`_codex.py:16`, `d
 **The runtime's impact on cache economics** (Session B in §6.3.1) is different for each provider:
 
 | Provider | Resume saves cost? | Resume causes harm? |
-|---|---|---|
+| --- | --- | --- |
 | Anthropic (Claude) | **YES** — warm prompt cache reused across bridge calls on same task_id | No — Claude `-p --resume <uuid>` is well-scoped to a session |
 | Google (Gemini) | Likely yes (caching mechanics unclear but similar model) | No — multi-turn bridge coherence |
 | OpenAI (Codex) | **NO** — Codex quota is per-message, not per-token; resume doesn't save slots | **YES** — resume + `-C` flag limitation = cross-worktree contamination (see Codex's consultation, footgun #5) |
@@ -426,18 +428,21 @@ Layer 2 — caller enforcement:
 **Session B** = bridge subprocess `claude -p --resume <uuid>` invocations. **This is what the resume policy above applies to.** Each Session B invocation is a short-lived subprocess that runs for seconds; the UUID lets Anthropic's prompt cache hit across multiple bridge calls on the same `task_id`.
 
 ### 6.4 Headroom check semantics
+
 `runner.invoke()` refuses to call an agent that's rate-limited (raises `RateLimitedError` pre-call). Strict refuse is safer; callers that want the retry behavior can catch and handle.
 
 ### 6.5 Parallel consultation support
+
 The runner is **synchronous** per invocation. `consult.py` (future) will sequence calls or use `concurrent.futures.ThreadPoolExecutor` around `runner.invoke()`. No `asyncio` in the runtime itself — Gemini's residual risk warning. Keeps the code simple.
 
 ### 6.6 Grok stub behavior
+
 Load loudly — `GrokAdapter.build_invocation()` raises `NotImplementedError` with a clear message. The registry flag `cli_available: False` prevents the runner from ever calling it; `runner.invoke("grok", ...)` raises `AgentUnavailableError` immediately. Silent skip would hide configuration errors.
 
 ## 7. Vulnerabilities and mitigations
 
 | Vulnerability | Mitigation in v1 |
-|---|---|
+| --- | --- |
 | Env var leakage between adapters | `InvocationPlan.env_overrides` merged fresh per subprocess; no `os.environ.update()` ever. `env_unsets` deferred to v2 if needed. |
 | Concurrent usage log corruption | `os.open(O_APPEND\|O_CREAT\|O_WRONLY) + os.write()` — POSIX atomicity guarantee for sub-PIPE_BUF writes. No filelock. |
 | Stall detection missing (kills healthy slow calls) | Streaming stdout watchdog (primary) + `liveness_signal_paths()` mtime polling (fallback). New `"stalled"` outcome distinguishes from hard timeout. |
@@ -524,7 +529,7 @@ This is AC #11 on #1184. The guide is shipped in the same PR as the runtime code
 **Changes landed in v1:**
 
 | # | Source | Change |
-|---|---|---|
+| --- | --- | --- |
 | 1 | Codex #5 + Gemini #1 (HIGH) | Added `tool_config: dict \| None` to `build_invocation()` and `runner.invoke()` — would have silently broken dispatch.py MCP tool restrictions |
 | 2 | Gemini #3 (HIGH) + cost data | Added `session_id: str \| None` to `build_invocation()` and `runner.invoke()` with per-adapter `resume_policy` + caller-level enforcement |
 | 3 | Gemini #2/#5 + user | NEW §4.6 stall detection: streaming stdout watchdog + liveness mtime polling + new `"stalled"` outcome |

--- a/docs/design/agent-runtime.md
+++ b/docs/design/agent-runtime.md
@@ -29,7 +29,7 @@ The Codex integration for issue #1177 already surfaced this pain: Gemini's adver
 4. **Shared stall detection** — streaming stdout watchdog + liveness-file fallback, lifted from `_gemini.py` prior art.
 5. **Unified subprocess logic**: timeouts, stdout capture, stderr capture, `-o` output files, worktree cwd, JSON event parsing.
 6. **Pluggable agent registry** that captures capabilities, cost tier, default model, invocation flags.
-7. **Backward compatible** — existing `ask-gemini`, `ask-claude`, `ask-codex`, and `dispatch.py` callers keep working without changes during migration.
+7. **Backward compatible** — existing `ask-gemini` callers route through the retired compatibility shim to AGY; `ask-claude`, `ask-codex`, and `dispatch.py` callers keep working during migration.
 8. **Session resume policy is data-driven and enforced at the caller level**, not the runtime level (see §6.3).
 
 ## 3. Non-goals
@@ -197,7 +197,7 @@ AGENTS: dict[str, dict] = {
     },
     "gemini": {
         "adapter": "scripts.agent_runtime.adapters.gemini:GeminiAdapter",
-        "default_model": "gemini-3.1-pro-preview",
+        "default_model": "gemini-3.1-pro-high",
         "cost_tier": "low",
         "capabilities": {"content_writing", "content_review", "adversarial_review"},
         "cli_available": True,

--- a/docs/guardrails/agent-fleet-tooling.md
+++ b/docs/guardrails/agent-fleet-tooling.md
@@ -1,0 +1,50 @@
+# Agent Fleet Tooling Guardrail
+
+## Current Supported Routes
+
+Use these project entry points for agent fleet work:
+
+- `.venv/bin/python scripts/ai_agent_bridge/__main__.py ...` for bridge
+  messages, channel posts, one-shot review requests, and discussion commands.
+- `scripts/delegate.py dispatch ...` for worktree-isolated implementation,
+  review, validation, and long-running delegated work.
+- AGY is the current Gemini-family route. Use it through `ai_agent_bridge` for
+  bridge work or through `scripts/delegate.py dispatch --agent agy ...` for
+  dispatched work.
+
+Gemini CLI and Gemini Code Assist are unsupported for this project. Do not
+document them as current fallback, review, dispatch, or restoration paths.
+
+## Command Examples
+
+```bash
+printf '%s\n' "<review prompt>" | \
+  .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy - \
+    --task-id review-123 \
+    --to-model gemini-3.1-pro-high \
+    --review
+
+scripts/delegate.py dispatch \
+  --agent agy \
+  --brief docs/dispatch-briefs/example.md \
+  --worktree
+```
+
+Avoid bare `ab ...` examples. On the user's machine `ab` resolves to
+ApacheBench (`/usr/sbin/ab`), so `ab ask-agy`, `ab ask-gemini`, `ab post`, and
+`ab discuss` examples may run the wrong binary. If a local project wrapper is
+ever reintroduced, documentation must prove it exists in the execution
+environment before relying on it.
+
+## AGY Model Names
+
+Direct `agy --model` calls use display labels printed by `agy models`, for
+example:
+
+- `Gemini 3.1 Pro (High)`
+- `Gemini 3.5 Flash (High)`
+
+The project bridge and runtime may accept slugs such as
+`gemini-3.1-pro-high` and map them to AGY display labels before invoking AGY.
+Use slugs only in bridge/runtime examples, not in direct `agy --model`
+examples.

--- a/docs/prompts/orchestrators/b2/preflight-readiness-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/b2/preflight-readiness-audit-orchestrator.md
@@ -116,7 +116,7 @@ Do not run builds. Do not modify B2 plans, wiki files, discovery files, or modul
 
 ## Independent-Family Review Gate
 
-Before merge, request a read-only independent-family review of the preflight audit-report PR. Prefer Claude Opus 4.8. If Claude Opus 4.8 is unavailable, use Agy with Gemini 3.1 Pro High, for example `agy --model gemini-3.1-pro-high --print-timeout 10m -p "<review prompt>"`.
+Before merge, request a read-only independent-family review of the preflight audit-report PR. Prefer Claude Opus 4.8. If Claude Opus 4.8 is unavailable, use Agy with Gemini 3.1 Pro High, for example `agy --model "Gemini 3.1 Pro (High)" --print-timeout 10m -p "<review prompt>"`.
 
 The review prompt must include the PR diff, preflight scope, validation summary, artifact-clean statement, helper/swarm note, and an explicit request for blocker-only findings. Record reviewer identity, review model, review scope, unresolved findings, and final disposition in the durable audit report or PR body. The merge rule is explicit: unresolved findings are blockers.
 

--- a/docs/prompts/orchestrators/b2/production-build-orchestrator.md
+++ b/docs/prompts/orchestrators/b2/production-build-orchestrator.md
@@ -128,7 +128,7 @@ Required PR/telemetry fields: `run_id`, `level`, `slug`, `branch`, `commit_sha`,
 
 ## Independent-Family Review Gate
 
-Before merge, request a read-only independent-family review. Prefer Claude Opus 4.8. If Claude Opus 4.8 is unavailable, use Agy with Gemini 3.1 Pro High, for example `agy --model gemini-3.1-pro-high --print-timeout 10m -p "<review prompt>"` when that is the available local route.
+Before merge, request a read-only independent-family review. Prefer Claude Opus 4.8. If Claude Opus 4.8 is unavailable, use Agy with Gemini 3.1 Pro High, for example `agy --model "Gemini 3.1 Pro (High)" --print-timeout 10m -p "<review prompt>"` when that is the available local route.
 
 The review prompt must include the PR diff, validation summary, telemetry summary, artifact-clean statement, and explicit request for blocker-only findings. Record reviewer identity, review model, review scope, unresolved findings, and final disposition in the PR body or final orchestration note. The merge rule is explicit: unresolved findings are blockers.
 

--- a/docs/prompts/orchestrators/b2/quality-audit-orchestrator.md
+++ b/docs/prompts/orchestrators/b2/quality-audit-orchestrator.md
@@ -129,7 +129,7 @@ Adapt the `audit_module.py --skip-review` path and cleanup paths for each built 
 
 ## Independent-Family Review Gate
 
-Before merge, request a read-only independent-family review of the audit-report PR. Prefer Claude Opus 4.8. If Claude Opus 4.8 is unavailable, use Agy with Gemini 3.1 Pro High, for example `agy --model gemini-3.1-pro-high --print-timeout 10m -p "<review prompt>"`.
+Before merge, request a read-only independent-family review of the audit-report PR. Prefer Claude Opus 4.8. If Claude Opus 4.8 is unavailable, use Agy with Gemini 3.1 Pro High, for example `agy --model "Gemini 3.1 Pro (High)" --print-timeout 10m -p "<review prompt>"`.
 
 The review prompt must include the PR diff, audited-module scope, validation summary, artifact-clean statement, helper/swarm note, and an explicit request for blocker-only findings. Record reviewer identity, review model, review scope, unresolved findings, and final disposition in the durable audit report or PR body. The merge rule is explicit: unresolved findings are blockers.
 

--- a/scripts/ai_agent_bridge/_agy.py
+++ b/scripts/ai_agent_bridge/_agy.py
@@ -71,6 +71,8 @@ def ask_agy(
     to_model: str | None = None,
     no_timeout: bool = False,
     review: bool = False,
+    stdout_only: bool = False,
+    output_path: str | None = None,
 ):
     """Send message to Agy AND invoke Agy to process it (one-shot)."""
     msg_id = send_message(
@@ -83,8 +85,18 @@ def ask_agy(
         from_model=from_model,
         to_model=to_model,
     )
-    print(f"\n🚀 Invoking Agy to process message #{msg_id}...")
-    process_for_agy(msg_id, new_session, no_timeout, review=review)
+    if not stdout_only:
+        print(f"\n🚀 Invoking Agy to process message #{msg_id}...")
+    response = process_for_agy(
+        msg_id,
+        new_session,
+        no_timeout,
+        review=review,
+        stdout_only=stdout_only,
+        output_path=output_path,
+    )
+    if stdout_only and response:
+        print(response)
     return msg_id
 
 
@@ -93,7 +105,9 @@ def process_for_agy(
     new_session: bool = False,
     no_timeout: bool = False,
     review: bool = False,
-):
+    stdout_only: bool = False,
+    output_path: str | None = None,
+) -> str | None:
     """Read message addressed to Agy, invoke via agent_runtime, send response.
 
     ``new_session`` is accepted for API parity with the codex bridge but
@@ -112,15 +126,16 @@ def process_for_agy(
 
     prompt = build_agy_prompt(msg, review)
 
-    print(f"📨 Message #{msg['id']}")
-    print(f"   From: {msg['from']} → To: {msg['to']}")
-    print(f"   Type: {msg['type']}")
-    print(f"   Task: {msg['task_id'] or 'N/A'}")
-    print(f"   Model: {model}")
-    if timeout_val == _NO_TIMEOUT_AGY_BRIDGE_TIMEOUT_SECONDS:
-        print("   Hard timeout: no-timeout requested (24h ceiling)")
-    else:
-        print(f"   Hard timeout: {timeout_val}s")
+    if not stdout_only:
+        print(f"📨 Message #{msg['id']}")
+        print(f"   From: {msg['from']} → To: {msg['to']}")
+        print(f"   Type: {msg['type']}")
+        print(f"   Task: {msg['task_id'] or 'N/A'}")
+        print(f"   Model: {model}")
+        if timeout_val == _NO_TIMEOUT_AGY_BRIDGE_TIMEOUT_SECONDS:
+            print("   Hard timeout: no-timeout requested (24h ceiling)")
+        else:
+            print(f"   Hard timeout: {timeout_val}s")
 
     try:
         result = agent_runner.invoke(
@@ -138,16 +153,16 @@ def process_for_agy(
         )
     except RateLimitedError as exc:
         _handle_agy_error(msg, message_id, f"Agy rate limited: {exc}")
-        return
+        return None
     except AgentStalledError as exc:
         _handle_agy_error(msg, message_id, f"Agy stalled: {exc}")
-        return
+        return None
     except AgentTimeoutError as exc:
         _handle_agy_error(msg, message_id, f"Agy hard timeout: {exc}")
-        return
+        return None
     except AgentUnavailableError as exc:
         _handle_agy_error(msg, message_id, f"Agy unavailable: {exc}")
-        return
+        return None
 
     if not result.ok:
         _handle_agy_error(
@@ -155,7 +170,7 @@ def process_for_agy(
             message_id,
             result.stderr_excerpt or "Agy returned no final message",
         )
-        return
+        return None
 
     if result.session_id and msg["task_id"]:
         set_session(msg["task_id"], "agy", result.session_id)
@@ -163,9 +178,17 @@ def process_for_agy(
     response = result.response
     if not response:
         _handle_agy_error(msg, message_id, "Agy returned no final message")
-        return
+        return None
 
-    print(f"\n✅ Agy finished ({len(response)} chars)")
+    if output_path:
+        from pathlib import Path
+
+        out_path = Path(output_path)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(response, encoding="utf-8")
+
+    if not stdout_only:
+        print(f"\n✅ Agy finished ({len(response)} chars)")
     reply_id = send_message(
         content=response,
         task_id=msg["task_id"],
@@ -175,6 +198,7 @@ def process_for_agy(
     )
     acknowledge(message_id)
     acknowledge(reply_id)
+    return response
 
 
 def _fetch_agy_message(message_id: int) -> dict | None:

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -54,6 +54,17 @@ _CALLER_IDENTITY_ENV_HINTS = (
     "GEMINI_SESSION",
 )
 
+_LEGACY_GEMINI_TO_AGY_MODEL = {
+    "gemini-3.1-pro-preview": "gemini-3.1-pro-high",
+    "gemini-3.0-flash-preview": "gemini-3.5-flash-high",
+}
+
+
+def _map_legacy_gemini_model_to_agy(model: str | None) -> str | None:
+    if not model:
+        return None
+    return _LEGACY_GEMINI_TO_AGY_MODEL.get(model, model)
+
 
 def _detect_caller_identity_from_env() -> str | None:
     """Infer the sending agent for legacy ask-* commands from wrapper env."""
@@ -518,23 +529,27 @@ def _build_parser() -> argparse.ArgumentParser:
     ask_codex_parser.add_argument("--review", action="store_true",
                                   help="Prepend docs/review-protocol.md")
 
-    # ask-gemini
-    ask_gemini_parser = subparsers.add_parser("ask-gemini", help="Send message AND invoke Gemini (one-step)")
+    # ask-gemini legacy compatibility shim
+    ask_gemini_parser = subparsers.add_parser(
+        "ask-gemini",
+        help="Retired compatibility alias; routes through ask-agy",
+    )
     ask_gemini_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
     ask_gemini_parser.add_argument("--task-id", required=True, help="Task ID (required for session tracking)")
     ask_gemini_parser.add_argument("--type", default="query", help="Message type (default: query)")
     ask_gemini_parser.add_argument("--data", help="Path to data file to attach")
     ask_gemini_parser.add_argument(
-        "--model", default=GEMINI_DEFAULT_MODEL, help="Gemini model to use"
+        "--model", default=GEMINI_DEFAULT_MODEL,
+        help="Legacy Gemini model slug; mapped to AGY where needed"
     )
     ask_gemini_parser.add_argument("--from-model", dest="from_model",
                                    help="Exact sender model ID")
     ask_gemini_parser.add_argument("--from", dest="from_llm",
                                    help="Sender agent family. Default: inferred from environment")
     ask_gemini_parser.add_argument("--async", dest="async_mode", action="store_true",
-                                   help="Queue only, don't invoke Gemini CLI")
+                                   help="Queue only; legacy no-op for AGY shim")
     ask_gemini_parser.add_argument("--stdout-only", dest="stdout_only", action="store_true",
-                                   help="Print Gemini's response body to stdout for the "
+                                   help="Print AGY response body to stdout for the "
                                         "caller to parse; a thin summary still goes to the "
                                         "broker so the thread stays consistent. Suppresses "
                                         "all bridge progress logging on stdout.")
@@ -578,6 +593,10 @@ def _build_parser() -> argparse.ArgumentParser:
                                 help="Exact sender model ID")
     ask_agy_parser.add_argument("--to-model", dest="to_model",
                                 help="Target Agy model ID (default: gemini-3.5-flash-high)")
+    ask_agy_parser.add_argument("--stdout-only", dest="stdout_only", action="store_true",
+                                help="Print Agy response body to stdout for caller parsing")
+    ask_agy_parser.add_argument("--output-path", dest="output_path",
+                                help="Write Agy response body to a file")
     ask_agy_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true",
                                 help="Run sync without timeout")
     ask_agy_parser.add_argument("--review", action="store_true",
@@ -1101,7 +1120,10 @@ def _handle_ask_agy(args):
     from_llm = _resolve_from_llm(args)
     ask_agy(content, args.task_id, args.type, data,
             args.new_session, from_llm, args.from_model,
-            args.to_model, args.no_timeout, **kwargs)
+            args.to_model, args.no_timeout,
+            stdout_only=getattr(args, "stdout_only", False),
+            output_path=getattr(args, "output_path", None),
+            **kwargs)
 
 
 def _handle_ask_hermes(args):
@@ -1178,26 +1200,29 @@ def _handle_ask_grok_build(args):
 
 
 def _handle_ask_gemini(args):
-    """Handle ask-gemini subcommand."""
+    """Compatibility shim: ask-gemini is retired and delegates to ask-agy."""
     data = None
     if args.data:
         data = Path(args.data).read_text()
     content = sys.stdin.read() if args.content == "-" else args.content
     kwargs = {"review": True} if getattr(args, "review", False) else {}
     from_llm = _resolve_from_llm(args)
-    ask_gemini(content, args.task_id, args.type, data, args.model,
-               from_llm,
-               getattr(args, 'from_model', None),
-               getattr(args, 'async_mode', False),
-               getattr(args, 'stdout_only', False),
-               getattr(args, 'output_path', None),
-               getattr(args, 'extract', None),
-               getattr(args, 'skip_model_check', False),
-               getattr(args, 'allow_write', False),
-               getattr(args, 'delimiters', None),
-               getattr(args, 'no_github', False),
-               getattr(args, 'auth', None),
-               **kwargs)
+    if not getattr(args, "stdout_only", False):
+        print("⚠️ ask-gemini is retired; routing through ask-agy.", file=sys.stderr)
+    ask_agy(
+        content,
+        args.task_id,
+        args.type,
+        data,
+        new_session=False,
+        from_llm=from_llm,
+        from_model=getattr(args, "from_model", None),
+        to_model=_map_legacy_gemini_model_to_agy(getattr(args, "model", None)) or "gemini-3.5-flash-high",
+        no_timeout=False,
+        stdout_only=getattr(args, "stdout_only", False),
+        output_path=getattr(args, "output_path", None),
+        **kwargs,
+    )
 
 
 def main():

--- a/scripts/audit/naturalness_check.py
+++ b/scripts/audit/naturalness_check.py
@@ -97,17 +97,20 @@ def _parse_naturalness_json(raw_output: str) -> dict | None:
     return parsed if "score" in parsed else None
 
 
-def call_gemini(prompt: str, task_id: str) -> tuple[str, dict]:
-    """Call Gemini and return raw response + parsed JSON."""
+def call_agy(prompt: str, task_id: str) -> tuple[str, dict]:
+    """Call AGY and return raw response + parsed JSON."""
     try:
         result = subprocess.run(
             [
                 str(VENV_PYTHON),
                 str(PROJECT_ROOT / "scripts" / "ai_agent_bridge" / "__main__.py"),
-                "ask-gemini",
+                "ask-agy",
                 "-",  # read prompt from stdin
                 "--task-id", task_id,
-                "--from-model", "claude-opus-4-5-20251101"  # Track sender model
+                "--from", "claude",
+                "--from-model", "claude-opus-4-5-20251101",  # Track sender model
+                "--to-model", "gemini-3.1-pro-high",
+                "--stdout-only",
             ],
             capture_output=True,
             text=True,
@@ -329,9 +332,9 @@ def check_naturalness(
     timestamp = datetime.now(UTC).isoformat()
     task_id = f"naturalness-{md_path.stem}-{int(datetime.now().timestamp())}"
 
-    # Call Gemini
-    print("  📤 Sending to Gemini...")
-    gemini_raw, gemini_parsed = call_gemini(prompt, task_id)
+    # Call AGY
+    print("  📤 Sending to AGY...")
+    gemini_raw, gemini_parsed = call_agy(prompt, task_id)
     print(f"  📥 Gemini: {gemini_parsed.get('score', '?')}/10 - {gemini_parsed.get('status', '?')}")
 
     # Call Claude (headless)

--- a/scripts/audit/russianism_eval.py
+++ b/scripts/audit/russianism_eval.py
@@ -30,8 +30,8 @@ from scripts.audit.checks.russicism_detection import check_russicisms
 PYTHON, BRIDGE = Path(".venv/bin/python"), Path("scripts/ai_agent_bridge/__main__.py")
 DEFAULT_MODELS = (
     "claude-opus-4-7,claude-sonnet-4-5,claude-haiku-4-5,"
-    "gpt-5.5,gpt-5.5-mini,gemini-3.1-pro-preview,"
-    "gemini-3-pro-preview,gemini-3.0-flash-preview"
+    "gpt-5.5,gpt-5.5-mini,gemini-3.1-pro-high,"
+    "gemini-3.5-flash-high"
 )
 FROM_AGENT = "russianism-eval"
 _FOUND_COUNT_RE, _WORD_RE = re.compile(r"Found\s+(\d+)\s+Russicism", re.IGNORECASE), re.compile(r"[\w'’-]+", re.UNICODE)
@@ -152,7 +152,7 @@ class BridgeCaller:
         if family == "codex":
             argv = [*base, "ask-codex", "-", "--task-id", task_id, "--from", FROM_AGENT, "--to-model", model, "--new-session"]
             return BridgeCall(prompt.id, model, family, task_id, argv, prompt.prompt_text)
-        argv = [*base, "ask-gemini", "-", "--task-id", task_id, "--from", FROM_AGENT, "--model", model, "--stdout-only", "--skip-model-check", "--no-github"]
+        argv = [*base, "ask-agy", "-", "--task-id", task_id, "--from", FROM_AGENT, "--to-model", model, "--stdout-only"]
         return BridgeCall(prompt.id, model, family, task_id, argv, prompt.prompt_text)
 
     def __call__(self, prompt: PromptCase, model: str) -> tuple[BridgeCall, str]:

--- a/scripts/ops/smoketest_bridge_stdout_only.sh
+++ b/scripts/ops/smoketest_bridge_stdout_only.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
-# Smoketest: ai_agent_bridge `--stdout-only` writes Gemini's response to stdout.
+# Smoketest: ai_agent_bridge `--stdout-only` writes AGY response to stdout.
 #
 # Why this exists: the wiki review pipeline (scripts/wiki/compile.py) captures
 # subprocess stdout and parses it for `X/10` scores. A bridge regression in
 # 2026-04-18 had `--stdout-only` suppress broker delivery WITHOUT writing the
 # response to stdout — wiki reviews silently returned 0.0/10 across every
 # dimension and the per-dim audit floor failed the article. Run this after any
-# change to scripts/ai_agent_bridge/_gemini.py or _cli.py to catch a re-regression
+# change to scripts/ai_agent_bridge/_agy.py or _cli.py to catch a re-regression
 # before it pollutes a wiki compile run.
 #
-# Pass criteria: a single non-empty line of output, no `[gemini] attempt N/M`
+# Pass criteria: a single non-empty line of output, no bridge progress
 # preamble, exit 0. We deliberately don't check semantic correctness of the
-# response — Gemini occasionally over-explains a one-shot reply — only that
+# response — AGY occasionally over-explains a one-shot reply — only that
 # something parseable made it to stdout.
 #
 # Usage:
@@ -31,18 +31,18 @@ OUT_FILE="$(mktemp -t bridge-smoke-out.XXXXXX)"
 ERR_FILE="$(mktemp -t bridge-smoke-err.XXXXXX)"
 trap 'rm -f "$OUT_FILE" "$ERR_FILE"' EXIT
 
-# `unset` of GEMINI_API_KEY / GOOGLE_API_KEY forces the bridge through the
+# `unset` of AGY bridge credentials forces the bridge through the
 # subscription path (matches how production wiki compiles call it).
 unset GEMINI_API_KEY GOOGLE_API_KEY
 
 if ! printf '%s\n' "$PROMPT" | timeout 180 \
-        .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-gemini - \
+        .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy - \
             --task-id "$TASK_ID" \
-            --model gemini-3.1-pro-preview \
+            --to-model gemini-3.1-pro-high \
             --stdout-only \
             --from claude \
         > "$OUT_FILE" 2> "$ERR_FILE"; then
-    echo "FAIL: ask-gemini --stdout-only exited non-zero." >&2
+    echo "FAIL: ask-agy --stdout-only exited non-zero." >&2
     echo "--- stderr ---" >&2
     head -40 "$ERR_FILE" >&2
     exit 1
@@ -50,7 +50,7 @@ fi
 
 # Must contain something — empty stdout means the response was eaten.
 if [[ ! -s "$OUT_FILE" ]]; then
-    echo "FAIL: stdout was empty. Bridge is not writing Gemini's response." >&2
+    echo "FAIL: stdout was empty. Bridge is not writing AGY response." >&2
     echo "--- stderr ---" >&2
     head -40 "$ERR_FILE" >&2
     exit 1
@@ -59,9 +59,9 @@ fi
 # Must NOT contain the bridge progress preamble — that line leaking into stdout
 # is the exact regression Phase A canary 2026-04-18 surfaced (was masking real
 # review scores under "0.0/10 across all dims").
-if grep -q '\[gemini\] attempt' "$OUT_FILE"; then
-    echo "FAIL: '[gemini] attempt N/M' bridge preamble leaked into stdout." >&2
-    echo "      The --stdout-only guard in _run_gemini_attempt regressed." >&2
+if grep -Eq '\[(gemini|agy|bridge)\].*attempt|bridge progress' "$OUT_FILE"; then
+    echo "FAIL: bridge progress preamble leaked into stdout." >&2
+    echo "      The --stdout-only guard in AGY stdout-only path regressed." >&2
     echo "--- stdout ---" >&2
     head -10 "$OUT_FILE" >&2
     exit 1

--- a/scripts/pipeline/dispatch.py
+++ b/scripts/pipeline/dispatch.py
@@ -86,10 +86,10 @@ def run_with_heartbeat(
 
 
 # ---------------------------------------------------------------------------
-# Gemini dispatch
+# AGY dispatch
 # ---------------------------------------------------------------------------
 
-# Rate limit / auth failure signatures in Gemini CLI output
+# Rate limit / auth failure signatures in AGY/Gemini-family output
 _RATE_LIMIT_PATTERNS = [
     "Error authenticating",
     "FatalAuthenti",
@@ -111,6 +111,17 @@ _TRANSIENT_PATTERNS = [
     "epipe",
     "connection reset",
 ]
+
+_LEGACY_GEMINI_TO_AGY_MODEL = {
+    "gemini-3.1-pro-preview": "gemini-3.1-pro-high",
+    "gemini-3.0-flash-preview": "gemini-3.5-flash-high",
+}
+
+
+def _agy_model(model: str | None) -> str:
+    if not model:
+        return "gemini-3.1-pro-high"
+    return _LEGACY_GEMINI_TO_AGY_MODEL.get(model, model)
 
 
 def _is_rate_limited(output: str) -> bool:
@@ -138,26 +149,25 @@ def dispatch_gemini_raw(
 
     Returns (success, raw_output_text).
     """
-    if model is None:
-        model = _pro_model()
+    model = _agy_model(model or _pro_model())
     args = [
-        str(_SCRIPTS_DIR / "ai_agent_bridge/__main__.py"), "ask-gemini",
+        str(_SCRIPTS_DIR / "ai_agent_bridge/__main__.py"), "ask-agy",
         "-",  # read prompt from stdin
         "--task-id", task_id,
-        "--model", model,
+        "--to-model", model,
     ]
     if stdout_only:
         args.append("--stdout-only")
     if allow_write:
-        args.append("--allow-write")
+        _log(" [dispatch] AGY bridge ignores allow_write; bridge Q&A is read-only")
 
-    _log(f"  [dispatch] Gemini {task_id}: prompt={len(prompt)} chars, model={model}")
+    _log(f"  [dispatch] AGY {task_id}: prompt={len(prompt)} chars, model={model}")
     last_output = ""
     for attempt in range(1, max_retries + 1):
         try:
             result = run_with_heartbeat(
                 [_venv_python(), *args],
-                label=f"Gemini {task_id}",
+                label=f"AGY {task_id}",
                 timeout=timeout,
                 cwd=str(_PROJECT_ROOT), capture_output=True, text=True,
                 input=prompt,
@@ -183,7 +193,7 @@ def dispatch_gemini_raw(
                 output_file.write_text(output_text, encoding="utf-8")
             return False, output_text
         except subprocess.TimeoutExpired:
-            _log(f"  TIMEOUT: Gemini dispatch {task_id} exceeded {timeout}s "
+            _log(f"  TIMEOUT: AGY dispatch {task_id} exceeded {timeout}s "
                  f"(model={model}, prompt={len(prompt)} chars)")
             return False, ""
 

--- a/scripts/tools/upgrade_activity_hints.py
+++ b/scripts/tools/upgrade_activity_hints.py
@@ -1,7 +1,7 @@
-"""Upgrade vague A1 activity_hints to exact exercise templates using Gemini.
+"""Upgrade vague A1 activity_hints to exact exercise templates using AGY.
 
 Reads plan YAML files, identifies vague activity_hints (no Ukrainian text,
-no exercise markers like ↔/→/___/{}), sends them to Gemini with the full
+no exercise markers like ↔/→/___/{}), sends them to AGY with the full
 plan context, and writes back upgraded hints with a version bump.
 
 Usage:
@@ -15,7 +15,6 @@ from __future__ import annotations
 import argparse
 import logging
 import re
-import shutil
 import subprocess
 import sys
 from datetime import UTC, datetime
@@ -43,8 +42,10 @@ _CYRILLIC_RE = re.compile(r"[\u0400-\u04FF]{2,}")
 
 # Minimum number of Cyrillic words to consider a hint "specific"
 _MIN_CYRILLIC_WORDS = 2
-
-GEMINI_CLI = shutil.which("gemini") or "gemini"
+BRIDGE_CLI = [
+    str(REPO_ROOT / ".venv/bin/python"),
+    str(SCRIPTS_DIR / "ai_agent_bridge/__main__.py"),
+]
 
 # Snapshot environment (same as bridge uses)
 import os
@@ -99,8 +100,8 @@ def count_vague_hints(plan: dict) -> tuple[int, int]:
     return vague, len(hints)
 
 
-def build_gemini_prompt(plan: dict, plan_text: str) -> str:
-    """Build the prompt for Gemini to upgrade vague activity_hints."""
+def build_agy_prompt(plan: dict, plan_text: str) -> str:
+    """Build the prompt for AGY to upgrade vague activity_hints."""
     # Identify which hints are vague
     hints = plan.get("activity_hints", [])
     vague_indices = [
@@ -156,12 +157,22 @@ Example output format:
 """
 
 
-def call_gemini(prompt: str, model: str = "gemini-3.1-pro-preview",
-                timeout: int = 120) -> str | None:
-    """Call Gemini CLI with a prompt and return stdout."""
+def call_agy(prompt: str, model: str = "gemini-3.1-pro-high", timeout: int = 120) -> str | None:
+    """Call AGY through ai_agent_bridge and return stdout."""
     try:
         result = subprocess.run(
-            [GEMINI_CLI, "-m", model, "-y"],
+            [
+                *BRIDGE_CLI,
+                "ask-agy",
+                "-",
+                "--task-id",
+                f"upgrade-activity-hints-{datetime.now(UTC).strftime('%Y%m%d%H%M%S')}",
+                "--to-model",
+                model,
+                "--stdout-only",
+                "--from",
+                "claude",
+            ],
             input=prompt,
             capture_output=True,
             text=True,
@@ -170,19 +181,19 @@ def call_gemini(prompt: str, model: str = "gemini-3.1-pro-preview",
             env=_PARENT_ENV,
         )
         if result.returncode != 0:
-            logger.error("Gemini CLI failed (exit %d): %s", result.returncode, result.stderr[:500])
+            logger.error("AGY bridge failed (exit %d): %s", result.returncode, result.stderr[:500])
             return None
         return result.stdout.strip()
     except subprocess.TimeoutExpired:
-        logger.error("Gemini CLI timed out after %ds", timeout)
+        logger.error("AGY bridge timed out after %ds", timeout)
         return None
     except FileNotFoundError:
-        logger.error("Gemini CLI not found at: %s", GEMINI_CLI)
+        logger.error("Bridge python not found at: %s", BRIDGE_CLI[0])
         return None
 
 
-def parse_gemini_response(response: str) -> list[dict] | None:
-    """Parse Gemini's YAML response into a list of activity_hints."""
+def parse_agy_response(response: str) -> list[dict] | None:
+    """Parse AGY YAML response into a list of activity_hints."""
     # Strip markdown fences if present
     cleaned = response.strip()
     if cleaned.startswith("```"):
@@ -199,11 +210,11 @@ def parse_gemini_response(response: str) -> list[dict] | None:
     try:
         parsed = yaml.safe_load(cleaned)
     except yaml.YAMLError as e:
-        logger.error("Failed to parse Gemini YAML response: %s", e)
+        logger.error("Failed to parse AGY YAML response: %s", e)
         return None
 
     if not isinstance(parsed, list):
-        logger.error("Gemini response is not a YAML list: %s", type(parsed))
+        logger.error("AGY response is not a YAML list: %s", type(parsed))
         return None
 
     # Validate each hint has required fields
@@ -222,7 +233,7 @@ def upgrade_plan(
     plan_path: Path,
     *,
     dry_run: bool = False,
-    model: str = "gemini-3.1-pro-preview",
+    model: str = "gemini-3.1-pro-high",
 ) -> tuple[int, list[str]]:
     """Upgrade vague activity_hints in a plan file.
 
@@ -259,23 +270,23 @@ def upgrade_plan(
             print(f"    [{idx}] {h.get('type', '?')}: {h.get('focus', '?')[:80]}")
         return len(vague_indices), [f"[dry-run] {len(vague_indices)} vague hints in {slug}"]
 
-    # Build prompt and call Gemini
-    prompt = build_gemini_prompt(plan, raw)
-    print(f"  Calling Gemini ({model})...")
-    response = call_gemini(prompt, model=model)
+    # Build prompt and call AGY
+    prompt = build_agy_prompt(plan, raw)
+    print(f"  Calling AGY ({model})...")
+    response = call_agy(prompt, model=model)
     if not response:
-        logger.error("No response from Gemini for %s", slug)
+        logger.error("No response from AGY for %s", slug)
         return 0, changelog
 
     # Parse response
-    upgraded = parse_gemini_response(response)
+    upgraded = parse_agy_response(response)
     if not upgraded:
-        logger.error("Failed to parse Gemini response for %s", slug)
+        logger.error("Failed to parse AGY response for %s", slug)
         return 0, changelog
 
     if len(upgraded) != len(vague_indices):
         logger.error(
-            "Gemini returned %d hints but expected %d for %s",
+            "AGY returned %d hints but expected %d for %s",
             len(upgraded), len(vague_indices), slug,
         )
         return 0, changelog
@@ -296,7 +307,7 @@ def upgrade_plan(
         "version": new_version,
         "date": datetime.now(UTC).strftime("%Y-%m-%d"),
         "changes": [
-            f"Upgraded {len(vague_indices)} vague activity_hints to exact exercise templates (Gemini)"
+            f"Upgraded {len(vague_indices)} vague activity_hints to exact exercise templates (AGY)"
         ],
     }
     if "plan_fixes" not in plan:
@@ -325,13 +336,13 @@ def get_all_plan_paths(level: str) -> list[Path]:
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Upgrade vague activity_hints to exact exercise templates using Gemini"
+        description="Upgrade vague activity_hints to exact exercise templates using AGY"
     )
     parser.add_argument("level", help="Level (e.g., a1)")
     parser.add_argument("slug", nargs="?", help="Module slug (or --all for all plans)")
     parser.add_argument("--all", action="store_true", help="Process all plans with vague hints")
     parser.add_argument("--dry-run", action="store_true", help="Show what would change without modifying")
-    parser.add_argument("--model", default="gemini-3.1-pro-preview", help="Gemini model to use")
+    parser.add_argument("--model", default="gemini-3.1-pro-high", help="AGY model to use")
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")

--- a/tests/ai_agent_bridge/test_ab_discuss_bugs.py
+++ b/tests/ai_agent_bridge/test_ab_discuss_bugs.py
@@ -154,3 +154,75 @@ def test_ask_codex_infers_from_claude_agent_name(
 
     assert _cli._dispatch_command(args) is True
     assert captured["from_llm"] == "claude"
+
+
+def test_legacy_gemini_model_slugs_map_to_agy_slugs() -> None:
+    assert (
+        _cli._map_legacy_gemini_model_to_agy("gemini-3.1-pro-preview")
+        == "gemini-3.1-pro-high"
+    )
+    assert (
+        _cli._map_legacy_gemini_model_to_agy("gemini-3.0-flash-preview")
+        == "gemini-3.5-flash-high"
+    )
+    assert (
+        _cli._map_legacy_gemini_model_to_agy("Gemini 3.1 Pro (High)")
+        == "Gemini 3.1 Pro (High)"
+    )
+
+
+def test_ask_gemini_shim_routes_to_agy_with_mapped_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_ask_agy(
+        content,
+        task_id,
+        msg_type,
+        data,
+        new_session,
+        from_llm,
+        from_model,
+        to_model,
+        no_timeout,
+        **kwargs,
+    ):
+        captured.update(
+            content=content,
+            task_id=task_id,
+            msg_type=msg_type,
+            data=data,
+            new_session=new_session,
+            from_llm=from_llm,
+            from_model=from_model,
+            to_model=to_model,
+            no_timeout=no_timeout,
+            kwargs=kwargs,
+        )
+        return 123
+
+    monkeypatch.setattr(_cli, "ask_agy", fake_ask_agy)
+    parser = _cli._build_parser()
+    args = parser.parse_args(
+        [
+            "ask-gemini",
+            "hello",
+            "--task-id",
+            "task-1",
+            "--model",
+            "gemini-3.1-pro-preview",
+            "--stdout-only",
+            "--from",
+            "codex",
+        ]
+    )
+
+    assert _cli._dispatch_command(args) is True
+    assert captured["content"] == "hello"
+    assert captured["task_id"] == "task-1"
+    assert captured["from_llm"] == "codex"
+    assert captured["to_model"] == "gemini-3.1-pro-high"
+    assert captured["new_session"] is False
+    assert captured["no_timeout"] is False
+    assert captured["kwargs"] == {"stdout_only": True, "output_path": None}

--- a/tests/test_agent_fleet_tooling_guardrails.py
+++ b/tests/test_agent_fleet_tooling_guardrails.py
@@ -9,9 +9,13 @@ ACTIVE_GUIDANCE = [
     "AGENTS.md",
     "CLAUDE.md",
     "GEMINI.md",
+    "docs/RUNBOOK-BUILD.md",
+    "docs/SCRIPTS.md",
     "docs/agent-bridge-setup-guide.md",
     "docs/agent-channels/shared/context.md",
     "docs/agents/AGENT-CAPABILITY-MATRIX.md",
+    "docs/architecture/ARCHITECTURE.md",
+    "docs/architecture/system-topology.md",
     "docs/best-practices/agent-activity-matrix.md",
     "docs/best-practices/agent-bridge.md",
     "docs/best-practices/agent-cooperation.md",
@@ -19,11 +23,20 @@ ACTIVE_GUIDANCE = [
     "docs/best-practices/harness-engineering.md",
     "docs/best-practices/issue-tracking.md",
     "docs/best-practices/wiki-plan-review-and-lock.md",
+    "docs/design/agent-runtime.md",
     "docs/guardrails/agent-fleet-tooling.md",
 ]
 
 ACTIVE_GUIDANCE_GLOBS = [
     "docs/prompts/orchestrators/**/*.md",
+]
+
+ACTIVE_RUNTIME_CALLERS = [
+    "scripts/audit/naturalness_check.py",
+    "scripts/audit/russianism_eval.py",
+    "scripts/ops/smoketest_bridge_stdout_only.sh",
+    "scripts/pipeline/dispatch.py",
+    "scripts/tools/upgrade_activity_hints.py",
 ]
 
 FORBIDDEN_PATTERNS = [
@@ -41,6 +54,7 @@ ALLOWED_WARNING_WORDS = (
     "not supported",
     "not a current route",
     "legacy",
+    "retired",
     "avoid",
     "do not",
     "wrong binary",
@@ -83,3 +97,18 @@ def test_guardrail_documents_current_agy_model_names() -> None:
     assert "Gemini 3.1 Pro (High)" in guardrail
     assert "Gemini 3.5 Flash (High)" in guardrail
     assert "gemini-3.1-pro-high" in guardrail
+
+
+def test_active_runtime_callers_use_agy_not_retired_gemini_cli() -> None:
+    forbidden = [
+        re.compile(r"\bask-gemini\b"),
+        re.compile(r"\bGemini CLI\b"),
+    ]
+    failures: list[str] = []
+    for rel in ACTIVE_RUNTIME_CALLERS:
+        text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        for pattern in forbidden:
+            if pattern.search(text):
+                failures.append(f"{rel}: {pattern.pattern}")
+
+    assert not failures, "Retired Gemini route in active runtime caller:\n" + "\n".join(failures)

--- a/tests/test_agent_fleet_tooling_guardrails.py
+++ b/tests/test_agent_fleet_tooling_guardrails.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+ACTIVE_GUIDANCE = [
+    "AGENTS.md",
+    "CLAUDE.md",
+    "GEMINI.md",
+    "docs/agent-bridge-setup-guide.md",
+    "docs/agent-channels/shared/context.md",
+    "docs/agents/AGENT-CAPABILITY-MATRIX.md",
+    "docs/best-practices/agent-activity-matrix.md",
+    "docs/best-practices/agent-bridge.md",
+    "docs/best-practices/agent-cooperation.md",
+    "docs/best-practices/api-ui-improvements-proposal.md",
+    "docs/best-practices/harness-engineering.md",
+    "docs/best-practices/issue-tracking.md",
+    "docs/best-practices/wiki-plan-review-and-lock.md",
+    "docs/guardrails/agent-fleet-tooling.md",
+]
+
+ACTIVE_GUIDANCE_GLOBS = [
+    "docs/prompts/orchestrators/**/*.md",
+]
+
+FORBIDDEN_PATTERNS = [
+    re.compile(r"\bab ask-(?:gemini|agy)\b"),
+    re.compile(r"\bab (?:post|p|discuss)\b"),
+    re.compile(r"\bask-gemini\b"),
+    re.compile(r"\bGemini CLI\b"),
+    re.compile(r"\bGemini Code Assist\b"),
+    re.compile(r"\bgemini-3\.(?:0-flash|1-pro)-preview\b"),
+    re.compile(r"\bagy --model gemini-[\w.-]+"),
+]
+
+ALLOWED_WARNING_WORDS = (
+    "unsupported",
+    "not supported",
+    "not a current route",
+    "legacy",
+    "avoid",
+    "do not",
+    "wrong binary",
+    "apachebench",
+    "brittle",
+    "resolves to apachebench",
+    "historical",
+    "not gemini cli",
+)
+
+
+def _active_guidance_paths() -> list[Path]:
+    paths = [REPO_ROOT / rel_path for rel_path in ACTIVE_GUIDANCE]
+    for pattern in ACTIVE_GUIDANCE_GLOBS:
+        paths.extend(REPO_ROOT.glob(pattern))
+    return sorted(path for path in paths if path.exists())
+
+
+def test_active_guidance_does_not_reintroduce_dead_gemini_routes() -> None:
+    failures: list[str] = []
+
+    for path in _active_guidance_paths():
+        for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            for pattern in FORBIDDEN_PATTERNS:
+                if not pattern.search(line):
+                    continue
+                normalized = line.lower()
+                if any(word in normalized for word in ALLOWED_WARNING_WORDS):
+                    continue
+                rel_path = path.relative_to(REPO_ROOT)
+                failures.append(f"{rel_path}:{line_no}: {line.strip()}")
+
+    assert not failures, "Dead Gemini/ab route guidance found:\n" + "\n".join(failures)
+
+
+def test_guardrail_documents_current_agy_model_names() -> None:
+    guardrail = (REPO_ROOT / "docs/guardrails/agent-fleet-tooling.md").read_text(encoding="utf-8")
+
+    assert "Gemini CLI and Gemini Code Assist are unsupported" in guardrail
+    assert "Gemini 3.1 Pro (High)" in guardrail
+    assert "Gemini 3.5 Flash (High)" in guardrail
+    assert "gemini-3.1-pro-high" in guardrail

--- a/tests/test_gemini_bridge.py
+++ b/tests/test_gemini_bridge.py
@@ -175,14 +175,15 @@ def test_run_gemini_sync_passes_auth_mode_to_runtime(
     assert mock_invoke.call_args.kwargs["tool_config"] == {"auth_mode": "subscription"}
 
 
-def test_handle_ask_gemini_passes_auth_mode(monkeypatch):
+def test_handle_ask_gemini_routes_to_agy(monkeypatch):
     captured: dict[str, object] = {}
 
-    def _fake_ask_gemini(*args):
+    def _fake_ask_agy(*args, **kwargs):
         captured["args"] = args
+        captured["kwargs"] = kwargs
         return 123
 
-    monkeypatch.setattr("ai_agent_bridge._cli.ask_gemini", _fake_ask_gemini)
+    monkeypatch.setattr("ai_agent_bridge._cli.ask_agy", _fake_ask_agy)
 
     class _Args:
         content = "hello"
@@ -203,4 +204,7 @@ def test_handle_ask_gemini_passes_auth_mode(monkeypatch):
         auth = "api-key"
 
     _handle_ask_gemini(_Args())
-    assert captured["args"][-1] == "api-key"
+    assert captured["args"] == ("hello", "task-1", "query", None)
+    assert captured["kwargs"]["to_model"] == "gemini-3.1-pro-high"
+    assert captured["kwargs"]["stdout_only"] is False
+    assert captured["kwargs"]["output_path"] is None

--- a/tests/test_russianism_eval.py
+++ b/tests/test_russianism_eval.py
@@ -206,7 +206,7 @@ def test_bridge_caller_builds_family_specific_commands() -> None:
 
     claude = caller.plan(prompt, "claude-opus-4-7")
     codex = caller.plan(prompt, "gpt-5.5")
-    gemini = caller.plan(prompt, "gemini-3.1-pro-preview")
+    gemini = caller.plan(prompt, "gemini-3.1-pro-high")
 
     assert claude.argv[2] == "ask-claude"
     assert "--to-model" in claude.argv
@@ -214,9 +214,9 @@ def test_bridge_caller_builds_family_specific_commands() -> None:
     assert codex.argv[2] == "ask-codex"
     assert codex.stdin == "Translate."
     assert "--to-model" in codex.argv
-    assert gemini.argv[2] == "ask-gemini"
+    assert gemini.argv[2] == "ask-agy"
     assert "--stdout-only" in gemini.argv
-    assert gemini.argv[gemini.argv.index("--model") + 1] == "gemini-3.1-pro-preview"
+    assert gemini.argv[gemini.argv.index("--to-model") + 1] == "gemini-3.1-pro-high"
 
 
 def test_claude_bridge_extracts_target_model_metadata() -> None:

--- a/tests/test_upgrade_activity_hints.py
+++ b/tests/test_upgrade_activity_hints.py
@@ -13,10 +13,10 @@ if scripts_dir not in sys.path:
     sys.path.insert(0, scripts_dir)
 
 from tools.upgrade_activity_hints import (
-    build_gemini_prompt,
+    build_agy_prompt,
     count_vague_hints,
     is_hint_vague,
-    parse_gemini_response,
+    parse_agy_response,
 )
 
 # --- is_hint_vague ---
@@ -178,10 +178,10 @@ class TestCountVagueHints:
         assert total == 2
 
 
-# --- parse_gemini_response ---
+# --- parse_agy_response ---
 
 
-class TestParseGeminiResponse:
+class TestParseAgyResponse:
     def test_plain_yaml(self):
         response = """\
 - type: quiz
@@ -192,7 +192,7 @@ class TestParseGeminiResponse:
   pairs:
   - "привіт ↔ hello"
 """
-        result = parse_gemini_response(response)
+        result = parse_agy_response(response)
         assert result is not None
         assert len(result) == 2
         assert result[0]["type"] == "quiz"
@@ -206,25 +206,25 @@ class TestParseGeminiResponse:
   items: 4
 ```
 """
-        result = parse_gemini_response(response)
+        result = parse_agy_response(response)
         assert result is not None
         assert len(result) == 1
         assert result[0]["type"] == "fill-in"
 
     def test_invalid_yaml(self):
         response = "This is not YAML at all: {broken"
-        result = parse_gemini_response(response)
+        result = parse_agy_response(response)
         # Could be None or could parse as string — either way, not a list
         assert result is None or isinstance(result, list)
 
     def test_not_a_list(self):
         response = "type: quiz\nfocus: test\n"
-        result = parse_gemini_response(response)
+        result = parse_agy_response(response)
         assert result is None
 
     def test_missing_required_fields(self):
         response = "- items: 6\n  something: else\n"
-        result = parse_gemini_response(response)
+        result = parse_agy_response(response)
         assert result is None
 
     def test_fenced_with_backticks(self):
@@ -235,15 +235,15 @@ class TestParseGeminiResponse:
   items: 4
 ```
 """
-        result = parse_gemini_response(response)
+        result = parse_agy_response(response)
         assert result is not None
         assert len(result) == 1
 
 
-# --- build_gemini_prompt ---
+# --- build_agy_prompt ---
 
 
-class TestBuildGeminiPrompt:
+class TestBuildAgyPrompt:
     def test_prompt_contains_plan(self):
         plan = {
             "slug": "test-module",
@@ -253,7 +253,7 @@ class TestBuildGeminiPrompt:
             ],
         }
         plan_text = yaml.dump(plan, allow_unicode=True)
-        prompt = build_gemini_prompt(plan, plan_text)
+        prompt = build_agy_prompt(plan, plan_text)
         assert "слово" in prompt
         assert "Test vocabulary" in prompt
         assert "ONLY vocabulary from this plan" in prompt
@@ -265,6 +265,6 @@ class TestBuildGeminiPrompt:
             ],
         }
         plan_text = yaml.dump(plan, allow_unicode=True)
-        prompt = build_gemini_prompt(plan, plan_text)
+        prompt = build_agy_prompt(plan, plan_text)
         assert "YAML array" in prompt
         assert "exactly 1 elements" in prompt


### PR DESCRIPTION
## Summary

- Retires Gemini CLI / Gemini Code Assist as current project guidance and documents AGY via `ai_agent_bridge` as the Gemini-family route.
- Replaces active `ab ...` examples with explicit `.venv/bin/python scripts/ai_agent_bridge/__main__.py ...` or `scripts/delegate.py dispatch ...` forms.
- Makes `ask-gemini` a retired compatibility shim that routes to `ask-agy`, including old preview-model slug mapping to AGY slugs.
- Updates active runtime callers and audit helpers to call `ask-agy` directly; adds guard tests for docs and runtime callers.
- Rebases onto current `origin/main`, fixes changed-file markdownlint, and aligns stale tests with the AGY shim.

Closes #3961.
Closes #3962.

## Validation

- `.venv/bin/python -m pytest tests/test_upgrade_activity_hints.py tests/test_gemini_bridge.py tests/test_russianism_eval.py tests/test_agent_fleet_tooling_guardrails.py tests/ai_agent_bridge/test_ab_discuss_bugs.py tests/ai_agent_bridge/test_agy_model_selection.py -q`
- `npm exec -- markdownlint-cli2 docs/RUNBOOK-BUILD.md docs/SCRIPTS.md docs/architecture/ARCHITECTURE.md docs/architecture/system-topology.md docs/design/agent-runtime.md`
- `.venv/bin/python -m py_compile scripts/ai_agent_bridge/_agy.py scripts/ai_agent_bridge/_cli.py scripts/pipeline/dispatch.py scripts/tools/upgrade_activity_hints.py scripts/audit/naturalness_check.py scripts/audit/russianism_eval.py`
- `bash -n scripts/ops/smoketest_bridge_stdout_only.sh`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- pre-commit affected-file hooks passed, including affected pytest for `tests/test_gemini_bridge.py` and `tests/test_upgrade_activity_hints.py`
