### PR TITLE
fix(atlas): clarify browse count semantics

### DIFF
--- a/site/src/lexicon/AtlasFullIndex.astro
+++ b/site/src/lexicon/AtlasFullIndex.astro
@@ -20,7 +20,7 @@ const clsLabels = {
 const chipCounts = (browseMeta.chipCounts ?? {}) as Record<string, number>;
 const chips = Object.entries(clsLabels).filter(([code]) => (chipCounts[code] ?? 0) > 0);
 const letterCounts = (browseMeta.letterCounts ?? {}) as Record<string, number>;
-const totalLabel = `${browseMeta.total ?? 0} слів · ${UKRAINIAN_ALPHABET.length} літери`;
+const totalLabel = `${browseMeta.total ?? 0} записів Атласу · ${UKRAINIAN_ALPHABET.length} літери`;
 ---
 
 <section
@@ -154,7 +154,7 @@ const GLOBAL_SEARCH_LIMIT = 200;
   if (root) {
   const meta = JSON.parse(root.dataset.browseMeta ?? "{}") as BrowseMeta;
   const flaggedRows = JSON.parse(root.dataset.flaggedRows ?? "[]") as BrowseRow[];
-  const totalLabel = root.dataset.totalLabel ?? `${meta.total ?? 0} слів · ${UKRAINIAN_ALPHABET.length} літери`;
+  const totalLabel = root.dataset.totalLabel ?? `${meta.total ?? 0} записів Атласу · ${UKRAINIAN_ALPHABET.length} літери`;
     const searchInput = root.querySelector<HTMLInputElement>("[data-index-search]");
     const status = root.querySelector<HTMLElement>("[data-index-status]");
     const section = root.querySelector<HTMLElement>("[data-letter-section]");
@@ -277,7 +277,7 @@ const GLOBAL_SEARCH_LIMIT = 200;
         return;
       }
       if (state.cls) {
-        status.textContent = `${CLS_LABELS[state.cls] ?? state.cls}: ${filteredCount} слів`;
+        status.textContent = `${CLS_LABELS[state.cls] ?? state.cls}: ${filteredCount} записів`;
         return;
       }
       status.textContent = totalLabel;
@@ -291,7 +291,7 @@ const GLOBAL_SEARCH_LIMIT = 200;
         status.textContent = state.error;
         return;
       }
-      status.textContent = `${state.letter}: ${filteredCount} слів`;
+      status.textContent = `${state.letter}: ${filteredCount} записів`;
     };
 
     const updateControls = (): void => {

--- a/site/src/lexicon/AtlasFullIndex.astro
+++ b/site/src/lexicon/AtlasFullIndex.astro
@@ -20,7 +20,16 @@ const clsLabels = {
 const chipCounts = (browseMeta.chipCounts ?? {}) as Record<string, number>;
 const chips = Object.entries(clsLabels).filter(([code]) => (chipCounts[code] ?? 0) > 0);
 const letterCounts = (browseMeta.letterCounts ?? {}) as Record<string, number>;
-const totalLabel = `${browseMeta.total ?? 0} записів Атласу · ${UKRAINIAN_ALPHABET.length} літери`;
+const atlasEntryNoun = (count: number): string => {
+  const mod100 = Math.abs(count) % 100;
+  if (mod100 >= 11 && mod100 <= 14) return "записів";
+  const mod10 = Math.abs(count) % 10;
+  if (mod10 === 1) return "запис";
+  if (mod10 >= 2 && mod10 <= 4) return "записи";
+  return "записів";
+};
+const totalCount = browseMeta.total ?? 0;
+const totalLabel = `${totalCount} ${atlasEntryNoun(totalCount)} Атласу · ${UKRAINIAN_ALPHABET.length} літери`;
 ---
 
 <section
@@ -134,9 +143,18 @@ type BrowseRow = {
     borr: "запозичення",
   };
 
-const CHUNK_SIZE = 150;
-const GLOBAL_SEARCH_LIMIT = 200;
+  const CHUNK_SIZE = 150;
+  const GLOBAL_SEARCH_LIMIT = 200;
   const alphabet = new Set<string>(UKRAINIAN_ALPHABET);
+  const atlasEntryNoun = (count: number): string => {
+    const mod100 = Math.abs(count) % 100;
+    if (mod100 >= 11 && mod100 <= 14) return "записів";
+    const mod10 = Math.abs(count) % 10;
+    if (mod10 === 1) return "запис";
+    if (mod10 >= 2 && mod10 <= 4) return "записи";
+    return "записів";
+  };
+  const atlasEntryCountLabel = (count: number): string => `${count} ${atlasEntryNoun(count)}`;
   const root = document.querySelector<HTMLElement>("[data-atlas-index]");
   const normalize = (value: string): string => value.normalize("NFC").toLocaleLowerCase("uk-UA");
   const escapeHtml = (value: string): string =>
@@ -154,7 +172,9 @@ const GLOBAL_SEARCH_LIMIT = 200;
   if (root) {
   const meta = JSON.parse(root.dataset.browseMeta ?? "{}") as BrowseMeta;
   const flaggedRows = JSON.parse(root.dataset.flaggedRows ?? "[]") as BrowseRow[];
-  const totalLabel = root.dataset.totalLabel ?? `${meta.total ?? 0} записів Атласу · ${UKRAINIAN_ALPHABET.length} літери`;
+  const totalCount = meta.total ?? 0;
+  const totalLabel = root.dataset.totalLabel
+    ?? `${atlasEntryCountLabel(totalCount)} Атласу · ${UKRAINIAN_ALPHABET.length} літери`;
     const searchInput = root.querySelector<HTMLInputElement>("[data-index-search]");
     const status = root.querySelector<HTMLElement>("[data-index-status]");
     const section = root.querySelector<HTMLElement>("[data-letter-section]");
@@ -277,7 +297,7 @@ const GLOBAL_SEARCH_LIMIT = 200;
         return;
       }
       if (state.cls) {
-        status.textContent = `${CLS_LABELS[state.cls] ?? state.cls}: ${filteredCount} записів`;
+        status.textContent = `${CLS_LABELS[state.cls] ?? state.cls}: ${atlasEntryCountLabel(filteredCount)}`;
         return;
       }
       status.textContent = totalLabel;
@@ -291,7 +311,7 @@ const GLOBAL_SEARCH_LIMIT = 200;
         status.textContent = state.error;
         return;
       }
-      status.textContent = `${state.letter}: ${filteredCount} записів`;
+      status.textContent = `${state.letter}: ${atlasEntryCountLabel(filteredCount)}`;
     };
 
     const updateControls = (): void => {

--- a/tests/test_generate_search_index.py
+++ b/tests/test_generate_search_index.py
@@ -4,11 +4,17 @@ import json
 from pathlib import Path
 
 from scripts.audit.generate_search_index import (
+    DEFAULT_BROWSE_DIR,
+    DEFAULT_BROWSE_META_OUT,
+    DEFAULT_SEARCH_OUT,
+    UKRAINIAN_ALPHABET,
     build_browse_outputs,
     build_index,
     classification_code,
     main,
 )
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 
 def entry(
@@ -266,3 +272,21 @@ def test_main_writes_search_meta_and_per_letter_shards(tmp_path: Path) -> None:
             "cls": "avoid",
         }
     ]
+
+
+def test_committed_browse_counts_match_search_index() -> None:
+    search_rows = json.loads((PROJECT_ROOT / DEFAULT_SEARCH_OUT).read_text(encoding="utf-8"))
+    meta = json.loads((PROJECT_ROOT / DEFAULT_BROWSE_META_OUT).read_text(encoding="utf-8"))
+    letter_counts = meta["letterCounts"]
+
+    assert set(letter_counts) == set(UKRAINIAN_ALPHABET)
+    assert meta["total"] == len(search_rows)
+
+    shard_total = 0
+    for letter in UKRAINIAN_ALPHABET:
+        shard_path = PROJECT_ROOT / DEFAULT_BROWSE_DIR / f"{letter}.json"
+        rows = json.loads(shard_path.read_text(encoding="utf-8")) if shard_path.exists() else []
+        assert len(rows) == letter_counts[letter]
+        shard_total += len(rows)
+
+    assert shard_total == len(search_rows)


### PR DESCRIPTION
## Summary\n- Relabel the Atlas browse total from a word count to Atlas index entries, so the live 5,250 count is not read as a full dictionary size.\n- Add a committed-output invariant tying browse metadata total to search-index length and per-letter browse shard lengths.\n\n## Validation\n- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_generate_search_index.py\n- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check tests/test_generate_search_index.py scripts/audit/generate_search_index.py\n- git diff --check\n- npm --prefix site run build (using temporary symlink to root site/node_modules for this worktree; symlink/build artifacts removed)\n- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py\n\n## Scope\nNo Atlas data regeneration. No daily/practice/cloze changes.