### PR TITLE
Plan approved source inventory promotion

### DIFF
--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -1,38 +1,37 @@
 # Word Atlas Source Inventory Review Candidates
 
-Use this workflow to turn the committed source inventory seeds into a small
+Use this workflow to turn committed source inventory seeds into a small
 review-only Atlas candidate artifact.
 
 ```bash
 .venv/bin/python -m scripts.audit.generate_source_inventory_review_candidates --report
 ```
 
-By default the command writes
-`/tmp/atlas-source-inventory-review-candidates.json`. The output is review
-material only. Do not commit it and do not copy it into the live Atlas data
-files.
+The default command writes `/tmp/atlas-source-inventory-review-candidates.json`.
+The output is review material only. Do not commit it and do not copy it into
+live Atlas data files.
 
 The committed source inventory input is:
 
 - `data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml`
-
-The older `ohoiko-abetka-keywords.yaml` and
-`bolshakova-bukvar-keywords.yaml` files remain tracked as noun smoke
-inventories, but they are not the representative review-candidate input.
+- `data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml`
+- `data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml`
+- `data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml`
 
 The candidate JSON follows the existing grow-candidate shape: `counts`,
-`auto_merge`, and `needs_review`. The wrapper also adds `review_only` metadata
-with the workflow id, inventory paths, review output path, and
+`auto_merge`, and `needs_review`. The wrapper also adds `review_only` metadata:
+workflow id, inventory paths, review output path, and
 `production_outputs_updated: []`.
-It also adds `review_triage`, a review-only publish-readiness summary. The
-grow `auto_merge` bucket means the candidate passed low-level dictionary/POS
-gates; it is not approval to publish. `review_triage.counts.publish_ready`
-requires grow `auto_merge` plus source provenance, POS, and a visible English
-anchor. `review_triage.counts.needs_publish_review` lists candidates that need
-human review before any live Atlas publish batch.
 
-To render the full human review queue for those held rows, write a Markdown
-report outside the repository:
+It also adds `review_triage`, a review-only publish-readiness summary. The grow
+`auto_merge` bucket means a candidate passed low-level dictionary/POS gates; it
+is not approval to publish. `review_triage.counts.publish_ready` requires grow
+`auto_merge` plus source provenance, POS, and visible English anchor.
+`review_triage.counts.needs_publish_review` lists candidates that need human
+review before any live Atlas publish batch.
+
+To render the full human-review queue for held rows, write a Markdown report
+outside the repository:
 
 ```bash
 .venv/bin/python -m scripts.audit.generate_source_inventory_review_candidates \
@@ -42,15 +41,15 @@ report outside the repository:
 
 The queue report is intentionally ephemeral. The script rejects
 `--queue-report-out` paths inside the repository so generated review material
-does not land in `docs/reports/`, `curriculum/**/review/`, `status/`,
-`audit/`, or live Atlas output paths by accident. Use `--queue-report` only
-when you want the full Markdown queue on stdout. Queue rows include stable
-queue ids, lemma, POS, grow bucket, English-anchor state, review reasons, and
-source references.
+does not land in `docs/reports/`, `curriculum/**/review/`, `status/`, `audit/`,
+or live Atlas output paths by accident. Use `--queue-report` only when you want
+the full Markdown queue on stdout.
 
-Human review decisions that should survive beyond the ephemeral queue live in
-tracked ledger files under `data/lexicon/source-inventory-review-decisions/`.
-Those files are still review records, not live Atlas output. Validate them with:
+Queue rows include stable queue ids, lemma, POS, grow bucket,
+English-anchor state, review reasons, and source references. Human review
+decisions should survive beyond the ephemeral queue in tracked ledger files
+under `data/lexicon/source-inventory-review-decisions/`. Those files are still
+review records, not live Atlas output. Validate them with:
 
 ```bash
 .venv/bin/python -m scripts.audit.source_inventory_review_decisions
@@ -60,24 +59,43 @@ Decision rows use stable source-inventory keys derived from lemma, inventory
 path, and source locator. Do not use queue row numbers as publish keys; queue
 ids can change when row ordering changes.
 
+After review decisions are committed, build the next publish boundary as
+another review-only artifact:
+
+```bash
+.venv/bin/python -m scripts.audit.plan_source_inventory_promotion \
+  --generate-candidates \
+  --out /tmp/atlas-source-inventory-approved-promotion-plan.json \
+  --report-out /tmp/atlas-source-inventory-approved-promotion-plan.md \
+  --report
+```
+
+This consumes approved ledger rows and the review-candidate payload, then writes
+proposed manifest additions to `/tmp`. It does not publish them. The plan maps
+`approved_pos` and `approved_gloss` into the proposed manifest entry, preserves
+`source_provenance`, records the source-inventory key, and reports skipped or
+missing candidates. The command rejects outputs inside the repository, including
+live Atlas data, static lexicon outputs, `status/`, `audit/`, `review/`, and
+telemetry artifact paths.
+
 Every generated candidate must retain non-empty `source_provenance`. The
-representative smoke run currently processes 20 source inventory headwords:
-two rows each for noun, adjective, numeral, pronoun, verb, adverb,
-preposition, conjunction, particle, and interjection.
-Optional per-headword `gloss` is for curated learner-facing English anchors
-when dictionary enrichment lacks a visible English translation.
+POS-balanced grammar sample contributes 20 source inventory headwords: two rows
+each for noun, adjective, numeral, pronoun, verb, adverb, preposition,
+conjunction, particle, and interjection. Optional per-headword `gloss` values
+are curated learner-facing English anchors for cases where dictionary
+enrichment lacks a visible English translation.
 
 When a candidate is later promoted into a manifest entry,
 `promote_grow_candidates.manifest_entry_from_candidate()` copies
-`source_provenance` through verbatim at the top level, so the granular
-source-id/title/locator/context origin is not dropped on promotion. This is
-separate from `course_usage`, which is derived only from
-`source_context`/`source_contexts` and stays empty for source-inventory rows.
+`source_provenance` through verbatim at top level, so granular
+source-id/title/locator/context origin is not dropped on promotion. Separate
+`course_usage`, derived only from `source_context`/`source_contexts`, stays empty
+for source-inventory rows.
 
-This workflow does not update the live Atlas manifest, search index, browse
-files, Words Day pool, daily practice sources, cloze outputs, manifest pointer,
-or manifest fingerprint. In this repository those live outputs are under
-`site/src/data/`, including:
+This workflow does not update live Atlas manifest, search index, browse files,
+Words of the Day pool, daily practice sources, cloze outputs, manifest pointer,
+or manifest fingerprint. In-repository live outputs under `site/src/data/`
+include:
 
 - `site/src/data/lexicon-manifest.json`
 - `site/src/data/lexicon-search-index.json`
@@ -88,6 +106,14 @@ or manifest fingerprint. In this repository those live outputs are under
 - `site/src/data/lexicon-manifest.pointer.json`
 - `site/src/data/lexicon-manifest.fingerprint.json`
 
-The full enrichment step requires the local ignored `data/sources.db`. If a
-worktree does not have that database, link or copy the local project database
-into the worktree before the smoke run. Keep `data/sources.db` untracked.
+The full enrichment step requires local ignored `data/sources.db`. A worktree
+does not contain the database by default; symlink the local project database
+into the worktree before a smoke run and remove it afterward:
+
+```bash
+ln -s /Users/krisztiankoos/projects/learn-ukrainian/data/sources.db data/sources.db
+.venv/bin/python -m scripts.audit.generate_source_inventory_review_candidates --report
+rm -f data/sources.db
+```
+
+Keep `data/sources.db` untracked.

--- a/scripts/audit/plan_source_inventory_promotion.py
+++ b/scripts/audit/plan_source_inventory_promotion.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""Build a review-only publish plan from approved source-inventory decisions."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.audit import generate_source_inventory_review_candidates as review
+from scripts.audit import source_inventory_review_decisions as decisions
+from scripts.audit.source_inventory_intake import SourceInventoryError
+from scripts.lexicon import promote_grow_candidates as promote
+from scripts.lexicon.build_data_manifest import _lemma_key
+from scripts.lexicon.lemma_normalization import strip_acute_stress
+
+WORKFLOW_ID = "source_inventory_approved_promotion_plan.v1"
+DEFAULT_CANDIDATES = Path("/tmp/atlas-source-inventory-review-candidates.json")
+DEFAULT_OUT = Path("/tmp/atlas-source-inventory-approved-promotion-plan.json")
+DEFAULT_REPORT_OUT = Path("/tmp/atlas-source-inventory-approved-promotion-plan.md")
+
+
+@dataclass(frozen=True)
+class ApprovedDecision:
+    lemma: str
+    approved_pos: str
+    approved_gloss: str
+    sense_note: str
+    source_inventory: Mapping[str, Any]
+    evidence_refs: tuple[str, ...]
+    review_queue_reasons: tuple[str, ...]
+    batch_id: str
+    batch_label: str
+    decision_file: str
+
+    @property
+    def source_key(self) -> str:
+        return str(self.source_inventory["key"])
+
+
+@dataclass(frozen=True)
+class CandidateMatch:
+    entry: Mapping[str, Any]
+    bucket: str
+    reasons: tuple[str, ...]
+
+
+def build_promotion_plan(
+    *,
+    candidates_path: Path = DEFAULT_CANDIDATES,
+    decision_files: Sequence[Path] | None = None,
+    manifest_path: Path | None = None,
+) -> dict[str, Any]:
+    """Return approved source-inventory rows as proposed manifest additions."""
+    decision_paths = _decision_paths(decision_files)
+    decision_summary = decisions.validate_committed_decision_files(decision_paths)
+    approved = _approved_decisions(decision_paths)
+    candidate_payload = _read_candidate_payload(candidates_path)
+    candidate_index = _candidate_index(candidate_payload)
+    manifest_keys = _manifest_keys(manifest_path)
+
+    proposed: list[dict[str, Any]] = []
+    skipped_existing: list[dict[str, Any]] = []
+    missing_candidates: list[dict[str, Any]] = []
+
+    for decision in approved:
+        match = candidate_index.get(decision.source_key)
+        base_row = {
+            "lemma": decision.lemma,
+            "source_inventory_key": decision.source_key,
+            "source_inventory": dict(decision.source_inventory),
+            "decision_file": decision.decision_file,
+            "batch_id": decision.batch_id,
+            "batch_label": decision.batch_label,
+        }
+        if match is None:
+            missing_candidates.append({**base_row, "reason": "candidate_not_found"})
+            continue
+        if _lemma_key(decision.lemma) in manifest_keys:
+            skipped_existing.append({**base_row, "reason": "already_in_manifest"})
+            continue
+        proposed.append(_planned_addition(decision, match))
+
+    return {
+        "workflow": WORKFLOW_ID,
+        "policy": (
+            "Review-only source-inventory promotion plan. This file proposes "
+            "manifest additions but does not update live Atlas, search, browse, "
+            "daily, practice, cloze, pointer, fingerprint, status, audit, review, "
+            "or telemetry outputs."
+        ),
+        "source_candidate_payload": str(candidates_path),
+        "source_decision_files": [str(path) for path in decision_paths],
+        "manifest_path": str(manifest_path) if manifest_path else None,
+        "manifest_loaded": manifest_path is not None,
+        "production_outputs_updated": [],
+        "counts": {
+            "decision_files": decision_summary["files"],
+            "approved_decisions": len(approved),
+            "candidate_source_keys": len(candidate_index),
+            "matched_candidates": len(proposed) + len(skipped_existing),
+            "proposed_additions": len(proposed),
+            "skipped_existing": len(skipped_existing),
+            "missing_candidates": len(missing_candidates),
+        },
+        "proposed_manifest_additions": proposed,
+        "skipped_existing": skipped_existing,
+        "missing_candidates": missing_candidates,
+    }
+
+
+def write_plan(plan: Mapping[str, Any], out: Path = DEFAULT_OUT) -> Path:
+    """Write promotion plan outside the repository."""
+    output_path = resolve_ephemeral_plan_output_path(out)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(plan, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return output_path
+
+
+def write_report(plan: Mapping[str, Any], out: Path = DEFAULT_REPORT_OUT) -> Path:
+    """Write a human Markdown summary outside the repository."""
+    output_path = resolve_ephemeral_plan_output_path(out)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(format_report(plan) + "\n", encoding="utf-8")
+    return output_path
+
+
+def format_report(plan: Mapping[str, Any]) -> str:
+    counts = plan["counts"]
+    lines = [
+        "# Source Inventory Approved Promotion Plan",
+        "",
+        f"- workflow: `{plan['workflow']}`",
+        f"- approved_decisions: {counts['approved_decisions']}",
+        f"- proposed_additions: {counts['proposed_additions']}",
+        f"- skipped_existing: {counts['skipped_existing']}",
+        f"- missing_candidates: {counts['missing_candidates']}",
+        "- production_outputs_updated: []",
+        "",
+        str(plan["policy"]),
+        "",
+        "## Proposed Manifest Additions",
+        "",
+        "| Lemma | POS | Gloss | Bucket | Source Key | Notes |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    proposed = plan.get("proposed_manifest_additions")
+    if not proposed:
+        lines.append("| - | - | - | - | - | - |")
+    else:
+        for row in proposed:
+            lines.append(
+                "| "
+                + " | ".join(
+                    [
+                        _markdown_cell(row["lemma"]),
+                        _markdown_cell(row["approved_pos"]),
+                        _markdown_cell(row["approved_gloss"]),
+                        _markdown_cell(row["candidate_bucket"]),
+                        _markdown_cell(row["source_inventory_key"]),
+                        _markdown_cell(row["sense_note"]),
+                    ]
+                )
+                + " |"
+            )
+
+    if plan.get("skipped_existing"):
+        lines.extend(["", "## Skipped Existing", ""])
+        lines.extend(
+            f"- `{row['lemma']}` ({row['source_inventory_key']}): {row['reason']}"
+            for row in plan["skipped_existing"]
+        )
+    if plan.get("missing_candidates"):
+        lines.extend(["", "## Missing Candidates", ""])
+        lines.extend(
+            f"- `{row['lemma']}` ({row['source_inventory_key']}): {row['reason']}"
+            for row in plan["missing_candidates"]
+        )
+    return "\n".join(lines)
+
+
+def resolve_ephemeral_plan_output_path(out: Path) -> Path:
+    """Reject committed or live output paths for review-only promotion plans."""
+    return review.resolve_ephemeral_review_output_path(out)
+
+
+def _planned_addition(decision: ApprovedDecision, match: CandidateMatch) -> dict[str, Any]:
+    candidate = copy.deepcopy(dict(match.entry))
+    candidate["pos"] = decision.approved_pos
+    candidate["gloss"] = decision.approved_gloss
+    manifest_entry = promote.manifest_entry_from_candidate(candidate)
+    manifest_entry["gloss"] = decision.approved_gloss
+    manifest_entry["pos"] = decision.approved_pos
+    if candidate.get("primary_source"):
+        manifest_entry["primary_source"] = candidate["primary_source"]
+    return {
+        "lemma": decision.lemma,
+        "approved_pos": decision.approved_pos,
+        "approved_gloss": decision.approved_gloss,
+        "sense_note": decision.sense_note,
+        "source_inventory_key": decision.source_key,
+        "source_inventory": dict(decision.source_inventory),
+        "evidence_refs": list(decision.evidence_refs),
+        "review_queue_reasons": list(decision.review_queue_reasons),
+        "candidate_bucket": match.bucket,
+        "candidate_reasons": list(match.reasons),
+        "batch_id": decision.batch_id,
+        "batch_label": decision.batch_label,
+        "decision_file": decision.decision_file,
+        "manifest_entry": manifest_entry,
+    }
+
+
+def _candidate_index(payload: Mapping[str, Any]) -> dict[str, CandidateMatch]:
+    index: dict[str, CandidateMatch] = {}
+    for entry, bucket, reasons in _candidate_entries(payload):
+        for source_key in _candidate_source_keys(entry):
+            if source_key in index:
+                raise SourceInventoryError(f"duplicate candidate source key {source_key!r}")
+            index[source_key] = CandidateMatch(
+                entry=entry,
+                bucket=bucket,
+                reasons=tuple(reasons),
+            )
+    return index
+
+
+def _candidate_entries(
+    payload: Mapping[str, Any],
+) -> list[tuple[Mapping[str, Any], str, list[str]]]:
+    entries: list[tuple[Mapping[str, Any], str, list[str]]] = []
+    for entry in payload.get("auto_merge", []):
+        if isinstance(entry, Mapping):
+            entries.append((entry, "auto_merge", review.publish_review_reasons(entry)))
+    for item in payload.get("needs_review", []):
+        if not isinstance(item, Mapping) or not isinstance(item.get("entry"), Mapping):
+            continue
+        entry = item["entry"]
+        reason = _clean_text(item.get("reason")) or "unspecified"
+        reasons = [f"grow_needs_review:{reason}"]
+        reasons.extend(review.publish_review_reasons(entry))
+        entries.append((entry, "needs_review", reasons))
+    return entries
+
+
+def _candidate_source_keys(entry: Mapping[str, Any]) -> list[str]:
+    lemma = strip_acute_stress(_clean_text(entry.get("lemma")))
+    provenance = entry.get("source_provenance")
+    if not lemma or not isinstance(provenance, list):
+        return []
+    keys: list[str] = []
+    for item in provenance:
+        if not isinstance(item, Mapping):
+            continue
+        inventory_path = _clean_text(item.get("inventory_path"))
+        locator = _clean_text(item.get("source_locator"))
+        if not inventory_path or not locator:
+            continue
+        keys.append(
+            decisions.source_inventory_key(
+                lemma=lemma,
+                inventory_path=inventory_path,
+                locator=locator,
+            )
+        )
+    return keys
+
+
+def _read_candidate_payload(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise SourceInventoryError(f"candidate payload not found: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SourceInventoryError(f"{path}: candidate payload must be a mapping")
+    review.validate_source_provenance(payload)
+    return payload
+
+
+def _approved_decisions(paths: Sequence[Path]) -> list[ApprovedDecision]:
+    approved: list[ApprovedDecision] = []
+    for path in paths:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, Mapping):
+            raise SourceInventoryError(f"{path}: expected mapping")
+        for row in payload.get("decisions", []):
+            if not isinstance(row, Mapping) or row.get("decision") != "approve_for_publish":
+                continue
+            approved.append(
+                ApprovedDecision(
+                    lemma=str(row["lemma"]),
+                    approved_pos=str(row["approved_pos"]),
+                    approved_gloss=str(row["approved_gloss"]),
+                    sense_note=str(row["sense_note"]),
+                    source_inventory=row["source_inventory"],
+                    evidence_refs=tuple(str(item) for item in row["evidence_refs"]),
+                    review_queue_reasons=tuple(
+                        str(item) for item in row.get("review_queue_reasons", [])
+                    ),
+                    batch_id=str(payload["batch_id"]),
+                    batch_label=str(payload["batch_label"]),
+                    decision_file=str(path),
+                )
+            )
+    return approved
+
+
+def _decision_paths(paths: Sequence[Path] | None) -> list[Path]:
+    if paths:
+        return [Path(path) for path in paths]
+    return sorted(decisions.DEFAULT_DECISION_DIR.glob("*.yaml"))
+
+
+def _manifest_keys(path: Path | None) -> set[str]:
+    if path is None:
+        return set()
+    if not path.exists():
+        raise SourceInventoryError(f"manifest not found: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    entries = payload.get("entries") if isinstance(payload, Mapping) else None
+    if not isinstance(entries, list):
+        raise SourceInventoryError(f"{path}: manifest entries must be a list")
+    return {
+        _lemma_key(str(entry["lemma"]))
+        for entry in entries
+        if isinstance(entry, Mapping) and entry.get("lemma")
+    }
+
+
+def _clean_text(value: object) -> str:
+    return "" if value is None else str(value).strip()
+
+
+def _markdown_cell(value: object) -> str:
+    text = "" if value is None else str(value)
+    return text.replace("\n", " ").replace("|", r"\|")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidates", type=Path, default=DEFAULT_CANDIDATES)
+    parser.add_argument("--decision-file", type=Path, action="append", dest="decision_files")
+    parser.add_argument("--manifest", type=Path, help="Optional existing manifest for duplicate checks")
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--report-out", type=Path, default=DEFAULT_REPORT_OUT)
+    parser.add_argument(
+        "--generate-candidates",
+        action="store_true",
+        help="Generate the review-only candidate payload before planning",
+    )
+    parser.add_argument("--limit", type=int, help="Limit candidate generation when used with --generate-candidates")
+    parser.add_argument("--report", action="store_true", help="Print plan summary")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.generate_candidates:
+            review.generate_review_candidates(limit=args.limit, out=args.candidates)
+        plan = build_promotion_plan(
+            candidates_path=args.candidates,
+            decision_files=args.decision_files,
+            manifest_path=args.manifest,
+        )
+        plan_path = write_plan(plan, args.out)
+        report_path = write_report(plan, args.report_out)
+    except (OSError, SourceInventoryError, json.JSONDecodeError, yaml.YAMLError) as exc:
+        print(exc, file=sys.stderr)
+        return 2
+    if args.report:
+        counts = plan["counts"]
+        print(f"approved_decisions: {counts['approved_decisions']}")
+        print(f"matched_candidates: {counts['matched_candidates']}")
+        print(f"proposed_additions: {counts['proposed_additions']}")
+        print(f"skipped_existing: {counts['skipped_existing']}")
+        print(f"missing_candidates: {counts['missing_candidates']}")
+        print(f"production_outputs_updated: {plan['production_outputs_updated']}")
+        print(f"plan_output: {plan_path}")
+        print(f"report_output: {report_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_source_inventory_promotion_plan.py
+++ b/tests/test_source_inventory_promotion_plan.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.audit import plan_source_inventory_promotion as planner
+from scripts.audit import source_inventory_review_decisions as decisions
+from scripts.audit.source_inventory_intake import SourceInventoryError
+from scripts.lexicon.content_lexicon_reconciler import PROJECT_ROOT
+
+FIRST_BATCH = decisions.DEFAULT_DECISION_DIR / "2026-06-29-first-approved-publish-batch.yaml"
+
+
+def _first_decision() -> dict[str, object]:
+    payload = yaml.safe_load(FIRST_BATCH.read_text(encoding="utf-8"))
+    return payload["decisions"][0]
+
+
+def _candidate_payload_for(row: dict[str, object]) -> dict[str, object]:
+    source_inventory = row["source_inventory"]
+    assert isinstance(source_inventory, dict)
+    return {
+        "generated_from": "fixture",
+        "counts": {"total_delta": 1, "processed": 1, "auto_merge": 0, "needs_review": 1},
+        "auto_merge": [],
+        "needs_review": [
+            {
+                "reason": "heritage_status flags russian_shadow",
+                "entry": {
+                    "lemma": row["lemma"],
+                    "pos": "noun",
+                    "primary_source": "source_inventory_grow",
+                    "source_provenance": [
+                        {
+                            "source_family": source_inventory["source_family"],
+                            "inventory_path": source_inventory["path"],
+                            "source_locator": source_inventory["locator"],
+                            "source_id": source_inventory["source_id"],
+                            "context": "fixture context",
+                        }
+                    ],
+                    "enrichment": {
+                        "translation": {"en": [row["approved_gloss"]]},
+                        "meaning": {
+                            "definitions": [
+                                {"text": "dictionary definition must not replace approved gloss"}
+                            ]
+                        },
+                    },
+                },
+            }
+        ],
+        "review_only": {"production_outputs_updated": []},
+    }
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+def test_plan_maps_approved_decision_to_manifest_addition(tmp_path: Path) -> None:
+    decision = _first_decision()
+    candidates = tmp_path / "candidates.json"
+    _write_json(candidates, _candidate_payload_for(decision))
+
+    plan = planner.build_promotion_plan(
+        candidates_path=candidates,
+        decision_files=[FIRST_BATCH],
+    )
+
+    assert plan["production_outputs_updated"] == []
+    assert plan["counts"]["approved_decisions"] == 20
+    assert plan["counts"]["proposed_additions"] == 1
+    assert plan["counts"]["missing_candidates"] == 19
+    addition = plan["proposed_manifest_additions"][0]
+    assert addition["lemma"] == decision["lemma"]
+    assert addition["source_inventory_key"] == decision["source_inventory"]["key"]
+    assert addition["approved_pos"] == decision["approved_pos"]
+    assert addition["approved_gloss"] == decision["approved_gloss"]
+    assert addition["candidate_bucket"] == "needs_review"
+    assert addition["manifest_entry"]["lemma"] == decision["lemma"]
+    assert addition["manifest_entry"]["pos"] == decision["approved_pos"]
+    assert addition["manifest_entry"]["gloss"] == decision["approved_gloss"]
+    assert addition["manifest_entry"]["primary_source"] == "source_inventory_grow"
+    assert addition["manifest_entry"]["course_usage"] == []
+    assert addition["manifest_entry"]["source_provenance"][0]["source_id"] == (
+        decision["source_inventory"]["source_id"]
+    )
+
+
+def test_plan_skips_existing_lemmas_when_manifest_supplied(tmp_path: Path) -> None:
+    decision = _first_decision()
+    candidates = tmp_path / "candidates.json"
+    manifest = tmp_path / "manifest.json"
+    _write_json(candidates, _candidate_payload_for(decision))
+    _write_json(manifest, {"entries": [{"lemma": decision["lemma"]}]})
+
+    plan = planner.build_promotion_plan(
+        candidates_path=candidates,
+        decision_files=[FIRST_BATCH],
+        manifest_path=manifest,
+    )
+
+    assert plan["counts"]["proposed_additions"] == 0
+    assert plan["counts"]["skipped_existing"] == 1
+    assert plan["skipped_existing"][0]["reason"] == "already_in_manifest"
+
+
+def test_candidate_matching_uses_stable_source_key_not_queue_id(tmp_path: Path) -> None:
+    decision = _first_decision()
+    candidates = tmp_path / "candidates.json"
+    payload = _candidate_payload_for(decision)
+    payload["needs_review"][0]["entry"]["queue_id"] = "source-inventory-publish-review-9999"
+    _write_json(candidates, payload)
+
+    plan = planner.build_promotion_plan(candidates_path=candidates, decision_files=[FIRST_BATCH])
+
+    assert plan["counts"]["proposed_additions"] == 1
+    assert plan["proposed_manifest_additions"][0]["source_inventory_key"] == (
+        decision["source_inventory"]["key"]
+    )
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        PROJECT_ROOT / "site/src/data/source-inventory-approved-promotion-plan.json",
+        PROJECT_ROOT / "site/public/lexicon/source-inventory-approved-promotion-plan.json",
+        PROJECT_ROOT / "data/telemetry/source-inventory-approved-promotion-plan.json",
+        PROJECT_ROOT / "curriculum/l2-uk-en/a1/status/source-inventory-approved-promotion-plan.json",
+        PROJECT_ROOT / "curriculum/l2-uk-en/a1/audit/source-inventory-approved-promotion-plan.md",
+        PROJECT_ROOT / "curriculum/l2-uk-en/a1/review/source-inventory-approved-promotion-plan.md",
+    ],
+)
+def test_plan_output_rejects_repository_paths(bad_path: Path) -> None:
+    with pytest.raises(SourceInventoryError):
+        planner.resolve_ephemeral_plan_output_path(bad_path)
+
+
+def test_write_plan_and_report_stay_ephemeral(tmp_path: Path) -> None:
+    plan = {
+        "workflow": planner.WORKFLOW_ID,
+        "policy": "fixture",
+        "production_outputs_updated": [],
+        "counts": {
+            "approved_decisions": 0,
+            "proposed_additions": 0,
+            "skipped_existing": 0,
+            "missing_candidates": 0,
+        },
+        "proposed_manifest_additions": [],
+        "skipped_existing": [],
+        "missing_candidates": [],
+    }
+
+    plan_path = planner.write_plan(plan, tmp_path / "plan.json")
+    report_path = planner.write_report(plan, tmp_path / "plan.md")
+
+    assert json.loads(plan_path.read_text(encoding="utf-8"))["production_outputs_updated"] == []
+    assert "Source Inventory Approved Promotion Plan" in report_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add a review-only source inventory promotion planner that consumes approved decision ledger rows and review candidate payloads
- join approved rows to candidates by stable source-inventory key and emit proposed manifest additions to /tmp/outside-repo outputs only
- document the approved-promotion boundary and current committed inventory inputs

## Boundary
- no live Atlas/search/browse/daily/practice/cloze/manifest/pointer/fingerprint outputs changed
- no status/audit/review/telemetry artifacts committed
- planner output carries production_outputs_updated: []

## Validation
- .venv/bin/python -m pytest tests/test_source_inventory_promotion_plan.py tests/test_source_inventory_review_decisions.py tests/test_source_inventory_review_candidates.py tests/test_grow_lexicon_from_sources.py tests/test_promote_grow_candidates.py -> 57 passed
- .venv/bin/python -m pytest tests/test_source_inventory_promotion_plan.py -> 10 passed after rebase
- .venv/bin/ruff check scripts/audit/plan_source_inventory_promotion.py tests/test_source_inventory_promotion_plan.py -> passed
- npx --yes markdownlint-cli2 docs/runbooks/word-atlas-source-inventory-review-candidates.md -> 0 errors
- .venv/bin/python scripts/audit/check_static_practice_assets.py --format json -> ok=true, daily=300, total_cloze=0, reviewed_sources=0
- .venv/bin/python -m scripts.audit.source_inventory_review_decisions -> files=1 rows=20 decisions={approve_for_publish: 20}
- .venv/bin/python scripts/audit/lint_agent_trailer.py -> passed
- git diff --check -> passed

## Smoke
- .venv/bin/python -m scripts.audit.plan_source_inventory_promotion --generate-candidates --out /tmp/atlas-source-inventory-approved-promotion-plan.json --report-out /tmp/atlas-source-inventory-approved-promotion-plan.md --report
- Result: approved_decisions=20, matched_candidates=20, proposed_additions=20, skipped_existing=0, missing_candidates=0, production_outputs_updated=[]
- Verified first proposed manifest entry keeps approved gloss: автобус -> bus

## Independent Review
- AGY/Gemini review initially flagged a possible optional-field KeyError; follow-up confirmed the decision validator guarantees required approved-row fields and withdrew the finding.
- Final AGY verdict: no blockers.