### PR TITLE
[codex] Expand review-only Atlas source inventory

### DIFF
--- a/data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml
+++ b/data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml
@@ -7,18 +7,167 @@ sources:
     extraction_mode: curated_headword
     title: Болшакова І.О. Буквар. 1 клас. Частина 1. Ранок, 2025
     path: docs/l2-uk-direct/textbook-reading-notes/bolshakova-bukvar-mapping.md
-    locator: letter sequence table key words for Я, Є, Ц
-    notes: Seed uses tracked reading notes mapped to the local source PDF; the PDF is not committed.
+    locator: Complete Letter Mapping plus Correct key words block
+    notes: Seed uses tracked reading notes mapped to the source PDF; PDF is not committed.
     headwords:
+      - lemma: автобус
+        pos: noun
+        locator: correct key words block; letter А
+        context: "Correct key words Bolshakova Буквар 2025 lists А: автобус."
+      - lemma: окуляри
+        pos: noun
+        locator: correct key words block; letter О
+        context: "Correct key words Bolshakova Буквар 2025 lists О: окуляри."
+      - lemma: Україна
+        pos: noun
+        gloss: Ukraine
+        locator: correct key words block; letter У
+        context: "Correct key words Bolshakova Буквар 2025 lists У: Україна."
+      - lemma: мама
+        pos: noun
+        locator: correct key words block; letter М
+        context: "Correct key words Bolshakova Буквар 2025 lists М: мама."
+      - lemma: сумка
+        pos: noun
+        locator: complete letter mapping row С с
+        context: "Letter table row С с lists key words сумка / сітка."
+      - lemma: сітка
+        pos: noun
+        locator: complete letter mapping row С с
+        context: "Letter table row С с lists key words сумка / сітка."
+      - lemma: намет
+        pos: noun
+        locator: complete letter mapping row Н н
+        context: "Letter table row Н н lists key words намет / нірка."
+      - lemma: нірка
+        pos: noun
+        locator: complete letter mapping row Н н
+        context: "Letter table row Н н lists key words намет / нірка."
+      - lemma: лис
+        pos: noun
+        locator: complete letter mapping row Л л
+        context: "Letter table row Л л lists key words лис / ліс."
+      - lemma: ліс
+        pos: noun
+        locator: complete letter mapping row Л л
+        context: "Letter table row Л л lists key words лис / ліс."
+      - lemma: капелюх
+        pos: noun
+        locator: complete letter mapping row К к
+        context: "Letter table row К к lists key word капелюх."
+      - lemma: ріка
+        pos: noun
+        locator: complete letter mapping row Р р
+        context: "Letter table row Р р lists key words ріка / робот."
+      - lemma: робот
+        pos: noun
+        locator: complete letter mapping row Р р
+        context: "Letter table row Р р lists key words ріка / робот."
+      - lemma: вареники
+        pos: noun
+        locator: complete letter mapping row В в
+        context: "Letter table row В в lists key word вареники."
+      - lemma: барабан
+        pos: noun
+        locator: complete letter mapping row Б б
+        context: "Letter table row Б б lists key word барабан."
+      - lemma: ібіс
+        pos: noun
+        locator: complete letter mapping row І і
+        context: "Letter table row І і lists key word ібіс."
+      - lemma: лелека
+        pos: noun
+        locator: complete letter mapping row Е е
+        context: "Letter table row Е е lists key word лелека."
+      - lemma: парк
+        pos: noun
+        locator: complete letter mapping row П п
+        context: "Letter table row П п lists key word парк."
+      - lemma: дуб
+        pos: noun
+        locator: complete letter mapping row Д д
+        context: "Letter table row Д д lists key words дуб / дім."
+      - lemma: дім
+        pos: noun
+        locator: complete letter mapping row Д д
+        context: "Letter table row Д д lists key words дуб / дім."
+      - lemma: торт
+        pos: noun
+        locator: complete letter mapping row Т т
+        context: "Letter table row Т т lists key words торт / тісто."
+      - lemma: тісто
+        pos: noun
+        locator: complete letter mapping row Т т
+        context: "Letter table row Т т lists key words торт / тісто."
+      - lemma: город
+        pos: noun
+        locator: complete letter mapping row Г г
+        context: "Letter table row Г г lists key word город."
+      - lemma: ґава
+        pos: noun
+        locator: complete letter mapping row Ґ ґ
+        context: "Letter table row Ґ ґ lists key word ґава."
+      - lemma: йогурт
+        pos: noun
+        locator: complete letter mapping row Й й
+        context: "Letter table row Й й lists key word йогурт."
+      - lemma: зірка
+        pos: noun
+        locator: complete letter mapping row З з
+        context: "Letter table row З з lists key word зірка."
+      - lemma: жабка
+        pos: noun
+        locator: complete letter mapping row Ж ж
+        context: "Letter table row Ж ж lists key word жабка."
+      - lemma: шафа
+        pos: noun
+        locator: complete letter mapping row Ш ш
+        context: "Letter table row Ш ш lists key word шафа."
+      - lemma: ховрах
+        pos: noun
+        locator: thematic categories; тварини
+        context: "Thematic categories list Х examples ховрах, муха, хом'як."
+      - lemma: муха
+        pos: noun
+        locator: thematic categories; тварини
+        context: "Thematic categories list Х examples ховрах, муха, хом'як."
+      - lemma: хом'як
+        pos: noun
+        locator: thematic categories; тварини
+        context: "Thematic categories list Х examples ховрах, муха, хом'як."
+      - lemma: чайник
+        pos: noun
+        locator: complete letter mapping row Ч ч
+        context: "Letter table row Ч ч lists key word чайник."
       - lemma: яблуко
         pos: noun
-        locator: letter table row Я я; content page 103 / PDF page 108
-        context: Row lists Я я with key word яблуко.
+        locator: complete letter mapping row Я я
+        context: "Letter table row Я я lists key word яблуко."
+      - lemma: юшка
+        pos: noun
+        locator: complete letter mapping row Ю ю
+        context: "Letter table row Ю ю lists key word юшка."
       - lemma: єнот
         pos: noun
-        locator: letter table row Є є; content page 111 / PDF page 116
-        context: Row lists Є є with key word єнот.
+        locator: complete letter mapping row Є є
+        context: "Letter table row Є є lists key word єнот."
+      - lemma: їжак
+        pos: noun
+        locator: complete letter mapping row Ї ї
+        context: "Letter table row Ї ї lists key word їжак."
+      - lemma: щука
+        pos: noun
+        locator: complete letter mapping row Щ щ
+        context: "Letter table row Щ щ lists key word щука."
       - lemma: цирк
         pos: noun
-        locator: letter table row Ц ц; content page 120 / PDF page 125
-        context: Row lists Ц ц with key words цирк / цікавий.
+        locator: complete letter mapping row Ц ц
+        context: "Letter table row Ц ц lists key words цирк / цікавий."
+      - lemma: цікавий
+        pos: adjective
+        locator: complete letter mapping row Ц ц
+        context: "Letter table row Ц ц lists key words цирк / цікавий."
+      - lemma: фокус
+        pos: noun
+        locator: complete letter mapping row Ф ф
+        context: "Letter table row Ф ф lists key word фокус."

--- a/data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+++ b/data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
@@ -2,6 +2,44 @@
 version: 1
 kind: atlas_source_inventory
 sources:
+  - id: ohoiko-abetka-1-keywords
+    source_family: ohoiko
+    extraction_mode: curated_key_word
+    title: Anna Ohoiko - Ukrainian Lessons alphabet pronunciation playlist
+    url: https://www.youtube.com/playlist?list=PLpkSIXDyaJi3mlJlKXWKhdiJZj67fPXQV
+    path: curriculum/l2-uk-direct/a1/abetka-1.yaml
+    locator: playlist_credit plus letters key_word/pronunciation_video entries
+    notes: Seed uses only tracked abetka key_word rows; no ULP premium vocabulary lists inferred.
+    headwords:
+      - lemma: ананас
+        pos: noun
+        locator: letters[А].key_word
+        context: "А key_word pronunciation video https://www.youtube.com/watch?v=hvB3VpcR3ZE"
+      - lemma: око
+        pos: noun
+        locator: letters[О].key_word
+        context: "О key_word; pronunciation_video is null in the tracked module"
+      - lemma: морква
+        pos: noun
+        locator: letters[М].key_word
+        context: "М key_word pronunciation video https://www.youtube.com/watch?v=Ez95H4ibuJo"
+      - lemma: літак
+        pos: noun
+        locator: letters[Л].key_word
+        context: "Л key_word pronunciation video https://www.youtube.com/watch?v=v6-3Xg52Buk"
+      - lemma: Україна
+        pos: noun
+        gloss: Ukraine
+        locator: letters[У].key_word
+        context: "У key_word pronunciation video https://www.youtube.com/watch?v=VB1O6PmtYRU"
+      - lemma: ножиці
+        pos: noun
+        locator: letters[Н].key_word
+        context: "Н key_word pronunciation video https://www.youtube.com/watch?v=vNUfiKHPYaU"
+      - lemma: сумка
+        pos: noun
+        locator: letters[С].key_word
+        context: "С key_word pronunciation video https://www.youtube.com/watch?v=7UsFBgSL91E"
   - id: ohoiko-abetka-2-keywords
     source_family: ohoiko
     extraction_mode: curated_key_word
@@ -14,12 +52,122 @@ sources:
       - lemma: кіт
         pos: noun
         locator: letters[К].key_word
-        context: К key_word with pronunciation video https://www.youtube.com/watch?v=J7sGEI4-xJo
+        context: "К key_word pronunciation video https://www.youtube.com/watch?v=J7sGEI4-xJo"
       - lemma: риба
         pos: noun
         locator: letters[И].key_word
-        context: И key_word with pronunciation video https://www.youtube.com/watch?v=W-1rCu0indE
+        context: "И key_word pronunciation video https://www.youtube.com/watch?v=W-1rCu0indE"
       - lemma: ракета
         pos: noun
         locator: letters[Р].key_word
-        context: Р key_word with pronunciation video https://www.youtube.com/watch?v=fMGsQ5KPQgg
+        context: "Р key_word pronunciation video https://www.youtube.com/watch?v=fMGsQ5KPQgg"
+      - lemma: банан
+        pos: noun
+        locator: letters[Б].key_word
+        context: "Б key_word pronunciation video https://www.youtube.com/watch?v=V1hxBE_JbGg"
+      - lemma: вовк
+        pos: noun
+        locator: letters[В].key_word
+        context: "В key_word pronunciation video https://www.youtube.com/watch?v=aFcvYfvQ2X4"
+      - lemma: дім
+        pos: noun
+        locator: letters[Д].key_word
+        context: "Д key_word pronunciation video https://www.youtube.com/watch?v=g4Bh-lqzd48"
+      - lemma: індик
+        pos: noun
+        locator: letters[І].key_word
+        context: "І key_word pronunciation video https://www.youtube.com/watch?v=Z9TH0H4ShGo"
+  - id: ohoiko-abetka-3-keywords
+    source_family: ohoiko
+    extraction_mode: curated_key_word
+    title: Anna Ohoiko - Ukrainian Lessons alphabet pronunciation playlist
+    url: https://www.youtube.com/playlist?list=PLpkSIXDyaJi3mlJlKXWKhdiJZj67fPXQV
+    path: curriculum/l2-uk-direct/a1/abetka-3.yaml
+    locator: playlist_credit plus letters key_word/pronunciation_video entries
+    notes: Seed uses only tracked abetka key_word rows; no ULP premium vocabulary lists inferred.
+    headwords:
+      - lemma: павук
+        pos: noun
+        locator: letters[П].key_word
+        context: "П key_word pronunciation video https://www.youtube.com/watch?v=JksSjjxyW5Y"
+      - lemma: тигр
+        pos: noun
+        locator: letters[Т].key_word
+        context: "Т key_word pronunciation video https://www.youtube.com/watch?v=m-jcLR_gK0k"
+      - lemma: гора
+        pos: noun
+        locator: letters[Г].key_word
+        context: "Г key_word pronunciation video https://www.youtube.com/watch?v=gVnclpSI0DU"
+      - lemma: ґанок
+        pos: noun
+        locator: letters[Ґ].key_word
+        context: "Ґ key_word pronunciation video https://www.youtube.com/watch?v=gNjHqjTW9WQ"
+      - lemma: екран
+        pos: noun
+        locator: letters[Е].key_word
+        context: "Е key_word pronunciation video https://www.youtube.com/watch?v=KFlsroBW0dk"
+      - lemma: зебра
+        pos: noun
+        locator: letters[З].key_word
+        context: "З key_word pronunciation video https://www.youtube.com/watch?v=BhASNxitC1A"
+      - lemma: жук
+        pos: noun
+        locator: letters[Ж].key_word
+        context: "Ж key_word pronunciation video https://www.youtube.com/watch?v=dIrGVcqPwqM"
+      - lemma: шапка
+        pos: noun
+        locator: letters[Ш].key_word
+        context: "Ш key_word pronunciation video https://www.youtube.com/watch?v=1D-6MIw3OXY"
+      - lemma: хліб
+        pos: noun
+        locator: letters[Х].key_word
+        context: "Х key_word pronunciation video https://www.youtube.com/watch?v=vpr58zJSJKc"
+  - id: ohoiko-abetka-4-keywords
+    source_family: ohoiko
+    extraction_mode: curated_key_word
+    title: Anna Ohoiko - Ukrainian Lessons alphabet pronunciation playlist
+    url: https://www.youtube.com/playlist?list=PLpkSIXDyaJi3mlJlKXWKhdiJZj67fPXQV
+    path: curriculum/l2-uk-direct/a1/abetka-4.yaml
+    locator: playlist_credit plus letters key_word/pronunciation_video entries
+    notes: Seed uses only tracked abetka key_word rows; no ULP premium vocabulary lists inferred.
+    headwords:
+      - lemma: йогурт
+        pos: noun
+        locator: letters[Й].key_word
+        context: "Й key_word pronunciation video https://www.youtube.com/watch?v=aq0cjB90s3w"
+      - lemma: черепаха
+        pos: noun
+        locator: letters[Ч].key_word
+        context: "Ч key_word pronunciation video https://www.youtube.com/watch?v=UsJkbdsY2RA"
+      - lemma: щітка
+        pos: noun
+        locator: letters[Щ].key_word
+        context: "Щ key_word pronunciation video https://www.youtube.com/watch?v=QmBLieIuf6Q"
+      - lemma: яблуко
+        pos: noun
+        locator: letters[Я].key_word
+        context: "Я key_word pronunciation video https://www.youtube.com/watch?v=yhSAf41LX8I"
+      - lemma: юнак
+        pos: noun
+        locator: letters[Ю].key_word
+        context: "Ю key_word pronunciation video https://www.youtube.com/watch?v=9JdIBYCTWGw"
+      - lemma: єнот
+        pos: noun
+        locator: letters[Є].key_word
+        context: "Є key_word pronunciation video https://www.youtube.com/watch?v=O0bwRyyBQSc"
+      - lemma: сіль
+        pos: noun
+        locator: letters[Ь].key_word
+        context: "Ь key_word pronunciation video https://www.youtube.com/watch?v=cJlal8XKBxo"
+      - lemma: їжак
+        pos: noun
+        locator: letters[Ї].key_word
+        context: "Ї key_word pronunciation video https://www.youtube.com/watch?v=UcjdjQXhAY8"
+      - lemma: цибуля
+        pos: noun
+        locator: letters[Ц].key_word
+        context: "Ц key_word pronunciation video https://www.youtube.com/watch?v=u44eCjR2Oz8"
+      - lemma: фламінго
+        pos: noun
+        locator: letters[Ф].key_word
+        context: "Ф key_word pronunciation video https://www.youtube.com/watch?v=haHRsFFZRQI"

--- a/data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml
+++ b/data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml
@@ -1,0 +1,196 @@
+---
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: vashulenko-grade3-2020-school-vocabulary
+    source_family: textbook
+    extraction_mode: headword_inventory
+    title: Вашуленко М.С. Українська мова та читання. 3 клас. Частина 1, 2020
+    path: docs/l2-uk-direct/textbook-map.yaml
+    locator: topic_index.vocabulary_school
+    notes: Seed uses only tracked textbook-map word lists; source PDF is not committed.
+    headwords:
+      - lemma: крейда
+        pos: noun
+        locator: topic_index.vocabulary_school.words[0]
+        context: "Grade 3 p63 school vocabulary word list includes крейда."
+      - lemma: урок
+        pos: noun
+        locator: topic_index.vocabulary_school.words[1]
+        context: "Grade 3 p63 school vocabulary word list includes урок."
+      - lemma: парта
+        pos: noun
+        locator: topic_index.vocabulary_school.words[2]
+        context: "Grade 3 p63 school vocabulary word list includes парта."
+      - lemma: ручка
+        pos: noun
+        locator: topic_index.vocabulary_school.words[3]
+        context: "Grade 3 p63 school vocabulary word list includes ручка."
+      - lemma: дошка
+        pos: noun
+        locator: topic_index.vocabulary_school.words[4]
+        context: "Grade 3 p63 school vocabulary word list includes дошка."
+      - lemma: зошит
+        pos: noun
+        locator: topic_index.vocabulary_school.words[5]
+        context: "Grade 3 p63 school vocabulary word list includes зошит."
+      - lemma: клас
+        pos: noun
+        locator: topic_index.vocabulary_school.words[6]
+        context: "Grade 3 p63 school vocabulary word list includes клас."
+  - id: vashulenko-grade3-2020-interior-vocabulary
+    source_family: textbook
+    extraction_mode: headword_inventory
+    title: Вашуленко М.С. Українська мова та читання. 3 клас. Частина 1, 2020
+    path: docs/l2-uk-direct/textbook-map.yaml
+    locator: topic_index.vocabulary_interior
+    notes: Seed uses only tracked textbook-map word lists; source PDF is not committed.
+    headwords:
+      - lemma: стіл
+        pos: noun
+        locator: topic_index.vocabulary_interior.words[0]
+        context: "Grade 3 pp130-131 interior vocabulary word list includes стіл."
+      - lemma: шафа
+        pos: noun
+        locator: topic_index.vocabulary_interior.words[1]
+        context: "Grade 3 pp130-131 interior vocabulary word list includes шафа."
+      - lemma: ліжко
+        pos: noun
+        locator: topic_index.vocabulary_interior.words[2]
+        context: "Grade 3 pp130-131 interior vocabulary word list includes ліжко."
+      - lemma: диван
+        pos: noun
+        locator: topic_index.vocabulary_interior.words[3]
+        context: "Grade 3 pp130-131 interior vocabulary word list includes диван."
+      - lemma: крісло
+        pos: noun
+        locator: topic_index.vocabulary_interior.words[4]
+        context: "Grade 3 pp130-131 interior vocabulary word list includes крісло."
+      - lemma: скатертина
+        pos: noun
+        locator: topic_index.vocabulary_interior.words[5]
+        context: "Grade 3 pp130-131 interior vocabulary word list includes скатертина."
+      - lemma: тумбочка
+        pos: noun
+        locator: topic_index.vocabulary_interior.words[6]
+        context: "Grade 3 pp130-131 interior vocabulary word list includes тумбочка."
+      - lemma: стілець
+        pos: noun
+        locator: topic_index.vocabulary_interior.words[7]
+        context: "Grade 3 pp130-131 interior vocabulary word list includes стілець."
+      - lemma: підлога
+        pos: noun
+        locator: topic_index.vocabulary_interior.words[8]
+        context: "Grade 3 pp130-131 interior vocabulary word list includes підлога."
+      - lemma: стеля
+        pos: noun
+        locator: topic_index.vocabulary_interior.words[9]
+        context: "Grade 3 pp130-131 interior vocabulary word list includes стеля."
+      - lemma: коридор
+        pos: noun
+        locator: topic_index.vocabulary_interior.words[10]
+        context: "Grade 3 pp130-131 interior vocabulary word list includes коридор."
+      - lemma: балкон
+        pos: noun
+        locator: topic_index.vocabulary_interior.words[11]
+        context: "Grade 3 pp130-131 interior vocabulary word list includes балкон."
+      - lemma: дерев'яний
+        pos: adjective
+        locator: topic_index.vocabulary_interior.adjectives[0]
+        context: "Grade 3 pp130-131 interior vocabulary adjective list includes дерев'яний."
+      - lemma: синій
+        pos: adjective
+        locator: topic_index.vocabulary_interior.adjectives[1]
+        context: "Grade 3 pp130-131 interior vocabulary adjective list includes синій."
+      - lemma: зручний
+        pos: adjective
+        locator: topic_index.vocabulary_interior.adjectives[2]
+        context: "Grade 3 pp130-131 interior vocabulary adjective list includes зручний."
+      - lemma: просторий
+        pos: adjective
+        locator: topic_index.vocabulary_interior.adjectives[3]
+        context: "Grade 3 pp130-131 interior vocabulary adjective list includes просторий."
+      - lemma: затишний
+        pos: adjective
+        locator: topic_index.vocabulary_interior.adjectives[4]
+        context: "Grade 3 pp130-131 interior vocabulary adjective list includes затишний."
+  - id: vashulenko-grade3-2020-marine-vocabulary
+    source_family: textbook
+    extraction_mode: headword_inventory
+    title: Вашуленко М.С. Українська мова та читання. 3 клас. Частина 1, 2020
+    path: docs/l2-uk-direct/textbook-map.yaml
+    locator: topic_index.vocabulary_marine
+    notes: Seed uses only tracked textbook-map word lists; source PDF is not committed.
+    headwords:
+      - lemma: медуза
+        pos: noun
+        locator: topic_index.vocabulary_marine.words[0]
+        context: "Grade 3 pp119-121 marine vocabulary word list includes медуза."
+      - lemma: дельфін
+        pos: noun
+        locator: topic_index.vocabulary_marine.words[1]
+        context: "Grade 3 pp119-121 marine vocabulary word list includes дельфін."
+      - lemma: кит
+        pos: noun
+        locator: topic_index.vocabulary_marine.words[2]
+        context: "Grade 3 pp119-121 marine vocabulary word list includes кит."
+      - lemma: косатка
+        pos: noun
+        locator: topic_index.vocabulary_marine.words[3]
+        context: "Grade 3 pp119-121 marine vocabulary word list includes косатка."
+      - lemma: риба
+        pos: noun
+        locator: topic_index.vocabulary_marine.words[4]
+        context: "Grade 3 pp119-121 marine vocabulary word list includes риба."
+      - lemma: плавні
+        pos: noun
+        locator: topic_index.vocabulary_marine.words[5]
+        context: "Grade 3 pp119-121 marine vocabulary word list includes плавні."
+  - id: vashulenko-grade3-2020-birds-vocabulary
+    source_family: textbook
+    extraction_mode: headword_inventory
+    title: Вашуленко М.С. Українська мова та читання. 3 клас. Частина 1, 2020
+    path: docs/l2-uk-direct/textbook-map.yaml
+    locator: topic_index.vocabulary_birds_extended
+    notes: Seed uses only tracked textbook-map word lists; source PDF is not committed.
+    headwords:
+      - lemma: снігур
+        pos: noun
+        locator: topic_index.vocabulary_birds_extended.words[0]
+        context: "Grade 3 pp102,135 bird vocabulary word list includes снігур."
+      - lemma: синиця
+        pos: noun
+        locator: topic_index.vocabulary_birds_extended.words[1]
+        context: "Grade 3 pp102,135 bird vocabulary word list includes синиця."
+      - lemma: лелека
+        pos: noun
+        locator: topic_index.vocabulary_birds_extended.words[2]
+        context: "Grade 3 pp102,135 bird vocabulary word list includes лелека."
+      - lemma: чапля
+        pos: noun
+        locator: topic_index.vocabulary_birds_extended.words[3]
+        context: "Grade 3 pp102,135 bird vocabulary word list includes чапля."
+      - lemma: колібрі
+        pos: noun
+        locator: topic_index.vocabulary_birds_extended.words[4]
+        context: "Grade 3 pp102,135 bird vocabulary word list includes колібрі."
+      - lemma: дятел
+        pos: noun
+        locator: topic_index.vocabulary_birds_extended.words[5]
+        context: "Grade 3 pp102,135 bird vocabulary word list includes дятел."
+      - lemma: рябчик
+        pos: noun
+        locator: topic_index.vocabulary_birds_extended.words[7]
+        context: "Grade 3 pp102,135 bird vocabulary word list includes рябчик."
+      - lemma: горобець
+        pos: noun
+        locator: topic_index.vocabulary_birds_extended.words[8]
+        context: "Grade 3 pp102,135 bird vocabulary word list includes горобець."
+      - lemma: галка
+        pos: noun
+        locator: topic_index.vocabulary_birds_extended.words[9]
+        context: "Grade 3 pp102,135 bird vocabulary word list includes галка."
+      - lemma: ластівка
+        pos: noun
+        locator: topic_index.vocabulary_birds_extended.words[10]
+        context: "Grade 3 pp102,135 bird vocabulary word list includes ластівка."

--- a/scripts/audit/generate_source_inventory_review_candidates.py
+++ b/scripts/audit/generate_source_inventory_review_candidates.py
@@ -15,7 +15,10 @@ from scripts.audit.source_inventory_intake import SourceInventoryError
 from scripts.lexicon.content_lexicon_reconciler import PROJECT_ROOT
 
 COMMITTED_SOURCE_INVENTORIES: tuple[Path, ...] = (
+    PROJECT_ROOT / "data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml",
+    PROJECT_ROOT / "data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml",
+    PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml",
 )
 
 DEFAULT_OUT = Path("/tmp/atlas-source-inventory-review-candidates.json")
@@ -32,6 +35,11 @@ LIVE_ATLAS_OUTPUTS: tuple[Path, ...] = (
     PROJECT_ROOT / "site/src/data/lexicon-manifest.fingerprint.json",
 )
 LIVE_ATLAS_OUTPUT_DIR = PROJECT_ROOT / "site/src/data"
+LIVE_STATIC_LEXICON_OUTPUT_DIR = PROJECT_ROOT / "site/public/lexicon"
+LIVE_REVIEW_FORBIDDEN_OUTPUT_DIRS: tuple[Path, ...] = (
+    LIVE_ATLAS_OUTPUT_DIR,
+    LIVE_STATIC_LEXICON_OUTPUT_DIR,
+)
 
 
 def generate_review_candidates(
@@ -99,9 +107,12 @@ def resolve_review_output_path(out: Path) -> Path:
         raise SourceInventoryError(
             f"review-only source candidates must not overwrite {resolved.relative_to(PROJECT_ROOT)}"
         )
-    if resolved.is_relative_to(LIVE_ATLAS_OUTPUT_DIR.resolve()):
+    for output_dir in LIVE_REVIEW_FORBIDDEN_OUTPUT_DIRS:
+        if not resolved.is_relative_to(output_dir.resolve()):
+            continue
         raise SourceInventoryError(
-            "review-only source candidates must not write under site/src/data"
+            "review-only source candidates must not write under "
+            f"{output_dir.relative_to(PROJECT_ROOT)}"
         )
     return resolved
 

--- a/tests/test_source_inventory_intake.py
+++ b/tests/test_source_inventory_intake.py
@@ -200,6 +200,11 @@ def test_committed_source_inventory_files_are_valid() -> None:
 
     candidates = source_inventory_candidates(records)
     assert candidates
+    assert len(records) >= 100
+    assert len(candidates) >= 100
+    assert {"curriculum", "ohoiko", "textbook"} <= {
+        record.source_family for record in records
+    }
 
     for candidate in candidates:
         assert candidate.source_provenance

--- a/tests/test_source_inventory_review_candidates.py
+++ b/tests/test_source_inventory_review_candidates.py
@@ -8,31 +8,13 @@ from typing import Any
 import pytest
 
 from scripts.audit import generate_source_inventory_review_candidates as review
-from scripts.audit.source_inventory_intake import SourceInventoryError
+from scripts.audit.source_inventory_intake import (
+    SourceInventoryError,
+    read_source_inventories,
+    source_inventory_candidates,
+)
 from scripts.lexicon.content_lexicon_reconciler import PROJECT_ROOT
 
-POS_BALANCED_LEMMAS = {
-    "школа",
-    "море",
-    "великий",
-    "гарний",
-    "один",
-    "два",
-    "ніхто",
-    "себе",
-    "робити",
-    "читати",
-    "швидко",
-    "добре",
-    "щодо",
-    "через",
-    "і",
-    "але",
-    "не",
-    "хіба",
-    "ой",
-    "ура",
-}
 POS_BALANCED_POS = {
     "noun",
     "adjective",
@@ -45,6 +27,7 @@ POS_BALANCED_POS = {
     "particle",
     "interjection",
 }
+REQUIRED_REVIEW_SOURCE_FAMILIES = {"curriculum", "ohoiko", "textbook"}
 
 
 def test_review_candidates_use_committed_inventories_and_keep_provenance(
@@ -52,6 +35,16 @@ def test_review_candidates_use_committed_inventories_and_keep_provenance(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     out = tmp_path / "atlas-source-inventory-review-candidates.json"
+    records = read_source_inventories(
+        review.COMMITTED_SOURCE_INVENTORIES,
+        project_root=PROJECT_ROOT,
+    )
+    expected_candidates = source_inventory_candidates(records)
+    expected_inventory_paths = [
+        str(path.relative_to(PROJECT_ROOT)) for path in review.COMMITTED_SOURCE_INVENTORIES
+    ]
+    expected_lemmas = {candidate.lemma for candidate in expected_candidates}
+    expected_pos = {candidate.pos for candidate in expected_candidates if candidate.pos}
 
     monkeypatch.setattr(review.grow, "_source_connection", lambda path: nullcontext(object()))
     monkeypatch.setattr(review.grow, "_preserve_wiki_reference_cache", lambda: nullcontext())
@@ -85,16 +78,14 @@ def test_review_candidates_use_committed_inventories_and_keep_provenance(
     payload = review.generate_review_candidates(out=out)
 
     assert payload["counts"] == {
-        "total_delta": len(POS_BALANCED_LEMMAS),
-        "processed": len(POS_BALANCED_LEMMAS),
-        "auto_merge": len(POS_BALANCED_LEMMAS),
+        "total_delta": len(expected_candidates),
+        "processed": len(expected_candidates),
+        "auto_merge": len(expected_candidates),
         "needs_review": 0,
     }
     assert payload["review_only"] == {
         "workflow": review.WORKFLOW_ID,
-        "source_inventory_paths": [
-            "data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml",
-        ],
+        "source_inventory_paths": expected_inventory_paths,
         "candidate_output": str(out.resolve()),
         "production_outputs_updated": [],
     }
@@ -103,8 +94,14 @@ def test_review_candidates_use_committed_inventories_and_keep_provenance(
     )
 
     entries = payload["auto_merge"]
-    assert {entry["lemma"] for entry in entries} == POS_BALANCED_LEMMAS
-    assert {entry["pos"] for entry in entries} == POS_BALANCED_POS
+    assert {entry["lemma"] for entry in entries} == expected_lemmas
+    assert {entry["pos"] for entry in entries} == expected_pos
+    assert expected_pos >= POS_BALANCED_POS
+    entries_by_lemma = {entry["lemma"]: entry for entry in entries}
+    assert entries_by_lemma["Україна"]["gloss"] == "Ukraine"
+
+    provenance_families = set()
+    provenance_inventory_paths = set()
     for entry in entries:
         assert entry["source_provenance"]
         for provenance in entry["source_provenance"]:
@@ -113,6 +110,10 @@ def test_review_candidates_use_committed_inventories_and_keep_provenance(
             )
             assert provenance["source_id"]
             assert provenance["source_title"]
+            provenance_families.add(provenance["source_family"])
+            provenance_inventory_paths.add(provenance["inventory_path"])
+    assert provenance_families >= REQUIRED_REVIEW_SOURCE_FAMILIES
+    assert provenance_inventory_paths >= set(expected_inventory_paths)
 
 
 def test_review_workflow_validates_source_provenance_in_needs_review() -> None:
@@ -174,6 +175,11 @@ def test_review_workflow_defaults_outside_repo() -> None:
     assert resolved == review.DEFAULT_OUT.resolve()
     assert not resolved.is_relative_to(PROJECT_ROOT)
     assert all(path.exists() for path in review.COMMITTED_SOURCE_INVENTORIES)
+    records = read_source_inventories(
+        review.COMMITTED_SOURCE_INVENTORIES,
+        project_root=PROJECT_ROOT,
+    )
+    assert source_inventory_candidates(records)
 
 
 @pytest.mark.parametrize("production_output", review.LIVE_ATLAS_OUTPUTS)
@@ -187,3 +193,17 @@ def test_review_workflow_rejects_live_atlas_output_directory() -> None:
         review.resolve_review_output_path(
             PROJECT_ROOT / "site/src/data/source-inventory-review-candidates.json"
         )
+
+
+@pytest.mark.parametrize(
+    "static_output",
+    [
+        PROJECT_ROOT / "site/public/lexicon/browse/а.json",
+        PROJECT_ROOT / "site/public/lexicon/daily-pool.json",
+        PROJECT_ROOT / "site/public/lexicon/practice-lexemes.A1.json",
+        PROJECT_ROOT / "site/public/lexicon/cloze-lexemes.A1.json",
+    ],
+)
+def test_review_workflow_rejects_static_lexicon_outputs(static_output: Path) -> None:
+    with pytest.raises(SourceInventoryError, match="site/public/lexicon"):
+        review.resolve_review_output_path(static_output)


### PR DESCRIPTION
## Summary

Expands the Static Word Atlas source-inventory review batch without publishing live Atlas or static practice outputs.

- Expands `ohoiko-abetka-keywords.yaml` from 3 to 33 tracked alphabet keyword rows across `abetka-1` through `abetka-4`.
- Expands `bolshakova-bukvar-keywords.yaml` from 3 to 40 tracked mapping-note rows.
- Adds `vashulenko-grade3-headwords.yaml` with 40 tracked textbook-map rows from school, interior, marine, and bird vocabulary lists.
- Includes all committed inventory files in the review-only generator and rejects review outputs under both `site/src/data` and `site/public/lexicon`.

## Counts

Committed inventory set now parses to 133 source records and 123 deduped review candidates.

Source-family balance:

- `textbook`: 80 rows
- `ohoiko`: 33 rows
- `curriculum`: 20 rows

POS balance from source records:

- `noun`: 109
- `adjective`: 8
- `numeral`, `pronoun`, `verb`, `adverb`, `preposition`, `conjunction`, `particle`, `interjection`: 2 each

Review generator report:

- `total_delta`: 123
- `processed`: 123
- `auto_merge`: 42
- `needs_review`: 81
- `review_output`: `/private/tmp/atlas-source-inventory-review-candidates.json`
- `production_outputs_updated`: `[]`

## Validation

- `.venv/bin/python -m pytest tests/test_source_inventory_intake.py tests/test_grow_lexicon_from_sources.py tests/test_source_inventory_review_candidates.py` - passed, 28 tests
- `.venv/bin/python -m scripts.audit.generate_source_inventory_review_candidates --report` - passed, 123 processed
- `.venv/bin/python scripts/audit/check_static_practice_assets.py --format json` - `ok: true`, daily count 300, total cloze 0
- `.venv/bin/ruff check scripts/audit/generate_source_inventory_review_candidates.py tests/test_source_inventory_intake.py tests/test_source_inventory_review_candidates.py` - passed
- `git diff --check` and `git diff --cached --check` - passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` - passed

## Independent review

AGY/Gemini review via `scripts/ai_agent_bridge/__main__.py ask-agy --review --to-model gemini-3.1-pro-high` found no actionable blockers/regressions. It flagged a possible `Ващуленко` typo in the new Vashulenko inventory title; fixed to `Вашуленко` before this PR.

Refs #3933, #3934, #3936.