### PR TITLE
[codex] Add tiny A1 cloze pilot

### DIFF
--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -564,6 +564,8 @@ def _case_form(
         return None
     forms = cases.get(case_name)
     if not isinstance(forms, dict):
+        forms = cases.get(CASE_LABELS_UA.get(case_name, ""))
+    if not isinstance(forms, dict):
         return None
     return _clean_text(forms.get(number))
 
@@ -603,6 +605,8 @@ def _eligible_decoys(
         if lexeme["lemmaId"] == answer["lemmaId"]:
             continue
         if lexeme.get("pos") != answer.get("pos"):
+            continue
+        if CEFR_RANK[lexeme["cefr"]] > CEFR_RANK[answer["cefr"]]:
             continue
         if _headword(lexeme["gloss"]) == answer_head:
             continue
@@ -998,6 +1002,7 @@ def _build_cloze_items(
                 "lemma": lexeme["lemma"],
                 "caseRule": case_rule,
                 "clozeEn": cloze_en,
+                "cefr": _clean_text(candidate.get("cefr")) or lexeme["cefr"],
                 "acceptedAlt": _accepted_alts(candidate),
                 "provenance": {
                     "status": provenance["status"],

--- a/site/public/lexicon/practice-cloze.A1.json
+++ b/site/public/lexicon/practice-cloze.A1.json
@@ -1,14 +1,79 @@
 {
-  "cloze": [],
-  "deckVersion": "atlas-practice-v1-9cf4a4d7319d19ce",
+  "cloze": [
+    {
+      "acceptedAlt": [],
+      "blankCase": "accusative",
+      "caseRule": {
+        "case": "accusative",
+        "caseLabel": "знахідний",
+        "feedback": "бачити/мати/читати + знахідний (валіза -> валізу)",
+        "ruleId": "accusative_direct_object",
+        "trigger": "direct-object",
+        "triggerLabel": "прямий додаток"
+      },
+      "cefr": "A1",
+      "clozeEn": "I take my suitcase.",
+      "clozeId": "валіза:cloze:1",
+      "form": "валізу",
+      "lemma": "валіза",
+      "lemmaId": "валіза",
+      "number": "singular",
+      "options": [
+        {
+          "case": "accusative",
+          "kind": "answer",
+          "label": "валізу",
+          "lemmaId": "валіза",
+          "optionId": "валіза:cloze:1:answer",
+          "pos": "noun",
+          "strategy": "no-pair"
+        },
+        {
+          "case": "accusative",
+          "kind": "decoy-oblique",
+          "label": "вулицю",
+          "lemmaId": "вулиця",
+          "optionId": "валіза:cloze:1:decoy-1",
+          "pos": "noun",
+          "strategy": "no-pair"
+        },
+        {
+          "case": "accusative",
+          "kind": "decoy-oblique",
+          "label": "бібліотеку",
+          "lemmaId": "бібліотека",
+          "optionId": "валіза:cloze:1:decoy-2",
+          "pos": "noun",
+          "strategy": "no-pair"
+        },
+        {
+          "case": "nominative",
+          "kind": "decoy-lemma",
+          "label": "пісня",
+          "lemmaId": "пісня",
+          "optionId": "валіза:cloze:1:decoy-3",
+          "pos": "noun",
+          "strategy": "no-pair"
+        }
+      ],
+      "provenance": {
+        "cardId": "a2-all-cases-practice-valiza-accusative-1",
+        "path": "curriculum/l2-uk-en/a2/all-cases-practice/vocabulary.yaml",
+        "status": "reviewed"
+      },
+      "sentence": "Я беру ___.",
+      "sentenceFrameId": "sf_ee601d3f2e32"
+    }
+  ],
+  "deckVersion": "atlas-practice-v1-c5a52e54cdf8d828",
   "level": "A1",
   "schema": "atlas-practice-cloze",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 199,
+    "gzipBytes": 769,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 312,
+    "rawBytes": 2351,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/public/lexicon/practice-cloze.A2.json
+++ b/site/public/lexicon/practice-cloze.A2.json
@@ -1,14 +1,14 @@
 {
   "cloze": [],
-  "deckVersion": "atlas-practice-v1-9cf4a4d7319d19ce",
+  "deckVersion": "atlas-practice-v1-c5a52e54cdf8d828",
   "level": "A2",
   "schema": "atlas-practice-cloze",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 199,
+    "gzipBytes": 136,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 312,
+    "rawBytes": 172,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/public/lexicon/practice-cloze.B1.json
+++ b/site/public/lexicon/practice-cloze.B1.json
@@ -1,6 +1,6 @@
 {
   "cloze": [],
-  "deckVersion": "atlas-practice-v1-9cf4a4d7319d19ce",
+  "deckVersion": "atlas-practice-v1-c5a52e54cdf8d828",
   "level": "B1",
   "schema": "atlas-practice-cloze",
   "schemaVersion": 1,

--- a/site/public/lexicon/practice-cloze.B2.json
+++ b/site/public/lexicon/practice-cloze.B2.json
@@ -1,6 +1,6 @@
 {
   "cloze": [],
-  "deckVersion": "atlas-practice-v1-9cf4a4d7319d19ce",
+  "deckVersion": "atlas-practice-v1-c5a52e54cdf8d828",
   "level": "B2",
   "schema": "atlas-practice-cloze",
   "schemaVersion": 1,

--- a/site/public/lexicon/practice-cloze.C1.json
+++ b/site/public/lexicon/practice-cloze.C1.json
@@ -1,6 +1,6 @@
 {
   "cloze": [],
-  "deckVersion": "atlas-practice-v1-9cf4a4d7319d19ce",
+  "deckVersion": "atlas-practice-v1-c5a52e54cdf8d828",
   "level": "C1",
   "schema": "atlas-practice-cloze",
   "schemaVersion": 1,

--- a/site/public/lexicon/practice-index.A1.json
+++ b/site/public/lexicon/practice-index.A1.json
@@ -1,11 +1,11 @@
 {
   "counts": {
-    "cloze": 0,
-    "clozeCoverage": 0.0,
-    "clozeEligibleLexemes": 0,
-    "lexemes": 1114
+    "cloze": 1,
+    "clozeCoverage": 0.0009,
+    "clozeEligibleLexemes": 1,
+    "lexemes": 1125
   },
-  "deckVersion": "atlas-practice-v1-9cf4a4d7319d19ce",
+  "deckVersion": "atlas-practice-v1-c5a52e54cdf8d828",
   "items": [
     {
       "cefr": "A1",
@@ -59,6 +59,19 @@
       "cefr": "A1",
       "clozeIds": [],
       "hasCloze": false,
+      "lemma": "Карпати",
+      "lemmaId": "карпати",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 4
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
       "lemma": "карта",
       "lemmaId": "карта",
       "modes": [
@@ -66,7 +79,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 4
+      "newOrder": 5
     },
     {
       "cefr": "A1",
@@ -79,7 +92,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 5
+      "newOrder": 6
     },
     {
       "cefr": "A1",
@@ -92,7 +105,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 6
+      "newOrder": 7
     },
     {
       "cefr": "A1",
@@ -105,7 +118,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 7
+      "newOrder": 8
     },
     {
       "cefr": "A1",
@@ -118,7 +131,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 8
+      "newOrder": 9
     },
     {
       "cefr": "A1",
@@ -131,7 +144,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 9
+      "newOrder": 10
     },
     {
       "cefr": "A1",
@@ -142,7 +155,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 10
+      "newOrder": 11
     },
     {
       "cefr": "A1",
@@ -155,7 +168,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 11
+      "newOrder": 12
     },
     {
       "cefr": "A1",
@@ -168,7 +181,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 12
+      "newOrder": 13
     },
     {
       "cefr": "A1",
@@ -181,7 +194,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 13
+      "newOrder": 14
     },
     {
       "cefr": "A1",
@@ -194,7 +207,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 14
+      "newOrder": 15
     },
     {
       "cefr": "A1",
@@ -205,7 +218,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 15
+      "newOrder": 16
     },
     {
       "cefr": "A1",
@@ -218,7 +231,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 16
+      "newOrder": 17
     },
     {
       "cefr": "A1",
@@ -231,7 +244,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 17
+      "newOrder": 18
     },
     {
       "cefr": "A1",
@@ -244,7 +257,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 18
+      "newOrder": 19
     },
     {
       "cefr": "A1",
@@ -257,7 +270,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 19
+      "newOrder": 20
     },
     {
       "cefr": "A1",
@@ -270,7 +283,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 20
+      "newOrder": 21
     },
     {
       "cefr": "A1",
@@ -283,7 +296,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 21
+      "newOrder": 22
     },
     {
       "cefr": "A1",
@@ -296,7 +309,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 22
+      "newOrder": 23
     },
     {
       "cefr": "A1",
@@ -309,7 +322,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 23
+      "newOrder": 24
     },
     {
       "cefr": "A1",
@@ -322,7 +335,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 24
+      "newOrder": 25
     },
     {
       "cefr": "A1",
@@ -335,7 +348,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 25
+      "newOrder": 26
     },
     {
       "cefr": "A1",
@@ -346,7 +359,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 26
+      "newOrder": 27
     },
     {
       "cefr": "A1",
@@ -359,7 +372,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 27
+      "newOrder": 28
     },
     {
       "cefr": "A1",
@@ -372,7 +385,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 28
+      "newOrder": 29
     },
     {
       "cefr": "A1",
@@ -385,7 +398,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 29
+      "newOrder": 30
     },
     {
       "cefr": "A1",
@@ -398,7 +411,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 30
+      "newOrder": 31
     },
     {
       "cefr": "A1",
@@ -411,7 +424,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 31
+      "newOrder": 32
     },
     {
       "cefr": "A1",
@@ -422,7 +435,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 32
+      "newOrder": 33
     },
     {
       "cefr": "A1",
@@ -435,7 +448,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 33
+      "newOrder": 34
     },
     {
       "cefr": "A1",
@@ -448,7 +461,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 34
+      "newOrder": 35
     },
     {
       "cefr": "A1",
@@ -461,7 +474,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 35
+      "newOrder": 36
     },
     {
       "cefr": "A1",
@@ -474,7 +487,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 36
+      "newOrder": 37
     },
     {
       "cefr": "A1",
@@ -487,7 +500,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 37
+      "newOrder": 38
     },
     {
       "cefr": "A1",
@@ -500,7 +513,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 38
+      "newOrder": 39
     },
     {
       "cefr": "A1",
@@ -513,7 +526,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 39
+      "newOrder": 40
     },
     {
       "cefr": "A1",
@@ -526,7 +539,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 40
+      "newOrder": 41
     },
     {
       "cefr": "A1",
@@ -537,7 +550,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 41
+      "newOrder": 42
     },
     {
       "cefr": "A1",
@@ -550,7 +563,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 42
+      "newOrder": 43
     },
     {
       "cefr": "A1",
@@ -563,7 +576,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 43
+      "newOrder": 44
     },
     {
       "cefr": "A1",
@@ -576,7 +589,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 44
+      "newOrder": 45
     },
     {
       "cefr": "A1",
@@ -589,7 +602,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 45
+      "newOrder": 46
     },
     {
       "cefr": "A1",
@@ -602,7 +615,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 46
+      "newOrder": 47
     },
     {
       "cefr": "A1",
@@ -615,7 +628,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 47
+      "newOrder": 48
     },
     {
       "cefr": "A1",
@@ -628,7 +641,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 48
+      "newOrder": 49
     },
     {
       "cefr": "A1",
@@ -641,7 +654,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 49
+      "newOrder": 50
     },
     {
       "cefr": "A1",
@@ -654,7 +667,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 50
+      "newOrder": 51
     },
     {
       "cefr": "A1",
@@ -665,7 +678,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 51
+      "newOrder": 52
     },
     {
       "cefr": "A1",
@@ -676,7 +689,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 52
+      "newOrder": 53
     },
     {
       "cefr": "A1",
@@ -689,7 +702,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 53
+      "newOrder": 54
     },
     {
       "cefr": "A1",
@@ -702,7 +715,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 54
+      "newOrder": 55
     },
     {
       "cefr": "A1",
@@ -715,7 +728,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 55
+      "newOrder": 56
     },
     {
       "cefr": "A1",
@@ -728,7 +741,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 56
+      "newOrder": 57
     },
     {
       "cefr": "A1",
@@ -741,7 +754,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 57
+      "newOrder": 58
     },
     {
       "cefr": "A1",
@@ -754,7 +767,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 58
+      "newOrder": 59
     },
     {
       "cefr": "A1",
@@ -767,7 +780,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 59
+      "newOrder": 60
     },
     {
       "cefr": "A1",
@@ -780,7 +793,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 60
+      "newOrder": 61
     },
     {
       "cefr": "A1",
@@ -793,7 +806,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 61
+      "newOrder": 62
     },
     {
       "cefr": "A1",
@@ -806,7 +819,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 62
+      "newOrder": 63
     },
     {
       "cefr": "A1",
@@ -819,7 +832,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 63
+      "newOrder": 64
     },
     {
       "cefr": "A1",
@@ -832,7 +845,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 64
+      "newOrder": 65
     },
     {
       "cefr": "A1",
@@ -845,7 +858,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 65
+      "newOrder": 66
     },
     {
       "cefr": "A1",
@@ -856,7 +869,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 66
+      "newOrder": 67
     },
     {
       "cefr": "A1",
@@ -869,7 +882,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 67
+      "newOrder": 68
     },
     {
       "cefr": "A1",
@@ -882,7 +895,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 68
+      "newOrder": 69
     },
     {
       "cefr": "A1",
@@ -893,7 +906,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 69
+      "newOrder": 70
     },
     {
       "cefr": "A1",
@@ -904,7 +917,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 70
+      "newOrder": 71
     },
     {
       "cefr": "A1",
@@ -917,7 +930,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 71
+      "newOrder": 72
     },
     {
       "cefr": "A1",
@@ -930,7 +943,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 72
+      "newOrder": 73
     },
     {
       "cefr": "A1",
@@ -943,7 +956,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 73
+      "newOrder": 74
     },
     {
       "cefr": "A1",
@@ -956,7 +969,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 74
+      "newOrder": 75
     },
     {
       "cefr": "A1",
@@ -969,7 +982,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 75
+      "newOrder": 76
     },
     {
       "cefr": "A1",
@@ -982,7 +995,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 76
+      "newOrder": 77
     },
     {
       "cefr": "A1",
@@ -995,7 +1008,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 77
+      "newOrder": 78
     },
     {
       "cefr": "A1",
@@ -1008,7 +1021,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 78
+      "newOrder": 79
     },
     {
       "cefr": "A1",
@@ -1021,7 +1034,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 79
+      "newOrder": 80
     },
     {
       "cefr": "A1",
@@ -1034,7 +1047,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 80
+      "newOrder": 81
     },
     {
       "cefr": "A1",
@@ -1047,7 +1060,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 81
+      "newOrder": 82
     },
     {
       "cefr": "A1",
@@ -1060,7 +1073,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 82
+      "newOrder": 83
     },
     {
       "cefr": "A1",
@@ -1073,7 +1086,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 83
+      "newOrder": 84
     },
     {
       "cefr": "A1",
@@ -1086,7 +1099,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 84
+      "newOrder": 85
     },
     {
       "cefr": "A1",
@@ -1099,7 +1112,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 85
+      "newOrder": 86
     },
     {
       "cefr": "A1",
@@ -1112,7 +1125,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 86
+      "newOrder": 87
     },
     {
       "cefr": "A1",
@@ -1125,7 +1138,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 87
+      "newOrder": 88
     },
     {
       "cefr": "A1",
@@ -1138,7 +1151,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 88
+      "newOrder": 89
     },
     {
       "cefr": "A1",
@@ -1151,7 +1164,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 89
+      "newOrder": 90
     },
     {
       "cefr": "A1",
@@ -1164,7 +1177,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 90
+      "newOrder": 91
     },
     {
       "cefr": "A1",
@@ -1177,7 +1190,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 91
+      "newOrder": 92
     },
     {
       "cefr": "A1",
@@ -1190,7 +1203,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 92
+      "newOrder": 93
     },
     {
       "cefr": "A1",
@@ -1203,7 +1216,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 93
+      "newOrder": 94
     },
     {
       "cefr": "A1",
@@ -1214,7 +1227,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 94
+      "newOrder": 95
     },
     {
       "cefr": "A1",
@@ -1227,7 +1240,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 95
+      "newOrder": 96
     },
     {
       "cefr": "A1",
@@ -1240,7 +1253,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 96
+      "newOrder": 97
     },
     {
       "cefr": "A1",
@@ -1251,7 +1264,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 97
+      "newOrder": 98
     },
     {
       "cefr": "A1",
@@ -1262,7 +1275,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 98
+      "newOrder": 99
     },
     {
       "cefr": "A1",
@@ -1275,7 +1288,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 99
+      "newOrder": 100
     },
     {
       "cefr": "A1",
@@ -1288,7 +1301,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 100
+      "newOrder": 101
     },
     {
       "cefr": "A1",
@@ -1299,7 +1312,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 101
+      "newOrder": 102
     },
     {
       "cefr": "A1",
@@ -1312,7 +1325,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 102
+      "newOrder": 103
     },
     {
       "cefr": "A1",
@@ -1325,7 +1338,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 103
+      "newOrder": 104
     },
     {
       "cefr": "A1",
@@ -1336,7 +1349,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 104
+      "newOrder": 105
     },
     {
       "cefr": "A1",
@@ -1349,7 +1362,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 105
+      "newOrder": 106
     },
     {
       "cefr": "A1",
@@ -1360,7 +1373,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 106
+      "newOrder": 107
     },
     {
       "cefr": "A1",
@@ -1371,7 +1384,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 107
+      "newOrder": 108
     },
     {
       "cefr": "A1",
@@ -1382,7 +1395,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 108
+      "newOrder": 109
     },
     {
       "cefr": "A1",
@@ -1395,7 +1408,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 109
+      "newOrder": 110
     },
     {
       "cefr": "A1",
@@ -1408,7 +1421,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 110
+      "newOrder": 111
     },
     {
       "cefr": "A1",
@@ -1419,7 +1432,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 111
+      "newOrder": 112
     },
     {
       "cefr": "A1",
@@ -1432,7 +1445,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 112
+      "newOrder": 113
     },
     {
       "cefr": "A1",
@@ -1443,7 +1456,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 113
+      "newOrder": 114
     },
     {
       "cefr": "A1",
@@ -1456,7 +1469,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 114
+      "newOrder": 115
     },
     {
       "cefr": "A1",
@@ -1469,7 +1482,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 115
+      "newOrder": 116
     },
     {
       "cefr": "A1",
@@ -1482,7 +1495,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 116
+      "newOrder": 117
     },
     {
       "cefr": "A1",
@@ -1495,7 +1508,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 117
+      "newOrder": 118
     },
     {
       "cefr": "A1",
@@ -1508,7 +1521,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 118
+      "newOrder": 119
     },
     {
       "cefr": "A1",
@@ -1521,7 +1534,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 119
+      "newOrder": 120
     },
     {
       "cefr": "A1",
@@ -1534,7 +1547,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 120
+      "newOrder": 121
     },
     {
       "cefr": "A1",
@@ -1547,7 +1560,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 121
+      "newOrder": 122
     },
     {
       "cefr": "A1",
@@ -1560,7 +1573,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 122
+      "newOrder": 123
     },
     {
       "cefr": "A1",
@@ -1571,7 +1584,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 123
+      "newOrder": 124
     },
     {
       "cefr": "A1",
@@ -1584,7 +1597,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 124
+      "newOrder": 125
     },
     {
       "cefr": "A1",
@@ -1595,7 +1608,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 125
+      "newOrder": 126
     },
     {
       "cefr": "A1",
@@ -1608,7 +1621,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 126
+      "newOrder": 127
     },
     {
       "cefr": "A1",
@@ -1621,7 +1634,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 127
+      "newOrder": 128
     },
     {
       "cefr": "A1",
@@ -1632,7 +1645,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 128
+      "newOrder": 129
     },
     {
       "cefr": "A1",
@@ -1645,7 +1658,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 129
+      "newOrder": 130
     },
     {
       "cefr": "A1",
@@ -1658,7 +1671,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 130
+      "newOrder": 131
     },
     {
       "cefr": "A1",
@@ -1671,7 +1684,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 131
+      "newOrder": 132
     },
     {
       "cefr": "A1",
@@ -1684,7 +1697,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 132
+      "newOrder": 133
     },
     {
       "cefr": "A1",
@@ -1697,7 +1710,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 133
+      "newOrder": 134
     },
     {
       "cefr": "A1",
@@ -1710,7 +1723,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 134
+      "newOrder": 135
     },
     {
       "cefr": "A1",
@@ -1723,7 +1736,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 135
+      "newOrder": 136
     },
     {
       "cefr": "A1",
@@ -1736,7 +1749,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 136
+      "newOrder": 137
     },
     {
       "cefr": "A1",
@@ -1749,7 +1762,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 137
+      "newOrder": 138
     },
     {
       "cefr": "A1",
@@ -1762,7 +1775,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 138
+      "newOrder": 139
     },
     {
       "cefr": "A1",
@@ -1775,7 +1788,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 139
+      "newOrder": 140
     },
     {
       "cefr": "A1",
@@ -1788,7 +1801,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 140
+      "newOrder": 141
     },
     {
       "cefr": "A1",
@@ -1799,7 +1812,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 141
+      "newOrder": 142
     },
     {
       "cefr": "A1",
@@ -1812,7 +1825,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 142
+      "newOrder": 143
     },
     {
       "cefr": "A1",
@@ -1825,7 +1838,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 143
+      "newOrder": 144
     },
     {
       "cefr": "A1",
@@ -1838,7 +1851,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 144
+      "newOrder": 145
     },
     {
       "cefr": "A1",
@@ -1851,7 +1864,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 145
+      "newOrder": 146
     },
     {
       "cefr": "A1",
@@ -1864,7 +1877,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 146
+      "newOrder": 147
     },
     {
       "cefr": "A1",
@@ -1877,7 +1890,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 147
+      "newOrder": 148
     },
     {
       "cefr": "A1",
@@ -1890,7 +1903,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 148
+      "newOrder": 149
     },
     {
       "cefr": "A1",
@@ -1903,7 +1916,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 149
+      "newOrder": 150
     },
     {
       "cefr": "A1",
@@ -1916,7 +1929,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 150
+      "newOrder": 151
     },
     {
       "cefr": "A1",
@@ -1929,7 +1942,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 151
+      "newOrder": 152
     },
     {
       "cefr": "A1",
@@ -1940,7 +1953,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 152
+      "newOrder": 153
     },
     {
       "cefr": "A1",
@@ -1951,7 +1964,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 153
+      "newOrder": 154
     },
     {
       "cefr": "A1",
@@ -1964,7 +1977,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 154
+      "newOrder": 155
     },
     {
       "cefr": "A1",
@@ -1977,7 +1990,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 155
+      "newOrder": 156
     },
     {
       "cefr": "A1",
@@ -1990,7 +2003,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 156
+      "newOrder": 157
     },
     {
       "cefr": "A1",
@@ -2003,7 +2016,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 157
+      "newOrder": 158
     },
     {
       "cefr": "A1",
@@ -2016,7 +2029,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 158
+      "newOrder": 159
     },
     {
       "cefr": "A1",
@@ -2029,7 +2042,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 159
+      "newOrder": 160
     },
     {
       "cefr": "A1",
@@ -2042,7 +2055,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 160
+      "newOrder": 161
     },
     {
       "cefr": "A1",
@@ -2055,7 +2068,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 161
+      "newOrder": 162
     },
     {
       "cefr": "A1",
@@ -2068,7 +2081,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 162
+      "newOrder": 163
     },
     {
       "cefr": "A1",
@@ -2081,7 +2094,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 163
+      "newOrder": 164
     },
     {
       "cefr": "A1",
@@ -2094,7 +2107,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 164
+      "newOrder": 165
     },
     {
       "cefr": "A1",
@@ -2107,7 +2120,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 165
+      "newOrder": 166
     },
     {
       "cefr": "A1",
@@ -2120,7 +2133,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 166
+      "newOrder": 167
     },
     {
       "cefr": "A1",
@@ -2133,7 +2146,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 167
+      "newOrder": 168
     },
     {
       "cefr": "A1",
@@ -2146,7 +2159,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 168
+      "newOrder": 169
     },
     {
       "cefr": "A1",
@@ -2159,7 +2172,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 169
+      "newOrder": 170
     },
     {
       "cefr": "A1",
@@ -2172,7 +2185,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 170
+      "newOrder": 171
     },
     {
       "cefr": "A1",
@@ -2185,7 +2198,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 171
+      "newOrder": 172
     },
     {
       "cefr": "A1",
@@ -2198,7 +2211,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 172
+      "newOrder": 173
     },
     {
       "cefr": "A1",
@@ -2211,7 +2224,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 173
+      "newOrder": 174
     },
     {
       "cefr": "A1",
@@ -2224,7 +2237,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 174
+      "newOrder": 175
     },
     {
       "cefr": "A1",
@@ -2237,7 +2250,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 175
+      "newOrder": 176
     },
     {
       "cefr": "A1",
@@ -2250,7 +2263,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 176
+      "newOrder": 177
     },
     {
       "cefr": "A1",
@@ -2263,7 +2276,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 177
+      "newOrder": 178
     },
     {
       "cefr": "A1",
@@ -2276,7 +2289,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 178
+      "newOrder": 179
     },
     {
       "cefr": "A1",
@@ -2289,7 +2302,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 179
+      "newOrder": 180
     },
     {
       "cefr": "A1",
@@ -2302,7 +2315,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 180
+      "newOrder": 181
     },
     {
       "cefr": "A1",
@@ -2313,7 +2326,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 181
+      "newOrder": 182
     },
     {
       "cefr": "A1",
@@ -2326,7 +2339,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 182
+      "newOrder": 183
     },
     {
       "cefr": "A1",
@@ -2339,7 +2352,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 183
+      "newOrder": 184
     },
     {
       "cefr": "A1",
@@ -2352,7 +2365,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 184
+      "newOrder": 185
     },
     {
       "cefr": "A1",
@@ -2365,7 +2378,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 185
+      "newOrder": 186
     },
     {
       "cefr": "A1",
@@ -2378,7 +2391,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 186
+      "newOrder": 187
     },
     {
       "cefr": "A1",
@@ -2391,7 +2404,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 187
+      "newOrder": 188
     },
     {
       "cefr": "A1",
@@ -2404,7 +2417,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 188
+      "newOrder": 189
     },
     {
       "cefr": "A1",
@@ -2417,7 +2430,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 189
+      "newOrder": 190
     },
     {
       "cefr": "A1",
@@ -2430,7 +2443,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 190
+      "newOrder": 191
     },
     {
       "cefr": "A1",
@@ -2443,7 +2456,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 191
+      "newOrder": 192
     },
     {
       "cefr": "A1",
@@ -2456,7 +2469,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 192
+      "newOrder": 193
     },
     {
       "cefr": "A1",
@@ -2469,7 +2482,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 193
+      "newOrder": 194
     },
     {
       "cefr": "A1",
@@ -2482,7 +2495,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 194
+      "newOrder": 195
     },
     {
       "cefr": "A1",
@@ -2495,7 +2508,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 195
+      "newOrder": 196
     },
     {
       "cefr": "A1",
@@ -2508,7 +2521,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 196
+      "newOrder": 197
     },
     {
       "cefr": "A1",
@@ -2521,7 +2534,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 197
+      "newOrder": 198
     },
     {
       "cefr": "A1",
@@ -2532,7 +2545,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 198
+      "newOrder": 199
     },
     {
       "cefr": "A1",
@@ -2543,7 +2556,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 199
+      "newOrder": 200
     },
     {
       "cefr": "A1",
@@ -2556,7 +2569,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 200
+      "newOrder": 201
     },
     {
       "cefr": "A1",
@@ -2567,7 +2580,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 201
+      "newOrder": 202
     },
     {
       "cefr": "A1",
@@ -2578,7 +2591,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 202
+      "newOrder": 203
     },
     {
       "cefr": "A1",
@@ -2591,7 +2604,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 203
+      "newOrder": 204
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "червоні",
+      "lemmaId": "червоні",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 205
     },
     {
       "cefr": "A1",
@@ -2604,7 +2630,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 204
+      "newOrder": 206
     },
     {
       "cefr": "A1",
@@ -2617,7 +2643,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 205
+      "newOrder": 207
     },
     {
       "cefr": "A1",
@@ -2628,7 +2654,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 206
+      "newOrder": 208
     },
     {
       "cefr": "A1",
@@ -2641,7 +2667,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 207
+      "newOrder": 209
     },
     {
       "cefr": "A1",
@@ -2652,7 +2678,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 208
+      "newOrder": 210
     },
     {
       "cefr": "A1",
@@ -2663,7 +2689,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 209
+      "newOrder": 211
     },
     {
       "cefr": "A1",
@@ -2674,7 +2700,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 210
+      "newOrder": 212
     },
     {
       "cefr": "A1",
@@ -2685,7 +2711,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 211
+      "newOrder": 213
     },
     {
       "cefr": "A1",
@@ -2696,7 +2722,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 212
+      "newOrder": 214
     },
     {
       "cefr": "A1",
@@ -2707,7 +2733,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 213
+      "newOrder": 215
     },
     {
       "cefr": "A1",
@@ -2718,7 +2744,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 214
+      "newOrder": 216
     },
     {
       "cefr": "A1",
@@ -2731,7 +2757,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 215
+      "newOrder": 217
     },
     {
       "cefr": "A1",
@@ -2744,7 +2770,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 216
+      "newOrder": 218
     },
     {
       "cefr": "A1",
@@ -2757,7 +2783,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 217
+      "newOrder": 219
     },
     {
       "cefr": "A1",
@@ -2768,7 +2794,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 218
+      "newOrder": 220
     },
     {
       "cefr": "A1",
@@ -2781,7 +2807,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 219
+      "newOrder": 221
     },
     {
       "cefr": "A1",
@@ -2792,7 +2818,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 220
+      "newOrder": 222
     },
     {
       "cefr": "A1",
@@ -2803,7 +2829,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 221
+      "newOrder": 223
     },
     {
       "cefr": "A1",
@@ -2816,7 +2842,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 222
+      "newOrder": 224
     },
     {
       "cefr": "A1",
@@ -2829,7 +2855,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 223
+      "newOrder": 225
     },
     {
       "cefr": "A1",
@@ -2842,7 +2868,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 224
+      "newOrder": 226
     },
     {
       "cefr": "A1",
@@ -2855,7 +2881,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 225
+      "newOrder": 227
     },
     {
       "cefr": "A1",
@@ -2868,7 +2894,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 226
+      "newOrder": 228
     },
     {
       "cefr": "A1",
@@ -2881,7 +2907,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 227
+      "newOrder": 229
     },
     {
       "cefr": "A1",
@@ -2894,7 +2920,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 228
+      "newOrder": 230
     },
     {
       "cefr": "A1",
@@ -2905,7 +2931,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 229
+      "newOrder": 231
     },
     {
       "cefr": "A1",
@@ -2918,7 +2944,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 230
+      "newOrder": 232
     },
     {
       "cefr": "A1",
@@ -2931,7 +2957,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 231
+      "newOrder": 233
     },
     {
       "cefr": "A1",
@@ -2944,7 +2970,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 232
+      "newOrder": 234
     },
     {
       "cefr": "A1",
@@ -2955,7 +2981,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 233
+      "newOrder": 235
     },
     {
       "cefr": "A1",
@@ -2968,7 +2994,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 234
+      "newOrder": 236
     },
     {
       "cefr": "A1",
@@ -2981,7 +3007,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 235
+      "newOrder": 237
     },
     {
       "cefr": "A1",
@@ -2994,7 +3020,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 236
+      "newOrder": 238
     },
     {
       "cefr": "A1",
@@ -3007,7 +3033,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 237
+      "newOrder": 239
     },
     {
       "cefr": "A1",
@@ -3020,7 +3046,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 238
+      "newOrder": 240
     },
     {
       "cefr": "A1",
@@ -3033,7 +3059,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 239
+      "newOrder": 241
     },
     {
       "cefr": "A1",
@@ -3046,7 +3072,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 240
+      "newOrder": 242
     },
     {
       "cefr": "A1",
@@ -3059,7 +3085,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 241
+      "newOrder": 243
     },
     {
       "cefr": "A1",
@@ -3072,7 +3098,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 242
+      "newOrder": 244
     },
     {
       "cefr": "A1",
@@ -3085,7 +3111,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 243
+      "newOrder": 245
     },
     {
       "cefr": "A1",
@@ -3096,7 +3122,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 244
+      "newOrder": 246
     },
     {
       "cefr": "A1",
@@ -3107,7 +3133,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 245
+      "newOrder": 247
     },
     {
       "cefr": "A1",
@@ -3120,7 +3146,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 246
+      "newOrder": 248
     },
     {
       "cefr": "A1",
@@ -3133,7 +3159,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 247
+      "newOrder": 249
     },
     {
       "cefr": "A1",
@@ -3146,7 +3172,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 248
+      "newOrder": 250
     },
     {
       "cefr": "A1",
@@ -3159,7 +3185,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 249
+      "newOrder": 251
     },
     {
       "cefr": "A1",
@@ -3170,7 +3196,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 250
+      "newOrder": 252
     },
     {
       "cefr": "A1",
@@ -3183,7 +3209,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 251
+      "newOrder": 253
     },
     {
       "cefr": "A1",
@@ -3196,7 +3222,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 252
+      "newOrder": 254
     },
     {
       "cefr": "A1",
@@ -3209,7 +3235,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 253
+      "newOrder": 255
     },
     {
       "cefr": "A1",
@@ -3222,7 +3248,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 254
+      "newOrder": 256
     },
     {
       "cefr": "A1",
@@ -3235,7 +3261,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 255
+      "newOrder": 257
     },
     {
       "cefr": "A1",
@@ -3248,7 +3274,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 256
+      "newOrder": 258
     },
     {
       "cefr": "A1",
@@ -3261,7 +3287,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 257
+      "newOrder": 259
     },
     {
       "cefr": "A1",
@@ -3274,7 +3300,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 258
+      "newOrder": 260
     },
     {
       "cefr": "A1",
@@ -3287,7 +3313,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 259
+      "newOrder": 261
     },
     {
       "cefr": "A1",
@@ -3300,7 +3326,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 260
+      "newOrder": 262
     },
     {
       "cefr": "A1",
@@ -3311,7 +3337,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 261
+      "newOrder": 263
     },
     {
       "cefr": "A1",
@@ -3324,7 +3350,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 262
+      "newOrder": 264
     },
     {
       "cefr": "A1",
@@ -3337,7 +3363,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 263
+      "newOrder": 265
     },
     {
       "cefr": "A1",
@@ -3350,7 +3376,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 264
+      "newOrder": 266
     },
     {
       "cefr": "A1",
@@ -3363,7 +3389,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 265
+      "newOrder": 267
     },
     {
       "cefr": "A1",
@@ -3376,7 +3402,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 266
+      "newOrder": 268
     },
     {
       "cefr": "A1",
@@ -3389,7 +3415,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 267
+      "newOrder": 269
     },
     {
       "cefr": "A1",
@@ -3402,7 +3428,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 268
+      "newOrder": 270
     },
     {
       "cefr": "A1",
@@ -3415,7 +3441,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 269
+      "newOrder": 271
     },
     {
       "cefr": "A1",
@@ -3428,7 +3454,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 270
+      "newOrder": 272
     },
     {
       "cefr": "A1",
@@ -3441,7 +3467,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 271
+      "newOrder": 273
     },
     {
       "cefr": "A1",
@@ -3454,7 +3480,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 272
+      "newOrder": 274
     },
     {
       "cefr": "A1",
@@ -3467,7 +3493,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 273
+      "newOrder": 275
     },
     {
       "cefr": "A1",
@@ -3480,7 +3506,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 274
+      "newOrder": 276
     },
     {
       "cefr": "A1",
@@ -3493,7 +3519,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 275
+      "newOrder": 277
     },
     {
       "cefr": "A1",
@@ -3506,7 +3532,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 276
+      "newOrder": 278
     },
     {
       "cefr": "A1",
@@ -3519,7 +3545,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 277
+      "newOrder": 279
     },
     {
       "cefr": "A1",
@@ -3532,7 +3558,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 278
+      "newOrder": 280
     },
     {
       "cefr": "A1",
@@ -3545,7 +3571,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 279
+      "newOrder": 281
     },
     {
       "cefr": "A1",
@@ -3558,7 +3584,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 280
+      "newOrder": 282
     },
     {
       "cefr": "A1",
@@ -3571,7 +3597,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 281
+      "newOrder": 283
     },
     {
       "cefr": "A1",
@@ -3584,7 +3610,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 282
+      "newOrder": 284
     },
     {
       "cefr": "A1",
@@ -3597,7 +3623,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 283
+      "newOrder": 285
     },
     {
       "cefr": "A1",
@@ -3610,7 +3636,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 284
+      "newOrder": 286
     },
     {
       "cefr": "A1",
@@ -3623,7 +3649,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 285
+      "newOrder": 287
     },
     {
       "cefr": "A1",
@@ -3636,7 +3662,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 286
+      "newOrder": 288
     },
     {
       "cefr": "A1",
@@ -3649,7 +3675,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 287
+      "newOrder": 289
     },
     {
       "cefr": "A1",
@@ -3662,7 +3688,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 288
+      "newOrder": 290
     },
     {
       "cefr": "A1",
@@ -3675,7 +3701,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 289
+      "newOrder": 291
     },
     {
       "cefr": "A1",
@@ -3688,7 +3714,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 290
+      "newOrder": 292
     },
     {
       "cefr": "A1",
@@ -3701,7 +3727,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 291
+      "newOrder": 293
     },
     {
       "cefr": "A1",
@@ -3714,7 +3740,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 292
+      "newOrder": 294
     },
     {
       "cefr": "A1",
@@ -3727,7 +3753,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 293
+      "newOrder": 295
     },
     {
       "cefr": "A1",
@@ -3740,7 +3766,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 294
+      "newOrder": 296
     },
     {
       "cefr": "A1",
@@ -3753,7 +3779,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 295
+      "newOrder": 297
     },
     {
       "cefr": "A1",
@@ -3766,7 +3792,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 296
+      "newOrder": 298
     },
     {
       "cefr": "A1",
@@ -3779,7 +3805,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 297
+      "newOrder": 299
     },
     {
       "cefr": "A1",
@@ -3792,7 +3818,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 298
+      "newOrder": 300
     },
     {
       "cefr": "A1",
@@ -3805,7 +3831,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 299
+      "newOrder": 301
     },
     {
       "cefr": "A1",
@@ -3818,7 +3844,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 300
+      "newOrder": 302
     },
     {
       "cefr": "A1",
@@ -3831,7 +3857,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 301
+      "newOrder": 303
     },
     {
       "cefr": "A1",
@@ -3844,7 +3870,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 302
+      "newOrder": 304
     },
     {
       "cefr": "A1",
@@ -3857,7 +3883,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 303
+      "newOrder": 305
     },
     {
       "cefr": "A1",
@@ -3870,7 +3896,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 304
+      "newOrder": 306
     },
     {
       "cefr": "A1",
@@ -3883,7 +3909,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 305
+      "newOrder": 307
     },
     {
       "cefr": "A1",
@@ -3896,7 +3922,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 306
+      "newOrder": 308
     },
     {
       "cefr": "A1",
@@ -3909,7 +3935,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 307
+      "newOrder": 309
     },
     {
       "cefr": "A1",
@@ -3922,7 +3948,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 308
+      "newOrder": 310
     },
     {
       "cefr": "A1",
@@ -3935,7 +3961,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 309
+      "newOrder": 311
     },
     {
       "cefr": "A1",
@@ -3948,7 +3974,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 310
+      "newOrder": 312
     },
     {
       "cefr": "A1",
@@ -3961,7 +3987,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 311
+      "newOrder": 313
     },
     {
       "cefr": "A1",
@@ -3974,7 +4000,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 312
+      "newOrder": 314
     },
     {
       "cefr": "A1",
@@ -3987,7 +4013,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 313
+      "newOrder": 315
     },
     {
       "cefr": "A1",
@@ -3998,7 +4024,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 314
+      "newOrder": 316
     },
     {
       "cefr": "A1",
@@ -4011,7 +4037,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 315
+      "newOrder": 317
     },
     {
       "cefr": "A1",
@@ -4024,7 +4050,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 316
+      "newOrder": 318
     },
     {
       "cefr": "A1",
@@ -4037,7 +4063,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 317
+      "newOrder": 319
     },
     {
       "cefr": "A1",
@@ -4048,7 +4074,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 318
+      "newOrder": 320
     },
     {
       "cefr": "A1",
@@ -4061,7 +4087,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 319
+      "newOrder": 321
     },
     {
       "cefr": "A1",
@@ -4074,7 +4100,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 320
+      "newOrder": 322
     },
     {
       "cefr": "A1",
@@ -4087,7 +4113,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 321
+      "newOrder": 323
     },
     {
       "cefr": "A1",
@@ -4100,7 +4126,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 322
+      "newOrder": 324
     },
     {
       "cefr": "A1",
@@ -4113,7 +4139,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 323
+      "newOrder": 325
     },
     {
       "cefr": "A1",
@@ -4126,7 +4152,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 324
+      "newOrder": 326
     },
     {
       "cefr": "A1",
@@ -4139,7 +4165,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 325
+      "newOrder": 327
     },
     {
       "cefr": "A1",
@@ -4150,7 +4176,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 326
+      "newOrder": 328
     },
     {
       "cefr": "A1",
@@ -4163,7 +4189,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 327
+      "newOrder": 329
     },
     {
       "cefr": "A1",
@@ -4176,7 +4202,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 328
+      "newOrder": 330
     },
     {
       "cefr": "A1",
@@ -4187,7 +4213,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 329
+      "newOrder": 331
     },
     {
       "cefr": "A1",
@@ -4198,7 +4224,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 330
+      "newOrder": 332
     },
     {
       "cefr": "A1",
@@ -4211,7 +4237,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 331
+      "newOrder": 333
     },
     {
       "cefr": "A1",
@@ -4224,7 +4250,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 332
+      "newOrder": 334
     },
     {
       "cefr": "A1",
@@ -4237,7 +4263,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 333
+      "newOrder": 335
     },
     {
       "cefr": "A1",
@@ -4250,7 +4276,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 334
+      "newOrder": 336
     },
     {
       "cefr": "A1",
@@ -4263,7 +4289,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 335
+      "newOrder": 337
     },
     {
       "cefr": "A1",
@@ -4276,7 +4302,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 336
+      "newOrder": 338
     },
     {
       "cefr": "A1",
@@ -4289,7 +4315,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 337
+      "newOrder": 339
     },
     {
       "cefr": "A1",
@@ -4302,7 +4328,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 338
+      "newOrder": 340
     },
     {
       "cefr": "A1",
@@ -4315,7 +4341,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 339
+      "newOrder": 341
     },
     {
       "cefr": "A1",
@@ -4328,7 +4354,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 340
+      "newOrder": 342
     },
     {
       "cefr": "A1",
@@ -4341,7 +4367,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 341
+      "newOrder": 343
     },
     {
       "cefr": "A1",
@@ -4354,7 +4380,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 342
+      "newOrder": 344
     },
     {
       "cefr": "A1",
@@ -4367,7 +4393,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 343
+      "newOrder": 345
     },
     {
       "cefr": "A1",
@@ -4380,7 +4406,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 344
+      "newOrder": 346
     },
     {
       "cefr": "A1",
@@ -4393,7 +4419,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 345
+      "newOrder": 347
     },
     {
       "cefr": "A1",
@@ -4406,7 +4432,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 346
+      "newOrder": 348
     },
     {
       "cefr": "A1",
@@ -4419,7 +4445,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 347
+      "newOrder": 349
     },
     {
       "cefr": "A1",
@@ -4432,7 +4458,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 348
+      "newOrder": 350
     },
     {
       "cefr": "A1",
@@ -4445,7 +4471,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 349
+      "newOrder": 351
     },
     {
       "cefr": "A1",
@@ -4458,7 +4484,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 350
+      "newOrder": 352
     },
     {
       "cefr": "A1",
@@ -4471,7 +4497,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 351
+      "newOrder": 353
     },
     {
       "cefr": "A1",
@@ -4484,7 +4510,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 352
+      "newOrder": 354
     },
     {
       "cefr": "A1",
@@ -4497,7 +4523,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 353
+      "newOrder": 355
     },
     {
       "cefr": "A1",
@@ -4510,7 +4536,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 354
+      "newOrder": 356
     },
     {
       "cefr": "A1",
@@ -4523,7 +4549,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 355
+      "newOrder": 357
     },
     {
       "cefr": "A1",
@@ -4536,7 +4562,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 356
+      "newOrder": 358
     },
     {
       "cefr": "A1",
@@ -4549,7 +4575,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 357
+      "newOrder": 359
     },
     {
       "cefr": "A1",
@@ -4562,7 +4588,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 358
+      "newOrder": 360
     },
     {
       "cefr": "A1",
@@ -4575,7 +4601,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 359
+      "newOrder": 361
     },
     {
       "cefr": "A1",
@@ -4588,7 +4614,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 360
+      "newOrder": 362
     },
     {
       "cefr": "A1",
@@ -4601,7 +4627,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 361
+      "newOrder": 363
     },
     {
       "cefr": "A1",
@@ -4614,7 +4640,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 362
+      "newOrder": 364
     },
     {
       "cefr": "A1",
@@ -4627,7 +4653,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 363
+      "newOrder": 365
     },
     {
       "cefr": "A1",
@@ -4640,7 +4666,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 364
+      "newOrder": 366
     },
     {
       "cefr": "A1",
@@ -4653,7 +4679,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 365
+      "newOrder": 367
     },
     {
       "cefr": "A1",
@@ -4666,7 +4692,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 366
+      "newOrder": 368
     },
     {
       "cefr": "A1",
@@ -4679,7 +4705,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 367
+      "newOrder": 369
     },
     {
       "cefr": "A1",
@@ -4692,7 +4718,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 368
+      "newOrder": 370
     },
     {
       "cefr": "A1",
@@ -4705,7 +4731,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 369
+      "newOrder": 371
     },
     {
       "cefr": "A1",
@@ -4718,7 +4744,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 370
+      "newOrder": 372
     },
     {
       "cefr": "A1",
@@ -4731,7 +4757,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 371
+      "newOrder": 373
     },
     {
       "cefr": "A1",
@@ -4744,7 +4770,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 372
+      "newOrder": 374
     },
     {
       "cefr": "A1",
@@ -4757,7 +4783,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 373
+      "newOrder": 375
     },
     {
       "cefr": "A1",
@@ -4770,7 +4796,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 374
+      "newOrder": 376
     },
     {
       "cefr": "A1",
@@ -4781,7 +4807,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 375
+      "newOrder": 377
     },
     {
       "cefr": "A1",
@@ -4794,7 +4820,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 376
+      "newOrder": 378
     },
     {
       "cefr": "A1",
@@ -4807,7 +4833,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 377
+      "newOrder": 379
     },
     {
       "cefr": "A1",
@@ -4820,7 +4846,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 378
+      "newOrder": 380
     },
     {
       "cefr": "A1",
@@ -4833,7 +4859,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 379
+      "newOrder": 381
     },
     {
       "cefr": "A1",
@@ -4846,7 +4872,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 380
+      "newOrder": 382
     },
     {
       "cefr": "A1",
@@ -4859,7 +4885,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 381
+      "newOrder": 383
     },
     {
       "cefr": "A1",
@@ -4870,7 +4896,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 382
+      "newOrder": 384
     },
     {
       "cefr": "A1",
@@ -4881,7 +4907,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 383
+      "newOrder": 385
     },
     {
       "cefr": "A1",
@@ -4892,7 +4918,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 384
+      "newOrder": 386
     },
     {
       "cefr": "A1",
@@ -4905,7 +4931,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 385
+      "newOrder": 387
     },
     {
       "cefr": "A1",
@@ -4918,7 +4944,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 386
+      "newOrder": 388
     },
     {
       "cefr": "A1",
@@ -4931,7 +4957,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 387
+      "newOrder": 389
     },
     {
       "cefr": "A1",
@@ -4944,7 +4970,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 388
+      "newOrder": 390
     },
     {
       "cefr": "A1",
@@ -4957,7 +4983,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 389
+      "newOrder": 391
     },
     {
       "cefr": "A1",
@@ -4970,7 +4996,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 390
+      "newOrder": 392
     },
     {
       "cefr": "A1",
@@ -4983,7 +5009,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 391
+      "newOrder": 393
     },
     {
       "cefr": "A1",
@@ -4996,7 +5022,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 392
+      "newOrder": 394
     },
     {
       "cefr": "A1",
@@ -5009,7 +5035,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 393
+      "newOrder": 395
     },
     {
       "cefr": "A1",
@@ -5022,7 +5048,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 394
+      "newOrder": 396
     },
     {
       "cefr": "A1",
@@ -5035,7 +5061,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 395
+      "newOrder": 397
     },
     {
       "cefr": "A1",
@@ -5048,7 +5074,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 396
+      "newOrder": 398
     },
     {
       "cefr": "A1",
@@ -5061,7 +5087,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 397
+      "newOrder": 399
     },
     {
       "cefr": "A1",
@@ -5074,7 +5100,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 398
+      "newOrder": 400
     },
     {
       "cefr": "A1",
@@ -5087,7 +5113,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 399
+      "newOrder": 401
     },
     {
       "cefr": "A1",
@@ -5100,7 +5126,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 400
+      "newOrder": 402
     },
     {
       "cefr": "A1",
@@ -5111,7 +5137,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 401
+      "newOrder": 403
     },
     {
       "cefr": "A1",
@@ -5124,7 +5150,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 402
+      "newOrder": 404
     },
     {
       "cefr": "A1",
@@ -5137,7 +5163,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 403
+      "newOrder": 405
     },
     {
       "cefr": "A1",
@@ -5150,7 +5176,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 404
+      "newOrder": 406
     },
     {
       "cefr": "A1",
@@ -5161,7 +5187,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 405
+      "newOrder": 407
     },
     {
       "cefr": "A1",
@@ -5172,7 +5198,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 406
+      "newOrder": 408
     },
     {
       "cefr": "A1",
@@ -5183,7 +5209,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 407
+      "newOrder": 409
     },
     {
       "cefr": "A1",
@@ -5196,7 +5222,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 408
+      "newOrder": 410
     },
     {
       "cefr": "A1",
@@ -5207,7 +5233,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 409
+      "newOrder": 411
     },
     {
       "cefr": "A1",
@@ -5220,7 +5246,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 410
+      "newOrder": 412
     },
     {
       "cefr": "A1",
@@ -5233,7 +5259,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 411
+      "newOrder": 413
     },
     {
       "cefr": "A1",
@@ -5246,7 +5272,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 412
+      "newOrder": 414
     },
     {
       "cefr": "A1",
@@ -5259,7 +5285,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 413
+      "newOrder": 415
     },
     {
       "cefr": "A1",
@@ -5272,7 +5298,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 414
+      "newOrder": 416
     },
     {
       "cefr": "A1",
@@ -5285,7 +5311,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 415
+      "newOrder": 417
     },
     {
       "cefr": "A1",
@@ -5298,7 +5324,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 416
+      "newOrder": 418
     },
     {
       "cefr": "A1",
@@ -5311,7 +5337,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 417
+      "newOrder": 419
     },
     {
       "cefr": "A1",
@@ -5324,7 +5350,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 418
+      "newOrder": 420
     },
     {
       "cefr": "A1",
@@ -5337,7 +5363,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 419
+      "newOrder": 421
     },
     {
       "cefr": "A1",
@@ -5350,7 +5376,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 420
+      "newOrder": 422
     },
     {
       "cefr": "A1",
@@ -5363,7 +5389,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 421
+      "newOrder": 423
     },
     {
       "cefr": "A1",
@@ -5376,7 +5402,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 422
+      "newOrder": 424
     },
     {
       "cefr": "A1",
@@ -5389,7 +5415,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 423
+      "newOrder": 425
     },
     {
       "cefr": "A1",
@@ -5402,7 +5428,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 424
+      "newOrder": 426
     },
     {
       "cefr": "A1",
@@ -5413,7 +5439,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 425
+      "newOrder": 427
     },
     {
       "cefr": "A1",
@@ -5424,7 +5450,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 426
+      "newOrder": 428
     },
     {
       "cefr": "A1",
@@ -5435,7 +5461,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 427
+      "newOrder": 429
     },
     {
       "cefr": "A1",
@@ -5448,7 +5474,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 428
+      "newOrder": 430
     },
     {
       "cefr": "A1",
@@ -5461,7 +5487,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 429
+      "newOrder": 431
     },
     {
       "cefr": "A1",
@@ -5474,7 +5500,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 430
+      "newOrder": 432
     },
     {
       "cefr": "A1",
@@ -5487,7 +5513,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 431
+      "newOrder": 433
     },
     {
       "cefr": "A1",
@@ -5500,7 +5526,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 432
+      "newOrder": 434
     },
     {
       "cefr": "A1",
@@ -5513,7 +5539,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 433
+      "newOrder": 435
     },
     {
       "cefr": "A1",
@@ -5526,7 +5552,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 434
+      "newOrder": 436
     },
     {
       "cefr": "A1",
@@ -5539,7 +5565,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 435
+      "newOrder": 437
     },
     {
       "cefr": "A1",
@@ -5552,7 +5578,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 436
+      "newOrder": 438
     },
     {
       "cefr": "A1",
@@ -5565,7 +5591,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 437
+      "newOrder": 439
     },
     {
       "cefr": "A1",
@@ -5578,7 +5604,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 438
+      "newOrder": 440
     },
     {
       "cefr": "A1",
@@ -5591,7 +5617,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 439
+      "newOrder": 441
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "п'ятдесят",
+      "lemmaId": "п-ятдесят",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 442
     },
     {
       "cefr": "A1",
@@ -5604,7 +5643,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 440
+      "newOrder": 443
     },
     {
       "cefr": "A1",
@@ -5617,7 +5656,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 441
+      "newOrder": 444
     },
     {
       "cefr": "A1",
@@ -5630,7 +5669,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 442
+      "newOrder": 445
     },
     {
       "cefr": "A1",
@@ -5643,7 +5682,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 443
+      "newOrder": 446
     },
     {
       "cefr": "A1",
@@ -5656,7 +5695,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 444
+      "newOrder": 447
     },
     {
       "cefr": "A1",
@@ -5669,7 +5708,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 445
+      "newOrder": 448
     },
     {
       "cefr": "A1",
@@ -5682,7 +5721,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 446
+      "newOrder": 449
     },
     {
       "cefr": "A1",
@@ -5693,7 +5732,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 447
+      "newOrder": 450
     },
     {
       "cefr": "A1",
@@ -5706,7 +5745,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 448
+      "newOrder": 451
     },
     {
       "cefr": "A1",
@@ -5719,7 +5758,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 449
+      "newOrder": 452
     },
     {
       "cefr": "A1",
@@ -5732,7 +5771,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 450
+      "newOrder": 453
     },
     {
       "cefr": "A1",
@@ -5745,7 +5784,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 451
+      "newOrder": 454
     },
     {
       "cefr": "A1",
@@ -5758,7 +5797,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 452
+      "newOrder": 455
     },
     {
       "cefr": "A1",
@@ -5771,7 +5810,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 453
+      "newOrder": 456
     },
     {
       "cefr": "A1",
@@ -5784,7 +5823,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 454
+      "newOrder": 457
     },
     {
       "cefr": "A1",
@@ -5797,7 +5836,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 455
+      "newOrder": 458
     },
     {
       "cefr": "A1",
@@ -5810,7 +5849,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 456
+      "newOrder": 459
     },
     {
       "cefr": "A1",
@@ -5823,7 +5862,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 457
+      "newOrder": 460
     },
     {
       "cefr": "A1",
@@ -5836,7 +5875,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 458
+      "newOrder": 461
     },
     {
       "cefr": "A1",
@@ -5849,7 +5888,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 459
+      "newOrder": 462
     },
     {
       "cefr": "A1",
@@ -5862,7 +5901,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 460
+      "newOrder": 463
     },
     {
       "cefr": "A1",
@@ -5875,7 +5914,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 461
+      "newOrder": 464
     },
     {
       "cefr": "A1",
@@ -5888,7 +5927,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 462
+      "newOrder": 465
     },
     {
       "cefr": "A1",
@@ -5901,7 +5940,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 463
+      "newOrder": 466
     },
     {
       "cefr": "A1",
@@ -5912,7 +5951,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 464
+      "newOrder": 467
     },
     {
       "cefr": "A1",
@@ -5923,7 +5962,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 465
+      "newOrder": 468
     },
     {
       "cefr": "A1",
@@ -5936,7 +5975,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 466
+      "newOrder": 469
     },
     {
       "cefr": "A1",
@@ -5949,7 +5988,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 467
+      "newOrder": 470
     },
     {
       "cefr": "A1",
@@ -5962,7 +6001,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 468
+      "newOrder": 471
     },
     {
       "cefr": "A1",
@@ -5975,7 +6014,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 469
+      "newOrder": 472
     },
     {
       "cefr": "A1",
@@ -5988,7 +6027,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 470
+      "newOrder": 473
     },
     {
       "cefr": "A1",
@@ -5999,7 +6038,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 471
+      "newOrder": 474
     },
     {
       "cefr": "A1",
@@ -6010,7 +6049,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 472
+      "newOrder": 475
     },
     {
       "cefr": "A1",
@@ -6023,7 +6062,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 473
+      "newOrder": 476
     },
     {
       "cefr": "A1",
@@ -6036,7 +6075,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 474
+      "newOrder": 477
     },
     {
       "cefr": "A1",
@@ -6049,7 +6088,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 475
+      "newOrder": 478
     },
     {
       "cefr": "A1",
@@ -6062,7 +6101,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 476
+      "newOrder": 479
     },
     {
       "cefr": "A1",
@@ -6075,7 +6114,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 477
+      "newOrder": 480
     },
     {
       "cefr": "A1",
@@ -6088,7 +6127,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 478
+      "newOrder": 481
     },
     {
       "cefr": "A1",
@@ -6101,7 +6140,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 479
+      "newOrder": 482
     },
     {
       "cefr": "A1",
@@ -6112,7 +6151,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 480
+      "newOrder": 483
     },
     {
       "cefr": "A1",
@@ -6123,7 +6162,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 481
+      "newOrder": 484
     },
     {
       "cefr": "A1",
@@ -6134,7 +6173,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 482
+      "newOrder": 485
     },
     {
       "cefr": "A1",
@@ -6145,7 +6184,20 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 483
+      "newOrder": 486
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "маленькі",
+      "lemmaId": "маленькі",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 487
     },
     {
       "cefr": "A1",
@@ -6158,7 +6210,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 484
+      "newOrder": 488
     },
     {
       "cefr": "A1",
@@ -6169,7 +6221,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 485
+      "newOrder": 489
     },
     {
       "cefr": "A1",
@@ -6182,7 +6234,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 486
+      "newOrder": 490
     },
     {
       "cefr": "A1",
@@ -6195,7 +6247,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 487
+      "newOrder": 491
     },
     {
       "cefr": "A1",
@@ -6206,7 +6258,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 488
+      "newOrder": 492
     },
     {
       "cefr": "A1",
@@ -6219,7 +6271,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 489
+      "newOrder": 493
     },
     {
       "cefr": "A1",
@@ -6232,7 +6284,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 490
+      "newOrder": 494
     },
     {
       "cefr": "A1",
@@ -6245,7 +6297,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 491
+      "newOrder": 495
     },
     {
       "cefr": "A1",
@@ -6258,7 +6310,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 492
+      "newOrder": 496
     },
     {
       "cefr": "A1",
@@ -6271,7 +6323,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 493
+      "newOrder": 497
     },
     {
       "cefr": "A1",
@@ -6284,7 +6336,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 494
+      "newOrder": 498
     },
     {
       "cefr": "A1",
@@ -6297,7 +6349,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 495
+      "newOrder": 499
     },
     {
       "cefr": "A1",
@@ -6310,7 +6362,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 496
+      "newOrder": 500
     },
     {
       "cefr": "A1",
@@ -6323,7 +6375,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 497
+      "newOrder": 501
     },
     {
       "cefr": "A1",
@@ -6336,7 +6388,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 498
+      "newOrder": 502
     },
     {
       "cefr": "A1",
@@ -6349,7 +6401,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 499
+      "newOrder": 503
     },
     {
       "cefr": "A1",
@@ -6360,7 +6412,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 500
+      "newOrder": 504
     },
     {
       "cefr": "A1",
@@ -6373,7 +6425,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 501
+      "newOrder": 505
     },
     {
       "cefr": "A1",
@@ -6386,7 +6438,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 502
+      "newOrder": 506
     },
     {
       "cefr": "A1",
@@ -6399,7 +6451,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 503
+      "newOrder": 507
     },
     {
       "cefr": "A1",
@@ -6412,7 +6464,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 504
+      "newOrder": 508
     },
     {
       "cefr": "A1",
@@ -6425,7 +6477,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 505
+      "newOrder": 509
     },
     {
       "cefr": "A1",
@@ -6438,7 +6490,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 506
+      "newOrder": 510
     },
     {
       "cefr": "A1",
@@ -6451,7 +6503,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 507
+      "newOrder": 511
     },
     {
       "cefr": "A1",
@@ -6464,7 +6516,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 508
+      "newOrder": 512
     },
     {
       "cefr": "A1",
@@ -6477,7 +6529,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 509
+      "newOrder": 513
     },
     {
       "cefr": "A1",
@@ -6490,7 +6542,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 510
+      "newOrder": 514
     },
     {
       "cefr": "A1",
@@ -6503,7 +6555,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 511
+      "newOrder": 515
     },
     {
       "cefr": "A1",
@@ -6516,7 +6568,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 512
+      "newOrder": 516
     },
     {
       "cefr": "A1",
@@ -6529,7 +6581,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 513
+      "newOrder": 517
     },
     {
       "cefr": "A1",
@@ -6542,7 +6594,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 514
+      "newOrder": 518
     },
     {
       "cefr": "A1",
@@ -6555,7 +6607,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 515
+      "newOrder": 519
     },
     {
       "cefr": "A1",
@@ -6568,7 +6620,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 516
+      "newOrder": 520
     },
     {
       "cefr": "A1",
@@ -6581,7 +6633,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 517
+      "newOrder": 521
     },
     {
       "cefr": "A1",
@@ -6594,7 +6646,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 518
+      "newOrder": 522
     },
     {
       "cefr": "A1",
@@ -6607,7 +6659,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 519
+      "newOrder": 523
     },
     {
       "cefr": "A1",
@@ -6618,7 +6670,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 520
+      "newOrder": 524
     },
     {
       "cefr": "A1",
@@ -6631,7 +6683,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 521
+      "newOrder": 525
     },
     {
       "cefr": "A1",
@@ -6644,7 +6696,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 522
+      "newOrder": 526
     },
     {
       "cefr": "A1",
@@ -6657,7 +6709,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 523
+      "newOrder": 527
     },
     {
       "cefr": "A1",
@@ -6670,7 +6722,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 524
+      "newOrder": 528
     },
     {
       "cefr": "A1",
@@ -6683,7 +6735,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 525
+      "newOrder": 529
     },
     {
       "cefr": "A1",
@@ -6696,7 +6748,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 526
+      "newOrder": 530
     },
     {
       "cefr": "A1",
@@ -6709,7 +6761,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 527
+      "newOrder": 531
     },
     {
       "cefr": "A1",
@@ -6722,7 +6774,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 528
+      "newOrder": 532
     },
     {
       "cefr": "A1",
@@ -6735,7 +6787,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 529
+      "newOrder": 533
     },
     {
       "cefr": "A1",
@@ -6748,7 +6800,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 530
+      "newOrder": 534
     },
     {
       "cefr": "A1",
@@ -6761,7 +6813,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 531
+      "newOrder": 535
     },
     {
       "cefr": "A1",
@@ -6774,7 +6826,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 532
+      "newOrder": 536
     },
     {
       "cefr": "A1",
@@ -6787,7 +6839,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 533
+      "newOrder": 537
     },
     {
       "cefr": "A1",
@@ -6800,7 +6852,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 534
+      "newOrder": 538
     },
     {
       "cefr": "A1",
@@ -6813,7 +6865,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 535
+      "newOrder": 539
     },
     {
       "cefr": "A1",
@@ -6826,7 +6878,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 536
+      "newOrder": 540
     },
     {
       "cefr": "A1",
@@ -6837,7 +6889,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 537
+      "newOrder": 541
     },
     {
       "cefr": "A1",
@@ -6848,7 +6900,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 538
+      "newOrder": 542
     },
     {
       "cefr": "A1",
@@ -6861,7 +6913,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 539
+      "newOrder": 543
     },
     {
       "cefr": "A1",
@@ -6874,7 +6926,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 540
+      "newOrder": 544
     },
     {
       "cefr": "A1",
@@ -6887,7 +6939,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 541
+      "newOrder": 545
     },
     {
       "cefr": "A1",
@@ -6900,7 +6952,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 542
+      "newOrder": 546
     },
     {
       "cefr": "A1",
@@ -6911,7 +6963,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 543
+      "newOrder": 547
     },
     {
       "cefr": "A1",
@@ -6924,7 +6976,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 544
+      "newOrder": 548
     },
     {
       "cefr": "A1",
@@ -6937,7 +6989,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 545
+      "newOrder": 549
     },
     {
       "cefr": "A1",
@@ -6948,7 +7000,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 546
+      "newOrder": 550
     },
     {
       "cefr": "A1",
@@ -6961,7 +7013,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 547
+      "newOrder": 551
     },
     {
       "cefr": "A1",
@@ -6974,7 +7026,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 548
+      "newOrder": 552
     },
     {
       "cefr": "A1",
@@ -6987,7 +7039,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 549
+      "newOrder": 553
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "м'яч",
+      "lemmaId": "м-яч",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 554
     },
     {
       "cefr": "A1",
@@ -7000,7 +7065,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 550
+      "newOrder": 555
     },
     {
       "cefr": "A1",
@@ -7013,7 +7078,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 551
+      "newOrder": 556
     },
     {
       "cefr": "A1",
@@ -7026,7 +7091,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 552
+      "newOrder": 557
     },
     {
       "cefr": "A1",
@@ -7039,7 +7104,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 553
+      "newOrder": 558
     },
     {
       "cefr": "A1",
@@ -7052,7 +7117,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 554
+      "newOrder": 559
     },
     {
       "cefr": "A1",
@@ -7063,7 +7128,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 555
+      "newOrder": 560
     },
     {
       "cefr": "A1",
@@ -7074,7 +7139,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 556
+      "newOrder": 561
     },
     {
       "cefr": "A1",
@@ -7087,7 +7152,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 557
+      "newOrder": 562
     },
     {
       "cefr": "A1",
@@ -7100,7 +7165,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 558
+      "newOrder": 563
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "апостроф",
+      "lemmaId": "апостроф",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 564
     },
     {
       "cefr": "A1",
@@ -7113,20 +7191,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 559
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "джерело",
-      "lemmaId": "джерело",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 560
+      "newOrder": 565
     },
     {
       "cefr": "A1",
@@ -7139,7 +7204,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 561
+      "newOrder": 566
     },
     {
       "cefr": "A1",
@@ -7152,7 +7217,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 562
+      "newOrder": 567
     },
     {
       "cefr": "A1",
@@ -7165,7 +7230,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 563
+      "newOrder": 568
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "столиця",
+      "lemmaId": "столиця",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 569
     },
     {
       "cefr": "A1",
@@ -7178,7 +7256,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 564
+      "newOrder": 570
     },
     {
       "cefr": "A1",
@@ -7191,7 +7269,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 565
+      "newOrder": 571
     },
     {
       "cefr": "A1",
@@ -7204,7 +7282,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 566
+      "newOrder": 572
     },
     {
       "cefr": "A1",
@@ -7217,7 +7295,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 567
+      "newOrder": 573
     },
     {
       "cefr": "A1",
@@ -7230,7 +7308,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 568
+      "newOrder": 574
     },
     {
       "cefr": "A1",
@@ -7243,7 +7321,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 569
+      "newOrder": 575
     },
     {
       "cefr": "A1",
@@ -7256,7 +7334,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 570
+      "newOrder": 576
     },
     {
       "cefr": "A1",
@@ -7269,7 +7347,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 571
+      "newOrder": 577
     },
     {
       "cefr": "A1",
@@ -7280,7 +7358,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 572
+      "newOrder": 578
     },
     {
       "cefr": "A1",
@@ -7291,7 +7369,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 573
+      "newOrder": 579
     },
     {
       "cefr": "A1",
@@ -7304,7 +7382,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 574
+      "newOrder": 580
     },
     {
       "cefr": "A1",
@@ -7317,7 +7395,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 575
+      "newOrder": 581
     },
     {
       "cefr": "A1",
@@ -7330,7 +7408,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 576
+      "newOrder": 582
     },
     {
       "cefr": "A1",
@@ -7343,7 +7421,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 577
+      "newOrder": 583
     },
     {
       "cefr": "A1",
@@ -7356,7 +7434,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 578
+      "newOrder": 584
     },
     {
       "cefr": "A1",
@@ -7367,7 +7445,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 579
+      "newOrder": 585
     },
     {
       "cefr": "A1",
@@ -7378,7 +7456,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 580
+      "newOrder": 586
     },
     {
       "cefr": "A1",
@@ -7391,7 +7469,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 581
+      "newOrder": 587
     },
     {
       "cefr": "A1",
@@ -7402,7 +7480,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 582
+      "newOrder": 588
     },
     {
       "cefr": "A1",
@@ -7415,7 +7493,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 583
+      "newOrder": 589
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "ложка",
+      "lemmaId": "ложка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 590
     },
     {
       "cefr": "A1",
@@ -7428,7 +7519,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 584
+      "newOrder": 591
     },
     {
       "cefr": "A1",
@@ -7441,7 +7532,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 585
+      "newOrder": 592
     },
     {
       "cefr": "A1",
@@ -7454,7 +7545,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 586
+      "newOrder": 593
     },
     {
       "cefr": "A1",
@@ -7467,7 +7558,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 587
+      "newOrder": 594
     },
     {
       "cefr": "A1",
@@ -7480,7 +7571,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 588
+      "newOrder": 595
     },
     {
       "cefr": "A1",
@@ -7493,7 +7584,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 589
+      "newOrder": 596
     },
     {
       "cefr": "A1",
@@ -7506,7 +7597,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 590
+      "newOrder": 597
     },
     {
       "cefr": "A1",
@@ -7519,7 +7610,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 591
+      "newOrder": 598
     },
     {
       "cefr": "A1",
@@ -7532,7 +7623,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 592
+      "newOrder": 599
     },
     {
       "cefr": "A1",
@@ -7543,7 +7634,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 593
+      "newOrder": 600
     },
     {
       "cefr": "A1",
@@ -7554,7 +7645,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 594
+      "newOrder": 601
     },
     {
       "cefr": "A1",
@@ -7567,7 +7658,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 595
+      "newOrder": 602
     },
     {
       "cefr": "A1",
@@ -7580,7 +7671,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 596
+      "newOrder": 603
     },
     {
       "cefr": "A1",
@@ -7591,7 +7682,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 597
+      "newOrder": 604
     },
     {
       "cefr": "A1",
@@ -7602,7 +7693,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 598
+      "newOrder": 605
     },
     {
       "cefr": "A1",
@@ -7615,7 +7706,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 599
+      "newOrder": 606
     },
     {
       "cefr": "A1",
@@ -7628,7 +7719,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 600
+      "newOrder": 607
     },
     {
       "cefr": "A1",
@@ -7641,7 +7732,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 601
+      "newOrder": 608
     },
     {
       "cefr": "A1",
@@ -7654,7 +7745,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 602
+      "newOrder": 609
     },
     {
       "cefr": "A1",
@@ -7667,7 +7758,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 603
+      "newOrder": 610
     },
     {
       "cefr": "A1",
@@ -7680,7 +7771,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 604
+      "newOrder": 611
     },
     {
       "cefr": "A1",
@@ -7691,7 +7782,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 605
+      "newOrder": 612
     },
     {
       "cefr": "A1",
@@ -7702,7 +7793,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 606
+      "newOrder": 613
     },
     {
       "cefr": "A1",
@@ -7713,7 +7804,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 607
+      "newOrder": 614
     },
     {
       "cefr": "A1",
@@ -7724,7 +7815,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 608
+      "newOrder": 615
     },
     {
       "cefr": "A1",
@@ -7735,7 +7826,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 609
+      "newOrder": 616
     },
     {
       "cefr": "A1",
@@ -7748,7 +7839,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 610
+      "newOrder": 617
     },
     {
       "cefr": "A1",
@@ -7761,7 +7852,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 611
+      "newOrder": 618
     },
     {
       "cefr": "A1",
@@ -7774,7 +7865,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 612
+      "newOrder": 619
     },
     {
       "cefr": "A1",
@@ -7787,7 +7878,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 613
+      "newOrder": 620
     },
     {
       "cefr": "A1",
@@ -7800,7 +7891,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 614
+      "newOrder": 621
     },
     {
       "cefr": "A1",
@@ -7813,7 +7904,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 615
+      "newOrder": 622
     },
     {
       "cefr": "A1",
@@ -7826,7 +7917,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 616
+      "newOrder": 623
     },
     {
       "cefr": "A1",
@@ -7839,7 +7930,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 617
+      "newOrder": 624
     },
     {
       "cefr": "A1",
@@ -7850,7 +7941,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 618
+      "newOrder": 625
     },
     {
       "cefr": "A1",
@@ -7863,7 +7954,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 619
+      "newOrder": 626
     },
     {
       "cefr": "A1",
@@ -7876,7 +7967,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 620
+      "newOrder": 627
     },
     {
       "cefr": "A1",
@@ -7889,7 +7980,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 621
+      "newOrder": 628
     },
     {
       "cefr": "A1",
@@ -7902,7 +7993,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 622
+      "newOrder": 629
     },
     {
       "cefr": "A1",
@@ -7915,7 +8006,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 623
+      "newOrder": 630
     },
     {
       "cefr": "A1",
@@ -7928,7 +8019,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 624
+      "newOrder": 631
     },
     {
       "cefr": "A1",
@@ -7941,7 +8032,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 625
+      "newOrder": 632
     },
     {
       "cefr": "A1",
@@ -7952,7 +8043,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 626
+      "newOrder": 633
     },
     {
       "cefr": "A1",
@@ -7965,7 +8056,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 627
+      "newOrder": 634
     },
     {
       "cefr": "A1",
@@ -7978,7 +8069,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 628
+      "newOrder": 635
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "просимо",
+      "lemmaId": "просимо",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 636
     },
     {
       "cefr": "A1",
@@ -7991,7 +8095,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 629
+      "newOrder": 637
     },
     {
       "cefr": "A1",
@@ -8004,7 +8108,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 630
+      "newOrder": 638
     },
     {
       "cefr": "A1",
@@ -8017,7 +8121,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 631
+      "newOrder": 639
     },
     {
       "cefr": "A1",
@@ -8030,7 +8134,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 632
+      "newOrder": 640
     },
     {
       "cefr": "A1",
@@ -8043,7 +8147,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 633
+      "newOrder": 641
     },
     {
       "cefr": "A1",
@@ -8056,7 +8160,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 634
+      "newOrder": 642
     },
     {
       "cefr": "A1",
@@ -8069,7 +8173,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 635
+      "newOrder": 643
     },
     {
       "cefr": "A1",
@@ -8082,7 +8186,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 636
+      "newOrder": 644
     },
     {
       "cefr": "A1",
@@ -8095,7 +8199,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 637
+      "newOrder": 645
     },
     {
       "cefr": "A1",
@@ -8108,7 +8212,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 638
+      "newOrder": 646
     },
     {
       "cefr": "A1",
@@ -8121,7 +8225,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 639
+      "newOrder": 647
     },
     {
       "cefr": "A1",
@@ -8134,7 +8238,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 640
+      "newOrder": 648
     },
     {
       "cefr": "A1",
@@ -8147,7 +8251,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 641
+      "newOrder": 649
     },
     {
       "cefr": "A1",
@@ -8160,7 +8264,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 642
+      "newOrder": 650
     },
     {
       "cefr": "A1",
@@ -8173,7 +8277,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 643
+      "newOrder": 651
     },
     {
       "cefr": "A1",
@@ -8184,7 +8288,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 644
+      "newOrder": 652
     },
     {
       "cefr": "A1",
@@ -8195,7 +8299,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 645
+      "newOrder": 653
     },
     {
       "cefr": "A1",
@@ -8206,7 +8310,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 646
+      "newOrder": 654
     },
     {
       "cefr": "A1",
@@ -8219,7 +8323,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 647
+      "newOrder": 655
     },
     {
       "cefr": "A1",
@@ -8232,7 +8336,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 648
+      "newOrder": 656
     },
     {
       "cefr": "A1",
@@ -8245,7 +8349,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 649
+      "newOrder": 657
     },
     {
       "cefr": "A1",
@@ -8258,7 +8362,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 650
+      "newOrder": 658
     },
     {
       "cefr": "A1",
@@ -8271,7 +8375,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 651
+      "newOrder": 659
     },
     {
       "cefr": "A1",
@@ -8284,7 +8388,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 652
+      "newOrder": 660
     },
     {
       "cefr": "A1",
@@ -8297,7 +8401,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 653
+      "newOrder": 661
     },
     {
       "cefr": "A1",
@@ -8310,7 +8414,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 654
+      "newOrder": 662
     },
     {
       "cefr": "A1",
@@ -8323,7 +8427,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 655
+      "newOrder": 663
     },
     {
       "cefr": "A1",
@@ -8336,7 +8440,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 656
+      "newOrder": 664
     },
     {
       "cefr": "A1",
@@ -8349,7 +8453,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 657
+      "newOrder": 665
     },
     {
       "cefr": "A1",
@@ -8362,7 +8466,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 658
+      "newOrder": 666
     },
     {
       "cefr": "A1",
@@ -8375,7 +8479,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 659
+      "newOrder": 667
     },
     {
       "cefr": "A1",
@@ -8388,7 +8492,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 660
+      "newOrder": 668
     },
     {
       "cefr": "A1",
@@ -8401,7 +8505,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 661
+      "newOrder": 669
     },
     {
       "cefr": "A1",
@@ -8414,7 +8518,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 662
+      "newOrder": 670
     },
     {
       "cefr": "A1",
@@ -8427,7 +8531,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 663
+      "newOrder": 671
     },
     {
       "cefr": "A1",
@@ -8440,7 +8544,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 664
+      "newOrder": 672
     },
     {
       "cefr": "A1",
@@ -8453,7 +8557,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 665
+      "newOrder": 673
     },
     {
       "cefr": "A1",
@@ -8464,7 +8568,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 666
+      "newOrder": 674
     },
     {
       "cefr": "A1",
@@ -8477,7 +8581,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 667
+      "newOrder": 675
     },
     {
       "cefr": "A1",
@@ -8490,7 +8594,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 668
+      "newOrder": 676
     },
     {
       "cefr": "A1",
@@ -8503,7 +8607,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 669
+      "newOrder": 677
     },
     {
       "cefr": "A1",
@@ -8516,7 +8620,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 670
+      "newOrder": 678
     },
     {
       "cefr": "A1",
@@ -8529,7 +8633,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 671
+      "newOrder": 679
     },
     {
       "cefr": "A1",
@@ -8542,7 +8646,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 672
+      "newOrder": 680
     },
     {
       "cefr": "A1",
@@ -8555,7 +8659,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 673
+      "newOrder": 681
     },
     {
       "cefr": "A1",
@@ -8568,7 +8672,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 674
+      "newOrder": 682
     },
     {
       "cefr": "A1",
@@ -8581,7 +8685,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 675
+      "newOrder": 683
     },
     {
       "cefr": "A1",
@@ -8594,7 +8698,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 676
+      "newOrder": 684
     },
     {
       "cefr": "A1",
@@ -8607,7 +8711,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 677
+      "newOrder": 685
     },
     {
       "cefr": "A1",
@@ -8620,7 +8724,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 678
+      "newOrder": 686
     },
     {
       "cefr": "A1",
@@ -8633,7 +8737,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 679
+      "newOrder": 687
     },
     {
       "cefr": "A1",
@@ -8646,7 +8750,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 680
+      "newOrder": 688
     },
     {
       "cefr": "A1",
@@ -8659,7 +8763,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 681
+      "newOrder": 689
     },
     {
       "cefr": "A1",
@@ -8672,7 +8776,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 682
+      "newOrder": 690
     },
     {
       "cefr": "A1",
@@ -8685,7 +8789,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 683
+      "newOrder": 691
     },
     {
       "cefr": "A1",
@@ -8698,7 +8802,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 684
+      "newOrder": 692
     },
     {
       "cefr": "A1",
@@ -8711,7 +8815,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 685
+      "newOrder": 693
     },
     {
       "cefr": "A1",
@@ -8724,7 +8828,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 686
+      "newOrder": 694
     },
     {
       "cefr": "A1",
@@ -8737,7 +8841,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 687
+      "newOrder": 695
     },
     {
       "cefr": "A1",
@@ -8750,7 +8854,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 688
+      "newOrder": 696
     },
     {
       "cefr": "A1",
@@ -8763,7 +8867,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 689
+      "newOrder": 697
     },
     {
       "cefr": "A1",
@@ -8774,7 +8878,20 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 690
+      "newOrder": 698
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "Канада",
+      "lemmaId": "канада",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 699
     },
     {
       "cefr": "A1",
@@ -8787,7 +8904,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 691
+      "newOrder": 700
     },
     {
       "cefr": "A1",
@@ -8800,7 +8917,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 692
+      "newOrder": 701
     },
     {
       "cefr": "A1",
@@ -8813,7 +8930,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 693
+      "newOrder": 702
     },
     {
       "cefr": "A1",
@@ -8826,7 +8943,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 694
+      "newOrder": 703
     },
     {
       "cefr": "A1",
@@ -8839,7 +8956,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 695
+      "newOrder": 704
     },
     {
       "cefr": "A1",
@@ -8852,7 +8969,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 696
+      "newOrder": 705
     },
     {
       "cefr": "A1",
@@ -8865,7 +8982,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 697
+      "newOrder": 706
     },
     {
       "cefr": "A1",
@@ -8878,7 +8995,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 698
+      "newOrder": 707
     },
     {
       "cefr": "A1",
@@ -8891,7 +9008,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 699
+      "newOrder": 708
     },
     {
       "cefr": "A1",
@@ -8904,7 +9021,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 700
+      "newOrder": 709
     },
     {
       "cefr": "A1",
@@ -8917,7 +9034,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 701
+      "newOrder": 710
     },
     {
       "cefr": "A1",
@@ -8930,7 +9047,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 702
+      "newOrder": 711
     },
     {
       "cefr": "A1",
@@ -8941,7 +9058,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 703
+      "newOrder": 712
     },
     {
       "cefr": "A1",
@@ -8952,7 +9069,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 704
+      "newOrder": 713
     },
     {
       "cefr": "A1",
@@ -8965,7 +9082,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 705
+      "newOrder": 714
     },
     {
       "cefr": "A1",
@@ -8978,7 +9095,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 706
+      "newOrder": 715
     },
     {
       "cefr": "A1",
@@ -8991,7 +9108,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 707
+      "newOrder": 716
     },
     {
       "cefr": "A1",
@@ -9002,7 +9119,20 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 708
+      "newOrder": 717
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "продукт",
+      "lemmaId": "продукт",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 718
     },
     {
       "cefr": "A1",
@@ -9015,7 +9145,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 709
+      "newOrder": 719
     },
     {
       "cefr": "A1",
@@ -9028,7 +9158,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 710
+      "newOrder": 720
     },
     {
       "cefr": "A1",
@@ -9041,7 +9171,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 711
+      "newOrder": 721
     },
     {
       "cefr": "A1",
@@ -9054,7 +9184,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 712
+      "newOrder": 722
     },
     {
       "cefr": "A1",
@@ -9067,7 +9197,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 713
+      "newOrder": 723
     },
     {
       "cefr": "A1",
@@ -9080,7 +9210,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 714
+      "newOrder": 724
     },
     {
       "cefr": "A1",
@@ -9093,7 +9223,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 715
+      "newOrder": 725
     },
     {
       "cefr": "A1",
@@ -9106,7 +9236,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 716
+      "newOrder": 726
     },
     {
       "cefr": "A1",
@@ -9119,7 +9249,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 717
+      "newOrder": 727
     },
     {
       "cefr": "A1",
@@ -9132,20 +9262,23 @@
         "matching",
         "choice"
       ],
-      "newOrder": 718
+      "newOrder": 728
     },
     {
       "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
+      "clozeIds": [
+        "валіза:cloze:1"
+      ],
+      "hasCloze": true,
       "lemma": "валіза",
       "lemmaId": "валіза",
       "modes": [
         "flashcards",
         "matching",
-        "choice"
+        "choice",
+        "cloze"
       ],
-      "newOrder": 719
+      "newOrder": 729
     },
     {
       "cefr": "A1",
@@ -9158,7 +9291,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 720
+      "newOrder": 730
     },
     {
       "cefr": "A1",
@@ -9171,7 +9304,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 721
+      "newOrder": 731
     },
     {
       "cefr": "A1",
@@ -9184,7 +9317,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 722
+      "newOrder": 732
     },
     {
       "cefr": "A1",
@@ -9197,7 +9330,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 723
+      "newOrder": 733
     },
     {
       "cefr": "A1",
@@ -9210,7 +9343,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 724
+      "newOrder": 734
     },
     {
       "cefr": "A1",
@@ -9223,7 +9356,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 725
+      "newOrder": 735
     },
     {
       "cefr": "A1",
@@ -9236,7 +9369,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 726
+      "newOrder": 736
     },
     {
       "cefr": "A1",
@@ -9249,7 +9382,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 727
+      "newOrder": 737
     },
     {
       "cefr": "A1",
@@ -9262,7 +9395,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 728
+      "newOrder": 738
     },
     {
       "cefr": "A1",
@@ -9275,7 +9408,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 729
+      "newOrder": 739
     },
     {
       "cefr": "A1",
@@ -9288,7 +9421,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 730
+      "newOrder": 740
     },
     {
       "cefr": "A1",
@@ -9301,7 +9434,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 731
+      "newOrder": 741
     },
     {
       "cefr": "A1",
@@ -9314,7 +9447,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 732
+      "newOrder": 742
     },
     {
       "cefr": "A1",
@@ -9327,7 +9460,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 733
+      "newOrder": 743
     },
     {
       "cefr": "A1",
@@ -9340,7 +9473,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 734
+      "newOrder": 744
     },
     {
       "cefr": "A1",
@@ -9353,7 +9486,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 735
+      "newOrder": 745
     },
     {
       "cefr": "A1",
@@ -9366,7 +9499,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 736
+      "newOrder": 746
     },
     {
       "cefr": "A1",
@@ -9379,7 +9512,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 737
+      "newOrder": 747
     },
     {
       "cefr": "A1",
@@ -9392,7 +9525,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 738
+      "newOrder": 748
     },
     {
       "cefr": "A1",
@@ -9405,7 +9538,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 739
+      "newOrder": 749
     },
     {
       "cefr": "A1",
@@ -9418,7 +9551,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 740
+      "newOrder": 750
     },
     {
       "cefr": "A1",
@@ -9431,7 +9564,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 741
+      "newOrder": 751
     },
     {
       "cefr": "A1",
@@ -9444,7 +9577,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 742
+      "newOrder": 752
     },
     {
       "cefr": "A1",
@@ -9457,7 +9590,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 743
+      "newOrder": 753
     },
     {
       "cefr": "A1",
@@ -9470,7 +9603,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 744
+      "newOrder": 754
     },
     {
       "cefr": "A1",
@@ -9483,7 +9616,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 745
+      "newOrder": 755
     },
     {
       "cefr": "A1",
@@ -9496,7 +9629,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 746
+      "newOrder": 756
     },
     {
       "cefr": "A1",
@@ -9509,7 +9642,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 747
+      "newOrder": 757
     },
     {
       "cefr": "A1",
@@ -9522,7 +9655,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 748
+      "newOrder": 758
     },
     {
       "cefr": "A1",
@@ -9535,7 +9668,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 749
+      "newOrder": 759
     },
     {
       "cefr": "A1",
@@ -9548,7 +9681,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 750
+      "newOrder": 760
     },
     {
       "cefr": "A1",
@@ -9561,7 +9694,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 751
+      "newOrder": 761
     },
     {
       "cefr": "A1",
@@ -9574,7 +9707,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 752
+      "newOrder": 762
     },
     {
       "cefr": "A1",
@@ -9587,7 +9720,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 753
+      "newOrder": 763
     },
     {
       "cefr": "A1",
@@ -9600,7 +9733,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 754
+      "newOrder": 764
     },
     {
       "cefr": "A1",
@@ -9613,7 +9746,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 755
+      "newOrder": 765
     },
     {
       "cefr": "A1",
@@ -9626,7 +9759,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 756
+      "newOrder": 766
     },
     {
       "cefr": "A1",
@@ -9637,7 +9770,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 757
+      "newOrder": 767
     },
     {
       "cefr": "A1",
@@ -9650,7 +9783,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 758
+      "newOrder": 768
     },
     {
       "cefr": "A1",
@@ -9663,7 +9796,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 759
+      "newOrder": 769
     },
     {
       "cefr": "A1",
@@ -9676,7 +9809,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 760
+      "newOrder": 770
     },
     {
       "cefr": "A1",
@@ -9689,7 +9822,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 761
+      "newOrder": 771
     },
     {
       "cefr": "A1",
@@ -9702,7 +9835,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 762
+      "newOrder": 772
     },
     {
       "cefr": "A1",
@@ -9715,7 +9848,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 763
+      "newOrder": 773
     },
     {
       "cefr": "A1",
@@ -9728,7 +9861,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 764
+      "newOrder": 774
     },
     {
       "cefr": "A1",
@@ -9741,7 +9874,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 765
+      "newOrder": 775
     },
     {
       "cefr": "A1",
@@ -9752,7 +9885,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 766
+      "newOrder": 776
     },
     {
       "cefr": "A1",
@@ -9765,7 +9898,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 767
+      "newOrder": 777
     },
     {
       "cefr": "A1",
@@ -9776,7 +9909,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 768
+      "newOrder": 778
     },
     {
       "cefr": "A1",
@@ -9787,7 +9920,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 769
+      "newOrder": 779
     },
     {
       "cefr": "A1",
@@ -9798,7 +9931,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 770
+      "newOrder": 780
     },
     {
       "cefr": "A1",
@@ -9811,7 +9944,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 771
+      "newOrder": 781
     },
     {
       "cefr": "A1",
@@ -9824,7 +9957,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 772
+      "newOrder": 782
     },
     {
       "cefr": "A1",
@@ -9837,7 +9970,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 773
+      "newOrder": 783
     },
     {
       "cefr": "A1",
@@ -9850,7 +9983,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 774
+      "newOrder": 784
     },
     {
       "cefr": "A1",
@@ -9863,7 +9996,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 775
+      "newOrder": 785
     },
     {
       "cefr": "A1",
@@ -9876,7 +10009,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 776
+      "newOrder": 786
     },
     {
       "cefr": "A1",
@@ -9889,7 +10022,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 777
+      "newOrder": 787
     },
     {
       "cefr": "A1",
@@ -9902,7 +10035,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 778
+      "newOrder": 788
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "вживати",
+      "lemmaId": "вживати",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 789
     },
     {
       "cefr": "A1",
@@ -9915,7 +10061,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 779
+      "newOrder": 790
     },
     {
       "cefr": "A1",
@@ -9928,7 +10074,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 780
+      "newOrder": 791
     },
     {
       "cefr": "A1",
@@ -9941,7 +10087,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 781
+      "newOrder": 792
     },
     {
       "cefr": "A1",
@@ -9954,7 +10100,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 782
+      "newOrder": 793
     },
     {
       "cefr": "A1",
@@ -9967,7 +10113,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 783
+      "newOrder": 794
     },
     {
       "cefr": "A1",
@@ -9980,7 +10126,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 784
+      "newOrder": 795
     },
     {
       "cefr": "A1",
@@ -9993,7 +10139,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 785
+      "newOrder": 796
     },
     {
       "cefr": "A1",
@@ -10006,7 +10152,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 786
+      "newOrder": 797
     },
     {
       "cefr": "A1",
@@ -10019,7 +10165,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 787
+      "newOrder": 798
     },
     {
       "cefr": "A1",
@@ -10032,7 +10178,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 788
+      "newOrder": 799
     },
     {
       "cefr": "A1",
@@ -10045,7 +10191,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 789
+      "newOrder": 800
     },
     {
       "cefr": "A1",
@@ -10058,7 +10204,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 790
+      "newOrder": 801
     },
     {
       "cefr": "A1",
@@ -10071,7 +10217,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 791
+      "newOrder": 802
     },
     {
       "cefr": "A1",
@@ -10084,7 +10230,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 792
+      "newOrder": 803
     },
     {
       "cefr": "A1",
@@ -10097,7 +10243,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 793
+      "newOrder": 804
     },
     {
       "cefr": "A1",
@@ -10110,7 +10256,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 794
+      "newOrder": 805
     },
     {
       "cefr": "A1",
@@ -10123,7 +10269,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 795
+      "newOrder": 806
     },
     {
       "cefr": "A1",
@@ -10136,7 +10282,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 796
+      "newOrder": 807
     },
     {
       "cefr": "A1",
@@ -10149,7 +10295,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 797
+      "newOrder": 808
     },
     {
       "cefr": "A1",
@@ -10162,7 +10308,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 798
+      "newOrder": 809
     },
     {
       "cefr": "A1",
@@ -10175,7 +10321,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 799
+      "newOrder": 810
     },
     {
       "cefr": "A1",
@@ -10188,7 +10334,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 800
+      "newOrder": 811
     },
     {
       "cefr": "A1",
@@ -10201,7 +10347,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 801
+      "newOrder": 812
     },
     {
       "cefr": "A1",
@@ -10214,7 +10360,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 802
+      "newOrder": 813
     },
     {
       "cefr": "A1",
@@ -10227,7 +10373,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 803
+      "newOrder": 814
     },
     {
       "cefr": "A1",
@@ -10240,7 +10386,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 804
+      "newOrder": 815
     },
     {
       "cefr": "A1",
@@ -10253,7 +10399,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 805
+      "newOrder": 816
     },
     {
       "cefr": "A1",
@@ -10266,7 +10412,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 806
+      "newOrder": 817
     },
     {
       "cefr": "A1",
@@ -10279,7 +10425,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 807
+      "newOrder": 818
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "сумнів",
+      "lemmaId": "сумнів",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 819
     },
     {
       "cefr": "A1",
@@ -10292,7 +10451,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 808
+      "newOrder": 820
     },
     {
       "cefr": "A1",
@@ -10305,7 +10464,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 809
+      "newOrder": 821
     },
     {
       "cefr": "A1",
@@ -10318,7 +10477,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 810
+      "newOrder": 822
     },
     {
       "cefr": "A1",
@@ -10331,7 +10490,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 811
+      "newOrder": 823
     },
     {
       "cefr": "A1",
@@ -10344,7 +10503,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 812
+      "newOrder": 824
     },
     {
       "cefr": "A1",
@@ -10357,7 +10516,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 813
+      "newOrder": 825
     },
     {
       "cefr": "A1",
@@ -10370,7 +10529,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 814
+      "newOrder": 826
     },
     {
       "cefr": "A1",
@@ -10383,7 +10542,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 815
+      "newOrder": 827
     },
     {
       "cefr": "A1",
@@ -10396,7 +10555,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 816
+      "newOrder": 828
     },
     {
       "cefr": "A1",
@@ -10409,7 +10568,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 817
+      "newOrder": 829
     },
     {
       "cefr": "A1",
@@ -10422,7 +10581,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 818
+      "newOrder": 830
     },
     {
       "cefr": "A1",
@@ -10435,7 +10594,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 819
+      "newOrder": 831
     },
     {
       "cefr": "A1",
@@ -10448,7 +10607,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 820
+      "newOrder": 832
     },
     {
       "cefr": "A1",
@@ -10461,7 +10620,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 821
+      "newOrder": 833
     },
     {
       "cefr": "A1",
@@ -10474,7 +10633,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 822
+      "newOrder": 834
     },
     {
       "cefr": "A1",
@@ -10487,7 +10646,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 823
+      "newOrder": 835
     },
     {
       "cefr": "A1",
@@ -10498,7 +10657,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 824
+      "newOrder": 836
     },
     {
       "cefr": "A1",
@@ -10511,7 +10670,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 825
+      "newOrder": 837
     },
     {
       "cefr": "A1",
@@ -10524,7 +10683,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 826
+      "newOrder": 838
     },
     {
       "cefr": "A1",
@@ -10537,7 +10696,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 827
+      "newOrder": 839
     },
     {
       "cefr": "A1",
@@ -10550,7 +10709,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 828
+      "newOrder": 840
     },
     {
       "cefr": "A1",
@@ -10563,7 +10722,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 829
+      "newOrder": 841
     },
     {
       "cefr": "A1",
@@ -10576,7 +10735,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 830
+      "newOrder": 842
     },
     {
       "cefr": "A1",
@@ -10589,7 +10748,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 831
+      "newOrder": 843
     },
     {
       "cefr": "A1",
@@ -10602,7 +10761,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 832
+      "newOrder": 844
     },
     {
       "cefr": "A1",
@@ -10615,7 +10774,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 833
+      "newOrder": 845
     },
     {
       "cefr": "A1",
@@ -10628,7 +10787,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 834
+      "newOrder": 846
     },
     {
       "cefr": "A1",
@@ -10641,7 +10800,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 835
+      "newOrder": 847
     },
     {
       "cefr": "A1",
@@ -10654,7 +10813,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 836
+      "newOrder": 848
     },
     {
       "cefr": "A1",
@@ -10667,7 +10826,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 837
+      "newOrder": 849
     },
     {
       "cefr": "A1",
@@ -10678,7 +10837,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 838
+      "newOrder": 850
     },
     {
       "cefr": "A1",
@@ -10691,7 +10850,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 839
+      "newOrder": 851
     },
     {
       "cefr": "A1",
@@ -10704,7 +10863,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 840
+      "newOrder": 852
     },
     {
       "cefr": "A1",
@@ -10717,7 +10876,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 841
+      "newOrder": 853
     },
     {
       "cefr": "A1",
@@ -10730,7 +10889,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 842
+      "newOrder": 854
     },
     {
       "cefr": "A1",
@@ -10743,7 +10902,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 843
+      "newOrder": 855
     },
     {
       "cefr": "A1",
@@ -10756,7 +10915,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 844
+      "newOrder": 856
     },
     {
       "cefr": "A1",
@@ -10769,7 +10928,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 845
+      "newOrder": 857
     },
     {
       "cefr": "A1",
@@ -10782,7 +10941,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 846
+      "newOrder": 858
     },
     {
       "cefr": "A1",
@@ -10795,7 +10954,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 847
+      "newOrder": 859
     },
     {
       "cefr": "A1",
@@ -10808,7 +10967,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 848
+      "newOrder": 860
     },
     {
       "cefr": "A1",
@@ -10821,7 +10980,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 849
+      "newOrder": 861
     },
     {
       "cefr": "A1",
@@ -10834,7 +10993,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 850
+      "newOrder": 862
     },
     {
       "cefr": "A1",
@@ -10847,7 +11006,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 851
+      "newOrder": 863
     },
     {
       "cefr": "A1",
@@ -10860,7 +11019,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 852
+      "newOrder": 864
     },
     {
       "cefr": "A1",
@@ -10873,7 +11032,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 853
+      "newOrder": 865
     },
     {
       "cefr": "A1",
@@ -10886,7 +11045,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 854
+      "newOrder": 866
     },
     {
       "cefr": "A1",
@@ -10899,7 +11058,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 855
+      "newOrder": 867
     },
     {
       "cefr": "A1",
@@ -10912,7 +11071,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 856
+      "newOrder": 868
     },
     {
       "cefr": "A1",
@@ -10925,7 +11084,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 857
+      "newOrder": 869
     },
     {
       "cefr": "A1",
@@ -10938,7 +11097,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 858
+      "newOrder": 870
     },
     {
       "cefr": "A1",
@@ -10951,7 +11110,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 859
+      "newOrder": 871
     },
     {
       "cefr": "A1",
@@ -10964,7 +11123,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 860
+      "newOrder": 872
     },
     {
       "cefr": "A1",
@@ -10977,7 +11136,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 861
+      "newOrder": 873
     },
     {
       "cefr": "A1",
@@ -10990,7 +11149,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 862
+      "newOrder": 874
     },
     {
       "cefr": "A1",
@@ -11003,7 +11162,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 863
+      "newOrder": 875
     },
     {
       "cefr": "A1",
@@ -11016,7 +11175,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 864
+      "newOrder": 876
     },
     {
       "cefr": "A1",
@@ -11029,7 +11188,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 865
+      "newOrder": 877
     },
     {
       "cefr": "A1",
@@ -11042,7 +11201,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 866
+      "newOrder": 878
     },
     {
       "cefr": "A1",
@@ -11055,7 +11214,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 867
+      "newOrder": 879
     },
     {
       "cefr": "A1",
@@ -11068,7 +11227,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 868
+      "newOrder": 880
     },
     {
       "cefr": "A1",
@@ -11081,7 +11240,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 869
+      "newOrder": 881
     },
     {
       "cefr": "A1",
@@ -11094,7 +11253,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 870
+      "newOrder": 882
     },
     {
       "cefr": "A1",
@@ -11107,7 +11266,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 871
+      "newOrder": 883
     },
     {
       "cefr": "A1",
@@ -11120,7 +11279,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 872
+      "newOrder": 884
     },
     {
       "cefr": "A1",
@@ -11133,7 +11292,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 873
+      "newOrder": 885
     },
     {
       "cefr": "A1",
@@ -11146,7 +11305,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 874
+      "newOrder": 886
     },
     {
       "cefr": "A1",
@@ -11159,7 +11318,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 875
+      "newOrder": 887
     },
     {
       "cefr": "A1",
@@ -11172,7 +11331,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 876
+      "newOrder": 888
     },
     {
       "cefr": "A1",
@@ -11185,7 +11344,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 877
+      "newOrder": 889
     },
     {
       "cefr": "A1",
@@ -11198,7 +11357,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 878
+      "newOrder": 890
     },
     {
       "cefr": "A1",
@@ -11211,7 +11370,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 879
+      "newOrder": 891
     },
     {
       "cefr": "A1",
@@ -11224,7 +11383,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 880
+      "newOrder": 892
     },
     {
       "cefr": "A1",
@@ -11237,7 +11396,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 881
+      "newOrder": 893
     },
     {
       "cefr": "A1",
@@ -11250,7 +11409,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 882
+      "newOrder": 894
     },
     {
       "cefr": "A1",
@@ -11263,7 +11422,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 883
+      "newOrder": 895
     },
     {
       "cefr": "A1",
@@ -11274,7 +11433,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 884
+      "newOrder": 896
     },
     {
       "cefr": "A1",
@@ -11287,7 +11446,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 885
+      "newOrder": 897
     },
     {
       "cefr": "A1",
@@ -11300,7 +11459,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 886
+      "newOrder": 898
     },
     {
       "cefr": "A1",
@@ -11313,7 +11472,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 887
+      "newOrder": 899
     },
     {
       "cefr": "A1",
@@ -11326,7 +11485,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 888
+      "newOrder": 900
     },
     {
       "cefr": "A1",
@@ -11339,7 +11498,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 889
+      "newOrder": 901
     },
     {
       "cefr": "A1",
@@ -11352,7 +11511,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 890
+      "newOrder": 902
     },
     {
       "cefr": "A1",
@@ -11365,7 +11524,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 891
+      "newOrder": 903
     },
     {
       "cefr": "A1",
@@ -11378,7 +11537,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 892
+      "newOrder": 904
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "складання",
+      "lemmaId": "складання",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 905
     },
     {
       "cefr": "A1",
@@ -11391,7 +11563,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 893
+      "newOrder": 906
     },
     {
       "cefr": "A1",
@@ -11404,7 +11576,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 894
+      "newOrder": 907
     },
     {
       "cefr": "A1",
@@ -11417,7 +11589,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 895
+      "newOrder": 908
     },
     {
       "cefr": "A1",
@@ -11430,7 +11602,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 896
+      "newOrder": 909
     },
     {
       "cefr": "A1",
@@ -11443,7 +11615,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 897
+      "newOrder": 910
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "припущення",
+      "lemmaId": "припущення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 911
     },
     {
       "cefr": "A1",
@@ -11456,7 +11641,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 898
+      "newOrder": 912
     },
     {
       "cefr": "A1",
@@ -11469,7 +11654,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 899
+      "newOrder": 913
     },
     {
       "cefr": "A1",
@@ -11482,7 +11667,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 900
+      "newOrder": 914
     },
     {
       "cefr": "A1",
@@ -11495,7 +11680,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 901
+      "newOrder": 915
     },
     {
       "cefr": "A1",
@@ -11508,7 +11693,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 902
+      "newOrder": 916
     },
     {
       "cefr": "A1",
@@ -11521,7 +11706,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 903
+      "newOrder": 917
     },
     {
       "cefr": "A1",
@@ -11534,7 +11719,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 904
+      "newOrder": 918
     },
     {
       "cefr": "A1",
@@ -11547,7 +11732,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 905
+      "newOrder": 919
     },
     {
       "cefr": "A1",
@@ -11560,7 +11745,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 906
+      "newOrder": 920
     },
     {
       "cefr": "A1",
@@ -11573,7 +11758,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 907
+      "newOrder": 921
     },
     {
       "cefr": "A1",
@@ -11586,7 +11771,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 908
+      "newOrder": 922
     },
     {
       "cefr": "A1",
@@ -11599,7 +11784,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 909
+      "newOrder": 923
     },
     {
       "cefr": "A1",
@@ -11612,7 +11797,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 910
+      "newOrder": 924
     },
     {
       "cefr": "A1",
@@ -11625,7 +11810,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 911
+      "newOrder": 925
     },
     {
       "cefr": "A1",
@@ -11638,7 +11823,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 912
+      "newOrder": 926
     },
     {
       "cefr": "A1",
@@ -11651,7 +11836,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 913
+      "newOrder": 927
     },
     {
       "cefr": "A1",
@@ -11664,7 +11849,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 914
+      "newOrder": 928
     },
     {
       "cefr": "A1",
@@ -11677,7 +11862,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 915
+      "newOrder": 929
     },
     {
       "cefr": "A1",
@@ -11690,7 +11875,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 916
+      "newOrder": 930
     },
     {
       "cefr": "A1",
@@ -11703,7 +11888,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 917
+      "newOrder": 931
     },
     {
       "cefr": "A1",
@@ -11716,7 +11901,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 918
+      "newOrder": 932
     },
     {
       "cefr": "A1",
@@ -11729,7 +11914,33 @@
         "matching",
         "choice"
       ],
-      "newOrder": 919
+      "newOrder": 933
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "довкілля",
+      "lemmaId": "довкілля",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 934
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "не/ні",
+      "lemmaId": "не-ні",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 935
     },
     {
       "cefr": "A1",
@@ -11742,7 +11953,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 920
+      "newOrder": 936
     },
     {
       "cefr": "A1",
@@ -11755,7 +11966,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 921
+      "newOrder": 937
     },
     {
       "cefr": "A1",
@@ -11766,7 +11977,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 922
+      "newOrder": 938
     },
     {
       "cefr": "A1",
@@ -11777,7 +11988,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 923
+      "newOrder": 939
     },
     {
       "cefr": "A1",
@@ -11790,7 +12001,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 924
+      "newOrder": 940
     },
     {
       "cefr": "A1",
@@ -11803,7 +12014,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 925
+      "newOrder": 941
     },
     {
       "cefr": "A1",
@@ -11816,7 +12027,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 926
+      "newOrder": 942
     },
     {
       "cefr": "A1",
@@ -11829,7 +12040,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 927
+      "newOrder": 943
     },
     {
       "cefr": "A1",
@@ -11842,7 +12053,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 928
+      "newOrder": 944
     },
     {
       "cefr": "A1",
@@ -11855,7 +12066,31 @@
         "matching",
         "choice"
       ],
-      "newOrder": 929
+      "newOrder": 945
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "ухвалено",
+      "lemmaId": "ухвалено",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 946
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "всупереч",
+      "lemmaId": "всупереч",
+      "modes": [
+        "flashcards"
+      ],
+      "newOrder": 947
     },
     {
       "cefr": "A1",
@@ -11866,7 +12101,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 930
+      "newOrder": 948
     },
     {
       "cefr": "A1",
@@ -11877,7 +12112,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 931
+      "newOrder": 949
     },
     {
       "cefr": "A1",
@@ -11888,7 +12123,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 932
+      "newOrder": 950
     },
     {
       "cefr": "A1",
@@ -11901,7 +12136,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 933
+      "newOrder": 951
     },
     {
       "cefr": "A1",
@@ -11914,7 +12149,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 934
+      "newOrder": 952
     },
     {
       "cefr": "A1",
@@ -11927,7 +12162,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 935
+      "newOrder": 953
     },
     {
       "cefr": "A1",
@@ -11940,7 +12175,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 936
+      "newOrder": 954
     },
     {
       "cefr": "A1",
@@ -11953,7 +12188,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 937
+      "newOrder": 955
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "перенести",
+      "lemmaId": "перенести",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 956
     },
     {
       "cefr": "A1",
@@ -11966,7 +12214,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 938
+      "newOrder": 957
     },
     {
       "cefr": "A1",
@@ -11979,7 +12227,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 939
+      "newOrder": 958
     },
     {
       "cefr": "A1",
@@ -11992,7 +12240,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 940
+      "newOrder": 959
     },
     {
       "cefr": "A1",
@@ -12005,7 +12253,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 941
+      "newOrder": 960
     },
     {
       "cefr": "A1",
@@ -12018,7 +12266,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 942
+      "newOrder": 961
     },
     {
       "cefr": "A1",
@@ -12031,7 +12279,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 943
+      "newOrder": 962
     },
     {
       "cefr": "A1",
@@ -12042,7 +12290,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 944
+      "newOrder": 963
     },
     {
       "cefr": "A1",
@@ -12055,7 +12303,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 945
+      "newOrder": 964
     },
     {
       "cefr": "A1",
@@ -12068,7 +12316,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 946
+      "newOrder": 965
     },
     {
       "cefr": "A1",
@@ -12081,7 +12329,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 947
+      "newOrder": 966
     },
     {
       "cefr": "A1",
@@ -12094,7 +12342,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 948
+      "newOrder": 967
     },
     {
       "cefr": "A1",
@@ -12107,7 +12355,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 949
+      "newOrder": 968
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "корпус",
+      "lemmaId": "корпус",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 969
     },
     {
       "cefr": "A1",
@@ -12120,7 +12381,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 950
+      "newOrder": 970
     },
     {
       "cefr": "A1",
@@ -12131,7 +12392,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 951
+      "newOrder": 971
     },
     {
       "cefr": "A1",
@@ -12144,7 +12405,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 952
+      "newOrder": 972
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "ціле",
+      "lemmaId": "ціле",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 973
     },
     {
       "cefr": "A1",
@@ -12157,7 +12431,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 953
+      "newOrder": 974
     },
     {
       "cefr": "A1",
@@ -12170,7 +12444,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 954
+      "newOrder": 975
     },
     {
       "cefr": "A1",
@@ -12183,7 +12457,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 955
+      "newOrder": 976
     },
     {
       "cefr": "A1",
@@ -12196,7 +12470,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 956
+      "newOrder": 977
     },
     {
       "cefr": "A1",
@@ -12209,7 +12483,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 957
+      "newOrder": 978
     },
     {
       "cefr": "A1",
@@ -12222,7 +12496,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 958
+      "newOrder": 979
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "комунальні",
+      "lemmaId": "комунальні",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 980
     },
     {
       "cefr": "A1",
@@ -12235,7 +12522,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 959
+      "newOrder": 981
     },
     {
       "cefr": "A1",
@@ -12248,7 +12535,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 960
+      "newOrder": 982
     },
     {
       "cefr": "A1",
@@ -12261,7 +12548,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 961
+      "newOrder": 983
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "подвір'я",
+      "lemmaId": "подвір-я",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 984
     },
     {
       "cefr": "A1",
@@ -12274,7 +12574,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 962
+      "newOrder": 985
     },
     {
       "cefr": "A1",
@@ -12287,7 +12587,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 963
+      "newOrder": 986
     },
     {
       "cefr": "A1",
@@ -12298,7 +12598,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 964
+      "newOrder": 987
     },
     {
       "cefr": "A1",
@@ -12311,7 +12611,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 965
+      "newOrder": 988
     },
     {
       "cefr": "A1",
@@ -12324,7 +12624,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 966
+      "newOrder": 989
     },
     {
       "cefr": "A1",
@@ -12337,7 +12637,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 967
+      "newOrder": 990
     },
     {
       "cefr": "A1",
@@ -12350,7 +12650,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 968
+      "newOrder": 991
     },
     {
       "cefr": "A1",
@@ -12363,7 +12663,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 969
+      "newOrder": 992
     },
     {
       "cefr": "A1",
@@ -12376,7 +12676,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 970
+      "newOrder": 993
     },
     {
       "cefr": "A1",
@@ -12389,7 +12689,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 971
+      "newOrder": 994
     },
     {
       "cefr": "A1",
@@ -12402,7 +12702,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 972
+      "newOrder": 995
     },
     {
       "cefr": "A1",
@@ -12415,7 +12715,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 973
+      "newOrder": 996
     },
     {
       "cefr": "A1",
@@ -12428,7 +12728,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 974
+      "newOrder": 997
     },
     {
       "cefr": "A1",
@@ -12439,7 +12739,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 975
+      "newOrder": 998
     },
     {
       "cefr": "A1",
@@ -12452,7 +12752,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 976
+      "newOrder": 999
     },
     {
       "cefr": "A1",
@@ -12465,7 +12765,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 977
+      "newOrder": 1000
     },
     {
       "cefr": "A1",
@@ -12478,7 +12778,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 978
+      "newOrder": 1001
     },
     {
       "cefr": "A1",
@@ -12491,7 +12791,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 979
+      "newOrder": 1002
     },
     {
       "cefr": "A1",
@@ -12504,7 +12804,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 980
+      "newOrder": 1003
     },
     {
       "cefr": "A1",
@@ -12515,7 +12815,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 981
+      "newOrder": 1004
     },
     {
       "cefr": "A1",
@@ -12528,7 +12828,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 982
+      "newOrder": 1005
     },
     {
       "cefr": "A1",
@@ -12541,7 +12841,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 983
+      "newOrder": 1006
     },
     {
       "cefr": "A1",
@@ -12554,7 +12854,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 984
+      "newOrder": 1007
     },
     {
       "cefr": "A1",
@@ -12567,7 +12867,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 985
+      "newOrder": 1008
     },
     {
       "cefr": "A1",
@@ -12580,7 +12880,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 986
+      "newOrder": 1009
     },
     {
       "cefr": "A1",
@@ -12591,7 +12891,20 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 987
+      "newOrder": 1010
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "забруднення",
+      "lemmaId": "забруднення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1011
     },
     {
       "cefr": "A1",
@@ -12604,7 +12917,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 988
+      "newOrder": 1012
     },
     {
       "cefr": "A1",
@@ -12617,7 +12930,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 989
+      "newOrder": 1013
     },
     {
       "cefr": "A1",
@@ -12630,7 +12943,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 990
+      "newOrder": 1014
     },
     {
       "cefr": "A1",
@@ -12643,7 +12956,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 991
+      "newOrder": 1015
     },
     {
       "cefr": "A1",
@@ -12656,7 +12969,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 992
+      "newOrder": 1016
     },
     {
       "cefr": "A1",
@@ -12669,7 +12982,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 993
+      "newOrder": 1017
     },
     {
       "cefr": "A1",
@@ -12682,7 +12995,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 994
+      "newOrder": 1018
     },
     {
       "cefr": "A1",
@@ -12695,7 +13008,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 995
+      "newOrder": 1019
     },
     {
       "cefr": "A1",
@@ -12708,7 +13021,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 996
+      "newOrder": 1020
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "встановлюється",
+      "lemmaId": "встановлюється",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1021
     },
     {
       "cefr": "A1",
@@ -12721,7 +13047,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 997
+      "newOrder": 1022
     },
     {
       "cefr": "A1",
@@ -12734,7 +13060,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 998
+      "newOrder": 1023
     },
     {
       "cefr": "A1",
@@ -12747,7 +13073,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 999
+      "newOrder": 1024
     },
     {
       "cefr": "A1",
@@ -12760,7 +13086,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1000
+      "newOrder": 1025
     },
     {
       "cefr": "A1",
@@ -12773,7 +13099,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1001
+      "newOrder": 1026
     },
     {
       "cefr": "A1",
@@ -12786,7 +13112,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1002
+      "newOrder": 1027
     },
     {
       "cefr": "A1",
@@ -12799,7 +13125,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1003
+      "newOrder": 1028
     },
     {
       "cefr": "A1",
@@ -12812,7 +13138,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1004
+      "newOrder": 1029
     },
     {
       "cefr": "A1",
@@ -12825,7 +13151,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1005
+      "newOrder": 1030
     },
     {
       "cefr": "A1",
@@ -12838,7 +13164,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1006
+      "newOrder": 1031
     },
     {
       "cefr": "A1",
@@ -12851,7 +13177,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1007
+      "newOrder": 1032
     },
     {
       "cefr": "A1",
@@ -12864,7 +13190,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1008
+      "newOrder": 1033
     },
     {
       "cefr": "A1",
@@ -12877,7 +13203,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1009
+      "newOrder": 1034
     },
     {
       "cefr": "A1",
@@ -12890,7 +13216,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1010
+      "newOrder": 1035
     },
     {
       "cefr": "A1",
@@ -12903,7 +13229,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1011
+      "newOrder": 1036
     },
     {
       "cefr": "A1",
@@ -12914,7 +13240,18 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 1012
+      "newOrder": 1037
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "Черкаси",
+      "lemmaId": "черкаси",
+      "modes": [
+        "flashcards"
+      ],
+      "newOrder": 1038
     },
     {
       "cefr": "A1",
@@ -12927,7 +13264,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1013
+      "newOrder": 1039
     },
     {
       "cefr": "A1",
@@ -12940,7 +13277,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1014
+      "newOrder": 1040
     },
     {
       "cefr": "A1",
@@ -12953,7 +13290,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1015
+      "newOrder": 1041
     },
     {
       "cefr": "A1",
@@ -12964,7 +13301,18 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 1016
+      "newOrder": 1042
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "унаслідок",
+      "lemmaId": "унаслідок",
+      "modes": [
+        "flashcards"
+      ],
+      "newOrder": 1043
     },
     {
       "cefr": "A1",
@@ -12977,7 +13325,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1017
+      "newOrder": 1044
     },
     {
       "cefr": "A1",
@@ -12988,7 +13336,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 1018
+      "newOrder": 1045
     },
     {
       "cefr": "A1",
@@ -12999,7 +13347,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 1019
+      "newOrder": 1046
     },
     {
       "cefr": "A1",
@@ -13010,7 +13358,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 1020
+      "newOrder": 1047
     },
     {
       "cefr": "A1",
@@ -13023,7 +13371,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1021
+      "newOrder": 1048
     },
     {
       "cefr": "A1",
@@ -13034,7 +13382,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 1022
+      "newOrder": 1049
     },
     {
       "cefr": "A1",
@@ -13045,7 +13393,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 1023
+      "newOrder": 1050
     },
     {
       "cefr": "A1",
@@ -13056,7 +13404,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 1024
+      "newOrder": 1051
     },
     {
       "cefr": "A1",
@@ -13069,7 +13417,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1025
+      "newOrder": 1052
     },
     {
       "cefr": "A1",
@@ -13080,7 +13428,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 1026
+      "newOrder": 1053
     },
     {
       "cefr": "A1",
@@ -13093,7 +13441,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1027
+      "newOrder": 1054
     },
     {
       "cefr": "A1",
@@ -13106,7 +13454,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1028
+      "newOrder": 1055
     },
     {
       "cefr": "A1",
@@ -13119,7 +13467,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1029
+      "newOrder": 1056
     },
     {
       "cefr": "A1",
@@ -13132,7 +13480,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1030
+      "newOrder": 1057
     },
     {
       "cefr": "A1",
@@ -13145,7 +13493,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1031
+      "newOrder": 1058
     },
     {
       "cefr": "A1",
@@ -13158,7 +13506,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1032
+      "newOrder": 1059
     },
     {
       "cefr": "A1",
@@ -13171,7 +13519,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1033
+      "newOrder": 1060
     },
     {
       "cefr": "A1",
@@ -13184,7 +13532,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1034
+      "newOrder": 1061
     },
     {
       "cefr": "A1",
@@ -13197,7 +13545,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1035
+      "newOrder": 1062
     },
     {
       "cefr": "A1",
@@ -13210,7 +13558,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1036
+      "newOrder": 1063
     },
     {
       "cefr": "A1",
@@ -13223,7 +13571,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1037
+      "newOrder": 1064
     },
     {
       "cefr": "A1",
@@ -13236,7 +13584,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1038
+      "newOrder": 1065
     },
     {
       "cefr": "A1",
@@ -13249,7 +13597,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1039
+      "newOrder": 1066
     },
     {
       "cefr": "A1",
@@ -13262,7 +13610,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1040
+      "newOrder": 1067
     },
     {
       "cefr": "A1",
@@ -13275,7 +13623,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1041
+      "newOrder": 1068
     },
     {
       "cefr": "A1",
@@ -13288,7 +13636,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1042
+      "newOrder": 1069
     },
     {
       "cefr": "A1",
@@ -13301,7 +13649,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1043
+      "newOrder": 1070
     },
     {
       "cefr": "A1",
@@ -13314,7 +13662,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1044
+      "newOrder": 1071
     },
     {
       "cefr": "A1",
@@ -13327,7 +13675,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1045
+      "newOrder": 1072
     },
     {
       "cefr": "A1",
@@ -13340,7 +13688,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1046
+      "newOrder": 1073
     },
     {
       "cefr": "A1",
@@ -13353,7 +13701,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1047
+      "newOrder": 1074
     },
     {
       "cefr": "A1",
@@ -13366,7 +13714,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1048
+      "newOrder": 1075
     },
     {
       "cefr": "A1",
@@ -13379,7 +13727,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1049
+      "newOrder": 1076
     },
     {
       "cefr": "A1",
@@ -13392,7 +13740,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1050
+      "newOrder": 1077
     },
     {
       "cefr": "A1",
@@ -13405,7 +13753,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1051
+      "newOrder": 1078
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "вигоди",
+      "lemmaId": "вигоди",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1079
     },
     {
       "cefr": "A1",
@@ -13418,7 +13779,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1052
+      "newOrder": 1080
     },
     {
       "cefr": "A1",
@@ -13431,7 +13792,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1053
+      "newOrder": 1081
     },
     {
       "cefr": "A1",
@@ -13444,7 +13805,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1054
+      "newOrder": 1082
     },
     {
       "cefr": "A1",
@@ -13457,7 +13818,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1055
+      "newOrder": 1083
     },
     {
       "cefr": "A1",
@@ -13470,7 +13831,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1056
+      "newOrder": 1084
     },
     {
       "cefr": "A1",
@@ -13483,7 +13844,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1057
+      "newOrder": 1085
     },
     {
       "cefr": "A1",
@@ -13496,7 +13857,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1058
+      "newOrder": 1086
     },
     {
       "cefr": "A1",
@@ -13509,7 +13870,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1059
+      "newOrder": 1087
     },
     {
       "cefr": "A1",
@@ -13522,7 +13883,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1060
+      "newOrder": 1088
     },
     {
       "cefr": "A1",
@@ -13535,7 +13896,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1061
+      "newOrder": 1089
     },
     {
       "cefr": "A1",
@@ -13548,7 +13909,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1062
+      "newOrder": 1090
     },
     {
       "cefr": "A1",
@@ -13561,7 +13922,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1063
+      "newOrder": 1091
     },
     {
       "cefr": "A1",
@@ -13574,7 +13935,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1064
+      "newOrder": 1092
     },
     {
       "cefr": "A1",
@@ -13587,7 +13948,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1065
+      "newOrder": 1093
     },
     {
       "cefr": "A1",
@@ -13600,7 +13961,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1066
+      "newOrder": 1094
     },
     {
       "cefr": "A1",
@@ -13613,7 +13974,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1067
+      "newOrder": 1095
     },
     {
       "cefr": "A1",
@@ -13626,7 +13987,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1068
+      "newOrder": 1096
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "денний",
+      "lemmaId": "денний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1097
     },
     {
       "cefr": "A1",
@@ -13639,7 +14013,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1069
+      "newOrder": 1098
     },
     {
       "cefr": "A1",
@@ -13652,7 +14026,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1070
+      "newOrder": 1099
     },
     {
       "cefr": "A1",
@@ -13663,7 +14037,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 1071
+      "newOrder": 1100
     },
     {
       "cefr": "A1",
@@ -13674,7 +14048,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 1072
+      "newOrder": 1101
     },
     {
       "cefr": "A1",
@@ -13687,7 +14061,85 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1073
+      "newOrder": 1102
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "акт",
+      "lemmaId": "акт",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1103
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "вилучено",
+      "lemmaId": "вилучено",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1104
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "зареєстровано",
+      "lemmaId": "зареєстровано",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1105
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "затримано",
+      "lemmaId": "затримано",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1106
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "зафіксовано",
+      "lemmaId": "зафіксовано",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1107
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "передано",
+      "lemmaId": "передано",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1108
     },
     {
       "cefr": "A1",
@@ -13700,70 +14152,111 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1074
+      "newOrder": 1109
     },
     {
       "cefr": "A1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "здійснювати",
-      "lemmaId": "здійснювати",
+      "lemma": "витрати",
+      "lemmaId": "витрати",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 1075
+      "newOrder": 1110
     },
     {
       "cefr": "A1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "визволення",
-      "lemmaId": "визволення",
+      "lemma": "дохід",
+      "lemmaId": "дохід",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 1076
+      "newOrder": 1111
     },
     {
       "cefr": "A1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "полон",
-      "lemmaId": "полон",
+      "lemma": "законопроєкт",
+      "lemmaId": "законопроєкт",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 1077
+      "newOrder": 1112
     },
     {
       "cefr": "A1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "активний",
-      "lemmaId": "активний",
+      "lemma": "позов",
+      "lemmaId": "позов",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 1078
+      "newOrder": 1113
     },
     {
       "cefr": "A1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "алфавіт",
-      "lemmaId": "алфавіт",
+      "lemma": "фінансування",
+      "lemmaId": "фінансування",
       "modes": [
-        "flashcards"
+        "flashcards",
+        "matching",
+        "choice"
       ],
-      "newOrder": 1079
+      "newOrder": 1114
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "цілісність",
+      "lemmaId": "цілісність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1115
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "клієнт",
+      "lemmaId": "клієнт",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1116
+    },
+    {
+      "cefr": "A1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "сервіс",
+      "lemmaId": "сервіс",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1117
     },
     {
       "cefr": "A1",
@@ -13776,420 +14269,95 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1080
+      "newOrder": 1118
     },
     {
       "cefr": "A1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "багатий",
-      "lemmaId": "багатий",
+      "lemma": "потік",
+      "lemmaId": "потік",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 1081
+      "newOrder": 1119
     },
     {
       "cefr": "A1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "без",
-      "lemmaId": "без",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1082
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "більше",
-      "lemmaId": "більше",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1083
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "ваза",
-      "lemmaId": "ваза",
+      "lemma": "вилучення",
+      "lemmaId": "вилучення",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 1084
+      "newOrder": 1120
     },
     {
       "cefr": "A1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "ванна",
-      "lemmaId": "ванна",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1085
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "ванний",
-      "lemmaId": "ванний",
+      "lemma": "договір",
+      "lemmaId": "договір",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 1086
+      "newOrder": 1121
     },
     {
       "cefr": "A1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "весело",
-      "lemmaId": "весело",
+      "lemma": "сприйняття",
+      "lemmaId": "сприйняття",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 1087
+      "newOrder": 1122
     },
     {
       "cefr": "A1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "взуття",
-      "lemmaId": "взуття",
+      "lemma": "відповідність",
+      "lemmaId": "відповідність",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 1088
+      "newOrder": 1123
     },
     {
       "cefr": "A1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "водій",
-      "lemmaId": "водій",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1089
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "волосся",
-      "lemmaId": "волосся",
+      "lemma": "здійснюється",
+      "lemmaId": "здійснюється",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 1090
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вперед",
-      "lemmaId": "вперед",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1091
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "встати",
-      "lemmaId": "встати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1092
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "відео",
-      "lemmaId": "відео",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1093
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вісімнадцятий",
-      "lemmaId": "вісімнадцятий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1094
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вісімсот",
-      "lemmaId": "вісімсот",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1095
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "газета",
-      "lemmaId": "газета",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1096
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "гамбургер",
-      "lemmaId": "гамбургер",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1097
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "горіх",
-      "lemmaId": "горіх",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1098
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "гостя",
-      "lemmaId": "гостя",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1099
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "гра",
-      "lemmaId": "гра",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1100
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "група",
-      "lemmaId": "група",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1101
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "гітара",
-      "lemmaId": "гітара",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1102
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "давати",
-      "lemmaId": "давати",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1103
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "давно",
-      "lemmaId": "давно",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1104
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "двадцятий",
-      "lemmaId": "двадцятий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1105
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "добрий",
-      "lemmaId": "добрий",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1106
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "довгий",
-      "lemmaId": "довгий",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1107
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "долар",
-      "lemmaId": "долар",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1108
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "дошка",
-      "lemmaId": "дошка",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1109
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "дуже",
-      "lemmaId": "дуже",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1110
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "душ",
-      "lemmaId": "душ",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1111
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "дівчина",
-      "lemmaId": "дівчина",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1112
-    },
-    {
-      "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "дівчинка",
-      "lemmaId": "дівчинка",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1113
+      "newOrder": 1124
     }
   ],
   "level": "A1",
   "schema": "atlas-practice-index",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 17099,
+    "gzipBytes": 17333,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 280888,
+    "rawBytes": 284475,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/public/lexicon/practice-index.A2.json
+++ b/site/public/lexicon/practice-index.A2.json
@@ -3,9 +3,9 @@
     "cloze": 0,
     "clozeCoverage": 0.0,
     "clozeEligibleLexemes": 0,
-    "lexemes": 1082
+    "lexemes": 962
   },
-  "deckVersion": "atlas-practice-v1-9cf4a4d7319d19ce",
+  "deckVersion": "atlas-practice-v1-c5a52e54cdf8d828",
   "items": [
     {
       "cefr": "A2",
@@ -37,19 +37,6 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "Карпати",
-      "lemmaId": "карпати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 2
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
       "lemma": "круасан",
       "lemmaId": "круасан",
       "modes": [
@@ -57,7 +44,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 3
+      "newOrder": 2
     },
     {
       "cefr": "A2",
@@ -70,7 +57,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 4
+      "newOrder": 3
     },
     {
       "cefr": "A2",
@@ -83,7 +70,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 5
+      "newOrder": 4
     },
     {
       "cefr": "A2",
@@ -96,7 +83,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 6
+      "newOrder": 5
     },
     {
       "cefr": "A2",
@@ -109,7 +96,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 7
+      "newOrder": 6
     },
     {
       "cefr": "A2",
@@ -122,7 +109,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 8
+      "newOrder": 7
     },
     {
       "cefr": "A2",
@@ -135,7 +122,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 9
+      "newOrder": 8
     },
     {
       "cefr": "A2",
@@ -148,7 +135,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 10
+      "newOrder": 9
     },
     {
       "cefr": "A2",
@@ -161,7 +148,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 11
+      "newOrder": 10
     },
     {
       "cefr": "A2",
@@ -174,7 +161,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 12
+      "newOrder": 11
     },
     {
       "cefr": "A2",
@@ -187,7 +174,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 13
+      "newOrder": 12
     },
     {
       "cefr": "A2",
@@ -195,6 +182,19 @@
       "hasCloze": false,
       "lemma": "праворуч",
       "lemmaId": "праворуч",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 13
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "гостре",
+      "lemmaId": "гостре",
       "modes": [
         "flashcards",
         "matching",
@@ -466,8 +466,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "ринок",
-      "lemmaId": "ринок",
+      "lemma": "підсумок",
+      "lemmaId": "підсумок",
       "modes": [
         "flashcards",
         "matching",
@@ -479,12 +479,25 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
+      "lemma": "ринок",
+      "lemmaId": "ринок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 36
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
       "lemma": "сало",
       "lemmaId": "сало",
       "modes": [
         "flashcards"
       ],
-      "newOrder": 36
+      "newOrder": 37
     },
     {
       "cefr": "A2",
@@ -495,7 +508,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 37
+      "newOrder": 38
     },
     {
       "cefr": "A2",
@@ -508,7 +521,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 38
+      "newOrder": 39
     },
     {
       "cefr": "A2",
@@ -521,7 +534,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 39
+      "newOrder": 40
     },
     {
       "cefr": "A2",
@@ -531,19 +544,6 @@
       "lemmaId": "намисто",
       "modes": [
         "flashcards"
-      ],
-      "newOrder": 40
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "червоні",
-      "lemmaId": "червоні",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
       ],
       "newOrder": 41
     },
@@ -720,6 +720,19 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
+      "lemma": "п'ятниця",
+      "lemmaId": "п-ятниця",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 55
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
       "lemma": "викликати",
       "lemmaId": "викликати",
       "modes": [
@@ -727,7 +740,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 55
+      "newOrder": 56
     },
     {
       "cefr": "A2",
@@ -740,7 +753,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 56
+      "newOrder": 57
     },
     {
       "cefr": "A2",
@@ -753,7 +766,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 57
+      "newOrder": 58
     },
     {
       "cefr": "A2",
@@ -766,7 +779,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 58
+      "newOrder": 59
     },
     {
       "cefr": "A2",
@@ -779,7 +792,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 59
+      "newOrder": 60
     },
     {
       "cefr": "A2",
@@ -792,7 +805,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 60
+      "newOrder": 61
     },
     {
       "cefr": "A2",
@@ -805,7 +818,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 61
+      "newOrder": 62
     },
     {
       "cefr": "A2",
@@ -818,7 +831,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 62
+      "newOrder": 63
     },
     {
       "cefr": "A2",
@@ -831,7 +844,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 63
+      "newOrder": 64
     },
     {
       "cefr": "A2",
@@ -844,7 +857,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 64
+      "newOrder": 65
     },
     {
       "cefr": "A2",
@@ -857,7 +870,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 65
+      "newOrder": 66
     },
     {
       "cefr": "A2",
@@ -870,7 +883,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 66
+      "newOrder": 67
     },
     {
       "cefr": "A2",
@@ -883,7 +896,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 67
+      "newOrder": 68
     },
     {
       "cefr": "A2",
@@ -894,7 +907,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 68
+      "newOrder": 69
     },
     {
       "cefr": "A2",
@@ -907,7 +920,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 69
+      "newOrder": 70
     },
     {
       "cefr": "A2",
@@ -920,7 +933,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 70
+      "newOrder": 71
     },
     {
       "cefr": "A2",
@@ -933,7 +946,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 71
+      "newOrder": 72
     },
     {
       "cefr": "A2",
@@ -946,7 +959,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 72
+      "newOrder": 73
     },
     {
       "cefr": "A2",
@@ -959,7 +972,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 73
+      "newOrder": 74
     },
     {
       "cefr": "A2",
@@ -972,7 +985,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 74
+      "newOrder": 75
     },
     {
       "cefr": "A2",
@@ -985,7 +998,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 75
+      "newOrder": 76
     },
     {
       "cefr": "A2",
@@ -998,7 +1011,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 76
+      "newOrder": 77
     },
     {
       "cefr": "A2",
@@ -1011,7 +1024,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 77
+      "newOrder": 78
     },
     {
       "cefr": "A2",
@@ -1024,7 +1037,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 78
+      "newOrder": 79
     },
     {
       "cefr": "A2",
@@ -1037,7 +1050,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 79
+      "newOrder": 80
     },
     {
       "cefr": "A2",
@@ -1050,7 +1063,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 80
+      "newOrder": 81
     },
     {
       "cefr": "A2",
@@ -1063,7 +1076,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 81
+      "newOrder": 82
     },
     {
       "cefr": "A2",
@@ -1076,7 +1089,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 82
+      "newOrder": 83
     },
     {
       "cefr": "A2",
@@ -1089,7 +1102,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 83
+      "newOrder": 84
     },
     {
       "cefr": "A2",
@@ -1102,7 +1115,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 84
+      "newOrder": 85
     },
     {
       "cefr": "A2",
@@ -1113,7 +1126,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 85
+      "newOrder": 86
     },
     {
       "cefr": "A2",
@@ -1126,7 +1139,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 86
+      "newOrder": 87
     },
     {
       "cefr": "A2",
@@ -1139,7 +1152,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 87
+      "newOrder": 88
     },
     {
       "cefr": "A2",
@@ -1152,7 +1165,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 88
+      "newOrder": 89
     },
     {
       "cefr": "A2",
@@ -1165,7 +1178,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 89
+      "newOrder": 90
     },
     {
       "cefr": "A2",
@@ -1178,7 +1191,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 90
+      "newOrder": 91
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "дев'яносто",
+      "lemmaId": "дев-яносто",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 92
     },
     {
       "cefr": "A2",
@@ -1191,20 +1217,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 91
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "п'ятдесят",
-      "lemmaId": "п-ятдесят",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 92
+      "newOrder": 93
     },
     {
       "cefr": "A2",
@@ -1217,7 +1230,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 93
+      "newOrder": 94
     },
     {
       "cefr": "A2",
@@ -1230,7 +1243,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 94
+      "newOrder": 95
     },
     {
       "cefr": "A2",
@@ -1243,7 +1256,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 95
+      "newOrder": 96
     },
     {
       "cefr": "A2",
@@ -1256,7 +1269,18 @@
         "matching",
         "choice"
       ],
-      "newOrder": 96
+      "newOrder": 97
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "маслом",
+      "lemmaId": "маслом",
+      "modes": [
+        "flashcards"
+      ],
+      "newOrder": 98
     },
     {
       "cefr": "A2",
@@ -1269,7 +1293,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 97
+      "newOrder": 99
     },
     {
       "cefr": "A2",
@@ -1282,7 +1306,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 98
+      "newOrder": 100
     },
     {
       "cefr": "A2",
@@ -1293,7 +1317,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 99
+      "newOrder": 101
     },
     {
       "cefr": "A2",
@@ -1306,20 +1330,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 100
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "маленькі",
-      "lemmaId": "маленькі",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 101
+      "newOrder": 102
     },
     {
       "cefr": "A2",
@@ -1332,7 +1343,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 102
+      "newOrder": 103
     },
     {
       "cefr": "A2",
@@ -1345,7 +1356,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 103
+      "newOrder": 104
     },
     {
       "cefr": "A2",
@@ -1358,7 +1369,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 104
+      "newOrder": 105
     },
     {
       "cefr": "A2",
@@ -1369,7 +1380,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 105
+      "newOrder": 106
     },
     {
       "cefr": "A2",
@@ -1382,7 +1393,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 106
+      "newOrder": 107
     },
     {
       "cefr": "A2",
@@ -1395,7 +1406,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 107
+      "newOrder": 108
     },
     {
       "cefr": "A2",
@@ -1408,7 +1419,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 108
+      "newOrder": 109
     },
     {
       "cefr": "A2",
@@ -1421,7 +1432,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 109
+      "newOrder": 110
     },
     {
       "cefr": "A2",
@@ -1434,7 +1445,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 110
+      "newOrder": 111
     },
     {
       "cefr": "A2",
@@ -1447,7 +1458,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 111
+      "newOrder": 112
     },
     {
       "cefr": "A2",
@@ -1460,7 +1471,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 112
+      "newOrder": 113
     },
     {
       "cefr": "A2",
@@ -1473,7 +1484,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 113
+      "newOrder": 114
     },
     {
       "cefr": "A2",
@@ -1484,7 +1495,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 114
+      "newOrder": 115
     },
     {
       "cefr": "A2",
@@ -1497,7 +1508,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 115
+      "newOrder": 116
     },
     {
       "cefr": "A2",
@@ -1510,7 +1521,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 116
+      "newOrder": 117
     },
     {
       "cefr": "A2",
@@ -1523,7 +1534,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 117
+      "newOrder": 118
     },
     {
       "cefr": "A2",
@@ -1536,7 +1547,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 118
+      "newOrder": 119
     },
     {
       "cefr": "A2",
@@ -1549,7 +1560,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 119
+      "newOrder": 120
     },
     {
       "cefr": "A2",
@@ -1562,7 +1573,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 120
+      "newOrder": 121
     },
     {
       "cefr": "A2",
@@ -1570,19 +1581,6 @@
       "hasCloze": false,
       "lemma": "істота",
       "lemmaId": "істота",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 121
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "м'яч",
-      "lemmaId": "м-яч",
       "modes": [
         "flashcards",
         "matching",
@@ -1633,8 +1631,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "столиця",
-      "lemmaId": "столиця",
+      "lemma": "абетка",
+      "lemmaId": "абетка",
       "modes": [
         "flashcards",
         "matching",
@@ -1711,8 +1709,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "наголос",
-      "lemmaId": "наголос",
+      "lemma": "літера",
+      "lemmaId": "літера",
       "modes": [
         "flashcards",
         "matching",
@@ -1989,8 +1987,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "вчить",
-      "lemmaId": "вчить",
+      "lemma": "вчать",
+      "lemmaId": "вчать",
       "modes": [
         "flashcards",
         "matching",
@@ -2002,10 +2000,12 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "говорите",
-      "lemmaId": "говорите",
+      "lemma": "вчить",
+      "lemmaId": "вчить",
       "modes": [
-        "flashcards"
+        "flashcards",
+        "matching",
+        "choice"
       ],
       "newOrder": 155
     },
@@ -2013,12 +2013,10 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "просимо",
-      "lemmaId": "просимо",
+      "lemma": "говорите",
+      "lemmaId": "говорите",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
       "newOrder": 156
     },
@@ -2258,8 +2256,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "Канада",
-      "lemmaId": "канада",
+      "lemma": "киянин",
+      "lemmaId": "киянин",
       "modes": [
         "flashcards",
         "matching",
@@ -2826,6 +2824,17 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
+      "lemma": "вітаємо",
+      "lemmaId": "вітаємо",
+      "modes": [
+        "flashcards"
+      ],
+      "newOrder": 219
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
       "lemma": "маршрут",
       "lemmaId": "маршрут",
       "modes": [
@@ -2833,7 +2842,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 219
+      "newOrder": 220
     },
     {
       "cefr": "A2",
@@ -2846,7 +2855,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 220
+      "newOrder": 221
     },
     {
       "cefr": "A2",
@@ -2859,7 +2868,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 221
+      "newOrder": 222
     },
     {
       "cefr": "A2",
@@ -2872,7 +2881,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 222
+      "newOrder": 223
     },
     {
       "cefr": "A2",
@@ -2885,7 +2894,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 223
+      "newOrder": 224
     },
     {
       "cefr": "A2",
@@ -2898,7 +2907,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 224
+      "newOrder": 225
     },
     {
       "cefr": "A2",
@@ -2911,7 +2920,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 225
+      "newOrder": 226
     },
     {
       "cefr": "A2",
@@ -2924,7 +2933,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 226
+      "newOrder": 227
     },
     {
       "cefr": "A2",
@@ -2937,7 +2946,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 227
+      "newOrder": 228
     },
     {
       "cefr": "A2",
@@ -2950,7 +2959,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 228
+      "newOrder": 229
     },
     {
       "cefr": "A2",
@@ -2963,7 +2972,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 229
+      "newOrder": 230
     },
     {
       "cefr": "A2",
@@ -2974,7 +2983,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 230
+      "newOrder": 231
     },
     {
       "cefr": "A2",
@@ -2987,7 +2996,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 231
+      "newOrder": 232
     },
     {
       "cefr": "A2",
@@ -3000,7 +3009,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 232
+      "newOrder": 233
     },
     {
       "cefr": "A2",
@@ -3013,7 +3022,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 233
+      "newOrder": 234
     },
     {
       "cefr": "A2",
@@ -3026,7 +3035,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 234
+      "newOrder": 235
     },
     {
       "cefr": "A2",
@@ -3039,7 +3048,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 235
+      "newOrder": 236
     },
     {
       "cefr": "A2",
@@ -3052,7 +3061,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 236
+      "newOrder": 237
     },
     {
       "cefr": "A2",
@@ -3065,7 +3074,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 237
+      "newOrder": 238
     },
     {
       "cefr": "A2",
@@ -3078,7 +3087,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 238
+      "newOrder": 239
     },
     {
       "cefr": "A2",
@@ -3091,7 +3100,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 239
+      "newOrder": 240
     },
     {
       "cefr": "A2",
@@ -3104,7 +3113,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 240
+      "newOrder": 241
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "базовий",
+      "lemmaId": "базовий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 242
     },
     {
       "cefr": "A2",
@@ -3117,7 +3139,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 241
+      "newOrder": 243
     },
     {
       "cefr": "A2",
@@ -3130,7 +3152,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 242
+      "newOrder": 244
     },
     {
       "cefr": "A2",
@@ -3143,7 +3165,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 243
+      "newOrder": 245
     },
     {
       "cefr": "A2",
@@ -3156,7 +3178,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 244
+      "newOrder": 246
     },
     {
       "cefr": "A2",
@@ -3169,7 +3191,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 245
+      "newOrder": 247
     },
     {
       "cefr": "A2",
@@ -3182,7 +3204,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 246
+      "newOrder": 248
     },
     {
       "cefr": "A2",
@@ -3195,7 +3217,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 247
+      "newOrder": 249
     },
     {
       "cefr": "A2",
@@ -3208,7 +3230,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 248
+      "newOrder": 250
     },
     {
       "cefr": "A2",
@@ -3221,7 +3243,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 249
+      "newOrder": 251
     },
     {
       "cefr": "A2",
@@ -3234,7 +3256,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 250
+      "newOrder": 252
     },
     {
       "cefr": "A2",
@@ -3247,7 +3269,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 251
+      "newOrder": 253
     },
     {
       "cefr": "A2",
@@ -3260,7 +3282,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 252
+      "newOrder": 254
     },
     {
       "cefr": "A2",
@@ -3273,7 +3295,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 253
+      "newOrder": 255
     },
     {
       "cefr": "A2",
@@ -3286,7 +3308,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 254
+      "newOrder": 256
     },
     {
       "cefr": "A2",
@@ -3299,7 +3321,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 255
+      "newOrder": 257
     },
     {
       "cefr": "A2",
@@ -3312,7 +3334,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 256
+      "newOrder": 258
     },
     {
       "cefr": "A2",
@@ -3325,7 +3347,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 257
+      "newOrder": 259
     },
     {
       "cefr": "A2",
@@ -3338,7 +3360,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 258
+      "newOrder": 260
     },
     {
       "cefr": "A2",
@@ -3351,7 +3373,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 259
+      "newOrder": 261
     },
     {
       "cefr": "A2",
@@ -3364,7 +3386,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 260
+      "newOrder": 262
     },
     {
       "cefr": "A2",
@@ -3377,7 +3399,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 261
+      "newOrder": 263
     },
     {
       "cefr": "A2",
@@ -3390,7 +3412,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 262
+      "newOrder": 264
     },
     {
       "cefr": "A2",
@@ -3403,7 +3425,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 263
+      "newOrder": 265
     },
     {
       "cefr": "A2",
@@ -3416,7 +3438,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 264
+      "newOrder": 266
     },
     {
       "cefr": "A2",
@@ -3429,7 +3451,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 265
+      "newOrder": 267
     },
     {
       "cefr": "A2",
@@ -3442,7 +3464,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 266
+      "newOrder": 268
     },
     {
       "cefr": "A2",
@@ -3455,7 +3477,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 267
+      "newOrder": 269
     },
     {
       "cefr": "A2",
@@ -3468,7 +3490,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 268
+      "newOrder": 270
     },
     {
       "cefr": "A2",
@@ -3481,7 +3503,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 269
+      "newOrder": 271
     },
     {
       "cefr": "A2",
@@ -3494,7 +3516,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 270
+      "newOrder": 272
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "впізнати",
+      "lemmaId": "впізнати",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 273
     },
     {
       "cefr": "A2",
@@ -3507,7 +3542,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 271
+      "newOrder": 274
     },
     {
       "cefr": "A2",
@@ -3520,7 +3555,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 272
+      "newOrder": 275
     },
     {
       "cefr": "A2",
@@ -3533,7 +3568,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 273
+      "newOrder": 276
     },
     {
       "cefr": "A2",
@@ -3546,7 +3581,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 274
+      "newOrder": 277
     },
     {
       "cefr": "A2",
@@ -3559,7 +3594,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 275
+      "newOrder": 278
     },
     {
       "cefr": "A2",
@@ -3572,7 +3607,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 276
+      "newOrder": 279
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "означення",
+      "lemmaId": "означення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 280
     },
     {
       "cefr": "A2",
@@ -3585,7 +3633,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 277
+      "newOrder": 281
     },
     {
       "cefr": "A2",
@@ -3598,7 +3646,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 278
+      "newOrder": 282
     },
     {
       "cefr": "A2",
@@ -3611,7 +3659,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 279
+      "newOrder": 283
     },
     {
       "cefr": "A2",
@@ -3624,7 +3672,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 280
+      "newOrder": 284
     },
     {
       "cefr": "A2",
@@ -3637,7 +3685,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 281
+      "newOrder": 285
     },
     {
       "cefr": "A2",
@@ -3650,7 +3698,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 282
+      "newOrder": 286
     },
     {
       "cefr": "A2",
@@ -3663,7 +3711,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 283
+      "newOrder": 287
     },
     {
       "cefr": "A2",
@@ -3676,7 +3724,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 284
+      "newOrder": 288
     },
     {
       "cefr": "A2",
@@ -3689,7 +3737,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 285
+      "newOrder": 289
     },
     {
       "cefr": "A2",
@@ -3702,7 +3750,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 286
+      "newOrder": 290
     },
     {
       "cefr": "A2",
@@ -3715,7 +3763,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 287
+      "newOrder": 291
     },
     {
       "cefr": "A2",
@@ -3728,7 +3776,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 288
+      "newOrder": 292
     },
     {
       "cefr": "A2",
@@ -3741,7 +3789,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 289
+      "newOrder": 293
     },
     {
       "cefr": "A2",
@@ -3754,7 +3802,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 290
+      "newOrder": 294
     },
     {
       "cefr": "A2",
@@ -3767,7 +3815,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 291
+      "newOrder": 295
     },
     {
       "cefr": "A2",
@@ -3780,7 +3828,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 292
+      "newOrder": 296
     },
     {
       "cefr": "A2",
@@ -3793,7 +3841,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 293
+      "newOrder": 297
     },
     {
       "cefr": "A2",
@@ -3806,7 +3854,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 294
+      "newOrder": 298
     },
     {
       "cefr": "A2",
@@ -3819,7 +3867,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 295
+      "newOrder": 299
     },
     {
       "cefr": "A2",
@@ -3832,7 +3880,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 296
+      "newOrder": 300
     },
     {
       "cefr": "A2",
@@ -3845,7 +3893,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 297
+      "newOrder": 301
     },
     {
       "cefr": "A2",
@@ -3858,7 +3906,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 298
+      "newOrder": 302
     },
     {
       "cefr": "A2",
@@ -3871,7 +3919,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 299
+      "newOrder": 303
     },
     {
       "cefr": "A2",
@@ -3884,7 +3932,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 300
+      "newOrder": 304
     },
     {
       "cefr": "A2",
@@ -3897,7 +3945,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 301
+      "newOrder": 305
     },
     {
       "cefr": "A2",
@@ -3910,7 +3958,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 302
+      "newOrder": 306
     },
     {
       "cefr": "A2",
@@ -3923,7 +3971,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 303
+      "newOrder": 307
     },
     {
       "cefr": "A2",
@@ -3936,7 +3984,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 304
+      "newOrder": 308
     },
     {
       "cefr": "A2",
@@ -3949,7 +3997,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 305
+      "newOrder": 309
     },
     {
       "cefr": "A2",
@@ -3962,7 +4010,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 306
+      "newOrder": 310
     },
     {
       "cefr": "A2",
@@ -3975,7 +4023,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 307
+      "newOrder": 311
     },
     {
       "cefr": "A2",
@@ -3988,7 +4036,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 308
+      "newOrder": 312
     },
     {
       "cefr": "A2",
@@ -4001,20 +4049,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 309
+      "newOrder": 313
     },
     {
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "вживати",
-      "lemmaId": "вживати",
+      "lemma": "пауза",
+      "lemmaId": "пауза",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 310
+      "newOrder": 314
     },
     {
       "cefr": "A2",
@@ -4027,7 +4075,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 311
+      "newOrder": 315
     },
     {
       "cefr": "A2",
@@ -4040,7 +4088,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 312
+      "newOrder": 316
     },
     {
       "cefr": "A2",
@@ -4053,7 +4101,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 313
+      "newOrder": 317
     },
     {
       "cefr": "A2",
@@ -4066,7 +4114,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 314
+      "newOrder": 318
     },
     {
       "cefr": "A2",
@@ -4079,7 +4127,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 315
+      "newOrder": 319
     },
     {
       "cefr": "A2",
@@ -4092,7 +4140,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 316
+      "newOrder": 320
     },
     {
       "cefr": "A2",
@@ -4105,7 +4153,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 317
+      "newOrder": 321
     },
     {
       "cefr": "A2",
@@ -4118,7 +4166,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 318
+      "newOrder": 322
     },
     {
       "cefr": "A2",
@@ -4131,7 +4179,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 319
+      "newOrder": 323
     },
     {
       "cefr": "A2",
@@ -4144,7 +4192,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 320
+      "newOrder": 324
     },
     {
       "cefr": "A2",
@@ -4157,7 +4205,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 321
+      "newOrder": 325
     },
     {
       "cefr": "A2",
@@ -4170,7 +4218,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 322
+      "newOrder": 326
     },
     {
       "cefr": "A2",
@@ -4183,7 +4231,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 323
+      "newOrder": 327
     },
     {
       "cefr": "A2",
@@ -4196,7 +4244,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 324
+      "newOrder": 328
     },
     {
       "cefr": "A2",
@@ -4209,7 +4257,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 325
+      "newOrder": 329
     },
     {
       "cefr": "A2",
@@ -4222,7 +4270,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 326
+      "newOrder": 330
     },
     {
       "cefr": "A2",
@@ -4235,7 +4283,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 327
+      "newOrder": 331
     },
     {
       "cefr": "A2",
@@ -4248,7 +4296,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 328
+      "newOrder": 332
     },
     {
       "cefr": "A2",
@@ -4261,7 +4309,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 329
+      "newOrder": 333
     },
     {
       "cefr": "A2",
@@ -4274,7 +4322,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 330
+      "newOrder": 334
     },
     {
       "cefr": "A2",
@@ -4287,7 +4335,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 331
+      "newOrder": 335
     },
     {
       "cefr": "A2",
@@ -4300,20 +4348,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 332
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "сумнів",
-      "lemmaId": "сумнів",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 333
+      "newOrder": 336
     },
     {
       "cefr": "A2",
@@ -4326,7 +4361,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 334
+      "newOrder": 337
     },
     {
       "cefr": "A2",
@@ -4337,7 +4372,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 335
+      "newOrder": 338
     },
     {
       "cefr": "A2",
@@ -4350,7 +4385,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 336
+      "newOrder": 339
     },
     {
       "cefr": "A2",
@@ -4363,7 +4398,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 337
+      "newOrder": 340
     },
     {
       "cefr": "A2",
@@ -4376,7 +4411,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 338
+      "newOrder": 341
     },
     {
       "cefr": "A2",
@@ -4389,7 +4424,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 339
+      "newOrder": 342
     },
     {
       "cefr": "A2",
@@ -4402,7 +4437,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 340
+      "newOrder": 343
     },
     {
       "cefr": "A2",
@@ -4415,7 +4450,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 341
+      "newOrder": 344
     },
     {
       "cefr": "A2",
@@ -4428,7 +4463,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 342
+      "newOrder": 345
     },
     {
       "cefr": "A2",
@@ -4441,7 +4476,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 343
+      "newOrder": 346
     },
     {
       "cefr": "A2",
@@ -4454,7 +4489,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 344
+      "newOrder": 347
     },
     {
       "cefr": "A2",
@@ -4467,7 +4502,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 345
+      "newOrder": 348
     },
     {
       "cefr": "A2",
@@ -4480,7 +4515,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 346
+      "newOrder": 349
     },
     {
       "cefr": "A2",
@@ -4493,7 +4528,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 347
+      "newOrder": 350
     },
     {
       "cefr": "A2",
@@ -4504,7 +4539,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 348
+      "newOrder": 351
     },
     {
       "cefr": "A2",
@@ -4517,7 +4552,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 349
+      "newOrder": 352
     },
     {
       "cefr": "A2",
@@ -4528,7 +4563,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 350
+      "newOrder": 353
     },
     {
       "cefr": "A2",
@@ -4539,7 +4574,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 351
+      "newOrder": 354
     },
     {
       "cefr": "A2",
@@ -4552,7 +4587,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 352
+      "newOrder": 355
     },
     {
       "cefr": "A2",
@@ -4565,7 +4600,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 353
+      "newOrder": 356
     },
     {
       "cefr": "A2",
@@ -4578,7 +4613,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 354
+      "newOrder": 357
     },
     {
       "cefr": "A2",
@@ -4591,7 +4626,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 355
+      "newOrder": 358
     },
     {
       "cefr": "A2",
@@ -4604,7 +4639,18 @@
         "matching",
         "choice"
       ],
-      "newOrder": 356
+      "newOrder": 359
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "ніякий",
+      "lemmaId": "ніякий",
+      "modes": [
+        "flashcards"
+      ],
+      "newOrder": 360
     },
     {
       "cefr": "A2",
@@ -4615,7 +4661,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 357
+      "newOrder": 361
     },
     {
       "cefr": "A2",
@@ -4626,7 +4672,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 358
+      "newOrder": 362
     },
     {
       "cefr": "A2",
@@ -4639,7 +4685,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 359
+      "newOrder": 363
     },
     {
       "cefr": "A2",
@@ -4652,7 +4698,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 360
+      "newOrder": 364
     },
     {
       "cefr": "A2",
@@ -4665,7 +4711,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 361
+      "newOrder": 365
     },
     {
       "cefr": "A2",
@@ -4678,7 +4724,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 362
+      "newOrder": 366
     },
     {
       "cefr": "A2",
@@ -4691,7 +4737,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 363
+      "newOrder": 367
     },
     {
       "cefr": "A2",
@@ -4704,7 +4750,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 364
+      "newOrder": 368
     },
     {
       "cefr": "A2",
@@ -4717,7 +4763,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 365
+      "newOrder": 369
     },
     {
       "cefr": "A2",
@@ -4730,7 +4776,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 366
+      "newOrder": 370
     },
     {
       "cefr": "A2",
@@ -4743,7 +4789,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 367
+      "newOrder": 371
     },
     {
       "cefr": "A2",
@@ -4754,7 +4800,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 368
+      "newOrder": 372
     },
     {
       "cefr": "A2",
@@ -4765,7 +4811,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 369
+      "newOrder": 373
     },
     {
       "cefr": "A2",
@@ -4776,7 +4822,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 370
+      "newOrder": 374
     },
     {
       "cefr": "A2",
@@ -4789,7 +4835,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 371
+      "newOrder": 375
     },
     {
       "cefr": "A2",
@@ -4802,7 +4848,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 372
+      "newOrder": 376
     },
     {
       "cefr": "A2",
@@ -4815,7 +4861,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 373
+      "newOrder": 377
     },
     {
       "cefr": "A2",
@@ -4828,7 +4874,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 374
+      "newOrder": 378
     },
     {
       "cefr": "A2",
@@ -4841,7 +4887,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 375
+      "newOrder": 379
     },
     {
       "cefr": "A2",
@@ -4854,7 +4900,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 376
+      "newOrder": 380
     },
     {
       "cefr": "A2",
@@ -4867,7 +4913,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 377
+      "newOrder": 381
     },
     {
       "cefr": "A2",
@@ -4880,7 +4926,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 378
+      "newOrder": 382
     },
     {
       "cefr": "A2",
@@ -4893,7 +4939,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 379
+      "newOrder": 383
     },
     {
       "cefr": "A2",
@@ -4906,7 +4952,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 380
+      "newOrder": 384
     },
     {
       "cefr": "A2",
@@ -4919,7 +4965,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 381
+      "newOrder": 385
     },
     {
       "cefr": "A2",
@@ -4932,7 +4978,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 382
+      "newOrder": 386
     },
     {
       "cefr": "A2",
@@ -4945,7 +4991,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 383
+      "newOrder": 387
     },
     {
       "cefr": "A2",
@@ -4958,7 +5004,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 384
+      "newOrder": 388
     },
     {
       "cefr": "A2",
@@ -4971,7 +5017,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 385
+      "newOrder": 389
     },
     {
       "cefr": "A2",
@@ -4984,7 +5030,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 386
+      "newOrder": 390
     },
     {
       "cefr": "A2",
@@ -4997,7 +5043,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 387
+      "newOrder": 391
     },
     {
       "cefr": "A2",
@@ -5010,7 +5056,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 388
+      "newOrder": 392
     },
     {
       "cefr": "A2",
@@ -5023,7 +5069,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 389
+      "newOrder": 393
     },
     {
       "cefr": "A2",
@@ -5036,7 +5082,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 390
+      "newOrder": 394
     },
     {
       "cefr": "A2",
@@ -5049,7 +5095,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 391
+      "newOrder": 395
     },
     {
       "cefr": "A2",
@@ -5062,7 +5108,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 392
+      "newOrder": 396
     },
     {
       "cefr": "A2",
@@ -5075,7 +5121,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 393
+      "newOrder": 397
     },
     {
       "cefr": "A2",
@@ -5088,7 +5134,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 394
+      "newOrder": 398
     },
     {
       "cefr": "A2",
@@ -5101,7 +5147,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 395
+      "newOrder": 399
     },
     {
       "cefr": "A2",
@@ -5114,7 +5160,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 396
+      "newOrder": 400
     },
     {
       "cefr": "A2",
@@ -5127,7 +5173,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 397
+      "newOrder": 401
     },
     {
       "cefr": "A2",
@@ -5140,7 +5186,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 398
+      "newOrder": 402
     },
     {
       "cefr": "A2",
@@ -5153,7 +5199,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 399
+      "newOrder": 403
     },
     {
       "cefr": "A2",
@@ -5166,7 +5212,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 400
+      "newOrder": 404
     },
     {
       "cefr": "A2",
@@ -5179,7 +5225,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 401
+      "newOrder": 405
     },
     {
       "cefr": "A2",
@@ -5192,7 +5238,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 402
+      "newOrder": 406
     },
     {
       "cefr": "A2",
@@ -5205,7 +5251,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 403
+      "newOrder": 407
     },
     {
       "cefr": "A2",
@@ -5218,7 +5264,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 404
+      "newOrder": 408
     },
     {
       "cefr": "A2",
@@ -5231,7 +5277,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 405
+      "newOrder": 409
     },
     {
       "cefr": "A2",
@@ -5244,7 +5290,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 406
+      "newOrder": 410
     },
     {
       "cefr": "A2",
@@ -5257,7 +5303,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 407
+      "newOrder": 411
     },
     {
       "cefr": "A2",
@@ -5270,7 +5316,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 408
+      "newOrder": 412
     },
     {
       "cefr": "A2",
@@ -5283,7 +5329,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 409
+      "newOrder": 413
     },
     {
       "cefr": "A2",
@@ -5296,7 +5342,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 410
+      "newOrder": 414
     },
     {
       "cefr": "A2",
@@ -5309,7 +5355,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 411
+      "newOrder": 415
     },
     {
       "cefr": "A2",
@@ -5322,7 +5368,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 412
+      "newOrder": 416
     },
     {
       "cefr": "A2",
@@ -5335,7 +5381,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 413
+      "newOrder": 417
     },
     {
       "cefr": "A2",
@@ -5348,7 +5394,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 414
+      "newOrder": 418
     },
     {
       "cefr": "A2",
@@ -5361,7 +5407,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 415
+      "newOrder": 419
     },
     {
       "cefr": "A2",
@@ -5374,7 +5420,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 416
+      "newOrder": 420
     },
     {
       "cefr": "A2",
@@ -5387,7 +5433,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 417
+      "newOrder": 421
     },
     {
       "cefr": "A2",
@@ -5400,7 +5446,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 418
+      "newOrder": 422
     },
     {
       "cefr": "A2",
@@ -5413,7 +5459,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 419
+      "newOrder": 423
     },
     {
       "cefr": "A2",
@@ -5426,7 +5472,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 420
+      "newOrder": 424
     },
     {
       "cefr": "A2",
@@ -5439,7 +5485,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 421
+      "newOrder": 425
     },
     {
       "cefr": "A2",
@@ -5452,7 +5498,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 422
+      "newOrder": 426
     },
     {
       "cefr": "A2",
@@ -5465,7 +5511,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 423
+      "newOrder": 427
     },
     {
       "cefr": "A2",
@@ -5478,7 +5524,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 424
+      "newOrder": 428
     },
     {
       "cefr": "A2",
@@ -5491,7 +5537,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 425
+      "newOrder": 429
     },
     {
       "cefr": "A2",
@@ -5504,7 +5550,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 426
+      "newOrder": 430
     },
     {
       "cefr": "A2",
@@ -5517,7 +5563,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 427
+      "newOrder": 431
     },
     {
       "cefr": "A2",
@@ -5530,7 +5576,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 428
+      "newOrder": 432
     },
     {
       "cefr": "A2",
@@ -5543,7 +5589,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 429
+      "newOrder": 433
     },
     {
       "cefr": "A2",
@@ -5556,7 +5602,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 430
+      "newOrder": 434
     },
     {
       "cefr": "A2",
@@ -5569,7 +5615,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 431
+      "newOrder": 435
     },
     {
       "cefr": "A2",
@@ -5582,7 +5628,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 432
+      "newOrder": 436
     },
     {
       "cefr": "A2",
@@ -5595,7 +5641,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 433
+      "newOrder": 437
     },
     {
       "cefr": "A2",
@@ -5608,7 +5654,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 434
+      "newOrder": 438
     },
     {
       "cefr": "A2",
@@ -5621,7 +5667,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 435
+      "newOrder": 439
     },
     {
       "cefr": "A2",
@@ -5634,7 +5680,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 436
+      "newOrder": 440
     },
     {
       "cefr": "A2",
@@ -5647,7 +5693,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 437
+      "newOrder": 441
     },
     {
       "cefr": "A2",
@@ -5660,7 +5706,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 438
+      "newOrder": 442
     },
     {
       "cefr": "A2",
@@ -5673,7 +5719,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 439
+      "newOrder": 443
     },
     {
       "cefr": "A2",
@@ -5686,7 +5732,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 440
+      "newOrder": 444
     },
     {
       "cefr": "A2",
@@ -5699,7 +5745,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 441
+      "newOrder": 445
     },
     {
       "cefr": "A2",
@@ -5712,7 +5758,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 442
+      "newOrder": 446
     },
     {
       "cefr": "A2",
@@ -5725,7 +5771,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 443
+      "newOrder": 447
     },
     {
       "cefr": "A2",
@@ -5738,7 +5784,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 444
+      "newOrder": 448
     },
     {
       "cefr": "A2",
@@ -5751,7 +5797,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 445
+      "newOrder": 449
     },
     {
       "cefr": "A2",
@@ -5764,7 +5810,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 446
+      "newOrder": 450
     },
     {
       "cefr": "A2",
@@ -5777,7 +5823,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 447
+      "newOrder": 451
     },
     {
       "cefr": "A2",
@@ -5790,7 +5836,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 448
+      "newOrder": 452
     },
     {
       "cefr": "A2",
@@ -5803,7 +5849,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 449
+      "newOrder": 453
     },
     {
       "cefr": "A2",
@@ -5816,7 +5862,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 450
+      "newOrder": 454
     },
     {
       "cefr": "A2",
@@ -5829,7 +5875,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 451
+      "newOrder": 455
     },
     {
       "cefr": "A2",
@@ -5842,7 +5888,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 452
+      "newOrder": 456
     },
     {
       "cefr": "A2",
@@ -5855,7 +5901,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 453
+      "newOrder": 457
     },
     {
       "cefr": "A2",
@@ -5868,7 +5914,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 454
+      "newOrder": 458
     },
     {
       "cefr": "A2",
@@ -5881,7 +5927,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 455
+      "newOrder": 459
     },
     {
       "cefr": "A2",
@@ -5894,7 +5940,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 456
+      "newOrder": 460
     },
     {
       "cefr": "A2",
@@ -5907,7 +5953,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 457
+      "newOrder": 461
     },
     {
       "cefr": "A2",
@@ -5920,7 +5966,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 458
+      "newOrder": 462
     },
     {
       "cefr": "A2",
@@ -5933,7 +5979,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 459
+      "newOrder": 463
     },
     {
       "cefr": "A2",
@@ -5946,7 +5992,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 460
+      "newOrder": 464
     },
     {
       "cefr": "A2",
@@ -5959,7 +6005,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 461
+      "newOrder": 465
     },
     {
       "cefr": "A2",
@@ -5970,7 +6016,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 462
+      "newOrder": 466
     },
     {
       "cefr": "A2",
@@ -5983,7 +6029,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 463
+      "newOrder": 467
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "знаходитися",
+      "lemmaId": "знаходитися",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 468
     },
     {
       "cefr": "A2",
@@ -5996,7 +6055,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 464
+      "newOrder": 469
     },
     {
       "cefr": "A2",
@@ -6009,7 +6068,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 465
+      "newOrder": 470
     },
     {
       "cefr": "A2",
@@ -6022,7 +6081,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 466
+      "newOrder": 471
     },
     {
       "cefr": "A2",
@@ -6035,7 +6094,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 467
+      "newOrder": 472
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "апетит",
+      "lemmaId": "апетит",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 473
     },
     {
       "cefr": "A2",
@@ -6048,7 +6120,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 468
+      "newOrder": 474
     },
     {
       "cefr": "A2",
@@ -6061,7 +6133,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 469
+      "newOrder": 475
     },
     {
       "cefr": "A2",
@@ -6074,7 +6146,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 470
+      "newOrder": 476
     },
     {
       "cefr": "A2",
@@ -6087,7 +6159,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 471
+      "newOrder": 477
     },
     {
       "cefr": "A2",
@@ -6100,7 +6172,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 472
+      "newOrder": 478
     },
     {
       "cefr": "A2",
@@ -6113,7 +6185,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 473
+      "newOrder": 479
     },
     {
       "cefr": "A2",
@@ -6126,7 +6198,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 474
+      "newOrder": 480
     },
     {
       "cefr": "A2",
@@ -6139,7 +6211,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 475
+      "newOrder": 481
     },
     {
       "cefr": "A2",
@@ -6152,7 +6224,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 476
+      "newOrder": 482
     },
     {
       "cefr": "A2",
@@ -6165,7 +6237,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 477
+      "newOrder": 483
     },
     {
       "cefr": "A2",
@@ -6178,7 +6250,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 478
+      "newOrder": 484
     },
     {
       "cefr": "A2",
@@ -6191,7 +6263,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 479
+      "newOrder": 485
     },
     {
       "cefr": "A2",
@@ -6204,7 +6276,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 480
+      "newOrder": 486
     },
     {
       "cefr": "A2",
@@ -6215,7 +6287,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 481
+      "newOrder": 487
     },
     {
       "cefr": "A2",
@@ -6228,7 +6300,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 482
+      "newOrder": 488
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "гучний",
+      "lemmaId": "гучний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 489
     },
     {
       "cefr": "A2",
@@ -6241,7 +6326,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 483
+      "newOrder": 490
     },
     {
       "cefr": "A2",
@@ -6254,7 +6339,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 484
+      "newOrder": 491
     },
     {
       "cefr": "A2",
@@ -6267,7 +6352,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 485
+      "newOrder": 492
     },
     {
       "cefr": "A2",
@@ -6280,7 +6365,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 486
+      "newOrder": 493
     },
     {
       "cefr": "A2",
@@ -6293,7 +6378,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 487
+      "newOrder": 494
     },
     {
       "cefr": "A2",
@@ -6306,7 +6391,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 488
+      "newOrder": 495
     },
     {
       "cefr": "A2",
@@ -6319,7 +6404,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 489
+      "newOrder": 496
     },
     {
       "cefr": "A2",
@@ -6330,7 +6415,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 490
+      "newOrder": 497
     },
     {
       "cefr": "A2",
@@ -6343,7 +6428,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 491
+      "newOrder": 498
     },
     {
       "cefr": "A2",
@@ -6356,7 +6441,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 492
+      "newOrder": 499
     },
     {
       "cefr": "A2",
@@ -6367,7 +6452,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 493
+      "newOrder": 500
     },
     {
       "cefr": "A2",
@@ -6380,7 +6465,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 494
+      "newOrder": 501
     },
     {
       "cefr": "A2",
@@ -6391,7 +6476,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 495
+      "newOrder": 502
     },
     {
       "cefr": "A2",
@@ -6404,7 +6489,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 496
+      "newOrder": 503
     },
     {
       "cefr": "A2",
@@ -6417,7 +6502,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 497
+      "newOrder": 504
     },
     {
       "cefr": "A2",
@@ -6430,7 +6515,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 498
+      "newOrder": 505
     },
     {
       "cefr": "A2",
@@ -6443,7 +6528,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 499
+      "newOrder": 506
     },
     {
       "cefr": "A2",
@@ -6454,7 +6539,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 500
+      "newOrder": 507
     },
     {
       "cefr": "A2",
@@ -6467,7 +6552,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 501
+      "newOrder": 508
     },
     {
       "cefr": "A2",
@@ -6478,7 +6563,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 502
+      "newOrder": 509
     },
     {
       "cefr": "A2",
@@ -6491,7 +6576,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 503
+      "newOrder": 510
     },
     {
       "cefr": "A2",
@@ -6504,7 +6589,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 504
+      "newOrder": 511
     },
     {
       "cefr": "A2",
@@ -6517,7 +6602,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 505
+      "newOrder": 512
     },
     {
       "cefr": "A2",
@@ -6530,7 +6615,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 506
+      "newOrder": 513
     },
     {
       "cefr": "A2",
@@ -6543,7 +6628,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 507
+      "newOrder": 514
     },
     {
       "cefr": "A2",
@@ -6556,7 +6641,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 508
+      "newOrder": 515
     },
     {
       "cefr": "A2",
@@ -6569,7 +6654,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 509
+      "newOrder": 516
     },
     {
       "cefr": "A2",
@@ -6582,7 +6667,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 510
+      "newOrder": 517
     },
     {
       "cefr": "A2",
@@ -6595,7 +6680,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 511
+      "newOrder": 518
     },
     {
       "cefr": "A2",
@@ -6608,7 +6693,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 512
+      "newOrder": 519
     },
     {
       "cefr": "A2",
@@ -6621,7 +6706,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 513
+      "newOrder": 520
     },
     {
       "cefr": "A2",
@@ -6634,7 +6719,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 514
+      "newOrder": 521
     },
     {
       "cefr": "A2",
@@ -6647,7 +6732,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 515
+      "newOrder": 522
     },
     {
       "cefr": "A2",
@@ -6660,7 +6745,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 516
+      "newOrder": 523
     },
     {
       "cefr": "A2",
@@ -6673,7 +6758,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 517
+      "newOrder": 524
     },
     {
       "cefr": "A2",
@@ -6686,7 +6771,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 518
+      "newOrder": 525
     },
     {
       "cefr": "A2",
@@ -6699,7 +6784,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 519
+      "newOrder": 526
     },
     {
       "cefr": "A2",
@@ -6712,7 +6797,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 520
+      "newOrder": 527
     },
     {
       "cefr": "A2",
@@ -6725,7 +6810,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 521
+      "newOrder": 528
     },
     {
       "cefr": "A2",
@@ -6738,7 +6823,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 522
+      "newOrder": 529
     },
     {
       "cefr": "A2",
@@ -6751,7 +6836,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 523
+      "newOrder": 530
     },
     {
       "cefr": "A2",
@@ -6764,20 +6849,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 524
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "складання",
-      "lemmaId": "складання",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 525
+      "newOrder": 531
     },
     {
       "cefr": "A2",
@@ -6790,7 +6862,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 526
+      "newOrder": 532
     },
     {
       "cefr": "A2",
@@ -6801,7 +6873,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 527
+      "newOrder": 533
     },
     {
       "cefr": "A2",
@@ -6814,7 +6886,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 528
+      "newOrder": 534
     },
     {
       "cefr": "A2",
@@ -6827,7 +6899,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 529
+      "newOrder": 535
     },
     {
       "cefr": "A2",
@@ -6838,7 +6910,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 530
+      "newOrder": 536
     },
     {
       "cefr": "A2",
@@ -6851,7 +6923,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 531
+      "newOrder": 537
     },
     {
       "cefr": "A2",
@@ -6864,7 +6936,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 532
+      "newOrder": 538
     },
     {
       "cefr": "A2",
@@ -6877,7 +6949,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 533
+      "newOrder": 539
     },
     {
       "cefr": "A2",
@@ -6890,7 +6962,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 534
+      "newOrder": 540
     },
     {
       "cefr": "A2",
@@ -6903,20 +6975,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 535
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "припущення",
-      "lemmaId": "припущення",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 536
+      "newOrder": 541
     },
     {
       "cefr": "A2",
@@ -6929,7 +6988,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 537
+      "newOrder": 542
     },
     {
       "cefr": "A2",
@@ -6942,7 +7001,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 538
+      "newOrder": 543
     },
     {
       "cefr": "A2",
@@ -6955,7 +7014,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 539
+      "newOrder": 544
     },
     {
       "cefr": "A2",
@@ -6966,7 +7025,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 540
+      "newOrder": 545
     },
     {
       "cefr": "A2",
@@ -6977,7 +7036,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 541
+      "newOrder": 546
     },
     {
       "cefr": "A2",
@@ -6990,7 +7049,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 542
+      "newOrder": 547
     },
     {
       "cefr": "A2",
@@ -7003,7 +7062,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 543
+      "newOrder": 548
     },
     {
       "cefr": "A2",
@@ -7016,7 +7075,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 544
+      "newOrder": 549
     },
     {
       "cefr": "A2",
@@ -7029,7 +7088,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 545
+      "newOrder": 550
     },
     {
       "cefr": "A2",
@@ -7042,7 +7101,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 546
+      "newOrder": 551
     },
     {
       "cefr": "A2",
@@ -7055,7 +7114,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 547
+      "newOrder": 552
     },
     {
       "cefr": "A2",
@@ -7068,7 +7127,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 548
+      "newOrder": 553
     },
     {
       "cefr": "A2",
@@ -7081,7 +7140,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 549
+      "newOrder": 554
     },
     {
       "cefr": "A2",
@@ -7094,7 +7153,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 550
+      "newOrder": 555
     },
     {
       "cefr": "A2",
@@ -7107,7 +7166,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 551
+      "newOrder": 556
     },
     {
       "cefr": "A2",
@@ -7120,7 +7179,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 552
+      "newOrder": 557
     },
     {
       "cefr": "A2",
@@ -7133,7 +7192,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 553
+      "newOrder": 558
     },
     {
       "cefr": "A2",
@@ -7146,7 +7205,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 554
+      "newOrder": 559
     },
     {
       "cefr": "A2",
@@ -7159,7 +7218,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 555
+      "newOrder": 560
     },
     {
       "cefr": "A2",
@@ -7172,7 +7231,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 556
+      "newOrder": 561
     },
     {
       "cefr": "A2",
@@ -7185,7 +7244,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 557
+      "newOrder": 562
     },
     {
       "cefr": "A2",
@@ -7198,7 +7257,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 558
+      "newOrder": 563
     },
     {
       "cefr": "A2",
@@ -7211,7 +7270,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 559
+      "newOrder": 564
     },
     {
       "cefr": "A2",
@@ -7224,7 +7283,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 560
+      "newOrder": 565
     },
     {
       "cefr": "A2",
@@ -7237,7 +7296,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 561
+      "newOrder": 566
     },
     {
       "cefr": "A2",
@@ -7250,7 +7309,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 562
+      "newOrder": 567
     },
     {
       "cefr": "A2",
@@ -7263,7 +7322,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 563
+      "newOrder": 568
     },
     {
       "cefr": "A2",
@@ -7276,7 +7335,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 564
+      "newOrder": 569
     },
     {
       "cefr": "A2",
@@ -7289,7 +7348,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 565
+      "newOrder": 570
     },
     {
       "cefr": "A2",
@@ -7302,7 +7361,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 566
+      "newOrder": 571
     },
     {
       "cefr": "A2",
@@ -7315,7 +7374,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 567
+      "newOrder": 572
     },
     {
       "cefr": "A2",
@@ -7328,7 +7387,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 568
+      "newOrder": 573
     },
     {
       "cefr": "A2",
@@ -7341,7 +7400,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 569
+      "newOrder": 574
     },
     {
       "cefr": "A2",
@@ -7354,7 +7413,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 570
+      "newOrder": 575
     },
     {
       "cefr": "A2",
@@ -7367,7 +7426,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 571
+      "newOrder": 576
     },
     {
       "cefr": "A2",
@@ -7380,7 +7439,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 572
+      "newOrder": 577
     },
     {
       "cefr": "A2",
@@ -7393,7 +7452,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 573
+      "newOrder": 578
     },
     {
       "cefr": "A2",
@@ -7406,7 +7465,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 574
+      "newOrder": 579
     },
     {
       "cefr": "A2",
@@ -7419,7 +7478,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 575
+      "newOrder": 580
     },
     {
       "cefr": "A2",
@@ -7432,7 +7491,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 576
+      "newOrder": 581
     },
     {
       "cefr": "A2",
@@ -7445,7 +7504,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 577
+      "newOrder": 582
     },
     {
       "cefr": "A2",
@@ -7458,7 +7517,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 578
+      "newOrder": 583
     },
     {
       "cefr": "A2",
@@ -7471,7 +7530,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 579
+      "newOrder": 584
     },
     {
       "cefr": "A2",
@@ -7484,7 +7543,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 580
+      "newOrder": 585
     },
     {
       "cefr": "A2",
@@ -7497,7 +7556,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 581
+      "newOrder": 586
     },
     {
       "cefr": "A2",
@@ -7510,7 +7569,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 582
+      "newOrder": 587
     },
     {
       "cefr": "A2",
@@ -7523,7 +7582,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 583
+      "newOrder": 588
     },
     {
       "cefr": "A2",
@@ -7536,7 +7595,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 584
+      "newOrder": 589
     },
     {
       "cefr": "A2",
@@ -7549,7 +7608,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 585
+      "newOrder": 590
     },
     {
       "cefr": "A2",
@@ -7562,7 +7621,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 586
+      "newOrder": 591
     },
     {
       "cefr": "A2",
@@ -7575,7 +7634,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 587
+      "newOrder": 592
     },
     {
       "cefr": "A2",
@@ -7588,7 +7647,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 588
+      "newOrder": 593
     },
     {
       "cefr": "A2",
@@ -7601,7 +7660,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 589
+      "newOrder": 594
     },
     {
       "cefr": "A2",
@@ -7614,7 +7673,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 590
+      "newOrder": 595
     },
     {
       "cefr": "A2",
@@ -7627,7 +7686,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 591
+      "newOrder": 596
     },
     {
       "cefr": "A2",
@@ -7640,7 +7699,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 592
+      "newOrder": 597
     },
     {
       "cefr": "A2",
@@ -7653,7 +7712,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 593
+      "newOrder": 598
     },
     {
       "cefr": "A2",
@@ -7666,7 +7725,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 594
+      "newOrder": 599
     },
     {
       "cefr": "A2",
@@ -7679,7 +7738,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 595
+      "newOrder": 600
     },
     {
       "cefr": "A2",
@@ -7692,7 +7751,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 596
+      "newOrder": 601
     },
     {
       "cefr": "A2",
@@ -7705,7 +7764,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 597
+      "newOrder": 602
     },
     {
       "cefr": "A2",
@@ -7718,7 +7777,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 598
+      "newOrder": 603
     },
     {
       "cefr": "A2",
@@ -7731,7 +7790,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 599
+      "newOrder": 604
     },
     {
       "cefr": "A2",
@@ -7744,7 +7803,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 600
+      "newOrder": 605
     },
     {
       "cefr": "A2",
@@ -7757,7 +7816,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 601
+      "newOrder": 606
     },
     {
       "cefr": "A2",
@@ -7770,20 +7829,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 602
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "довкілля",
-      "lemmaId": "довкілля",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 603
+      "newOrder": 607
     },
     {
       "cefr": "A2",
@@ -7796,7 +7842,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 604
+      "newOrder": 608
     },
     {
       "cefr": "A2",
@@ -7809,7 +7855,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 605
+      "newOrder": 609
     },
     {
       "cefr": "A2",
@@ -7822,7 +7868,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 606
+      "newOrder": 610
     },
     {
       "cefr": "A2",
@@ -7835,7 +7881,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 607
+      "newOrder": 611
     },
     {
       "cefr": "A2",
@@ -7848,7 +7894,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 608
+      "newOrder": 612
     },
     {
       "cefr": "A2",
@@ -7861,31 +7907,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 609
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "ухвалено",
-      "lemmaId": "ухвалено",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 610
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "всупереч",
-      "lemmaId": "всупереч",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 611
+      "newOrder": 613
     },
     {
       "cefr": "A2",
@@ -7896,7 +7918,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 612
+      "newOrder": 614
     },
     {
       "cefr": "A2",
@@ -7909,7 +7931,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 613
+      "newOrder": 615
     },
     {
       "cefr": "A2",
@@ -7922,7 +7944,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 614
+      "newOrder": 616
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "діапазон",
+      "lemmaId": "діапазон",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 617
     },
     {
       "cefr": "A2",
@@ -7935,7 +7970,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 615
+      "newOrder": 618
     },
     {
       "cefr": "A2",
@@ -7948,20 +7983,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 616
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "перенести",
-      "lemmaId": "перенести",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 617
+      "newOrder": 619
     },
     {
       "cefr": "A2",
@@ -7974,7 +7996,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 618
+      "newOrder": 620
     },
     {
       "cefr": "A2",
@@ -7987,7 +8009,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 619
+      "newOrder": 621
     },
     {
       "cefr": "A2",
@@ -8000,7 +8022,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 620
+      "newOrder": 622
     },
     {
       "cefr": "A2",
@@ -8013,7 +8035,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 621
+      "newOrder": 623
     },
     {
       "cefr": "A2",
@@ -8026,7 +8048,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 622
+      "newOrder": 624
     },
     {
       "cefr": "A2",
@@ -8039,7 +8061,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 623
+      "newOrder": 625
     },
     {
       "cefr": "A2",
@@ -8052,7 +8074,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 624
+      "newOrder": 626
     },
     {
       "cefr": "A2",
@@ -8065,7 +8087,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 625
+      "newOrder": 627
     },
     {
       "cefr": "A2",
@@ -8078,7 +8100,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 626
+      "newOrder": 628
     },
     {
       "cefr": "A2",
@@ -8091,7 +8113,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 627
+      "newOrder": 629
     },
     {
       "cefr": "A2",
@@ -8104,7 +8126,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 628
+      "newOrder": 630
     },
     {
       "cefr": "A2",
@@ -8117,7 +8139,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 629
+      "newOrder": 631
     },
     {
       "cefr": "A2",
@@ -8130,7 +8152,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 630
+      "newOrder": 632
     },
     {
       "cefr": "A2",
@@ -8143,7 +8165,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 631
+      "newOrder": 633
     },
     {
       "cefr": "A2",
@@ -8156,7 +8178,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 632
+      "newOrder": 634
     },
     {
       "cefr": "A2",
@@ -8169,20 +8191,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 633
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "корпус",
-      "lemmaId": "корпус",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 634
+      "newOrder": 635
     },
     {
       "cefr": "A2",
@@ -8195,7 +8204,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 635
+      "newOrder": 636
     },
     {
       "cefr": "A2",
@@ -8206,7 +8215,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 636
+      "newOrder": 637
     },
     {
       "cefr": "A2",
@@ -8219,7 +8228,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 637
+      "newOrder": 638
     },
     {
       "cefr": "A2",
@@ -8232,7 +8241,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 638
+      "newOrder": 639
     },
     {
       "cefr": "A2",
@@ -8243,7 +8252,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 639
+      "newOrder": 640
     },
     {
       "cefr": "A2",
@@ -8256,7 +8265,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 640
+      "newOrder": 641
     },
     {
       "cefr": "A2",
@@ -8269,20 +8278,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 641
+      "newOrder": 642
     },
     {
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "ціле",
-      "lemmaId": "ціле",
+      "lemma": "речовина",
+      "lemmaId": "речовина",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 642
+      "newOrder": 643
     },
     {
       "cefr": "A2",
@@ -8293,7 +8302,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 643
+      "newOrder": 644
     },
     {
       "cefr": "A2",
@@ -8304,7 +8313,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 644
+      "newOrder": 645
     },
     {
       "cefr": "A2",
@@ -8315,7 +8324,31 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 645
+      "newOrder": 646
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "усміхаючись",
+      "lemmaId": "усміхаючись",
+      "modes": [
+        "flashcards"
+      ],
+      "newOrder": 647
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "дізнавшись",
+      "lemmaId": "дізнавшись",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 648
     },
     {
       "cefr": "A2",
@@ -8328,7 +8361,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 646
+      "newOrder": 649
     },
     {
       "cefr": "A2",
@@ -8341,7 +8374,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 647
+      "newOrder": 650
     },
     {
       "cefr": "A2",
@@ -8354,7 +8387,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 648
+      "newOrder": 651
     },
     {
       "cefr": "A2",
@@ -8367,7 +8400,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 649
+      "newOrder": 652
     },
     {
       "cefr": "A2",
@@ -8380,7 +8413,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 650
+      "newOrder": 653
     },
     {
       "cefr": "A2",
@@ -8393,7 +8426,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 651
+      "newOrder": 654
     },
     {
       "cefr": "A2",
@@ -8406,7 +8439,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 652
+      "newOrder": 655
     },
     {
       "cefr": "A2",
@@ -8419,7 +8452,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 653
+      "newOrder": 656
     },
     {
       "cefr": "A2",
@@ -8432,7 +8465,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 654
+      "newOrder": 657
     },
     {
       "cefr": "A2",
@@ -8443,7 +8476,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 655
+      "newOrder": 658
     },
     {
       "cefr": "A2",
@@ -8456,7 +8489,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 656
+      "newOrder": 659
     },
     {
       "cefr": "A2",
@@ -8469,7 +8502,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 657
+      "newOrder": 660
     },
     {
       "cefr": "A2",
@@ -8482,7 +8515,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 658
+      "newOrder": 661
     },
     {
       "cefr": "A2",
@@ -8495,7 +8528,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 659
+      "newOrder": 662
     },
     {
       "cefr": "A2",
@@ -8508,20 +8541,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 660
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "комунальні",
-      "lemmaId": "комунальні",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 661
+      "newOrder": 663
     },
     {
       "cefr": "A2",
@@ -8534,7 +8554,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 662
+      "newOrder": 664
     },
     {
       "cefr": "A2",
@@ -8547,7 +8567,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 663
+      "newOrder": 665
     },
     {
       "cefr": "A2",
@@ -8560,7 +8580,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 664
+      "newOrder": 666
     },
     {
       "cefr": "A2",
@@ -8573,7 +8593,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 665
+      "newOrder": 667
     },
     {
       "cefr": "A2",
@@ -8586,20 +8606,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 666
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "подвір'я",
-      "lemmaId": "подвір-я",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 667
+      "newOrder": 668
     },
     {
       "cefr": "A2",
@@ -8612,7 +8619,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 668
+      "newOrder": 669
     },
     {
       "cefr": "A2",
@@ -8625,7 +8632,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 669
+      "newOrder": 670
     },
     {
       "cefr": "A2",
@@ -8638,7 +8645,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 670
+      "newOrder": 671
     },
     {
       "cefr": "A2",
@@ -8651,7 +8658,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 671
+      "newOrder": 672
     },
     {
       "cefr": "A2",
@@ -8664,7 +8671,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 672
+      "newOrder": 673
     },
     {
       "cefr": "A2",
@@ -8677,7 +8684,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 673
+      "newOrder": 674
     },
     {
       "cefr": "A2",
@@ -8690,7 +8697,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 674
+      "newOrder": 675
     },
     {
       "cefr": "A2",
@@ -8703,7 +8710,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 675
+      "newOrder": 676
     },
     {
       "cefr": "A2",
@@ -8716,7 +8723,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 676
+      "newOrder": 677
     },
     {
       "cefr": "A2",
@@ -8729,7 +8736,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 677
+      "newOrder": 678
     },
     {
       "cefr": "A2",
@@ -8742,7 +8749,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 678
+      "newOrder": 679
     },
     {
       "cefr": "A2",
@@ -8755,7 +8762,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 679
+      "newOrder": 680
     },
     {
       "cefr": "A2",
@@ -8768,7 +8775,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 680
+      "newOrder": 681
     },
     {
       "cefr": "A2",
@@ -8781,7 +8788,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 681
+      "newOrder": 682
     },
     {
       "cefr": "A2",
@@ -8794,7 +8801,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 682
+      "newOrder": 683
     },
     {
       "cefr": "A2",
@@ -8807,7 +8814,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 683
+      "newOrder": 684
     },
     {
       "cefr": "A2",
@@ -8820,7 +8827,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 684
+      "newOrder": 685
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "обряд",
+      "lemmaId": "обряд",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 686
     },
     {
       "cefr": "A2",
@@ -8833,7 +8853,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 685
+      "newOrder": 687
     },
     {
       "cefr": "A2",
@@ -8844,7 +8864,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 686
+      "newOrder": 688
     },
     {
       "cefr": "A2",
@@ -8855,7 +8875,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 687
+      "newOrder": 689
     },
     {
       "cefr": "A2",
@@ -8866,7 +8886,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 688
+      "newOrder": 690
     },
     {
       "cefr": "A2",
@@ -8879,7 +8899,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 689
+      "newOrder": 691
     },
     {
       "cefr": "A2",
@@ -8890,7 +8910,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 690
+      "newOrder": 692
     },
     {
       "cefr": "A2",
@@ -8903,7 +8923,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 691
+      "newOrder": 693
     },
     {
       "cefr": "A2",
@@ -8916,7 +8936,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 692
+      "newOrder": 694
     },
     {
       "cefr": "A2",
@@ -8929,7 +8949,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 693
+      "newOrder": 695
     },
     {
       "cefr": "A2",
@@ -8942,7 +8962,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 694
+      "newOrder": 696
     },
     {
       "cefr": "A2",
@@ -8953,7 +8973,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 695
+      "newOrder": 697
     },
     {
       "cefr": "A2",
@@ -8966,7 +8986,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 696
+      "newOrder": 698
     },
     {
       "cefr": "A2",
@@ -8977,7 +8997,20 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 697
+      "newOrder": 699
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "кур'єр",
+      "lemmaId": "кур-єр",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 700
     },
     {
       "cefr": "A2",
@@ -8990,7 +9023,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 698
+      "newOrder": 701
     },
     {
       "cefr": "A2",
@@ -9001,7 +9034,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 699
+      "newOrder": 702
     },
     {
       "cefr": "A2",
@@ -9012,7 +9045,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 700
+      "newOrder": 703
     },
     {
       "cefr": "A2",
@@ -9025,7 +9058,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 701
+      "newOrder": 704
     },
     {
       "cefr": "A2",
@@ -9038,7 +9071,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 702
+      "newOrder": 705
     },
     {
       "cefr": "A2",
@@ -9051,7 +9084,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 703
+      "newOrder": 706
     },
     {
       "cefr": "A2",
@@ -9064,7 +9097,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 704
+      "newOrder": 707
     },
     {
       "cefr": "A2",
@@ -9075,7 +9108,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 705
+      "newOrder": 708
     },
     {
       "cefr": "A2",
@@ -9088,7 +9121,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 706
+      "newOrder": 709
     },
     {
       "cefr": "A2",
@@ -9101,7 +9134,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 707
+      "newOrder": 710
     },
     {
       "cefr": "A2",
@@ -9114,7 +9147,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 708
+      "newOrder": 711
     },
     {
       "cefr": "A2",
@@ -9125,7 +9158,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 709
+      "newOrder": 712
     },
     {
       "cefr": "A2",
@@ -9136,7 +9169,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 710
+      "newOrder": 713
     },
     {
       "cefr": "A2",
@@ -9149,7 +9182,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 711
+      "newOrder": 714
     },
     {
       "cefr": "A2",
@@ -9162,7 +9195,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 712
+      "newOrder": 715
     },
     {
       "cefr": "A2",
@@ -9175,7 +9208,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 713
+      "newOrder": 716
     },
     {
       "cefr": "A2",
@@ -9188,7 +9221,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 714
+      "newOrder": 717
     },
     {
       "cefr": "A2",
@@ -9201,7 +9234,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 715
+      "newOrder": 718
     },
     {
       "cefr": "A2",
@@ -9214,7 +9247,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 716
+      "newOrder": 719
     },
     {
       "cefr": "A2",
@@ -9227,7 +9260,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 717
+      "newOrder": 720
     },
     {
       "cefr": "A2",
@@ -9240,7 +9273,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 718
+      "newOrder": 721
     },
     {
       "cefr": "A2",
@@ -9253,7 +9286,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 719
+      "newOrder": 722
     },
     {
       "cefr": "A2",
@@ -9264,7 +9297,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 720
+      "newOrder": 723
     },
     {
       "cefr": "A2",
@@ -9277,20 +9310,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 721
+      "newOrder": 724
     },
     {
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "забруднення",
-      "lemmaId": "забруднення",
+      "lemma": "заповідник",
+      "lemmaId": "заповідник",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 722
+      "newOrder": 725
     },
     {
       "cefr": "A2",
@@ -9303,7 +9336,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 723
+      "newOrder": 726
     },
     {
       "cefr": "A2",
@@ -9316,7 +9349,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 724
+      "newOrder": 727
     },
     {
       "cefr": "A2",
@@ -9329,7 +9362,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 725
+      "newOrder": 728
     },
     {
       "cefr": "A2",
@@ -9342,7 +9375,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 726
+      "newOrder": 729
     },
     {
       "cefr": "A2",
@@ -9355,7 +9388,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 727
+      "newOrder": 730
     },
     {
       "cefr": "A2",
@@ -9368,7 +9401,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 728
+      "newOrder": 731
     },
     {
       "cefr": "A2",
@@ -9381,7 +9414,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 729
+      "newOrder": 732
     },
     {
       "cefr": "A2",
@@ -9394,7 +9427,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 730
+      "newOrder": 733
     },
     {
       "cefr": "A2",
@@ -9407,7 +9440,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 731
+      "newOrder": 734
     },
     {
       "cefr": "A2",
@@ -9420,7 +9453,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 732
+      "newOrder": 735
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "доповідач",
+      "lemmaId": "доповідач",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 736
     },
     {
       "cefr": "A2",
@@ -9433,7 +9479,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 733
+      "newOrder": 737
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "монтаж",
+      "lemmaId": "монтаж",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 738
     },
     {
       "cefr": "A2",
@@ -9446,7 +9505,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 734
+      "newOrder": 739
     },
     {
       "cefr": "A2",
@@ -9459,7 +9518,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 735
+      "newOrder": 740
     },
     {
       "cefr": "A2",
@@ -9472,7 +9531,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 736
+      "newOrder": 741
     },
     {
       "cefr": "A2",
@@ -9485,7 +9544,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 737
+      "newOrder": 742
     },
     {
       "cefr": "A2",
@@ -9498,7 +9557,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 738
+      "newOrder": 743
     },
     {
       "cefr": "A2",
@@ -9511,7 +9570,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 739
+      "newOrder": 744
     },
     {
       "cefr": "A2",
@@ -9524,7 +9583,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 740
+      "newOrder": 745
     },
     {
       "cefr": "A2",
@@ -9537,7 +9596,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 741
+      "newOrder": 746
     },
     {
       "cefr": "A2",
@@ -9550,20 +9609,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 742
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "встановлюється",
-      "lemmaId": "встановлюється",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 743
+      "newOrder": 747
     },
     {
       "cefr": "A2",
@@ -9576,7 +9622,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 744
+      "newOrder": 748
     },
     {
       "cefr": "A2",
@@ -9589,7 +9635,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 745
+      "newOrder": 749
     },
     {
       "cefr": "A2",
@@ -9602,7 +9648,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 746
+      "newOrder": 750
     },
     {
       "cefr": "A2",
@@ -9615,7 +9661,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 747
+      "newOrder": 751
     },
     {
       "cefr": "A2",
@@ -9628,7 +9674,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 748
+      "newOrder": 752
     },
     {
       "cefr": "A2",
@@ -9641,7 +9687,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 749
+      "newOrder": 753
     },
     {
       "cefr": "A2",
@@ -9654,7 +9700,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 750
+      "newOrder": 754
     },
     {
       "cefr": "A2",
@@ -9667,7 +9713,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 751
+      "newOrder": 755
     },
     {
       "cefr": "A2",
@@ -9680,7 +9726,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 752
+      "newOrder": 756
     },
     {
       "cefr": "A2",
@@ -9693,7 +9739,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 753
+      "newOrder": 757
     },
     {
       "cefr": "A2",
@@ -9706,7 +9752,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 754
+      "newOrder": 758
     },
     {
       "cefr": "A2",
@@ -9719,7 +9765,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 755
+      "newOrder": 759
     },
     {
       "cefr": "A2",
@@ -9732,7 +9778,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 756
+      "newOrder": 760
     },
     {
       "cefr": "A2",
@@ -9745,7 +9791,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 757
+      "newOrder": 761
     },
     {
       "cefr": "A2",
@@ -9758,7 +9804,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 758
+      "newOrder": 762
     },
     {
       "cefr": "A2",
@@ -9771,7 +9817,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 759
+      "newOrder": 763
     },
     {
       "cefr": "A2",
@@ -9784,7 +9830,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 760
+      "newOrder": 764
     },
     {
       "cefr": "A2",
@@ -9797,7 +9843,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 761
+      "newOrder": 765
     },
     {
       "cefr": "A2",
@@ -9810,7 +9856,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 762
+      "newOrder": 766
     },
     {
       "cefr": "A2",
@@ -9823,7 +9869,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 763
+      "newOrder": 767
     },
     {
       "cefr": "A2",
@@ -9836,7 +9882,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 764
+      "newOrder": 768
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "блідий",
+      "lemmaId": "блідий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 769
     },
     {
       "cefr": "A2",
@@ -9849,7 +9908,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 765
+      "newOrder": 770
     },
     {
       "cefr": "A2",
@@ -9862,7 +9921,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 766
+      "newOrder": 771
     },
     {
       "cefr": "A2",
@@ -9875,7 +9934,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 767
+      "newOrder": 772
     },
     {
       "cefr": "A2",
@@ -9888,7 +9947,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 768
+      "newOrder": 773
     },
     {
       "cefr": "A2",
@@ -9901,7 +9960,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 769
+      "newOrder": 774
     },
     {
       "cefr": "A2",
@@ -9914,7 +9973,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 770
+      "newOrder": 775
     },
     {
       "cefr": "A2",
@@ -9927,7 +9986,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 771
+      "newOrder": 776
     },
     {
       "cefr": "A2",
@@ -9940,7 +9999,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 772
+      "newOrder": 777
     },
     {
       "cefr": "A2",
@@ -9953,7 +10012,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 773
+      "newOrder": 778
     },
     {
       "cefr": "A2",
@@ -9966,7 +10025,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 774
+      "newOrder": 779
     },
     {
       "cefr": "A2",
@@ -9979,7 +10038,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 775
+      "newOrder": 780
     },
     {
       "cefr": "A2",
@@ -9992,7 +10051,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 776
+      "newOrder": 781
     },
     {
       "cefr": "A2",
@@ -10005,7 +10064,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 777
+      "newOrder": 782
     },
     {
       "cefr": "A2",
@@ -10018,7 +10077,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 778
+      "newOrder": 783
     },
     {
       "cefr": "A2",
@@ -10031,7 +10090,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 779
+      "newOrder": 784
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "пам'ятка",
+      "lemmaId": "пам-ятка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 785
     },
     {
       "cefr": "A2",
@@ -10044,7 +10116,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 780
+      "newOrder": 786
     },
     {
       "cefr": "A2",
@@ -10057,18 +10129,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 781
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "Черкаси",
-      "lemmaId": "черкаси",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 782
+      "newOrder": 787
     },
     {
       "cefr": "A2",
@@ -10079,7 +10140,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 783
+      "newOrder": 788
     },
     {
       "cefr": "A2",
@@ -10092,7 +10153,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 784
+      "newOrder": 789
     },
     {
       "cefr": "A2",
@@ -10105,7 +10166,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 785
+      "newOrder": 790
     },
     {
       "cefr": "A2",
@@ -10118,18 +10179,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 786
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "унаслідок",
-      "lemmaId": "унаслідок",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 787
+      "newOrder": 791
     },
     {
       "cefr": "A2",
@@ -10140,7 +10190,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 788
+      "newOrder": 792
     },
     {
       "cefr": "A2",
@@ -10153,7 +10203,18 @@
         "matching",
         "choice"
       ],
-      "newOrder": 789
+      "newOrder": 793
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "обабіч",
+      "lemmaId": "обабіч",
+      "modes": [
+        "flashcards"
+      ],
+      "newOrder": 794
     },
     {
       "cefr": "A2",
@@ -10166,7 +10227,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 790
+      "newOrder": 795
     },
     {
       "cefr": "A2",
@@ -10177,7 +10238,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 791
+      "newOrder": 796
     },
     {
       "cefr": "A2",
@@ -10190,7 +10251,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 792
+      "newOrder": 797
     },
     {
       "cefr": "A2",
@@ -10203,7 +10264,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 793
+      "newOrder": 798
     },
     {
       "cefr": "A2",
@@ -10216,7 +10277,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 794
+      "newOrder": 799
     },
     {
       "cefr": "A2",
@@ -10229,7 +10290,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 795
+      "newOrder": 800
     },
     {
       "cefr": "A2",
@@ -10242,7 +10303,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 796
+      "newOrder": 801
     },
     {
       "cefr": "A2",
@@ -10255,7 +10316,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 797
+      "newOrder": 802
     },
     {
       "cefr": "A2",
@@ -10268,7 +10329,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 798
+      "newOrder": 803
     },
     {
       "cefr": "A2",
@@ -10281,7 +10342,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 799
+      "newOrder": 804
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "уривок",
+      "lemmaId": "уривок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 805
     },
     {
       "cefr": "A2",
@@ -10294,7 +10368,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 800
+      "newOrder": 806
     },
     {
       "cefr": "A2",
@@ -10307,7 +10381,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 801
+      "newOrder": 807
     },
     {
       "cefr": "A2",
@@ -10320,7 +10394,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 802
+      "newOrder": 808
     },
     {
       "cefr": "A2",
@@ -10333,7 +10407,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 803
+      "newOrder": 809
     },
     {
       "cefr": "A2",
@@ -10346,7 +10420,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 804
+      "newOrder": 810
     },
     {
       "cefr": "A2",
@@ -10359,7 +10433,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 805
+      "newOrder": 811
     },
     {
       "cefr": "A2",
@@ -10372,7 +10446,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 806
+      "newOrder": 812
     },
     {
       "cefr": "A2",
@@ -10385,7 +10459,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 807
+      "newOrder": 813
     },
     {
       "cefr": "A2",
@@ -10398,7 +10472,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 808
+      "newOrder": 814
     },
     {
       "cefr": "A2",
@@ -10411,7 +10485,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 809
+      "newOrder": 815
     },
     {
       "cefr": "A2",
@@ -10424,7 +10498,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 810
+      "newOrder": 816
     },
     {
       "cefr": "A2",
@@ -10437,7 +10511,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 811
+      "newOrder": 817
     },
     {
       "cefr": "A2",
@@ -10450,7 +10524,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 812
+      "newOrder": 818
     },
     {
       "cefr": "A2",
@@ -10463,7 +10537,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 813
+      "newOrder": 819
     },
     {
       "cefr": "A2",
@@ -10476,7 +10550,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 814
+      "newOrder": 820
     },
     {
       "cefr": "A2",
@@ -10489,7 +10563,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 815
+      "newOrder": 821
     },
     {
       "cefr": "A2",
@@ -10502,7 +10576,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 816
+      "newOrder": 822
     },
     {
       "cefr": "A2",
@@ -10515,7 +10589,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 817
+      "newOrder": 823
     },
     {
       "cefr": "A2",
@@ -10528,7 +10602,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 818
+      "newOrder": 824
     },
     {
       "cefr": "A2",
@@ -10541,7 +10615,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 819
+      "newOrder": 825
     },
     {
       "cefr": "A2",
@@ -10554,7 +10628,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 820
+      "newOrder": 826
     },
     {
       "cefr": "A2",
@@ -10567,7 +10641,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 821
+      "newOrder": 827
     },
     {
       "cefr": "A2",
@@ -10580,7 +10654,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 822
+      "newOrder": 828
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "прес-конференція",
+      "lemmaId": "прес-конференція",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 829
     },
     {
       "cefr": "A2",
@@ -10593,7 +10680,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 823
+      "newOrder": 830
     },
     {
       "cefr": "A2",
@@ -10606,7 +10693,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 824
+      "newOrder": 831
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "фейк",
+      "lemmaId": "фейк",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 832
     },
     {
       "cefr": "A2",
@@ -10619,7 +10719,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 825
+      "newOrder": 833
     },
     {
       "cefr": "A2",
@@ -10632,20 +10732,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 826
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вигоди",
-      "lemmaId": "вигоди",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 827
+      "newOrder": 834
     },
     {
       "cefr": "A2",
@@ -10658,7 +10745,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 828
+      "newOrder": 835
     },
     {
       "cefr": "A2",
@@ -10671,7 +10758,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 829
+      "newOrder": 836
     },
     {
       "cefr": "A2",
@@ -10684,7 +10771,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 830
+      "newOrder": 837
     },
     {
       "cefr": "A2",
@@ -10697,7 +10784,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 831
+      "newOrder": 838
     },
     {
       "cefr": "A2",
@@ -10710,7 +10797,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 832
+      "newOrder": 839
     },
     {
       "cefr": "A2",
@@ -10723,7 +10810,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 833
+      "newOrder": 840
     },
     {
       "cefr": "A2",
@@ -10736,7 +10823,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 834
+      "newOrder": 841
     },
     {
       "cefr": "A2",
@@ -10749,7 +10836,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 835
+      "newOrder": 842
     },
     {
       "cefr": "A2",
@@ -10762,7 +10849,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 836
+      "newOrder": 843
     },
     {
       "cefr": "A2",
@@ -10775,7 +10862,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 837
+      "newOrder": 844
     },
     {
       "cefr": "A2",
@@ -10788,7 +10875,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 838
+      "newOrder": 845
     },
     {
       "cefr": "A2",
@@ -10801,7 +10888,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 839
+      "newOrder": 846
     },
     {
       "cefr": "A2",
@@ -10814,7 +10901,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 840
+      "newOrder": 847
     },
     {
       "cefr": "A2",
@@ -10827,7 +10914,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 841
+      "newOrder": 848
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "документація",
+      "lemmaId": "документація",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 849
     },
     {
       "cefr": "A2",
@@ -10840,7 +10940,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 842
+      "newOrder": 850
     },
     {
       "cefr": "A2",
@@ -10853,7 +10953,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 843
+      "newOrder": 851
     },
     {
       "cefr": "A2",
@@ -10866,7 +10966,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 844
+      "newOrder": 852
     },
     {
       "cefr": "A2",
@@ -10879,7 +10979,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 845
+      "newOrder": 853
     },
     {
       "cefr": "A2",
@@ -10892,7 +10992,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 846
+      "newOrder": 854
     },
     {
       "cefr": "A2",
@@ -10905,7 +11005,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 847
+      "newOrder": 855
     },
     {
       "cefr": "A2",
@@ -10918,7 +11018,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 848
+      "newOrder": 856
     },
     {
       "cefr": "A2",
@@ -10931,7 +11031,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 849
+      "newOrder": 857
     },
     {
       "cefr": "A2",
@@ -10944,20 +11044,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 850
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "денний",
-      "lemmaId": "денний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 851
+      "newOrder": 858
     },
     {
       "cefr": "A2",
@@ -10970,7 +11057,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 852
+      "newOrder": 859
     },
     {
       "cefr": "A2",
@@ -10983,7 +11070,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 853
+      "newOrder": 860
     },
     {
       "cefr": "A2",
@@ -10996,7 +11083,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 854
+      "newOrder": 861
     },
     {
       "cefr": "A2",
@@ -11009,7 +11096,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 855
+      "newOrder": 862
     },
     {
       "cefr": "A2",
@@ -11022,7 +11109,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 856
+      "newOrder": 863
     },
     {
       "cefr": "A2",
@@ -11035,7 +11122,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 857
+      "newOrder": 864
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "звільнитися",
+      "lemmaId": "звільнитися",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 865
     },
     {
       "cefr": "A2",
@@ -11048,7 +11148,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 858
+      "newOrder": 866
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "роботодавець",
+      "lemmaId": "роботодавець",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 867
     },
     {
       "cefr": "A2",
@@ -11061,59 +11174,33 @@
         "matching",
         "choice"
       ],
-      "newOrder": 859
+      "newOrder": 868
     },
     {
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "впроваджувати",
-      "lemmaId": "впроваджувати",
+      "lemma": "користувач",
+      "lemmaId": "користувач",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 860
+      "newOrder": 869
     },
     {
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "доцільно",
-      "lemmaId": "доцільно",
+      "lemma": "охочі",
+      "lemmaId": "охочі",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 861
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "звітність",
-      "lemmaId": "звітність",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 862
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "моніторинг",
-      "lemmaId": "моніторинг",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 863
+      "newOrder": 870
     },
     {
       "cefr": "A2",
@@ -11126,105 +11213,14 @@
         "matching",
         "choice"
       ],
-      "newOrder": 864
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "оприлюднити",
-      "lemmaId": "оприлюднити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 865
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "ухвалити",
-      "lemmaId": "ухвалити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 866
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "затверджений",
-      "lemmaId": "затверджений",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 867
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "підписаний",
-      "lemmaId": "підписаний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 868
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "викуп",
-      "lemmaId": "викуп",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 869
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "мотив",
-      "lemmaId": "мотив",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 870
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "господиня",
-      "lemmaId": "господиня",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
       "newOrder": 871
     },
     {
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "привласнення",
-      "lemmaId": "привласнення",
+      "lemma": "інструмент",
+      "lemmaId": "інструмент",
       "modes": [
         "flashcards"
       ],
@@ -11234,10 +11230,12 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "реконструкція",
-      "lemmaId": "реконструкція",
+      "lemma": "відсторонення",
+      "lemmaId": "відсторонення",
       "modes": [
-        "flashcards"
+        "flashcards",
+        "matching",
+        "choice"
       ],
       "newOrder": 873
     },
@@ -11245,8 +11243,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "спротив",
-      "lemmaId": "спротив",
+      "lemma": "узагальнення",
+      "lemmaId": "узагальнення",
       "modes": [
         "flashcards",
         "matching",
@@ -11258,10 +11256,12 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "ідентичність",
-      "lemmaId": "ідентичність",
+      "lemma": "аудит",
+      "lemmaId": "аудит",
       "modes": [
-        "flashcards"
+        "flashcards",
+        "matching",
+        "choice"
       ],
       "newOrder": 875
     },
@@ -11269,10 +11269,12 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "бандура",
-      "lemmaId": "бандура",
+      "lemma": "демократія",
+      "lemmaId": "демократія",
       "modes": [
-        "flashcards"
+        "flashcards",
+        "matching",
+        "choice"
       ],
       "newOrder": 876
     },
@@ -11280,8 +11282,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "обхід",
-      "lemmaId": "обхід",
+      "lemma": "корупція",
+      "lemmaId": "корупція",
       "modes": [
         "flashcards",
         "matching",
@@ -11293,8 +11295,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "фольклор",
-      "lemmaId": "фольклор",
+      "lemma": "мандат",
+      "lemmaId": "мандат",
       "modes": [
         "flashcards",
         "matching",
@@ -11306,10 +11308,12 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "автомобіль",
-      "lemmaId": "автомобіль",
+      "lemma": "прозорість",
+      "lemmaId": "прозорість",
       "modes": [
-        "flashcards"
+        "flashcards",
+        "matching",
+        "choice"
       ],
       "newOrder": 879
     },
@@ -11317,8 +11321,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "автор",
-      "lemmaId": "автор",
+      "lemma": "розгорнути",
+      "lemmaId": "розгорнути",
       "modes": [
         "flashcards",
         "matching",
@@ -11330,10 +11334,12 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "академія",
-      "lemmaId": "академія",
+      "lemma": "уточнення",
+      "lemmaId": "уточнення",
       "modes": [
-        "flashcards"
+        "flashcards",
+        "matching",
+        "choice"
       ],
       "newOrder": 881
     },
@@ -11341,8 +11347,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "активно",
-      "lemmaId": "активно",
+      "lemma": "фрагмент",
+      "lemmaId": "фрагмент",
       "modes": [
         "flashcards",
         "matching",
@@ -11354,8 +11360,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "акція",
-      "lemmaId": "акція",
+      "lemma": "обов'язковий",
+      "lemmaId": "обов-язковий",
       "modes": [
         "flashcards",
         "matching",
@@ -11367,8 +11373,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "алкоголь",
-      "lemmaId": "алкоголь",
+      "lemma": "відшкодувати",
+      "lemmaId": "відшкодувати",
       "modes": [
         "flashcards",
         "matching",
@@ -11380,8 +11386,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "антибіотик",
-      "lemmaId": "антибіотик",
+      "lemma": "забудовник",
+      "lemmaId": "забудовник",
       "modes": [
         "flashcards",
         "matching",
@@ -11393,10 +11399,12 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "арахіс",
-      "lemmaId": "арахіс",
+      "lemma": "зафіксувати",
+      "lemmaId": "зафіксувати",
       "modes": [
-        "flashcards"
+        "flashcards",
+        "matching",
+        "choice"
       ],
       "newOrder": 886
     },
@@ -11404,10 +11412,12 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "ароматний",
-      "lemmaId": "ароматний",
+      "lemma": "компенсувати",
+      "lemmaId": "компенсувати",
       "modes": [
-        "flashcards"
+        "flashcards",
+        "matching",
+        "choice"
       ],
       "newOrder": 887
     },
@@ -11415,8 +11425,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "архітектор",
-      "lemmaId": "архітектор",
+      "lemma": "нерухомість",
+      "lemmaId": "нерухомість",
       "modes": [
         "flashcards",
         "matching",
@@ -11428,8 +11438,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "банкомат",
-      "lemmaId": "банкомат",
+      "lemma": "облаштування",
+      "lemmaId": "облаштування",
       "modes": [
         "flashcards",
         "matching",
@@ -11441,8 +11451,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "бар",
-      "lemmaId": "бар",
+      "lemma": "орендувати",
+      "lemmaId": "орендувати",
       "modes": [
         "flashcards",
         "matching",
@@ -11454,8 +11464,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "безкоштовний",
-      "lemmaId": "безкоштовний",
+      "lemma": "ОСББ",
+      "lemmaId": "осбб",
       "modes": [
         "flashcards",
         "matching",
@@ -11467,8 +11477,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "безкоштовно",
-      "lemmaId": "безкоштовно",
+      "lemma": "погодити",
+      "lemmaId": "погодити",
       "modes": [
         "flashcards",
         "matching",
@@ -11480,10 +11490,12 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "безпечний",
-      "lemmaId": "безпечний",
+      "lemma": "пофарбувати",
+      "lemmaId": "пофарбувати",
       "modes": [
-        "flashcards"
+        "flashcards",
+        "matching",
+        "choice"
       ],
       "newOrder": 893
     },
@@ -11491,8 +11503,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "бити",
-      "lemmaId": "бити",
+      "lemma": "підрядник",
+      "lemmaId": "підрядник",
       "modes": [
         "flashcards",
         "matching",
@@ -11504,8 +11516,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "благословення",
-      "lemmaId": "благословення",
+      "lemma": "сходи",
+      "lemmaId": "сходи",
       "modes": [
         "flashcards",
         "matching",
@@ -11517,10 +11529,12 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "близький",
-      "lemmaId": "близький",
+      "lemma": "узгодити",
+      "lemmaId": "узгодити",
       "modes": [
-        "flashcards"
+        "flashcards",
+        "matching",
+        "choice"
       ],
       "newOrder": 896
     },
@@ -11528,10 +11542,12 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "блискавка",
-      "lemmaId": "блискавка",
+      "lemma": "наголосити",
+      "lemmaId": "наголосити",
       "modes": [
-        "flashcards"
+        "flashcards",
+        "matching",
+        "choice"
       ],
       "newOrder": 897
     },
@@ -11539,8 +11555,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "блог",
-      "lemmaId": "блог",
+      "lemma": "непрямий",
+      "lemmaId": "непрямий",
       "modes": [
         "flashcards",
         "matching",
@@ -11552,8 +11568,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "бог",
-      "lemmaId": "бог",
+      "lemma": "припустити",
+      "lemmaId": "припустити",
       "modes": [
         "flashcards",
         "matching",
@@ -11565,10 +11581,12 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "брова",
-      "lemmaId": "брова",
+      "lemma": "варити",
+      "lemmaId": "варити",
       "modes": [
-        "flashcards"
+        "flashcards",
+        "matching",
+        "choice"
       ],
       "newOrder": 900
     },
@@ -11576,8 +11594,8 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "бувати",
-      "lemmaId": "бувати",
+      "lemma": "грамів",
+      "lemmaId": "грамів",
       "modes": [
         "flashcards",
         "matching",
@@ -11589,2073 +11607,14 @@
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "бульйон",
-      "lemmaId": "бульйон",
+      "lemma": "смажити",
+      "lemmaId": "смажити",
       "modes": [
-        "flashcards"
+        "flashcards",
+        "matching",
+        "choice"
       ],
       "newOrder": 902
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "бізнес",
-      "lemmaId": "бізнес",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 903
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "більшість",
-      "lemmaId": "більшість",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 904
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вага",
-      "lemmaId": "вага",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 905
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "важкий",
-      "lemmaId": "важкий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 906
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "важливо",
-      "lemmaId": "важливо",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 907
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вазон",
-      "lemmaId": "вазон",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 908
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "валюта",
-      "lemmaId": "валюта",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 909
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "варити",
-      "lemmaId": "варити",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 910
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вартість",
-      "lemmaId": "вартість",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 911
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вгору",
-      "lemmaId": "вгору",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 912
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вегетаріанець",
-      "lemmaId": "вегетаріанець",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 913
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вегетаріанка",
-      "lemmaId": "вегетаріанка",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 914
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вегетаріанський",
-      "lemmaId": "вегетаріанський",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 915
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "ведмідь",
-      "lemmaId": "ведмідь",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 916
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "весняний",
-      "lemmaId": "весняний",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 917
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вечірній",
-      "lemmaId": "вечірній",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 918
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "взути",
-      "lemmaId": "взути",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 919
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вибачити",
-      "lemmaId": "вибачити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 920
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вибирати",
-      "lemmaId": "вибирати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 921
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вигляд",
-      "lemmaId": "вигляд",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 922
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "викладати",
-      "lemmaId": "викладати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 923
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "виконати",
-      "lemmaId": "виконати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 924
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "використовувати",
-      "lemmaId": "використовувати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 925
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вилікувати",
-      "lemmaId": "вилікувати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 926
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "випити",
-      "lemmaId": "випити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 927
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вирости",
-      "lemmaId": "вирости",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 928
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вислів",
-      "lemmaId": "вислів",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 929
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "виступати",
-      "lemmaId": "виступати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 930
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "висіти",
-      "lemmaId": "висіти",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 931
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "внук",
-      "lemmaId": "внук",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 932
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вовк",
-      "lemmaId": "вовк",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 933
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "волейбол",
-      "lemmaId": "волейбол",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 934
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "все",
-      "lemmaId": "все",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 935
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "всі",
-      "lemmaId": "всі",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 936
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "втомлений",
-      "lemmaId": "втомлений",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 937
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вузький",
-      "lemmaId": "вузький",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 938
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "відбуватися",
-      "lemmaId": "відбуватися",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 939
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "відбутися",
-      "lemmaId": "відбутися",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 940
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "відвідати",
-      "lemmaId": "відвідати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 941
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "відвідувати",
-      "lemmaId": "відвідувати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 942
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "віддати",
-      "lemmaId": "віддати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 943
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "відпочити",
-      "lemmaId": "відпочити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 944
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "відправлятися",
-      "lemmaId": "відправлятися",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 945
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "відразу",
-      "lemmaId": "відразу",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 946
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "війна",
-      "lemmaId": "війна",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 947
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вірити",
-      "lemmaId": "вірити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 948
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вітамін",
-      "lemmaId": "вітамін",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 949
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вітряний",
-      "lemmaId": "вітряний",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 950
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вітряно",
-      "lemmaId": "вітряно",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 951
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "гадати",
-      "lemmaId": "гадати",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 952
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "гаманець",
-      "lemmaId": "гаманець",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 953
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "гаразд",
-      "lemmaId": "гаразд",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 954
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "гарбуз",
-      "lemmaId": "гарбуз",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 955
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "гелікоптер",
-      "lemmaId": "гелікоптер",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 956
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "герб",
-      "lemmaId": "герб",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 957
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "геть",
-      "lemmaId": "геть",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 958
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "глибина",
-      "lemmaId": "глибина",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 959
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "глибокий",
-      "lemmaId": "глибокий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 960
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "голос",
-      "lemmaId": "голос",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 961
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "голосно",
-      "lemmaId": "голосно",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 962
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "голуб",
-      "lemmaId": "голуб",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 963
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "голубий",
-      "lemmaId": "голубий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 964
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "город",
-      "lemmaId": "город",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 965
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "горох",
-      "lemmaId": "горох",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 966
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "гороховий",
-      "lemmaId": "гороховий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 967
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "горілка",
-      "lemmaId": "горілка",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 968
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "гречка",
-      "lemmaId": "гречка",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 969
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "гриль",
-      "lemmaId": "гриль",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 970
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "гроза",
-      "lemmaId": "гроза",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 971
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "громадянство",
-      "lemmaId": "громадянство",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 972
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "груди",
-      "lemmaId": "груди",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 973
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "груша",
-      "lemmaId": "груша",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 974
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "грім",
-      "lemmaId": "грім",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 975
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "гріти",
-      "lemmaId": "гріти",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 976
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "губа",
-      "lemmaId": "губа",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 977
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "гумка",
-      "lemmaId": "гумка",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 978
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "гурт",
-      "lemmaId": "гурт",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 979
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "гуска",
-      "lemmaId": "гуска",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 980
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "гімн",
-      "lemmaId": "гімн",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 981
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "давній",
-      "lemmaId": "давній",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 982
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "далекий",
-      "lemmaId": "далекий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 983
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "дальший",
-      "lemmaId": "дальший",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 984
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "дах",
-      "lemmaId": "дах",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 985
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "держава",
-      "lemmaId": "держава",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 986
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "державний",
-      "lemmaId": "державний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 987
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "джаз",
-      "lemmaId": "джаз",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 988
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "дивний",
-      "lemmaId": "дивний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 989
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "дивно",
-      "lemmaId": "дивно",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 990
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "дизайнер",
-      "lemmaId": "дизайнер",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 991
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "дикий",
-      "lemmaId": "дикий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 992
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "дитячий",
-      "lemmaId": "дитячий",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 993
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "доба",
-      "lemmaId": "доба",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 994
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "довжина",
-      "lemmaId": "довжина",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 995
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "дорослий",
-      "lemmaId": "дорослий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 996
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "досить",
-      "lemmaId": "досить",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 997
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "духовка",
-      "lemmaId": "духовка",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 998
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "душа",
-      "lemmaId": "душа",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 999
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "екзотичний",
-      "lemmaId": "екзотичний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1000
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "економіка",
-      "lemmaId": "економіка",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1001
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "електричний",
-      "lemmaId": "електричний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1002
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "енергія",
-      "lemmaId": "енергія",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1003
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "жаба",
-      "lemmaId": "жаба",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1004
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "жартувати",
-      "lemmaId": "жартувати",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1005
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "задоволений",
-      "lemmaId": "задоволений",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1006
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "закон",
-      "lemmaId": "закон",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1007
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "закінчитися",
-      "lemmaId": "закінчитися",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1008
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "залишити",
-      "lemmaId": "залишити",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1009
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "запах",
-      "lemmaId": "запах",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1010
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "запитувати",
-      "lemmaId": "запитувати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1011
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "заповнити",
-      "lemmaId": "заповнити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1012
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "засміятися",
-      "lemmaId": "засміятися",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1013
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "захворіти",
-      "lemmaId": "захворіти",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1014
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "захід",
-      "lemmaId": "захід",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1015
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "зачекати",
-      "lemmaId": "зачекати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1016
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "зачинити",
-      "lemmaId": "зачинити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1017
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "зварити",
-      "lemmaId": "зварити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1018
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "звідси",
-      "lemmaId": "звідси",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1019
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "зимовий",
-      "lemmaId": "зимовий",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1020
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "злий",
-      "lemmaId": "злий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1021
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "зліва",
-      "lemmaId": "зліва",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1022
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "змінити",
-      "lemmaId": "змінити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1023
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "змінювати",
-      "lemmaId": "змінювати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1024
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "знаходити",
-      "lemmaId": "знаходити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1025
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "зовсім",
-      "lemmaId": "зовсім",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1026
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "золотий",
-      "lemmaId": "золотий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1027
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "зоопарк",
-      "lemmaId": "зоопарк",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1028
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "зразок",
-      "lemmaId": "зразок",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1029
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "зручний",
-      "lemmaId": "зручний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1030
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "зручно",
-      "lemmaId": "зручно",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1031
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "зубний",
-      "lemmaId": "зубний",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1032
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "зілля",
-      "lemmaId": "зілля",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1033
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "зірка",
-      "lemmaId": "зірка",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1034
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "йога",
-      "lemmaId": "йога",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1035
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "кавун",
-      "lemmaId": "кавун",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1036
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "казка",
-      "lemmaId": "казка",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1037
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "календар",
-      "lemmaId": "календар",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1038
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "камінь",
-      "lemmaId": "камінь",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1039
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "капелюх",
-      "lemmaId": "капелюх",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1040
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "капець",
-      "lemmaId": "капець",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1041
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "карий",
-      "lemmaId": "карий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1042
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "каструля",
-      "lemmaId": "каструля",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1043
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "качка",
-      "lemmaId": "качка",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1044
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "кашляти",
-      "lemmaId": "кашляти",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1045
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "квасоля",
-      "lemmaId": "квасоля",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1046
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "квітка",
-      "lemmaId": "квітка",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1047
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "кетчуп",
-      "lemmaId": "кетчуп",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1048
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "кишеня",
-      "lemmaId": "кишеня",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1049
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "класичний",
-      "lemmaId": "класичний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1050
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "класти",
-      "lemmaId": "класти",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1051
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "клініка",
-      "lemmaId": "клініка",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1052
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "книжковий",
-      "lemmaId": "книжковий",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1053
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "коза",
-      "lemmaId": "коза",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1054
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "кокос",
-      "lemmaId": "кокос",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1055
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "коктейль",
-      "lemmaId": "коктейль",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1056
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "колишній",
-      "lemmaId": "колишній",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1057
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "кольоровий",
-      "lemmaId": "кольоровий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1058
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "коліно",
-      "lemmaId": "коліно",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1059
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "контакт",
-      "lemmaId": "контакт",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1060
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "континент",
-      "lemmaId": "континент",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1061
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "коробка",
-      "lemmaId": "коробка",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1062
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "косметика",
-      "lemmaId": "косметика",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1063
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "котлета",
-      "lemmaId": "котлета",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1064
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "кофеїн",
-      "lemmaId": "кофеїн",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1065
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "кохання",
-      "lemmaId": "кохання",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1066
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "кохати",
-      "lemmaId": "кохати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1067
     },
     {
       "cefr": "A2",
@@ -13668,174 +11627,763 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1068
+      "newOrder": 903
     },
     {
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "краватка",
-      "lemmaId": "краватка",
+      "lemma": "послуга",
+      "lemmaId": "послуга",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 904
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "споживач",
+      "lemmaId": "споживач",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 905
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "професіоналізм",
+      "lemmaId": "професіоналізм",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 906
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "фасад",
+      "lemmaId": "фасад",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 907
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "упевненість",
+      "lemmaId": "упевненість",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 908
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "враховано",
+      "lemmaId": "враховано",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 909
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "дискурс",
+      "lemmaId": "дискурс",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 910
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "забезпечено",
+      "lemmaId": "забезпечено",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 911
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "оприлюднити",
+      "lemmaId": "оприлюднити",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 912
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "погоджено",
+      "lemmaId": "погоджено",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 913
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "правка",
+      "lemmaId": "правка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 914
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "впроваджувати",
+      "lemmaId": "впроваджувати",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 915
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "доцільно",
+      "lemmaId": "доцільно",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 916
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "звітність",
+      "lemmaId": "звітність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 917
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "моніторинг",
+      "lemmaId": "моніторинг",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 918
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "затверджений",
+      "lemmaId": "затверджений",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 919
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "підписаний",
+      "lemmaId": "підписаний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 920
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "напруження",
+      "lemmaId": "напруження",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 921
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "пилосос",
+      "lemmaId": "пилосос",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 922
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "побут",
+      "lemmaId": "побут",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 923
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "прибирання",
+      "lemmaId": "прибирання",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 924
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "щоранку",
+      "lemmaId": "щоранку",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 925
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "виконується",
+      "lemmaId": "виконується",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 926
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "додається",
+      "lemmaId": "додається",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 927
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "контролюється",
+      "lemmaId": "контролюється",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 928
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "обговорюється",
+      "lemmaId": "обговорюється",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 929
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "передається",
+      "lemmaId": "передається",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 930
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "регламент",
+      "lemmaId": "регламент",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 931
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "альтернатива",
+      "lemmaId": "альтернатива",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 932
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "вартість",
+      "lemmaId": "вартість",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 933
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "партнерство",
+      "lemmaId": "партнерство",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 934
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "співпраця",
+      "lemmaId": "співпраця",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 935
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "пом'якшення",
+      "lemmaId": "пом-якшення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 936
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "актуальність",
+      "lemmaId": "актуальність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 937
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "наведено",
+      "lemmaId": "наведено",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 938
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "посилання",
+      "lemmaId": "посилання",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 939
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "правовий",
+      "lemmaId": "правовий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 940
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "натхнення",
+      "lemmaId": "натхнення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 941
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "світогляд",
+      "lemmaId": "світогляд",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 942
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "тлумачення",
+      "lemmaId": "тлумачення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 943
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "громадськість",
+      "lemmaId": "громадськість",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 944
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "доцільність",
+      "lemmaId": "доцільність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 945
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "капець",
+      "lemmaId": "капець",
       "modes": [
         "flashcards"
       ],
-      "newOrder": 1069
+      "newOrder": 946
     },
     {
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "краса",
-      "lemmaId": "краса",
+      "lemma": "класно",
+      "lemmaId": "класно",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 947
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "ого",
+      "lemmaId": "ого",
       "modes": [
         "flashcards"
       ],
-      "newOrder": 1070
+      "newOrder": 948
     },
     {
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "красивий",
-      "lemmaId": "красивий",
+      "lemma": "похід",
+      "lemmaId": "похід",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 1071
+      "newOrder": 949
     },
     {
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "крем",
-      "lemmaId": "крем",
+      "lemma": "доопрацювати",
+      "lemmaId": "доопрацювати",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 950
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "передавати",
+      "lemmaId": "передавати",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 951
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "поріг",
+      "lemmaId": "поріг",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 952
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "регіональний",
+      "lemmaId": "регіональний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 953
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "ідентичність",
+      "lemmaId": "ідентичність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 954
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "виснаження",
+      "lemmaId": "виснаження",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 955
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "декларація",
+      "lemmaId": "декларація",
       "modes": [
         "flashcards"
       ],
-      "newOrder": 1072
+      "newOrder": 956
     },
     {
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "круглий",
-      "lemmaId": "круглий",
+      "lemma": "лікування",
+      "lemmaId": "лікування",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 1073
+      "newOrder": 957
     },
     {
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "кріп",
-      "lemmaId": "кріп",
+      "lemma": "медицина",
+      "lemmaId": "медицина",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 1074
+      "newOrder": 958
     },
     {
       "cefr": "A2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "культурний",
-      "lemmaId": "культурний",
+      "lemma": "направлення",
+      "lemmaId": "направлення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 959
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "препарат",
+      "lemmaId": "препарат",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 960
+    },
+    {
+      "cefr": "A2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "ватажок",
+      "lemmaId": "ватажок",
       "modes": [
         "flashcards"
       ],
-      "newOrder": 1075
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "купатися",
-      "lemmaId": "купатися",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1076
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "куріння",
-      "lemmaId": "куріння",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1077
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "куток",
-      "lemmaId": "куток",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1078
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "ківі",
-      "lemmaId": "ківі",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1079
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "легенда",
-      "lemmaId": "легенда",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1080
-    },
-    {
-      "cefr": "A2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "легкий",
-      "lemmaId": "легкий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1081
+      "newOrder": 961
     }
   ],
   "level": "A2",
   "schema": "atlas-practice-index",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 16430,
+    "gzipBytes": 14929,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 276762,
+    "rawBytes": 248698,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/public/lexicon/practice-index.B1.json
+++ b/site/public/lexicon/practice-index.B1.json
@@ -3,9 +3,9 @@
     "cloze": 0,
     "clozeCoverage": 0.0,
     "clozeEligibleLexemes": 0,
-    "lexemes": 1119
+    "lexemes": 1122
   },
-  "deckVersion": "atlas-practice-v1-9cf4a4d7319d19ce",
+  "deckVersion": "atlas-practice-v1-c5a52e54cdf8d828",
   "items": [
     {
       "cefr": "B1",
@@ -35,19 +35,6 @@
       "cefr": "B1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "гостре",
-      "lemmaId": "гостре",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 2
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
       "lemma": "кав'ярня",
       "lemmaId": "кав-ярня",
       "modes": [
@@ -55,7 +42,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 3
+      "newOrder": 2
     },
     {
       "cefr": "B1",
@@ -68,7 +55,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 4
+      "newOrder": 3
     },
     {
       "cefr": "B1",
@@ -81,7 +68,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 5
+      "newOrder": 4
     },
     {
       "cefr": "B1",
@@ -94,7 +81,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 6
+      "newOrder": 5
     },
     {
       "cefr": "B1",
@@ -107,7 +94,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 7
+      "newOrder": 6
     },
     {
       "cefr": "B1",
@@ -120,7 +107,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 8
+      "newOrder": 7
     },
     {
       "cefr": "B1",
@@ -131,7 +118,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 9
+      "newOrder": 8
     },
     {
       "cefr": "B1",
@@ -142,7 +129,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 10
+      "newOrder": 9
     },
     {
       "cefr": "B1",
@@ -155,7 +142,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 11
+      "newOrder": 10
     },
     {
       "cefr": "B1",
@@ -168,7 +155,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 12
+      "newOrder": 11
     },
     {
       "cefr": "B1",
@@ -181,7 +168,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 13
+      "newOrder": 12
     },
     {
       "cefr": "B1",
@@ -194,7 +181,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 14
+      "newOrder": 13
     },
     {
       "cefr": "B1",
@@ -207,7 +194,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 15
+      "newOrder": 14
     },
     {
       "cefr": "B1",
@@ -220,7 +207,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 16
+      "newOrder": 15
     },
     {
       "cefr": "B1",
@@ -233,20 +220,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 17
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "підсумок",
-      "lemmaId": "підсумок",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 18
+      "newOrder": 16
     },
     {
       "cefr": "B1",
@@ -257,7 +231,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 19
+      "newOrder": 17
     },
     {
       "cefr": "B1",
@@ -268,7 +242,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 20
+      "newOrder": 18
     },
     {
       "cefr": "B1",
@@ -279,20 +253,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 21
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "п'ятниця",
-      "lemmaId": "п-ятниця",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 22
+      "newOrder": 19
     },
     {
       "cefr": "B1",
@@ -305,7 +266,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 23
+      "newOrder": 20
     },
     {
       "cefr": "B1",
@@ -316,7 +277,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 24
+      "newOrder": 21
     },
     {
       "cefr": "B1",
@@ -329,7 +290,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 25
+      "newOrder": 22
     },
     {
       "cefr": "B1",
@@ -342,7 +303,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 26
+      "newOrder": 23
     },
     {
       "cefr": "B1",
@@ -353,7 +314,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 27
+      "newOrder": 24
     },
     {
       "cefr": "B1",
@@ -366,7 +327,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 28
+      "newOrder": 25
     },
     {
       "cefr": "B1",
@@ -379,7 +340,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 29
+      "newOrder": 26
     },
     {
       "cefr": "B1",
@@ -392,7 +353,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 30
+      "newOrder": 27
     },
     {
       "cefr": "B1",
@@ -405,7 +366,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 31
+      "newOrder": 28
     },
     {
       "cefr": "B1",
@@ -418,20 +379,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 32
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "дев'яносто",
-      "lemmaId": "дев-яносто",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 33
+      "newOrder": 29
     },
     {
       "cefr": "B1",
@@ -444,18 +392,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 34
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "маслом",
-      "lemmaId": "маслом",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 35
+      "newOrder": 30
     },
     {
       "cefr": "B1",
@@ -468,7 +405,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 36
+      "newOrder": 31
     },
     {
       "cefr": "B1",
@@ -481,7 +418,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 37
+      "newOrder": 32
     },
     {
       "cefr": "B1",
@@ -492,7 +429,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 38
+      "newOrder": 33
     },
     {
       "cefr": "B1",
@@ -505,7 +442,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 39
+      "newOrder": 34
     },
     {
       "cefr": "B1",
@@ -516,7 +453,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 40
+      "newOrder": 35
     },
     {
       "cefr": "B1",
@@ -529,7 +466,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 41
+      "newOrder": 36
     },
     {
       "cefr": "B1",
@@ -540,7 +477,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 42
+      "newOrder": 37
     },
     {
       "cefr": "B1",
@@ -553,7 +490,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 43
+      "newOrder": 38
     },
     {
       "cefr": "B1",
@@ -566,7 +503,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 44
+      "newOrder": 39
     },
     {
       "cefr": "B1",
@@ -579,7 +516,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 45
+      "newOrder": 40
     },
     {
       "cefr": "B1",
@@ -592,7 +529,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 46
+      "newOrder": 41
     },
     {
       "cefr": "B1",
@@ -605,7 +542,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 47
+      "newOrder": 42
     },
     {
       "cefr": "B1",
@@ -616,7 +553,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 48
+      "newOrder": 43
     },
     {
       "cefr": "B1",
@@ -629,7 +566,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 49
+      "newOrder": 44
     },
     {
       "cefr": "B1",
@@ -642,7 +579,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 50
+      "newOrder": 45
     },
     {
       "cefr": "B1",
@@ -655,7 +592,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 51
+      "newOrder": 46
     },
     {
       "cefr": "B1",
@@ -668,7 +605,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 52
+      "newOrder": 47
     },
     {
       "cefr": "B1",
@@ -681,7 +618,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 53
+      "newOrder": 48
     },
     {
       "cefr": "B1",
@@ -694,7 +631,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 54
+      "newOrder": 49
     },
     {
       "cefr": "B1",
@@ -707,7 +644,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 55
+      "newOrder": 50
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "джерело",
+      "lemmaId": "джерело",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 51
     },
     {
       "cefr": "B1",
@@ -720,7 +670,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 56
+      "newOrder": 52
     },
     {
       "cefr": "B1",
@@ -733,20 +683,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 57
+      "newOrder": 53
     },
     {
       "cefr": "B1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "літера",
-      "lemmaId": "літера",
+      "lemma": "наголос",
+      "lemmaId": "наголос",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 58
+      "newOrder": 54
     },
     {
       "cefr": "B1",
@@ -759,20 +709,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 59
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "ложка",
-      "lemmaId": "ложка",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 60
+      "newOrder": 55
     },
     {
       "cefr": "B1",
@@ -785,7 +722,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 61
+      "newOrder": 56
     },
     {
       "cefr": "B1",
@@ -798,7 +735,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 62
+      "newOrder": 57
     },
     {
       "cefr": "B1",
@@ -811,7 +748,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 63
+      "newOrder": 58
     },
     {
       "cefr": "B1",
@@ -824,7 +761,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 64
+      "newOrder": 59
     },
     {
       "cefr": "B1",
@@ -837,20 +774,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 65
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вчать",
-      "lemmaId": "вчать",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 66
+      "newOrder": 60
     },
     {
       "cefr": "B1",
@@ -863,7 +787,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 67
+      "newOrder": 61
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "ходите",
+      "lemmaId": "ходите",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 62
     },
     {
       "cefr": "B1",
@@ -876,7 +813,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 68
+      "newOrder": 63
     },
     {
       "cefr": "B1",
@@ -889,7 +826,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 69
+      "newOrder": 64
     },
     {
       "cefr": "B1",
@@ -902,7 +839,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 70
+      "newOrder": 65
     },
     {
       "cefr": "B1",
@@ -915,7 +852,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 71
+      "newOrder": 66
     },
     {
       "cefr": "B1",
@@ -928,7 +865,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 72
+      "newOrder": 67
     },
     {
       "cefr": "B1",
@@ -941,7 +878,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 73
+      "newOrder": 68
     },
     {
       "cefr": "B1",
@@ -954,7 +891,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 74
+      "newOrder": 69
     },
     {
       "cefr": "B1",
@@ -967,7 +904,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 75
+      "newOrder": 70
     },
     {
       "cefr": "B1",
@@ -980,7 +917,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 76
+      "newOrder": 71
     },
     {
       "cefr": "B1",
@@ -993,7 +930,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 77
+      "newOrder": 72
     },
     {
       "cefr": "B1",
@@ -1006,7 +943,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 78
+      "newOrder": 73
     },
     {
       "cefr": "B1",
@@ -1019,20 +956,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 79
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "киянин",
-      "lemmaId": "киянин",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 80
+      "newOrder": 74
     },
     {
       "cefr": "B1",
@@ -1045,7 +969,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 81
+      "newOrder": 75
     },
     {
       "cefr": "B1",
@@ -1058,7 +982,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 82
+      "newOrder": 76
     },
     {
       "cefr": "B1",
@@ -1071,7 +995,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 83
+      "newOrder": 77
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "одесит",
+      "lemmaId": "одесит",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 78
     },
     {
       "cefr": "B1",
@@ -1084,7 +1021,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 84
+      "newOrder": 79
     },
     {
       "cefr": "B1",
@@ -1097,7 +1034,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 85
+      "newOrder": 80
     },
     {
       "cefr": "B1",
@@ -1108,7 +1045,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 86
+      "newOrder": 81
     },
     {
       "cefr": "B1",
@@ -1121,7 +1058,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 87
+      "newOrder": 82
     },
     {
       "cefr": "B1",
@@ -1134,7 +1071,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 88
+      "newOrder": 83
     },
     {
       "cefr": "B1",
@@ -1147,7 +1084,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 89
+      "newOrder": 84
     },
     {
       "cefr": "B1",
@@ -1160,7 +1097,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 90
+      "newOrder": 85
     },
     {
       "cefr": "B1",
@@ -1173,18 +1110,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 91
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вітаємо",
-      "lemmaId": "вітаємо",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 92
+      "newOrder": 86
     },
     {
       "cefr": "B1",
@@ -1197,7 +1123,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 93
+      "newOrder": 87
     },
     {
       "cefr": "B1",
@@ -1210,7 +1136,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 94
+      "newOrder": 88
     },
     {
       "cefr": "B1",
@@ -1223,7 +1149,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 95
+      "newOrder": 89
     },
     {
       "cefr": "B1",
@@ -1236,7 +1162,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 96
+      "newOrder": 90
     },
     {
       "cefr": "B1",
@@ -1249,7 +1175,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 97
+      "newOrder": 91
     },
     {
       "cefr": "B1",
@@ -1262,7 +1188,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 98
+      "newOrder": 92
     },
     {
       "cefr": "B1",
@@ -1275,7 +1201,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 99
+      "newOrder": 93
     },
     {
       "cefr": "B1",
@@ -1288,7 +1214,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 100
+      "newOrder": 94
     },
     {
       "cefr": "B1",
@@ -1301,7 +1227,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 101
+      "newOrder": 95
     },
     {
       "cefr": "B1",
@@ -1314,7 +1240,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 102
+      "newOrder": 96
     },
     {
       "cefr": "B1",
@@ -1327,7 +1253,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 103
+      "newOrder": 97
     },
     {
       "cefr": "B1",
@@ -1340,20 +1266,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 104
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "базовий",
-      "lemmaId": "базовий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 105
+      "newOrder": 98
     },
     {
       "cefr": "B1",
@@ -1366,7 +1279,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 106
+      "newOrder": 99
     },
     {
       "cefr": "B1",
@@ -1379,7 +1292,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 107
+      "newOrder": 100
     },
     {
       "cefr": "B1",
@@ -1392,7 +1305,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 108
+      "newOrder": 101
     },
     {
       "cefr": "B1",
@@ -1405,7 +1318,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 109
+      "newOrder": 102
     },
     {
       "cefr": "B1",
@@ -1418,7 +1331,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 110
+      "newOrder": 103
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "контрольна",
+      "lemmaId": "контрольна",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 104
     },
     {
       "cefr": "B1",
@@ -1431,7 +1357,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 111
+      "newOrder": 105
     },
     {
       "cefr": "B1",
@@ -1444,7 +1370,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 112
+      "newOrder": 106
     },
     {
       "cefr": "B1",
@@ -1457,7 +1383,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 113
+      "newOrder": 107
     },
     {
       "cefr": "B1",
@@ -1470,7 +1396,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 114
+      "newOrder": 108
     },
     {
       "cefr": "B1",
@@ -1483,7 +1409,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 115
+      "newOrder": 109
     },
     {
       "cefr": "B1",
@@ -1496,7 +1422,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 116
+      "newOrder": 110
     },
     {
       "cefr": "B1",
@@ -1509,20 +1435,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 117
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "впізнати",
-      "lemmaId": "впізнати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 118
+      "newOrder": 111
     },
     {
       "cefr": "B1",
@@ -1535,7 +1448,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 119
+      "newOrder": 112
     },
     {
       "cefr": "B1",
@@ -1548,7 +1461,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 120
+      "newOrder": 113
     },
     {
       "cefr": "B1",
@@ -1561,7 +1474,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 121
+      "newOrder": 114
     },
     {
       "cefr": "B1",
@@ -1574,7 +1487,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 122
+      "newOrder": 115
     },
     {
       "cefr": "B1",
@@ -1587,7 +1500,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 123
+      "newOrder": 116
     },
     {
       "cefr": "B1",
@@ -1600,20 +1513,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 124
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "означення",
-      "lemmaId": "означення",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 125
+      "newOrder": 117
     },
     {
       "cefr": "B1",
@@ -1626,7 +1526,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 126
+      "newOrder": 118
     },
     {
       "cefr": "B1",
@@ -1639,7 +1539,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 127
+      "newOrder": 119
     },
     {
       "cefr": "B1",
@@ -1652,7 +1552,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 128
+      "newOrder": 120
     },
     {
       "cefr": "B1",
@@ -1665,7 +1565,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 129
+      "newOrder": 121
     },
     {
       "cefr": "B1",
@@ -1678,7 +1578,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 130
+      "newOrder": 122
     },
     {
       "cefr": "B1",
@@ -1691,7 +1591,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 131
+      "newOrder": 123
     },
     {
       "cefr": "B1",
@@ -1704,7 +1604,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 132
+      "newOrder": 124
     },
     {
       "cefr": "B1",
@@ -1717,7 +1617,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 133
+      "newOrder": 125
     },
     {
       "cefr": "B1",
@@ -1730,7 +1630,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 134
+      "newOrder": 126
     },
     {
       "cefr": "B1",
@@ -1743,7 +1643,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 135
+      "newOrder": 127
     },
     {
       "cefr": "B1",
@@ -1756,7 +1656,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 136
+      "newOrder": 128
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "заздрити",
+      "lemmaId": "заздрити",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 129
     },
     {
       "cefr": "B1",
@@ -1769,7 +1682,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 137
+      "newOrder": 130
     },
     {
       "cefr": "B1",
@@ -1782,7 +1695,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 138
+      "newOrder": 131
     },
     {
       "cefr": "B1",
@@ -1795,7 +1708,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 139
+      "newOrder": 132
     },
     {
       "cefr": "B1",
@@ -1808,7 +1721,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 140
+      "newOrder": 133
     },
     {
       "cefr": "B1",
@@ -1821,7 +1734,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 141
+      "newOrder": 134
     },
     {
       "cefr": "B1",
@@ -1834,7 +1747,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 142
+      "newOrder": 135
     },
     {
       "cefr": "B1",
@@ -1847,7 +1760,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 143
+      "newOrder": 136
     },
     {
       "cefr": "B1",
@@ -1860,7 +1773,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 144
+      "newOrder": 137
     },
     {
       "cefr": "B1",
@@ -1873,7 +1786,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 145
+      "newOrder": 138
     },
     {
       "cefr": "B1",
@@ -1886,7 +1799,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 146
+      "newOrder": 139
     },
     {
       "cefr": "B1",
@@ -1899,7 +1812,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 147
+      "newOrder": 140
     },
     {
       "cefr": "B1",
@@ -1912,7 +1825,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 148
+      "newOrder": 141
     },
     {
       "cefr": "B1",
@@ -1925,7 +1838,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 149
+      "newOrder": 142
     },
     {
       "cefr": "B1",
@@ -1938,7 +1851,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 150
+      "newOrder": 143
     },
     {
       "cefr": "B1",
@@ -1951,7 +1864,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 151
+      "newOrder": 144
     },
     {
       "cefr": "B1",
@@ -1964,7 +1877,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 152
+      "newOrder": 145
     },
     {
       "cefr": "B1",
@@ -1977,7 +1890,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 153
+      "newOrder": 146
     },
     {
       "cefr": "B1",
@@ -1990,20 +1903,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 154
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "пауза",
-      "lemmaId": "пауза",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 155
+      "newOrder": 147
     },
     {
       "cefr": "B1",
@@ -2016,7 +1916,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 156
+      "newOrder": 148
     },
     {
       "cefr": "B1",
@@ -2029,7 +1929,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 157
+      "newOrder": 149
     },
     {
       "cefr": "B1",
@@ -2042,7 +1942,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 158
+      "newOrder": 150
     },
     {
       "cefr": "B1",
@@ -2055,7 +1955,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 159
+      "newOrder": 151
     },
     {
       "cefr": "B1",
@@ -2068,7 +1968,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 160
+      "newOrder": 152
     },
     {
       "cefr": "B1",
@@ -2081,7 +1981,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 161
+      "newOrder": 153
     },
     {
       "cefr": "B1",
@@ -2094,7 +1994,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 162
+      "newOrder": 154
     },
     {
       "cefr": "B1",
@@ -2107,7 +2007,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 163
+      "newOrder": 155
     },
     {
       "cefr": "B1",
@@ -2120,7 +2020,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 164
+      "newOrder": 156
     },
     {
       "cefr": "B1",
@@ -2133,7 +2033,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 165
+      "newOrder": 157
     },
     {
       "cefr": "B1",
@@ -2146,7 +2046,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 166
+      "newOrder": 158
     },
     {
       "cefr": "B1",
@@ -2159,7 +2059,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 167
+      "newOrder": 159
     },
     {
       "cefr": "B1",
@@ -2172,7 +2072,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 168
+      "newOrder": 160
     },
     {
       "cefr": "B1",
@@ -2185,7 +2085,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 169
+      "newOrder": 161
     },
     {
       "cefr": "B1",
@@ -2198,7 +2098,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 170
+      "newOrder": 162
     },
     {
       "cefr": "B1",
@@ -2211,7 +2111,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 171
+      "newOrder": 163
     },
     {
       "cefr": "B1",
@@ -2224,7 +2124,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 172
+      "newOrder": 164
     },
     {
       "cefr": "B1",
@@ -2237,7 +2137,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 173
+      "newOrder": 165
     },
     {
       "cefr": "B1",
@@ -2248,7 +2148,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 174
+      "newOrder": 166
     },
     {
       "cefr": "B1",
@@ -2261,7 +2161,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 175
+      "newOrder": 167
     },
     {
       "cefr": "B1",
@@ -2274,7 +2174,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 176
+      "newOrder": 168
     },
     {
       "cefr": "B1",
@@ -2287,7 +2187,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 177
+      "newOrder": 169
     },
     {
       "cefr": "B1",
@@ -2298,7 +2198,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 178
+      "newOrder": 170
     },
     {
       "cefr": "B1",
@@ -2309,7 +2209,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 179
+      "newOrder": 171
     },
     {
       "cefr": "B1",
@@ -2320,18 +2220,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 180
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "ніякий",
-      "lemmaId": "ніякий",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 181
+      "newOrder": 172
     },
     {
       "cefr": "B1",
@@ -2342,7 +2231,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 182
+      "newOrder": 173
     },
     {
       "cefr": "B1",
@@ -2353,7 +2242,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 183
+      "newOrder": 174
     },
     {
       "cefr": "B1",
@@ -2364,7 +2253,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 184
+      "newOrder": 175
     },
     {
       "cefr": "B1",
@@ -2377,7 +2266,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 185
+      "newOrder": 176
     },
     {
       "cefr": "B1",
@@ -2390,7 +2279,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 186
+      "newOrder": 177
     },
     {
       "cefr": "B1",
@@ -2401,7 +2290,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 187
+      "newOrder": 178
     },
     {
       "cefr": "B1",
@@ -2414,7 +2303,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 188
+      "newOrder": 179
     },
     {
       "cefr": "B1",
@@ -2427,7 +2316,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 189
+      "newOrder": 180
     },
     {
       "cefr": "B1",
@@ -2440,7 +2329,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 190
+      "newOrder": 181
     },
     {
       "cefr": "B1",
@@ -2453,7 +2342,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 191
+      "newOrder": 182
     },
     {
       "cefr": "B1",
@@ -2466,7 +2355,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 192
+      "newOrder": 183
     },
     {
       "cefr": "B1",
@@ -2479,7 +2368,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 193
+      "newOrder": 184
     },
     {
       "cefr": "B1",
@@ -2492,7 +2381,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 194
+      "newOrder": 185
     },
     {
       "cefr": "B1",
@@ -2505,7 +2394,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 195
+      "newOrder": 186
     },
     {
       "cefr": "B1",
@@ -2518,7 +2407,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 196
+      "newOrder": 187
     },
     {
       "cefr": "B1",
@@ -2531,7 +2420,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 197
+      "newOrder": 188
     },
     {
       "cefr": "B1",
@@ -2544,7 +2433,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 198
+      "newOrder": 189
     },
     {
       "cefr": "B1",
@@ -2557,7 +2446,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 199
+      "newOrder": 190
     },
     {
       "cefr": "B1",
@@ -2570,7 +2459,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 200
+      "newOrder": 191
     },
     {
       "cefr": "B1",
@@ -2583,7 +2472,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 201
+      "newOrder": 192
     },
     {
       "cefr": "B1",
@@ -2596,7 +2485,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 202
+      "newOrder": 193
     },
     {
       "cefr": "B1",
@@ -2609,7 +2498,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 203
+      "newOrder": 194
     },
     {
       "cefr": "B1",
@@ -2622,7 +2511,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 204
+      "newOrder": 195
     },
     {
       "cefr": "B1",
@@ -2635,7 +2524,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 205
+      "newOrder": 196
     },
     {
       "cefr": "B1",
@@ -2648,7 +2537,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 206
+      "newOrder": 197
     },
     {
       "cefr": "B1",
@@ -2661,7 +2550,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 207
+      "newOrder": 198
     },
     {
       "cefr": "B1",
@@ -2674,7 +2563,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 208
+      "newOrder": 199
     },
     {
       "cefr": "B1",
@@ -2687,7 +2576,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 209
+      "newOrder": 200
     },
     {
       "cefr": "B1",
@@ -2700,7 +2589,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 210
+      "newOrder": 201
     },
     {
       "cefr": "B1",
@@ -2713,7 +2602,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 211
+      "newOrder": 202
     },
     {
       "cefr": "B1",
@@ -2726,7 +2615,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 212
+      "newOrder": 203
     },
     {
       "cefr": "B1",
@@ -2739,7 +2628,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 213
+      "newOrder": 204
     },
     {
       "cefr": "B1",
@@ -2752,7 +2641,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 214
+      "newOrder": 205
     },
     {
       "cefr": "B1",
@@ -2765,7 +2654,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 215
+      "newOrder": 206
     },
     {
       "cefr": "B1",
@@ -2776,7 +2665,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 216
+      "newOrder": 207
     },
     {
       "cefr": "B1",
@@ -2789,7 +2678,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 217
+      "newOrder": 208
     },
     {
       "cefr": "B1",
@@ -2802,7 +2691,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 218
+      "newOrder": 209
     },
     {
       "cefr": "B1",
@@ -2815,7 +2704,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 219
+      "newOrder": 210
     },
     {
       "cefr": "B1",
@@ -2828,7 +2717,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 220
+      "newOrder": 211
     },
     {
       "cefr": "B1",
@@ -2841,7 +2730,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 221
+      "newOrder": 212
     },
     {
       "cefr": "B1",
@@ -2852,7 +2741,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 222
+      "newOrder": 213
     },
     {
       "cefr": "B1",
@@ -2863,7 +2752,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 223
+      "newOrder": 214
     },
     {
       "cefr": "B1",
@@ -2876,7 +2765,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 224
+      "newOrder": 215
     },
     {
       "cefr": "B1",
@@ -2889,7 +2778,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 225
+      "newOrder": 216
     },
     {
       "cefr": "B1",
@@ -2902,7 +2791,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 226
+      "newOrder": 217
     },
     {
       "cefr": "B1",
@@ -2915,7 +2804,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 227
+      "newOrder": 218
     },
     {
       "cefr": "B1",
@@ -2928,7 +2817,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 228
+      "newOrder": 219
     },
     {
       "cefr": "B1",
@@ -2941,7 +2830,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 229
+      "newOrder": 220
     },
     {
       "cefr": "B1",
@@ -2954,7 +2843,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 230
+      "newOrder": 221
     },
     {
       "cefr": "B1",
@@ -2967,7 +2856,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 231
+      "newOrder": 222
     },
     {
       "cefr": "B1",
@@ -2980,7 +2869,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 232
+      "newOrder": 223
     },
     {
       "cefr": "B1",
@@ -2993,7 +2882,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 233
+      "newOrder": 224
     },
     {
       "cefr": "B1",
@@ -3006,7 +2895,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 234
+      "newOrder": 225
     },
     {
       "cefr": "B1",
@@ -3019,7 +2908,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 235
+      "newOrder": 226
     },
     {
       "cefr": "B1",
@@ -3032,7 +2921,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 236
+      "newOrder": 227
     },
     {
       "cefr": "B1",
@@ -3045,7 +2934,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 237
+      "newOrder": 228
     },
     {
       "cefr": "B1",
@@ -3058,7 +2947,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 238
+      "newOrder": 229
     },
     {
       "cefr": "B1",
@@ -3069,20 +2958,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 239
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "знаходитися",
-      "lemmaId": "знаходитися",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 240
+      "newOrder": 230
     },
     {
       "cefr": "B1",
@@ -3095,7 +2971,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 241
+      "newOrder": 231
     },
     {
       "cefr": "B1",
@@ -3108,7 +2984,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 242
+      "newOrder": 232
     },
     {
       "cefr": "B1",
@@ -3121,7 +2997,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 243
+      "newOrder": 233
     },
     {
       "cefr": "B1",
@@ -3134,20 +3010,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 244
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "апетит",
-      "lemmaId": "апетит",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 245
+      "newOrder": 234
     },
     {
       "cefr": "B1",
@@ -3160,7 +3023,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 246
+      "newOrder": 235
     },
     {
       "cefr": "B1",
@@ -3173,7 +3036,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 247
+      "newOrder": 236
     },
     {
       "cefr": "B1",
@@ -3186,7 +3049,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 248
+      "newOrder": 237
     },
     {
       "cefr": "B1",
@@ -3199,7 +3062,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 249
+      "newOrder": 238
     },
     {
       "cefr": "B1",
@@ -3212,7 +3075,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 250
+      "newOrder": 239
     },
     {
       "cefr": "B1",
@@ -3223,7 +3086,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 251
+      "newOrder": 240
     },
     {
       "cefr": "B1",
@@ -3234,7 +3097,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 252
+      "newOrder": 241
     },
     {
       "cefr": "B1",
@@ -3247,7 +3110,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 253
+      "newOrder": 242
     },
     {
       "cefr": "B1",
@@ -3260,7 +3123,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 254
+      "newOrder": 243
     },
     {
       "cefr": "B1",
@@ -3273,7 +3136,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 255
+      "newOrder": 244
     },
     {
       "cefr": "B1",
@@ -3286,7 +3149,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 256
+      "newOrder": 245
     },
     {
       "cefr": "B1",
@@ -3299,20 +3162,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 257
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "гучний",
-      "lemmaId": "гучний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 258
+      "newOrder": 246
     },
     {
       "cefr": "B1",
@@ -3325,7 +3175,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 259
+      "newOrder": 247
     },
     {
       "cefr": "B1",
@@ -3338,7 +3188,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 260
+      "newOrder": 248
     },
     {
       "cefr": "B1",
@@ -3351,7 +3201,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 261
+      "newOrder": 249
     },
     {
       "cefr": "B1",
@@ -3364,7 +3214,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 262
+      "newOrder": 250
     },
     {
       "cefr": "B1",
@@ -3377,7 +3227,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 263
+      "newOrder": 251
     },
     {
       "cefr": "B1",
@@ -3390,7 +3240,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 264
+      "newOrder": 252
     },
     {
       "cefr": "B1",
@@ -3403,7 +3253,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 265
+      "newOrder": 253
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "прудко",
+      "lemmaId": "прудко",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 254
     },
     {
       "cefr": "B1",
@@ -3416,7 +3279,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 266
+      "newOrder": 255
     },
     {
       "cefr": "B1",
@@ -3429,7 +3292,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 267
+      "newOrder": 256
     },
     {
       "cefr": "B1",
@@ -3442,7 +3305,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 268
+      "newOrder": 257
     },
     {
       "cefr": "B1",
@@ -3455,7 +3318,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 269
+      "newOrder": 258
     },
     {
       "cefr": "B1",
@@ -3468,7 +3331,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 270
+      "newOrder": 259
     },
     {
       "cefr": "B1",
@@ -3481,7 +3344,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 271
+      "newOrder": 260
     },
     {
       "cefr": "B1",
@@ -3494,7 +3357,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 272
+      "newOrder": 261
     },
     {
       "cefr": "B1",
@@ -3507,7 +3370,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 273
+      "newOrder": 262
     },
     {
       "cefr": "B1",
@@ -3520,7 +3383,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 274
+      "newOrder": 263
     },
     {
       "cefr": "B1",
@@ -3533,7 +3396,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 275
+      "newOrder": 264
     },
     {
       "cefr": "B1",
@@ -3546,7 +3409,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 276
+      "newOrder": 265
     },
     {
       "cefr": "B1",
@@ -3559,7 +3422,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 277
+      "newOrder": 266
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "компас",
+      "lemmaId": "компас",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 267
     },
     {
       "cefr": "B1",
@@ -3572,7 +3448,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 278
+      "newOrder": 268
     },
     {
       "cefr": "B1",
@@ -3585,7 +3461,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 279
+      "newOrder": 269
     },
     {
       "cefr": "B1",
@@ -3598,7 +3474,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 280
+      "newOrder": 270
     },
     {
       "cefr": "B1",
@@ -3611,7 +3487,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 281
+      "newOrder": 271
     },
     {
       "cefr": "B1",
@@ -3624,7 +3500,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 282
+      "newOrder": 272
     },
     {
       "cefr": "B1",
@@ -3637,7 +3513,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 283
+      "newOrder": 273
     },
     {
       "cefr": "B1",
@@ -3650,7 +3526,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 284
+      "newOrder": 274
     },
     {
       "cefr": "B1",
@@ -3663,7 +3539,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 285
+      "newOrder": 275
     },
     {
       "cefr": "B1",
@@ -3676,7 +3552,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 286
+      "newOrder": 276
     },
     {
       "cefr": "B1",
@@ -3689,7 +3565,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 287
+      "newOrder": 277
     },
     {
       "cefr": "B1",
@@ -3702,7 +3578,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 288
+      "newOrder": 278
     },
     {
       "cefr": "B1",
@@ -3715,7 +3591,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 289
+      "newOrder": 279
     },
     {
       "cefr": "B1",
@@ -3728,7 +3604,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 290
+      "newOrder": 280
     },
     {
       "cefr": "B1",
@@ -3741,7 +3617,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 291
+      "newOrder": 281
     },
     {
       "cefr": "B1",
@@ -3752,7 +3628,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 292
+      "newOrder": 282
     },
     {
       "cefr": "B1",
@@ -3765,7 +3641,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 293
+      "newOrder": 283
     },
     {
       "cefr": "B1",
@@ -3778,7 +3654,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 294
+      "newOrder": 284
     },
     {
       "cefr": "B1",
@@ -3791,7 +3667,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 295
+      "newOrder": 285
     },
     {
       "cefr": "B1",
@@ -3804,7 +3680,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 296
+      "newOrder": 286
     },
     {
       "cefr": "B1",
@@ -3817,7 +3693,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 297
+      "newOrder": 287
     },
     {
       "cefr": "B1",
@@ -3830,7 +3706,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 298
+      "newOrder": 288
     },
     {
       "cefr": "B1",
@@ -3843,7 +3719,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 299
+      "newOrder": 289
     },
     {
       "cefr": "B1",
@@ -3856,7 +3732,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 300
+      "newOrder": 290
     },
     {
       "cefr": "B1",
@@ -3869,7 +3745,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 301
+      "newOrder": 291
     },
     {
       "cefr": "B1",
@@ -3882,7 +3758,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 302
+      "newOrder": 292
     },
     {
       "cefr": "B1",
@@ -3895,7 +3771,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 303
+      "newOrder": 293
     },
     {
       "cefr": "B1",
@@ -3908,7 +3784,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 304
+      "newOrder": 294
     },
     {
       "cefr": "B1",
@@ -3921,7 +3797,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 305
+      "newOrder": 295
     },
     {
       "cefr": "B1",
@@ -3934,7 +3810,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 306
+      "newOrder": 296
     },
     {
       "cefr": "B1",
@@ -3947,7 +3823,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 307
+      "newOrder": 297
     },
     {
       "cefr": "B1",
@@ -3960,7 +3836,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 308
+      "newOrder": 298
     },
     {
       "cefr": "B1",
@@ -3973,7 +3849,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 309
+      "newOrder": 299
     },
     {
       "cefr": "B1",
@@ -3986,7 +3862,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 310
+      "newOrder": 300
     },
     {
       "cefr": "B1",
@@ -3999,7 +3875,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 311
+      "newOrder": 301
     },
     {
       "cefr": "B1",
@@ -4012,7 +3888,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 312
+      "newOrder": 302
     },
     {
       "cefr": "B1",
@@ -4025,7 +3901,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 313
+      "newOrder": 303
     },
     {
       "cefr": "B1",
@@ -4038,7 +3914,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 314
+      "newOrder": 304
     },
     {
       "cefr": "B1",
@@ -4051,7 +3927,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 315
+      "newOrder": 305
     },
     {
       "cefr": "B1",
@@ -4064,7 +3940,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 316
+      "newOrder": 306
     },
     {
       "cefr": "B1",
@@ -4077,7 +3953,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 317
+      "newOrder": 307
     },
     {
       "cefr": "B1",
@@ -4090,7 +3966,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 318
+      "newOrder": 308
     },
     {
       "cefr": "B1",
@@ -4103,7 +3979,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 319
+      "newOrder": 309
     },
     {
       "cefr": "B1",
@@ -4116,7 +3992,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 320
+      "newOrder": 310
     },
     {
       "cefr": "B1",
@@ -4129,7 +4005,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 321
+      "newOrder": 311
     },
     {
       "cefr": "B1",
@@ -4142,7 +4018,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 322
+      "newOrder": 312
     },
     {
       "cefr": "B1",
@@ -4155,7 +4031,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 323
+      "newOrder": 313
     },
     {
       "cefr": "B1",
@@ -4168,7 +4044,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 324
+      "newOrder": 314
     },
     {
       "cefr": "B1",
@@ -4181,7 +4057,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 325
+      "newOrder": 315
     },
     {
       "cefr": "B1",
@@ -4194,7 +4070,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 326
+      "newOrder": 316
     },
     {
       "cefr": "B1",
@@ -4207,7 +4083,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 327
+      "newOrder": 317
     },
     {
       "cefr": "B1",
@@ -4220,7 +4096,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 328
+      "newOrder": 318
     },
     {
       "cefr": "B1",
@@ -4233,7 +4109,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 329
+      "newOrder": 319
     },
     {
       "cefr": "B1",
@@ -4246,7 +4122,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 330
+      "newOrder": 320
     },
     {
       "cefr": "B1",
@@ -4259,7 +4135,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 331
+      "newOrder": 321
     },
     {
       "cefr": "B1",
@@ -4272,7 +4148,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 332
+      "newOrder": 322
     },
     {
       "cefr": "B1",
@@ -4285,7 +4161,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 333
+      "newOrder": 323
     },
     {
       "cefr": "B1",
@@ -4298,7 +4174,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 334
+      "newOrder": 324
     },
     {
       "cefr": "B1",
@@ -4311,7 +4187,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 335
+      "newOrder": 325
     },
     {
       "cefr": "B1",
@@ -4324,7 +4200,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 336
+      "newOrder": 326
     },
     {
       "cefr": "B1",
@@ -4337,7 +4213,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 337
+      "newOrder": 327
     },
     {
       "cefr": "B1",
@@ -4350,7 +4226,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 338
+      "newOrder": 328
     },
     {
       "cefr": "B1",
@@ -4363,7 +4239,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 339
+      "newOrder": 329
     },
     {
       "cefr": "B1",
@@ -4376,7 +4252,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 340
+      "newOrder": 330
     },
     {
       "cefr": "B1",
@@ -4389,7 +4265,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 341
+      "newOrder": 331
     },
     {
       "cefr": "B1",
@@ -4402,7 +4278,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 342
+      "newOrder": 332
     },
     {
       "cefr": "B1",
@@ -4415,7 +4291,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 343
+      "newOrder": 333
     },
     {
       "cefr": "B1",
@@ -4428,7 +4304,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 344
+      "newOrder": 334
     },
     {
       "cefr": "B1",
@@ -4441,7 +4317,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 345
+      "newOrder": 335
     },
     {
       "cefr": "B1",
@@ -4454,7 +4330,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 346
+      "newOrder": 336
     },
     {
       "cefr": "B1",
@@ -4467,7 +4343,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 347
+      "newOrder": 337
     },
     {
       "cefr": "B1",
@@ -4480,7 +4356,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 348
+      "newOrder": 338
     },
     {
       "cefr": "B1",
@@ -4491,7 +4367,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 349
+      "newOrder": 339
     },
     {
       "cefr": "B1",
@@ -4504,7 +4380,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 350
+      "newOrder": 340
     },
     {
       "cefr": "B1",
@@ -4517,7 +4393,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 351
+      "newOrder": 341
     },
     {
       "cefr": "B1",
@@ -4530,7 +4406,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 352
+      "newOrder": 342
     },
     {
       "cefr": "B1",
@@ -4543,7 +4419,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 353
+      "newOrder": 343
     },
     {
       "cefr": "B1",
@@ -4556,7 +4432,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 354
+      "newOrder": 344
     },
     {
       "cefr": "B1",
@@ -4569,7 +4445,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 355
+      "newOrder": 345
     },
     {
       "cefr": "B1",
@@ -4582,7 +4458,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 356
+      "newOrder": 346
     },
     {
       "cefr": "B1",
@@ -4595,7 +4471,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 357
+      "newOrder": 347
     },
     {
       "cefr": "B1",
@@ -4608,7 +4484,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 358
+      "newOrder": 348
     },
     {
       "cefr": "B1",
@@ -4621,7 +4497,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 359
+      "newOrder": 349
     },
     {
       "cefr": "B1",
@@ -4634,7 +4510,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 360
+      "newOrder": 350
     },
     {
       "cefr": "B1",
@@ -4647,7 +4523,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 361
+      "newOrder": 351
     },
     {
       "cefr": "B1",
@@ -4660,7 +4536,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 362
+      "newOrder": 352
     },
     {
       "cefr": "B1",
@@ -4671,7 +4547,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 363
+      "newOrder": 353
     },
     {
       "cefr": "B1",
@@ -4684,7 +4560,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 364
+      "newOrder": 354
     },
     {
       "cefr": "B1",
@@ -4697,7 +4573,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 365
+      "newOrder": 355
     },
     {
       "cefr": "B1",
@@ -4710,7 +4586,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 366
+      "newOrder": 356
     },
     {
       "cefr": "B1",
@@ -4723,7 +4599,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 367
+      "newOrder": 357
     },
     {
       "cefr": "B1",
@@ -4736,7 +4612,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 368
+      "newOrder": 358
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "контрольований",
+      "lemmaId": "контрольований",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 359
     },
     {
       "cefr": "B1",
@@ -4749,7 +4638,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 369
+      "newOrder": 360
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "прагматичний",
+      "lemmaId": "прагматичний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 361
     },
     {
       "cefr": "B1",
@@ -4762,7 +4664,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 370
+      "newOrder": 362
     },
     {
       "cefr": "B1",
@@ -4775,7 +4677,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 371
+      "newOrder": 363
     },
     {
       "cefr": "B1",
@@ -4788,7 +4690,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 372
+      "newOrder": 364
     },
     {
       "cefr": "B1",
@@ -4801,7 +4703,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 373
+      "newOrder": 365
     },
     {
       "cefr": "B1",
@@ -4814,7 +4716,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 374
+      "newOrder": 366
     },
     {
       "cefr": "B1",
@@ -4827,7 +4729,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 375
+      "newOrder": 367
     },
     {
       "cefr": "B1",
@@ -4840,7 +4742,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 376
+      "newOrder": 368
     },
     {
       "cefr": "B1",
@@ -4853,7 +4755,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 377
+      "newOrder": 369
     },
     {
       "cefr": "B1",
@@ -4866,7 +4768,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 378
+      "newOrder": 370
     },
     {
       "cefr": "B1",
@@ -4879,7 +4781,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 379
+      "newOrder": 371
     },
     {
       "cefr": "B1",
@@ -4892,7 +4794,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 380
+      "newOrder": 372
     },
     {
       "cefr": "B1",
@@ -4905,7 +4807,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 381
+      "newOrder": 373
     },
     {
       "cefr": "B1",
@@ -4918,7 +4820,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 382
+      "newOrder": 374
     },
     {
       "cefr": "B1",
@@ -4931,7 +4833,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 383
+      "newOrder": 375
     },
     {
       "cefr": "B1",
@@ -4944,7 +4846,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 384
+      "newOrder": 376
     },
     {
       "cefr": "B1",
@@ -4957,7 +4859,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 385
+      "newOrder": 377
     },
     {
       "cefr": "B1",
@@ -4970,7 +4872,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 386
+      "newOrder": 378
     },
     {
       "cefr": "B1",
@@ -4983,7 +4885,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 387
+      "newOrder": 379
     },
     {
       "cefr": "B1",
@@ -4996,7 +4898,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 388
+      "newOrder": 380
     },
     {
       "cefr": "B1",
@@ -5009,7 +4911,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 389
+      "newOrder": 381
     },
     {
       "cefr": "B1",
@@ -5022,7 +4924,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 390
+      "newOrder": 382
     },
     {
       "cefr": "B1",
@@ -5035,7 +4937,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 391
+      "newOrder": 383
     },
     {
       "cefr": "B1",
@@ -5048,7 +4950,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 392
+      "newOrder": 384
     },
     {
       "cefr": "B1",
@@ -5061,7 +4963,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 393
+      "newOrder": 385
     },
     {
       "cefr": "B1",
@@ -5074,7 +4976,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 394
+      "newOrder": 386
     },
     {
       "cefr": "B1",
@@ -5087,7 +4989,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 395
+      "newOrder": 387
     },
     {
       "cefr": "B1",
@@ -5100,7 +5002,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 396
+      "newOrder": 388
     },
     {
       "cefr": "B1",
@@ -5113,7 +5015,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 397
+      "newOrder": 389
     },
     {
       "cefr": "B1",
@@ -5126,7 +5028,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 398
+      "newOrder": 390
     },
     {
       "cefr": "B1",
@@ -5139,7 +5041,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 399
+      "newOrder": 391
     },
     {
       "cefr": "B1",
@@ -5152,7 +5054,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 400
+      "newOrder": 392
     },
     {
       "cefr": "B1",
@@ -5165,7 +5067,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 401
+      "newOrder": 393
     },
     {
       "cefr": "B1",
@@ -5178,7 +5080,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 402
+      "newOrder": 394
     },
     {
       "cefr": "B1",
@@ -5191,7 +5093,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 403
+      "newOrder": 395
     },
     {
       "cefr": "B1",
@@ -5204,7 +5106,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 404
+      "newOrder": 396
     },
     {
       "cefr": "B1",
@@ -5217,7 +5119,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 405
+      "newOrder": 397
     },
     {
       "cefr": "B1",
@@ -5230,7 +5132,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 406
+      "newOrder": 398
     },
     {
       "cefr": "B1",
@@ -5243,7 +5145,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 407
+      "newOrder": 399
     },
     {
       "cefr": "B1",
@@ -5256,7 +5158,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 408
+      "newOrder": 400
     },
     {
       "cefr": "B1",
@@ -5269,7 +5171,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 409
+      "newOrder": 401
     },
     {
       "cefr": "B1",
@@ -5282,7 +5184,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 410
+      "newOrder": 402
     },
     {
       "cefr": "B1",
@@ -5295,7 +5197,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 411
+      "newOrder": 403
     },
     {
       "cefr": "B1",
@@ -5308,7 +5210,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 412
+      "newOrder": 404
     },
     {
       "cefr": "B1",
@@ -5319,7 +5221,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 413
+      "newOrder": 405
     },
     {
       "cefr": "B1",
@@ -5332,7 +5234,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 414
+      "newOrder": 406
     },
     {
       "cefr": "B1",
@@ -5345,7 +5247,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 415
+      "newOrder": 407
     },
     {
       "cefr": "B1",
@@ -5358,7 +5260,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 416
+      "newOrder": 408
     },
     {
       "cefr": "B1",
@@ -5371,7 +5273,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 417
+      "newOrder": 409
     },
     {
       "cefr": "B1",
@@ -5384,7 +5286,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 418
+      "newOrder": 410
     },
     {
       "cefr": "B1",
@@ -5397,7 +5299,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 419
+      "newOrder": 411
     },
     {
       "cefr": "B1",
@@ -5410,7 +5312,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 420
+      "newOrder": 412
     },
     {
       "cefr": "B1",
@@ -5423,7 +5325,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 421
+      "newOrder": 413
     },
     {
       "cefr": "B1",
@@ -5436,7 +5338,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 422
+      "newOrder": 414
     },
     {
       "cefr": "B1",
@@ -5449,7 +5351,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 423
+      "newOrder": 415
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "утретє",
+      "lemmaId": "утретє",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 416
     },
     {
       "cefr": "B1",
@@ -5462,7 +5377,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 424
+      "newOrder": 417
     },
     {
       "cefr": "B1",
@@ -5475,7 +5390,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 425
+      "newOrder": 418
     },
     {
       "cefr": "B1",
@@ -5488,7 +5403,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 426
+      "newOrder": 419
     },
     {
       "cefr": "B1",
@@ -5501,7 +5416,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 427
+      "newOrder": 420
     },
     {
       "cefr": "B1",
@@ -5514,7 +5429,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 428
+      "newOrder": 421
     },
     {
       "cefr": "B1",
@@ -5527,7 +5442,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 429
+      "newOrder": 422
     },
     {
       "cefr": "B1",
@@ -5540,7 +5455,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 430
+      "newOrder": 423
     },
     {
       "cefr": "B1",
@@ -5553,7 +5468,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 431
+      "newOrder": 424
     },
     {
       "cefr": "B1",
@@ -5564,7 +5479,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 432
+      "newOrder": 425
     },
     {
       "cefr": "B1",
@@ -5577,7 +5492,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 433
+      "newOrder": 426
     },
     {
       "cefr": "B1",
@@ -5590,7 +5505,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 434
+      "newOrder": 427
     },
     {
       "cefr": "B1",
@@ -5603,7 +5518,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 435
+      "newOrder": 428
     },
     {
       "cefr": "B1",
@@ -5616,7 +5531,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 436
+      "newOrder": 429
     },
     {
       "cefr": "B1",
@@ -5629,7 +5544,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 437
+      "newOrder": 430
     },
     {
       "cefr": "B1",
@@ -5642,7 +5557,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 438
+      "newOrder": 431
     },
     {
       "cefr": "B1",
@@ -5655,7 +5570,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 439
+      "newOrder": 432
     },
     {
       "cefr": "B1",
@@ -5668,7 +5583,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 440
+      "newOrder": 433
     },
     {
       "cefr": "B1",
@@ -5681,7 +5596,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 441
+      "newOrder": 434
     },
     {
       "cefr": "B1",
@@ -5694,7 +5609,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 442
+      "newOrder": 435
     },
     {
       "cefr": "B1",
@@ -5707,7 +5622,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 443
+      "newOrder": 436
     },
     {
       "cefr": "B1",
@@ -5720,7 +5635,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 444
+      "newOrder": 437
     },
     {
       "cefr": "B1",
@@ -5733,7 +5648,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 445
+      "newOrder": 438
     },
     {
       "cefr": "B1",
@@ -5746,7 +5661,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 446
+      "newOrder": 439
     },
     {
       "cefr": "B1",
@@ -5759,7 +5674,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 447
+      "newOrder": 440
     },
     {
       "cefr": "B1",
@@ -5772,7 +5687,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 448
+      "newOrder": 441
     },
     {
       "cefr": "B1",
@@ -5785,7 +5700,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 449
+      "newOrder": 442
     },
     {
       "cefr": "B1",
@@ -5798,7 +5713,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 450
+      "newOrder": 443
     },
     {
       "cefr": "B1",
@@ -5811,7 +5726,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 451
+      "newOrder": 444
     },
     {
       "cefr": "B1",
@@ -5824,7 +5739,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 452
+      "newOrder": 445
     },
     {
       "cefr": "B1",
@@ -5837,7 +5752,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 453
+      "newOrder": 446
     },
     {
       "cefr": "B1",
@@ -5850,7 +5765,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 454
+      "newOrder": 447
     },
     {
       "cefr": "B1",
@@ -5863,7 +5778,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 455
+      "newOrder": 448
     },
     {
       "cefr": "B1",
@@ -5876,7 +5791,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 456
+      "newOrder": 449
     },
     {
       "cefr": "B1",
@@ -5889,7 +5804,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 457
+      "newOrder": 450
     },
     {
       "cefr": "B1",
@@ -5902,7 +5817,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 458
+      "newOrder": 451
     },
     {
       "cefr": "B1",
@@ -5915,7 +5830,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 459
+      "newOrder": 452
     },
     {
       "cefr": "B1",
@@ -5928,7 +5843,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 460
+      "newOrder": 453
     },
     {
       "cefr": "B1",
@@ -5941,7 +5856,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 461
+      "newOrder": 454
     },
     {
       "cefr": "B1",
@@ -5954,7 +5869,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 462
+      "newOrder": 455
     },
     {
       "cefr": "B1",
@@ -5967,7 +5882,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 463
+      "newOrder": 456
     },
     {
       "cefr": "B1",
@@ -5980,7 +5895,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 464
+      "newOrder": 457
     },
     {
       "cefr": "B1",
@@ -5993,7 +5908,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 465
+      "newOrder": 458
     },
     {
       "cefr": "B1",
@@ -6006,7 +5921,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 466
+      "newOrder": 459
     },
     {
       "cefr": "B1",
@@ -6019,7 +5934,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 467
+      "newOrder": 460
     },
     {
       "cefr": "B1",
@@ -6032,7 +5947,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 468
+      "newOrder": 461
     },
     {
       "cefr": "B1",
@@ -6045,7 +5960,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 469
+      "newOrder": 462
     },
     {
       "cefr": "B1",
@@ -6058,7 +5973,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 470
+      "newOrder": 463
     },
     {
       "cefr": "B1",
@@ -6071,7 +5986,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 471
+      "newOrder": 464
     },
     {
       "cefr": "B1",
@@ -6084,7 +5999,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 472
+      "newOrder": 465
     },
     {
       "cefr": "B1",
@@ -6097,7 +6012,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 473
+      "newOrder": 466
     },
     {
       "cefr": "B1",
@@ -6110,7 +6025,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 474
+      "newOrder": 467
     },
     {
       "cefr": "B1",
@@ -6123,7 +6038,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 475
+      "newOrder": 468
     },
     {
       "cefr": "B1",
@@ -6136,7 +6051,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 476
+      "newOrder": 469
     },
     {
       "cefr": "B1",
@@ -6149,7 +6064,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 477
+      "newOrder": 470
     },
     {
       "cefr": "B1",
@@ -6162,7 +6077,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 478
+      "newOrder": 471
     },
     {
       "cefr": "B1",
@@ -6175,7 +6090,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 479
+      "newOrder": 472
     },
     {
       "cefr": "B1",
@@ -6188,7 +6103,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 480
+      "newOrder": 473
     },
     {
       "cefr": "B1",
@@ -6201,7 +6116,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 481
+      "newOrder": 474
     },
     {
       "cefr": "B1",
@@ -6214,7 +6129,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 482
+      "newOrder": 475
     },
     {
       "cefr": "B1",
@@ -6227,7 +6142,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 483
+      "newOrder": 476
     },
     {
       "cefr": "B1",
@@ -6240,7 +6155,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 484
+      "newOrder": 477
     },
     {
       "cefr": "B1",
@@ -6253,7 +6168,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 485
+      "newOrder": 478
     },
     {
       "cefr": "B1",
@@ -6266,7 +6181,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 486
+      "newOrder": 479
     },
     {
       "cefr": "B1",
@@ -6279,7 +6194,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 487
+      "newOrder": 480
     },
     {
       "cefr": "B1",
@@ -6292,7 +6207,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 488
+      "newOrder": 481
     },
     {
       "cefr": "B1",
@@ -6305,7 +6220,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 489
+      "newOrder": 482
     },
     {
       "cefr": "B1",
@@ -6318,7 +6233,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 490
+      "newOrder": 483
     },
     {
       "cefr": "B1",
@@ -6331,7 +6246,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 491
+      "newOrder": 484
     },
     {
       "cefr": "B1",
@@ -6344,7 +6259,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 492
+      "newOrder": 485
     },
     {
       "cefr": "B1",
@@ -6357,7 +6272,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 493
+      "newOrder": 486
     },
     {
       "cefr": "B1",
@@ -6370,7 +6285,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 494
+      "newOrder": 487
     },
     {
       "cefr": "B1",
@@ -6383,7 +6298,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 495
+      "newOrder": 488
     },
     {
       "cefr": "B1",
@@ -6396,7 +6311,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 496
+      "newOrder": 489
     },
     {
       "cefr": "B1",
@@ -6409,7 +6324,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 497
+      "newOrder": 490
     },
     {
       "cefr": "B1",
@@ -6422,7 +6337,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 498
+      "newOrder": 491
     },
     {
       "cefr": "B1",
@@ -6435,7 +6350,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 499
+      "newOrder": 492
     },
     {
       "cefr": "B1",
@@ -6448,7 +6363,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 500
+      "newOrder": 493
     },
     {
       "cefr": "B1",
@@ -6461,7 +6376,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 501
+      "newOrder": 494
     },
     {
       "cefr": "B1",
@@ -6474,7 +6389,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 502
+      "newOrder": 495
     },
     {
       "cefr": "B1",
@@ -6487,7 +6402,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 503
+      "newOrder": 496
     },
     {
       "cefr": "B1",
@@ -6500,7 +6415,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 504
+      "newOrder": 497
     },
     {
       "cefr": "B1",
@@ -6513,7 +6428,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 505
+      "newOrder": 498
     },
     {
       "cefr": "B1",
@@ -6526,7 +6441,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 506
+      "newOrder": 499
     },
     {
       "cefr": "B1",
@@ -6539,7 +6454,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 507
+      "newOrder": 500
     },
     {
       "cefr": "B1",
@@ -6552,7 +6467,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 508
+      "newOrder": 501
     },
     {
       "cefr": "B1",
@@ -6565,7 +6480,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 509
+      "newOrder": 502
     },
     {
       "cefr": "B1",
@@ -6578,7 +6493,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 510
+      "newOrder": 503
     },
     {
       "cefr": "B1",
@@ -6591,7 +6506,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 511
+      "newOrder": 504
     },
     {
       "cefr": "B1",
@@ -6604,7 +6519,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 512
+      "newOrder": 505
     },
     {
       "cefr": "B1",
@@ -6617,7 +6532,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 513
+      "newOrder": 506
     },
     {
       "cefr": "B1",
@@ -6630,7 +6545,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 514
+      "newOrder": 507
     },
     {
       "cefr": "B1",
@@ -6643,7 +6558,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 515
+      "newOrder": 508
     },
     {
       "cefr": "B1",
@@ -6656,7 +6571,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 516
+      "newOrder": 509
     },
     {
       "cefr": "B1",
@@ -6669,7 +6584,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 517
+      "newOrder": 510
     },
     {
       "cefr": "B1",
@@ -6682,7 +6597,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 518
+      "newOrder": 511
     },
     {
       "cefr": "B1",
@@ -6695,7 +6610,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 519
+      "newOrder": 512
     },
     {
       "cefr": "B1",
@@ -6708,7 +6623,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 520
+      "newOrder": 513
     },
     {
       "cefr": "B1",
@@ -6721,7 +6636,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 521
+      "newOrder": 514
     },
     {
       "cefr": "B1",
@@ -6734,7 +6649,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 522
+      "newOrder": 515
     },
     {
       "cefr": "B1",
@@ -6747,7 +6662,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 523
+      "newOrder": 516
     },
     {
       "cefr": "B1",
@@ -6760,7 +6675,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 524
+      "newOrder": 517
     },
     {
       "cefr": "B1",
@@ -6773,7 +6688,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 525
+      "newOrder": 518
     },
     {
       "cefr": "B1",
@@ -6786,7 +6701,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 526
+      "newOrder": 519
     },
     {
       "cefr": "B1",
@@ -6799,7 +6714,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 527
+      "newOrder": 520
     },
     {
       "cefr": "B1",
@@ -6812,7 +6727,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 528
+      "newOrder": 521
     },
     {
       "cefr": "B1",
@@ -6825,7 +6740,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 529
+      "newOrder": 522
     },
     {
       "cefr": "B1",
@@ -6836,7 +6751,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 530
+      "newOrder": 523
     },
     {
       "cefr": "B1",
@@ -6849,7 +6764,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 531
+      "newOrder": 524
     },
     {
       "cefr": "B1",
@@ -6862,7 +6777,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 532
+      "newOrder": 525
     },
     {
       "cefr": "B1",
@@ -6875,7 +6790,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 533
+      "newOrder": 526
     },
     {
       "cefr": "B1",
@@ -6886,7 +6801,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 534
+      "newOrder": 527
     },
     {
       "cefr": "B1",
@@ -6899,7 +6814,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 535
+      "newOrder": 528
     },
     {
       "cefr": "B1",
@@ -6912,7 +6827,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 536
+      "newOrder": 529
     },
     {
       "cefr": "B1",
@@ -6925,7 +6840,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 537
+      "newOrder": 530
     },
     {
       "cefr": "B1",
@@ -6938,7 +6853,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 538
+      "newOrder": 531
     },
     {
       "cefr": "B1",
@@ -6951,7 +6866,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 539
+      "newOrder": 532
     },
     {
       "cefr": "B1",
@@ -6964,7 +6879,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 540
+      "newOrder": 533
     },
     {
       "cefr": "B1",
@@ -6977,7 +6892,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 541
+      "newOrder": 534
     },
     {
       "cefr": "B1",
@@ -6990,7 +6905,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 542
+      "newOrder": 535
     },
     {
       "cefr": "B1",
@@ -7003,7 +6918,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 543
+      "newOrder": 536
     },
     {
       "cefr": "B1",
@@ -7016,7 +6931,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 544
+      "newOrder": 537
     },
     {
       "cefr": "B1",
@@ -7029,7 +6944,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 545
+      "newOrder": 538
     },
     {
       "cefr": "B1",
@@ -7042,7 +6957,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 546
+      "newOrder": 539
     },
     {
       "cefr": "B1",
@@ -7055,7 +6970,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 547
+      "newOrder": 540
     },
     {
       "cefr": "B1",
@@ -7068,7 +6983,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 548
+      "newOrder": 541
     },
     {
       "cefr": "B1",
@@ -7081,7 +6996,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 549
+      "newOrder": 542
     },
     {
       "cefr": "B1",
@@ -7094,7 +7009,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 550
+      "newOrder": 543
     },
     {
       "cefr": "B1",
@@ -7107,7 +7022,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 551
+      "newOrder": 544
     },
     {
       "cefr": "B1",
@@ -7118,7 +7033,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 552
+      "newOrder": 545
     },
     {
       "cefr": "B1",
@@ -7131,7 +7046,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 553
+      "newOrder": 546
     },
     {
       "cefr": "B1",
@@ -7144,7 +7059,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 554
+      "newOrder": 547
     },
     {
       "cefr": "B1",
@@ -7157,7 +7072,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 555
+      "newOrder": 548
     },
     {
       "cefr": "B1",
@@ -7170,7 +7085,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 556
+      "newOrder": 549
     },
     {
       "cefr": "B1",
@@ -7183,7 +7098,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 557
+      "newOrder": 550
     },
     {
       "cefr": "B1",
@@ -7196,7 +7111,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 558
+      "newOrder": 551
     },
     {
       "cefr": "B1",
@@ -7209,7 +7124,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 559
+      "newOrder": 552
     },
     {
       "cefr": "B1",
@@ -7222,7 +7137,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 560
+      "newOrder": 553
     },
     {
       "cefr": "B1",
@@ -7235,7 +7150,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 561
+      "newOrder": 554
     },
     {
       "cefr": "B1",
@@ -7248,7 +7163,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 562
+      "newOrder": 555
     },
     {
       "cefr": "B1",
@@ -7261,7 +7176,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 563
+      "newOrder": 556
     },
     {
       "cefr": "B1",
@@ -7274,7 +7189,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 564
+      "newOrder": 557
     },
     {
       "cefr": "B1",
@@ -7287,7 +7202,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 565
+      "newOrder": 558
     },
     {
       "cefr": "B1",
@@ -7300,7 +7215,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 566
+      "newOrder": 559
     },
     {
       "cefr": "B1",
@@ -7313,7 +7228,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 567
+      "newOrder": 560
     },
     {
       "cefr": "B1",
@@ -7326,7 +7241,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 568
+      "newOrder": 561
     },
     {
       "cefr": "B1",
@@ -7339,7 +7254,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 569
+      "newOrder": 562
     },
     {
       "cefr": "B1",
@@ -7352,7 +7267,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 570
+      "newOrder": 563
     },
     {
       "cefr": "B1",
@@ -7365,7 +7280,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 571
+      "newOrder": 564
     },
     {
       "cefr": "B1",
@@ -7378,7 +7293,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 572
+      "newOrder": 565
     },
     {
       "cefr": "B1",
@@ -7391,7 +7306,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 573
+      "newOrder": 566
     },
     {
       "cefr": "B1",
@@ -7404,7 +7319,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 574
+      "newOrder": 567
     },
     {
       "cefr": "B1",
@@ -7417,7 +7332,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 575
+      "newOrder": 568
     },
     {
       "cefr": "B1",
@@ -7430,7 +7345,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 576
+      "newOrder": 569
     },
     {
       "cefr": "B1",
@@ -7443,7 +7358,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 577
+      "newOrder": 570
     },
     {
       "cefr": "B1",
@@ -7456,7 +7371,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 578
+      "newOrder": 571
     },
     {
       "cefr": "B1",
@@ -7469,7 +7384,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 579
+      "newOrder": 572
     },
     {
       "cefr": "B1",
@@ -7482,7 +7397,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 580
+      "newOrder": 573
     },
     {
       "cefr": "B1",
@@ -7495,7 +7410,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 581
+      "newOrder": 574
     },
     {
       "cefr": "B1",
@@ -7508,7 +7423,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 582
+      "newOrder": 575
     },
     {
       "cefr": "B1",
@@ -7521,7 +7436,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 583
+      "newOrder": 576
     },
     {
       "cefr": "B1",
@@ -7534,7 +7449,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 584
+      "newOrder": 577
     },
     {
       "cefr": "B1",
@@ -7547,7 +7462,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 585
+      "newOrder": 578
     },
     {
       "cefr": "B1",
@@ -7558,7 +7473,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 586
+      "newOrder": 579
     },
     {
       "cefr": "B1",
@@ -7571,7 +7486,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 587
+      "newOrder": 580
     },
     {
       "cefr": "B1",
@@ -7582,7 +7497,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 588
+      "newOrder": 581
     },
     {
       "cefr": "B1",
@@ -7593,7 +7508,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 589
+      "newOrder": 582
     },
     {
       "cefr": "B1",
@@ -7606,7 +7521,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 590
+      "newOrder": 583
     },
     {
       "cefr": "B1",
@@ -7619,7 +7534,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 591
+      "newOrder": 584
     },
     {
       "cefr": "B1",
@@ -7630,7 +7545,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 592
+      "newOrder": 585
     },
     {
       "cefr": "B1",
@@ -7643,7 +7558,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 593
+      "newOrder": 586
     },
     {
       "cefr": "B1",
@@ -7654,7 +7569,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 594
+      "newOrder": 587
     },
     {
       "cefr": "B1",
@@ -7665,7 +7580,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 595
+      "newOrder": 588
     },
     {
       "cefr": "B1",
@@ -7678,7 +7593,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 596
+      "newOrder": 589
     },
     {
       "cefr": "B1",
@@ -7689,7 +7604,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 597
+      "newOrder": 590
     },
     {
       "cefr": "B1",
@@ -7700,7 +7615,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 598
+      "newOrder": 591
     },
     {
       "cefr": "B1",
@@ -7713,7 +7628,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 599
+      "newOrder": 592
     },
     {
       "cefr": "B1",
@@ -7726,7 +7641,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 600
+      "newOrder": 593
     },
     {
       "cefr": "B1",
@@ -7739,7 +7654,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 601
+      "newOrder": 594
     },
     {
       "cefr": "B1",
@@ -7752,7 +7667,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 602
+      "newOrder": 595
     },
     {
       "cefr": "B1",
@@ -7765,7 +7680,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 603
+      "newOrder": 596
     },
     {
       "cefr": "B1",
@@ -7776,7 +7691,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 604
+      "newOrder": 597
     },
     {
       "cefr": "B1",
@@ -7789,7 +7704,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 605
+      "newOrder": 598
     },
     {
       "cefr": "B1",
@@ -7802,7 +7717,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 606
+      "newOrder": 599
     },
     {
       "cefr": "B1",
@@ -7815,7 +7730,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 607
+      "newOrder": 600
     },
     {
       "cefr": "B1",
@@ -7828,7 +7743,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 608
+      "newOrder": 601
     },
     {
       "cefr": "B1",
@@ -7841,7 +7756,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 609
+      "newOrder": 602
     },
     {
       "cefr": "B1",
@@ -7854,7 +7769,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 610
+      "newOrder": 603
     },
     {
       "cefr": "B1",
@@ -7865,7 +7780,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 611
+      "newOrder": 604
     },
     {
       "cefr": "B1",
@@ -7878,7 +7793,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 612
+      "newOrder": 605
     },
     {
       "cefr": "B1",
@@ -7891,7 +7806,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 613
+      "newOrder": 606
     },
     {
       "cefr": "B1",
@@ -7904,7 +7819,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 614
+      "newOrder": 607
     },
     {
       "cefr": "B1",
@@ -7917,7 +7832,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 615
+      "newOrder": 608
     },
     {
       "cefr": "B1",
@@ -7930,7 +7845,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 616
+      "newOrder": 609
     },
     {
       "cefr": "B1",
@@ -7943,7 +7858,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 617
+      "newOrder": 610
     },
     {
       "cefr": "B1",
@@ -7954,7 +7869,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 618
+      "newOrder": 611
     },
     {
       "cefr": "B1",
@@ -7967,7 +7882,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 619
+      "newOrder": 612
     },
     {
       "cefr": "B1",
@@ -7980,7 +7895,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 620
+      "newOrder": 613
     },
     {
       "cefr": "B1",
@@ -7993,7 +7908,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 621
+      "newOrder": 614
     },
     {
       "cefr": "B1",
@@ -8006,7 +7921,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 622
+      "newOrder": 615
     },
     {
       "cefr": "B1",
@@ -8019,7 +7934,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 623
+      "newOrder": 616
     },
     {
       "cefr": "B1",
@@ -8032,7 +7947,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 624
+      "newOrder": 617
     },
     {
       "cefr": "B1",
@@ -8045,7 +7960,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 625
+      "newOrder": 618
     },
     {
       "cefr": "B1",
@@ -8058,7 +7973,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 626
+      "newOrder": 619
     },
     {
       "cefr": "B1",
@@ -8071,7 +7986,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 627
+      "newOrder": 620
     },
     {
       "cefr": "B1",
@@ -8082,7 +7997,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 628
+      "newOrder": 621
     },
     {
       "cefr": "B1",
@@ -8095,7 +8010,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 629
+      "newOrder": 622
     },
     {
       "cefr": "B1",
@@ -8108,7 +8023,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 630
+      "newOrder": 623
     },
     {
       "cefr": "B1",
@@ -8121,7 +8036,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 631
+      "newOrder": 624
     },
     {
       "cefr": "B1",
@@ -8134,7 +8049,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 632
+      "newOrder": 625
     },
     {
       "cefr": "B1",
@@ -8147,7 +8062,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 633
+      "newOrder": 626
     },
     {
       "cefr": "B1",
@@ -8160,7 +8075,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 634
+      "newOrder": 627
     },
     {
       "cefr": "B1",
@@ -8171,7 +8086,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 635
+      "newOrder": 628
     },
     {
       "cefr": "B1",
@@ -8184,7 +8099,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 636
+      "newOrder": 629
     },
     {
       "cefr": "B1",
@@ -8197,7 +8112,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 637
+      "newOrder": 630
     },
     {
       "cefr": "B1",
@@ -8210,7 +8125,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 638
+      "newOrder": 631
     },
     {
       "cefr": "B1",
@@ -8223,7 +8138,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 639
+      "newOrder": 632
     },
     {
       "cefr": "B1",
@@ -8234,7 +8149,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 640
+      "newOrder": 633
     },
     {
       "cefr": "B1",
@@ -8247,7 +8162,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 641
+      "newOrder": 634
     },
     {
       "cefr": "B1",
@@ -8258,7 +8173,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 642
+      "newOrder": 635
     },
     {
       "cefr": "B1",
@@ -8269,7 +8184,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 643
+      "newOrder": 636
     },
     {
       "cefr": "B1",
@@ -8282,7 +8197,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 644
+      "newOrder": 637
     },
     {
       "cefr": "B1",
@@ -8295,7 +8210,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 645
+      "newOrder": 638
     },
     {
       "cefr": "B1",
@@ -8308,7 +8223,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 646
+      "newOrder": 639
     },
     {
       "cefr": "B1",
@@ -8319,7 +8234,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 647
+      "newOrder": 640
     },
     {
       "cefr": "B1",
@@ -8332,7 +8247,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 648
+      "newOrder": 641
     },
     {
       "cefr": "B1",
@@ -8345,7 +8260,18 @@
         "matching",
         "choice"
       ],
-      "newOrder": 649
+      "newOrder": 642
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "доти...доки",
+      "lemmaId": "доти-доки",
+      "modes": [
+        "flashcards"
+      ],
+      "newOrder": 643
     },
     {
       "cefr": "B1",
@@ -8358,7 +8284,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 650
+      "newOrder": 644
     },
     {
       "cefr": "B1",
@@ -8371,7 +8297,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 651
+      "newOrder": 645
     },
     {
       "cefr": "B1",
@@ -8384,7 +8310,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 652
+      "newOrder": 646
     },
     {
       "cefr": "B1",
@@ -8397,7 +8323,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 653
+      "newOrder": 647
     },
     {
       "cefr": "B1",
@@ -8408,7 +8334,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 654
+      "newOrder": 648
     },
     {
       "cefr": "B1",
@@ -8419,7 +8345,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 655
+      "newOrder": 649
     },
     {
       "cefr": "B1",
@@ -8432,7 +8358,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 656
+      "newOrder": 650
     },
     {
       "cefr": "B1",
@@ -8445,20 +8371,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 657
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "діапазон",
-      "lemmaId": "діапазон",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 658
+      "newOrder": 651
     },
     {
       "cefr": "B1",
@@ -8471,7 +8384,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 659
+      "newOrder": 652
     },
     {
       "cefr": "B1",
@@ -8484,7 +8397,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 660
+      "newOrder": 653
     },
     {
       "cefr": "B1",
@@ -8497,7 +8410,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 661
+      "newOrder": 654
     },
     {
       "cefr": "B1",
@@ -8510,7 +8423,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 662
+      "newOrder": 655
     },
     {
       "cefr": "B1",
@@ -8523,7 +8436,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 663
+      "newOrder": 656
     },
     {
       "cefr": "B1",
@@ -8536,7 +8449,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 664
+      "newOrder": 657
     },
     {
       "cefr": "B1",
@@ -8549,7 +8462,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 665
+      "newOrder": 658
     },
     {
       "cefr": "B1",
@@ -8562,7 +8475,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 666
+      "newOrder": 659
     },
     {
       "cefr": "B1",
@@ -8575,7 +8488,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 667
+      "newOrder": 660
     },
     {
       "cefr": "B1",
@@ -8588,7 +8501,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 668
+      "newOrder": 661
     },
     {
       "cefr": "B1",
@@ -8601,7 +8514,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 669
+      "newOrder": 662
     },
     {
       "cefr": "B1",
@@ -8612,7 +8525,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 670
+      "newOrder": 663
     },
     {
       "cefr": "B1",
@@ -8623,7 +8536,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 671
+      "newOrder": 664
     },
     {
       "cefr": "B1",
@@ -8636,7 +8549,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 672
+      "newOrder": 665
     },
     {
       "cefr": "B1",
@@ -8649,7 +8562,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 673
+      "newOrder": 666
     },
     {
       "cefr": "B1",
@@ -8662,7 +8575,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 674
+      "newOrder": 667
     },
     {
       "cefr": "B1",
@@ -8675,7 +8588,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 675
+      "newOrder": 668
     },
     {
       "cefr": "B1",
@@ -8688,7 +8601,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 676
+      "newOrder": 669
     },
     {
       "cefr": "B1",
@@ -8701,7 +8614,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 677
+      "newOrder": 670
     },
     {
       "cefr": "B1",
@@ -8714,7 +8627,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 678
+      "newOrder": 671
     },
     {
       "cefr": "B1",
@@ -8727,7 +8640,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 679
+      "newOrder": 672
     },
     {
       "cefr": "B1",
@@ -8740,7 +8653,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 680
+      "newOrder": 673
     },
     {
       "cefr": "B1",
@@ -8753,7 +8666,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 681
+      "newOrder": 674
     },
     {
       "cefr": "B1",
@@ -8766,7 +8679,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 682
+      "newOrder": 675
     },
     {
       "cefr": "B1",
@@ -8779,7 +8692,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 683
+      "newOrder": 676
     },
     {
       "cefr": "B1",
@@ -8792,7 +8705,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 684
+      "newOrder": 677
     },
     {
       "cefr": "B1",
@@ -8805,7 +8718,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 685
+      "newOrder": 678
     },
     {
       "cefr": "B1",
@@ -8816,7 +8729,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 686
+      "newOrder": 679
     },
     {
       "cefr": "B1",
@@ -8829,7 +8742,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 687
+      "newOrder": 680
     },
     {
       "cefr": "B1",
@@ -8840,7 +8753,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 688
+      "newOrder": 681
     },
     {
       "cefr": "B1",
@@ -8853,7 +8766,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 689
+      "newOrder": 682
     },
     {
       "cefr": "B1",
@@ -8866,7 +8779,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 690
+      "newOrder": 683
     },
     {
       "cefr": "B1",
@@ -8879,7 +8792,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 691
+      "newOrder": 684
     },
     {
       "cefr": "B1",
@@ -8892,7 +8805,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 692
+      "newOrder": 685
     },
     {
       "cefr": "B1",
@@ -8905,7 +8818,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 693
+      "newOrder": 686
     },
     {
       "cefr": "B1",
@@ -8918,7 +8831,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 694
+      "newOrder": 687
     },
     {
       "cefr": "B1",
@@ -8931,7 +8844,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 695
+      "newOrder": 688
     },
     {
       "cefr": "B1",
@@ -8944,7 +8857,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 696
+      "newOrder": 689
     },
     {
       "cefr": "B1",
@@ -8957,7 +8870,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 697
+      "newOrder": 690
     },
     {
       "cefr": "B1",
@@ -8970,7 +8883,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 698
+      "newOrder": 691
     },
     {
       "cefr": "B1",
@@ -8983,7 +8896,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 699
+      "newOrder": 692
     },
     {
       "cefr": "B1",
@@ -8996,7 +8909,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 700
+      "newOrder": 693
     },
     {
       "cefr": "B1",
@@ -9009,7 +8922,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 701
+      "newOrder": 694
     },
     {
       "cefr": "B1",
@@ -9022,7 +8935,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 702
+      "newOrder": 695
     },
     {
       "cefr": "B1",
@@ -9035,7 +8948,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 703
+      "newOrder": 696
     },
     {
       "cefr": "B1",
@@ -9048,7 +8961,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 704
+      "newOrder": 697
     },
     {
       "cefr": "B1",
@@ -9061,7 +8974,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 705
+      "newOrder": 698
     },
     {
       "cefr": "B1",
@@ -9074,7 +8987,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 706
+      "newOrder": 699
     },
     {
       "cefr": "B1",
@@ -9087,7 +9000,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 707
+      "newOrder": 700
     },
     {
       "cefr": "B1",
@@ -9100,7 +9013,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 708
+      "newOrder": 701
     },
     {
       "cefr": "B1",
@@ -9113,7 +9026,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 709
+      "newOrder": 702
     },
     {
       "cefr": "B1",
@@ -9126,7 +9039,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 710
+      "newOrder": 703
     },
     {
       "cefr": "B1",
@@ -9139,7 +9052,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 711
+      "newOrder": 704
     },
     {
       "cefr": "B1",
@@ -9152,7 +9065,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 712
+      "newOrder": 705
     },
     {
       "cefr": "B1",
@@ -9165,7 +9078,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 713
+      "newOrder": 706
     },
     {
       "cefr": "B1",
@@ -9178,7 +9091,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 714
+      "newOrder": 707
     },
     {
       "cefr": "B1",
@@ -9191,7 +9104,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 715
+      "newOrder": 708
     },
     {
       "cefr": "B1",
@@ -9204,7 +9117,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 716
+      "newOrder": 709
     },
     {
       "cefr": "B1",
@@ -9217,7 +9130,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 717
+      "newOrder": 710
     },
     {
       "cefr": "B1",
@@ -9230,7 +9143,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 718
+      "newOrder": 711
     },
     {
       "cefr": "B1",
@@ -9243,7 +9156,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 719
+      "newOrder": 712
     },
     {
       "cefr": "B1",
@@ -9256,7 +9169,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 720
+      "newOrder": 713
     },
     {
       "cefr": "B1",
@@ -9269,7 +9182,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 721
+      "newOrder": 714
     },
     {
       "cefr": "B1",
@@ -9282,7 +9195,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 722
+      "newOrder": 715
     },
     {
       "cefr": "B1",
@@ -9295,7 +9208,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 723
+      "newOrder": 716
     },
     {
       "cefr": "B1",
@@ -9308,7 +9221,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 724
+      "newOrder": 717
     },
     {
       "cefr": "B1",
@@ -9321,7 +9234,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 725
+      "newOrder": 718
     },
     {
       "cefr": "B1",
@@ -9334,7 +9247,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 726
+      "newOrder": 719
     },
     {
       "cefr": "B1",
@@ -9347,7 +9260,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 727
+      "newOrder": 720
     },
     {
       "cefr": "B1",
@@ -9360,7 +9273,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 728
+      "newOrder": 721
     },
     {
       "cefr": "B1",
@@ -9373,7 +9286,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 729
+      "newOrder": 722
     },
     {
       "cefr": "B1",
@@ -9386,7 +9299,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 730
+      "newOrder": 723
     },
     {
       "cefr": "B1",
@@ -9399,7 +9312,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 731
+      "newOrder": 724
     },
     {
       "cefr": "B1",
@@ -9412,7 +9325,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 732
+      "newOrder": 725
     },
     {
       "cefr": "B1",
@@ -9425,7 +9338,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 733
+      "newOrder": 726
     },
     {
       "cefr": "B1",
@@ -9438,7 +9351,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 734
+      "newOrder": 727
     },
     {
       "cefr": "B1",
@@ -9451,7 +9364,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 735
+      "newOrder": 728
     },
     {
       "cefr": "B1",
@@ -9464,7 +9377,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 736
+      "newOrder": 729
     },
     {
       "cefr": "B1",
@@ -9477,7 +9390,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 737
+      "newOrder": 730
     },
     {
       "cefr": "B1",
@@ -9490,7 +9403,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 738
+      "newOrder": 731
     },
     {
       "cefr": "B1",
@@ -9503,7 +9416,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 739
+      "newOrder": 732
     },
     {
       "cefr": "B1",
@@ -9514,7 +9427,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 740
+      "newOrder": 733
     },
     {
       "cefr": "B1",
@@ -9527,7 +9440,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 741
+      "newOrder": 734
     },
     {
       "cefr": "B1",
@@ -9540,7 +9453,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 742
+      "newOrder": 735
     },
     {
       "cefr": "B1",
@@ -9553,7 +9466,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 743
+      "newOrder": 736
     },
     {
       "cefr": "B1",
@@ -9566,7 +9479,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 744
+      "newOrder": 737
     },
     {
       "cefr": "B1",
@@ -9579,7 +9492,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 745
+      "newOrder": 738
     },
     {
       "cefr": "B1",
@@ -9592,7 +9505,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 746
+      "newOrder": 739
     },
     {
       "cefr": "B1",
@@ -9605,7 +9518,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 747
+      "newOrder": 740
     },
     {
       "cefr": "B1",
@@ -9616,7 +9529,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 748
+      "newOrder": 741
     },
     {
       "cefr": "B1",
@@ -9629,7 +9542,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 749
+      "newOrder": 742
     },
     {
       "cefr": "B1",
@@ -9642,7 +9555,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 750
+      "newOrder": 743
     },
     {
       "cefr": "B1",
@@ -9655,7 +9568,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 751
+      "newOrder": 744
     },
     {
       "cefr": "B1",
@@ -9668,7 +9581,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 752
+      "newOrder": 745
     },
     {
       "cefr": "B1",
@@ -9681,7 +9594,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 753
+      "newOrder": 746
     },
     {
       "cefr": "B1",
@@ -9694,7 +9607,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 754
+      "newOrder": 747
     },
     {
       "cefr": "B1",
@@ -9705,7 +9618,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 755
+      "newOrder": 748
     },
     {
       "cefr": "B1",
@@ -9716,7 +9629,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 756
+      "newOrder": 749
     },
     {
       "cefr": "B1",
@@ -9727,7 +9640,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 757
+      "newOrder": 750
     },
     {
       "cefr": "B1",
@@ -9740,20 +9653,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 758
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "речовина",
-      "lemmaId": "речовина",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 759
+      "newOrder": 751
     },
     {
       "cefr": "B1",
@@ -9766,7 +9666,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 760
+      "newOrder": 752
     },
     {
       "cefr": "B1",
@@ -9777,7 +9677,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 761
+      "newOrder": 753
     },
     {
       "cefr": "B1",
@@ -9790,7 +9690,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 762
+      "newOrder": 754
     },
     {
       "cefr": "B1",
@@ -9803,7 +9703,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 763
+      "newOrder": 755
     },
     {
       "cefr": "B1",
@@ -9816,7 +9716,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 764
+      "newOrder": 756
     },
     {
       "cefr": "B1",
@@ -9829,7 +9729,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 765
+      "newOrder": 757
     },
     {
       "cefr": "B1",
@@ -9842,7 +9742,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 766
+      "newOrder": 758
     },
     {
       "cefr": "B1",
@@ -9855,7 +9755,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 767
+      "newOrder": 759
     },
     {
       "cefr": "B1",
@@ -9868,7 +9768,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 768
+      "newOrder": 760
     },
     {
       "cefr": "B1",
@@ -9881,7 +9781,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 769
+      "newOrder": 761
     },
     {
       "cefr": "B1",
@@ -9894,7 +9794,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 770
+      "newOrder": 762
     },
     {
       "cefr": "B1",
@@ -9905,7 +9805,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 771
+      "newOrder": 763
     },
     {
       "cefr": "B1",
@@ -9918,7 +9818,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 772
+      "newOrder": 764
     },
     {
       "cefr": "B1",
@@ -9931,7 +9831,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 773
+      "newOrder": 765
     },
     {
       "cefr": "B1",
@@ -9944,7 +9844,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 774
+      "newOrder": 766
     },
     {
       "cefr": "B1",
@@ -9957,7 +9857,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 775
+      "newOrder": 767
     },
     {
       "cefr": "B1",
@@ -9970,7 +9870,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 776
+      "newOrder": 768
     },
     {
       "cefr": "B1",
@@ -9983,7 +9883,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 777
+      "newOrder": 769
     },
     {
       "cefr": "B1",
@@ -9996,7 +9896,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 778
+      "newOrder": 770
     },
     {
       "cefr": "B1",
@@ -10009,7 +9909,18 @@
         "matching",
         "choice"
       ],
-      "newOrder": 779
+      "newOrder": 771
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "навчаючись",
+      "lemmaId": "навчаючись",
+      "modes": [
+        "flashcards"
+      ],
+      "newOrder": 772
     },
     {
       "cefr": "B1",
@@ -10022,7 +9933,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 780
+      "newOrder": 773
     },
     {
       "cefr": "B1",
@@ -10033,31 +9944,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 781
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "усміхаючись",
-      "lemmaId": "усміхаючись",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 782
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "дізнавшись",
-      "lemmaId": "дізнавшись",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 783
+      "newOrder": 774
     },
     {
       "cefr": "B1",
@@ -10070,7 +9957,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 784
+      "newOrder": 775
     },
     {
       "cefr": "B1",
@@ -10083,7 +9970,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 785
+      "newOrder": 776
     },
     {
       "cefr": "B1",
@@ -10096,7 +9983,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 786
+      "newOrder": 777
     },
     {
       "cefr": "B1",
@@ -10109,7 +9996,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 787
+      "newOrder": 778
     },
     {
       "cefr": "B1",
@@ -10122,7 +10009,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 788
+      "newOrder": 779
     },
     {
       "cefr": "B1",
@@ -10135,7 +10022,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 789
+      "newOrder": 780
     },
     {
       "cefr": "B1",
@@ -10148,7 +10035,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 790
+      "newOrder": 781
     },
     {
       "cefr": "B1",
@@ -10161,7 +10048,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 791
+      "newOrder": 782
     },
     {
       "cefr": "B1",
@@ -10174,7 +10061,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 792
+      "newOrder": 783
     },
     {
       "cefr": "B1",
@@ -10187,7 +10074,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 793
+      "newOrder": 784
     },
     {
       "cefr": "B1",
@@ -10200,7 +10087,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 794
+      "newOrder": 785
     },
     {
       "cefr": "B1",
@@ -10213,7 +10100,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 795
+      "newOrder": 786
     },
     {
       "cefr": "B1",
@@ -10226,7 +10113,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 796
+      "newOrder": 787
     },
     {
       "cefr": "B1",
@@ -10239,7 +10126,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 797
+      "newOrder": 788
     },
     {
       "cefr": "B1",
@@ -10252,7 +10139,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 798
+      "newOrder": 789
     },
     {
       "cefr": "B1",
@@ -10265,7 +10152,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 799
+      "newOrder": 790
     },
     {
       "cefr": "B1",
@@ -10278,7 +10165,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 800
+      "newOrder": 791
     },
     {
       "cefr": "B1",
@@ -10291,7 +10178,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 801
+      "newOrder": 792
     },
     {
       "cefr": "B1",
@@ -10304,7 +10191,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 802
+      "newOrder": 793
     },
     {
       "cefr": "B1",
@@ -10317,7 +10204,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 803
+      "newOrder": 794
     },
     {
       "cefr": "B1",
@@ -10330,7 +10217,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 804
+      "newOrder": 795
     },
     {
       "cefr": "B1",
@@ -10343,7 +10230,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 805
+      "newOrder": 796
     },
     {
       "cefr": "B1",
@@ -10356,7 +10243,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 806
+      "newOrder": 797
     },
     {
       "cefr": "B1",
@@ -10369,7 +10256,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 807
+      "newOrder": 798
     },
     {
       "cefr": "B1",
@@ -10382,7 +10269,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 808
+      "newOrder": 799
     },
     {
       "cefr": "B1",
@@ -10395,7 +10282,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 809
+      "newOrder": 800
     },
     {
       "cefr": "B1",
@@ -10408,7 +10295,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 810
+      "newOrder": 801
     },
     {
       "cefr": "B1",
@@ -10421,7 +10308,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 811
+      "newOrder": 802
     },
     {
       "cefr": "B1",
@@ -10434,7 +10321,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 812
+      "newOrder": 803
     },
     {
       "cefr": "B1",
@@ -10447,7 +10334,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 813
+      "newOrder": 804
     },
     {
       "cefr": "B1",
@@ -10460,7 +10347,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 814
+      "newOrder": 805
     },
     {
       "cefr": "B1",
@@ -10473,7 +10360,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 815
+      "newOrder": 806
     },
     {
       "cefr": "B1",
@@ -10486,7 +10373,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 816
+      "newOrder": 807
     },
     {
       "cefr": "B1",
@@ -10499,7 +10386,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 817
+      "newOrder": 808
     },
     {
       "cefr": "B1",
@@ -10512,7 +10399,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 818
+      "newOrder": 809
     },
     {
       "cefr": "B1",
@@ -10525,7 +10412,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 819
+      "newOrder": 810
     },
     {
       "cefr": "B1",
@@ -10538,7 +10425,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 820
+      "newOrder": 811
     },
     {
       "cefr": "B1",
@@ -10551,7 +10438,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 821
+      "newOrder": 812
     },
     {
       "cefr": "B1",
@@ -10564,7 +10451,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 822
+      "newOrder": 813
     },
     {
       "cefr": "B1",
@@ -10577,7 +10464,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 823
+      "newOrder": 814
     },
     {
       "cefr": "B1",
@@ -10590,7 +10477,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 824
+      "newOrder": 815
     },
     {
       "cefr": "B1",
@@ -10603,7 +10490,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 825
+      "newOrder": 816
     },
     {
       "cefr": "B1",
@@ -10616,7 +10503,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 826
+      "newOrder": 817
     },
     {
       "cefr": "B1",
@@ -10629,7 +10516,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 827
+      "newOrder": 818
     },
     {
       "cefr": "B1",
@@ -10642,7 +10529,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 828
+      "newOrder": 819
     },
     {
       "cefr": "B1",
@@ -10655,7 +10542,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 829
+      "newOrder": 820
     },
     {
       "cefr": "B1",
@@ -10668,7 +10555,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 830
+      "newOrder": 821
     },
     {
       "cefr": "B1",
@@ -10681,7 +10568,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 831
+      "newOrder": 822
     },
     {
       "cefr": "B1",
@@ -10694,7 +10581,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 832
+      "newOrder": 823
     },
     {
       "cefr": "B1",
@@ -10707,7 +10594,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 833
+      "newOrder": 824
     },
     {
       "cefr": "B1",
@@ -10720,7 +10607,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 834
+      "newOrder": 825
     },
     {
       "cefr": "B1",
@@ -10733,7 +10620,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 835
+      "newOrder": 826
     },
     {
       "cefr": "B1",
@@ -10746,7 +10633,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 836
+      "newOrder": 827
     },
     {
       "cefr": "B1",
@@ -10759,7 +10646,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 837
+      "newOrder": 828
     },
     {
       "cefr": "B1",
@@ -10770,7 +10657,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 838
+      "newOrder": 829
     },
     {
       "cefr": "B1",
@@ -10783,7 +10670,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 839
+      "newOrder": 830
     },
     {
       "cefr": "B1",
@@ -10794,7 +10681,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 840
+      "newOrder": 831
     },
     {
       "cefr": "B1",
@@ -10807,7 +10694,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 841
+      "newOrder": 832
     },
     {
       "cefr": "B1",
@@ -10820,7 +10707,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 842
+      "newOrder": 833
     },
     {
       "cefr": "B1",
@@ -10833,7 +10720,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 843
+      "newOrder": 834
     },
     {
       "cefr": "B1",
@@ -10846,7 +10733,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 844
+      "newOrder": 835
     },
     {
       "cefr": "B1",
@@ -10859,7 +10746,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 845
+      "newOrder": 836
     },
     {
       "cefr": "B1",
@@ -10872,7 +10759,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 846
+      "newOrder": 837
     },
     {
       "cefr": "B1",
@@ -10885,7 +10772,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 847
+      "newOrder": 838
     },
     {
       "cefr": "B1",
@@ -10898,7 +10785,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 848
+      "newOrder": 839
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "спонукання",
+      "lemmaId": "спонукання",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 840
     },
     {
       "cefr": "B1",
@@ -10911,7 +10811,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 849
+      "newOrder": 841
     },
     {
       "cefr": "B1",
@@ -10924,7 +10824,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 850
+      "newOrder": 842
     },
     {
       "cefr": "B1",
@@ -10937,7 +10837,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 851
+      "newOrder": 843
     },
     {
       "cefr": "B1",
@@ -10950,7 +10850,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 852
+      "newOrder": 844
     },
     {
       "cefr": "B1",
@@ -10963,7 +10863,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 853
+      "newOrder": 845
     },
     {
       "cefr": "B1",
@@ -10974,7 +10874,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 854
+      "newOrder": 846
     },
     {
       "cefr": "B1",
@@ -10987,7 +10887,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 855
+      "newOrder": 847
     },
     {
       "cefr": "B1",
@@ -10998,7 +10898,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 856
+      "newOrder": 848
     },
     {
       "cefr": "B1",
@@ -11011,7 +10911,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 857
+      "newOrder": 849
     },
     {
       "cefr": "B1",
@@ -11024,7 +10924,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 858
+      "newOrder": 850
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "сумісність",
+      "lemmaId": "сумісність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 851
     },
     {
       "cefr": "B1",
@@ -11035,7 +10948,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 859
+      "newOrder": 852
     },
     {
       "cefr": "B1",
@@ -11048,7 +10961,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 860
+      "newOrder": 853
     },
     {
       "cefr": "B1",
@@ -11061,7 +10974,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 861
+      "newOrder": 854
     },
     {
       "cefr": "B1",
@@ -11074,7 +10987,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 862
+      "newOrder": 855
     },
     {
       "cefr": "B1",
@@ -11087,7 +11000,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 863
+      "newOrder": 856
     },
     {
       "cefr": "B1",
@@ -11100,7 +11013,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 864
+      "newOrder": 857
     },
     {
       "cefr": "B1",
@@ -11113,7 +11026,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 865
+      "newOrder": 858
     },
     {
       "cefr": "B1",
@@ -11126,7 +11039,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 866
+      "newOrder": 859
     },
     {
       "cefr": "B1",
@@ -11139,7 +11052,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 867
+      "newOrder": 860
     },
     {
       "cefr": "B1",
@@ -11152,7 +11065,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 868
+      "newOrder": 861
     },
     {
       "cefr": "B1",
@@ -11165,7 +11078,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 869
+      "newOrder": 862
     },
     {
       "cefr": "B1",
@@ -11178,7 +11091,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 870
+      "newOrder": 863
     },
     {
       "cefr": "B1",
@@ -11189,7 +11102,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 871
+      "newOrder": 864
     },
     {
       "cefr": "B1",
@@ -11202,7 +11115,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 872
+      "newOrder": 865
     },
     {
       "cefr": "B1",
@@ -11215,20 +11128,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 873
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "обряд",
-      "lemmaId": "обряд",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 874
+      "newOrder": 866
     },
     {
       "cefr": "B1",
@@ -11241,7 +11141,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 875
+      "newOrder": 867
     },
     {
       "cefr": "B1",
@@ -11254,7 +11154,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 876
+      "newOrder": 868
     },
     {
       "cefr": "B1",
@@ -11267,7 +11167,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 877
+      "newOrder": 869
     },
     {
       "cefr": "B1",
@@ -11280,7 +11180,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 878
+      "newOrder": 870
     },
     {
       "cefr": "B1",
@@ -11293,7 +11193,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 879
+      "newOrder": 871
     },
     {
       "cefr": "B1",
@@ -11304,7 +11204,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 880
+      "newOrder": 872
     },
     {
       "cefr": "B1",
@@ -11315,7 +11215,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 881
+      "newOrder": 873
     },
     {
       "cefr": "B1",
@@ -11328,7 +11228,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 882
+      "newOrder": 874
     },
     {
       "cefr": "B1",
@@ -11341,7 +11241,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 883
+      "newOrder": 875
     },
     {
       "cefr": "B1",
@@ -11354,7 +11254,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 884
+      "newOrder": 876
     },
     {
       "cefr": "B1",
@@ -11367,7 +11267,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 885
+      "newOrder": 877
     },
     {
       "cefr": "B1",
@@ -11380,7 +11280,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 886
+      "newOrder": 878
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "лечу",
+      "lemmaId": "лечу",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 879
     },
     {
       "cefr": "B1",
@@ -11393,7 +11306,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 887
+      "newOrder": 880
     },
     {
       "cefr": "B1",
@@ -11406,7 +11319,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 888
+      "newOrder": 881
     },
     {
       "cefr": "B1",
@@ -11417,7 +11330,20 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 889
+      "newOrder": 882
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "пором",
+      "lemmaId": "пором",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 883
     },
     {
       "cefr": "B1",
@@ -11428,7 +11354,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 890
+      "newOrder": 884
     },
     {
       "cefr": "B1",
@@ -11441,7 +11367,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 891
+      "newOrder": 885
     },
     {
       "cefr": "B1",
@@ -11454,7 +11380,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 892
+      "newOrder": 886
     },
     {
       "cefr": "B1",
@@ -11467,7 +11393,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 893
+      "newOrder": 887
     },
     {
       "cefr": "B1",
@@ -11480,7 +11406,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 894
+      "newOrder": 888
     },
     {
       "cefr": "B1",
@@ -11491,7 +11417,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 895
+      "newOrder": 889
     },
     {
       "cefr": "B1",
@@ -11504,7 +11430,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 896
+      "newOrder": 890
     },
     {
       "cefr": "B1",
@@ -11517,7 +11443,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 897
+      "newOrder": 891
     },
     {
       "cefr": "B1",
@@ -11530,7 +11456,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 898
+      "newOrder": 892
     },
     {
       "cefr": "B1",
@@ -11541,7 +11467,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 899
+      "newOrder": 893
     },
     {
       "cefr": "B1",
@@ -11554,7 +11480,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 900
+      "newOrder": 894
     },
     {
       "cefr": "B1",
@@ -11567,20 +11493,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 901
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "кур'єр",
-      "lemmaId": "кур-єр",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 902
+      "newOrder": 895
     },
     {
       "cefr": "B1",
@@ -11593,7 +11506,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 903
+      "newOrder": 896
     },
     {
       "cefr": "B1",
@@ -11606,7 +11519,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 904
+      "newOrder": 897
     },
     {
       "cefr": "B1",
@@ -11619,7 +11532,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 905
+      "newOrder": 898
     },
     {
       "cefr": "B1",
@@ -11630,7 +11543,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 906
+      "newOrder": 899
     },
     {
       "cefr": "B1",
@@ -11641,7 +11554,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 907
+      "newOrder": 900
     },
     {
       "cefr": "B1",
@@ -11652,7 +11565,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 908
+      "newOrder": 901
     },
     {
       "cefr": "B1",
@@ -11663,7 +11576,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 909
+      "newOrder": 902
     },
     {
       "cefr": "B1",
@@ -11676,7 +11589,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 910
+      "newOrder": 903
     },
     {
       "cefr": "B1",
@@ -11689,7 +11602,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 911
+      "newOrder": 904
     },
     {
       "cefr": "B1",
@@ -11702,7 +11615,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 912
+      "newOrder": 905
     },
     {
       "cefr": "B1",
@@ -11715,7 +11628,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 913
+      "newOrder": 906
     },
     {
       "cefr": "B1",
@@ -11728,7 +11641,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 914
+      "newOrder": 907
     },
     {
       "cefr": "B1",
@@ -11741,7 +11654,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 915
+      "newOrder": 908
     },
     {
       "cefr": "B1",
@@ -11754,7 +11667,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 916
+      "newOrder": 909
     },
     {
       "cefr": "B1",
@@ -11767,7 +11680,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 917
+      "newOrder": 910
     },
     {
       "cefr": "B1",
@@ -11780,7 +11693,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 918
+      "newOrder": 911
     },
     {
       "cefr": "B1",
@@ -11793,7 +11706,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 919
+      "newOrder": 912
     },
     {
       "cefr": "B1",
@@ -11806,7 +11719,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 920
+      "newOrder": 913
     },
     {
       "cefr": "B1",
@@ -11819,7 +11732,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 921
+      "newOrder": 914
     },
     {
       "cefr": "B1",
@@ -11832,7 +11745,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 922
+      "newOrder": 915
     },
     {
       "cefr": "B1",
@@ -11843,7 +11756,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 923
+      "newOrder": 916
     },
     {
       "cefr": "B1",
@@ -11856,7 +11769,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 924
+      "newOrder": 917
     },
     {
       "cefr": "B1",
@@ -11869,7 +11782,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 925
+      "newOrder": 918
     },
     {
       "cefr": "B1",
@@ -11882,7 +11795,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 926
+      "newOrder": 919
     },
     {
       "cefr": "B1",
@@ -11895,7 +11808,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 927
+      "newOrder": 920
     },
     {
       "cefr": "B1",
@@ -11908,7 +11821,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 928
+      "newOrder": 921
     },
     {
       "cefr": "B1",
@@ -11921,7 +11834,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 929
+      "newOrder": 922
     },
     {
       "cefr": "B1",
@@ -11932,7 +11845,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 930
+      "newOrder": 923
     },
     {
       "cefr": "B1",
@@ -11945,7 +11858,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 931
+      "newOrder": 924
     },
     {
       "cefr": "B1",
@@ -11958,7 +11871,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 932
+      "newOrder": 925
     },
     {
       "cefr": "B1",
@@ -11971,7 +11884,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 933
+      "newOrder": 926
     },
     {
       "cefr": "B1",
@@ -11982,7 +11895,18 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 934
+      "newOrder": 927
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "пробігти",
+      "lemmaId": "пробігти",
+      "modes": [
+        "flashcards"
+      ],
+      "newOrder": 928
     },
     {
       "cefr": "B1",
@@ -11995,7 +11919,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 935
+      "newOrder": 929
     },
     {
       "cefr": "B1",
@@ -12008,7 +11932,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 936
+      "newOrder": 930
     },
     {
       "cefr": "B1",
@@ -12021,7 +11945,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 937
+      "newOrder": 931
     },
     {
       "cefr": "B1",
@@ -12034,7 +11958,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 938
+      "newOrder": 932
     },
     {
       "cefr": "B1",
@@ -12047,7 +11971,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 939
+      "newOrder": 933
     },
     {
       "cefr": "B1",
@@ -12060,7 +11984,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 940
+      "newOrder": 934
     },
     {
       "cefr": "B1",
@@ -12073,7 +11997,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 941
+      "newOrder": 935
     },
     {
       "cefr": "B1",
@@ -12086,7 +12010,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 942
+      "newOrder": 936
     },
     {
       "cefr": "B1",
@@ -12099,7 +12023,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 943
+      "newOrder": 937
     },
     {
       "cefr": "B1",
@@ -12112,20 +12036,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 944
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "заповідник",
-      "lemmaId": "заповідник",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 945
+      "newOrder": 938
     },
     {
       "cefr": "B1",
@@ -12138,7 +12049,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 946
+      "newOrder": 939
     },
     {
       "cefr": "B1",
@@ -12151,7 +12062,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 947
+      "newOrder": 940
     },
     {
       "cefr": "B1",
@@ -12164,7 +12075,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 948
+      "newOrder": 941
     },
     {
       "cefr": "B1",
@@ -12177,7 +12088,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 949
+      "newOrder": 942
     },
     {
       "cefr": "B1",
@@ -12190,7 +12101,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 950
+      "newOrder": 943
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "сортувати",
+      "lemmaId": "сортувати",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 944
     },
     {
       "cefr": "B1",
@@ -12203,7 +12127,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 951
+      "newOrder": 945
     },
     {
       "cefr": "B1",
@@ -12216,7 +12140,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 952
+      "newOrder": 946
     },
     {
       "cefr": "B1",
@@ -12229,7 +12153,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 953
+      "newOrder": 947
     },
     {
       "cefr": "B1",
@@ -12242,7 +12166,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 954
+      "newOrder": 948
     },
     {
       "cefr": "B1",
@@ -12255,7 +12179,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 955
+      "newOrder": 949
     },
     {
       "cefr": "B1",
@@ -12268,7 +12192,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 956
+      "newOrder": 950
     },
     {
       "cefr": "B1",
@@ -12281,20 +12205,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 957
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "доповідач",
-      "lemmaId": "доповідач",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 958
+      "newOrder": 951
     },
     {
       "cefr": "B1",
@@ -12307,20 +12218,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 959
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "монтаж",
-      "lemmaId": "монтаж",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 960
+      "newOrder": 952
     },
     {
       "cefr": "B1",
@@ -12333,7 +12231,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 961
+      "newOrder": 953
     },
     {
       "cefr": "B1",
@@ -12346,7 +12244,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 962
+      "newOrder": 954
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "слухач",
+      "lemmaId": "слухач",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 955
     },
     {
       "cefr": "B1",
@@ -12359,7 +12270,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 963
+      "newOrder": 956
     },
     {
       "cefr": "B1",
@@ -12372,7 +12283,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 964
+      "newOrder": 957
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "грузин",
+      "lemmaId": "грузин",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 958
     },
     {
       "cefr": "B1",
@@ -12385,7 +12309,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 965
+      "newOrder": 959
     },
     {
       "cefr": "B1",
@@ -12398,7 +12322,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 966
+      "newOrder": 960
     },
     {
       "cefr": "B1",
@@ -12411,7 +12335,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 967
+      "newOrder": 961
     },
     {
       "cefr": "B1",
@@ -12424,7 +12348,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 968
+      "newOrder": 962
     },
     {
       "cefr": "B1",
@@ -12437,7 +12361,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 969
+      "newOrder": 963
     },
     {
       "cefr": "B1",
@@ -12450,7 +12374,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 970
+      "newOrder": 964
     },
     {
       "cefr": "B1",
@@ -12463,7 +12387,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 971
+      "newOrder": 965
     },
     {
       "cefr": "B1",
@@ -12476,7 +12400,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 972
+      "newOrder": 966
     },
     {
       "cefr": "B1",
@@ -12489,7 +12413,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 973
+      "newOrder": 967
     },
     {
       "cefr": "B1",
@@ -12502,7 +12426,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 974
+      "newOrder": 968
     },
     {
       "cefr": "B1",
@@ -12515,7 +12439,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 975
+      "newOrder": 969
     },
     {
       "cefr": "B1",
@@ -12528,7 +12452,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 976
+      "newOrder": 970
     },
     {
       "cefr": "B1",
@@ -12541,7 +12465,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 977
+      "newOrder": 971
     },
     {
       "cefr": "B1",
@@ -12554,7 +12478,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 978
+      "newOrder": 972
     },
     {
       "cefr": "B1",
@@ -12567,7 +12491,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 979
+      "newOrder": 973
     },
     {
       "cefr": "B1",
@@ -12580,7 +12504,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 980
+      "newOrder": 974
     },
     {
       "cefr": "B1",
@@ -12591,7 +12515,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 981
+      "newOrder": 975
     },
     {
       "cefr": "B1",
@@ -12604,7 +12528,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 982
+      "newOrder": 976
     },
     {
       "cefr": "B1",
@@ -12617,7 +12541,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 983
+      "newOrder": 977
     },
     {
       "cefr": "B1",
@@ -12630,7 +12554,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 984
+      "newOrder": 978
     },
     {
       "cefr": "B1",
@@ -12641,7 +12565,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 985
+      "newOrder": 979
     },
     {
       "cefr": "B1",
@@ -12654,7 +12578,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 986
+      "newOrder": 980
     },
     {
       "cefr": "B1",
@@ -12667,7 +12591,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 987
+      "newOrder": 981
     },
     {
       "cefr": "B1",
@@ -12680,7 +12604,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 988
+      "newOrder": 982
     },
     {
       "cefr": "B1",
@@ -12693,7 +12617,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 989
+      "newOrder": 983
     },
     {
       "cefr": "B1",
@@ -12706,7 +12630,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 990
+      "newOrder": 984
     },
     {
       "cefr": "B1",
@@ -12719,7 +12643,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 991
+      "newOrder": 985
     },
     {
       "cefr": "B1",
@@ -12730,7 +12654,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 992
+      "newOrder": 986
     },
     {
       "cefr": "B1",
@@ -12743,7 +12667,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 993
+      "newOrder": 987
     },
     {
       "cefr": "B1",
@@ -12756,7 +12680,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 994
+      "newOrder": 988
     },
     {
       "cefr": "B1",
@@ -12769,7 +12693,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 995
+      "newOrder": 989
     },
     {
       "cefr": "B1",
@@ -12782,7 +12706,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 996
+      "newOrder": 990
     },
     {
       "cefr": "B1",
@@ -12795,7 +12719,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 997
+      "newOrder": 991
     },
     {
       "cefr": "B1",
@@ -12808,7 +12732,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 998
+      "newOrder": 992
     },
     {
       "cefr": "B1",
@@ -12821,7 +12745,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 999
+      "newOrder": 993
     },
     {
       "cefr": "B1",
@@ -12834,7 +12758,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1000
+      "newOrder": 994
     },
     {
       "cefr": "B1",
@@ -12847,7 +12771,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1001
+      "newOrder": 995
     },
     {
       "cefr": "B1",
@@ -12860,7 +12784,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1002
+      "newOrder": 996
     },
     {
       "cefr": "B1",
@@ -12873,7 +12797,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1003
+      "newOrder": 997
     },
     {
       "cefr": "B1",
@@ -12886,7 +12810,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1004
+      "newOrder": 998
     },
     {
       "cefr": "B1",
@@ -12899,7 +12823,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1005
+      "newOrder": 999
     },
     {
       "cefr": "B1",
@@ -12912,7 +12836,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1006
+      "newOrder": 1000
     },
     {
       "cefr": "B1",
@@ -12925,7 +12849,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1007
+      "newOrder": 1001
     },
     {
       "cefr": "B1",
@@ -12938,7 +12862,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1008
+      "newOrder": 1002
     },
     {
       "cefr": "B1",
@@ -12951,7 +12875,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1009
+      "newOrder": 1003
     },
     {
       "cefr": "B1",
@@ -12964,7 +12888,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1010
+      "newOrder": 1004
     },
     {
       "cefr": "B1",
@@ -12977,7 +12901,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1011
+      "newOrder": 1005
     },
     {
       "cefr": "B1",
@@ -12990,7 +12914,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1012
+      "newOrder": 1006
     },
     {
       "cefr": "B1",
@@ -13003,7 +12927,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1013
+      "newOrder": 1007
     },
     {
       "cefr": "B1",
@@ -13016,7 +12940,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1014
+      "newOrder": 1008
     },
     {
       "cefr": "B1",
@@ -13029,7 +12953,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1015
+      "newOrder": 1009
     },
     {
       "cefr": "B1",
@@ -13042,7 +12966,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1016
+      "newOrder": 1010
     },
     {
       "cefr": "B1",
@@ -13055,7 +12979,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1017
+      "newOrder": 1011
     },
     {
       "cefr": "B1",
@@ -13068,7 +12992,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1018
+      "newOrder": 1012
     },
     {
       "cefr": "B1",
@@ -13081,20 +13005,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1019
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "блідий",
-      "lemmaId": "блідий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1020
+      "newOrder": 1013
     },
     {
       "cefr": "B1",
@@ -13107,7 +13018,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1021
+      "newOrder": 1014
     },
     {
       "cefr": "B1",
@@ -13120,7 +13031,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1022
+      "newOrder": 1015
     },
     {
       "cefr": "B1",
@@ -13133,7 +13044,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1023
+      "newOrder": 1016
     },
     {
       "cefr": "B1",
@@ -13146,7 +13057,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1024
+      "newOrder": 1017
     },
     {
       "cefr": "B1",
@@ -13159,7 +13070,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1025
+      "newOrder": 1018
     },
     {
       "cefr": "B1",
@@ -13172,7 +13083,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1026
+      "newOrder": 1019
     },
     {
       "cefr": "B1",
@@ -13185,7 +13096,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1027
+      "newOrder": 1020
     },
     {
       "cefr": "B1",
@@ -13198,7 +13109,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1028
+      "newOrder": 1021
     },
     {
       "cefr": "B1",
@@ -13211,7 +13122,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1029
+      "newOrder": 1022
     },
     {
       "cefr": "B1",
@@ -13224,7 +13135,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1030
+      "newOrder": 1023
     },
     {
       "cefr": "B1",
@@ -13237,7 +13148,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1031
+      "newOrder": 1024
     },
     {
       "cefr": "B1",
@@ -13250,7 +13161,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1032
+      "newOrder": 1025
     },
     {
       "cefr": "B1",
@@ -13263,7 +13174,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1033
+      "newOrder": 1026
     },
     {
       "cefr": "B1",
@@ -13276,7 +13187,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1034
+      "newOrder": 1027
     },
     {
       "cefr": "B1",
@@ -13289,7 +13200,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1035
+      "newOrder": 1028
     },
     {
       "cefr": "B1",
@@ -13302,7 +13213,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1036
+      "newOrder": 1029
     },
     {
       "cefr": "B1",
@@ -13315,7 +13226,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1037
+      "newOrder": 1030
     },
     {
       "cefr": "B1",
@@ -13328,7 +13239,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1038
+      "newOrder": 1031
     },
     {
       "cefr": "B1",
@@ -13341,7 +13252,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1039
+      "newOrder": 1032
     },
     {
       "cefr": "B1",
@@ -13354,7 +13265,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1040
+      "newOrder": 1033
     },
     {
       "cefr": "B1",
@@ -13367,7 +13278,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1041
+      "newOrder": 1034
     },
     {
       "cefr": "B1",
@@ -13380,7 +13291,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1042
+      "newOrder": 1035
     },
     {
       "cefr": "B1",
@@ -13393,7 +13304,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1043
+      "newOrder": 1036
     },
     {
       "cefr": "B1",
@@ -13406,7 +13317,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1044
+      "newOrder": 1037
     },
     {
       "cefr": "B1",
@@ -13419,7 +13330,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1045
+      "newOrder": 1038
     },
     {
       "cefr": "B1",
@@ -13432,7 +13343,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1046
+      "newOrder": 1039
     },
     {
       "cefr": "B1",
@@ -13445,7 +13356,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1047
+      "newOrder": 1040
     },
     {
       "cefr": "B1",
@@ -13458,7 +13369,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1048
+      "newOrder": 1041
     },
     {
       "cefr": "B1",
@@ -13471,7 +13382,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1049
+      "newOrder": 1042
     },
     {
       "cefr": "B1",
@@ -13484,20 +13395,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1050
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "пам'ятка",
-      "lemmaId": "пам-ятка",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 1051
+      "newOrder": 1043
     },
     {
       "cefr": "B1",
@@ -13510,7 +13408,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1052
+      "newOrder": 1044
     },
     {
       "cefr": "B1",
@@ -13523,7 +13421,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1053
+      "newOrder": 1045
     },
     {
       "cefr": "B1",
@@ -13536,7 +13434,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1054
+      "newOrder": 1046
     },
     {
       "cefr": "B1",
@@ -13549,7 +13447,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1055
+      "newOrder": 1047
     },
     {
       "cefr": "B1",
@@ -13562,7 +13460,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1056
+      "newOrder": 1048
     },
     {
       "cefr": "B1",
@@ -13575,7 +13473,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1057
+      "newOrder": 1049
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "вершки",
+      "lemmaId": "вершки",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1050
     },
     {
       "cefr": "B1",
@@ -13588,7 +13499,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1058
+      "newOrder": 1051
     },
     {
       "cefr": "B1",
@@ -13601,7 +13512,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1059
+      "newOrder": 1052
     },
     {
       "cefr": "B1",
@@ -13614,7 +13525,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1060
+      "newOrder": 1053
     },
     {
       "cefr": "B1",
@@ -13627,7 +13538,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1061
+      "newOrder": 1054
     },
     {
       "cefr": "B1",
@@ -13640,7 +13551,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1062
+      "newOrder": 1055
     },
     {
       "cefr": "B1",
@@ -13653,7 +13564,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1063
+      "newOrder": 1056
     },
     {
       "cefr": "B1",
@@ -13666,7 +13577,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1064
+      "newOrder": 1057
     },
     {
       "cefr": "B1",
@@ -13679,7 +13590,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1065
+      "newOrder": 1058
     },
     {
       "cefr": "B1",
@@ -13692,7 +13603,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1066
+      "newOrder": 1059
     },
     {
       "cefr": "B1",
@@ -13705,7 +13616,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1067
+      "newOrder": 1060
     },
     {
       "cefr": "B1",
@@ -13718,7 +13629,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1068
+      "newOrder": 1061
     },
     {
       "cefr": "B1",
@@ -13731,7 +13642,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1069
+      "newOrder": 1062
     },
     {
       "cefr": "B1",
@@ -13744,7 +13655,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1070
+      "newOrder": 1063
     },
     {
       "cefr": "B1",
@@ -13757,7 +13668,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1071
+      "newOrder": 1064
     },
     {
       "cefr": "B1",
@@ -13770,7 +13681,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1072
+      "newOrder": 1065
     },
     {
       "cefr": "B1",
@@ -13783,7 +13694,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1073
+      "newOrder": 1066
     },
     {
       "cefr": "B1",
@@ -13796,7 +13707,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1074
+      "newOrder": 1067
     },
     {
       "cefr": "B1",
@@ -13809,7 +13720,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1075
+      "newOrder": 1068
     },
     {
       "cefr": "B1",
@@ -13822,7 +13733,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1076
+      "newOrder": 1069
     },
     {
       "cefr": "B1",
@@ -13835,7 +13746,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1077
+      "newOrder": 1070
     },
     {
       "cefr": "B1",
@@ -13848,7 +13759,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1078
+      "newOrder": 1071
     },
     {
       "cefr": "B1",
@@ -13861,7 +13772,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1079
+      "newOrder": 1072
     },
     {
       "cefr": "B1",
@@ -13874,7 +13785,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1080
+      "newOrder": 1073
     },
     {
       "cefr": "B1",
@@ -13887,7 +13798,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1081
+      "newOrder": 1074
     },
     {
       "cefr": "B1",
@@ -13900,7 +13811,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1082
+      "newOrder": 1075
     },
     {
       "cefr": "B1",
@@ -13913,7 +13824,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1083
+      "newOrder": 1076
     },
     {
       "cefr": "B1",
@@ -13926,7 +13837,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1084
+      "newOrder": 1077
     },
     {
       "cefr": "B1",
@@ -13939,7 +13850,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1085
+      "newOrder": 1078
     },
     {
       "cefr": "B1",
@@ -13952,7 +13863,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1086
+      "newOrder": 1079
     },
     {
       "cefr": "B1",
@@ -13965,7 +13876,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1087
+      "newOrder": 1080
     },
     {
       "cefr": "B1",
@@ -13978,7 +13889,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1088
+      "newOrder": 1081
     },
     {
       "cefr": "B1",
@@ -13989,7 +13900,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 1089
+      "newOrder": 1082
     },
     {
       "cefr": "B1",
@@ -14002,7 +13913,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1090
+      "newOrder": 1083
     },
     {
       "cefr": "B1",
@@ -14015,7 +13926,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1091
+      "newOrder": 1084
     },
     {
       "cefr": "B1",
@@ -14028,7 +13939,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1092
+      "newOrder": 1085
     },
     {
       "cefr": "B1",
@@ -14041,7 +13952,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1093
+      "newOrder": 1086
     },
     {
       "cefr": "B1",
@@ -14054,7 +13965,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1094
+      "newOrder": 1087
     },
     {
       "cefr": "B1",
@@ -14067,7 +13978,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1095
+      "newOrder": 1088
     },
     {
       "cefr": "B1",
@@ -14080,7 +13991,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1096
+      "newOrder": 1089
     },
     {
       "cefr": "B1",
@@ -14093,7 +14004,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1097
+      "newOrder": 1090
     },
     {
       "cefr": "B1",
@@ -14104,7 +14015,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 1098
+      "newOrder": 1091
     },
     {
       "cefr": "B1",
@@ -14117,18 +14028,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1099
-    },
-    {
-      "cefr": "B1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "обабіч",
-      "lemmaId": "обабіч",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 1100
+      "newOrder": 1092
     },
     {
       "cefr": "B1",
@@ -14141,7 +14041,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1101
+      "newOrder": 1093
     },
     {
       "cefr": "B1",
@@ -14154,7 +14054,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1102
+      "newOrder": 1094
     },
     {
       "cefr": "B1",
@@ -14165,7 +14065,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 1103
+      "newOrder": 1095
     },
     {
       "cefr": "B1",
@@ -14178,7 +14078,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1104
+      "newOrder": 1096
     },
     {
       "cefr": "B1",
@@ -14191,7 +14091,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1105
+      "newOrder": 1097
     },
     {
       "cefr": "B1",
@@ -14204,7 +14104,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1106
+      "newOrder": 1098
     },
     {
       "cefr": "B1",
@@ -14217,7 +14117,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1107
+      "newOrder": 1099
     },
     {
       "cefr": "B1",
@@ -14228,7 +14128,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 1108
+      "newOrder": 1100
     },
     {
       "cefr": "B1",
@@ -14241,7 +14141,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1109
+      "newOrder": 1101
     },
     {
       "cefr": "B1",
@@ -14254,7 +14154,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1110
+      "newOrder": 1102
     },
     {
       "cefr": "B1",
@@ -14267,7 +14167,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1111
+      "newOrder": 1103
     },
     {
       "cefr": "B1",
@@ -14280,7 +14180,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1112
+      "newOrder": 1104
     },
     {
       "cefr": "B1",
@@ -14293,7 +14193,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1113
+      "newOrder": 1105
     },
     {
       "cefr": "B1",
@@ -14306,7 +14206,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1114
+      "newOrder": 1106
     },
     {
       "cefr": "B1",
@@ -14317,7 +14217,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 1115
+      "newOrder": 1107
     },
     {
       "cefr": "B1",
@@ -14330,7 +14230,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1116
+      "newOrder": 1108
     },
     {
       "cefr": "B1",
@@ -14343,7 +14243,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 1117
+      "newOrder": 1109
     },
     {
       "cefr": "B1",
@@ -14356,17 +14256,160 @@
         "matching",
         "choice"
       ],
+      "newOrder": 1110
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "часовий",
+      "lemmaId": "часовий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1111
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "щопонеділка",
+      "lemmaId": "щопонеділка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1112
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "щосереди",
+      "lemmaId": "щосереди",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1113
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "ліричний герой",
+      "lemmaId": "ліричний-герой",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1114
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "надихнути",
+      "lemmaId": "надихнути",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1115
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "персонаж",
+      "lemmaId": "персонаж",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1116
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "проза",
+      "lemmaId": "проза",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1117
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "бачитися",
+      "lemmaId": "бачитися",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
       "newOrder": 1118
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "взаємний",
+      "lemmaId": "взаємний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1119
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "власне зворотний",
+      "lemmaId": "власне-зворотний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1120
+    },
+    {
+      "cefr": "B1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "відкриватися",
+      "lemmaId": "відкриватися",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 1121
     }
   ],
   "level": "B1",
   "schema": "atlas-practice-index",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 19972,
+    "gzipBytes": 20005,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 299715,
+    "rawBytes": 300715,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/public/lexicon/practice-index.B2.json
+++ b/site/public/lexicon/practice-index.B2.json
@@ -3,9 +3,9 @@
     "cloze": 0,
     "clozeCoverage": 0.0,
     "clozeEligibleLexemes": 0,
-    "lexemes": 469
+    "lexemes": 854
   },
-  "deckVersion": "atlas-practice-v1-9cf4a4d7319d19ce",
+  "deckVersion": "atlas-practice-v1-c5a52e54cdf8d828",
   "items": [
     {
       "cefr": "B2",
@@ -128,6 +128,19 @@
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
+      "lemma": "темно-зелений",
+      "lemmaId": "темно-зелений",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 9
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
       "lemma": "порятунок",
       "lemmaId": "порятунок",
       "modes": [
@@ -135,7 +148,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 9
+      "newOrder": 10
     },
     {
       "cefr": "B2",
@@ -148,7 +161,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 10
+      "newOrder": 11
     },
     {
       "cefr": "B2",
@@ -159,7 +172,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 11
+      "newOrder": 12
     },
     {
       "cefr": "B2",
@@ -170,7 +183,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 12
+      "newOrder": 13
     },
     {
       "cefr": "B2",
@@ -180,19 +193,6 @@
       "lemmaId": "однак",
       "modes": [
         "flashcards"
-      ],
-      "newOrder": 13
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "абетка",
-      "lemmaId": "абетка",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
       ],
       "newOrder": 14
     },
@@ -213,6 +213,19 @@
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
+      "lemma": "роздільно",
+      "lemmaId": "роздільно",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 16
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
       "lemma": "атлас",
       "lemmaId": "атлас",
       "modes": [
@@ -220,7 +233,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 16
+      "newOrder": 17
     },
     {
       "cefr": "B2",
@@ -233,7 +246,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 17
+      "newOrder": 18
     },
     {
       "cefr": "B2",
@@ -246,7 +259,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 18
+      "newOrder": 19
     },
     {
       "cefr": "B2",
@@ -259,7 +272,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 19
+      "newOrder": 20
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "вчиш",
+      "lemmaId": "вчиш",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 21
     },
     {
       "cefr": "B2",
@@ -272,7 +298,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 20
+      "newOrder": 22
     },
     {
       "cefr": "B2",
@@ -283,7 +309,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 21
+      "newOrder": 23
     },
     {
       "cefr": "B2",
@@ -291,32 +317,6 @@
       "hasCloze": false,
       "lemma": "просиш",
       "lemmaId": "просиш",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 22
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "ходите",
-      "lemmaId": "ходите",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 23
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "одесит",
-      "lemmaId": "одесит",
       "modes": [
         "flashcards",
         "matching",
@@ -523,19 +523,6 @@
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "контрольна",
-      "lemmaId": "контрольна",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 40
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
       "lemma": "відсутність",
       "lemmaId": "відсутність",
       "modes": [
@@ -543,7 +530,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 41
+      "newOrder": 40
     },
     {
       "cefr": "B2",
@@ -556,7 +543,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 42
+      "newOrder": 41
     },
     {
       "cefr": "B2",
@@ -569,7 +556,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 43
+      "newOrder": 42
     },
     {
       "cefr": "B2",
@@ -582,7 +569,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 44
+      "newOrder": 43
     },
     {
       "cefr": "B2",
@@ -595,7 +582,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 45
+      "newOrder": 44
     },
     {
       "cefr": "B2",
@@ -608,7 +595,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 46
+      "newOrder": 45
     },
     {
       "cefr": "B2",
@@ -621,7 +608,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 47
+      "newOrder": 46
     },
     {
       "cefr": "B2",
@@ -634,7 +621,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 48
+      "newOrder": 47
     },
     {
       "cefr": "B2",
@@ -647,7 +634,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 49
+      "newOrder": 48
     },
     {
       "cefr": "B2",
@@ -660,7 +647,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 50
+      "newOrder": 49
     },
     {
       "cefr": "B2",
@@ -673,7 +660,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 51
+      "newOrder": 50
     },
     {
       "cefr": "B2",
@@ -686,20 +673,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 52
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "заздрити",
-      "lemmaId": "заздрити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 53
+      "newOrder": 51
     },
     {
       "cefr": "B2",
@@ -712,7 +686,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 54
+      "newOrder": 52
     },
     {
       "cefr": "B2",
@@ -725,7 +699,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 55
+      "newOrder": 53
     },
     {
       "cefr": "B2",
@@ -738,7 +712,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 56
+      "newOrder": 54
     },
     {
       "cefr": "B2",
@@ -751,7 +725,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 57
+      "newOrder": 55
     },
     {
       "cefr": "B2",
@@ -764,7 +738,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 58
+      "newOrder": 56
     },
     {
       "cefr": "B2",
@@ -777,7 +751,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 59
+      "newOrder": 57
     },
     {
       "cefr": "B2",
@@ -788,7 +762,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 60
+      "newOrder": 58
     },
     {
       "cefr": "B2",
@@ -799,7 +773,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 61
+      "newOrder": 59
     },
     {
       "cefr": "B2",
@@ -812,7 +786,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 62
+      "newOrder": 60
     },
     {
       "cefr": "B2",
@@ -825,7 +799,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 63
+      "newOrder": 61
     },
     {
       "cefr": "B2",
@@ -838,7 +812,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 64
+      "newOrder": 62
     },
     {
       "cefr": "B2",
@@ -851,7 +825,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 65
+      "newOrder": 63
     },
     {
       "cefr": "B2",
@@ -864,7 +838,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 66
+      "newOrder": 64
     },
     {
       "cefr": "B2",
@@ -877,7 +851,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 67
+      "newOrder": 65
     },
     {
       "cefr": "B2",
@@ -890,7 +864,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 68
+      "newOrder": 66
     },
     {
       "cefr": "B2",
@@ -903,7 +877,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 69
+      "newOrder": 67
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "морфологія",
+      "lemmaId": "морфологія",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 68
     },
     {
       "cefr": "B2",
@@ -916,7 +903,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 70
+      "newOrder": 69
     },
     {
       "cefr": "B2",
@@ -929,7 +916,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 71
+      "newOrder": 70
     },
     {
       "cefr": "B2",
@@ -942,7 +929,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 72
+      "newOrder": 71
     },
     {
       "cefr": "B2",
@@ -955,7 +942,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 73
+      "newOrder": 72
     },
     {
       "cefr": "B2",
@@ -968,7 +955,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 74
+      "newOrder": 73
     },
     {
       "cefr": "B2",
@@ -976,6 +963,19 @@
       "hasCloze": false,
       "lemma": "присудок",
       "lemmaId": "присудок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 74
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "підкреслити",
+      "lemmaId": "підкреслити",
       "modes": [
         "flashcards",
         "matching",
@@ -1078,6 +1078,19 @@
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
+      "lemma": "розтанути",
+      "lemmaId": "розтанути",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 83
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
       "lemma": "кількісний",
       "lemmaId": "кількісний",
       "modes": [
@@ -1085,7 +1098,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 83
+      "newOrder": 84
     },
     {
       "cefr": "B2",
@@ -1098,7 +1111,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 84
+      "newOrder": 85
     },
     {
       "cefr": "B2",
@@ -1111,7 +1124,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 85
+      "newOrder": 86
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "пінгвін",
+      "lemmaId": "пінгвін",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 87
     },
     {
       "cefr": "B2",
@@ -1124,7 +1150,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 86
+      "newOrder": 88
     },
     {
       "cefr": "B2",
@@ -1137,7 +1163,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 87
+      "newOrder": 89
     },
     {
       "cefr": "B2",
@@ -1150,7 +1176,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 88
+      "newOrder": 90
     },
     {
       "cefr": "B2",
@@ -1163,7 +1189,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 89
+      "newOrder": 91
     },
     {
       "cefr": "B2",
@@ -1176,7 +1202,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 90
+      "newOrder": 92
     },
     {
       "cefr": "B2",
@@ -1189,7 +1215,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 91
+      "newOrder": 93
     },
     {
       "cefr": "B2",
@@ -1202,7 +1228,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 92
+      "newOrder": 94
     },
     {
       "cefr": "B2",
@@ -1215,7 +1241,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 93
+      "newOrder": 95
     },
     {
       "cefr": "B2",
@@ -1228,7 +1254,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 94
+      "newOrder": 96
     },
     {
       "cefr": "B2",
@@ -1241,7 +1267,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 95
+      "newOrder": 97
     },
     {
       "cefr": "B2",
@@ -1254,7 +1280,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 96
+      "newOrder": 98
     },
     {
       "cefr": "B2",
@@ -1267,20 +1293,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 97
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "прудко",
-      "lemmaId": "прудко",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 98
+      "newOrder": 99
     },
     {
       "cefr": "B2",
@@ -1293,7 +1306,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 99
+      "newOrder": 100
     },
     {
       "cefr": "B2",
@@ -1306,7 +1319,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 100
+      "newOrder": 101
     },
     {
       "cefr": "B2",
@@ -1319,7 +1332,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 101
+      "newOrder": 102
     },
     {
       "cefr": "B2",
@@ -1332,7 +1345,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 102
+      "newOrder": 103
     },
     {
       "cefr": "B2",
@@ -1345,7 +1358,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 103
+      "newOrder": 104
     },
     {
       "cefr": "B2",
@@ -1353,19 +1366,6 @@
       "hasCloze": false,
       "lemma": "ввічливий",
       "lemmaId": "ввічливий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 104
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "компас",
-      "lemmaId": "компас",
       "modes": [
         "flashcards",
         "matching",
@@ -1455,6 +1455,19 @@
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
+      "lemma": "синонімічний",
+      "lemmaId": "синонімічний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 112
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
       "lemma": "стилістичний",
       "lemmaId": "стилістичний",
       "modes": [
@@ -1462,7 +1475,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 112
+      "newOrder": 113
     },
     {
       "cefr": "B2",
@@ -1475,7 +1488,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 113
+      "newOrder": 114
     },
     {
       "cefr": "B2",
@@ -1488,7 +1501,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 114
+      "newOrder": 115
     },
     {
       "cefr": "B2",
@@ -1501,7 +1514,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 115
+      "newOrder": 116
     },
     {
       "cefr": "B2",
@@ -1514,7 +1527,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 116
+      "newOrder": 117
     },
     {
       "cefr": "B2",
@@ -1527,7 +1540,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 117
+      "newOrder": 118
     },
     {
       "cefr": "B2",
@@ -1540,7 +1553,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 118
+      "newOrder": 119
     },
     {
       "cefr": "B2",
@@ -1553,7 +1566,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 119
+      "newOrder": 120
     },
     {
       "cefr": "B2",
@@ -1566,7 +1579,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 120
+      "newOrder": 121
     },
     {
       "cefr": "B2",
@@ -1579,7 +1592,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 121
+      "newOrder": 122
     },
     {
       "cefr": "B2",
@@ -1592,7 +1605,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 122
+      "newOrder": 123
     },
     {
       "cefr": "B2",
@@ -1605,7 +1618,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 123
+      "newOrder": 124
     },
     {
       "cefr": "B2",
@@ -1618,7 +1631,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 124
+      "newOrder": 125
     },
     {
       "cefr": "B2",
@@ -1631,7 +1644,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 125
+      "newOrder": 126
     },
     {
       "cefr": "B2",
@@ -1644,7 +1657,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 126
+      "newOrder": 127
     },
     {
       "cefr": "B2",
@@ -1657,7 +1670,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 127
+      "newOrder": 128
     },
     {
       "cefr": "B2",
@@ -1670,7 +1683,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 128
+      "newOrder": 129
     },
     {
       "cefr": "B2",
@@ -1683,7 +1696,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 129
+      "newOrder": 130
     },
     {
       "cefr": "B2",
@@ -1691,19 +1704,6 @@
       "hasCloze": false,
       "lemma": "категоричний",
       "lemmaId": "категоричний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 130
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "контрольований",
-      "lemmaId": "контрольований",
       "modes": [
         "flashcards",
         "matching",
@@ -1728,19 +1728,6 @@
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "прагматичний",
-      "lemmaId": "прагматичний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 133
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
       "lemma": "розбивати",
       "lemmaId": "розбивати",
       "modes": [
@@ -1748,7 +1735,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 134
+      "newOrder": 133
     },
     {
       "cefr": "B2",
@@ -1761,7 +1748,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 135
+      "newOrder": 134
     },
     {
       "cefr": "B2",
@@ -1774,7 +1761,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 136
+      "newOrder": 135
     },
     {
       "cefr": "B2",
@@ -1787,7 +1774,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 137
+      "newOrder": 136
     },
     {
       "cefr": "B2",
@@ -1800,7 +1787,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 138
+      "newOrder": 137
     },
     {
       "cefr": "B2",
@@ -1813,7 +1800,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 139
+      "newOrder": 138
     },
     {
       "cefr": "B2",
@@ -1826,7 +1813,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 140
+      "newOrder": 139
     },
     {
       "cefr": "B2",
@@ -1839,7 +1826,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 141
+      "newOrder": 140
     },
     {
       "cefr": "B2",
@@ -1847,6 +1834,19 @@
       "hasCloze": false,
       "lemma": "очікування",
       "lemmaId": "очікування",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 141
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "прагматика",
+      "lemmaId": "прагматика",
       "modes": [
         "flashcards",
         "matching",
@@ -1988,19 +1988,6 @@
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "утретє",
-      "lemmaId": "утретє",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 153
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
       "lemma": "дедлайн",
       "lemmaId": "дедлайн",
       "modes": [
@@ -2008,7 +1995,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 154
+      "newOrder": 153
     },
     {
       "cefr": "B2",
@@ -2021,7 +2008,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 155
+      "newOrder": 154
     },
     {
       "cefr": "B2",
@@ -2034,7 +2021,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 156
+      "newOrder": 155
     },
     {
       "cefr": "B2",
@@ -2047,7 +2034,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 157
+      "newOrder": 156
     },
     {
       "cefr": "B2",
@@ -2060,7 +2047,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 158
+      "newOrder": 157
     },
     {
       "cefr": "B2",
@@ -2073,7 +2060,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 159
+      "newOrder": 158
     },
     {
       "cefr": "B2",
@@ -2086,7 +2073,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 160
+      "newOrder": 159
     },
     {
       "cefr": "B2",
@@ -2099,7 +2086,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 161
+      "newOrder": 160
     },
     {
       "cefr": "B2",
@@ -2112,7 +2099,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 162
+      "newOrder": 161
     },
     {
       "cefr": "B2",
@@ -2125,7 +2112,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 163
+      "newOrder": 162
     },
     {
       "cefr": "B2",
@@ -2138,7 +2125,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 164
+      "newOrder": 163
     },
     {
       "cefr": "B2",
@@ -2151,7 +2138,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 165
+      "newOrder": 164
     },
     {
       "cefr": "B2",
@@ -2164,7 +2151,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 166
+      "newOrder": 165
     },
     {
       "cefr": "B2",
@@ -2172,6 +2159,19 @@
       "hasCloze": false,
       "lemma": "регістр",
       "lemmaId": "регістр",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 166
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "білити",
+      "lemmaId": "білити",
       "modes": [
         "flashcards",
         "matching",
@@ -2294,6 +2294,19 @@
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
+      "lemma": "точковий",
+      "lemmaId": "точковий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 177
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
       "lemma": "уникнення",
       "lemmaId": "уникнення",
       "modes": [
@@ -2301,7 +2314,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 177
+      "newOrder": 178
     },
     {
       "cefr": "B2",
@@ -2314,7 +2327,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 178
+      "newOrder": 179
     },
     {
       "cefr": "B2",
@@ -2327,7 +2340,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 179
+      "newOrder": 180
     },
     {
       "cefr": "B2",
@@ -2340,7 +2353,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 180
+      "newOrder": 181
     },
     {
       "cefr": "B2",
@@ -2353,7 +2366,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 181
+      "newOrder": 182
     },
     {
       "cefr": "B2",
@@ -2366,7 +2379,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 182
+      "newOrder": 183
     },
     {
       "cefr": "B2",
@@ -2379,7 +2392,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 183
+      "newOrder": 184
     },
     {
       "cefr": "B2",
@@ -2392,7 +2405,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 184
+      "newOrder": 185
     },
     {
       "cefr": "B2",
@@ -2405,7 +2418,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 185
+      "newOrder": 186
     },
     {
       "cefr": "B2",
@@ -2418,7 +2431,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 186
+      "newOrder": 187
     },
     {
       "cefr": "B2",
@@ -2431,7 +2444,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 187
+      "newOrder": 188
     },
     {
       "cefr": "B2",
@@ -2444,7 +2457,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 188
+      "newOrder": 189
     },
     {
       "cefr": "B2",
@@ -2457,7 +2470,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 189
+      "newOrder": 190
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "облетіти",
+      "lemmaId": "облетіти",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 191
     },
     {
       "cefr": "B2",
@@ -2470,7 +2496,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 190
+      "newOrder": 192
     },
     {
       "cefr": "B2",
@@ -2483,7 +2509,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 191
+      "newOrder": 193
     },
     {
       "cefr": "B2",
@@ -2496,7 +2522,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 192
+      "newOrder": 194
     },
     {
       "cefr": "B2",
@@ -2507,7 +2533,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 193
+      "newOrder": 195
     },
     {
       "cefr": "B2",
@@ -2518,7 +2544,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 194
+      "newOrder": 196
     },
     {
       "cefr": "B2",
@@ -2529,18 +2555,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 195
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "навчаючись",
-      "lemmaId": "навчаючись",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 196
+      "newOrder": 197
     },
     {
       "cefr": "B2",
@@ -2553,7 +2568,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 197
+      "newOrder": 198
     },
     {
       "cefr": "B2",
@@ -2564,7 +2579,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 198
+      "newOrder": 199
     },
     {
       "cefr": "B2",
@@ -2575,7 +2590,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 199
+      "newOrder": 200
     },
     {
       "cefr": "B2",
@@ -2586,7 +2601,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 200
+      "newOrder": 201
     },
     {
       "cefr": "B2",
@@ -2599,7 +2614,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 201
+      "newOrder": 202
     },
     {
       "cefr": "B2",
@@ -2612,7 +2627,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 202
+      "newOrder": 203
     },
     {
       "cefr": "B2",
@@ -2625,7 +2640,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 203
+      "newOrder": 204
     },
     {
       "cefr": "B2",
@@ -2638,7 +2653,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 204
+      "newOrder": 205
     },
     {
       "cefr": "B2",
@@ -2651,7 +2666,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 205
+      "newOrder": 206
     },
     {
       "cefr": "B2",
@@ -2664,7 +2679,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 206
+      "newOrder": 207
     },
     {
       "cefr": "B2",
@@ -2677,7 +2692,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 207
+      "newOrder": 208
     },
     {
       "cefr": "B2",
@@ -2690,7 +2705,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 208
+      "newOrder": 209
     },
     {
       "cefr": "B2",
@@ -2703,7 +2718,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 209
+      "newOrder": 210
     },
     {
       "cefr": "B2",
@@ -2716,7 +2731,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 210
+      "newOrder": 211
     },
     {
       "cefr": "B2",
@@ -2729,7 +2744,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 211
+      "newOrder": 212
     },
     {
       "cefr": "B2",
@@ -2742,7 +2757,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 212
+      "newOrder": 213
     },
     {
       "cefr": "B2",
@@ -2755,7 +2770,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 213
+      "newOrder": 214
     },
     {
       "cefr": "B2",
@@ -2768,7 +2783,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 214
+      "newOrder": 215
     },
     {
       "cefr": "B2",
@@ -2781,7 +2796,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 215
+      "newOrder": 216
     },
     {
       "cefr": "B2",
@@ -2794,7 +2809,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 216
+      "newOrder": 217
     },
     {
       "cefr": "B2",
@@ -2807,7 +2822,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 217
+      "newOrder": 218
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "новобудова",
+      "lemmaId": "новобудова",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 219
     },
     {
       "cefr": "B2",
@@ -2820,7 +2848,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 218
+      "newOrder": 220
     },
     {
       "cefr": "B2",
@@ -2833,7 +2861,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 219
+      "newOrder": 221
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "сантехнік",
+      "lemmaId": "сантехнік",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 222
     },
     {
       "cefr": "B2",
@@ -2846,7 +2887,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 220
+      "newOrder": 223
     },
     {
       "cefr": "B2",
@@ -2859,7 +2900,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 221
+      "newOrder": 224
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "євроремонт",
+      "lemmaId": "євроремонт",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 225
     },
     {
       "cefr": "B2",
@@ -2872,7 +2926,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 222
+      "newOrder": 226
     },
     {
       "cefr": "B2",
@@ -2885,20 +2939,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 223
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "спонукання",
-      "lemmaId": "спонукання",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 224
+      "newOrder": 227
     },
     {
       "cefr": "B2",
@@ -2911,7 +2952,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 225
+      "newOrder": 228
     },
     {
       "cefr": "B2",
@@ -2924,20 +2965,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 226
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "сумісність",
-      "lemmaId": "сумісність",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 227
+      "newOrder": 229
     },
     {
       "cefr": "B2",
@@ -2948,7 +2976,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 228
+      "newOrder": 230
     },
     {
       "cefr": "B2",
@@ -2961,7 +2989,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 229
+      "newOrder": 231
     },
     {
       "cefr": "B2",
@@ -2972,7 +3000,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 230
+      "newOrder": 232
     },
     {
       "cefr": "B2",
@@ -2983,7 +3011,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 231
+      "newOrder": 233
     },
     {
       "cefr": "B2",
@@ -2996,7 +3024,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 232
+      "newOrder": 234
     },
     {
       "cefr": "B2",
@@ -3007,7 +3035,31 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 233
+      "newOrder": 235
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "доплисти",
+      "lemmaId": "доплисти",
+      "modes": [
+        "flashcards"
+      ],
+      "newOrder": 236
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "залетіти",
+      "lemmaId": "залетіти",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 237
     },
     {
       "cefr": "B2",
@@ -3020,7 +3072,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 234
+      "newOrder": 238
     },
     {
       "cefr": "B2",
@@ -3033,20 +3085,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 235
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "лечу",
-      "lemmaId": "лечу",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 236
+      "newOrder": 239
     },
     {
       "cefr": "B2",
@@ -3059,7 +3098,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 237
+      "newOrder": 240
     },
     {
       "cefr": "B2",
@@ -3070,7 +3109,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 238
+      "newOrder": 241
     },
     {
       "cefr": "B2",
@@ -3081,7 +3120,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 239
+      "newOrder": 242
     },
     {
       "cefr": "B2",
@@ -3094,20 +3133,18 @@
         "matching",
         "choice"
       ],
-      "newOrder": 240
+      "newOrder": 243
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "пором",
-      "lemmaId": "пором",
+      "lemma": "проплисти",
+      "lemmaId": "проплисти",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
-      "newOrder": 241
+      "newOrder": 244
     },
     {
       "cefr": "B2",
@@ -3118,7 +3155,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 242
+      "newOrder": 245
     },
     {
       "cefr": "B2",
@@ -3129,7 +3166,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 243
+      "newOrder": 246
     },
     {
       "cefr": "B2",
@@ -3140,7 +3177,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 244
+      "newOrder": 247
     },
     {
       "cefr": "B2",
@@ -3153,7 +3190,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 245
+      "newOrder": 248
     },
     {
       "cefr": "B2",
@@ -3164,7 +3201,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 246
+      "newOrder": 249
     },
     {
       "cefr": "B2",
@@ -3175,7 +3212,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 247
+      "newOrder": 250
     },
     {
       "cefr": "B2",
@@ -3186,7 +3223,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 248
+      "newOrder": 251
     },
     {
       "cefr": "B2",
@@ -3199,7 +3236,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 249
+      "newOrder": 252
     },
     {
       "cefr": "B2",
@@ -3212,7 +3249,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 250
+      "newOrder": 253
     },
     {
       "cefr": "B2",
@@ -3223,7 +3260,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 251
+      "newOrder": 254
     },
     {
       "cefr": "B2",
@@ -3236,7 +3273,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 252
+      "newOrder": 255
     },
     {
       "cefr": "B2",
@@ -3249,7 +3286,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 253
+      "newOrder": 256
     },
     {
       "cefr": "B2",
@@ -3262,7 +3299,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 254
+      "newOrder": 257
     },
     {
       "cefr": "B2",
@@ -3275,7 +3312,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 255
+      "newOrder": 258
     },
     {
       "cefr": "B2",
@@ -3288,7 +3325,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 256
+      "newOrder": 259
     },
     {
       "cefr": "B2",
@@ -3299,7 +3336,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 257
+      "newOrder": 260
     },
     {
       "cefr": "B2",
@@ -3312,7 +3349,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 258
+      "newOrder": 261
     },
     {
       "cefr": "B2",
@@ -3325,7 +3362,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 259
+      "newOrder": 262
     },
     {
       "cefr": "B2",
@@ -3336,7 +3373,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 260
+      "newOrder": 263
     },
     {
       "cefr": "B2",
@@ -3349,7 +3386,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 261
+      "newOrder": 264
     },
     {
       "cefr": "B2",
@@ -3360,18 +3397,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 262
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "пробігти",
-      "lemmaId": "пробігти",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 263
+      "newOrder": 265
     },
     {
       "cefr": "B2",
@@ -3382,7 +3408,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 264
+      "newOrder": 266
     },
     {
       "cefr": "B2",
@@ -3395,7 +3421,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 265
+      "newOrder": 267
     },
     {
       "cefr": "B2",
@@ -3406,7 +3432,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 266
+      "newOrder": 268
     },
     {
       "cefr": "B2",
@@ -3417,7 +3443,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 267
+      "newOrder": 269
     },
     {
       "cefr": "B2",
@@ -3430,7 +3456,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 268
+      "newOrder": 270
     },
     {
       "cefr": "B2",
@@ -3443,7 +3469,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 269
+      "newOrder": 271
     },
     {
       "cefr": "B2",
@@ -3456,7 +3482,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 270
+      "newOrder": 272
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "борсук",
+      "lemmaId": "борсук",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 273
     },
     {
       "cefr": "B2",
@@ -3469,7 +3508,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 271
+      "newOrder": 274
     },
     {
       "cefr": "B2",
@@ -3482,7 +3521,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 272
+      "newOrder": 275
     },
     {
       "cefr": "B2",
@@ -3495,7 +3534,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 273
+      "newOrder": 276
     },
     {
       "cefr": "B2",
@@ -3508,7 +3547,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 274
+      "newOrder": 277
     },
     {
       "cefr": "B2",
@@ -3521,7 +3560,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 275
+      "newOrder": 278
     },
     {
       "cefr": "B2",
@@ -3534,7 +3573,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 276
+      "newOrder": 279
     },
     {
       "cefr": "B2",
@@ -3547,20 +3586,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 277
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "сортувати",
-      "lemmaId": "сортувати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 278
+      "newOrder": 280
     },
     {
       "cefr": "B2",
@@ -3573,7 +3599,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 279
+      "newOrder": 281
     },
     {
       "cefr": "B2",
@@ -3586,7 +3612,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 280
+      "newOrder": 282
     },
     {
       "cefr": "B2",
@@ -3599,7 +3625,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 281
+      "newOrder": 283
     },
     {
       "cefr": "B2",
@@ -3612,7 +3638,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 282
+      "newOrder": 284
     },
     {
       "cefr": "B2",
@@ -3625,7 +3651,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 283
+      "newOrder": 285
     },
     {
       "cefr": "B2",
@@ -3638,7 +3664,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 284
+      "newOrder": 286
     },
     {
       "cefr": "B2",
@@ -3651,7 +3677,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 285
+      "newOrder": 287
     },
     {
       "cefr": "B2",
@@ -3664,20 +3690,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 286
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "слухач",
-      "lemmaId": "слухач",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 287
+      "newOrder": 288
     },
     {
       "cefr": "B2",
@@ -3690,7 +3703,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 288
+      "newOrder": 289
     },
     {
       "cefr": "B2",
@@ -3703,7 +3716,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 289
+      "newOrder": 290
     },
     {
       "cefr": "B2",
@@ -3711,19 +3724,6 @@
       "hasCloze": false,
       "lemma": "гончар",
       "lemmaId": "гончар",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 290
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "грузин",
-      "lemmaId": "грузин",
       "modes": [
         "flashcards",
         "matching",
@@ -3813,6 +3813,19 @@
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
+      "lemma": "живучий",
+      "lemmaId": "живучий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 298
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
       "lemma": "змарнілий",
       "lemmaId": "змарнілий",
       "modes": [
@@ -3820,7 +3833,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 298
+      "newOrder": 299
     },
     {
       "cefr": "B2",
@@ -3833,7 +3846,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 299
+      "newOrder": 300
     },
     {
       "cefr": "B2",
@@ -3846,7 +3859,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 300
+      "newOrder": 301
     },
     {
       "cefr": "B2",
@@ -3859,7 +3872,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 301
+      "newOrder": 302
     },
     {
       "cefr": "B2",
@@ -3872,7 +3885,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 302
+      "newOrder": 303
     },
     {
       "cefr": "B2",
@@ -3885,7 +3898,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 303
+      "newOrder": 304
     },
     {
       "cefr": "B2",
@@ -3898,7 +3911,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 304
+      "newOrder": 305
     },
     {
       "cefr": "B2",
@@ -3911,7 +3924,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 305
+      "newOrder": 306
     },
     {
       "cefr": "B2",
@@ -3924,7 +3937,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 306
+      "newOrder": 307
     },
     {
       "cefr": "B2",
@@ -3937,7 +3950,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 307
+      "newOrder": 308
     },
     {
       "cefr": "B2",
@@ -3950,7 +3963,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 308
+      "newOrder": 309
     },
     {
       "cefr": "B2",
@@ -3963,7 +3976,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 309
+      "newOrder": 310
     },
     {
       "cefr": "B2",
@@ -3976,7 +3989,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 310
+      "newOrder": 311
     },
     {
       "cefr": "B2",
@@ -3989,7 +4002,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 311
+      "newOrder": 312
     },
     {
       "cefr": "B2",
@@ -4002,7 +4015,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 312
+      "newOrder": 313
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "пофарбовано",
+      "lemmaId": "пофарбовано",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 314
     },
     {
       "cefr": "B2",
@@ -4015,7 +4041,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 313
+      "newOrder": 315
     },
     {
       "cefr": "B2",
@@ -4028,7 +4054,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 314
+      "newOrder": 316
     },
     {
       "cefr": "B2",
@@ -4041,7 +4067,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 315
+      "newOrder": 317
     },
     {
       "cefr": "B2",
@@ -4054,7 +4080,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 316
+      "newOrder": 318
     },
     {
       "cefr": "B2",
@@ -4067,7 +4093,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 317
+      "newOrder": 319
     },
     {
       "cefr": "B2",
@@ -4080,7 +4106,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 318
+      "newOrder": 320
     },
     {
       "cefr": "B2",
@@ -4093,7 +4119,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 319
+      "newOrder": 321
     },
     {
       "cefr": "B2",
@@ -4106,7 +4132,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 320
+      "newOrder": 322
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "заздрісний",
+      "lemmaId": "заздрісний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 323
     },
     {
       "cefr": "B2",
@@ -4119,7 +4158,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 321
+      "newOrder": 324
     },
     {
       "cefr": "B2",
@@ -4132,7 +4171,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 322
+      "newOrder": 325
     },
     {
       "cefr": "B2",
@@ -4145,7 +4184,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 323
+      "newOrder": 326
     },
     {
       "cefr": "B2",
@@ -4158,7 +4197,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 324
+      "newOrder": 327
     },
     {
       "cefr": "B2",
@@ -4171,7 +4210,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 325
+      "newOrder": 328
     },
     {
       "cefr": "B2",
@@ -4184,7 +4223,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 326
+      "newOrder": 329
     },
     {
       "cefr": "B2",
@@ -4197,7 +4236,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 327
+      "newOrder": 330
     },
     {
       "cefr": "B2",
@@ -4210,7 +4249,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 328
+      "newOrder": 331
     },
     {
       "cefr": "B2",
@@ -4223,7 +4262,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 329
+      "newOrder": 332
     },
     {
       "cefr": "B2",
@@ -4236,7 +4275,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 330
+      "newOrder": 333
     },
     {
       "cefr": "B2",
@@ -4249,7 +4288,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 331
+      "newOrder": 334
     },
     {
       "cefr": "B2",
@@ -4262,7 +4301,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 332
+      "newOrder": 335
     },
     {
       "cefr": "B2",
@@ -4275,7 +4314,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 333
+      "newOrder": 336
     },
     {
       "cefr": "B2",
@@ -4288,7 +4327,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 334
+      "newOrder": 337
     },
     {
       "cefr": "B2",
@@ -4301,7 +4340,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 335
+      "newOrder": 338
     },
     {
       "cefr": "B2",
@@ -4314,7 +4353,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 336
+      "newOrder": 339
     },
     {
       "cefr": "B2",
@@ -4327,7 +4366,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 337
+      "newOrder": 340
     },
     {
       "cefr": "B2",
@@ -4340,7 +4379,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 338
+      "newOrder": 341
     },
     {
       "cefr": "B2",
@@ -4353,7 +4392,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 339
+      "newOrder": 342
     },
     {
       "cefr": "B2",
@@ -4366,7 +4405,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 340
+      "newOrder": 343
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "Лесин",
+      "lemmaId": "лесин",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 344
     },
     {
       "cefr": "B2",
@@ -4379,7 +4431,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 341
+      "newOrder": 345
     },
     {
       "cefr": "B2",
@@ -4392,7 +4444,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 342
+      "newOrder": 346
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "Сергіїв",
+      "lemmaId": "сергіїв",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 347
     },
     {
       "cefr": "B2",
@@ -4405,7 +4470,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 343
+      "newOrder": 348
     },
     {
       "cefr": "B2",
@@ -4418,7 +4483,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 344
+      "newOrder": 349
     },
     {
       "cefr": "B2",
@@ -4431,7 +4496,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 345
+      "newOrder": 350
     },
     {
       "cefr": "B2",
@@ -4444,7 +4509,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 346
+      "newOrder": 351
     },
     {
       "cefr": "B2",
@@ -4457,7 +4522,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 347
+      "newOrder": 352
     },
     {
       "cefr": "B2",
@@ -4470,7 +4535,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 348
+      "newOrder": 353
     },
     {
       "cefr": "B2",
@@ -4483,7 +4548,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 349
+      "newOrder": 354
     },
     {
       "cefr": "B2",
@@ -4496,7 +4561,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 350
+      "newOrder": 355
     },
     {
       "cefr": "B2",
@@ -4509,20 +4574,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 351
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "надихнути",
-      "lemmaId": "надихнути",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 352
+      "newOrder": 356
     },
     {
       "cefr": "B2",
@@ -4535,7 +4587,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 353
+      "newOrder": 357
     },
     {
       "cefr": "B2",
@@ -4548,7 +4600,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 354
+      "newOrder": 358
     },
     {
       "cefr": "B2",
@@ -4561,7 +4613,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 355
+      "newOrder": 359
     },
     {
       "cefr": "B2",
@@ -4574,7 +4626,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 356
+      "newOrder": 360
     },
     {
       "cefr": "B2",
@@ -4587,7 +4639,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 357
+      "newOrder": 361
     },
     {
       "cefr": "B2",
@@ -4600,7 +4652,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 358
+      "newOrder": 362
     },
     {
       "cefr": "B2",
@@ -4613,20 +4665,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 359
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "хвилювати",
-      "lemmaId": "хвилювати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 360
+      "newOrder": 363
     },
     {
       "cefr": "B2",
@@ -4639,7 +4678,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 361
+      "newOrder": 364
     },
     {
       "cefr": "B2",
@@ -4652,7 +4691,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 362
+      "newOrder": 365
     },
     {
       "cefr": "B2",
@@ -4665,7 +4704,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 363
+      "newOrder": 366
     },
     {
       "cefr": "B2",
@@ -4678,7 +4717,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 364
+      "newOrder": 367
     },
     {
       "cefr": "B2",
@@ -4691,7 +4730,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 365
+      "newOrder": 368
     },
     {
       "cefr": "B2",
@@ -4704,7 +4743,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 366
+      "newOrder": 369
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "надійніший",
+      "lemmaId": "надійніший",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 370
     },
     {
       "cefr": "B2",
@@ -4717,7 +4769,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 367
+      "newOrder": 371
     },
     {
       "cefr": "B2",
@@ -4730,7 +4782,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 368
+      "newOrder": 372
     },
     {
       "cefr": "B2",
@@ -4743,7 +4795,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 369
+      "newOrder": 373
     },
     {
       "cefr": "B2",
@@ -4756,7 +4808,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 370
+      "newOrder": 374
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "масний",
+      "lemmaId": "масний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 375
     },
     {
       "cefr": "B2",
@@ -4769,7 +4834,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 371
+      "newOrder": 376
     },
     {
       "cefr": "B2",
@@ -4782,7 +4847,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 372
+      "newOrder": 377
     },
     {
       "cefr": "B2",
@@ -4795,7 +4860,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 373
+      "newOrder": 378
     },
     {
       "cefr": "B2",
@@ -4808,7 +4873,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 374
+      "newOrder": 379
     },
     {
       "cefr": "B2",
@@ -4821,7 +4886,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 375
+      "newOrder": 380
     },
     {
       "cefr": "B2",
@@ -4834,7 +4899,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 376
+      "newOrder": 381
     },
     {
       "cefr": "B2",
@@ -4847,20 +4912,33 @@
         "matching",
         "choice"
       ],
-      "newOrder": 377
+      "newOrder": 382
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "ярлик",
-      "lemmaId": "ярлик",
+      "lemma": "масмедіа",
+      "lemmaId": "масмедіа",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 378
+      "newOrder": 383
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "спецвипуск",
+      "lemmaId": "спецвипуск",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 384
     },
     {
       "cefr": "B2",
@@ -4873,7 +4951,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 379
+      "newOrder": 385
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "вищезазначений",
+      "lemmaId": "вищезазначений",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 386
     },
     {
       "cefr": "B2",
@@ -4886,18 +4977,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 380
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "бувай",
-      "lemmaId": "бувай",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 381
+      "newOrder": 387
     },
     {
       "cefr": "B2",
@@ -4910,7 +4990,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 382
+      "newOrder": 388
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "невимушеність",
+      "lemmaId": "невимушеність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 389
     },
     {
       "cefr": "B2",
@@ -4921,7 +5014,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 383
+      "newOrder": 390
     },
     {
       "cefr": "B2",
@@ -4934,7 +5027,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 384
+      "newOrder": 391
     },
     {
       "cefr": "B2",
@@ -4947,7 +5040,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 385
+      "newOrder": 392
     },
     {
       "cefr": "B2",
@@ -4960,7 +5053,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 386
+      "newOrder": 393
     },
     {
       "cefr": "B2",
@@ -4973,7 +5066,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 387
+      "newOrder": 394
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "навантажити",
+      "lemmaId": "навантажити",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 395
     },
     {
       "cefr": "B2",
@@ -4986,7 +5092,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 388
+      "newOrder": 396
     },
     {
       "cefr": "B2",
@@ -4999,7 +5105,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 389
+      "newOrder": 397
     },
     {
       "cefr": "B2",
@@ -5012,7 +5118,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 390
+      "newOrder": 398
     },
     {
       "cefr": "B2",
@@ -5025,7 +5131,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 391
+      "newOrder": 399
     },
     {
       "cefr": "B2",
@@ -5038,7 +5144,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 392
+      "newOrder": 400
     },
     {
       "cefr": "B2",
@@ -5051,7 +5157,18 @@
         "matching",
         "choice"
       ],
-      "newOrder": 393
+      "newOrder": 401
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "приставка",
+      "lemmaId": "приставка",
+      "modes": [
+        "flashcards"
+      ],
+      "newOrder": 402
     },
     {
       "cefr": "B2",
@@ -5064,7 +5181,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 394
+      "newOrder": 403
     },
     {
       "cefr": "B2",
@@ -5077,7 +5194,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 395
+      "newOrder": 404
     },
     {
       "cefr": "B2",
@@ -5090,7 +5207,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 396
+      "newOrder": 405
     },
     {
       "cefr": "B2",
@@ -5103,7 +5220,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 397
+      "newOrder": 406
     },
     {
       "cefr": "B2",
@@ -5116,20 +5233,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 398
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "штовхати",
-      "lemmaId": "штовхати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 399
+      "newOrder": 407
     },
     {
       "cefr": "B2",
@@ -5142,7 +5246,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 400
+      "newOrder": 408
     },
     {
       "cefr": "B2",
@@ -5155,7 +5259,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 401
+      "newOrder": 409
     },
     {
       "cefr": "B2",
@@ -5168,7 +5272,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 402
+      "newOrder": 410
     },
     {
       "cefr": "B2",
@@ -5181,7 +5285,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 403
+      "newOrder": 411
     },
     {
       "cefr": "B2",
@@ -5194,7 +5298,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 404
+      "newOrder": 412
     },
     {
       "cefr": "B2",
@@ -5207,7 +5311,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 405
+      "newOrder": 413
     },
     {
       "cefr": "B2",
@@ -5220,7 +5324,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 406
+      "newOrder": 414
     },
     {
       "cefr": "B2",
@@ -5233,7 +5337,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 407
+      "newOrder": 415
     },
     {
       "cefr": "B2",
@@ -5246,7 +5350,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 408
+      "newOrder": 416
     },
     {
       "cefr": "B2",
@@ -5257,7 +5361,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 409
+      "newOrder": 417
     },
     {
       "cefr": "B2",
@@ -5268,7 +5372,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 410
+      "newOrder": 418
     },
     {
       "cefr": "B2",
@@ -5281,20 +5385,20 @@
         "matching",
         "choice"
       ],
-      "newOrder": 411
+      "newOrder": 419
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "наближений",
-      "lemmaId": "наближений",
+      "lemma": "антивоєнний",
+      "lemmaId": "антивоєнний",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 412
+      "newOrder": 420
     },
     {
       "cefr": "B2",
@@ -5307,7 +5411,33 @@
         "matching",
         "choice"
       ],
-      "newOrder": 413
+      "newOrder": 421
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "передсвятковий",
+      "lemmaId": "передсвятковий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 422
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "прибережний",
+      "lemmaId": "прибережний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 423
     },
     {
       "cefr": "B2",
@@ -5320,7 +5450,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 414
+      "newOrder": 424
     },
     {
       "cefr": "B2",
@@ -5333,7 +5463,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 415
+      "newOrder": 425
     },
     {
       "cefr": "B2",
@@ -5346,7 +5476,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 416
+      "newOrder": 426
     },
     {
       "cefr": "B2",
@@ -5359,7 +5489,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 417
+      "newOrder": 427
     },
     {
       "cefr": "B2",
@@ -5372,7 +5502,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 418
+      "newOrder": 428
     },
     {
       "cefr": "B2",
@@ -5385,7 +5515,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 419
+      "newOrder": 429
     },
     {
       "cefr": "B2",
@@ -5398,7 +5528,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 420
+      "newOrder": 430
     },
     {
       "cefr": "B2",
@@ -5411,7 +5541,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 421
+      "newOrder": 431
     },
     {
       "cefr": "B2",
@@ -5424,137 +5554,33 @@
         "matching",
         "choice"
       ],
-      "newOrder": 422
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "впроваджуватися",
-      "lemmaId": "впроваджуватися",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 423
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "науковий стиль",
-      "lemmaId": "науковий-стиль",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 424
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "результат дії",
-      "lemmaId": "результат-дії",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 425
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "реформа",
-      "lemmaId": "реформа",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 426
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "розроблятися",
-      "lemmaId": "розроблятися",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 427
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "синтаксична норма",
-      "lemmaId": "синтаксична-норма",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 428
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "відредагувати",
-      "lemmaId": "відредагувати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 429
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "дієприкметник минулого часу",
-      "lemmaId": "дієприкметник-минулого-часу",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 430
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "забутий",
-      "lemmaId": "забутий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 431
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "зім'ятий",
-      "lemmaId": "зім-ятий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
       "newOrder": 432
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "експресивність",
+      "lemmaId": "експресивність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 433
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "застарілий",
+      "lemmaId": "застарілий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 434
     },
     {
       "cefr": "B2",
@@ -5567,7 +5593,2980 @@
         "matching",
         "choice"
       ],
-      "newOrder": 433
+      "newOrder": 435
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "віддієслівний прикметник",
+      "lemmaId": "віддієслівний-прикметник",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 436
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "відповідник",
+      "lemmaId": "відповідник",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 437
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "доречність",
+      "lemmaId": "доречність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 438
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "зворушливий",
+      "lemmaId": "зворушливий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 439
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "калькування",
+      "lemmaId": "калькування",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 440
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "мовна стійкість",
+      "lemmaId": "мовна-стійкість",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 441
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "мовний слух",
+      "lemmaId": "мовний-слух",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 442
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "панівний",
+      "lemmaId": "панівний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 443
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "початківець",
+      "lemmaId": "початківець",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 444
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "прийдешній",
+      "lemmaId": "прийдешній",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 445
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "підрядне означальне речення",
+      "lemmaId": "підрядне-означальне-речення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 446
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "робоча група",
+      "lemmaId": "робоча-група",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 447
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "родючий",
+      "lemmaId": "родючий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 448
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "стала ознака",
+      "lemmaId": "стала-ознака",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 449
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "тимчасова дія",
+      "lemmaId": "тимчасова-дія",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 450
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "цілющий",
+      "lemmaId": "цілющий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 451
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "іменник діяча",
+      "lemmaId": "іменник-діяча",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 452
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "благодійний марафон",
+      "lemmaId": "благодійний-марафон",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 453
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "синтаксична калька",
+      "lemmaId": "синтаксична-калька",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 454
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "головний член",
+      "lemmaId": "головний-член",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 455
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "двоскладне речення",
+      "lemmaId": "двоскладне-речення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 456
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "динамізм",
+      "lemmaId": "динамізм",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 457
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "категорія стану",
+      "lemmaId": "категорія-стану",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 458
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "називне речення",
+      "lemmaId": "називне-речення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 459
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "носій стану",
+      "lemmaId": "носій-стану",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 460
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "односкладне речення",
+      "lemmaId": "односкладне-речення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 461
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "самодостатній",
+      "lemmaId": "самодостатній",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 462
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "синтаксична незалежність",
+      "lemmaId": "синтаксична-незалежність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 463
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "синтаксична синонімія",
+      "lemmaId": "синтаксична-синонімія",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 464
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "відредагувати",
+      "lemmaId": "відредагувати",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 465
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "неозначено-особове речення",
+      "lemmaId": "неозначено-особове-речення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 466
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "нормативність",
+      "lemmaId": "нормативність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 467
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "пунктуаційна пильність",
+      "lemmaId": "пунктуаційна-пильність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 468
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "рефлексія",
+      "lemmaId": "рефлексія",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 469
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "стилістична гнучкість",
+      "lemmaId": "стилістична-гнучкість",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 470
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "фокус висловлення",
+      "lemmaId": "фокус-висловлення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 471
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "галузева лексика",
+      "lemmaId": "галузева-лексика",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 472
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "джерело фінансування",
+      "lemmaId": "джерело-фінансування",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 473
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "конотація",
+      "lemmaId": "конотація",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 474
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "критерій результативності",
+      "lemmaId": "критерій-результативності",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 475
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "мовна норма",
+      "lemmaId": "мовна-норма",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 476
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "нейтральність",
+      "lemmaId": "нейтральність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 477
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "оцінна лексика",
+      "lemmaId": "оцінна-лексика",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 478
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "правова експертиза",
+      "lemmaId": "правова-експертиза",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 479
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "презумпція невинуватості",
+      "lemmaId": "презумпція-невинуватості",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 480
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "прибуток",
+      "lemmaId": "прибуток",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 481
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "редакторська правка",
+      "lemmaId": "редакторська-правка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 482
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "стильова домінанта",
+      "lemmaId": "стильова-домінанта",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 483
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "стилістична норма",
+      "lemmaId": "стилістична-норма",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 484
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "стилістичний дисонанс",
+      "lemmaId": "стилістичний-дисонанс",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 485
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "термінологічна міграція",
+      "lemmaId": "термінологічна-міграція",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 486
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "функціональний стиль",
+      "lemmaId": "функціональний-стиль",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 487
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "інтерстилістика",
+      "lemmaId": "інтерстилістика",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 488
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "відокремлений член",
+      "lemmaId": "відокремлений-член",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 489
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "предикативний зв'язок",
+      "lemmaId": "предикативний-зв-язок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 490
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "простий присудок",
+      "lemmaId": "простий-присудок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 491
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "пунктуаційна норма",
+      "lemmaId": "пунктуаційна-норма",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 492
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "синтаксична модель",
+      "lemmaId": "синтаксична-модель",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 493
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "синтаксичний розбір",
+      "lemmaId": "синтаксичний-розбір",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 494
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "складений присудок",
+      "lemmaId": "складений-присудок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 495
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "уточнювальний член",
+      "lemmaId": "уточнювальний-член",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 496
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "варіативність",
+      "lemmaId": "варіативність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 497
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "невласне пряма мова",
+      "lemmaId": "невласне-пряма-мова",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 498
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "парний сполучник",
+      "lemmaId": "парний-сполучник",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 499
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "предикативна частина",
+      "lemmaId": "предикативна-частина",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 500
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "систематизація",
+      "lemmaId": "систематизація",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 501
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "складнопідрядний",
+      "lemmaId": "складнопідрядний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 502
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "базове речення",
+      "lemmaId": "базове-речення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 503
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "двозначність",
+      "lemmaId": "двозначність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 504
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "експресивний",
+      "lemmaId": "експресивний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 505
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "жанрова доречність",
+      "lemmaId": "жанрова-доречність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 506
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "зіставити",
+      "lemmaId": "зіставити",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 507
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "однозначність",
+      "lemmaId": "однозначність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 508
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "пропущений присудок",
+      "lemmaId": "пропущений-присудок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 509
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "публіцистика",
+      "lemmaId": "публіцистика",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 510
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "розчленування",
+      "lemmaId": "розчленування",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 511
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "синтаксична компресія",
+      "lemmaId": "синтаксична-компресія",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 512
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "ситуативний",
+      "lemmaId": "ситуативний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 513
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "скоротити",
+      "lemmaId": "скоротити",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 514
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "смисловий",
+      "lemmaId": "смисловий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 515
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "технічний текст",
+      "lemmaId": "технічний-текст",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 516
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "художній текст",
+      "lemmaId": "художній-текст",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 517
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "юридичний текст",
+      "lemmaId": "юридичний-текст",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 518
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "баласт",
+      "lemmaId": "баласт",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 519
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "каркас речення",
+      "lemmaId": "каркас-речення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 520
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "обставинний",
+      "lemmaId": "обставинний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 521
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "причиновий зв'язок",
+      "lemmaId": "причиновий-зв-язок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 522
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "просторовий зв'язок",
+      "lemmaId": "просторовий-зв-язок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 523
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "пунктуаційна межа",
+      "lemmaId": "пунктуаційна-межа",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 524
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "редакторська версія",
+      "lemmaId": "редакторська-версія",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 525
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "риторичний ефект",
+      "lemmaId": "риторичний-ефект",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 526
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "розчленування сполучника",
+      "lemmaId": "розчленування-сполучника",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 527
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "співвіднесення",
+      "lemmaId": "співвіднесення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 528
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "стислість",
+      "lemmaId": "стислість",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 529
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "часовий зв'язок",
+      "lemmaId": "часовий-зв-язок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 530
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "акцентування",
+      "lemmaId": "акцентування",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 531
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "відокремлений",
+      "lemmaId": "відокремлений",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 532
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "деталізація",
+      "lemmaId": "деталізація",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 533
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "одиничне означення",
+      "lemmaId": "одиничне-означення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 534
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "ритм речення",
+      "lemmaId": "ритм-речення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 535
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "синтаксична норма",
+      "lemmaId": "синтаксична-норма",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 536
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "смислова пауза",
+      "lemmaId": "смислова-пауза",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 537
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "інтонаційна пауза",
+      "lemmaId": "інтонаційна-пауза",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 538
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "акт приймання-передачі",
+      "lemmaId": "акт-приймання-передачі",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 539
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "винаймати",
+      "lemmaId": "винаймати",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 540
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "домовий чат",
+      "lemmaId": "домовий-чат",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 541
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "здавати в оренду",
+      "lemmaId": "здавати-в-оренду",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 542
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "капітальний ремонт",
+      "lemmaId": "капітальний-ремонт",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 543
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "керуюча компанія",
+      "lemmaId": "керуюча-компанія",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 544
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "косметичний ремонт",
+      "lemmaId": "косметичний-ремонт",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 545
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "кухонний гарнітур",
+      "lemmaId": "кухонний-гарнітур",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 546
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "орендна плата",
+      "lemmaId": "орендна-плата",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 547
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "побутова техніка",
+      "lemmaId": "побутова-техніка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 548
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "показник",
+      "lemmaId": "показник",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 549
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "поломка",
+      "lemmaId": "поломка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 550
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "пошкодити",
+      "lemmaId": "пошкодити",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 551
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "правило тиші",
+      "lemmaId": "правило-тиші",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 552
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "протікання",
+      "lemmaId": "протікання",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 553
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "співмешканець",
+      "lemmaId": "співмешканець",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 554
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "спільний простір",
+      "lemmaId": "спільний-простір",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 555
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "строк оренди",
+      "lemmaId": "строк-оренди",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 556
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "транспортна розв'язка",
+      "lemmaId": "транспортна-розв-язка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 557
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "інфраструктура",
+      "lemmaId": "інфраструктура",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 558
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "авторська розповідь",
+      "lemmaId": "авторська-розповідь",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 559
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "вирвати з контексту",
+      "lemmaId": "вирвати-з-контексту",
+      "modes": [
+        "flashcards"
+      ],
+      "newOrder": 560
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "внутрішній голос",
+      "lemmaId": "внутрішній-голос",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 561
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "дослівний",
+      "lemmaId": "дослівний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 562
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "зазначити",
+      "lemmaId": "зазначити",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 563
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "знак питання",
+      "lemmaId": "знак-питання",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 564
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "модальність",
+      "lemmaId": "модальність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 565
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "актуальне членування",
+      "lemmaId": "актуальне-членування",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 566
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "дистантне розташування",
+      "lemmaId": "дистантне-розташування",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 567
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "калькована конструкція",
+      "lemmaId": "калькована-конструкція",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 568
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "комунікативний центр",
+      "lemmaId": "комунікативний-центр",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 569
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "кінцева позиція",
+      "lemmaId": "кінцева-позиція",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 570
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "нейтральний порядок",
+      "lemmaId": "нейтральний-порядок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 571
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "приховане питання",
+      "lemmaId": "приховане-питання",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 572
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "рамка висловлення",
+      "lemmaId": "рамка-висловлення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 573
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "службовий стиль",
+      "lemmaId": "службовий-стиль",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 574
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "смисловий центр",
+      "lemmaId": "смисловий-центр",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 575
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "стилістична фігура",
+      "lemmaId": "стилістична-фігура",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 576
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "урочистість",
+      "lemmaId": "урочистість",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 577
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "антитеза",
+      "lemmaId": "антитеза",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 578
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "градація",
+      "lemmaId": "градація",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 579
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "логічна сумісність",
+      "lemmaId": "логічна-сумісність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 580
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "неоднорідні означення",
+      "lemmaId": "неоднорідні-означення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 581
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "однорідний ряд",
+      "lemmaId": "однорідний-ряд",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 582
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "однорідні означення",
+      "lemmaId": "однорідні-означення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 583
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "семантична однорідність",
+      "lemmaId": "семантична-однорідність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 584
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "симетрія",
+      "lemmaId": "симетрія",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 585
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "службовий текст",
+      "lemmaId": "службовий-текст",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 586
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "смислове поле",
+      "lemmaId": "смислове-поле",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 587
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "узагальнююче слово",
+      "lemmaId": "узагальнююче-слово",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 588
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "гостинність",
+      "lemmaId": "гостинність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 589
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "жменя",
+      "lemmaId": "жменя",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 590
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "запікати",
+      "lemmaId": "запікати",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 591
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "засіб дії",
+      "lemmaId": "засіб-дії",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 592
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "калорійність",
+      "lemmaId": "калорійність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 593
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "клітковина",
+      "lemmaId": "клітковина",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 594
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "кришка",
+      "lemmaId": "кришка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 595
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "спосіб приготування",
+      "lemmaId": "спосіб-приготування",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 596
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "тушкувати",
+      "lemmaId": "тушкувати",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 597
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "щіпка",
+      "lemmaId": "щіпка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 598
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "гарантійний випадок",
+      "lemmaId": "гарантійний-випадок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 599
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "завдати збитків",
+      "lemmaId": "завдати-збитків",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 600
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "комплектація",
+      "lemmaId": "комплектація",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 601
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "купівля",
+      "lemmaId": "купівля",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 602
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "передплата",
+      "lemmaId": "передплата",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 603
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "рейтинг",
+      "lemmaId": "рейтинг",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 604
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "свідоме споживання",
+      "lemmaId": "свідоме-споживання",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 605
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "алегорія",
+      "lemmaId": "алегорія",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 606
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "багатозначність",
+      "lemmaId": "багатозначність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 607
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "евфемізм",
+      "lemmaId": "евфемізм",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 608
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "лексичний пласт",
+      "lemmaId": "лексичний-пласт",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 609
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "мовна гра",
+      "lemmaId": "мовна-гра",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 610
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "неологізм",
+      "lemmaId": "неологізм",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 611
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "сарказм",
+      "lemmaId": "сарказм",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 612
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "стилістичне забарвлення",
+      "lemmaId": "стилістичне-забарвлення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 613
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "арка",
+      "lemmaId": "арка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 614
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "бруківка",
+      "lemmaId": "бруківка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 615
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "вежа",
+      "lemmaId": "вежа",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 616
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "карпатський",
+      "lemmaId": "карпатський",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 617
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "кінцева зупинка",
+      "lemmaId": "кінцева-зупинка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 618
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "полонина",
+      "lemmaId": "полонина",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 619
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "путівник",
+      "lemmaId": "путівник",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 620
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "багатокомпонентне речення",
+      "lemmaId": "багатокомпонентне-речення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 621
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "збіг сполучників",
+      "lemmaId": "збіг-сполучників",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 622
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "логічна єдність",
+      "lemmaId": "логічна-єдність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 623
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "причинно-наслідковий зв'язок",
+      "lemmaId": "причинно-наслідковий-зв-язок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 624
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "пунктуаційна грамотність",
+      "lemmaId": "пунктуаційна-грамотність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 625
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "синтаксична конструкція",
+      "lemmaId": "синтаксична-конструкція",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 626
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "смисловий зв'язок",
+      "lemmaId": "смисловий-зв-язок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 627
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "сурядна частина",
+      "lemmaId": "сурядна-частина",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 628
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "авторська позиція",
+      "lemmaId": "авторська-позиція",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 629
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "вставлене речення",
+      "lemmaId": "вставлене-речення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 630
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "відокремлювати",
+      "lemmaId": "відокремлювати",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 631
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "емоційна оцінка",
+      "lemmaId": "емоційна-оцінка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 632
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "комунікативна функція",
+      "lemmaId": "комунікативна-функція",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 633
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "логічність викладу",
+      "lemmaId": "логічність-викладу",
+      "modes": [
+        "flashcards"
+      ],
+      "newOrder": 634
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "порядок викладу",
+      "lemmaId": "порядок-викладу",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 635
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "присудкове слово",
+      "lemmaId": "присудкове-слово",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 636
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "семантична група",
+      "lemmaId": "семантична-група",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 637
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "синтаксично ізольований",
+      "lemmaId": "синтаксично-ізольований",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 638
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "ступінь упевненості",
+      "lemmaId": "ступінь-упевненості",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 639
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "суб'єктивність",
+      "lemmaId": "суб-єктивність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 640
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "еквівалентність",
+      "lemmaId": "еквівалентність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 641
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "когнітивний",
+      "lemmaId": "когнітивний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 642
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "логіка викладу",
+      "lemmaId": "логіка-викладу",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 643
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "монотонність",
+      "lemmaId": "монотонність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 644
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "морфологічний",
+      "lemmaId": "морфологічний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 645
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "особова форма",
+      "lemmaId": "особова-форма",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 646
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "семантична втрата",
+      "lemmaId": "семантична-втрата",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 647
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "вжито заходів",
+      "lemmaId": "вжито-заходів",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 648
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "крайній строк",
+      "lemmaId": "крайній-строк",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 649
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "медійний стиль",
+      "lemmaId": "медійний-стиль",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 650
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "наглядова рада",
+      "lemmaId": "наглядова-рада",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 651
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "науковий стиль",
+      "lemmaId": "науковий-стиль",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 652
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "пасив на -ся",
+      "lemmaId": "пасив-на-ся",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 653
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "пояснювальна записка",
+      "lemmaId": "пояснювальна-записка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 654
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "регламентація",
+      "lemmaId": "регламентація",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 655
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "суб'єктна перспектива",
+      "lemmaId": "суб-єктна-перспектива",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 656
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "впроваджуватися",
+      "lemmaId": "впроваджуватися",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 657
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "результат дії",
+      "lemmaId": "результат-дії",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 658
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "реформа",
+      "lemmaId": "реформа",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 659
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "розроблятися",
+      "lemmaId": "розроблятися",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 660
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "дієприкметник минулого часу",
+      "lemmaId": "дієприкметник-минулого-часу",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 661
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "забутий",
+      "lemmaId": "забутий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 662
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "зім'ятий",
+      "lemmaId": "зім-ятий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 663
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "спечений",
+      "lemmaId": "спечений",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 664
     },
     {
       "cefr": "B2",
@@ -5580,7 +8579,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 434
+      "newOrder": 665
     },
     {
       "cefr": "B2",
@@ -5591,316 +8590,1253 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 435
+      "newOrder": 666
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "анонімність",
-      "lemmaId": "анонімність",
+      "lemma": "жанровий режим",
+      "lemmaId": "жанровий-режим",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 436
+      "newOrder": 667
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "бранець",
-      "lemmaId": "бранець",
+      "lemma": "збіг голосних",
+      "lemmaId": "збіг-голосних",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 437
+      "newOrder": 668
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "галера",
-      "lemmaId": "галера",
+      "lemma": "звуковий ефект",
+      "lemmaId": "звуковий-ефект",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 669
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "звуковий повтор",
+      "lemmaId": "звуковий-повтор",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 670
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "публічний виступ",
+      "lemmaId": "публічний-виступ",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 671
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "слуховий образ",
+      "lemmaId": "слуховий-образ",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 672
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "темп мовлення",
+      "lemmaId": "темп-мовлення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 673
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "уривчастий",
+      "lemmaId": "уривчастий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 674
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "фонетична редактура",
+      "lemmaId": "фонетична-редактура",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 675
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "фонетичний засіб",
+      "lemmaId": "фонетичний-засіб",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 676
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "атрибутивний зв'язок",
+      "lemmaId": "атрибутивний-зв-язок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 677
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "безприйменникове керування",
+      "lemmaId": "безприйменникове-керування",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 678
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "граматична форма",
+      "lemmaId": "граматична-форма",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 679
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "морфологічне уподібнення",
+      "lemmaId": "морфологічне-уподібнення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 680
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "незмінність",
+      "lemmaId": "незмінність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 681
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "номінативна функція",
+      "lemmaId": "номінативна-функція",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 682
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "об'єктний зв'язок",
+      "lemmaId": "об-єктний-зв-язок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 683
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "обставинне значення",
+      "lemmaId": "обставинне-значення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 684
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "прийменникове керування",
+      "lemmaId": "прийменникове-керування",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 685
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "семантичний зв'язок",
+      "lemmaId": "семантичний-зв-язок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 686
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "сильне керування",
+      "lemmaId": "сильне-керування",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 687
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "синтаксична одиниця",
+      "lemmaId": "синтаксична-одиниця",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 688
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "синтаксичний центр",
+      "lemmaId": "синтаксичний-центр",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 689
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "сполучуваність",
+      "lemmaId": "сполучуваність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 690
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "будьмо уважні",
+      "lemmaId": "будьмо-уважні",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 691
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "ввічливе прохання",
+      "lemmaId": "ввічливе-прохання",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 692
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "взаємодопомога",
+      "lemmaId": "взаємодопомога",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 693
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "графік відключень",
+      "lemmaId": "графік-відключень",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 694
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "домогосподарство",
+      "lemmaId": "домогосподарство",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 695
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "зрідка",
+      "lemmaId": "зрідка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 696
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "коректна скарга",
+      "lemmaId": "коректна-скарга",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 697
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "мати рацію",
+      "lemmaId": "мати-рацію",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 698
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "невидима праця",
+      "lemmaId": "невидима-праця",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 699
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "особисті межі",
+      "lemmaId": "особисті-межі",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 700
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "побутовий конфлікт",
+      "lemmaId": "побутовий-конфлікт",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 701
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "прасування",
+      "lemmaId": "прасування",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 702
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "розподіл обов'язків",
+      "lemmaId": "розподіл-обов-язків",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 703
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "рутина",
+      "lemmaId": "рутина",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 704
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "сервісний центр",
+      "lemmaId": "сервісний-центр",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 705
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "ґендерна роль",
+      "lemmaId": "ґендерна-роль",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 706
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "допоміжне слово",
+      "lemmaId": "допоміжне-слово",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 707
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "кількісне сполучення",
+      "lemmaId": "кількісне-сполучення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 708
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "нульова зв'язка",
+      "lemmaId": "нульова-зв-язка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 709
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "предикативний центр",
+      "lemmaId": "предикативний-центр",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 710
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "складений дієслівний присудок",
+      "lemmaId": "складений-дієслівний-присудок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 711
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "складений іменний присудок",
+      "lemmaId": "складений-іменний-присудок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 712
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "стилістична трансформація",
+      "lemmaId": "стилістична-трансформація",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 713
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "фразеологічний присудок",
+      "lemmaId": "фразеологічний-присудок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 714
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "іменна частина",
+      "lemmaId": "іменна-частина",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 715
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "автономна зміна",
+      "lemmaId": "автономна-зміна",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 716
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "бездіячевий",
+      "lemmaId": "бездіячевий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 717
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "взаємно-зворотне значення",
+      "lemmaId": "взаємно-зворотне-значення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 718
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "власне-зворотне значення",
+      "lemmaId": "власне-зворотне-значення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 719
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "обробляється",
+      "lemmaId": "обробляється",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 720
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "пасивне значення",
+      "lemmaId": "пасивне-значення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 721
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "транслюватися",
+      "lemmaId": "транслюватися",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 722
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "будемо вдячні",
+      "lemmaId": "будемо-вдячні",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 723
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "відмова",
+      "lemmaId": "відмова",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 724
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "відповідальна особа",
+      "lemmaId": "відповідальна-особа",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 725
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "доповідна записка",
+      "lemmaId": "доповідна-записка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 726
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "з огляду на",
+      "lemmaId": "з-огляду-на",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 727
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "з повагою",
+      "lemmaId": "з-повагою",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 728
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "зворотний зв'язок",
+      "lemmaId": "зворотний-зв-язок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 729
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "комерційна пропозиція",
+      "lemmaId": "комерційна-пропозиція",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 730
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "мотиваційний лист",
+      "lemmaId": "мотиваційний-лист",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 731
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "порядок денний",
+      "lemmaId": "порядок-денний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 732
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "службова записка",
+      "lemmaId": "службова-записка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 733
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "технічне завдання",
+      "lemmaId": "технічне-завдання",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 734
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "у відповідь на",
+      "lemmaId": "у-відповідь-на",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 735
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "баг",
+      "lemmaId": "баг",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 736
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "глянути",
+      "lemmaId": "глянути",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 737
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "довести до відома",
+      "lemmaId": "довести-до-відома",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 738
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "змінити термін",
+      "lemmaId": "змінити-термін",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 739
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "канал спілкування",
+      "lemmaId": "канал-спілкування",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 740
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "комунікативна ситуація",
+      "lemmaId": "комунікативна-ситуація",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 741
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "нейтральний тон",
+      "lemmaId": "нейтральний-тон",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 742
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "посунути дедлайн",
+      "lemmaId": "посунути-дедлайн",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 743
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "пошанне Ви",
+      "lemmaId": "пошанне-ви",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 744
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "просимо розглянути",
+      "lemmaId": "просимо-розглянути",
       "modes": [
         "flashcards"
       ],
-      "newOrder": 438
+      "newOrder": 745
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "епос",
-      "lemmaId": "епос",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 439
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "жертовність",
-      "lemmaId": "жертовність",
+      "lemma": "підтверджую отримання",
+      "lemmaId": "підтверджую-отримання",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 440
+      "newOrder": 746
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "зозуля",
-      "lemmaId": "зозуля",
+      "lemma": "робочий чат",
+      "lemmaId": "робочий-чат",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 441
+      "newOrder": 747
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "каторга",
-      "lemmaId": "каторга",
+      "lemma": "сленг",
+      "lemmaId": "сленг",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 442
+      "newOrder": 748
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "набіг",
-      "lemmaId": "набіг",
+      "lemma": "соціальна дистанція",
+      "lemmaId": "соціальна-дистанція",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 443
+      "newOrder": 749
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "неволя",
-      "lemmaId": "неволя",
+      "lemma": "термін виконання",
+      "lemmaId": "термін-виконання",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 444
+      "newOrder": 750
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "невільник",
-      "lemmaId": "невільник",
+      "lemma": "технічна помилка",
+      "lemmaId": "технічна-помилка",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 445
+      "newOrder": 751
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "психологізм",
-      "lemmaId": "психологізм",
+      "lemma": "на підставі",
+      "lemmaId": "на-підставі",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 446
+      "newOrder": 752
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "явір",
-      "lemmaId": "явір",
+      "lemma": "претензія",
+      "lemmaId": "претензія",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 447
+      "newOrder": 753
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "яничар",
-      "lemmaId": "яничар",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 448
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "ясир",
-      "lemmaId": "ясир",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 449
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "дідух",
-      "lemmaId": "дідух",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 450
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "колядування",
-      "lemmaId": "колядування",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 451
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "обрядовість",
-      "lemmaId": "обрядовість",
+      "lemma": "реквізит",
+      "lemmaId": "реквізит",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 452
+      "newOrder": 754
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "родючість",
-      "lemmaId": "родючість",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 453
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "рівнодення",
-      "lemmaId": "рівнодення",
+      "lemma": "у встановлений строк",
+      "lemmaId": "у-встановлений-строк",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 454
+      "newOrder": 755
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "синкретизм",
-      "lemmaId": "синкретизм",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 455
-    },
-    {
-      "cefr": "B2",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "сонцестояння",
-      "lemmaId": "сонцестояння",
+      "lemma": "авторський голос",
+      "lemmaId": "авторський-голос",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 456
+      "newOrder": 756
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "цикл",
-      "lemmaId": "цикл",
+      "lemma": "авторський новотвір",
+      "lemmaId": "авторський-новотвір",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 457
+      "newOrder": 757
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "паралелізм",
-      "lemmaId": "паралелізм",
+      "lemma": "естетична функція",
+      "lemmaId": "естетична-функція",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 458
+      "newOrder": 758
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "побутування",
-      "lemmaId": "побутування",
+      "lemma": "етична точність",
+      "lemmaId": "етична-точність",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 459
+      "newOrder": 759
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "рефрен",
-      "lemmaId": "рефрен",
+      "lemma": "культурна деталь",
+      "lemmaId": "культурна-деталь",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 460
+      "newOrder": 760
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "ліричний голос",
+      "lemmaId": "ліричний-голос",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 761
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "опорна деталь",
+      "lemmaId": "опорна-деталь",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 762
     },
     {
       "cefr": "B2",
@@ -5913,104 +9849,1175 @@
         "matching",
         "choice"
       ],
-      "newOrder": 461
+      "newOrder": 763
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "тріада",
-      "lemmaId": "тріада",
+      "lemma": "художній переклад",
+      "lemmaId": "художній-переклад",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 462
+      "newOrder": 764
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "ушанування",
-      "lemmaId": "ушанування",
+      "lemma": "читання між рядками",
+      "lemmaId": "читання-між-рядками",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 463
+      "newOrder": 765
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "голосіння",
-      "lemmaId": "голосіння",
+      "lemma": "історизм",
+      "lemmaId": "історизм",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 464
+      "newOrder": 766
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "кобза",
-      "lemmaId": "кобза",
+      "lemma": "вплив",
+      "lemmaId": "вплив",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 767
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "дискурсивний маркер",
+      "lemmaId": "дискурсивний-маркер",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 768
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "замітка",
+      "lemmaId": "замітка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 769
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "канцелярський суржик",
+      "lemmaId": "канцелярський-суржик",
       "modes": [
         "flashcards"
       ],
-      "newOrder": 465
+      "newOrder": 770
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "коровай",
-      "lemmaId": "коровай",
+      "lemma": "короче",
+      "lemmaId": "короче",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 466
+      "newOrder": 771
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "ліра",
-      "lemmaId": "ліра",
+      "lemma": "невербальні засоби",
+      "lemmaId": "невербальні-засоби",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 772
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "перемикання регістрів",
+      "lemmaId": "перемикання-регістрів",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 773
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "прикольно",
+      "lemmaId": "прикольно",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 774
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "публічне мовлення",
+      "lemmaId": "публічне-мовлення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 775
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "риторичне запитання",
+      "lemmaId": "риторичне-запитання",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 776
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "суб'єкт дії",
+      "lemmaId": "суб-єкт-дії",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 777
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "та ну",
+      "lemmaId": "та-ну",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 778
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "українська мова",
+      "lemmaId": "українська-мова",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 779
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "другорядний член речення",
+      "lemmaId": "другорядний-член-речення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 780
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "непоширене речення",
+      "lemmaId": "непоширене-речення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 781
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "непрямий додаток",
+      "lemmaId": "непрямий-додаток",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 782
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "неузгоджене означення",
+      "lemmaId": "неузгоджене-означення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 783
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "обставина допусту",
+      "lemmaId": "обставина-допусту",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 784
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "обставина мети",
+      "lemmaId": "обставина-мети",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 785
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "обставина місця",
+      "lemmaId": "обставина-місця",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 786
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "обставина причини",
+      "lemmaId": "обставина-причини",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 787
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "обставина способу дії",
+      "lemmaId": "обставина-способу-дії",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 788
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "обставина умови",
+      "lemmaId": "обставина-умови",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 789
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "обставина часу",
+      "lemmaId": "обставина-часу",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 790
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "поширене речення",
+      "lemmaId": "поширене-речення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 791
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "стилістична доречність",
+      "lemmaId": "стилістична-доречність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 792
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "узгоджене означення",
+      "lemmaId": "узгоджене-означення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 793
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "активний відпочинок",
+      "lemmaId": "активний-відпочинок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 794
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "вболівальник",
+      "lemmaId": "вболівальник",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 795
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "культурне дозвілля",
+      "lemmaId": "культурне-дозвілля",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 796
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "розминка",
+      "lemmaId": "розминка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 797
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "рукоділля",
+      "lemmaId": "рукоділля",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 798
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "фізична активність",
+      "lemmaId": "фізична-активність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 799
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "цифрове дозвілля",
+      "lemmaId": "цифрове-дозвілля",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 800
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "аналітичний абзац",
+      "lemmaId": "аналітичний-абзац",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 801
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "засіб зв'язку",
+      "lemmaId": "засіб-зв-язку",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 802
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "логічний зв'язок",
+      "lemmaId": "логічний-зв-язок",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 803
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "нарощення аргументу",
+      "lemmaId": "нарощення-аргументу",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 804
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "синонімічна заміна",
+      "lemmaId": "синонімічна-заміна",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 805
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "службовий лист",
+      "lemmaId": "службовий-лист",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 806
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "смислова цілісність",
+      "lemmaId": "смислова-цілісність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 807
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "висхідна градація",
+      "lemmaId": "висхідна-градація",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 808
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "доказова межа",
+      "lemmaId": "доказова-межа",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 809
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "експресія",
+      "lemmaId": "експресія",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 810
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "ораторський стиль",
+      "lemmaId": "ораторський-стиль",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 811
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "паралелізм",
+      "lemmaId": "паралелізм",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 812
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "риторична фігура",
+      "lemmaId": "риторична-фігура",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 813
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "риторичне звертання",
+      "lemmaId": "риторичне-звертання",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 814
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "риторичний вигук",
+      "lemmaId": "риторичний-вигук",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 815
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "синтаксична фігура",
+      "lemmaId": "синтаксична-фігура",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 816
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "синтаксичний паралелізм",
+      "lemmaId": "синтаксичний-паралелізм",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 817
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "спадна градація",
+      "lemmaId": "спадна-градація",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 818
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "стилістична функція",
+      "lemmaId": "стилістична-функція",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 819
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "фокус речення",
+      "lemmaId": "фокус-речення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 820
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "громадське обговорення",
+      "lemmaId": "громадське-обговорення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 821
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "зазначати",
+      "lemmaId": "зазначати",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 822
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "результативний",
+      "lemmaId": "результативний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 823
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "синтаксичний фокус",
+      "lemmaId": "синтаксичний-фокус",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 824
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "стилістична синонімія",
+      "lemmaId": "стилістична-синонімія",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 825
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "третя особа множини",
+      "lemmaId": "третя-особа-множини",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 826
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "форма множини",
+      "lemmaId": "форма-множини",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 827
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "Водохреще",
+      "lemmaId": "водохреще",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 828
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "відроджувати",
+      "lemmaId": "відроджувати",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 829
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "День вишиванки",
+      "lemmaId": "день-вишиванки",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 830
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "дідух",
+      "lemmaId": "дідух",
       "modes": [
         "flashcards"
       ],
-      "newOrder": 467
+      "newOrder": 831
     },
     {
       "cefr": "B2",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "нашарування",
-      "lemmaId": "нашарування",
+      "lemma": "забобон",
+      "lemmaId": "забобон",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 468
+      "newOrder": 832
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "Зелені свята",
+      "lemmaId": "зелені-свята",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 833
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "колядування",
+      "lemmaId": "колядування",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 834
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "Маланка",
+      "lemmaId": "маланка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 835
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "обрядовість",
+      "lemmaId": "обрядовість",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 836
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "освячувати",
+      "lemmaId": "освячувати",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 837
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "поминки",
+      "lemmaId": "поминки",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 838
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "родинний",
+      "lemmaId": "родинний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 839
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "сватання",
+      "lemmaId": "сватання",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 840
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "хрестини",
+      "lemmaId": "хрестини",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 841
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "кардіолог",
+      "lemmaId": "кардіолог",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 842
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "побічний",
+      "lemmaId": "побічний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 843
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "протипоказання",
+      "lemmaId": "протипоказання",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 844
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "голота",
+      "lemmaId": "голота",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 845
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "Коліївщина",
+      "lemmaId": "коліївщина",
+      "modes": [
+        "flashcards"
+      ],
+      "newOrder": 846
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "куплет",
+      "lemmaId": "куплет",
+      "modes": [
+        "flashcards"
+      ],
+      "newOrder": 847
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "опришок",
+      "lemmaId": "опришок",
+      "modes": [
+        "flashcards"
+      ],
+      "newOrder": 848
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "фальсифікат",
+      "lemmaId": "фальсифікат",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 849
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "ясир",
+      "lemmaId": "ясир",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 850
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "реквієм",
+      "lemmaId": "реквієм",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 851
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "гетьман",
+      "lemmaId": "гетьман",
+      "modes": [
+        "flashcards"
+      ],
+      "newOrder": 852
+    },
+    {
+      "cefr": "B2",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "десятина",
+      "lemmaId": "десятина",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 853
     }
   ],
   "level": "B2",
   "schema": "atlas-practice-index",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 7423,
+    "gzipBytes": 15032,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 120828,
+    "rawBytes": 231048,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/public/lexicon/practice-index.C1.json
+++ b/site/public/lexicon/practice-index.C1.json
@@ -3,9 +3,9 @@
     "cloze": 0,
     "clozeCoverage": 0.0,
     "clozeEligibleLexemes": 0,
-    "lexemes": 339
+    "lexemes": 421
   },
-  "deckVersion": "atlas-practice-v1-9cf4a4d7319d19ce",
+  "deckVersion": "atlas-practice-v1-c5a52e54cdf8d828",
   "items": [
     {
       "cefr": "C1",
@@ -50,19 +50,6 @@
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "темно-зелений",
-      "lemmaId": "темно-зелений",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 3
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
       "lemma": "милозвучність",
       "lemmaId": "милозвучність",
       "modes": [
@@ -70,7 +57,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 4
+      "newOrder": 3
     },
     {
       "cefr": "C1",
@@ -83,7 +70,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 5
+      "newOrder": 4
     },
     {
       "cefr": "C1",
@@ -96,7 +83,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 6
+      "newOrder": 5
     },
     {
       "cefr": "C1",
@@ -109,7 +96,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 7
+      "newOrder": 6
     },
     {
       "cefr": "C1",
@@ -122,20 +109,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 8
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "апостроф",
-      "lemmaId": "апостроф",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 9
+      "newOrder": 7
     },
     {
       "cefr": "C1",
@@ -148,7 +122,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 10
+      "newOrder": 8
     },
     {
       "cefr": "C1",
@@ -161,7 +135,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 11
+      "newOrder": 9
     },
     {
       "cefr": "C1",
@@ -174,20 +148,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 12
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "роздільно",
-      "lemmaId": "роздільно",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 13
+      "newOrder": 10
     },
     {
       "cefr": "C1",
@@ -200,7 +161,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 14
+      "newOrder": 11
     },
     {
       "cefr": "C1",
@@ -213,7 +174,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 15
+      "newOrder": 12
     },
     {
       "cefr": "C1",
@@ -226,7 +187,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 16
+      "newOrder": 13
     },
     {
       "cefr": "C1",
@@ -239,7 +200,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 17
+      "newOrder": 14
     },
     {
       "cefr": "C1",
@@ -252,20 +213,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 18
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вчиш",
-      "lemmaId": "вчиш",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 19
+      "newOrder": 15
     },
     {
       "cefr": "C1",
@@ -278,7 +226,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 20
+      "newOrder": 16
     },
     {
       "cefr": "C1",
@@ -291,7 +239,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 21
+      "newOrder": 17
     },
     {
       "cefr": "C1",
@@ -304,7 +252,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 22
+      "newOrder": 18
     },
     {
       "cefr": "C1",
@@ -317,7 +265,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 23
+      "newOrder": 19
     },
     {
       "cefr": "C1",
@@ -328,7 +276,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 24
+      "newOrder": 20
     },
     {
       "cefr": "C1",
@@ -341,7 +289,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 25
+      "newOrder": 21
     },
     {
       "cefr": "C1",
@@ -354,7 +302,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 26
+      "newOrder": 22
     },
     {
       "cefr": "C1",
@@ -367,7 +315,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 27
+      "newOrder": 23
     },
     {
       "cefr": "C1",
@@ -380,7 +328,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 28
+      "newOrder": 24
     },
     {
       "cefr": "C1",
@@ -393,7 +341,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 29
+      "newOrder": 25
     },
     {
       "cefr": "C1",
@@ -406,7 +354,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 30
+      "newOrder": 26
     },
     {
       "cefr": "C1",
@@ -419,7 +367,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 31
+      "newOrder": 27
     },
     {
       "cefr": "C1",
@@ -432,7 +380,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 32
+      "newOrder": 28
     },
     {
       "cefr": "C1",
@@ -445,7 +393,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 33
+      "newOrder": 29
     },
     {
       "cefr": "C1",
@@ -456,7 +404,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 34
+      "newOrder": 30
     },
     {
       "cefr": "C1",
@@ -467,7 +415,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 35
+      "newOrder": 31
     },
     {
       "cefr": "C1",
@@ -480,7 +428,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 36
+      "newOrder": 32
     },
     {
       "cefr": "C1",
@@ -493,7 +441,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 37
+      "newOrder": 33
     },
     {
       "cefr": "C1",
@@ -506,7 +454,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 38
+      "newOrder": 34
     },
     {
       "cefr": "C1",
@@ -519,20 +467,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 39
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "морфологія",
-      "lemmaId": "морфологія",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 40
+      "newOrder": 35
     },
     {
       "cefr": "C1",
@@ -545,7 +480,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 41
+      "newOrder": 36
     },
     {
       "cefr": "C1",
@@ -558,7 +493,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 42
+      "newOrder": 37
     },
     {
       "cefr": "C1",
@@ -571,7 +506,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 43
+      "newOrder": 38
     },
     {
       "cefr": "C1",
@@ -584,7 +519,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 44
+      "newOrder": 39
     },
     {
       "cefr": "C1",
@@ -597,7 +532,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 45
+      "newOrder": 40
     },
     {
       "cefr": "C1",
@@ -610,7 +545,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 46
+      "newOrder": 41
     },
     {
       "cefr": "C1",
@@ -623,7 +558,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 47
+      "newOrder": 42
     },
     {
       "cefr": "C1",
@@ -636,7 +571,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 48
+      "newOrder": 43
     },
     {
       "cefr": "C1",
@@ -649,7 +584,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 49
+      "newOrder": 44
     },
     {
       "cefr": "C1",
@@ -662,7 +597,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 50
+      "newOrder": 45
     },
     {
       "cefr": "C1",
@@ -675,7 +610,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 51
+      "newOrder": 46
     },
     {
       "cefr": "C1",
@@ -688,7 +623,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 52
+      "newOrder": 47
     },
     {
       "cefr": "C1",
@@ -701,7 +636,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 53
+      "newOrder": 48
     },
     {
       "cefr": "C1",
@@ -714,7 +649,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 54
+      "newOrder": 49
     },
     {
       "cefr": "C1",
@@ -727,33 +662,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 55
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "розтанути",
-      "lemmaId": "розтанути",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 56
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "пінгвін",
-      "lemmaId": "пінгвін",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 57
+      "newOrder": 50
     },
     {
       "cefr": "C1",
@@ -766,7 +675,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 58
+      "newOrder": 51
     },
     {
       "cefr": "C1",
@@ -779,7 +688,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 59
+      "newOrder": 52
     },
     {
       "cefr": "C1",
@@ -792,7 +701,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 60
+      "newOrder": 53
     },
     {
       "cefr": "C1",
@@ -805,7 +714,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 61
+      "newOrder": 54
     },
     {
       "cefr": "C1",
@@ -818,7 +727,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 62
+      "newOrder": 55
     },
     {
       "cefr": "C1",
@@ -831,7 +740,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 63
+      "newOrder": 56
     },
     {
       "cefr": "C1",
@@ -844,7 +753,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 64
+      "newOrder": 57
     },
     {
       "cefr": "C1",
@@ -857,7 +766,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 65
+      "newOrder": 58
     },
     {
       "cefr": "C1",
@@ -870,7 +779,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 66
+      "newOrder": 59
     },
     {
       "cefr": "C1",
@@ -883,7 +792,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 67
+      "newOrder": 60
     },
     {
       "cefr": "C1",
@@ -896,7 +805,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 68
+      "newOrder": 61
     },
     {
       "cefr": "C1",
@@ -909,7 +818,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 69
+      "newOrder": 62
     },
     {
       "cefr": "C1",
@@ -922,20 +831,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 70
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "синонімічний",
-      "lemmaId": "синонімічний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 71
+      "newOrder": 63
     },
     {
       "cefr": "C1",
@@ -948,7 +844,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 72
+      "newOrder": 64
     },
     {
       "cefr": "C1",
@@ -961,7 +857,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 73
+      "newOrder": 65
     },
     {
       "cefr": "C1",
@@ -974,7 +870,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 74
+      "newOrder": 66
     },
     {
       "cefr": "C1",
@@ -987,7 +883,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 75
+      "newOrder": 67
     },
     {
       "cefr": "C1",
@@ -1000,7 +896,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 76
+      "newOrder": 68
     },
     {
       "cefr": "C1",
@@ -1013,7 +909,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 77
+      "newOrder": 69
     },
     {
       "cefr": "C1",
@@ -1026,7 +922,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 78
+      "newOrder": 70
     },
     {
       "cefr": "C1",
@@ -1039,7 +935,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 79
+      "newOrder": 71
     },
     {
       "cefr": "C1",
@@ -1052,7 +948,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 80
+      "newOrder": 72
     },
     {
       "cefr": "C1",
@@ -1065,7 +961,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 81
+      "newOrder": 73
     },
     {
       "cefr": "C1",
@@ -1078,7 +974,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 82
+      "newOrder": 74
     },
     {
       "cefr": "C1",
@@ -1091,7 +987,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 83
+      "newOrder": 75
     },
     {
       "cefr": "C1",
@@ -1104,7 +1000,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 84
+      "newOrder": 76
     },
     {
       "cefr": "C1",
@@ -1117,7 +1013,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 85
+      "newOrder": 77
     },
     {
       "cefr": "C1",
@@ -1130,7 +1026,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 86
+      "newOrder": 78
     },
     {
       "cefr": "C1",
@@ -1143,7 +1039,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 87
+      "newOrder": 79
     },
     {
       "cefr": "C1",
@@ -1156,7 +1052,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 88
+      "newOrder": 80
     },
     {
       "cefr": "C1",
@@ -1169,20 +1065,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 89
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "прагматика",
-      "lemmaId": "прагматика",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 90
+      "newOrder": 81
     },
     {
       "cefr": "C1",
@@ -1195,7 +1078,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 91
+      "newOrder": 82
     },
     {
       "cefr": "C1",
@@ -1208,7 +1091,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 92
+      "newOrder": 83
     },
     {
       "cefr": "C1",
@@ -1221,7 +1104,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 93
+      "newOrder": 84
     },
     {
       "cefr": "C1",
@@ -1234,7 +1117,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 94
+      "newOrder": 85
     },
     {
       "cefr": "C1",
@@ -1247,7 +1130,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 95
+      "newOrder": 86
     },
     {
       "cefr": "C1",
@@ -1260,7 +1143,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 96
+      "newOrder": 87
     },
     {
       "cefr": "C1",
@@ -1273,7 +1156,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 97
+      "newOrder": 88
     },
     {
       "cefr": "C1",
@@ -1286,7 +1169,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 98
+      "newOrder": 89
     },
     {
       "cefr": "C1",
@@ -1299,7 +1182,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 99
+      "newOrder": 90
     },
     {
       "cefr": "C1",
@@ -1312,7 +1195,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 100
+      "newOrder": 91
     },
     {
       "cefr": "C1",
@@ -1325,7 +1208,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 101
+      "newOrder": 92
     },
     {
       "cefr": "C1",
@@ -1338,7 +1221,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 102
+      "newOrder": 93
     },
     {
       "cefr": "C1",
@@ -1351,7 +1234,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 103
+      "newOrder": 94
     },
     {
       "cefr": "C1",
@@ -1364,7 +1247,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 104
+      "newOrder": 95
     },
     {
       "cefr": "C1",
@@ -1377,7 +1260,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 105
+      "newOrder": 96
     },
     {
       "cefr": "C1",
@@ -1390,20 +1273,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 106
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "білити",
-      "lemmaId": "білити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 107
+      "newOrder": 97
     },
     {
       "cefr": "C1",
@@ -1416,7 +1286,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 108
+      "newOrder": 98
     },
     {
       "cefr": "C1",
@@ -1429,7 +1299,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 109
+      "newOrder": 99
     },
     {
       "cefr": "C1",
@@ -1442,7 +1312,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 110
+      "newOrder": 100
     },
     {
       "cefr": "C1",
@@ -1455,7 +1325,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 111
+      "newOrder": 101
     },
     {
       "cefr": "C1",
@@ -1468,7 +1338,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 112
+      "newOrder": 102
     },
     {
       "cefr": "C1",
@@ -1481,7 +1351,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 113
+      "newOrder": 103
     },
     {
       "cefr": "C1",
@@ -1494,7 +1364,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 114
+      "newOrder": 104
     },
     {
       "cefr": "C1",
@@ -1507,7 +1377,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 115
+      "newOrder": 105
     },
     {
       "cefr": "C1",
@@ -1520,7 +1390,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 116
+      "newOrder": 106
     },
     {
       "cefr": "C1",
@@ -1533,7 +1403,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 117
+      "newOrder": 107
     },
     {
       "cefr": "C1",
@@ -1546,7 +1416,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 118
+      "newOrder": 108
     },
     {
       "cefr": "C1",
@@ -1559,7 +1429,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 119
+      "newOrder": 109
     },
     {
       "cefr": "C1",
@@ -1572,7 +1442,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 120
+      "newOrder": 110
     },
     {
       "cefr": "C1",
@@ -1585,7 +1455,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 121
+      "newOrder": 111
     },
     {
       "cefr": "C1",
@@ -1598,20 +1468,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 122
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "точковий",
-      "lemmaId": "точковий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 123
+      "newOrder": 112
     },
     {
       "cefr": "C1",
@@ -1624,7 +1481,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 124
+      "newOrder": 113
     },
     {
       "cefr": "C1",
@@ -1637,7 +1494,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 125
+      "newOrder": 114
     },
     {
       "cefr": "C1",
@@ -1650,7 +1507,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 126
+      "newOrder": 115
     },
     {
       "cefr": "C1",
@@ -1663,7 +1520,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 127
+      "newOrder": 116
     },
     {
       "cefr": "C1",
@@ -1676,7 +1533,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 128
+      "newOrder": 117
     },
     {
       "cefr": "C1",
@@ -1689,20 +1546,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 129
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "облетіти",
-      "lemmaId": "облетіти",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 130
+      "newOrder": 118
     },
     {
       "cefr": "C1",
@@ -1715,7 +1559,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 131
+      "newOrder": 119
     },
     {
       "cefr": "C1",
@@ -1728,7 +1572,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 132
+      "newOrder": 120
     },
     {
       "cefr": "C1",
@@ -1741,7 +1585,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 133
+      "newOrder": 121
     },
     {
       "cefr": "C1",
@@ -1754,7 +1598,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 134
+      "newOrder": 122
     },
     {
       "cefr": "C1",
@@ -1767,7 +1611,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 135
+      "newOrder": 123
     },
     {
       "cefr": "C1",
@@ -1778,7 +1622,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 136
+      "newOrder": 124
     },
     {
       "cefr": "C1",
@@ -1791,7 +1635,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 137
+      "newOrder": 125
     },
     {
       "cefr": "C1",
@@ -1804,7 +1648,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 138
+      "newOrder": 126
     },
     {
       "cefr": "C1",
@@ -1817,7 +1661,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 139
+      "newOrder": 127
     },
     {
       "cefr": "C1",
@@ -1830,7 +1674,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 140
+      "newOrder": 128
     },
     {
       "cefr": "C1",
@@ -1843,7 +1687,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 141
+      "newOrder": 129
     },
     {
       "cefr": "C1",
@@ -1856,7 +1700,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 142
+      "newOrder": 130
     },
     {
       "cefr": "C1",
@@ -1869,20 +1713,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 143
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "новобудова",
-      "lemmaId": "новобудова",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 144
+      "newOrder": 131
     },
     {
       "cefr": "C1",
@@ -1895,7 +1726,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 145
+      "newOrder": 132
     },
     {
       "cefr": "C1",
@@ -1908,33 +1739,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 146
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "сантехнік",
-      "lemmaId": "сантехнік",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 147
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "євроремонт",
-      "lemmaId": "євроремонт",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 148
+      "newOrder": 133
     },
     {
       "cefr": "C1",
@@ -1947,7 +1752,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 149
+      "newOrder": 134
     },
     {
       "cefr": "C1",
@@ -1960,7 +1765,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 150
+      "newOrder": 135
     },
     {
       "cefr": "C1",
@@ -1973,7 +1778,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 151
+      "newOrder": 136
     },
     {
       "cefr": "C1",
@@ -1986,7 +1791,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 152
+      "newOrder": 137
     },
     {
       "cefr": "C1",
@@ -1999,7 +1804,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 153
+      "newOrder": 138
     },
     {
       "cefr": "C1",
@@ -2012,7 +1817,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 154
+      "newOrder": 139
     },
     {
       "cefr": "C1",
@@ -2025,7 +1830,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 155
+      "newOrder": 140
     },
     {
       "cefr": "C1",
@@ -2038,7 +1843,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 156
+      "newOrder": 141
     },
     {
       "cefr": "C1",
@@ -2051,7 +1856,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 157
+      "newOrder": 142
     },
     {
       "cefr": "C1",
@@ -2062,7 +1867,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 158
+      "newOrder": 143
     },
     {
       "cefr": "C1",
@@ -2075,7 +1880,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 159
+      "newOrder": 144
     },
     {
       "cefr": "C1",
@@ -2086,7 +1891,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 160
+      "newOrder": 145
     },
     {
       "cefr": "C1",
@@ -2097,31 +1902,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 161
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "доплисти",
-      "lemmaId": "доплисти",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 162
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "залетіти",
-      "lemmaId": "залетіти",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 163
+      "newOrder": 146
     },
     {
       "cefr": "C1",
@@ -2132,7 +1913,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 164
+      "newOrder": 147
     },
     {
       "cefr": "C1",
@@ -2145,7 +1926,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 165
+      "newOrder": 148
     },
     {
       "cefr": "C1",
@@ -2156,7 +1937,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 166
+      "newOrder": 149
     },
     {
       "cefr": "C1",
@@ -2167,7 +1948,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 167
+      "newOrder": 150
     },
     {
       "cefr": "C1",
@@ -2178,7 +1959,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 168
+      "newOrder": 151
     },
     {
       "cefr": "C1",
@@ -2191,18 +1972,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 169
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "проплисти",
-      "lemmaId": "проплисти",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 170
+      "newOrder": 152
     },
     {
       "cefr": "C1",
@@ -2215,7 +1985,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 171
+      "newOrder": 153
     },
     {
       "cefr": "C1",
@@ -2226,7 +1996,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 172
+      "newOrder": 154
     },
     {
       "cefr": "C1",
@@ -2239,7 +2009,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 173
+      "newOrder": 155
     },
     {
       "cefr": "C1",
@@ -2252,7 +2022,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 174
+      "newOrder": 156
     },
     {
       "cefr": "C1",
@@ -2265,7 +2035,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 175
+      "newOrder": 157
     },
     {
       "cefr": "C1",
@@ -2278,7 +2048,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 176
+      "newOrder": 158
     },
     {
       "cefr": "C1",
@@ -2291,7 +2061,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 177
+      "newOrder": 159
     },
     {
       "cefr": "C1",
@@ -2304,7 +2074,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 178
+      "newOrder": 160
     },
     {
       "cefr": "C1",
@@ -2315,7 +2085,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 179
+      "newOrder": 161
     },
     {
       "cefr": "C1",
@@ -2326,7 +2096,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 180
+      "newOrder": 162
     },
     {
       "cefr": "C1",
@@ -2337,7 +2107,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 181
+      "newOrder": 163
     },
     {
       "cefr": "C1",
@@ -2350,7 +2120,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 182
+      "newOrder": 164
     },
     {
       "cefr": "C1",
@@ -2363,7 +2133,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 183
+      "newOrder": 165
     },
     {
       "cefr": "C1",
@@ -2376,7 +2146,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 184
+      "newOrder": 166
     },
     {
       "cefr": "C1",
@@ -2389,20 +2159,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 185
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "борсук",
-      "lemmaId": "борсук",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 186
+      "newOrder": 167
     },
     {
       "cefr": "C1",
@@ -2415,7 +2172,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 187
+      "newOrder": 168
     },
     {
       "cefr": "C1",
@@ -2428,7 +2185,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 188
+      "newOrder": 169
     },
     {
       "cefr": "C1",
@@ -2441,7 +2198,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 189
+      "newOrder": 170
     },
     {
       "cefr": "C1",
@@ -2454,7 +2211,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 190
+      "newOrder": 171
     },
     {
       "cefr": "C1",
@@ -2467,7 +2224,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 191
+      "newOrder": 172
     },
     {
       "cefr": "C1",
@@ -2480,7 +2237,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 192
+      "newOrder": 173
     },
     {
       "cefr": "C1",
@@ -2493,7 +2250,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 193
+      "newOrder": 174
     },
     {
       "cefr": "C1",
@@ -2506,20 +2263,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 194
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "живучий",
-      "lemmaId": "живучий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 195
+      "newOrder": 175
     },
     {
       "cefr": "C1",
@@ -2532,7 +2276,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 196
+      "newOrder": 176
     },
     {
       "cefr": "C1",
@@ -2545,7 +2289,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 197
+      "newOrder": 177
     },
     {
       "cefr": "C1",
@@ -2558,7 +2302,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 198
+      "newOrder": 178
     },
     {
       "cefr": "C1",
@@ -2571,7 +2315,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 199
+      "newOrder": 179
     },
     {
       "cefr": "C1",
@@ -2584,7 +2328,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 200
+      "newOrder": 180
     },
     {
       "cefr": "C1",
@@ -2597,7 +2341,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 201
+      "newOrder": 181
     },
     {
       "cefr": "C1",
@@ -2610,7 +2354,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 202
+      "newOrder": 182
     },
     {
       "cefr": "C1",
@@ -2623,7 +2367,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 203
+      "newOrder": 183
     },
     {
       "cefr": "C1",
@@ -2636,7 +2380,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 204
+      "newOrder": 184
     },
     {
       "cefr": "C1",
@@ -2649,7 +2393,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 205
+      "newOrder": 185
     },
     {
       "cefr": "C1",
@@ -2662,7 +2406,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 206
+      "newOrder": 186
     },
     {
       "cefr": "C1",
@@ -2675,7 +2419,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 207
+      "newOrder": 187
     },
     {
       "cefr": "C1",
@@ -2688,7 +2432,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 208
+      "newOrder": 188
     },
     {
       "cefr": "C1",
@@ -2701,7 +2445,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 209
+      "newOrder": 189
     },
     {
       "cefr": "C1",
@@ -2714,20 +2458,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 210
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "пофарбовано",
-      "lemmaId": "пофарбовано",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 211
+      "newOrder": 190
     },
     {
       "cefr": "C1",
@@ -2740,7 +2471,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 212
+      "newOrder": 191
     },
     {
       "cefr": "C1",
@@ -2753,20 +2484,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 213
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "заздрісний",
-      "lemmaId": "заздрісний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 214
+      "newOrder": 192
     },
     {
       "cefr": "C1",
@@ -2779,7 +2497,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 215
+      "newOrder": 193
     },
     {
       "cefr": "C1",
@@ -2792,7 +2510,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 216
+      "newOrder": 194
     },
     {
       "cefr": "C1",
@@ -2805,7 +2523,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 217
+      "newOrder": 195
     },
     {
       "cefr": "C1",
@@ -2818,20 +2536,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 218
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "Лесин",
-      "lemmaId": "лесин",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 219
+      "newOrder": 196
     },
     {
       "cefr": "C1",
@@ -2844,7 +2549,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 220
+      "newOrder": 197
     },
     {
       "cefr": "C1",
@@ -2857,7 +2562,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 221
+      "newOrder": 198
     },
     {
       "cefr": "C1",
@@ -2870,7 +2575,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 222
+      "newOrder": 199
     },
     {
       "cefr": "C1",
@@ -2883,7 +2588,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 223
+      "newOrder": 200
     },
     {
       "cefr": "C1",
@@ -2896,7 +2601,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 224
+      "newOrder": 201
     },
     {
       "cefr": "C1",
@@ -2909,20 +2614,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 225
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "Сергіїв",
-      "lemmaId": "сергіїв",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 226
+      "newOrder": 202
     },
     {
       "cefr": "C1",
@@ -2935,7 +2627,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 227
+      "newOrder": 203
     },
     {
       "cefr": "C1",
@@ -2948,7 +2640,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 228
+      "newOrder": 204
     },
     {
       "cefr": "C1",
@@ -2961,7 +2653,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 229
+      "newOrder": 205
     },
     {
       "cefr": "C1",
@@ -2974,7 +2666,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 230
+      "newOrder": 206
     },
     {
       "cefr": "C1",
@@ -2987,7 +2679,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 231
+      "newOrder": 207
     },
     {
       "cefr": "C1",
@@ -3000,7 +2692,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 232
+      "newOrder": 208
     },
     {
       "cefr": "C1",
@@ -3013,7 +2705,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 233
+      "newOrder": 209
     },
     {
       "cefr": "C1",
@@ -3026,7 +2718,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 234
+      "newOrder": 210
     },
     {
       "cefr": "C1",
@@ -3039,7 +2731,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 235
+      "newOrder": 211
     },
     {
       "cefr": "C1",
@@ -3052,7 +2744,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 236
+      "newOrder": 212
     },
     {
       "cefr": "C1",
@@ -3065,7 +2757,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 237
+      "newOrder": 213
     },
     {
       "cefr": "C1",
@@ -3078,7 +2770,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 238
+      "newOrder": 214
     },
     {
       "cefr": "C1",
@@ -3091,7 +2783,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 239
+      "newOrder": 215
     },
     {
       "cefr": "C1",
@@ -3102,7 +2794,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 240
+      "newOrder": 216
     },
     {
       "cefr": "C1",
@@ -3115,7 +2807,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 241
+      "newOrder": 217
     },
     {
       "cefr": "C1",
@@ -3128,20 +2820,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 242
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "надійніший",
-      "lemmaId": "надійніший",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 243
+      "newOrder": 218
     },
     {
       "cefr": "C1",
@@ -3154,7 +2833,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 244
+      "newOrder": 219
     },
     {
       "cefr": "C1",
@@ -3167,7 +2846,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 245
+      "newOrder": 220
     },
     {
       "cefr": "C1",
@@ -3180,7 +2859,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 246
+      "newOrder": 221
     },
     {
       "cefr": "C1",
@@ -3193,7 +2872,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 247
+      "newOrder": 222
     },
     {
       "cefr": "C1",
@@ -3206,7 +2885,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 248
+      "newOrder": 223
     },
     {
       "cefr": "C1",
@@ -3219,7 +2898,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 249
+      "newOrder": 224
     },
     {
       "cefr": "C1",
@@ -3232,7 +2911,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 250
+      "newOrder": 225
     },
     {
       "cefr": "C1",
@@ -3245,7 +2924,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 251
+      "newOrder": 226
     },
     {
       "cefr": "C1",
@@ -3258,7 +2937,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 252
+      "newOrder": 227
     },
     {
       "cefr": "C1",
@@ -3271,7 +2950,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 253
+      "newOrder": 228
     },
     {
       "cefr": "C1",
@@ -3284,7 +2963,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 254
+      "newOrder": 229
     },
     {
       "cefr": "C1",
@@ -3297,20 +2976,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 255
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "масний",
-      "lemmaId": "масний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 256
+      "newOrder": 230
     },
     {
       "cefr": "C1",
@@ -3323,7 +2989,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 257
+      "newOrder": 231
     },
     {
       "cefr": "C1",
@@ -3336,7 +3002,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 258
+      "newOrder": 232
     },
     {
       "cefr": "C1",
@@ -3349,7 +3015,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 259
+      "newOrder": 233
     },
     {
       "cefr": "C1",
@@ -3362,33 +3028,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 260
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "спецвипуск",
-      "lemmaId": "спецвипуск",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 261
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "вищезазначений",
-      "lemmaId": "вищезазначений",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 262
+      "newOrder": 234
     },
     {
       "cefr": "C1",
@@ -3401,7 +3041,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 263
+      "newOrder": 235
     },
     {
       "cefr": "C1",
@@ -3414,7 +3054,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 264
+      "newOrder": 236
     },
     {
       "cefr": "C1",
@@ -3427,20 +3067,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 265
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "невимушеність",
-      "lemmaId": "невимушеність",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 266
+      "newOrder": 237
     },
     {
       "cefr": "C1",
@@ -3453,20 +3080,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 267
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "навантажити",
-      "lemmaId": "навантажити",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 268
+      "newOrder": 238
     },
     {
       "cefr": "C1",
@@ -3479,7 +3093,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 269
+      "newOrder": 239
     },
     {
       "cefr": "C1",
@@ -3492,7 +3106,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 270
+      "newOrder": 240
     },
     {
       "cefr": "C1",
@@ -3505,18 +3119,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 271
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "приставка",
-      "lemmaId": "приставка",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 272
+      "newOrder": 241
     },
     {
       "cefr": "C1",
@@ -3529,7 +3132,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 273
+      "newOrder": 242
     },
     {
       "cefr": "C1",
@@ -3542,7 +3145,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 274
+      "newOrder": 243
     },
     {
       "cefr": "C1",
@@ -3555,7 +3158,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 275
+      "newOrder": 244
     },
     {
       "cefr": "C1",
@@ -3568,7 +3171,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 276
+      "newOrder": 245
     },
     {
       "cefr": "C1",
@@ -3581,7 +3184,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 277
+      "newOrder": 246
     },
     {
       "cefr": "C1",
@@ -3594,7 +3197,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 278
+      "newOrder": 247
     },
     {
       "cefr": "C1",
@@ -3607,7 +3210,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 279
+      "newOrder": 248
     },
     {
       "cefr": "C1",
@@ -3620,7 +3223,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 280
+      "newOrder": 249
     },
     {
       "cefr": "C1",
@@ -3633,7 +3236,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 281
+      "newOrder": 250
     },
     {
       "cefr": "C1",
@@ -3646,7 +3249,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 282
+      "newOrder": 251
     },
     {
       "cefr": "C1",
@@ -3657,7 +3260,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 283
+      "newOrder": 252
     },
     {
       "cefr": "C1",
@@ -3668,20 +3271,7 @@
       "modes": [
         "flashcards"
       ],
-      "newOrder": 284
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "антивоєнний",
-      "lemmaId": "антивоєнний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 285
+      "newOrder": 253
     },
     {
       "cefr": "C1",
@@ -3694,7 +3284,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 286
+      "newOrder": 254
     },
     {
       "cefr": "C1",
@@ -3707,33 +3297,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 287
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "передсвятковий",
-      "lemmaId": "передсвятковий",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 288
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "прибережний",
-      "lemmaId": "прибережний",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 289
+      "newOrder": 255
     },
     {
       "cefr": "C1",
@@ -3746,7 +3310,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 290
+      "newOrder": 256
     },
     {
       "cefr": "C1",
@@ -3759,7 +3323,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 291
+      "newOrder": 257
     },
     {
       "cefr": "C1",
@@ -3772,7 +3336,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 292
+      "newOrder": 258
     },
     {
       "cefr": "C1",
@@ -3785,7 +3349,371 @@
         "matching",
         "choice"
       ],
-      "newOrder": 293
+      "newOrder": 259
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "ад'єктивація",
+      "lemmaId": "ад-єктивація",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 260
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "архаїзм",
+      "lemmaId": "архаїзм",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 261
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "вицвілий",
+      "lemmaId": "вицвілий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 262
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "дозрілий",
+      "lemmaId": "дозрілий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 263
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "достиглий",
+      "lemmaId": "достиглий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 264
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "засохлий",
+      "lemmaId": "засохлий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 265
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "зблідлий",
+      "lemmaId": "зблідлий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 266
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "згорілий",
+      "lemmaId": "згорілий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 267
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "здичавілий",
+      "lemmaId": "здичавілий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 268
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "навислий",
+      "lemmaId": "навислий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 269
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "неперехідність",
+      "lemmaId": "неперехідність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 270
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "обвислий",
+      "lemmaId": "обвислий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 271
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "осиротілий",
+      "lemmaId": "осиротілий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 272
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "охололий",
+      "lemmaId": "охололий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 273
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "побілілий",
+      "lemmaId": "побілілий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 274
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "постарілий",
+      "lemmaId": "постарілий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 275
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "потемнілий",
+      "lemmaId": "потемнілий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 276
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "почорнілий",
+      "lemmaId": "почорнілий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 277
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "притихлий",
+      "lemmaId": "притихлий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 278
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "промоклий",
+      "lemmaId": "промоклий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 279
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "скреслий",
+      "lemmaId": "скреслий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 280
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "зволожувальний",
+      "lemmaId": "зволожувальний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 281
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "знеболювальний",
+      "lemmaId": "знеболювальний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 282
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "канцелярщина",
+      "lemmaId": "канцелярщина",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 283
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "лексикалізований",
+      "lemmaId": "лексикалізований",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 284
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "прилеглий",
+      "lemmaId": "прилеглий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 285
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "протестувальник",
+      "lemmaId": "протестувальник",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 286
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "інтерференція",
+      "lemmaId": "інтерференція",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 287
     },
     {
       "cefr": "C1",
@@ -3798,20 +3726,982 @@
         "matching",
         "choice"
       ],
+      "newOrder": 288
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "афористичність",
+      "lemmaId": "афористичність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 289
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "безособове",
+      "lemmaId": "безособове",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 290
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "неозначено-особове",
+      "lemmaId": "неозначено-особове",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 291
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "означено-особове",
+      "lemmaId": "означено-особове",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 292
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "узагальнено-особове",
+      "lemmaId": "узагальнено-особове",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 293
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "автоматизм",
+      "lemmaId": "автоматизм",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
       "newOrder": 294
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "спечений",
-      "lemmaId": "спечений",
+      "lemma": "лексикалізація",
+      "lemmaId": "лексикалізація",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
       "newOrder": 295
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "асонанс",
+      "lemmaId": "асонанс",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 296
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "метонімія",
+      "lemmaId": "метонімія",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 297
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "парцеляція",
+      "lemmaId": "парцеляція",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 298
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "троп",
+      "lemmaId": "троп",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 299
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "прилягання",
+      "lemmaId": "прилягання",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 300
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "безсполучниковий",
+      "lemmaId": "безсполучниковий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 301
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "емфаза",
+      "lemmaId": "емфаза",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 302
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "когезія",
+      "lemmaId": "когезія",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 303
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "конектор",
+      "lemmaId": "конектор",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 304
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "парцелят",
+      "lemmaId": "парцелят",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 305
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "підрядність",
+      "lemmaId": "підрядність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 306
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "реферування",
+      "lemmaId": "реферування",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 307
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "саморефлексія",
+      "lemmaId": "саморефлексія",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 308
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "складносурядний",
+      "lemmaId": "складносурядний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 309
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "сурядність",
+      "lemmaId": "сурядність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 310
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "відновлюваність",
+      "lemmaId": "відновлюваність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 311
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "дієслово-зв'язка",
+      "lemmaId": "дієслово-зв-язка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 312
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "контекстуальний",
+      "lemmaId": "контекстуальний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 313
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "лаконізм",
+      "lemmaId": "лаконізм",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 314
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "офіційно-діловий",
+      "lemmaId": "офіційно-діловий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 315
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "трикрапка",
+      "lemmaId": "трикрапка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 316
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "інтонаційний",
+      "lemmaId": "інтонаційний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 317
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "з'ясувальний",
+      "lemmaId": "з-ясувальний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 318
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "корелят",
+      "lemmaId": "корелят",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 319
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "факультативний",
+      "lemmaId": "факультативний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 320
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "додатковість",
+      "lemmaId": "додатковість",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 321
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "прикладка",
+      "lemmaId": "прикладка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 322
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "уточнювальний",
+      "lemmaId": "уточнювальний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 323
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "винаймач",
+      "lemmaId": "винаймач",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 324
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "домофон",
+      "lemmaId": "домофон",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 325
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "паркомісце",
+      "lemmaId": "паркомісце",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 326
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "скинутися",
+      "lemmaId": "скинутися",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 327
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "умебльований",
+      "lemmaId": "умебльований",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 328
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "джерельний",
+      "lemmaId": "джерельний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 329
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "контекстуалізація",
+      "lemmaId": "контекстуалізація",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 330
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "перцепція",
+      "lemmaId": "перцепція",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 331
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "ритмомелодика",
+      "lemmaId": "ритмомелодика",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 332
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "топікалізація",
+      "lemmaId": "топікалізація",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 333
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "супідрядність",
+      "lemmaId": "супідрядність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 334
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "вінчик",
+      "lemmaId": "вінчик",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 335
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "нарізавши",
+      "lemmaId": "нарізавши",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 336
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "парити",
+      "lemmaId": "парити",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 337
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "пательня",
+      "lemmaId": "пательня",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 338
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "рецептура",
+      "lemmaId": "рецептура",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 339
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "ферментований",
+      "lemmaId": "ферментований",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 340
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "цільнозерновий",
+      "lemmaId": "цільнозерновий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 341
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "маркетплейс",
+      "lemmaId": "маркетплейс",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 342
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "рекламація",
+      "lemmaId": "рекламація",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 343
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "вульгаризм",
+      "lemmaId": "вульгаризм",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 344
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "діалектизм",
+      "lemmaId": "діалектизм",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 345
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "жаргонізм",
+      "lemmaId": "жаргонізм",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 346
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "літота",
+      "lemmaId": "літота",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 347
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "оксюморон",
+      "lemmaId": "оксюморон",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 348
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "омонім",
+      "lemmaId": "омонім",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 349
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "паронім",
+      "lemmaId": "паронім",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 350
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "перифраз",
+      "lemmaId": "перифраз",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 351
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "просторіччя",
+      "lemmaId": "просторіччя",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 352
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "редактура",
+      "lemmaId": "редактура",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 353
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "синекдоха",
+      "lemmaId": "синекдоха",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 354
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "соціолект",
+      "lemmaId": "соціолект",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 355
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "чернівецький",
+      "lemmaId": "чернівецький",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 356
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "громіздкість",
+      "lemmaId": "громіздкість",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 357
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "допустовість",
+      "lemmaId": "допустовість",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 358
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "омонімічний",
+      "lemmaId": "омонімічний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 359
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "парантеза",
+      "lemmaId": "парантеза",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 360
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "повнозначний",
+      "lemmaId": "повнозначний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 361
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "нанизування",
+      "lemmaId": "нанизування",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 362
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "ритміка",
+      "lemmaId": "ритміка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 363
     },
     {
       "cefr": "C1",
@@ -3824,259 +4714,592 @@
         "matching",
         "choice"
       ],
-      "newOrder": 296
+      "newOrder": 364
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "агентність",
-      "lemmaId": "агентність",
+      "lemma": "дзвінкість",
+      "lemmaId": "дзвінкість",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 297
+      "newOrder": 365
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "бранка",
-      "lemmaId": "бранка",
+      "lemma": "звуконаслідування",
+      "lemmaId": "звуконаслідування",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 298
+      "newOrder": 366
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "бусурман",
-      "lemmaId": "бусурман",
+      "lemma": "звукопис",
+      "lemmaId": "звукопис",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 299
+      "newOrder": 367
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "віктимність",
-      "lemmaId": "віктимність",
+      "lemma": "оглушення",
+      "lemmaId": "оглушення",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 300
+      "newOrder": 368
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "віровідступництво",
-      "lemmaId": "віровідступництво",
+      "lemma": "ономатопея",
+      "lemmaId": "ономатопея",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 301
+      "newOrder": 369
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "героїка",
-      "lemmaId": "героїка",
+      "lemma": "ораторський",
+      "lemmaId": "ораторський",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 302
+      "newOrder": 370
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "мореплавство",
-      "lemmaId": "мореплавство",
+      "lemma": "плавність",
+      "lemmaId": "плавність",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 303
+      "newOrder": 371
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "поневолювач",
-      "lemmaId": "поневолювач",
+      "lemma": "редукція",
+      "lemmaId": "редукція",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 304
+      "newOrder": 372
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "попівна",
-      "lemmaId": "попівна",
+      "lemma": "валентність",
+      "lemmaId": "валентність",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 305
+      "newOrder": 373
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "потурчитися",
-      "lemmaId": "потурчитися",
+      "lemma": "колокація",
+      "lemmaId": "колокація",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 306
+      "newOrder": 374
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "работоргівля",
-      "lemmaId": "работоргівля",
+      "lemma": "плеоназм",
+      "lemmaId": "плеоназм",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 307
+      "newOrder": 375
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "ренегат",
-      "lemmaId": "ренегат",
+      "lemma": "ідіома",
+      "lemmaId": "ідіома",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 308
+      "newOrder": 376
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "темниця",
-      "lemmaId": "темниця",
+      "lemma": "домовмося",
+      "lemmaId": "домовмося",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 309
+      "newOrder": 377
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "величальний",
-      "lemmaId": "величальний",
+      "lemma": "онлайн-оплата",
+      "lemmaId": "онлайн-оплата",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 310
+      "newOrder": 378
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "веснянка",
-      "lemmaId": "веснянка",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 311
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "гагілки",
-      "lemmaId": "гагілки",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 312
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "гільце",
-      "lemmaId": "гільце",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 313
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "деколонізація",
-      "lemmaId": "деколонізація",
+      "lemma": "павербанк",
+      "lemmaId": "павербанк",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 314
+      "newOrder": 379
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "зажинки",
-      "lemmaId": "зажинки",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 315
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "закликальний",
-      "lemmaId": "закликальний",
+      "lemma": "приберімо",
+      "lemmaId": "приберімо",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 316
+      "newOrder": 380
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "предикативність",
+      "lemmaId": "предикативність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 381
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "фазовість",
+      "lemmaId": "фазовість",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 382
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "перемішується",
+      "lemmaId": "перемішується",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 383
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "субординація",
+      "lemmaId": "субординація",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 384
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "фамільярність",
+      "lemmaId": "фамільярність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 385
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "анотація",
+      "lemmaId": "анотація",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 386
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "безособовість",
+      "lemmaId": "безособовість",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 387
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "доказовість",
+      "lemmaId": "доказовість",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 388
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "парафраз",
+      "lemmaId": "парафраз",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 389
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "анафора",
+      "lemmaId": "анафора",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 390
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "епіфора",
+      "lemmaId": "епіфора",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 391
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "підтекстовий",
+      "lemmaId": "підтекстовий",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 392
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "демінутив",
+      "lemmaId": "демінутив",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 393
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "джерельність",
+      "lemmaId": "джерельність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 394
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "клікбейт",
+      "lemmaId": "клікбейт",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 395
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "самовиправлення",
+      "lemmaId": "самовиправлення",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 396
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "фреймінг",
+      "lemmaId": "фреймінг",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 397
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "катафора",
+      "lemmaId": "катафора",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 398
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "когерентність",
+      "lemmaId": "когерентність",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 399
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "переформулювання",
+      "lemmaId": "переформулювання",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 400
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "референція",
+      "lemmaId": "референція",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 401
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "акцентуація",
+      "lemmaId": "акцентуація",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 402
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "апосіопеза",
+      "lemmaId": "апосіопеза",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 403
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "симплока",
+      "lemmaId": "симплока",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 404
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "тавтологія",
+      "lemmaId": "тавтологія",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 405
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "хіазм",
+      "lemmaId": "хіазм",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 406
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "діалектний",
+      "lemmaId": "діалектний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 407
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "крашанка",
+      "lemmaId": "крашанка",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 408
+    },
+    {
+      "cefr": "C1",
+      "clozeIds": [],
+      "hasCloze": false,
+      "lemma": "нематеріальний",
+      "lemmaId": "нематеріальний",
+      "modes": [
+        "flashcards",
+        "matching",
+        "choice"
+      ],
+      "newOrder": 409
     },
     {
       "cefr": "C1",
@@ -4089,42 +5312,7 @@
         "matching",
         "choice"
       ],
-      "newOrder": 317
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "обрядовий",
-      "lemmaId": "обрядовий",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 318
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "обрядодія",
-      "lemmaId": "обрядодія",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 319
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "перформативність",
-      "lemmaId": "перформативність",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 320
+      "newOrder": 410
     },
     {
       "cefr": "C1",
@@ -4133,236 +5321,134 @@
       "lemma": "посівання",
       "lemmaId": "посівання",
       "modes": [
-        "flashcards"
+        "flashcards",
+        "matching",
+        "choice"
       ],
-      "newOrder": 321
+      "newOrder": 411
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "ряджений",
-      "lemmaId": "ряджений",
-      "modes": [
-        "flashcards"
-      ],
-      "newOrder": 322
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "синкретичний",
-      "lemmaId": "синкретичний",
+      "lemma": "ревіталізація",
+      "lemmaId": "ревіталізація",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 323
+      "newOrder": 412
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "хоровод",
-      "lemmaId": "хоровод",
+      "lemma": "щедрування",
+      "lemmaId": "щедрування",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 324
+      "newOrder": 413
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "автохтонний",
-      "lemmaId": "автохтонний",
+      "lemma": "кардіограма",
+      "lemmaId": "кардіограма",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 325
+      "newOrder": 414
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "величання",
-      "lemmaId": "величання",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 326
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "величати",
-      "lemmaId": "величати",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 327
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "дохристиянський",
-      "lemmaId": "дохристиянський",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 328
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "засівання",
-      "lemmaId": "засівання",
+      "lemma": "гайдамаччина",
+      "lemmaId": "гайдамаччина",
       "modes": [
         "flashcards"
       ],
-      "newOrder": 329
+      "newOrder": 415
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "космогонічний",
-      "lemmaId": "космогонічний",
+      "lemma": "екзонім",
+      "lemmaId": "екзонім",
       "modes": [
-        "flashcards",
-        "matching",
-        "choice"
+        "flashcards"
       ],
-      "newOrder": 330
+      "newOrder": 416
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "космогонія",
-      "lemmaId": "космогонія",
+      "lemma": "співаник",
+      "lemmaId": "співаник",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 331
+      "newOrder": 417
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "солярний",
-      "lemmaId": "солярний",
+      "lemma": "фольклоризація",
+      "lemmaId": "фольклоризація",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 332
+      "newOrder": 418
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "християнізація",
-      "lemmaId": "християнізація",
+      "lemma": "глагол",
+      "lemmaId": "глагол",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 333
+      "newOrder": 419
     },
     {
       "cefr": "C1",
       "clozeIds": [],
       "hasCloze": false,
-      "lemma": "язичницький",
-      "lemmaId": "язичницький",
+      "lemma": "кобіта",
+      "lemmaId": "кобіта",
       "modes": [
         "flashcards",
         "matching",
         "choice"
       ],
-      "newOrder": 334
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "кобзарство",
-      "lemmaId": "кобзарство",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 335
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "меншовартість",
-      "lemmaId": "меншовартість",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 336
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "речитатив",
-      "lemmaId": "речитатив",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 337
-    },
-    {
-      "cefr": "C1",
-      "clozeIds": [],
-      "hasCloze": false,
-      "lemma": "фольклористика",
-      "lemmaId": "фольклористика",
-      "modes": [
-        "flashcards",
-        "matching",
-        "choice"
-      ],
-      "newOrder": 338
+      "newOrder": 420
     }
   ],
   "level": "C1",
   "schema": "atlas-practice-index",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 5673,
+    "gzipBytes": 6941,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 88786,
+    "rawBytes": 111380,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/public/lexicon/practice-lexemes.A1.json
+++ b/site/public/lexicon/practice-lexemes.A1.json
@@ -1,5 +1,5 @@
 {
-  "deckVersion": "atlas-practice-v1-9cf4a4d7319d19ce",
+  "deckVersion": "atlas-practice-v1-c5a52e54cdf8d828",
   "level": "A1",
   "lexemes": [
     {
@@ -67,6 +67,23 @@
         "cases": {}
       },
       "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "Carpathians",
+      "glossClean": "Carpathians",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "Карпати",
+      "lemmaId": "карпати",
+      "lemmaPlain": "карпати",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "proper noun",
       "semanticBucket": null,
       "severity": null
     },
@@ -4245,6 +4262,23 @@
       "lemma": "червоний",
       "lemmaId": "червоний",
       "lemmaPlain": "червоний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "red, plural",
+      "glossClean": "red",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "червоні",
+      "lemmaId": "червоні",
+      "lemmaPlain": "червоні",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -8934,6 +8968,23 @@
     },
     {
       "cefr": "A1",
+      "gloss": "fifty",
+      "glossClean": "fifty",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "п'ятдесят",
+      "lemmaId": "п-ятдесят",
+      "lemmaPlain": "п'ятдесят",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "numeral",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
       "gloss": "five",
       "glossClean": "five",
       "heritage": "standard",
@@ -9735,6 +9786,23 @@
         "cases": {}
       },
       "pos": "conjunction",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "small, plural",
+      "glossClean": "small",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "маленькі",
+      "lemmaId": "маленькі",
+      "lemmaPlain": "маленькі",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
       "semanticBucket": null,
       "severity": null
     },
@@ -11007,6 +11075,23 @@
     },
     {
       "cefr": "A1",
+      "gloss": "ball",
+      "glossClean": "ball",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "м'яч",
+      "lemmaId": "м-яч",
+      "lemmaPlain": "м'яч",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
       "gloss": "imperative mood; command form",
       "glossClean": "imperative mood",
       "heritage": "standard",
@@ -11189,6 +11274,23 @@
     },
     {
       "cefr": "A1",
+      "gloss": "apostrophe",
+      "glossClean": "apostrophe",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "апостроф",
+      "lemmaId": "апостроф",
+      "lemmaPlain": "апостроф",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
       "gloss": "vowel sound",
       "glossClean": "vowel sound",
       "heritage": "unknown",
@@ -11201,23 +11303,6 @@
         "cases": {}
       },
       "pos": "noun phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "source / spring",
-      "glossClean": "source / spring",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "джерело",
-      "lemmaId": "джерело",
-      "lemmaPlain": "джерело",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     },
@@ -11266,7 +11351,82 @@
       "lemmaPlain": "пісня",
       "meaningMcEligible": true,
       "paradigm": {
-        "cases": {}
+        "cases": {
+          "давальний": {
+            "plural": "пісням",
+            "singular": "пісні"
+          },
+          "знахідний": {
+            "plural": "пісні",
+            "singular": "пісню"
+          },
+          "кличний": {
+            "plural": "пісні",
+            "singular": "пісне"
+          },
+          "місцевий": {
+            "plural": "піснях",
+            "singular": "пісні"
+          },
+          "називний": {
+            "plural": "пісні",
+            "singular": "пісня"
+          },
+          "орудний": {
+            "plural": "піснями",
+            "singular": "піснею"
+          },
+          "родовий": {
+            "plural": "пісень",
+            "singular": "пісні"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "capital",
+      "glossClean": "capital",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "столиця",
+      "lemmaId": "столиця",
+      "lemmaPlain": "столиця",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "столицям",
+            "singular": "столиці"
+          },
+          "знахідний": {
+            "plural": "столиці",
+            "singular": "столицю"
+          },
+          "кличний": {
+            "plural": "столиці",
+            "singular": "столице"
+          },
+          "місцевий": {
+            "plural": "столицях",
+            "singular": "столиці"
+          },
+          "називний": {
+            "plural": "столиці",
+            "singular": "столиця"
+          },
+          "орудний": {
+            "plural": "столицями",
+            "singular": "столицею"
+          },
+          "родовий": {
+            "plural": "столиць",
+            "singular": "столиці"
+          }
+        }
       },
       "pos": "noun",
       "semanticBucket": null,
@@ -11607,6 +11767,52 @@
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "spoon",
+      "glossClean": "spoon",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "ложка",
+      "lemmaId": "ложка",
+      "lemmaPlain": "ложка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "ложкам",
+            "singular": "ложці"
+          },
+          "знахідний": {
+            "plural": "ложки",
+            "singular": "ложку"
+          },
+          "кличний": {
+            "plural": "ложки",
+            "singular": "ложко"
+          },
+          "місцевий": {
+            "plural": "ложках",
+            "singular": "ложці"
+          },
+          "називний": {
+            "plural": "ложки",
+            "singular": "ложка"
+          },
+          "орудний": {
+            "plural": "ложками",
+            "singular": "ложкою"
+          },
+          "родовий": {
+            "plural": "ложок",
+            "singular": "ложки"
+          }
+        }
       },
       "pos": "noun",
       "semanticBucket": null,
@@ -12543,6 +12749,23 @@
       "lemma": "люблять",
       "lemmaId": "люблять",
       "lemmaPlain": "люблять",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb form",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "we ask for",
+      "glossClean": "we ask for",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "просимо",
+      "lemmaId": "просимо",
+      "lemmaPlain": "просимо",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -13694,6 +13917,23 @@
     },
     {
       "cefr": "A1",
+      "gloss": "Canada",
+      "glossClean": "Canada",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "Канада",
+      "lemmaId": "канада",
+      "lemmaPlain": "канада",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "proper noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
       "gloss": "country",
       "glossClean": "country",
       "heritage": "standard",
@@ -14024,6 +14264,23 @@
         "cases": {}
       },
       "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "food product",
+      "glossClean": "food product",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "продукт",
+      "lemmaId": "продукт",
+      "lemmaPlain": "продукт",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     },
@@ -15480,6 +15737,23 @@
     },
     {
       "cefr": "A1",
+      "gloss": "to use",
+      "glossClean": "to use",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "вживати",
+      "lemmaId": "вживати",
+      "lemmaPlain": "вживати",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
       "gloss": "phrase",
       "glossClean": "phrase",
       "heritage": "standard",
@@ -16024,6 +16298,23 @@
             "singular": "річки"
           }
         }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "doubt",
+      "glossClean": "doubt",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "сумнів",
+      "lemmaId": "сумнів",
+      "lemmaPlain": "сумнів",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
       },
       "pos": "noun",
       "semanticBucket": null,
@@ -17795,6 +18086,23 @@
     },
     {
       "cefr": "A1",
+      "gloss": "compounding",
+      "glossClean": "compounding",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "складання",
+      "lemmaId": "складання",
+      "lemmaPlain": "складання",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
       "gloss": "to finish, perfective",
       "glossClean": "to finish",
       "heritage": "standard",
@@ -17875,6 +18183,23 @@
         "cases": {}
       },
       "pos": "adverb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "assumption, hypothesis",
+      "glossClean": "assumption",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "припущення",
+      "lemmaId": "припущення",
+      "lemmaPlain": "припущення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:n",
       "semanticBucket": null,
       "severity": null
     },
@@ -18254,6 +18579,40 @@
     },
     {
       "cefr": "A1",
+      "gloss": "environment",
+      "glossClean": "environment",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "довкілля",
+      "lemmaId": "довкілля",
+      "lemmaPlain": "довкілля",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "ne/ni negative particles",
+      "glossClean": "ne/ni negative particles",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "не/ні",
+      "lemmaId": "не-ні",
+      "lemmaPlain": "не/ні",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "particle pair",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
       "gloss": "evaluation",
       "glossClean": "evaluation",
       "heritage": "standard",
@@ -18453,6 +18812,40 @@
     },
     {
       "cefr": "A1",
+      "gloss": "approved; adopted",
+      "glossClean": "approved",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "ухвалено",
+      "lemmaId": "ухвалено",
+      "lemmaPlain": "ухвалено",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "passive",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "contrary to (variant of усупереч)",
+      "glossClean": "contrary to (variant of усупереч)",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "всупереч",
+      "lemmaId": "всупереч",
+      "lemmaPlain": "всупереч",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "prep",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
       "gloss": "despite (+ Acc.)",
       "glossClean": "despite (+ Acc.)",
       "heritage": "standard",
@@ -18584,6 +18977,23 @@
         "cases": {}
       },
       "pos": "adverb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "to postpone, reschedule",
+      "glossClean": "to postpone",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "перенести",
+      "lemmaId": "перенести",
+      "lemmaPlain": "перенести",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb:pf",
       "semanticBucket": null,
       "severity": null
     },
@@ -18822,6 +19232,23 @@
     },
     {
       "cefr": "A1",
+      "gloss": "building, campus building",
+      "glossClean": "building",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "корпус",
+      "lemmaId": "корпус",
+      "lemmaPlain": "корпус",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
       "gloss": "it turned out, it worked",
       "glossClean": "it turned out",
       "heritage": "standard",
@@ -18868,6 +19295,23 @@
         "cases": {}
       },
       "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "whole",
+      "glossClean": "whole",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "ціле",
+      "lemmaId": "ціле",
+      "lemmaPlain": "ціле",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     },
@@ -18975,6 +19419,23 @@
     },
     {
       "cefr": "A1",
+      "gloss": "utilities",
+      "glossClean": "utilities",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "комунальні",
+      "lemmaId": "комунальні",
+      "lemmaPlain": "комунальні",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:pl",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
       "gloss": "to smoke",
       "glossClean": "to smoke",
       "heritage": "standard",
@@ -19021,6 +19482,23 @@
         "cases": {}
       },
       "pos": "form",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "courtyard",
+      "glossClean": "courtyard",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "подвір'я",
+      "lemmaId": "подвір-я",
+      "lemmaPlain": "подвір'я",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:n",
       "semanticBucket": null,
       "severity": null
     },
@@ -19468,6 +19946,23 @@
     },
     {
       "cefr": "A1",
+      "gloss": "pollution",
+      "glossClean": "pollution",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "забруднення",
+      "lemmaId": "забруднення",
+      "lemmaPlain": "забруднення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
       "gloss": "fog",
       "glossClean": "fog",
       "heritage": "standard",
@@ -19611,6 +20106,23 @@
       "lemma": "встановлено",
       "lemmaId": "встановлено",
       "lemmaPlain": "встановлено",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "form",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "is being installed",
+      "glossClean": "is being installed",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "встановлюється",
+      "lemmaId": "встановлюється",
+      "lemmaPlain": "встановлюється",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -19922,6 +20434,23 @@
     },
     {
       "cefr": "A1",
+      "gloss": "Cherkasy",
+      "glossClean": "Cherkasy",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "Черкаси",
+      "lemmaId": "черкаси",
+      "lemmaPlain": "черкаси",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "proper noun:pl",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
       "gloss": "chess",
       "glossClean": "chess",
       "heritage": "standard",
@@ -19980,6 +20509,23 @@
       "lemma": "для",
       "lemmaId": "для",
       "lemmaPlain": "для",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "preposition",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "as a result of",
+      "glossClean": "as a result of",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "унаслідок",
+      "lemmaId": "унаслідок",
+      "lemmaPlain": "унаслідок",
       "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
@@ -20585,6 +21131,23 @@
     },
     {
       "cefr": "A1",
+      "gloss": "amenities, conveniences",
+      "glossClean": "amenities",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "вигоди",
+      "lemmaId": "вигоди",
+      "lemmaPlain": "вигоди",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:pl",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
       "gloss": "construction",
       "glossClean": "construction",
       "heritage": "standard",
@@ -20874,6 +21437,23 @@
     },
     {
       "cefr": "A1",
+      "gloss": "daytime, daily",
+      "glossClean": "daytime",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "денний",
+      "lemmaId": "денний",
+      "lemmaPlain": "денний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
       "gloss": "journalist",
       "glossClean": "journalist",
       "heritage": "standard",
@@ -20959,6 +21539,108 @@
     },
     {
       "cefr": "A1",
+      "gloss": "official act, record",
+      "glossClean": "official act",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "акт",
+      "lemmaId": "акт",
+      "lemmaPlain": "акт",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "has been seized, removed",
+      "glossClean": "has been seized",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "вилучено",
+      "lemmaId": "вилучено",
+      "lemmaPlain": "вилучено",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "has been registered",
+      "glossClean": "has been registered",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "зареєстровано",
+      "lemmaId": "зареєстровано",
+      "lemmaPlain": "зареєстровано",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "has been detained",
+      "glossClean": "has been detained",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "затримано",
+      "lemmaId": "затримано",
+      "lemmaPlain": "затримано",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "has been recorded",
+      "glossClean": "has been recorded",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "зафіксовано",
+      "lemmaId": "зафіксовано",
+      "lemmaPlain": "зафіксовано",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "has been handed over, transferred",
+      "glossClean": "has been handed over",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "передано",
+      "lemmaId": "передано",
+      "lemmaPlain": "передано",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
       "gloss": "responsibility",
       "glossClean": "responsibility",
       "heritage": "standard",
@@ -20976,30 +21658,13 @@
     },
     {
       "cefr": "A1",
-      "gloss": "to carry out",
-      "glossClean": "to carry out",
+      "gloss": "expenses",
+      "glossClean": "expenses",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "здійснювати",
-      "lemmaId": "здійснювати",
-      "lemmaPlain": "здійснювати",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "liberation, release from captivity",
-      "glossClean": "liberation",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "визволення",
-      "lemmaId": "визволення",
-      "lemmaPlain": "визволення",
+      "lemma": "витрати",
+      "lemmaId": "витрати",
+      "lemmaPlain": "витрати",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -21010,13 +21675,13 @@
     },
     {
       "cefr": "A1",
-      "gloss": "captivity, being a prisoner",
-      "glossClean": "captivity",
+      "gloss": "revenue, income",
+      "glossClean": "revenue",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "полон",
-      "lemmaId": "полон",
-      "lemmaPlain": "полон",
+      "lemma": "дохід",
+      "lemmaId": "дохід",
+      "lemmaPlain": "дохід",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -21027,31 +21692,14 @@
     },
     {
       "cefr": "A1",
-      "gloss": "енергійний, діяльний",
-      "glossClean": "енергійний",
+      "gloss": "draft law",
+      "glossClean": "draft law",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "активний",
-      "lemmaId": "активний",
-      "lemmaPlain": "активний",
+      "lemma": "законопроєкт",
+      "lemmaId": "законопроєкт",
+      "lemmaPlain": "законопроєкт",
       "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "впорядкована певним чином сукупність різноманітних знаків (букв, цифр, спеціальних та службових знаків)",
-      "glossClean": "впорядкована певним чином сукупність різноманітних знаків (букв",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "алфавіт",
-      "lemmaId": "алфавіт",
-      "lemmaPlain": "алфавіт",
-      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -21061,8 +21709,93 @@
     },
     {
       "cefr": "A1",
-      "gloss": "мистецтво проектування, спорудження та художнього оздоблення будов; будівельне мистецтво",
-      "glossClean": "мистецтво проектування",
+      "gloss": "lawsuit, claim",
+      "glossClean": "lawsuit",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "позов",
+      "lemmaId": "позов",
+      "lemmaPlain": "позов",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "financing",
+      "glossClean": "financing",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "фінансування",
+      "lemmaId": "фінансування",
+      "lemmaPlain": "фінансування",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "coherence",
+      "glossClean": "coherence",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "цілісність",
+      "lemmaId": "цілісність",
+      "lemmaPlain": "цілісність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "client, customer",
+      "glossClean": "client",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "клієнт",
+      "lemmaId": "клієнт",
+      "lemmaPlain": "клієнт",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "service provider, service",
+      "glossClean": "service provider",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "сервіс",
+      "lemmaId": "сервіс",
+      "lemmaPlain": "сервіс",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "architecture",
+      "glossClean": "architecture",
       "heritage": "standard",
       "ipa": null,
       "lemma": "архітектура",
@@ -21107,161 +21840,13 @@
     },
     {
       "cefr": "A1",
-      "gloss": "який має багатство, володіє великими матеріальними цінностями; заможний; протилежне бідний. імущий",
-      "glossClean": "який має багатство",
+      "gloss": "mountain stream",
+      "glossClean": "mountain stream",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "багатий",
-      "lemmaId": "багатий",
-      "lemmaPlain": "багатий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "уживано при вказівці на ненаявність кого-, чого-небудь",
-      "glossClean": "уживано при вказівці на ненаявність кого-",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "без",
-      "lemmaId": "без",
-      "lemmaPlain": "без",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "prep",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "вищий ступінь до багато 2",
-      "glossClean": "вищий ступінь до багато 2",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "більше",
-      "lemmaId": "більше",
-      "lemmaPlain": "більше",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adv",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "різноманітної форми посудина, що використовується для квітів, фруктів, солодощів і т. ін. або як декоративна річ",
-      "glossClean": "різноманітної форми посудина",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "ваза",
-      "lemmaId": "ваза",
-      "lemmaPlain": "ваза",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "вазам",
-            "singular": "вазі"
-          },
-          "знахідний": {
-            "plural": "вази",
-            "singular": "вазу"
-          },
-          "кличний": {
-            "plural": "вази",
-            "singular": "вазо"
-          },
-          "місцевий": {
-            "plural": "вазах",
-            "singular": "вазі"
-          },
-          "називний": {
-            "plural": "вази",
-            "singular": "ваза"
-          },
-          "орудний": {
-            "plural": "вазами",
-            "singular": "вазою"
-          },
-          "родовий": {
-            "plural": "ваз",
-            "singular": "вази"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "велика довгаста посудина для миття і купання",
-      "glossClean": "велика довгаста посудина для миття і купання",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "ванна",
-      "lemmaId": "ванна",
-      "lemmaPlain": "ванна",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "прикметник до ванна",
-      "glossClean": "прикметник до ванна",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "ванний",
-      "lemmaId": "ванний",
-      "lemmaPlain": "ванний",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "merrily, cheerfully, happily",
-      "glossClean": "merrily",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "весело",
-      "lemmaId": "весело",
-      "lemmaPlain": "весело",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adv",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "footwear",
-      "glossClean": "footwear",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "взуття",
-      "lemmaId": "взуття",
-      "lemmaPlain": "взуття",
+      "lemma": "потік",
+      "lemmaId": "потік",
+      "lemmaPlain": "потік",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -21272,30 +21857,13 @@
     },
     {
       "cefr": "A1",
-      "gloss": "driver (of a vehicle)",
-      "glossClean": "driver (of a vehicle)",
+      "gloss": "removal",
+      "glossClean": "removal",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "водій",
-      "lemmaId": "водій",
-      "lemmaPlain": "водій",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "сукупність волосин, що ростуть на шкірі людини",
-      "glossClean": "сукупність волосин",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "волосся",
-      "lemmaId": "волосся",
-      "lemmaPlain": "волосся",
+      "lemma": "вилучення",
+      "lemmaId": "вилучення",
+      "lemmaPlain": "вилучення",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -21306,508 +21874,69 @@
     },
     {
       "cefr": "A1",
-      "gloss": "forward, forwards, forth, onwards, ahead, on",
-      "glossClean": "forward",
+      "gloss": "contract",
+      "glossClean": "contract",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "вперед",
-      "lemmaId": "вперед",
-      "lemmaPlain": "вперед",
+      "lemma": "договір",
+      "lemmaId": "договір",
+      "lemmaPlain": "договір",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
-      "pos": "adv",
+      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     },
     {
       "cefr": "A1",
-      "gloss": "to stand up, to get up, to rise",
-      "glossClean": "to stand up",
+      "gloss": "perception",
+      "glossClean": "perception",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "встати",
-      "lemmaId": "встати",
-      "lemmaPlain": "встати",
+      "lemma": "сприйняття",
+      "lemmaId": "сприйняття",
+      "lemmaPlain": "сприйняття",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "compliance, correspondence",
+      "glossClean": "compliance",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "відповідність",
+      "lemmaId": "відповідність",
+      "lemmaPlain": "відповідність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A1",
+      "gloss": "is carried out",
+      "glossClean": "is carried out",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "здійснюється",
+      "lemmaId": "здійснюється",
+      "lemmaPlain": "здійснюється",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
       "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "video",
-      "glossClean": "video",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "відео",
-      "lemmaId": "відео",
-      "lemmaPlain": "відео",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "відео",
-            "singular": "відео"
-          },
-          "знахідний": {
-            "plural": "відео",
-            "singular": "відео"
-          },
-          "кличний": {
-            "plural": "відео",
-            "singular": "відео"
-          },
-          "місцевий": {
-            "plural": "відео",
-            "singular": "відео"
-          },
-          "називний": {
-            "plural": "відео",
-            "singular": "відео"
-          },
-          "орудний": {
-            "plural": "відео",
-            "singular": "відео"
-          },
-          "родовий": {
-            "plural": "відео",
-            "singular": "відео"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "eighteenth",
-      "glossClean": "eighteenth",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вісімнадцятий",
-      "lemmaId": "вісімнадцятий",
-      "lemmaPlain": "вісімнадцятий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "назва числа 800 і його цифрового позначення",
-      "glossClean": "назва числа 800 і його цифрового позначення",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вісімсот",
-      "lemmaId": "вісімсот",
-      "lemmaPlain": "вісімсот",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "numr",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "періодичне, перев. щоденне, друковане на великих аркушах паперу видання, яке містить різноманітні матеріали про поточні події суспільно-політичного, культурного та економічного життя , щоб бути в курсі світової політики",
-      "glossClean": "періодичне",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "газета",
-      "lemmaId": "газета",
-      "lemmaPlain": "газета",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "газетам",
-            "singular": "газеті"
-          },
-          "знахідний": {
-            "plural": "газети",
-            "singular": "газету"
-          },
-          "кличний": {
-            "plural": "газети",
-            "singular": "газето"
-          },
-          "місцевий": {
-            "plural": "газетах",
-            "singular": "газеті"
-          },
-          "називний": {
-            "plural": "газети",
-            "singular": "газета"
-          },
-          "орудний": {
-            "plural": "газетами",
-            "singular": "газетою"
-          },
-          "родовий": {
-            "plural": "газет",
-            "singular": "газети"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "hamburger, beefburger, burger",
-      "glossClean": "hamburger",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "гамбургер",
-      "lemmaId": "гамбургер",
-      "lemmaPlain": "гамбургер",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "walnut tree, especially common walnut (Juglans regia)",
-      "glossClean": "walnut tree",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "горіх",
-      "lemmaId": "горіх",
-      "lemmaPlain": "горіх",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "female guest",
-      "glossClean": "female guest",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "гостя",
-      "lemmaId": "гостя",
-      "lemmaPlain": "гостя",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "game, play",
-      "glossClean": "game",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "гра",
-      "lemmaId": "гра",
-      "lemmaPlain": "гра",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "сукупність осіб, об'єднаних спільною працею, ідеєю і т.і",
-      "glossClean": "сукупність осіб",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "група",
-      "lemmaId": "група",
-      "lemmaPlain": "група",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "групам",
-            "singular": "групі"
-          },
-          "знахідний": {
-            "plural": "групи",
-            "singular": "групу"
-          },
-          "кличний": {
-            "plural": "групи",
-            "singular": "групо"
-          },
-          "місцевий": {
-            "plural": "групах",
-            "singular": "групі"
-          },
-          "називний": {
-            "plural": "групи",
-            "singular": "група"
-          },
-          "орудний": {
-            "plural": "групами",
-            "singular": "групою"
-          },
-          "родовий": {
-            "plural": "груп",
-            "singular": "групи"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "струнний щипковий музичний інструмент сімейства лютень",
-      "glossClean": "струнний щипковий музичний інструмент сімейства лютень",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "гітара",
-      "lemmaId": "гітара",
-      "lemmaPlain": "гітара",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "гітарам",
-            "singular": "гітарі"
-          },
-          "знахідний": {
-            "plural": "гітари",
-            "singular": "гітару"
-          },
-          "кличний": {
-            "plural": "гітари",
-            "singular": "гітаро"
-          },
-          "місцевий": {
-            "plural": "гітарах",
-            "singular": "гітарі"
-          },
-          "називний": {
-            "plural": "гітари",
-            "singular": "гітара"
-          },
-          "орудний": {
-            "plural": "гітарами",
-            "singular": "гітарою"
-          },
-          "родовий": {
-            "plural": "гітар",
-            "singular": "гітари"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "передавати від однієї особи до іншої",
-      "glossClean": "передавати від однієї особи до іншої",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "давати",
-      "lemmaId": "давати",
-      "lemmaPlain": "давати",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "long ago, a long time ago, long since",
-      "glossClean": "long ago",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "давно",
-      "lemmaId": "давно",
-      "lemmaPlain": "давно",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adv",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "twentieth",
-      "glossClean": "twentieth",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "двадцятий",
-      "lemmaId": "двадцятий",
-      "lemmaPlain": "двадцятий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "котрий має доброзичливі наміри та робить добро",
-      "glossClean": "котрий має доброзичливі наміри та робить добро",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "добрий",
-      "lemmaId": "добрий",
-      "lemmaPlain": "добрий",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "який має велику довжину волосся, що падало їй на очі",
-      "glossClean": "який має велику довжину волосся",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "довгий",
-      "lemmaId": "довгий",
-      "lemmaPlain": "довгий",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "грошова одиниця США і деяких інших країн",
-      "glossClean": "грошова одиниця США і деяких інших країн",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "долар",
-      "lemmaId": "долар",
-      "lemmaPlain": "долар",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "плоский, невеликої товщини кусок дерева, випиляний з колоди",
-      "glossClean": "плоский",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "дошка",
-      "lemmaId": "дошка",
-      "lemmaPlain": "дошка",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "сильною, великою мірою пізнім рум'яним вечором",
-      "glossClean": "сильною",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "дуже",
-      "lemmaId": "дуже",
-      "lemmaPlain": "дуже",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adv",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "пристосування для обливання тіла водяними струминками",
-      "glossClean": "пристосування для обливання тіла водяними струминками",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "душ",
-      "lemmaId": "душ",
-      "lemmaPlain": "душ",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "молода неодружена особа жіночої статі",
-      "glossClean": "молода неодружена особа жіночої статі",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "дівчина",
-      "lemmaId": "дівчина",
-      "lemmaPlain": "дівчина",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A1",
-      "gloss": "little girl",
-      "glossClean": "little girl",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "дівчинка",
-      "lemmaId": "дівчинка",
-      "lemmaPlain": "дівчинка",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     }
@@ -21815,10 +21944,10 @@
   "schema": "atlas-practice-lexemes",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 41825,
+    "gzipBytes": 41100,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 549660,
+    "rawBytes": 549735,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/public/lexicon/practice-lexemes.A2.json
+++ b/site/public/lexicon/practice-lexemes.A2.json
@@ -1,5 +1,5 @@
 {
-  "deckVersion": "atlas-practice-v1-9cf4a4d7319d19ce",
+  "deckVersion": "atlas-practice-v1-c5a52e54cdf8d828",
   "level": "A2",
   "lexemes": [
     {
@@ -33,23 +33,6 @@
         "cases": {}
       },
       "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "Carpathians",
-      "glossClean": "Carpathians",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "Карпати",
-      "lemmaId": "карпати",
-      "lemmaPlain": "карпати",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "proper noun",
       "semanticBucket": null,
       "severity": null
     },
@@ -283,6 +266,23 @@
         "cases": {}
       },
       "pos": "adverb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "spicy",
+      "glossClean": "spicy",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "гостре",
+      "lemmaId": "гостре",
+      "lemmaPlain": "гостре",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
       "semanticBucket": null,
       "severity": null
     },
@@ -773,6 +773,23 @@
     },
     {
       "cefr": "A2",
+      "gloss": "checkpoint; summary",
+      "glossClean": "checkpoint",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "підсумок",
+      "lemmaId": "підсумок",
+      "lemmaPlain": "підсумок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
       "gloss": "market",
       "glossClean": "market",
       "heritage": "standard",
@@ -899,23 +916,6 @@
         "cases": {}
       },
       "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "red, plural",
-      "glossClean": "red",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "червоні",
-      "lemmaId": "червоні",
-      "lemmaPlain": "червоні",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
       "semanticBucket": null,
       "severity": null
     },
@@ -1166,6 +1166,52 @@
         "cases": {}
       },
       "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "Friday",
+      "glossClean": "Friday",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "п'ятниця",
+      "lemmaId": "п-ятниця",
+      "lemmaPlain": "п'ятниця",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "п'ятницям",
+            "singular": "п'ятниці"
+          },
+          "знахідний": {
+            "plural": "п'ятниці",
+            "singular": "п'ятницю"
+          },
+          "кличний": {
+            "plural": "п'ятниці",
+            "singular": "п'ятнице"
+          },
+          "місцевий": {
+            "plural": "п'ятницях",
+            "singular": "п'ятниці"
+          },
+          "називний": {
+            "plural": "п'ятниці",
+            "singular": "п'ятниця"
+          },
+          "орудний": {
+            "plural": "п'ятницями",
+            "singular": "п'ятницею"
+          },
+          "родовий": {
+            "plural": "п'ятниць",
+            "singular": "п'ятниці"
+          }
+        }
+      },
+      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     },
@@ -1986,6 +2032,23 @@
     },
     {
       "cefr": "A2",
+      "gloss": "ninety",
+      "glossClean": "ninety",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "дев'яносто",
+      "lemmaId": "дев-яносто",
+      "lemmaPlain": "дев'яносто",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "numeral",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
       "gloss": "cost, plural",
       "glossClean": "cost",
       "heritage": "standard",
@@ -1998,23 +2061,6 @@
         "cases": {}
       },
       "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "fifty",
-      "glossClean": "fifty",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "п'ятдесят",
-      "lemmaId": "п-ятдесят",
-      "lemmaPlain": "п'ятдесят",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "numeral",
       "semanticBucket": null,
       "severity": null
     },
@@ -2083,6 +2129,23 @@
         "cases": {}
       },
       "pos": "numeral",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "butter (with butter form)",
+      "glossClean": "butter (with butter form)",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "маслом",
+      "lemmaId": "маслом",
+      "lemmaPlain": "маслом",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun form",
       "semanticBucket": null,
       "severity": null
     },
@@ -2180,23 +2243,6 @@
         "cases": {}
       },
       "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "small, plural",
-      "glossClean": "small",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "маленькі",
-      "lemmaId": "маленькі",
-      "lemmaPlain": "маленькі",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
       "semanticBucket": null,
       "severity": null
     },
@@ -2571,23 +2617,6 @@
     },
     {
       "cefr": "A2",
-      "gloss": "ball",
-      "glossClean": "ball",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "м'яч",
-      "lemmaId": "м-яч",
-      "lemmaPlain": "м'яч",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
       "gloss": "to sit down",
       "glossClean": "to sit down",
       "heritage": "standard",
@@ -2639,16 +2668,45 @@
     },
     {
       "cefr": "A2",
-      "gloss": "capital",
-      "glossClean": "capital",
+      "gloss": "alphabet",
+      "glossClean": "alphabet",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "столиця",
-      "lemmaId": "столиця",
-      "lemmaPlain": "столиця",
+      "lemma": "абетка",
+      "lemmaId": "абетка",
+      "lemmaPlain": "абетка",
       "meaningMcEligible": true,
       "paradigm": {
-        "cases": {}
+        "cases": {
+          "давальний": {
+            "plural": "абеткам",
+            "singular": "абетці"
+          },
+          "знахідний": {
+            "plural": "абетки",
+            "singular": "абетку"
+          },
+          "кличний": {
+            "plural": "абетки",
+            "singular": "абетко"
+          },
+          "місцевий": {
+            "plural": "абетках",
+            "singular": "абетці"
+          },
+          "називний": {
+            "plural": "абетки",
+            "singular": "абетка"
+          },
+          "орудний": {
+            "plural": "абетками",
+            "singular": "абеткою"
+          },
+          "родовий": {
+            "plural": "абеток",
+            "singular": "абетки"
+          }
+        }
       },
       "pos": "noun",
       "semanticBucket": null,
@@ -2857,16 +2915,45 @@
     },
     {
       "cefr": "A2",
-      "gloss": "stress",
-      "glossClean": "stress",
+      "gloss": "letter",
+      "glossClean": "letter",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "наголос",
-      "lemmaId": "наголос",
-      "lemmaPlain": "наголос",
+      "lemma": "літера",
+      "lemmaId": "літера",
+      "lemmaPlain": "літера",
       "meaningMcEligible": true,
       "paradigm": {
-        "cases": {}
+        "cases": {
+          "давальний": {
+            "plural": "літерам",
+            "singular": "літері"
+          },
+          "знахідний": {
+            "plural": "літери",
+            "singular": "літеру"
+          },
+          "кличний": {
+            "plural": "літери",
+            "singular": "літеро"
+          },
+          "місцевий": {
+            "plural": "літерах",
+            "singular": "літері"
+          },
+          "називний": {
+            "plural": "літери",
+            "singular": "літера"
+          },
+          "орудний": {
+            "plural": "літерами",
+            "singular": "літерою"
+          },
+          "родовий": {
+            "plural": "літер",
+            "singular": "літери"
+          }
+        }
       },
       "pos": "noun",
       "semanticBucket": null,
@@ -3260,6 +3347,23 @@
     },
     {
       "cefr": "A2",
+      "gloss": "they learn; they study",
+      "glossClean": "they learn",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "вчать",
+      "lemmaId": "вчать",
+      "lemmaPlain": "вчать",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb form",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
       "gloss": "he/she learns; he/she studies",
       "glossClean": "he/she learns",
       "heritage": "standard",
@@ -3285,23 +3389,6 @@
       "lemmaId": "говорите",
       "lemmaPlain": "говорите",
       "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb form",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "we ask for",
-      "glossClean": "we ask for",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "просимо",
-      "lemmaId": "просимо",
-      "lemmaPlain": "просимо",
-      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -3617,18 +3704,18 @@
     },
     {
       "cefr": "A2",
-      "gloss": "Canada",
-      "glossClean": "Canada",
-      "heritage": "unknown",
+      "gloss": "man from Kyiv",
+      "glossClean": "man from Kyiv",
+      "heritage": "standard",
       "ipa": null,
-      "lemma": "Канада",
-      "lemmaId": "канада",
-      "lemmaPlain": "канада",
+      "lemma": "киянин",
+      "lemmaId": "киянин",
+      "lemmaPlain": "киянин",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
-      "pos": "proper noun",
+      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     },
@@ -4394,6 +4481,23 @@
     },
     {
       "cefr": "A2",
+      "gloss": "congratulations",
+      "glossClean": "congratulations",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "вітаємо",
+      "lemmaId": "вітаємо",
+      "lemmaPlain": "вітаємо",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "interjection",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
       "gloss": "route",
       "glossClean": "route",
       "heritage": "standard",
@@ -4850,6 +4954,23 @@
         "cases": {}
       },
       "pos": "adv",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "basic",
+      "glossClean": "basic",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "базовий",
+      "lemmaId": "базовий",
+      "lemmaPlain": "базовий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
       "semanticBucket": null,
       "severity": null
     },
@@ -5394,6 +5515,23 @@
     },
     {
       "cefr": "A2",
+      "gloss": "to recognize",
+      "glossClean": "to recognize",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "впізнати",
+      "lemmaId": "впізнати",
+      "lemmaPlain": "впізнати",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
       "gloss": "guide",
       "glossClean": "guide",
       "heritage": "standard",
@@ -5491,6 +5629,23 @@
         "cases": {}
       },
       "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "description, attribute",
+      "glossClean": "description",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "означення",
+      "lemmaId": "означення",
+      "lemmaPlain": "означення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     },
@@ -6086,18 +6241,47 @@
     },
     {
       "cefr": "A2",
-      "gloss": "to use",
-      "glossClean": "to use",
+      "gloss": "pause",
+      "glossClean": "pause",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "вживати",
-      "lemmaId": "вживати",
-      "lemmaPlain": "вживати",
+      "lemma": "пауза",
+      "lemmaId": "пауза",
+      "lemmaPlain": "пауза",
       "meaningMcEligible": true,
       "paradigm": {
-        "cases": {}
+        "cases": {
+          "давальний": {
+            "plural": "паузам",
+            "singular": "паузі"
+          },
+          "знахідний": {
+            "plural": "паузи",
+            "singular": "паузу"
+          },
+          "кличний": {
+            "plural": "паузи",
+            "singular": "паузо"
+          },
+          "місцевий": {
+            "plural": "паузах",
+            "singular": "паузі"
+          },
+          "називний": {
+            "plural": "паузи",
+            "singular": "пауза"
+          },
+          "орудний": {
+            "plural": "паузами",
+            "singular": "паузою"
+          },
+          "родовий": {
+            "plural": "пауз",
+            "singular": "паузи"
+          }
+        }
       },
-      "pos": "verb",
+      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     },
@@ -6651,23 +6835,6 @@
     },
     {
       "cefr": "A2",
-      "gloss": "doubt",
-      "glossClean": "doubt",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "сумнів",
-      "lemmaId": "сумнів",
-      "lemmaPlain": "сумнів",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
       "gloss": "gold",
       "glossClean": "gold",
       "heritage": "standard",
@@ -7112,6 +7279,23 @@
         "cases": {}
       },
       "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "no, not any",
+      "glossClean": "no",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "ніякий",
+      "lemmaId": "ніякий",
+      "lemmaPlain": "ніякий",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "pronoun",
       "semanticBucket": null,
       "severity": null
     },
@@ -9139,6 +9323,23 @@
     },
     {
       "cefr": "A2",
+      "gloss": "to be located",
+      "glossClean": "to be located",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "знаходитися",
+      "lemmaId": "знаходитися",
+      "lemmaPlain": "знаходитися",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
       "gloss": "description",
       "glossClean": "description",
       "heritage": "standard",
@@ -9226,6 +9427,23 @@
       "lemma": "індекс",
       "lemmaId": "індекс",
       "lemmaPlain": "індекс",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "appetite",
+      "glossClean": "appetite",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "апетит",
+      "lemmaId": "апетит",
+      "lemmaPlain": "апетит",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -9515,6 +9733,23 @@
         "cases": {}
       },
       "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "loud",
+      "glossClean": "loud",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "гучний",
+      "lemmaId": "гучний",
+      "lemmaPlain": "гучний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
       "semanticBucket": null,
       "severity": null
     },
@@ -10263,23 +10498,6 @@
     },
     {
       "cefr": "A2",
-      "gloss": "compounding",
-      "glossClean": "compounding",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "складання",
-      "lemmaId": "складання",
-      "lemmaPlain": "складання",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
       "gloss": "faster, more quickly",
       "glossClean": "faster",
       "heritage": "standard",
@@ -10445,23 +10663,6 @@
         "cases": {}
       },
       "pos": "noun:f",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "assumption, hypothesis",
-      "glossClean": "assumption",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "припущення",
-      "lemmaId": "припущення",
-      "lemmaPlain": "припущення",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:n",
       "semanticBucket": null,
       "severity": null
     },
@@ -11763,23 +11964,6 @@
     },
     {
       "cefr": "A2",
-      "gloss": "environment",
-      "glossClean": "environment",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "довкілля",
-      "lemmaId": "довкілля",
-      "lemmaPlain": "довкілля",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
       "gloss": "is being built",
       "glossClean": "is being built",
       "heritage": "standard",
@@ -11882,40 +12066,6 @@
     },
     {
       "cefr": "A2",
-      "gloss": "approved; adopted",
-      "glossClean": "approved",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "ухвалено",
-      "lemmaId": "ухвалено",
-      "lemmaPlain": "ухвалено",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "passive",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "contrary to (variant of усупереч)",
-      "glossClean": "contrary to (variant of усупереч)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "всупереч",
-      "lemmaId": "всупереч",
-      "lemmaPlain": "всупереч",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "prep",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
       "gloss": "debate (pl. only)",
       "glossClean": "debate (pl. only)",
       "heritage": "standard",
@@ -11996,6 +12146,23 @@
     },
     {
       "cefr": "A2",
+      "gloss": "range",
+      "glossClean": "range",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "діапазон",
+      "lemmaId": "діапазон",
+      "lemmaPlain": "діапазон",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
       "gloss": "to reinforce",
       "glossClean": "to reinforce",
       "heritage": "standard",
@@ -12025,23 +12192,6 @@
         "cases": {}
       },
       "pos": "noun:n",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to postpone, reschedule",
-      "glossClean": "to postpone",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "перенести",
-      "lemmaId": "перенести",
-      "lemmaPlain": "перенести",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb:pf",
       "semanticBucket": null,
       "severity": null
     },
@@ -12348,23 +12498,6 @@
     },
     {
       "cefr": "A2",
-      "gloss": "building, campus building",
-      "glossClean": "building",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "корпус",
-      "lemmaId": "корпус",
-      "lemmaPlain": "корпус",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
       "gloss": "semester",
       "glossClean": "semester",
       "heritage": "standard",
@@ -12513,16 +12646,45 @@
     },
     {
       "cefr": "A2",
-      "gloss": "whole",
-      "glossClean": "whole",
+      "gloss": "substance, material",
+      "glossClean": "substance",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "ціле",
-      "lemmaId": "ціле",
-      "lemmaPlain": "ціле",
+      "lemma": "речовина",
+      "lemmaId": "речовина",
+      "lemmaPlain": "речовина",
       "meaningMcEligible": true,
       "paradigm": {
-        "cases": {}
+        "cases": {
+          "давальний": {
+            "plural": "речовинам",
+            "singular": "речовині"
+          },
+          "знахідний": {
+            "plural": "речовини",
+            "singular": "речовину"
+          },
+          "кличний": {
+            "plural": "речовини",
+            "singular": "речовино"
+          },
+          "місцевий": {
+            "plural": "речовинах",
+            "singular": "речовині"
+          },
+          "називний": {
+            "plural": "речовини",
+            "singular": "речовина"
+          },
+          "орудний": {
+            "plural": "речовинами",
+            "singular": "речовиною"
+          },
+          "родовий": {
+            "plural": "речовин",
+            "singular": "речовини"
+          }
+        }
       },
       "pos": "noun",
       "semanticBucket": null,
@@ -12572,6 +12734,40 @@
       "lemmaId": "слухаючи",
       "lemmaPlain": "слухаючи",
       "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "gerund",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "while smiling",
+      "glossClean": "while smiling",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "усміхаючись",
+      "lemmaId": "усміхаючись",
+      "lemmaPlain": "усміхаючись",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "gerund",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "having found out",
+      "glossClean": "having found out",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "дізнавшись",
+      "lemmaId": "дізнавшись",
+      "lemmaPlain": "дізнавшись",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -12836,23 +13032,6 @@
     },
     {
       "cefr": "A2",
-      "gloss": "utilities",
-      "glossClean": "utilities",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "комунальні",
-      "lemmaId": "комунальні",
-      "lemmaPlain": "комунальні",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:pl",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
       "gloss": "air conditioner",
       "glossClean": "air conditioner",
       "heritage": "standard",
@@ -12933,23 +13112,6 @@
         "cases": {}
       },
       "pos": "noun:f",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "courtyard",
-      "glossClean": "courtyard",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "подвір'я",
-      "lemmaId": "подвір-я",
-      "lemmaPlain": "подвір'я",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:n",
       "semanticBucket": null,
       "severity": null
     },
@@ -13244,6 +13406,23 @@
     },
     {
       "cefr": "A2",
+      "gloss": "ritual",
+      "glossClean": "ritual",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "обряд",
+      "lemmaId": "обряд",
+      "lemmaPlain": "обряд",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:m",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
       "gloss": "sculpture",
       "glossClean": "sculpture",
       "heritage": "standard",
@@ -13460,6 +13639,23 @@
         "cases": {}
       },
       "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "courier",
+      "glossClean": "courier",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "кур'єр",
+      "lemmaId": "кур-єр",
+      "lemmaPlain": "кур'єр",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:m",
       "semanticBucket": null,
       "severity": null
     },
@@ -13873,13 +14069,13 @@
     },
     {
       "cefr": "A2",
-      "gloss": "pollution",
-      "glossClean": "pollution",
+      "gloss": "nature reserve",
+      "glossClean": "nature reserve",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "забруднення",
-      "lemmaId": "забруднення",
-      "lemmaPlain": "забруднення",
+      "lemma": "заповідник",
+      "lemmaId": "заповідник",
+      "lemmaPlain": "заповідник",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -14060,6 +14256,23 @@
     },
     {
       "cefr": "A2",
+      "gloss": "presenter, speaker",
+      "glossClean": "presenter",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "доповідач",
+      "lemmaId": "доповідач",
+      "lemmaPlain": "доповідач",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:m",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
       "gloss": "cemetery",
       "glossClean": "cemetery",
       "heritage": "standard",
@@ -14072,6 +14285,23 @@
         "cases": {}
       },
       "pos": "noun:n",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "editing, installation",
+      "glossClean": "editing",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "монтаж",
+      "lemmaId": "монтаж",
+      "lemmaPlain": "монтаж",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:m",
       "semanticBucket": null,
       "severity": null
     },
@@ -14225,23 +14455,6 @@
         "cases": {}
       },
       "pos": "noun:f",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "is being installed",
-      "glossClean": "is being installed",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "встановлюється",
-      "lemmaId": "встановлюється",
-      "lemmaPlain": "встановлюється",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "form",
       "semanticBucket": null,
       "severity": null
     },
@@ -14604,6 +14817,23 @@
     },
     {
       "cefr": "A2",
+      "gloss": "pale",
+      "glossClean": "pale",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "блідий",
+      "lemmaId": "блідий",
+      "lemmaPlain": "блідий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
       "gloss": "mutual relations",
       "glossClean": "mutual relations",
       "heritage": "standard",
@@ -14917,6 +15147,52 @@
     },
     {
       "cefr": "A2",
+      "gloss": "landmark, monument, site",
+      "glossClean": "landmark",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "пам'ятка",
+      "lemmaId": "пам-ятка",
+      "lemmaPlain": "пам'ятка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "пам'яткам",
+            "singular": "пам'ятці"
+          },
+          "знахідний": {
+            "plural": "пам'ятки",
+            "singular": "пам'ятку"
+          },
+          "кличний": {
+            "plural": "пам'ятки",
+            "singular": "пам'ятко"
+          },
+          "місцевий": {
+            "plural": "пам'ятках",
+            "singular": "пам'ятці"
+          },
+          "називний": {
+            "plural": "пам'ятки",
+            "singular": "пам'ятка"
+          },
+          "орудний": {
+            "plural": "пам'ятками",
+            "singular": "пам'яткою"
+          },
+          "родовий": {
+            "plural": "пам'яток",
+            "singular": "пам'ятки"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
       "gloss": "suburb",
       "glossClean": "suburb",
       "heritage": "standard",
@@ -14946,23 +15222,6 @@
         "cases": {}
       },
       "pos": "noun:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "Cherkasy",
-      "glossClean": "Cherkasy",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "Черкаси",
-      "lemmaId": "черкаси",
-      "lemmaPlain": "черкаси",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "proper noun:pl",
       "semanticBucket": null,
       "severity": null
     },
@@ -15094,23 +15353,6 @@
     },
     {
       "cefr": "A2",
-      "gloss": "as a result of",
-      "glossClean": "as a result of",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "унаслідок",
-      "lemmaId": "унаслідок",
-      "lemmaPlain": "унаслідок",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "preposition",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
       "gloss": "near, by; takes genitive",
       "glossClean": "near",
       "heritage": "standard",
@@ -15140,6 +15382,23 @@
         "cases": {}
       },
       "pos": "preposition/adverb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "on both sides of; takes genitive",
+      "glossClean": "on both sides of",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "обабіч",
+      "lemmaId": "обабіч",
+      "lemmaPlain": "обабіч",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "preposition",
       "semanticBucket": null,
       "severity": null
     },
@@ -15305,6 +15564,23 @@
       "lemma": "ритм",
       "lemmaId": "ритм",
       "lemmaPlain": "ритм",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "excerpt",
+      "glossClean": "excerpt",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "уривок",
+      "lemmaId": "уривок",
+      "lemmaPlain": "уривок",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -15706,6 +15982,23 @@
     },
     {
       "cefr": "A2",
+      "gloss": "press conference",
+      "glossClean": "press conference",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "прес-конференція",
+      "lemmaId": "прес-конференція",
+      "lemmaPlain": "прес-конференція",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:f",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
       "gloss": "to refute, to deny",
       "glossClean": "to refute",
       "heritage": "standard",
@@ -15730,6 +16023,23 @@
       "lemma": "суверенітет",
       "lemmaId": "суверенітет",
       "lemmaPlain": "суверенітет",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:m",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "fake news, false claim",
+      "glossClean": "fake news",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "фейк",
+      "lemmaId": "фейк",
+      "lemmaPlain": "фейк",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -15769,23 +16079,6 @@
         "cases": {}
       },
       "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "amenities, conveniences",
-      "glossClean": "amenities",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вигоди",
-      "lemmaId": "вигоди",
-      "lemmaPlain": "вигоди",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:pl",
       "semanticBucket": null,
       "severity": null
     },
@@ -16029,6 +16322,23 @@
     },
     {
       "cefr": "A2",
+      "gloss": "documentation",
+      "glossClean": "documentation",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "документація",
+      "lemmaId": "документація",
+      "lemmaPlain": "документація",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:f",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
       "gloss": "oblivion; forgetting",
       "glossClean": "oblivion",
       "heritage": "standard",
@@ -16182,23 +16492,6 @@
     },
     {
       "cefr": "A2",
-      "gloss": "daytime, daily",
-      "glossClean": "daytime",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "денний",
-      "lemmaId": "денний",
-      "lemmaPlain": "денний",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
       "gloss": "Kyivan",
       "glossClean": "Kyivan",
       "heritage": "standard",
@@ -16330,6 +16623,23 @@
     },
     {
       "cefr": "A2",
+      "gloss": "to resign, to leave a job",
+      "glossClean": "to resign",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "звільнитися",
+      "lemmaId": "звільнитися",
+      "lemmaPlain": "звільнитися",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb:pf",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
       "gloss": "employment, hiring process",
       "glossClean": "employment",
       "heritage": "standard",
@@ -16347,6 +16657,23 @@
     },
     {
       "cefr": "A2",
+      "gloss": "employer",
+      "glossClean": "employer",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "роботодавець",
+      "lemmaId": "роботодавець",
+      "lemmaPlain": "роботодавець",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:m",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
       "gloss": "internship, traineeship",
       "glossClean": "internship",
       "heritage": "standard",
@@ -16359,6 +16686,904 @@
         "cases": {}
       },
       "pos": "noun:n",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "user",
+      "glossClean": "user",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "користувач",
+      "lemmaId": "користувач",
+      "lemmaPlain": "користувач",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "willing participants, volunteers",
+      "glossClean": "willing participants",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "охочі",
+      "lemmaId": "охочі",
+      "lemmaPlain": "охочі",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "has been published, made public",
+      "glossClean": "has been published",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "оприлюднено",
+      "lemmaId": "оприлюднено",
+      "lemmaPlain": "оприлюднено",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "instrument, tool",
+      "glossClean": "instrument",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "інструмент",
+      "lemmaId": "інструмент",
+      "lemmaPlain": "інструмент",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "distancing",
+      "glossClean": "distancing",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "відсторонення",
+      "lemmaId": "відсторонення",
+      "lemmaPlain": "відсторонення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "generalization",
+      "glossClean": "generalization",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "узагальнення",
+      "lemmaId": "узагальнення",
+      "lemmaPlain": "узагальнення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "audit",
+      "glossClean": "audit",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "аудит",
+      "lemmaId": "аудит",
+      "lemmaPlain": "аудит",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "democracy",
+      "glossClean": "democracy",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "демократія",
+      "lemmaId": "демократія",
+      "lemmaPlain": "демократія",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "демократіям",
+            "singular": "демократії"
+          },
+          "знахідний": {
+            "plural": "демократії",
+            "singular": "демократію"
+          },
+          "кличний": {
+            "plural": "демократії",
+            "singular": "демократіє"
+          },
+          "місцевий": {
+            "plural": "демократіях",
+            "singular": "демократії"
+          },
+          "називний": {
+            "plural": "демократії",
+            "singular": "демократія"
+          },
+          "орудний": {
+            "plural": "демократіями",
+            "singular": "демократією"
+          },
+          "родовий": {
+            "plural": "демократій",
+            "singular": "демократії"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "corruption",
+      "glossClean": "corruption",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "корупція",
+      "lemmaId": "корупція",
+      "lemmaPlain": "корупція",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "корупціям",
+            "singular": "корупції"
+          },
+          "знахідний": {
+            "plural": "корупції",
+            "singular": "корупцію"
+          },
+          "кличний": {
+            "plural": "корупції",
+            "singular": "корупціє"
+          },
+          "місцевий": {
+            "plural": "корупціях",
+            "singular": "корупції"
+          },
+          "називний": {
+            "plural": "корупції",
+            "singular": "корупція"
+          },
+          "орудний": {
+            "plural": "корупціями",
+            "singular": "корупцією"
+          },
+          "родовий": {
+            "plural": "корупцій",
+            "singular": "корупції"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "mandate",
+      "glossClean": "mandate",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "мандат",
+      "lemmaId": "мандат",
+      "lemmaPlain": "мандат",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "transparency",
+      "glossClean": "transparency",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "прозорість",
+      "lemmaId": "прозорість",
+      "lemmaPlain": "прозорість",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "to expand, to spell out",
+      "glossClean": "to expand",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "розгорнути",
+      "lemmaId": "розгорнути",
+      "lemmaPlain": "розгорнути",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "clarification",
+      "glossClean": "clarification",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "уточнення",
+      "lemmaId": "уточнення",
+      "lemmaPlain": "уточнення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "fragment",
+      "glossClean": "fragment",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "фрагмент",
+      "lemmaId": "фрагмент",
+      "lemmaPlain": "фрагмент",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "required",
+      "glossClean": "required",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "обов'язковий",
+      "lemmaId": "обов-язковий",
+      "lemmaPlain": "обов'язковий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "to compensate, reimburse",
+      "glossClean": "to compensate",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "відшкодувати",
+      "lemmaId": "відшкодувати",
+      "lemmaPlain": "відшкодувати",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "developer, builder",
+      "glossClean": "developer",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "забудовник",
+      "lemmaId": "забудовник",
+      "lemmaPlain": "забудовник",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "to record, to document",
+      "glossClean": "to record",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "зафіксувати",
+      "lemmaId": "зафіксувати",
+      "lemmaPlain": "зафіксувати",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "to compensate",
+      "glossClean": "to compensate",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "компенсувати",
+      "lemmaId": "компенсувати",
+      "lemmaPlain": "компенсувати",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "real estate",
+      "glossClean": "real estate",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "нерухомість",
+      "lemmaId": "нерухомість",
+      "lemmaPlain": "нерухомість",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "arrangement, furnishing",
+      "glossClean": "arrangement",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "облаштування",
+      "lemmaId": "облаштування",
+      "lemmaPlain": "облаштування",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "to rent, to lease",
+      "glossClean": "to rent",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "орендувати",
+      "lemmaId": "орендувати",
+      "lemmaPlain": "орендувати",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "condominium association",
+      "glossClean": "condominium association",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "ОСББ",
+      "lemmaId": "осбб",
+      "lemmaPlain": "осбб",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "to approve, to agree",
+      "glossClean": "to approve",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "погодити",
+      "lemmaId": "погодити",
+      "lemmaPlain": "погодити",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "to paint",
+      "glossClean": "to paint",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "пофарбувати",
+      "lemmaId": "пофарбувати",
+      "lemmaPlain": "пофарбувати",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "contractor",
+      "glossClean": "contractor",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "підрядник",
+      "lemmaId": "підрядник",
+      "lemmaPlain": "підрядник",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "stairs",
+      "glossClean": "stairs",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "сходи",
+      "lemmaId": "сходи",
+      "lemmaPlain": "сходи",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "to agree, to coordinate",
+      "glossClean": "to agree",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "узгодити",
+      "lemmaId": "узгодити",
+      "lemmaPlain": "узгодити",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "to stress, to emphasize",
+      "glossClean": "to stress",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "наголосити",
+      "lemmaId": "наголосити",
+      "lemmaPlain": "наголосити",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "indirect",
+      "glossClean": "indirect",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "непрямий",
+      "lemmaId": "непрямий",
+      "lemmaPlain": "непрямий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "to suppose",
+      "glossClean": "to suppose",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "припустити",
+      "lemmaId": "припустити",
+      "lemmaPlain": "припустити",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "to boil, to cook in liquid",
+      "glossClean": "to boil",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "варити",
+      "lemmaId": "варити",
+      "lemmaPlain": "варити",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "grams",
+      "glossClean": "grams",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "грамів",
+      "lemmaId": "грамів",
+      "lemmaPlain": "грамів",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "to fry",
+      "glossClean": "to fry",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "смажити",
+      "lemmaId": "смажити",
+      "lemmaPlain": "смажити",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "shopping cart",
+      "glossClean": "shopping cart",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "кошик",
+      "lemmaId": "кошик",
+      "lemmaPlain": "кошик",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "service",
+      "glossClean": "service",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "послуга",
+      "lemmaId": "послуга",
+      "lemmaPlain": "послуга",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "послугам",
+            "singular": "послузі"
+          },
+          "знахідний": {
+            "plural": "послуги",
+            "singular": "послугу"
+          },
+          "кличний": {
+            "plural": "послуги",
+            "singular": "послуго"
+          },
+          "місцевий": {
+            "plural": "послугах",
+            "singular": "послузі"
+          },
+          "називний": {
+            "plural": "послуги",
+            "singular": "послуга"
+          },
+          "орудний": {
+            "plural": "послугами",
+            "singular": "послугою"
+          },
+          "родовий": {
+            "plural": "послуг",
+            "singular": "послуги"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "consumer",
+      "glossClean": "consumer",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "споживач",
+      "lemmaId": "споживач",
+      "lemmaPlain": "споживач",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "professional term",
+      "glossClean": "professional term",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "професіоналізм",
+      "lemmaId": "професіоналізм",
+      "lemmaPlain": "професіоналізм",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "facade",
+      "glossClean": "facade",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "фасад",
+      "lemmaId": "фасад",
+      "lemmaPlain": "фасад",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "certainty",
+      "glossClean": "certainty",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "упевненість",
+      "lemmaId": "упевненість",
+      "lemmaPlain": "упевненість",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "taken into account",
+      "glossClean": "taken into account",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "враховано",
+      "lemmaId": "враховано",
+      "lemmaPlain": "враховано",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "discourse",
+      "glossClean": "discourse",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "дискурс",
+      "lemmaId": "дискурс",
+      "lemmaPlain": "дискурс",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "ensured, provided",
+      "glossClean": "ensured",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "забезпечено",
+      "lemmaId": "забезпечено",
+      "lemmaPlain": "забезпечено",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "to publish, to make public",
+      "glossClean": "to publish",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "оприлюднити",
+      "lemmaId": "оприлюднити",
+      "lemmaPlain": "оприлюднити",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "approved, agreed",
+      "glossClean": "approved",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "погоджено",
+      "lemmaId": "погоджено",
+      "lemmaPlain": "погоджено",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "edit, correction",
+      "glossClean": "edit",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "правка",
+      "lemmaId": "правка",
+      "lemmaPlain": "правка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "правкам",
+            "singular": "правці"
+          },
+          "знахідний": {
+            "plural": "правки",
+            "singular": "правку"
+          },
+          "кличний": {
+            "plural": "правки",
+            "singular": "правко"
+          },
+          "місцевий": {
+            "plural": "правках",
+            "singular": "правці"
+          },
+          "називний": {
+            "plural": "правки",
+            "singular": "правка"
+          },
+          "орудний": {
+            "plural": "правками",
+            "singular": "правкою"
+          },
+          "родовий": {
+            "plural": "правок",
+            "singular": "правки"
+          }
+        }
+      },
+      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     },
@@ -16432,57 +17657,6 @@
     },
     {
       "cefr": "A2",
-      "gloss": "published, made public",
-      "glossClean": "published",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "оприлюднено",
-      "lemmaId": "оприлюднено",
-      "lemmaPlain": "оприлюднено",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "other",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to publish, make public",
-      "glossClean": "to publish",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "оприлюднити",
-      "lemmaId": "оприлюднити",
-      "lemmaPlain": "оприлюднити",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to adopt, approve",
-      "glossClean": "to adopt",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "ухвалити",
-      "lemmaId": "ухвалити",
-      "lemmaPlain": "ухвалити",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
       "gloss": "approved, confirmed",
       "glossClean": "approved",
       "heritage": "standard",
@@ -16517,13 +17691,13 @@
     },
     {
       "cefr": "A2",
-      "gloss": "ransom",
-      "glossClean": "ransom",
+      "gloss": "tension",
+      "glossClean": "tension",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "викуп",
-      "lemmaId": "викуп",
-      "lemmaPlain": "викуп",
+      "lemma": "напруження",
+      "lemmaId": "напруження",
+      "lemmaPlain": "напруження",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -16534,13 +17708,13 @@
     },
     {
       "cefr": "A2",
-      "gloss": "motif; recurring image or formula",
-      "glossClean": "motif",
-      "heritage": "standard",
+      "gloss": "vacuum cleaner",
+      "glossClean": "vacuum cleaner",
+      "heritage": "russianism",
       "ipa": null,
-      "lemma": "мотив",
-      "lemmaId": "мотив",
-      "lemmaPlain": "мотив",
+      "lemma": "пилосос",
+      "lemmaId": "пилосос",
+      "lemmaPlain": "пилосос",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -16551,13 +17725,13 @@
     },
     {
       "cefr": "A2",
-      "gloss": "hostess; mistress of the house",
-      "glossClean": "hostess",
+      "gloss": "daily life, household life",
+      "glossClean": "daily life",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "господиня",
-      "lemmaId": "господиня",
-      "lemmaPlain": "господиня",
+      "lemma": "побут",
+      "lemmaId": "побут",
+      "lemmaPlain": "побут",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -16568,76 +17742,13 @@
     },
     {
       "cefr": "A2",
-      "gloss": "appropriation (here: cultural appropriation)",
-      "glossClean": "appropriation (here: cultural appropriation)",
+      "gloss": "cleaning",
+      "glossClean": "cleaning",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "привласнення",
-      "lemmaId": "привласнення",
-      "lemmaPlain": "привласнення",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "reconstruction (e.g. of an archaic layer by later scholars)",
-      "glossClean": "reconstruction (e.g. of an archaic layer by later scholars)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "реконструкція",
-      "lemmaId": "реконструкція",
-      "lemmaPlain": "реконструкція",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "реконструкціям",
-            "singular": "реконструкції"
-          },
-          "знахідний": {
-            "plural": "реконструкції",
-            "singular": "реконструкцію"
-          },
-          "кличний": {
-            "plural": "реконструкції",
-            "singular": "реконструкціє"
-          },
-          "місцевий": {
-            "plural": "реконструкціях",
-            "singular": "реконструкції"
-          },
-          "називний": {
-            "plural": "реконструкції",
-            "singular": "реконструкція"
-          },
-          "орудний": {
-            "plural": "реконструкціями",
-            "singular": "реконструкцією"
-          },
-          "родовий": {
-            "plural": "реконструкцій",
-            "singular": "реконструкції"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "resistance",
-      "glossClean": "resistance",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "спротив",
-      "lemmaId": "спротив",
-      "lemmaPlain": "спротив",
+      "lemma": "прибирання",
+      "lemmaId": "прибирання",
+      "lemmaPlain": "прибирання",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -16648,190 +17759,13 @@
     },
     {
       "cefr": "A2",
-      "gloss": "identity (cultural)",
-      "glossClean": "identity (cultural)",
+      "gloss": "every morning",
+      "glossClean": "every morning",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "ідентичність",
-      "lemmaId": "ідентичність",
-      "lemmaPlain": "ідентичність",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "bandura",
-      "glossClean": "bandura",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "бандура",
-      "lemmaId": "бандура",
-      "lemmaPlain": "бандура",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "бандурам",
-            "singular": "бандурі"
-          },
-          "знахідний": {
-            "plural": "бандури",
-            "singular": "бандуру"
-          },
-          "кличний": {
-            "plural": "бандури",
-            "singular": "бандуро"
-          },
-          "місцевий": {
-            "plural": "бандурах",
-            "singular": "бандурі"
-          },
-          "називний": {
-            "plural": "бандури",
-            "singular": "бандура"
-          },
-          "орудний": {
-            "plural": "бандурами",
-            "singular": "бандурою"
-          },
-          "родовий": {
-            "plural": "бандур",
-            "singular": "бандури"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "ritual procession, the round",
-      "glossClean": "ritual procession",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "обхід",
-      "lemmaId": "обхід",
-      "lemmaPlain": "обхід",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "folklore",
-      "glossClean": "folklore",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "фольклор",
-      "lemmaId": "фольклор",
-      "lemmaPlain": "фольклор",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "самохідна машина з двигуном внутрішнього згоряння для перевезення пасажирів і вантажів безрейковими дорогами",
-      "glossClean": "самохідна машина з двигуном внутрішнього згоряння для перевезення пасажирів і вантажів безрейковими дорогами",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "автомобіль",
-      "lemmaId": "автомобіль",
-      "lemmaPlain": "автомобіль",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "той, хто написав будь-яку працю, твір, картину, лист або розробив якийсь проект і ін.; той, хто має право володіти авторством на якусь річ",
-      "glossClean": "той",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "автор",
-      "lemmaId": "автор",
-      "lemmaPlain": "автор",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "назва найвищих державних наукових установ, завданням яких є розвиток наук або мистецтв",
-      "glossClean": "назва найвищих державних наукових установ",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "академія",
-      "lemmaId": "академія",
-      "lemmaPlain": "академія",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "академіям",
-            "singular": "академії"
-          },
-          "знахідний": {
-            "plural": "академії",
-            "singular": "академію"
-          },
-          "кличний": {
-            "plural": "академії",
-            "singular": "академіє"
-          },
-          "місцевий": {
-            "plural": "академіях",
-            "singular": "академії"
-          },
-          "називний": {
-            "plural": "академії",
-            "singular": "академія"
-          },
-          "орудний": {
-            "plural": "академіями",
-            "singular": "академією"
-          },
-          "родовий": {
-            "plural": "академій",
-            "singular": "академії"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "Прислівник до активний",
-      "glossClean": "Прислівник до активний",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "активно",
-      "lemmaId": "активно",
-      "lemmaPlain": "активно",
+      "lemma": "щоранку",
+      "lemmaId": "щоранку",
+      "lemmaPlain": "щоранку",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -16842,229 +17776,13 @@
     },
     {
       "cefr": "A2",
-      "gloss": "цінний папір, який свідчить про внесення паю в акціонерне товариство і дає право на отримання доходу у вигляді дивіденду",
-      "glossClean": "цінний папір",
+      "gloss": "is being performed",
+      "glossClean": "is being performed",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "акція",
-      "lemmaId": "акція",
-      "lemmaPlain": "акція",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "акціям",
-            "singular": "акції"
-          },
-          "знахідний": {
-            "plural": "акції",
-            "singular": "акцію"
-          },
-          "кличний": {
-            "plural": "акції",
-            "singular": "акціє"
-          },
-          "місцевий": {
-            "plural": "акціях",
-            "singular": "акції"
-          },
-          "називний": {
-            "plural": "акції",
-            "singular": "акція"
-          },
-          "орудний": {
-            "plural": "акціями",
-            "singular": "акцією"
-          },
-          "родовий": {
-            "plural": "акцій",
-            "singular": "акції"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "винний спирт",
-      "glossClean": "винний спирт",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "алкоголь",
-      "lemmaId": "алкоголь",
-      "lemmaPlain": "алкоголь",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "antibiotic",
-      "glossClean": "antibiotic",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "антибіотик",
-      "lemmaId": "антибіотик",
-      "lemmaPlain": "антибіотик",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "однорічна трав'яниста олійна рослина родини Бобових; земляний (китайський) горіх",
-      "glossClean": "однорічна трав'яниста олійна рослина родини Бобових",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "арахіс",
-      "lemmaId": "арахіс",
-      "lemmaPlain": "арахіс",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "Який виділяє аромат (у 1 знач.); запашний",
-      "glossClean": "Який виділяє аромат (у 1 знач.)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "ароматний",
-      "lemmaId": "ароматний",
-      "lemmaPlain": "ароматний",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "Фахівець в галузі архітектури; будівничий",
-      "glossClean": "Фахівець в галузі архітектури",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "архітектор",
-      "lemmaId": "архітектор",
-      "lemmaPlain": "архітектор",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "automated teller machine, ATM, cash machine",
-      "glossClean": "automated teller machine",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "банкомат",
-      "lemmaId": "банкомат",
-      "lemmaPlain": "банкомат",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "невеликий ресторан, в якому напої і закуски споживають біля стойки буфету або за столиками",
-      "glossClean": "невеликий ресторан",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "бар",
-      "lemmaId": "бар",
-      "lemmaPlain": "бар",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "який не потребує коштів, оплати; безплатний",
-      "glossClean": "який не потребує коштів",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "безкоштовний",
-      "lemmaId": "безкоштовний",
-      "lemmaPlain": "безкоштовний",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "прислівник до безкоштовний",
-      "glossClean": "прислівник до безкоштовний",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "безкоштовно",
-      "lemmaId": "безкоштовно",
-      "lemmaPlain": "безкоштовно",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adv",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "який не має в собі небезпеки або захищає кого-, що-небудь від небезпеки",
-      "glossClean": "який не має в собі небезпеки або захищає кого-",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "безпечний",
-      "lemmaId": "безпечний",
-      "lemmaPlain": "безпечний",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "стукати, ударяти по чому-небудь, об щось по клавішах і тріпала стиркою по струнах фортеп'яно, витираючи його",
-      "glossClean": "стукати",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "бити",
-      "lemmaId": "бити",
-      "lemmaPlain": "бити",
+      "lemma": "виконується",
+      "lemmaId": "виконується",
+      "lemmaPlain": "виконується",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -17075,173 +17793,13 @@
     },
     {
       "cefr": "A2",
-      "gloss": "blessing",
-      "glossClean": "blessing",
+      "gloss": "is being added",
+      "glossClean": "is being added",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "благословення",
-      "lemmaId": "благословення",
-      "lemmaPlain": "благословення",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "с.",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "який є або відбувається на невеликій відстані; недалекий; протилежне далекий",
-      "glossClean": "який є або відбувається на невеликій відстані",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "близький",
-      "lemmaId": "близький",
-      "lemmaPlain": "близький",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "зиґзаґоподібна електрична іскра — наслідок розряду атмосферної електрики в повітрі, що буває під час грози",
-      "glossClean": "зиґзаґоподібна електрична іскра — наслідок розряду атмосферної електрики в повітрі",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "блискавка",
-      "lemmaId": "блискавка",
-      "lemmaPlain": "блискавка",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "блискавкам",
-            "singular": "блискавці"
-          },
-          "знахідний": {
-            "plural": "блискавки",
-            "singular": "блискавку"
-          },
-          "кличний": {
-            "plural": "блискавки",
-            "singular": "блискавко"
-          },
-          "місцевий": {
-            "plural": "блискавках",
-            "singular": "блискавці"
-          },
-          "називний": {
-            "plural": "блискавки",
-            "singular": "блискавка"
-          },
-          "орудний": {
-            "plural": "блискавками",
-            "singular": "блискавкою"
-          },
-          "родовий": {
-            "plural": "блискавок",
-            "singular": "блискавки"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "blog",
-      "glossClean": "blog",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "блог",
-      "lemmaId": "блог",
-      "lemmaPlain": "блог",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "god",
-      "glossClean": "god",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "бог",
-      "lemmaId": "бог",
-      "lemmaPlain": "бог",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "дугаста смужка волосся над очною ямкою",
-      "glossClean": "дугаста смужка волосся над очною ямкою",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "брова",
-      "lemmaId": "брова",
-      "lemmaPlain": "брова",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "бровам",
-            "singular": "брові"
-          },
-          "знахідний": {
-            "plural": "брови",
-            "singular": "брову"
-          },
-          "кличний": {
-            "plural": "брови",
-            "singular": "брово"
-          },
-          "місцевий": {
-            "plural": "бровах",
-            "singular": "брові"
-          },
-          "називний": {
-            "plural": "брови",
-            "singular": "брова"
-          },
-          "орудний": {
-            "plural": "бровами",
-            "singular": "бровою"
-          },
-          "родовий": {
-            "plural": "брів",
-            "singular": "брови"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "існувати, бути (з відтінком багатократності)",
-      "glossClean": "існувати",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "бувати",
-      "lemmaId": "бувати",
-      "lemmaPlain": "бувати",
+      "lemma": "додається",
+      "lemmaId": "додається",
+      "lemmaPlain": "додається",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -17252,208 +17810,14 @@
     },
     {
       "cefr": "A2",
-      "gloss": "чистий відвар з м'яса без овочів і приправ",
-      "glossClean": "чистий відвар з м'яса без овочів і приправ",
+      "gloss": "is being monitored",
+      "glossClean": "is being monitored",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "бульйон",
-      "lemmaId": "бульйон",
-      "lemmaPlain": "бульйон",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "комерційна, біржова або підприємницька діяльність",
-      "glossClean": "комерційна",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "бізнес",
-      "lemmaId": "бізнес",
-      "lemmaPlain": "бізнес",
+      "lemma": "контролюється",
+      "lemmaId": "контролюється",
+      "lemmaPlain": "контролюється",
       "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "більша частина, більша кількість кого-, чого-небудь",
-      "glossClean": "більша частина",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "більшість",
-      "lemmaId": "більшість",
-      "lemmaPlain": "більшість",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "сила, з якою тіло притягується до центра Землі на якійсь географічній широті",
-      "glossClean": "сила",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вага",
-      "lemmaId": "вага",
-      "lemmaPlain": "вага",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "вагам",
-            "singular": "вазі"
-          },
-          "знахідний": {
-            "plural": "ваги",
-            "singular": "вагу"
-          },
-          "кличний": {
-            "plural": "ваги",
-            "singular": "ваго"
-          },
-          "місцевий": {
-            "plural": "вагах",
-            "singular": "вазі"
-          },
-          "називний": {
-            "plural": "ваги",
-            "singular": "вага"
-          },
-          "орудний": {
-            "plural": "вагами",
-            "singular": "вагою"
-          },
-          "родовий": {
-            "plural": "ваг",
-            "singular": "ваги"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "який має велику вагу; тяжкий",
-      "glossClean": "який має велику вагу",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "важкий",
-      "lemmaId": "важкий",
-      "lemmaPlain": "важкий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "має значення; істотно, потрібно",
-      "glossClean": "має значення",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "важливо",
-      "lemmaId": "важливо",
-      "lemmaPlain": "важливо",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adv",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "горщик для квітів",
-      "glossClean": "горщик для квітів",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вазон",
-      "lemmaId": "вазон",
-      "lemmaPlain": "вазон",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "грошова одиниця, прийнята за основу грошової системи певної країни",
-      "glossClean": "грошова одиниця",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "валюта",
-      "lemmaId": "валюта",
-      "lemmaPlain": "валюта",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "валютам",
-            "singular": "валюті"
-          },
-          "знахідний": {
-            "plural": "валюти",
-            "singular": "валюту"
-          },
-          "кличний": {
-            "plural": "валюти",
-            "singular": "валюто"
-          },
-          "місцевий": {
-            "plural": "валютах",
-            "singular": "валюті"
-          },
-          "називний": {
-            "plural": "валюти",
-            "singular": "валюта"
-          },
-          "орудний": {
-            "plural": "валютами",
-            "singular": "валютою"
-          },
-          "родовий": {
-            "plural": "валют",
-            "singular": "валюти"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "кип'ятити у воді або в іншій рідині якісь харчові продукти і т. ін., готуючи страву, напій",
-      "glossClean": "кип'ятити у воді або в іншій рідині якісь харчові продукти і т. ін.",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "варити",
-      "lemmaId": "варити",
-      "lemmaPlain": "варити",
-      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -17463,47 +17827,110 @@
     },
     {
       "cefr": "A2",
-      "gloss": "виражена у грошах ціна чого-небудь",
-      "glossClean": "виражена у грошах ціна чого-небудь",
+      "gloss": "is being discussed",
+      "glossClean": "is being discussed",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "обговорюється",
+      "lemmaId": "обговорюється",
+      "lemmaPlain": "обговорюється",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "is being transferred",
+      "glossClean": "is being transferred",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "передається",
+      "lemmaId": "передається",
+      "lemmaPlain": "передається",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "regulation, procedure manual",
+      "glossClean": "regulation",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "регламент",
+      "lemmaId": "регламент",
+      "lemmaPlain": "регламент",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "alternative",
+      "glossClean": "alternative",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "альтернатива",
+      "lemmaId": "альтернатива",
+      "lemmaPlain": "альтернатива",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "альтернативам",
+            "singular": "альтернативі"
+          },
+          "знахідний": {
+            "plural": "альтернативи",
+            "singular": "альтернативу"
+          },
+          "кличний": {
+            "plural": "альтернативи",
+            "singular": "альтернативо"
+          },
+          "місцевий": {
+            "plural": "альтернативах",
+            "singular": "альтернативі"
+          },
+          "називний": {
+            "plural": "альтернативи",
+            "singular": "альтернатива"
+          },
+          "орудний": {
+            "plural": "альтернативами",
+            "singular": "альтернативою"
+          },
+          "родовий": {
+            "plural": "альтернатив",
+            "singular": "альтернативи"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "cost, price",
+      "glossClean": "cost",
       "heritage": "standard",
       "ipa": null,
       "lemma": "вартість",
       "lemmaId": "вартість",
       "lemmaPlain": "вартість",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "за напрямком від землі у висоту; вниз",
-      "glossClean": "за напрямком від землі у висоту",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вгору",
-      "lemmaId": "вгору",
-      "lemmaPlain": "вгору",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adv",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "людина, яка не вживає м'яса і харчується тільки рослинною й молочною їжею; послідовник, прихильник вегетаріанства",
-      "glossClean": "людина",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вегетаріанець",
-      "lemmaId": "вегетаріанець",
-      "lemmaPlain": "вегетаріанець",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -17514,149 +17941,13 @@
     },
     {
       "cefr": "A2",
-      "gloss": "female equivalent of вегетаріа́нець (vehetariánecʹ): vegetarian",
-      "glossClean": "female equivalent of вегетаріа́нець (vehetariánecʹ): vegetarian",
+      "gloss": "partnership",
+      "glossClean": "partnership",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "вегетаріанка",
-      "lemmaId": "вегетаріанка",
-      "lemmaPlain": "вегетаріанка",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "прикметник до вегетаріанство і вегетаріанець",
-      "glossClean": "прикметник до вегетаріанство і вегетаріанець",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вегетаріанський",
-      "lemmaId": "вегетаріанський",
-      "lemmaPlain": "вегетаріанський",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "великий хижий ссавець з незграбним масивним тілом, укритий густою шерстю",
-      "glossClean": "великий хижий ссавець з незграбним масивним тілом",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "ведмідь",
-      "lemmaId": "ведмідь",
-      "lemmaPlain": "ведмідь",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "spring (attributive), vernal (of or pertaining to springtime)",
-      "glossClean": "spring (attributive)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "весняний",
-      "lemmaId": "весняний",
-      "lemmaPlain": "весняний",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "evening (attributive)",
-      "glossClean": "evening (attributive)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вечірній",
-      "lemmaId": "вечірній",
-      "lemmaPlain": "вечірній",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to put on (shoes)",
-      "glossClean": "to put on (shoes)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "взути",
-      "lemmaId": "взути",
-      "lemmaPlain": "взути",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to excuse, to pardon, to forgive",
-      "glossClean": "to excuse",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вибачити",
-      "lemmaId": "вибачити",
-      "lemmaPlain": "вибачити",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to choose, to select, to pick, to opt for",
-      "glossClean": "to choose",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вибирати",
-      "lemmaId": "вибирати",
-      "lemmaPlain": "вибирати",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "сукупність зовнішніх ознак, особливостей кого-, чого-небудь, що створює відповідне враження",
-      "glossClean": "сукупність зовнішніх ознак",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вигляд",
-      "lemmaId": "вигляд",
-      "lemmaPlain": "вигляд",
+      "lemma": "партнерство",
+      "lemmaId": "партнерство",
+      "lemmaPlain": "партнерство",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -17667,655 +17958,43 @@
     },
     {
       "cefr": "A2",
-      "gloss": "to lay out",
-      "glossClean": "to lay out",
+      "gloss": "cooperation",
+      "glossClean": "cooperation",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "викладати",
-      "lemmaId": "викладати",
-      "lemmaPlain": "викладати",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to execute, to perform, to carry out, to accomplish, to effectuate",
-      "glossClean": "to execute",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "виконати",
-      "lemmaId": "виконати",
-      "lemmaPlain": "виконати",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "застосовувати кого-, що-небудь для якої-небудь справи, знаходити застосування кому-, чому-небудь",
-      "glossClean": "застосовувати кого-",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "використовувати",
-      "lemmaId": "використовувати",
-      "lemmaPlain": "використовувати",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to cure, to heal (make better from a disease, wound, etc.; restore to health)",
-      "glossClean": "to cure",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вилікувати",
-      "lemmaId": "вилікувати",
-      "lemmaPlain": "вилікувати",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to drink, to drink up",
-      "glossClean": "to drink",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "випити",
-      "lemmaId": "випити",
-      "lemmaPlain": "випити",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to grow",
-      "glossClean": "to grow",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вирости",
-      "lemmaId": "вирости",
-      "lemmaPlain": "вирости",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "сполучення слів, що виражає закінчену думку або становить певну єдність; фраза, мовний зворот",
-      "glossClean": "сполучення слів",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вислів",
-      "lemmaId": "вислів",
-      "lemmaPlain": "вислів",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to step forth, to step forward, to come forward",
-      "glossClean": "to step forth",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "виступати",
-      "lemmaId": "виступати",
-      "lemmaPlain": "виступати",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to hang, to be suspended",
-      "glossClean": "to hang",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "висіти",
-      "lemmaId": "висіти",
-      "lemmaPlain": "висіти",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "син сина або дочки",
-      "glossClean": "син сина або дочки",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "внук",
-      "lemmaId": "внук",
-      "lemmaPlain": "внук",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "wolf",
-      "glossClean": "wolf",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вовк",
-      "lemmaId": "вовк",
-      "lemmaPlain": "вовк",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "volleyball",
-      "glossClean": "volleyball",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "волейбол",
-      "lemmaId": "волейбол",
-      "lemmaPlain": "волейбол",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "див. весь",
-      "glossClean": "див. весь",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "все",
-      "lemmaId": "все",
-      "lemmaPlain": "все",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adv",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "all, every",
-      "glossClean": "all",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "всі",
-      "lemmaId": "всі",
-      "lemmaPlain": "всі",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "tired",
-      "glossClean": "tired",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "втомлений",
-      "lemmaId": "втомлений",
-      "lemmaPlain": "втомлений",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "який має невелику ширину; протилежне широкий",
-      "glossClean": "який має невелику ширину",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вузький",
-      "lemmaId": "вузький",
-      "lemmaPlain": "вузький",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to happen, to occur, to take place, to come about, to go on",
-      "glossClean": "to happen",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "відбуватися",
-      "lemmaId": "відбуватися",
-      "lemmaPlain": "відбуватися",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to happen, to occur, to take place, to come about, to be held (for example, an event--a meeting, an inspection, funeral services)",
-      "glossClean": "to happen",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "відбутися",
-      "lemmaId": "відбутися",
-      "lemmaPlain": "відбутися",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to visit",
-      "glossClean": "to visit",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "відвідати",
-      "lemmaId": "відвідати",
-      "lemmaPlain": "відвідати",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to visit",
-      "glossClean": "to visit",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "відвідувати",
-      "lemmaId": "відвідувати",
-      "lemmaPlain": "відвідувати",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to give back, deliver, return, restore, repay",
-      "glossClean": "to give back",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "віддати",
-      "lemmaId": "віддати",
-      "lemmaPlain": "віддати",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to rest, to have a rest, to take a rest, to relax",
-      "glossClean": "to rest",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "відпочити",
-      "lemmaId": "відпочити",
-      "lemmaPlain": "відпочити",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to depart, to set off (to leave)",
-      "glossClean": "to depart",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "відправлятися",
-      "lemmaId": "відправлятися",
-      "lemmaPlain": "відправлятися",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "at once, forthwith, immediately, right away, straight away",
-      "glossClean": "at once",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "відразу",
-      "lemmaId": "відразу",
-      "lemmaPlain": "відразу",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adv",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "організована збройна боротьба між державами, народами або ж збройними угрупованнями всередині країни",
-      "glossClean": "організована збройна боротьба між державами",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "війна",
-      "lemmaId": "війна",
-      "lemmaPlain": "війна",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to believe",
-      "glossClean": "to believe",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вірити",
-      "lemmaId": "вірити",
-      "lemmaPlain": "вірити",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "vitamin",
-      "glossClean": "vitamin",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вітамін",
-      "lemmaId": "вітамін",
-      "lemmaPlain": "вітамін",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "windy (accompanied by wind)",
-      "glossClean": "windy (accompanied by wind)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вітряний",
-      "lemmaId": "вітряний",
-      "lemmaPlain": "вітряний",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "windy (the weather)",
-      "glossClean": "windy (the weather)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вітряно",
-      "lemmaId": "вітряно",
-      "lemmaPlain": "вітряно",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adv",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to think (about: про (pro) + accusative)",
-      "glossClean": "to think (about: про (pro) + accusative)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "гадати",
-      "lemmaId": "гадати",
-      "lemmaPlain": "гадати",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "purse, wallet",
-      "glossClean": "purse",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "гаманець",
-      "lemmaId": "гаманець",
-      "lemmaPlain": "гаманець",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "happiness, well-being, weal, health, success",
-      "glossClean": "happiness",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "гаразд",
-      "lemmaId": "гаразд",
-      "lemmaPlain": "гаразд",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adv",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "городня сланка рослина з великими круглими або овальними плодами",
-      "glossClean": "городня сланка рослина з великими круглими або овальними плодами",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "гарбуз",
-      "lemmaId": "гарбуз",
-      "lemmaPlain": "гарбуз",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "helicopter",
-      "glossClean": "helicopter",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "гелікоптер",
-      "lemmaId": "гелікоптер",
-      "lemmaPlain": "гелікоптер",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "coat of arms",
-      "glossClean": "coat of arms",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "герб",
-      "lemmaId": "герб",
-      "lemmaPlain": "герб",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "far away",
-      "glossClean": "far away",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "геть",
-      "lemmaId": "геть",
-      "lemmaPlain": "геть",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adv",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "depth",
-      "glossClean": "depth",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "глибина",
-      "lemmaId": "глибина",
-      "lemmaPlain": "глибина",
+      "lemma": "співпраця",
+      "lemmaId": "співпраця",
+      "lemmaPlain": "співпраця",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
-            "plural": "глибинам",
-            "singular": "глибині"
+            "plural": "співпрацям",
+            "singular": "співпраці"
           },
           "знахідний": {
-            "plural": "глибини",
-            "singular": "глибину"
+            "plural": "співпраці",
+            "singular": "співпрацю"
           },
           "кличний": {
-            "plural": "глибини",
-            "singular": "глибино"
+            "plural": "співпраці",
+            "singular": "співпраце"
           },
           "місцевий": {
-            "plural": "глибинах",
-            "singular": "глибині"
+            "plural": "співпрацях",
+            "singular": "співпраці"
           },
           "називний": {
-            "plural": "глибини",
-            "singular": "глибина"
+            "plural": "співпраці",
+            "singular": "співпраця"
           },
           "орудний": {
-            "plural": "глибинами",
-            "singular": "глибиною"
+            "plural": "співпрацями",
+            "singular": "співпрацею"
           },
           "родовий": {
-            "plural": "глибин",
-            "singular": "глибини"
+            "plural": "співпраць",
+            "singular": "співпраці"
           }
         }
       },
@@ -18325,64 +18004,13 @@
     },
     {
       "cefr": "A2",
-      "gloss": "deep",
-      "glossClean": "deep",
+      "gloss": "hedging, softening",
+      "glossClean": "hedging",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "глибокий",
-      "lemmaId": "глибокий",
-      "lemmaPlain": "глибокий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "сукупність різних стосовно висоти, сили і тембру звуків, що їх видає людина (або тварина, яка дихає легенями) за допомогою голосового апарата",
-      "glossClean": "сукупність різних стосовно висоти",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "голос",
-      "lemmaId": "голос",
-      "lemmaPlain": "голос",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "loudly, aloud",
-      "glossClean": "loudly",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "голосно",
-      "lemmaId": "голосно",
-      "lemmaPlain": "голосно",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adv",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "pigeon, dove",
-      "glossClean": "pigeon",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "голуб",
-      "lemmaId": "голуб",
-      "lemmaPlain": "голуб",
+      "lemma": "пом'якшення",
+      "lemmaId": "пом-якшення",
+      "lemmaPlain": "пом'якшення",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -18393,30 +18021,13 @@
     },
     {
       "cefr": "A2",
-      "gloss": "light blue",
-      "glossClean": "light blue",
+      "gloss": "relevance",
+      "glossClean": "relevance",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "голубий",
-      "lemmaId": "голубий",
-      "lemmaPlain": "голубий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "жила Дидона, // А звався Карфаген",
-      "glossClean": "жила Дидона",
-      "heritage": "authentic-archaism",
-      "ipa": null,
-      "lemma": "город",
-      "lemmaId": "город",
-      "lemmaPlain": "город",
+      "lemma": "актуальність",
+      "lemmaId": "актуальність",
+      "lemmaPlain": "актуальність",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -18427,13 +18038,30 @@
     },
     {
       "cefr": "A2",
-      "gloss": "peas",
-      "glossClean": "peas",
+      "gloss": "it is presented, provided",
+      "glossClean": "it is presented",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "горох",
-      "lemmaId": "горох",
-      "lemmaPlain": "горох",
+      "lemma": "наведено",
+      "lemmaId": "наведено",
+      "lemmaPlain": "наведено",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "impersonal verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "reference, citation link",
+      "glossClean": "reference",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "посилання",
+      "lemmaId": "посилання",
+      "lemmaPlain": "посилання",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -18444,185 +18072,30 @@
     },
     {
       "cefr": "A2",
-      "gloss": "pea",
-      "glossClean": "pea",
+      "gloss": "legal",
+      "glossClean": "legal",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "гороховий",
-      "lemmaId": "гороховий",
-      "lemmaPlain": "гороховий",
+      "lemma": "правовий",
+      "lemmaId": "правовий",
+      "lemmaPlain": "правовий",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
-      "pos": "adj",
+      "pos": "adjective",
       "semanticBucket": null,
       "severity": null
     },
     {
       "cefr": "A2",
-      "gloss": "Any distilled alcoholic liquor: vodka, whisky, brandy, etc.",
-      "glossClean": "Any distilled alcoholic liquor: vodka",
+      "gloss": "inspiration",
+      "glossClean": "inspiration",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "горілка",
-      "lemmaId": "горілка",
-      "lemmaPlain": "горілка",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "горілкам",
-            "singular": "горілці"
-          },
-          "знахідний": {
-            "plural": "горілки",
-            "singular": "горілку"
-          },
-          "кличний": {
-            "plural": "горілки",
-            "singular": "горілко"
-          },
-          "місцевий": {
-            "plural": "горілках",
-            "singular": "горілці"
-          },
-          "називний": {
-            "plural": "горілки",
-            "singular": "горілка"
-          },
-          "орудний": {
-            "plural": "горілками",
-            "singular": "горілкою"
-          },
-          "родовий": {
-            "plural": "горілок",
-            "singular": "горілки"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "buckwheat",
-      "glossClean": "buckwheat",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "гречка",
-      "lemmaId": "гречка",
-      "lemmaPlain": "гречка",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "гречкам",
-            "singular": "гречці"
-          },
-          "знахідний": {
-            "plural": "гречки",
-            "singular": "гречку"
-          },
-          "кличний": {
-            "plural": "гречки",
-            "singular": "гречко"
-          },
-          "місцевий": {
-            "plural": "гречках",
-            "singular": "гречці"
-          },
-          "називний": {
-            "plural": "гречки",
-            "singular": "гречка"
-          },
-          "орудний": {
-            "plural": "гречками",
-            "singular": "гречкою"
-          },
-          "родовий": {
-            "plural": "гречок",
-            "singular": "гречки"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "grill (barbecue)",
-      "glossClean": "grill (barbecue)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "гриль",
-      "lemmaId": "гриль",
-      "lemmaPlain": "гриль",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "thunder, thunderstorm",
-      "glossClean": "thunder",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "гроза",
-      "lemmaId": "гроза",
-      "lemmaPlain": "гроза",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "грозам",
-            "singular": "грозі"
-          },
-          "знахідний": {
-            "plural": "грози",
-            "singular": "грозу"
-          },
-          "кличний": {
-            "plural": "грози",
-            "singular": "грозо"
-          },
-          "місцевий": {
-            "plural": "грозах",
-            "singular": "грозі"
-          },
-          "називний": {
-            "plural": "грози",
-            "singular": "гроза"
-          },
-          "орудний": {
-            "plural": "грозами",
-            "singular": "грозою"
-          },
-          "родовий": {
-            "plural": "гроз",
-            "singular": "грози"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "citizenship",
-      "glossClean": "citizenship",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "громадянство",
-      "lemmaId": "громадянство",
-      "lemmaPlain": "громадянство",
+      "lemma": "натхнення",
+      "lemmaId": "натхнення",
+      "lemmaPlain": "натхнення",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -18633,13 +18106,13 @@
     },
     {
       "cefr": "A2",
-      "gloss": "thorax, chest, breast, bosom",
-      "glossClean": "thorax",
+      "gloss": "worldview",
+      "glossClean": "worldview",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "груди",
-      "lemmaId": "груди",
-      "lemmaPlain": "груди",
+      "lemma": "світогляд",
+      "lemmaId": "світогляд",
+      "lemmaPlain": "світогляд",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -18650,59 +18123,13 @@
     },
     {
       "cefr": "A2",
-      "gloss": "плід грушії звичайної (Pyrus communis)",
-      "glossClean": "плід грушії звичайної (Pyrus communis)",
+      "gloss": "interpretation",
+      "glossClean": "interpretation",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "груша",
-      "lemmaId": "груша",
-      "lemmaPlain": "груша",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "грушам",
-            "singular": "груші"
-          },
-          "знахідний": {
-            "plural": "груші",
-            "singular": "грушу"
-          },
-          "кличний": {
-            "plural": "груші",
-            "singular": "груше"
-          },
-          "місцевий": {
-            "plural": "грушах",
-            "singular": "груші"
-          },
-          "називний": {
-            "plural": "груші",
-            "singular": "груша"
-          },
-          "орудний": {
-            "plural": "грушами",
-            "singular": "грушею"
-          },
-          "родовий": {
-            "plural": "груш",
-            "singular": "груші"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "thunder, thunderbolt",
-      "glossClean": "thunder",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "грім",
-      "lemmaId": "грім",
-      "lemmaPlain": "грім",
+      "lemma": "тлумачення",
+      "lemmaId": "тлумачення",
+      "lemmaPlain": "тлумачення",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -18713,93 +18140,13 @@
     },
     {
       "cefr": "A2",
-      "gloss": "to give off warmth, to give off heat",
-      "glossClean": "to give off warmth",
+      "gloss": "public, community",
+      "glossClean": "public",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "гріти",
-      "lemmaId": "гріти",
-      "lemmaPlain": "гріти",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "кожна з двох шкірно-м'язових рухомих складок, що утворюють краї рота у людей і тварин",
-      "glossClean": "кожна з двох шкірно-м'язових рухомих складок",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "губа",
-      "lemmaId": "губа",
-      "lemmaPlain": "губа",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "eraser, rubber",
-      "glossClean": "eraser",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "гумка",
-      "lemmaId": "гумка",
-      "lemmaPlain": "гумка",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "гумкам",
-            "singular": "гумці"
-          },
-          "знахідний": {
-            "plural": "гумки",
-            "singular": "гумку"
-          },
-          "кличний": {
-            "plural": "гумки",
-            "singular": "гумко"
-          },
-          "місцевий": {
-            "plural": "гумках",
-            "singular": "гумці"
-          },
-          "називний": {
-            "plural": "гумки",
-            "singular": "гумка"
-          },
-          "орудний": {
-            "plural": "гумками",
-            "singular": "гумкою"
-          },
-          "родовий": {
-            "plural": "гумок",
-            "singular": "гумки"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "a group of people",
-      "glossClean": "a group of people",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "гурт",
-      "lemmaId": "гурт",
-      "lemmaPlain": "гурт",
+      "lemma": "громадськість",
+      "lemmaId": "громадськість",
+      "lemmaPlain": "громадськість",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -18810,13 +18157,13 @@
     },
     {
       "cefr": "A2",
-      "gloss": "goose",
-      "glossClean": "goose",
+      "gloss": "appropriateness",
+      "glossClean": "appropriateness",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "гуска",
-      "lemmaId": "гуска",
-      "lemmaPlain": "гуска",
+      "lemma": "доцільність",
+      "lemmaId": "доцільність",
+      "lemmaPlain": "доцільність",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -18827,1345 +18174,64 @@
     },
     {
       "cefr": "A2",
-      "gloss": "anthem",
-      "glossClean": "anthem",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "гімн",
-      "lemmaId": "гімн",
-      "lemmaPlain": "гімн",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "old, ancient, age-old, distant, bygone",
-      "glossClean": "old",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "давній",
-      "lemmaId": "давній",
-      "lemmaPlain": "давній",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "який знаходиться, відбувається на великій відстані",
-      "glossClean": "який знаходиться",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "далекий",
-      "lemmaId": "далекий",
-      "lemmaPlain": "далекий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "further (more, additional)",
-      "glossClean": "further (more",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "дальший",
-      "lemmaId": "дальший",
-      "lemmaPlain": "дальший",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "верхня частина будівлі, що служить її покриттям; покрівля",
-      "glossClean": "верхня частина будівлі",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "дах",
-      "lemmaId": "дах",
-      "lemmaPlain": "дах",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "апарат політичної влади у суспільстві",
-      "glossClean": "апарат політичної влади у суспільстві",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "держава",
-      "lemmaId": "держава",
-      "lemmaPlain": "держава",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "державам",
-            "singular": "державі"
-          },
-          "знахідний": {
-            "plural": "держави",
-            "singular": "державу"
-          },
-          "кличний": {
-            "plural": "держави",
-            "singular": "державо"
-          },
-          "місцевий": {
-            "plural": "державах",
-            "singular": "державі"
-          },
-          "називний": {
-            "plural": "держави",
-            "singular": "держава"
-          },
-          "орудний": {
-            "plural": "державами",
-            "singular": "державою"
-          },
-          "родовий": {
-            "plural": "держав",
-            "singular": "держави"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "прикм. до держава",
-      "glossClean": "прикм. до держава",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "державний",
-      "lemmaId": "державний",
-      "lemmaPlain": "державний",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "jazz",
-      "glossClean": "jazz",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "джаз",
-      "lemmaId": "джаз",
-      "lemmaPlain": "джаз",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "surprising",
-      "glossClean": "surprising",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "дивний",
-      "lemmaId": "дивний",
-      "lemmaPlain": "дивний",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "surprisingly",
-      "glossClean": "surprisingly",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "дивно",
-      "lemmaId": "дивно",
-      "lemmaPlain": "дивно",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adv",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "фахівець із дизайну; спеціаліст, що займається проектування рекламної продукції так, щоб вона об’єднувала потужну функціональність з високими естетичними стандартами та оригінальними відмінностями",
-      "glossClean": "фахівець із дизайну",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "дизайнер",
-      "lemmaId": "дизайнер",
-      "lemmaPlain": "дизайнер",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "wild, savage",
-      "glossClean": "wild",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "дикий",
-      "lemmaId": "дикий",
-      "lemmaPlain": "дикий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "child (attributive), childhood (attributive), child's, children's (of or pertaining to children)",
-      "glossClean": "child (attributive)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "дитячий",
-      "lemmaId": "дитячий",
-      "lemmaPlain": "дитячий",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "проміжок часу в 24 години — ніч і день",
-      "glossClean": "проміжок часу в 24 години — ніч і день",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "доба",
-      "lemmaId": "доба",
-      "lemmaPlain": "доба",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "добам",
-            "singular": "добі"
-          },
-          "знахідний": {
-            "plural": "доби",
-            "singular": "добу"
-          },
-          "кличний": {
-            "plural": "доби",
-            "singular": "добо"
-          },
-          "місцевий": {
-            "plural": "добах",
-            "singular": "добі"
-          },
-          "називний": {
-            "plural": "доби",
-            "singular": "доба"
-          },
-          "орудний": {
-            "plural": "добами",
-            "singular": "добою"
-          },
-          "родовий": {
-            "plural": "діб",
-            "singular": "доби"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "length",
-      "glossClean": "length",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "довжина",
-      "lemmaId": "довжина",
-      "lemmaPlain": "довжина",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "довжинам",
-            "singular": "довжині"
-          },
-          "знахідний": {
-            "plural": "довжини",
-            "singular": "довжину"
-          },
-          "кличний": {
-            "plural": "довжини",
-            "singular": "довжино"
-          },
-          "місцевий": {
-            "plural": "довжинах",
-            "singular": "довжині"
-          },
-          "називний": {
-            "plural": "довжини",
-            "singular": "довжина"
-          },
-          "орудний": {
-            "plural": "довжинами",
-            "singular": "довжиною"
-          },
-          "родовий": {
-            "plural": "довжин",
-            "singular": "довжини"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "grown-up, adult",
-      "glossClean": "grown-up",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "дорослий",
-      "lemmaId": "дорослий",
-      "lemmaPlain": "дорослий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "стільки, скільки треба; багато",
-      "glossClean": "стільки",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "досить",
-      "lemmaId": "досить",
-      "lemmaPlain": "досить",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adv",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "oven (chamber used for baking or heating)",
-      "glossClean": "oven (chamber used for baking or heating)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "духовка",
-      "lemmaId": "духовка",
-      "lemmaPlain": "духовка",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "духовкам",
-            "singular": "духовці"
-          },
-          "знахідний": {
-            "plural": "духовки",
-            "singular": "духовку"
-          },
-          "кличний": {
-            "plural": "духовки",
-            "singular": "духовко"
-          },
-          "місцевий": {
-            "plural": "духовках",
-            "singular": "духовці"
-          },
-          "називний": {
-            "plural": "духовки",
-            "singular": "духовка"
-          },
-          "орудний": {
-            "plural": "духовками",
-            "singular": "духовкою"
-          },
-          "родовий": {
-            "plural": "духовок",
-            "singular": "духовки"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "безсмертна нематеріальна основа в людині, що становить суть її життя, є джерелом психічних явищ і відрізняє її від тварини",
-      "glossClean": "безсмертна нематеріальна основа в людині",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "душа",
-      "lemmaId": "душа",
-      "lemmaPlain": "душа",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "exotic",
-      "glossClean": "exotic",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "екзотичний",
-      "lemmaId": "екзотичний",
-      "lemmaPlain": "екзотичний",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "сукупність виробничих відносин даного суспільного ладу, відповідних до продуктивних сил суспільства",
-      "glossClean": "сукупність виробничих відносин даного суспільного ладу",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "економіка",
-      "lemmaId": "економіка",
-      "lemmaPlain": "економіка",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "економікам",
-            "singular": "економіці"
-          },
-          "знахідний": {
-            "plural": "економіки",
-            "singular": "економіку"
-          },
-          "кличний": {
-            "plural": "економіки",
-            "singular": "економіко"
-          },
-          "місцевий": {
-            "plural": "економіках",
-            "singular": "економіці"
-          },
-          "називний": {
-            "plural": "економіки",
-            "singular": "економіка"
-          },
-          "орудний": {
-            "plural": "економіками",
-            "singular": "економікою"
-          },
-          "родовий": {
-            "plural": "економік",
-            "singular": "економіки"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "electric, electrical",
-      "glossClean": "electric",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "електричний",
-      "lemmaId": "електричний",
-      "lemmaPlain": "електричний",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "energy",
-      "glossClean": "energy",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "енергія",
-      "lemmaId": "енергія",
-      "lemmaPlain": "енергія",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "енергіям",
-            "singular": "енергії"
-          },
-          "знахідний": {
-            "plural": "енергії",
-            "singular": "енергію"
-          },
-          "кличний": {
-            "plural": "енергії",
-            "singular": "енергіє"
-          },
-          "місцевий": {
-            "plural": "енергіях",
-            "singular": "енергії"
-          },
-          "називний": {
-            "plural": "енергії",
-            "singular": "енергія"
-          },
-          "орудний": {
-            "plural": "енергіями",
-            "singular": "енергією"
-          },
-          "родовий": {
-            "plural": "енергій",
-            "singular": "енергії"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "frog",
-      "glossClean": "frog",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "жаба",
-      "lemmaId": "жаба",
-      "lemmaPlain": "жаба",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "говорити або робити що-небудь дотепно, веселитися, смішити когось; приваблювати когось, залицятися; бавитися, дітьми",
-      "glossClean": "говорити або робити що-небудь дотепно",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "жартувати",
-      "lemmaId": "жартувати",
-      "lemmaPlain": "жартувати",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "satisfied, content, contented, pleased",
-      "glossClean": "satisfied",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "задоволений",
-      "lemmaId": "задоволений",
-      "lemmaPlain": "задоволений",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "встановлене найвищим органом державної влади загальнообов'язкове правило, яке має найвищу юридичну силу",
-      "glossClean": "встановлене найвищим органом державної влади загальнообов'язкове правило",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "закон",
-      "lemmaId": "закон",
-      "lemmaPlain": "закон",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to end, to come to an end, to be over, to conclude, to terminate",
-      "glossClean": "to end",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "закінчитися",
-      "lemmaId": "закінчитися",
-      "lemmaPlain": "закінчитися",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to leave (:somebody/something somewhere)",
-      "glossClean": "to leave (:somebody/something somewhere)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "залишити",
-      "lemmaId": "залишити",
-      "lemmaPlain": "залишити",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "smell, odor, scent (sensation)",
-      "glossClean": "smell",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "запах",
-      "lemmaId": "запах",
-      "lemmaPlain": "запах",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to ask, to inquire",
-      "glossClean": "to ask",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "запитувати",
-      "lemmaId": "запитувати",
-      "lemmaPlain": "запитувати",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to fill, to fill up (:space)",
-      "glossClean": "to fill",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "заповнити",
-      "lemmaId": "заповнити",
-      "lemmaPlain": "заповнити",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to laugh, to start laughing, to break into laughter",
-      "glossClean": "to laugh",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "засміятися",
-      "lemmaId": "засміятися",
-      "lemmaPlain": "засміятися",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to fall ill, to sicken",
-      "glossClean": "to fall ill",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "захворіти",
-      "lemmaId": "захворіти",
-      "lemmaPlain": "захворіти",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "одна з чотирьох сторін світу; напрямок, бік, протилежні сходу",
-      "glossClean": "одна з чотирьох сторін світу",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "захід",
-      "lemmaId": "захід",
-      "lemmaPlain": "захід",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to wait",
-      "glossClean": "to wait",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "зачекати",
-      "lemmaId": "зачекати",
-      "lemmaPlain": "зачекати",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to close, to shut, to lock (:a door, a window)",
-      "glossClean": "to close",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "зачинити",
-      "lemmaId": "зачинити",
-      "lemmaPlain": "зачинити",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to boil, to cook (by boiling)",
-      "glossClean": "to boil",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "зварити",
-      "lemmaId": "зварити",
-      "lemmaPlain": "зварити",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "from here, hence",
-      "glossClean": "from here",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "звідси",
-      "lemmaId": "звідси",
-      "lemmaPlain": "звідси",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adv",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "winter (attributive), hibernal (pertaining to winter)",
-      "glossClean": "winter (attributive)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "зимовий",
-      "lemmaId": "зимовий",
-      "lemmaPlain": "зимовий",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "сповнений злості, ворожнечі, недоброзичливості",
-      "glossClean": "сповнений злості",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "злий",
-      "lemmaId": "злий",
-      "lemmaPlain": "злий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "from the left",
-      "glossClean": "from the left",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "зліва",
-      "lemmaId": "зліва",
-      "lemmaPlain": "зліва",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adv",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to change, to alter, to modify",
-      "glossClean": "to change",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "змінити",
-      "lemmaId": "змінити",
-      "lemmaPlain": "змінити",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to change, to alter, to modify",
-      "glossClean": "to change",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "змінювати",
-      "lemmaId": "змінювати",
-      "lemmaPlain": "змінювати",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "шукаючи, виявляти кого-, що-небудь десь; протилежне загублювати ізнайти́",
-      "glossClean": "шукаючи",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "знаходити",
-      "lemmaId": "знаходити",
-      "lemmaPlain": "знаходити",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "quite, entirely, totally",
-      "glossClean": "quite",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "зовсім",
-      "lemmaId": "зовсім",
-      "lemmaPlain": "зовсім",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adv",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "golden, gold",
-      "glossClean": "golden",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "золотий",
-      "lemmaId": "золотий",
-      "lemmaPlain": "золотий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "zoo",
-      "glossClean": "zoo",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "зоопарк",
-      "lemmaId": "зоопарк",
-      "lemmaPlain": "зоопарк",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "пробний виріб; окремий предмет, річ із ряду однакових",
-      "glossClean": "пробний виріб",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "зразок",
-      "lemmaId": "зразок",
-      "lemmaPlain": "зразок",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "comfortable",
-      "glossClean": "comfortable",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "зручний",
-      "lemmaId": "зручний",
-      "lemmaPlain": "зручний",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "comfortably",
-      "glossClean": "comfortably",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "зручно",
-      "lemmaId": "зручно",
-      "lemmaPlain": "зручно",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adv",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "tooth (attributive), dental (pertaining to teeth)",
-      "glossClean": "tooth (attributive)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "зубний",
-      "lemmaId": "зубний",
-      "lemmaPlain": "зубний",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "healing herbs, potion",
-      "glossClean": "healing herbs",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "зілля",
-      "lemmaId": "зілля",
-      "lemmaPlain": "зілля",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "с.",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "самосвітне небесне тіло, що являє собою скупчення розжарених газів",
-      "glossClean": "самосвітне небесне тіло",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "зірка",
-      "lemmaId": "зірка",
-      "lemmaPlain": "зірка",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "yoga",
-      "glossClean": "yoga",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "йога",
-      "lemmaId": "йога",
-      "lemmaPlain": "йога",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "йогам",
-            "singular": "йозі"
-          },
-          "знахідний": {
-            "plural": "йоги",
-            "singular": "йогу"
-          },
-          "кличний": {
-            "plural": "йоги",
-            "singular": "його"
-          },
-          "місцевий": {
-            "plural": "йогах",
-            "singular": "йозі"
-          },
-          "називний": {
-            "plural": "йоги",
-            "singular": "йога"
-          },
-          "орудний": {
-            "plural": "йогами",
-            "singular": "йогою"
-          },
-          "родовий": {
-            "plural": "йог",
-            "singular": "йоги"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "баштанна сланка рослина з великими їстівними плодами",
-      "glossClean": "баштанна сланка рослина з великими їстівними плодами",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "кавун",
-      "lemmaId": "кавун",
-      "lemmaPlain": "кавун",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "розповідний твір про вигаданих осіб і події, переважно за участю фантастичних сил",
-      "glossClean": "розповідний твір про вигаданих осіб і події",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "казка",
-      "lemmaId": "казка",
-      "lemmaPlain": "казка",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "казкам",
-            "singular": "казці"
-          },
-          "знахідний": {
-            "plural": "казки",
-            "singular": "казку"
-          },
-          "кличний": {
-            "plural": "казки",
-            "singular": "казко"
-          },
-          "місцевий": {
-            "plural": "казках",
-            "singular": "казці"
-          },
-          "називний": {
-            "plural": "казки",
-            "singular": "казка"
-          },
-          "орудний": {
-            "plural": "казками",
-            "singular": "казкою"
-          },
-          "родовий": {
-            "plural": "казок",
-            "singular": "казки"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "calendar",
-      "glossClean": "calendar",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "календар",
-      "lemmaId": "календар",
-      "lemmaPlain": "календар",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "stone, pebble (material)",
-      "glossClean": "stone",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "камінь",
-      "lemmaId": "камінь",
-      "lemmaPlain": "камінь",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "A brimmed hat",
-      "glossClean": "A brimmed hat",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "капелюх",
-      "lemmaId": "капелюх",
-      "lemmaPlain": "капелюх",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "slipper",
-      "glossClean": "slipper",
+      "gloss": "wow, oh no, disaster (colloquial)",
+      "glossClean": "wow",
       "heritage": "standard",
       "ipa": null,
       "lemma": "капець",
       "lemmaId": "капець",
       "lemmaPlain": "капець",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "brown, hazel (eyes)",
-      "glossClean": "brown",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "карий",
-      "lemmaId": "карий",
-      "lemmaPlain": "карий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "металевий посуд для варіння страви",
-      "glossClean": "металевий посуд для варіння страви",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "каструля",
-      "lemmaId": "каструля",
-      "lemmaPlain": "каструля",
       "meaningMcEligible": false,
       "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "каструлям",
-            "singular": "каструлі"
-          },
-          "знахідний": {
-            "plural": "каструлі",
-            "singular": "каструлю"
-          },
-          "кличний": {
-            "plural": "каструлі",
-            "singular": "каструле"
-          },
-          "місцевий": {
-            "plural": "каструлях",
-            "singular": "каструлі"
-          },
-          "називний": {
-            "plural": "каструлі",
-            "singular": "каструля"
-          },
-          "орудний": {
-            "plural": "каструлями",
-            "singular": "каструлею"
-          },
-          "родовий": {
-            "plural": "каструль",
-            "singular": "каструлі"
-          }
-        }
+        "cases": {}
       },
-      "pos": "noun",
+      "pos": "interjection",
       "semanticBucket": null,
       "severity": null
     },
     {
       "cefr": "A2",
-      "gloss": "duck",
-      "glossClean": "duck",
-      "heritage": "unknown",
+      "gloss": "cool, great",
+      "glossClean": "cool",
+      "heritage": "standard",
       "ipa": null,
-      "lemma": "качка",
-      "lemmaId": "качка",
-      "lemmaPlain": "качка",
+      "lemma": "класно",
+      "lemmaId": "класно",
+      "lemmaPlain": "класно",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adverb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "wow",
+      "glossClean": "wow",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "ого",
+      "lemmaId": "ого",
+      "lemmaPlain": "ого",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "interjection",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "hike",
+      "glossClean": "hike",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "похід",
+      "lemmaId": "похід",
+      "lemmaPlain": "похід",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -20176,13 +18242,13 @@
     },
     {
       "cefr": "A2",
-      "gloss": "to cough",
-      "glossClean": "to cough",
+      "gloss": "to revise, refine",
+      "glossClean": "to revise",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "кашляти",
-      "lemmaId": "кашляти",
-      "lemmaPlain": "кашляти",
+      "lemma": "доопрацювати",
+      "lemmaId": "доопрацювати",
+      "lemmaPlain": "доопрацювати",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -20193,185 +18259,13 @@
     },
     {
       "cefr": "A2",
-      "gloss": "bean (plant of the genus Phaseolus)",
-      "glossClean": "bean (plant of the genus Phaseolus)",
+      "gloss": "to pass on",
+      "glossClean": "to pass on",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "квасоля",
-      "lemmaId": "квасоля",
-      "lemmaPlain": "квасоля",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "квасолям",
-            "singular": "квасолі"
-          },
-          "знахідний": {
-            "plural": "квасолі",
-            "singular": "квасолю"
-          },
-          "кличний": {
-            "plural": "квасолі",
-            "singular": "квасоле"
-          },
-          "місцевий": {
-            "plural": "квасолях",
-            "singular": "квасолі"
-          },
-          "називний": {
-            "plural": "квасолі",
-            "singular": "квасоля"
-          },
-          "орудний": {
-            "plural": "квасолями",
-            "singular": "квасолею"
-          },
-          "родовий": {
-            "plural": "квасоль",
-            "singular": "квасолі"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "частина рослини, що виростає на кінці стебла або гілки й складається з маточки, тичинок та пелюсток навколо них; квітуча рослина",
-      "glossClean": "частина рослини",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "квітка",
-      "lemmaId": "квітка",
-      "lemmaPlain": "квітка",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "квіткам",
-            "singular": "квітці"
-          },
-          "знахідний": {
-            "plural": "квітки",
-            "singular": "квітку"
-          },
-          "кличний": {
-            "plural": "квітки",
-            "singular": "квітко"
-          },
-          "місцевий": {
-            "plural": "квітках",
-            "singular": "квітці"
-          },
-          "називний": {
-            "plural": "квітки",
-            "singular": "квітка"
-          },
-          "орудний": {
-            "plural": "квітками",
-            "singular": "квіткою"
-          },
-          "родовий": {
-            "plural": "квіток",
-            "singular": "квітки"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "гострий томатний соус",
-      "glossClean": "гострий томатний соус",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "кетчуп",
-      "lemmaId": "кетчуп",
-      "lemmaPlain": "кетчуп",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "частина одягу у формі мішечка для дрібних речей і грошей",
-      "glossClean": "частина одягу у формі мішечка для дрібних речей і грошей",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "кишеня",
-      "lemmaId": "кишеня",
-      "lemmaPlain": "кишеня",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "кишеням",
-            "singular": "кишені"
-          },
-          "знахідний": {
-            "plural": "кишені",
-            "singular": "кишеню"
-          },
-          "кличний": {
-            "plural": "кишені",
-            "singular": "кишене"
-          },
-          "місцевий": {
-            "plural": "кишенях",
-            "singular": "кишені"
-          },
-          "називний": {
-            "plural": "кишені",
-            "singular": "кишеня"
-          },
-          "орудний": {
-            "plural": "кишенями",
-            "singular": "кишенею"
-          },
-          "родовий": {
-            "plural": "кишень",
-            "singular": "кишені"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "стосовно до класицизму",
-      "glossClean": "стосовно до класицизму",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "класичний",
-      "lemmaId": "класичний",
-      "lemmaPlain": "класичний",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "поміщати, наносити на горизонтальну поверхню, зазвичай - надаючи лежаче положення",
-      "glossClean": "поміщати",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "класти",
-      "lemmaId": "класти",
-      "lemmaPlain": "класти",
+      "lemma": "передавати",
+      "lemmaId": "передавати",
+      "lemmaPlain": "передавати",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -20382,43 +18276,111 @@
     },
     {
       "cefr": "A2",
-      "gloss": "установа лікарняного типу, у якій лікування хворих поєднується з науково-дослідною та педагогічною роботою",
-      "glossClean": "установа лікарняного типу",
+      "gloss": "threshold",
+      "glossClean": "threshold",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "клініка",
-      "lemmaId": "клініка",
-      "lemmaPlain": "клініка",
+      "lemma": "поріг",
+      "lemmaId": "поріг",
+      "lemmaPlain": "поріг",
       "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "regional",
+      "glossClean": "regional",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "регіональний",
+      "lemmaId": "регіональний",
+      "lemmaPlain": "регіональний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "identity",
+      "glossClean": "identity",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "ідентичність",
+      "lemmaId": "ідентичність",
+      "lemmaPlain": "ідентичність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "exhaustion, burnout",
+      "glossClean": "exhaustion",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "виснаження",
+      "lemmaId": "виснаження",
+      "lemmaPlain": "виснаження",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "A2",
+      "gloss": "declaration with a family doctor",
+      "glossClean": "declaration with a family doctor",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "декларація",
+      "lemmaId": "декларація",
+      "lemmaPlain": "декларація",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {
           "давальний": {
-            "plural": "клінікам",
-            "singular": "клініці"
+            "plural": "деклараціям",
+            "singular": "декларації"
           },
           "знахідний": {
-            "plural": "клініки",
-            "singular": "клініку"
+            "plural": "декларації",
+            "singular": "декларацію"
           },
           "кличний": {
-            "plural": "клініки",
-            "singular": "клініко"
+            "plural": "декларації",
+            "singular": "деклараціє"
           },
           "місцевий": {
-            "plural": "клініках",
-            "singular": "клініці"
+            "plural": "деклараціях",
+            "singular": "декларації"
           },
           "називний": {
-            "plural": "клініки",
-            "singular": "клініка"
+            "plural": "декларації",
+            "singular": "декларація"
           },
           "орудний": {
-            "plural": "клініками",
-            "singular": "клінікою"
+            "plural": "деклараціями",
+            "singular": "декларацією"
           },
           "родовий": {
-            "plural": "клінік",
-            "singular": "клініки"
+            "plural": "декларацій",
+            "singular": "декларації"
           }
         }
       },
@@ -20428,47 +18390,13 @@
     },
     {
       "cefr": "A2",
-      "gloss": "book (attributive) (of or relating to books)",
-      "glossClean": "book (attributive) (of or relating to books)",
+      "gloss": "treatment",
+      "glossClean": "treatment",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "книжковий",
-      "lemmaId": "книжковий",
-      "lemmaPlain": "книжковий",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "невелика рогата жуйна тварина родини порожнисторогих, що дає молоко, м'ясо тощо; самиця козла",
-      "glossClean": "невелика рогата жуйна тварина родини порожнисторогих",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "коза",
-      "lemmaId": "коза",
-      "lemmaPlain": "коза",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "coconut",
-      "glossClean": "coconut",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "кокос",
-      "lemmaId": "кокос",
-      "lemmaPlain": "кокос",
+      "lemma": "лікування",
+      "lemmaId": "лікування",
+      "lemmaPlain": "лікування",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -20479,145 +18407,43 @@
     },
     {
       "cefr": "A2",
-      "gloss": "cocktail",
-      "glossClean": "cocktail",
+      "gloss": "medicine",
+      "glossClean": "medicine",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "коктейль",
-      "lemmaId": "коктейль",
-      "lemmaPlain": "коктейль",
+      "lemma": "медицина",
+      "lemmaId": "медицина",
+      "lemmaPlain": "медицина",
       "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "який був колись давно; минулий",
-      "glossClean": "який був колись давно",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "колишній",
-      "lemmaId": "колишній",
-      "lemmaPlain": "колишній",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "With colour, not colourless.",
-      "glossClean": "With colour",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "кольоровий",
-      "lemmaId": "кольоровий",
-      "lemmaPlain": "кольоровий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "суглоб, що з'єднує стегнову і гомілкову кістки; місце згину ноги",
-      "glossClean": "суглоб",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "коліно",
-      "lemmaId": "коліно",
-      "lemmaPlain": "коліно",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "contact",
-      "glossClean": "contact",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "контакт",
-      "lemmaId": "контакт",
-      "lemmaPlain": "контакт",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "один з найбільших масивів суші Землі, більша частина поверхні яких виступає над рівнем моря",
-      "glossClean": "один з найбільших масивів суші Землі",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "континент",
-      "lemmaId": "континент",
-      "lemmaPlain": "континент",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "невелике вмістище різної форми з картону, пластмаси, фанери тощо, звичайно з кришкою",
-      "glossClean": "невелике вмістище різної форми з картону",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "коробка",
-      "lemmaId": "коробка",
-      "lemmaPlain": "коробка",
-      "meaningMcEligible": false,
       "paradigm": {
         "cases": {
           "давальний": {
-            "plural": "коробкам",
-            "singular": "коробці"
+            "plural": "медицинам",
+            "singular": "медицині"
           },
           "знахідний": {
-            "plural": "коробки",
-            "singular": "коробку"
+            "plural": "медицини",
+            "singular": "медицину"
           },
           "кличний": {
-            "plural": "коробки",
-            "singular": "коробко"
+            "plural": "медицини",
+            "singular": "медицино"
           },
           "місцевий": {
-            "plural": "коробках",
-            "singular": "коробці"
+            "plural": "медицинах",
+            "singular": "медицині"
           },
           "називний": {
-            "plural": "коробки",
-            "singular": "коробка"
+            "plural": "медицини",
+            "singular": "медицина"
           },
           "орудний": {
-            "plural": "коробками",
-            "singular": "коробкою"
+            "plural": "медицинами",
+            "singular": "медициною"
           },
           "родовий": {
-            "plural": "коробок",
-            "singular": "коробки"
+            "plural": "медицин",
+            "singular": "медицини"
           }
         }
       },
@@ -20627,105 +18453,13 @@
     },
     {
       "cefr": "A2",
-      "gloss": "cosmetics",
-      "glossClean": "cosmetics",
+      "gloss": "referral",
+      "glossClean": "referral",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "косметика",
-      "lemmaId": "косметика",
-      "lemmaPlain": "косметика",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "косметикам",
-            "singular": "косметиці"
-          },
-          "знахідний": {
-            "plural": "косметики",
-            "singular": "косметику"
-          },
-          "кличний": {
-            "plural": "косметики",
-            "singular": "косметико"
-          },
-          "місцевий": {
-            "plural": "косметиках",
-            "singular": "косметиці"
-          },
-          "називний": {
-            "plural": "косметики",
-            "singular": "косметика"
-          },
-          "орудний": {
-            "plural": "косметиками",
-            "singular": "косметикою"
-          },
-          "родовий": {
-            "plural": "косметик",
-            "singular": "косметики"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "meat patty, meatball, frikadelle",
-      "glossClean": "meat patty",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "котлета",
-      "lemmaId": "котлета",
-      "lemmaPlain": "котлета",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "котлетам",
-            "singular": "котлеті"
-          },
-          "знахідний": {
-            "plural": "котлети",
-            "singular": "котлету"
-          },
-          "кличний": {
-            "plural": "котлети",
-            "singular": "котлето"
-          },
-          "місцевий": {
-            "plural": "котлетах",
-            "singular": "котлеті"
-          },
-          "називний": {
-            "plural": "котлети",
-            "singular": "котлета"
-          },
-          "орудний": {
-            "plural": "котлетами",
-            "singular": "котлетою"
-          },
-          "родовий": {
-            "plural": "котлет",
-            "singular": "котлети"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "caffeine",
-      "glossClean": "caffeine",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "кофеїн",
-      "lemmaId": "кофеїн",
-      "lemmaPlain": "кофеїн",
+      "lemma": "направлення",
+      "lemmaId": "направлення",
+      "lemmaPlain": "направлення",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -20736,13 +18470,13 @@
     },
     {
       "cefr": "A2",
-      "gloss": "почуття глибокої сердечної, романтичної прихильності до іншої людини",
-      "glossClean": "почуття глибокої сердечної",
+      "gloss": "medication, drug",
+      "glossClean": "medication",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "кохання",
-      "lemmaId": "кохання",
-      "lemmaPlain": "кохання",
+      "lemma": "препарат",
+      "lemmaId": "препарат",
+      "lemmaPlain": "препарат",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -20753,314 +18487,18 @@
     },
     {
       "cefr": "A2",
-      "gloss": "відчувати, виявляти глибоку сердечну, романтичну прихильність до іншої людини",
-      "glossClean": "відчувати",
+      "gloss": "leader of an armed group or uprising",
+      "glossClean": "leader of an armed group or uprising",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "кохати",
-      "lemmaId": "кохати",
-      "lemmaPlain": "кохати",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "виріб, різний за формою та розміром, виплетений із лози, стебел рогозу, дранки і т. ін., який використовують у побуті для зберігання або перенесення чого-небудь",
-      "glossClean": "виріб",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "кошик",
-      "lemmaId": "кошик",
-      "lemmaPlain": "кошик",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "зав'язана вузлом під коміром сорочки, блузки смужка тканини, яку носять для прикраси",
-      "glossClean": "зав'язана вузлом під коміром сорочки",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "краватка",
-      "lemmaId": "краватка",
-      "lemmaPlain": "краватка",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "краваткам",
-            "singular": "краватці"
-          },
-          "знахідний": {
-            "plural": "краватки",
-            "singular": "краватку"
-          },
-          "кличний": {
-            "plural": "краватки",
-            "singular": "краватко"
-          },
-          "місцевий": {
-            "plural": "краватках",
-            "singular": "краватці"
-          },
-          "називний": {
-            "plural": "краватки",
-            "singular": "краватка"
-          },
-          "орудний": {
-            "plural": "краватками",
-            "singular": "краваткою"
-          },
-          "родовий": {
-            "plural": "краваток",
-            "singular": "краватки"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "beauty (quality of being beautiful)",
-      "glossClean": "beauty (quality of being beautiful)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "краса",
-      "lemmaId": "краса",
-      "lemmaPlain": "краса",
+      "lemma": "ватажок",
+      "lemmaId": "ватажок",
+      "lemmaPlain": "ватажок",
       "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
       "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "приємний зовнішнім виглядом; який відзначається гармонією барв, ліній і т. ін",
-      "glossClean": "приємний зовнішнім виглядом",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "красивий",
-      "lemmaId": "красивий",
-      "lemmaPlain": "красивий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "густа маса зі збитих вершків, молока, масла, яєць, цукру з додаванням різних спецій, кави, шоколаду, горіхів і т. ін., що вживають у виготовленні тортів, тістечок, а також як десерт",
-      "glossClean": "густа маса зі збитих вершків",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "крем",
-      "lemmaId": "крем",
-      "lemmaPlain": "крем",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "який має форму круга, кулі, циліндра тощо або формою нагадує їх; округлий",
-      "glossClean": "який має форму круга",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "круглий",
-      "lemmaId": "круглий",
-      "lemmaPlain": "круглий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "однорічна, прянно-ароматична рослина",
-      "glossClean": "однорічна",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "кріп",
-      "lemmaId": "кріп",
-      "lemmaPlain": "кріп",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "cultural (pertaining to culture)",
-      "glossClean": "cultural (pertaining to culture)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "культурний",
-      "lemmaId": "культурний",
-      "lemmaPlain": "культурний",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "to bathe, to have/take a bath",
-      "glossClean": "to bathe",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "купатися",
-      "lemmaId": "купатися",
-      "lemmaPlain": "купатися",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "smoking",
-      "glossClean": "smoking",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "куріння",
-      "lemmaId": "куріння",
-      "lemmaPlain": "куріння",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "angle, corner, nook",
-      "glossClean": "angle",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "куток",
-      "lemmaId": "куток",
-      "lemmaPlain": "куток",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "нелітаючий безкрилий птах з довгим дзьобом і чотирипалими ногами, що живе на островах Нової Зеландії",
-      "glossClean": "нелітаючий безкрилий птах з довгим дзьобом і чотирипалими ногами",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "ківі",
-      "lemmaId": "ківі",
-      "lemmaPlain": "ківі",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "ківі",
-            "singular": "ківі"
-          },
-          "знахідний": {
-            "plural": "ківі",
-            "singular": "ківі"
-          },
-          "кличний": {
-            "plural": "ківі",
-            "singular": "ківі"
-          },
-          "місцевий": {
-            "plural": "ківі",
-            "singular": "ківі"
-          },
-          "називний": {
-            "plural": "ківі",
-            "singular": "ківі"
-          },
-          "орудний": {
-            "plural": "ківі",
-            "singular": "ківі"
-          },
-          "родовий": {
-            "plural": "ківі",
-            "singular": "ківі"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "народне сказання або оповідання про якісь події чи життя людей, оповите казковістю, фантастикою",
-      "glossClean": "народне сказання або оповідання про якісь події чи життя людей",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "легенда",
-      "lemmaId": "легенда",
-      "lemmaPlain": "легенда",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "A2",
-      "gloss": "light, lightweight",
-      "glossClean": "light",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "легкий",
-      "lemmaId": "легкий",
-      "lemmaPlain": "легкий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
       "semanticBucket": null,
       "severity": null
     }
@@ -21068,10 +18506,10 @@
   "schema": "atlas-practice-lexemes",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 45639,
+    "gzipBytes": 36145,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 549902,
+    "rawBytes": 471253,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/public/lexicon/practice-lexemes.B1.json
+++ b/site/public/lexicon/practice-lexemes.B1.json
@@ -1,5 +1,5 @@
 {
-  "deckVersion": "atlas-practice-v1-9cf4a4d7319d19ce",
+  "deckVersion": "atlas-practice-v1-c5a52e54cdf8d828",
   "level": "B1",
   "lexemes": [
     {
@@ -33,23 +33,6 @@
         "cases": {}
       },
       "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "spicy",
-      "glossClean": "spicy",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "гостре",
-      "lemmaId": "гостре",
-      "lemmaPlain": "гостре",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
       "semanticBucket": null,
       "severity": null
     },
@@ -368,23 +351,6 @@
     },
     {
       "cefr": "B1",
-      "gloss": "checkpoint; summary",
-      "glossClean": "checkpoint",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "підсумок",
-      "lemmaId": "підсумок",
-      "lemmaPlain": "підсумок",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
       "gloss": "clay jug (recognition)",
       "glossClean": "clay jug (recognition)",
       "heritage": "standard",
@@ -431,52 +397,6 @@
         "cases": {}
       },
       "pos": "pronoun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "Friday",
-      "glossClean": "Friday",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "п'ятниця",
-      "lemmaId": "п-ятниця",
-      "lemmaPlain": "п'ятниця",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "п'ятницям",
-            "singular": "п'ятниці"
-          },
-          "знахідний": {
-            "plural": "п'ятниці",
-            "singular": "п'ятницю"
-          },
-          "кличний": {
-            "plural": "п'ятниці",
-            "singular": "п'ятнице"
-          },
-          "місцевий": {
-            "plural": "п'ятницях",
-            "singular": "п'ятниці"
-          },
-          "називний": {
-            "plural": "п'ятниці",
-            "singular": "п'ятниця"
-          },
-          "орудний": {
-            "plural": "п'ятницями",
-            "singular": "п'ятницею"
-          },
-          "родовий": {
-            "plural": "п'ятниць",
-            "singular": "п'ятниці"
-          }
-        }
-      },
-      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     },
@@ -768,23 +688,6 @@
     },
     {
       "cefr": "B1",
-      "gloss": "ninety",
-      "glossClean": "ninety",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "дев'яносто",
-      "lemmaId": "дев-яносто",
-      "lemmaPlain": "дев'яносто",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "numeral",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
       "gloss": "nineteen",
       "glossClean": "nineteen",
       "heritage": "standard",
@@ -797,23 +700,6 @@
         "cases": {}
       },
       "pos": "numeral",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "butter (with butter form)",
-      "glossClean": "butter (with butter form)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "маслом",
-      "lemmaId": "маслом",
-      "lemmaPlain": "маслом",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun form",
       "semanticBucket": null,
       "severity": null
     },
@@ -1275,6 +1161,23 @@
     },
     {
       "cefr": "B1",
+      "gloss": "source / spring",
+      "glossClean": "source / spring",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "джерело",
+      "lemmaId": "джерело",
+      "lemmaPlain": "джерело",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
       "gloss": "syllable",
       "glossClean": "syllable",
       "heritage": "standard",
@@ -1309,13 +1212,13 @@
     },
     {
       "cefr": "B1",
-      "gloss": "letter",
-      "glossClean": "letter",
+      "gloss": "stress",
+      "glossClean": "stress",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "літера",
-      "lemmaId": "літера",
-      "lemmaPlain": "літера",
+      "lemma": "наголос",
+      "lemmaId": "наголос",
+      "lemmaPlain": "наголос",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -1333,23 +1236,6 @@
       "lemma": "бур'ян",
       "lemmaId": "бур-ян",
       "lemmaPlain": "бур'ян",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "spoon",
-      "glossClean": "spoon",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "ложка",
-      "lemmaId": "ложка",
-      "lemmaPlain": "ложка",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -1445,13 +1331,13 @@
     },
     {
       "cefr": "B1",
-      "gloss": "they learn; they study",
-      "glossClean": "they learn",
+      "gloss": "we go regularly; we walk",
+      "glossClean": "we go regularly",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "вчать",
-      "lemmaId": "вчать",
-      "lemmaPlain": "вчать",
+      "lemma": "ходимо",
+      "lemmaId": "ходимо",
+      "lemmaPlain": "ходимо",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -1462,13 +1348,13 @@
     },
     {
       "cefr": "B1",
-      "gloss": "we go regularly; we walk",
-      "glossClean": "we go regularly",
+      "gloss": "you go regularly; you walk (plural/formal)",
+      "glossClean": "you go regularly",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "ходимо",
-      "lemmaId": "ходимо",
-      "lemmaPlain": "ходимо",
+      "lemma": "ходите",
+      "lemmaId": "ходите",
+      "lemmaPlain": "ходите",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -1712,23 +1598,6 @@
     },
     {
       "cefr": "B1",
-      "gloss": "man from Kyiv",
-      "glossClean": "man from Kyiv",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "киянин",
-      "lemmaId": "киянин",
-      "lemmaPlain": "киянин",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
       "gloss": "woman from Kyiv",
       "glossClean": "woman from Kyiv",
       "heritage": "standard",
@@ -1775,6 +1644,23 @@
         "cases": {}
       },
       "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "man from Odesa",
+      "glossClean": "man from Odesa",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "одесит",
+      "lemmaId": "одесит",
+      "lemmaPlain": "одесит",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     },
@@ -1969,23 +1855,6 @@
         "cases": {}
       },
       "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "congratulations",
-      "glossClean": "congratulations",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вітаємо",
-      "lemmaId": "вітаємо",
-      "lemmaPlain": "вітаємо",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "interjection",
       "semanticBucket": null,
       "severity": null
     },
@@ -2253,23 +2122,6 @@
     },
     {
       "cefr": "B1",
-      "gloss": "basic",
-      "glossClean": "basic",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "базовий",
-      "lemmaId": "базовий",
-      "lemmaPlain": "базовий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
       "gloss": "root",
       "glossClean": "root",
       "heritage": "standard",
@@ -2350,6 +2202,52 @@
         "cases": {}
       },
       "pos": "verb pair",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "test",
+      "glossClean": "test",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "контрольна",
+      "lemmaId": "контрольна",
+      "lemmaPlain": "контрольна",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "контрольним",
+            "singular": "контрольній"
+          },
+          "знахідний": {
+            "plural": "контрольні",
+            "singular": "контрольну"
+          },
+          "кличний": {
+            "plural": "контрольні",
+            "singular": "контрольна"
+          },
+          "місцевий": {
+            "plural": "контрольних",
+            "singular": "контрольній"
+          },
+          "називний": {
+            "plural": "контрольні",
+            "singular": "контрольна"
+          },
+          "орудний": {
+            "plural": "контрольними",
+            "singular": "контрольною"
+          },
+          "родовий": {
+            "plural": "контрольних",
+            "singular": "контрольної"
+          }
+        }
+      },
+      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     },
@@ -2532,23 +2430,6 @@
     },
     {
       "cefr": "B1",
-      "gloss": "to recognize",
-      "glossClean": "to recognize",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "впізнати",
-      "lemmaId": "впізнати",
-      "lemmaPlain": "впізнати",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
       "gloss": "direction",
       "glossClean": "direction",
       "heritage": "standard",
@@ -2673,23 +2554,6 @@
             "singular": "мети"
           }
         }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "description, attribute",
-      "glossClean": "description",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "означення",
-      "lemmaId": "означення",
-      "lemmaPlain": "означення",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
       },
       "pos": "noun",
       "semanticBucket": null,
@@ -2932,6 +2796,23 @@
       "lemma": "вибачати",
       "lemmaId": "вибачати",
       "lemmaPlain": "вибачати",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "to envy",
+      "glossClean": "to envy",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "заздрити",
+      "lemmaId": "заздрити",
+      "lemmaPlain": "заздрити",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -3422,52 +3303,6 @@
     },
     {
       "cefr": "B1",
-      "gloss": "pause",
-      "glossClean": "pause",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "пауза",
-      "lemmaId": "пауза",
-      "lemmaPlain": "пауза",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "паузам",
-            "singular": "паузі"
-          },
-          "знахідний": {
-            "plural": "паузи",
-            "singular": "паузу"
-          },
-          "кличний": {
-            "plural": "паузи",
-            "singular": "паузо"
-          },
-          "місцевий": {
-            "plural": "паузах",
-            "singular": "паузі"
-          },
-          "називний": {
-            "plural": "паузи",
-            "singular": "пауза"
-          },
-          "орудний": {
-            "plural": "паузами",
-            "singular": "паузою"
-          },
-          "родовий": {
-            "plural": "пауз",
-            "singular": "паузи"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
       "gloss": "natural",
       "glossClean": "natural",
       "heritage": "standard",
@@ -3941,23 +3776,6 @@
       "lemma": "деякий",
       "lemmaId": "деякий",
       "lemmaPlain": "деякий",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "pronoun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "no, not any",
-      "glossClean": "no",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "ніякий",
-      "lemmaId": "ніякий",
-      "lemmaPlain": "ніякий",
       "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
@@ -5128,23 +4946,6 @@
     },
     {
       "cefr": "B1",
-      "gloss": "to be located",
-      "glossClean": "to be located",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "знаходитися",
-      "lemmaId": "знаходитися",
-      "lemmaPlain": "знаходитися",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
       "gloss": "form",
       "glossClean": "form",
       "heritage": "standard",
@@ -5232,23 +5033,6 @@
       "lemma": "листоноша",
       "lemmaId": "листоноша",
       "lemmaPlain": "листоноша",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "appetite",
-      "glossClean": "appetite",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "апетит",
-      "lemmaId": "апетит",
-      "lemmaPlain": "апетит",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -5463,23 +5247,6 @@
     },
     {
       "cefr": "B1",
-      "gloss": "loud",
-      "glossClean": "loud",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "гучний",
-      "lemmaId": "гучний",
-      "lemmaPlain": "гучний",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
       "gloss": "contrast",
       "glossClean": "contrast",
       "heritage": "standard",
@@ -5623,6 +5390,23 @@
         "cases": {}
       },
       "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "quickly, briskly",
+      "glossClean": "quickly",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "прудко",
+      "lemmaId": "прудко",
+      "lemmaPlain": "прудко",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adverb",
       "semanticBucket": null,
       "severity": null
     },
@@ -5885,6 +5669,23 @@
         "cases": {}
       },
       "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "compass",
+      "glossClean": "compass",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "компас",
+      "lemmaId": "компас",
+      "lemmaPlain": "компас",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     },
@@ -7437,6 +7238,23 @@
     },
     {
       "cefr": "B1",
+      "gloss": "controlled",
+      "glossClean": "controlled",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "контрольований",
+      "lemmaId": "контрольований",
+      "lemmaPlain": "контрольований",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
       "gloss": "to mix",
       "glossClean": "to mix",
       "heritage": "standard",
@@ -7449,6 +7267,23 @@
         "cases": {}
       },
       "pos": "verb:pf",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "pragmatic",
+      "glossClean": "pragmatic",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "прагматичний",
+      "lemmaId": "прагматичний",
+      "lemmaPlain": "прагматичний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
       "semanticBucket": null,
       "severity": null
     },
@@ -8396,6 +8231,23 @@
         "cases": {}
       },
       "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "for the third time",
+      "glossClean": "for the third time",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "утретє",
+      "lemmaId": "утретє",
+      "lemmaPlain": "утретє",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adverb",
       "semanticBucket": null,
       "severity": null
     },
@@ -12330,6 +12182,23 @@
     },
     {
       "cefr": "B1",
+      "gloss": "until, as long as",
+      "glossClean": "until",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "доти...доки",
+      "lemmaId": "доти-доки",
+      "lemmaPlain": "доти...доки",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "correlative conjunction",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
       "gloss": "comma between clauses",
       "glossClean": "comma between clauses",
       "heritage": "unknown",
@@ -12461,23 +12330,6 @@
         "cases": {}
       },
       "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "range",
-      "glossClean": "range",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "діапазон",
-      "lemmaId": "діапазон",
-      "lemmaPlain": "діапазон",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     },
@@ -14386,52 +14238,6 @@
     },
     {
       "cefr": "B1",
-      "gloss": "substance, material",
-      "glossClean": "substance",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "речовина",
-      "lemmaId": "речовина",
-      "lemmaPlain": "речовина",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "речовинам",
-            "singular": "речовині"
-          },
-          "знахідний": {
-            "plural": "речовини",
-            "singular": "речовину"
-          },
-          "кличний": {
-            "plural": "речовини",
-            "singular": "речовино"
-          },
-          "місцевий": {
-            "plural": "речовинах",
-            "singular": "речовині"
-          },
-          "називний": {
-            "plural": "речовини",
-            "singular": "речовина"
-          },
-          "орудний": {
-            "plural": "речовинами",
-            "singular": "речовиною"
-          },
-          "родовий": {
-            "plural": "речовин",
-            "singular": "речовини"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
       "gloss": "time expression",
       "glossClean": "time expression",
       "heritage": "unknown",
@@ -14772,6 +14578,23 @@
     },
     {
       "cefr": "B1",
+      "gloss": "while studying",
+      "glossClean": "while studying",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "навчаючись",
+      "lemmaId": "навчаючись",
+      "lemmaPlain": "навчаючись",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "gerund",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
       "gloss": "without thinking",
       "glossClean": "without thinking",
       "heritage": "unknown",
@@ -14797,40 +14620,6 @@
       "lemmaId": "пишучи",
       "lemmaPlain": "пишучи",
       "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "gerund",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "while smiling",
-      "glossClean": "while smiling",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "усміхаючись",
-      "lemmaId": "усміхаючись",
-      "lemmaPlain": "усміхаючись",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "gerund",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "having found out",
-      "glossClean": "having found out",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "дізнавшись",
-      "lemmaId": "дізнавшись",
-      "lemmaPlain": "дізнавшись",
-      "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
@@ -15945,6 +15734,23 @@
     },
     {
       "cefr": "B1",
+      "gloss": "prompting, encouragement to act",
+      "glossClean": "prompting",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "спонукання",
+      "lemmaId": "спонукання",
+      "lemmaPlain": "спонукання",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:n",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
       "gloss": "hold on, stay strong",
       "glossClean": "hold on",
       "heritage": "standard",
@@ -16137,6 +15943,23 @@
             "singular": "стежки"
           }
         }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "accompaniment, togetherness",
+      "glossClean": "accompaniment",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "сумісність",
+      "lemmaId": "сумісність",
+      "lemmaPlain": "сумісність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
       },
       "pos": "noun",
       "semanticBucket": null,
@@ -16399,23 +16222,6 @@
     },
     {
       "cefr": "B1",
-      "gloss": "ritual",
-      "glossClean": "ritual",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "обряд",
-      "lemmaId": "обряд",
-      "lemmaPlain": "обряд",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
       "gloss": "regional cuisine",
       "glossClean": "regional cuisine",
       "heritage": "unknown",
@@ -16620,6 +16426,23 @@
     },
     {
       "cefr": "B1",
+      "gloss": "I am flying",
+      "glossClean": "I am flying",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "лечу",
+      "lemmaId": "лечу",
+      "lemmaPlain": "лечу",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb form",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
       "gloss": "lighthouse",
       "glossClean": "lighthouse",
       "heritage": "standard",
@@ -16666,6 +16489,23 @@
         "cases": {}
       },
       "pos": "verb form",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "ferry",
+      "glossClean": "ferry",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "пором",
+      "lemmaId": "пором",
+      "lemmaPlain": "пором",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:m",
       "semanticBucket": null,
       "severity": null
     },
@@ -16870,23 +16710,6 @@
         "cases": {}
       },
       "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "courier",
-      "glossClean": "courier",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "кур'єр",
-      "lemmaId": "кур-єр",
-      "lemmaPlain": "кур'єр",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
       "semanticBucket": null,
       "severity": null
     },
@@ -17436,6 +17259,23 @@
     },
     {
       "cefr": "B1",
+      "gloss": "to run past or through; perfective",
+      "glossClean": "to run past or through",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "пробігти",
+      "lemmaId": "пробігти",
+      "lemmaPlain": "пробігти",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
       "gloss": "to pass, walk past, go through; perfective",
       "glossClean": "to pass",
       "heritage": "standard",
@@ -17635,23 +17475,6 @@
     },
     {
       "cefr": "B1",
-      "gloss": "nature reserve",
-      "glossClean": "nature reserve",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "заповідник",
-      "lemmaId": "заповідник",
-      "lemmaPlain": "заповідник",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
       "gloss": "viburnum, guelder rose",
       "glossClean": "viburnum",
       "heritage": "standard",
@@ -17824,6 +17647,23 @@
     },
     {
       "cefr": "B1",
+      "gloss": "to sort",
+      "glossClean": "to sort",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "сортувати",
+      "lemmaId": "сортувати",
+      "lemmaPlain": "сортувати",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
       "gloss": "pride",
       "glossClean": "pride",
       "heritage": "standard",
@@ -17943,23 +17783,6 @@
     },
     {
       "cefr": "B1",
-      "gloss": "presenter, speaker",
-      "glossClean": "presenter",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "доповідач",
-      "lemmaId": "доповідач",
-      "lemmaPlain": "доповідач",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
       "gloss": "massage",
       "glossClean": "massage",
       "heritage": "standard",
@@ -17967,23 +17790,6 @@
       "lemma": "масаж",
       "lemmaId": "масаж",
       "lemmaPlain": "масаж",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
-      "gloss": "editing, installation",
-      "glossClean": "editing",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "монтаж",
-      "lemmaId": "монтаж",
-      "lemmaPlain": "монтаж",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -18028,6 +17834,23 @@
     },
     {
       "cefr": "B1",
+      "gloss": "listener, course participant",
+      "glossClean": "listener",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "слухач",
+      "lemmaId": "слухач",
+      "lemmaPlain": "слухач",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:m",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
       "gloss": "reader",
       "glossClean": "reader",
       "heritage": "standard",
@@ -18057,6 +17880,23 @@
         "cases": {}
       },
       "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "Georgian man",
+      "glossClean": "Georgian man",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "грузин",
+      "lemmaId": "грузин",
+      "lemmaPlain": "грузин",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:m",
       "semanticBucket": null,
       "severity": null
     },
@@ -18997,23 +18837,6 @@
     },
     {
       "cefr": "B1",
-      "gloss": "pale",
-      "glossClean": "pale",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "блідий",
-      "lemmaId": "блідий",
-      "lemmaPlain": "блідий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
       "gloss": "beautiful, handsome",
       "glossClean": "beautiful",
       "heritage": "standard",
@@ -19611,52 +19434,6 @@
     },
     {
       "cefr": "B1",
-      "gloss": "landmark, monument, site",
-      "glossClean": "landmark",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "пам'ятка",
-      "lemmaId": "пам-ятка",
-      "lemmaPlain": "пам'ятка",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "пам'яткам",
-            "singular": "пам'ятці"
-          },
-          "знахідний": {
-            "plural": "пам'ятки",
-            "singular": "пам'ятку"
-          },
-          "кличний": {
-            "plural": "пам'ятки",
-            "singular": "пам'ятко"
-          },
-          "місцевий": {
-            "plural": "пам'ятках",
-            "singular": "пам'ятці"
-          },
-          "називний": {
-            "plural": "пам'ятки",
-            "singular": "пам'ятка"
-          },
-          "орудний": {
-            "plural": "пам'ятками",
-            "singular": "пам'яткою"
-          },
-          "родовий": {
-            "plural": "пам'яток",
-            "singular": "пам'ятки"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
       "gloss": "lane, alley",
       "glossClean": "lane",
       "heritage": "standard",
@@ -19754,6 +19531,23 @@
         "cases": {}
       },
       "pos": "proper noun:pl",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "cream",
+      "glossClean": "cream",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "вершки",
+      "lemmaId": "вершки",
+      "lemmaPlain": "вершки",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:pl",
       "semanticBucket": null,
       "severity": null
     },
@@ -20473,23 +20267,6 @@
     },
     {
       "cefr": "B1",
-      "gloss": "on both sides of; takes genitive",
-      "glossClean": "on both sides of",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "обабіч",
-      "lemmaId": "обабіч",
-      "lemmaPlain": "обабіч",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "preposition",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B1",
       "gloss": "next to; з/із/зі plus instrumental",
       "glossClean": "next to",
       "heritage": "unknown",
@@ -20793,15 +20570,231 @@
       "pos": "phrase",
       "semanticBucket": null,
       "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "temporal, related to time",
+      "glossClean": "temporal",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "часовий",
+      "lemmaId": "часовий",
+      "lemmaPlain": "часовий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "every Monday",
+      "glossClean": "every Monday",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "щопонеділка",
+      "lemmaId": "щопонеділка",
+      "lemmaPlain": "щопонеділка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adverb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "every Wednesday",
+      "glossClean": "every Wednesday",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "щосереди",
+      "lemmaId": "щосереди",
+      "lemmaPlain": "щосереди",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adverb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "lyrical persona",
+      "glossClean": "lyrical persona",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "ліричний герой",
+      "lemmaId": "ліричний-герой",
+      "lemmaPlain": "ліричний герой",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "to inspire",
+      "glossClean": "to inspire",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "надихнути",
+      "lemmaId": "надихнути",
+      "lemmaPlain": "надихнути",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "character",
+      "glossClean": "character",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "персонаж",
+      "lemmaId": "персонаж",
+      "lemmaPlain": "персонаж",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "prose",
+      "glossClean": "prose",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "проза",
+      "lemmaId": "проза",
+      "lemmaPlain": "проза",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "прозам",
+            "singular": "прозі"
+          },
+          "знахідний": {
+            "plural": "прози",
+            "singular": "прозу"
+          },
+          "кличний": {
+            "plural": "прози",
+            "singular": "прозо"
+          },
+          "місцевий": {
+            "plural": "прозах",
+            "singular": "прозі"
+          },
+          "називний": {
+            "plural": "прози",
+            "singular": "проза"
+          },
+          "орудний": {
+            "plural": "прозами",
+            "singular": "прозою"
+          },
+          "родовий": {
+            "plural": "проз",
+            "singular": "прози"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "to see each other",
+      "glossClean": "to see each other",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "бачитися",
+      "lemmaId": "бачитися",
+      "lemmaPlain": "бачитися",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb:impf",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "reciprocal",
+      "glossClean": "reciprocal",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "взаємний",
+      "lemmaId": "взаємний",
+      "lemmaPlain": "взаємний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "properly reflexive",
+      "glossClean": "properly reflexive",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "власне зворотний",
+      "lemmaId": "власне-зворотний",
+      "lemmaPlain": "власне зворотний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B1",
+      "gloss": "to open; become available",
+      "glossClean": "to open",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "відкриватися",
+      "lemmaId": "відкриватися",
+      "lemmaPlain": "відкриватися",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb:impf",
+      "semanticBucket": null,
+      "severity": null
     }
   ],
   "schema": "atlas-practice-lexemes",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 44931,
+    "gzipBytes": 45038,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 549914,
+    "rawBytes": 549744,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/public/lexicon/practice-lexemes.B2.json
+++ b/site/public/lexicon/practice-lexemes.B2.json
@@ -1,5 +1,5 @@
 {
-  "deckVersion": "atlas-practice-v1-9cf4a4d7319d19ce",
+  "deckVersion": "atlas-practice-v1-c5a52e54cdf8d828",
   "level": "B2",
   "lexemes": [
     {
@@ -157,6 +157,23 @@
     },
     {
       "cefr": "B2",
+      "gloss": "dark green",
+      "glossClean": "dark green",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "темно-зелений",
+      "lemmaId": "темно-зелений",
+      "lemmaPlain": "темно-зелений",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
       "gloss": "rescue",
       "glossClean": "rescue",
       "heritage": "standard",
@@ -242,23 +259,6 @@
     },
     {
       "cefr": "B2",
-      "gloss": "alphabet",
-      "glossClean": "alphabet",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "абетка",
-      "lemmaId": "абетка",
-      "lemmaPlain": "абетка",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
       "gloss": "cashier",
       "glossClean": "cashier",
       "heritage": "standard",
@@ -271,6 +271,23 @@
         "cases": {}
       },
       "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "separately",
+      "glossClean": "separately",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "роздільно",
+      "lemmaId": "роздільно",
+      "lemmaPlain": "роздільно",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adverb",
       "semanticBucket": null,
       "severity": null
     },
@@ -344,6 +361,23 @@
     },
     {
       "cefr": "B2",
+      "gloss": "you learn; you study",
+      "glossClean": "you learn",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "вчиш",
+      "lemmaId": "вчиш",
+      "lemmaPlain": "вчиш",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb form",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
       "gloss": "I am learning; I study (preview)",
       "glossClean": "I am learning",
       "heritage": "standard",
@@ -390,40 +424,6 @@
         "cases": {}
       },
       "pos": "verb form",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
-      "gloss": "you go regularly; you walk (plural/formal)",
-      "glossClean": "you go regularly",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "ходите",
-      "lemmaId": "ходите",
-      "lemmaPlain": "ходите",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb form",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
-      "gloss": "man from Odesa",
-      "glossClean": "man from Odesa",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "одесит",
-      "lemmaId": "одесит",
-      "lemmaPlain": "одесит",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     },
@@ -742,52 +742,6 @@
     },
     {
       "cefr": "B2",
-      "gloss": "test",
-      "glossClean": "test",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "контрольна",
-      "lemmaId": "контрольна",
-      "lemmaPlain": "контрольна",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "контрольним",
-            "singular": "контрольній"
-          },
-          "знахідний": {
-            "plural": "контрольні",
-            "singular": "контрольну"
-          },
-          "кличний": {
-            "plural": "контрольні",
-            "singular": "контрольна"
-          },
-          "місцевий": {
-            "plural": "контрольних",
-            "singular": "контрольній"
-          },
-          "називний": {
-            "plural": "контрольні",
-            "singular": "контрольна"
-          },
-          "орудний": {
-            "plural": "контрольними",
-            "singular": "контрольною"
-          },
-          "родовий": {
-            "plural": "контрольних",
-            "singular": "контрольної"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
       "gloss": "absence",
       "glossClean": "absence",
       "heritage": "standard",
@@ -1040,23 +994,6 @@
       "lemma": "заважати",
       "lemmaId": "заважати",
       "lemmaPlain": "заважати",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
-      "gloss": "to envy",
-      "glossClean": "to envy",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "заздрити",
-      "lemmaId": "заздрити",
-      "lemmaPlain": "заздрити",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -1397,6 +1334,23 @@
     },
     {
       "cefr": "B2",
+      "gloss": "morphology",
+      "glossClean": "morphology",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "морфологія",
+      "lemmaId": "морфологія",
+      "lemmaPlain": "морфологія",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
       "gloss": "related",
       "glossClean": "related",
       "heritage": "standard",
@@ -1552,6 +1506,23 @@
         "cases": {}
       },
       "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to emphasize",
+      "glossClean": "to emphasize",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "підкреслити",
+      "lemmaId": "підкреслити",
+      "lemmaPlain": "підкреслити",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
       "semanticBucket": null,
       "severity": null
     },
@@ -1734,6 +1705,23 @@
     },
     {
       "cefr": "B2",
+      "gloss": "to melt",
+      "glossClean": "to melt",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "розтанути",
+      "lemmaId": "розтанути",
+      "lemmaPlain": "розтанути",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
       "gloss": "cardinal",
       "glossClean": "cardinal",
       "heritage": "standard",
@@ -1780,6 +1768,23 @@
         "cases": {}
       },
       "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "penguin",
+      "glossClean": "penguin",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "пінгвін",
+      "lemmaId": "пінгвін",
+      "lemmaPlain": "пінгвін",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     },
@@ -2047,23 +2052,6 @@
     },
     {
       "cefr": "B2",
-      "gloss": "quickly, briskly",
-      "glossClean": "quickly",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "прудко",
-      "lemmaId": "прудко",
-      "lemmaPlain": "прудко",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adverb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
       "gloss": "stylistics",
       "glossClean": "stylistics",
       "heritage": "standard",
@@ -2282,23 +2270,6 @@
     },
     {
       "cefr": "B2",
-      "gloss": "compass",
-      "glossClean": "compass",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "компас",
-      "lemmaId": "компас",
-      "lemmaPlain": "компас",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
       "gloss": "characteristic, description",
       "glossClean": "characteristic",
       "heritage": "standard",
@@ -2420,6 +2391,23 @@
       "lemma": "підсилений",
       "lemmaId": "підсилений",
       "lemmaPlain": "підсилений",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "synonymic",
+      "glossClean": "synonymic",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "синонімічний",
+      "lemmaId": "синонімічний",
+      "lemmaPlain": "синонімічний",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -2753,23 +2741,6 @@
     },
     {
       "cefr": "B2",
-      "gloss": "controlled",
-      "glossClean": "controlled",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "контрольований",
-      "lemmaId": "контрольований",
-      "lemmaPlain": "контрольований",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
       "gloss": "to mix",
       "glossClean": "to mix",
       "heritage": "standard",
@@ -2782,23 +2753,6 @@
         "cases": {}
       },
       "pos": "verb:impf",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
-      "gloss": "pragmatic",
-      "glossClean": "pragmatic",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "прагматичний",
-      "lemmaId": "прагматичний",
-      "lemmaPlain": "прагматичний",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
       "semanticBucket": null,
       "severity": null
     },
@@ -2952,6 +2906,23 @@
         "cases": {}
       },
       "pos": "noun:n",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "pragmatics; context-shaped meaning",
+      "glossClean": "pragmatics",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "прагматика",
+      "lemmaId": "прагматика",
+      "lemmaPlain": "прагматика",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:f",
       "semanticBucket": null,
       "severity": null
     },
@@ -3209,23 +3180,6 @@
         "cases": {}
       },
       "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
-      "gloss": "for the third time",
-      "glossClean": "for the third time",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "утретє",
-      "lemmaId": "утретє",
-      "lemmaPlain": "утретє",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adverb",
       "semanticBucket": null,
       "severity": null
     },
@@ -3585,6 +3539,23 @@
     },
     {
       "cefr": "B2",
+      "gloss": "to whiten",
+      "glossClean": "to whiten",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "білити",
+      "lemmaId": "білити",
+      "lemmaPlain": "білити",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
       "gloss": "to become green",
       "glossClean": "to become green",
       "heritage": "standard",
@@ -3762,6 +3733,23 @@
         "cases": {}
       },
       "pos": "conjunction",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "targeted, precise",
+      "glossClean": "targeted",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "точковий",
+      "lemmaId": "точковий",
+      "lemmaPlain": "точковий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
       "semanticBucket": null,
       "severity": null
     },
@@ -3988,6 +3976,23 @@
     },
     {
       "cefr": "B2",
+      "gloss": "to spread rapidly",
+      "glossClean": "to spread rapidly",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "облетіти",
+      "lemmaId": "облетіти",
+      "lemmaPlain": "облетіти",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
       "gloss": "to behave",
       "glossClean": "to behave",
       "heritage": "standard",
@@ -4080,23 +4085,6 @@
       "lemma": "дивлячись",
       "lemmaId": "дивлячись",
       "lemmaPlain": "дивлячись",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "gerund",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
-      "gloss": "while studying",
-      "glossClean": "while studying",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "навчаючись",
-      "lemmaId": "навчаючись",
-      "lemmaPlain": "навчаючись",
       "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
@@ -4464,6 +4452,23 @@
     },
     {
       "cefr": "B2",
+      "gloss": "newly built building",
+      "glossClean": "newly built building",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "новобудова",
+      "lemmaId": "новобудова",
+      "lemmaPlain": "новобудова",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:f",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
       "gloss": "to leak",
       "glossClean": "to leak",
       "heritage": "standard",
@@ -4488,6 +4493,23 @@
       "lemma": "санвузол",
       "lemmaId": "санвузол",
       "lemmaPlain": "санвузол",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:m",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "plumber",
+      "glossClean": "plumber",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "сантехнік",
+      "lemmaId": "сантехнік",
+      "lemmaPlain": "сантехнік",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -4532,6 +4554,23 @@
     },
     {
       "cefr": "B2",
+      "gloss": "modern renovation",
+      "glossClean": "modern renovation",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "євроремонт",
+      "lemmaId": "євроремонт",
+      "lemmaPlain": "євроремонт",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:m",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
       "gloss": "instruction, direction",
       "glossClean": "instruction",
       "heritage": "standard",
@@ -4566,23 +4605,6 @@
     },
     {
       "cefr": "B2",
-      "gloss": "prompting, encouragement to act",
-      "glossClean": "prompting",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "спонукання",
-      "lemmaId": "спонукання",
-      "lemmaPlain": "спонукання",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:n",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
       "gloss": "to unite",
       "glossClean": "to unite",
       "heritage": "standard",
@@ -4612,23 +4634,6 @@
         "cases": {}
       },
       "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
-      "gloss": "accompaniment, togetherness",
-      "glossClean": "accompaniment",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "сумісність",
-      "lemmaId": "сумісність",
-      "lemmaPlain": "сумісність",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     },
@@ -4736,6 +4741,40 @@
     },
     {
       "cefr": "B2",
+      "gloss": "to swim or sail all the way to; perfective",
+      "glossClean": "to swim or sail all the way to",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "доплисти",
+      "lemmaId": "доплисти",
+      "lemmaPlain": "доплисти",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to fly into; perfective",
+      "glossClean": "to fly into",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "залетіти",
+      "lemmaId": "залетіти",
+      "lemmaPlain": "залетіти",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
       "gloss": "bay",
       "glossClean": "bay",
       "heritage": "standard",
@@ -4760,23 +4799,6 @@
       "lemma": "летиш",
       "lemmaId": "летиш",
       "lemmaPlain": "летиш",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb form",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
-      "gloss": "I am flying",
-      "glossClean": "I am flying",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "лечу",
-      "lemmaId": "лечу",
-      "lemmaPlain": "лечу",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -4855,18 +4877,18 @@
     },
     {
       "cefr": "B2",
-      "gloss": "ferry",
-      "glossClean": "ferry",
+      "gloss": "to swim or sail past, through, or along; perfective",
+      "glossClean": "to swim or sail past",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "пором",
-      "lemmaId": "пором",
-      "lemmaPlain": "пором",
-      "meaningMcEligible": true,
+      "lemma": "проплисти",
+      "lemmaId": "проплисти",
+      "lemmaPlain": "проплисти",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
-      "pos": "noun:m",
+      "pos": "verb",
       "semanticBucket": null,
       "severity": null
     },
@@ -5229,23 +5251,6 @@
     },
     {
       "cefr": "B2",
-      "gloss": "to run past or through; perfective",
-      "glossClean": "to run past or through",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "пробігти",
-      "lemmaId": "пробігти",
-      "lemmaPlain": "пробігти",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
       "gloss": "to transport through or past; perfective",
       "glossClean": "to transport through or past",
       "heritage": "standard",
@@ -5413,6 +5418,23 @@
       "lemma": "барвінок",
       "lemmaId": "барвінок",
       "lemmaPlain": "барвінок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "badger",
+      "glossClean": "badger",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "борсук",
+      "lemmaId": "борсук",
+      "lemmaPlain": "борсук",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -5658,23 +5680,6 @@
     },
     {
       "cefr": "B2",
-      "gloss": "to sort",
-      "glossClean": "to sort",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "сортувати",
-      "lemmaId": "сортувати",
-      "lemmaPlain": "сортувати",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
       "gloss": "marigolds",
       "glossClean": "marigolds",
       "heritage": "standard",
@@ -5811,23 +5816,6 @@
     },
     {
       "cefr": "B2",
-      "gloss": "listener, course participant",
-      "glossClean": "listener",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "слухач",
-      "lemmaId": "слухач",
-      "lemmaPlain": "слухач",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
       "gloss": "situation, position",
       "glossClean": "situation",
       "heritage": "standard",
@@ -5869,23 +5857,6 @@
       "lemma": "гончар",
       "lemmaId": "гончар",
       "lemmaPlain": "гончар",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
-      "gloss": "Georgian man",
-      "glossClean": "Georgian man",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "грузин",
-      "lemmaId": "грузин",
-      "lemmaPlain": "грузин",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -5993,6 +5964,23 @@
         "cases": {}
       },
       "pos": "noun:m",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "tenacious, resilient",
+      "glossClean": "tenacious",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "живучий",
+      "lemmaId": "живучий",
+      "lemmaPlain": "живучий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
       "semanticBucket": null,
       "severity": null
     },
@@ -6253,6 +6241,23 @@
     },
     {
       "cefr": "B2",
+      "gloss": "has been painted",
+      "glossClean": "has been painted",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "пофарбовано",
+      "lemmaId": "пофарбовано",
+      "lemmaPlain": "пофарбовано",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "form",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
       "gloss": "has been read",
       "glossClean": "has been read",
       "heritage": "standard",
@@ -6384,6 +6389,23 @@
         "cases": {}
       },
       "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "envious",
+      "glossClean": "envious",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "заздрісний",
+      "lemmaId": "заздрісний",
+      "lemmaPlain": "заздрісний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
       "semanticBucket": null,
       "severity": null
     },
@@ -6845,6 +6867,23 @@
     },
     {
       "cefr": "B2",
+      "gloss": "Lesia's",
+      "glossClean": "Lesia's",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "Лесин",
+      "lemmaId": "лесин",
+      "lemmaPlain": "лесин",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
       "gloss": "mother's",
       "glossClean": "mother's",
       "heritage": "standard",
@@ -6869,6 +6908,23 @@
       "lemma": "материна",
       "lemmaId": "материна",
       "lemmaPlain": "материна",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "Serhii's",
+      "glossClean": "Serhii's",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "Сергіїв",
+      "lemmaId": "сергіїв",
+      "lemmaPlain": "сергіїв",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -7090,23 +7146,6 @@
     },
     {
       "cefr": "B2",
-      "gloss": "to inspire",
-      "glossClean": "to inspire",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "надихнути",
-      "lemmaId": "надихнути",
-      "lemmaPlain": "надихнути",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
       "gloss": "imagery",
       "glossClean": "imagery",
       "heritage": "standard",
@@ -7255,23 +7294,6 @@
     },
     {
       "cefr": "B2",
-      "gloss": "to worry, move emotionally",
-      "glossClean": "to worry",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "хвилювати",
-      "lemmaId": "хвилювати",
-      "lemmaPlain": "хвилювати",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb:impf",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
       "gloss": "the day before",
       "glossClean": "the day before",
       "heritage": "standard",
@@ -7374,6 +7396,23 @@
     },
     {
       "cefr": "B2",
+      "gloss": "more reliable",
+      "glossClean": "more reliable",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "надійніший",
+      "lemmaId": "надійніший",
+      "lemmaPlain": "надійніший",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
       "gloss": "haircut",
       "glossClean": "haircut",
       "heritage": "standard",
@@ -7432,6 +7471,23 @@
       "lemma": "контрастний",
       "lemmaId": "контрастний",
       "lemmaPlain": "контрастний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "greasy, oily",
+      "glossClean": "greasy",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "масний",
+      "lemmaId": "масний",
+      "lemmaPlain": "масний",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -7561,18 +7617,35 @@
     },
     {
       "cefr": "B2",
-      "gloss": "label",
-      "glossClean": "label",
-      "heritage": "standard",
+      "gloss": "mass media",
+      "glossClean": "mass media",
+      "heritage": "unknown",
       "ipa": null,
-      "lemma": "ярлик",
-      "lemmaId": "ярлик",
-      "lemmaPlain": "ярлик",
+      "lemma": "масмедіа",
+      "lemmaId": "масмедіа",
+      "lemmaPlain": "масмедіа",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
-      "pos": "noun:m",
+      "pos": "plural noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "special edition",
+      "glossClean": "special edition",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "спецвипуск",
+      "lemmaId": "спецвипуск",
+      "lemmaPlain": "спецвипуск",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     },
@@ -7595,6 +7668,23 @@
     },
     {
       "cefr": "B2",
+      "gloss": "above-mentioned",
+      "glossClean": "above-mentioned",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "вищезазначений",
+      "lemmaId": "вищезазначений",
+      "lemmaPlain": "вищезазначений",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
       "gloss": "ugly, disgusting",
       "glossClean": "ugly",
       "heritage": "standard",
@@ -7612,23 +7702,6 @@
     },
     {
       "cefr": "B2",
-      "gloss": "bye, see you",
-      "glossClean": "bye",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "бувай",
-      "lemmaId": "бувай",
-      "lemmaPlain": "бувай",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "interjection",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
       "gloss": "impudent, brazen",
       "glossClean": "impudent",
       "heritage": "standard",
@@ -7641,6 +7714,23 @@
         "cases": {}
       },
       "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "spontaneity, ease",
+      "glossClean": "spontaneity",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "невимушеність",
+      "lemmaId": "невимушеність",
+      "lemmaPlain": "невимушеність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     },
@@ -7760,6 +7850,23 @@
     },
     {
       "cefr": "B2",
+      "gloss": "to load; to burden",
+      "glossClean": "to load",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "навантажити",
+      "lemmaId": "навантажити",
+      "lemmaPlain": "навантажити",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
       "gloss": "excess",
       "glossClean": "excess",
       "heritage": "standard",
@@ -7862,6 +7969,23 @@
     },
     {
       "cefr": "B2",
+      "gloss": "prefix (school synonym)",
+      "glossClean": "prefix (school synonym)",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "приставка",
+      "lemmaId": "приставка",
+      "lemmaPlain": "приставка",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun:f",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
       "gloss": "to forge; to work extra",
       "glossClean": "to forge",
       "heritage": "standard",
@@ -7937,23 +8061,6 @@
       "lemma": "червоніти",
       "lemmaId": "червоніти",
       "lemmaPlain": "червоніти",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
-      "gloss": "to push repeatedly",
-      "glossClean": "to push repeatedly",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "штовхати",
-      "lemmaId": "штовхати",
-      "lemmaPlain": "штовхати",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -8197,13 +8304,13 @@
     },
     {
       "cefr": "B2",
-      "gloss": "approximate",
-      "glossClean": "approximate",
+      "gloss": "anti-war",
+      "glossClean": "anti-war",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "наближений",
-      "lemmaId": "наближений",
-      "lemmaPlain": "наближений",
+      "lemma": "антивоєнний",
+      "lemmaId": "антивоєнний",
+      "lemmaPlain": "антивоєнний",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -8221,6 +8328,40 @@
       "lemma": "паризький",
       "lemmaId": "паризький",
       "lemmaPlain": "паризький",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "pre-holiday",
+      "glossClean": "pre-holiday",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "передсвятковий",
+      "lemmaId": "передсвятковий",
+      "lemmaPlain": "передсвятковий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "coastal, riverside",
+      "glossClean": "coastal",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "прибережний",
+      "lemmaId": "прибережний",
+      "lemmaPlain": "прибережний",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -8413,18 +8554,4304 @@
     },
     {
       "cefr": "B2",
-      "gloss": "to be implemented",
-      "glossClean": "to be implemented",
+      "gloss": "expressiveness",
+      "glossClean": "expressiveness",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "впроваджуватися",
-      "lemmaId": "впроваджуватися",
-      "lemmaPlain": "впроваджуватися",
+      "lemma": "експресивність",
+      "lemmaId": "експресивність",
+      "lemmaPlain": "експресивність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "outdated",
+      "glossClean": "outdated",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "застарілий",
+      "lemmaId": "застарілий",
+      "lemmaPlain": "застарілий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "conciseness",
+      "glossClean": "conciseness",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "лаконічність",
+      "lemmaId": "лаконічність",
+      "lemmaPlain": "лаконічність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "deverbal adjective",
+      "glossClean": "deverbal adjective",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "віддієслівний прикметник",
+      "lemmaId": "віддієслівний-прикметник",
+      "lemmaPlain": "віддієслівний прикметник",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "equivalent",
+      "glossClean": "equivalent",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "відповідник",
+      "lemmaId": "відповідник",
+      "lemmaPlain": "відповідник",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "appropriateness",
+      "glossClean": "appropriateness",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "доречність",
+      "lemmaId": "доречність",
+      "lemmaPlain": "доречність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "moving, touching",
+      "glossClean": "moving",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "зворушливий",
+      "lemmaId": "зворушливий",
+      "lemmaPlain": "зворушливий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "calquing",
+      "glossClean": "calquing",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "калькування",
+      "lemmaId": "калькування",
+      "lemmaPlain": "калькування",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "language resilience",
+      "glossClean": "language resilience",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "мовна стійкість",
+      "lemmaId": "мовна-стійкість",
+      "lemmaPlain": "мовна стійкість",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "linguistic intuition",
+      "glossClean": "linguistic intuition",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "мовний слух",
+      "lemmaId": "мовний-слух",
+      "lemmaPlain": "мовний слух",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "dominant, prevailing",
+      "glossClean": "dominant",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "панівний",
+      "lemmaId": "панівний",
+      "lemmaPlain": "панівний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "beginner",
+      "glossClean": "beginner",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "початківець",
+      "lemmaId": "початківець",
+      "lemmaPlain": "початківець",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "upcoming, forthcoming",
+      "glossClean": "upcoming",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "прийдешній",
+      "lemmaId": "прийдешній",
+      "lemmaPlain": "прийдешній",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "relative clause",
+      "glossClean": "relative clause",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "підрядне означальне речення",
+      "lemmaId": "підрядне-означальне-речення",
+      "lemmaPlain": "підрядне означальне речення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "working group",
+      "glossClean": "working group",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "робоча група",
+      "lemmaId": "робоча-група",
+      "lemmaPlain": "робоча група",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "fertile",
+      "glossClean": "fertile",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "родючий",
+      "lemmaId": "родючий",
+      "lemmaPlain": "родючий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "stable feature",
+      "glossClean": "stable feature",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "стала ознака",
+      "lemmaId": "стала-ознака",
+      "lemmaPlain": "стала ознака",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "temporary action",
+      "glossClean": "temporary action",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "тимчасова дія",
+      "lemmaId": "тимчасова-дія",
+      "lemmaPlain": "тимчасова дія",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "healing",
+      "glossClean": "healing",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "цілющий",
+      "lemmaId": "цілющий",
+      "lemmaPlain": "цілющий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "agent noun",
+      "glossClean": "agent noun",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "іменник діяча",
+      "lemmaId": "іменник-діяча",
+      "lemmaPlain": "іменник діяча",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "charity marathon",
+      "glossClean": "charity marathon",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "благодійний марафон",
+      "lemmaId": "благодійний-марафон",
+      "lemmaPlain": "благодійний марафон",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "syntactic calque",
+      "glossClean": "syntactic calque",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "синтаксична калька",
+      "lemmaId": "синтаксична-калька",
+      "lemmaPlain": "синтаксична калька",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "main member",
+      "glossClean": "main member",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "головний член",
+      "lemmaId": "головний-член",
+      "lemmaPlain": "головний член",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "two-member sentence",
+      "glossClean": "two-member sentence",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "двоскладне речення",
+      "lemmaId": "двоскладне-речення",
+      "lemmaPlain": "двоскладне речення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "dynamism",
+      "glossClean": "dynamism",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "динамізм",
+      "lemmaId": "динамізм",
+      "lemmaPlain": "динамізм",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "category of state",
+      "glossClean": "category of state",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "категорія стану",
+      "lemmaId": "категорія-стану",
+      "lemmaPlain": "категорія стану",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "nominative sentence",
+      "glossClean": "nominative sentence",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "називне речення",
+      "lemmaId": "називне-речення",
+      "lemmaPlain": "називне речення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "experiencer of a state",
+      "glossClean": "experiencer of a state",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "носій стану",
+      "lemmaId": "носій-стану",
+      "lemmaPlain": "носій стану",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "one-member sentence",
+      "glossClean": "one-member sentence",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "односкладне речення",
+      "lemmaId": "односкладне-речення",
+      "lemmaPlain": "односкладне речення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "self-sufficient",
+      "glossClean": "self-sufficient",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "самодостатній",
+      "lemmaId": "самодостатній",
+      "lemmaPlain": "самодостатній",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "syntactic independence",
+      "glossClean": "syntactic independence",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "синтаксична незалежність",
+      "lemmaId": "синтаксична-незалежність",
+      "lemmaPlain": "синтаксична незалежність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "syntactic synonymy",
+      "glossClean": "syntactic synonymy",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "синтаксична синонімія",
+      "lemmaId": "синтаксична-синонімія",
+      "lemmaPlain": "синтаксична синонімія",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to edit",
+      "glossClean": "to edit",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "відредагувати",
+      "lemmaId": "відредагувати",
+      "lemmaPlain": "відредагувати",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
       "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "indefinite-personal sentence",
+      "glossClean": "indefinite-personal sentence",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "неозначено-особове речення",
+      "lemmaId": "неозначено-особове-речення",
+      "lemmaPlain": "неозначено-особове речення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "normativity, standardness",
+      "glossClean": "normativity",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "нормативність",
+      "lemmaId": "нормативність",
+      "lemmaPlain": "нормативність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "punctuation vigilance",
+      "glossClean": "punctuation vigilance",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "пунктуаційна пильність",
+      "lemmaId": "пунктуаційна-пильність",
+      "lemmaPlain": "пунктуаційна пильність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "reflection",
+      "glossClean": "reflection",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "рефлексія",
+      "lemmaId": "рефлексія",
+      "lemmaPlain": "рефлексія",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "рефлексіям",
+            "singular": "рефлексії"
+          },
+          "знахідний": {
+            "plural": "рефлексії",
+            "singular": "рефлексію"
+          },
+          "кличний": {
+            "plural": "рефлексії",
+            "singular": "рефлексіє"
+          },
+          "місцевий": {
+            "plural": "рефлексіях",
+            "singular": "рефлексії"
+          },
+          "називний": {
+            "plural": "рефлексії",
+            "singular": "рефлексія"
+          },
+          "орудний": {
+            "plural": "рефлексіями",
+            "singular": "рефлексією"
+          },
+          "родовий": {
+            "plural": "рефлексій",
+            "singular": "рефлексії"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "stylistic flexibility",
+      "glossClean": "stylistic flexibility",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "стилістична гнучкість",
+      "lemmaId": "стилістична-гнучкість",
+      "lemmaPlain": "стилістична гнучкість",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "utterance focus",
+      "glossClean": "utterance focus",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "фокус висловлення",
+      "lemmaId": "фокус-висловлення",
+      "lemmaPlain": "фокус висловлення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "domain-specific vocabulary",
+      "glossClean": "domain-specific vocabulary",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "галузева лексика",
+      "lemmaId": "галузева-лексика",
+      "lemmaPlain": "галузева лексика",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "funding source",
+      "glossClean": "funding source",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "джерело фінансування",
+      "lemmaId": "джерело-фінансування",
+      "lemmaPlain": "джерело фінансування",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "connotation",
+      "glossClean": "connotation",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "конотація",
+      "lemmaId": "конотація",
+      "lemmaPlain": "конотація",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "конотаціям",
+            "singular": "конотації"
+          },
+          "знахідний": {
+            "plural": "конотації",
+            "singular": "конотацію"
+          },
+          "кличний": {
+            "plural": "конотації",
+            "singular": "конотаціє"
+          },
+          "місцевий": {
+            "plural": "конотаціях",
+            "singular": "конотації"
+          },
+          "називний": {
+            "plural": "конотації",
+            "singular": "конотація"
+          },
+          "орудний": {
+            "plural": "конотаціями",
+            "singular": "конотацією"
+          },
+          "родовий": {
+            "plural": "конотацій",
+            "singular": "конотації"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "performance criterion",
+      "glossClean": "performance criterion",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "критерій результативності",
+      "lemmaId": "критерій-результативності",
+      "lemmaPlain": "критерій результативності",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "language norm",
+      "glossClean": "language norm",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "мовна норма",
+      "lemmaId": "мовна-норма",
+      "lemmaPlain": "мовна норма",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "neutrality",
+      "glossClean": "neutrality",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "нейтральність",
+      "lemmaId": "нейтральність",
+      "lemmaPlain": "нейтральність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "evaluative vocabulary",
+      "glossClean": "evaluative vocabulary",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "оцінна лексика",
+      "lemmaId": "оцінна-лексика",
+      "lemmaPlain": "оцінна лексика",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "legal review",
+      "glossClean": "legal review",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "правова експертиза",
+      "lemmaId": "правова-експертиза",
+      "lemmaPlain": "правова експертиза",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "presumption of innocence",
+      "glossClean": "presumption of innocence",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "презумпція невинуватості",
+      "lemmaId": "презумпція-невинуватості",
+      "lemmaPlain": "презумпція невинуватості",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "profit",
+      "glossClean": "profit",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "прибуток",
+      "lemmaId": "прибуток",
+      "lemmaPlain": "прибуток",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "editorial edit",
+      "glossClean": "editorial edit",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "редакторська правка",
+      "lemmaId": "редакторська-правка",
+      "lemmaPlain": "редакторська правка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "stylistic dominant",
+      "glossClean": "stylistic dominant",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "стильова домінанта",
+      "lemmaId": "стильова-домінанта",
+      "lemmaPlain": "стильова домінанта",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "stylistic norm",
+      "glossClean": "stylistic norm",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "стилістична норма",
+      "lemmaId": "стилістична-норма",
+      "lemmaPlain": "стилістична норма",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "stylistic dissonance",
+      "glossClean": "stylistic dissonance",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "стилістичний дисонанс",
+      "lemmaId": "стилістичний-дисонанс",
+      "lemmaPlain": "стилістичний дисонанс",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "terminological migration",
+      "glossClean": "terminological migration",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "термінологічна міграція",
+      "lemmaId": "термінологічна-міграція",
+      "lemmaPlain": "термінологічна міграція",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "functional style",
+      "glossClean": "functional style",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "функціональний стиль",
+      "lemmaId": "функціональний-стиль",
+      "lemmaPlain": "функціональний стиль",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "interstylistics",
+      "glossClean": "interstylistics",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "інтерстилістика",
+      "lemmaId": "інтерстилістика",
+      "lemmaPlain": "інтерстилістика",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "detached member",
+      "glossClean": "detached member",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "відокремлений член",
+      "lemmaId": "відокремлений-член",
+      "lemmaPlain": "відокремлений член",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "predicative relation",
+      "glossClean": "predicative relation",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "предикативний зв'язок",
+      "lemmaId": "предикативний-зв-язок",
+      "lemmaPlain": "предикативний зв'язок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "simple predicate",
+      "glossClean": "simple predicate",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "простий присудок",
+      "lemmaId": "простий-присудок",
+      "lemmaPlain": "простий присудок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "punctuation norm",
+      "glossClean": "punctuation norm",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "пунктуаційна норма",
+      "lemmaId": "пунктуаційна-норма",
+      "lemmaPlain": "пунктуаційна норма",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "syntactic model",
+      "glossClean": "syntactic model",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "синтаксична модель",
+      "lemmaId": "синтаксична-модель",
+      "lemmaPlain": "синтаксична модель",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "syntactic analysis",
+      "glossClean": "syntactic analysis",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "синтаксичний розбір",
+      "lemmaId": "синтаксичний-розбір",
+      "lemmaPlain": "синтаксичний розбір",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "compound predicate",
+      "glossClean": "compound predicate",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "складений присудок",
+      "lemmaId": "складений-присудок",
+      "lemmaPlain": "складений присудок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "clarifying member",
+      "glossClean": "clarifying member",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "уточнювальний член",
+      "lemmaId": "уточнювальний-член",
+      "lemmaPlain": "уточнювальний член",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "variability",
+      "glossClean": "variability",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "варіативність",
+      "lemmaId": "варіативність",
+      "lemmaPlain": "варіативність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "free indirect discourse",
+      "glossClean": "free indirect discourse",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "невласне пряма мова",
+      "lemmaId": "невласне-пряма-мова",
+      "lemmaPlain": "невласне пряма мова",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "paired conjunction",
+      "glossClean": "paired conjunction",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "парний сполучник",
+      "lemmaId": "парний-сполучник",
+      "lemmaPlain": "парний сполучник",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "predicative clause",
+      "glossClean": "predicative clause",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "предикативна частина",
+      "lemmaId": "предикативна-частина",
+      "lemmaPlain": "предикативна частина",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "systematization",
+      "glossClean": "systematization",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "систематизація",
+      "lemmaId": "систематизація",
+      "lemmaPlain": "систематизація",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "систематизаціям",
+            "singular": "систематизації"
+          },
+          "знахідний": {
+            "plural": "систематизації",
+            "singular": "систематизацію"
+          },
+          "кличний": {
+            "plural": "систематизації",
+            "singular": "систематизаціє"
+          },
+          "місцевий": {
+            "plural": "систематизаціях",
+            "singular": "систематизації"
+          },
+          "називний": {
+            "plural": "систематизації",
+            "singular": "систематизація"
+          },
+          "орудний": {
+            "plural": "систематизаціями",
+            "singular": "систематизацією"
+          },
+          "родовий": {
+            "plural": "систематизацій",
+            "singular": "систематизації"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "complex",
+      "glossClean": "complex",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "складнопідрядний",
+      "lemmaId": "складнопідрядний",
+      "lemmaPlain": "складнопідрядний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "base sentence",
+      "glossClean": "base sentence",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "базове речення",
+      "lemmaId": "базове-речення",
+      "lemmaPlain": "базове речення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "ambiguity",
+      "glossClean": "ambiguity",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "двозначність",
+      "lemmaId": "двозначність",
+      "lemmaPlain": "двозначність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "expressive",
+      "glossClean": "expressive",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "експресивний",
+      "lemmaId": "експресивний",
+      "lemmaPlain": "експресивний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "genre appropriateness",
+      "glossClean": "genre appropriateness",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "жанрова доречність",
+      "lemmaId": "жанрова-доречність",
+      "lemmaPlain": "жанрова доречність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to compare, to juxtapose",
+      "glossClean": "to compare",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "зіставити",
+      "lemmaId": "зіставити",
+      "lemmaPlain": "зіставити",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "unambiguity",
+      "glossClean": "unambiguity",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "однозначність",
+      "lemmaId": "однозначність",
+      "lemmaPlain": "однозначність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "omitted predicate",
+      "glossClean": "omitted predicate",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "пропущений присудок",
+      "lemmaId": "пропущений-присудок",
+      "lemmaPlain": "пропущений присудок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "publicistic writing, journalism",
+      "glossClean": "publicistic writing",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "публіцистика",
+      "lemmaId": "публіцистика",
+      "lemmaPlain": "публіцистика",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "segmentation",
+      "glossClean": "segmentation",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "розчленування",
+      "lemmaId": "розчленування",
+      "lemmaPlain": "розчленування",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "syntactic compression",
+      "glossClean": "syntactic compression",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "синтаксична компресія",
+      "lemmaId": "синтаксична-компресія",
+      "lemmaPlain": "синтаксична компресія",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "situational",
+      "glossClean": "situational",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "ситуативний",
+      "lemmaId": "ситуативний",
+      "lemmaPlain": "ситуативний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to shorten",
+      "glossClean": "to shorten",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "скоротити",
+      "lemmaId": "скоротити",
+      "lemmaPlain": "скоротити",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "semantic, meaningful",
+      "glossClean": "semantic",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "смисловий",
+      "lemmaId": "смисловий",
+      "lemmaPlain": "смисловий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "technical text",
+      "glossClean": "technical text",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "технічний текст",
+      "lemmaId": "технічний-текст",
+      "lemmaPlain": "технічний текст",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "literary text",
+      "glossClean": "literary text",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "художній текст",
+      "lemmaId": "художній-текст",
+      "lemmaPlain": "художній текст",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "legal text",
+      "glossClean": "legal text",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "юридичний текст",
+      "lemmaId": "юридичний-текст",
+      "lemmaPlain": "юридичний текст",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "ballast, dead weight",
+      "glossClean": "ballast",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "баласт",
+      "lemmaId": "баласт",
+      "lemmaPlain": "баласт",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "sentence frame",
+      "glossClean": "sentence frame",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "каркас речення",
+      "lemmaId": "каркас-речення",
+      "lemmaPlain": "каркас речення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "adverbial",
+      "glossClean": "adverbial",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "обставинний",
+      "lemmaId": "обставинний",
+      "lemmaPlain": "обставинний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "causal relation",
+      "glossClean": "causal relation",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "причиновий зв'язок",
+      "lemmaId": "причиновий-зв-язок",
+      "lemmaPlain": "причиновий зв'язок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "spatial relation",
+      "glossClean": "spatial relation",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "просторовий зв'язок",
+      "lemmaId": "просторовий-зв-язок",
+      "lemmaPlain": "просторовий зв'язок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "punctuation boundary",
+      "glossClean": "punctuation boundary",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "пунктуаційна межа",
+      "lemmaId": "пунктуаційна-межа",
+      "lemmaPlain": "пунктуаційна межа",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "edited version",
+      "glossClean": "edited version",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "редакторська версія",
+      "lemmaId": "редакторська-версія",
+      "lemmaPlain": "редакторська версія",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "rhetorical effect",
+      "glossClean": "rhetorical effect",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "риторичний ефект",
+      "lemmaId": "риторичний-ефект",
+      "lemmaPlain": "риторичний ефект",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "splitting a conjunction",
+      "glossClean": "splitting a conjunction",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "розчленування сполучника",
+      "lemmaId": "розчленування-сполучника",
+      "lemmaPlain": "розчленування сполучника",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "correlation",
+      "glossClean": "correlation",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "співвіднесення",
+      "lemmaId": "співвіднесення",
+      "lemmaPlain": "співвіднесення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "concision",
+      "glossClean": "concision",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "стислість",
+      "lemmaId": "стислість",
+      "lemmaPlain": "стислість",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "temporal relation",
+      "glossClean": "temporal relation",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "часовий зв'язок",
+      "lemmaId": "часовий-зв-язок",
+      "lemmaPlain": "часовий зв'язок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "emphasis",
+      "glossClean": "emphasis",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "акцентування",
+      "lemmaId": "акцентування",
+      "lemmaPlain": "акцентування",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "detached, separated",
+      "glossClean": "detached",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "відокремлений",
+      "lemmaId": "відокремлений",
+      "lemmaPlain": "відокремлений",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "detailing",
+      "glossClean": "detailing",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "деталізація",
+      "lemmaId": "деталізація",
+      "lemmaPlain": "деталізація",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "деталізаціям",
+            "singular": "деталізації"
+          },
+          "знахідний": {
+            "plural": "деталізації",
+            "singular": "деталізацію"
+          },
+          "кличний": {
+            "plural": "деталізації",
+            "singular": "деталізаціє"
+          },
+          "місцевий": {
+            "plural": "деталізаціях",
+            "singular": "деталізації"
+          },
+          "називний": {
+            "plural": "деталізації",
+            "singular": "деталізація"
+          },
+          "орудний": {
+            "plural": "деталізаціями",
+            "singular": "деталізацією"
+          },
+          "родовий": {
+            "plural": "деталізацій",
+            "singular": "деталізації"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "single attribute",
+      "glossClean": "single attribute",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "одиничне означення",
+      "lemmaId": "одиничне-означення",
+      "lemmaPlain": "одиничне означення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "sentence rhythm",
+      "glossClean": "sentence rhythm",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "ритм речення",
+      "lemmaId": "ритм-речення",
+      "lemmaPlain": "ритм речення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "syntactic norm",
+      "glossClean": "syntactic norm",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "синтаксична норма",
+      "lemmaId": "синтаксична-норма",
+      "lemmaPlain": "синтаксична норма",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "semantic pause",
+      "glossClean": "semantic pause",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "смислова пауза",
+      "lemmaId": "смислова-пауза",
+      "lemmaPlain": "смислова пауза",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "intonational pause",
+      "glossClean": "intonational pause",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "інтонаційна пауза",
+      "lemmaId": "інтонаційна-пауза",
+      "lemmaPlain": "інтонаційна пауза",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "handover act",
+      "glossClean": "handover act",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "акт приймання-передачі",
+      "lemmaId": "акт-приймання-передачі",
+      "lemmaPlain": "акт приймання-передачі",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to rent, to lease",
+      "glossClean": "to rent",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "винаймати",
+      "lemmaId": "винаймати",
+      "lemmaPlain": "винаймати",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "building chat",
+      "glossClean": "building chat",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "домовий чат",
+      "lemmaId": "домовий-чат",
+      "lemmaPlain": "домовий чат",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to rent out",
+      "glossClean": "to rent out",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "здавати в оренду",
+      "lemmaId": "здавати-в-оренду",
+      "lemmaPlain": "здавати в оренду",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "major renovation",
+      "glossClean": "major renovation",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "капітальний ремонт",
+      "lemmaId": "капітальний-ремонт",
+      "lemmaPlain": "капітальний ремонт",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "property management company",
+      "glossClean": "property management company",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "керуюча компанія",
+      "lemmaId": "керуюча-компанія",
+      "lemmaPlain": "керуюча компанія",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "cosmetic renovation",
+      "glossClean": "cosmetic renovation",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "косметичний ремонт",
+      "lemmaId": "косметичний-ремонт",
+      "lemmaPlain": "косметичний ремонт",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "kitchen unit",
+      "glossClean": "kitchen unit",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "кухонний гарнітур",
+      "lemmaId": "кухонний-гарнітур",
+      "lemmaPlain": "кухонний гарнітур",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "rent payment",
+      "glossClean": "rent payment",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "орендна плата",
+      "lemmaId": "орендна-плата",
+      "lemmaPlain": "орендна плата",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "household appliances",
+      "glossClean": "household appliances",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "побутова техніка",
+      "lemmaId": "побутова-техніка",
+      "lemmaPlain": "побутова техніка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "meter reading, indicator",
+      "glossClean": "meter reading",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "показник",
+      "lemmaId": "показник",
+      "lemmaPlain": "показник",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "breakdown",
+      "glossClean": "breakdown",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "поломка",
+      "lemmaId": "поломка",
+      "lemmaPlain": "поломка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to damage",
+      "glossClean": "to damage",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "пошкодити",
+      "lemmaId": "пошкодити",
+      "lemmaPlain": "пошкодити",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "quiet-hours rule",
+      "glossClean": "quiet-hours rule",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "правило тиші",
+      "lemmaId": "правило-тиші",
+      "lemmaPlain": "правило тиші",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "leak",
+      "glossClean": "leak",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "протікання",
+      "lemmaId": "протікання",
+      "lemmaPlain": "протікання",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "flatmate, co-resident",
+      "glossClean": "flatmate",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "співмешканець",
+      "lemmaId": "співмешканець",
+      "lemmaPlain": "співмешканець",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "shared space",
+      "glossClean": "shared space",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "спільний простір",
+      "lemmaId": "спільний-простір",
+      "lemmaPlain": "спільний простір",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "lease term",
+      "glossClean": "lease term",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "строк оренди",
+      "lemmaId": "строк-оренди",
+      "lemmaPlain": "строк оренди",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "transport connection",
+      "glossClean": "transport connection",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "транспортна розв'язка",
+      "lemmaId": "транспортна-розв-язка",
+      "lemmaPlain": "транспортна розв'язка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "infrastructure",
+      "glossClean": "infrastructure",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "інфраструктура",
+      "lemmaId": "інфраструктура",
+      "lemmaPlain": "інфраструктура",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "інфраструктурам",
+            "singular": "інфраструктурі"
+          },
+          "знахідний": {
+            "plural": "інфраструктури",
+            "singular": "інфраструктуру"
+          },
+          "кличний": {
+            "plural": "інфраструктури",
+            "singular": "інфраструктуро"
+          },
+          "місцевий": {
+            "plural": "інфраструктурах",
+            "singular": "інфраструктурі"
+          },
+          "називний": {
+            "plural": "інфраструктури",
+            "singular": "інфраструктура"
+          },
+          "орудний": {
+            "plural": "інфраструктурами",
+            "singular": "інфраструктурою"
+          },
+          "родовий": {
+            "plural": "інфраструктур",
+            "singular": "інфраструктури"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "authorial narration",
+      "glossClean": "authorial narration",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "авторська розповідь",
+      "lemmaId": "авторська-розповідь",
+      "lemmaPlain": "авторська розповідь",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to take out of context",
+      "glossClean": "to take out of context",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "вирвати з контексту",
+      "lemmaId": "вирвати-з-контексту",
+      "lemmaPlain": "вирвати з контексту",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "inner voice",
+      "glossClean": "inner voice",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "внутрішній голос",
+      "lemmaId": "внутрішній-голос",
+      "lemmaPlain": "внутрішній голос",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "verbatim",
+      "glossClean": "verbatim",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "дослівний",
+      "lemmaId": "дослівний",
+      "lemmaPlain": "дослівний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to note, to state",
+      "glossClean": "to note",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "зазначити",
+      "lemmaId": "зазначити",
+      "lemmaPlain": "зазначити",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "question mark",
+      "glossClean": "question mark",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "знак питання",
+      "lemmaId": "знак-питання",
+      "lemmaPlain": "знак питання",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "modality",
+      "glossClean": "modality",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "модальність",
+      "lemmaId": "модальність",
+      "lemmaPlain": "модальність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "information structure",
+      "glossClean": "information structure",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "актуальне членування",
+      "lemmaId": "актуальне-членування",
+      "lemmaPlain": "актуальне членування",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "distant placement",
+      "glossClean": "distant placement",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "дистантне розташування",
+      "lemmaId": "дистантне-розташування",
+      "lemmaPlain": "дистантне розташування",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "calqued construction",
+      "glossClean": "calqued construction",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "калькована конструкція",
+      "lemmaId": "калькована-конструкція",
+      "lemmaPlain": "калькована конструкція",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "communicative center",
+      "glossClean": "communicative center",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "комунікативний центр",
+      "lemmaId": "комунікативний-центр",
+      "lemmaPlain": "комунікативний центр",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "final position",
+      "glossClean": "final position",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "кінцева позиція",
+      "lemmaId": "кінцева-позиція",
+      "lemmaPlain": "кінцева позиція",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "neutral word order",
+      "glossClean": "neutral word order",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "нейтральний порядок",
+      "lemmaId": "нейтральний-порядок",
+      "lemmaPlain": "нейтральний порядок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "implicit question",
+      "glossClean": "implicit question",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "приховане питання",
+      "lemmaId": "приховане-питання",
+      "lemmaPlain": "приховане питання",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "discourse frame",
+      "glossClean": "discourse frame",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "рамка висловлення",
+      "lemmaId": "рамка-висловлення",
+      "lemmaPlain": "рамка висловлення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "official style",
+      "glossClean": "official style",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "службовий стиль",
+      "lemmaId": "службовий-стиль",
+      "lemmaPlain": "службовий стиль",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "semantic center",
+      "glossClean": "semantic center",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "смисловий центр",
+      "lemmaId": "смисловий-центр",
+      "lemmaPlain": "смисловий центр",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "stylistic figure",
+      "glossClean": "stylistic figure",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "стилістична фігура",
+      "lemmaId": "стилістична-фігура",
+      "lemmaPlain": "стилістична фігура",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "solemnity",
+      "glossClean": "solemnity",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "урочистість",
+      "lemmaId": "урочистість",
+      "lemmaPlain": "урочистість",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "antithesis",
+      "glossClean": "antithesis",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "антитеза",
+      "lemmaId": "антитеза",
+      "lemmaPlain": "антитеза",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "антитезам",
+            "singular": "антитезі"
+          },
+          "знахідний": {
+            "plural": "антитези",
+            "singular": "антитезу"
+          },
+          "кличний": {
+            "plural": "антитези",
+            "singular": "антитезо"
+          },
+          "місцевий": {
+            "plural": "антитезах",
+            "singular": "антитезі"
+          },
+          "називний": {
+            "plural": "антитези",
+            "singular": "антитеза"
+          },
+          "орудний": {
+            "plural": "антитезами",
+            "singular": "антитезою"
+          },
+          "родовий": {
+            "plural": "антитез",
+            "singular": "антитези"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "gradation",
+      "glossClean": "gradation",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "градація",
+      "lemmaId": "градація",
+      "lemmaPlain": "градація",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "градаціям",
+            "singular": "градації"
+          },
+          "знахідний": {
+            "plural": "градації",
+            "singular": "градацію"
+          },
+          "кличний": {
+            "plural": "градації",
+            "singular": "градаціє"
+          },
+          "місцевий": {
+            "plural": "градаціях",
+            "singular": "градації"
+          },
+          "називний": {
+            "plural": "градації",
+            "singular": "градація"
+          },
+          "орудний": {
+            "plural": "градаціями",
+            "singular": "градацією"
+          },
+          "родовий": {
+            "plural": "градацій",
+            "singular": "градації"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "logical compatibility",
+      "glossClean": "logical compatibility",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "логічна сумісність",
+      "lemmaId": "логічна-сумісність",
+      "lemmaPlain": "логічна сумісність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "non-homogeneous attributes",
+      "glossClean": "non-homogeneous attributes",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "неоднорідні означення",
+      "lemmaId": "неоднорідні-означення",
+      "lemmaPlain": "неоднорідні означення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "homogeneous series",
+      "glossClean": "homogeneous series",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "однорідний ряд",
+      "lemmaId": "однорідний-ряд",
+      "lemmaPlain": "однорідний ряд",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "homogeneous attributes",
+      "glossClean": "homogeneous attributes",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "однорідні означення",
+      "lemmaId": "однорідні-означення",
+      "lemmaPlain": "однорідні означення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "semantic homogeneity",
+      "glossClean": "semantic homogeneity",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "семантична однорідність",
+      "lemmaId": "семантична-однорідність",
+      "lemmaPlain": "семантична однорідність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "symmetry",
+      "glossClean": "symmetry",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "симетрія",
+      "lemmaId": "симетрія",
+      "lemmaPlain": "симетрія",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "симетріям",
+            "singular": "симетрії"
+          },
+          "знахідний": {
+            "plural": "симетрії",
+            "singular": "симетрію"
+          },
+          "кличний": {
+            "plural": "симетрії",
+            "singular": "симетріє"
+          },
+          "місцевий": {
+            "plural": "симетріях",
+            "singular": "симетрії"
+          },
+          "називний": {
+            "plural": "симетрії",
+            "singular": "симетрія"
+          },
+          "орудний": {
+            "plural": "симетріями",
+            "singular": "симетрією"
+          },
+          "родовий": {
+            "plural": "симетрій",
+            "singular": "симетрії"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "administrative text",
+      "glossClean": "administrative text",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "службовий текст",
+      "lemmaId": "службовий-текст",
+      "lemmaPlain": "службовий текст",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "semantic field",
+      "glossClean": "semantic field",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "смислове поле",
+      "lemmaId": "смислове-поле",
+      "lemmaPlain": "смислове поле",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "generalizing word",
+      "glossClean": "generalizing word",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "узагальнююче слово",
+      "lemmaId": "узагальнююче-слово",
+      "lemmaPlain": "узагальнююче слово",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "hospitality",
+      "glossClean": "hospitality",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "гостинність",
+      "lemmaId": "гостинність",
+      "lemmaPlain": "гостинність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "handful",
+      "glossClean": "handful",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "жменя",
+      "lemmaId": "жменя",
+      "lemmaPlain": "жменя",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "жменям",
+            "singular": "жмені"
+          },
+          "знахідний": {
+            "plural": "жмені",
+            "singular": "жменю"
+          },
+          "кличний": {
+            "plural": "жмені",
+            "singular": "жмене"
+          },
+          "місцевий": {
+            "plural": "жменях",
+            "singular": "жмені"
+          },
+          "називний": {
+            "plural": "жмені",
+            "singular": "жменя"
+          },
+          "орудний": {
+            "plural": "жменями",
+            "singular": "жменею"
+          },
+          "родовий": {
+            "plural": "жмень",
+            "singular": "жмені"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to bake, to roast",
+      "glossClean": "to bake",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "запікати",
+      "lemmaId": "запікати",
+      "lemmaPlain": "запікати",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "means of action",
+      "glossClean": "means of action",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "засіб дії",
+      "lemmaId": "засіб-дії",
+      "lemmaPlain": "засіб дії",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "calorie content",
+      "glossClean": "calorie content",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "калорійність",
+      "lemmaId": "калорійність",
+      "lemmaPlain": "калорійність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "fiber",
+      "glossClean": "fiber",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "клітковина",
+      "lemmaId": "клітковина",
+      "lemmaPlain": "клітковина",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "клітковинам",
+            "singular": "клітковині"
+          },
+          "знахідний": {
+            "plural": "клітковини",
+            "singular": "клітковину"
+          },
+          "кличний": {
+            "plural": "клітковини",
+            "singular": "клітковино"
+          },
+          "місцевий": {
+            "plural": "клітковинах",
+            "singular": "клітковині"
+          },
+          "називний": {
+            "plural": "клітковини",
+            "singular": "клітковина"
+          },
+          "орудний": {
+            "plural": "клітковинами",
+            "singular": "клітковиною"
+          },
+          "родовий": {
+            "plural": "клітковин",
+            "singular": "клітковини"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "lid",
+      "glossClean": "lid",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "кришка",
+      "lemmaId": "кришка",
+      "lemmaPlain": "кришка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "кришкам",
+            "singular": "кришці"
+          },
+          "знахідний": {
+            "plural": "кришки",
+            "singular": "кришку"
+          },
+          "кличний": {
+            "plural": "кришки",
+            "singular": "кришко"
+          },
+          "місцевий": {
+            "plural": "кришках",
+            "singular": "кришці"
+          },
+          "називний": {
+            "plural": "кришки",
+            "singular": "кришка"
+          },
+          "орудний": {
+            "plural": "кришками",
+            "singular": "кришкою"
+          },
+          "родовий": {
+            "plural": "кришок",
+            "singular": "кришки"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "cooking method",
+      "glossClean": "cooking method",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "спосіб приготування",
+      "lemmaId": "спосіб-приготування",
+      "lemmaPlain": "спосіб приготування",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to stew, to braise",
+      "glossClean": "to stew",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "тушкувати",
+      "lemmaId": "тушкувати",
+      "lemmaPlain": "тушкувати",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "pinch",
+      "glossClean": "pinch",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "щіпка",
+      "lemmaId": "щіпка",
+      "lemmaPlain": "щіпка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "щіпкам",
+            "singular": "щіпці"
+          },
+          "знахідний": {
+            "plural": "щіпки",
+            "singular": "щіпку"
+          },
+          "кличний": {
+            "plural": "щіпки",
+            "singular": "щіпко"
+          },
+          "місцевий": {
+            "plural": "щіпках",
+            "singular": "щіпці"
+          },
+          "називний": {
+            "plural": "щіпки",
+            "singular": "щіпка"
+          },
+          "орудний": {
+            "plural": "щіпками",
+            "singular": "щіпкою"
+          },
+          "родовий": {
+            "plural": "щіпок",
+            "singular": "щіпки"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "warranty case",
+      "glossClean": "warranty case",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "гарантійний випадок",
+      "lemmaId": "гарантійний-випадок",
+      "lemmaPlain": "гарантійний випадок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "cause losses, cause damages",
+      "glossClean": "cause losses",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "завдати збитків",
+      "lemmaId": "завдати-збитків",
+      "lemmaPlain": "завдати збитків",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "package contents",
+      "glossClean": "package contents",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "комплектація",
+      "lemmaId": "комплектація",
+      "lemmaPlain": "комплектація",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "комплектаціям",
+            "singular": "комплектації"
+          },
+          "знахідний": {
+            "plural": "комплектації",
+            "singular": "комплектацію"
+          },
+          "кличний": {
+            "plural": "комплектації",
+            "singular": "комплектаціє"
+          },
+          "місцевий": {
+            "plural": "комплектаціях",
+            "singular": "комплектації"
+          },
+          "називний": {
+            "plural": "комплектації",
+            "singular": "комплектація"
+          },
+          "орудний": {
+            "plural": "комплектаціями",
+            "singular": "комплектацією"
+          },
+          "родовий": {
+            "plural": "комплектацій",
+            "singular": "комплектації"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "purchase, buying",
+      "glossClean": "purchase",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "купівля",
+      "lemmaId": "купівля",
+      "lemmaPlain": "купівля",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "купівлям",
+            "singular": "купівлі"
+          },
+          "знахідний": {
+            "plural": "купівлі",
+            "singular": "купівлю"
+          },
+          "кличний": {
+            "plural": "купівлі",
+            "singular": "купівле"
+          },
+          "місцевий": {
+            "plural": "купівлях",
+            "singular": "купівлі"
+          },
+          "називний": {
+            "plural": "купівлі",
+            "singular": "купівля"
+          },
+          "орудний": {
+            "plural": "купівлями",
+            "singular": "купівлею"
+          },
+          "родовий": {
+            "plural": "купівель",
+            "singular": "купівлі"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "prepayment",
+      "glossClean": "prepayment",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "передплата",
+      "lemmaId": "передплата",
+      "lemmaPlain": "передплата",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "передплатам",
+            "singular": "передплаті"
+          },
+          "знахідний": {
+            "plural": "передплати",
+            "singular": "передплату"
+          },
+          "кличний": {
+            "plural": "передплати",
+            "singular": "передплато"
+          },
+          "місцевий": {
+            "plural": "передплатах",
+            "singular": "передплаті"
+          },
+          "називний": {
+            "plural": "передплати",
+            "singular": "передплата"
+          },
+          "орудний": {
+            "plural": "передплатами",
+            "singular": "передплатою"
+          },
+          "родовий": {
+            "plural": "передплат",
+            "singular": "передплати"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "rating",
+      "glossClean": "rating",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "рейтинг",
+      "lemmaId": "рейтинг",
+      "lemmaPlain": "рейтинг",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "conscious consumption",
+      "glossClean": "conscious consumption",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "свідоме споживання",
+      "lemmaId": "свідоме-споживання",
+      "lemmaPlain": "свідоме споживання",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "allegory",
+      "glossClean": "allegory",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "алегорія",
+      "lemmaId": "алегорія",
+      "lemmaPlain": "алегорія",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "алегоріям",
+            "singular": "алегорії"
+          },
+          "знахідний": {
+            "plural": "алегорії",
+            "singular": "алегорію"
+          },
+          "кличний": {
+            "plural": "алегорії",
+            "singular": "алегоріє"
+          },
+          "місцевий": {
+            "plural": "алегоріях",
+            "singular": "алегорії"
+          },
+          "називний": {
+            "plural": "алегорії",
+            "singular": "алегорія"
+          },
+          "орудний": {
+            "plural": "алегоріями",
+            "singular": "алегорією"
+          },
+          "родовий": {
+            "plural": "алегорій",
+            "singular": "алегорії"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "polysemy",
+      "glossClean": "polysemy",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "багатозначність",
+      "lemmaId": "багатозначність",
+      "lemmaPlain": "багатозначність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "euphemism",
+      "glossClean": "euphemism",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "евфемізм",
+      "lemmaId": "евфемізм",
+      "lemmaPlain": "евфемізм",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "lexical layer",
+      "glossClean": "lexical layer",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "лексичний пласт",
+      "lemmaId": "лексичний-пласт",
+      "lemmaPlain": "лексичний пласт",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "wordplay",
+      "glossClean": "wordplay",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "мовна гра",
+      "lemmaId": "мовна-гра",
+      "lemmaPlain": "мовна гра",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "neologism",
+      "glossClean": "neologism",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "неологізм",
+      "lemmaId": "неологізм",
+      "lemmaPlain": "неологізм",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "sarcasm",
+      "glossClean": "sarcasm",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "сарказм",
+      "lemmaId": "сарказм",
+      "lemmaPlain": "сарказм",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "stylistic coloring",
+      "glossClean": "stylistic coloring",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "стилістичне забарвлення",
+      "lemmaId": "стилістичне-забарвлення",
+      "lemmaPlain": "стилістичне забарвлення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "arch",
+      "glossClean": "arch",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "арка",
+      "lemmaId": "арка",
+      "lemmaPlain": "арка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "аркам",
+            "singular": "арці"
+          },
+          "знахідний": {
+            "plural": "арки",
+            "singular": "арку"
+          },
+          "кличний": {
+            "plural": "арки",
+            "singular": "арко"
+          },
+          "місцевий": {
+            "plural": "арках",
+            "singular": "арці"
+          },
+          "називний": {
+            "plural": "арки",
+            "singular": "арка"
+          },
+          "орудний": {
+            "plural": "арками",
+            "singular": "аркою"
+          },
+          "родовий": {
+            "plural": "арок",
+            "singular": "арки"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "cobblestone pavement",
+      "glossClean": "cobblestone pavement",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "бруківка",
+      "lemmaId": "бруківка",
+      "lemmaPlain": "бруківка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "бруківкам",
+            "singular": "бруківці"
+          },
+          "знахідний": {
+            "plural": "бруківки",
+            "singular": "бруківку"
+          },
+          "кличний": {
+            "plural": "бруківки",
+            "singular": "бруківко"
+          },
+          "місцевий": {
+            "plural": "бруківках",
+            "singular": "бруківці"
+          },
+          "називний": {
+            "plural": "бруківки",
+            "singular": "бруківка"
+          },
+          "орудний": {
+            "plural": "бруківками",
+            "singular": "бруківкою"
+          },
+          "родовий": {
+            "plural": "бруківок",
+            "singular": "бруківки"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "tower",
+      "glossClean": "tower",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "вежа",
+      "lemmaId": "вежа",
+      "lemmaPlain": "вежа",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "вежам",
+            "singular": "вежі"
+          },
+          "знахідний": {
+            "plural": "вежі",
+            "singular": "вежу"
+          },
+          "кличний": {
+            "plural": "вежі",
+            "singular": "веже"
+          },
+          "місцевий": {
+            "plural": "вежах",
+            "singular": "вежі"
+          },
+          "називний": {
+            "plural": "вежі",
+            "singular": "вежа"
+          },
+          "орудний": {
+            "plural": "вежами",
+            "singular": "вежею"
+          },
+          "родовий": {
+            "plural": "веж",
+            "singular": "вежі"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "Carpathian",
+      "glossClean": "Carpathian",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "карпатський",
+      "lemmaId": "карпатський",
+      "lemmaPlain": "карпатський",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "final stop",
+      "glossClean": "final stop",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "кінцева зупинка",
+      "lemmaId": "кінцева-зупинка",
+      "lemmaPlain": "кінцева зупинка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "high mountain meadow",
+      "glossClean": "high mountain meadow",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "полонина",
+      "lemmaId": "полонина",
+      "lemmaPlain": "полонина",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "полонинам",
+            "singular": "полонині"
+          },
+          "знахідний": {
+            "plural": "полонини",
+            "singular": "полонину"
+          },
+          "кличний": {
+            "plural": "полонини",
+            "singular": "полонино"
+          },
+          "місцевий": {
+            "plural": "полонинах",
+            "singular": "полонині"
+          },
+          "називний": {
+            "plural": "полонини",
+            "singular": "полонина"
+          },
+          "орудний": {
+            "plural": "полонинами",
+            "singular": "полониною"
+          },
+          "родовий": {
+            "plural": "полонин",
+            "singular": "полонини"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "guidebook",
+      "glossClean": "guidebook",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "путівник",
+      "lemmaId": "путівник",
+      "lemmaPlain": "путівник",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "multi-clause sentence",
+      "glossClean": "multi-clause sentence",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "багатокомпонентне речення",
+      "lemmaId": "багатокомпонентне-речення",
+      "lemmaPlain": "багатокомпонентне речення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "conjunction cluster",
+      "glossClean": "conjunction cluster",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "збіг сполучників",
+      "lemmaId": "збіг-сполучників",
+      "lemmaPlain": "збіг сполучників",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "logical unity",
+      "glossClean": "logical unity",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "логічна єдність",
+      "lemmaId": "логічна-єдність",
+      "lemmaPlain": "логічна єдність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "cause-and-effect relation",
+      "glossClean": "cause-and-effect relation",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "причинно-наслідковий зв'язок",
+      "lemmaId": "причинно-наслідковий-зв-язок",
+      "lemmaPlain": "причинно-наслідковий зв'язок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "punctuation literacy",
+      "glossClean": "punctuation literacy",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "пунктуаційна грамотність",
+      "lemmaId": "пунктуаційна-грамотність",
+      "lemmaPlain": "пунктуаційна грамотність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "syntactic construction",
+      "glossClean": "syntactic construction",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "синтаксична конструкція",
+      "lemmaId": "синтаксична-конструкція",
+      "lemmaPlain": "синтаксична конструкція",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "semantic relation",
+      "glossClean": "semantic relation",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "смисловий зв'язок",
+      "lemmaId": "смисловий-зв-язок",
+      "lemmaPlain": "смисловий зв'язок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "coordinate clause",
+      "glossClean": "coordinate clause",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "сурядна частина",
+      "lemmaId": "сурядна-частина",
+      "lemmaPlain": "сурядна частина",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "authorial position",
+      "glossClean": "authorial position",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "авторська позиція",
+      "lemmaId": "авторська-позиція",
+      "lemmaPlain": "авторська позиція",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "inserted sentence",
+      "glossClean": "inserted sentence",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "вставлене речення",
+      "lemmaId": "вставлене-речення",
+      "lemmaPlain": "вставлене речення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to set off",
+      "glossClean": "to set off",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "відокремлювати",
+      "lemmaId": "відокремлювати",
+      "lemmaPlain": "відокремлювати",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "emotional evaluation",
+      "glossClean": "emotional evaluation",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "емоційна оцінка",
+      "lemmaId": "емоційна-оцінка",
+      "lemmaPlain": "емоційна оцінка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "communicative function",
+      "glossClean": "communicative function",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "комунікативна функція",
+      "lemmaId": "комунікативна-функція",
+      "lemmaPlain": "комунікативна функція",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "logical coherence of presentation",
+      "glossClean": "logical coherence of presentation",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "логічність викладу",
+      "lemmaId": "логічність-викладу",
+      "lemmaPlain": "логічність викладу",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "order of exposition",
+      "glossClean": "order of exposition",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "порядок викладу",
+      "lemmaId": "порядок-викладу",
+      "lemmaPlain": "порядок викладу",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "predicative word",
+      "glossClean": "predicative word",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "присудкове слово",
+      "lemmaId": "присудкове-слово",
+      "lemmaPlain": "присудкове слово",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "semantic group",
+      "glossClean": "semantic group",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "семантична група",
+      "lemmaId": "семантична-група",
+      "lemmaPlain": "семантична група",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "syntactically isolated",
+      "glossClean": "syntactically isolated",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "синтаксично ізольований",
+      "lemmaId": "синтаксично-ізольований",
+      "lemmaPlain": "синтаксично ізольований",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "degree of certainty",
+      "glossClean": "degree of certainty",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "ступінь упевненості",
+      "lemmaId": "ступінь-упевненості",
+      "lemmaPlain": "ступінь упевненості",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "subjectivity",
+      "glossClean": "subjectivity",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "суб'єктивність",
+      "lemmaId": "суб-єктивність",
+      "lemmaPlain": "суб'єктивність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "equivalence",
+      "glossClean": "equivalence",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "еквівалентність",
+      "lemmaId": "еквівалентність",
+      "lemmaPlain": "еквівалентність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "cognitive",
+      "glossClean": "cognitive",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "когнітивний",
+      "lemmaId": "когнітивний",
+      "lemmaPlain": "когнітивний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "logic of presentation",
+      "glossClean": "logic of presentation",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "логіка викладу",
+      "lemmaId": "логіка-викладу",
+      "lemmaPlain": "логіка викладу",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "monotony",
+      "glossClean": "monotony",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "монотонність",
+      "lemmaId": "монотонність",
+      "lemmaPlain": "монотонність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "morphological",
+      "glossClean": "morphological",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "морфологічний",
+      "lemmaId": "морфологічний",
+      "lemmaPlain": "морфологічний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "finite personal form",
+      "glossClean": "finite personal form",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "особова форма",
+      "lemmaId": "особова-форма",
+      "lemmaPlain": "особова форма",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "semantic loss",
+      "glossClean": "semantic loss",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "семантична втрата",
+      "lemmaId": "семантична-втрата",
+      "lemmaPlain": "семантична втрата",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "measures have been taken",
+      "glossClean": "measures have been taken",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "вжито заходів",
+      "lemmaId": "вжито-заходів",
+      "lemmaPlain": "вжито заходів",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "deadline, final deadline",
+      "glossClean": "deadline",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "крайній строк",
+      "lemmaId": "крайній-строк",
+      "lemmaPlain": "крайній строк",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "media style",
+      "glossClean": "media style",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "медійний стиль",
+      "lemmaId": "медійний-стиль",
+      "lemmaPlain": "медійний стиль",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "supervisory board",
+      "glossClean": "supervisory board",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "наглядова рада",
+      "lemmaId": "наглядова-рада",
+      "lemmaPlain": "наглядова рада",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
       "semanticBucket": null,
       "severity": null
     },
@@ -8442,6 +12869,120 @@
         "cases": {}
       },
       "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "reflexive passive in -sia",
+      "glossClean": "reflexive passive in -sia",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "пасив на -ся",
+      "lemmaId": "пасив-на-ся",
+      "lemmaPlain": "пасив на -ся",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "explanatory memo",
+      "glossClean": "explanatory memo",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "пояснювальна записка",
+      "lemmaId": "пояснювальна-записка",
+      "lemmaPlain": "пояснювальна записка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "regulation, procedural formalization",
+      "glossClean": "regulation",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "регламентація",
+      "lemmaId": "регламентація",
+      "lemmaPlain": "регламентація",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "регламентаціям",
+            "singular": "регламентації"
+          },
+          "знахідний": {
+            "plural": "регламентації",
+            "singular": "регламентацію"
+          },
+          "кличний": {
+            "plural": "регламентації",
+            "singular": "регламентаціє"
+          },
+          "місцевий": {
+            "plural": "регламентаціях",
+            "singular": "регламентації"
+          },
+          "називний": {
+            "plural": "регламентації",
+            "singular": "регламентація"
+          },
+          "орудний": {
+            "plural": "регламентаціями",
+            "singular": "регламентацією"
+          },
+          "родовий": {
+            "plural": "регламентацій",
+            "singular": "регламентації"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "subject perspective",
+      "glossClean": "subject perspective",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "суб'єктна перспектива",
+      "lemmaId": "суб-єктна-перспектива",
+      "lemmaPlain": "суб'єктна перспектива",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to be implemented",
+      "glossClean": "to be implemented",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "впроваджуватися",
+      "lemmaId": "впроваджуватися",
+      "lemmaPlain": "впроваджуватися",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
       "semanticBucket": null,
       "severity": null
     },
@@ -8527,40 +13068,6 @@
     },
     {
       "cefr": "B2",
-      "gloss": "syntactic norm",
-      "glossClean": "syntactic norm",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "синтаксична норма",
-      "lemmaId": "синтаксична-норма",
-      "lemmaPlain": "синтаксична норма",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "phrase",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
-      "gloss": "to edit",
-      "glossClean": "to edit",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "відредагувати",
-      "lemmaId": "відредагувати",
-      "lemmaPlain": "відредагувати",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
       "gloss": "past participle",
       "glossClean": "past participle",
       "heritage": "unknown",
@@ -8612,18 +13119,18 @@
     },
     {
       "cefr": "B2",
-      "gloss": "conciseness",
-      "glossClean": "conciseness",
+      "gloss": "baked",
+      "glossClean": "baked",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "лаконічність",
-      "lemmaId": "лаконічність",
-      "lemmaPlain": "лаконічність",
+      "lemma": "спечений",
+      "lemmaId": "спечений",
+      "lemmaPlain": "спечений",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
-      "pos": "noun",
+      "pos": "adj",
       "semanticBucket": null,
       "severity": null
     },
@@ -8663,13 +13170,251 @@
     },
     {
       "cefr": "B2",
-      "gloss": "anonymity, namelessness",
-      "glossClean": "anonymity",
+      "gloss": "genre mode",
+      "glossClean": "genre mode",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "жанровий режим",
+      "lemmaId": "жанровий-режим",
+      "lemmaPlain": "жанровий режим",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "vowel hiatus",
+      "glossClean": "vowel hiatus",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "збіг голосних",
+      "lemmaId": "збіг-голосних",
+      "lemmaPlain": "збіг голосних",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "sound effect",
+      "glossClean": "sound effect",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "звуковий ефект",
+      "lemmaId": "звуковий-ефект",
+      "lemmaPlain": "звуковий ефект",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "sound repetition",
+      "glossClean": "sound repetition",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "звуковий повтор",
+      "lemmaId": "звуковий-повтор",
+      "lemmaPlain": "звуковий повтор",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "public speech",
+      "glossClean": "public speech",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "публічний виступ",
+      "lemmaId": "публічний-виступ",
+      "lemmaPlain": "публічний виступ",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "auditory image",
+      "glossClean": "auditory image",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "слуховий образ",
+      "lemmaId": "слуховий-образ",
+      "lemmaPlain": "слуховий образ",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "speech tempo",
+      "glossClean": "speech tempo",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "темп мовлення",
+      "lemmaId": "темп-мовлення",
+      "lemmaPlain": "темп мовлення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "abrupt, staccato",
+      "glossClean": "abrupt",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "анонімність",
-      "lemmaId": "анонімність",
-      "lemmaPlain": "анонімність",
+      "lemma": "уривчастий",
+      "lemmaId": "уривчастий",
+      "lemmaPlain": "уривчастий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "phonetic editing",
+      "glossClean": "phonetic editing",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "фонетична редактура",
+      "lemmaId": "фонетична-редактура",
+      "lemmaPlain": "фонетична редактура",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "phonetic device",
+      "glossClean": "phonetic device",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "фонетичний засіб",
+      "lemmaId": "фонетичний-засіб",
+      "lemmaPlain": "фонетичний засіб",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "attributive connection",
+      "glossClean": "attributive connection",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "атрибутивний зв'язок",
+      "lemmaId": "атрибутивний-зв-язок",
+      "lemmaPlain": "атрибутивний зв'язок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "prepositionless government",
+      "glossClean": "prepositionless government",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "безприйменникове керування",
+      "lemmaId": "безприйменникове-керування",
+      "lemmaPlain": "безприйменникове керування",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "grammatical form",
+      "glossClean": "grammatical form",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "граматична форма",
+      "lemmaId": "граматична-форма",
+      "lemmaPlain": "граматична форма",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "morphological assimilation",
+      "glossClean": "morphological assimilation",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "морфологічне уподібнення",
+      "lemmaId": "морфологічне-уподібнення",
+      "lemmaPlain": "морфологічне уподібнення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "invariability",
+      "glossClean": "invariability",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "незмінність",
+      "lemmaId": "незмінність",
+      "lemmaPlain": "незмінність",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -8680,13 +13425,149 @@
     },
     {
       "cefr": "B2",
-      "gloss": "captive, prisoner taken in a raid",
-      "glossClean": "captive",
+      "gloss": "nominative function",
+      "glossClean": "nominative function",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "номінативна функція",
+      "lemmaId": "номінативна-функція",
+      "lemmaPlain": "номінативна функція",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "object connection",
+      "glossClean": "object connection",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "об'єктний зв'язок",
+      "lemmaId": "об-єктний-зв-язок",
+      "lemmaPlain": "об'єктний зв'язок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "adverbial meaning",
+      "glossClean": "adverbial meaning",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "обставинне значення",
+      "lemmaId": "обставинне-значення",
+      "lemmaPlain": "обставинне значення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "prepositional government",
+      "glossClean": "prepositional government",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "прийменникове керування",
+      "lemmaId": "прийменникове-керування",
+      "lemmaPlain": "прийменникове керування",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "semantic connection",
+      "glossClean": "semantic connection",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "семантичний зв'язок",
+      "lemmaId": "семантичний-зв-язок",
+      "lemmaPlain": "семантичний зв'язок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "strong government",
+      "glossClean": "strong government",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "сильне керування",
+      "lemmaId": "сильне-керування",
+      "lemmaPlain": "сильне керування",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "syntactic unit",
+      "glossClean": "syntactic unit",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "синтаксична одиниця",
+      "lemmaId": "синтаксична-одиниця",
+      "lemmaPlain": "синтаксична одиниця",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "syntactic center",
+      "glossClean": "syntactic center",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "синтаксичний центр",
+      "lemmaId": "синтаксичний-центр",
+      "lemmaPlain": "синтаксичний центр",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "collocability",
+      "glossClean": "collocability",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "бранець",
-      "lemmaId": "бранець",
-      "lemmaPlain": "бранець",
+      "lemma": "сполучуваність",
+      "lemmaId": "сполучуваність",
+      "lemmaPlain": "сполучуваність",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -8697,43 +13578,264 @@
     },
     {
       "cefr": "B2",
-      "gloss": "galley (oared warship); a place of penal rowing",
-      "glossClean": "galley (oared warship)",
+      "gloss": "let us be attentive",
+      "glossClean": "let us be attentive",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "будьмо уважні",
+      "lemmaId": "будьмо-уважні",
+      "lemmaPlain": "будьмо уважні",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "polite request",
+      "glossClean": "polite request",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "ввічливе прохання",
+      "lemmaId": "ввічливе-прохання",
+      "lemmaPlain": "ввічливе прохання",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "mutual aid",
+      "glossClean": "mutual aid",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "галера",
-      "lemmaId": "галера",
-      "lemmaPlain": "галера",
-      "meaningMcEligible": false,
+      "lemma": "взаємодопомога",
+      "lemmaId": "взаємодопомога",
+      "lemmaPlain": "взаємодопомога",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "power outage schedule",
+      "glossClean": "power outage schedule",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "графік відключень",
+      "lemmaId": "графік-відключень",
+      "lemmaPlain": "графік відключень",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "household, domestic economy",
+      "glossClean": "household",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "домогосподарство",
+      "lemmaId": "домогосподарство",
+      "lemmaPlain": "домогосподарство",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "rarely, seldom",
+      "glossClean": "rarely",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "зрідка",
+      "lemmaId": "зрідка",
+      "lemmaPlain": "зрідка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adv",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "proper complaint",
+      "glossClean": "proper complaint",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "коректна скарга",
+      "lemmaId": "коректна-скарга",
+      "lemmaPlain": "коректна скарга",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to be right, to have a point",
+      "glossClean": "to be right",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "мати рацію",
+      "lemmaId": "мати-рацію",
+      "lemmaPlain": "мати рацію",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "invisible labor",
+      "glossClean": "invisible labor",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "невидима праця",
+      "lemmaId": "невидима-праця",
+      "lemmaPlain": "невидима праця",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "personal boundaries",
+      "glossClean": "personal boundaries",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "особисті межі",
+      "lemmaId": "особисті-межі",
+      "lemmaPlain": "особисті межі",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "household conflict",
+      "glossClean": "household conflict",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "побутовий конфлікт",
+      "lemmaId": "побутовий-конфлікт",
+      "lemmaPlain": "побутовий конфлікт",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "ironing",
+      "glossClean": "ironing",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "прасування",
+      "lemmaId": "прасування",
+      "lemmaPlain": "прасування",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "division of responsibilities",
+      "glossClean": "division of responsibilities",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "розподіл обов'язків",
+      "lemmaId": "розподіл-обов-язків",
+      "lemmaPlain": "розподіл обов'язків",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "routine",
+      "glossClean": "routine",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "рутина",
+      "lemmaId": "рутина",
+      "lemmaPlain": "рутина",
+      "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
-            "plural": "галерам",
-            "singular": "галері"
+            "plural": "рутинам",
+            "singular": "рутині"
           },
           "знахідний": {
-            "plural": "галери",
-            "singular": "галеру"
+            "plural": "рутини",
+            "singular": "рутину"
           },
           "кличний": {
-            "plural": "галери",
-            "singular": "галеро"
+            "plural": "рутини",
+            "singular": "рутино"
           },
           "місцевий": {
-            "plural": "галерах",
-            "singular": "галері"
+            "plural": "рутинах",
+            "singular": "рутині"
           },
           "називний": {
-            "plural": "галери",
-            "singular": "галера"
+            "plural": "рутини",
+            "singular": "рутина"
           },
           "орудний": {
-            "plural": "галерами",
-            "singular": "галерою"
+            "plural": "рутинами",
+            "singular": "рутиною"
           },
           "родовий": {
-            "plural": "галер",
-            "singular": "галери"
+            "plural": "рутин",
+            "singular": "рутини"
           }
         }
       },
@@ -8743,94 +13845,366 @@
     },
     {
       "cefr": "B2",
-      "gloss": "epic (as genre)",
-      "glossClean": "epic (as genre)",
-      "heritage": "standard",
+      "gloss": "service center",
+      "glossClean": "service center",
+      "heritage": "unknown",
       "ipa": null,
-      "lemma": "епос",
-      "lemmaId": "епос",
-      "lemmaPlain": "епос",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
-      "gloss": "self-sacrifice",
-      "glossClean": "self-sacrifice",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "жертовність",
-      "lemmaId": "жертовність",
-      "lemmaPlain": "жертовність",
+      "lemma": "сервісний центр",
+      "lemmaId": "сервісний-центр",
+      "lemmaPlain": "сервісний центр",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
-      "pos": "noun",
+      "pos": "phrase",
       "semanticBucket": null,
       "severity": null
     },
     {
       "cefr": "B2",
-      "gloss": "cuckoo; symbol of a mother's lament and longing for home",
-      "glossClean": "cuckoo",
-      "heritage": "standard",
+      "gloss": "gender role",
+      "glossClean": "gender role",
+      "heritage": "unknown",
       "ipa": null,
-      "lemma": "зозуля",
-      "lemmaId": "зозуля",
-      "lemmaPlain": "зозуля",
+      "lemma": "ґендерна роль",
+      "lemmaId": "ґендерна-роль",
+      "lemmaPlain": "ґендерна роль",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
-      "pos": "noun",
+      "pos": "phrase",
       "semanticBucket": null,
       "severity": null
     },
     {
       "cefr": "B2",
-      "gloss": "galley; later, hard penal labour",
-      "glossClean": "galley",
+      "gloss": "auxiliary word",
+      "glossClean": "auxiliary word",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "допоміжне слово",
+      "lemmaId": "допоміжне-слово",
+      "lemmaPlain": "допоміжне слово",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "quantitative phrase",
+      "glossClean": "quantitative phrase",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "кількісне сполучення",
+      "lemmaId": "кількісне-сполучення",
+      "lemmaPlain": "кількісне сполучення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "zero copula",
+      "glossClean": "zero copula",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "нульова зв'язка",
+      "lemmaId": "нульова-зв-язка",
+      "lemmaPlain": "нульова зв'язка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "predicative center",
+      "glossClean": "predicative center",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "предикативний центр",
+      "lemmaId": "предикативний-центр",
+      "lemmaPlain": "предикативний центр",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "compound verbal predicate",
+      "glossClean": "compound verbal predicate",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "складений дієслівний присудок",
+      "lemmaId": "складений-дієслівний-присудок",
+      "lemmaPlain": "складений дієслівний присудок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "compound nominal predicate",
+      "glossClean": "compound nominal predicate",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "складений іменний присудок",
+      "lemmaId": "складений-іменний-присудок",
+      "lemmaPlain": "складений іменний присудок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "stylistic transformation",
+      "glossClean": "stylistic transformation",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "стилістична трансформація",
+      "lemmaId": "стилістична-трансформація",
+      "lemmaPlain": "стилістична трансформація",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "phraseological predicate",
+      "glossClean": "phraseological predicate",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "фразеологічний присудок",
+      "lemmaId": "фразеологічний-присудок",
+      "lemmaPlain": "фразеологічний присудок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "nominal part",
+      "glossClean": "nominal part",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "іменна частина",
+      "lemmaId": "іменна-частина",
+      "lemmaPlain": "іменна частина",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "autonomous change",
+      "glossClean": "autonomous change",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "автономна зміна",
+      "lemmaId": "автономна-зміна",
+      "lemmaPlain": "автономна зміна",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "agentless",
+      "glossClean": "agentless",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "бездіячевий",
+      "lemmaId": "бездіячевий",
+      "lemmaPlain": "бездіячевий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "reciprocal reflexive meaning",
+      "glossClean": "reciprocal reflexive meaning",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "взаємно-зворотне значення",
+      "lemmaId": "взаємно-зворотне-значення",
+      "lemmaPlain": "взаємно-зворотне значення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "proper reflexive meaning",
+      "glossClean": "proper reflexive meaning",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "власне-зворотне значення",
+      "lemmaId": "власне-зворотне-значення",
+      "lemmaPlain": "власне-зворотне значення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "is being processed",
+      "glossClean": "is being processed",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "каторга",
-      "lemmaId": "каторга",
-      "lemmaPlain": "каторга",
+      "lemma": "обробляється",
+      "lemmaId": "обробляється",
+      "lemmaPlain": "обробляється",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "passive meaning",
+      "glossClean": "passive meaning",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "пасивне значення",
+      "lemmaId": "пасивне-значення",
+      "lemmaPlain": "пасивне значення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to be transmitted",
+      "glossClean": "to be transmitted",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "транслюватися",
+      "lemmaId": "транслюватися",
+      "lemmaPlain": "транслюватися",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "we would appreciate",
+      "glossClean": "we would appreciate",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "будемо вдячні",
+      "lemmaId": "будемо-вдячні",
+      "lemmaPlain": "будемо вдячні",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "refusal",
+      "glossClean": "refusal",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "відмова",
+      "lemmaId": "відмова",
+      "lemmaPlain": "відмова",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
-            "plural": "каторгам",
-            "singular": "каторзі"
+            "plural": "відмовам",
+            "singular": "відмові"
           },
           "знахідний": {
-            "plural": "каторги",
-            "singular": "каторгу"
+            "plural": "відмови",
+            "singular": "відмову"
           },
           "кличний": {
-            "plural": "каторги",
-            "singular": "каторго"
+            "plural": "відмови",
+            "singular": "відмово"
           },
           "місцевий": {
-            "plural": "каторгах",
-            "singular": "каторзі"
+            "plural": "відмовах",
+            "singular": "відмові"
           },
           "називний": {
-            "plural": "каторги",
-            "singular": "каторга"
+            "plural": "відмови",
+            "singular": "відмова"
           },
           "орудний": {
-            "plural": "каторгами",
-            "singular": "каторгою"
+            "plural": "відмовами",
+            "singular": "відмовою"
           },
           "родовий": {
-            "plural": "каторг",
-            "singular": "каторги"
+            "plural": "відмов",
+            "singular": "відмови"
           }
         }
       },
@@ -8840,13 +14214,200 @@
     },
     {
       "cefr": "B2",
-      "gloss": "raid, sudden military incursion",
-      "glossClean": "raid",
+      "gloss": "responsible person",
+      "glossClean": "responsible person",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "відповідальна особа",
+      "lemmaId": "відповідальна-особа",
+      "lemmaPlain": "відповідальна особа",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "report memo",
+      "glossClean": "report memo",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "доповідна записка",
+      "lemmaId": "доповідна-записка",
+      "lemmaPlain": "доповідна записка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "in view of, considering",
+      "glossClean": "in view of",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "з огляду на",
+      "lemmaId": "з-огляду-на",
+      "lemmaPlain": "з огляду на",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "sincerely, respectfully",
+      "glossClean": "sincerely",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "з повагою",
+      "lemmaId": "з-повагою",
+      "lemmaPlain": "з повагою",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "feedback",
+      "glossClean": "feedback",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "зворотний зв'язок",
+      "lemmaId": "зворотний-зв-язок",
+      "lemmaPlain": "зворотний зв'язок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "commercial proposal",
+      "glossClean": "commercial proposal",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "комерційна пропозиція",
+      "lemmaId": "комерційна-пропозиція",
+      "lemmaPlain": "комерційна пропозиція",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "cover letter",
+      "glossClean": "cover letter",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "мотиваційний лист",
+      "lemmaId": "мотиваційний-лист",
+      "lemmaPlain": "мотиваційний лист",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "agenda",
+      "glossClean": "agenda",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "порядок денний",
+      "lemmaId": "порядок-денний",
+      "lemmaPlain": "порядок денний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "internal memo",
+      "glossClean": "internal memo",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "службова записка",
+      "lemmaId": "службова-записка",
+      "lemmaPlain": "службова записка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "technical specification",
+      "glossClean": "technical specification",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "технічне завдання",
+      "lemmaId": "технічне-завдання",
+      "lemmaPlain": "технічне завдання",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "in response to",
+      "glossClean": "in response to",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "у відповідь на",
+      "lemmaId": "у-відповідь-на",
+      "lemmaPlain": "у відповідь на",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "bug",
+      "glossClean": "bug",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "набіг",
-      "lemmaId": "набіг",
-      "lemmaPlain": "набіг",
+      "lemma": "баг",
+      "lemmaId": "баг",
+      "lemmaPlain": "баг",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -8857,43 +14418,315 @@
     },
     {
       "cefr": "B2",
-      "gloss": "captivity, bondage",
-      "glossClean": "captivity",
+      "gloss": "to take a look",
+      "glossClean": "to take a look",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "неволя",
-      "lemmaId": "неволя",
-      "lemmaPlain": "неволя",
+      "lemma": "глянути",
+      "lemmaId": "глянути",
+      "lemmaPlain": "глянути",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to bring to attention",
+      "glossClean": "to bring to attention",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "довести до відома",
+      "lemmaId": "довести-до-відома",
+      "lemmaPlain": "довести до відома",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to change the deadline",
+      "glossClean": "to change the deadline",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "змінити термін",
+      "lemmaId": "змінити-термін",
+      "lemmaPlain": "змінити термін",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "communication channel",
+      "glossClean": "communication channel",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "канал спілкування",
+      "lemmaId": "канал-спілкування",
+      "lemmaPlain": "канал спілкування",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "communicative situation",
+      "glossClean": "communicative situation",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "комунікативна ситуація",
+      "lemmaId": "комунікативна-ситуація",
+      "lemmaPlain": "комунікативна ситуація",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "neutral tone",
+      "glossClean": "neutral tone",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "нейтральний тон",
+      "lemmaId": "нейтральний-тон",
+      "lemmaPlain": "нейтральний тон",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to move a deadline",
+      "glossClean": "to move a deadline",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "посунути дедлайн",
+      "lemmaId": "посунути-дедлайн",
+      "lemmaPlain": "посунути дедлайн",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "polite capitalized you",
+      "glossClean": "polite capitalized you",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "пошанне Ви",
+      "lemmaId": "пошанне-ви",
+      "lemmaPlain": "пошанне ви",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "we ask you to consider",
+      "glossClean": "we ask you to consider",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "просимо розглянути",
+      "lemmaId": "просимо-розглянути",
+      "lemmaPlain": "просимо розглянути",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "I confirm receipt",
+      "glossClean": "I confirm receipt",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "підтверджую отримання",
+      "lemmaId": "підтверджую-отримання",
+      "lemmaPlain": "підтверджую отримання",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "work chat",
+      "glossClean": "work chat",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "робочий чат",
+      "lemmaId": "робочий-чат",
+      "lemmaPlain": "робочий чат",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "slang",
+      "glossClean": "slang",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "сленг",
+      "lemmaId": "сленг",
+      "lemmaPlain": "сленг",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "social distance",
+      "glossClean": "social distance",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "соціальна дистанція",
+      "lemmaId": "соціальна-дистанція",
+      "lemmaPlain": "соціальна дистанція",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "deadline, execution term",
+      "glossClean": "deadline",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "термін виконання",
+      "lemmaId": "термін-виконання",
+      "lemmaPlain": "термін виконання",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "technical error",
+      "glossClean": "technical error",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "технічна помилка",
+      "lemmaId": "технічна-помилка",
+      "lemmaPlain": "технічна помилка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "on the basis of",
+      "glossClean": "on the basis of",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "на підставі",
+      "lemmaId": "на-підставі",
+      "lemmaPlain": "на підставі",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "formal complaint, claim",
+      "glossClean": "formal complaint",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "претензія",
+      "lemmaId": "претензія",
+      "lemmaPlain": "претензія",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
-            "plural": "неволям",
-            "singular": "неволі"
+            "plural": "претензіям",
+            "singular": "претензії"
           },
           "знахідний": {
-            "plural": "неволі",
-            "singular": "неволю"
+            "plural": "претензії",
+            "singular": "претензію"
           },
           "кличний": {
-            "plural": "неволі",
-            "singular": "неволе"
+            "plural": "претензії",
+            "singular": "претензіє"
           },
           "місцевий": {
-            "plural": "неволях",
-            "singular": "неволі"
+            "plural": "претензіях",
+            "singular": "претензії"
           },
           "називний": {
-            "plural": "неволі",
-            "singular": "неволя"
+            "plural": "претензії",
+            "singular": "претензія"
           },
           "орудний": {
-            "plural": "неволями",
-            "singular": "неволею"
+            "plural": "претензіями",
+            "singular": "претензією"
           },
           "родовий": {
-            "plural": "неволь",
-            "singular": "неволі"
+            "plural": "претензій",
+            "singular": "претензії"
           }
         }
       },
@@ -8903,13 +14736,13 @@
     },
     {
       "cefr": "B2",
-      "gloss": "captive, slave; one deprived of freedom and torn from the homeland",
-      "glossClean": "captive",
+      "gloss": "required detail, requisite",
+      "glossClean": "required detail",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "невільник",
-      "lemmaId": "невільник",
-      "lemmaPlain": "невільник",
+      "lemma": "реквізит",
+      "lemmaId": "реквізит",
+      "lemmaPlain": "реквізит",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -8920,262 +14753,143 @@
     },
     {
       "cefr": "B2",
-      "gloss": "psychologism; focus on inner emotional state",
-      "glossClean": "psychologism",
-      "heritage": "standard",
+      "gloss": "within the established deadline",
+      "glossClean": "within the established deadline",
+      "heritage": "unknown",
       "ipa": null,
-      "lemma": "психологізм",
-      "lemmaId": "психологізм",
-      "lemmaPlain": "психологізм",
+      "lemma": "у встановлений строк",
+      "lemmaId": "у-встановлений-строк",
+      "lemmaPlain": "у встановлений строк",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
-      "pos": "noun",
+      "pos": "phrase",
       "semanticBucket": null,
       "severity": null
     },
     {
       "cefr": "B2",
-      "gloss": "sycamore; symbol of misfortune, sorrow and death in a foreign land",
-      "glossClean": "sycamore",
-      "heritage": "standard",
+      "gloss": "authorial voice",
+      "glossClean": "authorial voice",
+      "heritage": "unknown",
       "ipa": null,
-      "lemma": "явір",
-      "lemmaId": "явір",
-      "lemmaPlain": "явір",
+      "lemma": "авторський голос",
+      "lemmaId": "авторський-голос",
+      "lemmaPlain": "авторський голос",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
-      "pos": "noun",
+      "pos": "noun phrase",
       "semanticBucket": null,
       "severity": null
     },
     {
       "cefr": "B2",
-      "gloss": "janissary (Ottoman soldier)",
-      "glossClean": "janissary (Ottoman soldier)",
-      "heritage": "standard",
+      "gloss": "authorial neologism",
+      "glossClean": "authorial neologism",
+      "heritage": "unknown",
       "ipa": null,
-      "lemma": "яничар",
-      "lemmaId": "яничар",
-      "lemmaPlain": "яничар",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
-      "gloss": "captives seized as living goods during raids (Turkic borrowing)",
-      "glossClean": "captives seized as living goods during raids (Turkic borrowing)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "ясир",
-      "lemmaId": "ясир",
-      "lemmaPlain": "ясир",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
-      "gloss": "didukh (ceremonial sheaf)",
-      "glossClean": "didukh (ceremonial sheaf)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "дідух",
-      "lemmaId": "дідух",
-      "lemmaPlain": "дідух",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
-      "gloss": "carolling (the rite of going house to house)",
-      "glossClean": "carolling (the rite of going house to house)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "колядування",
-      "lemmaId": "колядування",
-      "lemmaPlain": "колядування",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
-      "gloss": "ritual practice, body of rites",
-      "glossClean": "ritual practice",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "обрядовість",
-      "lemmaId": "обрядовість",
-      "lemmaPlain": "обрядовість",
+      "lemma": "авторський новотвір",
+      "lemmaId": "авторський-новотвір",
+      "lemmaPlain": "авторський новотвір",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
-      "pos": "noun",
+      "pos": "noun phrase",
       "semanticBucket": null,
       "severity": null
     },
     {
       "cefr": "B2",
-      "gloss": "fertility (of land)",
-      "glossClean": "fertility (of land)",
-      "heritage": "standard",
+      "gloss": "aesthetic function",
+      "glossClean": "aesthetic function",
+      "heritage": "unknown",
       "ipa": null,
-      "lemma": "родючість",
-      "lemmaId": "родючість",
-      "lemmaPlain": "родючість",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
-      "gloss": "equinox",
-      "glossClean": "equinox",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "рівнодення",
-      "lemmaId": "рівнодення",
-      "lemmaPlain": "рівнодення",
+      "lemma": "естетична функція",
+      "lemmaId": "естетична-функція",
+      "lemmaPlain": "естетична функція",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
-      "pos": "noun",
+      "pos": "noun phrase",
       "semanticBucket": null,
       "severity": null
     },
     {
       "cefr": "B2",
-      "gloss": "syncretism (coexistence of religious layers)",
-      "glossClean": "syncretism (coexistence of religious layers)",
-      "heritage": "standard",
+      "gloss": "ethical precision",
+      "glossClean": "ethical precision",
+      "heritage": "unknown",
       "ipa": null,
-      "lemma": "синкретизм",
-      "lemmaId": "синкретизм",
-      "lemmaPlain": "синкретизм",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
-      "gloss": "solstice",
-      "glossClean": "solstice",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "сонцестояння",
-      "lemmaId": "сонцестояння",
-      "lemmaPlain": "сонцестояння",
+      "lemma": "етична точність",
+      "lemmaId": "етична-точність",
+      "lemmaPlain": "етична точність",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
-      "pos": "noun",
+      "pos": "noun phrase",
       "semanticBucket": null,
       "severity": null
     },
     {
       "cefr": "B2",
-      "gloss": "cycle",
-      "glossClean": "cycle",
-      "heritage": "standard",
+      "gloss": "cultural detail",
+      "glossClean": "cultural detail",
+      "heritage": "unknown",
       "ipa": null,
-      "lemma": "цикл",
-      "lemmaId": "цикл",
-      "lemmaPlain": "цикл",
+      "lemma": "культурна деталь",
+      "lemmaId": "культурна-деталь",
+      "lemmaPlain": "культурна деталь",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
-      "pos": "noun",
+      "pos": "noun phrase",
       "semanticBucket": null,
       "severity": null
     },
     {
       "cefr": "B2",
-      "gloss": "parallelism; repetition of similar syntactic constructions",
-      "glossClean": "parallelism",
-      "heritage": "standard",
+      "gloss": "lyric voice",
+      "glossClean": "lyric voice",
+      "heritage": "unknown",
       "ipa": null,
-      "lemma": "паралелізм",
-      "lemmaId": "паралелізм",
-      "lemmaPlain": "паралелізм",
+      "lemma": "ліричний голос",
+      "lemmaId": "ліричний-голос",
+      "lemmaPlain": "ліричний голос",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
-      "pos": "noun",
+      "pos": "noun phrase",
       "semanticBucket": null,
       "severity": null
     },
     {
       "cefr": "B2",
-      "gloss": "existence in everyday use; how a form lives among people",
-      "glossClean": "existence in everyday use",
-      "heritage": "standard",
+      "gloss": "key detail",
+      "glossClean": "key detail",
+      "heritage": "unknown",
       "ipa": null,
-      "lemma": "побутування",
-      "lemmaId": "побутування",
-      "lemmaPlain": "побутування",
+      "lemma": "опорна деталь",
+      "lemmaId": "опорна-деталь",
+      "lemmaPlain": "опорна деталь",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
-      "pos": "noun",
+      "pos": "noun phrase",
       "semanticBucket": null,
       "severity": null
     },
     {
       "cefr": "B2",
-      "gloss": "refrain; a repeated line returning after each verse",
-      "glossClean": "refrain",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "рефрен",
-      "lemmaId": "рефрен",
-      "lemmaPlain": "рефрен",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
-      "gloss": "stylization; conscious imitation of another era's or genre's style",
+      "gloss": "stylization",
       "glossClean": "stylization",
       "heritage": "standard",
       "ipa": null,
@@ -9221,43 +14935,128 @@
     },
     {
       "cefr": "B2",
-      "gloss": "triad; here: host–hostess–children as a cosmic model",
-      "glossClean": "triad",
+      "gloss": "literary translation",
+      "glossClean": "literary translation",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "художній переклад",
+      "lemmaId": "художній-переклад",
+      "lemmaPlain": "художній переклад",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "reading between the lines",
+      "glossClean": "reading between the lines",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "читання між рядками",
+      "lemmaId": "читання-між-рядками",
+      "lemmaPlain": "читання між рядками",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "historicism",
+      "glossClean": "historicism",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "тріада",
-      "lemmaId": "тріада",
-      "lemmaPlain": "тріада",
+      "lemma": "історизм",
+      "lemmaId": "історизм",
+      "lemmaPlain": "історизм",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "influence, impact",
+      "glossClean": "influence",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "вплив",
+      "lemmaId": "вплив",
+      "lemmaPlain": "вплив",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "discourse marker",
+      "glossClean": "discourse marker",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "дискурсивний маркер",
+      "lemmaId": "дискурсивний-маркер",
+      "lemmaPlain": "дискурсивний маркер",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "short news item",
+      "glossClean": "short news item",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "замітка",
+      "lemmaId": "замітка",
+      "lemmaPlain": "замітка",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
-            "plural": "тріадам",
-            "singular": "тріаді"
+            "plural": "заміткам",
+            "singular": "замітці"
           },
           "знахідний": {
-            "plural": "тріади",
-            "singular": "тріаду"
+            "plural": "замітки",
+            "singular": "замітку"
           },
           "кличний": {
-            "plural": "тріади",
-            "singular": "тріадо"
+            "plural": "замітки",
+            "singular": "замітко"
           },
           "місцевий": {
-            "plural": "тріадах",
-            "singular": "тріаді"
+            "plural": "замітках",
+            "singular": "замітці"
           },
           "називний": {
-            "plural": "тріади",
-            "singular": "тріада"
+            "plural": "замітки",
+            "singular": "замітка"
           },
           "орудний": {
-            "plural": "тріадами",
-            "singular": "тріадою"
+            "plural": "замітками",
+            "singular": "заміткою"
           },
           "родовий": {
-            "plural": "тріад",
-            "singular": "тріади"
+            "plural": "заміток",
+            "singular": "замітки"
           }
         }
       },
@@ -9267,93 +15066,438 @@
     },
     {
       "cefr": "B2",
-      "gloss": "veneration, honouring",
-      "glossClean": "veneration",
-      "heritage": "standard",
+      "gloss": "bureaucratic mixed-language calque",
+      "glossClean": "bureaucratic mixed-language calque",
+      "heritage": "unknown",
       "ipa": null,
-      "lemma": "ушанування",
-      "lemmaId": "ушанування",
-      "lemmaPlain": "ушанування",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
-      "gloss": "funeral lament",
-      "glossClean": "funeral lament",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "голосіння",
-      "lemmaId": "голосіння",
-      "lemmaPlain": "голосіння",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "B2",
-      "gloss": "kobza (folk lute)",
-      "glossClean": "kobza (folk lute)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "кобза",
-      "lemmaId": "кобза",
-      "lemmaPlain": "кобза",
+      "lemma": "канцелярський суржик",
+      "lemmaId": "канцелярський-суржик",
+      "lemmaPlain": "канцелярський суржик",
       "meaningMcEligible": false,
       "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "кобзам",
-            "singular": "кобзі"
-          },
-          "знахідний": {
-            "plural": "кобзи",
-            "singular": "кобзу"
-          },
-          "кличний": {
-            "plural": "кобзи",
-            "singular": "кобзо"
-          },
-          "місцевий": {
-            "plural": "кобзах",
-            "singular": "кобзі"
-          },
-          "називний": {
-            "plural": "кобзи",
-            "singular": "кобза"
-          },
-          "орудний": {
-            "plural": "кобзами",
-            "singular": "кобзою"
-          },
-          "родовий": {
-            "plural": "кобз",
-            "singular": "кобзи"
-          }
-        }
+        "cases": {}
       },
-      "pos": "noun",
+      "pos": "noun phrase",
       "semanticBucket": null,
       "severity": null
     },
     {
       "cefr": "B2",
-      "gloss": "ritual wedding bread",
-      "glossClean": "ritual wedding bread",
+      "gloss": "basically, in short (colloquial)",
+      "glossClean": "basically",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "коровай",
-      "lemmaId": "коровай",
-      "lemmaPlain": "коровай",
+      "lemma": "короче",
+      "lemmaId": "короче",
+      "lemmaPlain": "короче",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "discourse marker",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "nonverbal means",
+      "glossClean": "nonverbal means",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "невербальні засоби",
+      "lemmaId": "невербальні-засоби",
+      "lemmaPlain": "невербальні засоби",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "register switching",
+      "glossClean": "register switching",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "перемикання регістрів",
+      "lemmaId": "перемикання-регістрів",
+      "lemmaPlain": "перемикання регістрів",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "cool, funny",
+      "glossClean": "cool",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "прикольно",
+      "lemmaId": "прикольно",
+      "lemmaPlain": "прикольно",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adverb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "public discourse, public speech",
+      "glossClean": "public discourse",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "публічне мовлення",
+      "lemmaId": "публічне-мовлення",
+      "lemmaPlain": "публічне мовлення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "rhetorical question",
+      "glossClean": "rhetorical question",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "риторичне запитання",
+      "lemmaId": "риторичне-запитання",
+      "lemmaPlain": "риторичне запитання",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "acting subject, agent",
+      "glossClean": "acting subject",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "суб'єкт дії",
+      "lemmaId": "суб-єкт-дії",
+      "lemmaPlain": "суб'єкт дії",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "no way, come on",
+      "glossClean": "no way",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "та ну",
+      "lemmaId": "та-ну",
+      "lemmaPlain": "та ну",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "discourse marker",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "Ukrainian language",
+      "glossClean": "Ukrainian language",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "українська мова",
+      "lemmaId": "українська-мова",
+      "lemmaPlain": "українська мова",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "secondary sentence member",
+      "glossClean": "secondary sentence member",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "другорядний член речення",
+      "lemmaId": "другорядний-член-речення",
+      "lemmaPlain": "другорядний член речення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "unextended sentence",
+      "glossClean": "unextended sentence",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "непоширене речення",
+      "lemmaId": "непоширене-речення",
+      "lemmaPlain": "непоширене речення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "indirect object",
+      "glossClean": "indirect object",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "непрямий додаток",
+      "lemmaId": "непрямий-додаток",
+      "lemmaPlain": "непрямий додаток",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "non-agreeing attribute",
+      "glossClean": "non-agreeing attribute",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "неузгоджене означення",
+      "lemmaId": "неузгоджене-означення",
+      "lemmaPlain": "неузгоджене означення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "adverbial of concession",
+      "glossClean": "adverbial of concession",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "обставина допусту",
+      "lemmaId": "обставина-допусту",
+      "lemmaPlain": "обставина допусту",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "adverbial of purpose",
+      "glossClean": "adverbial of purpose",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "обставина мети",
+      "lemmaId": "обставина-мети",
+      "lemmaPlain": "обставина мети",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "adverbial of place",
+      "glossClean": "adverbial of place",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "обставина місця",
+      "lemmaId": "обставина-місця",
+      "lemmaPlain": "обставина місця",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "adverbial of cause",
+      "glossClean": "adverbial of cause",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "обставина причини",
+      "lemmaId": "обставина-причини",
+      "lemmaPlain": "обставина причини",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "adverbial of manner",
+      "glossClean": "adverbial of manner",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "обставина способу дії",
+      "lemmaId": "обставина-способу-дії",
+      "lemmaPlain": "обставина способу дії",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "adverbial of condition",
+      "glossClean": "adverbial of condition",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "обставина умови",
+      "lemmaId": "обставина-умови",
+      "lemmaPlain": "обставина умови",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "adverbial of time",
+      "glossClean": "adverbial of time",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "обставина часу",
+      "lemmaId": "обставина-часу",
+      "lemmaPlain": "обставина часу",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "extended sentence",
+      "glossClean": "extended sentence",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "поширене речення",
+      "lemmaId": "поширене-речення",
+      "lemmaPlain": "поширене речення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "stylistic appropriateness",
+      "glossClean": "stylistic appropriateness",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "стилістична доречність",
+      "lemmaId": "стилістична-доречність",
+      "lemmaPlain": "стилістична доречність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "agreeing attribute",
+      "glossClean": "agreeing attribute",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "узгоджене означення",
+      "lemmaId": "узгоджене-означення",
+      "lemmaPlain": "узгоджене означення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "active recreation",
+      "glossClean": "active recreation",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "активний відпочинок",
+      "lemmaId": "активний-відпочинок",
+      "lemmaPlain": "активний відпочинок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "supporter, fan",
+      "glossClean": "supporter",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "вболівальник",
+      "lemmaId": "вболівальник",
+      "lemmaPlain": "вболівальник",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -9364,45 +15508,640 @@
     },
     {
       "cefr": "B2",
-      "gloss": "lira (Ukrainian hurdy-gurdy)",
-      "glossClean": "lira (Ukrainian hurdy-gurdy)",
+      "gloss": "cultural leisure",
+      "glossClean": "cultural leisure",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "культурне дозвілля",
+      "lemmaId": "культурне-дозвілля",
+      "lemmaPlain": "культурне дозвілля",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "warm-up",
+      "glossClean": "warm-up",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "ліра",
-      "lemmaId": "ліра",
-      "lemmaPlain": "ліра",
+      "lemma": "розминка",
+      "lemmaId": "розминка",
+      "lemmaPlain": "розминка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "розминкам",
+            "singular": "розминці"
+          },
+          "знахідний": {
+            "plural": "розминки",
+            "singular": "розминку"
+          },
+          "кличний": {
+            "plural": "розминки",
+            "singular": "розминко"
+          },
+          "місцевий": {
+            "plural": "розминках",
+            "singular": "розминці"
+          },
+          "називний": {
+            "plural": "розминки",
+            "singular": "розминка"
+          },
+          "орудний": {
+            "plural": "розминками",
+            "singular": "розминкою"
+          },
+          "родовий": {
+            "plural": "розминок",
+            "singular": "розминки"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "handicraft",
+      "glossClean": "handicraft",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "рукоділля",
+      "lemmaId": "рукоділля",
+      "lemmaPlain": "рукоділля",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "physical activity",
+      "glossClean": "physical activity",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "фізична активність",
+      "lemmaId": "фізична-активність",
+      "lemmaPlain": "фізична активність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "digital leisure",
+      "glossClean": "digital leisure",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "цифрове дозвілля",
+      "lemmaId": "цифрове-дозвілля",
+      "lemmaPlain": "цифрове дозвілля",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "analytical paragraph",
+      "glossClean": "analytical paragraph",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "аналітичний абзац",
+      "lemmaId": "аналітичний-абзац",
+      "lemmaPlain": "аналітичний абзац",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "cohesive device",
+      "glossClean": "cohesive device",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "засіб зв'язку",
+      "lemmaId": "засіб-зв-язку",
+      "lemmaPlain": "засіб зв'язку",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "logical relation",
+      "glossClean": "logical relation",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "логічний зв'язок",
+      "lemmaId": "логічний-зв-язок",
+      "lemmaPlain": "логічний зв'язок",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "argument development",
+      "glossClean": "argument development",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "нарощення аргументу",
+      "lemmaId": "нарощення-аргументу",
+      "lemmaPlain": "нарощення аргументу",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "synonymic substitution",
+      "glossClean": "synonymic substitution",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "синонімічна заміна",
+      "lemmaId": "синонімічна-заміна",
+      "lemmaPlain": "синонімічна заміна",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "official letter",
+      "glossClean": "official letter",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "службовий лист",
+      "lemmaId": "службовий-лист",
+      "lemmaPlain": "службовий лист",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "semantic unity",
+      "glossClean": "semantic unity",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "смислова цілісність",
+      "lemmaId": "смислова-цілісність",
+      "lemmaPlain": "смислова цілісність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "ascending gradation",
+      "glossClean": "ascending gradation",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "висхідна градація",
+      "lemmaId": "висхідна-градація",
+      "lemmaPlain": "висхідна градація",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "evidential limit",
+      "glossClean": "evidential limit",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "доказова межа",
+      "lemmaId": "доказова-межа",
+      "lemmaPlain": "доказова межа",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "expression, emotional force",
+      "glossClean": "expression",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "експресія",
+      "lemmaId": "експресія",
+      "lemmaPlain": "експресія",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "oratorical style",
+      "glossClean": "oratorical style",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "ораторський стиль",
+      "lemmaId": "ораторський-стиль",
+      "lemmaPlain": "ораторський стиль",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "parallelism",
+      "glossClean": "parallelism",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "паралелізм",
+      "lemmaId": "паралелізм",
+      "lemmaPlain": "паралелізм",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "rhetorical figure",
+      "glossClean": "rhetorical figure",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "риторична фігура",
+      "lemmaId": "риторична-фігура",
+      "lemmaPlain": "риторична фігура",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "rhetorical address",
+      "glossClean": "rhetorical address",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "риторичне звертання",
+      "lemmaId": "риторичне-звертання",
+      "lemmaPlain": "риторичне звертання",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "rhetorical exclamation",
+      "glossClean": "rhetorical exclamation",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "риторичний вигук",
+      "lemmaId": "риторичний-вигук",
+      "lemmaPlain": "риторичний вигук",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "syntactic figure",
+      "glossClean": "syntactic figure",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "синтаксична фігура",
+      "lemmaId": "синтаксична-фігура",
+      "lemmaPlain": "синтаксична фігура",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "syntactic parallelism",
+      "glossClean": "syntactic parallelism",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "синтаксичний паралелізм",
+      "lemmaId": "синтаксичний-паралелізм",
+      "lemmaPlain": "синтаксичний паралелізм",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "descending gradation",
+      "glossClean": "descending gradation",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "спадна градація",
+      "lemmaId": "спадна-градація",
+      "lemmaPlain": "спадна градація",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "stylistic function",
+      "glossClean": "stylistic function",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "стилістична функція",
+      "lemmaId": "стилістична-функція",
+      "lemmaPlain": "стилістична функція",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "sentence focus",
+      "glossClean": "sentence focus",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "фокус речення",
+      "lemmaId": "фокус-речення",
+      "lemmaPlain": "фокус речення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "public consultation",
+      "glossClean": "public consultation",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "громадське обговорення",
+      "lemmaId": "громадське-обговорення",
+      "lemmaPlain": "громадське обговорення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to state, note",
+      "glossClean": "to state",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "зазначати",
+      "lemmaId": "зазначати",
+      "lemmaPlain": "зазначати",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "resultative",
+      "glossClean": "resultative",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "результативний",
+      "lemmaId": "результативний",
+      "lemmaPlain": "результативний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "syntactic focus",
+      "glossClean": "syntactic focus",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "синтаксичний фокус",
+      "lemmaId": "синтаксичний-фокус",
+      "lemmaPlain": "синтаксичний фокус",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "stylistic synonymy",
+      "glossClean": "stylistic synonymy",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "стилістична синонімія",
+      "lemmaId": "стилістична-синонімія",
+      "lemmaPlain": "стилістична синонімія",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "third person plural",
+      "glossClean": "third person plural",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "третя особа множини",
+      "lemmaId": "третя-особа-множини",
+      "lemmaPlain": "третя особа множини",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "plural form",
+      "glossClean": "plural form",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "форма множини",
+      "lemmaId": "форма-множини",
+      "lemmaPlain": "форма множини",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "Epiphany",
+      "glossClean": "Epiphany",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "Водохреще",
+      "lemmaId": "водохреще",
+      "lemmaPlain": "водохреще",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "propn",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to revive",
+      "glossClean": "to revive",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "відроджувати",
+      "lemmaId": "відроджувати",
+      "lemmaPlain": "відроджувати",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "Vyshyvanka Day",
+      "glossClean": "Vyshyvanka Day",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "День вишиванки",
+      "lemmaId": "день-вишиванки",
+      "lemmaPlain": "день вишиванки",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "propn",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "didukh, ritual sheaf",
+      "glossClean": "didukh",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "дідух",
+      "lemmaId": "дідух",
+      "lemmaPlain": "дідух",
       "meaningMcEligible": false,
       "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "лірам",
-            "singular": "лірі"
-          },
-          "знахідний": {
-            "plural": "ліри",
-            "singular": "ліру"
-          },
-          "кличний": {
-            "plural": "ліри",
-            "singular": "ліро"
-          },
-          "місцевий": {
-            "plural": "лірах",
-            "singular": "лірі"
-          },
-          "називний": {
-            "plural": "ліри",
-            "singular": "ліра"
-          },
-          "орудний": {
-            "plural": "лірами",
-            "singular": "лірою"
-          },
-          "родовий": {
-            "plural": "лір",
-            "singular": "ліри"
-          }
-        }
+        "cases": {}
       },
       "pos": "noun",
       "semanticBucket": null,
@@ -9410,16 +16149,402 @@
     },
     {
       "cefr": "B2",
-      "gloss": "layering, stratification",
-      "glossClean": "layering",
+      "gloss": "superstition",
+      "glossClean": "superstition",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "нашарування",
-      "lemmaId": "нашарування",
-      "lemmaPlain": "нашарування",
+      "lemma": "забобон",
+      "lemmaId": "забобон",
+      "lemmaPlain": "забобон",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "Green Holidays, Pentecost period",
+      "glossClean": "Green Holidays",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "Зелені свята",
+      "lemmaId": "зелені-свята",
+      "lemmaPlain": "зелені свята",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "caroling",
+      "glossClean": "caroling",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "колядування",
+      "lemmaId": "колядування",
+      "lemmaPlain": "колядування",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "Malanka celebration",
+      "glossClean": "Malanka celebration",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "Маланка",
+      "lemmaId": "маланка",
+      "lemmaPlain": "маланка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "propn",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "ritual culture",
+      "glossClean": "ritual culture",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "обрядовість",
+      "lemmaId": "обрядовість",
+      "lemmaPlain": "обрядовість",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "to bless, to consecrate",
+      "glossClean": "to bless",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "освячувати",
+      "lemmaId": "освячувати",
+      "lemmaPlain": "освячувати",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "memorial meal",
+      "glossClean": "memorial meal",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "поминки",
+      "lemmaId": "поминки",
+      "lemmaPlain": "поминки",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "family-related",
+      "glossClean": "family-related",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "родинний",
+      "lemmaId": "родинний",
+      "lemmaPlain": "родинний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "matchmaking ceremony",
+      "glossClean": "matchmaking ceremony",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "сватання",
+      "lemmaId": "сватання",
+      "lemmaPlain": "сватання",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "baptism celebration",
+      "glossClean": "baptism celebration",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "хрестини",
+      "lemmaId": "хрестини",
+      "lemmaPlain": "хрестини",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "cardiologist",
+      "glossClean": "cardiologist",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "кардіолог",
+      "lemmaId": "кардіолог",
+      "lemmaPlain": "кардіолог",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "side, adverse",
+      "glossClean": "side",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "побічний",
+      "lemmaId": "побічний",
+      "lemmaPlain": "побічний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "contraindication",
+      "glossClean": "contraindication",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "протипоказання",
+      "lemmaId": "протипоказання",
+      "lemmaPlain": "протипоказання",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "poor common people; dispossessed rank",
+      "glossClean": "poor common people",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "голота",
+      "lemmaId": "голота",
+      "lemmaPlain": "голота",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "Koliivshchyna; eighteenth-century haidamak uprising",
+      "glossClean": "Koliivshchyna",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "Коліївщина",
+      "lemmaId": "коліївщина",
+      "lemmaPlain": "коліївщина",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "verse or couplet-like song unit",
+      "glossClean": "verse or couplet-like song unit",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "куплет",
+      "lemmaId": "куплет",
+      "lemmaPlain": "куплет",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "opryshok; Carpathian rebel or outlaw figure",
+      "glossClean": "opryshok",
+      "heritage": "historism",
+      "ipa": null,
+      "lemma": "опришок",
+      "lemmaId": "опришок",
+      "lemmaPlain": "опришок",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "falsified or forged text",
+      "glossClean": "falsified or forged text",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "фальсифікат",
+      "lemmaId": "фальсифікат",
+      "lemmaPlain": "фальсифікат",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "captives taken in raids; forced captivity",
+      "glossClean": "captives taken in raids",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "ясир",
+      "lemmaId": "ясир",
+      "lemmaPlain": "ясир",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "requiem; elegiac memorial song",
+      "glossClean": "requiem",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "реквієм",
+      "lemmaId": "реквієм",
+      "lemmaPlain": "реквієм",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "hetman",
+      "glossClean": "hetman",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "гетьман",
+      "lemmaId": "гетьман",
+      "lemmaPlain": "гетьман",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "B2",
+      "gloss": "tithe; historical land unit",
+      "glossClean": "tithe",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "десятина",
+      "lemmaId": "десятина",
+      "lemmaPlain": "десятина",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "десятинам",
+            "singular": "десятині"
+          },
+          "знахідний": {
+            "plural": "десятини",
+            "singular": "десятину"
+          },
+          "кличний": {
+            "plural": "десятини",
+            "singular": "десятино"
+          },
+          "місцевий": {
+            "plural": "десятинах",
+            "singular": "десятині"
+          },
+          "називний": {
+            "plural": "десятини",
+            "singular": "десятина"
+          },
+          "орудний": {
+            "plural": "десятинами",
+            "singular": "десятиною"
+          },
+          "родовий": {
+            "plural": "десятин",
+            "singular": "десятини"
+          }
+        }
       },
       "pos": "noun",
       "semanticBucket": null,
@@ -9429,10 +16554,10 @@
   "schema": "atlas-practice-lexemes",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 19593,
+    "gzipBytes": 35395,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 246182,
+    "rawBytes": 444327,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/public/lexicon/practice-lexemes.C1.json
+++ b/site/public/lexicon/practice-lexemes.C1.json
@@ -1,5 +1,5 @@
 {
-  "deckVersion": "atlas-practice-v1-9cf4a4d7319d19ce",
+  "deckVersion": "atlas-practice-v1-c5a52e54cdf8d828",
   "level": "C1",
   "lexemes": [
     {
@@ -74,23 +74,6 @@
       "lemma": "світло-синій",
       "lemmaId": "світло-синій",
       "lemmaPlain": "світло-синій",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "dark green",
-      "glossClean": "dark green",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "темно-зелений",
-      "lemmaId": "темно-зелений",
-      "lemmaPlain": "темно-зелений",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -215,23 +198,6 @@
     },
     {
       "cefr": "C1",
-      "gloss": "apostrophe",
-      "glossClean": "apostrophe",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "апостроф",
-      "lemmaId": "апостроф",
-      "lemmaPlain": "апостроф",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
       "gloss": "loaf",
       "glossClean": "loaf",
       "heritage": "standard",
@@ -341,23 +307,6 @@
     },
     {
       "cefr": "C1",
-      "gloss": "separately",
-      "glossClean": "separately",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "роздільно",
-      "lemmaId": "роздільно",
-      "lemmaPlain": "роздільно",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adverb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
       "gloss": "melody / intonation",
       "glossClean": "melody / intonation",
       "heritage": "standard",
@@ -433,23 +382,6 @@
       "lemma": "вчите",
       "lemmaId": "вчите",
       "lemmaPlain": "вчите",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb form",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "you learn; you study",
-      "glossClean": "you learn",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вчиш",
-      "lemmaId": "вчиш",
-      "lemmaPlain": "вчиш",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -945,23 +877,6 @@
     },
     {
       "cefr": "C1",
-      "gloss": "morphology",
-      "glossClean": "morphology",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "морфологія",
-      "lemmaId": "морфологія",
-      "lemmaPlain": "морфологія",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
       "gloss": "word formation",
       "glossClean": "word formation",
       "heritage": "standard",
@@ -1333,40 +1248,6 @@
     },
     {
       "cefr": "C1",
-      "gloss": "to melt",
-      "glossClean": "to melt",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "розтанути",
-      "lemmaId": "розтанути",
-      "lemmaPlain": "розтанути",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "penguin",
-      "glossClean": "penguin",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "пінгвін",
-      "lemmaId": "пінгвін",
-      "lemmaPlain": "пінгвін",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
       "gloss": "to prefer",
       "glossClean": "to prefer",
       "heritage": "standard",
@@ -1636,23 +1517,6 @@
       "lemma": "білісінький",
       "lemmaId": "білісінький",
       "lemmaPlain": "білісінький",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "synonymic",
-      "glossClean": "synonymic",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "синонімічний",
-      "lemmaId": "синонімічний",
-      "lemmaPlain": "синонімічний",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -1969,23 +1833,6 @@
     },
     {
       "cefr": "C1",
-      "gloss": "pragmatics; context-shaped meaning",
-      "glossClean": "pragmatics",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "прагматика",
-      "lemmaId": "прагматика",
-      "lemmaPlain": "прагматика",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:f",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
       "gloss": "single occurrence",
       "glossClean": "single occurrence",
       "heritage": "standard",
@@ -2282,23 +2129,6 @@
         }
       },
       "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "to whiten",
-      "glossClean": "to whiten",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "білити",
-      "lemmaId": "білити",
-      "lemmaPlain": "білити",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
       "semanticBucket": null,
       "severity": null
     },
@@ -2617,23 +2447,6 @@
     },
     {
       "cefr": "C1",
-      "gloss": "targeted, precise",
-      "glossClean": "targeted",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "точковий",
-      "lemmaId": "точковий",
-      "lemmaPlain": "точковий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
       "gloss": "regret, pity",
       "glossClean": "regret",
       "heritage": "standard",
@@ -2731,23 +2544,6 @@
         "cases": {}
       },
       "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "to spread rapidly",
-      "glossClean": "to spread rapidly",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "облетіти",
-      "lemmaId": "облетіти",
-      "lemmaPlain": "облетіти",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
       "semanticBucket": null,
       "severity": null
     },
@@ -2974,23 +2770,6 @@
     },
     {
       "cefr": "C1",
-      "gloss": "newly built building",
-      "glossClean": "newly built building",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "новобудова",
-      "lemmaId": "новобудова",
-      "lemmaPlain": "новобудова",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:f",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
       "gloss": "female tenant",
       "glossClean": "female tenant",
       "heritage": "standard",
@@ -3020,40 +2799,6 @@
         "cases": {}
       },
       "pos": "noun:f",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "plumber",
-      "glossClean": "plumber",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "сантехнік",
-      "lemmaId": "сантехнік",
-      "lemmaPlain": "сантехнік",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "modern renovation",
-      "glossClean": "modern renovation",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "євроремонт",
-      "lemmaId": "євроремонт",
-      "lemmaPlain": "євроремонт",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:m",
       "semanticBucket": null,
       "severity": null
     },
@@ -3338,40 +3083,6 @@
     },
     {
       "cefr": "C1",
-      "gloss": "to swim or sail all the way to; perfective",
-      "glossClean": "to swim or sail all the way to",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "доплисти",
-      "lemmaId": "доплисти",
-      "lemmaPlain": "доплисти",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "to fly into; perfective",
-      "glossClean": "to fly into",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "залетіти",
-      "lemmaId": "залетіти",
-      "lemmaPlain": "залетіти",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
       "gloss": "to swim or sail into, beyond; perfective",
       "glossClean": "to swim or sail into",
       "heritage": "standard",
@@ -3465,23 +3176,6 @@
       "lemmaId": "припливти",
       "lemmaPlain": "припливти",
       "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "to swim or sail past, through, or along; perfective",
-      "glossClean": "to swim or sail past",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "проплисти",
-      "lemmaId": "проплисти",
-      "lemmaPlain": "проплисти",
-      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -3833,23 +3527,6 @@
     },
     {
       "cefr": "C1",
-      "gloss": "badger",
-      "glossClean": "badger",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "борсук",
-      "lemmaId": "борсук",
-      "lemmaPlain": "борсук",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
       "gloss": "bud",
       "glossClean": "bud",
       "heritage": "standard",
@@ -4068,23 +3745,6 @@
         }
       },
       "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "tenacious, resilient",
-      "glossClean": "tenacious",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "живучий",
-      "lemmaId": "живучий",
-      "lemmaPlain": "живучий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
       "semanticBucket": null,
       "severity": null
     },
@@ -4345,23 +4005,6 @@
     },
     {
       "cefr": "C1",
-      "gloss": "has been painted",
-      "glossClean": "has been painted",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "пофарбовано",
-      "lemmaId": "пофарбовано",
-      "lemmaPlain": "пофарбовано",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "form",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
       "gloss": "has been designed",
       "glossClean": "has been designed",
       "heritage": "standard",
@@ -4386,23 +4029,6 @@
       "lemma": "вередливий",
       "lemmaId": "вередливий",
       "lemmaPlain": "вередливий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "envious",
-      "glossClean": "envious",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "заздрісний",
-      "lemmaId": "заздрісний",
-      "lemmaPlain": "заздрісний",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -4539,23 +4165,6 @@
     },
     {
       "cefr": "C1",
-      "gloss": "Lesia's",
-      "glossClean": "Lesia's",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "Лесин",
-      "lemmaId": "лесин",
-      "lemmaPlain": "лесин",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
       "gloss": "Mariika's",
       "glossClean": "Mariika's",
       "heritage": "unknown",
@@ -4648,23 +4257,6 @@
       "lemma": "Ольжин",
       "lemmaId": "ольжин",
       "lemmaPlain": "ольжин",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "Serhii's",
-      "glossClean": "Serhii's",
-      "heritage": "unknown",
-      "ipa": null,
-      "lemma": "Сергіїв",
-      "lemmaId": "сергіїв",
-      "lemmaPlain": "сергіїв",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -5034,23 +4626,6 @@
     },
     {
       "cefr": "C1",
-      "gloss": "more reliable",
-      "glossClean": "more reliable",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "надійніший",
-      "lemmaId": "надійніший",
-      "lemmaPlain": "надійніший",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
       "gloss": "most advantageous",
       "glossClean": "most advantageous",
       "heritage": "standard",
@@ -5255,23 +4830,6 @@
     },
     {
       "cefr": "C1",
-      "gloss": "greasy, oily",
-      "glossClean": "greasy",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "масний",
-      "lemmaId": "масний",
-      "lemmaPlain": "масний",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
       "gloss": "boastful",
       "glossClean": "boastful",
       "heritage": "standard",
@@ -5340,40 +4898,6 @@
     },
     {
       "cefr": "C1",
-      "gloss": "special edition",
-      "glossClean": "special edition",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "спецвипуск",
-      "lemmaId": "спецвипуск",
-      "lemmaPlain": "спецвипуск",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "above-mentioned",
-      "glossClean": "above-mentioned",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "вищезазначений",
-      "lemmaId": "вищезазначений",
-      "lemmaPlain": "вищезазначений",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
       "gloss": "bureaucratic expression",
       "glossClean": "bureaucratic expression",
       "heritage": "standard",
@@ -5425,23 +4949,6 @@
     },
     {
       "cefr": "C1",
-      "gloss": "spontaneity, ease",
-      "glossClean": "spontaneity",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "невимушеність",
-      "lemmaId": "невимушеність",
-      "lemmaPlain": "невимушеність",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
       "gloss": "to dehydrate; to remove water",
       "glossClean": "to dehydrate",
       "heritage": "standard",
@@ -5449,23 +4956,6 @@
       "lemma": "зневоднити",
       "lemmaId": "зневоднити",
       "lemmaPlain": "зневоднити",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "to load; to burden",
-      "glossClean": "to load",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "навантажити",
-      "lemmaId": "навантажити",
-      "lemmaPlain": "навантажити",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -5522,23 +5012,6 @@
         "cases": {}
       },
       "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "prefix (school synonym)",
-      "glossClean": "prefix (school synonym)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "приставка",
-      "lemmaId": "приставка",
-      "lemmaPlain": "приставка",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun:f",
       "semanticBucket": null,
       "severity": null
     },
@@ -5748,23 +5221,6 @@
     },
     {
       "cefr": "C1",
-      "gloss": "anti-war",
-      "glossClean": "anti-war",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "антивоєнний",
-      "lemmaId": "антивоєнний",
-      "lemmaPlain": "антивоєнний",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
       "gloss": "cloudless",
       "glossClean": "cloudless",
       "heritage": "standard",
@@ -5789,40 +5245,6 @@
       "lemma": "збільшувальний",
       "lemmaId": "збільшувальний",
       "lemmaPlain": "збільшувальний",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "pre-holiday",
-      "glossClean": "pre-holiday",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "передсвятковий",
-      "lemmaId": "передсвятковий",
-      "lemmaPlain": "передсвятковий",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adjective",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "coastal, riverside",
-      "glossClean": "coastal",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "прибережний",
-      "lemmaId": "прибережний",
-      "lemmaPlain": "прибережний",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -5901,6 +5323,540 @@
     },
     {
       "cefr": "C1",
+      "gloss": "adjectivization",
+      "glossClean": "adjectivization",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "ад'єктивація",
+      "lemmaId": "ад-єктивація",
+      "lemmaPlain": "ад'єктивація",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "archaism",
+      "glossClean": "archaism",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "архаїзм",
+      "lemmaId": "архаїзм",
+      "lemmaPlain": "архаїзм",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "faded",
+      "glossClean": "faded",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "вицвілий",
+      "lemmaId": "вицвілий",
+      "lemmaPlain": "вицвілий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "ripened, mature",
+      "glossClean": "ripened",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "дозрілий",
+      "lemmaId": "дозрілий",
+      "lemmaPlain": "дозрілий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "ripened",
+      "glossClean": "ripened",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "достиглий",
+      "lemmaId": "достиглий",
+      "lemmaPlain": "достиглий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "dried out",
+      "glossClean": "dried out",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "засохлий",
+      "lemmaId": "засохлий",
+      "lemmaPlain": "засохлий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "paled",
+      "glossClean": "paled",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "зблідлий",
+      "lemmaId": "зблідлий",
+      "lemmaPlain": "зблідлий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "burned down",
+      "glossClean": "burned down",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "згорілий",
+      "lemmaId": "згорілий",
+      "lemmaPlain": "згорілий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "gone wild",
+      "glossClean": "gone wild",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "здичавілий",
+      "lemmaId": "здичавілий",
+      "lemmaPlain": "здичавілий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "overhanging",
+      "glossClean": "overhanging",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "навислий",
+      "lemmaId": "навислий",
+      "lemmaPlain": "навислий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "intransitivity",
+      "glossClean": "intransitivity",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "неперехідність",
+      "lemmaId": "неперехідність",
+      "lemmaPlain": "неперехідність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "sagging",
+      "glossClean": "sagging",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "обвислий",
+      "lemmaId": "обвислий",
+      "lemmaPlain": "обвислий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "orphaned, left lonely",
+      "glossClean": "orphaned",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "осиротілий",
+      "lemmaId": "осиротілий",
+      "lemmaPlain": "осиротілий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "cooled",
+      "glossClean": "cooled",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "охололий",
+      "lemmaId": "охололий",
+      "lemmaPlain": "охололий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "turned white",
+      "glossClean": "turned white",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "побілілий",
+      "lemmaId": "побілілий",
+      "lemmaPlain": "побілілий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "aged",
+      "glossClean": "aged",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "постарілий",
+      "lemmaId": "постарілий",
+      "lemmaPlain": "постарілий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "darkened",
+      "glossClean": "darkened",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "потемнілий",
+      "lemmaId": "потемнілий",
+      "lemmaPlain": "потемнілий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "blackened",
+      "glossClean": "blackened",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "почорнілий",
+      "lemmaId": "почорнілий",
+      "lemmaPlain": "почорнілий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "fallen silent",
+      "glossClean": "fallen silent",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "притихлий",
+      "lemmaId": "притихлий",
+      "lemmaPlain": "притихлий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "soaked, wet through",
+      "glossClean": "soaked",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "промоклий",
+      "lemmaId": "промоклий",
+      "lemmaPlain": "промоклий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "thawed, broken up after freezing",
+      "glossClean": "thawed",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "скреслий",
+      "lemmaId": "скреслий",
+      "lemmaPlain": "скреслий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "moisturizing",
+      "glossClean": "moisturizing",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "зволожувальний",
+      "lemmaId": "зволожувальний",
+      "lemmaPlain": "зволожувальний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "pain-relieving",
+      "glossClean": "pain-relieving",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "знеболювальний",
+      "lemmaId": "знеболювальний",
+      "lemmaPlain": "знеболювальний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "bureaucratic jargon",
+      "glossClean": "bureaucratic jargon",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "канцелярщина",
+      "lemmaId": "канцелярщина",
+      "lemmaPlain": "канцелярщина",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "канцелярщинам",
+            "singular": "канцелярщині"
+          },
+          "знахідний": {
+            "plural": "канцелярщини",
+            "singular": "канцелярщину"
+          },
+          "кличний": {
+            "plural": "канцелярщини",
+            "singular": "канцелярщино"
+          },
+          "місцевий": {
+            "plural": "канцелярщинах",
+            "singular": "канцелярщині"
+          },
+          "називний": {
+            "plural": "канцелярщини",
+            "singular": "канцелярщина"
+          },
+          "орудний": {
+            "plural": "канцелярщинами",
+            "singular": "канцелярщиною"
+          },
+          "родовий": {
+            "plural": "канцелярщин",
+            "singular": "канцелярщини"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "lexicalized",
+      "glossClean": "lexicalized",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "лексикалізований",
+      "lemmaId": "лексикалізований",
+      "lemmaPlain": "лексикалізований",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "adjacent",
+      "glossClean": "adjacent",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "прилеглий",
+      "lemmaId": "прилеглий",
+      "lemmaPlain": "прилеглий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "protester",
+      "glossClean": "protester",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "протестувальник",
+      "lemmaId": "протестувальник",
+      "lemmaPlain": "протестувальник",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "interference",
+      "glossClean": "interference",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "інтерференція",
+      "lemmaId": "інтерференція",
+      "lemmaPlain": "інтерференція",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "інтерференціям",
+            "singular": "інтерференції"
+          },
+          "знахідний": {
+            "plural": "інтерференції",
+            "singular": "інтерференцію"
+          },
+          "кличний": {
+            "plural": "інтерференції",
+            "singular": "інтерференціє"
+          },
+          "місцевий": {
+            "plural": "інтерференціях",
+            "singular": "інтерференції"
+          },
+          "називний": {
+            "plural": "інтерференції",
+            "singular": "інтерференція"
+          },
+          "орудний": {
+            "plural": "інтерференціями",
+            "singular": "інтерференцією"
+          },
+          "родовий": {
+            "plural": "інтерференцій",
+            "singular": "інтерференції"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
       "gloss": "non-standard",
       "glossClean": "non-standard",
       "heritage": "standard",
@@ -5918,18 +5874,1653 @@
     },
     {
       "cefr": "C1",
-      "gloss": "baked",
-      "glossClean": "baked",
+      "gloss": "aphoristic quality",
+      "glossClean": "aphoristic quality",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "спечений",
-      "lemmaId": "спечений",
-      "lemmaPlain": "спечений",
+      "lemma": "афористичність",
+      "lemmaId": "афористичність",
+      "lemmaPlain": "афористичність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "impersonal",
+      "glossClean": "impersonal",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "безособове",
+      "lemmaId": "безособове",
+      "lemmaPlain": "безособове",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "indefinite-personal",
+      "glossClean": "indefinite-personal",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "неозначено-особове",
+      "lemmaId": "неозначено-особове",
+      "lemmaPlain": "неозначено-особове",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "definite-personal",
+      "glossClean": "definite-personal",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "означено-особове",
+      "lemmaId": "означено-особове",
+      "lemmaPlain": "означено-особове",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "generalized-personal",
+      "glossClean": "generalized-personal",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "узагальнено-особове",
+      "lemmaId": "узагальнено-особове",
+      "lemmaPlain": "узагальнено-особове",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "automaticity",
+      "glossClean": "automaticity",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "автоматизм",
+      "lemmaId": "автоматизм",
+      "lemmaPlain": "автоматизм",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "lexicalization",
+      "glossClean": "lexicalization",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "лексикалізація",
+      "lemmaId": "лексикалізація",
+      "lemmaPlain": "лексикалізація",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "лексикалізаціям",
+            "singular": "лексикалізації"
+          },
+          "знахідний": {
+            "plural": "лексикалізації",
+            "singular": "лексикалізацію"
+          },
+          "кличний": {
+            "plural": "лексикалізації",
+            "singular": "лексикалізаціє"
+          },
+          "місцевий": {
+            "plural": "лексикалізаціях",
+            "singular": "лексикалізації"
+          },
+          "називний": {
+            "plural": "лексикалізації",
+            "singular": "лексикалізація"
+          },
+          "орудний": {
+            "plural": "лексикалізаціями",
+            "singular": "лексикалізацією"
+          },
+          "родовий": {
+            "plural": "лексикалізацій",
+            "singular": "лексикалізації"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "assonance",
+      "glossClean": "assonance",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "асонанс",
+      "lemmaId": "асонанс",
+      "lemmaPlain": "асонанс",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "metonymy",
+      "glossClean": "metonymy",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "метонімія",
+      "lemmaId": "метонімія",
+      "lemmaPlain": "метонімія",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "метоніміям",
+            "singular": "метонімії"
+          },
+          "знахідний": {
+            "plural": "метонімії",
+            "singular": "метонімію"
+          },
+          "кличний": {
+            "plural": "метонімії",
+            "singular": "метоніміє"
+          },
+          "місцевий": {
+            "plural": "метоніміях",
+            "singular": "метонімії"
+          },
+          "називний": {
+            "plural": "метонімії",
+            "singular": "метонімія"
+          },
+          "орудний": {
+            "plural": "метоніміями",
+            "singular": "метонімією"
+          },
+          "родовий": {
+            "plural": "метонімій",
+            "singular": "метонімії"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "parceling",
+      "glossClean": "parceling",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "парцеляція",
+      "lemmaId": "парцеляція",
+      "lemmaPlain": "парцеляція",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "парцеляціям",
+            "singular": "парцеляції"
+          },
+          "знахідний": {
+            "plural": "парцеляції",
+            "singular": "парцеляцію"
+          },
+          "кличний": {
+            "plural": "парцеляції",
+            "singular": "парцеляціє"
+          },
+          "місцевий": {
+            "plural": "парцеляціях",
+            "singular": "парцеляції"
+          },
+          "називний": {
+            "plural": "парцеляції",
+            "singular": "парцеляція"
+          },
+          "орудний": {
+            "plural": "парцеляціями",
+            "singular": "парцеляцією"
+          },
+          "родовий": {
+            "plural": "парцеляцій",
+            "singular": "парцеляції"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "trope",
+      "glossClean": "trope",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "троп",
+      "lemmaId": "троп",
+      "lemmaPlain": "троп",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "adjunction",
+      "glossClean": "adjunction",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "прилягання",
+      "lemmaId": "прилягання",
+      "lemmaPlain": "прилягання",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "asyndetic",
+      "glossClean": "asyndetic",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "безсполучниковий",
+      "lemmaId": "безсполучниковий",
+      "lemmaPlain": "безсполучниковий",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
       },
       "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "emphasis",
+      "glossClean": "emphasis",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "емфаза",
+      "lemmaId": "емфаза",
+      "lemmaPlain": "емфаза",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "емфазам",
+            "singular": "емфазі"
+          },
+          "знахідний": {
+            "plural": "емфази",
+            "singular": "емфазу"
+          },
+          "кличний": {
+            "plural": "емфази",
+            "singular": "емфазо"
+          },
+          "місцевий": {
+            "plural": "емфазах",
+            "singular": "емфазі"
+          },
+          "називний": {
+            "plural": "емфази",
+            "singular": "емфаза"
+          },
+          "орудний": {
+            "plural": "емфазами",
+            "singular": "емфазою"
+          },
+          "родовий": {
+            "plural": "емфаз",
+            "singular": "емфази"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "cohesion",
+      "glossClean": "cohesion",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "когезія",
+      "lemmaId": "когезія",
+      "lemmaPlain": "когезія",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "когезіям",
+            "singular": "когезії"
+          },
+          "знахідний": {
+            "plural": "когезії",
+            "singular": "когезію"
+          },
+          "кличний": {
+            "plural": "когезії",
+            "singular": "когезіє"
+          },
+          "місцевий": {
+            "plural": "когезіях",
+            "singular": "когезії"
+          },
+          "називний": {
+            "plural": "когезії",
+            "singular": "когезія"
+          },
+          "орудний": {
+            "plural": "когезіями",
+            "singular": "когезією"
+          },
+          "родовий": {
+            "plural": "когезій",
+            "singular": "когезії"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "connector",
+      "glossClean": "connector",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "конектор",
+      "lemmaId": "конектор",
+      "lemmaPlain": "конектор",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "parceled fragment",
+      "glossClean": "parceled fragment",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "парцелят",
+      "lemmaId": "парцелят",
+      "lemmaPlain": "парцелят",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "subordination",
+      "glossClean": "subordination",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "підрядність",
+      "lemmaId": "підрядність",
+      "lemmaPlain": "підрядність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "paraphrasing",
+      "glossClean": "paraphrasing",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "реферування",
+      "lemmaId": "реферування",
+      "lemmaPlain": "реферування",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "self-reflection",
+      "glossClean": "self-reflection",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "саморефлексія",
+      "lemmaId": "саморефлексія",
+      "lemmaPlain": "саморефлексія",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "саморефлексіям",
+            "singular": "саморефлексії"
+          },
+          "знахідний": {
+            "plural": "саморефлексії",
+            "singular": "саморефлексію"
+          },
+          "кличний": {
+            "plural": "саморефлексії",
+            "singular": "саморефлексіє"
+          },
+          "місцевий": {
+            "plural": "саморефлексіях",
+            "singular": "саморефлексії"
+          },
+          "називний": {
+            "plural": "саморефлексії",
+            "singular": "саморефлексія"
+          },
+          "орудний": {
+            "plural": "саморефлексіями",
+            "singular": "саморефлексією"
+          },
+          "родовий": {
+            "plural": "саморефлексій",
+            "singular": "саморефлексії"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "compound",
+      "glossClean": "compound",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "складносурядний",
+      "lemmaId": "складносурядний",
+      "lemmaPlain": "складносурядний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "coordination",
+      "glossClean": "coordination",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "сурядність",
+      "lemmaId": "сурядність",
+      "lemmaPlain": "сурядність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "recoverability",
+      "glossClean": "recoverability",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "відновлюваність",
+      "lemmaId": "відновлюваність",
+      "lemmaPlain": "відновлюваність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "linking verb",
+      "glossClean": "linking verb",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "дієслово-зв'язка",
+      "lemmaId": "дієслово-зв-язка",
+      "lemmaPlain": "дієслово-зв'язка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "contextual",
+      "glossClean": "contextual",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "контекстуальний",
+      "lemmaId": "контекстуальний",
+      "lemmaPlain": "контекстуальний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "concision",
+      "glossClean": "concision",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "лаконізм",
+      "lemmaId": "лаконізм",
+      "lemmaPlain": "лаконізм",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "official-business",
+      "glossClean": "official-business",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "офіційно-діловий",
+      "lemmaId": "офіційно-діловий",
+      "lemmaPlain": "офіційно-діловий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "ellipsis mark",
+      "glossClean": "ellipsis mark",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "трикрапка",
+      "lemmaId": "трикрапка",
+      "lemmaPlain": "трикрапка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "трикрапкам",
+            "singular": "трикрапці"
+          },
+          "знахідний": {
+            "plural": "трикрапки",
+            "singular": "трикрапку"
+          },
+          "кличний": {
+            "plural": "трикрапки",
+            "singular": "трикрапко"
+          },
+          "місцевий": {
+            "plural": "трикрапках",
+            "singular": "трикрапці"
+          },
+          "називний": {
+            "plural": "трикрапки",
+            "singular": "трикрапка"
+          },
+          "орудний": {
+            "plural": "трикрапками",
+            "singular": "трикрапкою"
+          },
+          "родовий": {
+            "plural": "трикрапок",
+            "singular": "трикрапки"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "intonational",
+      "glossClean": "intonational",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "інтонаційний",
+      "lemmaId": "інтонаційний",
+      "lemmaPlain": "інтонаційний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "content-clause",
+      "glossClean": "content-clause",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "з'ясувальний",
+      "lemmaId": "з-ясувальний",
+      "lemmaPlain": "з'ясувальний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "correlate",
+      "glossClean": "correlate",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "корелят",
+      "lemmaId": "корелят",
+      "lemmaPlain": "корелят",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "optional",
+      "glossClean": "optional",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "факультативний",
+      "lemmaId": "факультативний",
+      "lemmaPlain": "факультативний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "additivity",
+      "glossClean": "additivity",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "додатковість",
+      "lemmaId": "додатковість",
+      "lemmaPlain": "додатковість",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "apposition",
+      "glossClean": "apposition",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "прикладка",
+      "lemmaId": "прикладка",
+      "lemmaPlain": "прикладка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "прикладкам",
+            "singular": "прикладці"
+          },
+          "знахідний": {
+            "plural": "прикладки",
+            "singular": "прикладку"
+          },
+          "кличний": {
+            "plural": "прикладки",
+            "singular": "прикладко"
+          },
+          "місцевий": {
+            "plural": "прикладках",
+            "singular": "прикладці"
+          },
+          "називний": {
+            "plural": "прикладки",
+            "singular": "прикладка"
+          },
+          "орудний": {
+            "plural": "прикладками",
+            "singular": "прикладкою"
+          },
+          "родовий": {
+            "plural": "прикладок",
+            "singular": "прикладки"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "clarifying",
+      "glossClean": "clarifying",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "уточнювальний",
+      "lemmaId": "уточнювальний",
+      "lemmaPlain": "уточнювальний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "tenant, renter",
+      "glossClean": "tenant",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "винаймач",
+      "lemmaId": "винаймач",
+      "lemmaPlain": "винаймач",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "intercom",
+      "glossClean": "intercom",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "домофон",
+      "lemmaId": "домофон",
+      "lemmaPlain": "домофон",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "parking space",
+      "glossClean": "parking space",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "паркомісце",
+      "lemmaId": "паркомісце",
+      "lemmaPlain": "паркомісце",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "to chip in",
+      "glossClean": "to chip in",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "скинутися",
+      "lemmaId": "скинутися",
+      "lemmaPlain": "скинутися",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "furnished",
+      "glossClean": "furnished",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "умебльований",
+      "lemmaId": "умебльований",
+      "lemmaPlain": "умебльований",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "source-based",
+      "glossClean": "source-based",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "джерельний",
+      "lemmaId": "джерельний",
+      "lemmaPlain": "джерельний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "contextualization",
+      "glossClean": "contextualization",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "контекстуалізація",
+      "lemmaId": "контекстуалізація",
+      "lemmaPlain": "контекстуалізація",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "perception",
+      "glossClean": "perception",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "перцепція",
+      "lemmaId": "перцепція",
+      "lemmaPlain": "перцепція",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "перцепціям",
+            "singular": "перцепції"
+          },
+          "знахідний": {
+            "plural": "перцепції",
+            "singular": "перцепцію"
+          },
+          "кличний": {
+            "plural": "перцепції",
+            "singular": "перцепціє"
+          },
+          "місцевий": {
+            "plural": "перцепціях",
+            "singular": "перцепції"
+          },
+          "називний": {
+            "plural": "перцепції",
+            "singular": "перцепція"
+          },
+          "орудний": {
+            "plural": "перцепціями",
+            "singular": "перцепцією"
+          },
+          "родовий": {
+            "plural": "перцепцій",
+            "singular": "перцепції"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "rhythm and melody",
+      "glossClean": "rhythm and melody",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "ритмомелодика",
+      "lemmaId": "ритмомелодика",
+      "lemmaPlain": "ритмомелодика",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "topicalization",
+      "glossClean": "topicalization",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "топікалізація",
+      "lemmaId": "топікалізація",
+      "lemmaPlain": "топікалізація",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "co-subordination",
+      "glossClean": "co-subordination",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "супідрядність",
+      "lemmaId": "супідрядність",
+      "lemmaPlain": "супідрядність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "whisk",
+      "glossClean": "whisk",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "вінчик",
+      "lemmaId": "вінчик",
+      "lemmaPlain": "вінчик",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "having cut",
+      "glossClean": "having cut",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "нарізавши",
+      "lemmaId": "нарізавши",
+      "lemmaPlain": "нарізавши",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adverbial participle",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "to steam",
+      "glossClean": "to steam",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "парити",
+      "lemmaId": "парити",
+      "lemmaPlain": "парити",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "verb",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "frying pan",
+      "glossClean": "frying pan",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "пательня",
+      "lemmaId": "пательня",
+      "lemmaPlain": "пательня",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "пательням",
+            "singular": "пательні"
+          },
+          "знахідний": {
+            "plural": "пательні",
+            "singular": "пательню"
+          },
+          "кличний": {
+            "plural": "пательні",
+            "singular": "пательне"
+          },
+          "місцевий": {
+            "plural": "пательнях",
+            "singular": "пательні"
+          },
+          "називний": {
+            "plural": "пательні",
+            "singular": "пательня"
+          },
+          "орудний": {
+            "plural": "пательнями",
+            "singular": "пательнею"
+          },
+          "родовий": {
+            "plural": "пателень",
+            "singular": "пательні"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "recipe formulation",
+      "glossClean": "recipe formulation",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "рецептура",
+      "lemmaId": "рецептура",
+      "lemmaPlain": "рецептура",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "рецептурам",
+            "singular": "рецептурі"
+          },
+          "знахідний": {
+            "plural": "рецептури",
+            "singular": "рецептуру"
+          },
+          "кличний": {
+            "plural": "рецептури",
+            "singular": "рецептуро"
+          },
+          "місцевий": {
+            "plural": "рецептурах",
+            "singular": "рецептурі"
+          },
+          "називний": {
+            "plural": "рецептури",
+            "singular": "рецептура"
+          },
+          "орудний": {
+            "plural": "рецептурами",
+            "singular": "рецептурою"
+          },
+          "родовий": {
+            "plural": "рецептур",
+            "singular": "рецептури"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "fermented",
+      "glossClean": "fermented",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "ферментований",
+      "lemmaId": "ферментований",
+      "lemmaPlain": "ферментований",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "whole-grain",
+      "glossClean": "whole-grain",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "цільнозерновий",
+      "lemmaId": "цільнозерновий",
+      "lemmaPlain": "цільнозерновий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "marketplace",
+      "glossClean": "marketplace",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "маркетплейс",
+      "lemmaId": "маркетплейс",
+      "lemmaPlain": "маркетплейс",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "complaint, claim",
+      "glossClean": "complaint",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "рекламація",
+      "lemmaId": "рекламація",
+      "lemmaPlain": "рекламація",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "рекламаціям",
+            "singular": "рекламації"
+          },
+          "знахідний": {
+            "plural": "рекламації",
+            "singular": "рекламацію"
+          },
+          "кличний": {
+            "plural": "рекламації",
+            "singular": "рекламаціє"
+          },
+          "місцевий": {
+            "plural": "рекламаціях",
+            "singular": "рекламації"
+          },
+          "називний": {
+            "plural": "рекламації",
+            "singular": "рекламація"
+          },
+          "орудний": {
+            "plural": "рекламаціями",
+            "singular": "рекламацією"
+          },
+          "родовий": {
+            "plural": "рекламацій",
+            "singular": "рекламації"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "vulgarism",
+      "glossClean": "vulgarism",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "вульгаризм",
+      "lemmaId": "вульгаризм",
+      "lemmaPlain": "вульгаризм",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "dialect word",
+      "glossClean": "dialect word",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "діалектизм",
+      "lemmaId": "діалектизм",
+      "lemmaPlain": "діалектизм",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "jargon word, slang item",
+      "glossClean": "jargon word",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "жаргонізм",
+      "lemmaId": "жаргонізм",
+      "lemmaPlain": "жаргонізм",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "litotes, understatement",
+      "glossClean": "litotes",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "літота",
+      "lemmaId": "літота",
+      "lemmaPlain": "літота",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "oxymoron",
+      "glossClean": "oxymoron",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "оксюморон",
+      "lemmaId": "оксюморон",
+      "lemmaPlain": "оксюморон",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "homonym",
+      "glossClean": "homonym",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "омонім",
+      "lemmaId": "омонім",
+      "lemmaPlain": "омонім",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "paronym",
+      "glossClean": "paronym",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "паронім",
+      "lemmaId": "паронім",
+      "lemmaPlain": "паронім",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "periphrasis",
+      "glossClean": "periphrasis",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "перифраз",
+      "lemmaId": "перифраз",
+      "lemmaPlain": "перифраз",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "colloquial nonstandard speech",
+      "glossClean": "colloquial nonstandard speech",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "просторіччя",
+      "lemmaId": "просторіччя",
+      "lemmaPlain": "просторіччя",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "editing",
+      "glossClean": "editing",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "редактура",
+      "lemmaId": "редактура",
+      "lemmaPlain": "редактура",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "synecdoche",
+      "glossClean": "synecdoche",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "синекдоха",
+      "lemmaId": "синекдоха",
+      "lemmaPlain": "синекдоха",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "синекдохам",
+            "singular": "синекдосі"
+          },
+          "знахідний": {
+            "plural": "синекдохи",
+            "singular": "синекдоху"
+          },
+          "кличний": {
+            "plural": "синекдохи",
+            "singular": "синекдохо"
+          },
+          "місцевий": {
+            "plural": "синекдохах",
+            "singular": "синекдосі"
+          },
+          "називний": {
+            "plural": "синекдохи",
+            "singular": "синекдоха"
+          },
+          "орудний": {
+            "plural": "синекдохами",
+            "singular": "синекдохою"
+          },
+          "родовий": {
+            "plural": "синекдох",
+            "singular": "синекдохи"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "sociolect",
+      "glossClean": "sociolect",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "соціолект",
+      "lemmaId": "соціолект",
+      "lemmaPlain": "соціолект",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "Chernivtsi-related",
+      "glossClean": "Chernivtsi-related",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "чернівецький",
+      "lemmaId": "чернівецький",
+      "lemmaPlain": "чернівецький",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adj",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "unwieldiness",
+      "glossClean": "unwieldiness",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "громіздкість",
+      "lemmaId": "громіздкість",
+      "lemmaPlain": "громіздкість",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "concessive relation",
+      "glossClean": "concessive relation",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "допустовість",
+      "lemmaId": "допустовість",
+      "lemmaPlain": "допустовість",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "homonymous",
+      "glossClean": "homonymous",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "омонімічний",
+      "lemmaId": "омонімічний",
+      "lemmaPlain": "омонімічний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "parenthesis",
+      "glossClean": "parenthesis",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "парантеза",
+      "lemmaId": "парантеза",
+      "lemmaPlain": "парантеза",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "lexical, full-meaning",
+      "glossClean": "lexical",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "повнозначний",
+      "lemmaId": "повнозначний",
+      "lemmaPlain": "повнозначний",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "stringing together",
+      "glossClean": "stringing together",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "нанизування",
+      "lemmaId": "нанизування",
+      "lemmaPlain": "нанизування",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "rhythm",
+      "glossClean": "rhythm",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "ритміка",
+      "lemmaId": "ритміка",
+      "lemmaPlain": "ритміка",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     },
@@ -5952,13 +7543,13 @@
     },
     {
       "cefr": "C1",
-      "gloss": "agency; capacity to act as a subject",
-      "glossClean": "agency",
+      "gloss": "voicing",
+      "glossClean": "voicing",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "агентність",
-      "lemmaId": "агентність",
-      "lemmaPlain": "агентність",
+      "lemma": "дзвінкість",
+      "lemmaId": "дзвінкість",
+      "lemmaPlain": "дзвінкість",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -5969,13 +7560,13 @@
     },
     {
       "cefr": "C1",
-      "gloss": "female captive",
-      "glossClean": "female captive",
+      "gloss": "sound imitation",
+      "glossClean": "sound imitation",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "бранка",
-      "lemmaId": "бранка",
-      "lemmaPlain": "бранка",
+      "lemma": "звуконаслідування",
+      "lemmaId": "звуконаслідування",
+      "lemmaPlain": "звуконаслідування",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -5986,13 +7577,13 @@
     },
     {
       "cefr": "C1",
-      "gloss": "infidel, Muslim (archaic, in folk usage)",
-      "glossClean": "infidel",
+      "gloss": "sound patterning",
+      "glossClean": "sound patterning",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "бусурман",
-      "lemmaId": "бусурман",
-      "lemmaPlain": "бусурман",
+      "lemma": "звукопис",
+      "lemmaId": "звукопис",
+      "lemmaPlain": "звукопис",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -6003,13 +7594,13 @@
     },
     {
       "cefr": "C1",
-      "gloss": "victimhood, the condition of being a victim",
-      "glossClean": "victimhood",
+      "gloss": "devoicing",
+      "glossClean": "devoicing",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "віктимність",
-      "lemmaId": "віктимність",
-      "lemmaPlain": "віктимність",
+      "lemma": "оглушення",
+      "lemmaId": "оглушення",
+      "lemmaPlain": "оглушення",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -6020,13 +7611,76 @@
     },
     {
       "cefr": "C1",
-      "gloss": "apostasy, renunciation of one's faith",
-      "glossClean": "apostasy",
+      "gloss": "onomatopoeia",
+      "glossClean": "onomatopoeia",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "віровідступництво",
-      "lemmaId": "віровідступництво",
-      "lemmaPlain": "віровідступництво",
+      "lemma": "ономатопея",
+      "lemmaId": "ономатопея",
+      "lemmaPlain": "ономатопея",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "ономатопеям",
+            "singular": "ономатопеї"
+          },
+          "знахідний": {
+            "plural": "ономатопеї",
+            "singular": "ономатопею"
+          },
+          "кличний": {
+            "plural": "ономатопеї",
+            "singular": "ономатопеє"
+          },
+          "місцевий": {
+            "plural": "ономатопеях",
+            "singular": "ономатопеї"
+          },
+          "називний": {
+            "plural": "ономатопеї",
+            "singular": "ономатопея"
+          },
+          "орудний": {
+            "plural": "ономатопеями",
+            "singular": "ономатопеєю"
+          },
+          "родовий": {
+            "plural": "ономатопей",
+            "singular": "ономатопеї"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "oratorical",
+      "glossClean": "oratorical",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "ораторський",
+      "lemmaId": "ораторський",
+      "lemmaPlain": "ораторський",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "fluency, smoothness",
+      "glossClean": "fluency",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "плавність",
+      "lemmaId": "плавність",
+      "lemmaPlain": "плавність",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -6037,13 +7691,59 @@
     },
     {
       "cefr": "C1",
-      "gloss": "the heroic register, heroic dimension",
-      "glossClean": "the heroic register",
+      "gloss": "reduction",
+      "glossClean": "reduction",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "героїка",
-      "lemmaId": "героїка",
-      "lemmaPlain": "героїка",
+      "lemma": "редукція",
+      "lemmaId": "редукція",
+      "lemmaPlain": "редукція",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "редукціям",
+            "singular": "редукції"
+          },
+          "знахідний": {
+            "plural": "редукції",
+            "singular": "редукцію"
+          },
+          "кличний": {
+            "plural": "редукції",
+            "singular": "редукціє"
+          },
+          "місцевий": {
+            "plural": "редукціях",
+            "singular": "редукції"
+          },
+          "називний": {
+            "plural": "редукції",
+            "singular": "редукція"
+          },
+          "орудний": {
+            "plural": "редукціями",
+            "singular": "редукцією"
+          },
+          "родовий": {
+            "plural": "редукцій",
+            "singular": "редукції"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "valency",
+      "glossClean": "valency",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "валентність",
+      "lemmaId": "валентність",
+      "lemmaPlain": "валентність",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -6054,13 +7754,59 @@
     },
     {
       "cefr": "C1",
-      "gloss": "seafaring, navigation",
-      "glossClean": "seafaring",
+      "gloss": "collocation",
+      "glossClean": "collocation",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "мореплавство",
-      "lemmaId": "мореплавство",
-      "lemmaPlain": "мореплавство",
+      "lemma": "колокація",
+      "lemmaId": "колокація",
+      "lemmaPlain": "колокація",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "колокаціям",
+            "singular": "колокації"
+          },
+          "знахідний": {
+            "plural": "колокації",
+            "singular": "колокацію"
+          },
+          "кличний": {
+            "plural": "колокації",
+            "singular": "колокаціє"
+          },
+          "місцевий": {
+            "plural": "колокаціях",
+            "singular": "колокації"
+          },
+          "називний": {
+            "plural": "колокації",
+            "singular": "колокація"
+          },
+          "орудний": {
+            "plural": "колокаціями",
+            "singular": "колокацією"
+          },
+          "родовий": {
+            "plural": "колокацій",
+            "singular": "колокації"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "pleonasm",
+      "glossClean": "pleonasm",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "плеоназм",
+      "lemmaId": "плеоназм",
+      "lemmaPlain": "плеоназм",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -6071,13 +7817,76 @@
     },
     {
       "cefr": "C1",
-      "gloss": "enslaver, oppressor",
-      "glossClean": "enslaver",
+      "gloss": "idiom",
+      "glossClean": "idiom",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "поневолювач",
-      "lemmaId": "поневолювач",
-      "lemmaPlain": "поневолювач",
+      "lemma": "ідіома",
+      "lemmaId": "ідіома",
+      "lemmaPlain": "ідіома",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "ідіомам",
+            "singular": "ідіомі"
+          },
+          "знахідний": {
+            "plural": "ідіоми",
+            "singular": "ідіому"
+          },
+          "кличний": {
+            "plural": "ідіоми",
+            "singular": "ідіомо"
+          },
+          "місцевий": {
+            "plural": "ідіомах",
+            "singular": "ідіомі"
+          },
+          "називний": {
+            "plural": "ідіоми",
+            "singular": "ідіома"
+          },
+          "орудний": {
+            "plural": "ідіомами",
+            "singular": "ідіомою"
+          },
+          "родовий": {
+            "plural": "ідіом",
+            "singular": "ідіоми"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "let us agree, let's agree",
+      "glossClean": "let us agree",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "домовмося",
+      "lemmaId": "домовмося",
+      "lemmaPlain": "домовмося",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "online payment",
+      "glossClean": "online payment",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "онлайн-оплата",
+      "lemmaId": "онлайн-оплата",
+      "lemmaPlain": "онлайн-оплата",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -6088,13 +7897,13 @@
     },
     {
       "cefr": "C1",
-      "gloss": "a priest's daughter",
-      "glossClean": "a priest's daughter",
+      "gloss": "power bank",
+      "glossClean": "power bank",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "попівна",
-      "lemmaId": "попівна",
-      "lemmaPlain": "попівна",
+      "lemma": "павербанк",
+      "lemmaId": "павербанк",
+      "lemmaPlain": "павербанк",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -6105,13 +7914,64 @@
     },
     {
       "cefr": "C1",
-      "gloss": "to turn Turk, to convert to Islam (a betrayal of faith in folk view)",
-      "glossClean": "to turn Turk",
+      "gloss": "let us clean, let's clean",
+      "glossClean": "let us clean",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "потурчитися",
-      "lemmaId": "потурчитися",
-      "lemmaPlain": "потурчитися",
+      "lemma": "приберімо",
+      "lemmaId": "приберімо",
+      "lemmaPlain": "приберімо",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "phrase",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "predicativity",
+      "glossClean": "predicativity",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "предикативність",
+      "lemmaId": "предикативність",
+      "lemmaPlain": "предикативність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "phasal meaning",
+      "glossClean": "phasal meaning",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "фазовість",
+      "lemmaId": "фазовість",
+      "lemmaPlain": "фазовість",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "is being mixed",
+      "glossClean": "is being mixed",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "перемішується",
+      "lemmaId": "перемішується",
+      "lemmaPlain": "перемішується",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -6122,13 +7982,13 @@
     },
     {
       "cefr": "C1",
-      "gloss": "slave trade",
-      "glossClean": "slave trade",
+      "gloss": "hierarchy, subordination",
+      "glossClean": "hierarchy",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "работоргівля",
-      "lemmaId": "работоргівля",
-      "lemmaPlain": "работоргівля",
+      "lemma": "субординація",
+      "lemmaId": "субординація",
+      "lemmaPlain": "субординація",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -6139,13 +7999,13 @@
     },
     {
       "cefr": "C1",
-      "gloss": "renegade, one who has betrayed faith or side",
-      "glossClean": "renegade",
+      "gloss": "overfamiliarity",
+      "glossClean": "overfamiliarity",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "ренегат",
-      "lemmaId": "ренегат",
-      "lemmaPlain": "ренегат",
+      "lemma": "фамільярність",
+      "lemmaId": "фамільярність",
+      "lemmaPlain": "фамільярність",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -6156,43 +8016,43 @@
     },
     {
       "cefr": "C1",
-      "gloss": "dungeon, prison",
-      "glossClean": "dungeon",
+      "gloss": "abstract, annotation",
+      "glossClean": "abstract",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "темниця",
-      "lemmaId": "темниця",
-      "lemmaPlain": "темниця",
+      "lemma": "анотація",
+      "lemmaId": "анотація",
+      "lemmaPlain": "анотація",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
-            "plural": "темницям",
-            "singular": "темниці"
+            "plural": "анотаціям",
+            "singular": "анотації"
           },
           "знахідний": {
-            "plural": "темниці",
-            "singular": "темницю"
+            "plural": "анотації",
+            "singular": "анотацію"
           },
           "кличний": {
-            "plural": "темниці",
-            "singular": "темнице"
+            "plural": "анотації",
+            "singular": "анотаціє"
           },
           "місцевий": {
-            "plural": "темницях",
-            "singular": "темниці"
+            "plural": "анотаціях",
+            "singular": "анотації"
           },
           "називний": {
-            "plural": "темниці",
-            "singular": "темниця"
+            "plural": "анотації",
+            "singular": "анотація"
           },
           "орудний": {
-            "plural": "темницями",
-            "singular": "темницею"
+            "plural": "анотаціями",
+            "singular": "анотацією"
           },
           "родовий": {
-            "plural": "темниць",
-            "singular": "темниці"
+            "plural": "анотацій",
+            "singular": "анотації"
           }
         }
       },
@@ -6202,13 +8062,527 @@
     },
     {
       "cefr": "C1",
-      "gloss": "glorifying, laudatory",
-      "glossClean": "glorifying",
+      "gloss": "impersonality",
+      "glossClean": "impersonality",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "величальний",
-      "lemmaId": "величальний",
-      "lemmaPlain": "величальний",
+      "lemma": "безособовість",
+      "lemmaId": "безособовість",
+      "lemmaPlain": "безособовість",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "evidentiality, proof-based quality",
+      "glossClean": "evidentiality",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "доказовість",
+      "lemmaId": "доказовість",
+      "lemmaPlain": "доказовість",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "paraphrase",
+      "glossClean": "paraphrase",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "парафраз",
+      "lemmaId": "парафраз",
+      "lemmaPlain": "парафраз",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "anaphora",
+      "glossClean": "anaphora",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "анафора",
+      "lemmaId": "анафора",
+      "lemmaPlain": "анафора",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "анафорам",
+            "singular": "анафорі"
+          },
+          "знахідний": {
+            "plural": "анафори",
+            "singular": "анафору"
+          },
+          "кличний": {
+            "plural": "анафори",
+            "singular": "анафоро"
+          },
+          "місцевий": {
+            "plural": "анафорах",
+            "singular": "анафорі"
+          },
+          "називний": {
+            "plural": "анафори",
+            "singular": "анафора"
+          },
+          "орудний": {
+            "plural": "анафорами",
+            "singular": "анафорою"
+          },
+          "родовий": {
+            "plural": "анафор",
+            "singular": "анафори"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "epistrophe",
+      "glossClean": "epistrophe",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "епіфора",
+      "lemmaId": "епіфора",
+      "lemmaPlain": "епіфора",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "епіфорам",
+            "singular": "епіфорі"
+          },
+          "знахідний": {
+            "plural": "епіфори",
+            "singular": "епіфору"
+          },
+          "кличний": {
+            "plural": "епіфори",
+            "singular": "епіфоро"
+          },
+          "місцевий": {
+            "plural": "епіфорах",
+            "singular": "епіфорі"
+          },
+          "називний": {
+            "plural": "епіфори",
+            "singular": "епіфора"
+          },
+          "орудний": {
+            "plural": "епіфорами",
+            "singular": "епіфорою"
+          },
+          "родовий": {
+            "plural": "епіфор",
+            "singular": "епіфори"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "subtextual",
+      "glossClean": "subtextual",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "підтекстовий",
+      "lemmaId": "підтекстовий",
+      "lemmaPlain": "підтекстовий",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "adjective",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "diminutive",
+      "glossClean": "diminutive",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "демінутив",
+      "lemmaId": "демінутив",
+      "lemmaPlain": "демінутив",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "source grounding",
+      "glossClean": "source grounding",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "джерельність",
+      "lemmaId": "джерельність",
+      "lemmaPlain": "джерельність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "clickbait",
+      "glossClean": "clickbait",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "клікбейт",
+      "lemmaId": "клікбейт",
+      "lemmaPlain": "клікбейт",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "self-correction",
+      "glossClean": "self-correction",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "самовиправлення",
+      "lemmaId": "самовиправлення",
+      "lemmaPlain": "самовиправлення",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "framing",
+      "glossClean": "framing",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "фреймінг",
+      "lemmaId": "фреймінг",
+      "lemmaPlain": "фреймінг",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "cataphora",
+      "glossClean": "cataphora",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "катафора",
+      "lemmaId": "катафора",
+      "lemmaPlain": "катафора",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "coherence",
+      "glossClean": "coherence",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "когерентність",
+      "lemmaId": "когерентність",
+      "lemmaPlain": "когерентність",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "reformulation",
+      "glossClean": "reformulation",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "переформулювання",
+      "lemmaId": "переформулювання",
+      "lemmaPlain": "переформулювання",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "reference",
+      "glossClean": "reference",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "референція",
+      "lemmaId": "референція",
+      "lemmaPlain": "референція",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "референціям",
+            "singular": "референції"
+          },
+          "знахідний": {
+            "plural": "референції",
+            "singular": "референцію"
+          },
+          "кличний": {
+            "plural": "референції",
+            "singular": "референціє"
+          },
+          "місцевий": {
+            "plural": "референціях",
+            "singular": "референції"
+          },
+          "називний": {
+            "plural": "референції",
+            "singular": "референція"
+          },
+          "орудний": {
+            "plural": "референціями",
+            "singular": "референцією"
+          },
+          "родовий": {
+            "plural": "референцій",
+            "singular": "референції"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "emphasis, accentuation",
+      "glossClean": "emphasis",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "акцентуація",
+      "lemmaId": "акцентуація",
+      "lemmaPlain": "акцентуація",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "акцентуаціям",
+            "singular": "акцентуації"
+          },
+          "знахідний": {
+            "plural": "акцентуації",
+            "singular": "акцентуацію"
+          },
+          "кличний": {
+            "plural": "акцентуації",
+            "singular": "акцентуаціє"
+          },
+          "місцевий": {
+            "plural": "акцентуаціях",
+            "singular": "акцентуації"
+          },
+          "називний": {
+            "plural": "акцентуації",
+            "singular": "акцентуація"
+          },
+          "орудний": {
+            "plural": "акцентуаціями",
+            "singular": "акцентуацією"
+          },
+          "родовий": {
+            "plural": "акцентуацій",
+            "singular": "акцентуації"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "aposiopesis, deliberate break",
+      "glossClean": "aposiopesis",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "апосіопеза",
+      "lemmaId": "апосіопеза",
+      "lemmaPlain": "апосіопеза",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "апосіопезам",
+            "singular": "апосіопезі"
+          },
+          "знахідний": {
+            "plural": "апосіопези",
+            "singular": "апосіопезу"
+          },
+          "кличний": {
+            "plural": "апосіопези",
+            "singular": "апосіопезо"
+          },
+          "місцевий": {
+            "plural": "апосіопезах",
+            "singular": "апосіопезі"
+          },
+          "називний": {
+            "plural": "апосіопези",
+            "singular": "апосіопеза"
+          },
+          "орудний": {
+            "plural": "апосіопезами",
+            "singular": "апосіопезою"
+          },
+          "родовий": {
+            "plural": "апосіопез",
+            "singular": "апосіопези"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "symploce",
+      "glossClean": "symploce",
+      "heritage": "unknown",
+      "ipa": null,
+      "lemma": "симплока",
+      "lemmaId": "симплока",
+      "lemmaPlain": "симплока",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "tautology",
+      "glossClean": "tautology",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "тавтологія",
+      "lemmaId": "тавтологія",
+      "lemmaPlain": "тавтологія",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {
+          "давальний": {
+            "plural": "тавтологіям",
+            "singular": "тавтології"
+          },
+          "знахідний": {
+            "plural": "тавтології",
+            "singular": "тавтологію"
+          },
+          "кличний": {
+            "plural": "тавтології",
+            "singular": "тавтологіє"
+          },
+          "місцевий": {
+            "plural": "тавтологіях",
+            "singular": "тавтології"
+          },
+          "називний": {
+            "plural": "тавтології",
+            "singular": "тавтологія"
+          },
+          "орудний": {
+            "plural": "тавтологіями",
+            "singular": "тавтологією"
+          },
+          "родовий": {
+            "plural": "тавтологій",
+            "singular": "тавтології"
+          }
+        }
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "chiasmus",
+      "glossClean": "chiasmus",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "хіазм",
+      "lemmaId": "хіазм",
+      "lemmaPlain": "хіазм",
+      "meaningMcEligible": true,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "dialectal",
+      "glossClean": "dialectal",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "діалектний",
+      "lemmaId": "діалектний",
+      "lemmaPlain": "діалектний",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -6219,67 +8593,45 @@
     },
     {
       "cefr": "C1",
-      "gloss": "vesnianka (spring ritual song)",
-      "glossClean": "vesnianka (spring ritual song)",
+      "gloss": "dyed Easter egg",
+      "glossClean": "dyed Easter egg",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "веснянка",
-      "lemmaId": "веснянка",
-      "lemmaPlain": "веснянка",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "hahilky (Galician spring songs)",
-      "glossClean": "hahilky (Galician spring songs)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "гагілки",
-      "lemmaId": "гагілки",
-      "lemmaPlain": "гагілки",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "giltse (decorated ritual treelet)",
-      "glossClean": "giltse (decorated ritual treelet)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "гільце",
-      "lemmaId": "гільце",
-      "lemmaPlain": "гільце",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "decolonization",
-      "glossClean": "decolonization",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "деколонізація",
-      "lemmaId": "деколонізація",
-      "lemmaPlain": "деколонізація",
+      "lemma": "крашанка",
+      "lemmaId": "крашанка",
+      "lemmaPlain": "крашанка",
       "meaningMcEligible": true,
       "paradigm": {
-        "cases": {}
+        "cases": {
+          "давальний": {
+            "plural": "крашанкам",
+            "singular": "крашанці"
+          },
+          "знахідний": {
+            "plural": "крашанки",
+            "singular": "крашанку"
+          },
+          "кличний": {
+            "plural": "крашанки",
+            "singular": "крашанко"
+          },
+          "місцевий": {
+            "plural": "крашанках",
+            "singular": "крашанці"
+          },
+          "називний": {
+            "plural": "крашанки",
+            "singular": "крашанка"
+          },
+          "орудний": {
+            "plural": "крашанками",
+            "singular": "крашанкою"
+          },
+          "родовий": {
+            "plural": "крашанок",
+            "singular": "крашанки"
+          }
+        }
       },
       "pos": "noun",
       "semanticBucket": null,
@@ -6287,30 +8639,13 @@
     },
     {
       "cefr": "C1",
-      "gloss": "rite of starting the harvest",
-      "glossClean": "rite of starting the harvest",
+      "gloss": "intangible",
+      "glossClean": "intangible",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "зажинки",
-      "lemmaId": "зажинки",
-      "lemmaPlain": "зажинки",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "invocatory, summoning",
-      "glossClean": "invocatory",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "закликальний",
-      "lemmaId": "закликальний",
-      "lemmaPlain": "закликальний",
+      "lemma": "нематеріальний",
+      "lemmaId": "нематеріальний",
+      "lemmaPlain": "нематеріальний",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -6321,8 +8656,8 @@
     },
     {
       "cefr": "C1",
-      "gloss": "harvest-end rite",
-      "glossClean": "harvest-end rite",
+      "gloss": "harvest celebration",
+      "glossClean": "harvest celebration",
       "heritage": "standard",
       "ipa": null,
       "lemma": "обжинки",
@@ -6338,144 +8673,13 @@
     },
     {
       "cefr": "C1",
-      "gloss": "ritual (adjective)",
-      "glossClean": "ritual (adjective)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "обрядовий",
-      "lemmaId": "обрядовий",
-      "lemmaPlain": "обрядовий",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "ritual act",
-      "glossClean": "ritual act",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "обрядодія",
-      "lemmaId": "обрядодія",
-      "lemmaPlain": "обрядодія",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {
-          "давальний": {
-            "plural": "обрядодіям",
-            "singular": "обрядодії"
-          },
-          "знахідний": {
-            "plural": "обрядодії",
-            "singular": "обрядодію"
-          },
-          "кличний": {
-            "plural": "обрядодії",
-            "singular": "обрядодіє"
-          },
-          "місцевий": {
-            "plural": "обрядодіях",
-            "singular": "обрядодії"
-          },
-          "називний": {
-            "plural": "обрядодії",
-            "singular": "обрядодія"
-          },
-          "орудний": {
-            "plural": "обрядодіями",
-            "singular": "обрядодією"
-          },
-          "родовий": {
-            "plural": "обрядодій",
-            "singular": "обрядодії"
-          }
-        }
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "performativity (text bound to action)",
-      "glossClean": "performativity (text bound to action)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "перформативність",
-      "lemmaId": "перформативність",
-      "lemmaPlain": "перформативність",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "ritual sowing of grain on New Year",
-      "glossClean": "ritual sowing of grain on New Year",
+      "gloss": "ritual sowing",
+      "glossClean": "ritual sowing",
       "heritage": "standard",
       "ipa": null,
       "lemma": "посівання",
       "lemmaId": "посівання",
       "lemmaPlain": "посівання",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "costumed (mummer)",
-      "glossClean": "costumed (mummer)",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "ряджений",
-      "lemmaId": "ряджений",
-      "lemmaPlain": "ряджений",
-      "meaningMcEligible": false,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "syncretic",
-      "glossClean": "syncretic",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "синкретичний",
-      "lemmaId": "синкретичний",
-      "lemmaPlain": "синкретичний",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "round dance with song",
-      "glossClean": "round dance with song",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "хоровод",
-      "lemmaId": "хоровод",
-      "lemmaPlain": "хоровод",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -6486,30 +8690,13 @@
     },
     {
       "cefr": "C1",
-      "gloss": "autochthonous; of local, native origin (opposite of borrowed)",
-      "glossClean": "autochthonous",
+      "gloss": "revitalization",
+      "glossClean": "revitalization",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "автохтонний",
-      "lemmaId": "автохтонний",
-      "lemmaPlain": "автохтонний",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "glorification; the praising of the host in ritual song",
-      "glossClean": "glorification",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "величання",
-      "lemmaId": "величання",
-      "lemmaPlain": "величання",
+      "lemma": "ревіталізація",
+      "lemmaId": "ревіталізація",
+      "lemmaPlain": "ревіталізація",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -6520,48 +8707,14 @@
     },
     {
       "cefr": "C1",
-      "gloss": "to glorify, extol (a host in song)",
-      "glossClean": "to glorify",
+      "gloss": "singing New Year carols",
+      "glossClean": "singing New Year carols",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "величати",
-      "lemmaId": "величати",
-      "lemmaPlain": "величати",
+      "lemma": "щедрування",
+      "lemmaId": "щедрування",
+      "lemmaPlain": "щедрування",
       "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "verb",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "pre-Christian",
-      "glossClean": "pre-Christian",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "дохристиянський",
-      "lemmaId": "дохристиянський",
-      "lemmaPlain": "дохристиянський",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "New Year rite of sprinkling grain on the floor for prosperity and harvest",
-      "glossClean": "New Year rite of sprinkling grain on the floor for prosperity and harvest",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "засівання",
-      "lemmaId": "засівання",
-      "lemmaPlain": "засівання",
-      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
@@ -6571,60 +8724,43 @@
     },
     {
       "cefr": "C1",
-      "gloss": "cosmogonic; relating to the creation of the world",
-      "glossClean": "cosmogonic",
+      "gloss": "cardiogram",
+      "glossClean": "cardiogram",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "космогонічний",
-      "lemmaId": "космогонічний",
-      "lemmaPlain": "космогонічний",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "cosmogony; myth or account of the origin of the universe",
-      "glossClean": "cosmogony",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "космогонія",
-      "lemmaId": "космогонія",
-      "lemmaPlain": "космогонія",
+      "lemma": "кардіограма",
+      "lemmaId": "кардіограма",
+      "lemmaPlain": "кардіограма",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {
           "давальний": {
-            "plural": "космогоніям",
-            "singular": "космогонії"
+            "plural": "кардіограмам",
+            "singular": "кардіограмі"
           },
           "знахідний": {
-            "plural": "космогонії",
-            "singular": "космогонію"
+            "plural": "кардіограми",
+            "singular": "кардіограму"
           },
           "кличний": {
-            "plural": "космогонії",
-            "singular": "космогоніє"
+            "plural": "кардіограми",
+            "singular": "кардіограмо"
           },
           "місцевий": {
-            "plural": "космогоніях",
-            "singular": "космогонії"
+            "plural": "кардіограмах",
+            "singular": "кардіограмі"
           },
           "називний": {
-            "plural": "космогонії",
-            "singular": "космогонія"
+            "plural": "кардіограми",
+            "singular": "кардіограма"
           },
           "орудний": {
-            "plural": "космогоніями",
-            "singular": "космогонією"
+            "plural": "кардіограмами",
+            "singular": "кардіограмою"
           },
           "родовий": {
-            "plural": "космогоній",
-            "singular": "космогонії"
+            "plural": "кардіограм",
+            "singular": "кардіограми"
           }
         }
       },
@@ -6634,30 +8770,47 @@
     },
     {
       "cefr": "C1",
-      "gloss": "solar; connected with the sun and the solar cult",
-      "glossClean": "solar",
+      "gloss": "haidamak movement and its historical-song layer",
+      "glossClean": "haidamak movement and its historical-song layer",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "солярний",
-      "lemmaId": "солярний",
-      "lemmaPlain": "солярний",
-      "meaningMcEligible": true,
+      "lemma": "гайдамаччина",
+      "lemmaId": "гайдамаччина",
+      "lemmaPlain": "гайдамаччина",
+      "meaningMcEligible": false,
       "paradigm": {
         "cases": {}
       },
-      "pos": "adj",
+      "pos": "noun",
       "semanticBucket": null,
       "severity": null
     },
     {
       "cefr": "C1",
-      "gloss": "Christianization",
-      "glossClean": "Christianization",
+      "gloss": "outside name applied by another power or language",
+      "glossClean": "outside name applied by another power or language",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "християнізація",
-      "lemmaId": "християнізація",
-      "lemmaPlain": "християнізація",
+      "lemma": "екзонім",
+      "lemmaId": "екзонім",
+      "lemmaPlain": "екзонім",
+      "meaningMcEligible": false,
+      "paradigm": {
+        "cases": {}
+      },
+      "pos": "noun",
+      "semanticBucket": null,
+      "severity": null
+    },
+    {
+      "cefr": "C1",
+      "gloss": "songbook",
+      "glossClean": "songbook",
+      "heritage": "standard",
+      "ipa": null,
+      "lemma": "співаник",
+      "lemmaId": "співаник",
+      "lemmaPlain": "співаник",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -6668,30 +8821,13 @@
     },
     {
       "cefr": "C1",
-      "gloss": "pagan; pre-Christian",
-      "glossClean": "pagan",
+      "gloss": "folklorization; entry of authored text into communal circulation",
+      "glossClean": "folklorization",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "язичницький",
-      "lemmaId": "язичницький",
-      "lemmaPlain": "язичницький",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "adj",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "kobzar tradition",
-      "glossClean": "kobzar tradition",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "кобзарство",
-      "lemmaId": "кобзарство",
-      "lemmaPlain": "кобзарство",
+      "lemma": "фольклоризація",
+      "lemmaId": "фольклоризація",
+      "lemmaPlain": "фольклоризація",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -6702,13 +8838,13 @@
     },
     {
       "cefr": "C1",
-      "gloss": "sense of inferiority",
-      "glossClean": "sense of inferiority",
-      "heritage": "standard",
+      "gloss": "archaic: word, speech",
+      "glossClean": "archaic: word",
+      "heritage": "authentic-archaism",
       "ipa": null,
-      "lemma": "меншовартість",
-      "lemmaId": "меншовартість",
-      "lemmaPlain": "меншовартість",
+      "lemma": "глагол",
+      "lemmaId": "глагол",
+      "lemmaPlain": "глагол",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -6719,30 +8855,13 @@
     },
     {
       "cefr": "C1",
-      "gloss": "recitative",
-      "glossClean": "recitative",
+      "gloss": "regional: woman",
+      "glossClean": "regional: woman",
       "heritage": "standard",
       "ipa": null,
-      "lemma": "речитатив",
-      "lemmaId": "речитатив",
-      "lemmaPlain": "речитатив",
-      "meaningMcEligible": true,
-      "paradigm": {
-        "cases": {}
-      },
-      "pos": "noun",
-      "semanticBucket": null,
-      "severity": null
-    },
-    {
-      "cefr": "C1",
-      "gloss": "folkloristics, folklore studies",
-      "glossClean": "folkloristics",
-      "heritage": "standard",
-      "ipa": null,
-      "lemma": "фольклористика",
-      "lemmaId": "фольклористика",
-      "lemmaPlain": "фольклористика",
+      "lemma": "кобіта",
+      "lemmaId": "кобіта",
+      "lemmaPlain": "кобіта",
       "meaningMcEligible": true,
       "paradigm": {
         "cases": {}
@@ -6755,10 +8874,10 @@
   "schema": "atlas-practice-lexemes",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 14360,
+    "gzipBytes": 18226,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 179123,
+    "rawBytes": 238042,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/src/data/lexicon-practice-cloze-sources.json
+++ b/site/src/data/lexicon-practice-cloze-sources.json
@@ -1,0 +1,18 @@
+[
+  {
+    "lemma": "валіза",
+    "lemmaId": "валіза",
+    "sentence": "Я беру ___.",
+    "blankCase": "accusative",
+    "form": "валізу",
+    "number": "singular",
+    "caseRule": "accusative_direct_object",
+    "clozeEn": "I take my suitcase.",
+    "cefr": "A1",
+    "provenance": {
+      "status": "reviewed",
+      "path": "curriculum/l2-uk-en/a2/all-cases-practice/vocabulary.yaml",
+      "cardId": "a2-all-cases-practice-valiza-accusative-1"
+    }
+  }
+]

--- a/site/src/data/lexicon-practice-reviewed-sources.json
+++ b/site/src/data/lexicon-practice-reviewed-sources.json
@@ -1,3 +1,8 @@
 {
-  "reviewed": []
+  "reviewed": [
+    {
+      "status": "reviewed",
+      "path": "curriculum/l2-uk-en/a2/all-cases-practice/vocabulary.yaml"
+    }
+  ]
 }

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -11,6 +11,7 @@ from scripts.audit.generate_practice_deck import (
     JsonVesumVerifier,
     ReviewedSourceAllowlist,
     _build_lexeme,
+    _eligible_decoys,
     _option_strategy_for_level,
     apply_size_budgets,
     build_practice_shards,
@@ -345,3 +346,58 @@ def test_source_inventory_cloze_requires_explicit_cloze_admission() -> None:
         for item in level["cloze"]["cloze"]
     }
     assert "knyha" in cloze_ids
+
+
+def test_cloze_output_preserves_sentence_cefr() -> None:
+    cloze = _build()["A1"]["cloze"]["cloze"][0]
+
+    assert cloze["cefr"] == "A1"
+
+
+def test_cloze_decoys_support_ukrainian_case_keys() -> None:
+    entries = read_manifest(MANIFEST)
+    for entry in entries:
+        morphology = entry.get("enrichment", {}).get("morphology", {})
+        paradigm = morphology.get("paradigm", {})
+        cases = paradigm.get("cases", {})
+        if isinstance(cases, dict) and "accusative" in cases:
+            cases["знахідний"] = cases.pop("accusative")
+        if isinstance(cases, dict) and "locative" in cases:
+            cases["місцевий"] = cases.pop("locative")
+
+    shards = build_practice_shards(
+        entries,
+        ReviewedSourceAllowlist.from_path(ALLOWLIST),
+        JsonVesumVerifier.from_path(VESUM),
+        read_cloze_sources(CLOZE_SOURCES),
+        BuildConfig(),
+    )
+
+    assert shards["A1"]["cloze"]["cloze"]
+
+
+def test_cloze_decoys_do_not_exceed_answer_cefr() -> None:
+    answer = {"lemmaId": "валіза", "gloss": "suitcase", "pos": "noun", "cefr": "A1"}
+    lexemes = [
+        answer,
+        {
+            "lemmaId": "школа",
+            "lemma": "школа",
+            "gloss": "school",
+            "pos": "noun",
+            "cefr": "A1",
+            "paradigm": {"cases": {"accusative": {"singular": "школу"}}},
+        },
+        {
+            "lemmaId": "термінологія",
+            "lemma": "термінологія",
+            "gloss": "terminology",
+            "pos": "noun",
+            "cefr": "B2",
+            "paradigm": {"cases": {"accusative": {"singular": "термінологію"}}},
+        },
+    ]
+
+    assert _eligible_decoys(answer, lexemes, "accusative", "singular") == [
+        (lexemes[1], "школу")
+    ]


### PR DESCRIPTION
## Summary

Adds a deliberately tiny A1 cloze pilot for Atlas practice admission:

- adds one reviewed cloze source for `валіза` -> `валізу`
- keeps Daily Word unchanged at 300 items
- emits `total_cloze=1` in static practice assets
- preserves `cefr` on emitted cloze items
- caps cloze decoys so they do not exceed the answer CEFR
- supports Ukrainian real-manifest case keys such as `знахідний` in cloze decoy generation

The larger `site/public/lexicon` diff is deterministic static practice regeneration from the updated generator and reviewed cloze source.

## Validation

- `.venv/bin/ruff check --fix scripts/audit/generate_practice_deck.py tests/test_generate_practice_deck.py`
- `env -u AGENT_NO_TELEMETRY_FOOTER PYTHONPATH=. .venv/bin/python -m pytest tests/test_generate_practice_deck.py tests/test_check_static_practice_assets.py -q`
- `PYTHONPATH=. .venv/bin/python -m py_compile scripts/audit/generate_practice_deck.py scripts/audit/check_static_practice_assets.py`
- `PYTHONPATH=. .venv/bin/python scripts/audit/check_static_practice_assets.py --format json`
- `npm --prefix site test -- tests/unit/LexiconPractice.test.tsx`
- `npm --prefix site run build`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

Independent AGY review was run before commit; its only blocker was the initially untracked cloze source file, which is now included in this commit.