### PR TITLE
[codex] Add small A1 cloze batch

### DIFF
--- a/site/public/lexicon/practice-cloze.A1.json
+++ b/site/public/lexicon/practice-cloze.A1.json
@@ -6,6 +6,326 @@
       "caseRule": {
         "case": "accusative",
         "caseLabel": "знахідний",
+        "feedback": "бачити/мати/читати + знахідний (бібліотека -> бібліотеку)",
+        "ruleId": "accusative_direct_object",
+        "trigger": "direct-object",
+        "triggerLabel": "прямий додаток"
+      },
+      "cefr": "A1",
+      "clozeEn": "I see the library.",
+      "clozeId": "бібліотека:cloze:1",
+      "form": "бібліотеку",
+      "lemma": "бібліотека",
+      "lemmaId": "бібліотека",
+      "number": "singular",
+      "options": [
+        {
+          "case": "accusative",
+          "kind": "answer",
+          "label": "бібліотеку",
+          "lemmaId": "бібліотека",
+          "optionId": "бібліотека:cloze:1:answer",
+          "pos": "noun",
+          "strategy": "no-pair"
+        },
+        {
+          "case": "accusative",
+          "kind": "decoy-oblique",
+          "label": "зупинку",
+          "lemmaId": "зупинка",
+          "optionId": "бібліотека:cloze:1:decoy-1",
+          "pos": "noun",
+          "strategy": "no-pair"
+        },
+        {
+          "case": "accusative",
+          "kind": "decoy-oblique",
+          "label": "вулицю",
+          "lemmaId": "вулиця",
+          "optionId": "бібліотека:cloze:1:decoy-2",
+          "pos": "noun",
+          "strategy": "no-pair"
+        },
+        {
+          "case": "nominative",
+          "kind": "decoy-lemma",
+          "label": "столиця",
+          "lemmaId": "столиця",
+          "optionId": "бібліотека:cloze:1:decoy-3",
+          "pos": "noun",
+          "strategy": "no-pair"
+        }
+      ],
+      "provenance": {
+        "cardId": "a1-my-city-biblioteka-accusative-1",
+        "path": "curriculum/l2-uk-en/a1/my-city/vocabulary.yaml",
+        "status": "reviewed"
+      },
+      "sentence": "Я бачу ___.",
+      "sentenceFrameId": "sf_c19022120eec"
+    },
+    {
+      "acceptedAlt": [],
+      "blankCase": "accusative",
+      "caseRule": {
+        "case": "accusative",
+        "caseLabel": "знахідний",
+        "feedback": "бачити/мати/читати + знахідний (вулиця -> вулицю)",
+        "ruleId": "accusative_direct_object",
+        "trigger": "direct-object",
+        "triggerLabel": "прямий додаток"
+      },
+      "cefr": "A1",
+      "clozeEn": "I see the street.",
+      "clozeId": "вулиця:cloze:1",
+      "form": "вулицю",
+      "lemma": "вулиця",
+      "lemmaId": "вулиця",
+      "number": "singular",
+      "options": [
+        {
+          "case": "nominative",
+          "kind": "decoy-lemma",
+          "label": "лампа",
+          "lemmaId": "лампа",
+          "optionId": "вулиця:cloze:1:decoy-3",
+          "pos": "noun",
+          "strategy": "no-pair"
+        },
+        {
+          "case": "accusative",
+          "kind": "answer",
+          "label": "вулицю",
+          "lemmaId": "вулиця",
+          "optionId": "вулиця:cloze:1:answer",
+          "pos": "noun",
+          "strategy": "no-pair"
+        },
+        {
+          "case": "accusative",
+          "kind": "decoy-oblique",
+          "label": "середу",
+          "lemmaId": "середа",
+          "optionId": "вулиця:cloze:1:decoy-1",
+          "pos": "noun",
+          "strategy": "no-pair"
+        },
+        {
+          "case": "accusative",
+          "kind": "decoy-oblique",
+          "label": "годину",
+          "lemmaId": "година",
+          "optionId": "вулиця:cloze:1:decoy-2",
+          "pos": "noun",
+          "strategy": "no-pair"
+        }
+      ],
+      "provenance": {
+        "cardId": "a1-my-city-vulytsia-accusative-1",
+        "path": "curriculum/l2-uk-en/a1/my-city/vocabulary.yaml",
+        "status": "reviewed"
+      },
+      "sentence": "Я бачу ___.",
+      "sentenceFrameId": "sf_73b53becd433"
+    },
+    {
+      "acceptedAlt": [],
+      "blankCase": "accusative",
+      "caseRule": {
+        "case": "accusative",
+        "caseLabel": "знахідний",
+        "feedback": "бачити/мати/читати + знахідний (вода -> воду)",
+        "ruleId": "accusative_direct_object",
+        "trigger": "direct-object",
+        "triggerLabel": "прямий додаток"
+      },
+      "cefr": "A1",
+      "clozeEn": "I drink water.",
+      "clozeId": "вода:cloze:1",
+      "form": "воду",
+      "lemma": "вода",
+      "lemmaId": "вода",
+      "number": "singular",
+      "options": [
+        {
+          "case": "accusative",
+          "kind": "decoy-oblique",
+          "label": "пошту",
+          "lemmaId": "пошта",
+          "optionId": "вода:cloze:1:decoy-1",
+          "pos": "noun",
+          "strategy": "no-pair"
+        },
+        {
+          "case": "nominative",
+          "kind": "decoy-lemma",
+          "label": "дата",
+          "lemmaId": "дата",
+          "optionId": "вода:cloze:1:decoy-3",
+          "pos": "noun",
+          "strategy": "no-pair"
+        },
+        {
+          "case": "accusative",
+          "kind": "decoy-oblique",
+          "label": "валізу",
+          "lemmaId": "валіза",
+          "optionId": "вода:cloze:1:decoy-2",
+          "pos": "noun",
+          "strategy": "no-pair"
+        },
+        {
+          "case": "accusative",
+          "kind": "answer",
+          "label": "воду",
+          "lemmaId": "вода",
+          "optionId": "вода:cloze:1:answer",
+          "pos": "noun",
+          "strategy": "no-pair"
+        }
+      ],
+      "provenance": {
+        "cardId": "a1-food-and-drink-voda-accusative-1",
+        "path": "curriculum/l2-uk-en/a1/food-and-drink/vocabulary.yaml",
+        "status": "reviewed"
+      },
+      "sentence": "Я п'ю ___.",
+      "sentenceFrameId": "sf_0b2f65c4ffa8"
+    },
+    {
+      "acceptedAlt": [],
+      "blankCase": "accusative",
+      "caseRule": {
+        "case": "accusative",
+        "caseLabel": "знахідний",
+        "feedback": "бачити/мати/читати + знахідний (кава -> каву)",
+        "ruleId": "accusative_direct_object",
+        "trigger": "direct-object",
+        "triggerLabel": "прямий додаток"
+      },
+      "cefr": "A1",
+      "clozeEn": "I drink coffee.",
+      "clozeId": "кава:cloze:1",
+      "form": "каву",
+      "lemma": "кава",
+      "lemmaId": "кава",
+      "number": "singular",
+      "options": [
+        {
+          "case": "accusative",
+          "kind": "decoy-oblique",
+          "label": "страву",
+          "lemmaId": "страва",
+          "optionId": "кава:cloze:1:decoy-2",
+          "pos": "noun",
+          "strategy": "no-pair"
+        },
+        {
+          "case": "accusative",
+          "kind": "decoy-oblique",
+          "label": "частину",
+          "lemmaId": "частина",
+          "optionId": "кава:cloze:1:decoy-1",
+          "pos": "noun",
+          "strategy": "no-pair"
+        },
+        {
+          "case": "nominative",
+          "kind": "decoy-lemma",
+          "label": "адреса",
+          "lemmaId": "адреса",
+          "optionId": "кава:cloze:1:decoy-3",
+          "pos": "noun",
+          "strategy": "no-pair"
+        },
+        {
+          "case": "accusative",
+          "kind": "answer",
+          "label": "каву",
+          "lemmaId": "кава",
+          "optionId": "кава:cloze:1:answer",
+          "pos": "noun",
+          "strategy": "no-pair"
+        }
+      ],
+      "provenance": {
+        "cardId": "a1-food-and-drink-kava-accusative-1",
+        "path": "curriculum/l2-uk-en/a1/food-and-drink/vocabulary.yaml",
+        "status": "reviewed"
+      },
+      "sentence": "Я п'ю ___.",
+      "sentenceFrameId": "sf_b5d89c597aad"
+    },
+    {
+      "acceptedAlt": [],
+      "blankCase": "accusative",
+      "caseRule": {
+        "case": "accusative",
+        "caseLabel": "знахідний",
+        "feedback": "бачити/мати/читати + знахідний (машина -> машину)",
+        "ruleId": "accusative_direct_object",
+        "trigger": "direct-object",
+        "triggerLabel": "прямий додаток"
+      },
+      "cefr": "A1",
+      "clozeEn": "I see the car.",
+      "clozeId": "машина:cloze:1",
+      "form": "машину",
+      "lemma": "машина",
+      "lemmaId": "машина",
+      "number": "singular",
+      "options": [
+        {
+          "case": "accusative",
+          "kind": "decoy-oblique",
+          "label": "ціну",
+          "lemmaId": "ціна",
+          "optionId": "машина:cloze:1:decoy-1",
+          "pos": "noun",
+          "strategy": "no-pair"
+        },
+        {
+          "case": "accusative",
+          "kind": "decoy-oblique",
+          "label": "допомогу",
+          "lemmaId": "допомога",
+          "optionId": "машина:cloze:1:decoy-2",
+          "pos": "noun",
+          "strategy": "no-pair"
+        },
+        {
+          "case": "accusative",
+          "kind": "answer",
+          "label": "машину",
+          "lemmaId": "машина",
+          "optionId": "машина:cloze:1:answer",
+          "pos": "noun",
+          "strategy": "no-pair"
+        },
+        {
+          "case": "nominative",
+          "kind": "decoy-lemma",
+          "label": "бібліотека",
+          "lemmaId": "бібліотека",
+          "optionId": "машина:cloze:1:decoy-3",
+          "pos": "noun",
+          "strategy": "no-pair"
+        }
+      ],
+      "provenance": {
+        "cardId": "a1-transport-mashyna-accusative-1",
+        "path": "curriculum/l2-uk-en/a1/transport/vocabulary.yaml",
+        "status": "reviewed"
+      },
+      "sentence": "Я бачу ___.",
+      "sentenceFrameId": "sf_356278937794"
+    },
+    {
+      "acceptedAlt": [],
+      "blankCase": "accusative",
+      "caseRule": {
+        "case": "accusative",
+        "caseLabel": "знахідний",
         "feedback": "бачити/мати/читати + знахідний (валіза -> валізу)",
         "ruleId": "accusative_direct_object",
         "trigger": "direct-object",
@@ -29,10 +349,19 @@
           "strategy": "no-pair"
         },
         {
+          "case": "nominative",
+          "kind": "decoy-lemma",
+          "label": "громада",
+          "lemmaId": "громада",
+          "optionId": "валіза:cloze:1:decoy-3",
+          "pos": "noun",
+          "strategy": "no-pair"
+        },
+        {
           "case": "accusative",
           "kind": "decoy-oblique",
-          "label": "вулицю",
-          "lemmaId": "вулиця",
+          "label": "годину",
+          "lemmaId": "година",
           "optionId": "валіза:cloze:1:decoy-1",
           "pos": "noun",
           "strategy": "no-pair"
@@ -40,18 +369,9 @@
         {
           "case": "accusative",
           "kind": "decoy-oblique",
-          "label": "бібліотеку",
-          "lemmaId": "бібліотека",
+          "label": "каву",
+          "lemmaId": "кава",
           "optionId": "валіза:cloze:1:decoy-2",
-          "pos": "noun",
-          "strategy": "no-pair"
-        },
-        {
-          "case": "nominative",
-          "kind": "decoy-lemma",
-          "label": "пісня",
-          "lemmaId": "пісня",
-          "optionId": "валіза:cloze:1:decoy-3",
           "pos": "noun",
           "strategy": "no-pair"
         }
@@ -70,10 +390,10 @@
   "schema": "atlas-practice-cloze",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 769,
+    "gzipBytes": 1453,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 2351,
+    "rawBytes": 12371,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/public/lexicon/practice-index.A1.json
+++ b/site/public/lexicon/practice-index.A1.json
@@ -1,8 +1,8 @@
 {
   "counts": {
-    "cloze": 1,
-    "clozeCoverage": 0.0009,
-    "clozeEligibleLexemes": 1,
+    "cloze": 6,
+    "clozeCoverage": 0.0053,
+    "clozeEligibleLexemes": 6,
     "lexemes": 1125
   },
   "deckVersion": "atlas-practice-v1-c5a52e54cdf8d828",
@@ -222,14 +222,17 @@
     },
     {
       "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
+      "clozeIds": [
+        "бібліотека:cloze:1"
+      ],
+      "hasCloze": true,
       "lemma": "бібліотека",
       "lemmaId": "бібліотека",
       "modes": [
         "flashcards",
         "matching",
-        "choice"
+        "choice",
+        "cloze"
       ],
       "newOrder": 17
     },
@@ -248,14 +251,17 @@
     },
     {
       "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
+      "clozeIds": [
+        "вулиця:cloze:1"
+      ],
+      "hasCloze": true,
       "lemma": "вулиця",
       "lemmaId": "вулиця",
       "modes": [
         "flashcards",
         "matching",
-        "choice"
+        "choice",
+        "cloze"
       ],
       "newOrder": 19
     },
@@ -1662,14 +1668,17 @@
     },
     {
       "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
+      "clozeIds": [
+        "вода:cloze:1"
+      ],
+      "hasCloze": true,
       "lemma": "вода",
       "lemmaId": "вода",
       "modes": [
         "flashcards",
         "matching",
-        "choice"
+        "choice",
+        "cloze"
       ],
       "newOrder": 131
     },
@@ -1714,14 +1723,17 @@
     },
     {
       "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
+      "clozeIds": [
+        "кава:cloze:1"
+      ],
+      "hasCloze": true,
       "lemma": "кава",
       "lemmaId": "кава",
       "modes": [
         "flashcards",
         "matching",
-        "choice"
+        "choice",
+        "cloze"
       ],
       "newOrder": 135
     },
@@ -7882,14 +7894,17 @@
     },
     {
       "cefr": "A1",
-      "clozeIds": [],
-      "hasCloze": false,
+      "clozeIds": [
+        "машина:cloze:1"
+      ],
+      "hasCloze": true,
       "lemma": "машина",
       "lemmaId": "машина",
       "modes": [
         "flashcards",
         "matching",
-        "choice"
+        "choice",
+        "cloze"
       ],
       "newOrder": 621
     },
@@ -14354,10 +14369,10 @@
   "schema": "atlas-practice-index",
   "schemaVersion": 1,
   "sizeBudget": {
-    "gzipBytes": 17333,
+    "gzipBytes": 17400,
     "gzipLimitBytes": 140000,
     "ok": true,
-    "rawBytes": 284475,
+    "rawBytes": 284745,
     "rawLimitBytes": 550000
   },
   "source": "manifest"

--- a/site/src/data/lexicon-practice-cloze-sources.json
+++ b/site/src/data/lexicon-practice-cloze-sources.json
@@ -14,5 +14,85 @@
       "path": "curriculum/l2-uk-en/a2/all-cases-practice/vocabulary.yaml",
       "cardId": "a2-all-cases-practice-valiza-accusative-1"
     }
+  },
+  {
+    "lemma": "вулиця",
+    "lemmaId": "вулиця",
+    "sentence": "Я бачу ___.",
+    "blankCase": "accusative",
+    "form": "вулицю",
+    "number": "singular",
+    "caseRule": "accusative_direct_object",
+    "clozeEn": "I see the street.",
+    "cefr": "A1",
+    "provenance": {
+      "status": "reviewed",
+      "path": "curriculum/l2-uk-en/a1/my-city/vocabulary.yaml",
+      "cardId": "a1-my-city-vulytsia-accusative-1"
+    }
+  },
+  {
+    "lemma": "бібліотека",
+    "lemmaId": "бібліотека",
+    "sentence": "Я бачу ___.",
+    "blankCase": "accusative",
+    "form": "бібліотеку",
+    "number": "singular",
+    "caseRule": "accusative_direct_object",
+    "clozeEn": "I see the library.",
+    "cefr": "A1",
+    "provenance": {
+      "status": "reviewed",
+      "path": "curriculum/l2-uk-en/a1/my-city/vocabulary.yaml",
+      "cardId": "a1-my-city-biblioteka-accusative-1"
+    }
+  },
+  {
+    "lemma": "машина",
+    "lemmaId": "машина",
+    "sentence": "Я бачу ___.",
+    "blankCase": "accusative",
+    "form": "машину",
+    "number": "singular",
+    "caseRule": "accusative_direct_object",
+    "clozeEn": "I see the car.",
+    "cefr": "A1",
+    "provenance": {
+      "status": "reviewed",
+      "path": "curriculum/l2-uk-en/a1/transport/vocabulary.yaml",
+      "cardId": "a1-transport-mashyna-accusative-1"
+    }
+  },
+  {
+    "lemma": "кава",
+    "lemmaId": "кава",
+    "sentence": "Я п'ю ___.",
+    "blankCase": "accusative",
+    "form": "каву",
+    "number": "singular",
+    "caseRule": "accusative_direct_object",
+    "clozeEn": "I drink coffee.",
+    "cefr": "A1",
+    "provenance": {
+      "status": "reviewed",
+      "path": "curriculum/l2-uk-en/a1/food-and-drink/vocabulary.yaml",
+      "cardId": "a1-food-and-drink-kava-accusative-1"
+    }
+  },
+  {
+    "lemma": "вода",
+    "lemmaId": "вода",
+    "sentence": "Я п'ю ___.",
+    "blankCase": "accusative",
+    "form": "воду",
+    "number": "singular",
+    "caseRule": "accusative_direct_object",
+    "clozeEn": "I drink water.",
+    "cefr": "A1",
+    "provenance": {
+      "status": "reviewed",
+      "path": "curriculum/l2-uk-en/a1/food-and-drink/vocabulary.yaml",
+      "cardId": "a1-food-and-drink-voda-accusative-1"
+    }
   }
 ]

--- a/site/src/data/lexicon-practice-reviewed-sources.json
+++ b/site/src/data/lexicon-practice-reviewed-sources.json
@@ -2,6 +2,18 @@
   "reviewed": [
     {
       "status": "reviewed",
+      "path": "curriculum/l2-uk-en/a1/food-and-drink/vocabulary.yaml"
+    },
+    {
+      "status": "reviewed",
+      "path": "curriculum/l2-uk-en/a1/my-city/vocabulary.yaml"
+    },
+    {
+      "status": "reviewed",
+      "path": "curriculum/l2-uk-en/a1/transport/vocabulary.yaml"
+    },
+    {
+      "status": "reviewed",
       "path": "curriculum/l2-uk-en/a2/all-cases-practice/vocabulary.yaml"
     }
   ]


### PR DESCRIPTION
## Summary

Adds the next controlled A1 cloze batch after the one-item pilot:

- adds five reviewed A1 accusative direct-object cloze rows
- keeps the existing `валіза -> валізу` pilot row
- updates the reviewed-source allowlist for the three new curriculum source paths
- regenerates only the A1 cloze shard and A1 practice index
- keeps Daily Word frozen at 300 items
- keeps A2/B1/B2/C1 cloze at 0

Static generation used:

```bash
.venv/bin/python scripts/audit/generate_practice_deck.py --target 6000
```

The explicit target preserves the current all-eligible practice lexeme surface. Running the script default would cap the deck at 3,000 lexemes, which is not part of this PR.

## Static Result

`check_static_practice_assets.py --format json` reports:

- `ok=true`
- Daily count: `300`
- `total_cloze=6`
- `reviewed_sources=4`
- A1: `index=1125`, `lexemes=1125`, `cloze=6`
- A2: `index=962`, `lexemes=962`, `cloze=0`
- B1: `index=1122`, `lexemes=1122`, `cloze=0`
- B2: `index=854`, `lexemes=854`, `cloze=0`
- C1: `index=421`, `lexemes=421`, `cloze=0`

## Review

Independent AGY review (`review-3797-small-a1-cloze-batch`) reported no blockers for Ukrainian grammar, case rules, or A1 appropriateness.

Two non-blocking checks were pinned locally:

- `валіза` is emitted in the A1 lexeme shard with `cefr=A1` despite its A2 all-cases provenance path.
- all six curated cloze source rows are allowlisted and all six appear in the generated A1 cloze shard.

## Validation

- `.venv/bin/python -m json.tool site/src/data/lexicon-practice-cloze-sources.json`
- `.venv/bin/python -m json.tool site/src/data/lexicon-practice-reviewed-sources.json`
- `.venv/bin/python scripts/audit/check_static_practice_assets.py --format json`
- `env -u AGENT_NO_TELEMETRY_FOOTER PYTHONPATH=. .venv/bin/python -m pytest tests/test_generate_practice_deck.py tests/test_check_static_practice_assets.py -q` (`26 passed`)
- `PYTHONPATH=. .venv/bin/python -m py_compile scripts/audit/generate_practice_deck.py scripts/audit/check_static_practice_assets.py`
- `npm --prefix site test -- tests/unit/LexiconPractice.test.tsx` (`9 passed`)
- `npm --prefix site run build` (`5633 page(s) built`)
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`