### PR TITLE
data(atlas): add curated source inventory seeds

### DIFF
--- a/data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml
+++ b/data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml
@@ -1,0 +1,24 @@
+---
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: bolshakova-bukvar-2025-part1-keywords
+    source_family: textbook
+    extraction_mode: curated_headword
+    title: Болшакова І.О. Буквар. 1 клас. Частина 1. Ранок, 2025
+    path: docs/l2-uk-direct/textbook-reading-notes/bolshakova-bukvar-mapping.md
+    locator: letter sequence table key words for Я, Є, Ц
+    notes: Seed uses tracked reading notes mapped to the local source PDF; the PDF is not committed.
+    headwords:
+      - lemma: яблуко
+        pos: noun
+        locator: letter table row Я я; content page 103 / PDF page 108
+        context: Row lists Я я with key word яблуко.
+      - lemma: єнот
+        pos: noun
+        locator: letter table row Є є; content page 111 / PDF page 116
+        context: Row lists Є є with key word єнот.
+      - lemma: цирк
+        pos: noun
+        locator: letter table row Ц ц; content page 120 / PDF page 125
+        context: Row lists Ц ц with key words цирк / цікавий.

--- a/data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+++ b/data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
@@ -1,0 +1,25 @@
+---
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: ohoiko-abetka-2-keywords
+    source_family: ohoiko
+    extraction_mode: curated_key_word
+    title: Anna Ohoiko - Ukrainian Lessons alphabet pronunciation playlist
+    url: https://www.youtube.com/playlist?list=PLpkSIXDyaJi3mlJlKXWKhdiJZj67fPXQV
+    path: curriculum/l2-uk-direct/a1/abetka-2.yaml
+    locator: playlist_credit plus letters key_word/pronunciation_video entries
+    notes: Seed uses only tracked abetka key_word rows; no ULP premium vocabulary lists inferred.
+    headwords:
+      - lemma: кіт
+        pos: noun
+        locator: letters[К].key_word
+        context: К key_word with pronunciation video https://www.youtube.com/watch?v=J7sGEI4-xJo
+      - lemma: риба
+        pos: noun
+        locator: letters[И].key_word
+        context: И key_word with pronunciation video https://www.youtube.com/watch?v=W-1rCu0indE
+      - lemma: ракета
+        pos: noun
+        locator: letters[Р].key_word
+        context: Р key_word with pronunciation video https://www.youtube.com/watch?v=fMGsQ5KPQgg

--- a/tests/test_source_inventory_intake.py
+++ b/tests/test_source_inventory_intake.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from scripts.audit.source_inventory_intake import (
@@ -7,6 +9,8 @@ from scripts.audit.source_inventory_intake import (
     read_source_inventory,
     source_inventory_candidates,
 )
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 
 def test_structured_inventory_preserves_source_provenance(tmp_path) -> None:
@@ -138,3 +142,31 @@ def test_inventory_rejects_conflicting_pos_after_canonicalization(tmp_path) -> N
     records = read_source_inventory(inventory, project_root=tmp_path)
     with pytest.raises(SourceInventoryError, match="conflicting pos"):
         source_inventory_candidates(records)
+
+
+def test_committed_source_inventory_files_are_valid() -> None:
+    inventory_dir = PROJECT_ROOT / "data" / "lexicon" / "source-inventory"
+    supported_suffixes = {".csv", ".tsv", ".jsonl", ".json", ".yaml", ".yml"}
+    inventory_paths = sorted(
+        path
+        for path in inventory_dir.iterdir()
+        if path.suffix.lower() in supported_suffixes
+    )
+
+    assert inventory_paths
+
+    records = []
+    for inventory_path in inventory_paths:
+        records.extend(read_source_inventory(inventory_path, project_root=PROJECT_ROOT))
+
+    candidates = source_inventory_candidates(records)
+    assert candidates
+
+    for candidate in candidates:
+        assert candidate.source_provenance
+        for provenance in candidate.source_provenance:
+            assert provenance["inventory_path"].startswith(
+                "data/lexicon/source-inventory/"
+            )
+            assert provenance.get("source_id")
+            assert provenance.get("source_title")


### PR DESCRIPTION
## Summary

Adds the first small curated Word Atlas source inventory seed after #3976:

- `data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml` — 3 Ohoiko-style key-word rows from the tracked Anna Ohoiko / Ukrainian Lessons abetka source material.
- `data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml` — 3 textbook/headword rows from the tracked Bolshakova bukvar reading notes.
- `tests/test_source_inventory_intake.py` — validates every committed inventory file under `data/lexicon/source-inventory/` and requires preserved provenance.

Refs #3933, #3934, #3936.

## Provenance policy

Every row cites real tracked provenance with source family, extraction mode, source title, source path or URL, row locator, context, and noun POS. The Ohoiko seed uses only committed `curriculum/l2-uk-direct/a1/abetka-2.yaml` key-word/pronunciation-video rows credited to Anna Ohoiko / Ukrainian Lessons. It does not infer or reproduce unavailable ULP premium vocabulary lists. The textbook seed uses committed `docs/l2-uk-direct/textbook-reading-notes/bolshakova-bukvar-mapping.md` rows mapped to the local source PDF; the PDF itself is not committed.

## Validation

- `.venv/bin/python -m pytest -q tests/test_source_inventory_intake.py tests/test_grow_lexicon_from_sources.py` -> 9 passed.
- `.venv/bin/python -m pytest -q tests/test_content_lexicon_reconciler.py tests/test_grow_lexicon_from_content.py` -> 10 passed, 1 existing skip.
- `.venv/bin/python scripts/audit/check_static_practice_assets.py --format json` -> `ok: true`, 0 errors.
- `.venv/bin/ruff check tests/test_source_inventory_intake.py` -> passed.
- `.venv/bin/yamllint data/lexicon/source-inventory/*.yaml` -> passed.
- `git diff --check` -> passed.
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` -> passed for 1 commit.
- Source-grow smoke validation to `/tmp/atlas-grow-candidates-3933.json` processed 6 source-fed candidates: 2 auto-merge, 4 needs-review, 0 missing `source_provenance`. The generated file is local-only and not committed.

## Non-expansion note

This PR does not update or expand Atlas manifest, pointer, fingerprint, search, browse, Words of the Day, Daily Practice, practice deck, or cloze outputs. No generated status/audit/review/telemetry artifacts are included.

## Independent review

AGY (`gemini-3.1-pro-high`, task `review-3933-curated-seed-inventories`) returned: "No actionable findings." It specifically confirmed provenance is explicit, source claims are not fabricated, validation is strengthened, and no manifest/search/browse/daily/practice/cloze outputs are expanded.
