### PR TITLE
docs(bio): add Mykola Sadovskyi dossier

### DIFF
--- a/docs/research/bio/mykola-sadovskyi.md
+++ b/docs/research/bio/mykola-sadovskyi.md
@@ -1,0 +1,135 @@
+# Микола Карпович Садовський — Research Dossier
+
+- **Slug:** `mykola-sadovskyi`
+- **Block:** +77 expansion — Ukrainian theater / visual culture additions
+- **Tier:** 2
+- **Issue:** #2535 / BIO +77 readiness gate; BIO #358
+- **Researcher:** Codex orchestrator (GPT-5)
+- **Completed:** 2026-06-30
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Микола Карпович Садовський.
+- **Civil surname / family name:** Тобілевич. `Садовський` is the stage name by which the actor-director is canonically remembered.
+- **Born:** 1856, с. Кам'яно-Костувате, then Kherson gubernia of the Russian Empire, now Mykolaiv oblast, Ukraine. Exact date is source-conflicted: Енциклопедія історії України gives 18 (6) March 1856 and notes an alternative 13 (1) December 1856; Wikimedia/uk.wikipedia metadata gives 6 (18) July 1856; several local or teaching sources repeat March, July, or December. Use year/place in module prose until primary civil/church records are checked.
+- **Died:** 7 February 1933, Kyiv; buried at Baikove Cemetery.
+- **Family network:** Brother of Ivan Karpenko-Karyi, Panas Saksahanskyi, and Maria Sadovska-Barilotti. This Tobilevych sibling network is central to the Ukrainian theater canon.
+- **Roles:** actor, director, theater organizer, writer, translator, memoirist, singer of Ukrainian folk songs.
+- **Education / early path:** Studied in Kherson gymnasium and Yelysavethrad real school; volunteered for the Russo-Turkish War of 1877-1878; performed in amateur theater during military service in Bendery, where he met Maria Zankovetska; demobilized in 1881 and entered the professional Ukrainian troupe of H. Ashkarenko in Kremenchuk.
+
+## 2. Oppression mechanism
+
+No Tier 1/Tier 2 person-specific NKVD/GPU/KGB case was used for this dossier. Do not frame Sadovskyi primarily as a security-service biography unless a future archival source proves a concrete case file.
+
+The documented oppression mechanism is **Russian imperial censorship and permit control over Ukrainian-language theater**. The 1876 Ems Ukase forbade the staging of plays and public readings in Ukrainian. Later partial relaxation did not equal freedom: theater activity remained subject to censorship, governor permits, repertory restrictions, and rules that forced Ukrainian performances into mixed or constrained programs. A 2024 theater-history article summarizes the 1881 restrictions: Ukrainian plays faced strict censorship; Ukrainian performances were admitted only together with Russian-language ones the same evening; exclusively Ukrainian troupes were excluded.
+
+Sadovskyi's career belongs inside that system. He worked through itinerant troupes, permissions, seasonal Kyiv access, and repertoire compromise before building a stationary theater. Local History's extract on 1890s Kyiv tours records the practical permit logic: after administrative restrictions eased, his troupe still received permission for a limited number of performances and faced venue/time constraints. In 1907 his Kyiv theater became a stationary institution in the Troitsky People's House, but that success followed decades of censorship pressure, touring instability, and Ukrainian cultural negotiation inside empire.
+
+The Soviet-era endpoint also needs care. EIU and VUFKU agree that after returning to Soviet Ukraine in 1926, Sadovskyi worked as actor/director and appeared in cinema, but he no longer had his own theater. That is a real institutional narrowing, not enough by itself to assert an archival police case.
+
+## 3. Major works / contributions
+
+- **First stationary Ukrainian theater:** In 1906 Sadovskyi and Maria Zankovetska founded a traveling theater in Poltava. In 1907 it moved to Kyiv, settled in the Troitsky People's House, and became the first Ukrainian stationary theater, lasting until 1919 according to EIU. Open Kurbas dates the first Kyiv season to autumn 1907.
+- **Theater of the Coryphaei continuity:** He acted in the troupes of Marko Kropyvnytskyi and Mykhailo Starytskyi, founded his own troupe in 1888, merged with the Tobilevych brothers' society in 1898, and later connected with Kropyvnytskyi's ensemble. This makes him a bridge between itinerant coryphaei theater and permanent urban institution.
+- **Repertoire expansion:** Open Kurbas emphasizes that the Kyiv theater continued nineteenth-century Ukrainian stage traditions while expanding into new Ukrainian drama, Russian classics, European plays, Polish and Jewish dramatists, and works by Vynnychenko and Cherkasenko. It also notes Sadovskyi as one of the first to stage Gogol's `Ревізор` in Ukrainian in 1907.
+- **Acting roles:** EIU lists dramatic roles such as Dmytro in Starytskyi's `Не судилося`, Panas and Hnat in Karpenko-Karyi plays, comic/character roles including the Mayor in `Ревізор` and Martin Borulia, and heroic/tragedy roles such as Bohdan Khmelnytskyi, Sava Chalyi, Hetman Doroshenko, and the Commander in Lesia Ukrainka's `Камінний господар`.
+- **Writing / translation:** EIU lists libretti for `Галька`, `Продана наречена`, and Lysenko's `Енеїда`; translations into Ukrainian of Gogol, Ostrovsky, Tolstoy, Chekhov, and Słowacki; and memoirs `Спомини з російсько-турецької війни 1877-1878 рр.` and `Мої театральні згадки: 1881-1917`.
+- **Film endpoint:** VUFKU records his role in Arnold Kordium's film `Вітер з порогів` (1929), where the elderly actor performed the lead role.
+
+## 4. Primary-source quote anchors
+
+- **Theater-mission quote:** `служити рідному мистецтву` — Sadovskyi's 1930 memoir `Мої театральні згадки` describes the first Ukrainian troupe as serving native art. Use as a compact mission phrase, with OCR checked against scan before learner-facing quotation.
+- **Imperial-ban quote:** `книжку, театр навіть пісню` — in the same memoir, Sadovskyi describes the 1876 ban as reaching book, theater, and song. This is useful because it names theater as part of a broader anti-Ukrainian cultural restriction. Verify against the printed scan before using in a module.
+- **Title anchors:** `Мої театральні згадки: 1881-1917` and `Спомини з російсько-турецької війни 1877-1878 рр.` are primary works; use titles and bibliographic facts freely, but do not overquote long memoir passages without rights review.
+
+## 5. Language register
+
+- **Register:** theater-historical and memoir register: old orthography/OCR in primary texts, public-stage vocabulary, names of institutions, roles, and genres.
+- **CEFR readiness:** B2 for a biographical lesson; C1 for a source-reading lesson on imperial censorship, repertoire politics, and the transformation from itinerant troupe to stationary theater. Selected role names and family network can be adapted to B1 with glossing.
+- **Lexicon notes:** Useful vocabulary includes `актор`, `режисер`, `антреприза`, `трупа`, `стаціонарний театр`, `гастролі`, `репертуар`, `цензура`, `дозвіл`, `вистава`, `роль`, `переклад`, `лібрето`, `мемуари`, `корифеї`.
+- **Stylistic features:** learners need contrast between everyday `театр` vocabulary and specialized theater history terms. The lesson can also teach old/new place names: Єлисаветград / Kropyvnytskyi, Троїцький народний дім, Кам'яно-Костувате, Бобринецький повіт.
+
+## 6. Contested points
+
+- **Birth date:** Do not normalize silently. March, July, and December forms circulate. The dossier's stable claim is 1856, Kamiano-Kostuvate; a module should add a footnote if it prints an exact date.
+- **Imperial army service:** The Russo-Turkish War service is factual, but it should not overshadow the Ukrainian theater-building frame. It matters because it shaped the Bendery amateur-theater episode and his later memoir, not because imperial military honors define his cultural role.
+- **Coryphaei vs modernizing director:** Popular summaries can freeze Sadovskyi as only a coryphaei-era folk-realism figure. Open Kurbas complicates this: the Kyiv theater expanded repertoire, staged translated European/Russian texts in Ukrainian, and connected to Les Kurbas's early career.
+- **Relationship with Maria Zankovetska:** Sources often mention artistic and personal partnership. Use only what is relevant to theater institution-building; avoid gossip framing.
+- **Soviet return:** VUFKU says he could no longer hold his own theater after return. Treat this as institutional constraint unless a higher-trust source supplies direct political-police documentation.
+
+## 7. Cross-track links
+
+- **Existing BIO links (VERIFIED `test -e`):**
+  - `docs/research/bio/marko-kropyvnytskyi.md`
+  - `curriculum/l2-uk-en/plans/bio/marko-kropyvnytskyi.yaml`
+  - `docs/research/bio/mariya-zankovetska.md`
+  - `curriculum/l2-uk-en/plans/bio/mariya-zankovetska.yaml`
+  - `docs/research/bio/ivan-karpenko-karyi.md`
+  - `curriculum/l2-uk-en/plans/bio/ivan-karpenko-karyi.yaml`
+  - `docs/research/bio/semen-hulak-artemovskyy.md`
+  - `curriculum/l2-uk-en/plans/bio/semen-hulak-artemovskyy.yaml`
+  - `docs/research/bio/mykola-lysenko.md`
+  - `curriculum/l2-uk-en/plans/bio/mykola-lysenko.yaml`
+  - `docs/research/bio/lesya-ukrainka.md`
+  - `curriculum/l2-uk-en/plans/bio/lesya-ukrainka.yaml`
+- **Existing theater/drama links (VERIFIED `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit-drama/karpenko-karyi-theatre.yaml`
+  - `curriculum/l2-uk-en/plans/lit-drama/kurbas-berezil-theater.yaml`
+  - `curriculum/l2-uk-en/plans/lit-drama/ukrainian-drama-origins.yaml`
+  - `curriculum/l2-uk-en/plans/lit-drama/kotliarevsky-drama-tradition.yaml`
+  - `curriculum/l2-uk-en/plans/c1/teatralne-mystetstvo-1.yaml`
+  - `curriculum/l2-uk-en/plans/c1/teatralne-mystetstvo-2.yaml`
+  - `curriculum/l2-uk-en/plans/ruth/vertep-ukrainskyi-teatr.yaml`
+  - `curriculum/l2-uk-en/plans/folk/vertep-narodna-drama.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/teatr-kurbasa.yaml`
+  - `curriculum/l2-uk-en/plans/lit/natalka-poltavka.yaml`
+- **Candidate future links:** BIO #359 `panas-saksahanskyi`; Sadovskyi theater institution mini-module; a censorship close-reading activity around Ems Ukase and theater permits.
+
+## 8. Naming-canonical
+
+Per `docs/best-practices/bio-naming-canonical.md` (#2313):
+
+- **Slug:** `mykola-sadovskyi`.
+- **EN canonical:** Mykola Sadovskyi.
+- **UA canonical:** Микола Карпович Садовський.
+- **Aliases:** Микола Карпович Тобілевич; Тобілевич Микола Карпович; Микола Садовський; Mykola Karpovych Sadovskyi; Mykola Tobilevych; Mykola Sadovsky.
+- **Forbidden / source-critical forms:** Russianized `Николай Садовский`, `Николай Карпович Садовский`, and `малоросійський театр` labels should not be canonical. If a historical source uses `російсько-малоросійських артистів`, keep it as a quoted institutional name with source criticism.
+
+## 9. Image candidates
+
+Follow `docs/best-practices/bio-image-rights.md` (#2316).
+
+- **Best route:** Wikimedia Commons category `Mykola Sadovsky` has multiple portrait and role images. Candidate files include `Микола Садовський.jpg`, `Садовський Микола Карпович.jpg`, and role images such as Sadovskyi as Bohdan Khmelnytskyi. Check each file's license page before module use.
+- **Context visuals:** Commons also includes group images with Kropyvnytskyi and Zankovetska and grave photographs. Use only if license permits and if the visual supports the specific lesson frame.
+- **Fallback:** Use a rights-cleared image of Troitsky People's House / Kyiv operetta building or a public-domain coryphaei-era theater image, clearly labeled as institutional context rather than portrait.
+
+## 10. Sources used
+
+**Tier 1 / Tier 2 encyclopedic and institutional sources:**
+
+- Енциклопедія історії України / Інститут історії України НАН України. "Садовський Микола Карпович." https://www.history.org.ua/?termin=Sadovskyj_M_1. Accessed 2026-06-30.
+- Internet Encyclopedia of Ukraine. "Ems Ukase." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CE%5CM%5CEmsUkase.htm. Accessed 2026-06-30.
+- Open Kurbas. "Київський театр Миколи Садовського." https://openkurbas.org/theatres/kyivskyy-teatr-mykoly-sadovskoho/. Accessed 2026-06-30.
+- ВУФКУ. "Микола Садовський." https://vufku.org/names/mykola-sadovskyj-tobilevych/. Accessed 2026-06-30.
+
+**Tier 3 / source and reception aids:**
+
+- Садовський М. К. `Мої театральні згадки: 1881-1917`. Державне видавництво України, 1930. Digitized PDF: https://library.kr.ua/wp-content/elib/sadovskiy/mteatrzghad.pdf. Accessed 2026-06-30.
+- Локальна історія. "Київські гастролі 1890-х років. Фрагмент із книжки про Миколу Садовського." https://localhistory.org.ua/rubrics/book/sadovskii/. Accessed 2026-06-30.
+- Слуцький В. "Український професійний театр у Російській імперії..." `Актуальні питання гуманітарних наук`, 2024. PDF: https://aphn-journal.in.ua/archive/72_2024/part_3/14.pdf. Accessed 2026-06-30.
+- Wikimedia Commons. "Category:Mykola Sadovsky." https://commons.wikimedia.org/wiki/Category:Mykola_Sadovsky. Accessed 2026-06-30.
+
+---
+
+## Dossier self-check
+
+- [x] All 10 sections completed.
+- [x] At least three Tier 1/Tier 2 sources cited.
+- [x] No person-specific security-service narrative invented.
+- [x] Birth-date conflict surfaced instead of normalized.
+- [x] Cross-track "Existing" paths verified with `test -e` on 2026-06-30.
+- [x] Naming-canonical applied.
+- [x] Image candidates rights-cautioned.
+- [x] Dossier-only slice; no plan/module/activity/vocabulary/site/generated artifacts.


### PR DESCRIPTION
## Summary

- Add the BIO #358 research dossier for `mykola-sadovskyi`.
- Keep the slice dossier-only: no plan, module, activity, vocabulary, site, generated audit/status, package, or config changes.
- Surface the major birth-date conflict across sources instead of silently normalizing it.
- Frame oppression through Russian imperial theater censorship, Ems Ukase restrictions, and permit control; no person-specific NKVD/GPU/KGB case is asserted.

## Validation

- `./.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/mykola-sadovskyi.md`
- `npx markdownlint-cli2 docs/research/bio/mykola-sadovskyi.md`
- `git diff --check`
- `./.venv/bin/python scripts/audit/lint_agent_trailer.py`
- pre-commit/pre-push hooks passed

## Telemetry

- Module-build telemetry: not applicable; this is a dossier-only base-prep slice and no module build was run.
- `swarm_used: false`
- `swarm_note: solo orchestrator inline run; no swarm used`
