### PR TITLE
docs(bio): add Oleksa Novakivskyi dossier

### DIFF
--- a/docs/research/bio/oleksa-novakivskyi.md
+++ b/docs/research/bio/oleksa-novakivskyi.md
@@ -1,0 +1,338 @@
+# Олекса Харлампійович Новаківський — Research Dossier
+
+**Slug:** `oleksa-novakivskyi`
+**Block:** +77 expansion — Ukrainian theater / visual culture additions
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #364
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Source acronym legend:** ESU = Encyclopedia of Modern Ukraine /
+`Енциклопедія Сучасної України`; EIU = Encyclopedia of History of Ukraine /
+`Енциклопедія історії України`; IEU = Internet Encyclopedia of Ukraine.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional sources cited
+- [x] Pressure mechanism framed as documented institutional, wartime, and
+      museum-object pressure, without inventing an NKVD/KGB case
+- [x] Primary-source visual anchors identified without overquoting
+- [x] Cross-track links verified `test -e` on 2026-07-01
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Олекса Харлампійович Новаківський.
+- **Project English canonical:** Oleksa Novakivskyi.
+- **Name variants / aliases:** Oleksa Novakivsky; Oleksa Novakivs'kyi;
+  Novakivs'kyj; Olexa Novakivsky; Oleksa Kharlampiyovych Novakivskyi;
+  Ołeksa Nowakiwśkyj / Aleksy Nowakowski in Polish contexts; Алексей
+  Харлампиевич Новаковский / Новакивский only Russian-imperial or Soviet
+  metadata.
+- **Born:** 14 March 1872, Slobodo-Obodivka, Olhopil county, Podilia
+  gubernia, Russian Empire; now Nova Obodivka, Haisyn raion, Vinnytsia oblast,
+  Ukraine. ESU gives old/new style as 2/14 March 1872.
+- **Died:** 29 August 1935, Lviv; buried at Lychakiv Cemetery.
+- **Family / education key facts:** son of a forester; father of Yaroslav
+  Novakivskyi and grandfather of Zhdan-Andrii Novakivskyi. ESU, EIU, and IEU
+  record training with Pylyp/F. Klymenko in Odesa in 1888-1892, then at the
+  Cracow Academy of Fine Arts in the 1890s. ESU names teachers including Leon
+  Wyczolkowski, Jacek Malczewski, Jan Stanislawski, and Jozef Unierzyski.
+- **Cracow / Mogiła period:** after study in Cracow, he lived near Cracow in
+  Mogiła, now part of Nowa Huta. IEU describes this as a landscape-painting
+  period; ESU treats 1904-1913 as the early "Mogiła" period.
+- **Lviv move:** in 1913 he moved to Lviv under the patronage and invitation
+  of Metropolitan Andrey Sheptytskyi. National Museum in Lviv states he lived
+  and worked in the building at 11 Lystopadovoho Chynu Street.
+- **Art school:** in 1923 he founded a drawing and painting school in his Lviv
+  studio. IEU's separate Art School entry says it initially functioned as a
+  separate art faculty of the Lviv Underground Ukrainian Higher Polytechnical
+  School; the National Museum in Lviv calls the studio the first Ukrainian art
+  school in Halychyna / Western Ukraine.
+- **Museum memory:** the Oleksa Novakivskyi Memorial Art Museum opened in
+  March 1972 in his former studio, marking the centenary of his birth.
+
+## 2. Oppression / pressure mechanism
+
+- **Load-bearing pressure frame:** Novakivskyi is not a security-service
+  martyr biography. Do not invent an NKVD, MGB, or KGB case. His BIO fit is
+  visual-culture nation-building under imperial/post-imperial border regimes,
+  Ukrainian educational institution-building without a stable state, and later
+  Soviet museum-object loss.
+- **Imperial / partition context:** he was born in Podilia under the Russian
+  Empire, trained in Odesa and Cracow, and built his mature public Ukrainian
+  work in Habsburg and then Polish-ruled Galicia. The lesson should show how a
+  Ukrainian painter's path crossed Odesa, Cracow, Mogiła, the Boikivshchyna,
+  and Lviv, rather than forcing a simple east/west or Russian-only frame.
+- **Wartime transformation:** IEU says his Lviv-period style changed under the
+  impact of the First World War toward symbolism and expressionism, with works
+  such as `Воєнна мадонна` / `The War Madonna`, `Собор святого Юра`, `Ангел
+  смерті`, and `Молох війни`. ESU also stresses dramatic visions of the
+  Ukrainian people's fate during the First World War.
+- **Institutional pressure:** his school trained young Ukrainian artists, but
+  IEU's Art School entry notes it lacked a formal curriculum and diplomas. It
+  had rapid enrollment and strong cultural support, then lost much public and
+  financial support after curricular disagreements in 1929, and dissolved
+  around 1932 amid insufficient community support and declining student
+  interest. This is a concrete institution-building pressure point.
+- **Poverty / patronage:** Local History presents Sheptytskyi's patronage,
+  including regular financial support, as decisive for Novakivskyi's move to
+  Lviv and studio life. The lesson can tell this as artistic dependence on
+  Ukrainian patronage networks, not as aristocratic rescue romance.
+- **Soviet object loss after his death:** Local History reports that in 1940,
+  for a Moscow exhibition marking Soviet annexation of western Ukrainian
+  lands, works from the National Museum in Lviv and then-Lviv State Picture
+  Gallery were sent to Moscow and not returned; among them were 20 paintings by
+  Novakivskyi, including portraits of Anna-Maria. Treat this as posthumous
+  Soviet museum-object displacement, not personal arrest.
+- **What survived:** the school memory, the Lviv studio museum, works in the
+  National Museum in Lviv and other collections, student networks, and the
+  symbolic vocabulary of color, Saint George's Cathedral, Dovbush, Hutsul /
+  Boikivshchyna landscapes, and Ukrainian cultural patronage.
+
+## 3. Major works / contributions
+
+- **Ukrainian modernist painting in western Ukraine:** ESU places modern,
+  impressionist, symbolist, and expressionist tendencies in his work and says
+  his Lviv-period painting strengthened expressionist and mystical-exalted
+  elements. Keep the lesson art-historical but human: painter, teacher,
+  husband, dependent on patrons and friends, trying to build a studio culture.
+- **Cracow / Mogiła naturalist-impressionist phase:** IEU lists `Liberation`,
+  `Caroling`, `Spring in Mogiła`, and `Awakening` as examples of his earlier
+  style. Local History adds that the earliest known surviving painting is
+  `Гарбузи` from 1892.
+- **Lviv wartime / expressionist phase:** IEU lists `The War Madonna`,
+  `St. George's Cathedral`, `The Angel of Death`, `Moloch of War`,
+  `Self-portrait`, `Dovbush`, and `Oleksander Barvinsky` as examples of the
+  mature symbolist/expressionist direction.
+- **Portraits of Ukrainian public figures:** EIU and IEU record portraits of
+  Metropolitan Andrey Sheptytskyi, Oleksander Barvinsky, Dovbush, and
+  historical / cultural figures. These works make the bridge from private
+  sitter to national memory.
+- **Novakivskyi Art School:** IEU lists students including Roman Selsky,
+  Sofiia Zarytska, Hryhorii Smolsky, Mykhailo Moroz, Vasyl Diadyniuk, Antin
+  Maliutsa, Sviatoslav Hordynsky, Stefaniia Gebus-Baranetska, Ivanna Vynnykiv,
+  Olha Pleshkan, Stepan Lutsyk, Volodymyr Lasovsky, Edvard Kozak, and Myron
+  Levytsky. Use the school as the main human story: a studio becoming a
+  Ukrainian art institution.
+- **Sheptytskyi patronage and National Museum ecology:** National Museum in
+  Lviv states the building was bought by Metropolitan Andrey Sheptytskyi for
+  museum needs in 1907 and became one of his first foundations for Ukrainian
+  culture; Novakivskyi moved there in 1913 and used the studio/school there in
+  1923-1935.
+- **Over 500 oils:** IEU states his oeuvre consists of more than 500 oils,
+  many unfinished. The unfinished quality can be taught carefully as evidence
+  of restless search rather than failure.
+
+## 4. Primary-source quote / visual anchors
+
+For Novakivskyi, primary material should be visual first: paintings, studio
+photographs, museum building, school photographs, and traceable object records.
+
+- **Portrait / self-portrait anchors:** Commons has portraits and
+  self-fashioning material; verify file-level metadata before use. A
+  self-portrait lets learners describe gaze, brush, color, and artistic persona
+  without leaning on long secondary exposition.
+- **`Моя муза` / Anna-Maria Palmowska:** Local History's museum-authored
+  article makes this a strong human anchor: wife, model, letters, family, and
+  posthumous loss of the painting after the 1940 Moscow exhibition. Do not
+  over-romanticize; teach the relationship as archive, image, and vulnerability
+  of museum objects.
+- **`Собор святого Юра`:** use as Lviv visual anchor: architecture, color,
+  city, church, Sheptytskyi network, and the studio located near St George's
+  cultural geography.
+- **`Молох війни` / `Ангел смерті` / wartime works:** candidate C1 anchor for
+  how war pressure changes color and allegory. Verify image availability and
+  date before publishing learner-facing captions.
+- **`Довбуш`, Hutsul / mountain works:** bridge to Hutsulshchyna / FOLK only
+  if the module has source-checked images and avoids reducing mountain culture
+  to decorative folklore.
+- **Novakivskyi Art School photographs:** IEU's Art School page includes
+  school photographs with students and Sheptytskyi. These are better for
+  institution-building activities than a generic portrait.
+- **Museum-space anchor:** the National Museum in Lviv page gives the current
+  museum address and states the permanent exhibition is in his former studio
+  and residence. Use the room/studio as a primary place anchor.
+
+## 5. Language register
+
+- **Register:** museum-label, art-historical, studio pedagogy, patronage,
+  western-Ukrainian modernism, Lviv cultural institution-building, wartime
+  allegory, memory-of-objects register.
+- **CEFR readiness:** B2 biography and painting-description work; C1
+  discussion of patronage, institution-building without state support,
+  interwar Lviv cultural life, and posthumous Soviet displacement of museum
+  objects.
+- **Learner lexicon:** `живописець`, `майстерня`, `студія`, `мистецька
+  школа`, `меценат`, `покровитель`, `портрет`, `пейзаж`, `натюрморт`,
+  `алегорія`, `символізм`, `експресіонізм`, `імпресіонізм`, `колорит`,
+  `мазок`, `полотно`, `мольберт`, `виставка`, `меморіальний музей`.
+- **Style note:** future lessons should tell a human tale: a boy from a
+  forester's family, trained in Odesa and Cracow, meets Sheptytskyi, moves to
+  Lviv, turns a studio into a school, paints family and war, loses security
+  through poverty and fragile institutions, and leaves a room where students
+  can still imagine the work happening.
+
+## 6. Contested points
+
+- **Name spelling:** English sources often use `Novakivsky`; project slug and
+  BGN/PCGN-style Ukrainian transliteration should use `Novakivskyi`. Keep older
+  spellings as aliases and source metadata.
+- **Birthplace wording:** sources name Slobodo-Obodivka / Nova Obodivka and
+  older Olhopil / Podilia administrative units. Teach modern Ukrainian place
+  after first historical mention.
+- **"First Ukrainian Art School in Western Ukraine":** National Museum in
+  Lviv uses this claim for the studio in 1923-1935. IEU gives a narrower
+  institutional description: founded in February 1923, linked initially to
+  underground Ukrainian higher schooling, lacking formal curriculum and
+  diplomas. Use both: first in cultural-memory terms, but not a diploma-granting
+  academy.
+- **Style labels:** impressionism, symbolism, expressionism, and modern style
+  all appear. Avoid one-label reduction such as "Ukrainian Impressionist" if
+  the lesson is about his whole life.
+- **Sheptytskyi patronage:** central, but do not make Novakivskyi passive. The
+  better frame is reciprocal cultural work: a patron creates conditions; an
+  artist builds paintings, students, and an institution.
+- **Soviet loss claim:** 1940 object loss is posthumous and should be sourced
+  to Local History / museum context. Do not imply Novakivskyi himself was
+  arrested by Soviet power.
+- **Russianized metadata:** Commons/Wikidata and older catalogues may carry
+  Russian forms. Use them only for search/source-critical notes.
+
+## 7. Cross-track links
+
+**Existing BIO / visual-culture links (VERIFIED `test -e` on 2026-07-01):**
+
+- `docs/research/bio/olena-kulchytska.md`
+- `docs/research/bio/fedir-krychevskyi.md`
+- `docs/research/bio/oleksandr-murashko.md`
+- `docs/research/bio/vasyl-krychevskyi.md`
+- `curriculum/l2-uk-en/plans/bio/vasyl-krychevskyi.yaml`
+- `docs/research/bio/heorhii-narbut.md`
+- `docs/research/bio/mykhailo-boichuk.md`
+- `curriculum/l2-uk-en/plans/bio/mykhailo-boichuk.yaml`
+- `docs/research/bio/anatol-petrytskyi.md`
+- `curriculum/l2-uk-en/plans/bio/anatol-petrytskyi.yaml`
+- `docs/research/bio/andrey-sheptytsky.md`
+- `curriculum/l2-uk-en/plans/bio/andrey-sheptytsky.yaml`
+- `docs/research/bio/sofiya-okunevska.md`
+
+**Existing C1 / fine-arts links (VERIFIED `test -e` on 2026-07-01):**
+
+- `curriculum/l2-uk-en/plans/c1/obrazotvorche-mystetstvo-1.yaml`
+- `curriculum/l2-uk-en/plans/c1/obrazotvorche-mystetstvo-2.yaml`
+- `curriculum/l2-uk-en/plans/c1/checkpoint-fine-arts.yaml`
+
+**Candidate future links (not yet existing or not yet built):**
+
+- `curriculum/l2-uk-en/plans/bio/oleksa-novakivskyi.yaml`
+- MDX `oleksa-novakivskyi`
+- BIO #365 `ivan-trush`
+- BIO #366 `mykhailo-zhuk`
+- BIO #367 / later western-Ukrainian visual-culture and art-school figures
+- FOLK/Hutsulshchyna modules if Dovbush / mountain imagery is used
+
+## 8. Naming-canonical
+
+- **Slug:** `oleksa-novakivskyi`
+- **EN canonical:** Oleksa Novakivskyi
+- **UA canonical:** Олекса Харлампійович Новаківський
+- **Source aliases to track:** Oleksa Novakivsky; Oleksa Novakivs'kyi;
+  Novakivs'kyj; Olexa Novakivsky; Oleksa Kharlampiyovych Novakivskyi;
+  Ołeksa Nowakiwśkyj; Aleksy Nowakowski.
+- **Forbidden / source-critical forms:** Алексей Харлампиевич Новаковский;
+  Алексей Новаковский; Новакивский. These can appear in source metadata,
+  authority records, or Russian catalogues, but not as learner-facing canonical
+  names.
+- **Patronymic note:** use `Харлампійович` in Ukrainian full-name contexts.
+  English pages often omit the patronymic; if included, prefer a Ukrainian
+  transliteration and keep spelling consistent within a module.
+
+## 9. Image-rights and media anchors
+
+- **Rights principle:** works by Novakivskyi (1872-1935) are generally
+  life-plus-70 public-domain candidates in many jurisdictions, but each file
+  still needs file-level rights verification before use in generated MDX or
+  learner pages.
+- **Commons category:** `Category:Oleksa Novakivsky` and `Category:Works by
+  Oleksa Novakivskyi` contain portraits, grave/memorial images, school-related
+  material, and works. Commons also lists Russianized aliases; do not copy
+  those into learner-facing captions.
+- **Strong portrait / person anchor:** Commons `File:Новаківський О.jpg` /
+  related portrait files may be useful after checking license, source, and
+  image quality.
+- **Work anchors:** candidate works include `Ukrainian Madonna`, `Digging in
+  the Garden`, `Dovbush`, `St George's Cathedral`, and self-portraits, but
+  match the exact work title/date/source before publishing.
+- **Museum-space image:** National Museum in Lviv / Commons images of the
+  Oleksa Novakivskyi Memorial Art Museum can anchor the lesson in place, but
+  verify licensing and avoid scraping restricted museum images.
+- **Lost-work caution:** do not illustrate `Моя муза` as if its current object
+  record is settled. Use it as a story of loss and archive if rights and source
+  context are clear.
+
+## 10. Sources used
+
+**Tier 1 / Tier 2 encyclopedic institutional sources:**
+
+- Енциклопедія Сучасної України. "Новаківський Олекса Харлампійович."
+  https://esu.com.ua/article-72250. Accessed 2026-07-01.
+- Енциклопедія історії України / Інститут історії України НАН України.
+  "Новаківський Олекса Харлампійович."
+  https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIU&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Novakivskyj_O&Z21ID=.
+  Accessed 2026-07-01.
+- Internet Encyclopedia of Ukraine. "Novakivsky, Oleksa."
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CN%5CO%5CNovakivskyOleksa.htm.
+  Accessed 2026-07-01.
+- Internet Encyclopedia of Ukraine. "Novakivsky Art School."
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CN%5CO%5CNovakivskyArtSchool.htm.
+  Accessed 2026-07-01.
+- Andrey Sheptytsky National Museum in Lviv. "Oleksa Novakivsky Memorial Art
+  Museum."
+  https://nml.com.ua/en/museum/hudozhno-memorialniy-muzey-oleksi-novakivskogo/.
+  Accessed 2026-07-01.
+
+**Modern reception / museum-context sources:**
+
+- Локальна історія. "Олекса Новаківський. Путівник життям і найбільш
+  знаковими роботами."
+  https://localhistory.org.ua/texts/statti/150-rokiv-oleksi-novakivskomu-onlain-vistavka-naibilsh-znakovikh-robit/.
+  Accessed 2026-07-01.
+- Локальна історія. "Муза Олекси Новаківського."
+  https://localhistory.org.ua/rubrics/painting/muza-oleksi-novakivskogo/.
+  Accessed 2026-07-01.
+
+**Image / rights leads:**
+
+- Wikimedia Commons. "Category:Oleksa Novakivsky."
+  https://commons.wikimedia.org/wiki/Category:Oleksa_Novakivsky. Accessed
+  2026-07-01.
+- Wikimedia Commons. "Category:Works by Oleksa Novakivskyi."
+  https://commons.wikimedia.org/wiki/Category:Works_by_Oleksa_Novakivskyi.
+  Accessed 2026-07-01.
+- Wikimedia Commons. "Creator:Oleksa Novakivsky."
+  https://commons.wikimedia.org/wiki/Creator:Oleksa_Novakivsky. Accessed
+  2026-07-01.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric learner-facing framing.
+- [x] Russianized names isolated as aliases/source-critical metadata.
+- [x] Cracow, Odesa, Mogiła, Lviv, Boikivshchyna, and Podilia handled as a
+      Ukrainian artist's transregional path, not foreign ownership of his work.
+- [x] Sheptytskyi patronage framed as Ukrainian cultural institution-building,
+      not patron-only heroization.
+- [x] No invented NKVD/KGB/security-service case.
+- [x] Soviet 1940 loss framed as posthumous museum-object displacement.
+- [x] Cross-track "Existing" paths verified `test -e`.
+- [x] Naming and image-rights policy checked.
+- [x] Dossier-only slice: no plan YAML, module markdown, activity YAML,
+      vocabulary YAML, generated site MDX, wiki packet, status JSON, or
+      telemetry DB.


### PR DESCRIPTION
## Summary
- Add BIO #364 dossier oleksa-novakivskyi.
- Keep slice dossier-only: no plan YAML, module, activities, vocabulary, MDX, wiki packet, generated artifacts, linter config, package, or telemetry files.
- Ground dossier in ESU, EIU, IEU, National Museum in Lviv, Local History, and Commons source leads.
- Frame pressure conservatively: Ukrainian art-school building under fragile interwar institutions, wartime allegory, patronage networks, and posthumous Soviet museum-object loss, without inventing a personal security-service case.

## Validation
- npx markdownlint-cli2 docs/research/bio/oleksa-novakivskyi.md
- ../../../../.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/oleksa-novakivskyi.md
- git diff --check
- ../../../../.venv/bin/python scripts/audit/lint_agent_trailer.py

## Telemetry
- Not applicable: dossier-only base-prep PR, not module-build PR.
- swarm_used: false
- swarm_note: solo run; no swarm used