### PR TITLE
feat(atlas): add source-fed lexicon intake v1

### DIFF
--- a/scripts/audit/grow_lexicon_from_sources.py
+++ b/scripts/audit/grow_lexicon_from_sources.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Generate gated Atlas-entry candidates from curated source inventories.
+
+Run from repository root:
+
+    .venv/bin/python -m scripts.lexicon.grow_lexicon_from_sources \
+        --inventory data/lexicon/source-inventory/ulp.yaml \
+        --out data/lexicon/grow_candidates.json \
+        --report
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from scripts.audit.source_inventory_intake import (
+    SourceInventoryCandidate,
+    SourceInventoryError,
+    read_source_inventories,
+    source_inventory_candidates,
+)
+from scripts.lexicon import enrich_manifest
+from scripts.lexicon.content_lexicon_reconciler import PROJECT_ROOT
+from scripts.lexicon.grow_lexicon_from_content import (
+    _preserve_wiki_reference_cache,
+    _source_connection,
+    build_payload,
+    build_skeleton_entry,
+    format_report,
+    split_candidates,
+    write_candidates,
+)
+
+DEFAULT_OUT = PROJECT_ROOT / "data" / "lexicon" / "grow_candidates_from_sources.json"
+GENERATED_FROM = "source_inventory_intake.v1"
+PRIMARY_SOURCE = "source_inventory_grow"
+
+
+def generate_candidates(
+    *,
+    inventory_paths: Sequence[Path],
+    limit: int | None = None,
+    out: Path = DEFAULT_OUT,
+) -> dict[str, Any]:
+    """Generate, enrich, split, and write source-fed Atlas candidates."""
+    if not inventory_paths:
+        raise SourceInventoryError("at least one --inventory file is required")
+
+    records = read_source_inventories(inventory_paths, project_root=PROJECT_ROOT)
+    candidates = source_inventory_candidates(records)
+    delta = _limited_candidates(candidates, limit)
+
+    entries: list[dict[str, Any]] = []
+    kaikki_lookup = enrich_manifest._load_kaikki_lookup()
+    with _source_connection(enrich_manifest.SOURCES_DB) as conn, _preserve_wiki_reference_cache():
+        has_sum11_flags = enrich_manifest._sum11_has_flag_columns(conn)
+        for item in delta:
+            entry = build_skeleton_entry(item.lemma)
+            if item.pos and not entry.get("pos"):
+                entry["pos"] = item.pos
+            entry["primary_source"] = PRIMARY_SOURCE
+            entry["source_provenance"] = list(item.source_provenance)
+            enrich_manifest.enrich_entry(
+                entry,
+                conn,
+                kaikki_lookup,
+                has_sum11_flags=has_sum11_flags,
+            )
+            entries.append(entry)
+
+    auto_merge, needs_review = split_candidates(entries)
+    payload = build_payload(
+        total_delta=len(candidates),
+        processed=len(delta),
+        auto_merge=auto_merge,
+        needs_review=needs_review,
+        limit=limit,
+    )
+    payload["generated_from"] = GENERATED_FROM
+    write_candidates(payload, out)
+    return payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate Atlas candidates from source inventories.")
+    parser.add_argument(
+        "--inventory",
+        dest="inventory_paths",
+        action="append",
+        type=Path,
+        required=True,
+        help="Curated source inventory file (repeat for multiple files).",
+    )
+    parser.add_argument("--limit", type=int, help="Limit processed source headwords")
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=DEFAULT_OUT,
+        help=f"Candidate JSON output path (default: {DEFAULT_OUT.relative_to(PROJECT_ROOT)})",
+    )
+    parser.add_argument("--report", action="store_true", help="Print candidate bucket counts")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.limit is not None and args.limit < 0:
+        parser.error("--limit must be non-negative")
+
+    try:
+        payload = generate_candidates(
+            inventory_paths=args.inventory_paths,
+            limit=args.limit,
+            out=args.out,
+        )
+    except (FileNotFoundError, SourceInventoryError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.report:
+        print(format_report(payload))
+    return 0
+
+
+def _limited_candidates(
+    items: Sequence[SourceInventoryCandidate],
+    limit: int | None,
+) -> Sequence[SourceInventoryCandidate]:
+    if limit is None:
+        return items
+    return items[:limit]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/source_inventory_intake.py
+++ b/scripts/audit/source_inventory_intake.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""Parse curated source inventories for Word Atlas growth candidates."""
+
+from __future__ import annotations
+
+import csv
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.lexicon.build_data_manifest import _lemma_key
+from scripts.lexicon.lemma_normalization import strip_acute_stress
+
+INVENTORY_KIND = "atlas_source_inventory"
+INVENTORY_VERSION = 1
+_TEXT_ENCODING = "utf-8-sig"
+
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_.:-]*$")
+
+_TOP_LEVEL_FIELDS = {"version", "kind", "sources"}
+_SOURCE_FIELDS = {
+    "id",
+    "source_family",
+    "extraction_mode",
+    "title",
+    "url",
+    "path",
+    "locator",
+    "notes",
+    "headwords",
+}
+_HEADWORD_FIELDS = {"lemma", "headword", "word", "pos", "locator", "context", "notes"}
+_FLAT_FIELDS = {
+    "lemma",
+    "source_family",
+    "extraction_mode",
+    "source_id",
+    "source_title",
+    "source_url",
+    "source_path",
+    "source_locator",
+    "context",
+    "pos",
+    "notes",
+}
+_FLAT_ALIASES = {
+    "headword": "lemma",
+    "word": "lemma",
+    "family": "source_family",
+    "source": "source_family",
+    "mode": "extraction_mode",
+    "extraction": "extraction_mode",
+    "id": "source_id",
+    "title": "source_title",
+    "url": "source_url",
+    "path": "source_path",
+    "locator": "source_locator",
+    "snippet": "context",
+    "example": "context",
+    "part_of_speech": "pos",
+}
+
+
+class SourceInventoryError(ValueError):
+    """Raised when a source inventory is malformed."""
+
+
+@dataclass(frozen=True)
+class SourceInventoryRecord:
+    """One source-backed Atlas headword row."""
+
+    lemma: str
+    source_family: str
+    extraction_mode: str
+    inventory_path: str
+    inventory_locator: str
+    source_id: str | None = None
+    source_title: str | None = None
+    source_url: str | None = None
+    source_path: str | None = None
+    source_locator: str | None = None
+    context: str | None = None
+    pos: str | None = None
+    notes: str | None = None
+
+    def provenance_payload(self) -> dict[str, Any]:
+        """Return JSON-ready provenance for a candidate entry."""
+        payload: dict[str, Any] = {
+            "source_family": self.source_family,
+            "extraction_mode": self.extraction_mode,
+            "inventory_path": self.inventory_path,
+            "inventory_locator": self.inventory_locator,
+        }
+        optional = {
+            "source_id": self.source_id,
+            "source_title": self.source_title,
+            "source_url": self.source_url,
+            "source_path": self.source_path,
+            "source_locator": self.source_locator,
+            "context": self.context,
+            "notes": self.notes,
+        }
+        payload.update({key: value for key, value in optional.items() if value})
+        return payload
+
+
+@dataclass(frozen=True)
+class SourceInventoryCandidate:
+    """One deduped Atlas candidate plus merged source provenance."""
+
+    lemma: str
+    pos: str | None
+    source_provenance: tuple[dict[str, Any], ...]
+
+
+def read_source_inventories(
+    paths: Sequence[Path],
+    *,
+    project_root: Path | None = None,
+) -> list[SourceInventoryRecord]:
+    """Read and validate one or more source inventory files."""
+    records: list[SourceInventoryRecord] = []
+    for path in paths:
+        records.extend(read_source_inventory(path, project_root=project_root))
+    return records
+
+
+def read_source_inventory(
+    path: Path,
+    *,
+    project_root: Path | None = None,
+) -> list[SourceInventoryRecord]:
+    """Read a CSV/TSV/JSONL row inventory or YAML/JSON source inventory."""
+    if not path.exists():
+        raise SourceInventoryError(f"source inventory not found: {path}")
+
+    suffix = path.suffix.lower()
+    inventory_path = _display_path(path, project_root)
+    if suffix == ".csv":
+        return _read_delimited_inventory(path, delimiter=",", inventory_path=inventory_path)
+    if suffix == ".tsv":
+        return _read_delimited_inventory(path, delimiter="\t", inventory_path=inventory_path)
+    if suffix == ".jsonl":
+        return _read_jsonl_inventory(path, inventory_path=inventory_path)
+    if suffix in {".yaml", ".yml"}:
+        return _records_from_structured_inventory(
+            yaml.safe_load(path.read_text(encoding=_TEXT_ENCODING)),
+            inventory_path=inventory_path,
+        )
+    if suffix == ".json":
+        return _records_from_json_payload(
+            json.loads(path.read_text(encoding=_TEXT_ENCODING)),
+            inventory_path=inventory_path,
+        )
+    raise SourceInventoryError(
+        f"unsupported source inventory extension for {inventory_path}; use csv, tsv, jsonl, json, or yaml"
+    )
+
+
+def source_inventory_candidates(
+    records: Sequence[SourceInventoryRecord],
+) -> list[SourceInventoryCandidate]:
+    """Canonicalize source rows into deterministic, deduped candidates."""
+    grouped: dict[str, dict[str, Any]] = {}
+    for record in records:
+        key = _lemma_key(record.lemma)
+        group = grouped.setdefault(
+            key,
+            {"lemma": record.lemma, "pos": record.pos, "source_provenance": []},
+        )
+        existing_pos = group["pos"]
+        if record.pos and existing_pos and record.pos != existing_pos:
+            raise SourceInventoryError(
+                f"conflicting pos for {record.lemma!r}: {existing_pos!r} vs {record.pos!r}"
+            )
+        if record.pos and not existing_pos:
+            group["pos"] = record.pos
+        group["source_provenance"].append(record.provenance_payload())
+
+    candidates = [
+        SourceInventoryCandidate(
+            lemma=str(group["lemma"]),
+            pos=group["pos"],
+            source_provenance=tuple(group["source_provenance"]),
+        )
+        for group in grouped.values()
+    ]
+    return sorted(candidates, key=lambda item: _lemma_key(item.lemma))
+
+
+def _read_delimited_inventory(
+    path: Path,
+    *,
+    delimiter: str,
+    inventory_path: str,
+) -> list[SourceInventoryRecord]:
+    with path.open(newline="", encoding=_TEXT_ENCODING) as handle:
+        reader = csv.DictReader(handle, delimiter=delimiter)
+        if not reader.fieldnames:
+            raise SourceInventoryError(f"{inventory_path}: missing header row")
+        return [
+            _record_from_flat_row(row, inventory_path=inventory_path, locator=f"row {line_number}")
+            for line_number, row in enumerate(reader, start=2)
+        ]
+
+
+def _read_jsonl_inventory(path: Path, *, inventory_path: str) -> list[SourceInventoryRecord]:
+    records: list[SourceInventoryRecord] = []
+    for line_number, line in enumerate(path.read_text(encoding=_TEXT_ENCODING).splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise SourceInventoryError(f"{inventory_path}: row {line_number}: invalid JSON") from exc
+        if not isinstance(row, Mapping):
+            raise SourceInventoryError(f"{inventory_path}: row {line_number}: expected JSON object")
+        records.append(
+            _record_from_flat_row(row, inventory_path=inventory_path, locator=f"row {line_number}")
+        )
+    return records
+
+
+def _records_from_json_payload(payload: object, *, inventory_path: str) -> list[SourceInventoryRecord]:
+    if isinstance(payload, list):
+        records: list[SourceInventoryRecord] = []
+        for index, row in enumerate(payload, start=1):
+            if not isinstance(row, Mapping):
+                raise SourceInventoryError(f"{inventory_path}: row {index}: expected JSON object")
+            records.append(_record_from_flat_row(row, inventory_path=inventory_path, locator=f"row {index}"))
+        return records
+    return _records_from_structured_inventory(payload, inventory_path=inventory_path)
+
+
+def _records_from_structured_inventory(
+    payload: object,
+    *,
+    inventory_path: str,
+) -> list[SourceInventoryRecord]:
+    if not isinstance(payload, Mapping):
+        raise SourceInventoryError(f"{inventory_path}: expected mapping inventory")
+    _reject_unknown_fields(payload, _TOP_LEVEL_FIELDS, f"{inventory_path}: top level")
+    if payload.get("version") != INVENTORY_VERSION:
+        raise SourceInventoryError(f"{inventory_path}: version must be {INVENTORY_VERSION}")
+    if payload.get("kind") != INVENTORY_KIND:
+        raise SourceInventoryError(f"{inventory_path}: kind must be {INVENTORY_KIND!r}")
+    sources = payload.get("sources")
+    if not isinstance(sources, list) or not sources:
+        raise SourceInventoryError(f"{inventory_path}: sources must be a non-empty list")
+
+    records: list[SourceInventoryRecord] = []
+    seen_source_ids: set[str] = set()
+    for source_index, source in enumerate(sources, start=1):
+        if not isinstance(source, Mapping):
+            raise SourceInventoryError(f"{inventory_path}: sources[{source_index}] must be a mapping")
+        locator = f"sources[{source_index}]"
+        _reject_unknown_fields(source, _SOURCE_FIELDS, f"{inventory_path}: {locator}")
+        source_id = _required_text(source.get("id"), "id", inventory_path, locator)
+        if source_id in seen_source_ids:
+            raise SourceInventoryError(f"{inventory_path}: duplicate source id {source_id!r}")
+        seen_source_ids.add(source_id)
+        family = _required_slug(source.get("source_family"), "source_family", inventory_path, locator)
+        mode = _required_slug(source.get("extraction_mode"), "extraction_mode", inventory_path, locator)
+        headwords = source.get("headwords")
+        if not isinstance(headwords, list) or not headwords:
+            raise SourceInventoryError(f"{inventory_path}: {locator}.headwords must be a non-empty list")
+        for headword_index, headword in enumerate(headwords, start=1):
+            headword_locator = f"{locator}.headwords[{headword_index}]"
+            record = _record_from_structured_headword(
+                headword,
+                source=source,
+                source_id=source_id,
+                source_family=family,
+                extraction_mode=mode,
+                inventory_path=inventory_path,
+                inventory_locator=headword_locator,
+            )
+            records.append(record)
+    return records
+
+
+def _record_from_structured_headword(
+    headword: object,
+    *,
+    source: Mapping[str, object],
+    source_id: str,
+    source_family: str,
+    extraction_mode: str,
+    inventory_path: str,
+    inventory_locator: str,
+) -> SourceInventoryRecord:
+    if isinstance(headword, str):
+        row: Mapping[str, object] = {"lemma": headword}
+    elif isinstance(headword, Mapping):
+        _reject_unknown_fields(headword, _HEADWORD_FIELDS, f"{inventory_path}: {inventory_locator}")
+        row = headword
+    else:
+        raise SourceInventoryError(f"{inventory_path}: {inventory_locator} must be string or mapping")
+
+    return SourceInventoryRecord(
+        lemma=_required_lemma(_first_present(row, ("lemma", "headword", "word")), inventory_path, inventory_locator),
+        source_family=source_family,
+        extraction_mode=extraction_mode,
+        inventory_path=inventory_path,
+        inventory_locator=inventory_locator,
+        source_id=source_id,
+        source_title=_optional_text(source.get("title")),
+        source_url=_optional_text(source.get("url")),
+        source_path=_optional_text(source.get("path")),
+        source_locator=_optional_text(_first_present(row, ("locator",))) or _optional_text(source.get("locator")),
+        context=_optional_text(row.get("context")),
+        pos=_optional_slug(row.get("pos"), "pos", inventory_path, inventory_locator),
+        notes=_optional_text(row.get("notes")) or _optional_text(source.get("notes")),
+    )
+
+
+def _record_from_flat_row(
+    row: Mapping[object, object],
+    *,
+    inventory_path: str,
+    locator: str,
+) -> SourceInventoryRecord:
+    if None in row:
+        raise SourceInventoryError(f"{inventory_path}: {locator}: row has more columns than headers")
+    normalized = _normalize_flat_row(row, inventory_path=inventory_path, locator=locator)
+    return SourceInventoryRecord(
+        lemma=_required_lemma(normalized.get("lemma"), inventory_path, locator),
+        source_family=_required_slug(normalized.get("source_family"), "source_family", inventory_path, locator),
+        extraction_mode=_required_slug(normalized.get("extraction_mode"), "extraction_mode", inventory_path, locator),
+        inventory_path=inventory_path,
+        inventory_locator=locator,
+        source_id=_optional_text(normalized.get("source_id")),
+        source_title=_optional_text(normalized.get("source_title")),
+        source_url=_optional_text(normalized.get("source_url")),
+        source_path=_optional_text(normalized.get("source_path")),
+        source_locator=_optional_text(normalized.get("source_locator")),
+        context=_optional_text(normalized.get("context")),
+        pos=_optional_slug(normalized.get("pos"), "pos", inventory_path, locator),
+        notes=_optional_text(normalized.get("notes")),
+    )
+
+
+def _normalize_flat_row(
+    row: Mapping[object, object],
+    *,
+    inventory_path: str,
+    locator: str,
+) -> dict[str, object]:
+    normalized: dict[str, object] = {}
+    for raw_key, value in row.items():
+        key = _normalize_key(raw_key)
+        key = _FLAT_ALIASES.get(key, key)
+        if key not in _FLAT_FIELDS:
+            raise SourceInventoryError(f"{inventory_path}: {locator}: unknown field {raw_key!r}")
+        if key in normalized:
+            raise SourceInventoryError(f"{inventory_path}: {locator}: duplicate field {key!r}")
+        normalized[key] = value
+    return normalized
+
+
+def _reject_unknown_fields(
+    row: Mapping[object, object],
+    allowed: set[str],
+    context: str,
+) -> None:
+    for key in row:
+        if not isinstance(key, str) or key not in allowed:
+            raise SourceInventoryError(f"{context}: unknown field {key!r}")
+
+
+def _required_lemma(value: object, inventory_path: str, locator: str) -> str:
+    lemma = strip_acute_stress(_required_text(value, "lemma", inventory_path, locator))
+    if not lemma:
+        raise SourceInventoryError(f"{inventory_path}: {locator}: lemma is required")
+    return lemma
+
+
+def _required_slug(value: object, field: str, inventory_path: str, locator: str) -> str:
+    slug = _required_text(value, field, inventory_path, locator).casefold()
+    if not _SLUG_RE.fullmatch(slug):
+        raise SourceInventoryError(f"{inventory_path}: {locator}: {field} must be a lowercase slug")
+    return slug
+
+
+def _optional_slug(value: object, field: str, inventory_path: str, locator: str) -> str | None:
+    text = _optional_text(value)
+    if not text:
+        return None
+    slug = text.casefold()
+    if not _SLUG_RE.fullmatch(slug):
+        raise SourceInventoryError(f"{inventory_path}: {locator}: {field} must be a lowercase slug")
+    return slug
+
+
+def _required_text(value: object, field: str, inventory_path: str, locator: str) -> str:
+    text = _optional_text(value)
+    if not text:
+        raise SourceInventoryError(f"{inventory_path}: {locator}: {field} is required")
+    return text
+
+
+def _optional_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _first_present(row: Mapping[str, object], keys: Sequence[str]) -> object | None:
+    for key in keys:
+        if key in row:
+            return row[key]
+    return None
+
+
+def _normalize_key(value: object) -> str:
+    return str(value).strip().casefold().replace("-", "_").replace(" ", "_")
+
+
+def _display_path(path: Path, project_root: Path | None) -> str:
+    if project_root is not None:
+        try:
+            return str(path.resolve().relative_to(project_root.resolve()))
+        except ValueError:
+            pass
+    return str(path)

--- a/scripts/lexicon/README.md
+++ b/scripts/lexicon/README.md
@@ -29,3 +29,39 @@ For module promotions, `scripts/sync/promote_module.py --refresh-atlas ...` can 
 `make atlas` after `vocabulary.yaml` is promoted and include the manifest outputs in the
 promotion commit. Use it only on machines with the local dictionary data and caches needed
 by Atlas enrichment.
+
+## Source Inventory Candidate Intake
+
+Curated ULP/Ohoiko/textbook/headword lists feed Atlas growth candidates with
+explicit provenance through:
+
+```bash
+.venv/bin/python -m scripts.audit.grow_lexicon_from_sources \
+  --inventory data/lexicon/source-inventory/ulp.yaml \
+  --out data/lexicon/grow_candidates.json \
+  --report
+```
+
+The source inventory parser accepts CSV, TSV, JSONL, JSON, or YAML. YAML/JSON
+structured inventories use this minimal v1 shape:
+
+```yaml
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: ulp-001
+    source_family: ulp
+    extraction_mode: curated_headword
+    title: Ukrainian Lessons Podcast 1
+    url: https://example.test/ulp-001
+    headwords:
+      - lemma: авто
+        context: lesson headword list
+```
+
+Flat CSV/TSV/JSONL rows require `lemma`, `source_family`, and
+`extraction_mode`; optional provenance fields are `source_id`, `source_title`,
+`source_url`, `source_path`, `source_locator`, `context`, `pos`, and `notes`.
+Malformed rows fail before candidate output is written. Source-fed candidates
+use the same `auto_merge` / `needs_review` payload as content-grown candidates
+and carry `source_provenance` through promotion.

--- a/tests/test_grow_lexicon_from_sources.py
+++ b/tests/test_grow_lexicon_from_sources.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+from contextlib import nullcontext
+from typing import Any
+
+from scripts.audit import grow_lexicon_from_sources as grow
+
+
+def test_generate_candidates_from_source_inventory_retains_provenance(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    inventory = tmp_path / "sources.yaml"
+    inventory.write_text(
+        """
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: ulp-001
+    source_family: ulp
+    extraction_mode: curated_headword
+    title: ULP Lesson 1
+    url: https://example.test/ulp-001
+    headwords:
+      - lemma: авто
+        context: lesson headword
+      - lemma: ревю
+        context: lesson headword
+""".lstrip(),
+        encoding="utf-8",
+    )
+    out = tmp_path / "grow_candidates.json"
+    seen: list[str] = []
+
+    monkeypatch.setattr(grow, "_source_connection", lambda path: nullcontext(object()))
+    monkeypatch.setattr(grow, "_preserve_wiki_reference_cache", lambda: nullcontext())
+    monkeypatch.setattr(grow.enrich_manifest, "_load_kaikki_lookup", lambda: {"fixture": True})
+    monkeypatch.setattr(grow.enrich_manifest, "_sum11_has_flag_columns", lambda conn: False)
+    monkeypatch.setattr(
+        grow,
+        "build_skeleton_entry",
+        lambda lemma: {"lemma": lemma, "pos": "noun"},
+    )
+
+    def fake_enrich_entry(
+        entry: dict[str, Any],
+        conn: object,
+        kaikki_lookup: dict[str, bool],
+        *,
+        has_sum11_flags: bool,
+    ) -> bool:
+        seen.append(entry["lemma"])
+        entry["heritage_status"] = {
+            "classification": "standard",
+            "is_russianism": False,
+            "russian_shadow": False,
+        }
+        if entry["lemma"] == "авто":
+            entry["enrichment"] = {
+                "meaning": {
+                    "definitions": ["автомобіль"],
+                    "source": "fixture",
+                }
+            }
+            return True
+        return False
+
+    monkeypatch.setattr(grow.enrich_manifest, "enrich_entry", fake_enrich_entry)
+
+    payload = grow.generate_candidates(inventory_paths=[inventory], limit=2, out=out)
+    written = json.loads(out.read_text(encoding="utf-8"))
+
+    assert payload == written
+    assert seen == ["авто", "ревю"]
+    assert written["generated_from"] == grow.GENERATED_FROM
+    assert written["counts"] == {
+        "total_delta": 2,
+        "processed": 2,
+        "auto_merge": 1,
+        "needs_review": 1,
+    }
+    auto_entry = written["auto_merge"][0]
+    held_entry = written["needs_review"][0]["entry"]
+    assert auto_entry["primary_source"] == grow.PRIMARY_SOURCE
+    assert auto_entry["source_provenance"][0]["source_family"] == "ulp"
+    assert auto_entry["source_provenance"][0]["source_id"] == "ulp-001"
+    assert auto_entry["source_provenance"][0]["context"] == "lesson headword"
+    assert held_entry["source_provenance"][0]["source_title"] == "ULP Lesson 1"
+    assert not list(tmp_path.glob("*daily*"))
+    assert not list(tmp_path.glob("*practice*"))
+    assert not list(tmp_path.glob("*cloze*"))
+
+
+def test_malformed_inventory_does_not_write_candidates(tmp_path, capsys) -> None:
+    inventory = tmp_path / "bad.csv"
+    inventory.write_text(
+        "lemma,source_family,extraction_mode,unknown\n"
+        "авто,ulp,curated_headword,nope\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "grow_candidates.json"
+
+    status = grow.main(["--inventory", str(inventory), "--out", str(out)])
+
+    assert status == 2
+    assert not out.exists()
+    assert "unknown field" in capsys.readouterr().err

--- a/tests/test_source_inventory_intake.py
+++ b/tests/test_source_inventory_intake.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.audit.source_inventory_intake import (
+    SourceInventoryError,
+    read_source_inventory,
+    source_inventory_candidates,
+)
+
+
+def test_structured_inventory_preserves_source_provenance(tmp_path) -> None:
+    inventory = tmp_path / "ulp.yaml"
+    inventory.write_text(
+        """
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: ulp-001
+    source_family: ULP
+    extraction_mode: curated_headword
+    title: Ukrainian Lessons Podcast 1
+    url: https://example.test/ulp-001
+    locator: episode 1 vocabulary
+    notes: curated external list
+    headwords:
+      - lemma: авто́
+        pos: noun
+        locator: 00:10
+        context: lesson headword list
+      - ревю
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    records = read_source_inventory(inventory, project_root=tmp_path)
+
+    assert [record.lemma for record in records] == ["авто", "ревю"]
+    assert records[0].source_family == "ulp"
+    assert records[0].extraction_mode == "curated_headword"
+    assert records[0].pos == "noun"
+    assert records[0].provenance_payload() == {
+        "source_family": "ulp",
+        "extraction_mode": "curated_headword",
+        "inventory_path": "ulp.yaml",
+        "inventory_locator": "sources[1].headwords[1]",
+        "source_id": "ulp-001",
+        "source_title": "Ukrainian Lessons Podcast 1",
+        "source_url": "https://example.test/ulp-001",
+        "source_locator": "00:10",
+        "context": "lesson headword list",
+        "notes": "curated external list",
+    }
+    assert records[1].source_locator == "episode 1 vocabulary"
+
+
+def test_flat_inventory_dedupes_stressed_variants_and_merges_provenance(tmp_path) -> None:
+    inventory = tmp_path / "headwords.csv"
+    inventory.write_text(
+        "\n".join(
+            [
+                "lemma,source_family,source_id,source_title,extraction_mode,source_path,context,pos",
+                "авто́,textbook,tb-1,Textbook 1,headword_inventory,data/textbook.txt,row one,noun",
+                "авто,textbook,tb-2,Textbook 2,headword_inventory,data/textbook-2.txt,row two,noun",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    records = read_source_inventory(inventory, project_root=tmp_path)
+    candidates = source_inventory_candidates(records)
+
+    assert len(candidates) == 1
+    assert candidates[0].lemma == "авто"
+    assert candidates[0].pos == "noun"
+    assert [item["source_id"] for item in candidates[0].source_provenance] == ["tb-1", "tb-2"]
+    assert [item["inventory_locator"] for item in candidates[0].source_provenance] == [
+        "row 2",
+        "row 3",
+    ]
+
+
+def test_flat_inventory_accepts_utf8_bom(tmp_path) -> None:
+    inventory = tmp_path / "headwords.csv"
+    inventory.write_text(
+        "\ufefflemma,source_family,extraction_mode\n"
+        "авто,ulp,curated_headword\n",
+        encoding="utf-8",
+    )
+
+    records = read_source_inventory(inventory, project_root=tmp_path)
+
+    assert records[0].lemma == "авто"
+    assert records[0].source_family == "ulp"
+
+
+def test_inventory_rejects_unknown_fields(tmp_path) -> None:
+    inventory = tmp_path / "bad.csv"
+    inventory.write_text(
+        "lemma,source_family,extraction_mode,source_titel\n"
+        "авто,ulp,curated_headword,typo\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SourceInventoryError, match="unknown field"):
+        read_source_inventory(inventory, project_root=tmp_path)
+
+
+def test_structured_inventory_rejects_noncanonical_keys(tmp_path) -> None:
+    inventory = tmp_path / "bad.yaml"
+    inventory.write_text(
+        """
+Version: 1
+kind: atlas_source_inventory
+sources: []
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SourceInventoryError, match="unknown field 'Version'"):
+        read_source_inventory(inventory, project_root=tmp_path)
+
+
+def test_inventory_rejects_conflicting_pos_after_canonicalization(tmp_path) -> None:
+    inventory = tmp_path / "bad.jsonl"
+    inventory.write_text(
+        "\n".join(
+            [
+                '{"lemma":"авто́","source_family":"ulp","extraction_mode":"curated_headword","pos":"noun"}',
+                '{"lemma":"авто","source_family":"ohoiko","extraction_mode":"headword_inventory","pos":"verb"}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    records = read_source_inventory(inventory, project_root=tmp_path)
+    with pytest.raises(SourceInventoryError, match="conflicting pos"):
+        source_inventory_candidates(records)


### PR DESCRIPTION
Refs #3933, #3934, #3936.

## Scope
- Add source-backed Atlas inventory parsing for curated ULP/Ohoiko/textbook/headword inputs.
- Add `scripts.audit.grow_lexicon_from_sources` to produce existing-compatible grow candidate payloads with `source_provenance`.
- Keep candidate output compatible with the existing grow/promote payload shape (`auto_merge`, `needs_review`, counts, limit) without expanding manifest, daily, practice, or cloze data.
- Document the v1 structured and flat inventory formats in `scripts/lexicon/README.md`.

## Files changed
- `scripts/audit/source_inventory_intake.py`
- `scripts/audit/grow_lexicon_from_sources.py`
- `scripts/lexicon/README.md`
- `tests/test_source_inventory_intake.py`
- `tests/test_grow_lexicon_from_sources.py`

## Validation
- `.venv/bin/python -m pytest tests/test_content_lexicon_reconciler.py tests/test_grow_lexicon_from_content.py` -> 10 passed, 1 skipped.
- `.venv/bin/python -m pytest tests/test_source_inventory_intake.py tests/test_grow_lexicon_from_sources.py` -> 8 passed.
- `.venv/bin/ruff check scripts/audit/source_inventory_intake.py scripts/audit/grow_lexicon_from_sources.py tests/test_source_inventory_intake.py tests/test_grow_lexicon_from_sources.py` -> passed.
- `.venv/bin/python scripts/audit/check_static_practice_assets.py --format json` -> passed (`ok: true`, daily count 300, total cloze 0).
- `git diff --check` -> passed.
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` -> passed.
- Commit hook affected pytest -> passed.

## Daily / practice / cloze
This PR does not expand Words of the Day, Daily Practice shards, or cloze content. It also avoids Atlas manifest, pointer, and fingerprint changes; the source-fed intake produces candidate JSON only when explicitly run.

## Independent review
Final review requested through AGY via:

```bash
printf '%s\n' "<review prompt + final patch>" | .venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy - --task-id review-3933-source-intake-final --to-model gemini-3.1-pro-high --review
```

Result: no blockers after applying AGY's structured-key validation finding. Earlier AGY BOM robustness notes were also addressed with `utf-8-sig` reads and a regression test.