### PR TITLE
[codex] build(b2): harden rebuild prompt gates

### DIFF
--- a/docs/prompts/orchestrators/b2/production-build-orchestrator.md
+++ b/docs/prompts/orchestrators/b2/production-build-orchestrator.md
@@ -1,169 +1,218 @@
-# B2 Production Build Orchestrator
+# B2 Rebuild Production Prompt Contract
 
-> **SUSPENDED 2026-06-29:** Do not use this prompt for new B2 production.
-> Current B2 M01-M68 is archived as a superseded preview generation by
+> **REBUILD-SAFE CONTRACT 2026-06-29:** Do not use this prompt to continue
+> old B2 production or build M69+. Current B2 M01-M68 is archived superseded
+> preview generation by
 > `docs/decisions/2026-06-29-b2-preview-archive-and-rebuild.md`.
-> Resume B2 production only after the rebuild prompt/gate hardening, source
-> readiness audit, and golden pilot rebuild stages are complete.
+> Use this contract only after PR 3 source readiness passes and PR 4 golden
+> pilot acceptance explicitly authorizes rebuild-era production.
 
-Prompt version: 0.5
-Last reviewed: 2026-06-22
+Prompt version: 1.0
+Last reviewed: 2026-06-29
 
-## Source Assumptions
+## Current Production Freeze
 
-- Use this prompt only after `docs/audits/b2-preflight-readiness-*.md` says production may proceed.
-- B2 modules require advanced Ukrainian immersion, register control, argumentation, professional/academic readiness, and richer syntax.
-- B2 production should run in small sequential batches with module-tailored prompts, not generic batch instructions.
-- Plans are source of truth. Do not edit plans unless a preflight remediation PR explicitly scopes that work.
-- Some legacy B2 plans contain English planning scaffolding such as `Підсумок — Summary`, `Self-check`, English objectives, or English grammar labels. Treat that material as internal planning metadata only; do not copy it into B2 modules.
-- Some B2 discovery YAML files are auto-generated keyword stubs with empty `rag_chunks` and `rag_literary`. Treat them as query-keyword scaffolding unless they contain source chunks.
+- B2 M01-M68 remain in the repo for provenance, source mining, comparison, and
+  route stability only.
+- Existing B2 LLM scores are content-validity provenance. They are not
+  teaching-quality approval and must not be cited as proof that learner-facing
+  B2 lessons are ready.
+- Do not continue B2 production at M69.
+- Do not hand-patch archived preview modules as if they were release candidates.
+- Rebuilt B2 modules require fresh rebuild-era validation, route checks, and
+  independent pedagogy review.
 
-## Goal
+## Stage Gate
 
-Build the selected B2 module batch from local plans, discovery files, and wiki/source coverage. Create source modules, activities, vocabulary, resources where needed, generate site MDX, validate, record telemetry, and require independent review before merge.
+Run B2 rebuild work only in this order:
 
-## WORKTREE_ROOT Setup
+1. Prompt and deterministic gate hardening.
+2. B2 source, plan, wiki, and research readiness audit.
+3. One golden pilot rebuild accepted against this contract.
+4. Small rebuild waves after the pilot is accepted.
+
+If the current PR is stage 1 or stage 2, do not build modules.
+
+## Startup Rules
+
+- Read `AGENTS.md` for shared Codex runtime rules.
+- Do not read `CLAUDE.md` or `GEMINI.md` as normal Codex startup context.
+- Use Claude, Agy, Hermes, or other collaborators only through project bridge
+  routes, not by importing provider-specific startup instructions.
+- Use subtree worktrees:
 
 ```bash
-REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
-cd "$REPO_ROOT"
-git fetch origin main
-git worktree add -b codex/b2-production-<batch> .worktrees/dispatch/codex/b2-production-<batch> origin/main
-cd .worktrees/dispatch/codex/b2-production-<batch>
+git worktree add -b codex/b2-rebuild-<scope> .worktrees/dispatch/codex/b2-rebuild-<scope> origin/main
+cd .worktrees/dispatch/codex/b2-rebuild-<scope>
 test -e .venv || ln -s "$REPO_ROOT/.venv" .venv
-export WORKTREE_ROOT="$(pwd)"
-pwd
-git status --short --branch
-git rev-parse --show-toplevel
 ```
 
-## Read First
+- Every commit must include `X-Agent: codex/<task>`.
 
-- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
-- `docs/prompts/orchestrators/shared/repo-rules.md`
-- `docs/prompts/orchestrators/shared/validation-checklist.md`
-- `docs/prompts/orchestrators/shared/telemetry-and-pr.md`
-- passing or conditionally passing `docs/audits/b2-preflight-readiness-*.md`
-- `curriculum/l2-uk-en/curriculum.yaml`, target B2 modules
-- `docs/l2-uk-en/MODULE-RICHNESS-GUIDELINES-v2.md`
-- `scripts/config.py`, especially B2/default immersion policy
-- `scripts/audit/config.py`, especially B2 thresholds and activity types
-- for each target slug:
-  - `curriculum/l2-uk-en/plans/b2/<slug>.yaml`
-  - `curriculum/l2-uk-en/b2/discovery/<slug>.yaml`
-  - `wiki/grammar/b2/<slug>.md`
-  - `wiki/grammar/b2/<slug>.sources.yaml`
-  - existing `curriculum/l2-uk-en/b2/<slug>/` source directory if present
-  - existing `site/src/content/docs/b2/<slug>.mdx` if present
+## Lesson Contract
 
-## Allowed Writes
+A rebuilt B2 module is a taught lesson, not a reference article.
 
-- For scoped target slugs only:
-  - `curriculum/l2-uk-en/b2/<slug>/module.md`
-  - `curriculum/l2-uk-en/b2/<slug>/activities.yaml`
-  - `curriculum/l2-uk-en/b2/<slug>/vocabulary.yaml`
-  - `curriculum/l2-uk-en/b2/<slug>/resources.yaml`
-  - `site/src/content/docs/b2/<slug>.mdx`
-  - `site/src/content/docs/b2/index.mdx` only if current repo generation or navigation requires it
-- PR body or final orchestration note text
+Reference-article behavior:
 
-## Forbidden Writes
+- opens with long abstract explanation before the learner does anything;
+- piles up correct facts but does not model a decision;
+- explains grammar or lexical contrasts only in prose;
+- pushes practice into workbook-only activities;
+- leaves the lesson tab without rendered activity markers.
 
-- B2 plans, discovery, or wiki files unless explicitly authorized by a preflight remediation scope
-- modules outside the selected batch
-- `.python-version`, `.yamllint`, `.markdownlint.json`
-- `data/telemetry/**`
-- generated `status/`, curriculum `audit/`, or curriculum `review/` artifacts
+Taught-lesson behavior:
 
-## Production Rules
+- examples appear before compact rules;
+- concepts are split into short chunks;
+- normal modules contain 4-6 inline lesson activities;
+- each inline activity is placed by `<!-- INJECT_ACTIVITY: <id> -->`;
+- workbook activities consolidate after lesson practice;
+- dense grammar and vocabulary contrasts use tables, grids, or decision rules;
+- every major concept includes at least one learner decision, transformation,
+  correction, or comparison moment.
 
-- Work in small sequential batches. Finish and validate each module before moving to the next.
-- Write a module-tailored mini-prompt for each slug using that module's plan, discovery, wiki, and source YAML.
-- In each module-tailored mini-prompt, include a `Plan Scaffolding Filter` note:
-  - Ignore any plan section titled `Підсумок — Summary` or containing English `Self-check` prose as copy source.
-  - Convert any legacy English planning notes into Ukrainian intent before writing.
-  - Do not quote English plan prose in the module body.
-  - English is allowed only in vocabulary translation/gloss contexts already permitted by live B2 config.
-- In each module-tailored mini-prompt, include a `Discovery Authority Check` note:
-  - If discovery YAML has empty `rag_chunks` and `rag_literary`, use only `query_keywords` as hints.
-  - The authoritative teaching brief is `wiki/grammar/b2/<slug>.md` plus `<slug>.sources.yaml`.
-  - Stop only when the target wiki article or source registry is missing, has no sources, or contains unresolved verification markers.
-- B2 content should be advanced but teachable: richer syntax, register and style awareness, argumentation, professional or academic tasks, and precise vocabulary.
-- Avoid generic filler, decorative complexity, and content trivia. Activities must practice Ukrainian language skills through the module topic.
-- Maintain B2 immersion according to current config; English should be limited to vocabulary glosses or current repo-permitted contexts.
-- If preflight blockers reappear, stop and record them rather than building around missing sources.
+## Source Rules
+
+- Plans remain source of truth. Do not edit plans inside a build PR unless a
+  preflight remediation PR explicitly scopes that change.
+- Treat archived B2 module text as reference-mining material only. Do not copy
+  its structure forward.
+- Treat old B2 scores as provenance only. Rebuilt modules need fresh
+  rebuild-era scoring.
+- If source, wiki, or research readiness is missing, stop and record the
+  blocker. Do not build around missing evidence.
+
+## Activity Contract
+
+Normal B2 `activities.yaml` uses V2 buckets:
+
+```yaml
+version: '1.0'
+module: <slug>
+level: b2
+inline:
+  - id: act-1
+    type: quiz
+    ...
+workbook:
+  - id: workbook-1
+    type: reading
+    ...
+```
+
+Rules:
+
+- `inline` contains the lesson-tab activities.
+- `workbook` contains consolidation practice after the taught lesson.
+- Do not wrap activities in an `activities:` key.
+- Do not reference workbook-only ids from `INJECT_ACTIVITY` markers.
+- Normal modules should have 4-6 inline activities. Fewer than 4 is a hard
+  failure; more than 6 needs a clear reason.
+
+Explicit exemption shape:
+
+```yaml
+b2_rebuild_contract_exemption:
+  reason: "checkpoint module uses workbook-only synthesis"
+```
+
+Exemptions must be rare, metadata-scoped, and reasoned. The deterministic gate
+reports them as informational findings so reviewers can see them.
+
+## Deterministic Gate Contract
+
+Normal B2 modules must fail deterministic audit when any of these are true:
+
+- `activities.yaml` has no `inline` bucket.
+- `inline: []` or fewer than 4 inline activities appears without exemption.
+- `module.md` has no `INJECT_ACTIVITY` markers.
+- a marker references an activity outside `inline`, including workbook-only ids;
+- an inline activity is not injected into the lesson;
+- a concept H2 section has more than 900 words before lesson practice;
+- a B2 grammar or lexical contrast module has no table, contrast grid, or
+  decision-rule block;
+- raw callouts such as `[!note]` appear outside accepted blockquote syntax.
+
+The 900-word concept-section threshold is calibrated above the B1 p95
+pre-practice span. Do not replace it with a whole-module "words before first
+marker" threshold; that false-fails B1-shaped lessons.
+
+## Required Build Rhythm
+
+For each major concept:
+
+1. Give a short Ukrainian example first.
+2. Ask the learner to decide, compare, transform, or correct.
+3. State the rule compactly.
+4. Show a table, grid, or decision rule when forms contrast.
+5. Place an inline activity marker before moving into the next dense concept.
+
+Workbook practice may be longer, but it does not substitute for lesson-tab
+practice.
 
 ## Helper Swarm Policy
 
-Default to a solo run for one-module patches unless a helper will materially reduce risk or wall-clock time. When helpers are useful, keep routine delegation to one to three helpers total.
+Default to solo work for prompt/gate PRs and one-module pilot rebuilds unless a
+helper materially reduces risk or wall-clock time.
 
-- Use `gpt-5.4-mini` explorer helpers for bounded source lookup, plan/wiki/source coverage summaries, prompt consistency checks, and simple validation summaries.
-- Use `gpt-5.3-codex-spark` worker helpers only for narrow mechanical edits with a clearly owned file set.
-- The main orchestrator owns planning, integration, final review, PR creation, independent-family review routing, merge decisions, and git hygiene.
-- Do not let helpers read secrets, source `.envrc`, call `gh`, request reviews, open PRs, merge PRs, or revert unrelated changes.
-- Assign clear file ownership to every worker and tell helpers they are not alone in the codebase.
-- Record helper roles in telemetry `participants`; set `swarm_used: true` when any helper or reviewer thread did bounded module-build work. Solo runs still require `swarm_used: false`, `swarm_label: none`, and `swarm_note`.
-- Use Headroom compression for helper output or logs over 200 lines or 20 KB; pass the hash plus a short summary.
+- Use `gpt-5.4-mini` explorer helpers for bounded source lookup, prompt
+  consistency checks, docs/index checks, and simple validation summaries.
+- Use `gpt-5.3-codex-spark` worker helpers only for narrow mechanical edits
+  with a clearly owned file set.
+- The main orchestrator owns planning, integration, final review, PR creation,
+  independent-family review routing, merge decisions, and git hygiene.
+- Do not let helpers read secrets, source `.envrc`, call `gh`, request reviews,
+  open PRs, merge PRs, or revert unrelated changes.
+- Record helper roles in PR text; set `swarm_used: true` when any helper or
+  reviewer thread did bounded build work. Solo runs still require
+  `swarm_used: false`, `swarm_label: none`, and `swarm_note`.
+- Use Headroom compression for helper output or logs over 200 lines or 20 KB;
+  pass the hash plus a short summary.
 
-## Validation Commands
+## Validation
 
-Adapt module numbers from `curriculum.yaml`:
+Adapt module numbers to `curriculum/l2-uk-en/curriculum.yaml`:
 
 ```bash
 .venv/bin/python scripts/validate_activities.py l2-uk-en b2 <module_num>
 .venv/bin/python scripts/validate_vocab_yaml.py curriculum/l2-uk-en/b2/<slug>/vocabulary.yaml
 .venv/bin/python scripts/generate_mdx.py l2-uk-en b2 <module_num> --validate
 .venv/bin/python scripts/audit_module.py --skip-review curriculum/l2-uk-en/b2/<slug>/module.md
-rm -f .cache/lemma-frequency-b2-<module_num>.json
-rm -rf curriculum/l2-uk-en/b2/<slug>/audit curriculum/l2-uk-en/b2/<slug>/status
 git diff --check
-CHANGED_FILES="$( { git diff --name-only; git diff --cached --name-only; git ls-files --others --exclude-standard; } | sort -u )"
-if [ -n "$CHANGED_FILES" ] && printf '%s\n' "$CHANGED_FILES" | rg '(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/'; then
-  echo "Forbidden generated artifact in diff" >&2
-  exit 1
-fi
+.venv/bin/python scripts/audit/lint_agent_trailer.py
 ```
 
-Run `scripts/audit/check_mdx_generation_drift.py` only when a drift-only check is needed after generation. The `audit_module.py --skip-review` command intentionally validates deterministic module gates while leaving the review gate to the independent-review requirement below. It still writes local generated cache/status/audit outputs, so remove those known outputs before the diff gate; do not commit curriculum `review/`, `audit/`, or `status/` artifacts to satisfy the review gate.
+Remove generated local cache/status/audit outputs before staging. Do not commit
+`curriculum/l2-uk-en/**/status/*.json`, curriculum `audit/*-review.md`,
+curriculum `review/*-review.md`, or `data/telemetry/**`.
 
 ## Telemetry Workflow
 
-For every module-build PR, persist a record through `POST /api/telemetry/module-builds` and include the same summary in the PR body. Use `docs/runbooks/module-build-token-telemetry.md` and `docs/prompts/orchestrators/shared/telemetry-and-pr.md`.
-
-Required PR/telemetry fields: `run_id`, `level`, `slug`, `branch`, `commit_sha`, `pr_number`, `pr_url`, `status`, `swarm_used`, `swarm_label`, `swarm_note`, `participants`, and each participant `token_source`. Use `token_source: unavailable` rather than inventing counts when provider usage is unavailable. Do not commit `data/telemetry/**`.
+For module-build PRs, persist telemetry through `POST /api/telemetry/module-builds`
+and include the same summary in PR text. Required fields include `pr_number`,
+`pr_url`, `swarm_used`, `swarm_label`, and `swarm_note`. If no module is built,
+state that telemetry is not applicable for the prompt/gate PR.
 
 ## Independent-Family Review Gate
 
-Before merge, request a read-only independent-family review. Prefer Claude Opus 4.8. If Claude Opus 4.8 is unavailable, use Agy with Gemini 3.1 Pro High, for example `agy --model "Gemini 3.1 Pro (High)" --print-timeout 10m -p "<review prompt>"` when that is the available local route.
-
-The review prompt must include the PR diff, validation summary, telemetry summary, artifact-clean statement, and explicit request for blocker-only findings. Record reviewer identity, review model, review scope, unresolved findings, and final disposition in the PR body or final orchestration note. The merge rule is explicit: unresolved findings are blockers.
+Before merge, request read-only independent-family review. Prefer Claude Opus 4.8
+through the project bridge when available; otherwise use an approved
+non-Codex route such as Gemini 3.1 Pro High through Agy. Include PR diff,
+validation summary, artifact-clean statement, and blocker-only instructions.
+Record reviewer identity, review model, review scope, unresolved findings, and
+final disposition in PR text. Merge rule: unresolved findings are blockers.
 
 ## PR Body Requirements
 
-PR body must include: changed modules, source/preflight report used, validation commands and outcomes, telemetry `run_id`, `swarm_used`, `swarm_label`, `swarm_note`, reviewer identity, review scope, final disposition, unresolved findings count, and a statement that no generated `status/`, curriculum `audit/`, curriculum `review/`, or telemetry DB artifacts are included.
+For rebuild PRs, include:
 
-## PR, Commit, And Telemetry Requirements
-
-- Branch: `codex/b2-production-<batch>`
-- Commit trailer: `X-Agent: codex/b2-production-<batch>`
-- Run `.venv/bin/python scripts/audit/lint_agent_trailer.py` before pushing.
-- Persist module-build telemetry using `docs/prompts/orchestrators/shared/telemetry-and-pr.md`.
-- Include `swarm_used`, `swarm_label`, and `swarm_note` in telemetry and PR text.
-- Require independent-family review before merge; unresolved findings are blockers.
-
-## Expected Final Response
-
-```text
-B2 preflight report used: <path>
-Modules built: <slugs>
-Files changed: <paths>
-Validation run: <commands and outcomes>
-Telemetry: <run_id, POST status, unavailable reason if any>
-PR: <url, ready/merged/blocked>
-Independent review: <reviewer identity, model, scope, final disposition>
-Unresolved review findings: <n>
-Forbidden artifacts included: no
-swarm_used: true/false
-swarm_label: <none | solo | helper | swarm>
-swarm_note: <helpers used, or solo run; no swarm used>
-```
+- stage and scope;
+- modules rebuilt or statement that no modules were built;
+- files changed;
+- validation commands and outcomes;
+- telemetry summary when module build telemetry applies;
+- `swarm_used`, `swarm_label`, and `swarm_note`;
+- independent review identity, model, scope, and final disposition;
+- unresolved review findings count;
+- forbidden artifacts included: no.

--- a/scripts/audit/checks/b2_rebuild_contract.py
+++ b/scripts/audit/checks/b2_rebuild_contract.py
@@ -1,0 +1,372 @@
+"""Deterministic B2 rebuild lesson-shape contract checks."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+INJECT_ACTIVITY_RE = re.compile(r"<!--\s*INJECT_ACTIVITY:\s*([A-Za-z0-9_-]+)\s*-->")
+RAW_CALLOUT_RE = re.compile(r"\[![A-Za-z][\w-]*\]")
+ACCEPTED_CALLOUT_RE = re.compile(r"^\s*>\s*\[![A-Za-z][\w-]*\]")
+TABLE_SEPARATOR_RE = re.compile(r"^\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$")
+H2_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+
+B2_REBUILD_EXEMPTION_KEY = "b2_rebuild_contract_exemption"
+B2_INLINE_MIN = 4
+B2_INLINE_SOFT_MAX = 6
+B2_SECTION_PRACTICE_WORD_LIMIT = 900
+
+CONTRAST_KEYWORDS = (
+    "aspect",
+    "case",
+    "conjunction",
+    "contrast",
+    "coordination",
+    "grammar",
+    "lexical",
+    "morphology",
+    "punctuation",
+    "register",
+    "style",
+    "synonym",
+    "syntax",
+    "відмін",
+    "вид ",
+    "грамат",
+    "лексич",
+    "морфолог",
+    "пунктуац",
+    "регістр",
+    "синон",
+    "сполуч",
+    "стил",
+    "суряд",
+    "підряд",
+    "протист",
+    "зістав",
+)
+
+DECISION_RULE_PATTERNS = (
+    re.compile(r"^#{2,4}\s+.*(?:decision rule|rule of thumb)", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^#{2,4}\s+.*(?:алгоритм|правило вибору|як вибрати|коли обрати)", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"(?im)^\s*(?:якщо|коли)\b.{12,120}\b(?:то|обирайте|уживайте)\b"),
+)
+
+NON_CONCEPT_SECTION_RE = re.compile(
+    r"\b("
+    r"summary|recap|resources|vocabulary|workbook|answer key|"
+    r"підсумок|словник|зошит|ресурси|самоперевірка|рубрика"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+def check_b2_rebuild_contract(
+    module_text: str,
+    activities_path: Path | None,
+    *,
+    meta_data: Mapping[str, Any] | None = None,
+    plan_data: Mapping[str, Any] | None = None,
+    module_focus: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return B2 rebuild contract findings for one module.
+
+    Blocking findings are intended to fail normal B2 rebuild-era modules. A
+    metadata exemption with a non-empty reason skips shape checks but is still
+    reported as informational so exemptions cannot be silent.
+    """
+
+    meta_data = meta_data or {}
+    plan_data = plan_data or {}
+    if _level(meta_data, plan_data) != "b2":
+        return []
+
+    exemption_reason = _exemption_reason(meta_data, plan_data)
+    if exemption_reason:
+        return [
+            _finding(
+                "B2_REBUILD_EXEMPTION",
+                f"B2 rebuild contract explicitly exempted: {exemption_reason}",
+                "Review the exemption before accepting rebuilt B2 output.",
+                severity="info",
+                blocking=False,
+            )
+        ]
+
+    findings: list[dict[str, Any]] = []
+    raw_activities = _load_activities_yaml(activities_path)
+    if raw_activities["error"]:
+        findings.append(
+            _finding(
+                "B2_ACTIVITY_YAML_UNREADABLE",
+                raw_activities["error"],
+                "Provide readable V2 activities.yaml with inline and workbook lists.",
+            )
+        )
+        inline_activities: list[dict[str, Any]] = []
+        workbook_activities: list[dict[str, Any]] = []
+    else:
+        activities_data = raw_activities["data"]
+        inline_activities, workbook_activities = _activity_buckets(activities_data)
+        findings.extend(_check_inline_bucket(activities_data, inline_activities))
+
+    findings.extend(_check_injection_markers(module_text, inline_activities, workbook_activities))
+    findings.extend(_check_section_practice_spacing(module_text))
+    findings.extend(_check_structured_contrast(module_text, meta_data, plan_data, module_focus))
+    findings.extend(_check_callout_syntax(module_text))
+    return findings
+
+
+def _level(meta_data: Mapping[str, Any], plan_data: Mapping[str, Any]) -> str:
+    return str(meta_data.get("level") or plan_data.get("level") or "").strip().lower()
+
+
+def _exemption_reason(
+    meta_data: Mapping[str, Any], plan_data: Mapping[str, Any]
+) -> str | None:
+    for source in (meta_data, plan_data):
+        raw = source.get(B2_REBUILD_EXEMPTION_KEY)
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip()
+        if isinstance(raw, Mapping):
+            reason = raw.get("reason")
+            if isinstance(reason, str) and reason.strip():
+                return reason.strip()
+    return None
+
+
+def _load_activities_yaml(path: Path | None) -> dict[str, Any]:
+    if path is None or not path.exists():
+        return {"data": None, "error": "B2 rebuild contract requires activities.yaml."}
+    try:
+        return {"data": yaml.safe_load(path.read_text(encoding="utf-8")) or {}, "error": None}
+    except yaml.YAMLError as exc:
+        return {"data": None, "error": f"activities.yaml is invalid YAML: {exc}"}
+    except OSError as exc:
+        return {"data": None, "error": f"activities.yaml cannot be read: {exc}"}
+
+
+def _activity_buckets(data: Any) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    if not isinstance(data, Mapping):
+        return [], []
+    inline = data.get("inline")
+    workbook = data.get("workbook")
+    return _dict_list(inline), _dict_list(workbook)
+
+
+def _dict_list(raw: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw, list):
+        return []
+    return [item for item in raw if isinstance(item, dict)]
+
+
+def _check_inline_bucket(data: Any, inline_activities: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    if not isinstance(data, Mapping) or "inline" not in data:
+        findings.append(
+            _finding(
+                "B2_INLINE_BUCKET_MISSING",
+                "Normal B2 rebuild modules must use activities.yaml inline/workbook buckets.",
+                "Use V2 shape with inline lesson practice and workbook consolidation.",
+            )
+        )
+        return findings
+
+    if len(inline_activities) < B2_INLINE_MIN:
+        findings.append(
+            _finding(
+                "B2_INLINE_ACTIVITY_FLOOR",
+                f"Found {len(inline_activities)} inline activities; normal B2 modules require at least {B2_INLINE_MIN}.",
+                "Add 4-6 inline lesson activities before workbook consolidation.",
+            )
+        )
+    elif len(inline_activities) > B2_INLINE_SOFT_MAX:
+        findings.append(
+            _finding(
+                "B2_INLINE_ACTIVITY_SOFT_MAX",
+                f"Found {len(inline_activities)} inline activities; normal target is 4-6.",
+                "Keep extra inline activities only when every concept needs lesson practice.",
+                severity="warning",
+                blocking=False,
+            )
+        )
+    return findings
+
+
+def _check_injection_markers(
+    module_text: str,
+    inline_activities: list[dict[str, Any]],
+    workbook_activities: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    markers = INJECT_ACTIVITY_RE.findall(module_text)
+    findings: list[dict[str, Any]] = []
+    if not markers:
+        findings.append(
+            _finding(
+                "B2_INJECT_MARKERS_MISSING",
+                "module.md has no INJECT_ACTIVITY markers.",
+                "Insert lesson practice markers after short concept chunks.",
+            )
+        )
+        return findings
+
+    inline_ids = _ids(inline_activities)
+    workbook_ids = _ids(workbook_activities)
+    outside_inline = sorted({activity_id for activity_id in markers if activity_id not in inline_ids})
+    if outside_inline:
+        workbook_hits = sorted(set(outside_inline) & workbook_ids)
+        detail = ", ".join(outside_inline)
+        if workbook_hits:
+            detail += f" (workbook-only: {', '.join(workbook_hits)})"
+        findings.append(
+            _finding(
+                "B2_INJECT_MARKER_OUTSIDE_INLINE",
+                f"INJECT_ACTIVITY references ids outside inline activities: {detail}.",
+                "Move referenced activities into inline or change markers to inline ids.",
+            )
+        )
+
+    unused_inline = sorted(inline_ids - set(markers))
+    if unused_inline:
+        findings.append(
+            _finding(
+                "B2_INLINE_ACTIVITY_NOT_INJECTED",
+                f"Inline activities not referenced by INJECT_ACTIVITY markers: {', '.join(unused_inline)}.",
+                "Every inline activity should appear in the lesson where it practices a concept.",
+            )
+        )
+    return findings
+
+
+def _ids(activities: list[dict[str, Any]]) -> set[str]:
+    return {str(activity.get("id")).strip() for activity in activities if activity.get("id")}
+
+
+def _check_section_practice_spacing(module_text: str) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    for title, section_text in _h2_sections(_strip_frontmatter(module_text)):
+        if _is_non_concept_section(title):
+            continue
+        first_marker = section_text.find("INJECT_ACTIVITY")
+        measured_text = section_text if first_marker < 0 else section_text[:first_marker]
+        words_before_practice = _word_count(measured_text)
+        if words_before_practice > B2_SECTION_PRACTICE_WORD_LIMIT:
+            issue = (
+                f"Section '{title}' has {words_before_practice} words before lesson practice; "
+                f"limit is {B2_SECTION_PRACTICE_WORD_LIMIT}."
+            )
+            findings.append(
+                _finding(
+                    "B2_LONG_EXPOSITION_BEFORE_PRACTICE",
+                    issue,
+                    "Split the concept or add an inline practice marker earlier in the section.",
+                )
+            )
+    return findings
+
+
+def _strip_frontmatter(text: str) -> str:
+    return re.sub(r"\A---\s*\n.*?\n---\s*\n", "", text, flags=re.DOTALL)
+
+
+def _h2_sections(text: str) -> list[tuple[str, str]]:
+    matches = list(H2_RE.finditer(text))
+    sections: list[tuple[str, str]] = []
+    for index, match in enumerate(matches):
+        start = match.start()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        sections.append((match.group(1).strip(), text[start:end]))
+    return sections
+
+
+def _is_non_concept_section(title: str) -> bool:
+    return bool(NON_CONCEPT_SECTION_RE.search(title))
+
+
+def _word_count(text: str) -> int:
+    text = re.sub(r"<!--.*?-->", " ", text, flags=re.DOTALL)
+    text = re.sub(r"`[^`]*`", " ", text)
+    return len(re.findall(r"[A-Za-zА-Яа-яІіЇїЄєҐґ0-9]+", text))
+
+
+def _check_structured_contrast(
+    module_text: str,
+    meta_data: Mapping[str, Any],
+    plan_data: Mapping[str, Any],
+    module_focus: str | None,
+) -> list[dict[str, Any]]:
+    if not _requires_structured_contrast(module_text, meta_data, plan_data, module_focus):
+        return []
+    if _has_markdown_table(module_text) or _has_decision_rule(module_text):
+        return []
+    return [
+        _finding(
+            "B2_STRUCTURED_CONTRAST_MISSING",
+            "B2 grammar/lexical contrast module is prose-only: no table, contrast grid, or decision-rule block found.",
+            "Add a compact table/grid or explicit decision-rule block for the contrast.",
+        )
+    ]
+
+
+def _requires_structured_contrast(
+    module_text: str,
+    meta_data: Mapping[str, Any],
+    plan_data: Mapping[str, Any],
+    module_focus: str | None,
+) -> bool:
+    focus = str(module_focus or meta_data.get("focus") or plan_data.get("focus") or "").lower()
+    tags = " ".join(str(tag).lower() for tag in meta_data.get("tags", []) if tag)
+    title = str(meta_data.get("title") or plan_data.get("title") or "").lower()
+    slug = str(meta_data.get("slug") or plan_data.get("slug") or "").lower()
+    outline = " ".join(str(item).lower() for item in plan_data.get("content_outline", []) if item)
+    haystack = " ".join([focus, tags, title, slug, outline, module_text[:2000].lower()])
+    return any(keyword in haystack for keyword in CONTRAST_KEYWORDS)
+
+
+def _has_markdown_table(text: str) -> bool:
+    return any(TABLE_SEPARATOR_RE.match(line) for line in text.splitlines())
+
+
+def _has_decision_rule(text: str) -> bool:
+    return any(pattern.search(text) for pattern in DECISION_RULE_PATTERNS)
+
+
+def _check_callout_syntax(module_text: str) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    in_fence = False
+    for line_no, line in enumerate(module_text.splitlines(), start=1):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if RAW_CALLOUT_RE.search(line) and not ACCEPTED_CALLOUT_RE.match(line):
+            findings.append(
+                _finding(
+                    "B2_MALFORMED_CALLOUT",
+                    f"Line {line_no} uses raw callout syntax outside accepted blockquote form: {line.strip()}",
+                    "Use '> [!note]' blockquote callouts or site-supported directive syntax.",
+                )
+            )
+    return findings
+
+
+def _finding(
+    finding_type: str,
+    issue: str,
+    fix: str,
+    *,
+    severity: str = "error",
+    blocking: bool = True,
+) -> dict[str, Any]:
+    return {
+        "type": finding_type,
+        "severity": severity,
+        "blocking": blocking,
+        "issue": issue,
+        "fix": fix,
+    }

--- a/scripts/audit/core.py
+++ b/scripts/audit/core.py
@@ -21,6 +21,7 @@ if str(SCRIPT_DIR) not in sys.path:
 from slug_utils import to_bare_slug
 from yaml_activities import ActivityParser
 
+from .checks.b2_rebuild_contract import check_b2_rebuild_contract
 from .checks.outline_compliance import (
     check_outline_compliance,
     print_section_summary,
@@ -444,6 +445,36 @@ def _evaluate_vocab_progression(ctx: AuditContext, state: AuditState) -> None:
         print(f"  ℹ️  Vocab progression unavailable: {exc}")
 
 
+def _run_b2_rebuild_contract_checks(ctx: AuditContext, state: AuditState) -> None:
+    """Fail B2 rebuild-era modules that look like reference articles."""
+    if ctx.skip_activities:
+        return
+
+    findings = check_b2_rebuild_contract(
+        ctx.content,
+        ctx.yaml_file,
+        meta_data=ctx.meta_data,
+        plan_data=ctx.plan_data,
+        module_focus=ctx.module_focus,
+    )
+    if not findings:
+        return
+
+    blocking = 0
+    for finding in findings:
+        severity = str(finding.get("severity") or "error")
+        icon = "❌" if finding.get("blocking") else "ℹ️" if severity == "info" else "⚠️"
+        print(f" {icon} [{finding['type']}] {finding['issue']}")
+        if finding.get("fix"):
+            print(f"    Fix: {finding['fix']}")
+        state.pedagogical_violations.append(finding)
+        if finding.get("blocking"):
+            blocking += 1
+
+    if blocking:
+        state.fail(f"{blocking} B2 rebuild contract violation(s)")
+
+
 def audit_module(file_path: str, skip_activities: bool = False,
                  skip_review: bool = False) -> bool:
     """
@@ -464,6 +495,7 @@ def audit_module(file_path: str, skip_activities: bool = False,
      invalid_type_violations, _forbidden_type_violations) = validate_yaml_activities(ctx, state)
 
     validate_activity_answers(ctx, state)
+    _run_b2_rebuild_contract_checks(ctx, state)
 
     process_activity_sections(ctx, state)
 

--- a/tests/test_b2_rebuild_contract.py
+++ b/tests/test_b2_rebuild_contract.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.audit.checks.b2_rebuild_contract import check_b2_rebuild_contract
+
+
+def _activities_file(tmp_path: Path, payload: Any) -> Path:
+    path = tmp_path / "activities.yaml"
+    path.write_text(yaml.safe_dump(payload, allow_unicode=True, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _inline_activity(activity_id: str) -> dict[str, Any]:
+    return {
+        "id": activity_id,
+        "type": "quiz",
+        "title": f"Practice {activity_id}",
+        "instruction": "Оберіть точний варіант.",
+        "items": [
+            {
+                "question": "Що точніше?",
+                "options": ["але", "і", "або"],
+                "correct": 0,
+            }
+        ],
+    }
+
+
+def _valid_activities() -> dict[str, Any]:
+    return {
+        "version": "1.0",
+        "module": "advanced-conjunctions-rebuild",
+        "level": "b2",
+        "inline": [_inline_activity(f"act-{idx}") for idx in range(1, 5)],
+        "workbook": [_inline_activity("workbook-1")],
+    }
+
+
+def _valid_module_text(extra: str = "") -> str:
+    return f"""---
+title: "Advanced conjunctions rebuild"
+level: B2
+focus: grammar
+slug: advanced-conjunctions-rebuild
+---
+# Сполучники в аргументі
+
+## Вибір зв'язку
+
+| Форма | Сигнал |
+| --- | --- |
+| але | обмеження |
+| зате | компенсація |
+
+Почніть з прикладу: **план короткий, але переконливий**. Потім перевірте, чи
+друга частина обмежує першу, додає компенсацію або відкриває альтернативу.
+
+<!-- INJECT_ACTIVITY: act-1 -->
+
+Коли зв'язок уже видно, правило стає коротким: не перекладайте English
+“but” одним словом щоразу; перевіряйте смислову роль.
+
+<!-- INJECT_ACTIVITY: act-2 -->
+
+## Пунктуаційне рішення
+
+Якщо частини рівноправні, то обирайте сурядний зв'язок і перевіряйте кому.
+
+<!-- INJECT_ACTIVITY: act-3 -->
+
+Порівняйте два речення і виправте зайву кому перед одиничним **і**.
+
+<!-- INJECT_ACTIVITY: act-4 -->
+
+> [!note] Коротке правило після прикладів легше застосувати в редагуванні.
+
+{extra}
+"""
+
+
+def _finding_types(findings: list[dict[str, Any]]) -> set[str]:
+    return {finding["type"] for finding in findings}
+
+
+def test_valid_b2_rebuild_contract_passes(tmp_path: Path) -> None:
+    findings = check_b2_rebuild_contract(
+        _valid_module_text(),
+        _activities_file(tmp_path, _valid_activities()),
+        meta_data={"level": "B2", "focus": "grammar", "slug": "advanced-conjunctions-rebuild"},
+    )
+
+    assert [finding for finding in findings if finding["blocking"]] == []
+
+
+def test_inline_empty_and_workbook_marker_fail(tmp_path: Path) -> None:
+    activities = {
+        "version": "1.0",
+        "module": "advanced-conjunctions-rebuild",
+        "level": "b2",
+        "inline": [],
+        "workbook": [_inline_activity("workbook-1")],
+    }
+    text = _valid_module_text().replace("INJECT_ACTIVITY: act-1", "INJECT_ACTIVITY: workbook-1")
+
+    findings = check_b2_rebuild_contract(
+        text,
+        _activities_file(tmp_path, activities),
+        meta_data={"level": "B2", "focus": "grammar", "slug": "advanced-conjunctions-rebuild"},
+    )
+
+    types = _finding_types(findings)
+    assert "B2_INLINE_ACTIVITY_FLOOR" in types
+    assert "B2_INJECT_MARKER_OUTSIDE_INLINE" in types
+    assert all(finding["blocking"] for finding in findings if finding["severity"] == "error")
+
+
+def test_no_inject_markers_fail(tmp_path: Path) -> None:
+    findings = check_b2_rebuild_contract(
+        _valid_module_text().replace("INJECT_ACTIVITY", "OMIT_ACTIVITY"),
+        _activities_file(tmp_path, _valid_activities()),
+        meta_data={"level": "B2", "focus": "grammar", "slug": "advanced-conjunctions-rebuild"},
+    )
+
+    assert "B2_INJECT_MARKERS_MISSING" in _finding_types(findings)
+
+
+def test_long_h2_exposition_before_practice_fails(tmp_path: Path) -> None:
+    long_exposition = " ".join(["пояснення"] * 901)
+    text = _valid_module_text(
+        extra=f"""
+## Надто довгий концепт
+
+| Роль | Форма |
+| --- | --- |
+| вибір | або |
+
+{long_exposition}
+
+<!-- INJECT_ACTIVITY: act-4 -->
+"""
+    )
+
+    findings = check_b2_rebuild_contract(
+        text,
+        _activities_file(tmp_path, _valid_activities()),
+        meta_data={"level": "B2", "focus": "grammar", "slug": "advanced-conjunctions-rebuild"},
+    )
+
+    assert "B2_LONG_EXPOSITION_BEFORE_PRACTICE" in _finding_types(findings)
+
+
+def test_structured_contrast_required_for_prose_only_grammar(tmp_path: Path) -> None:
+    text = """---
+title: "Synonymy and register"
+level: B2
+focus: grammar
+slug: synonymy-register
+---
+# Синонімія і регістр
+
+## Регістровий вибір
+
+Книжне слово й розмовний відповідник не є автоматичними дублетами.
+<!-- INJECT_ACTIVITY: act-1 -->
+Треба бачити жанр, адресата і ступінь офіційності.
+<!-- INJECT_ACTIVITY: act-2 -->
+Порівняйте два варіанти і виправте невдалий регістр.
+<!-- INJECT_ACTIVITY: act-3 -->
+Після цього перенесіть правило в короткий службовий лист.
+<!-- INJECT_ACTIVITY: act-4 -->
+"""
+
+    findings = check_b2_rebuild_contract(
+        text,
+        _activities_file(tmp_path, _valid_activities()),
+        meta_data={"level": "B2", "focus": "grammar", "slug": "synonymy-register"},
+    )
+
+    assert "B2_STRUCTURED_CONTRAST_MISSING" in _finding_types(findings)
+
+
+def test_raw_callout_syntax_fails_for_b2(tmp_path: Path) -> None:
+    findings = check_b2_rebuild_contract(
+        _valid_module_text(extra="[!note] Raw callout is not accepted here."),
+        _activities_file(tmp_path, _valid_activities()),
+        meta_data={"level": "B2", "focus": "grammar", "slug": "advanced-conjunctions-rebuild"},
+    )
+
+    assert "B2_MALFORMED_CALLOUT" in _finding_types(findings)
+
+
+def test_raw_callout_inside_fenced_code_is_allowed(tmp_path: Path) -> None:
+    findings = check_b2_rebuild_contract(
+        _valid_module_text(
+            extra="""```markdown
+[!note] This is an example of malformed syntax, not learner-facing callout prose.
+```"""
+        ),
+        _activities_file(tmp_path, _valid_activities()),
+        meta_data={"level": "B2", "focus": "grammar", "slug": "advanced-conjunctions-rebuild"},
+    )
+
+    assert "B2_MALFORMED_CALLOUT" not in _finding_types(findings)
+
+
+def test_explicit_exemption_is_auditable_nonblocking(tmp_path: Path) -> None:
+    findings = check_b2_rebuild_contract(
+        "# Контроль\n\nNo activities.",
+        _activities_file(tmp_path, {"inline": []}),
+        meta_data={
+            "level": "B2",
+            "focus": "checkpoint",
+            "b2_rebuild_contract_exemption": {"reason": "checkpoint module uses workbook-only synthesis"},
+        },
+    )
+
+    assert findings == [
+        {
+            "type": "B2_REBUILD_EXEMPTION",
+            "severity": "info",
+            "blocking": False,
+            "issue": "B2 rebuild contract explicitly exempted: checkpoint module uses workbook-only synthesis",
+            "fix": "Review the exemption before accepting rebuilt B2 output.",
+        }
+    ]
+
+
+def test_non_b2_modules_are_ignored(tmp_path: Path) -> None:
+    findings = check_b2_rebuild_contract(
+        "# B1 lesson\n\n[!note] Legacy raw callout.",
+        _activities_file(tmp_path, {"inline": []}),
+        meta_data={"level": "B1", "focus": "grammar"},
+    )
+
+    assert findings == []


### PR DESCRIPTION
## Summary

PR 2 foundation for the B2 rebuild program. This does not rebuild or modify any B2 modules.

Changed:
- Replaces the suspended B2 production prompt with a rebuild-safe taught-lesson contract.
- Adds deterministic B2 rebuild contract audit checks for inline lesson practice, marker/id alignment, long concept exposition, structured grammar/lexical contrast, and malformed raw callouts.
- Hooks the check into `scripts/audit/core.py` as a hard audit failure for normal B2 modules.
- Adds focused tests for good and bad B2 contract fixtures.

## Stage / Scope

Stage: PR 2 prompt deterministic gate hardening.

Modules rebuilt: none.

Files changed:
- `docs/prompts/orchestrators/b2/production-build-orchestrator.md`
- `scripts/audit/checks/b2_rebuild_contract.py`
- `scripts/audit/core.py`
- `tests/test_b2_rebuild_contract.py`

## Old B2 Score Interpretation

The new B2 prompt contract documents that current B2 M01-M68 scores are content-validity provenance only, not teaching-quality approval. Rebuilt modules require fresh rebuild-era validation/review.

## Claude Contract Pre-Review Disposition

Reviewer: Claude via project bridge.

Accepted recommendations:
- Replaced the proposed 300-word whole-module pre-practice threshold with a per-H2 concept-section check at 900 words, calibrated above B1 p95.
- Kept metadata-scoped exemptions but require a reason and report them as info findings.
- Made hard findings call `state.fail()` through the audit hook.
- Kept the inline floor scoped to normal B2 rebuild modules; checkpoint/exam/review shapes require explicit exemption.
- Scoped structured contrast detection to B2 grammar/lexical contrast surfaces.

Rejected recommendations: none.

## Independent Review

Reviewer identity: Claude via project bridge.
Review model: `claude-opus-4-8`.
Scope: cached staged diff, validation summary, artifact-clean statement, blocker-only review.
Final disposition: no hard blockers.
Unresolved review findings: 0.

Review follow-up applied:
- Collapsed a duplicated contrast-detection branch.
- Ignored raw callout examples inside fenced code blocks and added a regression test.

Conscious non-blocking decision:
- Claude noted existing archived B2 preview modules will fail this new B2 gate if audited. Accepted by design for PR 2: those failures are the archived-preview condition this rebuild gate is meant to expose, and this PR does not edit archived B2 content. If track-health consumers need old-preview isolation, PR 3 can add a positive rebuild-era manifest or reporting filter.

## Validation

Passed:
- `.venv/bin/python -m pytest tests/test_b2_rebuild_contract.py -q` (9 passed)
- `.venv/bin/ruff check scripts/audit/checks/b2_rebuild_contract.py tests/test_b2_rebuild_contract.py scripts/audit/core.py`
- `.venv/bin/python scripts/lint/lint_prompts.py`
- `npm exec -- markdownlint-cli2 docs/prompts/orchestrators/b2/production-build-orchestrator.md`
- `git diff --check --cached`
- `.venv/bin/python -m py_compile scripts/audit/core.py scripts/audit/checks/b2_rebuild_contract.py tests/test_b2_rebuild_contract.py`
- protected/generated artifact guard
- changed-file `sys.executable` scan
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

Forbidden artifacts included: no.

## Telemetry / Swarm

Telemetry: not applicable; no module build in this PR.

`swarm_used: false`
`swarm_label: none`
`swarm_note: solo implementation; Claude used only for required read-only review, no worker swarm used.`