### PR TITLE
docs(bio): add Oleksandr Murashko dossier

### DIFF
--- a/docs/research/bio/oleksandr-murashko.md
+++ b/docs/research/bio/oleksandr-murashko.md
@@ -1,0 +1,237 @@
+# Олександр Олександрович Мурашко — Research Dossier
+
+- **Slug:** `oleksandr-murashko`
+- **Block:** +77 expansion — Ukrainian theater / visual culture additions
+- **Tier:** 2
+- **Issue:** #2535 / BIO +77 readiness gate; BIO #361
+- **Researcher:** Codex orchestrator (GPT-5)
+- **Completed:** 2026-06-30
+- **Acceptance self-check:**
+  - [x] All 10 sections completed
+  - [x] At least 3 Tier 1/Tier 2 institutional sources cited
+  - [x] Oppression mechanism framed as 1919 political-violence attribution conflict
+  - [x] Primary-source visual/text anchors identified without overquoting
+  - [x] Cross-track links verified with `test -e` on 2026-06-30
+  - [x] Naming-canonical policy applied
+  - [x] Image-rights policy applied
+  - [x] Dossier-only scope observed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Олександр Олександрович Мурашко.
+- **Birth name / early surname:** ЕСУ records `Крачковський` until 1891.
+  Treat this as biographical alias, not a competing public canon.
+- **Born:** 26 August (7 September) 1875, Kyiv, Russian Empire; now Ukraine.
+- **Died:** 14 June 1919, Kyiv.
+- **Family / training context:** stepson of icon painter Oleksandr Ivanovych
+  Murashko and nephew of Mykola Murashko, founder of the Kyiv Drawing School.
+  His early training passed through icon-painting workshop practice and the
+  Kyiv Drawing School before imperial academy study.
+- **Education / artistic path:** studied at the Saint Petersburg Academy of
+  Arts from 1894 to 1900/1901, in Ilya Repin's workshop from 1897; travelled to
+  Europe after `Похорон кошового`; worked in Munich and Paris contexts.
+- **Roles:** painter, portraitist, genre painter, pedagogue, studio founder,
+  organizer of Kyiv artists, and one of the founders/professors of the
+  Ukrainian Academy of Arts.
+
+## 2. Oppression mechanism
+
+Murashko's dossier should not invent a neat security-service file. The
+load-bearing harm is his violent death in Kyiv in 1919 and the source conflict
+around attribution, placed inside revolutionary-war instability.
+
+- **What happened:** Murashko was killed in Kyiv on 14 June 1919. EIU states
+  that he was killed by an unknown person. ESU states that he was shot by a
+  night patrol of the VChK in Kyiv. The module must flag this discrepancy
+  rather than choose a stronger police-claim than the evidence supports.
+- **When:** 14 June 1919, during the Ukrainian revolutionary war / civil-war
+  instability in Kyiv.
+- **By whom:** source-conflicted. Safe learner-facing wording: "killed in Kyiv
+  in 1919; ESU attributes the shooting to a VChK night patrol, while EIU gives
+  the killer as unknown."
+- **Mechanism specifics:** this is political-violence context, not a courtroom
+  case with a preserved file number. Use it to discuss how artists and new
+  Ukrainian cultural institutions were exposed to state collapse, patrol
+  violence, and regime turnover.
+- **What survived / what was distorted:** his pedagogical network, studio, and
+  Academy work survived in Ukrainian art history, while imperial/Soviet
+  framings can reduce him to a Petersburg-trained painter rather than a Kyiv
+  institution-builder and Ukrainian modernist.
+
+## 3. Major works / contributions
+
+- **Psychological portrait and genre painting:** EIU calls Murashko a master of
+  psychological portraiture. His portraits combine strong drawing with a
+  loosened color and light language shaped by European modernism.
+- **European study and exhibition network:** after `Похорон кошового`, he
+  received the right to travel in Europe. EIU/ESU place his work in Munich,
+  Paris, Berlin, Vienna, Venice, Rome, Amsterdam, Düsseldorf, Cologne, and
+  other European exhibition contexts.
+- **Kyiv modernist pedagogy:** he taught at the Kyiv Art School, then opened his
+  own studio in 1913. The studio and the Ukrainian Academy of Arts make him a
+  bridge from individual painter to institutional teacher.
+- **Ukrainian Academy of Arts:** ESU records him as one of the founders of the
+  Ukrainian Academy of Arts in 1917 and professor of its painting workshop in
+  1917-1919. This is the statehood/institution-building anchor shared with
+  Narbut, Krychevskyi, and Boichuk.
+- **Color and modernism:** NAMU's 2025 exhibition `Кольорові модуляції` frames
+  him as one of the bright representatives of Ukrainian modernism and traces
+  his movement from early restrained color to impressionist pink/golden-blue
+  tones and later deeper violet-blue intensity.
+- **Representative works:** `Похорон кошового` (1900), `Портрет дівчини в
+  червоному капелюсі`, `Недільний день`, `Праля`, `Селянська родина`,
+  `Карусель`, `Зима`, `Кав'ярня`, `Паризька кав'ярня`, `Жінка з квітами`.
+
+## 4. Primary-source quote / visual anchors
+
+Murashko's strongest learner anchors are paintings, exhibition catalogues, and
+memoir/correspondence evidence. Do not overquote modern exhibition prose.
+
+- **`Похорон кошового`:** early program painting; useful for discussing academy
+  training, historical subject matter, and the move toward European study.
+- **`Карусель`:** major modernist/color-work anchor; use image/object reading
+  rather than a long secondary description.
+- **`Дівчина в червоному капелюсі`:** portrait anchor for color, gaze,
+  psychological characterization, and learner vocabulary around costume/light.
+- **`Праля` / `Селянська родина`:** genre-painting anchors for everyday labor,
+  social observation, and realism-to-modernism transition.
+- **`Жінка з квітами` (1918):** NAMU identifies it as the last major work and a
+  marker of late stylistic searching.
+- **Memoir anchor:** the 2016 publication of Margarita Murashko's memoirs can
+  supply private-life / studio evidence later; verify passages before quoting.
+
+## 5. Language register
+
+- **Register:** art-historical, museum-label, pedagogy, modernism, portrait and
+  color-analysis register.
+- **CEFR readiness:** B2 for biographical and painting-description work; C1 for
+  art-critical comparison across realism, impressionism, Secession, modernism,
+  and Ukrainian institution-building.
+- **Learner lexicon:** `живописець`, `портрет`, `жанровий живопис`,
+  `імпресіонізм`, `модерн`, `Сецесія`, `пленер`, `світлотінь`,
+  `контражур`, `колорит`, `мазок`, `силуетність`, `психологізм`,
+  `майстерня`, `студія`, `академія`.
+- **Style note:** learners should practice object description: who is shown,
+  where the light falls, what color relationships dominate, and how a painting
+  creates mood without narrative exposition.
+
+## 6. Contested points
+
+- **Murder attribution:** EIU says an unknown person killed him; ESU attributes
+  the shooting to a VChK night patrol. Flag both. Do not collapse the dossier
+  into "Cheka victim" unless a later primary or high-trust specialist source
+  confirms the attribution.
+- **Russian/Petersburg training:** Repin's workshop and the Saint Petersburg
+  Academy are real. They are training context, not ownership. Murashko's mature
+  work and institutional impact belong strongly to Kyiv and Ukrainian modernism.
+- **European vs national frame:** international exhibitions do not make him a
+  de-nationalized European painter; they show Ukrainian painting entering
+  European modernist circuits.
+- **"Ukrainian Cezanne" / genius labels:** popular media may use easy labels.
+  The module should prefer concrete art vocabulary: portrait psychology, color,
+  light, academy/studio pedagogy, and Kyiv institution-building.
+- **Jewish/urban art context:** some summaries mention later influence on
+  Jewish artists and Kyiv studios. This can be useful, but should be grounded
+  carefully if expanded; do not overclaim from unsourced popular lines.
+
+## 7. Cross-track links
+
+- **Existing BIO / visual-culture links (VERIFIED `test -e` on 2026-06-30):**
+  - `docs/research/bio/heorhii-narbut.md`
+  - `docs/research/bio/vasyl-krychevskyi.md`
+  - `curriculum/l2-uk-en/plans/bio/vasyl-krychevskyi.yaml`
+  - `docs/research/bio/mykhailo-boichuk.md`
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-boichuk.yaml`
+  - `docs/research/bio/oleksandr-bohomazov.md`
+  - `curriculum/l2-uk-en/plans/bio/oleksandr-bohomazov.yaml`
+  - `docs/research/bio/anatol-petrytskyi.md`
+  - `curriculum/l2-uk-en/plans/bio/anatol-petrytskyi.yaml`
+- **Existing fine-arts / statehood links (VERIFIED `test -e` on 2026-06-30):**
+  - `curriculum/l2-uk-en/plans/c1/obrazotvorche-mystetstvo-1.yaml`
+  - `curriculum/l2-uk-en/plans/c1/obrazotvorche-mystetstvo-2.yaml`
+  - `curriculum/l2-uk-en/plans/c1/checkpoint-fine-arts.yaml`
+  - `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml`
+  - `curriculum/l2-uk-en/plans/hist/skoropadskyi.yaml`
+  - `curriculum/l2-uk-en/plans/istorio/universaly-unr.yaml`
+  - `curriculum/l2-uk-en/plans/lit-war/unr-war-literature.yaml`
+  - `wiki/academic/c1/obrazotvorche-mystetstvo-1.md`
+- **Candidate / not yet existing in this slice:**
+  - `curriculum/l2-uk-en/plans/bio/oleksandr-murashko.yaml`
+  - site MDX / wiki article for `oleksandr-murashko`
+  - BIO #362 `fedir-krychevskyi`
+  - BIO #365 `ivan-trush`
+
+## 8. Naming-canonical
+
+Per `docs/best-practices/bio-naming-canonical.md`:
+
+- **Slug:** `oleksandr-murashko`
+- **EN canonical:** Oleksandr Murashko
+- **UA canonical:** Олександр Олександрович Мурашко
+- **Aliases:** Крачковський (birth/early surname before 1891); Alexander
+  Murashko; Aleksandr Murashko; Олександр Крачковський.
+- **Forbidden / source-critical forms:** Russianized `Александр Мурашко` or
+  imperial academy catalog forms should not be the module's own identity label.
+  They may appear only as source metadata or alias notes.
+
+## 9. Image candidates
+
+Per `docs/best-practices/bio-image-rights.md`:
+
+- **Best PD/CC route:** Wikimedia Commons / museum reproductions of works by
+  Murashko. He died in 1919, so paintings are generally public domain by
+  life-plus-70 logic, but file-level license and reproduction source still must
+  be checked.
+- **Primary object candidates:** `Карусель`, `Дівчина в червоному капелюсі`,
+  `Праля`, `Похорон кошового`, `Жінка з квітами`, and NAMU-held works from the
+  `Кольорові модуляції` exhibition.
+- **Portrait / studio context:** use only if file-level rights are clear.
+  A painting is likely a stronger pedagogical image than a formal portrait.
+- **Caption caution:** captions should identify him as a Ukrainian painter and
+  Academy founder; do not copy imperial or Russian-only catalog labels without
+  source-critical context.
+
+## 10. Sources used
+
+**Tier 1 / Tier 2 encyclopedic and institutional sources:**
+
+- Енциклопедія історії України / Інститут історії України НАН України.
+  "Мурашко Олександр Олександрович."
+  https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIU&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Murashko_O&Z21ID=
+  Accessed 2026-06-30.
+- Енциклопедія Сучасної України. "Мурашко Олександр Олександрович."
+  https://esu.com.ua/article-70443. Accessed 2026-06-30.
+- Національний художній музей України. "Виставка «Олександр Мурашко.
+  Кольорові модуляції»."
+  https://namu.ua/exhibitions/vystavka-oleksandr-murashko-kolorovi-modulyacziyi/.
+  Accessed 2026-06-30.
+- Міністерство культури України. "Національний художній музей України
+  відкриває виставку «Олександр Мурашко. Кольорові модуляції»."
+  https://mincult.gov.ua/news/naczionalnyj-hudozhnij-muzej-ukrayiny-vidkryvaye-vystavku-oleksandr-murashko-kolorovi-modulyacziyi/.
+  Accessed 2026-06-30.
+- `curriculum/l2-uk-en/plans/c1/obrazotvorche-mystetstvo-1.yaml` for learner
+  bridge: "Олександр Мурашко: паризька школа та київські традиції."
+
+**Tier 3 / image and reception aids:**
+
+- Wikimedia Commons. "Category:Oleksandr Murashko."
+  https://commons.wikimedia.org/wiki/Category:Oleksandr_Murashko.
+  Accessed 2026-06-30.
+- Wikipedia reference list for bibliographic leads only; not used for core
+  claims without institutional corroboration.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric learner-facing framing.
+- [x] Murder attribution conflict flagged; no unsupported police-case overclaim.
+- [x] Petersburg/Repin training contextualized without ceding identity.
+- [x] European exhibition success framed with Ukrainian modernism, not erasure.
+- [x] Russianized forms kept to alias/source-critical notes.
+- [x] Cross-track "Existing" paths verified with `test -e`.
+- [x] Naming and image-rights policy checked.
+- [x] Dossier-only slice: no plan YAML, module markdown, activity YAML,
+  vocabulary YAML, generated site MDX, wiki packet, status JSON, or telemetry DB.


### PR DESCRIPTION
## Summary

- Add BIO #361 research dossier for `oleksandr-murashko`.
- Frame Murashko through Ukrainian modernism, Kyiv art pedagogy, Ukrainian Academy of Arts institution-building, European exhibition context, and art-language pedagogy.
- Preserve the 1919 murder attribution conflict: EIU says unknown killer; ESU attributes the shooting to a VChK night patrol.
- Keep this as a dossier-only base-prep slice: no plan YAML, module markdown, activities, vocabulary, site MDX, wiki packet, status JSON, audit artifact, or telemetry DB.

## Validation

- `git diff --check`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/oleksandr-murashko.md`
- `npx markdownlint-cli2 docs/research/bio/oleksandr-murashko.md`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Telemetry

Not applicable: dossier-only slice, no module build. `swarm_used: false`; `swarm_note: solo dossier pass; no swarm used`.

## Reviewer notes

Please check:

- whether the 1919 killing is framed safely without overclaiming the VChK attribution;
- whether Petersburg/Repin training is contextualized without ceding Ukrainian identity;
- whether the Ukrainian modernism / NAMU color-language framing is pedagogically useful;
- whether cross-track links and image-rights cautions are sufficient for later plan/module work.
