### PR TITLE
docs(bio): add Andrii Malyshko research dossier

### DIFF
--- a/docs/research/bio/andrii-malyshko.md
+++ b/docs/research/bio/andrii-malyshko.md
@@ -1,0 +1,137 @@
+# Андрій Самійлович Малишко — Research Dossier
+
+**Slug:** `andrii-malyshko`
+**Block:** +77 expansion — "Music song-canon" group (2026-06-29 memo)
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #347
+**Researcher:** Codex orchestration pass
+**Completed:** 2026-06-30
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Андрій Самійлович Малишко.
+- **Pseudonyms / aliases:** Андрій Малишко; Малишко Андрій Самійлович; Andrii Malyshko; Andriy Malyshko. Russianized transliterations belong only in forbidden-forms metadata, not learner-facing prose.
+- **Born:** 14 November 1912 | Обухів, Київська губернія | Russian Empire. ЕСУ gives 01(14).11.1912 and modern Obukhiv, Kyiv region; ЕІУ gives 14(02).11.1912, while another literary-encyclopedia lead gives 2(15).XI.1912. Use 14 November 1912 for learner-facing chronology and flag the dual-date discrepancy in instructor notes.
+- **Died:** 17 February 1970 | Kyiv, Ukrainian SSR; buried at Baikove cemetery according to ЦДАМЛМ України.
+- **Family / education key facts:** Born in a large family in Obukhiv; institutional sources identify his father as a shoemaker and place his early formation in local school, Kyiv medical school, and the Kyiv Institute of People's Education, which he finished in 1932. He taught in Ovruch, served in the Red Army in 1934-1935, worked as a journalist, and became a major Ukrainian poet, translator, critic, editor, and public figure.
+
+Core identity for BIO: Ukrainian poet whose public career moved through Soviet institutions, while the durable reception of his work rests on Ukrainian-language lyric, folk-song poetics, and the song canon around "Пісня про рушник", "Київський вальс", "Стежина", "Вчителько моя", and related texts.
+
+## 2. Oppression mechanism
+
+- **What happened:** Not a repression-primary biography. No Tier 1/Tier 2 source found in this pass documents arrest, imprisonment, exile, execution, or a formal security-service case against Andrii Malyshko. The relevant mechanism is ideological containment and co-optation inside Soviet Ukrainian cultural institutions, plus specific pressure points around family memory, Holodomor-era conduct, and solidarity with arrested Ukrainian intellectuals.
+- **When (specific dates):** 1930s-1960s Soviet Ukrainian literary field; 1932-1933 Ovruch period noted in UINP account; May 1966 protest against political arrests documented by ЕІУ.
+- **By whom:** Soviet party-cultural apparatus, writers' institutions, military/front press, and state publishing/reward structures. Do not name NKVD, MGB, or KGB as direct persecutors of Malyshko unless a future archival source proves a case.
+- **Document references:** No case number, archival security file, court decision, or rehabilitation document found for Malyshko in this pass. ЕІУ notes the May 1966 protest but does not provide the protest document. ЦДАМЛМ України identifies Malyshko's personal fond no. 22, 1017 storage units across five inventories for 1927-1987, which should be the first archive target for a future deeper pass.
+- **Mechanism specifics:** Malyshko received Stalin prizes, Soviet state honours, editorial posts, and deputy roles; those facts must be named directly. At the same time, ESU's literary assessment distinguishes his folk-rooted ethical/melodic layer from the overt socialist-realist pathos of many prewar texts. A BIO module should teach that tension rather than flatten him into either "Soviet classic" or hidden dissident.
+- **What survived / what was destroyed:** What survived most strongly is the Ukrainian song memory attached to maternal, road, village, Kyiv, and homeland imagery. What was damaged is interpretive clarity: Soviet institutional celebration and later school-canon sentimentalization both make it easy to miss the harder question of how Ukrainian lyric survived inside official forms.
+
+## 3. Major works / contributions
+
+- **Early and wartime poetry:** First publications appeared in 1930. Early books include "Батьківщина" (1936), "Лірика" (1938), "З книги життя" (1938), "Народження синів" (1939), and 1940 collections. Wartime books include "Понад пожари" (1942), "Слово о полку" (1943), and "Битва" (1943); ЦДАМЛМ highlights the 1941 cycle "Україно моя!" as a major Ukrainian literary event of the war years.
+- **Song canon:** ЕСУ says roughly 100 lyric poems were set to music and emphasizes the collaboration with Platon Maiboroda: more than 30 songs, including "Київський вальс", "Пісня про рушник", "Вчителько моя", "Стежина", "Ми підем, де трави похилі", "Білі каштани", "Пролягла доріженька", and "Цвітуть осінні тихі небеса". ЦДАМЛМ records that "Пісня про рушник" first sounded widely through the film "Літа молодії" in 1959.
+- **Public reception and commemoration:** National-library and state-memory sources continue to frame him through "Україно моя!", "Пісня про рушник", the Maiboroda collaboration, and Ukrainian song culture. A BIO module can use this reception evidence as modern Ukrainian memory, not as a substitute for literary judgment.
+- **Literary criticism and large forms:** He wrote literary-critical books including "Думки про поезію" (1959) and "Слово про поета. М. Т. Рильський та його творчість" (1960), wrote libretti for "Молода гвардія" and "Арсенал" (with Oleksandr Levada), and supplied poetic bases for Ukrainian musical works.
+- **Institutional/public role:** Responsible editor of "Дніпро" in 1944-1947; chairman of the Ukrainian public branch of APN from 1960; deputy of the Supreme Soviet of the Ukrainian SSR across the 1950s-1960s according to ЕІУ and recent scholarship on deputy activity.
+
+## 4. Primary-source quotes
+
+- **Quote 1, song-memory anchor:** "Рідна мати моя..."
+  - Source: Andrii Malyshko, "Пісня про рушник"; online text host УкрЛіб; canonical song associated with Platon Maiboroda's music and the film "Літа молодії".
+  - Pedagogical use: One short phrase is enough to trigger learners' recognition of maternal image, road image, and embroidered-cloth symbolism without overquoting a copyrighted song lyric.
+- **Quote 2, late-life road image:** "Чому, сказати, й сам не знаю..."
+  - Source: Andrii Malyshko, "Чому, сказати, й сам не знаю..." / "Стежина"; online text host УкрЛіб.
+  - Pedagogical use: The opening phrase makes the module's central register visible: intimate, folk-song-like, deceptively simple, but not primitive. It can anchor a close-reading activity on syntax, repetition, and memory.
+
+Do not quote long passages from Malyshko in generated modules. His work is not public domain in 2026; use brief excerpts, paraphrase, and point learners to lawful text editions or licensed sources.
+
+## 5. Language register
+
+- **Register:** lyrical, folk-song-adjacent, emotionally direct, with strong colloquial and proverbial resources; at times official-socialist pathos in early and institutional texts.
+- **CEFR readiness for full reading:** C1 for BIO/LIT analysis because the hardest work is not vocabulary alone but ideological framing and register contrast. Selected song excerpts are accessible from B1/B2 with teacher scaffolding.
+- **Lexicon notes:** Watch terms around Soviet institutions, awards, депутатська діяльність, фронтовий кореспондент, соцреалізм, фольклоризм, пісенність, рушник, стежина, колиска, явір, калина.
+- **Stylistic features:** melody-first syntax, repetition, parallelism, folk-song imagery, direct address, diminutives, road/home/mother archetypes, ballad and narrative lyric structures. ESU specifically stresses idioms, phraseology, direct speech, organic melodic pull toward song tradition, and a folk-rooted ethical layer that coexists uneasily with official prewar texts.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** The central issue is not whether Malyshko belongs in Ukrainian literature, but how to read a poet whose official Soviet prestige, Stalin prizes, deputy role, and public posts coexist with a Ukrainian-language lyric corpus that became national song memory. The recent article on his deputy activity usefully frames Soviet deputy work as institutionally different from present-day parliamentary politics, which helps avoid anachronism.
+- **What gets simplified in popular memory:** School and concert culture often reduce him to "Пісня про рушник" and maternal tenderness. Anti-Soviet shorthand can reduce him to the opposite caricature: a decorated Soviet poet. Both are too thin. The module should hold the contradiction: songs that feel intimate and nationally durable were produced by a writer also embedded in official Soviet structures.
+- **Where modern Russian disinformation attacks them (if applicable):** No Malyshko-specific modern Russian disinformation campaign identified. The broader colonial risk is absorptive: treating "Ukrainian Soviet" as a branch of Russian/Soviet culture and ignoring the Ukrainian language, folk-song substrate, and later national reception.
+- **Polish / Jewish / other-perspective considerations (if applicable):** None central to the BIO module identified. If wartime correspondence or journalism is later used, check for period language and Soviet wartime framing before quoting.
+- **HIST-alignment check for +77 roster:** Align with Soviet-era Ukrainian culture, wartime literature, postwar institutional culture, and the 1960s pressure on Ukrainian intellectuals. Do not invent a dissident spine; the correct historical frame is cultural survival, official compromise, and late solidarity.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/malyshko-poetry.yaml` — "Андрій Малишко: Поезія, що стала піснею".
+  - `curriculum/l2-uk-en/plans/lit/malyshko-songs.yaml` — "Пісня як зброя і молитва: Поезія Андрія Малишка".
+- **Existing HIST modules (VERIFIED `test -e`):**
+  - None found in this pass.
+- **Existing BIO modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/oleksandr-bilash.yaml` — existing BIO plan for a composer who worked with Malyshko texts and the broader Ukrainian song-memory problem.
+- **Candidate cross-track connections (not Existing):**
+  - `curriculum/l2-uk-en/plans/bio/platon-maiboroda.yaml` — composer partner for "Пісня про рушник" and broader song canon; not yet present in +77 base prep.
+  - Future HIST/LIT synthesis on Soviet Ukrainian cultural institutions, the 1965-1966 arrests, and the place of officially published writers in language preservation.
+- **Potential LIT additions surfaced research:**
+  - None. Existing LIT coverage already covers the obvious Malyshko poetry/song path.
+
+## 8. Naming-canonical
+
+Per `docs/best-practices/bio-naming-canonical.md` (#2313):
+
+- **Slug:** `andrii-malyshko`.
+- **EN canonical (BGN/PCGN 2010):** Andrii Malyshko.
+- **UA canonical (with patronymic attested):** Андрій Самійлович Малишко.
+- **Aliases:** Андрій Малишко; Малишко Андрій Самійлович; Andriy Malyshko (common non-project spelling); A. Malyshko.
+- **Forbidden forms:** Russianized or Russian-via-English forms such as "Andrey Malyshko" or Russian patronymic presentation in body text. Mention only in metadata if a source requires disambiguation.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** No cleared portrait selected in this pass. Malyshko died in 1970, so photographs are presumptively copyright-sensitive unless a specific license, author death date, or archival release is verified.
+- **Backup candidates:** ЦДАМЛМ article includes archival images, but the page does not by itself establish reusable license for curriculum media. Wikimedia/commemorative-coin images require separate license review before use.
+- **Fallback strategy:** ship text-only or use a rights-cleared contextual object if later found: book cover with license clearance, public-domain pre-1920s Obukhiv context image, or NBU commemorative coin only if the project image policy permits it.
+- **Era-appropriate context image:** Potentially the "Пісня про рушник" film/song context or ROLIT exterior, but do not add without verifying media rights.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- Енциклопедія Сучасної України. "Малишко Андрій Самійлович." https://esu.com.ua/article-63095. Accessed 2026-06-30.
+- Герасимова Г. П. "Малишко Андрій Самійлович." Енциклопедія історії України, т. 6: Ла-Мі. Інститут історії України НАН України. https://resource.history.org.ua/cgi-bin/eiu/history.exe?S21STR=Malyshko_A_S. Accessed 2026-06-30.
+- Велика українська енциклопедія. "Малишко, Андрій Самійлович." https://vue.gov.ua/Малишко,_Андрій_Самійлович. Accessed 2026-06-30.
+
+**Tier 2 (institutional):**
+
+- Центральний державний архів-музей літератури і мистецтва України. "Андрій Самійлович Малишко (1912-1970)." https://csamm.archives.gov.ua/2022/11/15/andrii-samiilovych-malyshko-1912-1970/. Accessed 2026-06-30.
+- Український інститут національної пам'яті. "1912 - народився Андрій Малишко, поет." https://uinp.gov.ua/istorychnyy-kalendar/lystopad/14/1912-narodyvsya-andriy-malyshko-poet. Accessed 2026-06-30.
+
+**Tier 3 (encyclopedic):**
+
+- Українська Вікіпедія. "Малишко Андрій Самійлович." Used only for navigation and alternate identifiers; core claims checked against ЕСУ/ЕІУ/ЦДАМЛМ.
+
+**Tier 4 (modern scholarly post-1991):**
+
+- Плісецький Д. "Депутатська діяльність Андрія Малишка (1951-1967 рр.)." Консенсус, no. 1 (2026): 75-90. https://doi.org/10.31110/consensus/2026-01/075-090. Accessed 2026-06-30.
+
+**Tier 5 / text hosts and general web:**
+
+- УкрЛіб. "Малишко Андрій Самійлович." https://www.ukrlib.com.ua/books/author.php?id=76. Accessed 2026-06-30.
+- УкрЛіб. "Пісня про рушник - Малишко Андрій." https://www.ukrlib.com.ua/books/printit.php?tid=961. Accessed 2026-06-30.
+- УкрЛіб. "Чому, сказати, й сам не знаю... - Андрій Малишко." https://www.ukrlib.com.ua/books/printit.php?tid=976. Accessed 2026-06-30.
+
+**Primary-source documents accessed (NKVD/KGB/FSB, court, police, censorship, rehabilitation documents):**
+
+- None found or accessed in this pass. Do not claim a direct security-service file. Future archival work should start with ЦДАМЛМ fond no. 22 and, only if a specific lead appears, declassified Soviet security archives.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; Soviet institutions named as context, not identity authority.
+- [x] No invented security-service storyline.
+- [x] Ukrainian language and Ukrainian song reception foregrounded.
+- [x] Soviet honours and official posts not hidden.
+- [x] Existing cross-track paths verified before being listed.
+- [x] Copyright-sensitive lyric quotations kept to short excerpts only.


### PR DESCRIPTION
## Summary
- Add BIO #347 Andrii Malyshko research dossier as a base-prep slice.
- Frame Malyshko as an official Soviet-era literary figure whose Ukrainian-language lyrics became durable song canon.
- Keep security-service/repression framing explicit as not evidenced; no module, plan YAML, site MDX, wiki, generated status, audit, review, or telemetry artifacts included.

## Validation
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/andrii-malyshko.md
- /Users/krisztiankoos/projects/learn-ukrainian/node_modules/.bin/markdownlint-cli2 docs/research/bio/andrii-malyshko.md
- git diff --check
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py
- AGY independent read-only review: one blocker found and fixed (Bilash existing BIO path moved under VERIFIED existing BIO subsection).

## Scope
- Changed files: 1
- No protected config files changed
- No generated status/audit/review/telemetry artifacts included
