### PR TITLE
[codex] Preserve practice deck default target

### DIFF
--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -35,7 +35,9 @@ DEFAULT_MANIFEST = Path("site/src/data/lexicon-manifest.json")
 DEFAULT_OUT_DIR = Path("site/public/lexicon")
 DEFAULT_ALLOWLIST = Path("site/src/data/lexicon-practice-reviewed-sources.json")
 DEFAULT_CLOZE_SOURCES = Path("site/src/data/lexicon-practice-cloze-sources.json")
-DEFAULT_TARGET = 3000
+# Keep the default above the current all-eligible deck size. A lower default
+# silently contracts the committed practice surface during routine cloze regen.
+DEFAULT_TARGET = 6000
 DEFAULT_RAW_LIMIT = 550_000
 DEFAULT_GZIP_LIMIT = 140_000
 SCHEMA_VERSION = 1

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from scripts.audit.generate_practice_deck import (
+    DEFAULT_TARGET,
     BuildConfig,
     JsonVesumVerifier,
     ReviewedSourceAllowlist,
@@ -26,6 +27,11 @@ MANIFEST = FIXTURES / "lexicon-practice-manifest.json"
 ALLOWLIST = FIXTURES / "lexicon-practice-reviewed-allowlist.json"
 VESUM = FIXTURES / "lexicon-practice-vesum.json"
 CLOZE_SOURCES = FIXTURES / "lexicon-practice-cloze-sources.json"
+
+
+def test_default_target_preserves_committed_practice_surface() -> None:
+    assert DEFAULT_TARGET >= 6000
+    assert BuildConfig().target == DEFAULT_TARGET
 
 
 def _build(config: BuildConfig | None = None, cloze_sources_path: Path | None = CLOZE_SOURCES):


### PR DESCRIPTION
## Summary

Fixes a practice-deck regeneration footgun found while preparing PR #4045:

- raises `generate_practice_deck.py` default target from `3000` to `6000`
- adds a regression test that the default stays at least `6000` and `BuildConfig()` inherits it
- leaves committed static practice assets unchanged when the generator is run with no `--target`

Without this, a routine cloze regeneration using the default command would silently shrink the current all-eligible practice surface to exactly 3,000 lexemes.

## Review

Independent AGY review requested one tweak: use `DEFAULT_TARGET >= 6000` rather than strict equality so future safe increases do not fail the test. Applied.

## Validation

- `.venv/bin/python scripts/audit/generate_practice_deck.py` with no `--target`; completed with expected size-budget trimming warnings and produced no static git diff
- `env -u AGENT_NO_TELEMETRY_FOOTER PYTHONPATH=. .venv/bin/python -m pytest tests/test_generate_practice_deck.py tests/test_check_static_practice_assets.py -q` (`27 passed`)
- `PYTHONPATH=. .venv/bin/python -m py_compile scripts/audit/generate_practice_deck.py scripts/audit/check_static_practice_assets.py`
- `.venv/bin/python scripts/audit/check_static_practice_assets.py --format json` (`ok=true`, Daily `300`, total cloze `6`)
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`