### PR TITLE
[codex] Gate source inventory learner surfaces

### DIFF
--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -92,6 +92,14 @@ source-id/title/locator/context origin is not dropped on promotion. Separate
 `course_usage`, derived only from `source_context`/`source_contexts`, stays empty
 for source-inventory rows.
 
+Source-inventory manifest promotion is browse/search by default. Do not use
+manifest promotion as implicit permission for Words of the Day, practice, or
+cloze. If a reviewed row should enter a learner-facing surface later, add a
+`surface_admission` mapping to the decision row with explicit boolean keys:
+`daily`, `practice`, and `cloze`. Missing `surface_admission` means
+`daily: false`, `practice: false`, `cloze: false` for `source_inventory_grow`
+entries.
+
 This workflow does not update live Atlas manifest, search index, browse files,
 Words of the Day pool, daily practice sources, cloze outputs, manifest pointer,
 or manifest fingerprint. In-repository live outputs under `site/src/data/`

--- a/scripts/audit/generate_daily_pool.py
+++ b/scripts/audit/generate_daily_pool.py
@@ -10,8 +10,10 @@ from typing import Any
 
 from scripts.audit.lexeme_filter import (
     DERIVED_FORM_SOURCES,
+    SURFACE_DAILY,
     SURZHYK_SOURCE,
     is_lexeme_entry,
+    is_surface_admitted,
 )
 
 DEFAULT_MANIFEST = Path("site/src/data/lexicon-manifest.json")
@@ -83,6 +85,7 @@ def _is_eligible(entry: dict[str, Any]) -> bool:
         is_lexeme_entry(entry)
         and _has_text(entry.get("gloss"))
         and entry.get("primary_source") not in _DERIVED_FORM_SOURCES
+        and is_surface_admitted(entry, SURFACE_DAILY)
     )
 
 

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -25,7 +25,7 @@ if str(PROJECT_ROOT) not in sys.path:
 if str(AUDIT_DIR) not in sys.path:
     sys.path.insert(0, str(AUDIT_DIR))
 
-from lexeme_filter import is_practice_eligible
+from lexeme_filter import SURFACE_CLOZE, is_practice_eligible, is_surface_admitted
 
 DEFAULT_MANIFEST = Path("site/src/data/lexicon-manifest.json")
 # Deck shards are served as literal static files from public/ (not via dynamic .json.ts
@@ -1078,10 +1078,13 @@ def build_practice_shards(
     cloze_by_level: dict[str, list[dict[str, Any]]] = {level: [] for level in CEFR_ORDER}
     cloze_ids_by_lemma: dict[str, list[str]] = {}
     for _entry, lexeme in lexemes_by_entry:
-        source_rows = [
-            *cloze_by_lemma_id.get(lexeme["lemmaId"], []),
-            *cloze_by_lemma.get(lexeme["lemmaPlain"], []),
-        ]
+        if is_surface_admitted(_entry, SURFACE_CLOZE):
+            source_rows = [
+                *cloze_by_lemma_id.get(lexeme["lemmaId"], []),
+                *cloze_by_lemma.get(lexeme["lemmaPlain"], []),
+            ]
+        else:
+            source_rows = []
         items = _build_cloze_items(lexeme, source_rows, allowlist, verifier, deck_version)
         for item in items:
             item["options"] = _make_options(item, lexeme, all_lexemes, rng)

--- a/scripts/audit/lexeme_filter.py
+++ b/scripts/audit/lexeme_filter.py
@@ -43,9 +43,35 @@ DERIVED_FORM_SOURCES = frozenset(
 # Surzhyk forms curated for the Atlas "avoid" tier — shown with a warning, never drilled.
 SURZHYK_SOURCE = "surzhyk_to_avoid"
 
+# Source-inventory growth is reviewed enough for Atlas search/browse, but each
+# learner-facing surface needs a separate curriculum decision.
+SOURCE_INVENTORY_SOURCE = "source_inventory_grow"
+SURFACE_ADMISSION_FIELD = "surface_admission"
+SURFACE_DAILY = "daily"
+SURFACE_PRACTICE = "practice"
+SURFACE_CLOZE = "cloze"
+
 
 def _has_text(value: Any) -> bool:
     return isinstance(value, str) and bool(value.strip())
+
+
+def is_surface_admitted(entry: dict[str, Any], surface: str) -> bool:
+    """True when *entry* may appear on a learner-facing surface.
+
+    Non-source-inventory entries keep their existing behavior. Reviewed
+    source-inventory rows default to Atlas search/browse only unless a later
+    curriculum decision opts them into the requested surface.
+    """
+    if entry.get("primary_source") != SOURCE_INVENTORY_SOURCE:
+        return True
+
+    admission = entry.get(SURFACE_ADMISSION_FIELD)
+    if isinstance(admission, dict):
+        return admission.get(surface) is True
+    if isinstance(admission, (list, tuple, set)):
+        return surface in admission
+    return False
 
 
 def is_lexeme_entry(entry: dict[str, Any]) -> bool:
@@ -96,5 +122,7 @@ def is_practice_eligible(entry: dict[str, Any]) -> bool:
     if entry.get("primary_source") in DERIVED_FORM_SOURCES:
         return False
     if entry.get("primary_source") == SURZHYK_SOURCE:
+        return False
+    if not is_surface_admitted(entry, SURFACE_PRACTICE):
         return False
     return _has_course_usage(entry) or _has_cefr_level(entry)

--- a/scripts/audit/plan_source_inventory_promotion.py
+++ b/scripts/audit/plan_source_inventory_promotion.py
@@ -36,6 +36,7 @@ class ApprovedDecision:
     source_inventory: Mapping[str, Any]
     evidence_refs: tuple[str, ...]
     review_queue_reasons: tuple[str, ...]
+    surface_admission: Mapping[str, bool]
     batch_id: str
     batch_label: str
     decision_file: str
@@ -198,11 +199,14 @@ def _planned_addition(decision: ApprovedDecision, match: CandidateMatch) -> dict
     candidate = copy.deepcopy(dict(match.entry))
     candidate["pos"] = decision.approved_pos
     candidate["gloss"] = decision.approved_gloss
+    candidate.pop("surface_admission", None)
     manifest_entry = promote.manifest_entry_from_candidate(candidate)
     manifest_entry["gloss"] = decision.approved_gloss
     manifest_entry["pos"] = decision.approved_pos
     if candidate.get("primary_source"):
         manifest_entry["primary_source"] = candidate["primary_source"]
+    if decision.surface_admission:
+        manifest_entry["surface_admission"] = dict(decision.surface_admission)
     return {
         "lemma": decision.lemma,
         "approved_pos": decision.approved_pos,
@@ -212,6 +216,7 @@ def _planned_addition(decision: ApprovedDecision, match: CandidateMatch) -> dict
         "source_inventory": dict(decision.source_inventory),
         "evidence_refs": list(decision.evidence_refs),
         "review_queue_reasons": list(decision.review_queue_reasons),
+        "surface_admission": dict(decision.surface_admission),
         "candidate_bucket": match.bucket,
         "candidate_reasons": list(match.reasons),
         "batch_id": decision.batch_id,
@@ -306,6 +311,7 @@ def _approved_decisions(paths: Sequence[Path]) -> list[ApprovedDecision]:
                     review_queue_reasons=tuple(
                         str(item) for item in row.get("review_queue_reasons", [])
                     ),
+                    surface_admission=dict(row.get("surface_admission") or {}),
                     batch_id=str(payload["batch_id"]),
                     batch_label=str(payload["batch_label"]),
                     decision_file=str(path),

--- a/scripts/audit/source_inventory_review_decisions.py
+++ b/scripts/audit/source_inventory_review_decisions.py
@@ -63,8 +63,10 @@ DECISION_FIELDS = {
     "evidence_refs",
     "review_queue_reasons",
     "original_flags",
+    "surface_admission",
     "supersedes",
 }
+SURFACE_ADMISSION_FIELDS = {"daily", "practice", "cloze"}
 SOURCE_INVENTORY_FIELDS = {
     "key",
     "path",
@@ -185,6 +187,12 @@ def _validate_decision_row(
         )
     if "original_flags" in row:
         _validate_text_list(path, row.get("original_flags"), f"decisions[{idx}].original_flags")
+    if "surface_admission" in row:
+        _validate_surface_admission(
+            path,
+            row.get("surface_admission"),
+            f"decisions[{idx}].surface_admission",
+        )
 
     source_inventory = row.get("source_inventory")
     if not isinstance(source_inventory, Mapping):
@@ -272,6 +280,17 @@ def _require_positive_int(path: Path, value: object, field: str) -> int:
     if not isinstance(value, int) or value <= 0:
         raise SourceInventoryError(f"{path}: {field} must be a positive integer")
     return value
+
+
+def _validate_surface_admission(path: Path, value: object, field: str) -> None:
+    if not isinstance(value, Mapping):
+        raise SourceInventoryError(f"{path}: {field} must be a mapping")
+    unknown = sorted(set(value) - SURFACE_ADMISSION_FIELDS)
+    if unknown:
+        raise SourceInventoryError(f"{path}: {field} unknown keys {', '.join(unknown)}")
+    for key, admitted in value.items():
+        if not isinstance(admitted, bool):
+            raise SourceInventoryError(f"{path}: {field}.{key} must be boolean")
 
 
 def _validate_text_list(path: Path, value: object, field: str) -> None:

--- a/tests/test_generate_daily_pool.py
+++ b/tests/test_generate_daily_pool.py
@@ -146,3 +146,28 @@ def test_main_writes_deterministic_json_bytes(tmp_path) -> None:
 
     assert out_one.read_bytes() == out_two.read_bytes()
     assert out_one.read_text(encoding="utf-8").endswith("\n")
+
+
+
+def test_build_pool_keeps_source_inventory_browse_only_by_default() -> None:
+    entries = [
+        {
+            "lemma": "барабан",
+            "url_slug": "baraban",
+            "gloss": "drum",
+            "primary_source": "source_inventory_grow",
+            "course_usage": [],
+            "enrichment": {"cefr": {"level": "A1", "source": "fixture", "text": "A1"}},
+        },
+        {
+            "lemma": "кіт",
+            "url_slug": "kit",
+            "gloss": "cat",
+            "primary_source": "source_inventory_grow",
+            "course_usage": [],
+            "enrichment": {"cefr": {"level": "A1", "source": "fixture", "text": "A1"}},
+            "surface_admission": {"daily": True},
+        },
+    ]
+
+    assert [item["lemma"] for item in build_pool(entries, size=10)] == ["кіт"]

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -292,3 +292,56 @@ def test_unverified_paradigm_is_blanked_not_dropped() -> None:
     lexeme = _build_lexeme(entry, verifier)
     assert lexeme is not None  # word kept
     assert lexeme["paradigm"] == {"cases": {}}  # unverified paradigm blanked
+
+
+
+def test_source_inventory_rows_stay_out_of_practice_by_default() -> None:
+    entries = read_manifest(MANIFEST)
+    source_entry = json.loads(json.dumps(entries[0]))
+    source_entry["primary_source"] = "source_inventory_grow"
+    source_entry["course_usage"] = []
+    source_entry.pop("surface_admission", None)
+
+    shards = build_practice_shards(
+        [source_entry],
+        ReviewedSourceAllowlist.from_payload([]),
+        JsonVesumVerifier.from_path(VESUM),
+        [],
+        BuildConfig(),
+    )
+
+    assert shards == {}
+
+
+def test_source_inventory_cloze_requires_explicit_cloze_admission() -> None:
+    entries = read_manifest(MANIFEST)
+    for entry in entries:
+        if entry["lemma"] == "книга":
+            entry["primary_source"] = "source_inventory_grow"
+            entry["course_usage"] = []
+            entry["surface_admission"] = {"practice": True}
+            break
+
+    allowlist = ReviewedSourceAllowlist.from_path(ALLOWLIST)
+    verifier = JsonVesumVerifier.from_path(VESUM)
+    cloze_sources = read_cloze_sources(CLOZE_SOURCES)
+    shards = build_practice_shards(entries, allowlist, verifier, cloze_sources, BuildConfig())
+    cloze_ids = {
+        item["lemmaId"]
+        for level in shards.values()
+        for item in level["cloze"]["cloze"]
+    }
+    assert "knyha" not in cloze_ids
+
+    for entry in entries:
+        if entry["lemma"] == "книга":
+            entry["surface_admission"]["cloze"] = True
+            break
+
+    shards = build_practice_shards(entries, allowlist, verifier, cloze_sources, BuildConfig())
+    cloze_ids = {
+        item["lemmaId"]
+        for level in shards.values()
+        for item in level["cloze"]["cloze"]
+    }
+    assert "knyha" in cloze_ids

--- a/tests/test_lexeme_filter.py
+++ b/tests/test_lexeme_filter.py
@@ -8,9 +8,13 @@ from __future__ import annotations
 from scripts.audit.lexeme_filter import (
     DERIVED_FORM_SOURCES,
     GRAMMAR_TERM_POS,
+    SURFACE_CLOZE,
+    SURFACE_DAILY,
+    SURFACE_PRACTICE,
     SURZHYK_SOURCE,
     is_lexeme_entry,
     is_practice_eligible,
+    is_surface_admitted,
 )
 
 
@@ -91,3 +95,25 @@ def test_practice_rejects_no_curriculum_anchor():
     # No course_usage and no CEFR level -> not curriculum-anchored.
     entry = _noun(course_usage=[], enrichment={})
     assert is_practice_eligible(entry) is False
+
+
+def test_source_inventory_lexeme_defaults_to_browse_only() -> None:
+    entry = _noun(primary_source="source_inventory_grow", course_usage=[])
+
+    assert is_lexeme_entry(entry) is True
+    assert is_surface_admitted(entry, SURFACE_DAILY) is False
+    assert is_surface_admitted(entry, SURFACE_PRACTICE) is False
+    assert is_surface_admitted(entry, SURFACE_CLOZE) is False
+    assert is_practice_eligible(entry) is False
+
+
+def test_source_inventory_practice_requires_explicit_surface_admission() -> None:
+    entry = _noun(
+        primary_source="source_inventory_grow",
+        course_usage=[],
+        enrichment={"cefr": {"level": "A1", "source": "fixture", "text": "A1"}},
+        surface_admission={SURFACE_PRACTICE: True},
+    )
+
+    assert is_surface_admitted(entry, SURFACE_PRACTICE) is True
+    assert is_practice_eligible(entry) is True

--- a/tests/test_source_inventory_promotion_plan.py
+++ b/tests/test_source_inventory_promotion_plan.py
@@ -161,3 +161,44 @@ def test_write_plan_and_report_stay_ephemeral(tmp_path: Path) -> None:
 
     assert json.loads(plan_path.read_text(encoding="utf-8"))["production_outputs_updated"] == []
     assert "Source Inventory Approved Promotion Plan" in report_path.read_text(encoding="utf-8")
+
+
+
+def test_plan_carries_surface_admission_to_manifest_entry(tmp_path: Path) -> None:
+    payload = yaml.safe_load(FIRST_BATCH.read_text(encoding="utf-8"))
+    decision = payload["decisions"][0]
+    payload["decisions"] = [decision]
+    decision["surface_admission"] = {"daily": False, "practice": True, "cloze": False}
+    decision_path = tmp_path / "decision.yaml"
+    decision_path.write_text(yaml.safe_dump(payload, allow_unicode=True, sort_keys=False), encoding="utf-8")
+    candidates = tmp_path / "candidates.json"
+    _write_json(candidates, _candidate_payload_for(decision))
+
+    plan = planner.build_promotion_plan(candidates_path=candidates, decision_files=[decision_path])
+    addition = plan["proposed_manifest_additions"][0]
+
+    assert addition["surface_admission"] == {"daily": False, "practice": True, "cloze": False}
+    assert addition["manifest_entry"]["surface_admission"] == {
+        "daily": False,
+        "practice": True,
+        "cloze": False,
+    }
+
+
+
+def test_plan_drops_candidate_surface_admission_without_decision_opt_in(tmp_path: Path) -> None:
+    decision = _first_decision()
+    candidates_payload = _candidate_payload_for(decision)
+    candidates_payload["needs_review"][0]["entry"]["surface_admission"] = {
+        "daily": True,
+        "practice": True,
+        "cloze": True,
+    }
+    candidates = tmp_path / "candidates.json"
+    _write_json(candidates, candidates_payload)
+
+    plan = planner.build_promotion_plan(candidates_path=candidates, decision_files=[FIRST_BATCH])
+    addition = plan["proposed_manifest_additions"][0]
+
+    assert addition["surface_admission"] == {}
+    assert "surface_admission" not in addition["manifest_entry"]

--- a/tests/test_source_inventory_review_decisions.py
+++ b/tests/test_source_inventory_review_decisions.py
@@ -167,3 +167,25 @@ def test_decision_validator_rejects_production_outputs(tmp_path: Path) -> None:
 
     with pytest.raises(SourceInventoryError, match=r"production_outputs_updated must be \[\]"):
         decisions.validate_committed_decision_files([path])
+
+
+
+def test_decision_accepts_surface_admission_mapping(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    payload["decisions"][0]["surface_admission"] = {"daily": False, "practice": True, "cloze": False}
+    path = tmp_path / "surface.yaml"
+    _write_decision_file(path, payload)
+
+    summary = decisions.validate_committed_decision_files([path])
+
+    assert summary["rows"] == 1
+
+
+def test_decision_rejects_invalid_surface_admission(tmp_path: Path) -> None:
+    payload = _minimal_payload()
+    payload["decisions"][0]["surface_admission"] = {"practice": "yes"}
+    path = tmp_path / "bad-surface.yaml"
+    _write_decision_file(path, payload)
+
+    with pytest.raises(SourceInventoryError, match=r"surface_admission\.practice must be boolean"):
+        decisions.validate_committed_decision_files([path])


### PR DESCRIPTION
## Changed

- Adds explicit `surface_admission` policy handling for source-inventory Atlas rows.
- Keeps `source_inventory_grow` entries in Atlas browse/search by default, while requiring explicit admission for Daily Word, practice, and cloze.
- Carries decision-row `surface_admission` into planned manifest entries and strips stale candidate-side admission metadata unless the decision explicitly opts in.
- Updates focused tests and the source-inventory review runbook.

## Why

The next Atlas lane needs a safe separation between lexicon growth and learner-facing curriculum surfaces. Approved source-inventory rows can be published for search/browse without automatically changing Word of the Day, practice decks, or cloze behavior.

## Impact

Existing non-source-inventory entries preserve prior behavior. New `source_inventory_grow` rows are browse/search-only unless a reviewed decision row explicitly sets `surface_admission.daily`, `surface_admission.practice`, or `surface_admission.cloze` to `true`.

## Validation

- `.venv/bin/ruff check ...`
- `env -u AGENT_NO_TELEMETRY_FOOTER PYTHONPATH=. .venv/bin/python -m pytest tests/test_lexeme_filter.py tests/test_generate_daily_pool.py tests/test_generate_practice_deck.py tests/test_source_inventory_review_decisions.py tests/test_source_inventory_promotion_plan.py tests/test_promote_grow_candidates.py -q` -> 74 passed
- `PYTHONPATH=. .venv/bin/python scripts/audit/check_static_practice_assets.py` -> 300 daily words, 4123 practice lexemes, 0 cloze items
- `node site/scripts/hydrate-manifest.mjs` -> hydrated manifest successfully
- `npm --prefix site run build` -> passed
- `npx markdownlint-cli2 docs/runbooks/word-atlas-source-inventory-review-candidates.md` -> 0 errors
- `git diff --check`
- `PYTHONPATH=. .venv/bin/python scripts/audit/lint_agent_trailer.py`
- Pre-commit and pre-push hooks passed
- Independent AGY review: no blockers
