### PR TITLE
docs(bio): add Dmytro Hnatiuk dossier

### DIFF
--- a/docs/research/bio/dmytro-hnatiuk.md
+++ b/docs/research/bio/dmytro-hnatiuk.md
@@ -1,0 +1,268 @@
+# Дмитро Михайлович Гнатюк — Research Dossier
+
+**Slug:** `dmytro-hnatiuk`
+**Block:** +77 expansion — "Music / opera and song-canon performance"
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #355
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-06-30
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Дмитро Михайлович Гнатюк.
+- **Pseudonyms / aliases:** Дмитро Гнатюк; Гнатюк Дмитро Михайлович;
+  Dmytro Hnatiuk; Dmytro Mykhailovych Hnatiuk; legacy source forms
+  `Dmitro Gnatyuk`, `Dmitry Gnatyuk`, `Дмитрий Михайлович Гнатюк`.
+- **Born:** 28 March 1925 | source wording differs: ЕСУ and ЕІУ give
+  Мамаївці, Chernivtsi oblast; the Shevchenko Prize Committee and UINP
+  give Старосілля, now Мамаївка/Мамаївці | then Kingdom of Romania.
+- **Died:** 29 April 2016 | Kyiv, Ukraine | cause not verified in the
+  Tier 1/Tier 2 sources used here.
+- **Family / education key facts:** Son of Mykhailo Dmytrovych and Mariia
+  Ivanivna, from a Bukovynian peasant household. ЕСУ and ЕІУ identify him
+  as a Ukrainian baritone, opera singer, director, and pedagogue. He
+  graduated from Kyiv Conservatory in 1951 in Ivan Patorzhynskyi's solo
+  singing class, and from Kyiv Theatre Institute in 1975.
+
+Core career facts are well corroborated. From 1951 his professional base
+was the Kyiv / National Opera: soloist, director, stage director, and from
+1988 chief director. ЕСУ also records his 1983-1993 leadership of the
+Kyiv Conservatory opera-training department. Rada records confirm his
+1998-2002 term as a people's deputy of Ukraine and deputy chair of the
+parliamentary culture and spirituality committee.
+
+## 2. Oppression mechanism
+
+- **What happened:** Not a direct repression-primary biography. No Tier
+  1/Tier 2 source used in this pass documents a person-specific arrest,
+  exile, court case, NKVD/MGB/KGB file, rehabilitation file, or forced
+  emigration episode for Dmytro Hnatiuk.
+- **When (specific dates):** Not applicable for person-specific repression.
+  Relevant pressure belongs to Soviet cultural institutions across his
+  postwar Ukrainian opera and song career.
+- **By whom:** No person-specific security-service agency should be named
+  without archival proof. The relevant mechanism is Soviet cultural-state
+  management: official repertory, award systems, touring, recording,
+  artistic councils, and public roles that could both enable and constrain
+  Ukrainian-language performance.
+- **Document references:** None found for an NKVD/MGB/KGB/court file.
+  TSDAEA identifies audiovisual holdings and recording units, not a
+  security-service case.
+- **Mechanism specifics:** Teach Hnatiuk as a performer who carried
+  Ukrainian opera roles, folk-song performance, and song-canon memory
+  through Soviet and post-Soviet institutions. The interpretive risk is
+  flattening: official Soviet titles can make him look like only a state
+  cultural official, while nationalist overcorrection could invent
+  martyrdom. Neither is supported by the current evidence.
+- **What survived / what was damaged:** Survived: a large recorded vocal
+  corpus, public memory of "Два кольори", "Києве мій", "Пісня про рушник",
+  and Ukrainian opera roles such as Остап, Микола, and Еней. Obscured:
+  how Ukrainian song and opera circulated inside Soviet systems without
+  becoming reducible to those systems.
+
+## 3. Major works / contributions
+
+- **Opera performance:** ЕІУ and the National Opera list major roles
+  including Остап, Микола, and Еней in Mykola Lysenko's "Тарас Бульба",
+  "Наталка Полтавка", and "Енеїда"; Султан in Semen Hulak-Artemovskyi's
+  "Запорожець за Дунаєм"; Ігор in Borodin's "Князь Ігор"; Онєгін,
+  Єлецький, Томський, and Мазепа in Tchaikovsky operas; Ескамільо in
+  Bizet's "Кармен"; and major Verdi and Rossini roles.
+- **Directing and institution-building:** ЕСУ lists productions from
+  "Князь Ігор" in 1975 through "Тарас Бульба", "Наталка Полтавка",
+  "Запорожець за Дунаєм", "Золотий обруч", "Травіата", "Аїда", and
+  "Війна і мир". ЕІУ states that he staged more than twenty productions.
+- **Song-canon performance:** ЕСУ records more than 200 concert-repertoire
+  works, over 70 Ukrainian folk songs, more than 30 records, and six CDs.
+  TSDAEA holdings document recordings of "Ніч яка місячна", "Черемшина",
+  "Чорнобривці", "Києве мій", "Два кольори", and "Ой під вишнею".
+- **Public culture:** Rada records confirm his parliamentary cultural role.
+  The 2005 presidential decree confirms the Hero of Ukraine title for his
+  work as chief director of the National Opera and people's artist of
+  Ukraine.
+
+## 4. Primary-source quote anchors
+
+- **Recording anchor 1:** "Ніч яка місячна" — TSDAEA phonodocument, 1955,
+  Ukrainian folk song performed by D. Hnatiuk with bandurists A. Bobyr and
+  V. Kukhta, archival units 1594 / M-717. Pedagogical use: diction,
+  bandura-backed concert sound, and Ukrainian folk-song register. Do not
+  quote lyrics in module prose.
+- **Recording anchor 2:** "Два кольори" — TSDAEA phonodocument, 1983,
+  music by Oleksandr Bilash and words by Dmytro Pavlychko, performed by
+  D. Hnatiuk with the Merited Symphony Orchestra of State Radio and
+  Television of the Ukrainian SSR, archival units 34685 / M-15462.
+  Pedagogical use: connects BIO #355 with Pavlychko and Bilash song-memory
+  modules; use title only unless rights review approves a very short
+  incipit.
+- **Recorded voice lead:** TSDAEA lists "Діалог. Дмитро Гнатюк" (2010,
+  DTRK "Культура", archival unit ЦВ 1521). Future module writers should
+  consult this before using first-person quotation.
+
+## 5. Language register
+
+- **Register:** opera and public-song register: formal, diction-centered,
+  stage-ready, emotionally direct, and institutionally polished.
+- **CEFR readiness full reading:** B2/C1 for biography and cultural-policy
+  framing; A2/B1 for selected role names, song titles, and listening tasks.
+- **Lexicon notes:** Useful vocabulary includes `баритон`, `партія`,
+  `постановник`, `головний режисер`, `фонодокумент`, `репертуар`,
+  `народна пісня`, `Національна опера`, and `пісенний канон`.
+- **Stylistic features:** The learning value is not lyric quotation but
+  recognizing how titles, roles, vocal register, and institutional terms
+  place a performer inside Ukrainian cultural memory.
+
+## 6. Contested points
+
+- **What's debated / unsettled:** Birthplace wording differs between
+  Мамаївці and Старосілля (now Мамаївка/Мамаївці). Keep both forms visible
+  until local administrative history is checked.
+- **What gets simplified in popular memory:** Hnatiuk is often reduced to
+  "Два кольори" or "Києве мій". A stronger BIO lesson keeps three strands
+  together: opera roles, song-canon recordings, and institutional teaching
+  and directing.
+- **Where Russian-imperial framing can distort:** Russianized spellings
+  and a generic "Soviet singer" label underplay Ukrainian-language diction,
+  Lysenko / Hulak-Artemovskyi roles, and later Ukrainian public culture.
+- **Family / borderland caution:** UINP recounts an NKVD killing of
+  Hnatiuk's brother Ivan, but that is a family-context lead, not a
+  documented person-specific repression mechanism for Dmytro Hnatiuk.
+  Wartime evacuation to Нижня Салда should be presented as wartime
+  displacement, not as security-service persecution.
+- **HIST-alignment check:** Align with Bukovyna/Romania borderland history,
+  postwar Kyiv opera, Ukrainian-language song circulation, and post-1991
+  cultural-state institution building.
+
+## 7. Cross-track links
+
+- **Existing C1 modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/c1/vokalne-mystetstvo.yaml`
+  - `curriculum/l2-uk-en/plans/c1/klasychna-muzyka-2-natsionalna-shkola.yaml`
+- **Existing LIT modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/malyshko-songs.yaml`
+  - `curriculum/l2-uk-en/plans/lit/cult-of-shevchenko.yaml`
+  - `curriculum/l2-uk-en/plans/lit/natalka-poltavka.yaml`
+- **Existing BIO links (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/dmytro-pavlychko.yaml`
+  - `docs/research/bio/dmytro-pavlychko.md`
+  - `curriculum/l2-uk-en/plans/bio/oleksandr-bilash.yaml`
+  - `docs/research/bio/oleksandr-bilash.md`
+  - `docs/research/bio/platon-maiboroda.md`
+  - `curriculum/l2-uk-en/plans/bio/mykola-lysenko.yaml`
+  - `curriculum/l2-uk-en/plans/bio/taras-shevchenko.yaml`
+- **Candidate future links:** BIO #356 `anatolii-solovianenko`; a
+  Bukovyna/Romania HIST module if/when the track adds one; a listening
+  activity around archival song recordings once rights are reviewed.
+
+## 8. Naming-canonical
+
+Per `docs/best-practices/bio-naming-canonical.md` (#2313):
+
+- **Slug:** `dmytro-hnatiuk`.
+- **EN canonical (BGN/PCGN 2010):** Dmytro Hnatiuk.
+- **UA canonical (with patronymic attested):** Дмитро Михайлович Гнатюк.
+- **Aliases (track `aliases:` YAML field later):** Дмитро Гнатюк; Гнатюк
+  Дмитро Михайлович; Dmytro Mykhailovych Hnatiuk; Dmytro Hnatiuk.
+- **Forbidden forms (Russian-imperial transliterations flag in body text):**
+  Dmitry Gnatyuk; Dmitri Gnatiuk; Dmitry Hnatyuk; Дмитрий Михайлович
+  Гнатюк. These may appear only in aliases or source-criticism notes.
+
+## 9. Image candidates
+
+Per `docs/best-practices/bio-image-rights.md` (#2316):
+
+- **Best PD/CC portrait:** TSDAEA exhibition "Дмитро Гнатюк. З Україною в
+  серці" includes photodocuments from archive holdings and states page
+  content is available under Creative Commons Attribution 4.0 International
+  unless otherwise noted. Use only after checking the specific image
+  caption and metadata.
+- **Backup candidates:** ЕСУ, National Opera, and Rada pages include
+  portraits, but reuse licenses are not established here; treat as
+  reference-only until verified.
+- **Fallback strategy:** If no portrait metadata is safe enough, ship a
+  text-led module with a CC-BY TSDAEA archive link or a rights-cleared
+  National Opera context image, not an AI portrait.
+- **Era-appropriate context image:** TSDAEA phonodocument or film listings
+  may support a lesson focused on recorded song memory better than a generic
+  portrait.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- Енциклопедія Сучасної України. "Гнатюк Дмитро Михайлович."
+  https://esu.com.ua/article-30632. Accessed 2026-06-30.
+- Енциклопедія історії України / Інститут історії України НАН України.
+  Шевченко Л. А. "ГНАТЮК Дмитро Михайлович."
+  https://www.history.org.ua/?termin=Gnatyuk_D. Accessed 2026-06-30.
+
+**Tier 2 (institutional / archival):**
+
+- Національна опера України. "ГНАТЮК Дмитро."
+  https://opera.com.ua/persons/gnatyuk-dmitro. Accessed 2026-06-30.
+- Комітет з Національної премії України імені Тараса Шевченка. "Легенда
+  українського оперного співу."
+  https://knpu.gov.ua/lehenda-ukrainskoho-opernoho-spivu/. Accessed
+  2026-06-30.
+- Центральний державний аудіовізуальний та електронний архів. "Дмитро
+  Гнатюк. З Україною в серці."
+  https://tsdaea.archives.gov.ua/Publications/2025/With-Ukraine-in-my-heart/.
+  Accessed 2026-06-30.
+- Бібліотека Національної музичної академії України. "Дмитро Гнатюк :
+  віртуальна виставка."
+  https://lib.knmau.com.ua/дмитро-гнатюк-віртуальна-виставка/. Accessed
+  2026-06-30.
+- Верховна Рада України. "Гнатюк Дмитро Михайлович / Народний депутат
+  України / III скликання." https://people.rada.gov.ua/body/view/mp-d409_skl3.
+  Accessed 2026-06-30.
+- Верховна Рада України, законодавча база. Указ Президента України від
+  28.03.2005 № 537/2005 "Про присвоєння Д. Гнатюку звання Герой України."
+  https://zakon.rada.gov.ua/go/537/2005. Accessed 2026-06-30.
+
+**Tier 3 (encyclopedic / navigation):**
+
+- Wikipedia was used only as navigation. Final identity, dates, repertoire,
+  roles, awards, and public-office claims rely on the sources above.
+
+**Tier 4 (modern scholarly post-1991):**
+
+- Бондарчук В. О. "Дмитро Гнатюк - у боротьбі за естетичну ідентифікацію
+  вітчизняного культурно-мистецького простору 1960-х років." Listed in the
+  NMAU library bibliography; full text not accessed in this pass.
+- Рожок Ол. В. "'Опера - моя радість і любов, а пісня - то душа моя'
+  (Дмитро Гнатюк)." Часопис НМАУ, 2015, № 2, с. 140-146. Listed in the
+  NMAU library bibliography; full text not accessed in this pass.
+
+**Tier 5 (general web):**
+
+- Радіо Свобода. "На 92-му році життя помер оперний співак Дмитро Гнатюк."
+  https://www.radiosvoboda.org/a/news/27706399.html. Accessed 2026-06-30.
+  Used as obituary / Ministry of Culture relay; core facts cross-checked
+  against Tier 1/Tier 2.
+- Український інститут національної пам'яті. "1925 - народився Дмитро
+  Гнатюк, співак."
+  https://uinp.gov.ua/istorychnyy-kalendar/berezen/28/1925-narodyvsya-dmytro-gnatyuk-spivak.
+  Accessed 2026-06-30. Used for birthplace and family-context comparison,
+  not as sole authority for core claims.
+
+**Primary-source documents accessed (NKVD files, KGB files, court records):**
+
+- None. No person-specific security-service or court document was located
+  or cited in this pass.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing.
+- [x] Russian-imperial transliterations appear only as forbidden alias
+  forms or source-criticism forms.
+- [x] No invented NKVD/KGB/security-service oppression narrative.
+- [x] Soviet award and office facts are present but not treated as the whole
+  biography.
+- [x] Ukrainian opera, public song, and archival recording memory remain the
+  center of the dossier.
+- [x] Existing cross-track paths verified with `test -e` before listing.
+- [x] Copyright-sensitive lyrics avoided; song titles only.


### PR DESCRIPTION
## Summary

- Adds the BIO #355 base-prep research dossier for `dmytro-hnatiuk`.
- Keeps the slice dossier-only: no plan YAML, module content, activities, vocabulary, site MDX, wiki output, telemetry, or generated artifacts.
- Frames Hnatiuk as a Ukrainian opera/baritone and public song-canon performer, with explicit caution against inventing a person-specific NKVD/KGB/security-service repression narrative.

## Validation

- `./.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/dmytro-hnatiuk.md`
- `npx markdownlint-cli2 docs/research/bio/dmytro-hnatiuk.md`
- `git diff --check origin/main...HEAD`
- `./.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `git diff --name-status origin/main...HEAD` -> one file only

## Telemetry

- Module-build telemetry: not applicable; this PR is a dossier-only base-prep slice, not a module build.
- `swarm_used: false`
- `swarm_note: solo orchestrator repair/integration after draft-only worker output; no module-build swarm used`