### PR TITLE
docs(bio): add Platon Maiboroda research dossier

### DIFF
--- a/docs/research/bio/platon-maiboroda.md
+++ b/docs/research/bio/platon-maiboroda.md
@@ -1,0 +1,140 @@
+# Платон Іларіонович Майборода — Research Dossier
+
+**Slug:** `platon-maiboroda`
+**Block:** +77 expansion — "Music song-canon" group (2026-06-29 memo)
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #348
+**Researcher:** Codex background worker; Codex orchestrator cleanup
+**Completed:** 2026-06-30
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Платон Іларіонович Майборода.
+- **Pseudonyms / aliases:** Платон Майборода; Майборода Платон Іларіонович; Platon Maiboroda; Platon Mayboroda.
+- **Born:** 1 December 1918 | хутір Пелехівщина, now in Poltava region | Ukrainian state/revolutionary-war context, later Soviet administrative framing varies by source.
+- **Died:** 8 July 1989 | Kyiv, Ukrainian SSR | buried at Baikove cemetery per ЦДАМЛМ України.
+- **Family / education key facts:** Younger brother of composer Heorhii Maiboroda. ЕСУ, НСКУ, and NBUV agree on the core arc: musical formation under Levko Revutskyi, folklore study with Dmytro Revutskyi, Kyiv Conservatory graduation in 1947, teaching work in Kyiv after the war, and long activity in Soviet Ukrainian musical institutions.
+
+Core identity for BIO: Ukrainian composer and song-canon builder whose most durable public legacy is not a symphony or opera but lyric songs that carried Ukrainian domestic, school, Kyiv, road, and memory imagery through late Soviet public culture and into post-Soviet Ukrainian listening.
+
+## 2. Oppression mechanism
+
+- **What happened:** Not a direct repression-primary biography. No reviewed Tier 1/Tier 2 source documents arrest, imprisonment, exile, execution, or a security-service case against Platon Maiboroda himself. The dossier should instead name two historical pressures: family trauma under Stalinist repression and Soviet institutional co-optation of Ukrainian music.
+- **When (specific dates):** НСКУ states that after young Platon went to Kyiv in summer 1936, his father was arrested and executed as an "enemy of the people." ЕСУ documents wartime rupture: in June 1941 Platon and Heorhii joined the people's militia, were captured, escaped in 1942, were interned in Katowice in 1943, and later ended the war with the First Ukrainian Front.
+- **By whom:** For the father episode, reviewed sources do not provide a case file or agency name, so do not name NKVD unless a future archival source proves it. For the composer himself, the relevant actor is the Soviet cultural-state apparatus: unions, awards, film and radio infrastructure, and official repertory systems.
+- **Document references:** No case number, security archive citation, court decision, or rehabilitation document found in this pass. ЦДАМЛМ identifies Platon Maiboroda's personal fond no. 855, with 191 storage units dated 1914-1998; this is the first archive target for any future document-level claim.
+- **Mechanism specifics:** Maiboroda received Stalin and Soviet-state honours, served in official unions, and worked in state-managed musical media. Those facts must not be hidden. But reducing him to a "Soviet composer" also misses why Ukrainian audiences kept these songs: they organized Ukrainian-language memory through mother, path, school, Kyiv, chestnut, and landscape images.
+- **What survived / what was destroyed:** The songs survived as shared public memory. The harder loss is interpretive clarity: Soviet reward language and later sentimental concert culture can both obscure the Ukrainian melodic tradition, folklore training, and collaboration networks behind the songs.
+
+## 3. Major works / contributions
+
+- **Malyshko collaboration:** ЕСУ says that from 1948 Maiboroda worked with Andrii Malyshko and that more than 22 joint works became model examples of Ukrainian melodic tradition and national aesthetic thinking. This is the central BIO connection to #347.
+- **Song canon:** Key works include "Київський вальс", "Білі каштани", "Пісня про вчительку", "Ми підем, де трави похилі", "Ти моя вірна любов", "Колискова", "Пісня про козацькі могили", "Моя стежина", and "Рідна мати моя" / "Пісня про рушник". ЕСУ notes that "Пісня про рушник" was translated into 18 languages and later recognized as a leading song of the twentieth century.
+- **Folklore and Ukrainian musical training:** ЕСУ records folklore lessons with Dmytro Revutskyi and expeditions in Poltava region and Eastern Galicia. That matters pedagogically: his song language should be taught as professional composition rooted in Ukrainian folk-song listening, not as vague "natural melodiousness."
+- **Larger musical output:** ЦДАМЛМ lists vocal-symphonic works including "Дума про Дніпро" and "Тополя", theater and film music, and more than 100 songs. NBUV also names his film work, including "Літа молодії", "Долина синіх скель", "Кров людська - не водиця", and "Абітурієнтка".
+- **Institutional role:** ЦДАМЛМ identifies him as the first composer to receive the Shevchenko Prize, for "Вибрані пісні" in 1962, and notes later positions in the boards of the Union of Composers of Ukraine and the Union of Composers of the USSR.
+
+## 4. Primary-source quotes
+
+- **Quote 1, song-memory anchor:** "Рідна мати моя..."
+  - Source: "Пісня про рушник" / "Рідна мати моя"; words by Andrii Malyshko, music by Platon Maiboroda; text host Pisni.org.ua.
+  - Pedagogical use: This short incipit is the public doorway into Maiboroda's most famous musical setting. Use it to connect melody, maternal image, and ritual textile memory without overquoting copyrighted lyrics.
+- **Quote 2, late-life path image:** "Де ти, моя стежино..."
+  - Source: "Моя стежина" / "Чому, сказати, й сам не знаю..."; words by Andrii Malyshko, music by Platon Maiboroda; text host Pisni.org.ua / Ukrlib cross-check.
+  - Pedagogical use: The phrase lets learners hear the road/home image that links Malyshko's lyric register to Maiboroda's cantilena and public-memory function.
+
+Composer-specific note: these are not Maiboroda's verbal authorship; they are lyric incipits from songs where his music is the primary artistic contribution. Do not quote long lyric passages in generated modules. Use short incipits, paraphrase, and point learners to lawful text/music sources.
+
+## 5. Language register
+
+- **Register:** lyrical, song-centered, public but intimate; folk-song contour shaped by professional composition.
+- **CEFR readiness for full reading:** C1 for BIO analysis because the difficulty is historical framing and cultural interpretation, not raw vocabulary. Short song incipits can be used earlier with teacher scaffolding.
+- **Lexicon notes:** пісняр, кантилена, фольклорна експедиція, композиторська спілка, позивні, кінофільм, вальс, рушник, стежина, каштани, вчителька.
+- **Stylistic features:** memorability, refrain, flowing melodic line, domestic/public bridge, Kyiv urban memory, school memory, mother/path imagery, and the transformation of short lyric images into mass public repertoire.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** The main issue is how to describe a composer whose career was institutionally Soviet but whose strongest works became Ukrainian-language cultural memory. This is not a contradiction to flatten; it is the module's interpretive spine.
+- **What gets simplified in popular memory:** Popular reception often reduces Maiboroda to one song, "Пісня про рушник." Soviet-era accounts can emphasize honours and official posts. A good BIO module should instead show the ecosystem: Malyshko's words, Maiboroda's melody, Revutskyi-line training, folklore collection, film/radio circulation, and family/war context.
+- **Where modern Russian disinformation attacks them (if applicable):** No Maiboroda-specific modern Russian disinformation campaign identified. The broader colonial risk is absorptive: presenting Ukrainian song culture as merely Soviet mass culture and underplaying language, place, and Ukrainian composer networks.
+- **Polish / Jewish / other-perspective considerations (if applicable):** None central to this module. Wartime captivity and Katowice internment should be stated carefully from Ukrainian institutional sources and not dramatized beyond the evidence.
+- **HIST-alignment check for +77 roster:** Align with Soviet Ukrainian culture, Second World War disruption, postwar official institutions, Ukrainian-language media circulation, and the longer biography sequence around Malyshko, Bilash, and Ivasyuk.
+
+## 7. Cross-track links
+
+- **Existing LIT modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/malyshko-poetry.yaml` — Malyshko lyric canon; direct textual partner for Maiboroda's best-known songs.
+  - `curriculum/l2-uk-en/plans/lit/malyshko-songs.yaml` — song-poetry framing and Soviet-era compromise context.
+- **Existing BIO modules (VERIFIED `test -e`):**
+  - `docs/research/bio/andrii-malyshko.md` — BIO #347 dossier, direct collaborator and immediate sequence neighbor.
+  - `curriculum/l2-uk-en/plans/bio/oleksandr-bilash.yaml` — existing BIO plan for a later song-canon composer connected to Malyshko texts and Ukrainian song memory.
+- **Existing HIST modules (VERIFIED `test -e`):**
+  - None found in this pass.
+- **Candidate cross-track connections (not Existing):**
+  - `curriculum/l2-uk-en/plans/bio/volodymyr-ivasyuk.yaml` — later Ukrainian song-canon comparison if production planning wants a wider arc.
+  - Future HIST/LIT material on Soviet Ukrainian cultural institutions, radio/film circulation, and postwar Ukrainian song.
+- **Potential LIT additions surfaced research:**
+  - None. Existing Malyshko LIT plans already cover the direct song-text path.
+
+## 8. Naming-canonical
+
+Per `docs/best-practices/bio-naming-canonical.md` (#2313):
+
+- **Slug:** `platon-maiboroda`.
+- **EN canonical (BGN/PCGN 2010):** Platon Maiboroda.
+- **UA canonical (with patronymic attested):** Платон Іларіонович Майборода.
+- **Aliases:** Платон Майборода; Майборода Платон Іларіонович; Platon Mayboroda (common alternate English spelling); P. Maiboroda.
+- **Forbidden forms:** Russianized spellings or Russian patronymic presentation in learner-facing body text. Mention only as source metadata if needed for disambiguation.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** No cleared portrait selected in this pass. Maiboroda died in 1989, so portraits are presumptively copyright-sensitive unless a specific free license or archival release is verified.
+- **Backup candidates:** ЕСУ and НСКУ pages include portraits, but their reuse rights must be checked before any curriculum media use. Wikimedia results require separate license review and should not be assumed usable.
+- **Fallback strategy:** ship text-only or use a rights-cleared contextual image later: licensed concert program, score cover, memorial plaque, or a public-domain place image from Poltava/Kyiv only if it genuinely serves the lesson.
+- **Era-appropriate context image:** A scan or photograph tied to "Пісня про рушник", "Київський вальс", or radio/film circulation could work, but only after license verification.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- Енциклопедія Сучасної України. "Майборода Платон Іларіонович." https://esu.com.ua/article-60475. Accessed 2026-06-30.
+- Енциклопедія українознавства. "Майборода Платон." https://litopys.org.ua/encycl/euii107.htm. Accessed 2026-06-30.
+
+**Tier 2 (institutional):**
+
+- Національна спілка композиторів України. "Майборода Платон Іларіонович." https://composersukraine.org/index.php?id=2405. Accessed 2026-06-30.
+- Центральний державний архів-музей літератури і мистецтва України. "Георгій і Платон Майбороди..." https://csamm.archives.gov.ua/2023/12/01/георгій-і-платон-майбороди/. Accessed 2026-06-30.
+- Національна бібліотека України імені В. І. Вернадського. "Народився Платон Майборода, український композитор, педагог, фольклорист." https://www.nbuv.gov.ua/node/4474. Accessed 2026-06-30.
+- NBUV Україніка. "Майборода Платон Іларіонович." https://irbis-nbuv.gov.ua/ulib/item/REF0005551. Accessed 2026-06-30.
+
+**Tier 3 (encyclopedic):**
+
+- Українська Вікіпедія. "Майборода Платон Іларіонович." Used only for navigation and alternate identifiers; core claims checked against ЕСУ/НСКУ/ЦДАМЛМ/NBUV.
+
+**Tier 4 (modern scholarly post-1991):**
+
+- None found in this pass. Future production planning would benefit from musicological scholarship on postwar Ukrainian song and radio/film circulation.
+
+**Tier 5 / text hosts and general web:**
+
+- Pisni.org.ua. "Пісня про рушник." https://www.pisni.org.ua/songs/2292.html. Accessed 2026-06-30.
+- Pisni.org.ua. "Моя стежина." https://www.pisni.org.ua/songs/523003.html. Accessed 2026-06-30.
+- Суспільне Культура. "Платон Майборода народився 1 грудня." https://suspilne.media/culture/887825-koli-a-pisov-na-front-z-sobou-vzav-tri-reci-hlib-zbrou-ta-pisnu-platon-majboroda-kompozitor-dobrovolec-i-drug/. Accessed 2026-06-30.
+
+**Primary-source documents accessed (NKVD/KGB/FSB, court, police, censorship, rehabilitation documents):**
+
+- None found or accessed in this pass. Do not claim a direct security-service file. Future archival work should start with ЦДАМЛМ fond no. 855 and only then pursue security-archive leads if a specific case reference appears.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; Soviet institutions named as context, not identity authority.
+- [x] No invented repression or security-service storyline for Maiboroda himself.
+- [x] Family repression and wartime disruption included only to the level sourced.
+- [x] Ukrainian language, song canon, and folklore training foregrounded.
+- [x] Soviet honours and official posts not hidden.
+- [x] Existing cross-track paths verified before being listed.
+- [x] Copyright-sensitive lyric quotations kept to short incipits only.


### PR DESCRIPTION
## Summary
- Add BIO #348 Platon Maiboroda research dossier as a base-prep slice.
- Frame Maiboroda through Ukrainian song canon, Maiboroda-Malyshko collaboration, folklore training, and Soviet-era institutional compromise.
- Keep repression/security-service framing explicit as not evidenced for Maiboroda himself; no module, plan YAML, site MDX, wiki, generated status, audit, review, or telemetry artifacts included.

## Validation
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/platon-maiboroda.md
- /Users/krisztiankoos/projects/learn-ukrainian/node_modules/.bin/markdownlint-cli2 docs/research/bio/platon-maiboroda.md
- git diff --check
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py
- AGY independent read-only review: no blockers.

## Scope
- Changed files: 1
- No protected config files changed
- No generated status/audit/review/telemetry artifacts included
