### PR TITLE
docs(bio): add Panas Saksahanskyi dossier

### DIFF
--- a/docs/research/bio/panas-saksahanskyi.md
+++ b/docs/research/bio/panas-saksahanskyi.md
@@ -1,0 +1,246 @@
+# Панас Карпович Саксаганський — Research Dossier
+
+- **Slug:** `panas-saksahanskyi`
+- **Block:** +77 expansion — Ukrainian theater / visual culture additions
+- **Tier:** 2
+- **Issue:** #2535 / BIO +77 readiness gate; BIO #359
+- **Researcher:** Codex orchestrator (GPT-5)
+- **Completed:** 2026-06-30
+- **Acceptance self-check:**
+  - [x] All 10 sections completed
+  - [x] At least 3 Tier 1/Tier 2 institutional sources cited
+  - [x] Oppression mechanism framed as imperial censorship / Ukrainian-stage restriction
+  - [x] Primary-source anchors identified without unverified long quotation
+  - [x] Cross-track links verified with `test -e` on 2026-06-30
+  - [x] Naming-canonical policy applied
+  - [x] Image-rights policy applied
+  - [x] Dossier-only scope observed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Панас Карпович Саксаганський.
+- **Civil surname / family name:** Тобілевич. `Саксаганський` is the
+  canonical stage name used in Ukrainian theater history.
+- **Born:** 1859, с. Кам'яно-Костувате, then Kherson gubernia, Russian Empire,
+  now Mykolaiv oblast, Ukraine.
+- **Birth-date caution:** authoritative sources conflict. Енциклопедія історії
+  України gives `15(03).05.1859`; Internet Encyclopedia of Ukraine gives
+  15 May 1859; the National Library exhibition gives `15 (27) травня 1859`.
+  Module prose should use the year and place unless a primary civil/church
+  record is checked.
+- **Died:** 17 September 1940, Kyiv; buried at Baikove Cemetery.
+- **Family network:** brother of Ivan Karpenko-Karyi, Mykola Sadovskyi, and
+  Mariia Sadovska-Barilotti. The Tobilevych sibling network is central, not
+  ornamental: it connects drama writing, acting, troupe organization, and
+  Ukrainian-language public culture.
+- **Roles:** actor, director, playwright, translator, memoirist, theater
+  teacher, and one of the Coryphaei of Ukrainian professional theater.
+- **Education / early path:** studied in Yelysavethrad; IEU records work in
+  Starytskyi's, Kropyvnytskyi's, and Sadovskyi's troupes before he led his own
+  company.
+
+## 2. Oppression mechanism
+
+Saksahanskyi should not be framed through a person-specific security-service
+file: no NKVD/GPU/KGB case is the dossier's factual core. His load-bearing
+oppression context is the Russian imperial system that made Ukrainian-language
+public theater administratively conditional.
+
+- **What happened:** Ukrainian-language stage work was constrained by the
+  Valuev/Ems-era regime, censorship, permit systems, and repertory controls.
+  Ukrainian performances could be allowed, limited, routed through mixed-bill
+  compromises, or banned, depending on location and administrative decision.
+- **When:** the relevant regime begins before Saksahanskyi's professional
+  career with the Valuev Circular (1863) and Ems Ukase (1876), with partial
+  openings and renewed restrictions around the early 1880s. His career from
+  the 1880s onward belongs inside that constrained public-stage system.
+- **By whom:** Russian imperial state censorship and theater administration;
+  for track-level context, use `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml`.
+- **Mechanism specifics:** troupe titles, permissions, and repertory categories
+  often embedded imperial vocabulary. If archival names such as
+  `російсько-малоросійських артистів` are quoted, they should be identified as
+  administrative language, not adopted as neutral learner-facing description.
+- **What survived / what was distorted:** Ukrainian acting craft, ensemble
+  discipline, role preparation, and repertory continuity survived through
+  itinerant theater and later institutions. Soviet titles are factual late-life
+  context, but they should not turn the biography into a Soviet-cultural
+  success story.
+
+## 3. Major works / contributions
+
+- **Theater of the Coryphaei continuity:** IEU places Saksahanskyi in
+  Mykhailo Starytskyi's troupe from 1883, Marko Kropyvnytskyi's in 1885, and
+  Mykola Sadovskyi's in 1888, before his own troupe. This makes him a bridge
+  from itinerant Ukrainian professional theater to later actor-training and
+  repertory institutions.
+- **Own troupe / institutional leadership:** IEU records Saksahanskyi's troupe
+  from 1890 to 1909; EIU records his separate company to 1898 before later
+  reorganizations. Treat these as institutional-history notes, not a single
+  smoothed date range.
+- **People's Theater:** he directed the People's Theater in Kyiv from 1918 to
+  1922. The National Library summary says the Zankovetska Ukrainian Drama
+  Theater was created in 1922 on that basis.
+- **Acting method:** IEU characterizes him as a realistic-psychological actor
+  especially strong in gesture and mimicry. For learners, the strongest frame
+  is craft: preparation, plasticity, comic precision, and ensemble discipline.
+- **Signature roles:** source lists include Kопач in Karpenko-Karyi's
+  `Сто тисяч`, Голохвастий in Starytskyi's `За двома зайцями`, Карась in
+  Hulak-Artemovskyi's `Запорожець за Дунаєм`, and roles in `Наталка Полтавка`.
+- **Directing / translation:** IEU lists Ukrainian productions of Schiller's
+  `Розбійники`, Gutzkow's `Uriel Acosta`, and Shakespeare's `Отелло`.
+- **Authored works:** plays `Лицеміри` (1908) and `Шантрапа` (1914); memoir
+  and theater books `По шляху життя` (1935), `Моя праця над роллю` (1937),
+  `Із минулого українського театру` / `Из прошлого украинского театра` (1938),
+  and the later collection `Думки про театр` (1955).
+
+## 4. Primary-source quote anchors
+
+Do not use long excerpts until scans/OCR and rights status are checked.
+For a later module, the safest primary-source anchors are title-level and
+short excerpt candidates:
+
+- **Actor-method anchor:** `Моя праця над роллю` is the key primary/theoretical
+  work for a lesson on preparing a role. Use the title concept freely; verify
+  scan text before quoting continuous prose.
+- **Memoir anchor:** `По шляху життя` and `Із минулого українського театру`
+  can support source-reading about how Coryphaei actors remembered theater
+  under censorship, touring instability, and institutional change.
+- **Drama anchor:** `Шантрапа` (1914) is a public-domain/source-reading
+  candidate via Commons/NBUV routes after scan verification.
+- **Reception caution:** the Maksym Rylskyi tribute used in exhibition
+  material is reception evidence, not Saksahanskyi's own voice.
+
+## 5. Language register
+
+- **Register:** theater-historical, actor-training, repertory, memoir, and
+  public-stage vocabulary.
+- **CEFR readiness:** B2 for a biographical lesson on the Tobilevych network
+  and Theater of the Coryphaei; C1 for source-reading on actor method,
+  repertory politics, and institution-building.
+- **Learner lexicon:** `корифеї`, `трупа`, `роль`, `амплуа`, `репертуар`,
+  `режисер`, `постановка`, `гастролі`, `жест`, `міміка`, `сценічний образ`,
+  `попередня робота над роллю`.
+- **Style note:** avoid reducing him to "folk household theater." The craft
+  frame should include psychological realism, comic technique, role analysis,
+  and expansion into European repertoire in Ukrainian.
+
+## 6. Contested points
+
+- **Birth date:** do not normalize the date silently. EIU gives
+  `15(03).05.1859`; IEU gives 15 May; the National Library page gives
+  `15 (27) травня`. Until a primary record is checked, module prose can safely
+  say 1859, Kamiano-Kostuvate, with a source note if an exact date is needed.
+- **"Pobutovyi theater" flattening:** popular memory can reduce Saksahanskyi
+  to household or ethnographic comedy. That misses psychological-actor craft,
+  role-method writing, and the repertoire expansion into Schiller, Shakespeare,
+  and Gutzkow in Ukrainian.
+- **Imperial institution names:** archival troupe names may contain
+  `малоросійський`. Treat the term as imperial administrative language, not
+  the module's own descriptive category.
+- **Soviet titles:** People's Artist titles are factual, but should be placed
+  after the Ukrainian theater-building story. They are not the interpretive
+  center of the biography.
+- **Image metadata:** some Commons metadata uses Russian/Soviet wording. Keep
+  learner-facing captions in Ukrainian canonical form and explain source labels
+  only where they matter pedagogically.
+
+## 7. Cross-track links
+
+- **Existing BIO research / plans (VERIFIED `test -e` on 2026-06-30):**
+  - `docs/research/bio/marko-kropyvnytskyi.md`
+  - `curriculum/l2-uk-en/plans/bio/marko-kropyvnytskyi.yaml`
+  - `docs/research/bio/mykola-sadovskyi.md`
+  - `docs/research/bio/ivan-karpenko-karyi.md`
+  - `curriculum/l2-uk-en/plans/bio/ivan-karpenko-karyi.yaml`
+  - `docs/research/bio/mariya-zankovetska.md`
+  - `curriculum/l2-uk-en/plans/bio/mariya-zankovetska.yaml`
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-starytsky.yaml`
+- **Existing theater / drama / history links (VERIFIED `test -e` on 2026-06-30):**
+  - `curriculum/l2-uk-en/plans/lit-drama/karpenko-karyi-theatre.yaml`
+  - `curriculum/l2-uk-en/plans/lit-drama/ukrainian-drama-origins.yaml`
+  - `curriculum/l2-uk-en/plans/lit-drama/kurbas-berezil-theater.yaml`
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml`
+  - `curriculum/l2-uk-en/plans/ruth/vertep-ukrainskyi-teatr.yaml`
+  - `curriculum/l2-uk-en/plans/folk/vertep-narodna-drama.yaml`
+- **Candidate / not yet existing in this slice:**
+  - `curriculum/l2-uk-en/plans/bio/mykola-sadovskyi.yaml`
+  - `curriculum/l2-uk-en/plans/bio/panas-saksahanskyi.yaml`
+  - site MDX / wiki article for `panas-saksahanskyi`
+  - BIO #360: `heorhii-narbut`
+
+## 8. Naming-canonical
+
+Per `docs/best-practices/bio-naming-canonical.md`:
+
+- **Slug:** `panas-saksahanskyi`
+- **EN canonical:** Panas Saksahanskyi
+- **UA canonical:** Панас Карпович Саксаганський
+- **Aliases:** Панас Тобілевич; Panas Tobilevych; Panas Saksahansky; IEU form
+  `Saksahansky, Panas`; stage/civil pairing `Саксаганський / Тобілевич`.
+- **Forbidden / source-critical forms:** Russianized or imperial forms should
+  appear only as source labels or alias notes, not as learner-facing identity.
+
+## 9. Image candidates
+
+Per `docs/best-practices/bio-image-rights.md`:
+
+- **Best PD/CC portrait route:** Wikimedia Commons category
+  `Category:Panas Saksahansky`; candidate portrait files include
+  `Panas Saksahansky 1907.png`, `Panas Saksahansky.jpg`,
+  `Панас Саксаганський.png`, and `Саксаганський П.jpg`. Check each file page's
+  license module before YAML use.
+- **Primary-work visual:** Commons file
+  `Саксаганський П. Шантрапа (1914).djvu` can support a public-domain
+  source-reading route after edition and license confirmation.
+- **Context visuals:** Theater of the Coryphaei group images, Baikove grave
+  photographs, or building/institution images linked to the Zankovetska /
+  People's Theater context may work if license-cleared.
+- **Caption caution:** use Ukrainian canonical naming. If Commons metadata
+  carries Russian/Soviet labels, do not copy them uncritically into learner
+  material.
+
+## 10. Sources used
+
+**Tier 1 / Tier 2 encyclopedic and institutional sources:**
+
+- Енциклопедія історії України / Інститут історії України НАН України.
+  "Саксаганський Панас Карпович."
+  https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIu&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Saksahanskyj_P&Z21ID=
+  Accessed 2026-06-30.
+- Internet Encyclopedia of Ukraine. "Saksahansky, Panas."
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CA%5CSaksahanskyPanas.htm.
+  Accessed 2026-06-30.
+- Національна бібліотека України імені Ярослава Мудрого.
+  "До 165-річчя від дня народження Панаса Саксаганського (1859-1940)."
+  https://nlu.org.ua/vustavki.php?id=1297.
+  Accessed 2026-06-30.
+- `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml` for track-level
+  Valuev/Ems context.
+
+**Tier 3 / source and image aids:**
+
+- Wikimedia Commons. "Category:Panas Saksahansky."
+  https://commons.wikimedia.org/wiki/Category:Panas_Saksahansky.
+  Accessed 2026-06-30.
+- Wikimedia Commons. "File:Саксаганський П. Шантрапа (1914).djvu."
+  https://commons.wikimedia.org/wiki/File:%D0%A1%D0%B0%D0%BA%D1%81%D0%B0%D0%B3%D0%B0%D0%BD%D1%81%D1%8C%D0%BA%D0%B8%D0%B9_%D0%9F._%D0%A8%D0%B0%D0%BD%D1%82%D1%80%D0%B0%D0%BF%D0%B0_(1914).djvu.
+  Accessed 2026-06-30.
+- NBUV electronic-library reference for `Шантрапа`:
+  https://search.nbuv.gov.ua/cgi-bin/ua/elib.exe?C21COM=S&I21DBN=UKRLIB&P21DBN=UKRLIB&S21All=%3C.%3EID%3Dref0000012777%3C.%3E&S21CNR=20&S21FMT=fullwebr&S21REF=2&S21STN=1.
+  Accessed 2026-06-30.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric learner-facing framing.
+- [x] No security-service framing without evidence.
+- [x] Birth-date conflict flagged, not smoothed.
+- [x] `малоросійський` treated only as source-critical imperial wording.
+- [x] Soviet titles subordinated to Ukrainian theater-building frame.
+- [x] Cross-track "Existing" paths verified with `test -e`.
+- [x] Naming and image-rights policy checked.
+- [x] Dossier-only slice: no plan YAML, module markdown, activity YAML,
+  vocabulary YAML, generated site MDX, wiki packet, status JSON, or telemetry DB.


### PR DESCRIPTION
## Summary

- Add BIO #359 research dossier for `panas-saksahanskyi`.
- Frame Saksahanskyi through Ukrainian theater craft, Theater of the Coryphaei continuity, the Tobilevych network, and imperial Ukrainian-stage restrictions.
- Preserve the birth-date source conflict instead of silently normalizing it.
- Keep this as a dossier-only base-prep slice: no plan YAML, module markdown, activities, vocabulary, site MDX, wiki packet, status JSON, audit artifact, or telemetry DB.

## Validation

- `git diff --check`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/panas-saksahanskyi.md`
- `npx markdownlint-cli2 docs/research/bio/panas-saksahanskyi.md`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Telemetry

Not applicable: dossier-only slice, no module build. `swarm_used: false`; `swarm_note: solo dossier pass; no swarm used`.

## Reviewer notes

Please check:

- whether the imperial theater-censorship framing is specific enough without inventing a person-specific police case;
- whether the birth-date conflict is represented fairly;
- whether the image/source cautions are sufficient for a later plan/module pass.
