### PR TITLE
docs(b2): update M58 M59 repair scores

### DIFF
--- a/docs/audits/b2-current-llm-scores-2026-06-28.md
+++ b/docs/audits/b2-current-llm-scores-2026-06-28.md
@@ -56,8 +56,8 @@ B2 M54 `aspect-nuances-secondary-imperfectivization`,9/10,B+,Yes,Strong aspect n
 B2 M55 `aspect-nuances-imperative-infinitive`,9/10,B+,Yes,Strong imperative/infinitive aspect module 10 workbook activities, 40 vocabulary items, external review pass. Score held at 9 conservative post-build polish risk and minor deterministic advisories.
 B2 M56 `pluperfect-tense`,9/10,B+,Yes,Strong pluperfect module 11 workbook activities, 40 vocabulary items, external review pass. Score held at 9 dense tense/register coverage and non-blocking deterministic style/UA-GEC advisories.
 B2 M57 `conditional-mood-particles`,9/10,B+,Yes,Strong conditional mood particles module 11 workbook activities, 40 vocabulary items, external review pass. Score held at 9 dense mood/particle coverage and minor deterministic advisories.
-B2 M58 `numeral-declension-time-dates`,9/10,B+,Yes,Strong numeral declension time/dates module 11 workbook activities, 40 vocabulary items, Agy/Gemini 3.1 Pro High re-review pass. Score held at 9 conservative post-fix human-polish reserve.
-B2 M59 `numeral-declension-compound-numbers`,9/10,B+,Yes,Strong compound-number declension module 10 workbook activities, 32 vocabulary items, external review pass. Score held at 9 dense numeral paradigm coverage conservative post-build polish reserve.
+B2 M58 `numeral-declension-time-dates`,9/10,B+,Yes,Repaired in PR #3988 with table-first numeral scaffolding, 5 inline and 6 workbook activities, 40 vocabulary items, rendered Markdown smoke pass, and Hermes/DeepSeek v4 Pro PASS review. Score remains 9 for dense time/date numeral scope and human-polish reserve.
+B2 M59 `numeral-declension-compound-numbers`,9/10,B+,Yes,Repaired in PR #3988 with table-first compound-number scaffolding, 5 inline and 5 workbook activities, 32 vocabulary items, corrected normative instrumental hundreds treatment, rendered Markdown smoke pass, and Hermes/DeepSeek v4 Pro PASS review. Score remains 9 for dense numeral paradigm scope and human-polish reserve.
 B2 M60 `word-formation-person-suffixes`,9/10,B+,Yes,Strong person-suffix word-formation module 13 workbook activities, 49 vocabulary items, external review pass. Score held at 9 dense suffix/feminitive/register coverage non-blocking deterministic advisories.
 B2 M61 `word-formation-abstract-nouns`,9/10,B+,Yes,Strong abstract-noun word-formation module 13 workbook activities, 44 vocabulary items, Agy/Gemini 3.1 Pro High review pass. Score held at 9 compact section-balance reserve and dense nominalization scope.
 B2 M62 `word-formation-place-object-names`,9/10,B+,Yes,Strong place/object-name word-formation module 13 workbook activities, 45 vocabulary items, Agy/Gemini 3.1 Pro High blocker follow-up review pass. Score held at 9 after model-answer/task-density fixes and conservative human-polish reserve.
@@ -88,6 +88,7 @@ Durable Report,Scope
 `docs/audits/b2-m54-m58-llm-score-report-2026-06-28.md`,M54-M58
 `docs/audits/b2-m59-m63-llm-score-report-2026-06-28.md`,M59-M63
 `docs/audits/b2-m64-m68-llm-score-report-2026-06-28.md`,M64-M68
+`docs/audits/b2-m58-m59-repair-llm-score-update-2026-06-29.md`,M58-M59 repair
 
 Module,Raw Word Count,Activities,Vocabulary
 M03 `b2-impersonal-passive`,4608,7 workbook / 4 inline,35
@@ -145,8 +146,8 @@ M54 `aspect-nuances-secondary-imperfectivization`,4973,10 workbook / 0 inline,40
 M55 `aspect-nuances-imperative-infinitive`,4317,10 workbook / 0 inline,40
 M56 `pluperfect-tense`,4636,11 workbook / 0 inline,40
 M57 `conditional-mood-particles`,4306,11 workbook / 0 inline,40
-M58 `numeral-declension-time-dates`,4246,11 workbook / 0 inline,40
-M59 `numeral-declension-compound-numbers`,4336,10 workbook / 0 inline,32
+M58 `numeral-declension-time-dates`,4718,6 workbook / 5 inline,40
+M59 `numeral-declension-compound-numbers`,4547,5 workbook / 5 inline,32
 M60 `word-formation-person-suffixes`,4362,13 workbook / 0 inline,49
 M61 `word-formation-abstract-nouns`,4071,13 workbook / 0 inline,44
 M62 `word-formation-place-object-names`,4264,13 workbook / 0 inline,45

--- a/docs/audits/b2-m54-m58-llm-score-report-2026-06-28.md
+++ b/docs/audits/b2-m54-m58-llm-score-report-2026-06-28.md
@@ -3,14 +3,14 @@ M54 `aspect-nuances-secondary-imperfectivization`,9/10,B+,PASS,10 workbook / 0 i
 M55 `aspect-nuances-imperative-infinitive`,9/10,B+,PASS,10 workbook / 0 inline; 40 vocab,Yes
 M56 `pluperfect-tense`,9/10,B+,PASS,11 workbook / 0 inline; 40 vocab,Yes
 M57 `conditional-mood-particles`,9/10,B+,PASS,11 workbook / 0 inline; 40 vocab,Yes
-M58 `numeral-declension-time-dates`,9/10,B+,PASS,11 workbook / 0 inline; 40 vocab,Yes
+M58 `numeral-declension-time-dates`,9/10,B+,PASS,6 workbook / 5 inline; 40 vocab,Yes
 
 Module,Notes
 M54 `aspect-nuances-secondary-imperfectivization`,Strong aspect nuance module 10 workbook activities and 40 vocabulary items, merged PR #3947 after external review pass. Score held at 9 for dense aspect semantics and non-blocking audit polish notes around redundancy/formulaic style.
 M55 `aspect-nuances-imperative-infinitive`,Strong imperative/infinitive aspect module 10 workbook activities and 40 vocabulary items, merged PR #3948 after external review pass. Score held at 9 for conservative post-build polish risk and minor deterministic advisory notes.
 M56 `pluperfect-tense`,Strong pluperfect module 11 workbook activities and 40 vocabulary items, merged PR #3950 after external review pass. Score held at 9 for dense tense/register coverage and non-blocking deterministic style/UA-GEC advisories.
 M57 `conditional-mood-particles`,Strong conditional mood particles module 11 workbook activities and 40 vocabulary items, merged PR #3951 after external review pass. Score held at 9 for dense mood/particle coverage and minor non-blocking deterministic advisory notes.
-M58 `numeral-declension-time-dates`,Strong numeral declension for time and dates module 11 workbook activities and 40 vocabulary items, merged PR #3953 after Agy/Gemini 3.1 Pro High re-review passed with 0 unresolved blockers. Score held at 9 for conservative post-fix human-polish reserve rather than content blockers.
+M58 `numeral-declension-time-dates`,Originally merged in PR #3953, then repaired in PR #3988 after learner-quality findings. Current version has table-first numeral/date scaffolding, 5 inline activities, 6 workbook activities, 40 vocabulary items, rendered Markdown smoke pass, and Hermes/DeepSeek v4 Pro PASS review. Score remains 9 for dense time/date numeral scope and human-polish reserve rather than content blockers.
 
 Score Rationale,Disposition
 Deterministic audit,All five modules passed deterministic module audit local validation.

--- a/docs/audits/b2-m58-m59-repair-llm-score-update-2026-06-29.md
+++ b/docs/audits/b2-m58-m59-repair-llm-score-update-2026-06-29.md
@@ -1,0 +1,14 @@
+Module,Score,Verdict,Deterministic Audit,Activity/Vocab Coverage,Ready Human Review?
+M58 `numeral-declension-time-dates`,9/10,B+,PASS,6 workbook / 5 inline; 40 vocab,Yes
+M59 `numeral-declension-compound-numbers`,9/10,B+,PASS,5 workbook / 5 inline; 32 vocab,Yes
+
+Module,Repair Score Notes
+M58 `numeral-declension-time-dates`,Re-scored after PR #3988 learner-quality repair. The module now teaches time/date numeral forms with table-first scaffolding, decision rules, inline checks, and workbook consolidation instead of workbook-only practice. Hermes/DeepSeek v4 Pro independent review returned PASS / mergeable with only minor findings, all fixed before merge. Score remains 9/10 because the content is review-ready but dense numeral/date coverage still deserves human polish before release.
+M59 `numeral-declension-compound-numbers`,Re-scored after PR #3988 learner-quality repair. The module now teaches compound, collective, and fractional numeral forms with table-first scaffolding, inline checks, and workbook consolidation. Normative instrumental forms for `вісімсот` are handled as `вісьмастами / вісьмомастами`, while `восьмистами` appears only as an error form. Hermes/DeepSeek v4 Pro independent review returned PASS / mergeable with only minor findings, all fixed before merge. Score remains 9/10 because the content is review-ready but dense numeral paradigms still deserve human polish before release.
+
+Evidence,Result
+Content repair PR,#3988 merged as `7db34d0526ae51958e0feceb0e59adfafbbc5f28`
+External review,Hermes / DeepSeek v4 Pro PASS / mergeable; two minor findings fixed before merge
+Local validation,M58/M59 MDX generation, activity validation, vocab validation, module audits, source markdownlint, git diff check, site build, and rendered-output smoke passed
+Rendered-output smoke,No raw `**` and no `INJECT_ACTIVITY` on repaired B2 module routes
+Scoring disposition,Keep both modules at 9/10 B+ and ready for human review; do not promote to A/A+ until human polish confirms learner experience

--- a/docs/audits/b2-m59-m63-llm-score-report-2026-06-28.md
+++ b/docs/audits/b2-m59-m63-llm-score-report-2026-06-28.md
@@ -1,12 +1,12 @@
 Module,Score,Verdict,Deterministic Audit,Activity/Vocab Coverage,Ready Human Review?
-M59 `numeral-declension-compound-numbers`,9/10,B+,PASS,10 workbook / 0 inline; 32 vocab,Yes
+M59 `numeral-declension-compound-numbers`,9/10,B+,PASS,5 workbook / 5 inline; 32 vocab,Yes
 M60 `word-formation-person-suffixes`,9/10,B+,PASS,13 workbook / 0 inline; 49 vocab,Yes
 M61 `word-formation-abstract-nouns`,9/10,B+,PASS,13 workbook / 0 inline; 44 vocab,Yes
 M62 `word-formation-place-object-names`,9/10,B+,PASS,13 workbook / 0 inline; 45 vocab,Yes
 M63 `word-formation-adjective-adverbs`,9/10,B+,PASS,13 workbook / 0 inline; 47 vocab,Yes
 
 Module,Notes
-M59 `numeral-declension-compound-numbers`,Strong compound-number declension module 10 workbook activities 32 vocabulary items, merged PR #3967 after external review pass. Score held at 9 due dense numeral paradigm coverage and conservative post-build polish reserve.
+M59 `numeral-declension-compound-numbers`,Originally merged in PR #3967, then repaired in PR #3988 after learner-quality findings. Current version has table-first compound-number scaffolding, 5 inline activities, 5 workbook activities, 32 vocabulary items, corrected normative instrumental hundreds treatment, rendered Markdown smoke pass, and Hermes/DeepSeek v4 Pro PASS review. Score remains 9 for dense numeral paradigm scope and human-polish reserve.
 M60 `word-formation-person-suffixes`,Strong person-suffix word-formation module 13 workbook activities 49 vocabulary items, merged PR #3970 after external review pass. Score held at 9 due dense suffix/feminitive/register coverage and non-blocking deterministic advisories.
 M61 `word-formation-abstract-nouns`,Strong abstract-noun word-formation module 13 workbook activities 44 vocabulary items, merged PR #3971 after Agy/Gemini 3.1 Pro High PASS review. Score held at 9 due compact section-balance reserve and dense nominalization scope.
 M62 `word-formation-place-object-names`,Strong place/object-name word-formation module 13 workbook activities 45 vocabulary items, merged PR #3972 after Agy/Gemini 3.1 Pro High blocker follow-up PASS review. Score held at 9 after model-answer/task-density fixes and conservative human-polish reserve.


### PR DESCRIPTION
## Summary
- Update B2 current score ledger for M58/M59 after the learner-quality repair merged in PR #3988.
- Add a durable M58/M59 repair score update report dated 2026-06-29.
- Correct stale activity coverage from workbook-only to current inline/workbook splits.

## Score disposition
- M58 remains 9/10 B+, ready for human review: 5 inline / 6 workbook activities, 40 vocab.
- M59 remains 9/10 B+, ready for human review: 5 inline / 5 workbook activities, 32 vocab.
- No A/A+ promotion yet; dense numeral modules still deserve human polish before release.

## Validation
- git diff --check
- npx markdownlint-cli2 on all changed docs
- forbidden generated artifact/config guard
- lint_agent_trailer.py via project venv