### PR TITLE
docs(bio): add Heorhii Narbut dossier

### DIFF
--- a/docs/research/bio/heorhii-narbut.md
+++ b/docs/research/bio/heorhii-narbut.md
@@ -1,0 +1,259 @@
+# Георгій Іванович Нарбут — Research Dossier
+
+- **Slug:** `heorhii-narbut`
+- **Block:** +77 expansion — Ukrainian theater / visual culture additions
+- **Tier:** 2
+- **Issue:** #2535 / BIO +77 readiness gate; BIO #360
+- **Researcher:** Codex orchestrator (GPT-5)
+- **Completed:** 2026-06-30
+- **Acceptance self-check:**
+  - [x] All 10 sections completed
+  - [x] At least 3 Tier 1/Tier 2 institutional sources cited
+  - [x] Oppression mechanism framed as war/statehood-institution pressure
+  - [x] Primary-source visual/text anchors identified without overquoting
+  - [x] Cross-track links verified with `test -e` on 2026-06-30
+  - [x] Naming-canonical policy applied
+  - [x] Image-rights policy applied
+  - [x] Dossier-only scope observed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Георгій Іванович Нарбут.
+- **Name variants in sources:** ЕІУ gives `Георгій (Юрій) Іванович`;
+  ЕСУ gives `Георгій (Юрій, Єгор) Іванович`. Use `Георгій` /
+  `Heorhii` as project canonical; keep variants in aliases, not as the
+  learner-facing primary form.
+- **Born:** 25 February (9 March) 1886, хутір Нарбутівка, Hlukhiv county,
+  Chernihiv gubernia, Russian Empire; now Sumy oblast, Ukraine.
+- **Died:** 23 May 1920, Kyiv. ЕІУ gives typhus as cause of death; avoid
+  treating death as execution or security-service repression.
+- **Family / network:** brother of poet Volodymyr Narbut; father of artist
+  Danylo Narbut. Sources describe the family as linked to old Cossack-starshyna
+  / noble lineages; keep this as heritage/context, not aristocratic glamour.
+- **Education:** Hlukhiv classical gymnasium; short period at Saint Petersburg
+  University; private art training with Ivan Bilibin / Mstislav Dobuzhinsky
+  circles, the Zvantseva school, and Munich study.
+- **Roles:** graphic artist, illustrator, designer, book artist, heraldry and
+  typography practitioner, professor and rector of the Ukrainian Academy of
+  Arts.
+
+## 2. Oppression mechanism
+
+Narbut is not a BIO case for an invented NKVD/GPU/KGB file. The load-bearing
+pressure is institutional and statehood-related: he gave visual form to Ukrainian
+statehood during the 1917-1921 revolutionary war period, when the institutions
+that needed those symbols were repeatedly threatened, displaced, or absorbed by
+successive regimes.
+
+- **What happened:** Narbut returned to Kyiv in 1917 and worked on Ukrainian
+  state papers, money, stamps, heraldry, and art education while the Ukrainian
+  People's Republic / Ukrainian State project faced war, regime turnover,
+  Bolshevik pressure, White-imperial pressure, and institutional breakdown.
+- **When:** core Kyiv period 1917-1920. UINP records his return to Kyiv in
+  April 1917, work as organizer/professor/rector of the Ukrainian Academy of
+  Arts, and participation in commissions for state-symbol and print culture.
+- **By whom / against what:** not a single police agency in this dossier. The
+  relevant mechanism is the instability of Ukrainian state institutions under
+  war and occupation, plus later Russocentric/Soviet labeling that can recode a
+  Ukrainian statehood designer as merely "imperial Russian" or "Soviet" artist.
+- **Specific institutional pressure:** the Ukrainian Academy of Arts was founded
+  in 1917; EIU's academy article records Narbut as rector from 1918 to 1920.
+  UINP and Suspilne note that by 1919 academy work was fragile enough that he
+  held classes in his apartment after institutional disruption.
+- **What survived:** banknote, stamp, seal, book, alphabet, and Academy visual
+  practices survived as state-memory material. Teach this as design under
+  endangered sovereignty, not as decorative graphic art detached from politics.
+
+## 3. Major works / contributions
+
+- **UNR visual statehood:** UINP calls Narbut a creator of the artistic
+  aesthetics of the UNR and lists projects for monetary signs, act papers,
+  military uniform, diplomatic/ratification documents, diplomas, playing cards,
+  stamps, and paper money.
+- **First Ukrainian state banknote:** the National Bank of Ukraine records that
+  the first banknote of the independent Ukrainian state, the 100-karbovanets
+  state credit note, was emitted on 5 January 1918. NBU specifically identifies
+  Narbut as the artist who inserted the trident into that design.
+- **Money and symbol count caution:** UINP states that 12 monetary signs were
+  issued from his designs in 1918-1920. Some popular summaries give 13 of 24
+  paper signs. Use UINP/NBU wording in module prose unless a numismatic source
+  is checked.
+- **Heraldry and seals:** UINP records his work in commissions for the state
+  coat of arms. Avoid claiming he single-handedly created the modern state coat
+  of arms: UINP's state-symbol page says the first 100-karbovanets banknote made
+  the trident widely known, and that later large/small emblem sketches were
+  approved in Vasyl Krychevskyi's ornamented form.
+- **Ukrainian Academy of Arts:** co-organizer, professor, and rector. EIU records
+  the academy as the first higher art educational institution in Ukraine, with
+  Narbut heading graphic arts and serving as rector from 1918 to 1920.
+- **Ukrainian alphabet / type:** ЕСУ notes that in 1917-1919 he created an
+  alphabet in the traditions of Ukrainian baroque, later remembered as
+  `нарбутівський шрифт`. This is a key language-learning bridge: letters,
+  print culture, and state identity meet directly.
+- **Book art:** ЕСУ and ЕІУ list illustrations and designs for Andersen,
+  Kotliarevsky's `Енеїда`, Vynnychenko works, heraldic publications, magazines
+  such as `Мистецтво`, and Ukrainian-history materials.
+
+## 4. Primary-source quote / visual anchors
+
+For Narbut, the strongest primary-source anchors are visual artifacts. Do not
+quote long passages from modern articles when the lesson can show/read the
+object itself.
+
+- **100-karbovanets banknote:** use NBU/UINP context for the 1918 state credit
+  note and trident placement. This is the cleanest statehood-design anchor.
+- **UNR stamps / shahy:** candidate source-reading on how a stamp becomes both
+  postal, monetary, and symbolic evidence during state formation.
+- **`Українська абетка`:** use as a typography-reading anchor: letterforms,
+  baroque ornament, book design, and the politics of script.
+- **Signature / self-fashioning:** ЕІУ records a 1912 self-description using
+  the word `Мазепинец`; use only as a short source-critical quote after checking
+  scan context. It is valuable for discussing how Narbut staged Cossack and
+  Mazepa-era memory inside imperial Petersburg.
+- **Lupa Hrabuzdov material:** humorous/satirical persona is optional advanced
+  material. Keep it secondary to state-symbol and typography anchors.
+
+## 5. Language register
+
+- **Register:** visual-culture, heraldry, book-art, typography, statehood, and
+  museum/object description.
+- **CEFR readiness:** B2 for biography + "what is on the banknote/stamp";
+  C1 for debates about state symbols, Ukrainian baroque, heraldry, and
+  Russocentric/Soviet relabeling.
+- **Learner lexicon:** `графік`, `ілюстратор`, `герб`, `печатка`, `тризуб`,
+  `банкнота`, `кредитовий білет`, `грошовий знак`, `поштова марка`, `шрифт`,
+  `абетка`, `орнамент`, `геральдика`, `композиція`, `віньєтка`,
+  `державність`.
+- **Stylistic features:** high-density noun phrases and art-history adjectives;
+  many source titles preserve old orthography or Russian-imperial titles.
+  Learner-facing prose should explain the title context rather than normalize
+  it silently.
+
+## 6. Contested points
+
+- **Heorhii / Yurii / Yegor:** source aliases reflect multilingual and imperial
+  documentation. Project canonical should stay `Георгій Іванович Нарбут` /
+  `Heorhii Narbut`; Russian forms belong only in aliases/source-critical notes.
+- **"Designed the coat of arms" overclaim:** Narbut's trident banknote and
+  heraldic work are essential, but the official modern emblem story also
+  involves Vasyl Krychevskyi and government commissions. State this as a design
+  ecology, not a lone-genius myth.
+- **Petersburg period:** he trained and worked in Saint Petersburg and the
+  `Мир искусства` milieu. Do not let that become a Russian-cultural ownership
+  frame. ЕІУ stresses his repeated returns to Hlukhiv, Ukrainian antiquities,
+  baroque, ornament, and heraldry.
+- **Soviet endpoint:** some metadata calls him a Soviet or Russian Empire
+  painter. The dossier should treat 1920 Kyiv and Soviet-era labels as context,
+  not learner-facing identity.
+- **Death:** typhus in Kyiv, not execution. The tragedy belongs to wartime
+  disease and institutional collapse; do not invent martyrdom.
+
+## 7. Cross-track links
+
+- **Existing BIO / visual-culture links (VERIFIED `test -e` on 2026-06-30):**
+  - `docs/research/bio/vasyl-krychevskyi.md`
+  - `curriculum/l2-uk-en/plans/bio/vasyl-krychevskyi.yaml`
+  - `docs/research/bio/mykhailo-boichuk.md`
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-boichuk.yaml`
+  - `docs/research/bio/oleksandr-bohomazov.md`
+  - `curriculum/l2-uk-en/plans/bio/oleksandr-bohomazov.yaml`
+  - `docs/research/bio/mykhailo-hrushevskyi.md`
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-hrushevskyi.yaml`
+- **Existing HIST / ISTORIO / language links (VERIFIED `test -e` on 2026-06-30):**
+  - `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml`
+  - `curriculum/l2-uk-en/plans/hist/skoropadskyi.yaml`
+  - `curriculum/l2-uk-en/plans/hist/symon-petliura-revolution.yaml`
+  - `curriculum/l2-uk-en/plans/hist/bilshovytsko-ukrainska-viyna.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/universaly-unr.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/unr-vybory.yaml`
+  - `curriculum/l2-uk-en/plans/lit-war/unr-war-literature.yaml`
+  - `curriculum/l2-uk-en/plans/c1/obrazotvorche-mystetstvo-2.yaml`
+  - `curriculum/l2-uk-en/plans/c1/checkpoint-fine-arts.yaml`
+  - `curriculum/l2-uk-en/plans/oes/numbers-currency.yaml`
+- **Candidate / not yet existing in this slice:**
+  - `curriculum/l2-uk-en/plans/bio/heorhii-narbut.yaml`
+  - site MDX / wiki article for `heorhii-narbut`
+  - BIO #361 `oleksandr-murashko`
+  - BIO #362 `fedir-krychevskyi`
+
+## 8. Naming-canonical
+
+Per `docs/best-practices/bio-naming-canonical.md`:
+
+- **Slug:** `heorhii-narbut`
+- **EN canonical:** Heorhii Narbut
+- **UA canonical:** Георгій Іванович Нарбут
+- **Aliases:** Юрій Нарбут; Єгор Нарбут; Heorhiy Narbut; Georgy Narbut;
+  George Narbut; Yurii Narbut; Jerzy Narbut; Георгій (Юрій) Іванович Нарбут.
+- **Forbidden / source-critical forms:** Russianized `Георгий Иванович Нарбут`,
+  `Егор Нарбут`, or `Georgy Narbut` should not be used as the module's own
+  identity label. They may appear only in alias lists or when discussing source
+  metadata.
+
+## 9. Image candidates
+
+Per `docs/best-practices/bio-image-rights.md`:
+
+- **Best PD/CC portrait route:** Wikimedia Commons category
+  `Category:Heorhiy Narbut`; use a portrait only after checking the file-level
+  license tag, not just category metadata.
+- **Primary object images:** first Ukrainian state banknote / 100 karbovanets,
+  UNR stamps or shahy, pages from `Українська абетка`, and heraldic/seal
+  sketches. These are often stronger than a portrait for this figure.
+- **Institutional context images:** Ukrainian Academy of Arts founder photo,
+  Narbut-associated Academy documents, or Kyiv / Hlukhiv context images if
+  rights-cleared.
+- **Caption caution:** avoid copying Commons descriptions that identify him
+  first as Russian/Soviet. Use Ukrainian canonical naming and make any source
+  label a source-critical note.
+
+## 10. Sources used
+
+**Tier 1 / Tier 2 encyclopedic and institutional sources:**
+
+- Енциклопедія історії України / Інститут історії України НАН України.
+  "Нарбут Георгій (Юрій) Іванович."
+  https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIu&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Narbut_H&Z21ID=
+  Accessed 2026-06-30.
+- Енциклопедія Сучасної України. "Нарбут Георгій Іванович."
+  https://esu.com.ua/article-71305. Accessed 2026-06-30.
+- Енциклопедія історії України / Інститут історії України НАН України.
+  "Українська академія мистецтв."
+  https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=DOP&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Ukrainska_mystetstv&Z21ID=
+  Accessed 2026-06-30.
+- Український інститут національної пам'яті. "1886 - народився Георгій
+  Нарбут, художник."
+  https://uinp.gov.ua/istorychnyy-kalendar/berezen/9/1886-narodyvsya-georgiy-narbut-hudozhnyk.
+  Accessed 2026-06-30.
+- Український інститут національної пам'яті. "Нарбут Георгій."
+  https://unr.uinp.gov.ua/figures/narbut-georgiy. Accessed 2026-06-30.
+- Національний банк України. "Історія української гривні."
+  https://bank.gov.ua/ua/uah/uah-history. Accessed 2026-06-30.
+- Український інститут національної пам'яті. "Державна символіка."
+  https://unr.uinp.gov.ua/photohistory/derzhavna-simvolika.
+  Accessed 2026-06-30.
+
+**Tier 3 / image and reception aids:**
+
+- Wikimedia Commons. "Category:Heorhiy Narbut."
+  https://commons.wikimedia.org/wiki/Category:Heorhiy_Narbut.
+  Accessed 2026-06-30.
+- Суспільне Культура. "Інтелігентське товариство на Золотих воротах..."
+  https://suspilne.media/culture/698744-inteligentske-tovaristvo-na-zolotih-vorotah-tvorec-vigadanogo-personaza-j-gerba-ukrainskoi-derzavi-georgij-narbut/.
+  Accessed 2026-06-30.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric learner-facing framing.
+- [x] No security-service case invented.
+- [x] State-symbol claims kept precise; no lone-genius emblem overclaim.
+- [x] Russian/Soviet metadata treated as source-critical, not identity.
+- [x] Death framed as typhus during wartime instability, not execution.
+- [x] Cross-track "Existing" paths verified with `test -e`.
+- [x] Naming and image-rights policy checked.
+- [x] Dossier-only slice: no plan YAML, module markdown, activity YAML,
+  vocabulary YAML, generated site MDX, wiki packet, status JSON, or telemetry DB.


### PR DESCRIPTION
## Summary

- Add BIO #360 research dossier for `heorhii-narbut`.
- Frame Narbut through UNR visual statehood, Ukrainian Academy institution-building, typography, heraldry, banknote/stamp design, and Ukrainian baroque graphic memory.
- Avoid invented security-service framing; handle oppression context as wartime statehood-institution pressure and later Russocentric/Soviet metadata recoding.
- Keep this as a dossier-only base-prep slice: no plan YAML, module markdown, activities, vocabulary, site MDX, wiki packet, status JSON, audit artifact, or telemetry DB.

## Validation

- `git diff --check`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/heorhii-narbut.md`
- `npx markdownlint-cli2 docs/research/bio/heorhii-narbut.md`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Telemetry

Not applicable: dossier-only slice, no module build. `swarm_used: false`; `swarm_note: solo dossier pass; no swarm used`.

## Reviewer notes

Please check:

- whether the statehood/institutional-pressure framing is specific enough without inventing a police case;
- whether the state-emblem / trident / banknote claims avoid overclaiming Narbut as sole designer;
- whether the Heorhii/Yurii/Yegor alias handling follows naming-canonical policy;
- whether the image/object candidates are rights-cautioned enough for later plan/module work.
