### PR TITLE
docs(atlas): define Ohoiko source scope

### DIFF
--- a/docs/runbooks/word-atlas-ohoiko-ulp-source-scope.md
+++ b/docs/runbooks/word-atlas-ohoiko-ulp-source-scope.md
@@ -1,0 +1,64 @@
+# Word Atlas Ohoiko / ULP Source Scope
+
+This note defines what the Atlas source-inventory lane may use from Anna
+Ohoiko / Ukrainian Lessons material without crossing into proprietary lesson
+content.
+
+## Current Safe Source
+
+The only committed Anna Ohoiko lexical source currently approved for Atlas
+headword intake is the local abetka material:
+
+- `curriculum/l2-uk-direct/a1/abetka-1.yaml`
+- `curriculum/l2-uk-direct/a1/abetka-2.yaml`
+- `curriculum/l2-uk-direct/a1/abetka-3.yaml`
+- `curriculum/l2-uk-direct/a1/abetka-4.yaml`
+
+Those modules contain public YouTube pronunciation-video metadata and explicit
+`key_word` rows. The matching inventory is:
+
+- `data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml`
+
+Current committed coverage is complete for that source: 4 abetka modules, 33
+`key_word` rows, and 33 Ohoiko source-inventory headwords.
+
+## Link-Only Sources
+
+The Ukrainian Lessons resource indexes are useful for curriculum alignment and
+for deciding which public articles or podcast episodes to recommend:
+
+- `docs/resources/ukrainianlessons/blog_db.json`
+- `docs/resources/ulp-article-mappings.yaml`
+- `docs/resources/ulp-articles-index.yaml`
+- `docs/resources/podcasts/raw/episode_021.html`
+- `docs/resources/podcasts/raw/episode_022.html`
+
+These files are not an approved lexical corpus. The resource policy says ULP is
+inspiration-only and link-only: study patterns, sequence, and topics, but do not
+copy lesson vocabulary or premium notes. Public episode pages advertise
+vocabulary lists as premium material; the committed raw HTML does not expose the
+lists themselves.
+
+## Not In Scope Without A New Decision
+
+Do not create Atlas headwords from these sources unless a separate reviewed
+source decision explicitly approves the exact rows:
+
+- premium ULP lesson notes, PDFs, flashcards, or transcripts
+- Ohoiko books that are not committed as source-inventory-safe headword rows
+- topic labels from resource metadata, such as `food`, `family`, or `cases`
+- public article titles when the title only names a topic, not an explicit
+  Ukrainian headword list
+
+## Next Valid #3933 PR Shapes
+
+A safe follow-up PR may do one of these:
+
+- add a manually reviewed Ohoiko/ULP headword inventory where every row cites a
+  public, non-premium source locator and includes review notes
+- add reviewed decision-ledger rows for already-generated Ohoiko candidates
+- publish an already-approved Ohoiko batch to Atlas browse/search only
+
+Daily Word, Practice, and cloze admission must remain separate
+`surface_admission` decisions. Missing `surface_admission` means Atlas
+browse/search only.

--- a/tests/test_ohoiko_source_inventory_scope.py
+++ b/tests/test_ohoiko_source_inventory_scope.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+
+import yaml
+
+from scripts.audit.source_inventory_intake import read_source_inventory
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+ABETKA_DIR = PROJECT_ROOT / "curriculum/l2-uk-direct/a1"
+OHOIKO_INVENTORY = PROJECT_ROOT / "data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml"
+ULP_SCHEMA = PROJECT_ROOT / "docs/resources/EXTERNAL_RESOURCES_SCHEMA.md"
+ULP_BLOG_DB = PROJECT_ROOT / "docs/resources/ukrainianlessons/blog_db.json"
+
+
+def _abetka_key_words() -> Counter[tuple[str, str]]:
+    rows: Counter[tuple[str, str]] = Counter()
+    for path in sorted(ABETKA_DIR.glob("abetka-*.yaml")):
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for row in data["letters"]:
+            key_word = row.get("key_word")
+            if key_word:
+                rows[(str(path.relative_to(PROJECT_ROOT)), key_word)] += 1
+    return rows
+
+
+def test_ohoiko_abetka_inventory_covers_all_committed_key_words() -> None:
+    records = read_source_inventory(OHOIKO_INVENTORY, project_root=PROJECT_ROOT)
+    ohoiko_rows = Counter(
+        (record.source_path, record.lemma)
+        for record in records
+        if record.source_family == "ohoiko"
+    )
+
+    assert _abetka_key_words() == ohoiko_rows
+    assert sum(ohoiko_rows.values()) == 33
+
+
+def test_ulp_resource_policy_remains_link_only_for_lexicon_scope() -> None:
+    schema = ULP_SCHEMA.read_text(encoding="utf-8")
+
+    assert "ULP (Ukrainian Lessons Podcast)" in schema
+    assert "Inspiration only" in schema
+    assert "Never copy content" in schema
+
+
+def test_ulp_blog_database_is_metadata_not_headword_corpus() -> None:
+    payload = json.loads(ULP_BLOG_DB.read_text(encoding="utf-8"))
+    articles = payload["articles"]
+
+    assert len(articles) >= 400
+    for article in articles:
+        assert {"id", "url", "title", "topics"} <= set(article)
+        assert not {
+            "body",
+            "content",
+            "headwords",
+            "lesson_notes",
+            "text",
+            "transcript",
+            "vocabulary",
+        } & set(article)


### PR DESCRIPTION
## Summary

Defines the safe Atlas source scope for #3933 Ohoiko / Ukrainian Lessons intake.

What this clarifies:
- The committed Anna Ohoiko source currently approved for Atlas headword intake is the four local abetka modules.
- `data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml` fully covers those modules: 33 committed `key_word` rows.
- ULP/Ukrainian Lessons resource indexes are link-only/inspiration-only metadata, not an approved headword corpus.
- Premium notes, transcripts, flashcards, and vocabulary lists remain out of scope without a separate reviewed source decision.
- Daily Word, Practice, and cloze still require explicit `surface_admission` decisions.

## Validation

- `.venv/bin/python -m pytest tests/test_ohoiko_source_inventory_scope.py tests/test_source_inventory_intake.py -q` — 12 passed
- `.venv/bin/ruff check tests/test_ohoiko_source_inventory_scope.py` — passed
- `npx markdownlint-cli2 docs/runbooks/word-atlas-ohoiko-ulp-source-scope.md` — passed
- `.venv/bin/python scripts/audit/check_static_practice_assets.py` — Daily 300, practice 4,484, cloze 6
- `git diff --check` — passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed

Independent review: Hermes/DeepSeek (`deepseek/deepseek-v4-pro`) returned no blockers.

## Scope Guard

- No Atlas manifest/search/browse data regeneration
- No Daily Word, Practice, or cloze content changes
- No generated status/audit/review/telemetry artifacts
- No `.python-version`, `.yamllint`, or `.markdownlint.json` changes

Refs #3933
