### PR TITLE
fix(ci): normalize zizmor.yml pin comments (clears ref-version-mismatch #253/#254)

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -31,12 +31,12 @@ jobs:
       actions: read
     steps:
       - name: 'Checkout repository'
-        uses: 'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0' # ratchet:actions/checkout@v7.0.0
+        uses: 'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0' # v7.0.0
         with:
           persist-credentials: false
 
       - name: 'Run zizmor 🌈'
-        uses: 'zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa' # ratchet:zizmorcore/zizmor-action@v0.5.7
+        uses: 'zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa' # v0.5.7
         with:
           # 2026-05-23: workflow began failing at 15:57Z with the artipacked
           # audit hitting HTTP 401 on `actions/checkout` git-upload-pack.


### PR DESCRIPTION
Clears the two **new** zizmor code-scanning alerts that surfaced after the github-actions group bump (#3995): `zizmor/ref-version-mismatch` on `.github/workflows/zizmor.yml:34` (#254) and `:39` (#253) — "hash pin has mismatched or missing version comment: points to unknown ref".

## Root cause
The zizmor-action `0.5.6 → 0.5.7` bump tightened the `ref-version-mismatch` audit. zizmor runs `--offline` (per #2247, to dodge the artipacked 401) and can't parse the orphan `# ratchet:owner/repo@vX.Y.Z` comment format, so it reports "unknown ref" for both pins.

## Why this is a false positive (verified)
The SHAs are correct for the stated versions:
- `actions/checkout@v7.0.0` → `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` ✓
- `zizmorcore/zizmor-action@v0.5.7` → `192e21d79ab29983730a13d1382995c2307fbcaa` ✓

## Fix
`ratchet` is **not** wired into CI anywhere (no run step, no config) and these were the **only two** `# ratchet:` comments in the repo. Normalize both to the plain `# vX.Y.Z` comment style every other workflow uses — and which zizmor accepts (deploy-pages.yml carries the identical `actions/checkout@9c091bb… # v7.0.0` pin unflagged). Fixes the alerts at the source and prevents recurrence on future bumps. No SHA change, no behavior change.

actionlint: all 9 workflow files valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
