### PR TITLE
feat(atlas): preserve curriculum provenance on existing entries

### DIFF
--- a/site/src/data/lexicon-manifest.pointer.json
+++ b/site/src/data/lexicon-manifest.pointer.json
@@ -4,10 +4,10 @@
   "manifest_version": "0.1",
   "manifest_fingerprint": "60367f42ef5f2dda11f6e7c52bc55c16353f3ca84a5c516c3972c89e7d992ce1",
   "fingerprint_schema_version": 1,
-  "generated_at": "2026-06-30T20:08:38+00:00",
-  "gz_sha256": "6c3ba1311c03729d30d7f4f927a0e712882c33c31d832dd376c9d861f868f3fa",
-  "json_sha256": "337b92e71726910be085e7922984bb8e0c5905d8e151e5e64634df9634842209",
-  "gz_bytes": 6155035,
-  "json_bytes": 44680916,
+  "generated_at": "2026-06-30T20:43:45+00:00",
+  "gz_sha256": "89dd6165250b80c800c14d56dfd8bc40b47e79355cbbc389a8a152420adb2ba1",
+  "json_sha256": "b87078dfef662ce2fd70233018bed56b8cb15fe72cdf3dda37e92ddce69c7165",
+  "gz_bytes": 6157621,
+  "json_bytes": 44686390,
   "note": "Pins GitHub Release asset manifest for #3659; hydrate it build time instead committing raw JSON."
 }


### PR DESCRIPTION
## Summary

- apply the existing source-inventory provenance overlay for `source_family: curriculum`
- publish the updated Atlas manifest release asset and pointer
- keep Atlas row counts, search/browse, Daily Word, practice, and cloze surfaces unchanged

## Atlas Effect

- Hydrated Atlas manifest remains 5,280 entries
- Public Atlas search/browse remains 5,270 entries
- 7 approved curriculum/lesson decisions are now represented as existing-entry provenance overlays
- Updated entries: великий, два, один, читати, але, добре, море
- No missing candidates and no missing manifest entries

## Frozen Surfaces

- Daily Word: 300
- Practice lexemes: 4,484
- Cloze items: 22
- A1 cloze: 22
- Search shards: 61

## Validation

- `node site/scripts/hydrate-manifest.mjs`
- `.venv/bin/python -m scripts.audit.apply_source_inventory_provenance --generate-candidates --source-family curriculum --manifest site/src/data/lexicon-manifest.json --report`
- `.venv/bin/python scripts/audit/check_static_practice_assets.py --format json`
- `.venv/bin/python -m scripts.audit.generate_search_index`
- `npm run build`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

Refs #3936
