### PR TITLE
[codex] Add source review decision ledger

### DIFF
--- a/data/lexicon/source-inventory-review-decisions/2026-06-29-first-approved-publish-batch.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-06-29-first-approved-publish-batch.yaml
@@ -1,0 +1,315 @@
+---
+version: 1
+kind: atlas_source_inventory_review_decisions
+batch_id: source-inventory-first-approved-publish-batch-2026-06-29
+batch_label: first-approved-publish-batch
+reviewer: content-review
+reviewed_at: '2026-06-29'
+source_queue:
+  workflow: source_inventory_publish_review_queue.v1
+  generated_from_pr: 4021
+  total_queue_rows: 83
+  approved_in_queue: 83
+  first_promotion_batch_size: 20
+production_outputs_updated: []
+decisions:
+- lemma: автобус
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: bus
+  sense_note: Bolshakova + dictionary
+  source_inventory:
+    key: 76553a9a3c3f6c61
+    path: data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml
+    locator: correct key words block; letter А
+    source_id: bolshakova-bukvar-2025-part1-keywords
+    source_family: textbook
+  evidence_refs:
+  - Bolshakova + dictionary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: ананас
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: pineapple
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: b122da27e9a38818
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[А].key_word
+    source_id: ohoiko-abetka-1-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: банан
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: banana
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: 648c9d9b40ab0769
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Б].key_word
+    source_id: ohoiko-abetka-2-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: великий
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: big; large
+  sense_note: curriculum A1
+  source_inventory:
+    key: a7edd0c505227031
+    path: data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml
+    locator: vocabulary[0].items[0].word
+    source_id: l2-direct-a1-yakyi-vocabulary
+    source_family: curriculum
+  evidence_refs:
+  - curriculum A1
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: гора
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: mountain
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: b7a03b3347c454e0
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Г].key_word
+    source_id: ohoiko-abetka-3-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: два
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: two
+  sense_note: curriculum A1
+  source_inventory:
+    key: e0fd4b34ad5f1d06
+    path: data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml
+    locator: vocabulary[0].items[1].word
+    source_id: l2-direct-a1-chysla-vocabulary
+    source_family: curriculum
+  evidence_refs:
+  - curriculum A1
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: дуб
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: oak tree
+  sense_note: Bolshakova + dictionary
+  source_inventory:
+    key: 6d54eb7091d03a41
+    path: data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml
+    locator: complete letter mapping row Д д
+    source_id: bolshakova-bukvar-2025-part1-keywords
+    source_family: textbook
+  evidence_refs:
+  - Bolshakova + dictionary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: дім
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: home; house
+  sense_note: Ohoiko/Bolshakova
+  source_inventory:
+    key: f5a679b717d5cb27
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Д].key_word
+    source_id: ohoiko-abetka-2-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko/Bolshakova
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: жук
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: beetle
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: b1ad9747ebb30401
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Ж].key_word
+    source_id: ohoiko-abetka-3-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: зебра
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: zebra
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: 2c589c491dee35cd
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[З].key_word
+    source_id: ohoiko-abetka-3-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: крейда
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: chalk
+  sense_note: Vashulenko school vocab
+  source_inventory:
+    key: 39d2d772ec67a27a
+    path: data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml
+    locator: topic_index.vocabulary_school.words[0]
+    source_id: vashulenko-grade3-2020-school-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko school vocab
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: кіт
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: cat
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: c4a889419752979e
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[К].key_word
+    source_id: ohoiko-abetka-2-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: лис
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: fox
+  sense_note: Bolshakova + dictionary
+  source_inventory:
+    key: e3612cc17cc5f8e8
+    path: data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml
+    locator: complete letter mapping row Л л
+    source_id: bolshakova-bukvar-2025-part1-keywords
+    source_family: textbook
+  evidence_refs:
+  - Bolshakova + dictionary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: ліс
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: forest; woods
+  sense_note: Bolshakova + dictionary
+  source_inventory:
+    key: 698e8a22c5d7974f
+    path: data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml
+    locator: complete letter mapping row Л л
+    source_id: bolshakova-bukvar-2025-part1-keywords
+    source_family: textbook
+  evidence_refs:
+  - Bolshakova + dictionary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: мама
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: mom; mother
+  sense_note: Bolshakova + dictionary
+  source_inventory:
+    key: a50121a4ffabb13e
+    path: data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml
+    locator: correct key words block; letter М
+    source_id: bolshakova-bukvar-2025-part1-keywords
+    source_family: textbook
+  evidence_refs:
+  - Bolshakova + dictionary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: один
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: one
+  sense_note: curriculum A1
+  source_inventory:
+    key: 9d52a8860d52edab
+    path: data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml
+    locator: vocabulary[0].items[0].word
+    source_id: l2-direct-a1-chysla-vocabulary
+    source_family: curriculum
+  evidence_refs:
+  - curriculum A1
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: око
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: eye
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: ba94d236ce30e9b3
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[О].key_word
+    source_id: ohoiko-abetka-1-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: тигр
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: tiger
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: a4b1a422693e080a
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Т].key_word
+    source_id: ohoiko-abetka-3-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: черепаха
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: turtle; tortoise
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: 59e79f22405d341c
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Ч].key_word
+    source_id: ohoiko-abetka-4-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: читати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to read
+  sense_note: curriculum verb row
+  source_inventory:
+    key: e1dea8d49585ce8d
+    path: data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml
+    locator: vocabulary[1].items[4].word
+    source_id: l2-direct-b2-diieslovo-povtorennia-vocabulary
+    source_family: curriculum
+  evidence_refs:
+  - curriculum verb row
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow

--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -48,6 +48,18 @@ when you want the full Markdown queue on stdout. Queue rows include stable
 queue ids, lemma, POS, grow bucket, English-anchor state, review reasons, and
 source references.
 
+Human review decisions that should survive beyond the ephemeral queue live in
+tracked ledger files under `data/lexicon/source-inventory-review-decisions/`.
+Those files are still review records, not live Atlas output. Validate them with:
+
+```bash
+.venv/bin/python -m scripts.audit.source_inventory_review_decisions
+```
+
+Decision rows use stable source-inventory keys derived from lemma, inventory
+path, and source locator. Do not use queue row numbers as publish keys; queue
+ids can change when row ordering changes.
+
 Every generated candidate must retain non-empty `source_provenance`. The
 representative smoke run currently processes 20 source inventory headwords:
 two rows each for noun, adjective, numeral, pronoun, verb, adverb,

--- a/scripts/audit/source_inventory_review_decisions.py
+++ b/scripts/audit/source_inventory_review_decisions.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Validate tracked Word Atlas source-inventory review decisions."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.audit.generate_source_inventory_review_candidates import (
+    COMMITTED_SOURCE_INVENTORIES,
+)
+from scripts.audit.source_inventory_intake import (
+    SourceInventoryError,
+    SourceInventoryRecord,
+    read_source_inventories,
+)
+from scripts.lexicon.content_lexicon_reconciler import PROJECT_ROOT
+
+DECISION_KIND = "atlas_source_inventory_review_decisions"
+DECISION_VERSION = 1
+DEFAULT_DECISION_DIR = PROJECT_ROOT / "data/lexicon/source-inventory-review-decisions"
+QUEUE_WORKFLOW = "source_inventory_publish_review_queue.v1"
+ALLOWED_DECISIONS = {
+    "approve_for_publish",
+    "needs_more_evidence",
+    "reject",
+    "merge_duplicate",
+}
+
+TOP_LEVEL_FIELDS = {
+    "version",
+    "kind",
+    "batch_id",
+    "batch_label",
+    "reviewer",
+    "reviewed_at",
+    "source_queue",
+    "production_outputs_updated",
+    "decisions",
+}
+SOURCE_QUEUE_FIELDS = {
+    "workflow",
+    "generated_from_pr",
+    "total_queue_rows",
+    "approved_in_queue",
+    "first_promotion_batch_size",
+}
+DECISION_FIELDS = {
+    "lemma",
+    "decision",
+    "approved_pos",
+    "approved_gloss",
+    "sense_note",
+    "source_inventory",
+    "evidence_refs",
+    "review_queue_reasons",
+    "original_flags",
+    "supersedes",
+}
+SOURCE_INVENTORY_FIELDS = {
+    "key",
+    "path",
+    "locator",
+    "source_id",
+    "source_family",
+}
+
+
+def source_inventory_key(*, lemma: str, inventory_path: str, locator: str) -> str:
+    """Return stable source-record key independent of review queue row numbering."""
+    key_material = f"{lemma}\0{inventory_path}\0{locator}"
+    return hashlib.sha256(key_material.encode("utf-8")).hexdigest()[:16]
+
+
+def validate_committed_decision_files(
+    paths: Sequence[Path] | None = None,
+) -> dict[str, Any]:
+    decision_paths = list(paths) if paths else sorted(DEFAULT_DECISION_DIR.glob("*.yaml"))
+    if not decision_paths:
+        raise SourceInventoryError("no source-inventory review decision files found")
+
+    records = read_source_inventories(COMMITTED_SOURCE_INVENTORIES, project_root=PROJECT_ROOT)
+    source_index = _source_record_index(records)
+    summaries = [validate_decision_file(path, source_index=source_index) for path in decision_paths]
+    decision_counts: Counter[str] = Counter()
+    total_rows = 0
+    for summary in summaries:
+        decision_counts.update(summary["decision_counts"])
+        total_rows += summary["rows"]
+    return {
+        "files": len(summaries),
+        "rows": total_rows,
+        "decision_counts": dict(sorted(decision_counts.items())),
+    }
+
+
+def validate_decision_file(
+    path: Path,
+    *,
+    source_index: Mapping[tuple[str, str, str], SourceInventoryRecord] | None = None,
+) -> dict[str, Any]:
+    payload = _read_yaml_mapping(path)
+    _reject_unknown_fields(path, payload, allowed=TOP_LEVEL_FIELDS, scope="top level")
+    _require_equal(path, payload.get("version"), DECISION_VERSION, "version")
+    _require_equal(path, payload.get("kind"), DECISION_KIND, "kind")
+    for field in ("batch_id", "batch_label", "reviewer", "reviewed_at"):
+        _require_text(path, payload.get(field), field)
+    if payload.get("production_outputs_updated") != []:
+        raise SourceInventoryError(f"{path}: production_outputs_updated must be []")
+
+    source_queue = payload.get("source_queue")
+    if not isinstance(source_queue, Mapping):
+        raise SourceInventoryError(f"{path}: source_queue must be a mapping")
+    _reject_unknown_fields(path, source_queue, allowed=SOURCE_QUEUE_FIELDS, scope="source_queue")
+    _require_equal(path, source_queue.get("workflow"), QUEUE_WORKFLOW, "source_queue.workflow")
+
+    decisions = payload.get("decisions")
+    if not isinstance(decisions, list) or not decisions:
+        raise SourceInventoryError(f"{path}: decisions must be a non-empty list")
+
+    index = source_index or _source_record_index(
+        read_source_inventories(COMMITTED_SOURCE_INVENTORIES, project_root=PROJECT_ROOT)
+    )
+    seen_source_keys: set[str] = set()
+    decision_counts: Counter[str] = Counter()
+    for idx, row in enumerate(decisions, start=1):
+        if not isinstance(row, Mapping):
+            raise SourceInventoryError(f"{path}: decisions[{idx}] must be a mapping")
+        _validate_decision_row(path, idx, row, source_index=index, seen_source_keys=seen_source_keys)
+        decision_counts[str(row["decision"])] += 1
+
+    return {
+        "path": str(path),
+        "rows": len(decisions),
+        "decision_counts": dict(sorted(decision_counts.items())),
+    }
+
+
+def _validate_decision_row(
+    path: Path,
+    idx: int,
+    row: Mapping[str, Any],
+    *,
+    source_index: Mapping[tuple[str, str, str], SourceInventoryRecord],
+    seen_source_keys: set[str],
+) -> None:
+    prefix = f"{path}: decisions[{idx}]"
+    _reject_unknown_fields(path, row, allowed=DECISION_FIELDS, scope=f"decisions[{idx}]")
+    lemma = _require_text(path, row.get("lemma"), f"decisions[{idx}].lemma")
+    decision = _require_text(path, row.get("decision"), f"decisions[{idx}].decision")
+    if decision not in ALLOWED_DECISIONS:
+        raise SourceInventoryError(f"{prefix} invalid decision {decision!r}")
+    if decision == "approve_for_publish":
+        _require_text(path, row.get("approved_pos"), f"decisions[{idx}].approved_pos")
+        _require_text(path, row.get("approved_gloss"), f"decisions[{idx}].approved_gloss")
+    _require_text(path, row.get("sense_note"), f"decisions[{idx}].sense_note")
+    _validate_text_list(path, row.get("evidence_refs"), f"decisions[{idx}].evidence_refs")
+    if "review_queue_reasons" in row:
+        _validate_text_list(
+            path,
+            row.get("review_queue_reasons"),
+            f"decisions[{idx}].review_queue_reasons",
+        )
+    if "original_flags" in row:
+        _validate_text_list(path, row.get("original_flags"), f"decisions[{idx}].original_flags")
+
+    source_inventory = row.get("source_inventory")
+    if not isinstance(source_inventory, Mapping):
+        raise SourceInventoryError(f"{prefix} source_inventory must be a mapping")
+    _reject_unknown_fields(
+        path,
+        source_inventory,
+        allowed=SOURCE_INVENTORY_FIELDS,
+        scope=f"decisions[{idx}].source_inventory",
+    )
+    source_key = _require_text(path, source_inventory.get("key"), f"decisions[{idx}].source_inventory.key")
+    inventory_path = _require_text(
+        path,
+        source_inventory.get("path"),
+        f"decisions[{idx}].source_inventory.path",
+    )
+    locator = _require_text(
+        path,
+        source_inventory.get("locator"),
+        f"decisions[{idx}].source_inventory.locator",
+    )
+    expected_key = source_inventory_key(lemma=lemma, inventory_path=inventory_path, locator=locator)
+    if source_key != expected_key:
+        raise SourceInventoryError(
+            f"{prefix} source_inventory.key {source_key!r} does not match {expected_key!r}"
+        )
+    if source_key in seen_source_keys:
+        raise SourceInventoryError(f"{prefix} duplicate source_inventory.key {source_key!r}")
+    seen_source_keys.add(source_key)
+
+    record = source_index.get((lemma, inventory_path, locator))
+    if record is None:
+        raise SourceInventoryError(
+            f"{prefix} source inventory record not found for {lemma!r} at {inventory_path}:{locator}"
+        )
+    if source_inventory.get("source_id") != record.source_id:
+        raise SourceInventoryError(f"{prefix} source_id does not match committed inventory")
+    if source_inventory.get("source_family") != record.source_family:
+        raise SourceInventoryError(f"{prefix} source_family does not match committed inventory")
+
+
+def _source_record_index(
+    records: Sequence[SourceInventoryRecord],
+) -> dict[tuple[str, str, str], SourceInventoryRecord]:
+    return {
+        (record.lemma, record.inventory_path, record.source_locator): record
+        for record in records
+    }
+
+
+def _read_yaml_mapping(path: Path) -> dict[str, Any]:
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise SourceInventoryError(f"{path}: not found") from exc
+    if not isinstance(payload, dict):
+        raise SourceInventoryError(f"{path}: expected mapping")
+    return payload
+
+
+def _reject_unknown_fields(
+    path: Path,
+    mapping: Mapping[str, Any],
+    *,
+    allowed: set[str],
+    scope: str,
+) -> None:
+    unknown = sorted(str(key) for key in mapping if key not in allowed)
+    if unknown:
+        raise SourceInventoryError(f"{path}: {scope} unknown field(s): {', '.join(unknown)}")
+
+
+def _require_text(path: Path, value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise SourceInventoryError(f"{path}: {field} must be non-empty text")
+    return value.strip()
+
+
+def _require_equal(path: Path, actual: object, expected: object, field: str) -> None:
+    if actual != expected:
+        raise SourceInventoryError(f"{path}: {field} must be {expected!r}")
+
+
+def _validate_text_list(path: Path, value: object, field: str) -> None:
+    if not isinstance(value, list) or not value:
+        raise SourceInventoryError(f"{path}: {field} must be a non-empty list")
+    for idx, item in enumerate(value, start=1):
+        if not isinstance(item, str) or not item.strip():
+            raise SourceInventoryError(f"{path}: {field}[{idx}] must be non-empty text")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate tracked Word Atlas source-inventory review decisions."
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        help=f"Decision YAML paths (default: {DEFAULT_DECISION_DIR})",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        summary = validate_committed_decision_files(args.paths or None)
+    except SourceInventoryError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(
+        "source_inventory_review_decisions: "
+        f"files={summary['files']} rows={summary['rows']} "
+        f"decisions={summary['decision_counts']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_source_inventory_review_decisions.py
+++ b/tests/test_source_inventory_review_decisions.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.audit import source_inventory_review_decisions as decisions
+from scripts.audit.source_inventory_intake import SourceInventoryError
+
+FIRST_BATCH = (
+    decisions.DEFAULT_DECISION_DIR / "2026-06-29-first-approved-publish-batch.yaml"
+)
+
+
+def _write_decision_file(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, allow_unicode=True, sort_keys=False), encoding="utf-8")
+
+
+def _minimal_payload() -> dict[str, object]:
+    source_inventory = {
+        "path": "data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml",
+        "locator": "letters[А].key_word",
+    }
+    source_inventory["key"] = decisions.source_inventory_key(
+        lemma="ананас",
+        inventory_path=str(source_inventory["path"]),
+        locator=str(source_inventory["locator"]),
+    )
+    source_inventory["source_id"] = "ohoiko-abetka-1-keywords"
+    source_inventory["source_family"] = "ohoiko"
+    return {
+        "version": decisions.DECISION_VERSION,
+        "kind": decisions.DECISION_KIND,
+        "batch_id": "fixture-batch",
+        "batch_label": "fixture",
+        "reviewer": "test",
+        "reviewed_at": "2026-06-29",
+        "source_queue": {
+            "workflow": decisions.QUEUE_WORKFLOW,
+            "generated_from_pr": 4021,
+            "total_queue_rows": 1,
+            "approved_in_queue": 1,
+            "first_promotion_batch_size": 1,
+        },
+        "production_outputs_updated": [],
+        "decisions": [
+            {
+                "lemma": "ананас",
+                "decision": "approve_for_publish",
+                "approved_pos": "noun",
+                "approved_gloss": "pineapple",
+                "sense_note": "fixture",
+                "source_inventory": source_inventory,
+                "evidence_refs": ["fixture"],
+                "review_queue_reasons": [
+                    "grow_needs_review:heritage_status flags russian_shadow"
+                ],
+            }
+        ],
+    }
+
+
+def test_committed_first_source_inventory_review_batch_validates() -> None:
+    summary = decisions.validate_committed_decision_files([FIRST_BATCH])
+
+    assert summary == {
+        "files": 1,
+        "rows": 20,
+        "decision_counts": {"approve_for_publish": 20},
+    }
+
+
+def test_default_committed_decision_files_validate() -> None:
+    summary = decisions.validate_committed_decision_files()
+
+    assert summary["files"] >= 1
+    assert summary["rows"] >= 20
+    assert summary["decision_counts"]["approve_for_publish"] >= 20
+
+
+def test_decision_validator_rejects_bad_source_key(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    row = payload["decisions"][0]  # type: ignore[index]
+    row["source_inventory"]["key"] = "badbadbadbadbad1"  # type: ignore[index]
+    path = tmp_path / "bad.yaml"
+    _write_decision_file(path, payload)
+
+    with pytest.raises(SourceInventoryError, match="does not match"):
+        decisions.validate_committed_decision_files([path])
+
+
+def test_decision_validator_requires_approved_gloss(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    row = payload["decisions"][0]  # type: ignore[index]
+    row["approved_gloss"] = ""  # type: ignore[index]
+    path = tmp_path / "bad.yaml"
+    _write_decision_file(path, payload)
+
+    with pytest.raises(SourceInventoryError, match="approved_gloss"):
+        decisions.validate_committed_decision_files([path])
+
+
+def test_decision_validator_allows_clean_rows_without_flags(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    row = payload["decisions"][0]  # type: ignore[index]
+    row.pop("review_queue_reasons")  # type: ignore[attr-defined]
+    path = tmp_path / "ok.yaml"
+    _write_decision_file(path, payload)
+
+    summary = decisions.validate_committed_decision_files([path])
+
+    assert summary["rows"] == 1
+
+
+def test_decision_validator_rejects_duplicate_source_key(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    payload["decisions"].append(dict(payload["decisions"][0]))  # type: ignore[index, union-attr]
+    path = tmp_path / "bad.yaml"
+    _write_decision_file(path, payload)
+
+    with pytest.raises(SourceInventoryError, match=r"duplicate source_inventory\.key"):
+        decisions.validate_committed_decision_files([path])
+
+
+def test_decision_validator_rejects_production_outputs(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    payload["production_outputs_updated"] = ["site/src/data/lexicon-manifest.json"]
+    path = tmp_path / "bad.yaml"
+    _write_decision_file(path, payload)
+
+    with pytest.raises(SourceInventoryError, match=r"production_outputs_updated must be \[\]"):
+        decisions.validate_committed_decision_files([path])


### PR DESCRIPTION
## Summary

Adds a tracked review-decision ledger for the first approved source-inventory publish batch. The batch captures 20 `approve_for_publish` decisions from the 83-row human review queue using stable source-inventory keys derived from lemma, inventory path, and locator.

Also adds a validator for tracked source-inventory review decisions and documents the queue-to-ledger workflow. This is still review metadata only; it does not publish Atlas entries or update practice/cloze outputs.

## Validation

- `.venv/bin/python -m scripts.audit.source_inventory_review_decisions` -> files=1, rows=20, approve_for_publish=20
- `.venv/bin/python -m pytest tests/test_source_inventory_review_decisions.py tests/test_source_inventory_intake.py tests/test_source_inventory_review_candidates.py tests/test_grow_lexicon_from_sources.py` -> 44 passed
- `.venv/bin/ruff check scripts/audit/source_inventory_review_decisions.py tests/test_source_inventory_review_decisions.py` -> passed
- `.venv/bin/yamllint data/lexicon/source-inventory-review-decisions/2026-06-29-first-approved-publish-batch.yaml` -> passed
- `npx --yes markdownlint-cli2 docs/runbooks/word-atlas-source-inventory-review-candidates.md` -> 0 errors
- `git diff --check origin/main...HEAD` -> passed
- `.venv/bin/python scripts/audit/check_static_practice_assets.py --format json` -> ok true, daily 300, total_cloze 0, reviewed_sources 0
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` -> passed

## Production Boundary

No live Atlas/search/browse/daily/practice/cloze outputs are changed. No manifest, pointer, fingerprint, status, audit, review, report, or telemetry artifacts are committed.