### PR TITLE
docs(bio): add Fedir Krychevskyi dossier

### DIFF
--- a/docs/research/bio/fedir-krychevskyi.md
+++ b/docs/research/bio/fedir-krychevskyi.md
@@ -1,0 +1,299 @@
+# Федір Григорович Кричевський — Research Dossier
+
+**Slug:** `fedir-krychevskyi`
+**Block:** +77 expansion — Ukrainian theater / visual culture additions
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #362
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional sources cited
+- [x] Oppression mechanism framed as documented Soviet security-service
+  arrest/control and postwar deprivation, without inventing a case number
+- [x] Primary-source visual anchors identified without overquoting
+- [x] Cross-track links verified `test -e` on 2026-07-01
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Федір Григорович Кричевський.
+- **Pseudonyms / aliases:** Fedir Krychevsky (legacy English usage in IEU
+  and many museum pages), Kryčevs'kyj (IEU scholarly transliteration),
+  Федор Кричевский (Russian/Soviet form; source-critical only).
+- **Born:** 10/22 May 1879, Lebedyn, Kharkiv gubernia, Russian Empire;
+  now Sumy oblast, Ukraine. ESU records an alternate date, 16 May 1880,
+  while EIU and IEU use 22 May 1879; teach the 1879 date with the
+  discrepancy flagged.
+- **Died:** 30 July 1947, Irpin, Kyiv oblast, Ukrainian SSR; buried in Kyiv.
+  EIU adds that he was reburied at Lukianivske Cemetery in 1965.
+- **Family / education key facts:** brother of Vasyl Krychevskyi. He grew up
+  in the Lebedyn/Vorozhba milieu, learned drawing and modelling near the
+  pottery center of Mezhyrich, studied at the Moscow School of Painting,
+  Sculpture and Architecture and then at the Saint Petersburg Academy of Arts.
+  After `Наречена` won academy recognition in 1910, he travelled through
+  major European art centers and returned to Kyiv as an art teacher.
+- **Institutional role:** director of the Kyiv Art School in 1914-1918;
+  active founder of the Ukrainian Academy of Arts in 1917; EIU calls him its
+  first rector after the academy opened in December 1917. ESU/IEU record
+  later rector/director periods in 1918 and 1920-1922.
+
+## 2. Oppression mechanism
+
+This is a state-pressure and deprivation case, not an NKVD execution case.
+
+- **What happened:** after the German-Soviet war displaced him westward,
+  Soviet counterintelligence arrested and interrogated him; after release he
+  was deprived of standing and pushed out of Kyiv into controlled poverty.
+  IEU says he was released after prolonged interrogation and torture, in a
+  severely weakened condition, and stripped of titles and honors. EIU gives
+  the concrete postwar sequence: arrest by SMERSH at Koenigsberg, later arrest
+  again in Kyiv, release because of illness, then security-service removal to
+  Irpin under control.
+- **When:** 1943 move west; Soviet arrest after the Red Army took Koenigsberg;
+  postwar Kyiv arrest and Irpin control before his death on 30 July 1947.
+- **By whom:** SMERSH for the Koenigsberg arrest, according to EIU. EIU later
+  says `спецслужби` moved him outside Kyiv and kept him under control; do not
+  name NKVD/MGB/KGB in learner-facing prose unless a later source gives that
+  specific agency for the Irpin control.
+- **Document references:** no stable case number, interrogation file, or formal
+  rehabilitation document was located in this pass. Do not invent one. IEU's
+  word `rehabilitated` appears to describe the 1959 cultural restoration
+  marked by the first posthumous retrospective; treat formal legal
+  rehabilitation as unverified until a document is found.
+- **Mechanism specifics:** Soviet power had already narrowed his creative
+  field in the early 1930s. ESU states that under vulgar sociologism and the
+  forced introduction of socialist realism he had to make works such as
+  `Свято колгоспного врожаю` and `Молотьба`. Later, war, occupation,
+  suspicion of collaboration, security-service control, loss of housing, hunger,
+  and removal from Kyiv formed the terminal pressure.
+- **What survived / what was distorted:** his early modernist and national
+  school-building work survived in museums and students' memory. Soviet memory
+  could tolerate him more easily as a later socialist-realist painter than as
+  the first rector of a Ukrainian state art academy and the author of `Життя`.
+
+## 3. Major works / contributions
+
+- **Ukrainian Academy of Arts:** one of the key founders in 1917 and first
+  rector in EIU's account. This links him directly to Hrushevskyi, Murashko,
+  Narbut, Vasyl Krychevskyi, and Boichuk as institution-builders during the
+  Ukrainian Revolution.
+- **Kyiv school and pedagogy:** director of the Kyiv Art School, then professor
+  and administrator at the academy / Kyiv Art Institute, with teaching periods
+  also at Kharkiv Art Institute. ESU and EIU list students including
+  Anatol Petrytskyi, Tetiana Yablonska, Yevhen Volobuev, Heorhii Melikhov,
+  and others.
+- **`Наречена` (1910):** academy-success painting that opened the way for
+  European travel. Use it to teach how education, gendered ritual, and national
+  costume enter modern painting without becoming folklore decoration.
+- **`Три віки` (1913):** strong early work for a lesson on age, continuity,
+  and monumental composition.
+- **`Життя` / `Life` triptych (1925-1927):** central modernist work. IEU lists
+  `Love`, `Family`, and `Return`; EIU calls it his most famous painting.
+  It is the strongest visual anchor for Ukrainian modernism, family memory,
+  return from war, and monumental rhythm.
+- **Venice Biennale reception:** IEU says `Життя` was highly praised at the
+  1928 Venice Biennale. Use this as a careful international-recognition point,
+  not as a triumphalist anecdote detached from later erasure.
+- **National portrait and Shevchenko cycle:** portraits of cultural figures
+  and the `Катерина` tempera cycle create a bridge to literature and national
+  cultural memory.
+- **Later constrained works:** `Переможці Врангеля`, `Веселі доярки`, and
+  collectivized-labor subjects belong in a discussion of artists working under
+  ideological constraint, not as proof of inner Soviet loyalty.
+
+## 4. Primary-source quote / visual anchors
+
+For Krychevskyi, primary pedagogical material should be visual first.
+
+- **`Життя` triptych:** use the image itself as primary evidence. Ask learners
+  to identify the three panels, body positions, return motif, costume, blank
+  ground, and color rhythm before reading interpretation.
+- **`Автопортрет у білому кожусі`:** a strong object for self-fashioning:
+  the painter presents himself through stance, fur coat, scale, and frontal
+  energy. Pair with a caution that datings differ across pages.
+- **`Наречена`:** visual anchor for academic training and Ukrainian ritual.
+- **`Катерина` cycle:** cross-link to Shevchenko; use only source-checked
+  reproductions and avoid turning the picture into a plot summary of the poem.
+- **Memoir/anecdote anchor:** Suspilne records a popular late-life line about
+  not painting temporary favorites because his `сан` would not allow it. Treat
+  this as a memoir tradition and source-critical discussion prompt, not as the
+  documentary center of the lesson.
+
+## 5. Language register
+
+- **Register:** art-historical, museum-label, studio pedagogy, modernist
+  composition, state-cultural institution-building.
+- **CEFR readiness:** B2 for basic biography and object description; C1 for
+  repression, socialist-realist constraint, and debates about national
+  modernism.
+- **Learner lexicon:** `живописець`, `педагог`, `ректор`, `академія`,
+  `триптих`, `темпера`, `композиція`, `силует`, `палітра`, `декоративність`,
+  `монументальність`, `модернізм`, `соцреалізм`, `українізація`,
+  `згортання`, `репресія`, `спецслужби`.
+- **Style note:** activities should train looking: describe what a viewer can
+  see, then connect evidence to biography. Avoid prose that sounds like a
+  prompt talking to itself. The human story is teacher, painter, first rector,
+  brother, survivor of war and interrogation, and hungry old man still working
+  at the easel.
+
+## 6. Contested points
+
+- **Birth date:** ESU gives 10/22 May 1879 with an alternate 16 May 1880; EIU
+  and IEU use 22 May 1879. Use 22 May 1879 as the main date and flag the
+  alternate in notes.
+- **Academy title chronology:** EIU says he was elected first rector after the
+  Ukrainian Academy of Arts opened on 18 December 1917. ESU and IEU record
+  rector/director periods in 1918 and 1920-1922. Teach the stable point:
+  founder and rector/leader of the new Ukrainian art academy; do not overfix
+  one title-year formula unless the plan cites a source.
+- **WWII and collaboration charge:** EIU/IEU support Soviet arrest and
+  suspicion after his westward flight; they do not support reducing his life to
+  a collaboration label. The lesson should explain why artists caught between
+  Nazi occupation and returning Soviet power faced impossible survival choices.
+- **Death by hunger:** EIU says he lacked proper help and went hungry in Irpin;
+  Suspilne and popular memory sharpen this into death by hunger at the easel.
+  ESU gives only date/place. Use the hunger claim with EIU support and mark the
+  easel image as reception/memoir tradition unless independently documented.
+- **Jewish-family / Babi Yar claims:** English Wikipedia and popular retellings
+  mention Jewish origin and wartime hiding. This pass did not locate a Tier 1
+  or Tier 2 Ukrainian institutional source for that claim. Do not make it
+  load-bearing in the module until corroborated.
+- **Soviet-era source language:** EIU's page uses inherited Soviet war
+  terminology in places. Learner-facing prose should say Second World War,
+  Nazi occupation, Soviet counterintelligence, and Ukrainian Academy of Arts.
+
+## 7. Cross-track links
+
+**Existing BIO / visual-culture links (VERIFIED `test -e` on 2026-07-01):**
+
+- `docs/research/bio/vasyl-krychevskyi.md`
+- `curriculum/l2-uk-en/plans/bio/vasyl-krychevskyi.yaml`
+- `docs/research/bio/heorhii-narbut.md`
+- `docs/research/bio/oleksandr-murashko.md`
+- `docs/research/bio/mykhailo-boichuk.md`
+- `curriculum/l2-uk-en/plans/bio/mykhailo-boichuk.yaml`
+- `docs/research/bio/anatol-petrytskyi.md`
+- `curriculum/l2-uk-en/plans/bio/anatol-petrytskyi.yaml`
+- `docs/research/bio/ivan-padalka.md`
+- `curriculum/l2-uk-en/plans/bio/ivan-padalka.yaml`
+- `docs/research/bio/vasyl-sedliar.md`
+- `curriculum/l2-uk-en/plans/bio/vasyl-sedliar.yaml`
+
+**Existing C1 / HIST / ISTORIO / LIT links (VERIFIED `test -e` on 2026-07-01):**
+
+- `curriculum/l2-uk-en/plans/c1/obrazotvorche-mystetstvo-1.yaml`
+- `curriculum/l2-uk-en/plans/c1/obrazotvorche-mystetstvo-2.yaml`
+- `curriculum/l2-uk-en/plans/c1/checkpoint-fine-arts.yaml`
+- `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml`
+- `curriculum/l2-uk-en/plans/hist/skoropadskyi.yaml`
+- `curriculum/l2-uk-en/plans/istorio/universaly-unr.yaml`
+- `curriculum/l2-uk-en/plans/lit/rozstriliane-vidrodzennia-phenomenon.yaml`
+
+**Candidate links, not yet existing for this slug:**
+
+- `curriculum/l2-uk-en/plans/bio/fedir-krychevskyi.yaml`
+- site MDX / module artifacts for `fedir-krychevskyi`
+- BIO #363 `olena-kulchytska`, BIO #364 `oleksa-novakivskyi`,
+  BIO #365 `ivan-trush`, as future Ukrainian visual-culture sequence.
+
+## 8. Naming-canonical
+
+- **Slug:** `fedir-krychevskyi`
+- **EN canonical (BGN/PCGN 2010):** Fedir Krychevskyi
+- **UA canonical (with patronymic):** Федір Григорович Кричевський
+- **Aliases (track in future YAML):** Fedir Krychevsky; Fedir Hryhorovych
+  Krychevsky; Kryčevs'kyj; Кричевський Федір Григорович
+- **Forbidden forms (Russian-imperial / Soviet metadata only):** Fedor
+  Krichevsky; Fedor Krychevsky; Федор Григорьевич Кричевский; Федор
+  Кричевский. Do not use these in teacher voice except as a source-critical
+  alias note.
+
+## 9. Image candidates
+
+- **Best PD/CC visual anchor:** Wikimedia Commons file
+  `File:Fedir_Krychevsky_-_Life_triptych_-_1925-29.jpg`. Commons marks the
+  two-dimensional reproduction/publication as public domain under Ukrainian
+  public-domain rules; verify the file page again before publishing.
+- **Best portrait/self-portrait candidate:** Wikimedia Commons file
+  `File:Федір Кричевський_-_Автопортрет у білому кожусі.jpg`, or the Commons
+  category `Category:Fedir Krychevsky` for file-level selection. Use file page
+  license metadata, not category-level assumptions.
+- **Backup candidates:** `Наречена`, `Три віки`, or a first-Ukrainian-Academy
+  founders photograph if file-level rights are clean.
+- **Caption caution:** avoid Picryl/Russian-style metadata that labels the work
+  as Russian art. Caption teacher voice should use Ukrainian canonical naming
+  and, where relevant, mention National Art Museum of Ukraine holdings.
+
+## 10. Sources used
+
+**Tier 1 / authoritative:**
+
+- Інститут історії України НАН України / Енциклопедія історії України.
+  "КРИЧЕВСЬКИЙ ФЕДІР ГРИГОРОВИЧ."
+  https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=DOP&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Krichevskiy_F&Z21ID=
+  Accessed 2026-07-01.
+- Енциклопедія Сучасної України. "Кричевський Федір Григорович."
+  https://esu.com.ua/article-1653. Accessed 2026-07-01.
+- Internet Encyclopedia of Ukraine. "Krychevsky, Fedir."
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CR%5CKrychevskyFedir.htm.
+  Accessed 2026-07-01.
+
+**Tier 2 / institutional and museum-context sources:**
+
+- Національна академія образотворчого мистецтва і архітектури.
+  "Федір Кричевський."
+  https://naoma.edu.ua/akademiya/istoriya-naoma/vydatni-osobystosti/fedir-krychevskyj-3/.
+  Accessed 2026-07-01.
+- Полтавський художній музей ім. М. Ярошенка. "Пам'яті Федора
+  Кричевського." https://www.gallery.pl.ua/pamyati-fedora-krichevskogo.html.
+  Accessed 2026-07-01.
+- ART Ukraine / National Art Museum of Ukraine exhibition notice.
+  "В НХМУ відкриється ретроспективна виставка творів Федора Кричевського."
+  https://artukraine.com.ua/n/v-nkhmu-vidkriyetsya-retrospektivna-vistavka-tvoriv-fedora-krichevskogo/.
+  Accessed 2026-07-01.
+
+**Tier 3 / navigation and image metadata:**
+
+- Wikimedia Commons. "Category:Fedir Krychevsky."
+  https://commons.wikimedia.org/wiki/Category:Fedir_Krychevsky. Accessed
+  2026-07-01.
+- Wikimedia Commons. "File:Fedir Krychevsky - Life triptych - 1925-29.jpg."
+  https://commons.wikimedia.org/wiki/File:Fedir_Krychevsky_-_Life_triptych_-_1925-29.jpg.
+  Accessed 2026-07-01.
+
+**Tier 5 / modern reception, used only with Tier 1/Tier 2 corroboration:**
+
+- Суспільне Культура. "Федір Кричевський: що треба знати про художника, який
+  відмовився малювати Сталіна."
+  https://suspilne.media/culture/461879-mandri-evropou-ar-nuvo-v-seli-sisaki-vidmova-maluvati-stalina-kim-buv-hudoznik-fedir-kricevskij/.
+  Accessed 2026-07-01.
+
+**Primary-source documents accessed:**
+
+- No NKVD/MGB/KGB/SMERSH case file or formal rehabilitation document was
+  accessed in this dossier pass. Use EIU/IEU for the arrest/control narrative
+  and mark document-level claims as unverified until archival citation is found.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing in teacher voice.
+- [x] Moscow/Petersburg education contextualized as training, not ownership.
+- [x] Ukrainian Academy of Arts and state-building frame kept central.
+- [x] SMERSH / security-service pressure named only where sourced.
+- [x] No invented KGB/NKVD case number or formal rehabilitation document.
+- [x] Socialist-realism works framed as constrained production, not simple
+  ideological identity.
+- [x] Russianized forms limited to naming/source-critical section.
+- [x] Cross-track "Existing" paths verified with `test -e`.
+- [x] Image-rights policy checked at file-page level.
+- [x] Dossier-only slice: no plan YAML, module markdown, activity YAML,
+  vocabulary YAML, generated site MDX, wiki packet, status JSON, or telemetry DB.


### PR DESCRIPTION
## Summary
- Add the BIO #362 dossier for `fedir-krychevskyi`.
- Keep the slice dossier-only: no plan YAML, module, activities, vocabulary, MDX, wiki packet, generated artifacts, linter config, package, or telemetry files.
- Ground the dossier in EIU, ESU, IEU, NAOMA/museum context, and file-level Commons image notes.
- Frame the oppression mechanism conservatively: SMERSH arrest/control and postwar deprivation, without inventing an NKVD/KGB case number or formal rehabilitation document.

## Validation
- `npx markdownlint-cli2 "docs/research/bio/fedir-krychevskyi.md"`
- `../../../../.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/fedir-krychevskyi.md`
- `git diff --check`
- `../../../../.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Telemetry
- Not applicable: dossier-only base-prep PR, not a module-build PR.
- `swarm_used: false`
- `swarm_note: solo run; no swarm used`