### PR TITLE
feat(atlas): add static lexicon API status

### DIFF
--- a/docs/runbooks/word-atlas-static-api.md
+++ b/docs/runbooks/word-atlas-static-api.md
@@ -1,0 +1,38 @@
+# Word Atlas Static API Contract
+
+The learner site is GitHub Pages/static-first. Atlas runtime data is exposed as
+static JSON, not a live backend service.
+
+## Canonical Endpoints
+
+- `/api/lexicon/status.json` — status and counts across Atlas search/browse,
+  manifest hydration, Daily Word, Practice, cloze, and source-inventory
+  admission.
+- `/api/lexicon/search-index.json` — compact typeahead/search rows.
+- `/api/lexicon/daily-pool.json` — Daily Word pool.
+
+The status payload also points at the existing static practice and browse
+assets:
+
+- `/lexicon/browse/{letter}.json`
+- `/lexicon/practice-index.{level}.json`
+- `/lexicon/practice-lexemes.{level}.json`
+- `/lexicon/practice-cloze.{level}.json`
+
+## Contract Checks
+
+Consumers should treat `status: "ok"` as the normal state. A warning means at
+least one public surface drifted, such as search and browse counts disagreeing,
+practice deck versions splitting, Daily Word becoming empty, or the hydrated
+manifest no longer matching the public Atlas count.
+
+`sourceInventory` counts only become non-null when the build has hydrated the
+release manifest. Missing `surface_admission` remains false; source-inventory
+growth is Atlas browse/search only until a reviewed decision admits Daily Word,
+Practice, or cloze.
+
+## Deployment Rule
+
+Do not add FastAPI routes for public Atlas learner data unless the deployment
+target changes away from GitHub Pages or the route is explicitly local/admin
+only. Public learner data must stay available as static JSON.

--- a/site/src/lexicon/AtlasRuntimeStatus.astro
+++ b/site/src/lexicon/AtlasRuntimeStatus.astro
@@ -1,0 +1,232 @@
+---
+const statusUrl = "/api/lexicon/status.json";
+---
+
+<section
+  class="atlas-runtime-panel"
+  aria-labelledby="atlas-runtime-title"
+  data-atlas-runtime
+  data-status-url={statusUrl}
+>
+  <div class="atlas-runtime-heading">
+    <span class="atlas-runtime-badge">Дані</span>
+    <h2 id="atlas-runtime-title">Покриття Атласу</h2>
+    <p data-runtime-status>Завантажуємо поточний стан...</p>
+  </div>
+
+  <dl class="atlas-runtime-grid" aria-live="polite">
+    <div class="atlas-runtime-card">
+      <dt>Публічний Атлас</dt>
+      <dd data-runtime-value="publicAtlas">-</dd>
+      <p data-runtime-detail="publicAtlas">Пошук і перегляд</p>
+    </div>
+    <div class="atlas-runtime-card">
+      <dt>Маніфест</dt>
+      <dd data-runtime-value="manifest">-</dd>
+      <p data-runtime-detail="manifest">Маніфест релізу</p>
+    </div>
+    <div class="atlas-runtime-card">
+      <dt>Слова дня</dt>
+      <dd data-runtime-value="daily">-</dd>
+      <p data-runtime-detail="daily">Рівні A1-B1</p>
+    </div>
+    <div class="atlas-runtime-card">
+      <dt>Практика</dt>
+      <dd data-runtime-value="practice">-</dd>
+      <p data-runtime-detail="practice">Лексеми в деці</p>
+    </div>
+    <div class="atlas-runtime-card">
+      <dt>Пропуски</dt>
+      <dd data-runtime-value="cloze">-</dd>
+      <p data-runtime-detail="cloze">Перевірені речення</p>
+    </div>
+    <div class="atlas-runtime-card">
+      <dt>Джерела</dt>
+      <dd data-runtime-value="sourceInventory">-</dd>
+      <p data-runtime-detail="sourceInventory">Слова дня / практика / пропуски</p>
+    </div>
+  </dl>
+</section>
+
+<script>
+  const numberFormatter = new Intl.NumberFormat("uk-UA");
+  const formatCount = (value) =>
+    typeof value === "number" ? numberFormatter.format(value) : "-";
+  const formatBytes = (value) =>
+    typeof value === "number" ? `${(value / (1024 * 1024)).toFixed(1)} MB` : "-";
+
+  function setRuntimeText(root, key, value) {
+    const node = root.querySelector(`[data-runtime-value="${key}"]`);
+    if (node) node.textContent = value;
+  }
+
+  function setRuntimeDetail(root, key, value) {
+    const node = root.querySelector(`[data-runtime-detail="${key}"]`);
+    if (node) node.textContent = value;
+  }
+
+  function renderRuntimeStatus(root, status) {
+    setRuntimeText(root, "publicAtlas", formatCount(status.publicAtlas.searchEntries));
+    setRuntimeDetail(
+      root,
+      "publicAtlas",
+      `${formatCount(status.publicAtlas.browseEntries)} перегляд · ${status.publicAtlas.browseShards} шардів`,
+    );
+
+    setRuntimeText(root, "manifest", formatCount(status.manifest.entries));
+    setRuntimeDetail(
+      root,
+      "manifest",
+      status.manifest.hydrated
+        ? `${formatCount(status.manifest.publicLexemes)} публічних · ${formatCount(
+            status.manifest.grammarTermRows,
+          )} внутрішніх`
+        : `${formatBytes(status.manifest.jsonBytes)} pinned`,
+    );
+
+    setRuntimeText(root, "daily", formatCount(status.daily.poolEntries));
+    setRuntimeDetail(root, "daily", "Навчальна добірка");
+
+    setRuntimeText(root, "practice", formatCount(status.practice.totalLexemes));
+    setRuntimeDetail(
+      root,
+      "practice",
+      status.practice.deckVersions.length
+        ? status.practice.deckVersions.join(", ")
+        : "Без версії",
+    );
+
+    setRuntimeText(root, "cloze", formatCount(status.cloze.totalItems));
+    setRuntimeDetail(
+      root,
+      "cloze",
+      `${formatCount(status.cloze.sourceRows)} джерел · ${formatCount(
+        status.cloze.reviewedSourceRows,
+      )} дозволено`,
+    );
+
+    setRuntimeText(root, "sourceInventory", formatCount(status.sourceInventory.atlasRows));
+    setRuntimeDetail(
+      root,
+      "sourceInventory",
+      `${formatCount(status.sourceInventory.dailyAdmitted)} / ${formatCount(
+        status.sourceInventory.practiceAdmitted,
+      )} / ${formatCount(status.sourceInventory.clozeAdmitted)}`,
+    );
+
+    const statusNode = root.querySelector("[data-runtime-status]");
+    if (statusNode) {
+      statusNode.textContent =
+        status.status === "ok"
+          ? "Дані узгоджені: пошук, перегляд, Слова дня і практика синхронізовані."
+          : "Дані потребують перевірки: одна з поверхонь Атласу не збігається.";
+    }
+    root.dataset.runtimeLoaded = "true";
+  }
+
+  for (const root of document.querySelectorAll("[data-atlas-runtime]")) {
+    const endpoint = root.dataset.statusUrl || "/api/lexicon/status.json";
+    fetch(endpoint)
+      .then((response) => {
+        if (!response.ok) throw new Error(`Atlas status failed: ${response.status}`);
+        return response.json();
+      })
+      .then((status) => renderRuntimeStatus(root, status))
+      .catch(() => {
+        const statusNode = root.querySelector("[data-runtime-status]");
+        if (statusNode) statusNode.textContent = "Стан Атласу зараз недоступний.";
+        root.dataset.runtimeLoaded = "false";
+      });
+  }
+</script>
+
+<style>
+  .atlas-runtime-panel {
+    width: min(960px, calc(100% - 2rem));
+    margin: 0 auto 4rem;
+    padding: 1.25rem 0 0;
+    border-top: 1px solid var(--lu-border);
+  }
+
+  .atlas-runtime-heading {
+    text-align: left;
+  }
+
+  .atlas-runtime-badge {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.65rem;
+    padding: 0 0.55rem;
+    border-radius: 4px;
+    background: var(--lu-state-active);
+    color: var(--lu-primary);
+    font-size: 0.72rem;
+    font-weight: 900;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .atlas-runtime-heading h2 {
+    margin: 0.65rem 0 0;
+    color: var(--lu-text);
+    font-size: 1.45rem;
+    line-height: 1.2;
+  }
+
+  .atlas-runtime-heading p {
+    margin: 0.45rem 0 0;
+    color: var(--lu-text-muted);
+    font-size: 0.95rem;
+    line-height: 1.55;
+  }
+
+  .atlas-runtime-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.8rem;
+    margin: 1rem 0 0;
+  }
+
+  .atlas-runtime-card {
+    min-width: 0;
+    padding: 0.95rem;
+    border: 1px solid var(--lu-border);
+    border-radius: 8px;
+    background: var(--lu-surface);
+  }
+
+  .atlas-runtime-card dt {
+    color: var(--lu-text-muted);
+    font-size: 0.75rem;
+    font-weight: 900;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .atlas-runtime-card dd {
+    margin: 0.35rem 0 0;
+    color: var(--lu-text);
+    font-size: 1.55rem;
+    font-weight: 900;
+    line-height: 1;
+  }
+
+  .atlas-runtime-card p {
+    margin: 0.45rem 0 0;
+    color: var(--lu-text-muted);
+    font-size: 0.82rem;
+    line-height: 1.35;
+  }
+
+  @media (max-width: 760px) {
+    .atlas-runtime-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 520px) {
+    .atlas-runtime-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/site/src/lib/lexicon/runtime-contract.ts
+++ b/site/src/lib/lexicon/runtime-contract.ts
@@ -1,0 +1,239 @@
+// Matches the committed static practice shard set and
+// scripts/audit/check_static_practice_assets.py::DEFAULT_LEVELS.
+export const PRACTICE_LEVELS = ["A1", "A2", "B1", "B2", "C1"] as const;
+
+export type PracticeLevel = (typeof PRACTICE_LEVELS)[number];
+
+type JsonObject = Record<string, unknown>;
+
+export interface LexiconRuntimeStatus {
+  schema: "atlas-runtime-status";
+  schemaVersion: 1;
+  generatedAt: string;
+  status: "ok" | "warning";
+  endpoints: {
+    status: string;
+    searchIndex: string;
+    dailyPool: string;
+    browseShardTemplate: string;
+    practiceIndexTemplate: string;
+    practiceLexemesTemplate: string;
+    practiceClozeTemplate: string;
+  };
+  manifest: {
+    hydrated: boolean;
+    entries: number | null;
+    publicLexemes: number | null;
+    grammarTermRows: number | null;
+    version: string | null;
+    releaseTag: string | null;
+    generatedAt: string | null;
+    jsonBytes: number | null;
+    jsonSha256: string | null;
+  };
+  publicAtlas: {
+    searchEntries: number;
+    browseEntries: number;
+    browseShards: number;
+    browseLetters: number;
+  };
+  daily: {
+    poolEntries: number;
+  };
+  practice: {
+    totalLexemes: number;
+    deckVersions: string[];
+    levels: Record<PracticeLevel, PracticeLevelStatus>;
+  };
+  cloze: {
+    totalItems: number;
+    sourceRows: number;
+    reviewedSourceRows: number;
+  };
+  sourceInventory: {
+    atlasRows: number | null;
+    dailyAdmitted: number | null;
+    practiceAdmitted: number | null;
+    clozeAdmitted: number | null;
+  };
+  checks: {
+    searchMatchesBrowse: boolean;
+    manifestCoversPublic: boolean | null;
+    singlePracticeDeckVersion: boolean;
+  };
+}
+
+export interface PracticeLevelStatus {
+  lexemes: number;
+  cloze: number;
+  clozeEligibleLexemes: number;
+  clozeCoverage: number;
+}
+
+interface BuildRuntimeStatusInput {
+  generatedAt?: string;
+  manifest?: unknown;
+  manifestPointer?: unknown;
+  searchIndex?: unknown;
+  browseMeta?: unknown;
+  dailyPool?: unknown;
+  practiceIndexes?: Partial<Record<PracticeLevel, unknown>>;
+  clozeSources?: unknown;
+  reviewedSources?: unknown;
+}
+
+function asObject(value: unknown): JsonObject {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonObject)
+    : {};
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function asOptionalNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function manifestEntries(manifest: unknown): JsonObject[] | null {
+  const payload = asObject(manifest);
+  const entries = asArray(payload.entries);
+  if (!entries.length) return null;
+  return entries.filter((entry): entry is JsonObject => {
+    return Boolean(entry) && typeof entry === "object" && !Array.isArray(entry);
+  });
+}
+
+function surfaceAdmission(entry: JsonObject, surface: "daily" | "practice" | "cloze"): boolean {
+  return asObject(entry.surface_admission)[surface] === true;
+}
+
+function practiceLevelStatus(indexPayload: unknown): PracticeLevelStatus {
+  const index = asObject(indexPayload);
+  const counts = asObject(index.counts);
+  return {
+    lexemes: asNumber(counts.lexemes),
+    cloze: asNumber(counts.cloze),
+    clozeEligibleLexemes: asNumber(counts.clozeEligibleLexemes),
+    clozeCoverage: asNumber(counts.clozeCoverage),
+  };
+}
+
+function reviewedSourceCount(payload: unknown): number {
+  const obj = asObject(payload);
+  if (Array.isArray(obj.reviewed)) return obj.reviewed.length;
+  return asArray(payload).length;
+}
+
+export function buildLexiconRuntimeStatus(input: BuildRuntimeStatusInput): LexiconRuntimeStatus {
+  const entries = manifestEntries(input.manifest);
+  const manifest = asObject(input.manifest);
+  const pointer = asObject(input.manifestPointer);
+  const searchEntries = asArray(input.searchIndex).length;
+  const browseMeta = asObject(input.browseMeta);
+  const letterCounts = asObject(browseMeta.letterCounts);
+  const browseEntries = asNumber(browseMeta.total);
+  const browseLetters = Object.keys(letterCounts).length;
+  const browseShards = Object.values(letterCounts).filter((count) => asNumber(count) > 0).length;
+  const dailyPoolEntries = asArray(input.dailyPool).length;
+  const practiceLevels = {} as Record<PracticeLevel, PracticeLevelStatus>;
+  const deckVersions = new Set<string>();
+
+  for (const level of PRACTICE_LEVELS) {
+    const index = asObject(input.practiceIndexes?.[level]);
+    practiceLevels[level] = practiceLevelStatus(index);
+    const deckVersion = asString(index.deckVersion);
+    if (deckVersion) deckVersions.add(deckVersion);
+  }
+
+  const totalPracticeLexemes = Object.values(practiceLevels).reduce(
+    (sum, row) => sum + row.lexemes,
+    0,
+  );
+  const totalCloze = Object.values(practiceLevels).reduce((sum, row) => sum + row.cloze, 0);
+  const publicLexemes = entries
+    ? entries.filter((entry) => entry.pos !== "grammar term").length
+    : null;
+  const sourceInventoryRows = entries
+    ? entries.filter((entry) => entry.primary_source === "source_inventory_grow")
+    : null;
+  const searchMatchesBrowse = searchEntries === browseEntries;
+  const manifestCoversPublic =
+    publicLexemes === null ? null : publicLexemes === searchEntries && publicLexemes === browseEntries;
+  const singlePracticeDeckVersion = deckVersions.size <= 1;
+  const status =
+    searchMatchesBrowse &&
+    (manifestCoversPublic ?? true) &&
+    singlePracticeDeckVersion &&
+    dailyPoolEntries > 0 &&
+    totalPracticeLexemes > 0
+      ? "ok"
+      : "warning";
+
+  return {
+    schema: "atlas-runtime-status",
+    schemaVersion: 1,
+    generatedAt: input.generatedAt ?? new Date().toISOString(),
+    status,
+    endpoints: {
+      status: "/api/lexicon/status.json",
+      searchIndex: "/api/lexicon/search-index.json",
+      dailyPool: "/api/lexicon/daily-pool.json",
+      browseShardTemplate: "/lexicon/browse/{letter}.json",
+      practiceIndexTemplate: "/lexicon/practice-index.{level}.json",
+      practiceLexemesTemplate: "/lexicon/practice-lexemes.{level}.json",
+      practiceClozeTemplate: "/lexicon/practice-cloze.{level}.json",
+    },
+    manifest: {
+      hydrated: entries !== null,
+      entries: entries?.length ?? null,
+      publicLexemes,
+      grammarTermRows: entries && publicLexemes !== null ? entries.length - publicLexemes : null,
+      version: asString(manifest.version) ?? asString(pointer.manifest_version),
+      releaseTag: asString(pointer.release_tag),
+      generatedAt: asString(manifest.generated_at) ?? asString(pointer.generated_at),
+      jsonBytes: asOptionalNumber(pointer.json_bytes),
+      jsonSha256: asString(pointer.json_sha256),
+    },
+    publicAtlas: {
+      searchEntries,
+      browseEntries,
+      browseShards,
+      browseLetters,
+    },
+    daily: {
+      poolEntries: dailyPoolEntries,
+    },
+    practice: {
+      totalLexemes: totalPracticeLexemes,
+      deckVersions: [...deckVersions].sort(),
+      levels: practiceLevels,
+    },
+    cloze: {
+      totalItems: totalCloze,
+      sourceRows: asArray(input.clozeSources).length,
+      reviewedSourceRows: reviewedSourceCount(input.reviewedSources),
+    },
+    sourceInventory: {
+      atlasRows: sourceInventoryRows?.length ?? null,
+      dailyAdmitted: sourceInventoryRows?.filter((entry) => surfaceAdmission(entry, "daily")).length ?? null,
+      practiceAdmitted:
+        sourceInventoryRows?.filter((entry) => surfaceAdmission(entry, "practice")).length ?? null,
+      clozeAdmitted: sourceInventoryRows?.filter((entry) => surfaceAdmission(entry, "cloze")).length ?? null,
+    },
+    checks: {
+      searchMatchesBrowse,
+      manifestCoversPublic,
+      singlePracticeDeckVersion,
+    },
+  };
+}

--- a/site/src/pages/api/lexicon/daily-pool.json.ts
+++ b/site/src/pages/api/lexicon/daily-pool.json.ts
@@ -1,0 +1,12 @@
+import type { APIRoute } from "astro";
+import pool from "../../../data/lexicon-daily-pool.json";
+
+export const prerender = true;
+
+export const GET: APIRoute = () =>
+  new Response(JSON.stringify(pool), {
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });

--- a/site/src/pages/api/lexicon/search-index.json.ts
+++ b/site/src/pages/api/lexicon/search-index.json.ts
@@ -1,0 +1,12 @@
+import type { APIRoute } from "astro";
+import index from "../../../data/lexicon-search-index.json";
+
+export const prerender = true;
+
+export const GET: APIRoute = () =>
+  new Response(JSON.stringify(index), {
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });

--- a/site/src/pages/api/lexicon/status.json.ts
+++ b/site/src/pages/api/lexicon/status.json.ts
@@ -1,0 +1,46 @@
+import type { APIRoute } from "astro";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  PRACTICE_LEVELS,
+  buildLexiconRuntimeStatus,
+  type PracticeLevel,
+} from "../../../lib/lexicon/runtime-contract";
+
+export const prerender = true;
+
+const JSON_HEADERS = {
+  "Content-Type": "application/json; charset=utf-8",
+  "Cache-Control": "public, max-age=3600",
+};
+
+function readJson(relativePath: string): unknown {
+  return JSON.parse(readFileSync(resolve(process.cwd(), relativePath), "utf8"));
+}
+
+function readOptionalJson(relativePath: string): unknown {
+  const path = resolve(process.cwd(), relativePath);
+  return existsSync(path) ? JSON.parse(readFileSync(path, "utf8")) : undefined;
+}
+
+export const GET: APIRoute = () => {
+  const practiceIndexes: Partial<Record<PracticeLevel, unknown>> = {};
+  for (const level of PRACTICE_LEVELS) {
+    practiceIndexes[level] = readOptionalJson(`public/lexicon/practice-index.${level}.json`);
+  }
+
+  const status = buildLexiconRuntimeStatus({
+    manifest: readOptionalJson("src/data/lexicon-manifest.json"),
+    manifestPointer: readJson("src/data/lexicon-manifest.pointer.json"),
+    searchIndex: readJson("src/data/lexicon-search-index.json"),
+    browseMeta: readJson("src/data/lexicon-browse-meta.json"),
+    dailyPool: readJson("src/data/lexicon-daily-pool.json"),
+    practiceIndexes,
+    clozeSources: readJson("src/data/lexicon-practice-cloze-sources.json"),
+    reviewedSources: readJson("src/data/lexicon-practice-reviewed-sources.json"),
+  });
+
+  return new Response(JSON.stringify(status), {
+    headers: JSON_HEADERS,
+  });
+};

--- a/site/src/pages/lexicon/index.astro
+++ b/site/src/pages/lexicon/index.astro
@@ -3,6 +3,7 @@
  * Атлас слів (Лексикон) landing page.
  */
 import CourseLayout from "../../layouts/CourseLayout.astro";
+import AtlasRuntimeStatus from "../../lexicon/AtlasRuntimeStatus.astro";
 import AtlasTypeahead from "../../lexicon/AtlasTypeahead.astro";
 
 const frontmatter = {
@@ -35,6 +36,8 @@ const frontmatter = {
       />
       <a class="lexicon-browse-link" href="/lexicon/browse/">Перегляд А–Я →</a>
     </section>
+
+    <AtlasRuntimeStatus />
   </div>
 </CourseLayout>
 

--- a/site/tests/unit/lexicon-api-routes.test.ts
+++ b/site/tests/unit/lexicon-api-routes.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+import { GET as getDailyPool } from "@site/src/pages/api/lexicon/daily-pool.json";
+import { GET as getSearchIndex } from "@site/src/pages/api/lexicon/search-index.json";
+import { GET as getStatus } from "@site/src/pages/api/lexicon/status.json";
+
+async function routeJson<T>(route: typeof getStatus): Promise<T> {
+  const response = await route({} as Parameters<typeof route>[0]);
+  expect(response).toBeInstanceOf(Response);
+  expect(response.headers.get("Content-Type")).toContain("application/json");
+  return (await response.json()) as T;
+}
+
+describe("lexicon static API routes", () => {
+  test("emits runtime status for public Atlas, Daily Word, and Practice", async () => {
+    const search = await routeJson<unknown[]>(getSearchIndex);
+    const daily = await routeJson<unknown[]>(getDailyPool);
+    const status = await routeJson<{
+      schema: string;
+      status: string;
+      publicAtlas: { searchEntries: number; browseEntries: number };
+      daily: { poolEntries: number };
+      practice: { totalLexemes: number };
+      checks: { searchMatchesBrowse: boolean; singlePracticeDeckVersion: boolean };
+      endpoints: { searchIndex: string; dailyPool: string };
+    }>(getStatus);
+
+    expect(status.schema).toBe("atlas-runtime-status");
+    expect(status.status).toBe("ok");
+    expect(status.publicAtlas.searchEntries).toBe(search.length);
+    expect(status.publicAtlas.searchEntries).toBe(status.publicAtlas.browseEntries);
+    expect(status.daily.poolEntries).toBe(daily.length);
+    expect(status.practice.totalLexemes).toBeGreaterThan(0);
+    expect(status.checks.searchMatchesBrowse).toBe(true);
+    expect(status.checks.singlePracticeDeckVersion).toBe(true);
+    expect(status.endpoints.searchIndex).toBe("/api/lexicon/search-index.json");
+    expect(status.endpoints.dailyPool).toBe("/api/lexicon/daily-pool.json");
+  });
+
+  test("aliases search and Daily Word data under /api/lexicon", async () => {
+    const search = await routeJson<unknown[]>(getSearchIndex);
+    const daily = await routeJson<unknown[]>(getDailyPool);
+
+    expect(search.length).toBeGreaterThan(5000);
+    expect(daily.length).toBeGreaterThanOrEqual(250);
+  });
+});

--- a/site/tests/unit/lexicon-runtime-contract.test.ts
+++ b/site/tests/unit/lexicon-runtime-contract.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "vitest";
+import {
+  PRACTICE_LEVELS,
+  buildLexiconRuntimeStatus,
+  type PracticeLevel,
+} from "@site/src/lib/lexicon/runtime-contract";
+
+function practiceIndexes(overrides: Partial<Record<PracticeLevel, unknown>> = {}) {
+  return Object.fromEntries(
+    PRACTICE_LEVELS.map((level) => [
+      level,
+      {
+        deckVersion: "atlas-practice-v1-test",
+        counts: {
+          lexemes: level === "A1" ? 2 : 0,
+          cloze: level === "A1" ? 1 : 0,
+          clozeEligibleLexemes: level === "A1" ? 1 : 0,
+          clozeCoverage: level === "A1" ? 0.5 : 0,
+        },
+        ...((overrides[level] as Record<string, unknown> | undefined) ?? {}),
+      },
+    ]),
+  ) as Record<PracticeLevel, unknown>;
+}
+
+describe("buildLexiconRuntimeStatus", () => {
+  test("summarizes the static Atlas contract", () => {
+    const status = buildLexiconRuntimeStatus({
+      generatedAt: "2026-06-30T00:00:00.000Z",
+      manifest: {
+        version: "0.1",
+        generated_at: "2026-06-29T00:00:00Z",
+        entries: [
+          { lemma: "дім", url_slug: "дім", primary_source: "built_vocabulary" },
+          { lemma: "ананас", url_slug: "ананас", primary_source: "source_inventory_grow" },
+          {
+            lemma: "тигр",
+            url_slug: "тигр",
+            primary_source: "source_inventory_grow",
+            surface_admission: { daily: true, practice: false, cloze: false },
+          },
+          { lemma: "pluralia tantum", url_slug: "pluralia-tantum", pos: "grammar term" },
+        ],
+      },
+      manifestPointer: {
+        release_tag: "atlas-manifest",
+        json_bytes: 42,
+        json_sha256: "abc123",
+      },
+      searchIndex: [{ l: "дім" }, { l: "ананас" }, { l: "тигр" }],
+      browseMeta: {
+        total: 3,
+        letterCounts: { А: 2, Д: 1, И: 0 },
+      },
+      dailyPool: [{ lemma: "дім" }],
+      practiceIndexes: practiceIndexes(),
+      clozeSources: [{ lemma: "дім" }],
+      reviewedSources: { reviewed: [{ path: "curriculum/l2-uk-en/a1/vocabulary.yaml" }] },
+    });
+
+    expect(status.schema).toBe("atlas-runtime-status");
+    expect(status.status).toBe("ok");
+    expect(status.manifest.entries).toBe(4);
+    expect(status.manifest.publicLexemes).toBe(3);
+    expect(status.manifest.grammarTermRows).toBe(1);
+    expect(status.publicAtlas.searchEntries).toBe(3);
+    expect(status.publicAtlas.browseEntries).toBe(3);
+    expect(status.publicAtlas.browseShards).toBe(2);
+    expect(status.daily.poolEntries).toBe(1);
+    expect(status.practice.totalLexemes).toBe(2);
+    expect(status.cloze.totalItems).toBe(1);
+    expect(status.cloze.sourceRows).toBe(1);
+    expect(status.cloze.reviewedSourceRows).toBe(1);
+    expect(status.sourceInventory.atlasRows).toBe(2);
+    expect(status.sourceInventory.dailyAdmitted).toBe(1);
+    expect(status.sourceInventory.practiceAdmitted).toBe(0);
+    expect(status.checks.searchMatchesBrowse).toBe(true);
+    expect(status.checks.manifestCoversPublic).toBe(true);
+  });
+
+  test("warns when static surfaces drift", () => {
+    const status = buildLexiconRuntimeStatus({
+      manifest: {
+        entries: [{ lemma: "дім", url_slug: "дім" }],
+      },
+      manifestPointer: {},
+      searchIndex: [{ l: "дім" }, { l: "кава" }],
+      browseMeta: { total: 1, letterCounts: { Д: 1 } },
+      dailyPool: [],
+      practiceIndexes: practiceIndexes({
+        A2: { deckVersion: "atlas-practice-v1-other", counts: { lexemes: 1 } },
+      }),
+      clozeSources: [],
+      reviewedSources: { reviewed: [] },
+    });
+
+    expect(status.status).toBe("warning");
+    expect(status.checks.searchMatchesBrowse).toBe(false);
+    expect(status.checks.manifestCoversPublic).toBe(false);
+    expect(status.checks.singlePracticeDeckVersion).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds static `/api/lexicon/status.json`, `/api/lexicon/search-index.json`, and `/api/lexicon/daily-pool.json` endpoints for the GitHub Pages deployment.
- Adds a reusable runtime status contract summarizing Atlas search/browse, hydrated manifest, Daily Word, practice deck, cloze, and source-inventory admission.
- Adds a visible Atlas coverage panel on `/lexicon/` so current counts are visible in the UI.
- Documents the static API contract and why this does not add a FastAPI backend.

## Current status payload after build
- manifest: 5,280 entries, 5,270 public lexemes, 10 internal grammar rows
- search/browse: 5,270 entries, 31 browse shards
- Daily Word: 300
- practice: 4,484 lexemes
- cloze: 6
- source-inventory Atlas rows: 20, with 0 Daily / 0 Practice / 0 Cloze admissions

## Validation
- `npm test -- tests/unit/lexicon-runtime-contract.test.ts tests/unit/lexicon-api-routes.test.ts` — 2 files / 4 tests passed
- `.venv/bin/python scripts/audit/check_static_practice_assets.py` — Daily 300, practice 4,484, cloze 6
- `npm run build` — 5,636 pages built; `/api/lexicon/status.json` prerendered
- Playwright smoke on built `/lexicon/` — status panel hydrated; no browser console errors
- `git diff --check` — passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed

## Independent review
- AGY / Gemini 3.1 Pro High reviewed the diff.
- Initial findings: optional practice reads, uk-UA formatting, dynamic route tests; applied.
- Follow-up AGY review: no blockers.

## Scope guard
- No backend API added; this stays static-first for GitHub Pages.
- No package files, linter configs, `.python-version`, generated status/audit/review files, or telemetry files changed.
