### PR TITLE
fix(bio): publish Bilash landing route

### DIFF
--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -5,9 +5,9 @@ export const collections = {
 	docs: defineCollection({
 		loader: glob({
 			pattern: [
-				'{a1,a2,folk}/**/*.{md,mdx}',
+				'{a1,a2,bio,folk}/**/*.{md,mdx}',
 				'{b1,b2}/**/*.{md,mdx}',
-				'{bio,c1,c2,hist,istorio,lit,lit-drama,lit-essay,lit-fantastika,lit-hist-fic,lit-humor,lit-war,lit-youth,oes,ruth}/index.{md,mdx}',
+				'{c1,c2,hist,istorio,lit,lit-drama,lit-essay,lit-fantastika,lit-hist-fic,lit-humor,lit-war,lit-youth,oes,ruth}/index.{md,mdx}',
 			],
 			base: './src/content/docs',
 		}),

--- a/site/src/content/docs/bio/index.mdx
+++ b/site/src/content/docs/bio/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "BIO - Біографії"
-description: "Biography Track — 346 modules in curriculum order"
+description: "Biography Track — 387 modules in curriculum order"
 template: splash
 ---
 
@@ -10,10 +10,10 @@ import LevelLanding from '@site/src/components/LevelLanding';
   client:load
   level="BIO"
   title="BIO - Біографії"
-  subtitle="Biography Track — 346 modules"
+  subtitle="Biography Track — 1 learner page available · 387 modules"
   progressTitle="BIO Build Status"
-  progressDescription="1 available · 0 reviewed · 346 planned"
-  moduleCount={346}
+  progressDescription="1 available · 0 reviewed · 386 planned"
+  moduleCount={387}
   wordTarget={4000}
   color="var(--lu-id-bio)"
   modules={[
@@ -383,9 +383,110 @@ import LevelLanding from '@site/src/components/LevelLanding';
       ]
     },
     {
-      unit: "BIO pilots",
+      unit: "Ukrainian social resistance and contested memory additions",
       items: [
-        { num: 346, slug: "oleksandr-bilash", title: "Олександр Білаш: Українська пісня і пам'ять", sub: "Oleksandr Bilash: Ukrainian Song and Cultural Memory", status: "done" },
+        { num: 311, slug: "ustym-karmaliuk", title: "Ustym Karmaliuk", sub: "", status: "locked" },
+        { num: 312, slug: "oleksa-dovbush", title: "Oleksa Dovbush", sub: "", status: "locked" },
+        { num: 313, slug: "lukian-kobylytsia", title: "Lukian Kobylytsia", sub: "", status: "locked" },
+        { num: 314, slug: "maksym-zalizniak", title: "Maksym Zalizniak", sub: "", status: "locked" },
+        { num: 315, slug: "ivan-gonta", title: "Ivan Gonta", sub: "", status: "locked" },
+        { num: 316, slug: "nestor-makhno", title: "Nestor Makhno", sub: "", status: "locked" },
+      ]
+    },
+    {
+      unit: "Ukrainian state-building, education, and civic institutions additions",
+      items: [
+        { num: 317, slug: "yevhen-petrushevych", title: "Yevhen Petrushevych", sub: "", status: "locked" },
+        { num: 318, slug: "marko-bezruchko", title: "Marko Bezruchko", sub: "", status: "locked" },
+        { num: 319, slug: "dmytro-vitovskyi", title: "Dmytro Vitovskyi", sub: "", status: "locked" },
+        { num: 320, slug: "oleksandr-lototskyi", title: "Oleksandr Lototskyi", sub: "", status: "locked" },
+        { num: 321, slug: "borys-martos", title: "Borys Martos", sub: "", status: "locked" },
+        { num: 322, slug: "volodymyr-chekhivskyi", title: "Volodymyr Chekhivskyi", sub: "", status: "locked" },
+        { num: 323, slug: "sofiia-rusova", title: "Sofiia Rusova", sub: "", status: "locked" },
+        { num: 324, slug: "khrystyna-alchevska", title: "Khrystyna Alchevska", sub: "", status: "locked" },
+        { num: 325, slug: "mykhailo-tuhan-baranovskyi", title: "Mykhailo Tuhan Baranovskyi", sub: "", status: "locked" },
+        { num: 326, slug: "serhii-yefremov", title: "Serhii Yefremov", sub: "", status: "locked" },
+        { num: 327, slug: "ivan-steshenko", title: "Ivan Steshenko", sub: "", status: "locked" },
+        { num: 328, slug: "nadiia-surovtsova", title: "Nadiia Surovtsova", sub: "", status: "locked" },
+        { num: 329, slug: "dmytro-doroshenko", title: "Dmytro Doroshenko", sub: "", status: "locked" },
+        { num: 330, slug: "mykola-arkas", title: "Mykola Arkas", sub: "", status: "locked" },
+        { num: 331, slug: "oleksandr-barvinskyi", title: "Oleksandr Barvinskyi", sub: "", status: "locked" },
+      ]
+    },
+    {
+      unit: "Ukrainian language, ethnography, translation, and scholarship additions",
+      items: [
+        { num: 332, slug: "pavlo-chubynskyi", title: "Pavlo Chubynskyi", sub: "", status: "locked" },
+        { num: 333, slug: "markiian-shashkevych", title: "Markiian Shashkevych", sub: "", status: "locked" },
+        { num: 334, slug: "oleksandr-konyskyi", title: "Oleksandr Konyskyi", sub: "", status: "locked" },
+        { num: 335, slug: "fedir-vovk", title: "Fedir Vovk", sub: "", status: "locked" },
+        { num: 336, slug: "volodymyr-hnatiuk", title: "Volodymyr Hnatiuk", sub: "", status: "locked" },
+        { num: 337, slug: "filaret-kolessa", title: "Filaret Kolessa", sub: "", status: "locked" },
+        { num: 338, slug: "klyment-kvitka", title: "Klyment Kvitka", sub: "", status: "locked" },
+        { num: 339, slug: "mykola-lukash", title: "Mykola Lukash", sub: "", status: "locked" },
+        { num: 340, slug: "hryhorii-kochur", title: "Hryhorii Kochur", sub: "", status: "locked" },
+        { num: 341, slug: "larysa-masenko", title: "Larysa Masenko", sub: "", status: "locked" },
+        { num: 342, slug: "ivan-lysiak-rudnytskyi", title: "Ivan Lysiak Rudnytskyi", sub: "", status: "locked" },
+        { num: 343, slug: "yurii-lutskyi", title: "Yurii Lutskyi", sub: "", status: "locked" },
+        { num: 344, slug: "volodymyr-yermolenko", title: "Volodymyr Yermolenko", sub: "", status: "locked" },
+      ]
+    },
+    {
+      unit: "Ukrainian music and song-canon additions",
+      items: [
+        { num: 345, slug: "kyrylo-stetsenko", title: "Kyrylo Stetsenko", sub: "", status: "locked" },
+        { num: 346, slug: "oleksandr-bilash", title: "Олександр Білаш: Українська пісня і пам'ять", sub: "Oleksandr Bilash: Ukrainian Song and Cultural Memory", status: "active" },
+        { num: 347, slug: "andrii-malyshko", title: "Andrii Malyshko", sub: "", status: "locked" },
+        { num: 348, slug: "platon-maiboroda", title: "Platon Maiboroda", sub: "", status: "locked" },
+        { num: 349, slug: "levko-revutskyi", title: "Levko Revutskyi", sub: "", status: "locked" },
+        { num: 350, slug: "stanislav-liudkevych", title: "Stanislav Liudkevych", sub: "", status: "locked" },
+        { num: 351, slug: "myroslav-skoryk", title: "Myroslav Skoryk", sub: "", status: "locked" },
+        { num: 352, slug: "ivan-karabyts", title: "Ivan Karabyts", sub: "", status: "locked" },
+        { num: 353, slug: "yevhen-stankovych", title: "Yevhen Stankovych", sub: "", status: "locked" },
+        { num: 354, slug: "anatolii-kos-anatolskyi", title: "Anatolii Kos Anatolskyi", sub: "", status: "locked" },
+        { num: 355, slug: "dmytro-hnatiuk", title: "Dmytro Hnatiuk", sub: "", status: "locked" },
+        { num: 356, slug: "anatolii-solovianenko", title: "Anatolii Solovianenko", sub: "", status: "locked" },
+        { num: 357, slug: "raisa-kyrychenko", title: "Raisa Kyrychenko", sub: "", status: "locked" },
+      ]
+    },
+    {
+      unit: "Ukrainian theater and visual culture additions",
+      items: [
+        { num: 358, slug: "mykola-sadovskyi", title: "Mykola Sadovskyi", sub: "", status: "locked" },
+        { num: 359, slug: "panas-saksahanskyi", title: "Panas Saksahanskyi", sub: "", status: "locked" },
+        { num: 360, slug: "heorhii-narbut", title: "Heorhii Narbut", sub: "", status: "locked" },
+        { num: 361, slug: "oleksandr-murashko", title: "Oleksandr Murashko", sub: "", status: "locked" },
+        { num: 362, slug: "fedir-krychevskyi", title: "Fedir Krychevskyi", sub: "", status: "locked" },
+        { num: 363, slug: "olena-kulchytska", title: "Olena Kulchytska", sub: "", status: "locked" },
+        { num: 364, slug: "oleksa-novakivskyi", title: "Oleksa Novakivskyi", sub: "", status: "locked" },
+        { num: 365, slug: "ivan-trush", title: "Ivan Trush", sub: "", status: "locked" },
+        { num: 366, slug: "mykhailo-zhuk", title: "Mykhailo Zhuk", sub: "", status: "locked" },
+        { num: 367, slug: "sofiia-yablonska", title: "Sofiia Yablonska", sub: "", status: "locked" },
+      ]
+    },
+    {
+      unit: "Ukrainian literary and civic culture additions",
+      items: [
+        { num: 368, slug: "bohdan-lepkyi", title: "Bohdan Lepkyi", sub: "", status: "locked" },
+        { num: 369, slug: "ulas-samchuk", title: "Ulas Samchuk", sub: "", status: "locked" },
+        { num: 370, slug: "andrian-kashchenko", title: "Andrian Kashchenko", sub: "", status: "locked" },
+        { num: 371, slug: "roman-ivanychuk", title: "Roman Ivanychuk", sub: "", status: "locked" },
+        { num: 372, slug: "pavlo-zahrebelnyi", title: "Pavlo Zahrebelnyi", sub: "", status: "locked" },
+        { num: 373, slug: "valerii-shevchuk", title: "Valerii Shevchuk", sub: "", status: "locked" },
+        { num: 374, slug: "vsevolod-nestaiko", title: "Vsevolod Nestaiko", sub: "", status: "locked" },
+        { num: 375, slug: "volodymyr-rutkivskyi", title: "Volodymyr Rutkivskyi", sub: "", status: "locked" },
+        { num: 376, slug: "ivan-malkovych", title: "Ivan Malkovych", sub: "", status: "locked" },
+        { num: 377, slug: "oles-berdnyk", title: "Oles Berdnyk", sub: "", status: "locked" },
+        { num: 378, slug: "natalena-koroleva", title: "Natalena Koroleva", sub: "", status: "locked" },
+        { num: 379, slug: "mykhailo-stelmakh", title: "Mykhailo Stelmakh", sub: "", status: "locked" },
+        { num: 380, slug: "yurii-shcherbak", title: "Yurii Shcherbak", sub: "", status: "locked" },
+        { num: 381, slug: "vira-aheieva", title: "Vira Aheieva", sub: "", status: "locked" },
+        { num: 382, slug: "tamara-hundorova", title: "Tamara Hundorova", sub: "", status: "locked" },
+        { num: 383, slug: "oksana-kis", title: "Oksana Kis", sub: "", status: "locked" },
+        { num: 384, slug: "mykola-riabchuk", title: "Mykola Riabchuk", sub: "", status: "locked" },
+        { num: 385, slug: "iryna-tsilyk", title: "Iryna Tsilyk", sub: "", status: "locked" },
+        { num: 386, slug: "nataliia-vorozhbyt", title: "Nataliia Vorozhbyt", sub: "", status: "locked" },
+        { num: 387, slug: "artem-chekh", title: "Artem Chekh", sub: "", status: "locked" },
       ]
     },
   ]}

--- a/site/src/pages/[...slug].astro
+++ b/site/src/pages/[...slug].astro
@@ -371,7 +371,7 @@ const searchItems: SearchItem[] = [
 
 export async function getStaticPaths() {
   const normalizeDocId = (id: string) => id.replace(/\.mdx?$/, '').replace(/\/index$/, '');
-  const publicLessonPrefixes = new Set(['a1', 'a2', 'b1', 'b2', 'folk']);
+  const publicLessonPrefixes = new Set(['a1', 'a2', 'b1', 'b2', 'bio', 'folk']);
   const hiddenDocs = new Set(['a1/review-clears-needs-human']);
   const configuredTracks = ['a1', 'a2', 'b1', 'b2', 'c1', 'c2', 'folk', 'bio', 'hist', 'istorio', 'lit', 'oes', 'ruth'];
   const pathDocs = await getCollection('docs');


### PR DESCRIPTION
## Summary

Fixes the BIO landing/Bilash click regression.

## What changed

- Regenerated the BIO landing page from `curriculum/l2-uk-en/curriculum.yaml`, so it now shows the full 387-module BIO roster instead of stopping at 310 plus a separate `BIO pilots` bucket.
- Included BIO module docs in the Astro content collection.
- Allowed BIO docs through the custom `[...slug].astro` static path filter, so `/bio/oleksandr-bilash/` is emitted as a real page.

## Root cause

PR #4025 added `site/src/content/docs/bio/oleksandr-bilash.mdx` and a landing-card link, but BIO module pages were still excluded by two routing gates: `site/src/content.config.ts` loaded only `bio/index.mdx`, and `site/src/pages/[...slug].astro` generated static lesson paths only for A1/A2/B1/B2/FOLK. The landing page was also stale/manual, showing 310 canonical entries plus a separate pilot group.

## Validation

- `.venv/bin/python scripts/generate_landing_pages.py --track bio`
- `.venv/bin/python scripts/audit/check_mdx_source_parity.py --changed-vs-base origin/main`
- `.venv/bin/python scripts/audit/check_mdx_generation_drift.py --changed-vs-base origin/main`
- `.venv/bin/python scripts/audit/check_mdx_forward_parity.py --changed-vs-base origin/main`
- `git diff --check`
- `npm -C site ci`
- `npm -C site run build` -> 5636 pages built
- Preview smoke test:
  - `GET /bio/` -> 200
  - `GET /bio/oleksandr-bilash/` -> 200
  - rendered BIO landing contains `href="/bio/oleksandr-bilash/"`
  - rendered BIO landing no longer contains `BIO pilots`

## Telemetry

Not a module-build PR; no module-build token telemetry record required.

X-Agent: codex/bio-landing-bilash-fix