### PR TITLE
data(atlas): add POS-balanced source inventory sample

### DIFF
--- a/data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml
+++ b/data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml
@@ -1,0 +1,173 @@
+---
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: l2-direct-b1-imennyky-vidminy-vocabulary
+    source_family: curriculum
+    extraction_mode: grammar_vocabulary_item
+    title: "L2 Ukrainian Direct B1 — Іменники: чотири відміни"
+    path: curriculum/l2-uk-direct/b1/imennyky-vidminy.yaml
+    locator: vocabulary
+    notes: Representative noun rows from the noun-declension grammar module.
+    headwords:
+      - lemma: школа
+        pos: noun
+        locator: vocabulary[0].items[0].word
+        context: 'word: "школа"; sentence: "Школа стоїть на горі."'
+      - lemma: море
+        pos: noun
+        locator: vocabulary[1].items[4].word
+        context: 'word: "море"; sentence: "Море блищить на сонці."'
+
+  - id: l2-direct-a1-yakyi-vocabulary
+    source_family: curriculum
+    extraction_mode: grammar_vocabulary_item
+    title: "L2 Ukrainian Direct A1 — Який? Яка? Яке?"
+    path: curriculum/l2-uk-direct/a1/yakyi.yaml
+    locator: vocabulary
+    notes: Representative adjective rows from adjective-noun pair examples.
+    headwords:
+      - lemma: великий
+        pos: adjective
+        locator: vocabulary[0].items[0].word
+        context: 'word: "великий стіл"; sentence: "Це великий стіл."'
+      - lemma: гарний
+        pos: adjective
+        locator: vocabulary[0].items[2].word
+        context: 'word: "гарний птах"; sentence: "Це гарний птах."'
+
+  - id: l2-direct-a1-chysla-vocabulary
+    source_family: curriculum
+    extraction_mode: grammar_vocabulary_item
+    title: "L2 Ukrainian Direct A1 — Числа"
+    path: curriculum/l2-uk-direct/a1/chysla.yaml
+    locator: vocabulary
+    notes: Representative numeral rows from the numbers vocabulary module.
+    headwords:
+      - lemma: один
+        pos: numeral
+        locator: vocabulary[0].items[0].word
+        context: 'word: "один / одна / одне"; sentence: "Один стіл. Одна книга. Одне вікно."'
+      - lemma: два
+        pos: numeral
+        locator: vocabulary[0].items[1].word
+        context: 'word: "два / дві"; sentence: "Два коти. Дві книги."'
+
+  - id: l2-direct-b1-zaimennyk-morfolohiia-vocabulary
+    source_family: curriculum
+    extraction_mode: grammar_vocabulary_item
+    title: "L2 Ukrainian Direct B1 — Займенники: повна морфологія"
+    path: curriculum/l2-uk-direct/b1/zaimennyk-morfolohiia.yaml
+    locator: vocabulary
+    notes: Representative pronoun rows from pronoun-type vocabulary sections.
+    headwords:
+      - lemma: ніхто
+        pos: pronoun
+        locator: vocabulary[1].items[0].word
+        context: 'word: "ніхто"; sentence: "Ніхто не прийшов на зустріч."'
+      - lemma: себе
+        pos: pronoun
+        locator: vocabulary[2].items[0].word
+        context: 'word: "себе"; sentence: "Подивися на себе в дзеркало."'
+
+  - id: l2-direct-b2-diieslovo-povtorennia-vocabulary
+    source_family: curriculum
+    extraction_mode: grammar_vocabulary_item
+    title: "L2 Ukrainian Direct B2 — Дієслово: повторення"
+    path: curriculum/l2-uk-direct/b2/diieslovo-povtorennia.yaml
+    locator: vocabulary
+    notes: Representative infinitive verb rows from the verb-review module.
+    headwords:
+      - lemma: робити
+        pos: verb
+        locator: vocabulary[1].items[2].word
+        context: 'word: "робити"; sentence: "Що ти робиш?"'
+      - lemma: читати
+        pos: verb
+        locator: vocabulary[1].items[4].word
+        context: 'word: "читати"; sentence: "Він читає газету щоранку."'
+
+  - id: l2-direct-b1-pryslivnyky-vocabulary
+    source_family: curriculum
+    extraction_mode: grammar_vocabulary_item
+    title: "L2 Ukrainian Direct B1 — Прислівники: повний огляд"
+    path: curriculum/l2-uk-direct/b1/pryslivnyky.yaml
+    locator: vocabulary
+    notes: Representative adverb rows from adverb-type vocabulary sections.
+    headwords:
+      - lemma: швидко
+        pos: adverb
+        locator: vocabulary[2].items[0].word
+        context: 'word: "швидко"; sentence: "Він біжить дуже швидко."'
+      - lemma: добре
+        pos: adverb
+        locator: vocabulary[2].items[2].word
+        context: 'word: "добре"; sentence: "Вона добре грає на фортепіано."'
+
+  - id: l2-direct-b2-pryimennyky-pohlybleno-vocabulary
+    source_family: curriculum
+    extraction_mode: grammar_vocabulary_item
+    title: "L2 Ukrainian Direct B2 — Прийменники: поглиблення"
+    path: curriculum/l2-uk-direct/b2/pryimennyky-pohlybleno.yaml
+    locator: vocabulary
+    notes: Representative preposition rows from the preposition grammar module.
+    headwords:
+      - lemma: щодо
+        pos: preposition
+        locator: vocabulary[0].items[3].word
+        context: 'word: "щодо"; sentence: "Щодо вашого запитання — відповімо завтра."'
+      - lemma: через
+        pos: preposition
+        locator: vocabulary[1].items[0].word
+        context: 'word: "через"; sentence: "Він запізнився через затори."'
+
+  - id: l2-direct-a1-spoluchnyky-vocabulary
+    source_family: curriculum
+    extraction_mode: grammar_vocabulary_item
+    title: "L2 Ukrainian Direct A1 — Сполучники"
+    path: curriculum/l2-uk-direct/a1/spoluchnyky.yaml
+    locator: vocabulary
+    notes: Representative conjunction rows from the conjunction grammar module.
+    headwords:
+      - lemma: і
+        pos: conjunction
+        locator: vocabulary[0].items[0].word
+        context: 'word: "і"; sentence: "Мама і тато вдома."'
+      - lemma: але
+        pos: conjunction
+        locator: vocabulary[1].items[1].word
+        context: 'word: "але"; sentence: "Вона хоче спати, але не може."'
+
+  - id: l2-direct-b2-chastky-vocabulary
+    source_family: curriculum
+    extraction_mode: grammar_vocabulary_item
+    title: "L2 Ukrainian Direct B2 — Частки"
+    path: curriculum/l2-uk-direct/b2/chastky.yaml
+    locator: vocabulary
+    notes: Representative particle rows from the particle grammar module.
+    headwords:
+      - lemma: не
+        pos: particle
+        locator: vocabulary[1].items[0].word
+        context: 'word: "не"; sentence: "Він не знає відповіді."'
+      - lemma: хіба
+        pos: particle
+        locator: vocabulary[2].items[0].word
+        context: 'word: "хіба"; sentence: "Хіба ти цього не знав?"'
+
+  - id: l2-direct-b2-vyhuky-ta-zvukonasl-vocabulary
+    source_family: curriculum
+    extraction_mode: grammar_vocabulary_item
+    title: "L2 Ukrainian Direct B2 — Вигуки та звуконаслідування"
+    path: curriculum/l2-uk-direct/b2/vyhuki-ta-zvukonasl.yaml
+    locator: vocabulary
+    notes: Representative interjection rows from the interjection grammar module.
+    headwords:
+      - lemma: ой
+        pos: interjection
+        locator: vocabulary[0].items[0].word
+        context: 'word: "ой"; sentence: "Ой, як гарно тут!"'
+      - lemma: ура
+        pos: interjection
+        locator: vocabulary[0].items[1].word
+        context: 'word: "ура"; sentence: "Ура! Ми перемогли!"'

--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -12,19 +12,23 @@ By default the command writes
 material only. Do not commit it and do not copy it into the live Atlas data
 files.
 
-The committed source inventory inputs are:
+The committed source inventory input is:
 
-- `data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml`
-- `data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml`
+- `data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml`
+
+The older `ohoiko-abetka-keywords.yaml` and
+`bolshakova-bukvar-keywords.yaml` files remain tracked as noun smoke
+inventories, but they are not the representative review-candidate input.
 
 The candidate JSON follows the existing grow-candidate shape: `counts`,
 `auto_merge`, and `needs_review`. The wrapper also adds `review_only` metadata
 with the workflow id, inventory paths, review output path, and
 `production_outputs_updated: []`.
 
-Every generated candidate must retain non-empty `source_provenance`. The seed
-smoke run currently processes all six source inventory headwords: `кіт`,
-`риба`, `ракета`, `яблуко`, `єнот`, and `цирк`.
+Every generated candidate must retain non-empty `source_provenance`. The
+representative smoke run currently processes 20 source inventory headwords:
+two rows each for noun, adjective, numeral, pronoun, verb, adverb,
+preposition, conjunction, particle, and interjection.
 
 This workflow does not update the live Atlas manifest, search index, browse
 files, Words Day pool, daily practice sources, cloze outputs, manifest pointer,

--- a/scripts/audit/generate_source_inventory_review_candidates.py
+++ b/scripts/audit/generate_source_inventory_review_candidates.py
@@ -15,8 +15,7 @@ from scripts.audit.source_inventory_intake import SourceInventoryError
 from scripts.lexicon.content_lexicon_reconciler import PROJECT_ROOT
 
 COMMITTED_SOURCE_INVENTORIES: tuple[Path, ...] = (
-    PROJECT_ROOT / "data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml",
-    PROJECT_ROOT / "data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml",
+    PROJECT_ROOT / "data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml",
 )
 
 DEFAULT_OUT = Path("/tmp/atlas-source-inventory-review-candidates.json")

--- a/tests/test_source_inventory_intake.py
+++ b/tests/test_source_inventory_intake.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import re
+from collections import Counter
 from pathlib import Path
 
 import pytest
+import yaml
 
 from scripts.audit.source_inventory_intake import (
     SourceInventoryError,
@@ -11,6 +14,22 @@ from scripts.audit.source_inventory_intake import (
 )
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
+POS_BALANCED_SAMPLE = (
+    PROJECT_ROOT / "data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml"
+)
+VOCABULARY_WORD_LOCATOR_RE = re.compile(r"^vocabulary\[(\d+)\]\.items\[(\d+)\]\.word$")
+REQUIRED_POS_BUCKETS = {
+    "noun",
+    "adjective",
+    "numeral",
+    "pronoun",
+    "verb",
+    "adverb",
+    "preposition",
+    "conjunction",
+    "particle",
+    "interjection",
+}
 
 
 def test_structured_inventory_preserves_source_provenance(tmp_path) -> None:
@@ -170,3 +189,48 @@ def test_committed_source_inventory_files_are_valid() -> None:
             )
             assert provenance.get("source_id")
             assert provenance.get("source_title")
+
+
+def test_pos_balanced_sample_has_required_pos_buckets_and_source_fields() -> None:
+    records = read_source_inventory(POS_BALANCED_SAMPLE, project_root=PROJECT_ROOT)
+
+    assert records
+    counts = Counter(record.pos for record in records)
+    assert set(counts) == REQUIRED_POS_BUCKETS
+    assert all(2 <= count <= 4 for count in counts.values())
+
+    source_payloads = {}
+    for record in records:
+        assert record.pos
+        source_path = record.source_path
+        assert source_path
+        source_file = PROJECT_ROOT / source_path
+        assert source_file.exists()
+        assert record.source_locator
+        assert record.context
+
+        if source_path not in source_payloads:
+            source_payloads[source_path] = yaml.safe_load(
+                source_file.read_text(encoding="utf-8")
+            )
+        locator_match = VOCABULARY_WORD_LOCATOR_RE.fullmatch(record.source_locator)
+        assert locator_match
+        category_index, item_index = (int(part) for part in locator_match.groups())
+        source_word = source_payloads[source_path]["vocabulary"][category_index][
+            "items"
+        ][item_index]["word"]
+        assert f'word: "{source_word}"' in record.context
+
+        provenance = record.provenance_payload()
+        assert (
+            provenance["inventory_path"]
+            == "data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml"
+        )
+        assert provenance["source_path"]
+        assert provenance["source_locator"]
+        assert provenance["context"]
+
+    candidates = source_inventory_candidates(records)
+    assert len(candidates) == len(records)
+    assert all(candidate.pos for candidate in candidates)
+    assert all(candidate.source_provenance for candidate in candidates)

--- a/tests/test_source_inventory_review_candidates.py
+++ b/tests/test_source_inventory_review_candidates.py
@@ -11,7 +11,40 @@ from scripts.audit import generate_source_inventory_review_candidates as review
 from scripts.audit.source_inventory_intake import SourceInventoryError
 from scripts.lexicon.content_lexicon_reconciler import PROJECT_ROOT
 
-SEED_LEMMAS = {"кіт", "риба", "ракета", "яблуко", "єнот", "цирк"}
+POS_BALANCED_LEMMAS = {
+    "школа",
+    "море",
+    "великий",
+    "гарний",
+    "один",
+    "два",
+    "ніхто",
+    "себе",
+    "робити",
+    "читати",
+    "швидко",
+    "добре",
+    "щодо",
+    "через",
+    "і",
+    "але",
+    "не",
+    "хіба",
+    "ой",
+    "ура",
+}
+POS_BALANCED_POS = {
+    "noun",
+    "adjective",
+    "numeral",
+    "pronoun",
+    "verb",
+    "adverb",
+    "preposition",
+    "conjunction",
+    "particle",
+    "interjection",
+}
 
 
 def test_review_candidates_use_committed_inventories_and_keep_provenance(
@@ -27,7 +60,7 @@ def test_review_candidates_use_committed_inventories_and_keep_provenance(
     monkeypatch.setattr(
         review.grow,
         "build_skeleton_entry",
-        lambda lemma: {"lemma": lemma, "pos": "noun"},
+        lambda lemma: {"lemma": lemma},
     )
 
     def fake_enrich_entry(
@@ -52,23 +85,26 @@ def test_review_candidates_use_committed_inventories_and_keep_provenance(
     payload = review.generate_review_candidates(out=out)
 
     assert payload["counts"] == {
-        "total_delta": 6,
-        "processed": 6,
-        "auto_merge": 6,
+        "total_delta": len(POS_BALANCED_LEMMAS),
+        "processed": len(POS_BALANCED_LEMMAS),
+        "auto_merge": len(POS_BALANCED_LEMMAS),
         "needs_review": 0,
     }
     assert payload["review_only"] == {
         "workflow": review.WORKFLOW_ID,
         "source_inventory_paths": [
-            "data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml",
-            "data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml",
+            "data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml",
         ],
         "candidate_output": str(out.resolve()),
         "production_outputs_updated": [],
     }
+    assert not Path(payload["review_only"]["candidate_output"]).is_relative_to(
+        review.LIVE_ATLAS_OUTPUT_DIR
+    )
 
     entries = payload["auto_merge"]
-    assert {entry["lemma"] for entry in entries} == SEED_LEMMAS
+    assert {entry["lemma"] for entry in entries} == POS_BALANCED_LEMMAS
+    assert {entry["pos"] for entry in entries} == POS_BALANCED_POS
     for entry in entries:
         assert entry["source_provenance"]
         for provenance in entry["source_provenance"]:


### PR DESCRIPTION
## Summary

Links #3933, #3934, #3936.

- Adds `data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml` as the representative Word Atlas source-inventory sample.
- Switches review-only candidate generation to that POS-balanced sample instead of the six noun-only keyword rows.
- Leaves the two alphabet/bukvar noun files tracked as noun smoke inventories, and updates the runbook to reflect the new default.

## POS Counts

Each required Ukrainian school POS bucket has exactly 2 rows:

- noun: 2
- adjective: 2
- numeral: 2
- pronoun: 2
- verb: 2
- adverb: 2
- preposition: 2
- conjunction: 2
- particle: 2
- interjection: 2

## Source Files Used

- `curriculum/l2-uk-direct/b1/imennyky-vidminy.yaml`
- `curriculum/l2-uk-direct/a1/yakyi.yaml`
- `curriculum/l2-uk-direct/a1/chysla.yaml`
- `curriculum/l2-uk-direct/b1/zaimennyk-morfolohiia.yaml`
- `curriculum/l2-uk-direct/b2/diieslovo-povtorennia.yaml`
- `curriculum/l2-uk-direct/b1/pryslivnyky.yaml`
- `curriculum/l2-uk-direct/b2/pryimennyky-pohlybleno.yaml`
- `curriculum/l2-uk-direct/a1/spoluchnyky.yaml`
- `curriculum/l2-uk-direct/b2/chastky.yaml`
- `curriculum/l2-uk-direct/b2/vyhuki-ta-zvukonasl.yaml`

## Provenance Proof

- Every sample row has non-null `pos`, source `path`, row `locator`, and `context`.
- `test_pos_balanced_sample_has_required_pos_buckets_and_source_fields` reads the sample through strict source inventory intake, verifies POS bucket counts, verifies each source file exists, resolves each `vocabulary[N].items[M].word` locator against the source YAML, and asserts candidate `source_provenance` is non-empty.
- `test_review_candidates_use_committed_inventories_and_keep_provenance` verifies review candidate generation preserves non-empty `source_provenance` for the POS-balanced default.

## Live Output Proof

- No `site/src/data/` files changed in the diff.
- No live Atlas manifest/search/browse, Words of the Day, Daily Practice, cloze, status/audit/review, or telemetry artifacts changed.
- Review-only output path checks still reject `site/src/data/` destinations.
- Static practice asset check returned `ok: true`.

## Validation

- `.venv/bin/python -m pytest tests/test_source_inventory_intake.py tests/test_grow_lexicon_from_sources.py tests/test_source_inventory_review_candidates.py` — passed, 23 tests
- `.venv/bin/python scripts/audit/check_static_practice_assets.py --format json` — passed, `ok: true`
- `.venv/bin/ruff check scripts/audit/generate_source_inventory_review_candidates.py tests/test_source_inventory_intake.py tests/test_source_inventory_review_candidates.py` — passed
- `git diff --check origin/main...HEAD` — passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed

## Independent Review

Claude Opus 4.8 review (`review-3933-pos-balanced-source-inventory`) found one stale runbook reference to the old noun-only default. Fixed in this PR. No remaining code blockers were reported.