### PR TITLE
feat(atlas): preserve Ohoiko provenance on existing entries

### DIFF
--- a/scripts/audit/apply_source_inventory_provenance.py
+++ b/scripts/audit/apply_source_inventory_provenance.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Attach approved source-inventory provenance to existing Atlas entries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) in sys.path:
+    sys.path.remove(str(SCRIPT_DIR))
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.audit import generate_source_inventory_review_candidates as review
+from scripts.audit import plan_source_inventory_promotion as plan
+from scripts.audit.source_inventory_intake import SourceInventoryError
+from scripts.lexicon import promote_grow_candidates as promote
+from scripts.lexicon.build_data_manifest import _lemma_key
+from scripts.lexicon.manifest_fingerprint import DEFAULT_FINGERPRINT, write_fingerprint
+
+DEFAULT_MANIFEST = Path("site/src/data/lexicon-manifest.json")
+WORKFLOW_ID = "source_inventory_existing_provenance_overlay.v1"
+
+
+def apply_existing_provenance_overlay(
+    manifest: dict[str, Any],
+    candidate_index: Mapping[str, plan.CandidateMatch],
+    approved_decisions: Sequence[plan.ApprovedDecision],
+    *,
+    source_family: str | None = None,
+) -> dict[str, Any]:
+    entries = manifest.get("entries")
+    if not isinstance(entries, list):
+        raise SourceInventoryError("manifest entries must be list")
+
+    entries_by_key: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict) or not entry.get("lemma"):
+            continue
+        entries_by_key[_lemma_key(str(entry["lemma"]))] = entry
+
+    updates: list[dict[str, Any]] = []
+    missing_candidates: list[dict[str, Any]] = []
+    missing_manifest_entries: list[dict[str, Any]] = []
+    unchanged_existing: list[dict[str, Any]] = []
+    filtered_decisions = 0
+    added_refs = 0
+
+    for decision in approved_decisions:
+        if source_family and decision.source_inventory.get("source_family") != source_family:
+            continue
+        filtered_decisions += 1
+
+        base_row = {
+            "lemma": decision.lemma,
+            "source_inventory_key": decision.source_key,
+            "source_family": decision.source_inventory.get("source_family"),
+            "decision_file": decision.decision_file,
+        }
+        match = candidate_index.get(decision.source_key)
+        if match is None:
+            missing_candidates.append({**base_row, "reason": "approved source key missing from candidates"})
+            continue
+
+        entry = entries_by_key.get(_lemma_key(decision.lemma))
+        if entry is None:
+            missing_manifest_entries.append({**base_row, "reason": "approved lemma missing from manifest"})
+            continue
+
+        candidate_provenance = _source_provenance(match.entry)
+        if not candidate_provenance:
+            missing_candidates.append({**base_row, "reason": "matched candidate lacks source_provenance"})
+            continue
+
+        added = _append_missing_provenance(entry, candidate_provenance)
+        if added:
+            added_refs += added
+            updates.append(
+                {
+                    **base_row,
+                    "primary_source": entry.get("primary_source"),
+                    "added_provenance_refs": added,
+                    "manifest_lemma": entry.get("lemma"),
+                }
+            )
+        else:
+            unchanged_existing.append({**base_row, "reason": "source provenance already present"})
+
+    return {
+        "workflow": WORKFLOW_ID,
+        "source_family": source_family,
+        "counts": {
+            "approved_decisions": len(approved_decisions),
+            "filtered_decisions": filtered_decisions,
+            "updated_entries": len(updates),
+            "added_provenance_refs": added_refs,
+            "unchanged_existing": len(unchanged_existing),
+            "missing_candidates": len(missing_candidates),
+            "missing_manifest_entries": len(missing_manifest_entries),
+        },
+        "updated_entries": updates,
+        "unchanged_existing": unchanged_existing,
+        "missing_candidates": missing_candidates,
+        "missing_manifest_entries": missing_manifest_entries,
+        "production_outputs_updated": [],
+    }
+
+
+def format_report(result: Mapping[str, Any]) -> str:
+    counts = result["counts"]
+    lines = [
+        "# Source Inventory Existing Provenance Overlay",
+        "",
+        f"- workflow: `{result['workflow']}`",
+        f"- source_family: `{result.get('source_family') or 'all'}`",
+        f"- filtered_decisions: {counts['filtered_decisions']}",
+        f"- updated_entries: {counts['updated_entries']}",
+        f"- added_provenance_refs: {counts['added_provenance_refs']}",
+        f"- unchanged_existing: {counts['unchanged_existing']}",
+        f"- missing_candidates: {counts['missing_candidates']}",
+        f"- missing_manifest_entries: {counts['missing_manifest_entries']}",
+        "- production_outputs_updated: []",
+    ]
+    if result.get("updated_entries"):
+        lines.extend(["", "## Updated Existing Entries", ""])
+        lines.extend(
+            f"- `{row['lemma']}` ({row['source_inventory_key']}): +{row['added_provenance_refs']} provenance ref(s)"
+            for row in result["updated_entries"]
+        )
+    if result.get("missing_candidates"):
+        lines.extend(["", "## Missing Candidates", ""])
+        lines.extend(
+            f"- `{row['lemma']}` ({row['source_inventory_key']}): {row['reason']}"
+            for row in result["missing_candidates"]
+        )
+    if result.get("missing_manifest_entries"):
+        lines.extend(["", "## Missing Manifest Entries", ""])
+        lines.extend(
+            f"- `{row['lemma']}` ({row['source_inventory_key']}): {row['reason']}"
+            for row in result["missing_manifest_entries"]
+        )
+    return "\n".join(lines)
+
+
+def _source_provenance(entry: Mapping[str, Any]) -> list[dict[str, Any]]:
+    provenance = entry.get("source_provenance")
+    if not isinstance(provenance, list):
+        return []
+    return [dict(item) for item in provenance if isinstance(item, Mapping)]
+
+
+def _append_missing_provenance(entry: dict[str, Any], provenance: Sequence[Mapping[str, Any]]) -> int:
+    existing_raw = entry.get("source_provenance")
+    if existing_raw is None:
+        existing: list[dict[str, Any]] = []
+    elif isinstance(existing_raw, list):
+        existing = [dict(item) for item in existing_raw if isinstance(item, Mapping)]
+    else:
+        raise SourceInventoryError(f"{entry.get('lemma')}: source_provenance must be list when present")
+
+    seen = {_canonical_provenance_key(item) for item in existing}
+    added = 0
+    for item in provenance:
+        row = dict(item)
+        key = _canonical_provenance_key(row)
+        if key in seen:
+            continue
+        existing.append(row)
+        seen.add(key)
+        added += 1
+
+    if added:
+        entry["source_provenance"] = existing
+    return added
+
+
+def _canonical_provenance_key(item: Mapping[str, Any]) -> str:
+    return json.dumps(dict(item), ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidates", type=Path, default=plan.DEFAULT_CANDIDATES)
+    parser.add_argument("--decision-file", type=Path, action="append", dest="decision_files")
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--fingerprint", type=Path, default=DEFAULT_FINGERPRINT)
+    parser.add_argument("--generate-candidates", action="store_true")
+    parser.add_argument("--source-family", help="Limit overlay to one source family, e.g. ohoiko")
+    parser.add_argument("--write", action="store_true", help="Write manifest and fingerprint sidecar")
+    parser.add_argument("--report", action="store_true", help="Print Markdown report")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.generate_candidates:
+            review.generate_review_candidates(out=args.candidates)
+        manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+        candidate_index = plan._candidate_index(plan._read_candidate_payload(args.candidates))
+        approved = plan._approved_decisions(plan._decision_paths(args.decision_files))
+        result = apply_existing_provenance_overlay(
+            manifest,
+            candidate_index,
+            approved,
+            source_family=args.source_family,
+        )
+        if args.write and result["counts"]["updated_entries"]:
+            promote._refresh_manifest_metadata(manifest)
+            promote._validate_before_write(manifest, args.manifest, promote.verify_prospective_manifest)
+            promote._write_json_atomically(args.manifest, manifest)
+            write_fingerprint(args.fingerprint)
+        if args.report:
+            print(format_report(result))
+        else:
+            print(json.dumps(result["counts"], ensure_ascii=False, sort_keys=True))
+    except (OSError, SourceInventoryError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/src/data/lexicon-manifest.pointer.json
+++ b/site/src/data/lexicon-manifest.pointer.json
@@ -4,10 +4,10 @@
   "manifest_version": "0.1",
   "manifest_fingerprint": "60367f42ef5f2dda11f6e7c52bc55c16353f3ca84a5c516c3972c89e7d992ce1",
   "fingerprint_schema_version": 1,
-  "generated_at": "2026-06-30T09:12:11+00:00",
-  "gz_sha256": "0e6f41f24c27ab62400f7c929d97649ad0ca53a44d4c1db6efbe10e7e5fe5a27",
-  "json_sha256": "710b410df122eef0bb3411a0939251f46e4661990f82fcd6d133c49c8fe7253b",
-  "gz_bytes": 6149724,
-  "json_bytes": 44668377,
+  "generated_at": "2026-06-30T19:43:19+00:00",
+  "gz_sha256": "c84982ebf9c0ac6de9555e55ae62b7f386eb5eecb5523b069e5b23df4775d341",
+  "json_sha256": "7b6fc88332ea23b459520a9b4317d2fd40fa8448d7f9679f149ad5afc9416e16",
+  "gz_bytes": 6151558,
+  "json_bytes": 44672605,
   "note": "Pins GitHub Release asset manifest for #3659; hydrate it build time instead committing raw JSON."
 }

--- a/tests/test_apply_source_inventory_provenance.py
+++ b/tests/test_apply_source_inventory_provenance.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from scripts.audit.apply_source_inventory_provenance import apply_existing_provenance_overlay
+from scripts.audit.plan_source_inventory_promotion import ApprovedDecision, CandidateMatch
+
+
+def decision(lemma: str, family: str = "ohoiko") -> ApprovedDecision:
+    return ApprovedDecision(
+        lemma=lemma,
+        approved_pos="noun",
+        approved_gloss="test gloss",
+        sense_note="reviewed",
+        source_inventory={
+            "key": f"{family}-{lemma}",
+            "path": f"data/lexicon/source-inventory/{family}.yaml",
+            "locator": "sources[0].headwords[0]",
+            "source_id": f"{family}-source",
+            "source_family": family,
+        },
+        evidence_refs=(family,),
+        review_queue_reasons=(),
+        surface_admission={},
+        batch_id="test-batch",
+        batch_label="test batch",
+        decision_file="decisions.yaml",
+    )
+
+
+def match(lemma: str, family: str = "ohoiko") -> CandidateMatch:
+    return CandidateMatch(
+        entry={
+            "lemma": lemma,
+            "source_provenance": [
+                {
+                    "source_family": family,
+                    "source_id": f"{family}-source",
+                    "source_locator": "letters[А].key_word",
+                    "inventory_path": f"data/lexicon/source-inventory/{family}.yaml",
+                    "inventory_locator": "sources[0].headwords[0]",
+                }
+            ],
+        },
+        bucket="auto_merge",
+        reasons=(),
+    )
+
+
+def test_overlay_adds_source_provenance_to_existing_manifest_entry() -> None:
+    manifest = {"entries": [{"lemma": "ананас", "primary_source": "built_vocabulary"}]}
+    result = apply_existing_provenance_overlay(
+        manifest,
+        {"ohoiko-ананас": match("ананас")},
+        [decision("ананас")],
+        source_family="ohoiko",
+    )
+
+    assert result["counts"] == {
+        "approved_decisions": 1,
+        "filtered_decisions": 1,
+        "updated_entries": 1,
+        "added_provenance_refs": 1,
+        "unchanged_existing": 0,
+        "missing_candidates": 0,
+        "missing_manifest_entries": 0,
+    }
+    assert manifest["entries"][0]["primary_source"] == "built_vocabulary"
+    assert manifest["entries"][0]["source_provenance"] == match("ананас").entry["source_provenance"]
+
+
+def test_overlay_is_idempotent_for_existing_provenance() -> None:
+    provenance = match("ананас").entry["source_provenance"]
+    manifest = {
+        "entries": [
+            {
+                "lemma": "ананас",
+                "primary_source": "built_vocabulary",
+                "source_provenance": provenance.copy(),
+            }
+        ]
+    }
+
+    result = apply_existing_provenance_overlay(
+        manifest,
+        {"ohoiko-ананас": match("ананас")},
+        [decision("ананас")],
+        source_family="ohoiko",
+    )
+
+    assert result["counts"]["updated_entries"] == 0
+    assert result["counts"]["unchanged_existing"] == 1
+    assert manifest["entries"][0]["source_provenance"] == provenance
+
+
+def test_overlay_source_family_filter_keeps_other_lanes_untouched() -> None:
+    manifest = {
+        "entries": [
+            {"lemma": "ананас", "primary_source": "built_vocabulary"},
+            {"lemma": "дошка", "primary_source": "built_vocabulary"},
+        ]
+    }
+
+    result = apply_existing_provenance_overlay(
+        manifest,
+        {
+            "ohoiko-ананас": match("ананас", "ohoiko"),
+            "textbook-дошка": match("дошка", "textbook"),
+        },
+        [decision("ананас", "ohoiko"), decision("дошка", "textbook")],
+        source_family="ohoiko",
+    )
+
+    assert result["counts"]["approved_decisions"] == 2
+    assert result["counts"]["filtered_decisions"] == 1
+    assert result["counts"]["updated_entries"] == 1
+    assert manifest["entries"][0]["source_provenance"][0]["source_family"] == "ohoiko"
+    assert "source_provenance" not in manifest["entries"][1]


### PR DESCRIPTION
## Summary

Refs #3933 and #3936.

- Adds `scripts/audit/apply_source_inventory_provenance.py`, an idempotent overlay for approved source-inventory rows whose lemmas already exist in the Atlas manifest.
- Applies it only for `source_family=ohoiko` in this PR.
- Updates the Atlas manifest release asset/pointer so approved Ohoiko provenance is visible on existing Atlas entries instead of being silently skipped as duplicates.
- Adds tests for provenance overlay, idempotency, and source-family filtering.

## Concrete Atlas Effect

No new Atlas rows are added. Atlas remains 5,280 manifest entries / 5,270 public search entries.

Ohoiko provenance is now present for 10 approved entries:

- ананас
- банан
- гора
- дім
- жук
- зебра
- кіт
- око
- тигр
- черепаха

This PR adds provenance to existing entries that lacked it:

- банан: +1 Ohoiko provenance ref
- гора: +1 Ohoiko provenance ref
- дім: +1 Ohoiko provenance ref, preserving existing textbook provenance
- око: +1 Ohoiko provenance ref

## Frozen Surfaces

Daily/practice/cloze remain frozen:

- Daily Word: 300
- Practice lexemes: 4,484
- Cloze items: 14
- Reviewed cloze sources: 7

Search/browse regenerated cleanly with no tracked output diff.

## Validation

- `.venv/bin/ruff check scripts/audit/apply_source_inventory_provenance.py tests/test_apply_source_inventory_provenance.py`
- `.venv/bin/python -m py_compile scripts/audit/apply_source_inventory_provenance.py`
- `.venv/bin/python -m pytest tests/test_apply_source_inventory_provenance.py -q`
- `node site/scripts/hydrate-manifest.mjs`
- `.venv/bin/python -m scripts.audit.apply_source_inventory_provenance --generate-candidates --source-family ohoiko --manifest site/src/data/lexicon-manifest.json --report`
- `.venv/bin/python scripts/audit/check_static_practice_assets.py --format json`
- `.venv/bin/python -m scripts.audit.generate_search_index`
- `cd site && npm run build`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Scope Guard

This is provenance-only for approved Ohoiko rows already present in Atlas. It does not admit any ULP link-only/premium content, does not add new headwords, and does not touch Daily Word, practice, or cloze admission.