### PR TITLE
docs: sync agent instruction boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # AGENTS.md - Rules for AI Coding Agents
 
-> This file is read by Jules, Gemini, and other AI agents working on this repository.
-> For Claude-specific instructions, see `CLAUDE.md`.
-> For Gemini-specific instructions, see `GEMINI.md`.
+> Shared source of truth for non-provider-specific repository rules.
+> Codex prompts read this file only as runtime instructions; do not load `CLAUDE.md` or `GEMINI.md` for normal Codex startup.
+> `CLAUDE.md` and `GEMINI.md` contain provider-specific context and may defer here for shared rules.
 
 ---
 
@@ -16,6 +16,7 @@
 - [ ] No `status/*.json` files in the diff
 - [ ] No `audit/*-review.md` files in the diff
 - [ ] No `review/*-review.md` files in the diff
+- [ ] No `data/telemetry/**` files in the diff
 - [ ] No `sys.executable` anywhere in code (use `.venv/bin/python`)
 - [ ] No `@pytest.mark.skip` with empty `pass` bodies
 - [ ] No assertions weakened (e.g., `is True` → `isinstance(..., bool)`)
@@ -74,6 +75,7 @@ These files are auto-generated and MUST NOT appear in PRs that change code/scrip
 - `curriculum/l2-uk-en/**/audit/*-review.md` — auto-generated reviews
 - `curriculum/l2-uk-en/**/review/*-review.md` — review files
 - `docs/*-STATUS.md` — level status reports
+- `data/telemetry/**` — local runtime telemetry state
 
 **Why this is critical:**
 - Creates massive diffs (one PR had 296 artifact files out of 301 total)
@@ -253,7 +255,7 @@ Cost controls:
 - Do not spawn a subagent for work the main agent can finish faster than delegation overhead.
 - Keep routine delegation to one to three subagents at a time unless the user explicitly asks for a larger sweep.
 - Do not let subagents read secrets, source `.envrc`, call `gh`, request reviews, or merge PRs.
-- Do not delegate the independent-family review requirement. Before merge, request a read-only Claude Opus 4.8 review and treat unresolved findings as blockers. If Claude Opus 4.8 is unavailable, use Agy with Gemini 3.1 Pro High (`ab ask-agy --to-model gemini-3.1-pro-high`) as the fallback independent-family review.
+- Do not delegate independent review requirement. Internal GPT helper swarms and Codex self-review do not satisfy the external gate. Request one read-only review through an independent non-Codex route and treat unresolved blockers as blockers. Current lanes: Hermes -> DeepSeek 4 Pro; Agy -> Gemini models and Claude Opus 4.6 when available; Cursor -> non-Codex models including Composer 2.5. If Claude main provider is unavailable before Monday, June 29, 2026 09:00 Budapest local time, do not block on Claude; use another independent non-Codex route.
 
 Module-build PRs must persist token telemetry through
 `POST /api/telemetry/module-builds` and include the same summary in the PR body

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md - Project Instructions
 
+> **Provider boundary:** Shared repository invariants live in `AGENTS.md`. Claude agents should read `AGENTS.md` plus this Claude-specific file; Codex prompts should not read this file as runtime instructions. Defer shared rules here instead of duplicating stale copies.
+
 > **Mission**: We are building something that doesn't exist — a full Ukrainian language curriculum with decolonized pedagogy, real textbook grounding, RAG-verified vocabulary, and adversarial review. This is a one-of-a-kind project for a great hero nation. Every shortcut degrades what makes it special. Quality is non-negotiable.
 
 > **ALWAYS aim for and research best-practice solutions and practices.** Before implementing or deciding, actively seek the established best practice — web-research current standards, read `docs/best-practices/`, check prior art and idiomatic patterns, consult authoritative sources. Never settle for the first thing that works; choose the well-supported, proven, state-of-the-art approach. This applies to code, pedagogy, linguistics, architecture, and process alike.
@@ -68,7 +70,7 @@ Detailed standards in `docs/best-practices/`. Read the relevant doc before worki
 
 ## Inter-Agent Communication
 
-**Codex and Claude are the top-priority agents; agy, DeepSeek, cursor, grok-build, and grok-4.\* are support/specialist lanes.** Claude = architect/reviewer, Codex = novel-impl + adversarial review, agy (Gemini-family, metered) = content/scripts, DeepSeek = off-seat review, grok-build = native-CLI writer/fixer. Full protocol: [`agent-cooperation.md`](docs/best-practices/agent-cooperation.md)
+For shared delegation, artifact hygiene, Python invocation, worktree layout, commit trailers, and independent review routing, defer to `AGENTS.md`. Independent review must not be self-review, and internal GPT helper swarms do not satisfy the external gate. Current external lanes: Hermes -> DeepSeek 4 Pro; Agy -> Gemini models and Claude Opus 4.6 when available; Cursor -> non-Codex models including Composer 2.5. If Claude main provider is unavailable before Monday, June 29, 2026 09:00 Budapest local time, do not block on Claude; use another independent non-Codex route. Full protocol: [`agent-cooperation.md`](docs/best-practices/agent-cooperation.md)
 
 > **Fleet roster + when-to-use + no-idle routing (READ to keep lanes busy):** [`docs/best-practices/agent-activity-matrix.md`](docs/best-practices/agent-activity-matrix.md) — §2 roster (current lanes/cost/models) + §2b capacity routing (free lane → next work). Canonical per-task routing rule: `agents_extensions/shared/rules/model-assignment.md` (served at `/api/rules`).
 
@@ -124,6 +126,6 @@ Monitor(
 `v7_build.py` emits JSONL events from the wrapper and `linear_pipeline.py`: single-module lifecycle notifications such as `phase_done`, `review_score`, and `module_done`; writer/reviewer telemetry such as `writer_cot_emit`, `writer_tool_call`, `writer_end_gate`, `writer_tool_theatre`, `phase_writer_summary`, `mcp_config_resolved`, `reviewer_dim_evidence`, `reviewer_audit_call`, and `phase_review_summary`; and correction diagnostics `writer_correction_unparseable`, `reviewer_fixes_unparseable`, `reviewer_fixes_anchor_unmatched`. Each line becomes a notification — zero polling overhead.
 
 For state queries without running builds, use the Monitor API (`docs/MONITOR-API.md`):
-- Track health: `curl -s http://localhost:8765/api/state/track-health/a1`
-- Failing modules: `curl -s http://localhost:8765/api/state/failing?track=a2`
-- Build status: `curl -s http://localhost:8765/api/state/build-status/a1`
+- Track health: `/api/state/track-health/a1`
+- Failing modules: `/api/state/failing?track=a2`
+- Build status: `/api/state/build-status/a1`

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,7 @@
 # GEMINI.md — Yellow Team Context
 
+> **Provider boundary:** Shared repository invariants live in `AGENTS.md`. Gemini/Agy agents should read `AGENTS.md` plus this Gemini-specific context; Codex prompts should not read this file as runtime instructions.
+
 ## Mission
 We are building the world's first comprehensive Ukrainian language curriculum. The goal is teaching learners to **think in Ukrainian**, not translate from English. Built with decolonized pedagogy grounded in the Ukrainian State Standard 2024, real Ukrainian school textbooks, wiki-compiled knowledge, and adversarial cross-agent review. Quality over quantity. 5 excellent modules beat 55 mediocre ones.
 
@@ -7,9 +9,11 @@ We are building the world's first comprehensive Ukrainian language curriculum. T
 This project will not be commercialized. It is and will remain a free, open-source educational resource. Decision recorded 2026-04-19. Dependencies under non-commercial licenses (CC BY-NC, etc.) are acceptable.
 
 ## Your Role
-You are **Gemini (Yellow Team)** — the content builder. You research, write content, and create activities. Claude (Blue Team) reviews your work and maintains infrastructure. **An LLM must NEVER review its own work** — but during Claude's offline periods you may review your own output as a temporary measure.
+You are **Gemini (Yellow Team)** — the content builder. You research, write content, and create activities. Claude (Blue Team) reviews work and maintains infrastructure. **An LLM must NEVER review its own work as an approval gate.** If Claude is unavailable, use another independent non-Codex review route from `AGENTS.md`; do not substitute self-review.
 
 ## Git & Shared Workspace Policy
+Shared PR hygiene rules are canonical in `AGENTS.md`: protected config files, generated artifacts, `.venv/bin/python`, worktree subtree layout, `X-Agent` trailers, and independent external review routing. This section only adds Gemini-specific examples.
+
 1. **Never work on `main` directly.** For any non-trivial task (bug fixes, features, refactoring), ALWAYS use `git worktree` to create a dedicated environment.
 2. **Protect the root.** The root project directory's branch must remain untouched to avoid disrupting other agents or the primary build state.
 3. **PR-first workflow.** All changes must be pushed to a remote branch and submitted via Pull Request. Never commit directly to `main` unless explicitly requested.
@@ -42,6 +46,8 @@ git branch -d gemini/<task>
 ```
 
 The flat `.worktrees/<name>/` layout is deprecated (the runtime warns on it). Do not create new flat worktrees — the subtree layout keeps `git worktree list` readable and makes bulk cleanup one command.
+
+Do not stage generated `curriculum/l2-uk-en/**/status/*.json`, `curriculum/l2-uk-en/**/audit/*-review.md`, `curriculum/l2-uk-en/**/review/*-review.md`, `docs/*-STATUS.md`, or `data/telemetry/**`.
 
 ---
 


### PR DESCRIPTION
## Summary
- Mark AGENTS.md as the shared source of truth for non-provider-specific agent rules and clarify that Codex runtime prompts should read AGENTS.md only.
- Update CLAUDE.md and GEMINI.md to treat their content as provider-specific context that defers shared invariants to AGENTS.md.
- Align shared hygiene on subtree worktrees, X-Agent trailers, `.venv/bin/python`, generated-artifact exclusions, protected config files, and independent non-Codex review routing.

## Contradictions removed
- Removed the stale Gemini allowance for temporary self-review as an approval gate.
- Replaced stale Claude/AGENTS external-review assumptions with current lanes: Hermes -> DeepSeek 4 Pro; Agy -> Gemini models and Claude Opus 4.6 when available; Cursor -> non-Codex models including Composer 2.5.
- Replaced CLAUDE.md Monitor API examples that used `localhost:8765` with relative API paths.

## Validation
- `git diff --check origin/main...HEAD`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `rg -n "sys\.executable|python3|/app/|localhost:8765" AGENTS.md CLAUDE.md GEMINI.md` (remaining matches are intentional AGENTS.md policy text / negative examples; CLAUDE.md and GEMINI.md are clean)
- `git status --short`
- Confirmed `.python-version`, `.yamllint`, and `.markdownlint.json` are unchanged.
- Confirmed no generated artifact paths are staged or in the diff.

## Scope
This PR does not alter B2 module content or score records.