### PR TITLE
docs(bio): add Yevhen Stankovych dossier

### DIFF
--- a/docs/research/bio/yevhen-stankovych.md
+++ b/docs/research/bio/yevhen-stankovych.md
@@ -1,0 +1,140 @@
+# Євген Федорович Станкович — Research Dossier
+
+**Slug:** `yevhen-stankovych`
+**Block:** +77 expansion — "Music / modern Ukrainian concert music" group
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #353
+**Researcher:** Codex background worker; Codex orchestrator repair
+**Completed:** 2026-06-30
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Євген Федорович Станкович.
+- **Pseudonyms / aliases:** Євген Станкович; Станкович Євген Федорович; Yevhen Stankovych; Yevhen Fedorovych Stankovych.
+- **Born:** 19 September 1942 | Svaliava, Zakarpattia | then under wartime Hungarian administration; now Ukraine. ЕІУ, НСКУ, and the Shevchenko Prize Committee agree on the date and place.
+- **Died:** Living figure. Use completed works and already-held roles only; do not write predictive legacy, health, or current-position speculation.
+- **Family / education key facts:** ЕІУ records early cello study in Uzhhorod, study with Adam Soltys in Lviv, and composition training with Borys Liatoshynskyi and Myroslav Skoryk in Kyiv. НСКУ gives the same broad teacher sequence, though some Lviv/Kyiv study-year boundaries vary by source. Treat the Liatoshynskyi-Skoryk lineage as stable; keep exact year ranges source-visible in later metadata.
+- **Institutional roles:** Sources record editorial work at `Музична Україна`, long teaching at Kyiv Conservatory / National Music Academy of Ukraine, leadership roles in the National Union of Composers of Ukraine, and membership in national arts institutions. Use dates carefully: sources differ slightly on union leadership boundary years.
+
+## 2. Oppression mechanism
+
+- **What happened:** No Tier 1/Tier 2 source accessed in this pass documents a person-specific arrest, exile, trial, rehabilitation case, NKVD/MGB/KGB file, or security-service persecution of Stankovych.
+- **When:** Not applicable as a direct repression biography.
+- **By whom:** Not applicable at person-specific file level. Do not assign a Soviet security agency to him without archival evidence.
+- **Document references:** No censorship order number, party resolution, security-service file, court case, or rehabilitation document was found in this pass.
+- **Mechanism specifics:** The sourced pressure point is cultural-institutional: the stage history of `Коли цвіте папороть` is repeatedly described as difficult, delayed, or blocked in Soviet-era performance contexts. This is a censorship/staging and cultural-policy frame, not proof of a personal criminal case. The module should teach the distinction.
+- **What survived / what was damaged:** Survived: symphonic, chamber, choral, stage, film, and pedagogical work; the Liatoshynskyi-Skoryk teaching line; and post-1991 Ukrainian concert institutions. Damaged: public stage access for `Коли цвіте папороть`, source clarity around exact censorship mechanisms, and interpretive clarity when Soviet awards or official posts flatten the Ukrainian cultural argument in the music.
+
+## 3. Major works / contributions
+
+- **Modern Ukrainian symphonism:** ЕІУ and НСКУ frame Stankovych as a major Ukrainian composer of large forms, chamber symphonies, orchestral music, ballet, opera, choral and vocal-symphonic works, and film music. Avoid overconfident work-counts because living-composer catalogues and institutional summaries vary.
+- **`Коли цвіте папороть`:** The folk-opera / stage work is the obvious pedagogical anchor. It lets a BIO module connect neo-folklore, ritual theatre, Gogol-related source transformation, Soviet-era staging obstruction, and later Ukrainian performance return. Do not reduce Stankovych to this single work, but do not bury it either.
+- **Memory works:** Stable public-memory anchors include `Бабин Яр`, `Чорна елегія`, `Панахида за померлими з голоду`, `Слово о полку Ігоревим`, psalm settings, and Symphony No. 3 `Я стверджуюсь` on Pavlo Tychyna's words, for which he received the Shevchenko Prize.
+- **Pedagogy and institutions:** Existing source paths place him after Liatoshynskyi and Skoryk in the modern Ukrainian composition lineage. He is useful in curriculum not only as an author of works but as a living bridge from late-Soviet Ukrainian concert music into post-1991 institutional continuity.
+
+## 4. Primary-source quote anchors
+
+- **Title anchor 1:** `Коли цвіте папороть`. Source: Stankovych folk-opera title; discussed by ЕІУ and later performance sources. Pedagogical use: title-level anchor for neo-folklore, Kupalo imagery, censorship/staging history, and modern return to the stage.
+- **Title anchor 2:** `Я стверджуюсь`. Source: Symphony No. 3 on Pavlo Tychyna's words; the Shevchenko Prize Committee identifies it as a prize work. Pedagogical use: short title anchor only. Do not reproduce long copyrighted Tychyna passages in generated materials.
+- **Title anchor 3:** `Слово о полку Ігоревим`. Source: large vocal-symphonic work listed in institutional biographies. Pedagogical use: connects modern Ukrainian symphonism with a medieval East Slavic text tradition while avoiding Russian-exclusive ownership framings.
+- **Composer-voice note:** A short interview line from a theatre or festival page may be useful later, but no stable first-person quotation was needed for this base-prep pass. Prefer title/work anchors until a source gives a clear citation.
+
+## 5. Language register
+
+- **Register:** high concert-music, neo-folkloric, sacred-choral, historical-memory, and technical modernist register.
+- **CEFR readiness full reading:** C1 for biography and work discussion. Selected title anchors can be glossed at B2.
+- **Lexicon notes:** Active module vocabulary can include `фольк-опера`, `камерна симфонія`, `партитура`, `постановка`, `цензура`, `прем'єра`. Passive/contextual vocabulary can include `ораторія`, `вокально-симфонічний`, `панахида`, `Бабин Яр`, `композиторська школа`.
+- **Stylistic features:** The strongest teaching frame is scale and memory: chamber-symphonic compression, ritual/folk theatre, sacred and memorial forms, dramatic orchestral writing, and public historical themes.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** The key interpretive question is how to describe a living composer whose career spans late Soviet institutions and independent Ukrainian cultural infrastructure. Treat Soviet awards and official posts as context, not as identity.
+- **What gets simplified in popular memory:** Public-facing accounts often reduce Stankovych to `Коли цвіте папороть` or to prize lists. A stronger module keeps the wider field visible: chamber symphonies, memory works, stage works, film music, teaching, and institutional leadership.
+- **Where modern Russian disinformation attacks them (if applicable):** No Stankovych-specific modern Russian disinformation campaign was identified. The broader colonial risk is absorptive labeling: making him primarily "Soviet" and treating Ukrainian institutional, folkloric, and historical-memory work as secondary.
+- **Other-perspective considerations:** `Бабин Яр` and `Каддиш` require Jewish-memory care; `Панахида за померлими з голоду` requires Holodomor context without melodrama; `Слово о полку Ігоревим` requires avoiding Russian-exclusive ownership claims; `Коли цвіте папороть` should not be flattened into a "Gogol equals Russian literature" shortcut.
+- **Living-figure constraint:** Use completed works, already-held roles, and already-awarded honors. Avoid predictions about future legacy, private life, health, or current political positions unless a later module has a verified curricular reason.
+- **HIST-alignment check for +77 roster:** Align with late-Soviet cultural institutions, post-1991 Ukrainian music infrastructure, Babyn Yar memory, Holodomor remembrance, and modern Ukrainian concert/stage music. Do not invent a security-service or dissident biography.
+
+## 7. Cross-track links
+
+- **Existing C1 modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/c1/klasychna-muzyka-2-natsionalna-shkola.yaml` — national-school concert-music context.
+  - `curriculum/l2-uk-en/plans/c1/klasychna-muzyka-3-modernizm-i-suchasnist.yaml` — existing C1 plan already names Stankovych and `Цвіт папороті`.
+  - `curriculum/l2-uk-en/plans/c1/vokalne-mystetstvo.yaml` — vocal-symphonic and choral vocabulary.
+- **Existing LIT/HIST modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/tychyna-tragic-turn.yaml` — Tychyna source-text context for `Я стверджуюсь`.
+  - `curriculum/l2-uk-en/plans/hist/babyn-yar.yaml` — memory context for `Бабин Яр` / `Каддиш` care.
+- **Existing BIO modules / dossiers (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/borys-liatoshynskyi.yaml` and `docs/research/bio/borys-liatoshynskyi.md` — teacher-line context.
+  - `docs/research/bio/myroslav-skoryk.md` — teacher-line context and adjacent modern-composer sequence.
+  - `docs/research/bio/ivan-karabyts.md` — immediate modern-composer sequence neighbor.
+- **Candidate cross-track connections (Phase 2+ NOT files):**
+  - A C1/BIO case study on `Коли цвіте папороть`: neo-folklore, censorship/staging, and modern Ukrainian performance return.
+  - A future LIT/HIST bridge around `Слово о полку Ігоревим`, Gogol-source transformation, and Ukrainian stage adaptation.
+  - A later music-history comparison with Valentyn Silvestrov only after a separate source pass.
+
+## 8. Naming-canonical
+
+Per `docs/best-practices/bio-naming-canonical.md` (#2313):
+
+- **Slug:** `yevhen-stankovych`.
+- **EN canonical (BGN/PCGN 2010):** Yevhen Stankovych.
+- **UA canonical (with patronymic attested):** Євген Федорович Станкович.
+- **Aliases for later `aliases:` field:** Євген Станкович; Станкович Євген Федорович; Yevhen Fedorovych Stankovych; Stankovych Yevhen.
+- **Forbidden / avoid in learner-facing body text:** `Evgeny Stankovich`, `Yevgeny Stankovich`, and Russian patronymic form `Евгений Фёдорович Станкович`, except where a source title or transliteration issue is explicitly analyzed.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons `File:Соломія Івахів, Євген Станкович.jpg`; meeting at the Ukrainian Institute of America, 19 March 2017; source/author listed as Solomiia Ivakhiv; license CC BY-SA 4.0. Treat this as the locked image choice for module planning unless a better license-confirmed archive image is later verified.
+- **Backup candidates:** National Academy of Arts / NAMU profile images can help identify the figure but were not verified as reusable in this pass. Do not reuse them without license confirmation.
+- **Era-appropriate context image:** A rights-cleared production or rehearsal image connected to `Коли цвіте папороть` would be pedagogically stronger than a second portrait if license can be verified.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- "Станкович Євген Федорович." Енциклопедія історії України / Інститут історії України НАН України. https://www.history.org.ua/?termin=Stankovych_Y. Accessed 2026-06-30.
+
+**Tier 2 (institutional):**
+
+- Національна спілка композиторів України. "Станкович Євген Федорович." https://composersukraine.org/index.php?id=675. Accessed 2026-06-30.
+- Комітет з Національної премії України імені Тараса Шевченка. "Станкович Євген Федорович." https://knpu.gov.ua/winners/stankovych-ievhen-fedorovych/. Accessed 2026-06-30.
+- Національна академія мистецтв України. "Станкович Євген." https://academyart.org.ua/academicians/stankovych-yevhen. Accessed 2026-06-30.
+
+**Tier 3 (encyclopedic/navigation):**
+
+- Велика українська енциклопедія. "Станкович, Євген Федорович." https://vue.gov.ua/Станкович,_Євген_Федорович. Accessed 2026-06-30. Used for navigation/corroboration, not sole authority.
+
+**Tier 4 (modern scholarly post-1991):**
+
+- Вовкун В. "Коли цвіте папороть" Є. Станковича: міфологема національного театру." `Мистецтвознавчі записки`, 2019, no. 2. DOI: https://doi.org/10.32461/2226-0285.2.2019.190597. Accessed 2026-06-30.
+- Lviv Opera. "Wiederauferstehung nach Verbot und Vergessenheit..." 2017 page on `Коли цвіте папороть`. https://opera.lviv.ua/wiederauferstehung-nach-verbot-und-vergessenheit-die-erste-szenische-premiere-der-ukrainischen-folk-oper-wenn-der-farn-bluht-von-yevhen-stankovych-an-der-lemberger-staatsoper-lwiw-ukraine-2017/. Accessed 2026-06-30.
+
+**Tier 5 (general web / public music platform):**
+
+- Ukrainian Live Classic. "Yevhen Stankovych / Євген Станкович." https://ukrainianlive.org/stankovych-yevhen. Accessed 2026-06-30. Used for public-listening and staging leads; core facts cross-checked above.
+
+**Image-rights source:**
+
+- Wikimedia Commons. `File:Соломія Івахів, Євген Станкович.jpg`. https://commons.wikimedia.org/wiki/File:Соломія_Івахів,_Євген_Станкович.jpg. Accessed 2026-06-30.
+
+**Primary-source text / title anchors:**
+
+- Євген Станкович. `Коли цвіте папороть`; `Я стверджуюсь`; `Слово о полку Ігоревим`. Title/work anchors verified through institutional sources; excerpts intentionally avoided for copyright and score/libretto reasons.
+
+**Primary-source documents accessed (NKVD/MGB/KGB, court, police, censorship, rehabilitation):**
+
+- None found or accessed in this pass. Do not fabricate person-specific repression documentation.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing.
+- [x] Living-figure constraint observed: completed works and established roles only.
+- [x] No invented NKVD/KGB/security-service narrative.
+- [x] Censorship/staging constraint for `Коли цвіте папороть` kept distinct from person-specific persecution.
+- [x] Existing cross-track paths verified before listing.
+- [x] Copyright-sensitive text excerpts avoided.


### PR DESCRIPTION
## Summary
- Adds the BIO #353 `yevhen-stankovych` research dossier only.
- Keeps the slice to `docs/research/bio/yevhen-stankovych.md`; no plan YAML, module content, site, wiki, status/audit/review, telemetry, or package/config files.
- Applies the living-figure constraint: completed works and established roles only, no predictive biography.
- Frames Stankovych through Liatoshynskyi/Skoryk lineage, modern Ukrainian concert music, `Коли цвіте папороть`, and historical-memory works.
- Explicitly avoids inventing a person-specific NKVD/KGB/security-service repression file.

## Validation
- `./.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/yevhen-stankovych.md`
- `npx markdownlint-cli2 docs/research/bio/yevhen-stankovych.md`
- `git diff --check`
- `./.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Scope check: `origin/main...HEAD` contains only `A docs/research/bio/yevhen-stankovych.md`.

## Notes
- Dossier-only base-prep slice; module-build telemetry is not applicable until plan/module production.
- Independent non-Codex content review still required before ready/merge.