### PR TITLE
docs(b2): expose scored modules through M58

### DIFF
--- a/site/src/content/docs/b2/index.mdx
+++ b/site/src/content/docs/b2/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: "B2 — Upper Intermediate Preview"
-description: "Upper-intermediate Ukrainian preview map — 10 learner pages available · 83 planned"
+title: "B2 — Upper Intermediate"
+description: "Upper-intermediate Ukrainian course — 93 modules in curriculum order"
 template: splash
 ---
 
@@ -10,9 +10,9 @@ import LevelLanding from '@site/src/components/LevelLanding';
   client:load
   level="B2"
   title="Впевнено"
-subtitle="Upper-intermediate Ukrainian preview map — 10 learner pages available · 83 planned"
-  progressTitle="B2 Preview Status"
-progressDescription="10 available · 0 reviewed · 83 planned"
+  subtitle="Upper-intermediate Ukrainian course — 58 learner pages available · 93 modules"
+  progressTitle="B2 Build Status"
+  progressDescription="58 available · 0 reviewed · 35 planned"
   moduleCount={93}
   wordTarget={4000}
   color="var(--lu-id-b2)"
@@ -35,74 +35,74 @@ progressDescription="10 available · 0 reviewed · 83 planned"
     {
       unit: "B2.1 [Participles & Sentence Structure]",
       items: [
-        { num: 11, slug: "active-participles-past", title: "Активні дієприкметники минулого часу", sub: "Активні дієприкметники минулого часу: творення, використання та лексикалізація", status: "locked" },
-        { num: 12, slug: "participles-vs-relative-clauses", title: "Дієприкметники та підрядні означальні речення", sub: "Дієприкметники проти підрядних означальних речень", status: "locked" },
-        { num: 13, slug: "zdorovya-i-medytsyna", title: "Здоров'я і медицина", sub: "Здоров'я і медицина", status: "locked" },
-        { num: 14, slug: "phrases-word-combinations", title: "Словосполучення та зв'язок слів", sub: "Словосполучення та їх типи: синтаксис і використання", status: "locked" },
-        { num: 15, slug: "predicate-types", title: "Типи присудків", sub: "Типи присудків: прості та складені конструкції", status: "locked" },
-        { num: 16, slug: "secondary-sentence-members", title: "Другорядні члени речення", sub: "Другорядні члени речення: означення, додатки, обставини", status: "locked" },
-        { num: 17, slug: "sport-i-dozvillia", title: "Спорт і дозвілля", sub: "Спорт і дозвілля", status: "locked" },
-        { num: 18, slug: "b2-one-member-sentences", title: "Односкладні речення", sub: "Односкладні речення: типи та стилістичні функції", status: "locked" },
-        { num: 19, slug: "homogeneous-members", title: "Однорідні члени речення", sub: "Однорідні члени речення: структура, пунктуація та стиль", status: "locked" },
-        { num: 20, slug: "detached-members", title: "Відокремлені члени речення", sub: "Відокремлені члени речення", status: "locked" },
-        { num: 21, slug: "checkpoint-syntax-i", title: "Контрольний модуль: Синтаксис I (просте речення)", sub: "Підсумковий контроль: просте ускладнене речення", status: "locked" },
+        { num: 11, slug: "active-participles-past", title: "Активні дієприкметники минулого часу", sub: "Активні дієприкметники минулого часу: творення, використання та лексикалізація", status: "active" },
+        { num: 12, slug: "participles-vs-relative-clauses", title: "Дієприкметники та підрядні означальні речення", sub: "Дієприкметники проти підрядних означальних речень", status: "active" },
+        { num: 13, slug: "zdorovya-i-medytsyna", title: "Здоров'я і медицина", sub: "Здоров'я і медицина", status: "active" },
+        { num: 14, slug: "phrases-word-combinations", title: "Словосполучення та зв'язок слів", sub: "Словосполучення та їх типи: синтаксис і використання", status: "active" },
+        { num: 15, slug: "predicate-types", title: "Типи присудків", sub: "Типи присудків: прості та складені конструкції", status: "active" },
+        { num: 16, slug: "secondary-sentence-members", title: "Другорядні члени речення", sub: "Другорядні члени речення: означення, додатки, обставини", status: "active" },
+        { num: 17, slug: "sport-i-dozvillia", title: "Спорт і дозвілля", sub: "Спорт і дозвілля", status: "active" },
+        { num: 18, slug: "b2-one-member-sentences", title: "Односкладні речення", sub: "Односкладні речення: типи та стилістичні функції", status: "active" },
+        { num: 19, slug: "homogeneous-members", title: "Однорідні члени речення", sub: "Однорідні члени речення: структура, пунктуація та стиль", status: "active" },
+        { num: 20, slug: "detached-members", title: "Відокремлені члени речення", sub: "Відокремлені члени речення", status: "active" },
+        { num: 21, slug: "checkpoint-syntax-i", title: "Контрольний модуль: Синтаксис I (просте речення)", sub: "Підсумковий контроль: просте ускладнене речення", status: "active" },
       ]
     },
     {
       unit: "B2.2 [Advanced Syntax & Stylistics]",
       items: [
-        { num: 22, slug: "parenthetical-expressions", title: "Вставні слова та конструкції", sub: "Вставні слова та конструкції", status: "locked" },
-        { num: 23, slug: "multi-clause-sentences", title: "Складні речення з різними видами зв'язку", sub: "Багатокомпонентні речення з різними видами зв'язку", status: "locked" },
-        { num: 24, slug: "kharchuvannia-i-kukhnia", title: "Харчування і кухня", sub: "Харчування і кухня", status: "locked" },
-        { num: 25, slug: "correlative-constructions", title: "Складні речення з корелятами (вказівними словами)", sub: "Складні речення зі співвідносними словами", status: "locked" },
-        { num: 26, slug: "emphasis-and-inversion", title: "Логічне наголошування та інверсія", sub: "Логічний наголос та інверсія", status: "locked" },
-        { num: 27, slug: "stylistic-connectors", title: "Стилістичні засоби зв'язку в тексті", sub: "Стилістичні конектори та зв'язність тексту", status: "locked" },
-        { num: 28, slug: "kupivlia-i-servisy", title: "Купівля і послуги", sub: "Купівля і послуги", status: "locked" },
-        { num: 29, slug: "complex-syntax-ellipsis-parcelling", title: "Складний синтаксис: еліпсис та парцеляція", sub: "Складний синтаксис: еліпсис і парцеляція", status: "locked" },
-        { num: 30, slug: "direct-indirect-speech", title: "Пряма та непряма мова: цитування та реферування", sub: "Пряма й непряма мова: цитування та передача мовлення", status: "locked" },
-        { num: 31, slug: "checkpoint-syntax-ii", title: "Контрольний модуль: Синтаксис II (складне речення)", sub: "Підсумковий контроль: складне речення та експресивний синтаксис", status: "locked" },
+        { num: 22, slug: "parenthetical-expressions", title: "Вставні слова та конструкції", sub: "Вставні слова та конструкції", status: "active" },
+        { num: 23, slug: "multi-clause-sentences", title: "Складні речення з різними видами зв'язку", sub: "Багатокомпонентні речення з різними видами зв'язку", status: "active" },
+        { num: 24, slug: "kharchuvannia-i-kukhnia", title: "Харчування і кухня", sub: "Харчування і кухня", status: "active" },
+        { num: 25, slug: "correlative-constructions", title: "Складні речення з корелятами (вказівними словами)", sub: "Складні речення зі співвідносними словами", status: "active" },
+        { num: 26, slug: "emphasis-and-inversion", title: "Логічне наголошування та інверсія", sub: "Логічний наголос та інверсія", status: "active" },
+        { num: 27, slug: "stylistic-connectors", title: "Стилістичні засоби зв'язку в тексті", sub: "Стилістичні конектори та зв'язність тексту", status: "active" },
+        { num: 28, slug: "kupivlia-i-servisy", title: "Купівля і послуги", sub: "Купівля і послуги", status: "active" },
+        { num: 29, slug: "complex-syntax-ellipsis-parcelling", title: "Складний синтаксис: еліпсис та парцеляція", sub: "Складний синтаксис: еліпсис і парцеляція", status: "active" },
+        { num: 30, slug: "direct-indirect-speech", title: "Пряма та непряма мова: цитування та реферування", sub: "Пряма й непряма мова: цитування та передача мовлення", status: "active" },
+        { num: 31, slug: "checkpoint-syntax-ii", title: "Контрольний модуль: Синтаксис II (складне речення)", sub: "Підсумковий контроль: складне речення та експресивний синтаксис", status: "active" },
       ]
     },
     {
       unit: "B2.3 [Stylistic Devices & Register]",
       items: [
-        { num: 32, slug: "phonetic-stylistic-devices", title: "Фонетичні стилістичні засоби", sub: "Фонетичні стилістичні засоби", status: "locked" },
-        { num: 33, slug: "lexical-stylistic-devices", title: "Лексичні стилістичні засоби", sub: "", status: "locked" },
-        { num: 34, slug: "syntactic-stylistic-devices", title: "Синтаксичні стилістичні засоби", sub: "", status: "locked" },
-        { num: 35, slug: "mistsia-i-oriientyry", title: "Місця й орієнтири", sub: "Місця й орієнтири", status: "locked" },
-        { num: 36, slug: "register-formal-informal", title: "Офіційний та неофіційний регістри", sub: "", status: "locked" },
-        { num: 37, slug: "register-business-ukrainian", title: "Ділова українська мова", sub: "", status: "locked" },
-        { num: 38, slug: "register-formal-written", title: "Офіційний писемний стиль: науковий та юридичний", sub: "Офіційний писемний стиль: науковий та юридичний", status: "locked" },
-        { num: 39, slug: "tradytsii-i-zvychai", title: "Традиції і звичаї", sub: "Традиції і звичаї", status: "locked" },
-        { num: 40, slug: "register-literary-ukrainian", title: "Художній (літературний) стиль", sub: "", status: "locked" },
-        { num: 41, slug: "register-public-discourse", title: "Публічне мовлення: медійний та розмовний регістри", sub: "Публічне мовлення: медійний та розмовний регістри", status: "locked" },
-        { num: 42, slug: "checkpoint-register-domain", title: "Контрольний модуль: Регістри та предметні сфери", sub: "Підсумковий контроль: стилістика, регістри та галузева лексика", status: "locked" },
+        { num: 32, slug: "phonetic-stylistic-devices", title: "Фонетичні стилістичні засоби", sub: "Фонетичні стилістичні засоби", status: "active" },
+        { num: 33, slug: "lexical-stylistic-devices", title: "Лексичні стилістичні засоби", sub: "", status: "active" },
+        { num: 34, slug: "syntactic-stylistic-devices", title: "Синтаксичні стилістичні засоби", sub: "", status: "active" },
+        { num: 35, slug: "mistsia-i-oriientyry", title: "Місця й орієнтири", sub: "Місця й орієнтири", status: "active" },
+        { num: 36, slug: "register-formal-informal", title: "Офіційний та неофіційний регістри", sub: "", status: "active" },
+        { num: 37, slug: "register-business-ukrainian", title: "Ділова українська мова", sub: "", status: "active" },
+        { num: 38, slug: "register-formal-written", title: "Офіційний писемний стиль: науковий та юридичний", sub: "Офіційний писемний стиль: науковий та юридичний", status: "active" },
+        { num: 39, slug: "tradytsii-i-zvychai", title: "Традиції і звичаї", sub: "Традиції і звичаї", status: "active" },
+        { num: 40, slug: "register-literary-ukrainian", title: "Художній (літературний) стиль", sub: "", status: "active" },
+        { num: 41, slug: "register-public-discourse", title: "Публічне мовлення: медійний та розмовний регістри", sub: "Публічне мовлення: медійний та розмовний регістри", status: "active" },
+        { num: 42, slug: "checkpoint-register-domain", title: "Контрольний модуль: Регістри та предметні сфери", sub: "Підсумковий контроль: стилістика, регістри та галузева лексика", status: "active" },
       ]
     },
     {
       unit: "B2.4 [Domain Vocabulary & Advanced Cases]",
       items: [
-        { num: 43, slug: "register-practice-cross-register-rewriting", title: "Практикум: Стилістична трансформація та перекодування", sub: "Практика: переписування між регістрами", status: "locked" },
-        { num: 44, slug: "politics-government-vocabulary", title: "Політика та державне управління: Лексика", sub: "Політика та влада: лексика", status: "locked" },
-        { num: 45, slug: "law-justice-vocabulary", title: "Право та правосуддя: Лексика", sub: "Право та юстиція: лексика", status: "locked" },
-        { num: 46, slug: "economics-business-vocabulary", title: "Економіка та бізнес: Лексика", sub: "Економіка та бізнес: лексика", status: "locked" },
-        { num: 47, slug: "genitive-advanced", title: "Родовий відмінок: поглиблений рівень", sub: "Родовий відмінок: поглиблений рівень", status: "locked" },
-        { num: 48, slug: "dative-advanced", title: "Давальний відмінок: поглиблений рівень", sub: "Давальний відмінок: поглиблений рівень", status: "locked" },
-        { num: 49, slug: "instrumental-advanced", title: "Орудний відмінок: поглиблений рівень", sub: "Орудний відмінок: поглиблений рівень", status: "locked" },
-        { num: 50, slug: "questions-deliberative-rhetorical", title: "Питальні речення: делібератив, риторика, вкладені", sub: "Питальні речення: делібератив, риторика, вкладені", status: "locked" },
-        { num: 51, slug: "advanced-case-semantics", title: "Поглиблена семантика відмінків", sub: "Поглиблена семантика відмінків", status: "locked" },
-        { num: 52, slug: "pronoun-system-advanced", title: "Складна система займенників", sub: "Складна система займенників: зворотні, взаємні, означальні", status: "locked" },
-        { num: 53, slug: "checkpoint-cases-morphology", title: "Контрольний модуль: Відмінки та морфологія", sub: "Підсумковий контроль: відмінки та морфологія", status: "locked" },
+        { num: 43, slug: "register-practice-cross-register-rewriting", title: "Практикум: Стилістична трансформація та перекодування", sub: "Практика: переписування між регістрами", status: "active" },
+        { num: 44, slug: "politics-government-vocabulary", title: "Політика та державне управління: Лексика", sub: "Політика та влада: лексика", status: "active" },
+        { num: 45, slug: "law-justice-vocabulary", title: "Право та правосуддя: Лексика", sub: "Право та юстиція: лексика", status: "active" },
+        { num: 46, slug: "economics-business-vocabulary", title: "Економіка та бізнес: Лексика", sub: "Економіка та бізнес: лексика", status: "active" },
+        { num: 47, slug: "genitive-advanced", title: "Родовий відмінок: поглиблений рівень", sub: "Родовий відмінок: поглиблений рівень", status: "active" },
+        { num: 48, slug: "dative-advanced", title: "Давальний відмінок: поглиблений рівень", sub: "Давальний відмінок: поглиблений рівень", status: "active" },
+        { num: 49, slug: "instrumental-advanced", title: "Орудний відмінок: поглиблений рівень", sub: "Орудний відмінок: поглиблений рівень", status: "active" },
+        { num: 50, slug: "questions-deliberative-rhetorical", title: "Питальні речення: делібератив, риторика, вкладені", sub: "Питальні речення: делібератив, риторика, вкладені", status: "active" },
+        { num: 51, slug: "advanced-case-semantics", title: "Поглиблена семантика відмінків", sub: "Поглиблена семантика відмінків", status: "active" },
+        { num: 52, slug: "pronoun-system-advanced", title: "Складна система займенників", sub: "Складна система займенників: зворотні, взаємні, означальні", status: "active" },
+        { num: 53, slug: "checkpoint-cases-morphology", title: "Контрольний модуль: Відмінки та морфологія", sub: "Підсумковий контроль: відмінки та морфологія", status: "active" },
       ]
     },
     {
       unit: "B2.5 [Verb Nuances & Word Formation]",
       items: [
-        { num: 54, slug: "aspect-nuances-secondary-imperfectivization", title: "Нюанси виду: Вторинна імперфективація", sub: "Нюанси виду: вторинна недоконаність", status: "locked" },
-        { num: 55, slug: "aspect-nuances-imperative-infinitive", title: "Нюанси виду: Наказовий спосіб та інфінітив", sub: "Нюанси виду: наказовий спосіб та інфінітив", status: "locked" },
-        { num: 56, slug: "pluperfect-tense", title: "Давньоминулий час", sub: "Давноминулий час", status: "locked" },
-        { num: 57, slug: "conditional-mood-particles", title: "Умовний спосіб: Частки та нюанси", sub: "Умовний спосіб: частки та нюанси", status: "locked" },
-        { num: 58, slug: "numeral-declension-time-dates", title: "Відмінювання числівників: Час та дати", sub: "Відмінювання числівників: час і дати", status: "locked" },
+        { num: 54, slug: "aspect-nuances-secondary-imperfectivization", title: "Нюанси виду: Вторинна імперфективація", sub: "Нюанси виду: вторинна недоконаність", status: "active" },
+        { num: 55, slug: "aspect-nuances-imperative-infinitive", title: "Нюанси виду: Наказовий спосіб та інфінітив", sub: "Нюанси виду: наказовий спосіб та інфінітив", status: "active" },
+        { num: 56, slug: "pluperfect-tense", title: "Давньоминулий час", sub: "Давноминулий час", status: "active" },
+        { num: 57, slug: "conditional-mood-particles", title: "Умовний спосіб: Частки та нюанси", sub: "Умовний спосіб: частки та нюанси", status: "active" },
+        { num: 58, slug: "numeral-declension-time-dates", title: "Відмінювання числівників: Час та дати", sub: "Відмінювання числівників: час і дати", status: "active" },
         { num: 59, slug: "numeral-declension-compound-numbers", title: "Відмінювання числівників: Складні, складені, збірні та дробові", sub: "Відмінювання числівників: складені, збірні та дробові", status: "locked" },
         { num: 60, slug: "word-formation-person-suffixes", title: "Словотвір: Суфікси на позначення осіб", sub: "Словотвір: суфікси осіб", status: "locked" },
         { num: 61, slug: "word-formation-abstract-nouns", title: "Словотвір: Абстрактні іменники", sub: "Словотвір: абстрактні іменники", status: "locked" },


### PR DESCRIPTION
## Summary

Regenerates the B2 landing page through the existing landing-page generator so completed written modules M01-M58 are exposed before the B2.5 wave B build starts.

## Scope

- Updated `site/src/content/docs/b2/index.mdx`
- Generated with `.venv/bin/python scripts/generate_landing_pages.py --track b2`
- M01-M58 are `active`
- M59-M93 remain `locked`

## Validation

- `.venv/bin/python scripts/generate_landing_pages.py --track b2` is idempotent after commit
- Parsed landing module statuses: total=93, active<=58=58, locked>=59=35, no mismatches
- `git diff --check` passed
- Protected configs unchanged: `.python-version`, `.yamllint`, `.markdownlint.json`
- Forbidden artifact grep passed for changed file
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` passed

## Independent review

- Route/model: Agy -> Claude Opus 4.6 Thinking (`claude-opus-4.6-thinking`)
- Scope: read-only blocker review of final generator-backed B2 landing diff
- Disposition: approve / ready to merge
- Unresolved blockers: 0

## Artifacts

Forbidden generated artifacts included: no
Telemetry DB included: no
