### PR TITLE
feat(atlas): add practice static API aliases

### DIFF
--- a/docs/runbooks/word-atlas-static-api.md
+++ b/docs/runbooks/word-atlas-static-api.md
@@ -1,32 +1,31 @@
 # Word Atlas Static API Contract
 
-The learner site is GitHub Pages/static-first. Atlas runtime data is exposed as
-static JSON, not a live backend service.
+The learner site is GitHub Pages/static-first. Atlas runtime data is exposed
+as static JSON, not as a live backend service.
 
 ## Canonical Endpoints
 
-- `/api/lexicon/status.json` — status and counts across Atlas search/browse,
+- `/api/lexicon/status.json` — status counts across Atlas search/browse,
   manifest hydration, Daily Word, Practice, cloze, and source-inventory
   admission.
 - `/api/lexicon/search-index.json` — compact typeahead/search rows.
 - `/api/lexicon/daily-pool.json` — Daily Word pool.
+- `/api/lexicon/practice-index.{level}.json` — per-level Practice index.
+- `/api/lexicon/practice-lexemes.{level}.json` — per-level Practice lexeme deck.
+- `/api/lexicon/practice-cloze.{level}.json` — per-level reviewed cloze deck.
 
-The status payload also points at the existing static practice and browse
-assets:
+The status payload also points to existing static browse assets:
 
 - `/lexicon/browse/{letter}.json`
-- `/lexicon/practice-index.{level}.json`
-- `/lexicon/practice-lexemes.{level}.json`
-- `/lexicon/practice-cloze.{level}.json`
 
 ## Contract Checks
 
-Consumers should treat `status: "ok"` as the normal state. A warning means at
-least one public surface drifted, such as search and browse counts disagreeing,
-practice deck versions splitting, Daily Word becoming empty, or the hydrated
-manifest no longer matching the public Atlas count.
+Consumers should treat `status: "ok"` as the normal state. `warning` means at
+least one public surface drifted, search/browse counts disagree, practice deck
+versions split, Daily Word became empty, or the hydrated manifest no longer
+matches the public Atlas count.
 
-`sourceInventory` counts only become non-null when the build has hydrated the
+`sourceInventory` counts only become non-null when the build has a hydrated
 release manifest. Missing `surface_admission` remains false; source-inventory
 growth is Atlas browse/search only until a reviewed decision admits Daily Word,
 Practice, or cloze.

--- a/site/src/lib/lexicon/runtime-contract.ts
+++ b/site/src/lib/lexicon/runtime-contract.ts
@@ -189,9 +189,9 @@ export function buildLexiconRuntimeStatus(input: BuildRuntimeStatusInput): Lexic
       searchIndex: "/api/lexicon/search-index.json",
       dailyPool: "/api/lexicon/daily-pool.json",
       browseShardTemplate: "/lexicon/browse/{letter}.json",
-      practiceIndexTemplate: "/lexicon/practice-index.{level}.json",
-      practiceLexemesTemplate: "/lexicon/practice-lexemes.{level}.json",
-      practiceClozeTemplate: "/lexicon/practice-cloze.{level}.json",
+      practiceIndexTemplate: "/api/lexicon/practice-index.{level}.json",
+      practiceLexemesTemplate: "/api/lexicon/practice-lexemes.{level}.json",
+      practiceClozeTemplate: "/api/lexicon/practice-cloze.{level}.json",
     },
     manifest: {
       hydrated: entries !== null,

--- a/site/src/pages/api/lexicon/practice-cloze.[level].json.ts
+++ b/site/src/pages/api/lexicon/practice-cloze.[level].json.ts
@@ -1,0 +1,33 @@
+import type { APIRoute, GetStaticPaths } from "astro";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { PRACTICE_LEVELS, type PracticeLevel } from "../../../lib/lexicon/runtime-contract";
+
+export const prerender = true;
+
+const JSON_HEADERS = {
+  "Content-Type": "application/json; charset=utf-8",
+  "Cache-Control": "public, max-age=3600",
+};
+
+function isPracticeLevel(value: string | undefined): value is PracticeLevel {
+  return PRACTICE_LEVELS.includes(value as PracticeLevel);
+}
+
+export const getStaticPaths: GetStaticPaths = () =>
+  PRACTICE_LEVELS.map((level) => ({ params: { level } }));
+
+export const GET: APIRoute = ({ params }) => {
+  const level = params.level;
+  if (!isPracticeLevel(level)) {
+    return new Response(JSON.stringify({ error: "Unknown practice level" }), {
+      headers: JSON_HEADERS,
+      status: 404,
+    });
+  }
+
+  return new Response(
+    readFileSync(resolve(process.cwd(), `public/lexicon/practice-cloze.${level}.json`)),
+    { headers: JSON_HEADERS },
+  );
+};

--- a/site/src/pages/api/lexicon/practice-index.[level].json.ts
+++ b/site/src/pages/api/lexicon/practice-index.[level].json.ts
@@ -1,0 +1,33 @@
+import type { APIRoute, GetStaticPaths } from "astro";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { PRACTICE_LEVELS, type PracticeLevel } from "../../../lib/lexicon/runtime-contract";
+
+export const prerender = true;
+
+const JSON_HEADERS = {
+  "Content-Type": "application/json; charset=utf-8",
+  "Cache-Control": "public, max-age=3600",
+};
+
+function isPracticeLevel(value: string | undefined): value is PracticeLevel {
+  return PRACTICE_LEVELS.includes(value as PracticeLevel);
+}
+
+export const getStaticPaths: GetStaticPaths = () =>
+  PRACTICE_LEVELS.map((level) => ({ params: { level } }));
+
+export const GET: APIRoute = ({ params }) => {
+  const level = params.level;
+  if (!isPracticeLevel(level)) {
+    return new Response(JSON.stringify({ error: "Unknown practice level" }), {
+      headers: JSON_HEADERS,
+      status: 404,
+    });
+  }
+
+  return new Response(
+    readFileSync(resolve(process.cwd(), `public/lexicon/practice-index.${level}.json`)),
+    { headers: JSON_HEADERS },
+  );
+};

--- a/site/src/pages/api/lexicon/practice-lexemes.[level].json.ts
+++ b/site/src/pages/api/lexicon/practice-lexemes.[level].json.ts
@@ -1,0 +1,33 @@
+import type { APIRoute, GetStaticPaths } from "astro";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { PRACTICE_LEVELS, type PracticeLevel } from "../../../lib/lexicon/runtime-contract";
+
+export const prerender = true;
+
+const JSON_HEADERS = {
+  "Content-Type": "application/json; charset=utf-8",
+  "Cache-Control": "public, max-age=3600",
+};
+
+function isPracticeLevel(value: string | undefined): value is PracticeLevel {
+  return PRACTICE_LEVELS.includes(value as PracticeLevel);
+}
+
+export const getStaticPaths: GetStaticPaths = () =>
+  PRACTICE_LEVELS.map((level) => ({ params: { level } }));
+
+export const GET: APIRoute = ({ params }) => {
+  const level = params.level;
+  if (!isPracticeLevel(level)) {
+    return new Response(JSON.stringify({ error: "Unknown practice level" }), {
+      headers: JSON_HEADERS,
+      status: 404,
+    });
+  }
+
+  return new Response(
+    readFileSync(resolve(process.cwd(), `public/lexicon/practice-lexemes.${level}.json`)),
+    { headers: JSON_HEADERS },
+  );
+};

--- a/site/tests/unit/lexicon-api-routes.test.ts
+++ b/site/tests/unit/lexicon-api-routes.test.ts
@@ -1,13 +1,38 @@
 import { describe, expect, test } from "vitest";
+import type { APIRoute, GetStaticPaths } from "astro";
 import { GET as getDailyPool } from "@site/src/pages/api/lexicon/daily-pool.json";
+import {
+  GET as getPracticeCloze,
+  getStaticPaths as getPracticeClozePaths,
+} from "@site/src/pages/api/lexicon/practice-cloze.[level].json";
+import {
+  GET as getPracticeIndex,
+  getStaticPaths as getPracticeIndexPaths,
+} from "@site/src/pages/api/lexicon/practice-index.[level].json";
+import {
+  GET as getPracticeLexemes,
+  getStaticPaths as getPracticeLexemesPaths,
+} from "@site/src/pages/api/lexicon/practice-lexemes.[level].json";
 import { GET as getSearchIndex } from "@site/src/pages/api/lexicon/search-index.json";
 import { GET as getStatus } from "@site/src/pages/api/lexicon/status.json";
+import { PRACTICE_LEVELS } from "@site/src/lib/lexicon/runtime-contract";
 
-async function routeJson<T>(route: typeof getStatus): Promise<T> {
-  const response = await route({} as Parameters<typeof route>[0]);
+async function routeJson<T>(
+  route: APIRoute,
+  params: Record<string, string | undefined> = {},
+): Promise<T> {
+  const response = await route({ params } as Parameters<APIRoute>[0]);
   expect(response).toBeInstanceOf(Response);
   expect(response.headers.get("Content-Type")).toContain("application/json");
   return (await response.json()) as T;
+}
+
+async function routePaths(getStaticPaths: GetStaticPaths): Promise<string[]> {
+  const paths = await getStaticPaths({ paginate: () => [] } as Parameters<GetStaticPaths>[0]);
+  return paths.map((path) => {
+    if (!("params" in path)) throw new Error("expected static params");
+    return String(path.params.level);
+  });
 }
 
 describe("lexicon static API routes", () => {
@@ -21,7 +46,13 @@ describe("lexicon static API routes", () => {
       daily: { poolEntries: number };
       practice: { totalLexemes: number };
       checks: { searchMatchesBrowse: boolean; singlePracticeDeckVersion: boolean };
-      endpoints: { searchIndex: string; dailyPool: string };
+      endpoints: {
+        searchIndex: string;
+        dailyPool: string;
+        practiceIndexTemplate: string;
+        practiceLexemesTemplate: string;
+        practiceClozeTemplate: string;
+      };
     }>(getStatus);
 
     expect(status.schema).toBe("atlas-runtime-status");
@@ -34,6 +65,15 @@ describe("lexicon static API routes", () => {
     expect(status.checks.singlePracticeDeckVersion).toBe(true);
     expect(status.endpoints.searchIndex).toBe("/api/lexicon/search-index.json");
     expect(status.endpoints.dailyPool).toBe("/api/lexicon/daily-pool.json");
+    expect(status.endpoints.practiceIndexTemplate).toBe(
+      "/api/lexicon/practice-index.{level}.json",
+    );
+    expect(status.endpoints.practiceLexemesTemplate).toBe(
+      "/api/lexicon/practice-lexemes.{level}.json",
+    );
+    expect(status.endpoints.practiceClozeTemplate).toBe(
+      "/api/lexicon/practice-cloze.{level}.json",
+    );
   });
 
   test("aliases search and Daily Word data under /api/lexicon", async () => {
@@ -42,5 +82,37 @@ describe("lexicon static API routes", () => {
 
     expect(search.length).toBeGreaterThan(5000);
     expect(daily.length).toBeGreaterThanOrEqual(250);
+  });
+
+  test("aliases static practice shards under /api/lexicon", async () => {
+    await expect(routePaths(getPracticeIndexPaths)).resolves.toEqual([...PRACTICE_LEVELS]);
+    await expect(routePaths(getPracticeLexemesPaths)).resolves.toEqual([...PRACTICE_LEVELS]);
+    await expect(routePaths(getPracticeClozePaths)).resolves.toEqual([...PRACTICE_LEVELS]);
+
+    const index = await routeJson<{
+      level: string;
+      deckVersion: string;
+      counts: { lexemes: number; cloze: number };
+    }>(getPracticeIndex, { level: "A1" });
+    const lexemes = await routeJson<{
+      level: string;
+      deckVersion: string;
+      lexemes: unknown[];
+    }>(getPracticeLexemes, { level: "A1" });
+    const cloze = await routeJson<{
+      level: string;
+      deckVersion: string;
+      cloze: unknown[];
+    }>(getPracticeCloze, { level: "A1" });
+
+    expect(index.level).toBe("A1");
+    expect(lexemes.level).toBe("A1");
+    expect(cloze.level).toBe("A1");
+    expect(index.deckVersion).toBe(lexemes.deckVersion);
+    expect(index.deckVersion).toBe(cloze.deckVersion);
+    expect(index.counts.lexemes).toBe(lexemes.lexemes.length);
+    expect(index.counts.cloze).toBe(cloze.cloze.length);
+    expect(index.counts.lexemes).toBeGreaterThan(1000);
+    expect(index.counts.cloze).toBe(6);
   });
 });


### PR DESCRIPTION
## Summary

Adds static GitHub Pages-compatible Practice API aliases under `/api/lexicon/`:

- `/api/lexicon/practice-index.{level}.json`
- `/api/lexicon/practice-lexemes.{level}.json`
- `/api/lexicon/practice-cloze.{level}.json`

The status contract now points Practice templates at the API aliases while the existing `/lexicon/practice-*` static assets remain available for compatibility.

## Validation

- `npm test -- tests/unit/lexicon-api-routes.test.ts tests/unit/lexicon-runtime-contract.test.ts` — passed, 2 files / 5 tests
- `npm run build` — passed; prerendered all Practice API aliases for A1/A2/B1/B2/C1
- `.venv/bin/python scripts/audit/check_static_practice_assets.py` — passed; Daily 300, practice 4,484, cloze 6
- `npx markdownlint-cli2 docs/runbooks/word-atlas-static-api.md` — passed
- `git diff --check` — passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed

Independent review: Hermes/DeepSeek (`deepseek/deepseek-v4-pro`) returned no blockers. AGY Pro timed out and AGY Flash was canceled after no timely response; no second implementation lane was started.

## Scope Guard

- No Atlas manifest/search/browse data regeneration
- No Daily Word, Practice, or cloze content changes
- No generated status/audit/review/telemetry artifacts
- No `.python-version`, `.yamllint`, or `.markdownlint.json` changes
