### PR TITLE
docs(bio): add Anatolii Kos-Anatolskyi dossier

### DIFF
--- a/docs/research/bio/anatolii-kos-anatolskyi.md
+++ b/docs/research/bio/anatolii-kos-anatolskyi.md
@@ -1,0 +1,142 @@
+# Анатолій Йосипович Кос-Анатольський — Research Dossier
+
+**Slug:** `anatolii-kos-anatolskyi`
+**Block:** +77 expansion — "Music / Galician song-stage bridge" group
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #354
+**Researcher:** Codex background worker; Codex orchestrator repair
+**Completed:** 2026-06-30
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Анатолій Йосипович Кос-Анатольський.
+- **Pseudonyms / aliases:** Анатолій Кос-Анатольський; Кос-Анатольський Анатолій Йосипович; family/legal surname Кос; Anatolii Kos-Anatolskyi; Anatolii Yosypovych Kos-Anatolskyi; legacy forms `Anatoliy Kos-Anatolsky`, `Анатолий Иосифович Кос-Анатольский`.
+- **Born:** 1 December 1909 | Kolomyia, Galicia | then Austria-Hungary; now Ivano-Frankivsk oblast, Ukraine. ЕСУ, ЕІУ, and the Shevchenko Prize Committee agree on date and place.
+- **Died:** 30 November 1983 | Lviv, Ukrainian SSR, Soviet Union. ЕСУ, ЕІУ, and the Shevchenko Prize Committee agree on date and place.
+- **Family / education key facts:** Core sources identify legal study at Lviv University and musical study in Lviv, including piano with Taras Shukhevych, theory with Stefania Lobachevska, and composition with Stefan Barbag. ЕСУ gives a law degree in 1931; ЕІУ gives 1937 for completing the law faculty. Keep that discrepancy visible until university-file evidence is checked.
+- **Institutional roles:** He taught and organized in Lviv musical institutions, served in Soviet Ukrainian official cultural structures, and became a public composer of songs, stage works, romances, choral pieces, and folk-song arrangements. ЕІУ also records civic letters to party and Soviet organs about Vasyl Barvinskyi's release and rehabilitation, a Mykola Lysenko monument in Kyiv, and defense of Ukrainian culture.
+
+## 2. Oppression mechanism
+
+- **What happened:** No Tier 1/Tier 2 source checked in this pass documents a person-specific arrest, exile, show trial, NKVD/MGB/KGB case, or rehabilitation file for Kos-Anatolskyi himself.
+- **When / by whom:** The verified frame is Soviet cultural-institutional constraint and accommodation in postwar Lviv, not a documented personal security-service case. He worked inside official Soviet Ukrainian music structures, received state honors, and served in Soviet institutions, while also using institutional position for Ukrainian cultural causes recorded by ЕІУ.
+- **Document references:** None found for an individual criminal or security-service case. ЕІУ is the strongest concise source for the civic-letter record; the ЦДАМЛМ finding aid is the first archive target for future document-level claims.
+- **Mechanism specifics:** Teach this as a Lviv/Galician Ukrainian composer carrying regional song, Franko/Shevchenko text memory, theatre music, and Ukrainian-language repertoire into public circulation under Soviet institutions. The risk is two-sided: Soviet award lists can flatten him into a safe Soviet cultural official, while anti-Soviet overcorrection can fabricate dissident martyrdom.
+- **What survived / what was damaged:** Survived: a large Galician-centered song and stage-music repertoire, Lviv teaching and organizational continuity, popular vocal memory, and institutional advocacy for Ukrainian music. Damaged: interpretive clarity around compromise, propaganda commissions, bilingual Soviet editions, and the boundary between official service and cultural self-defense.
+
+## 3. Major works / contributions
+
+- **Stage music:** Tier 1/Tier 2 lists identify the opera `Назустріч сонцю` (1957; second version `Заграва`, 1959), ballets `Хустка Довбуша` (1950/1951; source dating varies by libretto/composition versus premiere), `Сойчине крило` (1956, after Ivan Franko's novella), and `Орися` (1964; revised 1967), plus the operetta `Весняні грози` (1960). NMAU library holdings confirm score records for `Заграва`, `Орися`, and `Сойчине крило`.
+- **Vocal and song repertoire:** ЕСУ and the Shevchenko Prize Committee foreground vocal works, romances, choral pieces, folk-song arrangements, and settings of texts by Ivan Franko, Taras Shevchenko, Lesia Ukrainka, Volodymyr Sosiura, Dmytro Pavlychko, Rostyslav Bratun, and others. The 1980 Shevchenko Prize was awarded for the collection `Вокальні твори`.
+- **Galician public song memory:** His strongest BIO value is not only a work list. He gives learners a bridge from Lviv/Kolomyia regional imagery and Franko-centered literary song into late-Soviet Ukrainian public repertoire.
+- **Institutional advocacy:** ЕІУ's civic-letter evidence makes the dossier more than "composer with awards." It provides a careful way to discuss Ukrainian cultural defense inside Soviet institutions without inventing a secret-police persecution story.
+
+## 4. Primary-source quote anchors
+
+- **Quote 1, Franko text set by Kos-Anatolskyi:** "Ой ти, дівчино, з горіха зерня..." Source: Ivan Franko poem/song text; ЕСУ and NMAU library holdings identify Kos-Anatolskyi's setting. Pedagogical use: compact public-domain anchor for literary song memory, Galician diction, and the difference between poet's words and composer's musical canonization.
+- **Quote 2, Shevchenko text set by Kos-Anatolskyi:** "Садок вишневий коло хати..." Source: Taras Shevchenko; NMAU library holdings list `Садок вишневий` among vocal works. Pedagogical use: a familiar A2/B1-accessible title line can connect canonical poetry to concert song without overquoting.
+- **Title anchor 3:** `Ой піду я межи гори`. NMAU library records include editions with folk-text attribution and other holdings tied to Kos-Anatolskyi's own words. Use as a title anchor only until lyric authorship is checked against a score.
+- **Composer-voice gap:** No stable short first-person quotation by Kos-Anatolskyi from Tier 1/Tier 2 sources was verified in this pass. Future writers should prefer score prefaces, published criticism, or archive materials over unattributed web quotations.
+
+## 5. Language register
+
+- **Register:** accessible art-song and public-concert register, mixed with folk stylization, Galician/Carpathian regional imagery, literary-canonical Ukrainian, and some Soviet ceremonial vocabulary in official works.
+- **CEFR readiness full reading:** B2/C1 for biography and institutional context. Selected title anchors such as `Коломия-місто`, `Садок вишневий`, and `Ой ти, дівчино` can be glossed at A2/B1.
+- **Lexicon notes:** Active vocabulary can include `пісня`, `романс`, `балет`, `опера`, `обробка`, `вокальний`, `хоровий`, `сцена`, `Коломия`, `Львів`. Passive/contextual vocabulary can include `інституційний`, `реабілітація`, `церемоніальний`, `пропагандистський`, `композиторська організація`.
+- **Stylistic features:** Useful teaching frame: polished public song, literary text-setting, theatre/stage narrative, Lviv institutional culture, and regional Galician imagery entering Soviet-era public music.
+
+## 6. Contested points
+
+- **What's debated in modern UA scholarship:** The main interpretive problem is how to teach a Soviet-decorated Lviv composer who also defended Ukrainian musical culture. Tier 1/Tier 2 sources support both official posts/honors and recorded Ukrainian cultural advocacy; module prose should hold both facts together.
+- **What gets simplified in popular memory:** Popular accounts often remember song hits or stage works, especially `Ой ти, дівчино, з горіха зерня`, `Сойчине крило`, `Хустка Довбуша`, or `Білі троянди`. That is useful for learners but too thin unless paired with Lviv institutional role, Shevchenko Prize vocal collection, and support for Barvinskyi/Lysenko memory.
+- **Where modern Russian disinformation attacks them (if applicable):** No Kos-Anatolskyi-specific modern Russian disinformation campaign was identified. The broader colonial risk is absorptive framing: treating him primarily as a Soviet composer and defaulting to Russianized transliteration.
+- **Polish / Jewish / other-perspective considerations:** His life crosses Austrian Galicia, interwar Polish Lviv, Nazi occupation, and Soviet Lviv. No specific Polish/Jewish conflict frame was verified in this pass, but place names and political entities must remain historically precise.
+- **HIST-alignment check for +77 roster:** Align with Galician cultural continuity, Soviet annexation/postwar Lviv institutions, Ukrainian national music school, rehabilitation of suppressed Ukrainian composers, and public song memory. Do not invent a security-service oppression story.
+
+## 7. Cross-track links
+
+- **Existing C1 modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/c1/halychyna.yaml` — Galician/Lviv cultural geography.
+  - `curriculum/l2-uk-en/plans/c1/klasychna-muzyka-2-natsionalna-shkola.yaml` — Ukrainian national-school concert-music context.
+  - `curriculum/l2-uk-en/plans/c1/vokalne-mystetstvo.yaml` — vocal/choral and art-song vocabulary.
+- **Existing LIT modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/franko-social-poetry.yaml` — Franko public-poetry and song-text context.
+  - `curriculum/l2-uk-en/plans/lit/franko-lviv-period.yaml` — Lviv/Galician Franko context.
+  - `curriculum/l2-uk-en/plans/lit/cult-of-shevchenko.yaml` — Shevchenko text-setting memory.
+- **Existing BIO modules / dossiers (VERIFIED `test -e`):**
+  - `docs/research/bio/vasyl-barvinskyi.md` — Barvinskyi-side repression/rehabilitation context.
+  - `docs/research/bio/stanislav-liudkevych.md` — Galician composer-organizer context.
+  - `docs/research/bio/myroslav-skoryk.md` — later Soviet/post-Soviet Lviv/Kyiv composer context.
+- **Candidate cross-track connections (Phase 2+ NOT files):**
+  - LIT/BIO prose-to-ballet bridge for Franko's `Сойчине крило`.
+  - HIST/LIT bridge around Dovbush memory through `Хустка Довбуша`.
+  - A compact song-text module on Franko's `Ой ти, дівчино`, if later curriculum planning needs a poetry-to-song lesson.
+
+## 8. Naming-canonical
+
+Per `docs/best-practices/bio-naming-canonical.md` (#2313):
+
+- **Slug:** `anatolii-kos-anatolskyi`.
+- **EN canonical (BGN/PCGN 2010):** Anatolii Kos-Anatolskyi.
+- **UA canonical (with patronymic attested):** Анатолій Йосипович Кос-Анатольський.
+- **Aliases for later `aliases:` field:** Анатолій Кос-Анатольський; Кос-Анатольський Анатолій Йосипович; Анатолій Йосипович Кос; Anatolii Yosypovych Kos-Anatolskyi; Anatoliy Kos-Anatolsky; Kos-Anatolsky.
+- **Forbidden / avoid in learner-facing body text:** Russianized `Анатолий Иосифович Кос-Анатольский` and English forms derived through Russian, such as `Anatoly/Anatoliy Kos-Anatolsky`, except in source-title or image-rights discussion.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons `File:Кос-Анатольский Анатолий Иосифович (конверт).jpg`, a 1989 Soviet postal cover portrait. Commons lists a public-domain rationale for the postal stationery item. Use the full envelope image unless a separate portrait crop is rights-checked.
+- **Backup candidates:** NMAU virtual exhibition images and score covers are useful identification leads but were not license-confirmed in this pass. Local library or museum portraits require separate rights review.
+- **Era-appropriate context image:** A rights-cleared Lviv/Kolomyia music-institution image or score/cover scan could serve better than the Soviet postal envelope if licensing is verified later.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- Енциклопедія Сучасної України. "Кос-Анатольський Анатолій Йосипович." https://esu.com.ua/article-5473. Accessed 2026-06-30.
+- Енциклопедія історії України / Інститут історії України НАН України. "Кос-Анатольський Анатолій Йосипович." https://www.history.org.ua/?termin=Kos_Anatolskii_A. Accessed 2026-06-30.
+
+**Tier 2 (institutional):**
+
+- Комітет з Національної премії України імені Тараса Шевченка. "Кос-Анатольський Анатолій Йосипович." https://knpu.gov.ua/winners/kos-anatolskyj-anatolij-josypovych/. Accessed 2026-06-30.
+- Бібліотека Національної музичної академії України. "Анатолій Йосипович Кос-Анатольський." https://lib.knmau.com.ua/анатолій-йосипович-кос-анатольський/. Accessed 2026-06-30.
+- Центральний державний архів-музей літератури і мистецтва України. Finding aid for А. Й. Кос-Анатольський collection. https://old-csam.archives.gov.ua/includes/uploads/opisy/Kos_AY_opys_1.pdf. Accessed 2026-06-30.
+
+**Tier 3 (encyclopedic/navigation):**
+
+- Велика українська енциклопедія. "Кос-Анатольський, Анатолій Йосипович." https://vue.gov.ua/Кос-Анатольський,_Анатолій_Йосипович. Used for navigation only; core claims checked against Tier 1/Tier 2.
+- Ukrainian and English Wikipedia entries were used only to locate source leads and image candidates.
+
+**Tier 4 (modern scholarly post-1991):**
+
+- Чжан Яцзін. "Камерно-вокальна творчість Анатоля Кос-Анатольського: жанрово-стильовий вимір." Львівська національна музична академія ім. М. В. Лисенка, PDF. https://lnma.edu.ua/wp-content/uploads/2019/01/Чжан-Яцзін-Камерно-вокальна-творчість-Анатоля-Кос-Анатольського-жанрово-стильовий-вимір.pdf. Accessed 2026-06-30.
+- Опера на Подолі / Міністерство культури coverage of `Сойчине крило` return, 2023. Used as contemporary reception lead only; historical work claim checked against Tier 1/Tier 2.
+
+**Tier 5 (general web / listening leads):**
+
+- Ukrainian Live Classic. "Kos-Anatolskyi Anatoliy." https://ukrainianlive.org/kos-anatolskyi-anatoliy. Used as a listening/context lead only.
+
+**Image-rights source:**
+
+- Wikimedia Commons. `File:Кос-Анатольский Анатолий Иосифович (конверт).jpg`. https://commons.wikimedia.org/wiki/File:Кос-Анатольский_Анатолий_Иосифович_(конверт).jpg. Accessed 2026-06-30.
+
+**Primary-source text anchors:**
+
+- Ivan Franko, `Ой ти, дівчино, з горіха зерня` — public-domain text anchor for Kos-Anatolskyi's setting.
+- Taras Shevchenko, `Садок вишневий коло хати` — public-domain text anchor for Kos-Anatolskyi's setting.
+
+**Primary-source documents accessed (NKVD/MGB/KGB, court, police, censorship, rehabilitation):**
+
+- None found or accessed in this pass. Do not fabricate person-specific repression documentation.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing.
+- [x] No invented NKVD/KGB/security-service narrative.
+- [x] Soviet official/institutional context included without making it the whole biography.
+- [x] Ukrainian Galician song, stage music, Franko/Shevchenko text memory, and Barvinskyi/Lysenko advocacy foregrounded.
+- [x] Existing cross-track paths verified before listing.
+- [x] Copyright-sensitive text excerpts kept short and source-aware.


### PR DESCRIPTION
## Summary
- Adds the BIO #354 `anatolii-kos-anatolskyi` research dossier only.
- Keeps the slice to `docs/research/bio/anatolii-kos-anatolskyi.md`; no plan YAML, module content, site, wiki, status/audit/review, telemetry, or package/config files.
- Frames Kos-Anatolskyi through Galician/Lviv song-stage memory, Franko/Shevchenko text settings, Soviet institutional compromise, and documented Ukrainian cultural advocacy.
- Explicitly avoids inventing a person-specific NKVD/KGB/security-service repression file.

## Validation
- `./.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/anatolii-kos-anatolskyi.md`
- `npx markdownlint-cli2 docs/research/bio/anatolii-kos-anatolskyi.md`
- `git diff --check`
- `./.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Scope check: `origin/main...HEAD` contains only `A docs/research/bio/anatolii-kos-anatolskyi.md`.

## Notes
- Dossier-only base-prep slice; module-build telemetry is not applicable until plan/module production.
- Independent Claude review still required before ready/merge.