### PR TITLE
feat(atlas): preserve Tatoeba cloze attribution

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: f1693621dc1daa997d13194dbce428d7e84b5d1a4cbb894b1e37183b25160911
+  components_sha256: 581611447150cf1ee82a8f32b0ef0ba4346cc453b13d4d5faa1e5563d73d1687
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/scripts/audit/check_static_practice_assets.py
+++ b/scripts/audit/check_static_practice_assets.py
@@ -48,6 +48,52 @@ def _has_text(value: object) -> bool:
     return isinstance(value, str) and bool(value.strip())
 
 
+def _has_scalar(value: object) -> bool:
+    return isinstance(value, int) or _has_text(value)
+
+
+def _is_tatoeba_provenance(provenance: object) -> bool:
+    if not isinstance(provenance, dict):
+        return False
+    status = str(provenance.get("status") or "").strip()
+    source_path = str(provenance.get("path") or "").strip()
+    return status == "tatoeba" or source_path.startswith("tatoeba:")
+
+
+def _check_tatoeba_attribution(
+    prefix: str,
+    item: dict[str, Any],
+    provenance: dict[str, Any],
+    errors: list[str],
+) -> None:
+    if not _is_tatoeba_provenance(provenance):
+        return
+    source_path = str(provenance.get("path") or "").strip()
+    path_sentence_id = source_path.removeprefix("tatoeba:") if source_path.startswith("tatoeba:") else ""
+    for field in ("license", "author", "enSentenceId", "enAuthor", "enLicense"):
+        if not _has_scalar(provenance.get(field)):
+            errors.append(f"{prefix} Tatoeba provenance missing {field}")
+    if not _has_scalar(provenance.get("sentenceId")) and not path_sentence_id:
+        errors.append(f"{prefix} Tatoeba provenance missing sentenceId")
+    attribution = item.get("attribution")
+    if not isinstance(attribution, dict):
+        errors.append(f"{prefix} missing Tatoeba attribution")
+        return
+    if attribution.get("source") != "Tatoeba":
+        errors.append(f"{prefix} Tatoeba attribution source must be Tatoeba")
+    for key, label in (("uk", "Ukrainian"), ("en", "English")):
+        sentence = attribution.get(key)
+        if not isinstance(sentence, dict):
+            errors.append(f"{prefix} missing {label} Tatoeba attribution")
+            continue
+        for field in ("sentenceId", "author", "license"):
+            if not _has_scalar(sentence.get(field)):
+                errors.append(f"{prefix} missing {label} Tatoeba attribution {field}")
+    uk = attribution.get("uk") if isinstance(attribution, dict) else None
+    if path_sentence_id and isinstance(uk, dict) and str(uk.get("sentenceId") or "").strip() != path_sentence_id:
+        errors.append(f"{prefix} Tatoeba attribution sentenceId does not match provenance path")
+
+
 def _reviewed_source_keys(path: Path, errors: list[str]) -> set[tuple[str, str]]:
     payload = _read_json(path, errors)
     rows = payload.get("reviewed") if isinstance(payload, dict) else payload
@@ -212,6 +258,8 @@ def _check_cloze_item(
     key = (str(status or "").strip(), str(source_path or "").strip())
     if key not in reviewed:
         errors.append(f"{prefix} provenance {key!r} is not in reviewed source allowlist")
+    if isinstance(provenance, dict):
+        _check_tatoeba_attribution(prefix, item, provenance, errors)
 
 
 def _check_level(

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -152,6 +152,80 @@ class ReviewedSourceAllowlist:
         return (status, path) in self.reviewed
 
 
+def _is_tatoeba_provenance(provenance: Any) -> bool:
+    if not isinstance(provenance, dict):
+        return False
+    status = _clean_text(provenance.get("status"))
+    path = _clean_text(provenance.get("path"))
+    return status == "tatoeba" or path.startswith("tatoeba:")
+
+
+def _string_or_int(value: Any) -> str | int | None:
+    if isinstance(value, int):
+        return value
+    text = _clean_text(value)
+    if not text:
+        return None
+    try:
+        return int(text)
+    except ValueError:
+        return text
+
+
+def _build_tatoeba_attribution(provenance: Any) -> dict[str, Any] | None:
+    if not _is_tatoeba_provenance(provenance):
+        return None
+    assert isinstance(provenance, dict)
+    path = _clean_text(provenance.get("path"))
+    path_sentence_id = path.removeprefix("tatoeba:") if path.startswith("tatoeba:") else ""
+    uk_sentence_id = _string_or_int(provenance.get("sentenceId")) or _string_or_int(path_sentence_id)
+    en_sentence_id = _string_or_int(provenance.get("enSentenceId"))
+    uk_author = _clean_text(provenance.get("author"))
+    en_author = _clean_text(provenance.get("enAuthor"))
+    uk_license = _clean_text(provenance.get("license"))
+    en_license = _clean_text(provenance.get("enLicense"))
+    if not all((uk_sentence_id, en_sentence_id, uk_author, en_author, uk_license, en_license)):
+        return None
+    return {
+        "source": "Tatoeba",
+        "sourceUrl": f"https://tatoeba.org/en/sentences/show/{uk_sentence_id}",
+        "uk": {
+            "sentenceId": uk_sentence_id,
+            "author": uk_author,
+            "license": uk_license,
+        },
+        "en": {
+            "sentenceId": en_sentence_id,
+            "author": en_author,
+            "license": en_license,
+        },
+    }
+
+
+def _build_cloze_provenance(provenance: dict[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "status": provenance["status"],
+        "path": provenance["path"],
+    }
+    path = _clean_text(provenance.get("path"))
+    path_sentence_id = path.removeprefix("tatoeba:") if path.startswith("tatoeba:") else ""
+    if provenance.get("sentenceId") is None and path_sentence_id:
+        sentence_id = _string_or_int(path_sentence_id)
+        if sentence_id is not None:
+            payload["sentenceId"] = sentence_id
+    for key in ("cardId", "license", "author", "sentenceId", "enSentenceId", "enAuthor", "enLicense"):
+        if key in payload:
+            continue
+        value = provenance.get(key)
+        if isinstance(value, int):
+            payload[key] = value
+            continue
+        text = _clean_text(value)
+        if text:
+            payload[key] = text
+    return payload
+
+
 class RealVesumVerifier:
     """Runtime adapter for the production VESUM helper."""
 
@@ -992,27 +1066,28 @@ def _build_cloze_items(
         case_rule = _case_rule_payload(rule_id, lexeme["lemma"], form)
         if not case_rule:
             continue
-        items.append(
-            {
-                "clozeId": cloze_id,
-                "lemmaId": lexeme["lemmaId"],
-                "sentenceFrameId": sentence_frame_id,
-                "sentence": sentence,
-                "blankCase": case_name,
-                "form": form,
-                "number": number,
-                "lemma": lexeme["lemma"],
-                "caseRule": case_rule,
-                "clozeEn": cloze_en,
-                "cefr": _clean_text(candidate.get("cefr")) or lexeme["cefr"],
-                "acceptedAlt": _accepted_alts(candidate),
-                "provenance": {
-                    "status": provenance["status"],
-                    "path": provenance["path"],
-                    "cardId": _clean_text(provenance.get("cardId")),
-                },
-            }
-        )
+        assert isinstance(provenance, dict)
+        attribution = _build_tatoeba_attribution(provenance)
+        if _is_tatoeba_provenance(provenance) and attribution is None:
+            continue
+        item = {
+            "clozeId": cloze_id,
+            "lemmaId": lexeme["lemmaId"],
+            "sentenceFrameId": sentence_frame_id,
+            "sentence": sentence,
+            "blankCase": case_name,
+            "form": form,
+            "number": number,
+            "lemma": lexeme["lemma"],
+            "caseRule": case_rule,
+            "clozeEn": cloze_en,
+            "cefr": _clean_text(candidate.get("cefr")) or lexeme["cefr"],
+            "acceptedAlt": _accepted_alts(candidate),
+            "provenance": _build_cloze_provenance(provenance),
+        }
+        if attribution is not None:
+            item["attribution"] = attribution
+        items.append(item)
     return items
 
 

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -1130,6 +1130,18 @@ function PracticeCloze({
         <span>{after}</span>
       </p>
       <p className="lexicon-cloze-translation cz-translate">{cloze.clozeEn}</p>
+      {cloze.attribution ? (
+        <p className="lexicon-cloze-attribution">
+          Sentences from{' '}
+          {cloze.attribution.sourceUrl ? (
+            <a href={cloze.attribution.sourceUrl}>{cloze.attribution.source}</a>
+          ) : (
+            cloze.attribution.source
+          )}
+          : {cloze.attribution.uk.author} ({cloze.attribution.uk.license}) /{' '}
+          {cloze.attribution.en.author} ({cloze.attribution.en.license})
+        </p>
+      ) : null}
       <form
         className="lexicon-cloze-row cz-input-row"
         onSubmit={(event) => {

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -81,6 +81,19 @@ export interface PracticeCaseRule {
   feedback: string;
 }
 
+export interface PracticeClozeAttributionSentence {
+  sentenceId: string | number;
+  author: string;
+  license: string;
+}
+
+export interface PracticeClozeAttribution {
+  source: string;
+  sourceUrl?: string;
+  uk: PracticeClozeAttributionSentence;
+  en: PracticeClozeAttributionSentence;
+}
+
 export interface PracticeClozeItem {
   clozeId: string;
   lemmaId: string;
@@ -93,6 +106,7 @@ export interface PracticeClozeItem {
   caseRule: PracticeCaseRule;
   clozeEn: string;
   options: PracticeClozeOption[];
+  attribution?: PracticeClozeAttribution;
 }
 
 export interface PracticeShardMeta {

--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -222,6 +222,17 @@ const frontmatter = {
     font-weight: 850;
     line-height: 1.45;
   }
+  :global(.lexicon-cloze-attribution) {
+    margin: -0.45rem 0 0;
+    color: var(--lu-text-muted);
+    font-size: 0.82rem;
+    line-height: 1.35;
+  }
+  :global(.lexicon-cloze-attribution a) {
+    color: inherit;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.18em;
+  }
 
   :global(.lexicon-option-list) {
     display: grid;

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -474,4 +474,27 @@ describe('LexiconPractice', () => {
       expect(storedState().reviews).toHaveLength(1);
     });
   });
+
+  test('cloze renders Tatoeba attribution when present', () => {
+    seedRecognitionMastery('knyha');
+    const deck = sampleDeck();
+    deck.cloze[0] = {
+      ...deck.cloze[0],
+      attribution: {
+        source: 'Tatoeba',
+        sourceUrl: 'https://tatoeba.org/en/sentences/show/101',
+        uk: { sentenceId: 101, author: 'uk-author', license: 'CC-BY 2.0 FR' },
+        en: { sentenceId: 202, author: 'en-author', license: 'CC-BY 2.0 FR' },
+      },
+    };
+
+    render(<LexiconPractice initialDeck={deck} autoStart initialMode="cloze" />);
+
+    expect(screen.getByRole('link', { name: 'Tatoeba' })).toHaveAttribute(
+      'href',
+      'https://tatoeba.org/en/sentences/show/101',
+    );
+    expect(screen.getByText(/uk-author/)).toHaveTextContent('en-author');
+    expect(screen.getByText(/CC-BY 2.0 FR/)).toBeInTheDocument();
+  });
 });

--- a/tests/test_check_static_practice_assets.py
+++ b/tests/test_check_static_practice_assets.py
@@ -317,3 +317,75 @@ def test_cli_reports_missing_static_shard(tmp_path: Path) -> None:
 
     assert result.returncode == 1
     assert "practice-lexemes.A1.json: missing" in result.stdout
+
+
+def _set_tatoeba_cloze_metadata(practice_dir: Path, *, with_attribution: bool) -> None:
+    cloze_path = practice_dir / "practice-cloze.A1.json"
+    payload = json.loads(cloze_path.read_text(encoding="utf-8"))
+    item = payload["cloze"][0]
+    item["provenance"] = {
+        "status": "tatoeba",
+        "path": "tatoeba:101",
+        "license": "CC-BY 2.0 FR",
+        "author": "uk-author",
+        "sentenceId": 101,
+        "enSentenceId": 202,
+        "enAuthor": "en-author",
+        "enLicense": "CC-BY 2.0 FR",
+    }
+    if with_attribution:
+        item["attribution"] = {
+            "source": "Tatoeba",
+            "sourceUrl": "https://tatoeba.org/en/sentences/show/101",
+            "uk": {"sentenceId": 101, "author": "uk-author", "license": "CC-BY 2.0 FR"},
+            "en": {"sentenceId": 202, "author": "en-author", "license": "CC-BY 2.0 FR"},
+        }
+    _write_json(cloze_path, payload)
+
+
+def test_check_assets_requires_tatoeba_attribution(tmp_path: Path) -> None:
+    daily_pool = tmp_path / "lexicon-daily-pool.json"
+    practice_dir = tmp_path / "lexicon"
+    reviewed_sources = tmp_path / "lexicon-practice-reviewed-sources.json"
+    _write_daily_pool(daily_pool)
+    _write_json(reviewed_sources, {"reviewed": [{"status": "tatoeba", "path": "tatoeba:101"}]})
+    _write_level(practice_dir, with_cloze=True)
+    _set_tatoeba_cloze_metadata(practice_dir, with_attribution=False)
+
+    summary = check_assets(
+        daily_pool=daily_pool,
+        practice_dir=practice_dir,
+        reviewed_sources=reviewed_sources,
+        levels=("A1",),
+        min_daily_pool_size=2,
+        min_practice_lexemes_per_level=1,
+    )
+
+    assert summary["ok"] is False
+    assert any("missing Tatoeba attribution" in error for error in summary["errors"])
+
+
+def test_check_assets_accepts_tatoeba_attributed_cloze(tmp_path: Path) -> None:
+    daily_pool = tmp_path / "lexicon-daily-pool.json"
+    practice_dir = tmp_path / "lexicon"
+    reviewed_sources = tmp_path / "lexicon-practice-reviewed-sources.json"
+    _write_daily_pool(daily_pool)
+    _write_json(reviewed_sources, {"reviewed": [{"status": "tatoeba", "path": "tatoeba:101"}]})
+    _write_level(practice_dir, with_cloze=True)
+    _set_tatoeba_cloze_metadata(practice_dir, with_attribution=True)
+    cloze_path = practice_dir / "practice-cloze.A1.json"
+    cloze_payload = json.loads(cloze_path.read_text(encoding="utf-8"))
+    cloze_payload["cloze"][0]["provenance"].pop("sentenceId")
+    _write_json(cloze_path, cloze_payload)
+
+    summary = check_assets(
+        daily_pool=daily_pool,
+        practice_dir=practice_dir,
+        reviewed_sources=reviewed_sources,
+        levels=("A1",),
+        min_daily_pool_size=2,
+        min_practice_lexemes_per_level=1,
+    )
+
+    assert summary["ok"] is True
+    assert summary["total_cloze"] == 1

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -407,3 +407,85 @@ def test_cloze_decoys_do_not_exceed_answer_cefr() -> None:
     assert _eligible_decoys(answer, lexemes, "accusative", "singular") == [
         (lexemes[1], "школу")
     ]
+
+
+def _tatoeba_cloze_source() -> dict[str, object]:
+    return {
+        "lemma": "книга",
+        "lemmaId": "knyha",
+        "sentence": "Я читаю ___.",
+        "blankCase": "accusative",
+        "form": "книгу",
+        "number": "singular",
+        "caseRuleId": "accusative_direct_object",
+        "clozeEn": "I am reading a book.",
+        "cefr": "A1",
+        "provenance": {
+            "status": "tatoeba",
+            "path": "tatoeba:101",
+            "license": "CC-BY 2.0 FR",
+            "author": "uk-author",
+            "sentenceId": 101,
+            "enSentenceId": 202,
+            "enAuthor": "en-author",
+            "enLicense": "CC-BY 2.0 FR",
+        },
+    }
+
+
+def test_tatoeba_cloze_preserves_attribution_metadata() -> None:
+    shards = build_practice_shards(
+        read_manifest(MANIFEST),
+        ReviewedSourceAllowlist.from_payload([{"status": "tatoeba", "path": "tatoeba:101"}]),
+        JsonVesumVerifier.from_path(VESUM),
+        [_tatoeba_cloze_source()],
+        BuildConfig(),
+    )
+
+    cloze = shards["A1"]["cloze"]["cloze"][0]
+
+    assert cloze["provenance"]["license"] == "CC-BY 2.0 FR"
+    assert cloze["provenance"]["author"] == "uk-author"
+    assert cloze["provenance"]["sentenceId"] == 101
+    assert cloze["provenance"]["enSentenceId"] == 202
+    assert cloze["provenance"]["enAuthor"] == "en-author"
+    assert cloze["provenance"]["enLicense"] == "CC-BY 2.0 FR"
+    assert cloze["attribution"] == {
+        "source": "Tatoeba",
+        "sourceUrl": "https://tatoeba.org/en/sentences/show/101",
+        "uk": {"sentenceId": 101, "author": "uk-author", "license": "CC-BY 2.0 FR"},
+        "en": {"sentenceId": 202, "author": "en-author", "license": "CC-BY 2.0 FR"},
+    }
+
+
+def test_tatoeba_cloze_uses_path_sentence_id_when_field_missing() -> None:
+    source = _tatoeba_cloze_source()
+    assert isinstance(source["provenance"], dict)
+    source["provenance"].pop("sentenceId")
+
+    shards = build_practice_shards(
+        read_manifest(MANIFEST),
+        ReviewedSourceAllowlist.from_payload([{"status": "tatoeba", "path": "tatoeba:101"}]),
+        JsonVesumVerifier.from_path(VESUM),
+        [source],
+        BuildConfig(),
+    )
+
+    cloze = shards["A1"]["cloze"]["cloze"][0]
+    assert cloze["provenance"]["sentenceId"] == 101
+    assert cloze["attribution"]["uk"]["sentenceId"] == 101
+
+
+def test_tatoeba_cloze_without_attribution_metadata_fails_closed() -> None:
+    source = _tatoeba_cloze_source()
+    source["provenance"] = {"status": "tatoeba", "path": "tatoeba:101"}
+
+    shards = build_practice_shards(
+        read_manifest(MANIFEST),
+        ReviewedSourceAllowlist.from_payload([{"status": "tatoeba", "path": "tatoeba:101"}]),
+        JsonVesumVerifier.from_path(VESUM),
+        [source],
+        BuildConfig(),
+    )
+
+    assert shards["A1"]["cloze"]["cloze"] == []


### PR DESCRIPTION
## Summary

- Preserve Tatoeba cloze provenance fields (`license`, authors, sentence IDs) when reviewed cloze rows are emitted into practice shards.
- Add optional learner-visible Tatoeba attribution on cloze cards.
- Extend the static practice gate so future `tatoeba:` cloze items must include attribution and reviewed-source allowlist coverage.
- Keep this non-live for content: no new cloze rows, no Daily Word change, no practice-count change.

## Why

#3797's next go-live blocker is attribution safety. The generator and small reviewed batches already exist, but Tatoeba-backed cloze cannot safely ship unless the deck preserves sentence-level license/author metadata and the UI has a visible credit surface.

## Validation

- `.venv/bin/python -m py_compile scripts/audit/generate_practice_deck.py scripts/audit/check_static_practice_assets.py`
- `.venv/bin/python -m pytest tests/test_generate_practice_deck.py tests/test_check_static_practice_assets.py -q` -> 32 passed
- `.venv/bin/ruff check scripts/audit/generate_practice_deck.py scripts/audit/check_static_practice_assets.py tests/test_generate_practice_deck.py tests/test_check_static_practice_assets.py`
- `git diff --check`
- `.venv/bin/python scripts/audit/check_static_practice_assets.py --format json` -> ok, daily 300, practice 4,484, cloze 22
- `npm test -- tests/unit/LexiconPractice.test.tsx` -> 10 passed
- `npm run build` -> 5,638 pages built
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` -> passed

## Independent review

- AGY/Gemini review found one major static-gate false-negative: `sentenceId` could be inferred from `tatoeba:<id>` but the checker required a duplicated explicit field.
- Fixed by preserving the fallback ID in generated provenance and relaxing the checker to accept the path fallback; added regression tests.

Fixes part of #3797.
