### PR TITLE
[codex] BIO #351 Myroslav Skoryk research dossier

### DIFF
--- a/docs/research/bio/myroslav-skoryk.md
+++ b/docs/research/bio/myroslav-skoryk.md
@@ -1,0 +1,141 @@
+# Мирослав Михайлович Скорик — Research Dossier
+
+**Slug:** `myroslav-skoryk`
+**Block:** +77 expansion — "Music / modern Ukrainian concert music" group (2026-06-29 memo)
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #351
+**Researcher:** Codex background worker (GPT-5)
+**Completed:** 2026-06-30
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Мирослав Михайлович Скорик.
+- **Pseudonyms / aliases:** Мирослав Скорик; Скорик Мирослав Михайлович; Myroslav Skoryk.
+- **Born:** 13 July 1938 | Lviv | then Lwow, Second Polish Republic; now Lviv, Ukraine [T1: IEU — Skoryk, Myroslav] [T1: EIU — Скорик Мирослав Михайлович] [T2: НСКУ — СКОРИК Мирослав Михайлович].
+- **Died:** 1 June 2020 | Kyiv per НСКУ; IEU gives Lviv, so module metadata should prefer Kyiv only with visible source note until a primary death record is checked [T2: НСКУ — СКОРИК Мирослав Михайлович] [T1: IEU — Skoryk, Myroslav].
+- **Family / education key facts:** Born into a Galician Ukrainian intelligentsia family; sources identify Solomiia Krushelnytska as his great-aunt or grandmother's sister and as an early recognizer of his musical gift [T1: IEU] [T2: НСКУ]. In 1947 the Skoryk family was politically repressed and exiled to Siberia; he returned to Lviv in 1955, then studied at the Lviv Conservatory in 1955-1960 with Adam Soltys, Stanislav Liudkevych, and Roman Simovych before graduate work at the Moscow Conservatory with Dmitri Kabalevsky [T1: IEU] [T1: EIU] [T2: НСКУ]. Core BIO identity: Ukrainian composer, pedagogue, conductor, and musicologist whose works connect Galician/Lviv training, Kyiv teaching, Hutsul/Carpathian materials, film music, modern concert music, and Ukrainian cultural memory.
+
+## 2. Oppression mechanism
+
+- **What happened:** Childhood family repression: in 1947 the Skoryk family was arrested or repressed for political motives and exiled to Siberia; Skoryk's formal music education was interrupted until the family returned after Stalin's death [T1: IEU] [T2: НСКУ] [T5: official Skoryk biography].
+- **When:** 1947 exile; return to Lviv in 1955 is stated by IEU and НСКУ. No exact arrest date, transport date, or release document was located in this source pass.
+- **By whom:** Sources name "Soviet authorities" or political repression but do not identify a specific agency such as MGB or NKVD. Do not add an agency name unless a deportation file or archival source is found.
+- **Document references:** No case number, deportation-list citation, court decision, or rehabilitation document was accessed in this pass.
+- **Mechanism specifics:** The deportation matters as Soviet repression context and as a childhood rupture in a Galician Ukrainian family. It should not become the whole-life plot. Skoryk later held official posts, received Soviet and Ukrainian honors, taught in major conservatories, and led Ukrainian musical institutions. The stronger frame is constrained continuity and transmission: a deported child from Lviv became a teacher and public composer whose music helped later audiences hear Ukrainian memory inside and beyond Soviet cultural systems.
+- **What survived / what was damaged:** Survived: training, return to Lviv, professional education, teaching lineage, and major works. Damaged: childhood continuity, family security, and archival clarity around the family's repression mechanism.
+
+## 3. Major works / contributions
+
+- **Modern Ukrainian concert music:** EIU characterizes Skoryk's work through multigenre breadth, neofolklorism, vivid thematic writing, and neoclassical features. Strong anchors include `Гуцульський триптих` (1965), `Карпатський концерт` (1972), `24 каприси Паґаніні` (1989-1993), `1933` (1994), multiple violin and piano concertos, and chamber, choral, piano, theater, and film music [T1: EIU] [T2: Shevchenko Prize Committee].
+- **Film/music memory:** IEU and EIU connect `Гуцульський триптих` to the score for Serhii Paradzhanov's `Тіні забутих предків`. That film-music connection is a core BIO route because it joins Kotsiubynsky, Paradzhanov, Hutsul visual culture, and a young Galician composer's ear for mountain sound-worlds without reducing him to a film composer only [T1: IEU] [T1: EIU].
+- **`Мелодія`:** EIU names the melody from `Високий перевал` as an academic-music hit; Suspilne frames `Мелодія ля-мінор` as one of the most recognizable Ukrainian cultural-memory works and explains the film's censored postwar Galician setting. Treat the story carefully: the melody can carry memory beyond what Soviet film narration could say, but the dossier should not claim hidden political intent beyond sourced reception context [T1: EIU] [T5: Суспільне Культура].
+- **Franko / Shevchenko links:** `Мойсей` (2001) is based on Ivan Franko's poem, and the cantata `Гамалія` (2003) uses Taras Shevchenko's words [T1: IEU] [T2: Shevchenko Prize Committee]. These create verified LIT/BIO bridges to Franko and Shevchenko.
+- **Pedagogy and institutions:** EIU names students including Ivan Karabyts and Yevhen Stankovych; НСКУ and the Shevchenko Prize Committee record long service at Lviv and Kyiv conservatories, the National Academy of Music of Ukraine, the National Union of Composers of Ukraine, and the National Opera of Ukraine [T1: EIU] [T2: НСКУ] [T2: Shevchenko Prize Committee].
+- **Continuity from Liudkevych / Revutskyi-line pedagogy:** Verified direct continuity: Skoryk studied music history and theory with Stanislav Liudkevych in Lviv [T1: EIU] [T2: НСКУ]. Revutskyi-line continuity should be phrased as institutional/generational context only unless a direct teacher-student claim is sourced.
+
+## 4. Primary-source quote anchors
+
+- **Quote 1, Franko text set by Skoryk:** "Народе мій, замучений, розбитий..."
+  Source: Ivan Franko, `Мойсей`, prologue; Skoryk's opera `Мойсей` is based on Franko's poem [T1: IEU] [Primary text: Wikisource — `Мойсей/Пролог`].
+  Pedagogical use: short public-domain incipit ties Skoryk's post-Soviet opera to Franko's national-political poem. Words are Franko's, not Skoryk's; use only a short anchor and teach the musical setting as Skoryk's contribution.
+- **Quote 2, Shevchenko text set by Skoryk:** "У туркені яничари..."
+  Source: Taras Shevchenko, `Гамалія`; the Shevchenko Prize Committee and EIU list Skoryk's cantata `Гамалія` on Shevchenko's words [T1: EIU] [T2: Shevchenko Prize Committee] [Primary text: Wikisource — `Гамалія (1844)`].
+  Pedagogical use: short public-domain incipit links Skoryk's late choral/orchestral writing to Shevchenko's historical imagination. Words are Shevchenko's, not Skoryk's.
+- **Composer-voice gap:** No short, stable first-person Skoryk quotation was selected in this pass. Later module writers should prefer published interviews, program notes, or score prefaces over quote aggregators.
+
+## 5. Language register
+
+- **Register:** high modern concert-music register; neofolkloric and neoclassical vocabulary; Hutsul/Carpathian color; occasional jazz/popular-song idiom; elevated public-memory register around `Мелодія`, `Мойсей`, `1933`, and `Гамалія`.
+- **CEFR readiness full reading:** C1 for biography and cultural framing; B2-C1 for short title/incipit anchors; C1/advanced for Soviet/post-Soviet institutional complexity.
+- **Lexicon notes:** `неофольклоризм`, `неокласицизм`, `концерт`, `партита`, `кантата`, `опера`, `оркестрування`, `кіномузика`, `гуцульський`, `карпатський`, `ладова система`, `акордика`, `музична україністика`, `заслання`, `репресовано з політичних мотивів`.
+- **Stylistic features:** synthesis rather than single-school purity: Lviv/Galician training, professional academic form, Hutsul and Carpathian sound images, jazz/pop idioms, and public lyrical memory in pieces audiences can recognize immediately.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** The strongest interpretive question is how to balance Skoryk's official Soviet-era career with his Ukrainian musical substance. He was not an underground dissident composer; he also was not merely a Soviet cultural official. A sound module should show the mechanism by which Ukrainian idioms, film sound, pedagogy, and public memory worked through state institutions.
+- **What gets simplified in popular memory:** Popular memory can reduce him to `Мелодія` or to `Тіні забутих предків`; official biographies can reduce him to titles, prizes, and posts. The dossier should keep both visible but make the larger contribution modern Ukrainian composition and teaching.
+- **Where modern Russian disinformation attacks them (if applicable):** No Skoryk-specific modern Russian disinformation campaign was identified. The broader colonial risk is absorptive: calling him primarily "Soviet" or treating Lviv/Kyiv Ukrainian institutions as secondary to Moscow training.
+- **Polish / Jewish / other-perspective considerations (if applicable):** Birth-place wording needs historical precision: Lviv was in the Second Polish Republic in 1938. Siberian exile should not be narrated as generic suffering detached from postwar Soviet repression in Western Ukraine.
+- **HIST-alignment check for +77 roster:** Align with postwar Soviet rule in Western Ukraine, late-Soviet cultural institutions, Ukrainian poetic cinema, 1932-1933 Holodomor memory via `1933`, and post-1991 state/cultural institution-building. No new HIST frame should be invented for the Skoryk module.
+
+## 7. Cross-track links
+
+- **Existing C1 modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/c1/klasychna-muzyka-2-natsionalna-shkola.yaml` — national-school continuity context before Skoryk's modern concert-music generation.
+  - `curriculum/l2-uk-en/plans/c1/klasychna-muzyka-3-modernizm-i-suchasnist.yaml` — direct modernism/contemporary-classical context that already names Skoryk and `Мелодія`.
+  - `curriculum/l2-uk-en/plans/c1/vokalne-mystetstvo.yaml` — vocal/choral bridge for `Мойсей`, `Гамалія`, and late public sacred/civic works.
+- **Existing LIT modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/kotsiubynsky-shadows-forgotten.yaml` — literary source route for `Тіні забутих предків`.
+  - `curriculum/l2-uk-en/plans/lit/franko-moses.yaml` — Franko poem behind the opera `Мойсей`.
+  - `curriculum/l2-uk-en/plans/lit/franko-social-poetry.yaml` — Franko civic-poetry context for public-cultural reception.
+  - `curriculum/l2-uk-en/plans/lit/cult-of-shevchenko.yaml` — Shevchenko reception route for `Гамалія`.
+- **Existing HIST modules (VERIFIED `test -e`):**
+  - None asserted in this pass.
+- **Existing BIO modules / dossiers (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/serhii-paradzhanov.yaml` — film collaboration and `Тіні забутих предків`.
+  - `curriculum/l2-uk-en/plans/bio/ivan-franko.yaml` — source figure for `Мойсей`.
+  - `curriculum/l2-uk-en/plans/bio/taras-shevchenko.yaml` — source figure for `Гамалія`.
+  - `docs/research/bio/stanislav-liudkevych.md` — verified teacher-line Galician music continuity.
+  - `docs/research/bio/levko-revutskyi.md` — national-school continuity context; direct Skoryk connection not asserted.
+- **Candidate cross-track connections (Phase 2+ — NOT existing files):**
+  - BIO #352 `ivan-karabyts` and BIO #353 `yevhen-stankovych` as verified Skoryk students named by EIU.
+  - Future BIO/C1 bridge for `Високий перевал` / `Мелодія` if film-music memory becomes a focused module.
+  - Future music-history comparison with Liatoshynskyi and Silvestrov only if source-supported in module planning.
+- **Potential LIT additions surfaced research:** None proposed.
+
+## 8. Naming-canonical
+
+Per `docs/best-practices/bio-naming-canonical.md` (#2313):
+
+- **Slug:** `myroslav-skoryk`.
+- **EN canonical (BGN/PCGN 2010):** Myroslav Skoryk.
+- **UA canonical (with patronymic if attested):** Мирослав Михайлович Скорик.
+- **Aliases (track `aliases:` YAML field later):** Мирослав Скорик; Скорик Мирослав Михайлович; Myroslav Mykhailovych Skoryk; Myroslav Skoryk.
+- **Forbidden forms:** Russianized or legacy forms such as `Miroslav Skorik`, `Miroslav Skoryk`, `Lvov`, `Kiev`, or Russian patronymic spellings should appear only in source-critical notes or forbidden alias fields, not learner-facing prose.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** No cleared PD/CC portrait selected in this pass. Skoryk died in 2020; portraits and performance photographs are presumptively copyright-sensitive unless a specific free license is verified.
+- **Backup candidates:** IEU and НСКУ pages display portraits but do not by themselves establish reuse rights. Wikimedia/Commons results require separate license review before use.
+- **Fallback strategy:** text-only module is acceptable; later media pass could use rights-cleared contextual images of Lviv music institutions, public-domain Franko/Shevchenko textual sources, or licensed concert-program material if directly tied to the lesson.
+- **Era-appropriate context image:** a rights-cleared `Тіні забутих предків` / Hutsul music context image would be pedagogically useful, but only after license verification.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- Internet Encyclopedia of Ukraine. Marko Robert Stech. "Skoryk, Myroslav." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CK%5CSkorykMyroslav.htm. Accessed 2026-06-30.
+- Інститут історії України НАН України / Енциклопедія історії України. Сікорська І. М. "СКОРИК Мирослав Михайлович." https://www.history.org.ua/?termin=Skoryk. Accessed 2026-06-30.
+
+**Tier 2 (institutional):**
+
+- Національна спілка композиторів України. "СКОРИК Мирослав Михайлович." https://composersukraine.org/index.php?id=1371. Accessed 2026-06-30.
+- Комітет з Національної премії України імені Тараса Шевченка. "Скорик Мирослав Михайлович." https://knpu.gov.ua/winners/skoryk-myroslav-mykhajlovych/. Accessed 2026-06-30.
+
+**Tier 5 (official/public reception):**
+
+- Мирослав Скорик official site. "Біографія." https://myroslavskoryk.com/biografiya/. Accessed 2026-06-30. Used for family/education corroboration; core claims cross-checked against T1/T2.
+- Суспільне Культура. Міла Кравчук. "Мирослав Скорик: цікаві факти з життя і творчості композитора." 13 July 2022. https://suspilne.media/culture/260128-miroslav-skorik-cikavi-fakti-z-zitta-i-tvorcosti-kompozitora/. Accessed 2026-06-30. Used for public-reception and `Мелодія` context, not as sole authority for core dates.
+
+**Primary-source text anchors:**
+
+- Іван Франко. `Мойсей`, пролог. Wikisource text: https://uk.wikisource.org/wiki/Твори_(Франко,_1956–1962)/14/Мойсей/Пролог. Accessed 2026-06-30.
+- Тарас Шевченко. `Гамалія` (1844). Wikisource text: https://uk.wikisource.org/wiki/Гамалія_(1844). Accessed 2026-06-30.
+
+**Primary-source documents accessed (NKVD/MGB/KGB, court, police, censorship, rehabilitation documents):**
+
+- None accessed in this pass. Do not state a case number, agency-specific deportation mechanism, or rehabilitation record until archival evidence is found.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; Lviv/Kyiv Ukrainian institutions are not treated as secondary to Moscow training.
+- [x] Childhood deportation is included with sourced care and not inflated into a whole-life security-service plot.
+- [x] Soviet and post-Soviet official posts, awards, and institutional roles remain visible without becoming the identity frame.
+- [x] Ukrainian composer/pedagogue role, Galician/Lviv and Kyiv arcs, modern concert music, `Тіні забутих предків`, and `Мелодія` are foregrounded.
+- [x] Liudkevych continuity is stated as verified teacher-line; Revutskyi-line continuity is kept as context only.
+- [x] Existing cross-track paths were verified with `test -e`; unbuilt connections are under candidate links.
+- [x] Public-domain Franko/Shevchenko incipits are short and explicitly identified as not Skoryk's own words.


### PR DESCRIPTION
## Summary

- Adds the BIO #351 research dossier for Myroslav Skoryk / Мирослав Скорик.
- Keeps scope to exactly one repo file: `docs/research/bio/myroslav-skoryk.md`.
- Frames Skoryk as a Ukrainian composer, pedagogue, and institution-builder across Lviv/Galician and Kyiv arcs, with sourced coverage of `Тіні забутих предків`, `Мелодія`, Hutsul/Carpathian materials, Franko/Shevchenko links, and bounded childhood deportation context.

## Validation

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/myroslav-skoryk.md` — PASS
- `/Users/krisztiankoos/projects/learn-ukrainian/node_modules/.bin/markdownlint-cli2 docs/research/bio/myroslav-skoryk.md` — PASS
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/check_dossier_wordcount.py --paths docs/research/bio/myroslav-skoryk.md` — PASS, 2000 words
- `git diff --check origin/main..HEAD` — PASS
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` — PASS
- Commit and push hooks passed.

## Source Gaps / Risks

- No NKVD/MGB/KGB case file, deportation-list citation, court decision, or rehabilitation document was found for the family's 1947 exile; the dossier names only the sourced Soviet-authority/political-repression frame.
- Death place has a source discrepancy: НСКУ gives Kyiv, while IEU gives Lviv. The dossier flags this for later metadata review.
- No cleared PD/CC portrait selected; later media pass should verify image licensing.
- No stable first-person Skoryk quote selected; quote anchors use short public-domain Franko/Shevchenko incipits from works Skoryk set, with that limitation labeled.
- Liudkevych teacher-line is verified; Revutskyi-line continuity is kept as context only, not asserted as a direct teacher-student link.