### PR TITLE
[codex] Add BIO #349 Levko Revutskyi dossier

### DIFF
--- a/docs/research/bio/levko-revutskyi.md
+++ b/docs/research/bio/levko-revutskyi.md
@@ -1,0 +1,135 @@
+# Левко Миколайович Ревуцький — Research Dossier
+
+**Slug:** `levko-revutskyi`
+**Block:** +77 expansion — "Music, Theater, Visual Culture" group (2026-06-29 memo)
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #349
+**Researcher:** Codex background worker
+**Completed:** 2026-06-30
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Левко Миколайович Ревуцький. Major reference sources also use the official form Лев Миколайович Ревуцький.
+- **Pseudonyms / aliases:** Лев Ревуцький; Л. Ревуцький; Levko Revutskyi; Lev Revutsky; Lev Revuts'kyi; Lev Nikolaievich Revutskii in older bibliography.
+- **Born:** 20 February 1889 (8 February old style in ЕІУ) | Іржавець, Прилуцький повіт, Полтавська губернія | Russian Empire; now Chernihiv region.
+- **Died:** 30 March 1977 | Kyiv | Ukrainian SSR; later memorialized through the Іржавець museum-estate and the Revutskyi prize.
+- **Family / education key facts:** Brother of musicologist and folklorist Дмитро Ревуцький. Studied piano with Mykola Lysenko in Kyiv music schools, completed Kyiv Conservatory in Reinhold Gliere's composition class in 1916, and also completed legal studies at Kyiv University. From 1924 he taught in the Lysenko Music and Drama Institute, later Kyiv Conservatory, becoming professor in 1935 and a central composition/pedagogy figure.
+
+Core identity for BIO: Revutskyi is a Ukrainian art-music builder who carried the Lysenko national-school line into twentieth-century symphonic, piano, vocal, folk-song-arrangement, editorial, and pedagogical work. He is not a direct dissident-case module; he is a Soviet-era Ukrainian cultural-institution figure whose national-musical language survived under pressure, control, and official co-optation.
+
+## 2. Oppression / constraint mechanism
+
+- **What happened:** bounded Soviet pressure and constraint, not an arrest-to-dissident biography. Sources record a June/summer 1919 Cheka arrest risk; later NKVS/special-organ surveillance references; interruption of Lysenko editorial work in the early 1930s; severe official criticism of his Second Piano Concerto in 1934; and long-term channeling of his public work through Soviet cultural institutions.
+- **When (specific dates):** 1919 arrest episode; 1929-1932 Lysenko complete-edition work interrupted around the SVU-era climate; 1934 official criticism; surveillance said by EІU/UME to continue up to 1941; 1944-1948 chairmanship of the Union of Composers of Ukraine inside the Soviet institutional field.
+- **By whom:** Cheka in the 1919 episode; NKVS/special organs in the surveillance references; Soviet artistic, educational, union, prize, and publication structures for cultural control/co-optation. No KGB/FSB or court-case narrative is verified for this dossier.
+- **Document references:** No archival case number, court file, interrogation protocol, or rehabilitation document was accessed in this pass. EІU and the Ukrainian Music Encyclopedia state that special-organ/NKVS documents placed Levko and Dmytro Revutskyi under surveillance and mention them as "bourgeois nationalists." Treat that as a sourced warning flag and future archival target, not as a ready-made module plot.
+- **Mechanism specifics:** Revutskyi received major Soviet honours, including the 1941 State/Stalin Prize for the second edition of Symphony No. 2, People's Artist of the USSR, Academy membership, and later Hero of Socialist Labor. Those honours should not be hidden, but they also should not define him as merely a Soviet success story. IEU notes that after the 1934 criticism he shifted much energy toward teaching, revisions, editing earlier work, and occasional state-consumption pieces; Ukrainian Live Classic similarly stresses reduced composing in the 1930s under strict communist control.
+- **What survived / what was damaged:** Survived: Ukrainian symphonism, piano repertoire, folk-song processing, the Lysenko editorial line, and an extraordinary pedagogy lineage including Heorhii and Platon Maiboroda, Vitalii Kyreiko, Leonid Hrabovsky, and others. Damaged: freedom of composition, publication continuity, archival clarity, and later public interpretation, because official awards and Soviet terminology can blur the Ukrainian national-musical project at the center of his work.
+
+## 3. Major works / contributions
+
+- `1916-1920 / 1957` — **Symphony No. 1**, an early symphonic statement later reconstructed/revised.
+- `1923 / 1944` — **"Хустина"**, cantata-poem on Taras Shevchenko's text, a key bridge between Lysenko-line Shevchenko reception and Revutskyi's choral-symphonic language.
+- `1925-1928` — **Folk-song arrangement cycles**, including "Сонечко," "Козацькі пісні," and "Галицькі пісні." Sources consistently identify more than 120 folk-song arrangements; UME highlights the Ukrainian-language performance space and national-source pedagogy behind this work.
+- `1927 / 1940 / later revisions` — **Symphony No. 2**, recognized by Ukrainian sources as an epochal national symphonic work. Revision chronology differs by source: IEU lists revisions in 1940 and 1970, while Ukrainian sources foreground the second edition and later third-edition/reconstruction tradition. Flag version history for module writers.
+- `1934-1936 / 1963` — **F-major Piano Concerto**, a major Ukrainian piano-orchestral work; the later second edition received the Shevchenko Prize in 1966.
+- `1936-1955` — **Editorial work on Mykola Lysenko's "Taras Bulba"**, with Maksym Rylskyi and Borys Liatoshynskyi. Revutskyi handled musical material and added/expanded material including the heroic overture tradition; this is a verified cross-link to the Lysenko national-school problem.
+- **Pedagogy and institution-building:** Long professoriate at Kyiv Conservatory, head/chair roles in Soviet Ukrainian composer institutions, and nearly half a century shaping composition and polyphony training. BIO should emphasize this institutional transmission, because Maiboroda/Bilash/Soviet song-canon modules depend on the Revutskyi-line teacher network.
+
+## 4. Primary-source anchors
+
+- **Quote 1, self-authored vocal title:** "На крилах сонячних і ясних мрій" — Source: Revutskyi, "На крилах сонячних і ясних мрій (Тиша)," listed in the KNMAU library virtual exhibition as part of *Повне зібрання творів*, vol. 6, "Вокальні твори" (1983), with words by L. Revutskyi.
+  - Pedagogical use: a rare self-authored verbal anchor. Future writers should consult the score or collected volume before quoting more than this title/incipit.
+- **Quote 2, Lysenko-line article title:** "Струни Лисенка живі" — Source: literary works list in EІU/NСКУ, article published in *Мистецтво*, 1967, no. 4.
+  - Pedagogical use: useful short documentary phrase for Revutskyi's self-positioning in the Lysenko lineage. Full article text was not accessed here; do not build an interpretive paragraph around it until checked.
+
+Source gap: no digitized full-text scan of Revutskyi's "Автобіографічні записки," "Виховання композиторської молоді," or "Струни Лисенка живі" was accessed. The dossier therefore uses cataloged primary anchors and work titles, not long prose quotations.
+
+## 5. Language register
+
+- **Register:** high art-music, pedagogical, and musicological; for learner-facing texts, mix concise biography with carefully explained technical vocabulary.
+- **CEFR readiness full reading:** B2 for a short biography; C1 for institutional/cultural-pressure discussion; C1/C2 for score analysis, musicology, and revision-history debates.
+- **Lexicon notes:** `симфонія`, `обробка народної пісні`, `мелос`, `поліфонія`, `інтонаційно-гармонічне мислення`, `консерваторія`, `музично-драматичний інститут`, `Спілка композиторів`, `державна премія`.
+- **Stylistic features:** synthesis of European modern/romantic vocabulary with Ukrainian folk-melodic and harmonic thinking; free rather than decorative folk-song processing; national-school continuity in large forms; pedagogical precision.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** how to read a composer whose deepest artistic language was Ukrainian-national while his public career moved through Soviet institutional roles, prizes, and official cultural bodies. The correct BIO frame is neither hidden dissident nor state-composer celebration.
+- **Source-risk / pressure notes:** The 1919 Cheka episode, NKVS/special-organ surveillance references, and "bourgeois nationalist" file mentions are important but under-documented in this pass. They belong in a bounded pressure/source-gap paragraph unless a future archival pass supplies case identifiers.
+- **What gets simplified in popular memory:** Revutskyi is often summarized as "classic Ukrainian composer" or "teacher of famous composers." That is true but too soft; it can miss the 1930s contraction, surveillance climate, Lysenko edition interruption, and Soviet co-optation. The opposite simplification, "decorated Soviet composer," erases the Lysenko/folk/national-school continuity.
+- **Where modern Russian disinformation attacks them (if applicable):** No specific Revutskyi-targeted modern Russian disinformation campaign identified. The broader colonial risk is absorption: calling him only a Soviet composer, centering Russian-language transliterations, or treating Ukrainian symphonism as a regional Soviet derivative.
+- **Polish / Jewish / other-perspective considerations (if applicable):** Galician-song and western-Ukrainian music networks matter, especially through "Галицькі пісні" and contacts with Galician musicians, but no Polish/Jewish conflict frame is central to this BIO module.
+- **HIST-alignment check for +77 roster:** Align with Soviet Ukrainian cultural institutions, Ukrainization-to-terror transition, postwar cultural co-optation, and national-art continuity under constraint. Do not invent a security-service plot; do not omit state pressure either.
+
+## 7. Cross-track links
+
+- **Existing C1 modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/c1/klasychna-muzyka-1-vytoky.yaml` — Lysenko/source-line context.
+  - `curriculum/l2-uk-en/plans/c1/klasychna-muzyka-2-natsionalna-shkola.yaml` — direct national-school art-music frame.
+  - `curriculum/l2-uk-en/plans/c1/klasychna-muzyka-3-modernizm-i-suchasnist.yaml` — bridge to Liatoshynskyi, modernism, and twentieth-century constraints.
+- **Existing HIST modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/shevchenko-awakening.yaml` — context for "Хустина" and the broader Shevchenko-as-national-culture axis.
+- **Candidate BIO connections (not asserted as existing plans for this slug):**
+  - `platon-maiboroda` — student and later song-canon node.
+  - `borys-liatoshynskyi` — peer/editorial collaborator on Lysenko's "Taras Bulba"; useful contrast for formalism/pressure.
+  - `mykola-lysenko` — national-school source figure.
+  - `maksym-rylskyi` — literary/editorial collaborator and Soviet-pressure context around official song texts.
+- **Potential LIT additions surfaced research:** None. Use existing Shevchenko/HIST and C1 music infrastructure before proposing new LIT plans.
+
+## 8. Naming-canonical
+
+Per `docs/best-practices/bio-naming-canonical.md` (#2313):
+
+- **Slug:** `levko-revutskyi`.
+- **EN canonical (BGN/PCGN 2010):** Levko Revutskyi.
+- **UA canonical (with patronymic attested):** Левко Миколайович Ревуцький.
+- **Aliases:** Лев Миколайович Ревуцький; Л. Ревуцький; Lev Revutsky; Lev Revuts'kyi; Lev Mykolaiovych Revutskyi.
+- **Forbidden forms:** Russian-imperial or Russian-language bibliography forms such as "Lev Nikolaevich Revutskii," "Lev Nikolayevich Revutsky," "Лев Николаевич Ревуцкий," and default learner-facing "Revutsky" spelling. Use only when quoting or identifying source metadata.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** No rights-cleared portrait selected in this pass. Revutskyi died in 1977, so most photographs remain copyright-sensitive unless a specific public-domain or free-license status is verified.
+- **Backup candidates:** IEU includes an image of Borys Liatoshynskyi, Vasyl Barvinskyi, and Revutskyi; NСКУ and KNMAU pages include portraits/manuscript images. None should be reused without license review.
+- **Fallback strategy:** ship text-only in module planning, or later use a rights-cleared contextual image tied to the Іржавець museum, a public-domain Lysenko/Taras Bulba context item, or licensed score-cover/manuscript reproduction.
+- **Era-appropriate context image:** The 2020 first-edition score of Symphony No. 2 or a KNMAU catalog item would be pedagogically strong, but only if publication/image rights are cleared.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- Кузик В. В. "РЕВУЦЬКИЙ Лев Миколайович." *Енциклопедія історії України*. https://history.org.ua/index.php?termin=Revutskyj_L. Accessed 2026-06-30.
+- Antin Rudnytsky. "Revutsky, Lev." *Internet Encyclopedia of Ukraine*. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CR%5CE%5CRevutskyLev.htm. Accessed 2026-06-30.
+- Кузик В. В. "Ревуцький Лев Миколайович." *Українська музична енциклопедія*. Vol. 6. Kyiv: ІМФЕ ім. М. Т. Рильського НАН України, 2023, pp. 48-51. PDF: https://www.etnolog.org.ua/pdf/stories/dovidkovi/2023/ume_6.pdf. Accessed 2026-06-30.
+
+**Tier 2 (institutional):**
+
+- Національна спілка композиторів України. "Лев Миколайович РЕВУЦЬКИЙ." https://composersukraine.org/index.php?id=126. Accessed 2026-06-30.
+- Бібліотека Національної музичної академії України. "Лев Миколайович Ревуцький : віртуальна виставка." https://lib.knmau.com.ua/лев-миколайович-ревуцький-віртуальн/. Accessed 2026-06-30.
+
+**Tier 3 (encyclopedic):**
+
+- Ukrainian Wikipedia / English Wikipedia were used only for orientation and alternate identifiers; core claims above were checked against Tier 1/Tier 2 sources.
+
+**Tier 5 (general/professional web):**
+
+- Ukrainian Live Classic. "Levko Revutskyi." https://ukrainianlive.org/revutskyi-levko. Accessed 2026-06-30. Used for modern expert summary and constraint-language cross-check, not as sole authority.
+- "Гордість української музики" bibliographic PDF, Centralized Library System / children-library host. https://uhb.chl.kiev.ua/images/uploaded_files/mbm/1951/pdf/1951.pdf. Accessed 2026-06-30. Used for bibliography/work-list orientation only.
+
+**Primary-source documents accessed (NKVD/KGB/FSB, court, police, censorship, rehabilitation documents):**
+
+- None. No case file, court record, surveillance file, or rehabilitation document was accessed. Security-service facts must remain source-gap language until a future archival pass retrieves stable identifiers.
+- Cataloged primary-work anchors accessed through KNMAU/NСКУ: *Повне зібрання творів*, vol. 6 "Вокальні твори"; Revutskyi's listed articles "Автобіографічні записки," "Виховання композиторської молоді," and "Струни Лисенка живі."
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; Soviet institutions named as context and pressure/co-optation mechanisms, not identity authority.
+- [x] No invented dissident or security-service plot.
+- [x] 1919 Cheka and NKVS/surveillance references kept bounded and explicitly source-gapped.
+- [x] Ukrainian national-school formation, folk-song processing, pedagogy, and Lysenko editorial continuity foregrounded.
+- [x] Russian-imperial spellings appear only in aliases/forbidden metadata or source-title contexts.
+- [x] Existing cross-track paths verified before listing.
+- [x] Copyright-sensitive portrait reuse deferred.


### PR DESCRIPTION
## Summary

Adds the strict +77 base-prep research dossier for BIO #349 Levko Revutskyi / Левко Ревуцький.

Changed file:
- `docs/research/bio/levko-revutskyi.md`

Scope kept dossier-only: no plan YAML, module markdown, activities, vocabulary, generated status/audit/review artifacts, telemetry, package files, or linter config changes.

## Validation

- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/levko-revutskyi.md` — passed
- `npx --yes markdownlint-cli2 docs/research/bio/levko-revutskyi.md` — passed, 0 errors
- `git diff --check origin/main..HEAD` — passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed for commit `5d3aca6656`

## Known Source Gaps

- No NKVD/KGB/court/security case file was accessed; the 1919 Cheka and NKVS/surveillance items are kept as bounded source-risk/pressure notes, not as the dossier frame.
- Full text of Revutskyi's autobiographical/pedagogical articles was not accessed; primary-source anchors are limited to cataloged titles/work entries.
- No rights-cleared portrait was selected; image reuse is deferred pending license review.