### PR TITLE
docs(bio): add Mykhailo Zhuk dossier

### DIFF
--- a/docs/research/bio/mykhailo-zhuk.md
+++ b/docs/research/bio/mykhailo-zhuk.md
@@ -254,6 +254,8 @@ than long secondary quotations.
 - `curriculum/l2-uk-en/plans/bio/volodymyr-sosiura.yaml`
 - `docs/research/bio/mykola-kulish.md`
 - `curriculum/l2-uk-en/plans/bio/mykola-kulish.yaml`
+- `docs/research/bio/mykola-khvylovyi.md`
+- `curriculum/l2-uk-en/plans/bio/mykola-khvylovyi.yaml`
 
 **Existing C1 / fine-arts links (VERIFIED `test -e` on 2026-07-01):**
 
@@ -265,7 +267,6 @@ than long secondary quotations.
 
 - BIO #366 `mykhailo-zhuk`
 - BIO #367 `sofiia-yablonska`
-- Mykola Khvylovy as portrait subject if / when the BIO slug exists.
 
 ## 8. Naming-canonical
 

--- a/docs/research/bio/mykhailo-zhuk.md
+++ b/docs/research/bio/mykhailo-zhuk.md
@@ -10,7 +10,8 @@
 **Source acronym legend:** ESU = Encyclopedia of Modern Ukraine /
 `Енциклопедія Сучасної України`; EIU = Encyclopedia of History of Ukraine /
 `Енциклопедія історії України`; IEU = Internet Encyclopedia of Ukraine;
-ONNB = Odesa National Scientific Library; PMU = Pedagogical Museum of Ukraine.
+ONNB = Odesa National Scientific Library; PMU = Pedagogical Museum of Ukraine;
+DPU = State Political Directorate / `Державне політичне управління`.
 
 **Acceptance self-check:**
 

--- a/docs/research/bio/mykhailo-zhuk.md
+++ b/docs/research/bio/mykhailo-zhuk.md
@@ -1,0 +1,350 @@
+# Михайло Іванович Жук — Research Dossier
+
+**Slug:** `mykhailo-zhuk`
+**Block:** +77 expansion — Ukrainian theater / visual culture additions
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #366
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Source acronym legend:** ESU = Encyclopedia of Modern Ukraine /
+`Енциклопедія Сучасної України`; EIU = Encyclopedia of History of Ukraine /
+`Енциклопедія історії України`; IEU = Internet Encyclopedia of Ukraine;
+ONNB = Odesa National Scientific Library; PMU = Pedagogical Museum of Ukraine.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional sources cited
+- [x] Pressure mechanism framed as documented DPU arrest, Soviet-era aesthetic
+  pressure, and memory recovery; no invented NKVD/KGB case
+- [x] Primary-source visual/text anchors identified without overquoting
+- [x] Cross-track links verified `test -e` on 2026-07-01 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Михайло Іванович Жук.
+- **Project English canonical:** Mykhailo Zhuk.
+- **Name variants / aliases:** Mykhailo Zhuk; Zhuk, Mykhailo; Mykhailo
+  Ivanovych Zhuk; Žuk / Myxajlo in IEU transliteration; Михайло Жук. ESU gives
+  the pseudonym `О. Мігулес`; library sources also record variant spellings of
+  that pseudonym. Russianized forms belong only in source-critical metadata.
+- **Born / died:** ESU gives 20 September / 2 October 1882 in Kakhovka, now
+  Kherson oblast, and 7 June 1964 in Odesa. IEU gives 2 October 1883 and
+  7 June 1964; EIU gives 2 October 1883 and 8 June 1964. Treat birth year and
+  death day as source discrepancies.
+- **Core fields:** ESU, EIU, and IEU agree on the combined profile: painter,
+  graphic artist, teacher/pedagogue, and writer. ESU also emphasizes book and
+  easel graphics, ceramics, and children's literature.
+- **Education:** ESU and IEU record study at the Kyiv Drawing School
+  (1896-1899), the Moscow School of Painting, Sculpture, and Architecture
+  (1899-1900), and the Cracow Academy of Fine Arts / Academy of Arts by 1904.
+  Teachers include Stanislaw Wyspianski, Jan Stanislawski, and Jozef Mehoffer
+  in the Cracow context.
+- **Chernihiv period:** ESU and EIU record teaching in Chernihiv from 1905 to
+  1916. EIU links this period to the Kotsiubynsky family, Mykola Lysenko,
+  Mykola Voronyi, Pavlo Tychyna, and early literary publication.
+- **Ukrainian Academy of Arts:** EIU records that in 1917 Zhuk, together with
+  Heorhii Narbut, Mykhailo Boichuk, Oleksandr Murashko, Vasyl Krychevskyi,
+  Fedir Krychevskyi, Abram Manevych, and Mykola Burachek, founded the Ukrainian
+  Academy of Arts. IEU calls him one of its founding professors and says he
+  taught decorative arts there.
+- **Odesa period:** IEU states that after 1925 he lived and worked in Odesa,
+  where he taught at the Odesa Art School / later institute. ESU records
+  leadership of graphic and ceramic workshops in 1925-1932 and teaching drawing,
+  graphics, and ceramics at the art school from 1932 to 1955 with interruptions.
+- **Public memory:** ONNB frames Zhuk as a major Ukrainian modernist whose
+  recent recovery has depended heavily on researchers and exhibitions in Odesa,
+  Kyiv, Kharkiv, Chernihiv, and other centers.
+
+## 2. Oppression / pressure mechanism
+
+- **Load-bearing pressure frame:** Zhuk has a documented security-police
+  episode, but the dossier should not inflate it into a generic NKVD/KGB
+  biography. EIU specifically names an arrest by the State Political Directorate
+  of the Ukrainian SSR in February 1931, release after half a year, and
+  reinstatement. Keep the agency and chronology precise.
+- **Modernism under Soviet pressure:** ESU and IEU describe early work in
+  modernist, symbolist, secession, decorative, and folk-inspired forms. ONNB
+  states that in the 1930s he was for a long time effectively erased from the
+  history of national art, left painting and graphics, and moved almost
+  completely toward ceramic decoration while continuing to teach. Future module
+  should frame this as aesthetic/institutional pressure unless stronger causal
+  sources are added.
+- **Academy and state-building pressure:** His 1917 Academy role belongs to the
+  same fragile Ukrainian statehood-institution context as Narbut, Boichuk,
+  Murashko, and the Krychevsky brothers. The pressure is not just personal
+  repression; it is the difficulty of building a Ukrainian higher art
+  institution during war, revolution, and regime change.
+- **Literary-network vulnerability:** Zhuk's portrait series made Ukrainian
+  cultural figures visible. Some subjects and networks later became dangerous
+  under Soviet repression. Teach this carefully as a memory network; do not
+  imply every portrait caused risk.
+- **Wartime caution:** EIU records that during the Nazi occupation in the
+  German-Soviet war he remained in Odesa and continued work after liberation.
+  Do not turn this into accusation or apology without specialized wartime
+  sources.
+- **What survived:** Portraits of Ukrainian writers and artists, book covers,
+  children's books, graphic cycles, ceramics, Academy memory, Odesa teaching
+  lineage, and recovery exhibitions/catalogues.
+
+## 3. Major works / contributions
+
+- **Ukrainian modernism bridge:** Zhuk connects visual art, literature, book
+  design, pedagogy, and Ukrainian modernist networks. The BIO lesson should not
+  reduce him to painter, writer, or teacher alone.
+- **Academy founder-professor:** EIU and IEU establish him as part of the
+  Ukrainian Academy of Arts founding group in 1917. Local history textbook
+  material also lists him among the Academy's founding artists.
+- **Portrait gallery of Ukrainian culture:** ESU lists portraits of Mykola
+  Biliashivskyi, Bohdan Lepkyi, Mykhailo Kotsiubynsky, Mykola Voronyi, Les
+  Kurbas, Mykola Lysenko, Pavlo Tychyna, Dmytro Zahul, Yurii Mezhenko, Vasyl
+  Chumak, Hryhorii Skovoroda, Lesia Ukrainka, Mykola Khvylovy, Yevhen
+  Yefremov, Volodymyr Sosiura, Mykola Zerov, Ivan Nechui-Levytskyi, Panteleimon
+  Kulish, and others. IEU highlights 1919 portraits of Tychyna and Kurbas and a
+  1925-1926 lithographic portrait series of Ukrainian writers.
+- **Artist-portrait series:** IEU says he created a 1932 portrait etching
+  series of Ukrainian artists including Volodymyr Borovykovsky, Oleksa
+  Novakivskyi, Fedir Krychevskyi, Vasyl Krychevskyi, Heorhii Narbut, and
+  Mykhailo Boichuk. This makes him an archive-maker of Ukrainian art memory.
+- **Graphic and book art:** ESU identifies book and easel graphics as central
+  fields and says he valued woodcut, etching, xylography, and authorial
+  techniques. IEU lists posters, bookplates, book covers, and ceramic designs
+  inspired by Ukrainian folk art.
+- **Ceramics:** ESU states that from the late 1930s he became absorbed in
+  ceramics and created painted vessels from his own designs; ONNB uses this
+  shift as part of the story of 1930s pressure and partial forgetting.
+- **Literature:** ESU and EIU record early publication in `Літературно-науковий
+  вісник`, `Молода Україна`, `Дзвін`, `Шлях`, `Музагет`, and `Шквал`; poetry
+  collection `Співи Землі` (1912); sonnets; plays; art-critical articles;
+  translations of Blok and Wilde; and memoirs about Kotsiubynsky, Franko,
+  Lysenko, Nechui-Levytskyi, and Lesia Ukrainka.
+- **Children's literature / illustration:** ESU lists `Ох`, `Казки`,
+  `Дрімайлики`, `Прийшла зима`, and `Годинник`. PMU notes museum-held books
+  illustrated by Zhuk, including Ivan Franko material and readers for younger
+  pupils.
+
+## 4. Primary-source quote / visual anchors
+
+For Zhuk, the strongest anchors are visual artifacts and book objects rather
+than long secondary quotations.
+
+- **Academy founders photograph:** Commons category contains a 1917 photograph
+  of founders of the Ukrainian Academy of Arts. Verify file-level license
+  before use; it is a strong first-screen source for institutional context.
+- **Self-portrait:** IEU and ONNB show self-portrait material. Use for
+  artist-persona, modernist line, and comparison with portraits of other
+  writers/artists.
+- **Portrait of Pavlo Tychyna (1919):** Good bridge to BIO/LIT and local
+  textbook portrait captions. It lets learners see how a poet becomes a visual
+  modernist subject.
+- **Portrait of Les Kurbas (1919/1920):** Strong theater link; must be handled
+  carefully because Kurbas's later execution belongs to Kurbas's biography, not
+  Zhuk's pressure mechanism.
+- **Portrait series of Ukrainian writers (1925-1926):** Best comparative
+  activity: students match portraits to writer names, then discuss how visual
+  style creates a cultural canon.
+- **Portrait etchings of Ukrainian artists (1932):** Good cross-module link to
+  Narbut, Boichuk, Novakivskyi, and the Krychevsky family.
+- **`Біле і чорне` / `Black and White`:** ONNB and IEU surface this as a
+  memorable visual anchor for line, contrast, symbolism, and modernist
+  decorative thinking.
+- **`Ох` book cover / children's books:** PMU and ONNB give useful education
+  anchors: illustration, children's reading, book as object, artist-teacher.
+- **Ceramic sketches / vessels:** Use after source and rights verification to
+  show the late-career shift into decorative-applied art and teaching.
+
+## 5. Language register
+
+- **Register:** art-school, modernist, portrait-gallery, book-design,
+  literature-and-visual-culture, teacher/mentor, Odesa memory-recovery register.
+- **CEFR readiness:** B2 biography and portrait-description work; C1 discussion
+  of Ukrainian modernism, Academy institution-building, Soviet pressure on
+  formalist/modernist art, and how portraits build cultural memory.
+- **Learner lexicon:** `графік`, `живописець`, `портрет`, `літографія`,
+  `офорт`, `ксилографія`, `екслібрис`, `книжкова обкладинка`, `модерн`,
+  `символізм`, `сецесія`, `кераміка`, `майстерня`, `педагог`, `професор`,
+  `портретна галерея`, `дитяча книжка`, `казка`, `сонет`, `спогади`.
+- **Style note:** Future lessons should tell the human tale of a Kakhovka-born
+  worker's son who learned in Kyiv, Moscow, and Cracow; built friendships with
+  writers; helped found a Ukrainian art academy; drew and wrote the faces of a
+  culture; survived arrest and Soviet pressure; taught generations in Odesa;
+  and had to be recovered from partial forgetting.
+
+## 6. Contested points
+
+- **Birth year:** ESU gives 1882 with old/new style dates; IEU, EIU, ONNB, PMU,
+  and Commons use 1883. Future module should state the discrepancy. If schema
+  requires a single date, source-majority public teaching date is 2 October
+  1883, with dossier note.
+- **Death date:** ESU and IEU give 7 June 1964; EIU gives 8 June 1964. Keep the
+  discrepancy visible.
+- **Ukrainian / Soviet label:** Commons metadata and some catalogues may use
+  "Ukrainian and Soviet painter." Learner-facing identity should foreground
+  Ukrainian artist and teacher; Soviet institutional membership belongs in
+  context.
+- **DPU arrest scope:** EIU documents arrest, release, and reinstatement. Do
+  not generalize this into a broader KGB/NKVD story without source evidence.
+- **Odesa chronology:** Sources agree on Odesa significance after 1925, but ESU
+  wording around "in Odesa: from 1917" should be handled cautiously against IEU
+  and EIU, which place the main Odesa teaching period after 1925.
+- **"First Ukrainian sonnets" claim:** EIU says in 1918 Zhuk became author of
+  the first Ukrainian sonnets. This is potentially literary-history specific
+  and should be verified by a specialist source before it becomes a learner
+  claim.
+- **1930s erasure:** ONNB states he was effectively erased from art history in
+  the 1930s. Use as reception/memory-pressure frame, not as a fully explained
+  causal claim unless future module adds monograph evidence.
+
+## 7. Cross-track links
+
+**Existing BIO / visual-culture links (VERIFIED `test -e` on 2026-07-01):**
+
+- `docs/research/bio/heorhii-narbut.md`
+- `docs/research/bio/oleksandr-murashko.md`
+- `docs/research/bio/fedir-krychevskyi.md`
+- `docs/research/bio/vasyl-krychevskyi.md`
+- `curriculum/l2-uk-en/plans/bio/vasyl-krychevskyi.yaml`
+- `docs/research/bio/mykhailo-boichuk.md`
+- `curriculum/l2-uk-en/plans/bio/mykhailo-boichuk.yaml`
+- `docs/research/bio/oleksa-novakivskyi.md`
+- `docs/research/bio/ivan-trush.md`
+- `docs/research/bio/sofiia-nalepynska-boichuk.md`
+- `curriculum/l2-uk-en/plans/bio/sofiia-nalepynska-boichuk.yaml`
+
+**Existing BIO / literary-network links (VERIFIED `test -e` on 2026-07-01):**
+
+- `docs/research/bio/ivan-franko.md`
+- `curriculum/l2-uk-en/plans/bio/ivan-franko.yaml`
+- `docs/research/bio/lesya-ukrainka.md`
+- `curriculum/l2-uk-en/plans/bio/lesya-ukrainka.yaml`
+- `docs/research/bio/mykola-lysenko.md`
+- `curriculum/l2-uk-en/plans/bio/mykola-lysenko.yaml`
+- `docs/research/bio/pavlo-tychyna.md`
+- `curriculum/l2-uk-en/plans/bio/pavlo-tychyna.yaml`
+- `docs/research/bio/les-kurbas.md`
+- `curriculum/l2-uk-en/plans/bio/les-kurbas.yaml`
+- `docs/research/bio/mykhailo-kotsiubynsky.md`
+- `curriculum/l2-uk-en/plans/bio/mykhailo-kotsiubynsky.yaml`
+- `docs/research/bio/panteleimon-kulish.md`
+- `curriculum/l2-uk-en/plans/bio/panteleimon-kulish.yaml`
+- `docs/research/bio/hryhoriy-skovoroda.md`
+- `curriculum/l2-uk-en/plans/bio/hryhoriy-skovoroda.yaml`
+- `docs/research/bio/taras-shevchenko.md`
+- `curriculum/l2-uk-en/plans/bio/taras-shevchenko.yaml`
+- `docs/research/bio/mykola-zerov.md`
+- `curriculum/l2-uk-en/plans/bio/mykola-zerov.yaml`
+- `docs/research/bio/mykola-voronyi.md`
+- `curriculum/l2-uk-en/plans/bio/mykola-voronyi.yaml`
+- `docs/research/bio/volodymyr-sosiura.md`
+- `curriculum/l2-uk-en/plans/bio/volodymyr-sosiura.yaml`
+- `docs/research/bio/mykola-kulish.md`
+- `curriculum/l2-uk-en/plans/bio/mykola-kulish.yaml`
+
+**Existing C1 / fine-arts links (VERIFIED `test -e` on 2026-07-01):**
+
+- `curriculum/l2-uk-en/plans/c1/obrazotvorche-mystetstvo-1.yaml`
+- `curriculum/l2-uk-en/plans/c1/obrazotvorche-mystetstvo-2.yaml`
+- `curriculum/l2-uk-en/plans/c1/checkpoint-fine-arts.yaml`
+
+**Future / planned BIO links (not existing module files yet):**
+
+- BIO #366 `mykhailo-zhuk`
+- BIO #367 `sofiia-yablonska`
+- Mykola Khvylovy as portrait subject if / when the BIO slug exists.
+
+## 8. Naming-canonical
+
+- **Slug:** `mykhailo-zhuk`
+- **EN canonical:** Mykhailo Zhuk
+- **UA canonical:** Михайло Іванович Жук
+- **Source aliases track:** Zhuk, Mykhailo; Mykhailo Ivanovych Zhuk; Žuk;
+  Myxajlo; O. Migules / О. Мігулес.
+- **Forbidden / source-critical forms:** Russianized forms such as `Михаил Жук`
+  should not be used in learner-facing headings. They may appear only in source
+  metadata, library authority records, or cataloguing notes.
+- **Date note in YAML:** Future YAML should include a note for the 1882/1883
+  birth-year discrepancy and the 7/8 June 1964 death-date discrepancy if schema
+  supports date notes.
+
+## 9. Image-rights media anchors
+
+- **Rights principle:** Zhuk died in 1964, so his artwork is not automatically
+  life-plus-70 public domain in Ukraine/EU-style terms until 2035. Do not use
+  reproductions merely because they are old or visible online. Verify each file
+  license and publication status.
+- **Commons category:** `Category:Mykhailo Zhuk` has useful metadata and a
+  founders photograph lead, but limited file coverage. Check individual file
+  pages before use.
+- **Portraits on IEU / ONNB:** Strong visual anchors, but source pages do not
+  automatically grant reuse in site MDX. Use for research unless rights are
+  separately cleared.
+- **Book covers / children's books:** PMU and ONNB identify relevant books and
+  covers. Treat them as object/source leads; do not copy images without rights
+  clearance.
+- **Ceramics:** Late ceramic designs may be especially rights-sensitive because
+  of later object photography and publication. Prefer rights-cleared museum or
+  Commons files only.
+- **Caption caution:** Avoid Soviet-only or Russianized captions. Use Ukrainian
+  canonical name and explain any source labels as source metadata.
+
+## 10. Sources used
+
+**Tier 1 / Tier 2 encyclopedic institutional sources:**
+
+- Енциклопедія Сучасної України. "Жук Михайло Іванович."
+  https://esu.com.ua/article-18290. Accessed 2026-07-01.
+- Енциклопедія історії України / Інститут історії України НАН України. "Жук
+  Михайло Іванович."
+  https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIU&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=zhuk_mykhajlo_ivanovych&Z21ID=.
+  Accessed 2026-07-01.
+- Internet Encyclopedia of Ukraine. "Zhuk, Mykhailo."
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CZ%5CH%5CZhukMykhailo.htm.
+  Accessed 2026-07-01.
+
+**Museum / library / object-context sources:**
+
+- Одеська національна наукова бібліотека. "Михайло Жук — художник-просвітянин
+  (1883-1964): до 140-річчя від дня народження українського художника,
+  письменника, педагога." https://odnb.odessa.ua/view_post.php?id=4369.
+  Accessed 2026-07-01.
+- Педагогічний музей України. "Михайло Жук (1883-1964): художник, письменник,
+  ілюстратор дитячих книг, педагог."
+  https://pmu.in.ua/news/myxajlo-zhuk-1883-1964-xudozhnyk-pysmennyk-ilyustrator-dytyachyx-knyh-pedahoh/.
+  Accessed 2026-07-01.
+- Wikimedia Commons. `Category:Mykhailo Zhuk`.
+  https://commons.wikimedia.org/wiki/Category:Mykhailo_Zhuk. Accessed
+  2026-07-01.
+
+**Local curriculum / textbook anchors:**
+
+- `docs/references/textbooks-txt/10-klas-history.txt` — Ukrainian Academy of
+  Arts founders context.
+- `docs/references/textbooks-txt/10-klas-ukrlit-borzenko-2018-prof.txt` —
+  textbook portrait captions for Ivan Franko, Mykhailo Kotsiubynsky, Mykola
+  Voronyi, and other literary figures.
+- `curriculum/l2-uk-en/plans/c1/obrazotvorche-mystetstvo-1.yaml` and
+  `curriculum/l2-uk-en/plans/c1/obrazotvorche-mystetstvo-2.yaml` — fine-arts
+  sequence context.
+
+---
+
+## Decolonization self-check
+
+- [x] Ukrainian modernist / Academy / literary-network frame foregrounded.
+- [x] Documented DPU arrest kept precise; no invented NKVD/KGB case.
+- [x] Russian-imperial, Soviet, Ukrainian, and Odesa institutional contexts
+  separated rather than flattened.
+- [x] Portrait work framed as Ukrainian cultural-memory construction, not
+  decorative name-dropping.
+- [x] 1882/1883 and 7/8 June date discrepancies documented.
+- [x] Cross-track "Existing" paths verified with `test -e`.
+- [x] Naming and image-rights policy checked.
+- [x] Dossier-only slice: no plan YAML, module markdown, activity YAML,
+  vocabulary YAML, generated site MDX, wiki packet, status JSON, or telemetry
+  DB.

--- a/docs/research/bio/mykhailo-zhuk.md
+++ b/docs/research/bio/mykhailo-zhuk.md
@@ -156,9 +156,12 @@ than long secondary quotations.
   style creates a cultural canon.
 - **Portrait etchings of Ukrainian artists (1932):** Good cross-module link to
   Narbut, Boichuk, Novakivskyi, and the Krychevsky family.
-- **`Біле та чорне` / `Black and White`:** ONNB and IEU surface this as a
-  memorable visual anchor for line, contrast, symbolism, and modernist
-  decorative thinking.
+- **`Біле та чорне` / `Біле і чорне` / `Black and White`:** The Odesa Museum
+  of Modern Art online collection catalogs the work as `Біле та чорне`; ONNB
+  materials also use `Біле і чорне`, while IEU captions the image in English
+  as `Black and White`. Treat it as a memorable visual anchor for line,
+  contrast, symbolism, and modernist decorative thinking, and preserve
+  source-specific title wording in captions.
 - **`Ох` book cover / children's books:** PMU and ONNB give useful education
   anchors: illustration, children's reading, book as object, artist-teacher.
 - **Ceramic sketches / vessels:** Use after source and rights verification to
@@ -317,6 +320,8 @@ than long secondary quotations.
   (1883-1964): до 140-річчя від дня народження українського художника,
   письменника, педагога." https://odnb.odessa.ua/view_post.php?id=4369.
   Accessed 2026-07-01.
+- Музей сучасного мистецтва Одеси. "Біле та чорне."
+  https://onlinecollection.msio.com.ua/uk/works/1700. Accessed 2026-07-01.
 - Педагогічний музей України. "Михайло Жук (1883-1964): художник, письменник,
   ілюстратор дитячих книг, педагог."
   https://pmu.in.ua/news/myxajlo-zhuk-1883-1964-xudozhnyk-pysmennyk-ilyustrator-dytyachyx-knyh-pedahoh/.

--- a/docs/research/bio/mykhailo-zhuk.md
+++ b/docs/research/bio/mykhailo-zhuk.md
@@ -68,7 +68,10 @@ ONNB = Odesa National Scientific Library; PMU = Pedagogical Museum of Ukraine.
   episode, but the dossier should not inflate it into a generic NKVD/KGB
   biography. EIU specifically names an arrest by the State Political Directorate
   of the Ukrainian SSR in February 1931, release after half a year, and
-  reinstatement. Keep the agency and chronology precise.
+  reinstatement. Keep the agency and chronology precise; if later summaries
+  emphasize his avoidance of the Great Terror, treat that as a separate
+  reception point rather than a contradiction unless a specialist source
+  resolves the whole 1930s sequence.
 - **Modernism under Soviet pressure:** ESU and IEU describe early work in
   modernist, symbolist, secession, decorative, and folk-inspired forms. ONNB
   states that in the 1930s he was for a long time effectively erased from the
@@ -102,12 +105,13 @@ ONNB = Odesa National Scientific Library; PMU = Pedagogical Museum of Ukraine.
   Ukrainian Academy of Arts founding group in 1917. Local history textbook
   material also lists him among the Academy's founding artists.
 - **Portrait gallery of Ukrainian culture:** ESU lists portraits of Mykola
-  Biliashivskyi, Bohdan Lepkyi, Mykhailo Kotsiubynsky, Mykola Voronyi, Les
-  Kurbas, Mykola Lysenko, Pavlo Tychyna, Dmytro Zahul, Yurii Mezhenko, Vasyl
-  Chumak, Hryhorii Skovoroda, Lesia Ukrainka, Mykola Khvylovy, Yevhen
-  Yefremov, Volodymyr Sosiura, Mykola Zerov, Ivan Nechui-Levytskyi, Panteleimon
-  Kulish, and others. IEU highlights 1919 portraits of Tychyna and Kurbas and a
-  1925-1926 lithographic portrait series of Ukrainian writers.
+  Biliashivskyi, Bohdan Lepkyi, Mykhailo Kotsiubynsky, M. Voronyi, Les Kurbas,
+  Mykola Lysenko, Pavlo Tychyna, Dmytro Zahul, Yurii Mezhenko, Vasyl Chumak,
+  Hryhorii Skovoroda, Lesia Ukrainka, Mykola Khvylovy, Ye. Yefremov, Volodymyr
+  Sosiura, Mykola Zerov, Ivan Nechui-Levytskyi, Panteleimon Kulish, and others.
+  Keep the ESU initials for Voronyi and Yefremov until future module work
+  verifies exact first names. IEU highlights 1919 portraits of Tychyna and
+  Kurbas and a 1925-1926 lithographic portrait series of Ukrainian writers.
 - **Artist-portrait series:** IEU says he created a 1932 portrait etching
   series of Ukrainian artists including Volodymyr Borovykovsky, Oleksa
   Novakivskyi, Fedir Krychevskyi, Vasyl Krychevskyi, Heorhii Narbut, and
@@ -121,9 +125,10 @@ ONNB = Odesa National Scientific Library; PMU = Pedagogical Museum of Ukraine.
   shift as part of the story of 1930s pressure and partial forgetting.
 - **Literature:** ESU and EIU record early publication in `Літературно-науковий
   вісник`, `Молода Україна`, `Дзвін`, `Шлях`, `Музагет`, and `Шквал`; poetry
-  collection `Співи Землі` (1912); sonnets; plays; art-critical articles;
-  translations of Blok and Wilde; and memoirs about Kotsiubynsky, Franko,
-  Lysenko, Nechui-Levytskyi, and Lesia Ukrainka.
+  collection `Співи Землі` (1912); a `вінок сонетів` / crown of sonnets
+  (1918); plays; art-critical articles; translations of Blok and Wilde; and
+  memoirs about Kotsiubynsky, Franko, Lysenko, Nechui-Levytskyi, and Lesia
+  Ukrainka.
 - **Children's literature / illustration:** ESU lists `Ох`, `Казки`,
   `Дрімайлики`, `Прийшла зима`, and `Годинник`. PMU notes museum-held books
   illustrated by Zhuk, including Ivan Franko material and readers for younger
@@ -151,7 +156,7 @@ than long secondary quotations.
   style creates a cultural canon.
 - **Portrait etchings of Ukrainian artists (1932):** Good cross-module link to
   Narbut, Boichuk, Novakivskyi, and the Krychevsky family.
-- **`Біле і чорне` / `Black and White`:** ONNB and IEU surface this as a
+- **`Біле та чорне` / `Black and White`:** ONNB and IEU surface this as a
   memorable visual anchor for line, contrast, symbolism, and modernist
   decorative thinking.
 - **`Ох` book cover / children's books:** PMU and ONNB give useful education
@@ -193,10 +198,10 @@ than long secondary quotations.
 - **Odesa chronology:** Sources agree on Odesa significance after 1925, but ESU
   wording around "in Odesa: from 1917" should be handled cautiously against IEU
   and EIU, which place the main Odesa teaching period after 1925.
-- **"First Ukrainian sonnets" claim:** EIU says in 1918 Zhuk became author of
-  the first Ukrainian sonnets. This is potentially literary-history specific
-  and should be verified by a specialist source before it becomes a learner
-  claim.
+- **Sonnets claim:** EIU says in 1918 Zhuk became author of "first Ukrainian
+  sonnets," while ESU describes a `вінок сонетів` / crown of sonnets. Future
+  module should avoid a broad "first Ukrainian sonnets" learner claim unless a
+  specialist literary source confirms exactly what was first.
 - **1930s erasure:** ONNB states he was effectively erased from art history in
   the 1930s. Use as reception/memory-pressure frame, not as a fully explained
   causal claim unless future module adds monograph evidence.
@@ -300,8 +305,7 @@ than long secondary quotations.
 - Енциклопедія Сучасної України. "Жук Михайло Іванович."
   https://esu.com.ua/article-18290. Accessed 2026-07-01.
 - Енциклопедія історії України / Інститут історії України НАН України. "Жук
-  Михайло Іванович."
-  https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIU&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=zhuk_mykhajlo_ivanovych&Z21ID=.
+  Михайло Іванович." https://www.history.org.ua/?termin=zhuk_mykhajlo_ivanovych.
   Accessed 2026-07-01.
 - Internet Encyclopedia of Ukraine. "Zhuk, Mykhailo."
   https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CZ%5CH%5CZhukMykhailo.htm.


### PR DESCRIPTION
## Summary
- Add BIO #366 dossier `mykhailo-zhuk`.
- Keep slice dossier-only: no plan YAML, module, activities, vocabulary, MDX, wiki packet, generated artifacts, linter config, package, or telemetry files.
- Ground dossier in ESU, EIU, IEU, Odesa National Scientific Library, Pedagogical Museum of Ukraine, Commons, and local textbook/curriculum anchors.
- Frame pressure precisely: documented 1931 DPU arrest/release, Ukrainian Academy institution-building pressure, Soviet-era aesthetic/reception pressure, and memory recovery; no invented NKVD/KGB case.

## Validation
- `npx markdownlint-cli2 docs/research/bio/mykhailo-zhuk.md`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/mykhailo-zhuk.md`
- `git diff --check origin/main...HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Telemetry
- Not applicable: dossier-only base-prep PR, not module-build PR.
- swarm_used: false
- swarm_note: solo run; no swarm used