### PR TITLE
docs(bio): add Anatolii Solovianenko dossier

### DIFF
--- a/docs/research/bio/anatolii-solovianenko.md
+++ b/docs/research/bio/anatolii-solovianenko.md
@@ -1,0 +1,270 @@
+# Анатолій Борисович Солов’яненко — Research Dossier
+
+**Slug:** `anatolii-solovianenko`
+**Block:** +77 expansion — "Music / opera and song-canon performance"
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #356
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-06-30
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Анатолій Борисович Солов’яненко.
+- **Pseudonyms / aliases:** Анатолій Солов’яненко; Солов’яненко
+  Анатолій Борисович; Anatolii Solovianenko; Anatolii Borysovych
+  Solovianenko; source/legacy forms `Anatoly Solovianenko`,
+  `Solov’janenko, Anatolij`, `Anatoliy Solovyanenko`.
+- **Born:** 25 September 1932 | Staline / Сталіне, now Donetsk |
+  Ukrainian SSR, Soviet Union. EIU gives Donetsk directly; the National
+  Opera and Shevchenko Prize Committee give Staline, now Donetsk.
+- **Died:** 29 July 1999 | Kozyn, Kyiv oblast, Ukraine | cause not
+  verified in the Tier 1/Tier 2 sources used here.
+- **Family / education key facts:** Born in a miner's family. He entered
+  Donetsk Industrial / Polytechnic Institute in 1949, graduated in mining
+  and mechanical training in 1954, taught descriptive geometry and graphics,
+  and studied voice privately with Oleksandr Korobeichenko. He completed
+  Kyiv Conservatory vocal studies in 1978 in Yelyzaveta Chavdar's class.
+
+The main date nuance is institutional status. EIU and the Shevchenko Prize
+Committee describe his Kyiv opera relationship from 1962, while the National
+Opera and the Internet Encyclopedia of Ukraine distinguish the 1962 invitation
+from full soloist status from 1965. Keep both visible unless personnel records
+resolve the difference.
+
+## 2. Oppression mechanism
+
+- **What happened:** Not a repression-primary biography. No Tier 1/Tier 2
+  source accessed in this pass documents a person-specific arrest, exile,
+  show trial, security-service case, rehabilitation file, or forced-emigration
+  episode for Solovianenko.
+- **When (specific dates):** Not applicable for person-specific repression.
+  Relevant context is Soviet cultural-institutional constraint across the
+  1960s-1980s and the post-Soviet institutional dispute around his 1996
+  dismissal from the National Opera, which EIU describes only as caused by
+  "subjective reasons."
+- **By whom:** No specific Russian/Soviet/RF agency is identified for the
+  singer in the accessed sources. Do not name NKVD, KGB, or another security
+  service unless a future archival source supplies a person-specific document.
+- **Document references:** None found for security-service or court files.
+  CSAMM identifies personal archival fonds no. 1409, with 439 storage units
+  for 1935-2007; that fonds is the first document-level target for future
+  research.
+- **Mechanism specifics:** Teach him as a Ukrainian opera and song performer
+  who worked through Soviet and post-Soviet state institutions, not as an
+  underground dissident or fabricated martyr. The tension is cultural:
+  official Soviet titles and global opera access can obscure Ukrainian roles,
+  Ukrainian song repertoire, Donetsk/Kyiv biography, and post-1991 Ukrainian
+  public memory.
+- **What survived / what was damaged:** Survived: a large recorded voice
+  legacy, major opera roles, Ukrainian song performance, and public
+  commemoration. Damaged or blurred: clean explanation of the boundary between
+  Soviet cultural diplomacy, Ukrainian-language repertoire, and later national
+  memory.
+
+## 3. Major works / contributions
+
+- **Ukrainian opera roles:** National Opera and the Shevchenko Prize
+  Committee foreground Andrii in Hulak-Artemovskyi's "Запорожець за Дунаєм",
+  Petro in Lysenko's "Наталка Полтавка", and Kobzar in Lysenko's
+  "Тарас Бульба". These are the strongest Ukrainian-canon anchors.
+- **International repertoire:** Core roles include the Duke, Alfredo,
+  Manrico, Radames, Edgardo, Rodolfo, Cavaradossi, Faust, Nadir, Turiddu,
+  Lensky, the Pretender, and Golitsyn. EIU and the National Opera place his
+  Metropolitan Opera work in 1977-1978; role-level Met archive records should
+  be pulled before any module repeats specific Met performance claims.
+- **National Opera / global opera figure:** EIU gives more than twenty opera
+  roles, more than ten chamber programs, and more than one hundred world
+  stages. National Opera emphasizes his 1965-1993 soloist period and touring
+  through the Metropolitan Opera, Berlin, Sofia, Prague, Budapest, and Dresden.
+- **Recordings and media:** National Opera and the Shevchenko Prize Committee
+  record eighteen discs. National Opera also notes film work as Petro in
+  "Наталка Полтавка" (1978) and Faust in the 1982 film-opera. TSDAEA's 2024
+  catalogue preserves record-level entries for "Пісенька Герцога", Nadir's
+  romance from "Шукачі перлів", and "Сонце низенько".
+- **Public memory:** He received the Shevchenko Prize in 1997, Hero of Ukraine
+  posthumously in 2008, and the presidential distinction "Національна легенда
+  України" posthumously in 2022. The National Bank of Ukraine issued a 1999
+  memorial coin naming him one of the best opera singers of the twentieth
+  century.
+
+## 4. Primary-source quote anchors
+
+- **Quote 1, origin voice:** "Народився я ... в родині шахтаря..." CSAMM
+  cites this from Solovianenko's November 1978 interview in "Українські
+  вісті". Pedagogical use: anchors him in Donetsk industrial biography
+  without turning the lesson into a talent myth.
+- **Quote 2, work ethic:** "чого не посієш, того не матимеш." CSAMM cites
+  this from "Вітчизна", no. 8, 1980. Pedagogical use: compact B1/B2 line for
+  performer discipline; avoid moralizing beyond the source.
+- **Title anchor 3:** "Сонце низенько", Petro's song from "Наталка Полтавка",
+  TSDAEA catalogue entry, 1976. Use the title only unless rights review
+  approves more.
+- **Title anchor 4:** "Пісенька Герцога" from "Ріголетто", TSDAEA catalogue
+  entry, 1965. This lets learners compare Ukrainian documentation of an
+  Italian opera role with Ukrainian-stage roles.
+
+## 5. Language register
+
+- **Register:** formal opera and public-recital register: diction-centered,
+  polished, stage Ukrainian in Ukrainian roles and songs, plus international
+  opera terminology.
+- **CEFR readiness full reading:** B2/C1 for the biography because it requires
+  Soviet/post-Soviet institutional context; A2/B1 for selected title, role,
+  and listening vocabulary.
+- **Lexicon notes:** Useful vocabulary includes `тенор`, `лірико-драматичний`,
+  `партія`, `соліст`, `стажування`, `консерваторія`, `платівка`, `романс`,
+  `арія`, `репертуар`, `гастролі`, and `камерний репертуар`.
+- **Stylistic features:** The learning value is in role names, institutions,
+  and listening tasks rather than long lyric or aria quotation.
+
+## 6. Contested points
+
+- **What's debated / unsettled:** La Scala dates differ: National Opera gives
+  1962-1963, while EIU and the Shevchenko Prize Committee give 1963-1965.
+  Kyiv opera start wording also differs, as noted in §1.
+- **What gets simplified in popular memory:** Popular memory can reduce him
+  to the "Ukrainian nightingale" image or a generic world-famous tenor.
+  Official Soviet framing can reduce him to honours and cultural diplomacy.
+  The module should show the combination: Donetsk technical worker, privately
+  trained vocalist, Kyiv/National Opera artist, Ukrainian stage-role bearer,
+  recorder of songs and romances, and global opera performer.
+- **Where modern Russian disinformation attacks them (if applicable):** No
+  Solovianenko-specific disinformation campaign was identified. The broader
+  colonial risk is absorptive framing: treating him primarily as "Soviet" or
+  using Russianized spellings while Ukrainian repertoire and Ukrainian public
+  memory become secondary.
+- **Other-perspective considerations:** Historical place naming matters.
+  Staline/Donetsk should be tied to Ukrainian SSR and present-day Ukraine,
+  not left as a placeless Soviet city or folded into Russian geography.
+- **HIST-alignment check:** Align with Donbas Ukrainian cultural biography,
+  late-Soviet cultural institutions, National Opera history, Ukrainian
+  song/recording memory, and post-1991 state commemoration. Do not invent a
+  security-service oppression story.
+
+## 7. Cross-track links
+
+- **Existing C1 modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/c1/vokalne-mystetstvo.yaml`
+  - `curriculum/l2-uk-en/plans/c1/klasychna-muzyka-2-natsionalna-shkola.yaml`
+  - `curriculum/l2-uk-en/plans/c1/klasychna-muzyka-3-modernizm-i-suchasnist.yaml`
+- **Existing LIT modules (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/natalka-poltavka.yaml`
+- **Existing BIO links (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/mykola-lysenko.yaml`
+  - `docs/research/bio/semen-hulak-artemovskyy.md`
+  - `curriculum/l2-uk-en/plans/bio/solomiya-krushelnytska.yaml`
+  - `docs/research/bio/dmytro-hnatiuk.md`
+- **Candidate future links:** BIO #357 `raisa-kyrychenko`; a Donbas cultural
+  geography module if added; a rights-cleared listening pack around
+  TSDAEA/National Opera recordings.
+
+## 8. Naming-canonical
+
+Per `docs/best-practices/bio-naming-canonical.md` (#2313):
+
+- **Slug:** `anatolii-solovianenko`.
+- **EN canonical (BGN/PCGN 2010):** Anatolii Solovianenko.
+- **UA canonical (with patronymic attested):** Анатолій Борисович
+  Солов’яненко.
+- **Aliases (track `aliases:` YAML field later):** Анатолій Солов’яненко;
+  Солов’яненко Анатолій Борисович; Anatolii Borysovych Solovianenko;
+  Anatolii Solovianenko; Anatoly Solovianenko; Solov’janenko, Anatolij;
+  Anatoliy Solovyanenko.
+- **Forbidden forms (Russian-imperial transliterations flag in body text):**
+  `Анатолий Борисович Соловьяненко`; `Соловьяненко Анатолий Борисович`;
+  `Anatoly Solovyanenko`; any `Donetsk = Russia` framing.
+
+## 9. Image candidates
+
+Per `docs/best-practices/bio-image-rights.md` (#2316):
+
+- **Best PD/CC portrait:** Wikimedia Commons
+  `File:Anatoliy Solovianenko - Soviet Life, October 1984.jpg`; Commons marks
+  it public domain in the United States because the source magazine was
+  published in the U.S. without notice. Use only after Phase 4 rights review
+  checks non-U.S./Ukraine implications.
+- **Backup candidates:** Wikimedia Commons Kyiv monument photo
+  `File:Пам'ятник А. Б. Солов'яненку.jpg`, CC-BY-SA-4.0, author
+  AlexanderCh. CSAMM archival photographs from fonds 1409 and National Opera /
+  Shevchenko Committee portraits are reference-only until license is verified.
+- **Era-appropriate context image:** A rights-cleared National Opera or Kyiv
+  monument image can support public-memory context. A recording cover or
+  catalogue scan should be used only after rights verification.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- Крупина В. О. "СОЛОВ’ЯНЕНКО Анатолій Борисович." Енциклопедія історії
+  України / Інститут історії України НАН України.
+  https://www.history.org.ua/?termin=Solovianenko_A. Accessed 2026-06-30.
+- Internet Encyclopedia of Ukraine / CIUS. "Solovianenko, Anatolii."
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CO%5CSolovianenkoAnatolii.htm.
+  Accessed 2026-06-30.
+
+**Tier 2 (institutional / archival):**
+
+- Національна опера України. "СОЛОВ'ЯНЕНКО Анатолій."
+  https://opera.com.ua/persons/koryfeyi/solovyanenko-anatoliy. Accessed
+  2026-06-30.
+- Комітет з Національної премії України імені Тараса Шевченка.
+  "Солов’яненко Анатолій Борисович."
+  https://knpu.gov.ua/winners/solov-ianenko-anatolij-borysovych/. Accessed
+  2026-06-30.
+- ЦДАМЛМ України. "Анатолій Солов’яненко (1932-1999)."
+  https://csamm.archives.gov.ua/2022/09/26/anatolii-solovianenko-1932-1999/.
+  Accessed 2026-06-30.
+- Центральний державний аудіовізуальний та електронний архів.
+  `Мистецтво ХХ-ХХІ століття у фонодокументах. Том ІІ. Музичне театральне
+  мистецтво: анотований каталог`. Луцьк, 2024.
+  https://tsdaea.archives.gov.ua/wp-content/uploads/2024/02/fono-2_compressed.pdf.
+  Accessed 2026-06-30.
+- Верховна Рада України, законодавча база. Указ Президента України
+  №615/2008 "Про відзначення державними нагородами України."
+  https://zakon.rada.gov.ua/go/615/2008. Accessed 2026-06-30.
+- Верховна Рада України, законодавча база. Указ Президента України №588/2022
+  "Про нагородження відзнакою Президента України 'Національна легенда
+  України'." https://zakon.rada.gov.ua/go/588/2022. Accessed 2026-06-30.
+- Національний банк України / Верховна Рада України, законодавча база.
+  "Про випуск в обіг пам'ятної монети 'Анатолій Солов'яненко'."
+  https://zakon.rada.gov.ua/go/v7725500-99. Accessed 2026-06-30.
+
+**Tier 3 (encyclopedic / navigation):**
+
+- Wikipedia was used only as navigation to higher-tier and institutional
+  sources; no final claim relies on Wikipedia alone.
+
+**Tier 4 (modern scholarly post-1991):**
+
+- None used in this pass; future module writing may need post-1991 scholarship
+  on Soviet Ukrainian opera institutions and recorded-song culture.
+
+**Tier 5 (general web):**
+
+- Ukrinform and public-media pages were used only as leads; core facts rely on
+  Tier 1/Tier 2 sources.
+
+**Primary-source documents accessed (NKVD files, KGB files, court records):**
+
+- None found or accessed. No person-specific NKVD/MGB/KGB/court-file claim
+  should be made from this dossier.
+- Non-security archival primary materials accessed: CSAMM fonds references for
+  Solovianenko's personal archive and TSDAEA catalogue records for recordings
+  and photographs.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing.
+- [x] Russian-imperial transliterations appear only in aliases or forbidden
+  forms.
+- [x] No invented NKVD/KGB/security-service oppression narrative.
+- [x] Ukrainian opera roles, Ukrainian song performance, Donetsk/Kyiv
+  Ukrainian public memory foregrounded.
+- [x] Soviet honours and institutions included as context, not as the whole
+  story.
+- [x] Existing cross-track paths verified with `test -e` before listing.
+- [x] Copyright-sensitive lyric and aria quotations avoided.


### PR DESCRIPTION
## Summary

- Adds the BIO #356 base-prep research dossier for `anatolii-solovianenko`.
- Keeps the slice dossier-only: no plan YAML, module content, activities, vocabulary, site MDX, wiki output, telemetry, or generated artifacts.
- Frames Solovianenko as a Ukrainian opera tenor / song and recording performer with explicit caution against inventing a person-specific NKVD/KGB/security-service repression narrative.

## Validation

- `./.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/anatolii-solovianenko.md`
- `npx markdownlint-cli2 docs/research/bio/anatolii-solovianenko.md`
- `git diff --check origin/main...HEAD`
- `./.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `git diff --name-status origin/main...HEAD` -> one file only
- exact substring sanity check after replacing malformed worker draft

## Telemetry

- Module-build telemetry: not applicable; this PR is a dossier-only base-prep slice, not a module build.
- `swarm_used: true`
- `swarm_note: draft-only Codex worker gathered sources and produced a malformed draft; orchestrator repaired/integrated the single dossier file; no module-build swarm used`