### PR TITLE
docs(bio): add Liudkevych research dossier

### DIFF
--- a/docs/research/bio/stanislav-liudkevych.md
+++ b/docs/research/bio/stanislav-liudkevych.md
@@ -1,0 +1,298 @@
+# Станіслав Пилипович Людкевич — Research Dossier
+
+**Slug:** `stanislav-liudkevych`
+**Block:** +77 expansion — "Music / Galician national music school" group
+(2026-06-29 memo)
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #350
+**Researcher:** Codex orchestrator recovery
+**Completed:** 2026-06-30
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Станіслав Пилипович Людкевич.
+- **Pseudonyms / aliases:** Станіслав Людкевич; Людкевич Станіслав
+  Пилипович; Stanyslav Liudkevych; Stanislav Liudkevych; Stanyslav
+  Lyudkevych; legacy scholarly form `Ljudkevyč`.
+- **Born:** 24 January 1879 | Ярослав, now Jaroslaw, Poland | then
+  Austria-Hungary / Austrian Galicia. ESU, EIU, IEU, NCSU, UINP, and NBUV
+  agree on the date and place.
+- **Died:** most Ukrainian institutional sources give 10 September 1979 |
+  Lviv, Ukrainian SSR | buried in Lychakiv Cemetery. Source disagreement:
+  Internet Encyclopedia of Ukraine gives 12 September 1979. Use
+  10 September for curriculum metadata unless a primary death record is found;
+  keep the IEU discrepancy visible in notes.
+- **Family / education key facts:** His mother was his first music teacher;
+  UINP and NBUV note that she had studied with Mykhailo Verbytsky. He
+  graduated from the philosophy faculty of Lviv University in 1901 with
+  Ukrainian and classical philology formation, studied music in Lviv, then
+  studied in Vienna with Alexander Zemlinsky, Hermann Graedener, and Guido
+  Adler, and completed a musicology doctorate in 1908. Core BIO identity:
+  Ukrainian Galician composer, musicologist, folklorist, pedagogue, editor,
+  and civic music educator rooted in Lviv institutions.
+
+## 2. Oppression mechanism
+
+- **What happened:** This is not a repression-primary biography, and no
+  dossier-ready Soviet security-service case against Liudkevych himself was
+  found in this source pass. The verified pressure/disruption frame is a
+  century-long career across Austrian Galicia, the First World War, interwar
+  Polish Lviv, Nazi occupation, and Soviet rule in Western Ukraine.
+- **When:** During the First World War he was mobilized into the Austrian
+  army and spent roughly four years in Russian captivity, according to ESU and
+  UINP. In 1941, EIU reports that he was arrested by the Gestapo and then
+  released. In 1948 he refused to condemn Vasyl Barvinskyi after Barvinskyi's
+  Soviet arrest; in 1963 he signed a letter asking Leonid Brezhnev for
+  Barvinskyi's release and rehabilitation.
+- **By whom:** Russian imperial wartime captivity, Nazi Gestapo arrest, and
+  Soviet cultural/security pressure around colleagues and institutions. Do not
+  convert this into a fabricated NKVD/KGB martyr story for Liudkevych himself.
+- **Document references:** No Gestapo file number, POW file, NKVD/KGB case
+  file, or rehabilitation document for Liudkevych was located in this pass.
+  EIU is the strongest concise source for the Gestapo arrest and the
+  Barvinskyi-defense chronology.
+- **Mechanism specifics:** He remained in Lviv and kept working through
+  repeated state changes. Teach this as institutional and civic musical
+  continuity under changing regimes: the Lysenko Higher Institute of Music,
+  NTSh musicology, Galician choral societies, the Lviv Conservatory, Soviet
+  official posts, and public loyalty to Ukrainian musical tradition.
+- **What survived / what was damaged:** Survived: a Galician-Ukrainian
+  professional music school, Shevchenko/Franko monumental choral-symphonic
+  repertoire, folklore transcription and editing, teaching lineage, and civic
+  memory. Damaged: source clarity around wartime arrest/captivity details and
+  interpretive clarity when Soviet awards flatten the national-cultural
+  continuity he preserved.
+
+## 3. Major works / contributions
+
+- **Galician professional music infrastructure:** ESU and IEU identify
+  Liudkevych as an organizer, director, teacher, and later professor in the
+  Lysenko Higher Institute of Music / Lviv Conservatory orbit. NCSU and UINP
+  frame him as the first professional musician-composer of Galicia and a
+  founder of major symphonic and instrumental genres in Western Ukrainian
+  musical life.
+- **Folklore and ethnomusicology:** ESU says he deciphered and edited more
+  than 1,500 songs recorded by Osyp Rozdolskyi on phonograph for
+  `Галицько-руські народні мелодії` (1906-1907). This makes him a bridge
+  between field collection, notation, music pedagogy, and composed national
+  style.
+- **Lysenko-line continuity:** NCSU highlights his high valuation of Mykola
+  Lysenko and the Lysenko `Музика до Кобзаря` tradition. The later module
+  should connect him to Lysenko without claiming direct student lineage:
+  Liudkevych extends the national music program in Galician institutions
+  through choral, symphonic, pedagogical, and editorial work.
+- **Shevchenko works:** Main anchors are the symphony-cantata `Кавказ`
+  (1902-1913 in IEU; 1901-1913 in some Ukrainian accounts) and cantata
+  `Заповіт` (1934; later edition 1955), for which he received the Shevchenko
+  State Prize in 1964. Other Shevchenko settings include `Гамалія`,
+  `Наша дума, наша пісня`, `Косар`, `Ой вигострю товариша`, and `Наймит`.
+- **Franko works:** Major Franko-linked anchors include
+  `Вічний революціонер` (1898), symphonic poems `Каменярі` and `Мойсей`,
+  `Конкістадори`, and related solo songs. NCSU and UINP preserve the early
+  Franko-anniversary performance frame.
+- **Teacher and transmission figure:** ESU records his work in the Union of
+  Ukrainian Professional Musicians, the NTSh Musicological Commission, the
+  Lviv Conservatory, and the Lviv branch of the folklore institute. Named
+  students in ESU include Myroslav Skoryk, Stefania Hrytsa, Lesia Kornii, and
+  Bohdana Filts.
+
+## 4. Primary-source quote anchors
+
+- **Quote 1, Shevchenko text set by Liudkevych:** "Борітеся - поборете!"
+  Source anchor: Taras Shevchenko, `Кавказ`; Liudkevych's symphony-cantata
+  `Кавказ` uses Shevchenko's words. Pedagogical use: a short public-domain
+  text incipit that signals anti-imperial Shevchenko memory inside monumental
+  Galician Ukrainian music. Text is Shevchenko's, not Liudkevych's.
+- **Quote 2, Franko text set by Liudkevych:** "Вічний революціонер - дух..."
+  Source anchor: Ivan Franko, `Гімн` / `Вічний революціонер`; Liudkevych's
+  choral-orchestral setting entered public performance memory around Franko's
+  anniversary culture. Text is Franko's, not Liudkevych's.
+- **Composer-voice gap:** No reliable short first-person quotation from
+  Liudkevych himself was captured in this timeboxed pass. Future module work
+  should check Zenoviia Shtunder's two-volume monograph, Liubov Kyianovska's
+  scholarship, and the memorial museum archive before using direct personal
+  quotations.
+
+## 5. Language register
+
+- **Register:** high civic-cultural Ukrainian, Galician institutional,
+  musicological and folklore-specialist; public choral repertoire often uses
+  Shevchenko/Franko elevated poetic register.
+- **CEFR readiness full reading:** C1 for biography and musicological context;
+  B2-C1 for short title/incipit work anchors; C1/advanced for Soviet-era
+  compromise and cross-regime institutional analysis.
+- **Lexicon notes:** `симфонія-кантата`, `кантата`, `хор`, `солоспів`,
+  `музикознавство`, `фольклористика`, `обробка народної пісні`, `фонограф`,
+  `музичний інститут`, `консерваторія`, `НТШ`, `стрілецькі пісні`,
+  `пізній романтизм`, `модерн`.
+- **Stylistic features:** monumental choral-symphonic form, folk-song
+  transcription feeding professional composition, Shevchenko/Franko civic
+  poetry as public sound, and a Galician habit of linking education,
+  scholarship, choral societies, and national-cultural service.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** The main interpretive problem
+  is not whether Liudkevych belongs in Ukrainian music, but how to read a
+  century-long career crossing imperial, Polish, Nazi, and Soviet settings
+  without making any one regime the whole story. Strong module framing should
+  present him as Galician Ukrainian professionalization and continuity, not as
+  a simple Soviet honoree and not as an invented dissident martyr.
+- **What gets simplified in popular memory:** Popular accounts often compress
+  him into "first professional composer of Galicia," `Кавказ`, and longevity.
+  That is useful but thin. A better BIO module should show the whole ecology:
+  Lysenko-line national music, NTSh scholarship, the Lysenko Institute, choral
+  societies such as `Боян`, folklore editing, Shevchenko/Franko repertoire,
+  and later teaching lineage.
+- **Where modern Russian disinformation attacks them (if applicable):** No
+  Liudkevych-specific modern Russian disinformation campaign was identified in
+  this pass. The broader colonial risk is absorptive framing: treating him as
+  a Soviet Ukrainian composer whose awards matter more than his Galician
+  Ukrainian institutional and civic-musical work.
+- **Polish / Jewish / other-perspective considerations:** Jaroslaw, Przemysl,
+  and Lviv place him in multiethnic Galician history. The dossier found no
+  source requiring a Polish/Jewish controversy frame. Mention interwar Polish
+  Lviv and Austrian Galicia as political/cultural settings, but do not
+  fabricate conflict where the gathered sources do not support it.
+- **HIST-alignment check for +77 roster:** Align with Galician cultural
+  institutions, Shevchenko/Franko memory, First World War captivity, 1939
+  Soviet annexation of Western Ukraine, Nazi occupation, postwar Soviet
+  institutional pressure, and Ukrainian cultural continuity in Lviv.
+
+## 7. Cross-track links
+
+- **Existing C1 modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/c1/halychyna.yaml` — Galician cultural and
+    historical context for Lviv/Jaroslaw/Przemysl setting.
+  - `curriculum/l2-uk-en/plans/c1/klasychna-muzyka-2-natsionalna-shkola.yaml`
+    — national music school context, safest bridge for Lysenko-line and
+    Liudkevych's Galician professionalization.
+  - `curriculum/l2-uk-en/plans/c1/vokalne-mystetstvo.yaml` — choral/vocal
+    repertoire bridge for Shevchenko and Franko settings.
+- **Existing HIST modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/shevchenko-awakening.yaml` — Shevchenko
+    cultural memory route for `Кавказ` and `Заповіт`.
+  - `curriculum/l2-uk-en/plans/hist/franko-lesia-hrinchenko.yaml` — broader
+    late nineteenth-century national-cultural context around Franko-era public
+    work.
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml` — background on
+    language/cultural suppression before the professional national music
+    school frame.
+- **Existing LIT modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/the-testament.yaml` — direct text setting
+    route for `Заповіт`.
+  - `curriculum/l2-uk-en/plans/lit/franko-social-poetry.yaml` — Franko civic
+    poetry context for `Вічний революціонер`.
+  - `curriculum/l2-uk-en/plans/lit/franko-moses.yaml` — candidate literary
+    bridge for Liudkevych's `Мойсей` symphonic poem.
+- **Existing BIO dossiers / modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/mykola-lysenko.yaml` and
+    `docs/research/bio/mykola-lysenko.md` — Lysenko-line comparison.
+  - `docs/research/bio/ivan-franko.md` and
+    `docs/research/bio/taras-shevchenko.md` — direct text-source figures.
+  - `docs/research/bio/vasyl-barvinskyi.md` — colleague-defense context; use
+    only where Barvinskyi sources support it.
+  - `docs/research/bio/levko-revutskyi.md` — parallel national-school composer
+    under Soviet institutions.
+- **Candidate cross-track connections (not asserted as existing plans):**
+  - Future BIO dossiers/plans for `filaret-kolessa`, `volodymyr-hnatiuk`,
+    `myroslav-skoryk`, and `anatolii-kos-anatolskyi`.
+  - A future LIT/HIST treatment of Shevchenko's `Кавказ` as a literary module,
+    if such a plan is added later.
+
+## 8. Naming-canonical
+
+Per `docs/best-practices/bio-naming-canonical.md` (#2313):
+
+- **Slug:** `stanislav-liudkevych`.
+- **EN canonical (BGN/PCGN 2010):** Stanislav Liudkevych. Note: existing
+  scholarship also uses Stanyslav Liudkevych; use one canonical curriculum
+  form consistently and retain the alternate in aliases.
+- **UA canonical (with patronymic attested):** Станіслав Пилипович Людкевич.
+- **Aliases (track `aliases:` YAML field later):** Станіслав Людкевич;
+  Stanyslav Liudkevych; Stanislav Liudkevych; Stanyslav Lyudkevych;
+  Ljudkevyč; Людкевич Станіслав Пилипович.
+- **Forbidden forms (Russian-imperial transliterations flag in body text):**
+  Stanislav Lyudkevich; Stanislav Ljudkevic; Russian
+  `Станислав Филиппович Людкевич`. These may appear only in alias/source
+  metadata or explicit discussion of legacy transliteration, not in
+  learner-facing prose.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons `File:Людкевич Станіслав.jpg`,
+  described as a 1920s portrait, source `lib.mdpu.org.ua`, author unknown,
+  tagged public domain / Public Domain Mark. Use only after a later media pass
+  confirms United States public-domain tagging is sufficient for the project.
+- **Backup candidates:** Wikimedia Commons `File:Stanislav Lyudkevich 2.JPG`,
+  a 2007 own-work portrait based on a Ukrainian envelope, released by the
+  uploader into the public domain; usable only if derivative-source concerns
+  are resolved. Commons category `Stanyslav Lyudkevych` also contains grave
+  and context images needing normal license review.
+- **Era-appropriate context image:** A future media pass could use a
+  rights-cleared memorial-museum exterior, Lviv/Lychakiv context image, or
+  public-domain score/program reproduction if license is explicit.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- Енциклопедія Сучасної України. "Людкевич Станіслав Пилипович."
+  https://esu.com.ua/article-59909. Accessed 2026-06-30.
+- Інститут історії України НАН України / Енциклопедія історії України.
+  Галайчак Т. Ю. "Людкевич Станіслав Пилипович."
+  https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=DOP&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Lyudkevych_S_P&Z21ID=.
+  Accessed 2026-06-30.
+- Internet Encyclopedia of Ukraine. "Liudkevych, Stanyslav."
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CL%5CI%5CLiudkevychStanyslav.htm.
+  Accessed 2026-06-30. Used with death-date discrepancy noted.
+
+**Tier 2 (institutional):**
+
+- Національна спілка композиторів України. "Станіслав Пилипович Людкевич."
+  https://composersukraine.org/index.php?id=2412. Accessed 2026-06-30.
+- Український інститут національної пам'яті. "1879, народився Станіслав
+  Людкевич." https://uinp.gov.ua/istorychnyy-kalendar/sichen/24/1879-narodyvsya-stanislav-lyudkevych.
+  Accessed 2026-06-30.
+- Національна бібліотека України імені В. І. Вернадського. "Станіслав
+  Людкевич: патріот і митець, який вмів Україну любити."
+  https://www.nbuv.gov.ua/node/6388. Accessed 2026-06-30.
+
+**Tier 3 (encyclopedic):**
+
+- None used as final authority; Wikipedia/Wikidata-style leads were not needed
+  beyond navigation.
+
+**Tier 4 (modern scholarly post-1991):**
+
+- None used in this timeboxed pass. Gap: future module writing should check
+  Liudkevych specialist scholarship, especially Zenoviia Shtunder and Liubov
+  Kyianovska, for deeper interpretation and direct-voice material.
+
+**Tier 5 (general web / media-rights only):**
+
+- Wikimedia Commons. `File:Людкевич Станіслав.jpg`.
+  https://commons.wikimedia.org/wiki/File:%D0%9B%D1%8E%D0%B4%D0%BA%D0%B5%D0%B2%D0%B8%D1%87_%D0%A1%D1%82%D0%B0%D0%BD%D1%96%D1%81%D0%BB%D0%B0%D0%B2.jpg.
+  Accessed 2026-06-30.
+- Wikimedia Commons. `File:Stanislav Lyudkevich 2.JPG`.
+  https://commons.wikimedia.org/wiki/File:Stanislav_Lyudkevich_2.JPG.
+  Accessed 2026-06-30.
+
+**Primary-source documents accessed (NKVD/KGB/FSB, security-service):**
+
+- None. This dossier deliberately avoids a security-service primary frame for
+  Liudkevych himself.
+
+---
+
+## Decolonization self-check
+
+- [x] Galician Ukrainian composer/musicologist/civic-educator frame is primary.
+- [x] No invented martyr/security-service storyline.
+- [x] Soviet awards and posts are visible but not treated as core identity.
+- [x] Existing cross-track paths were verified before listing.
+- [x] Source disagreement on death date is recorded.
+- [x] Quote anchors are short public-domain text incipits from works he set,
+  with authorship clearly assigned to Shevchenko/Franko, not Liudkevych.


### PR DESCRIPTION
## Summary

Adds the BIO #350 strict +77 base-prep research dossier for Stanislav Liudkevych / Станіслав Людкевич.

Scope is dossier-only:

- `docs/research/bio/stanislav-liudkevych.md`

No plan YAML, module markdown, activities, vocabulary, site MDX, wiki output, status JSON, audit/review files, telemetry, generated artifacts, package files, or config changes are included.

## Framing

- Galician Ukrainian composer, musicologist, folklorist, pedagogue, editor, and civic music educator.
- Lysenko-line national music continuity through Lviv/Galician institutions.
- Shevchenko/Franko public-memory repertoire: `Кавказ`, `Заповіт`, `Вічний революціонер`, and related works.
- Twentieth-century regime changes are treated as institutional pressure and continuity, not as an invented martyr/security-service storyline.

## Source notes / gaps

- Ukrainian institutional sources give death date as 10 September 1979; Internet Encyclopedia of Ukraine gives 12 September 1979. The dossier records the discrepancy and uses 10 September for curriculum metadata unless a primary death record is found later.
- No dossier-ready NKVD/KGB/security-service case file for Liudkevych himself was found in this timeboxed pass.
- No reliable short first-person quote from Liudkevych was captured; future module work should check Zenoviia Shtunder, Liubov Kyianovska, and the memorial museum archive before using direct personal quotations.
- Image candidates are rights leads only and require a later media pass.

## Validation

- PASS: `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/stanislav-liudkevych.md`
- PASS: `/Users/krisztiankoos/projects/learn-ukrainian/node_modules/.bin/markdownlint-cli2 docs/research/bio/stanislav-liudkevych.md`
- PASS: `git diff --check origin/main..HEAD`
- PASS: `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
- PASS: commit/push hooks for this one-file docs change

## Pre-submit scope check

- `.python-version` unchanged
- `.yamllint` unchanged
- `.markdownlint.json` unchanged
- no `status/*.json`, `audit/*-review.md`, `review/*-review.md`, or `data/telemetry/**` files in diff
- no `sys.executable` changes
- total files changed: 1
