### PR TITLE
docs(bio): add Ivan Karabyts dossier

### DIFF
--- a/docs/research/bio/ivan-karabyts.md
+++ b/docs/research/bio/ivan-karabyts.md
@@ -1,0 +1,143 @@
+# Іван Федорович Карабиць — Research Dossier
+
+**Slug:** `ivan-karabyts`
+**Block:** +77 expansion — "Music / modern Ukrainian concert music" group (2026-06-29 memo)
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #352
+**Researcher:** Codex background worker; Codex orchestrator repair
+**Completed:** 2026-06-30
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Іван Федорович Карабиць.
+- **Pseudonyms / aliases:** Іван Карабиць; Карабиць Іван Федорович; Ivan Karabyts; Ivan Fedorovych Karabyts; legacy/foreign forms `Ivan Karabits`, `Ivan Karabic`.
+- **Born:** 17 January 1945 | village Yalta, Donetsk region | Ukrainian SSR, Soviet Union; now Ukraine. ЕСУ, ЕІУ, and НСКУ agree on the date and place.
+- **Died:** 20 January 2002 | Kyiv, Ukraine. ЕСУ, ЕІУ, and НСКУ agree.
+- **Family / education key facts:** ЕСУ identifies him as the husband of musicologist Marianna Kopytsia and father of conductor Kyrylo Karabyts. He graduated from Kyiv Conservatory in 1971; ЕСУ names Borys Liatoshynskyi and Myroslav Skoryk as teachers, while ЕІУ and НСКУ foreground the Skoryk composition class. He completed postgraduate study at the same conservatory in 1975 under Skoryk. The sources agree that he later taught composition at the Kyiv Conservatory / National Music Academy of Ukraine and became a major organizer of post-1991 Ukrainian musical life.
+- **Institutional roles:** Sources vary slightly on the dates of his work with the Kyiv Military District Song and Dance Ensemble: ЕСУ gives 1967-1975, while ЕІУ gives 1968-1974. ЕСУ also records work at the National Music Academy of Ukraine from 1983, artistic leadership of Kyiv Camerata in 1994-2000, founding leadership of Kyiv Music Fest in 1990-2001, and work with the Horowitz young pianists' competition.
+
+## 2. Oppression mechanism
+
+- **What happened:** No Tier 1/Tier 2 source accessed in this pass documents a person-specific arrest, exile, trial, ban, rehabilitation case, NKVD/MGB/KGB file, or security-service persecution of Karabyts.
+- **When:** Not applicable as a direct repression biography.
+- **By whom:** Not applicable at person-specific file level. Do not assign an NKVD, MGB, KGB, or other agency to Karabyts unless a future archival source identifies such a case.
+- **Document references:** No court file, security-service archive reference, censorship ruling, or rehabilitation document was found in this pass.
+- **Mechanism specifics:** The historically useful frame is late-Soviet and early-independent cultural institution work, not martyrdom. Karabyts moved through official Soviet Ukrainian musical structures, held prizes and union roles, and worked in military and state-linked musical settings. Those facts should remain visible. The same biography also shows how Ukrainian concert language, Skovoroda/Franko/Tychyna/Oliinyk text settings, folklore layers, baroque chant memory, and modernist technique continued inside and beyond those structures.
+- **What survived / what was damaged:** Survived: the Liatoshynskyi-Skoryk teaching line, Ukrainian orchestral and vocal-symphonic repertoire, the Kyiv Camerata and Kyiv Music Fest institutional legacy, and a generation of students. Damaged: interpretive clarity. Soviet award language can flatten him into a generic "Soviet composer"; the opposite overcorrection can invent a repression story the sources do not support.
+
+## 3. Major works / contributions
+
+- **Modern Ukrainian synthesis:** ЕСУ characterizes Karabyts's style as a combination of traditional musical forms with modern musical thinking. Its account names Ukrainian folklore layers, duma and drawn-out-song idioms, instrumental folk figuration, znamenny chant, kant and baroque choral culture, Liatoshynskyi's stylistic inheritance, twentieth-century European modernism, jazz vocabulary, non-serial dodecaphony, pointillism, clusters, aleatorics, sonorism, neoclassical, neobaroque, and neo-impressionist tendencies.
+- **Large vocal-symphonic and orchestral works:** Stable anchors include the vocal-symphonic concert `Сад божественних пісень` on Hryhorii Skovoroda texts (1971), Symphony No. 1 `П'ять пісень про Україну` (1974), the oratorio `Заклинання вогню` on Borys Oliinyk (1979), the opera-oratorio `Київські фрески` with an Oliinyk libretto (1983), orchestral concerts including No. 3 `Голосіння` (1989), `Молитва Катерини` (1992), and `Vio-Serenade` (2000).
+- **Donetsk/Kyiv geography:** The Donetsk-region birth place and works such as `Земле моя на ймення Донбас` make him useful for a careful Donbas cultural-geography bridge. That bridge should not become presentist war commentary, but it can help learners see Ukrainian concert culture as not only a Lviv/Kyiv story.
+- **Institution builder:** Karabyts is not only a repertoire figure. ЕСУ and ЕІУ record his role with Kyiv Camerata, Kyiv Music Fest, and the Horowitz competition orbit. A module can use him to teach how composers build stages, festivals, ensembles, and transmission networks, not only individual works.
+- **Teacher line:** ЕСУ names students including Andrii Honcharov, Olena Ilnytska, Viktoriia Poliova, Volodymyr Rakochi, Alla Roshchenko, and Natalia Yaremchuk. For BIO sequencing, the strong confirmed teacher link is backward: Karabyts studied with Skoryk and, through ЕСУ, also with Liatoshynskyi.
+
+## 4. Primary-source quote anchors
+
+- **Quote 1, Skovoroda text set by Karabyts:** "Всякому місту - звичай і права." Source: Hryhorii Skovoroda, `Сад божественних пісень`; Karabyts's 1971 vocal-symphonic work uses Skovoroda's texts. Pedagogical use: a compact public-domain line lets learners connect baroque moral-philosophical diction with modern Ukrainian concert music. The words are Skovoroda's, not Karabyts's.
+- **Quote 2, Franko title anchor:** "Vivere memento." Source: Ivan Franko phrase/title used for Karabyts's 1970 poem for bass and symphony orchestra. Pedagogical use: the title lets a lesson connect late-twentieth-century orchestral-vocal form with nineteenth-century Ukrainian literary memory. It should be taught as a title/source-text bridge, not as a direct Karabyts aphorism.
+- **Composer-voice gap:** No short first-person Ukrainian statement by Karabyts from a Tier 1/Tier 2 source was verified in this pass. Future module writers should prefer score prefaces, interviews in `Музика`, NMAU holdings, or published memoir volumes over unsourced web quotations.
+
+## 5. Language register
+
+- **Register:** high concert-music and philosophical public register, mixed with folklore, baroque, urban, jazz, and modernist technical vocabulary.
+- **CEFR readiness full reading:** C1 for biography and repertoire discussion. Selected titles and one-line source-text anchors can be glossed at B2.
+- **Lexicon notes:** Useful vocabulary includes `ораторія`, `кантата`, `симфонієта`, `додекафонія`, `сонористика`, `голосіння`, `камерний`, `хоровий`, `музично-громадський`, `фестиваль`, `композиторська школа`.
+- **Stylistic features:** The strongest learner frame is synthesis: Donetsk-region biography, Kyiv professional formation, Liatoshynskyi-Skoryk lineage, Ukrainian literary source texts, folk and chant memory, post-1991 institutional building, and modern compositional technique.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** The main interpretive question is how to describe a composer who was institutionally successful in late Soviet Ukraine without reducing him either to official culture or to retrospective dissidence. A strong module should show both official structures and Ukrainian musical agency.
+- **What gets simplified in popular memory:** Public memory often remembers individual festival/family/conductor associations or broad praise like "modern Ukrainian composer." That is true but too thin. The module should preserve the technical and institutional density: large vocal-symphonic forms, literary texts, Kyiv festival-building, and teacher-student continuity.
+- **Where modern Russian disinformation attacks them (if applicable):** No Karabyts-specific modern Russian disinformation campaign was identified. The broader colonial risk is absorptive labeling: treating his Ukrainian institutional and repertoire work as merely Soviet cultural production.
+- **Polish / Jewish / Greek / other-perspective considerations:** Some public pages describe Karabyts as from a Greek family, but this pass did not verify that through the Tier 1/Tier 2 sources used for core metadata. Treat it as a candidate identity note until confirmed by family, archival, or institutional sources.
+- **HIST-alignment check for +77 roster:** Align with late-Soviet Ukrainian cultural institutions, Donetsk-region Ukrainian cultural geography, Kyiv as a post-1991 music-institution center, and modern Ukrainian concert music. Do not invent a security-service, dissident, or martyr frame.
+
+## 7. Cross-track links
+
+- **Existing C1 modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/c1/klasychna-muzyka-2-natsionalna-shkola.yaml` — national-school concert-music context.
+  - `curriculum/l2-uk-en/plans/c1/klasychna-muzyka-3-modernizm-i-suchasnist.yaml` — modernism and contemporary-classical context.
+  - `curriculum/l2-uk-en/plans/c1/vokalne-mystetstvo.yaml` — vocal, choral, oratorio, and cantata vocabulary.
+- **Existing LIT/HIST/ISTORIO modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/skovoroda-baroque-philosophy.yaml` — text source for `Сад божественних пісень`.
+  - `curriculum/l2-uk-en/plans/lit/franko-social-poetry.yaml` — Franko public-poetry context for `Vivere memento`.
+  - `curriculum/l2-uk-en/plans/lit/tychyna-tragic-turn.yaml` — context for Karabyts's `Пастелі` on Tychyna texts.
+  - `curriculum/l2-uk-en/plans/hist/hryhorii-skovoroda.yaml` — historical-cultural anchor for Skovoroda reception.
+  - `curriculum/l2-uk-en/plans/istorio/donbas-industrializatsiia.yaml` — regional-history context for careful Donbas geography.
+- **Existing BIO modules / dossiers (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/borys-liatoshynskyi.yaml` and `docs/research/bio/borys-liatoshynskyi.md` — teacher-line context.
+  - `docs/research/bio/myroslav-skoryk.md` — verified teacher and graduate adviser.
+  - `curriculum/l2-uk-en/plans/bio/ivan-franko.yaml` and `curriculum/l2-uk-en/plans/bio/pavlo-tychyna.yaml` — source-figure links through text settings.
+- **Candidate cross-track connections (Phase 2+ NOT files):**
+  - BIO #353 `yevhen-stankovych` as the next modern-composer sequence neighbor.
+  - A future C1/BIO bridge on Kyiv Camerata, Kyiv Music Fest, or post-1991 Ukrainian concert institutions.
+  - A careful Donetsk-region cultural geography sidebar if supported by HIST/ISTORIO planning.
+
+## 8. Naming-canonical
+
+Per `docs/best-practices/bio-naming-canonical.md` (#2313):
+
+- **Slug:** `ivan-karabyts`.
+- **EN canonical (BGN/PCGN 2010):** Ivan Karabyts.
+- **UA canonical (with patronymic attested):** Іван Федорович Карабиць.
+- **Aliases for later `aliases:` field:** Іван Карабиць; Карабиць Іван Федорович; Ivan Fedorovych Karabyts; Ivan Karabits; Ivan Karabic.
+- **Forbidden / avoid in learner-facing body text:** Russianized or French/Russian-via-English spellings when they displace Ukrainian `Karabyts`. Legacy `Karabits` may appear in source titles or aliases only with a note.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons `File:І. Карабиць 1976.jpg`; photographer Yu. Mosenzhnyk; Central State Audiovisual and Electronic Archive of Ukraine; accession no. 2-213144; licensed CC BY 4.0. The file page states Kyiv, 1976, and identifies Karabyts at work.
+- **Backup candidates:** Commons category `Ivan Karabyts` includes other archival portraits and work photographs from the 1970s-1990s. Each file page must be checked before reuse; do not assume the whole category is equally usable.
+- **Era-appropriate context image:** `Kyiv Camerata performs Karabits.jpg`, if license-confirmed, could support an institution-building module better than another portrait.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- Степанченко Г. В. "Карабиць Іван Федорович." Енциклопедія Сучасної України. https://esu.com.ua/article-9552. Accessed 2026-06-30.
+- Лисенко І. М. "Карабиць Іван Федорович." Енциклопедія історії України, т. 4. Інститут історії України НАН України. https://www.history.org.ua/?termin=Karabyc_I. Accessed 2026-06-30.
+
+**Tier 2 (institutional):**
+
+- Національна спілка композиторів України. "Карабиць Іван Федорович." https://composersukraine.org/index.php?id=2400. Accessed 2026-06-30.
+- Бібліотека Національної музичної академії України. "Іван Федорович Карабиць: віртуальна виставка." https://lib.knmau.com.ua/%D0%BA%D0%B0%D1%80%D0%B0%D0%B1%D0%B8%D1%86%D1%8C/. Accessed 2026-06-30.
+- Бібліотека Національної музичної академії України. "Іван Карабиць. Особлива постать в українській культурі" (bibliographic list PDF). https://lib.knmau.com.ua/wp-content/uploads/2026/02/Karabyc-list.pdf. Accessed 2026-06-30.
+
+**Tier 3 (encyclopedic/navigation):**
+
+- Ukrainian and English Wikipedia were used only to navigate names and image leads; final identity and work claims above are anchored in Tier 1/Tier 2 sources.
+
+**Tier 4 (modern scholarly post-1991):**
+
+- NMAU-linked bibliography surfaced specialist articles, including Olga Hurkova on Karabyts as founder of Kyiv Music Fest. These are candidates for Phase 2 planning but were not used as sole authority for core identity claims.
+
+**Tier 5 (general / reception / estate):**
+
+- Official/memorial site `karabits.com` and recent culture journalism were consulted only for leads and public-reception context.
+
+**Image-rights source:**
+
+- Wikimedia Commons. `File:І. Карабиць 1976.jpg`. https://commons.wikimedia.org/wiki/File:І._Карабиць_1976.jpg. Accessed 2026-06-30.
+
+**Primary-source text anchors:**
+
+- Hryhorii Skovoroda, `Сад божественних пісень` — source-text anchor for Karabyts's 1971 vocal-symphonic work.
+- Ivan Franko, `Vivere memento` title/phrase — source-text anchor for Karabyts's 1970 poem for bass and symphony orchestra.
+
+**Primary-source documents accessed (NKVD/MGB/KGB, court, police, censorship, rehabilitation):**
+
+- None found or accessed in this pass. Do not fabricate person-specific repression documentation.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing.
+- [x] No invented NKVD/KGB/security-service narrative.
+- [x] Soviet institutional context included without making it the whole biography.
+- [x] Ukrainian musical language, teachers, students, literary source texts, Donetsk/Kyiv geography, and post-1991 institution-building foregrounded.
+- [x] Existing cross-track paths verified before listing.
+- [x] Copyright-sensitive text excerpts kept to short anchors only.


### PR DESCRIPTION
## Summary
- Adds the BIO #352 `ivan-karabyts` research dossier only.
- Keeps the slice to `docs/research/bio/ivan-karabyts.md`; no plan YAML, module content, site, wiki, status/audit/review, telemetry, or package/config files.
- Frames Karabyts through modern Ukrainian concert music, Skoryk/Liatoshynskyi lineage, Donetsk/Kyiv geography, and post-1991 institution-building.
- Explicitly avoids inventing a person-specific NKVD/KGB/security-service repression file.

## Validation
- `./.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/ivan-karabyts.md`
- `npx markdownlint-cli2 docs/research/bio/ivan-karabyts.md`
- `git diff --check`
- `./.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Scope check: `origin/main...HEAD` contains only `A docs/research/bio/ivan-karabyts.md`.

## Notes
- Dossier-only base-prep slice; module-build telemetry is not applicable until plan/module production.
- Independent non-Codex content review still required before ready/merge.