### PR TITLE
[codex] docs(b2): score and expose M64-M68

### DIFF
--- a/docs/audits/b2-current-llm-scores-2026-06-28.md
+++ b/docs/audits/b2-current-llm-scores-2026-06-28.md
@@ -62,10 +62,15 @@ B2 M60 `word-formation-person-suffixes`,9/10,B+,Yes,Strong person-suffix word-fo
 B2 M61 `word-formation-abstract-nouns`,9/10,B+,Yes,Strong abstract-noun word-formation module 13 workbook activities, 44 vocabulary items, Agy/Gemini 3.1 Pro High review pass. Score held at 9 compact section-balance reserve and dense nominalization scope.
 B2 M62 `word-formation-place-object-names`,9/10,B+,Yes,Strong place/object-name word-formation module 13 workbook activities, 45 vocabulary items, Agy/Gemini 3.1 Pro High blocker follow-up review pass. Score held at 9 after model-answer/task-density fixes and conservative human-polish reserve.
 B2 M63 `word-formation-adjective-adverbs`,9/10,B+,Yes,Strong adjective/adverb word-formation module 13 workbook activities, 47 vocabulary items, Agy/Gemini 3.1 Pro High review pass. Score held at 9 minor non-blocking section-length warnings despite deterministic audit pass.
+B2 M64 `advanced-conjunctions-i`,9/10,B+,Yes,Strong advanced conjunctions module 10 workbook activities, 41 vocabulary items, external review pass. Score held at 9 dense connector semantics conservative human-polish reserve.
+B2 M65 `advanced-conjunctions-ii`,9/10,B+,Yes,Strong advanced conjunctions continuation 10 workbook activities, 49 vocabulary items, Agy/Gemini 3.1 Pro High review pass. Score held at 9 dense concessive/conditional connector coverage.
+B2 M66 `checkpoint-morphology`,9/10,B+,Yes,Strong B2 morphology checkpoint 11 workbook activities, 53 vocabulary items, Agy/Gemini review and false-positive clarification pass. Score held at 9 broad checkpoint density.
+B2 M67 `synonymy-types-and-rows`,9/10,B+,Yes,Strong synonymy rows module 10 workbook activities, 55 vocabulary items, Agy/Gemini 3.1 Pro High review pass. Score held at 9 dense lexical-choice scope conservative polish reserve.
+B2 M68 `synonymy-in-registers`,9/10,B+,Yes,Strong register-sensitive synonymy module 10 workbook activities, 61 vocabulary items, Agy/Gemini blocker fix and PASS re-review. Score held at 9 dense register/collocation coverage.
 
 Score,Count,Modules
 10/10,2,"M01, M08"
-9/10,60,"M02-M07, M09-M13, M15-M63"
+9/10,65,"M02-M07, M09-M13, M15-M68"
 8/10,1,M14
 
 Durable Report,Scope
@@ -82,6 +87,7 @@ Durable Report,Scope
 `docs/audits/b2-m51-m53-llm-score-report-2026-06-28.md`,M51-M53
 `docs/audits/b2-m54-m58-llm-score-report-2026-06-28.md`,M54-M58
 `docs/audits/b2-m59-m63-llm-score-report-2026-06-28.md`,M59-M63
+`docs/audits/b2-m64-m68-llm-score-report-2026-06-28.md`,M64-M68
 
 Module,Raw Word Count,Activities,Vocabulary
 M03 `b2-impersonal-passive`,4608,7 workbook / 4 inline,35
@@ -145,6 +151,11 @@ M60 `word-formation-person-suffixes`,4362,13 workbook / 0 inline,49
 M61 `word-formation-abstract-nouns`,4071,13 workbook / 0 inline,44
 M62 `word-formation-place-object-names`,4264,13 workbook / 0 inline,45
 M63 `word-formation-adjective-adverbs`,4012,13 workbook / 0 inline,47
+M64 `advanced-conjunctions-i`,4709,10 workbook / 0 inline,41
+M65 `advanced-conjunctions-ii`,4605,10 workbook / 0 inline,49
+M66 `checkpoint-morphology`,4272,11 workbook / 0 inline,53
+M67 `synonymy-types-and-rows`,4158,10 workbook / 0 inline,55
+M68 `synonymy-in-registers`,4591,10 workbook / 0 inline,61
 
 Score,Pass Count
 10/10,5/5 with no meaningful content polish
@@ -167,3 +178,4 @@ See `docs/audits/b2-m47-m50-llm-score-report-2026-06-28.md`.,M47-M50
 See `docs/audits/b2-m51-m53-llm-score-report-2026-06-28.md`.,M51-M53
 See `docs/audits/b2-m54-m58-llm-score-report-2026-06-28.md`.,M54-M58
 See `docs/audits/b2-m59-m63-llm-score-report-2026-06-28.md`.,M59-M63
+See `docs/audits/b2-m64-m68-llm-score-report-2026-06-28.md`.,M64-M68

--- a/docs/audits/b2-m64-m68-llm-score-report-2026-06-28.md
+++ b/docs/audits/b2-m64-m68-llm-score-report-2026-06-28.md
@@ -1,0 +1,20 @@
+Module,Score,Verdict,Deterministic Audit,Activity/Vocab Coverage,Ready Human Review?
+M64 `advanced-conjunctions-i`,9/10,B+,PASS,10 workbook / 0 inline; 41 vocab,Yes
+M65 `advanced-conjunctions-ii`,9/10,B+,PASS,10 workbook / 0 inline; 49 vocab,Yes
+M66 `checkpoint-morphology`,9/10,B+,PASS,11 workbook / 0 inline; 53 vocab,Yes
+M67 `synonymy-types-and-rows`,9/10,B+,PASS,10 workbook / 0 inline; 55 vocab,Yes
+M68 `synonymy-in-registers`,9/10,B+,PASS,10 workbook / 0 inline; 61 vocab,Yes
+
+Module,Notes
+M64 `advanced-conjunctions-i`,Strong advanced conjunctions module 10 workbook activities 41 vocabulary items, merged PR #3977 after validation and independent review. Score held at 9 for dense connector semantics and conservative human-polish reserve.
+M65 `advanced-conjunctions-ii`,Strong advanced conjunctions continuation 10 workbook activities 49 vocabulary items, merged PR #3979 after Agy/Gemini 3.1 Pro High PASS review. Score held at 9 for dense concessive/conditional connector coverage.
+M66 `checkpoint-morphology`,Strong B2 morphology checkpoint 11 workbook activities 53 vocabulary items, merged PR #3980 after Agy/Gemini 3.1 Pro High review and false-positive clarification. Score held at 9 for broad checkpoint density.
+M67 `synonymy-types-and-rows`,Strong synonymy rows module 10 workbook activities 55 vocabulary items, merged PR #3983 after Agy/Gemini 3.1 Pro High PASS review. Score held at 9 for dense lexical-choice scope and conservative post-build polish reserve.
+M68 `synonymy-in-registers`,Strong register-sensitive synonymy module 10 workbook activities 61 vocabulary items, merged PR #3984 after Agy/Gemini 3.1 Pro High blocker fix and PASS re-review. Score held at 9 for dense register/collocation coverage.
+
+Module,PR,Head Commit,Merge Commit,Independent Review
+M64 `advanced-conjunctions-i`,#3977,`81f415329e6d5b160fae06efbaa8201d6dfdc477`,`6fce9ecf0f4ae783fc2bbef2d690a3932987bd6a`,PASS
+M65 `advanced-conjunctions-ii`,#3979,`29f56ce02e8ae49af86652541bb7113808681a3c`,`588160a57938114e9a3af7bab03052d96ef6d9c1`,PASS
+M66 `checkpoint-morphology`,#3980,`412e2c15e82b7afd69efa0fa760e7389ad4ab41d`,`6783919980e246b2a06cd7e1cd74c0d73076d41c`,PASS after false-positive clarification
+M67 `synonymy-types-and-rows`,#3983,`5a627c63eabdb19ec1e85e21eee2dc338ed36956`,`27213789450af3cad5bbf6742d0b3ec767878f26`,PASS
+M68 `synonymy-in-registers`,#3984,`521835450ef0e92581592c3e275deeb7e9835b81`,`fbc95472eeecc7aed5ce20e6e742298376448666`,PASS after blocker fixes

--- a/site/src/content/docs/b2/index.mdx
+++ b/site/src/content/docs/b2/index.mdx
@@ -10,9 +10,9 @@ import LevelLanding from '@site/src/components/LevelLanding';
   client:load
   level="B2"
   title="Впевнено"
-  subtitle="Upper-intermediate Ukrainian course — 63 learner pages available · 93 modules"
+  subtitle="Upper-intermediate Ukrainian course — 68 learner pages available · 93 modules"
   progressTitle="B2 Build Status"
-  progressDescription="63 available · 0 reviewed · 30 planned"
+  progressDescription="68 available · 68 reviewed · 25 planned"
   moduleCount={93}
   wordTarget={4000}
   color="var(--lu-id-b2)"
@@ -113,11 +113,11 @@ import LevelLanding from '@site/src/components/LevelLanding';
     {
       unit: "B2.6 [Connectors, Synonymy & Phraseology]",
       items: [
-        { num: 64, slug: "advanced-conjunctions-i", title: "Поглиблене вивчення сполучників: Сурядність", sub: "Складні сполучники I: сурядність", status: "locked" },
-        { num: 65, slug: "advanced-conjunctions-ii", title: "Поглиблене вивчення сполучників: Підрядність", sub: "Складні сполучники II: підрядність", status: "locked" },
-        { num: 66, slug: "checkpoint-morphology", title: "Контрольна точка: Морфологія", sub: "Підсумковий контроль: морфологія", status: "locked" },
-        { num: 67, slug: "synonymy-types-and-rows", title: "Типи синонімів та синонімічні ряди", sub: "Синонімія: типи та ряди", status: "locked" },
-        { num: 68, slug: "synonymy-in-registers", title: "Синонімія у різних реєстрах", sub: "Синонімія в регістрами", status: "locked" },
+        { num: 64, slug: "advanced-conjunctions-i", title: "Поглиблене вивчення сполучників: Сурядність", sub: "Складні сполучники I: сурядність", status: "active" },
+        { num: 65, slug: "advanced-conjunctions-ii", title: "Поглиблене вивчення сполучників: Підрядність", sub: "Складні сполучники II: підрядність", status: "active" },
+        { num: 66, slug: "checkpoint-morphology", title: "Контрольна точка: Морфологія", sub: "Підсумковий контроль: морфологія", status: "active" },
+        { num: 67, slug: "synonymy-types-and-rows", title: "Типи синонімів та синонімічні ряди", sub: "Синонімія: типи та ряди", status: "active" },
+        { num: 68, slug: "synonymy-in-registers", title: "Синонімія у різних реєстрах", sub: "Синонімія в регістрами", status: "active" },
         { num: 69, slug: "synonymy-practice-precision", title: "Практикум із синонімії: Точність слововживання", sub: "Практика синонімії: точність", status: "locked" },
         { num: 70, slug: "proverbs-work-wisdom-character", title: "Прислів'я та приказки: Праця, мудрість, характер", sub: "Прислів'я: праця, мудрість, характер", status: "locked" },
         { num: 71, slug: "proverbs-nature-time-caution", title: "Прислів'я та приказки: Природа, час, обережність", sub: "Прислів'я: природа, час, обережність", status: "locked" },


### PR DESCRIPTION
## Summary

- add a durable B2 M64-M68 LLM score report under `docs/audits/`
- update the current B2 score ledger through M68
- expose M64-M68 as active on the B2 landing page while keeping M69 locked

## Validation

- `npm --prefix site run build` (5605 pages built)
- HTTP preview route checks: `/b2/`, `/b2/advanced-conjunctions-i/`, `/b2/advanced-conjunctions-ii/`, `/b2/checkpoint-morphology/`, `/b2/synonymy-types-and-rows/`, `/b2/synonymy-in-registers/` all returned 200
- `/b2/` live payload: 68 available, M64-M68 active, M69 locked
- API: `/api/state/module-range/b2?start=64&end=68` returned `total=5`, `complete=5`, `content_complete=5`, `score_persisted=5`, `remaining=[]`
- `git diff --check origin/main...HEAD`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`