### PR TITLE
Add second source inventory decision ledger batch

### DIFF
--- a/data/lexicon/source-inventory-review-decisions/2026-06-30-second-approved-ledger-batch.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-06-30-second-approved-ledger-batch.yaml
@@ -1,0 +1,316 @@
+---
+version: 1
+kind: atlas_source_inventory_review_decisions
+batch_id: source-inventory-second-approved-ledger-batch-2026-06-30
+batch_label: second-approved-ledger-batch
+reviewer: content-review
+reviewed_at: '2026-06-30'
+source_queue:
+  workflow: source_inventory_publish_review_queue.v1
+  generated_from_pr: 4021
+  total_queue_rows: 83
+  approved_in_queue: 83
+  promotion_batch_size: 20
+production_outputs_updated: []
+decisions:
+- lemma: але
+  decision: approve_for_publish
+  approved_pos: conjunction
+  approved_gloss: but; however
+  sense_note: curriculum A1 conjunction
+  source_inventory:
+    key: c488438ed1ad929f
+    path: data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml
+    locator: vocabulary[1].items[1].word
+    source_id: l2-direct-a1-spoluchnyky-vocabulary
+    source_family: curriculum
+  evidence_refs:
+  - curriculum A1
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: балкон
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: balcony
+  sense_note: Vashulenko interior vocabulary
+  source_inventory:
+    key: 7c31663c58e44234
+    path: data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml
+    locator: topic_index.vocabulary_interior.words[11]
+    source_id: vashulenko-grade3-2020-interior-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko interior vocabulary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: барабан
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: drum
+  sense_note: Bolshakova + dictionary
+  source_inventory:
+    key: 52c09f107b3c30fd
+    path: data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml
+    locator: complete letter mapping row Б б
+    source_id: bolshakova-bukvar-2025-part1-keywords
+    source_family: textbook
+  evidence_refs:
+  - Bolshakova + dictionary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: вареники
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: varenyky; filled dumplings
+  sense_note: Bolshakova cultural food word
+  source_inventory:
+    key: ee6cdd12dbfccca4
+    path: data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml
+    locator: complete letter mapping row В в
+    source_id: bolshakova-bukvar-2025-part1-keywords
+    source_family: textbook
+  evidence_refs:
+  - Bolshakova + dictionary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags calque_warning; heritage_status flags
+    russian_shadow
+- lemma: галка
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: jackdaw
+  sense_note: Vashulenko bird vocabulary
+  source_inventory:
+    key: cec8d22a492ffbf4
+    path: data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml
+    locator: topic_index.vocabulary_birds_extended.words[9]
+    source_id: vashulenko-grade3-2020-birds-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko bird vocabulary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: диван
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: sofa
+  sense_note: Vashulenko interior vocabulary
+  source_inventory:
+    key: a3499bff22b6f90b
+    path: data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml
+    locator: topic_index.vocabulary_interior.words[3]
+    source_id: vashulenko-grade3-2020-interior-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko interior vocabulary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: добре
+  decision: approve_for_publish
+  approved_pos: adverb
+  approved_gloss: well; okay
+  sense_note: curriculum B1 adverb
+  source_inventory:
+    key: dd34659f8dc2e2a3
+    path: data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml
+    locator: vocabulary[2].items[2].word
+    source_id: l2-direct-b1-pryslivnyky-vocabulary
+    source_family: curriculum
+  evidence_refs:
+  - curriculum B1
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: дошка
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: blackboard; board
+  sense_note: Vashulenko school vocabulary
+  source_inventory:
+    key: ceaf5659f95ab4be
+    path: data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml
+    locator: topic_index.vocabulary_school.words[4]
+    source_id: vashulenko-grade3-2020-school-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko school vocabulary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: дятел
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: woodpecker
+  sense_note: Vashulenko bird vocabulary
+  source_inventory:
+    key: 16ffb905bfcc145f
+    path: data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml
+    locator: topic_index.vocabulary_birds_extended.words[5]
+    source_id: vashulenko-grade3-2020-birds-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko bird vocabulary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: зручний
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: comfortable; convenient
+  sense_note: Vashulenko interior adjective
+  source_inventory:
+    key: affa9dc2bfb27610
+    path: data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml
+    locator: topic_index.vocabulary_interior.adjectives[2]
+    source_id: vashulenko-grade3-2020-interior-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko interior vocabulary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: йогурт
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: yogurt
+  sense_note: Ohoiko/Bolshakova + dictionary
+  source_inventory:
+    key: beeb0ec471408dc6
+    path: data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml
+    locator: complete letter mapping row Й й
+    source_id: bolshakova-bukvar-2025-part1-keywords
+    source_family: textbook
+  evidence_refs:
+  - Ohoiko/Bolshakova + dictionary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: капелюх
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: hat
+  sense_note: Bolshakova + dictionary
+  source_inventory:
+    key: fc1f428f7130d8a1
+    path: data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml
+    locator: complete letter mapping row К к
+    source_id: bolshakova-bukvar-2025-part1-keywords
+    source_family: textbook
+  evidence_refs:
+  - Bolshakova + dictionary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: кит
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: whale
+  sense_note: Vashulenko marine vocabulary
+  source_inventory:
+    key: c85e50888d7408e5
+    path: data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml
+    locator: topic_index.vocabulary_marine.words[2]
+    source_id: vashulenko-grade3-2020-marine-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko marine vocabulary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: колібрі
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: hummingbird
+  sense_note: Vashulenko bird vocabulary
+  source_inventory:
+    key: c5a55fdde6834f51
+    path: data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml
+    locator: topic_index.vocabulary_birds_extended.words[4]
+    source_id: vashulenko-grade3-2020-birds-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko bird vocabulary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: коридор
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: corridor; hallway
+  sense_note: Vashulenko interior vocabulary
+  source_inventory:
+    key: b48312b0cdf213bb
+    path: data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml
+    locator: topic_index.vocabulary_interior.words[10]
+    source_id: vashulenko-grade3-2020-interior-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko interior vocabulary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: ластівка
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: swallow
+  sense_note: Vashulenko bird vocabulary
+  source_inventory:
+    key: 938efc31aa30e722
+    path: data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml
+    locator: topic_index.vocabulary_birds_extended.words[10]
+    source_id: vashulenko-grade3-2020-birds-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko bird vocabulary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: медуза
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: jellyfish
+  sense_note: Vashulenko marine vocabulary
+  source_inventory:
+    key: 7ef718b379daa44a
+    path: data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml
+    locator: topic_index.vocabulary_marine.words[0]
+    source_id: vashulenko-grade3-2020-marine-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko marine vocabulary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: море
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: sea
+  sense_note: curriculum B1 noun
+  source_inventory:
+    key: 39e1e7824983668b
+    path: data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml
+    locator: vocabulary[1].items[4].word
+    source_id: l2-direct-b1-imennyky-vidminy-vocabulary
+    source_family: curriculum
+  evidence_refs:
+  - curriculum B1
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: муха
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: fly
+  sense_note: Bolshakova animal vocabulary
+  source_inventory:
+    key: 21bb246a8349c7d0
+    path: data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml
+    locator: thematic categories; тварини
+    source_id: bolshakova-bukvar-2025-part1-keywords
+    source_family: textbook
+  evidence_refs:
+  - Bolshakova + dictionary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: намет
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: tent
+  sense_note: Bolshakova context; tent sense
+  source_inventory:
+    key: 31d47d5e77a5d487
+    path: data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml
+    locator: complete letter mapping row Н н
+    source_id: bolshakova-bukvar-2025-part1-keywords
+    source_family: textbook
+  evidence_refs:
+  - Bolshakova + dictionary
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow

--- a/scripts/audit/source_inventory_review_decisions.py
+++ b/scripts/audit/source_inventory_review_decisions.py
@@ -51,6 +51,7 @@ SOURCE_QUEUE_FIELDS = {
     "total_queue_rows",
     "approved_in_queue",
     "first_promotion_batch_size",
+    "promotion_batch_size",
 }
 DECISION_FIELDS = {
     "lemma",
@@ -120,6 +121,20 @@ def validate_decision_file(
         raise SourceInventoryError(f"{path}: source_queue must be a mapping")
     _reject_unknown_fields(path, source_queue, allowed=SOURCE_QUEUE_FIELDS, scope="source_queue")
     _require_equal(path, source_queue.get("workflow"), QUEUE_WORKFLOW, "source_queue.workflow")
+    batch_size_fields = [
+        field
+        for field in ("first_promotion_batch_size", "promotion_batch_size")
+        if field in source_queue
+    ]
+    if len(batch_size_fields) != 1:
+        raise SourceInventoryError(
+            f"{path}: source_queue must define exactly one promotion batch size field"
+        )
+    _require_positive_int(
+        path,
+        source_queue[batch_size_fields[0]],
+        f"source_queue.{batch_size_fields[0]}",
+    )
 
     decisions = payload.get("decisions")
     if not isinstance(decisions, list) or not decisions:
@@ -251,6 +266,12 @@ def _require_text(path: Path, value: object, field: str) -> str:
 def _require_equal(path: Path, actual: object, expected: object, field: str) -> None:
     if actual != expected:
         raise SourceInventoryError(f"{path}: {field} must be {expected!r}")
+
+
+def _require_positive_int(path: Path, value: object, field: str) -> int:
+    if not isinstance(value, int) or value <= 0:
+        raise SourceInventoryError(f"{path}: {field} must be a positive integer")
+    return value
 
 
 def _validate_text_list(path: Path, value: object, field: str) -> None:

--- a/tests/test_source_inventory_review_decisions.py
+++ b/tests/test_source_inventory_review_decisions.py
@@ -114,6 +114,41 @@ def test_decision_validator_allows_clean_rows_without_flags(tmp_path: Path) -> N
     assert summary["rows"] == 1
 
 
+def test_decision_validator_allows_general_promotion_batch_size(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    source_queue = payload["source_queue"]  # type: ignore[index]
+    source_queue.pop("first_promotion_batch_size")  # type: ignore[attr-defined]
+    source_queue["promotion_batch_size"] = 1  # type: ignore[index]
+    path = tmp_path / "ok.yaml"
+    _write_decision_file(path, payload)
+
+    summary = decisions.validate_committed_decision_files([path])
+
+    assert summary["rows"] == 1
+
+
+def test_decision_validator_rejects_missing_promotion_batch_size(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    source_queue = payload["source_queue"]  # type: ignore[index]
+    source_queue.pop("first_promotion_batch_size")  # type: ignore[attr-defined]
+    path = tmp_path / "bad.yaml"
+    _write_decision_file(path, payload)
+
+    with pytest.raises(SourceInventoryError, match="promotion batch size"):
+        decisions.validate_committed_decision_files([path])
+
+
+def test_decision_validator_rejects_duplicate_promotion_batch_size(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    source_queue = payload["source_queue"]  # type: ignore[index]
+    source_queue["promotion_batch_size"] = 1  # type: ignore[index]
+    path = tmp_path / "bad.yaml"
+    _write_decision_file(path, payload)
+
+    with pytest.raises(SourceInventoryError, match="promotion batch size"):
+        decisions.validate_committed_decision_files([path])
+
+
 def test_decision_validator_rejects_duplicate_source_key(tmp_path: Path) -> None:
     payload = _minimal_payload()
     payload["decisions"].append(dict(payload["decisions"][0]))  # type: ignore[index, union-attr]


### PR DESCRIPTION
## Summary

- Adds the second review-only source-inventory decision ledger batch with 20 approved rows.
- Keeps live Atlas manifest/search/browse outputs frozen.
- Keeps daily/practice/cloze frozen.
- Generalizes decision-ledger metadata from the first-batch-only `first_promotion_batch_size` field to `promotion_batch_size` for later batches while preserving compatibility with the first ledger.

## Ledger Batch

Approved rows:

- `але` - conjunction - but; however
- `балкон` - noun - balcony
- `барабан` - noun - drum
- `вареники` - noun - varenyky; filled dumplings
- `галка` - noun - jackdaw
- `диван` - noun - sofa
- `добре` - adverb - well; okay
- `дошка` - noun - blackboard; board
- `дятел` - noun - woodpecker
- `зручний` - adjective - comfortable; convenient
- `йогурт` - noun - yogurt
- `капелюх` - noun - hat
- `кит` - noun - whale
- `колібрі` - noun - hummingbird
- `коридор` - noun - corridor; hallway
- `ластівка` - noun - swallow
- `медуза` - noun - jellyfish
- `море` - noun - sea
- `муха` - noun - fly
- `намет` - noun - tent

Edge rows such as `город`, `жабка`, `нірка`, `косатка`, `хіба`, and `ібіс` remain out of this batch.

## Frozen Boundary

- `production_outputs_updated: []`
- No manifest/search/browse/pointer/fingerprint output changes.
- No daily/practice/cloze/status/audit-review/review/telemetry artifacts changed.

## Validation

- `.venv/bin/python -m scripts.audit.source_inventory_review_decisions` -> files=2, rows=40, approve_for_publish=40
- `.venv/bin/python -m pytest tests/test_source_inventory_review_decisions.py tests/test_source_inventory_promotion_plan.py` -> 20 passed
- `.venv/bin/python -m scripts.audit.plan_source_inventory_promotion --generate-candidates --out /tmp/atlas-second-ledger-promotion-plan.json --report-out /tmp/atlas-second-ledger-promotion-plan.md --report` -> approved_decisions=40, matched=40, proposed_additions=40, skipped_existing=0, missing_candidates=0, production_outputs_updated=[]
- `.venv/bin/python scripts/audit/check_static_practice_assets.py --format json` -> ok=true, daily=300, total_cloze=0, reviewed_sources=0
- `.venv/bin/ruff check scripts/audit/source_inventory_review_decisions.py tests/test_source_inventory_review_decisions.py` -> passed
- `.venv/bin/yamllint data/lexicon/source-inventory-review-decisions/2026-06-30-second-approved-ledger-batch.yaml` -> passed
- `git diff --check` -> passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` -> passed
- pre-commit on commit/push passed

## Independent Review

- AGY/Gemini review through `scripts/ai_agent_bridge/__main__.py ask-agy --to-model gemini-3.1-pro-high --review`: no blockers.
