### PR TITLE
docs(bio): add Raisa Kyrychenko dossier

### DIFF
--- a/docs/research/bio/raisa-kyrychenko.md
+++ b/docs/research/bio/raisa-kyrychenko.md
@@ -1,0 +1,118 @@
+# Раїса Кириченко — Research Dossier
+
+- **Slug:** `raisa-kyrychenko`
+- **Block:** +77 expansion — Ukrainian music song-canon additions
+- **Tier:** 2
+- **Issue:** #2535 / BIO +77 readiness gate; BIO #357
+- **Researcher:** Codex orchestrator (GPT-5)
+- **Completed:** 2026-06-30
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Раїса Кириченко. Patronymic is source-conflicted: Енциклопедія Сучасної України and the Shevchenko Prize Committee use **Раїса Панасівна**, while Енциклопедія історії України, the 2003 Hero of Ukraine decree, and many public-memory sources use **Раїса Опанасівна**. Treat `Раїса Панасівна Кириченко` and `Раїса Опанасівна Кириченко` as aliases until primary civil records are checked.
+- **Maiden name:** Корж. ЕІУ gives the maiden name and notes the autobiographical birth variant.
+- **Born:** 14 October 1943 is the working curriculum date. ESU and the Shevchenko Prize Committee give 14 October 1943 in Корещина, Poltava region. ЕІУ gives 14 October 1944 in the article header but immediately records her autobiographical statement that she was born 14 November 1943 in Землянки. This dossier keeps 14 October 1943 as the teaching date and flags both date/place variants for Phase 2.
+- **Died:** 9 February 2005, Kyiv; buried in Корещина, Poltava region.
+- **Role:** Ukrainian singer, mezzo-soprano, pedagogue; People's Artist of the Ukrainian SSR / Ukraine (1979), Shevchenko Prize laureate (1986), Hero of Ukraine (2003), full holder of the Order of Princess Olha.
+- **Education / career anchors:** Began in amateur and factory-choir settings; sang with the Poltava Philharmonic's `Веселка`, Zhytomyr Philharmonic's `Льонок`, Kherson Philharmonic, Cherkasy Folk Choir, `Росава`, and then Poltava Philharmonic. She graduated from Kharkiv Institute of Arts in choral conducting in 1989 and taught singing at the Mykola Lysenko Poltava Music College from 1994.
+
+## 2. Oppression mechanism
+
+No Tier 1/Tier 2 source found in this dossier pass documents a person-specific NKVD, KGB, court, exile, or security-service case against Kyrychenko. Do not invent one.
+
+The historically responsible mechanism is **Soviet institutional cultural control around Ukrainian folk and popular song**. Kyrychenko's career depended on state-run choirs, philharmonics, officially approved touring circuits, state recording, and repertory filters. ЕІУ notes that her repertory included Ukrainian, Russian, and Belarusian folk songs and works by Soviet-era composers; ESU and the Shevchenko Prize Committee show the same professional path through choirs, philharmonic ensembles, `Росава`, and `Чураївна`. That does not make her a dissident martyr, but it does matter pedagogically: Ukrainian-language song could carry regional memory and national feeling while moving through institutions that expected acceptable Soviet public culture.
+
+For curriculum use, frame the tension plainly. The singer's public legitimacy came from official titles and mass stages; her durable reception came from Ukrainian song, Poltava village memory, maternal/home imagery, and post-1991 national recognition. The Hero of Ukraine decree in 2003 explicitly recognized her contribution to preserving and enriching Ukrainian national song heritage. That decree is a better anchor than a fabricated persecution narrative.
+
+## 3. Major works / contributions
+
+- **Signature repertoire:** ESU lists `Біла хата`, `Пісня про хліб`, `Мамина вишня`, `Синові`, `Явір і яворина`, `Два кольори`, `Журавка`, `Стоять тополі`, and folk songs such as `Тиха вода`, `Ой гарна я, гарна`, and `Ой хотіла мене мати`.
+- **Public-song canon:** The Shevchenko Prize Committee foregrounds `Чураївна`, `Я козачка твоя`, `Жіноча доля`, and `Мамина вишня`, and names albums including `Ой гарна я, гарна`, `Долі моєї село`, `Цвіте черемшина`, `Я - козачка твоя`, and `Дорогу спадщину Дмитра Луценка співає Раїса Кириченко`.
+- **Institutional ensembles:** Her professional arc connects the Poltava, Zhytomyr, Kherson, and Cherkasy musical ecosystems. The Poltava Philharmonic's present-day `Чураївна` page still describes a repertoire that includes songs of Marusia Churai and Raisa Kyrychenko, giving a living-institution bridge for later lesson framing.
+- **Printed / memory works:** ESU records the song collection `Співає Раїса Кириченко` (1988) and the book `Я козачка твоя, Україно` (2003). The Poltava youth library bibliography lists the memoir as a 214-page Poltava publication and the 1988 `Музична Україна` songbook.
+- **Public reception:** Suspilne Poltava documents the museum-estate `Мамина вишня` in Корещина, annual visits, preserved home objects, and local stewardship. This is useful for modern reception: Kyrychenko is remembered not only as a stage voice, but as a Poltava village-memory figure.
+
+## 4. Primary-source quote anchors
+
+- **Official recognition quote:** `збереження та збагачення української національної пісенної спадщини` — from Presidential Decree no. 1236/2003 awarding Kyrychenko Hero of Ukraine. Use this short phrase to anchor the state-recognition frame without reproducing the full decree.
+- **Memoir / first-person access gap:** The 2003 memoir `Я козачка твоя, Україно` is attested by ESU and the Poltava youth library bibliography, but the full text was not accessed in this pass. A library scenario quotes a brief closing statement of gratitude to the Ukrainian people and native land; treat it as a lower-tier access copy until the printed book is checked.
+- **Song-title anchor:** `Я козачка твоя, Україно` is both the memoir title and the public image most learners will recognize. It should be used as a title/cultural marker, not as evidence for political statements unless the relevant passage is verified in print.
+
+## 5. Language register
+
+- **Register:** Ukrainian folk-pop / estrada public-song register; warm, declarative, emotionally direct, and image-rich. It sits between concert folk performance and late-Soviet / early-independence popular song.
+- **CEFR readiness:** B1 for selected song titles, family/home vocabulary, and career facts; B2 for the full biography; C1 if the module foregrounds Soviet cultural institutions, repertory politics, and post-1991 national-memory debates.
+- **Lexicon notes:** Useful vocabulary includes `співачка`, `мецо-сопрано`, `філармонія`, `народний хор`, `ансамбль`, `репертуар`, `пісенна спадщина`, `лауреатка`, `викладачка`, `музичне училище`, `гастролі`, `музей-садиба`.
+- **Stylistic features:** Repetition, kinship and home imagery (`мама`, `хата`, `вишня`, `село`), Poltava regional references, and strongly singable refrains. Learners can compare how titles such as `Мамина вишня`, `Долі моєї село`, and `Я козачка твоя` convert family/local imagery into national song memory.
+
+## 6. Contested points
+
+- **Patronymic and birth data:** The patronymic split (`Панасівна` / `Опанасівна`) and birth-date/place variants must be visible in teacher notes. The father is named as Панас Миколайович Корж in Suspilne's museum-estate article, which explains why `Панасівна` appears in ESU/Shevchenko Committee; official decrees and ЕІУ still preserve `Опанасівна`.
+- **Folk authenticity vs staged performance:** Kyrychenko came from village and amateur singing, but her public career was professional, state-institutional, and often estrada-adjacent. Do not present every performed item as unmediated village tradition.
+- **Soviet titles vs Ukrainian reception:** Soviet-era honors are part of the record. They should not be hidden, but they should not outweigh the Ukrainian-language repertoire, Poltava rootedness, and post-1991 national memory.
+- **Health narrative:** Her kidney illness and public support campaigns are documented in several public sources. Use sparingly; the module should not turn biography into illness melodrama.
+- **Modern wartime reception:** АрміяInform's 2020 article says `Я козачка твоя` was sung by military women in formation and `Мамина вишня` remained a family-holiday song. This is a useful bridge to wartime Ukrainian reception, but because it predates the 2022 full-scale invasion, later module writers should add post-2022 reception only from fresh sources.
+
+## 7. Cross-track links
+
+- **Existing BIO links (VERIFIED `test -e`):**
+  - `docs/research/bio/nina-matviyenko.md`
+  - `curriculum/l2-uk-en/plans/bio/nina-matviyenko.yaml`
+  - `docs/research/bio/platon-maiboroda.md`
+  - `docs/research/bio/oleksandr-bilash.md`
+  - `curriculum/l2-uk-en/plans/bio/oleksandr-bilash.yaml`
+- **Existing FOLK / LIT / C1 links (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/folk/istorychni-pisni.yaml`
+  - `curriculum/l2-uk-en/plans/lit/malyshko-songs.yaml`
+  - `curriculum/l2-uk-en/plans/c1/vokalne-mystetstvo.yaml`
+- **Candidate future links:** Dmytro Lutsenko BIO dossier/plan; generic Ukrainian folk-song plan if added; a listening-rights packet for `Мамина вишня`, `Я козачка твоя`, and `Два кольори`; museum-memory activity around `Мамина вишня`.
+
+## 8. Naming-canonical
+
+Per `docs/best-practices/bio-naming-canonical.md` (#2313):
+
+- **Slug:** `raisa-kyrychenko`.
+- **EN canonical:** Raisa Kyrychenko.
+- **UA canonical for YAML display:** `Раїса Кириченко`; include patronymic only in `aliases` or teacher notes until primary-record conflict is resolved.
+- **Aliases:** Раїса Панасівна Кириченко; Раїса Опанасівна Кириченко; Кириченко Раїса Панасівна; Кириченко Раїса Опанасівна; Раїса Корж; Raisa Panasivna Kyrychenko; Raisa Opanasivna Kyrychenko.
+- **Forbidden / source-critical forms:** Russianized `Раиса Кириченко`, `Раиса Панасовна`, `Раиса Афанасьевна`, and transliteration `Raisa Kirichenko` should not be canonical. They may appear only in source metadata or search notes.
+
+## 9. Image candidates
+
+Follow `docs/best-practices/bio-image-rights.md` (#2316). Do not reuse unattributed fan-upload portraits.
+
+- **Likely best route:** search Wikimedia Commons and Ukrainian institutional photo pages for a rights-cleared portrait; no definitive PD/CC portrait was confirmed in this pass.
+- **Museum/home visuals:** Suspilne Poltava's 2025 article contains photographs of the Корещина house, costumes, bust, and memorial complex. These are excellent visual-reference leads but not automatically reusable; request permission or use as reference only.
+- **Fallback:** text-led module card with a rights-cleared public-domain symbolic image from Poltava / Ukrainian embroidered towel / cherry-tree material, explicitly not claiming to depict Kyrychenko.
+
+## 10. Sources used
+
+**Tier 1 / Tier 2 encyclopedic and official sources:**
+
+- Енциклопедія Сучасної України. "Кириченко Раїса Панасівна." https://esu.com.ua/article-6435. Accessed 2026-06-30.
+- Енциклопедія історії України / Інститут історії України НАН України. "Кириченко Раїса Опанасівна." https://www.history.org.ua/?termin=Kyrychenko_R. Accessed 2026-06-30.
+- Комітет з Національної премії України імені Тараса Шевченка. "Кириченко Раїса Панасівна." https://knpu.gov.ua/winners/kyrychenko-raisa-panasivna/. Accessed 2026-06-30.
+- Президент України / законодавча база, Указ no. 1236/2003 "Про присвоєння Р. Кириченко звання Герой України"; mirror viewed via ZakonOnline with official source link. https://zakononline.ua/documents/show/243190___243255. Accessed 2026-06-30.
+- Полтавська обласна філармонія. "Концертний ансамбль 'Чураївна'." https://filarmonia-poltava.org.ua/partitions/collectives/koncertniy-ansambl-churayivna. Accessed 2026-06-30.
+
+**Tier 3 / reception and bibliography sources:**
+
+- Суспільне Полтава. "'Так все було при Раїсі Панасівні': як жила у селі народна артистка України Раїса Кириченко." 14 October 2025. https://suspilne.media/poltava/1138100-tak-vse-bulo-pri-raisi-panasivni-ak-zila-u-seli-narodna-artistka-ukraini-raisa-kiricenko/. Accessed 2026-06-30.
+- Полтавська обласна бібліотека для юнацтва ім. Олеся Гончара. "Пісня, що в серці з дитинства." https://libgonchar.org/index.php?catid=49&id=88%3Aq-----q&lang=uk&option=com_content&view=article. Accessed 2026-06-30.
+- АрміяInform. "'Не співай пісні, які ні про що. Вибирай ті, що западають в людську душу!..'" 15 October 2020. https://armyinform.com.ua/2020/10/15/ne-spivaj-pisni-yaki-ni-pro-shho-vybyraj-ti-shho-zapadayut-v-lyudsku-dushu/. Accessed 2026-06-30.
+- Apple Music / Skysta Music album pages for `Долі моєї село` and `Я козачка твоя`, used only as current discography corroboration, not as biographical authority. Accessed 2026-06-30.
+
+---
+
+## Dossier self-check
+
+- [x] All 10 sections completed.
+- [x] At least three Tier 1/Tier 2 sources cited.
+- [x] No person-specific security-service narrative invented.
+- [x] Patronymic and birth-date source conflicts surfaced.
+- [x] Cross-track "Existing" paths verified with `test -e` on 2026-06-30.
+- [x] Naming-canonical applied.
+- [x] Image candidates rights-cautioned.
+- [x] Dossier-only slice; no plan/module/activity/vocabulary/site/generated artifacts.


### PR DESCRIPTION
## Summary

- Add the BIO #357 research dossier for `raisa-kyrychenko`.
- Keep the slice dossier-only: no plan, module, activity, vocabulary, site, generated audit/status, package, or config changes.
- Surface the patronymic and birth-date/source conflicts explicitly instead of silently normalizing them.
- Frame Soviet-era context through cultural institutions and repertory control; no person-specific NKVD/KGB/security-service narrative is asserted.

## Validation

- `./.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/raisa-kyrychenko.md`
- `npx markdownlint-cli2 docs/research/bio/raisa-kyrychenko.md`
- `git diff --check`
- `./.venv/bin/python scripts/audit/lint_agent_trailer.py`
- pre-commit/pre-push hooks passed

## Telemetry

- Module-build telemetry: not applicable; this is a dossier-only base-prep slice and no module build was run.
- `swarm_used: false`
- `swarm_note: solo orchestrator inline run; no swarm used`
