### PR TITLE
[codex] Add source candidate triage report

### DIFF
--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -24,6 +24,12 @@ The candidate JSON follows the existing grow-candidate shape: `counts`,
 `auto_merge`, and `needs_review`. The wrapper also adds `review_only` metadata
 with the workflow id, inventory paths, review output path, and
 `production_outputs_updated: []`.
+It also adds `review_triage`, a review-only publish-readiness summary. The
+grow `auto_merge` bucket means the candidate passed low-level dictionary/POS
+gates; it is not approval to publish. `review_triage.counts.publish_ready`
+requires grow `auto_merge` plus source provenance, POS, and a visible English
+anchor. `review_triage.counts.needs_publish_review` lists candidates that need
+human review before any live Atlas publish batch.
 
 Every generated candidate must retain non-empty `source_provenance`. The
 representative smoke run currently processes 20 source inventory headwords:

--- a/scripts/audit/generate_source_inventory_review_candidates.py
+++ b/scripts/audit/generate_source_inventory_review_candidates.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 import argparse
 import sys
 import uuid
-from collections.abc import Sequence
+from collections import Counter
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +24,8 @@ COMMITTED_SOURCE_INVENTORIES: tuple[Path, ...] = (
 
 DEFAULT_OUT = Path("/tmp/atlas-source-inventory-review-candidates.json")
 WORKFLOW_ID = "source_inventory_review_candidates.v1"
+TRIAGE_WORKFLOW_ID = "source_inventory_review_triage.v1"
+TRIAGE_SAMPLE_LIMIT = 20
 
 LIVE_ATLAS_OUTPUTS: tuple[Path, ...] = (
     PROJECT_ROOT / "site/src/data/lexicon-manifest.json",
@@ -60,6 +63,7 @@ def generate_review_candidates(
     finally:
         temp_out.unlink(missing_ok=True)
 
+    payload["review_triage"] = build_review_triage(payload)
     payload["review_only"] = {
         "workflow": WORKFLOW_ID,
         "source_inventory_paths": [
@@ -97,6 +101,168 @@ def iter_candidate_entries(payload: dict[str, Any]) -> list[dict[str, Any]]:
         if isinstance(item, dict) and isinstance(item.get("entry"), dict)
     )
     return entries
+
+
+def build_review_triage(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return conservative review metadata before any live publish decision."""
+    publish_ready: list[dict[str, Any]] = []
+    needs_publish_review: list[dict[str, Any]] = []
+    reason_counts: Counter[str] = Counter()
+    source_family_counts: Counter[str] = Counter()
+    pos_counts: Counter[str] = Counter()
+
+    auto_merge_entries = [
+        entry for entry in payload.get("auto_merge", []) if isinstance(entry, dict)
+    ]
+    needs_review_items = [
+        item
+        for item in payload.get("needs_review", [])
+        if isinstance(item, dict) and isinstance(item.get("entry"), dict)
+    ]
+
+    for entry in auto_merge_entries:
+        _count_entry(entry, source_family_counts=source_family_counts, pos_counts=pos_counts)
+        reasons = publish_review_reasons(entry)
+        if reasons:
+            for reason in reasons:
+                reason_counts[reason] += 1
+            needs_publish_review.append(_triage_row(entry, bucket="auto_merge", reasons=reasons))
+            continue
+        publish_ready.append(_triage_row(entry, bucket="auto_merge", reasons=[]))
+
+    for item in needs_review_items:
+        entry = item["entry"]
+        _count_entry(entry, source_family_counts=source_family_counts, pos_counts=pos_counts)
+        grow_reason = str(item.get("reason") or "unspecified").strip()
+        reasons = [f"grow_needs_review:{grow_reason}"]
+        reasons.extend(publish_review_reasons(entry))
+        for reason in reasons:
+            reason_counts[reason] += 1
+        needs_publish_review.append(_triage_row(entry, bucket="needs_review", reasons=reasons))
+
+    publish_ready.sort(key=_triage_sort_key)
+    needs_publish_review.sort(key=_triage_sort_key)
+
+    return {
+        "workflow": TRIAGE_WORKFLOW_ID,
+        "policy": (
+            "Review-only triage; grow auto_merge is not publish approval. "
+            "Publish-ready requires grow auto_merge plus source provenance, POS, "
+            "and a visible English anchor."
+        ),
+        "counts": {
+            "total_candidates": len(auto_merge_entries) + len(needs_review_items),
+            "grow_auto_merge": len(auto_merge_entries),
+            "grow_needs_review": len(needs_review_items),
+            "publish_ready": len(publish_ready),
+            "needs_publish_review": len(needs_publish_review),
+        },
+        "needs_publish_review_reasons": dict(sorted(reason_counts.items())),
+        "by_source_family": dict(sorted(source_family_counts.items())),
+        "by_pos": dict(sorted(pos_counts.items())),
+        "publish_ready_sample": publish_ready[:TRIAGE_SAMPLE_LIMIT],
+        "needs_publish_review_sample": needs_publish_review[:TRIAGE_SAMPLE_LIMIT],
+    }
+
+
+def publish_review_reasons(entry: Mapping[str, Any]) -> list[str]:
+    """Return publish-review blockers independent of grow auto-merge bucket."""
+    reasons: list[str] = []
+    if not entry.get("source_provenance"):
+        reasons.append("missing_source_provenance")
+    if not _clean_text(entry.get("pos")):
+        reasons.append("missing_pos")
+    if not has_visible_english_anchor(entry):
+        reasons.append("missing_english_anchor")
+    return reasons
+
+
+def has_visible_english_anchor(entry: Mapping[str, Any]) -> bool:
+    """Return true if search/browse can surface learner-facing English."""
+    if _clean_text(entry.get("gloss")):
+        return True
+    enrichment = entry.get("enrichment")
+    if not isinstance(enrichment, Mapping):
+        return False
+    translation = enrichment.get("translation")
+    if not isinstance(translation, Mapping):
+        return False
+    terms = translation.get("en")
+    if not isinstance(terms, list):
+        return False
+    return any(_clean_text(term) for term in terms)
+
+
+def _count_entry(
+    entry: Mapping[str, Any],
+    *,
+    source_family_counts: Counter[str],
+    pos_counts: Counter[str],
+) -> None:
+    families = _source_families(entry)
+    for family in families or ["unknown"]:
+        source_family_counts[family] += 1
+    pos_counts[_clean_text(entry.get("pos")) or "unknown"] += 1
+
+
+def _triage_row(
+    entry: Mapping[str, Any], *, bucket: str, reasons: Sequence[str]
+) -> dict[str, Any]:
+    provenance = entry.get("source_provenance")
+    source_count = len(provenance) if isinstance(provenance, list) else 0
+    return {
+        "lemma": str(entry.get("lemma") or ""),
+        "pos": _clean_text(entry.get("pos")),
+        "bucket": bucket,
+        "source_families": _source_families(entry),
+        "source_count": source_count,
+        "has_english_anchor": has_visible_english_anchor(entry),
+        "reasons": list(reasons),
+    }
+
+
+def _source_families(entry: Mapping[str, Any]) -> list[str]:
+    provenance = entry.get("source_provenance")
+    if not isinstance(provenance, list):
+        return []
+    families = {
+        family
+        for item in provenance
+        if isinstance(item, Mapping)
+        for family in [_clean_text(item.get("source_family"))]
+        if family
+    }
+    return sorted(families)
+
+
+def _triage_sort_key(row: Mapping[str, Any]) -> tuple[str, str]:
+    return (
+        str(row.get("lemma") or "").casefold(),
+        str(row.get("pos") or "").casefold(),
+    )
+
+
+def _clean_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def format_triage_report(payload: Mapping[str, Any]) -> str:
+    triage = payload.get("review_triage")
+    if not isinstance(triage, Mapping):
+        return "review_triage: missing"
+    counts = triage.get("counts") if isinstance(triage.get("counts"), Mapping) else {}
+    lines = [
+        f"publish_ready: {counts.get('publish_ready', 0)}",
+        f"needs_publish_review: {counts.get('needs_publish_review', 0)}",
+    ]
+    reasons = triage.get("needs_publish_review_reasons")
+    if isinstance(reasons, Mapping) and reasons:
+        lines.append("needs_publish_review_reasons:")
+        lines.extend(f"- {reason}: {count}" for reason, count in sorted(reasons.items()))
+    return "\n".join(lines)
 
 
 def resolve_review_output_path(out: Path) -> Path:
@@ -148,6 +314,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.report:
         print(grow.format_report(payload))
+        print(format_triage_report(payload))
         print(f"review_output: {payload['review_only']['candidate_output']}")
     return 0
 

--- a/tests/test_source_inventory_review_candidates.py
+++ b/tests/test_source_inventory_review_candidates.py
@@ -89,6 +89,9 @@ def test_review_candidates_use_committed_inventories_and_keep_provenance(
         "candidate_output": str(out.resolve()),
         "production_outputs_updated": [],
     }
+    assert payload["review_triage"]["workflow"] == review.TRIAGE_WORKFLOW_ID
+    assert payload["review_triage"]["counts"]["total_candidates"] == len(expected_candidates)
+    assert payload["review_triage"]["counts"]["grow_auto_merge"] == len(expected_candidates)
     assert not Path(payload["review_only"]["candidate_output"]).is_relative_to(
         review.LIVE_ATLAS_OUTPUT_DIR
     )
@@ -131,6 +134,85 @@ def test_review_workflow_validates_source_provenance_in_needs_review() -> None:
     }
 
     review.validate_source_provenance(payload)
+
+
+def test_review_triage_is_stricter_than_grow_auto_merge() -> None:
+    payload = {
+        "auto_merge": [
+            {
+                "lemma": "кіт",
+                "pos": "noun",
+                "gloss": "cat",
+                "source_provenance": [{"source_family": "fixture"}],
+            },
+            {
+                "lemma": "жабка",
+                "pos": "noun",
+                "source_provenance": [{"source_family": "fixture"}],
+            },
+            {
+                "lemma": "безпос",
+                "gloss": "has gloss",
+                "source_provenance": [{"source_family": "fixture"}],
+            },
+        ],
+        "needs_review": [
+            {
+                "entry": {
+                    "lemma": "сумнів",
+                    "pos": "noun",
+                    "gloss": "doubt",
+                    "source_provenance": [{"source_family": "fixture"}],
+                },
+                "reason": "missing dictionary definition",
+            }
+        ],
+    }
+
+    triage = review.build_review_triage(payload)
+
+    assert triage["counts"] == {
+        "total_candidates": 4,
+        "grow_auto_merge": 3,
+        "grow_needs_review": 1,
+        "publish_ready": 1,
+        "needs_publish_review": 3,
+    }
+    assert triage["needs_publish_review_reasons"] == {
+        "grow_needs_review:missing dictionary definition": 1,
+        "missing_english_anchor": 1,
+        "missing_pos": 1,
+    }
+    assert triage["by_source_family"] == {"fixture": 4}
+    assert triage["by_pos"] == {"noun": 3, "unknown": 1}
+    assert triage["publish_ready_sample"][0]["lemma"] == "кіт"
+    assert triage["needs_publish_review_sample"][0]["reasons"] == ["missing_pos"]
+
+
+def test_review_triage_accepts_enrichment_translation_anchor() -> None:
+    entry = {
+        "lemma": "переклад",
+        "pos": "noun",
+        "source_provenance": [{"source_family": "fixture"}],
+        "enrichment": {"translation": {"en": ["translation"]}},
+    }
+
+    assert review.publish_review_reasons(entry) == []
+
+
+def test_review_triage_report_includes_publish_counts() -> None:
+    payload = {
+        "review_triage": {
+            "counts": {"publish_ready": 2, "needs_publish_review": 1},
+            "needs_publish_review_reasons": {"missing_english_anchor": 1},
+        }
+    }
+
+    report = review.format_triage_report(payload)
+
+    assert "publish_ready: 2" in report
+    assert "needs_publish_review: 1" in report
+    assert "- missing_english_anchor: 1" in report
 
 
 def test_review_workflow_rejects_missing_source_provenance_before_final_write(


### PR DESCRIPTION
## Summary

Adds a review-only `review_triage` block to the source inventory review-candidate generator. The triage layer keeps grow `auto_merge` separate from publish readiness: publish-ready now requires grow auto-merge plus source provenance, POS, and a visible English anchor.

## Validation

- `.venv/bin/python -m pytest tests/test_source_inventory_review_candidates.py tests/test_source_inventory_intake.py tests/test_grow_lexicon_from_sources.py` -> 31 passed
- `.venv/bin/ruff check scripts/audit/generate_source_inventory_review_candidates.py tests/test_source_inventory_review_candidates.py` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `npx --yes markdownlint-cli2 docs/runbooks/word-atlas-source-inventory-review-candidates.md` -> 0 errors
- `.venv/bin/python scripts/audit/check_static_practice_assets.py --format json` -> ok true, daily 300, total_cloze 0, reviewed_sources 0
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` -> passed
- DB-backed smoke with temporary worktree symlink to ignored local `data/sources.db`: 123 candidates, grow auto_merge=42, grow needs_review=81, publish_ready=40, needs_publish_review=83; output only `/private/tmp/atlas-source-inventory-review-candidates-triage.json`

## Production Boundary

No live Atlas/search/browse/daily/practice/cloze outputs are changed. No manifest, pointer, fingerprint, status, audit, review, or telemetry artifacts are committed.