### PR TITLE
test(atlas): review-only source candidate workflow

### DIFF
--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -1,0 +1,45 @@
+# Word Atlas Source Inventory Review Candidates
+
+Use this workflow to turn the committed source inventory seeds into a small
+review-only Atlas candidate artifact.
+
+```bash
+.venv/bin/python -m scripts.audit.generate_source_inventory_review_candidates --report
+```
+
+By default the command writes
+`/tmp/atlas-source-inventory-review-candidates.json`. The output is review
+material only. Do not commit it and do not copy it into the live Atlas data
+files.
+
+The committed source inventory inputs are:
+
+- `data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml`
+- `data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml`
+
+The candidate JSON follows the existing grow-candidate shape: `counts`,
+`auto_merge`, and `needs_review`. The wrapper also adds `review_only` metadata
+with the workflow id, inventory paths, review output path, and
+`production_outputs_updated: []`.
+
+Every generated candidate must retain non-empty `source_provenance`. The seed
+smoke run currently processes all six source inventory headwords: `кіт`,
+`риба`, `ракета`, `яблуко`, `єнот`, and `цирк`.
+
+This workflow does not update the live Atlas manifest, search index, browse
+files, Words Day pool, daily practice sources, cloze outputs, manifest pointer,
+or manifest fingerprint. In this repository those live outputs are under
+`site/src/data/`, including:
+
+- `site/src/data/lexicon-manifest.json`
+- `site/src/data/lexicon-search-index.json`
+- `site/src/data/lexicon-browse-meta.json`
+- `site/src/data/lexicon-browse-flagged.json`
+- `site/src/data/lexicon-daily-pool.json`
+- `site/src/data/lexicon-practice-reviewed-sources.json`
+- `site/src/data/lexicon-manifest.pointer.json`
+- `site/src/data/lexicon-manifest.fingerprint.json`
+
+The full enrichment step requires the local ignored `data/sources.db`. If a
+worktree does not have that database, link or copy the local project database
+into the worktree before the smoke run. Keep `data/sources.db` untracked.

--- a/scripts/audit/generate_source_inventory_review_candidates.py
+++ b/scripts/audit/generate_source_inventory_review_candidates.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Generate review-only Atlas candidates from committed source inventories."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import uuid
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from scripts.audit import grow_lexicon_from_sources as grow
+from scripts.audit.source_inventory_intake import SourceInventoryError
+from scripts.lexicon.content_lexicon_reconciler import PROJECT_ROOT
+
+COMMITTED_SOURCE_INVENTORIES: tuple[Path, ...] = (
+    PROJECT_ROOT / "data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml",
+    PROJECT_ROOT / "data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml",
+)
+
+DEFAULT_OUT = Path("/tmp/atlas-source-inventory-review-candidates.json")
+WORKFLOW_ID = "source_inventory_review_candidates.v1"
+
+LIVE_ATLAS_OUTPUTS: tuple[Path, ...] = (
+    PROJECT_ROOT / "site/src/data/lexicon-manifest.json",
+    PROJECT_ROOT / "site/src/data/lexicon-search-index.json",
+    PROJECT_ROOT / "site/src/data/lexicon-browse-meta.json",
+    PROJECT_ROOT / "site/src/data/lexicon-browse-flagged.json",
+    PROJECT_ROOT / "site/src/data/lexicon-daily-pool.json",
+    PROJECT_ROOT / "site/src/data/lexicon-practice-reviewed-sources.json",
+    PROJECT_ROOT / "site/src/data/lexicon-manifest.pointer.json",
+    PROJECT_ROOT / "site/src/data/lexicon-manifest.fingerprint.json",
+)
+LIVE_ATLAS_OUTPUT_DIR = PROJECT_ROOT / "site/src/data"
+
+
+def generate_review_candidates(
+    *,
+    limit: int | None = None,
+    out: Path = DEFAULT_OUT,
+) -> dict[str, Any]:
+    """Generate candidates without writing live Atlas/static-practice outputs."""
+    output_path = resolve_review_output_path(out)
+    temp_out = output_path.with_name(f".{output_path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        payload = grow.generate_candidates(
+            inventory_paths=COMMITTED_SOURCE_INVENTORIES,
+            limit=limit,
+            out=temp_out,
+        )
+        validate_source_provenance(payload)
+    finally:
+        temp_out.unlink(missing_ok=True)
+
+    payload["review_only"] = {
+        "workflow": WORKFLOW_ID,
+        "source_inventory_paths": [
+            str(path.relative_to(PROJECT_ROOT)) for path in COMMITTED_SOURCE_INVENTORIES
+        ],
+        "candidate_output": str(output_path),
+        "production_outputs_updated": [],
+    }
+    grow.write_candidates(payload, output_path)
+    return payload
+
+
+def validate_source_provenance(payload: dict[str, Any]) -> None:
+    """Reject candidate payloads that lost source inventory provenance."""
+    missing = [
+        str(entry.get("lemma") or "<unknown>")
+        for entry in iter_candidate_entries(payload)
+        if not entry.get("source_provenance")
+    ]
+    if missing:
+        raise SourceInventoryError(
+            "source inventory review candidates missing source_provenance: "
+            + ", ".join(missing)
+        )
+
+
+def iter_candidate_entries(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return auto-merge and review-wrapped candidate entries."""
+    entries = [
+        entry for entry in payload.get("auto_merge", []) if isinstance(entry, dict)
+    ]
+    entries.extend(
+        item["entry"]
+        for item in payload.get("needs_review", [])
+        if isinstance(item, dict) and isinstance(item.get("entry"), dict)
+    )
+    return entries
+
+
+def resolve_review_output_path(out: Path) -> Path:
+    """Resolve and reject live Atlas/static-practice output paths."""
+    output_path = out if out.is_absolute() else PROJECT_ROOT / out
+    resolved = output_path.resolve()
+    if resolved in {path.resolve() for path in LIVE_ATLAS_OUTPUTS}:
+        raise SourceInventoryError(
+            f"review-only source candidates must not overwrite {resolved.relative_to(PROJECT_ROOT)}"
+        )
+    if resolved.is_relative_to(LIVE_ATLAS_OUTPUT_DIR.resolve()):
+        raise SourceInventoryError(
+            "review-only source candidates must not write under site/src/data"
+        )
+    return resolved
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate review-only Atlas candidates from committed source inventories."
+        )
+    )
+    parser.add_argument("--limit", type=int, help="Limit processed source headwords")
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=DEFAULT_OUT,
+        help=f"Review-only JSON output path (default: {DEFAULT_OUT})",
+    )
+    parser.add_argument("--report", action="store_true", help="Print candidate bucket counts")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.limit is not None and args.limit < 0:
+        parser.error("--limit must be non-negative")
+
+    try:
+        payload = generate_review_candidates(limit=args.limit, out=args.out)
+    except (FileNotFoundError, SourceInventoryError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.report:
+        print(grow.format_report(payload))
+        print(f"review_output: {payload['review_only']['candidate_output']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_source_inventory_review_candidates.py
+++ b/tests/test_source_inventory_review_candidates.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+from contextlib import nullcontext
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.audit import generate_source_inventory_review_candidates as review
+from scripts.audit.source_inventory_intake import SourceInventoryError
+from scripts.lexicon.content_lexicon_reconciler import PROJECT_ROOT
+
+SEED_LEMMAS = {"кіт", "риба", "ракета", "яблуко", "єнот", "цирк"}
+
+
+def test_review_candidates_use_committed_inventories_and_keep_provenance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    out = tmp_path / "atlas-source-inventory-review-candidates.json"
+
+    monkeypatch.setattr(review.grow, "_source_connection", lambda path: nullcontext(object()))
+    monkeypatch.setattr(review.grow, "_preserve_wiki_reference_cache", lambda: nullcontext())
+    monkeypatch.setattr(review.grow.enrich_manifest, "_load_kaikki_lookup", lambda: {})
+    monkeypatch.setattr(review.grow.enrich_manifest, "_sum11_has_flag_columns", lambda conn: False)
+    monkeypatch.setattr(
+        review.grow,
+        "build_skeleton_entry",
+        lambda lemma: {"lemma": lemma, "pos": "noun"},
+    )
+
+    def fake_enrich_entry(
+        entry: dict[str, Any],
+        conn: object,
+        kaikki_lookup: dict[str, Any],
+        *,
+        has_sum11_flags: bool,
+    ) -> bool:
+        entry["heritage_status"] = {
+            "classification": "standard",
+            "is_russianism": False,
+            "russian_shadow": False,
+        }
+        entry["enrichment"] = {
+            "meaning": {"definitions": [f"{entry['lemma']} fixture definition"]}
+        }
+        return True
+
+    monkeypatch.setattr(review.grow.enrich_manifest, "enrich_entry", fake_enrich_entry)
+
+    payload = review.generate_review_candidates(out=out)
+
+    assert payload["counts"] == {
+        "total_delta": 6,
+        "processed": 6,
+        "auto_merge": 6,
+        "needs_review": 0,
+    }
+    assert payload["review_only"] == {
+        "workflow": review.WORKFLOW_ID,
+        "source_inventory_paths": [
+            "data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml",
+            "data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml",
+        ],
+        "candidate_output": str(out.resolve()),
+        "production_outputs_updated": [],
+    }
+
+    entries = payload["auto_merge"]
+    assert {entry["lemma"] for entry in entries} == SEED_LEMMAS
+    for entry in entries:
+        assert entry["source_provenance"]
+        for provenance in entry["source_provenance"]:
+            assert provenance["inventory_path"].startswith(
+                "data/lexicon/source-inventory/"
+            )
+            assert provenance["source_id"]
+            assert provenance["source_title"]
+
+
+def test_review_workflow_validates_source_provenance_in_needs_review() -> None:
+    payload = {
+        "auto_merge": [{"lemma": "риба", "source_provenance": [{"source_id": "ok"}]}],
+        "needs_review": [
+            {
+                "entry": {
+                    "lemma": "кіт",
+                    "source_provenance": [{"source_id": "ok"}],
+                },
+                "reason": "fixture",
+            }
+        ],
+    }
+
+    review.validate_source_provenance(payload)
+
+
+def test_review_workflow_rejects_missing_source_provenance_before_final_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    out = tmp_path / "atlas-source-inventory-review-candidates.json"
+
+    def fake_generate_candidates(
+        *,
+        inventory_paths: tuple[Path, ...],
+        limit: int | None,
+        out: Path,
+    ) -> dict[str, Any]:
+        payload = {
+            "counts": {
+                "total_delta": 1,
+                "processed": 1,
+                "auto_merge": 1,
+                "needs_review": 0,
+            },
+            "limit": limit,
+            "auto_merge": [{"lemma": "кіт", "source_provenance": []}],
+            "needs_review": [],
+        }
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(payload), encoding="utf-8")
+        return payload
+
+    monkeypatch.setattr(review.grow, "generate_candidates", fake_generate_candidates)
+
+    with pytest.raises(SourceInventoryError, match="missing source_provenance: кіт"):
+        review.generate_review_candidates(out=out)
+
+    assert not out.exists()
+    assert not list(tmp_path.glob(".*.tmp"))
+
+
+def test_review_workflow_defaults_outside_repo() -> None:
+    resolved = review.resolve_review_output_path(review.DEFAULT_OUT)
+
+    assert resolved == review.DEFAULT_OUT.resolve()
+    assert not resolved.is_relative_to(PROJECT_ROOT)
+    assert all(path.exists() for path in review.COMMITTED_SOURCE_INVENTORIES)
+
+
+@pytest.mark.parametrize("production_output", review.LIVE_ATLAS_OUTPUTS)
+def test_review_workflow_rejects_live_atlas_outputs(production_output: Path) -> None:
+    with pytest.raises(SourceInventoryError, match="review-only source candidates"):
+        review.resolve_review_output_path(production_output)
+
+
+def test_review_workflow_rejects_live_atlas_output_directory() -> None:
+    with pytest.raises(SourceInventoryError, match="site/src/data"):
+        review.resolve_review_output_path(
+            PROJECT_ROOT / "site/src/data/source-inventory-review-candidates.json"
+        )


### PR DESCRIPTION
## Summary

Refs #3933, #3934, #3936.

Adds a review-only Word Atlas source-inventory candidate workflow for the two committed seed inventories:

```bash
.venv/bin/python -m scripts.audit.generate_source_inventory_review_candidates --report
```

The wrapper hard-codes the committed inventory inputs, defaults the review artifact to `/tmp/atlas-source-inventory-review-candidates.json`, writes through a temporary candidate file, validates source provenance, then writes the final review-only JSON with `review_only` metadata and `production_outputs_updated: []`.

## Candidate Smoke Run

Command:

```bash
.venv/bin/python -m scripts.audit.generate_source_inventory_review_candidates --report
```

Result:

```text
total_delta: 6
processed: 6
auto_merge: 2
needs_review: 4
review_output: /private/tmp/atlas-source-inventory-review-candidates.json
```

All six seed candidates were included: `риба`, `яблуко`, `кіт`, `ракета`, `цирк`, `єнот`.

`source_provenance` confirmation: each of the six emitted candidates had non-empty provenance; smoke check reported one provenance record per candidate.

## Production Boundary

This PR does not publish candidates into live Atlas or practice outputs. No files under `site/src/data/` are changed, including manifest, search, browse, Words Day/daily pool, practice sources, cloze, pointer, or fingerprint outputs. The wrapper also rejects output paths under `site/src/data/`.

Static practice gate result stayed unchanged for this scope: `daily.count=300`, `total_cloze=0`, and every per-level practice cloze count is `0`.

## Validation

- `.venv/bin/python -m pytest tests/test_source_inventory_intake.py tests/test_grow_lexicon_from_sources.py tests/test_source_inventory_review_candidates.py` — passed, 22 tests
- `.venv/bin/python -m pytest tests/test_content_lexicon_reconciler.py tests/test_grow_lexicon_from_content.py` — passed, 10 passed / 1 existing VESUM smoke skipped by fixture gate
- `.venv/bin/python scripts/audit/check_static_practice_assets.py --format json` — passed, `ok=true`, `daily.count=300`, `total_cloze=0`
- `.venv/bin/ruff check scripts/audit/generate_source_inventory_review_candidates.py tests/test_source_inventory_review_candidates.py` — passed
- `npx --no-install markdownlint-cli2 docs/runbooks/word-atlas-source-inventory-review-candidates.md` — passed, 0 errors
- `git diff --cached --check && git diff --check` — passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed after commit

## Independent Review

AGY review via `gemini-3.1-pro-high` first found no blocking issue but requested a runtime `source_provenance` guard. I added the guard and tests. Follow-up AGY review on the final staged patch reported: no blocking findings.
