### PR TITLE
docs(bio): add Olena Kulchytska dossier

### DIFF
--- a/docs/research/bio/olena-kulchytska.md
+++ b/docs/research/bio/olena-kulchytska.md
@@ -1,0 +1,307 @@
+# Олена Львівна Кульчицька — Research Dossier
+
+**Slug:** `olena-kulchytska`
+**Block:** +77 expansion — Ukrainian theater / visual culture additions
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #363
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional sources cited
+- [x] Oppression mechanism framed as documented cultural/political pressure,
+  without inventing an NKVD/KGB case
+- [x] Primary-source visual anchors identified without overquoting
+- [x] Cross-track links verified `test -e` on 2026-07-01
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Олена Львівна Кульчицька.
+- **Name variants / aliases:** Olena Kulchytska; Olena Lvivna Kulchytska;
+  Kul'čyc'ka / Kul'chyts'ka in scholarly transliteration; Ołena Kulczycka in
+  Polish contexts; Елена Львовна Кульчицкая only as Russian/Soviet metadata.
+- **Born:** 15 September 1877, Berezhany, Kingdom of Galicia and Lodomeria,
+  Austria-Hungary; now Ternopil oblast, Ukraine.
+- **Died:** 8 March 1967, Lviv, Ukrainian SSR; buried at Lychakiv Cemetery.
+- **Family / education key facts:** sister of Olha-Melaniia Kulchytska. ESU and
+  EIU record study in Lviv art studios and at the Vienna higher school of arts
+  and crafts / industrial design; ESU adds enamel-specialist training and a
+  1908 European museum trip through London, Paris, and Munich.
+- **Professional roles:** graphic artist, painter, master of applied arts,
+  ethnographer, pedagogue, and civic figure. She taught in Peremyshl for nearly
+  three decades, then worked in Lviv museum and higher-education contexts.
+
+## 2. Oppression mechanism
+
+This is not an execution, prison-camp, or formal NKVD case dossier. The
+load-bearing mechanism is cultural survival under successive imperial,
+wartime, Polish, Nazi, and Soviet pressures.
+
+- **What happened:** during the First World War and after, her Ukrainian public
+  work in Peremyshl drew pressure from the Polish administration. Radio Svoboda
+  reports museum testimony that officials wanted to intern her during the war,
+  and that in 1919 she was interned by Polish authorities in a camp with many
+  Ukrainians.
+- **When / where:** Peremyshl and Vienna during the First World War; Peremyshl
+  again in 1919; Lviv after September 1939 and after the Soviet return in 1944.
+- **By whom:** Polish wartime and postwar authorities for the internment
+  episode; Soviet municipal/state cultural control in Lviv for housing and
+  ideological pressure. No source in this pass supports a named NKVD/MGB/KGB
+  case against Kulchytska personally.
+- **Document references:** no police file, court record, or rehabilitation
+  document located. Treat claims about direct secret-police prosecution as
+  unverified unless a future archive citation appears.
+- **Soviet pressure and legal civic work:** Radio Svoboda records that Soviet
+  authorities tried to divide her Lviv apartment because a four-room space for
+  one artist was considered too large; Filaret Kolessa defended the apartment
+  as necessary for a major artist and collection. Local History reports that as
+  a deputy she helped families affected by arrests and Gulag deportations,
+  petitioned Soviet institutions for cultural figures including Vira
+  Svientsitska, and defended the Lviv Art College in 1955. Treat 1951-1955 as
+  the activity window named in that article; her wider deputy record is usually
+  given as the third and fourth convocations, approximately 1951-1959.
+- **Modern memory pressure:** in 2021, a planned Peremyshl memorial plaque was
+  blocked/destroyed amid claims that her status as a Supreme Soviet deputy made
+  her a communist propagandist. Radio Svoboda and Local History both present
+  this as a contested simplification because she was not a Communist Party
+  member and was remembered by museum staff as not glorifying Soviet power.
+- **What survived:** EIU records that in 1950 she donated more than 3,000
+  works to the Lviv Museum of Ukrainian Art; broader summaries put her total
+  output above 4,000 works. Her Lviv apartment became a memorial museum in
+  1971. The survival mechanism is material stewardship: she preserved visual
+  archives of folk costume, architecture, book art, and graphic cycles when
+  political borders and regimes kept changing around western Ukraine.
+
+## 3. Major works / contributions
+
+- **Graphic art and printmaking:** EIU emphasizes woodcuts, color linocuts,
+  etchings, aquatints, and techniques that had few analogues in Ukrainian
+  graphic art. IEU lists print series including `Ukrainian Writers`,
+  `Folk Architecture`, `The Hutsul Region`, `Legend of the Mountains and
+  Forests`, and `Dovbush`.
+- **Book illustration:** IEU names illustrations for `Українська народна
+  мітологія`, Franko's `Лис Микита` and `Мойсей`, `Слово о полку Ігоревім`,
+  and works by Mykhailo Kotsiubynsky, Vasyl Stefanyk, and Yurii Fedkovych. The
+  western-Ukrainian children's book series `Нашим найменшим` is central to her
+  pedagogy and image-language for young readers.
+- **War and social graphic cycles:** IEU lists etchings such as `За морем`,
+  `Під чужим небом`, `Молох війни`, `Чорні хмари війни`, and `Помста` as a
+  condemnation of war and exploitation of Ukrainian peasants. This is the best
+  bridge to present-day war-image literacy without forcing presentism.
+- **Ethnographic visual archive:** her watercolor albums on western Ukrainian
+  folk costume and folk architecture created a scholarly-artistic record, not
+  decorative nostalgia. Treat her as artist-ethnographer, not just illustrator.
+- **Applied arts:** ESU and IEU record work in carpets/kilims, enamel,
+  decorative and applied arts, furniture/interior design, and object design.
+  For kilims, preserve the design/execution split where later summaries note it:
+  Olena designed ornaments, while her sister Olha wove some of the carpets. Her
+  art crosses page, wall, textile, bookplate, interior, and museum archive.
+- **Institution-builder:** co-initiated the Ukrainian regional museum
+  `Стривігор` in Peremyshl; worked in the Museum of the Shevchenko Scientific
+  Society / ethnographic museum contexts; left her archive to the Ukrainian
+  public through the National Museum in Lviv.
+
+## 4. Primary-source quote / visual anchors
+
+For Kulchytska, primary-source anchors should be works and museum spaces first.
+
+- **1910 portrait photograph:** Commons file `Олена Кульчицька.jpg`, marked
+  public domain, gives a usable portrait anchor before Soviet-era official
+  recognition reframed her later life.
+- **`Тур'є. Церква св. Миколая`:** file-level Commons image of a linocut after
+  Kulchytska, useful for teaching line, church architecture, village memory,
+  and the difference between documenting a building and stylizing it.
+- **War etching cycle:** use titles from IEU (`За морем`, `Під чужим небом`,
+  `Молох війни`, `Чорні хмари війни`, `Помста`) as close-reading anchors for
+  war vocabulary and visual metaphor. Verify reproductions before quoting image
+  captions in a future module.
+- **Book and children's-book illustration anchors:** `Нашим найменшим` can
+  anchor children's periodical and pedagogical work; `Лис Микита` and `Мойсей`
+  can anchor literary illustration and the relation between literature and
+  visual Ukrainian. Treat Kotsiubynsky works as a future LIT tie-in until a
+  specific source names which works she illustrated.
+- **Memorial apartment:** the National Museum in Lviv states that the apartment
+  and personal belongings were transferred to the Ukrainian people through the
+  National Museum. This museum-space anchor can teach how an artist's room
+  becomes a public archive.
+
+## 5. Language register
+
+- **Register:** museum-label, art-historical, ethnographic, book-arts,
+  civic-memory, western-Ukrainian cultural register.
+- **CEFR readiness:** B2 for biography and object description; C1 for
+  discussions of memory politics, ethnography, and Soviet/Polish pressure.
+- **Learner lexicon:** `графіка`, `дереворит`, `лінорит`, `офорт`,
+  `акватинта`, `екслібрис`, `ілюстрація`, `декоративно-ужиткове мистецтво`,
+  `килимарство`, `етнографія`, `народний одяг`, `народна архітектура`,
+  `інтернування`, `депортація`, `політв'язень`, `меморіальний музей`.
+- **Style note:** future lessons should teach her through looking, handling
+  media words, and telling a human story: a woman artist trained in Vienna,
+  teaching in Peremyshl, recording Hutsul and western Ukrainian material
+  culture, helping repressed families, and turning an apartment into a national
+  archive.
+
+## 6. Contested points
+
+- **"Soviet deputy" simplification:** she was a Supreme Soviet deputy in the
+  third and fourth convocations, but Radio Svoboda and Local History both warn
+  against reading this as simple communist allegiance. The dossier should
+  present it as a constrained Soviet public position she used for petitions and
+  cultural defense.
+- **Habsburg/Polish rather than Russian-oppression fit:** the 2026-05-26 audit
+  called her Russia-oppression fit weak. The +77 expansion later promoted her
+  for visual culture and women's recovery. Make that explicit: her module
+  belongs in BIO because of Ukrainian visual-memory work under multiple regimes,
+  not because she was executed or imprisoned by Soviet security organs.
+- **Polish memory dispute:** Peremyshl plaque conflict shows how memory can be
+  flattened by anti-communist shorthand or Polish-Ukrainian borderland politics.
+  Do not make "Polish radicals" the lesson's center; use it as modern reception.
+- **Ethnography vs folklore decoration:** her folk-costume and architecture
+  work is often softened into prettiness. Treat it as knowledge work and visual
+  nation-building: collecting forms, naming regions, making a portable archive.
+- **Gender framing:** avoid the thin line "first woman artist" unless a source
+  specifies exact scope. The stronger claim is that she was one of the central
+  professional women artists and educators in Ukrainian modern visual culture.
+
+## 7. Cross-track links
+
+**Existing BIO / visual-culture links (VERIFIED `test -e` on 2026-07-01):**
+
+- `docs/research/bio/fedir-krychevskyi.md`
+- `docs/research/bio/vasyl-krychevskyi.md`
+- `curriculum/l2-uk-en/plans/bio/vasyl-krychevskyi.yaml`
+- `docs/research/bio/heorhii-narbut.md`
+- `docs/research/bio/mykhailo-boichuk.md`
+- `curriculum/l2-uk-en/plans/bio/mykhailo-boichuk.yaml`
+- `docs/research/bio/sofiia-nalepynska-boichuk.md`
+- `curriculum/l2-uk-en/plans/bio/sofiia-nalepynska-boichuk.yaml`
+- `docs/research/bio/mykhailo-kotsiubynsky.md`
+- `curriculum/l2-uk-en/plans/bio/mykhailo-kotsiubynsky.yaml`
+- `curriculum/l2-uk-en/plans/bio/ivan-franko.yaml`
+- `docs/research/bio/vasyl-stefanyk.md`
+- `curriculum/l2-uk-en/plans/bio/vasyl-stefanyk.yaml`
+
+**Existing C1 / visual-arts links (VERIFIED `test -e` on 2026-07-01):**
+
+- `curriculum/l2-uk-en/plans/c1/obrazotvorche-mystetstvo-1.yaml`
+- `curriculum/l2-uk-en/plans/c1/obrazotvorche-mystetstvo-2.yaml`
+- `curriculum/l2-uk-en/plans/c1/checkpoint-fine-arts.yaml`
+
+**Candidate links, not yet existing for this slug:**
+
+- `curriculum/l2-uk-en/plans/bio/olena-kulchytska.yaml`
+- site MDX / module artifacts for `olena-kulchytska`
+- BIO #364 `oleksa-novakivskyi`, BIO #365 `ivan-trush`,
+  BIO #366 `mykhailo-zhuk`
+- a future FOLK/Hutsulshchyna plan and a future LIT plan for `Тіні забутих
+  предків` if those tracks add source-aligned files later
+
+## 8. Naming-canonical
+
+- **Slug:** `olena-kulchytska`
+- **EN canonical (BGN/PCGN 2010):** Olena Kulchytska
+- **UA canonical (with patronymic):** Олена Львівна Кульчицька
+- **Aliases (track in future YAML):** Olena Lvivna Kulchytska; Olena
+  Kul'chyts'ka; Kul'čyc'ka; Ołena Kulczycka
+- **Forbidden forms (Russian-imperial / Soviet metadata only):** Elena
+  Kulchitskaya; Yelena Kulchitskaya; Елена Львовна Кульчицкая; Кульчицкая.
+  Do not use these in teacher voice except as source-critical aliases.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons file `File:Олена Кульчицька.jpg`;
+  date 1910; author unknown; file page marks public domain / PD-old-70 and US
+  pre-1930. Verify file page again before publication.
+- **Best work image:** Wikimedia Commons file
+  `File:Тур'є. Церква св. Миколая. Лінорит Олени Кульчицької.jpg`; CC BY-SA
+  4.0 uploader photograph of the work, useful as an architecture/linocut
+  anchor. Verify derivative-work status and attribution before publication.
+- **Museum-space fallback:** National Museum in Lviv page for the
+  Художньо-меморіальний музей Олени Кульчицької; use as context image only if
+  rights allow.
+- **Caption caution:** avoid Soviet envelope / Russian-language metadata as
+  primary portrait unless deliberately teaching Soviet afterlife and source
+  framing.
+
+## 10. Sources used
+
+**Tier 1 / authoritative:**
+
+- Енциклопедія Сучасної України. "Кульчицька Олена Львівна."
+  https://esu.com.ua/article-51517. Accessed 2026-07-01.
+- Інститут історії України НАН України / Енциклопедія історії України.
+  "КУЛЬЧИЦЬКА Олена Львівна."
+  https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIu&P21DBN=&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Kulchitska_O_L&Z21ID=.
+  Accessed 2026-07-01.
+- Internet Encyclopedia of Ukraine. "Kulchytska, Olena."
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CU%5CKulchytskaOlena.htm.
+  Accessed 2026-07-01.
+
+**Tier 2 / institutional and scholarly sources:**
+
+- Національний музей у Львові імені Андрея Шептицького.
+  "Художньо-меморіальний музей Олени Кульчицької."
+  https://nml.com.ua/museum/hudozhno-memorialniy-muzey-oleni-kulchitskoyi/.
+  Accessed 2026-07-01.
+- Horichko, Yaryna. "Ukrainian identity in the images and symbols of Olena
+  Kulchytska's graphic works." *Journal of European Studies* 53, no. 4 (2023).
+  https://doi.org/10.1177/00472441231205726. Abstract accessed 2026-07-01.
+
+**Tier 3 / image metadata and navigation:**
+
+- Wikimedia Commons. "Category:Olena Kulchytska."
+  https://commons.wikimedia.org/wiki/Category:Olena_Kulchytska. Accessed
+  2026-07-01.
+- Wikimedia Commons. "File:Олена Кульчицька.jpg."
+  https://commons.wikimedia.org/wiki/File:Олена_Кульчицька.jpg. Accessed
+  2026-07-01.
+- Wikimedia Commons. "File:Тур'є. Церква св. Миколая. Лінорит Олени
+  Кульчицької.jpg."
+  https://commons.wikimedia.org/wiki/File:Тур%27є._Церква_св._Миколая._Лінорит_Олени_Кульчицької.jpg.
+  Accessed 2026-07-01.
+
+**Tier 5 / modern reception, used only with Tier 1/Tier 2 corroboration:**
+
+- Радіо Свобода. "Чим не догодила польським радикалам українська художниця
+  Олена Кульчицька?"
+  https://www.radiosvoboda.org/a/ukrayinska-khudozhnytsia-olena-kulchytska/31086480.html.
+  Accessed 2026-07-01.
+- Локальна історія. "У Перемишлі знищили пам'ятну дошку українській художниці
+  Олені Кульчицькій."
+  https://localhistory.org.ua/news/u-peremishli-znishchili-pamiatnu-doshku-ukrayinskii-khudozhnitsi-oleni-kulchitskii/.
+  Accessed 2026-07-01.
+- Бібліотека українського мистецтва. "Кульчицька Олена."
+  https://uartlib.org/ukrayinski-hudozhniki/kulchitska-olena/. Accessed
+  2026-07-01.
+
+**Primary-source documents accessed:**
+
+- No NKVD/MGB/KGB court or security-service file was accessed in this dossier
+  pass. Use only the sourced Polish-internment, Soviet-housing/cultural
+  pressure, and civic-petition evidence above until archival documents are
+  located.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing in teacher voice.
+- [x] Russian/Soviet forms kept to source-critical alias notes.
+- [x] Habsburg, Polish, Nazi, and Soviet contexts separated rather than blurred.
+- [x] No invented NKVD/KGB case or rehabilitation claim.
+- [x] Soviet deputy status treated as contested public position, not simple
+  loyalty.
+- [x] Folk costume and architecture framed as knowledge/archive work, not
+  decorative folklore.
+- [x] Women's cultural work centered without reducing her to a token "first."
+- [x] Cross-track "Existing" paths verified with `test -e`.
+- [x] Image-rights policy checked at file-page level.
+- [x] Dossier-only slice: no plan YAML, module markdown, activity YAML,
+  vocabulary YAML, generated site MDX, wiki packet, status JSON, or telemetry DB.


### PR DESCRIPTION
## Summary
- Add the BIO #363 dossier for `olena-kulchytska`.
- Keep the slice dossier-only: no plan YAML, module, activities, vocabulary, MDX, wiki packet, generated artifacts, linter config, package, or telemetry files.
- Ground the dossier in ESU, EIU, IEU, the National Museum in Lviv, a recent scholarly abstract, Commons image metadata, and modern reception sources.
- Frame pressure conservatively: Polish internment/memory pressure, Soviet housing/cultural pressure, and civic defense of repressed families, without inventing a personal NKVD/KGB case.

## Validation
- `npx markdownlint-cli2 "docs/research/bio/olena-kulchytska.md"`
- `../../../../.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/olena-kulchytska.md`
- `git diff --check`
- `../../../../.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Telemetry
- Not applicable: dossier-only base-prep PR, not a module-build PR.
- `swarm_used: false`
- `swarm_note: solo run; no swarm used`