### PR TITLE
feat(atlas): preserve textbook provenance on existing entries

### DIFF
--- a/site/src/data/lexicon-manifest.pointer.json
+++ b/site/src/data/lexicon-manifest.pointer.json
@@ -4,10 +4,10 @@
   "manifest_version": "0.1",
   "manifest_fingerprint": "60367f42ef5f2dda11f6e7c52bc55c16353f3ca84a5c516c3972c89e7d992ce1",
   "fingerprint_schema_version": 1,
-  "generated_at": "2026-06-30T19:43:19+00:00",
-  "gz_sha256": "c84982ebf9c0ac6de9555e55ae62b7f386eb5eecb5523b069e5b23df4775d341",
-  "json_sha256": "7b6fc88332ea23b459520a9b4317d2fd40fa8448d7f9679f149ad5afc9416e16",
-  "gz_bytes": 6151558,
-  "json_bytes": 44672605,
+  "generated_at": "2026-06-30T20:08:38+00:00",
+  "gz_sha256": "6c3ba1311c03729d30d7f4f927a0e712882c33c31d832dd376c9d861f868f3fa",
+  "json_sha256": "337b92e71726910be085e7922984bb8e0c5905d8e151e5e64634df9634842209",
+  "gz_bytes": 6155035,
+  "json_bytes": 44680916,
   "note": "Pins GitHub Release asset manifest for #3659; hydrate it build time instead committing raw JSON."
 }


### PR DESCRIPTION
## Summary

- publish the release-backed Atlas manifest pointer after applying the existing source-inventory provenance overlay for `source_family: textbook`
- preserve textbook provenance on existing Atlas entries without creating duplicate lexemes or changing `primary_source`
- keep Daily Word, practice, cloze, search, and browse outputs frozen

## Atlas Effect

- Hydrated Atlas manifest remains 5,280 entries
- Public Atlas search/browse remains 5,270 entries
- 23 approved textbook decisions are now represented as existing-entry provenance overlays
- 9 existing entries gained 10 textbook provenance references: автобус, ліс, мама, балкон, вареники, диван, йогурт, коридор, намет
- No missing candidates and no missing manifest entries

## Frozen Surfaces

- Daily Word: 300
- Practice lexemes: 4,484
- Cloze items: 14
- Reviewed cloze sources: 7

## Validation

- `node site/scripts/hydrate-manifest.mjs`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m scripts.audit.apply_source_inventory_provenance --generate-candidates --source-family textbook --manifest site/src/data/lexicon-manifest.json --report`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/check_static_practice_assets.py --format json`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m scripts.audit.generate_search_index`
- `npm run build`
- `git diff --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Notes

This PR intentionally updates only `site/src/data/lexicon-manifest.pointer.json`; the raw manifest and gzipped release asset remain outside git. Daily/practice/cloze policy remains a separate issue.

Refs #3934, #3936
