### PR TITLE
docs(b2): archive superseded preview

### DIFF
--- a/docs/audits/b2-current-llm-scores-2026-06-28.md
+++ b/docs/audits/b2-current-llm-scores-2026-06-28.md
@@ -88,6 +88,7 @@ Durable Report,Scope
 `docs/audits/b2-m54-m58-llm-score-report-2026-06-28.md`,M54-M58
 `docs/audits/b2-m59-m63-llm-score-report-2026-06-28.md`,M59-M63
 `docs/audits/b2-m64-m68-llm-score-report-2026-06-28.md`,M64-M68
+`docs/audits/b2-preview-archive-status-2026-06-29.md`,M01-M68 superseded preview archive
 `docs/audits/b2-m58-m59-repair-llm-score-update-2026-06-29.md`,M58-M59 repair
 
 Module,Raw Word Count,Activities,Vocabulary
@@ -180,3 +181,6 @@ See `docs/audits/b2-m51-m53-llm-score-report-2026-06-28.md`.,M51-M53
 See `docs/audits/b2-m54-m58-llm-score-report-2026-06-28.md`.,M54-M58
 See `docs/audits/b2-m59-m63-llm-score-report-2026-06-28.md`.,M59-M63
 See `docs/audits/b2-m64-m68-llm-score-report-2026-06-28.md`.,M64-M68
+
+Archive Status,Scope,Disposition
+Superseded preview,M01-M68,"Current scores are retained for content-validity provenance only. They do not certify B2 learner-facing lesson quality. See `docs/decisions/2026-06-29-b2-preview-archive-and-rebuild.md` and `docs/audits/b2-preview-archive-status-2026-06-29.md`."

--- a/docs/audits/b2-preview-archive-status-2026-06-29.md
+++ b/docs/audits/b2-preview-archive-status-2026-06-29.md
@@ -1,0 +1,30 @@
+# B2 Preview Archive Status — 2026-06-29
+
+Status,Scope,Disposition
+Superseded preview,B2 M01-M68,"Preserved for provenance and source mining; not a release-candidate learner-facing B2."
+Production freeze,M69+,"Do not build additional B2 modules until prompt/gate hardening, source readiness audit, and a golden pilot rebuild complete."
+Score interpretation,M01-M68,"Existing LLM scores are content-validity provenance only; they are not teaching-quality approval."
+
+Metric,Count,Interpretation
+B1 modules with inline activity YAML,94/94,B1 establishes the current successful lesson-practice baseline.
+B1 modules with `INJECT_ACTIVITY` markers,92/94,B1 usually interrupts teaching with in-lesson practice.
+B2 modules with inline activity YAML,7/68,B2 preview lacks in-lesson practice in most modules.
+B2 modules with `INJECT_ACTIVITY` markers,8/68,B2 preview mostly generated reference-style lessons.
+B2 modules with no `INJECT_ACTIVITY` markers,60/68,Most B2 modules cannot render in-lesson practice from source markers.
+B2 marker/inline mismatches,2,"M64 and M65 have injection markers but `inline: []` activity YAML."
+
+Affected recent modules,Observed status
+M64 `advanced-conjunctions-i`,4 injection markers; 0 inline activities; 10 workbook activities.
+M65 `advanced-conjunctions-ii`,4 injection markers; 0 inline activities; 10 workbook activities.
+M66 `checkpoint-morphology`,0 injection markers; 0 inline activities; 11 workbook activities.
+M67 `synonymy-types-and-rows`,0 injection markers; 0 inline activities; 10 workbook activities.
+M68 `synonymy-in-registers`,0 injection markers; 0 inline activities; 10 workbook activities.
+
+Decision,Reference
+B2 preview archived and rebuild accepted,`docs/decisions/2026-06-29-b2-preview-archive-and-rebuild.md`
+
+Next stage,Required before module production resumes
+PR 2,Prompt and deterministic gate hardening.
+PR 3,B2 source/plan/wiki/research readiness audit.
+PR 4,Golden pilot rebuild with teaching-quality comparison against B1.
+Wave rebuilds,Only after the pilot proves the new teaching contract.

--- a/docs/decisions/2026-06-29-b2-preview-archive-and-rebuild.md
+++ b/docs/decisions/2026-06-29-b2-preview-archive-and-rebuild.md
@@ -1,0 +1,60 @@
+# ACCEPTED — B2 preview archive and rebuild
+
+**Status:** ACCEPTED
+**Decided on:** 2026-06-29
+**Scope:** B2 production, B2 learner-facing modules, B2 score interpretation, future B2 rebuild orchestration.
+
+## Decision
+
+Current B2 M01-M68 is archived as a superseded preview generation. The existing module files remain in the repository for provenance, source mining, route stability, and comparison, but they are no longer treated as release-candidate lesson quality.
+
+New B2 production is frozen until the rebuild program completes the following stages:
+
+1. B2 rebuild decision record and current-status archival.
+2. Prompt and deterministic gate hardening.
+3. Source, plan, wiki, and research readiness audit for the rebuild.
+4. One golden pilot rebuild reviewed against B1 teaching quality.
+5. Wave rebuilds only after the pilot proves the new contract.
+
+Current B2 LLM scores are retained as content-validity provenance only. They must not be cited as evidence that the learner-facing B2 lessons are ready for release or human review as lessons. Rebuilt modules require fresh teaching-quality scoring.
+
+## Rationale
+
+The failure is architectural, not a small copy-editing backlog. B1 and B2 differ sharply in lesson practice structure:
+
+- B1: 94/94 modules have inline activity YAML; 92/94 have `INJECT_ACTIVITY` markers.
+- B2: 7/68 modules have inline activity YAML; 8/68 have `INJECT_ACTIVITY` markers; 60/68 have no lesson activity injection markers.
+- M64 and M65 contain lesson injection markers while their activity YAML has `inline: []`, proving at least one prompt/pipeline contract mismatch.
+- Recent B2 vocabulary and grammar modules often read as correct reference articles rather than taught lessons.
+
+Continuing M69+ production under the old prompt would multiply the same failure. Hand-patching the existing modules would also be expensive and likely misleading because the original artifact type is wrong.
+
+## Archive Meaning
+
+Archive does not mean delete. Archive means:
+
+- Preserve current files and score reports for provenance.
+- Stop using current B2 as the release candidate.
+- Stop using current B2 scores as teaching-quality approval.
+- Reuse useful vocabulary, examples, grammar facts, source references, and review findings only after the rebuild pipeline is fixed.
+- Rebuild learner-facing lesson structure from source under the new teaching contract.
+
+## Required Next Work
+
+PR 2 must harden prompts and gates before any new B2 module build. At minimum it must fail or block B2 builds with:
+
+- `inline: []` unless an explicit rebuild contract exemption exists.
+- `INJECT_ACTIVITY` markers that reference activities outside `inline`.
+- No in-lesson activity markers in normal B2 modules.
+- Long exposition before practice.
+- Grammar or lexical contrast taught only through prose when a table, contrast grid, or decision rule is required.
+- Malformed callouts such as raw `[!note]` outside the accepted syntax.
+
+PR 3 must audit B2 source readiness before rebuild. It should focus on B2 plans, source/wiki/research sufficiency, sequence coherence, and whether plan scaffolding encourages reference-style writing. It should not become a whole-repository curriculum audit unless evidence requires expanding scope.
+
+PR 4 must rebuild one golden pilot module and compare it with B1 teaching rhythm before approving wave rebuilds.
+
+## Supersedes
+
+- B2 production-build prompt version 0.5 as an active production prompt.
+- Current B2 M01-M68 score interpretation as release-candidate teaching quality.

--- a/docs/prompts/orchestrators/b2/production-build-orchestrator.md
+++ b/docs/prompts/orchestrators/b2/production-build-orchestrator.md
@@ -1,5 +1,11 @@
 # B2 Production Build Orchestrator
 
+> **SUSPENDED 2026-06-29:** Do not use this prompt for new B2 production.
+> Current B2 M01-M68 is archived as a superseded preview generation by
+> `docs/decisions/2026-06-29-b2-preview-archive-and-rebuild.md`.
+> Resume B2 production only after the rebuild prompt/gate hardening, source
+> readiness audit, and golden pilot rebuild stages are complete.
+
 Prompt version: 0.5
 Last reviewed: 2026-06-22
 


### PR DESCRIPTION
## Summary
- Accept the B2 preview archive/rebuild decision for M01-M68.
- Add a B2 preview archive status report with reproducible B1/B2 inline-practice counts.
- Mark the current B2 score ledger as superseded-preview provenance and suspend the old B2 production prompt.

## Scope
No curriculum module files, generated MDX, routes, telemetry, linter config, or runtime artifacts changed.

## Validation
- git diff --check
- npx markdownlint-cli2 on changed docs
- forbidden generated artifact/config guard
- scripts/audit/lint_agent_trailer.py

## Follow-up stages
- PR 2: prompt/gate hardening
- PR 3: B2 source/plan/wiki/research readiness audit
- PR 4: golden pilot rebuild
- Then wave rebuilds only after pilot acceptance