### PR TITLE
[codex] Add BIO #350 Stanislav Liudkevych research dossier

### DIFF
--- a/docs/research/bio/stanislav-liudkevych.md
+++ b/docs/research/bio/stanislav-liudkevych.md
@@ -1,0 +1,141 @@
+# Станіслав Пилипович Людкевич — Research Dossier
+
+**Slug:** `stanislav-liudkevych`
+**Block:** +77 expansion - "Music / Galician national music school" group (2026-06-29 memo)
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #350
+**Researcher:** Codex background worker
+**Completed:** 2026-06-30
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Станіслав Пилипович Людкевич.
+- **Pseudonyms / aliases:** Станіслав Людкевич; Людкевич Станіслав Пилипович; Stanyslav Liudkevych; Stanislav Liudkevych; Stanyslav Lyudkevych; legacy scholarly form `Ljudkevyč`.
+- **Born:** 24 January 1879 | Ярослав, now Jaroslaw, Poland | then Austrian Galicia, Austria-Hungary. ESU, EIU, IEU, NCSU, UINP, and NBUV agree on the date and place.
+- **Died:** Most Ukrainian institutional sources give 10 September 1979 | Lviv, Ukrainian SSR | buried at Lychakiv Cemetery. Source disagreement: Internet Encyclopedia of Ukraine gives 12 September 1979. Use 10 September for curriculum metadata unless a primary death record is found.
+- **Family / education key facts:** His mother was his first music teacher; NBUV and UINP note that she had studied with Mykhailo Verbytsky. He graduated from Lviv University's philosophy faculty in 1901, with Ukrainian/classical philology formation, then studied music in Lviv and Vienna. His Vienna teachers included Alexander Zemlinsky, Hermann Gredener, and Guido Adler; he completed a musicology doctorate in 1908.
+
+Core BIO identity: Galician Ukrainian composer, musicologist, folklorist, teacher, and civic music educator tying professional music to Ukrainian public culture.
+
+## 2. Oppression mechanism
+
+- **What happened:** Not a repression-primary biography. No dossier-ready Soviet security-service case was found. The verified pressure frame is repeated regime change across Austrian Galicia, the First World War, interwar Polish Lviv, Nazi occupation, and Soviet rule in Western Ukraine.
+- **When:** During the First World War he was mobilized into the Austrian army and held in Russian captivity for roughly four years, per ESU and UINP. In 1941, EIU reports that he was arrested by the Gestapo during Nazi occupation and then released. In 1948 and 1963, EIU and UINP document his defense of Vasyl Barvinskyi after Soviet security organs arrested Barvinskyi; in 1963 Liudkevych signed a letter seeking Barvinskyi's release or rehabilitation.
+- **By whom:** Russian imperial wartime captivity, Nazi Gestapo arrest, and Soviet cultural/security pressure around colleagues and institutions. Do not convert this into a fabricated NKVD/KGB martyr story for Liudkevych himself.
+- **Document references:** No Gestapo file number, POW file, NKVD/KGB case file, or rehabilitation document for Liudkevych was located in this pass. EIU is the strongest concise source for the Gestapo arrest and Barvinskyi defense; UINP corroborates the Barvinskyi defense in public-memory framing.
+- **Mechanism specifics:** Liudkevych stayed in Lviv and kept working through repeated state changes. Teach this as institutional and civic musical continuity under changing regimes: the Lysenko Institute, NTSh musicology, Galician choral societies, the Lviv Conservatory, Soviet-era official posts, and public loyalty to Ukrainian musical tradition.
+- **What survived / what was damaged:** Surviving evidence includes the Galician-Ukrainian professional music school, Shevchenko/Franko choral-symphonic repertory, folklore editing, teaching lineage, and civic memory. Remaining risk: wartime captivity and the 1941 arrest need document-level corroboration before they become a lesson spine.
+
+## 3. Major works / contributions
+
+- **Galician professional music infrastructure:** ESU and EIU identify Liudkevych as an organizer and director/teacher of the Lysenko Higher Institute of Music in Lviv, later connected to the Lviv Conservatory and Lviv National Music Academy. NCSU calls him the first professional musician on Western Ukrainian lands and a founder of leading symphonic and instrumental genres there.
+- **Folklore and ethnomusicology:** ESU says he deciphered and edited more than 1500 songs recorded by Osyp Rozdolskyi on phonograph for the collection `Галицько-руські народні мелодії` (1906-1907). This makes him a bridge between field collection, notation, pedagogy, and composed national style.
+- **Lysenko-line continuity:** NCSU highlights his valuation of Mykola Lysenko and the Lysenko `Музика до Кобзаря` tradition. The module should connect him to Lysenko without claiming direct student lineage: Liudkevych extends the national music program in Galician institutions through choral, symphonic, pedagogical, and editorial work.
+- **Shevchenko works:** Main anchors are the symphony-cantata `Кавказ` (1901-1913) and cantata `Заповіт` (1934; second edition 1955), for which he received the Shevchenko State Prize in 1964. Other Shevchenko settings include `Гамалія`, `Наша дума, наша пісня`, `Косар`, `Ой вигострю товариша`, and `Наймит`.
+- **Franko works:** Major Franko-linked anchors include `Вічний революціонер` (1898), symphonic poems `Каменярі` and `Мойсей`, `Конкістадори`, and related solo songs. NBUV and NCSU both preserve the early Franko anniversary performance frame.
+- **Institution-builder and teacher:** ESU records his leadership in the Union of Ukrainian Professional Musicians, the NTSh Musicological Commission, the Lviv Conservatory, and the Lviv branch of the folklore institute. Named students in ESU include Myroslav Skoryk, Stefania Hrytsa, Lesia Kornii, and Bohdana Filts, making him a twentieth-century transmission figure.
+
+## 4. Primary-source quote anchors
+
+- **Quote 1, Shevchenko text set by Liudkevych:** "Борітеся - поборете!" Source anchor: Taras Shevchenko, `Кавказ`; Liudkevych's symphony-cantata `Кавказ` on Shevchenko's words. Pedagogical use: a short public-domain incipit signaling anti-imperial Shevchenko memory inside monumental Galician Ukrainian music. Text authorship is Shevchenko's, not Liudkevych's.
+- **Quote 2, Franko text set by Liudkevych:** "Вічний революціонер - дух..." Source anchor: Ivan Franko, `Гімн` / `Вічний революціонер`; Liudkevych's choral-orchestral setting associated with Franko anniversary memory in 1898. Pedagogical use: a brief title/incipit connecting Franko civic poetry to choral public performance. Text authorship is Franko's, not Liudkevych's.
+- **Composer-voice gap:** No reliable short first-person quotation from Liudkevych himself was captured in this timeboxed pass. Future work should check Zenoviia Shtunder's two-volume monograph and the memorial museum archive before using direct personal quotations.
+
+## 5. Language register
+
+- **Register:** High civic-cultural Ukrainian, Galician institutional, musicological, and folklore-specialist. Public choral repertory uses Shevchenko/Franko elevated poetic register.
+- **CEFR readiness full reading:** C1 for biography and musicological context; B2-C1 for short title/incipit work anchors; C1/advanced for Soviet-era compromise and cross-regime institutional analysis.
+- **Lexicon notes:** `симфонія-кантата`, `кантата`, `хор`, `солоспів`, `музикознавство`, `фольклористика`, `обробка народної пісні`, `фонограф`, `музичний інститут`, `консерваторія`, `НТШ`, `стрілецькі пісні`, `пізній романтизм`, `модерн`.
+- **Stylistic features:** Monumental choral-symphonic form, folk-song transcription feeding professional composition, Shevchenko/Franko civic poetry as public sound, and a Galician habit of linking education, scholarship, choral societies, and national-cultural service.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** The main interpretive problem is not whether Liudkevych belongs in Ukrainian music, but how to read a century-long career crossing imperial, Polish, Nazi, and Soviet settings without making any one regime the whole story. Strong module framing should present him as Galician Ukrainian professionalization and continuity, not as a simple Soviet honoree and not as an invented dissident martyr.
+- **What gets simplified in popular memory:** Popular accounts often compress him into "first professional composer of Galicia," `Кавказ`, and longevity. That is useful but thin. A better BIO module should show the whole ecology: Lysenko-line national music, NTSh scholarship, the Lysenko Institute, choral societies such as `Боян`, folklore editing, Shevchenko/Franko repertory, and later teaching lineage.
+- **Where modern Russian disinformation attacks them:** No Liudkevych-specific modern Russian disinformation campaign was identified in this pass. The broader colonial risk is absorptive framing: treating him as a Soviet Ukrainian composer whose awards matter more than his Galician Ukrainian institutional and civic-musical work.
+- **Polish / Jewish / other-perspective considerations:** Jaroslaw, Przemysl, and Lviv place him in multiethnic Galician history. The gathered sources do not require a Polish/Jewish controversy frame. Mention interwar Polish Lviv and Austrian Galicia as settings, but do not fabricate conflict where sources do not support it.
+- **HIST-alignment check for +77 roster:** Align with Galician cultural institutions, Shevchenko/Franko memory, First World War captivity, 1939 Soviet annexation of Western Ukraine, Nazi occupation, postwar Soviet institutional pressure, and Ukrainian cultural continuity in Lviv.
+
+## 7. Cross-track links
+
+- **Existing C1 modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/c1/halychyna.yaml` - Galician cultural and historical context for the Lviv/Jaroslaw/Przemysl setting.
+  - `curriculum/l2-uk-en/plans/c1/klasychna-muzyka-2-natsionalna-shkola.yaml` - national music school context, safest bridge for Lysenko-line and Liudkevych's Galician professionalization.
+  - `curriculum/l2-uk-en/plans/c1/vokalne-mystetstvo.yaml` - choral/vocal repertory bridge for Shevchenko and Franko settings.
+- **Existing HIST modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/shevchenko-awakening.yaml` - Shevchenko cultural memory route for `Кавказ` and `Заповіт`.
+  - `curriculum/l2-uk-en/plans/hist/franko-lesia-hrinchenko.yaml` - broader late nineteenth-century national-cultural context around Franko-era public work.
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml` - background on language/cultural suppression before the professional national music school frame.
+- **Existing LIT modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/the-testament.yaml` - direct text-setting route for `Заповіт`.
+  - `curriculum/l2-uk-en/plans/lit/franko-social-poetry.yaml` - Franko civic poetry context for `Вічний революціонер`.
+  - `curriculum/l2-uk-en/plans/lit/franko-moses.yaml` - literary bridge for Liudkevych's `Мойсей` symphonic poem.
+- **Existing BIO dossiers / modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/mykola-lysenko.yaml` and `docs/research/bio/mykola-lysenko.md` - Lysenko-line comparison.
+  - `docs/research/bio/ivan-franko.md` and `docs/research/bio/taras-shevchenko.md` - direct text-source figures.
+  - `docs/research/bio/vasyl-barvinskyi.md` - colleague-defense context; use only where Barvinskyi sources support it.
+  - `docs/research/bio/levko-revutskyi.md` - parallel national-school composer under Soviet institutions.
+- **Candidate cross-track connections (not asserted as existing plans):**
+  - Future BIO dossiers/plans for `filaret-kolessa`, `volodymyr-hnatiuk`, `myroslav-skoryk`, and `anatolii-kos-anatolskyi`.
+  - A future LIT/HIST treatment of Shevchenko's `Кавказ` if such a plan is added later.
+
+## 8. Naming-canonical
+
+Per `docs/best-practices/bio-naming-canonical.md` (#2313):
+
+- **Slug:** `stanislav-liudkevych`.
+- **EN canonical (BGN/PCGN 2010):** Stanislav Liudkevych. Scholarship also uses Stanyslav Liudkevych; use one curriculum form and keep the alternate in aliases.
+- **UA canonical (with patronymic attested):** Станіслав Пилипович Людкевич.
+- **Aliases (track `aliases:` YAML field later):** Станіслав Людкевич; Stanyslav Liudkevych; Stanislav Liudkevych; Stanyslav Lyudkevych; Ljudkevyč; Людкевич Станіслав Пилипович.
+- **Forbidden forms (Russian-imperial transliterations flag in body text):** Stanislav Lyudkevich; Stanislav Ljudkevic; Russian `Станислав Филиппович Людкевич`. These may appear only in alias/source metadata or explicit discussion of legacy transliteration, not in learner-facing prose.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons `File:Людкевич Станіслав.jpg`, described as a 1920s portrait from `lib.mdpu.org.ua`, author unknown, tagged public domain / Public Domain Mark. Use only after a later media pass confirms United States public-domain tagging is sufficient for the project.
+- **Backup candidates:** Wikimedia Commons `File:Stanislav Lyudkevich 2.JPG`, a 2007 own-work portrait based on a Ukrainian envelope, released by the uploader into the public domain; usable only if derivative-source concerns are resolved. The Commons category `Stanyslav Lyudkevych` also contains grave and context images needing normal license review.
+- **Era-appropriate context image:** The ESU entry for the S. Liudkevych Memorial Museum notes an archive of more than 10,000 items and exhibitions on Liudkevych with Franko, Barvinskyi, Lysenko, and Shevchenko. Future media work could use a rights-cleared museum exterior, Lviv/Lychakiv context image, or public-domain score/program reproduction if the license is explicit.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- Енциклопедія Сучасної України. "Людкевич Станіслав Пилипович." https://esu.com.ua/article-59909. Accessed 2026-06-30.
+- Інститут історії України НАН України / Енциклопедія історії України. Галайчак Т. Ю. "Людкевич Станіслав Пилипович." https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=DOP&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Lyudkevych_S_P&Z21ID=. Accessed 2026-06-30.
+- Internet Encyclopedia of Ukraine. "Liudkevych, Stanyslav." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CL%5CI%5CLiudkevychStanyslav.htm. Accessed 2026-06-30. Used with death-date discrepancy noted.
+
+**Tier 2 (institutional):**
+
+- Національна спілка композиторів України. "Станіслав Пилипович Людкевич." https://composersukraine.org/index.php?id=2412. Accessed 2026-06-30.
+- Український інститут національної пам'яті. "1879, народився Станіслав Людкевич." https://uinp.gov.ua/istorychnyy-kalendar/sichen/24/1879-narodyvsya-stanislav-lyudkevych. Accessed 2026-06-30.
+- Національна бібліотека України імені В. І. Вернадського. "Станіслав Людкевич: патріот і митець, який вмів Україну любити." https://www.nbuv.gov.ua/node/6388. Accessed 2026-06-30.
+
+**Tier 3 (encyclopedic):**
+
+- None used as final authority; Wikipedia/Wikidata-style leads were not needed beyond navigation.
+
+**Tier 4 (modern scholarly post-1991):**
+
+- None used in this timeboxed pass. Gap: future module writing should check Liudkevych specialist scholarship, especially Zenoviia Shtunder and Liubov Kyianovska, for deeper interpretation and direct-voice material.
+
+**Tier 5 (general web / media-rights only):**
+
+- Wikimedia Commons. `File:Людкевич Станіслав.jpg`. https://commons.wikimedia.org/wiki/File:%D0%9B%D1%8E%D0%B4%D0%BA%D0%B5%D0%B2%D0%B8%D1%87_%D0%A1%D1%82%D0%B0%D0%BD%D1%96%D1%81%D0%BB%D0%B0%D0%B2.jpg. Accessed 2026-06-30.
+- Wikimedia Commons. `File:Stanislav Lyudkevich 2.JPG`. https://commons.wikimedia.org/wiki/File:Stanislav_Lyudkevich_2.JPG. Accessed 2026-06-30.
+- Енциклопедія Сучасної України. "Людкевича С. Меморіальний музей." https://esu.com.ua/article-59910. Accessed 2026-06-30. Used for archive and museum-context note, not core biography.
+
+**Primary-source documents accessed (NKVD/KGB/FSB, court, police, censorship, rehabilitation documents):**
+
+- None located in this pass. No security-service framing for Liudkevych should be asserted without future document-level evidence.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; Liudkevych is treated as a Galician Ukrainian composer/musicologist/civic educator.
+- [x] No invented martyr/security-service storyline.
+- [x] Soviet awards and posts are not hidden, but they are not treated as the center of identity.
+- [x] Existing cross-track paths were verified before listing.
+- [x] Source disagreement on death date is recorded.
+- [x] Quote anchors are short public-domain text incipits from works he set, with authorship clearly assigned to Shevchenko/Franko, not Liudkevych.


### PR DESCRIPTION
## Summary

Adds the strict +77 base-prep research dossier for BIO #350, `stanislav-liudkevych`.

Scope is intentionally limited to one file:

- `docs/research/bio/stanislav-liudkevych.md`

The dossier emphasizes Liudkevych as a Galician Ukrainian composer, musicologist, folklorist, and civic music educator, with Lysenko-line, Shevchenko, Franko, Lviv/Galician institution, and twentieth-century regime-change framing. It explicitly avoids unsupported martyr/security-service framing.

## Validation

- ` /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/stanislav-liudkevych.md` - passed
- `/Users/krisztiankoos/projects/learn-ukrainian/node_modules/.bin/markdownlint-cli2 docs/research/bio/stanislav-liudkevych.md` - passed, 0 errors
- `git diff --check origin/main..HEAD` - passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` - passed

## Known source gaps / risks

- Ukrainian institutional sources give death date as 10 September 1979; Internet Encyclopedia of Ukraine gives 12 September 1979. The dossier records the disagreement and recommends using 10 September unless a primary death record is found.
- No Gestapo file number, POW file, NKVD/KGB file, or rehabilitation document for Liudkevych was located in this timeboxed pass.
- No direct short first-person quotation from Liudkevych was captured; future module work should check Zenoviia Shtunder, Liubov Kyianovska, and the memorial museum archive.
- Image candidates are listed as candidates only and require a later rights pass.

## Pre-submit scope check

- `.python-version`, `.yamllint`, and `.markdownlint.json` unchanged.
- No status JSON, audit/review artifact, telemetry, generated module files, plan YAML, activities, vocabulary, site MDX, wiki output, package files, or config changes included.
- Total files changed: 1.