### PR TITLE
docs(bio): add Revutskyi research dossier

### DIFF
--- a/docs/research/bio/levko-revutskyi.md
+++ b/docs/research/bio/levko-revutskyi.md
@@ -1,0 +1,146 @@
+# Лев Миколайович Ревуцький — Research Dossier
+
+**Slug:** `levko-revutskyi`
+**Block:** +77 expansion — "Music song-canon / national music school" group (2026-06-29 memo)
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #349
+**Researcher:** Codex orchestrator inline recovery
+**Completed:** 2026-06-30
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Лев Миколайович Ревуцький. Learner-facing title may use the familiar Ukrainian form Левко Ревуцький, but the attested patronymic form is Лев Миколайович.
+- **Pseudonyms / aliases:** Лев Ревуцький; Левко Ревуцький; Ревуцький Лев Миколайович; Lev Revutsky; Levko Revutskyi; Revuc'kyj (legacy scholarly transliteration).
+- **Born:** 20 February 1889, with old-style form 8(20) February in Ukrainian sources | село Іржавець, Pryluky county, Poltava gubernia; now Chernihiv region, Ukraine.
+- **Died:** 30 March 1977 | Kyiv, Ukrainian SSR | buried at Baikove cemetery according to institutional biographical sources.
+- **Family / education key facts:** Brother of musicologist and folklorist Дмитро Ревуцький. Studied in Kyiv with Mykola Lysenko's school milieu and later at Kyiv Conservatory, graduating in 1916 in composition with Reinhold Gliere and piano studies with Hryhorii Khodorovsky / Serhii Korotkevych depending source level. Also completed the law faculty at Kyiv University in 1916. From 1924 he taught at the Lysenko Music and Drama Institute; after its reorganization he taught at Kyiv Conservatory and became one of the major pedagogical transmitters of Ukrainian professional composition.
+
+Core identity for BIO: Revutskyi is not mainly a Soviet prize biography. He is a Lysenko-line composer, pianist, teacher, editor, and folk-song processor whose work carried Ukrainian national-school continuity into a Soviet institutional environment that both rewarded and constrained him.
+
+## 2. Pressure / co-optation mechanism
+
+- **What happened:** Bounded pressure and institutional co-optation, not a dissident-arrest biography. National Composers Union and Pedagogical Museum summaries state that in summer 1919 Revutskyi was arrested by the Cheka and narrowly escaped execution. The Institute of History entry adds a later pressure layer: documents of "special organs" show Revutskyi and his brother under surveillance until 1941, with their names appearing as "bourgeois nationalists" in cases of repressed Ukrainian cultural figures.
+- **When:** Summer 1919 for the Cheka arrest claim; pre-1941 for surveillance/file mentions; 1934 for severe official criticism of his Piano Concerto in F major.
+- **By whom:** Cheka in the 1919 episode as reported by institutional biographies; Soviet cultural authorities and special organs in the 1930s-early 1940s. No dossier-ready case file number, interrogation protocol, or rehabilitation file was located in this pass.
+- **Document references:** ЕІУ gives the surveillance claim but not a file number in the online entry. Treat the claim as a verified high-level institutional signal, not as permission to build a security-service plot. Future archival work should start from the named ЕІУ literature, Valentina Kuzyk's Revutskyi scholarship, and any declassified files where the "Ревуцькі" / "буржуазні націоналісти" formula appears.
+- **Mechanism specifics:** Revutskyi was publicly decorated, held posts in Soviet Ukrainian musical institutions, and chaired the Union of Composers of Ukraine in 1944-1948. Those facts matter. The same record also shows constrained creativity after official criticism: IEU explicitly says he largely redirected energy toward teaching, revision, editing earlier works, and occasional state-consumption pieces.
+- **What survived / what was damaged:** Survived: the Second Symphony, Piano Concerto, folk-song arrangements, Lysenko editorial work, and a teaching lineage through composers such as Heorhii and Platon Maiboroda, Leonid Hrabovsky, Herman Zhukovsky, Vitalii Kyreiko, and others. Damaged: the conditions for free modernist/national-school development after the 1920s, and later interpretive clarity when official Soviet honors can obscure the Ukrainian national frame of the music.
+
+## 3. Major works / contributions
+
+- **Ukrainian national music school:** IEU frames Revutskyi as continuing the Ukrainian national-school trend into the Soviet period. ЕІУ describes his style as a synthesis of European modern musical language and Ukrainian folk-melodic / harmonic thinking.
+- **Symphonic and instrumental work:** Symphony No. 2, first written in 1927 and revised in 1940 and 1970, became a central Ukrainian symphonic work. The Piano Concerto in F major, later associated with the 1966 Shevchenko Prize, is a key Ukrainian concerto landmark. Piano sonata, preludes, chamber works, violin/cello pieces, and orchestral "Козачок" broaden the module beyond song alone.
+- **Folk-song processing:** Revutskyi made more than 120 folk-song arrangements. Important cycles include "Козацькі пісні", "Сонечко", and "Галицькі пісні". This is the strongest pedagogical bridge to Ukrainian listening, melody, dialect/region, and folklore transformation.
+- **Shevchenko and choral/vocal works:** Important works include the cantata-poem "Хустина" on Taras Shevchenko's words, "Ой чого ти почорніло", "У перетику ходила", and "На ріках круг Вавілона". These allow later modules to connect BIO, HIST, LIT, and C1 music lessons without inventing cross-track dependencies.
+- **Lysenko editorial work:** With Borys Liatoshynsky, Revutskyi worked on editions of Mykola Lysenko's opera "Тарас Бульба"; ЕІУ notes three editorial stages across 1936-1955 and additions such as the overture. In the 1950s he also supervised editing of Lysenko's collected works.
+- **Pedagogical lineage:** His classroom role is one of the safest BIO anchors: Maiboroda brothers and later Ukrainian composers pass through his teaching orbit, making Revutskyi a hinge between Lysenko-Leontovych inheritance and postwar Ukrainian composition.
+
+## 4. Primary-source quotes
+
+- **Quote 1, own-words vocal anchor:** "На крилах сонячних і ясних мрій"
+  - Source: Revutskyi vocal work "Тиша" in the contents of `Повне зібрання творів`, vol. 6, listed by the National Music Academy library as words by L. Revutskyi.
+  - Pedagogical use: shortest lawful anchor for showing that Revutskyi was not only an arranger/editor but also left verbal lyric traces. Keep quotations brief; use the line as a title/incitement, not a full text excerpt.
+- **Quote 2, folk-song processing anchor:** "Ой, гей! Та ой хто горя не знає"
+  - Source: Ukrainian folk song arranged by L. Revutskyi, listed in the same NMAU vol. 6 contents.
+  - Pedagogical use: strong miniature for hearing folk register before discussing professional arrangement. The quote is from the folk-song text, not original words by Revutskyi; the composer contribution is treatment, harmony, and form.
+- **Quote 3, Shevchenko bridge:** "Ой чого ти почорніло"
+  - Source: Shevchenko-text choral work by L. Revutskyi, listed by the Shevchenko Prize committee and NСКУ.
+  - Pedagogical use: enables a compact bridge from Shevchenko cultural memory to twentieth-century art music without overloading the BIO lesson with literary exegesis.
+
+## 5. Language / musical register
+
+- **Register:** high-art Ukrainian national school; folk-song-adjacent vocal/choral register; modernist/romantic symphonic language; academic institutional register in later prose and public writing.
+- **CEFR readiness full reading:** C1 for biography and interpretive prose; B2-C1 for short song-title and folk-song anchors; C1/PRO for analysis of Soviet institutional compromise.
+- **Lexicon notes:** music vocabulary: `симфонія`, `кантата-поема`, `обробка народної пісні`, `мелос`, `фортепіанний концерт`, `редакція`, `партитура`, `вокально-симфонічний`. Political/context vocabulary: `спецоргани`, `нагляд`, `буржуазний націоналіст`, `державна премія`, `офіційна критика`.
+- **Stylistic features:** movement between folk incipit and professional development; Ukrainian melodic contour inside academic forms; repeated pattern of revision/editing after pressure; public Soviet honor language coexisting with Ukrainian national-school substance.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** The key issue is how to read a composer who was officially decorated while his national-school language and family/cultural circle were surveilled or ideologically marked. The dossier should not flatten him into either "Soviet success" or "hidden dissident." The accurate teaching frame is constrained institutional survival and transmission.
+- **What gets simplified in popular memory:** Short summaries often list awards, posts, and the Second Symphony. Music-specialist accounts foreground national style and the Lysenko line. A BIO module should show both: Soviet institutionality made Revutskyi visible and constrained; Ukrainian musical continuity made him pedagogically central.
+- **Where modern Russian disinformation attacks them (if applicable):** No Revutskyi-specific modern Russian disinformation campaign identified. The broader colonial risk is absorptive framing: presenting him as simply a Soviet composer and treating Ukrainian folk/national-school features as regional decoration inside a Russian/Soviet center.
+- **Polish / Jewish / other-perspective considerations (if applicable):** Galician-song material and interwar/postwar west-Ukrainian musical memory should be handled carefully; "Галицькі пісні" is not only local color but a cultural geography signal. Jewish folk-song arrangements appear in work lists and should not be used superficially without specialist sourcing.
+- **HIST-alignment check for +77 roster:** Align with twentieth-century Soviet Ukrainian culture, 1920s Ukrainianization and musical institutions, 1930s ideological control, wartime evacuation/Tashkent, postwar official culture, and long transmission through conservatory pedagogy. Do not create an NKVD/KGB module spine from thin evidence.
+
+## 7. Cross-track links
+
+- **Existing C1 modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/c1/klasychna-muzyka-2-natsionalna-shkola.yaml` — national music school frame; safest future bridge for Lysenko-Revutskyi continuity.
+  - `curriculum/l2-uk-en/plans/c1/klasychna-muzyka-3-modernizm-i-suchasnist.yaml` — modernism/contemporary arc; useful for 1920s modern language and later constrained Soviet context.
+  - `curriculum/l2-uk-en/plans/c1/vokalne-mystetstvo.yaml` — vocal-art bridge for folk-song arrangements, choral works, and Shevchenko/Rylsky settings.
+- **Existing HIST modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml` — longer background on language/cultural suppression before the national-school frame.
+  - `curriculum/l2-uk-en/plans/hist/shevchenko-awakening.yaml` — careful bridge for "Хустина" and Shevchenko musical reception.
+  - `curriculum/l2-uk-en/plans/hist/destalinizatsiia.yaml` — post-Stalin context for rereading Soviet-era Ukrainian culture without treating honors as identity proof.
+- **Existing LIT modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/rylsky-liryka.yaml` — Rylsky text settings and literary-musical cross-reference.
+  - `curriculum/l2-uk-en/plans/lit/the-testament.yaml` — Shevchenko reception path if later module uses "Ой чого ти почорніло" or "Хустина" carefully.
+- **Existing BIO modules / dossiers (VERIFIED `test -e`):**
+  - `docs/research/bio/platon-maiboroda.md` — direct student-line and next-neighbor connection.
+  - `docs/research/bio/andrii-malyshko.md` — song-canon neighbor; not direct Revutskyi collaborator spine, but useful for Soviet-era cultural compromise pedagogy.
+  - `curriculum/l2-uk-en/plans/bio/oleksandr-bilash.yaml` — built song-canon pilot; compare later Soviet Ukrainian reception and post-Soviet memory.
+- **Candidate cross-track connections (not Existing):**
+  - `curriculum/l2-uk-en/plans/bio/platon-maiboroda.yaml` once promoted from dossier to plan.
+  - Future BIO `stanislav-liudkevych`, `myroslav-skoryk`, and `ivan-karabyts` dossiers/plans in the +77 music sequence.
+
+## 8. Naming-canonical
+
+Per `docs/best-practices/bio-naming-canonical.md` (#2313):
+
+- **Slug:** `levko-revutskyi`.
+- **EN canonical (BGN/PCGN 2010):** Levko Revutskyi.
+- **UA canonical (with patronymic attested):** Лев Миколайович Ревуцький.
+- **Aliases:** Левко Ревуцький; Лев Ревуцький; Ревуцький Лев Миколайович; Lev Revutsky (IEU legacy spelling); Lev Revuts'kyi; Revuc'kyj.
+- **Forbidden forms:** Russianized `Lev Nikolaevich Revutsky`, `Lev Revutskii`, `Kiev Conservatory` in learner-facing prose except inside source titles or historical bibliographic metadata. Use Kyiv / Київ and Ukrainian patronymic form.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons has `File:Levko Revutsky.jpg` with a public-domain rationale that still needs license review before curriculum use. Do not assume all Revutskyi portraits are reusable.
+- **Backup candidates:** IEU contains several Revutskyi images but marks copyright with CIUS; treat as reference-only unless license permission is separately established. NMAU library exhibition includes scans/covers for bibliographic context; those are not automatically reusable.
+- **Fallback strategy:** Ship text-only initially, or use a rights-cleared contextual image: Irzhavets memorial estate exterior, public-domain score/edition cover only if license verified, or a rights-cleared image tied to Ukrainian conservatory/music-school context.
+- **Era-appropriate context image:** Lysenko / Liatoshynsky / Revutskyi relation could be visually useful, but only if image rights are unambiguous.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- Інститут історії України НАН України / Енциклопедія історії України. Кузик В. В. "Ревуцький Лев Миколайович." https://history.org.ua/index.php?termin=Revutskyj_L. Accessed 2026-06-30.
+- Internet Encyclopedia of Ukraine. Antin Rudnytsky. "Revutsky, Lev." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CR%5CE%5CRevutskyLev.htm. Accessed 2026-06-30.
+- Українська музична енциклопедія. Том 6: Р-С. НАН України, ІМФЕ ім. М. Т. Рильського, 2023. Entry "Ревуцький Лев Миколайович"; NMAU library page and PDF link. https://lib.knmau.com.ua/2023-%D1%83%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D1%81%D1%8C%D0%BA%D0%B0-%D0%BC%D1%83%D0%B7%D0%B8%D1%87%D0%BD%D0%B0-%D0%B5%D0%BD%D1%86%D0%B8%D0%BA%D0%BB%D0%BE%D0%BF%D0%B5%D0%B4%D1%96%D1%8F-%D1%82%D0%BE/. Accessed 2026-06-30.
+
+**Tier 2 (institutional):**
+
+- Національна спілка композиторів України. "Лев Миколайович Ревуцький." https://composersukraine.org/index.php?id=126. Accessed 2026-06-30.
+- Комітет з Національної премії України імені Тараса Шевченка. "Ревуцький Лев Миколайович." https://knpu.gov.ua/winners/revutskyj-lev-mykolajovych/. Accessed 2026-06-30.
+- Бібліотека Національної музичної академії України. "Лев Миколайович Ревуцький: віртуальна виставка." https://lib.knmau.com.ua/%D0%BB%D0%B5%D0%B2-%D0%BC%D0%B8%D0%BA%D0%BE%D0%BB%D0%B0%D0%B9%D0%BE%D0%B2%D0%B8%D1%87-%D1%80%D0%B5%D0%B2%D1%83%D1%86%D1%8C%D0%BA%D0%B8%D0%B9-%D0%B2%D1%96%D1%80%D1%82%D1%83%D0%B0%D0%BB%D1%8C%D0%BD/. Accessed 2026-06-30.
+
+**Tier 3 (encyclopedic / navigation):**
+
+- Велика українська енциклопедія. "Ревуцький, Лев Миколайович." https://vue.gov.ua/Ревуцький,_Лев_Миколайович. Used for cross-checking pressure/co-optation wording; core claims kept tied to ЕІУ/IEU/NСКУ where possible. Accessed 2026-06-30.
+- Ukrainian Wikipedia / Commons used only to locate image and alternate-spelling leads; not used as authority for dossier claims.
+
+**Tier 4 (modern scholarly post-1991):**
+
+- Кузик В. "Лев Миколайович Ревуцький." Ніжин, 2009 / 2011, cited through ЕІУ and NСКУ bibliographies as the next deeper specialist source to consult.
+- Modern article leads on the Revutskyi brothers, Leontovych Music Society, and NKVS "bourgeois nationalists" framing were used only as leads unless corroborated by ЕІУ/NСКУ.
+
+**Tier 5 (general web):**
+
+- Pedagogical Museum Ukraine anniversary page for the 1919 Cheka arrest wording; used as institutional corroboration lead alongside NСКУ, not as sole framing authority.
+
+**Primary-source documents accessed (NKVD/KGB/FSB, court, police, censorship, rehabilitation documents):**
+
+- None accessed in this pass. No security-service case number should be stated in module production until a primary archival source is located.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; Soviet titles and awards are named as institutional facts, not identity authority.
+- [x] No invented dissident or security-service storyline; Cheka/surveillance evidence is bounded and source-limited.
+- [x] Ukrainian national music school, folk-song processing, and Lysenko-line pedagogy foregrounded.
+- [x] Existing cross-track paths verified before listed.
+- [x] Russianized names and legacy transliterations restricted to source/alias metadata.
+- [x] Copyright-sensitive lyric quotations kept to short incipits/titles only.


### PR DESCRIPTION
## Summary
- Adds BIO #349 research dossier for Levko Revutskyi / Левко Ревуцький.
- Scope is dossier-only: no plan YAML, module production, site MDX, wiki, status/audit/review artifacts, telemetry, package files, or config changes.
- Frames Revutskyi as Ukrainian national-music-school continuity, folk-song processing, pedagogy, and Soviet institutional constraint/co-optation.
- Keeps 1919 Cheka and surveillance/NKVS-file signals bounded as source-risk/pressure evidence, not as a dissident/security-service storyline.

## Files changed
- docs/research/bio/levko-revutskyi.md

## Validation
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/levko-revutskyi.md
- /Users/krisztiankoos/projects/learn-ukrainian/node_modules/.bin/markdownlint-cli2 docs/research/bio/levko-revutskyi.md
- git diff --check origin/main..HEAD
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py

## Source gaps / risks
- No primary Cheka/NKVS case file or archival call number was located in this pass.
- The dossier therefore cites the 1919 Cheka arrest and pre-1941 surveillance only as bounded institutional-source signals.
- Image use remains unresolved; portraits require separate rights review before module/media production.

## Checklist
- .python-version unchanged
- .yamllint unchanged
- .markdownlint.json unchanged
- no status/audit/review/telemetry generated artifacts
- no sys.executable usage
- changed files < 20