### PR TITLE
feat(atlas): expose static lexicon API contract

### DIFF
--- a/site/src/lexicon/AtlasRuntimeStatus.astro
+++ b/site/src/lexicon/AtlasRuntimeStatus.astro
@@ -26,6 +26,11 @@ const statusUrl = "/api/lexicon/status.json";
       <p data-runtime-detail="manifest">Маніфест релізу</p>
     </div>
     <div class="atlas-runtime-card">
+      <dt>API</dt>
+      <dd data-runtime-value="api">-</dd>
+      <p data-runtime-detail="api">Контракт даних</p>
+    </div>
+    <div class="atlas-runtime-card">
       <dt>Слова дня</dt>
       <dd data-runtime-value="daily">-</dd>
       <p data-runtime-detail="daily">Рівні A1-B1</p>
@@ -83,6 +88,9 @@ const statusUrl = "/api/lexicon/status.json";
           )} внутрішніх`
         : `${formatBytes(status.manifest.jsonBytes)} pinned`,
     );
+
+    setRuntimeText(root, "api", "4");
+    setRuntimeDetail(root, "api", status.endpoints.contract);
 
     setRuntimeText(root, "daily", formatCount(status.daily.poolEntries));
     setRuntimeDetail(root, "daily", "Навчальна добірка");

--- a/site/src/lib/lexicon/runtime-contract.ts
+++ b/site/src/lib/lexicon/runtime-contract.ts
@@ -12,6 +12,7 @@ export interface LexiconRuntimeStatus {
   generatedAt: string;
   status: "ok" | "warning";
   endpoints: {
+    contract: string;
     status: string;
     searchIndex: string;
     searchShards: string;
@@ -64,6 +65,50 @@ export interface LexiconRuntimeStatus {
     manifestCoversPublic: boolean | null;
     singlePracticeDeckVersion: boolean;
   };
+}
+
+export interface LexiconApiContract {
+  schema: "atlas-api-contract";
+  schemaVersion: 1;
+  generatedAt: string;
+  status: LexiconRuntimeStatus["status"];
+  staticOnly: true;
+  endpoints: LexiconRuntimeStatus["endpoints"];
+  surfaces: {
+    atlas: {
+      entries: number;
+      searchShards: number;
+      browseEntries: number;
+      browseShards: number;
+      endpoints: {
+        searchIndex: string;
+        searchShards: string;
+        browseShardTemplate: string;
+      };
+    };
+    dailyWord: {
+      poolEntries: number;
+      endpoint: string;
+      admission: "reviewed-static-pool";
+    };
+    practice: {
+      totalLexemes: number;
+      levels: PracticeLevel[];
+      deckVersions: string[];
+      endpoints: {
+        indexTemplate: string;
+        lexemesTemplate: string;
+        clozeTemplate: string;
+      };
+    };
+    cloze: {
+      totalItems: number;
+      sourceRows: number;
+      reviewedSourceRows: number;
+      endpointTemplate: string;
+    };
+  };
+  checks: LexiconRuntimeStatus["checks"];
 }
 
 export interface PracticeLevelStatus {
@@ -192,10 +237,11 @@ export function buildLexiconRuntimeStatus(input: BuildRuntimeStatusInput): Lexic
     generatedAt: input.generatedAt ?? new Date().toISOString(),
     status,
     endpoints: {
-        status: "/api/lexicon/status.json",
-        searchIndex: "/api/lexicon/search-index.json",
-        searchShards: "/lexicon/search-shards.json",
-        dailyPool: "/api/lexicon/daily-pool.json",
+      contract: "/api/lexicon/contract.json",
+      status: "/api/lexicon/status.json",
+      searchIndex: "/api/lexicon/search-index.json",
+      searchShards: "/lexicon/search-shards.json",
+      dailyPool: "/api/lexicon/daily-pool.json",
       browseShardTemplate: "/lexicon/browse/{letter}.json",
       practiceIndexTemplate: "/api/lexicon/practice-index.{level}.json",
       practiceLexemesTemplate: "/api/lexicon/practice-lexemes.{level}.json",
@@ -245,5 +291,51 @@ export function buildLexiconRuntimeStatus(input: BuildRuntimeStatusInput): Lexic
       manifestCoversPublic,
       singlePracticeDeckVersion,
     },
+  };
+}
+
+export function buildLexiconApiContract(status: LexiconRuntimeStatus): LexiconApiContract {
+  return {
+    schema: "atlas-api-contract",
+    schemaVersion: 1,
+    generatedAt: status.generatedAt,
+    status: status.status,
+    staticOnly: true,
+    endpoints: status.endpoints,
+    surfaces: {
+      atlas: {
+        entries: status.publicAtlas.searchEntries,
+        searchShards: status.publicAtlas.searchShards,
+        browseEntries: status.publicAtlas.browseEntries,
+        browseShards: status.publicAtlas.browseShards,
+        endpoints: {
+          searchIndex: status.endpoints.searchIndex,
+          searchShards: status.endpoints.searchShards,
+          browseShardTemplate: status.endpoints.browseShardTemplate,
+        },
+      },
+      dailyWord: {
+        poolEntries: status.daily.poolEntries,
+        endpoint: status.endpoints.dailyPool,
+        admission: "reviewed-static-pool",
+      },
+      practice: {
+        totalLexemes: status.practice.totalLexemes,
+        levels: [...PRACTICE_LEVELS],
+        deckVersions: status.practice.deckVersions,
+        endpoints: {
+          indexTemplate: status.endpoints.practiceIndexTemplate,
+          lexemesTemplate: status.endpoints.practiceLexemesTemplate,
+          clozeTemplate: status.endpoints.practiceClozeTemplate,
+        },
+      },
+      cloze: {
+        totalItems: status.cloze.totalItems,
+        sourceRows: status.cloze.sourceRows,
+        reviewedSourceRows: status.cloze.reviewedSourceRows,
+        endpointTemplate: status.endpoints.practiceClozeTemplate,
+      },
+    },
+    checks: status.checks,
   };
 }

--- a/site/src/pages/api/lexicon/contract.json.ts
+++ b/site/src/pages/api/lexicon/contract.json.ts
@@ -1,0 +1,49 @@
+import type { APIRoute } from "astro";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import {
+  PRACTICE_LEVELS,
+  buildLexiconApiContract,
+  buildLexiconRuntimeStatus,
+  type PracticeLevel,
+} from "../../../lib/lexicon/runtime-contract";
+
+export const prerender = true;
+
+const JSON_HEADERS = {
+  "Content-Type": "application/json; charset=utf-8",
+  "Cache-Control": "public, max-age=3600",
+};
+
+function readJson(relativePath: string): unknown {
+  return JSON.parse(readFileSync(resolve(process.cwd(), relativePath), "utf8"));
+}
+
+function readOptionalJson(relativePath: string): unknown {
+  const path = resolve(process.cwd(), relativePath);
+  return existsSync(path) ? JSON.parse(readFileSync(path, "utf8")) : undefined;
+}
+
+export const GET: APIRoute = () => {
+  const practiceIndexes: Partial<Record<PracticeLevel, unknown>> = {};
+  for (const level of PRACTICE_LEVELS) {
+    practiceIndexes[level] = readOptionalJson(`public/lexicon/practice-index.${level}.json`);
+  }
+
+  const status = buildLexiconRuntimeStatus({
+    manifest: readOptionalJson("src/data/lexicon-manifest.json"),
+    manifestPointer: readJson("src/data/lexicon-manifest.pointer.json"),
+    searchIndex: readJson("src/data/lexicon-search-index.json"),
+    searchShards: readJson("src/data/lexicon-search-shards.json"),
+    browseMeta: readJson("src/data/lexicon-browse-meta.json"),
+    dailyPool: readJson("src/data/lexicon-daily-pool.json"),
+    practiceIndexes,
+    clozeSources: readJson("src/data/lexicon-practice-cloze-sources.json"),
+    reviewedSources: readJson("src/data/lexicon-practice-reviewed-sources.json"),
+  });
+
+  return new Response(JSON.stringify(buildLexiconApiContract(status)), {
+    headers: JSON_HEADERS,
+  });
+};

--- a/site/tests/unit/lexicon-api-routes.test.ts
+++ b/site/tests/unit/lexicon-api-routes.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import type { APIRoute, GetStaticPaths } from "astro";
+import { GET as getContract } from "@site/src/pages/api/lexicon/contract.json";
 import { GET as getDailyPool } from "@site/src/pages/api/lexicon/daily-pool.json";
 import {
   GET as getPracticeCloze,
@@ -45,10 +46,11 @@ describe("lexicon static API routes", () => {
       publicAtlas: { searchEntries: number; browseEntries: number };
       daily: { poolEntries: number };
       practice: { totalLexemes: number };
-    checks: { searchMatchesBrowse: boolean; singlePracticeDeckVersion: boolean };
-    endpoints: {
-      searchIndex: string;
-      searchShards: string;
+      checks: { searchMatchesBrowse: boolean; singlePracticeDeckVersion: boolean };
+      endpoints: {
+        contract: string;
+        searchIndex: string;
+        searchShards: string;
       dailyPool: string;
       practiceIndexTemplate: string;
         practiceLexemesTemplate: string;
@@ -62,9 +64,10 @@ describe("lexicon static API routes", () => {
     expect(status.publicAtlas.searchEntries).toBe(status.publicAtlas.browseEntries);
     expect(status.daily.poolEntries).toBe(daily.length);
     expect(status.practice.totalLexemes).toBeGreaterThan(0);
-  expect(status.checks.searchMatchesBrowse).toBe(true);
-  expect(status.checks.singlePracticeDeckVersion).toBe(true);
-  expect(status.endpoints.searchIndex).toBe("/api/lexicon/search-index.json");
+    expect(status.checks.searchMatchesBrowse).toBe(true);
+    expect(status.checks.singlePracticeDeckVersion).toBe(true);
+    expect(status.endpoints.contract).toBe("/api/lexicon/contract.json");
+    expect(status.endpoints.searchIndex).toBe("/api/lexicon/search-index.json");
   expect(status.endpoints.searchShards).toBe("/lexicon/search-shards.json");
   expect(status.endpoints.dailyPool).toBe("/api/lexicon/daily-pool.json");
     expect(status.endpoints.practiceIndexTemplate).toBe(
@@ -75,6 +78,36 @@ describe("lexicon static API routes", () => {
     );
     expect(status.endpoints.practiceClozeTemplate).toBe(
       "/api/lexicon/practice-cloze.{level}.json",
+    );
+  });
+
+  test("publishes one static API contract for Atlas, Daily Word, and practice", async () => {
+    const contract = await routeJson<{
+      schema: string;
+      staticOnly: boolean;
+      surfaces: {
+        atlas: { entries: number; searchShards: number; browseEntries: number };
+        dailyWord: { poolEntries: number; endpoint: string };
+        practice: { totalLexemes: number; levels: string[] };
+        cloze: { totalItems: number; reviewedSourceRows: number };
+      };
+      endpoints: { contract: string; dailyPool: string; practiceIndexTemplate: string };
+    }>(getContract);
+
+    expect(contract.schema).toBe("atlas-api-contract");
+    expect(contract.staticOnly).toBe(true);
+    expect(contract.endpoints.contract).toBe("/api/lexicon/contract.json");
+    expect(contract.surfaces.atlas.entries).toBeGreaterThan(5000);
+    expect(contract.surfaces.atlas.entries).toBe(contract.surfaces.atlas.browseEntries);
+    expect(contract.surfaces.atlas.searchShards).toBeGreaterThan(1);
+    expect(contract.surfaces.dailyWord.poolEntries).toBeGreaterThanOrEqual(250);
+    expect(contract.surfaces.dailyWord.endpoint).toBe(contract.endpoints.dailyPool);
+    expect(contract.surfaces.practice.totalLexemes).toBeGreaterThan(1000);
+    expect(contract.surfaces.practice.levels).toEqual([...PRACTICE_LEVELS]);
+    expect(contract.surfaces.cloze.totalItems).toBe(14);
+    expect(contract.surfaces.cloze.reviewedSourceRows).toBeGreaterThan(0);
+    expect(contract.endpoints.practiceIndexTemplate).toBe(
+      "/api/lexicon/practice-index.{level}.json",
     );
   });
 

--- a/site/tests/unit/lexicon-runtime-contract.test.ts
+++ b/site/tests/unit/lexicon-runtime-contract.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   PRACTICE_LEVELS,
+  buildLexiconApiContract,
   buildLexiconRuntimeStatus,
   type PracticeLevel,
 } from "@site/src/lib/lexicon/runtime-contract";
@@ -75,6 +76,7 @@ describe("buildLexiconRuntimeStatus", () => {
     expect(status.publicAtlas.searchShardPrefixes).toBe(2);
     expect(status.publicAtlas.browseEntries).toBe(3);
     expect(status.publicAtlas.browseShards).toBe(2);
+    expect(status.endpoints.contract).toBe("/api/lexicon/contract.json");
     expect(status.daily.poolEntries).toBe(1);
     expect(status.practice.totalLexemes).toBe(2);
     expect(status.cloze.totalItems).toBe(1);
@@ -85,6 +87,17 @@ describe("buildLexiconRuntimeStatus", () => {
     expect(status.sourceInventory.practiceAdmitted).toBe(0);
     expect(status.checks.searchMatchesBrowse).toBe(true);
     expect(status.checks.manifestCoversPublic).toBe(true);
+
+    const contract = buildLexiconApiContract(status);
+    expect(contract.schema).toBe("atlas-api-contract");
+    expect(contract.staticOnly).toBe(true);
+    expect(contract.surfaces.atlas.entries).toBe(3);
+    expect(contract.surfaces.dailyWord.poolEntries).toBe(1);
+    expect(contract.surfaces.dailyWord.admission).toBe("reviewed-static-pool");
+    expect(contract.surfaces.practice.totalLexemes).toBe(2);
+    expect(contract.surfaces.practice.levels).toEqual([...PRACTICE_LEVELS]);
+    expect(contract.surfaces.cloze.totalItems).toBe(1);
+    expect(contract.endpoints.contract).toBe("/api/lexicon/contract.json");
   });
 
   test("warns when static surfaces drift", () => {


### PR DESCRIPTION
## Summary

Refs #3936.

- Adds `/api/lexicon/contract.json`, a static API contract that exposes Atlas, Daily Word, practice, and cloze surfaces from one discoverable endpoint.
- Links the contract from `/api/lexicon/status.json` under `endpoints.contract`.
- Adds an API card to the Atlas runtime panel so the UI shows the contract surface alongside Atlas, manifest, Daily Word, practice, cloze, and source inventory counts.
- Keeps Atlas/Daily/practice/cloze data unchanged.

## Current Contract Counts

Built `/api/lexicon/contract.json` reports:

- Atlas entries: 5,270.
- Browse entries: 5,270.
- Search shards: 61.
- Daily Word pool: 300.
- Practice lexemes: 4,484.
- Cloze items: 14.
- Practice levels: A1, A2, B1, B2, C1.

## Validation

- `cd site && npm test -- tests/unit/lexicon-runtime-contract.test.ts tests/unit/lexicon-api-routes.test.ts`
- `cd site && npm run build`
- Built `/api/lexicon/contract.json` inspected with `jq` for Atlas/Daily/practice/cloze counts and endpoint templates.
- `git diff --check`
- no forbidden generated status/audit/review/telemetry files in diff
- no `sys.executable` in diff
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Scope Guard

This PR does not publish new Atlas rows, Daily Word rows, practice lexemes, or cloze items. It only exposes the existing static contract more clearly for tools and UI.