### PR TITLE
docs(atlas): define textbook source scope

### DIFF
--- a/docs/runbooks/word-atlas-textbook-source-scope.md
+++ b/docs/runbooks/word-atlas-textbook-source-scope.md
@@ -1,0 +1,49 @@
+# Word Atlas Textbook Source Scope
+
+This note defines the current textbook/headword source scope for Atlas intake.
+It answers where the committed textbook words live and what is still missing
+before broader textbook ingestion can be treated as resolved.
+
+## Current Textbook Inventories
+
+The committed textbook source-inventory lane currently has 80 rows:
+
+- `data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml`
+  - 40 headwords
+  - source notes:
+    `docs/l2-uk-direct/textbook-reading-notes/bolshakova-bukvar-mapping.md`
+- `data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml`
+  - 40 headwords
+  - source map: `docs/l2-uk-direct/textbook-map.yaml`
+
+These inventory rows cite tracked notes/maps, not untracked source PDFs. The
+source PDFs are not committed, so the reviewable repository evidence is the
+tracked note/map locator plus each row's context.
+
+## Current Vashulenko Subsets
+
+The Vashulenko Grade 3 inventory is deliberately topic-bounded:
+
+- school vocabulary: 7 rows
+- interior vocabulary: 17 rows
+- marine vocabulary: 6 rows
+- bird vocabulary: 10 rows
+
+The row locators point into `docs/l2-uk-direct/textbook-map.yaml`, for example
+`topic_index.vocabulary_school.words[0]`. Tests resolve those locators back to
+the exact lemma so later edits cannot silently drift the inventory away from
+the tracked source map.
+
+## Not Yet Done
+
+Issue #3934 remains open because the current 80 rows are only a reviewed seed, not a
+complete textbook corpus. The missing work is:
+
+- add more reviewed textbook/headword inventories with tracked source locators
+- review held rows before publishing
+- publish approved browse/search batches separately from source review
+- make separate `surface_admission` decisions for Daily Word, Practice, and
+  cloze
+
+Do not infer new rows from private PDFs or broad textbook titles without a
+tracked note/map row and reviewed source decision.

--- a/tests/test_textbook_source_inventory_scope.py
+++ b/tests/test_textbook_source_inventory_scope.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.audit.source_inventory_intake import read_source_inventory
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+BOLSHAKOVA_INVENTORY = (
+    PROJECT_ROOT / "data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml"
+)
+VASHULENKO_INVENTORY = (
+    PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml"
+)
+VASHULENKO_MAP = PROJECT_ROOT / "docs/l2-uk-direct/textbook-map.yaml"
+BOLSHAKOVA_NOTES = (
+    PROJECT_ROOT / "docs/l2-uk-direct/textbook-reading-notes/bolshakova-bukvar-mapping.md"
+)
+
+LOCATOR_PART_RE = re.compile(r"^([A-Za-z0-9_]+)(?:\[(\d+)\])?$")
+
+
+def _records() -> list:
+    records = []
+    for path in [BOLSHAKOVA_INVENTORY, VASHULENKO_INVENTORY]:
+        records.extend(read_source_inventory(path, project_root=PROJECT_ROOT))
+    return records
+
+
+def _resolve_locator(data: Any, locator: str) -> Any:
+    current = data
+    for part in locator.split("."):
+        match = LOCATOR_PART_RE.fullmatch(part)
+        assert match, locator
+        current = current[match.group(1)]
+        if match.group(2) is not None:
+            current = current[int(match.group(2))]
+    return current
+
+
+def test_textbook_inventory_counts_and_source_paths_are_stable() -> None:
+    records = _records()
+    counts = Counter(record.source_id for record in records)
+
+    assert len(records) == 80
+    assert counts == {
+        "bolshakova-bukvar-2025-part1-keywords": 40,
+        "vashulenko-grade3-2020-school-vocabulary": 7,
+        "vashulenko-grade3-2020-interior-vocabulary": 17,
+        "vashulenko-grade3-2020-marine-vocabulary": 6,
+        "vashulenko-grade3-2020-birds-vocabulary": 10,
+    }
+    for record in records:
+        assert record.source_family == "textbook"
+        assert record.source_path
+        assert (PROJECT_ROOT / record.source_path).exists()
+        assert record.source_locator
+        assert record.context
+
+
+def test_vashulenko_inventory_locators_resolve_to_tracked_source_map() -> None:
+    textbook_map = yaml.safe_load(VASHULENKO_MAP.read_text(encoding="utf-8"))
+    records = read_source_inventory(VASHULENKO_INVENTORY, project_root=PROJECT_ROOT)
+
+    for record in records:
+        assert record.source_path == str(VASHULENKO_MAP.relative_to(PROJECT_ROOT))
+        assert _resolve_locator(textbook_map, record.source_locator) == record.lemma
+
+
+def test_bolshakova_inventory_rows_are_backed_by_tracked_notes() -> None:
+    notes = BOLSHAKOVA_NOTES.read_text(encoding="utf-8")
+    records = read_source_inventory(BOLSHAKOVA_INVENTORY, project_root=PROJECT_ROOT)
+
+    assert len(records) == 40
+    for record in records:
+        assert record.source_path == str(BOLSHAKOVA_NOTES.relative_to(PROJECT_ROOT))
+        assert record.lemma in notes


### PR DESCRIPTION
## Summary

- Document the current safe textbook/headword source scope for Atlas intake.
- Add a focused scope test for the committed Bolshakova Bukvar and Vashulenko grade 3 inventory rows.
- Keep live Atlas manifest/search/browse, daily, practice, and cloze outputs unchanged.

## Validation

- `.venv/bin/python -m pytest tests/test_textbook_source_inventory_scope.py tests/test_source_inventory_intake.py -q`
- `.venv/bin/ruff check tests/test_textbook_source_inventory_scope.py`
- `npx markdownlint-cli2 docs/runbooks/word-atlas-textbook-source-scope.md`
- `.venv/bin/python scripts/audit/check_static_practice_assets.py`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Independent Review

Hermes / DeepSeek review initially flagged the Bolshakova assertion as too weak because it could pass from row context alone. The test was tightened to require each lemma to be present in the tracked source notes. Follow-up review reported no blockers.

Refs #3934.
Refs #3936.