### PR TITLE
docs(bio): add Bohdan Lepkyi dossier

### DIFF
--- a/docs/research/bio/bohdan-lepkyi.md
+++ b/docs/research/bio/bohdan-lepkyi.md
@@ -141,6 +141,9 @@ module without a rights and edition check.
 - **Mazepa restoration vs. new myth:** The `Мазепа` cycle is decolonial because
   it resists imperial demonization, but it can also idealize. Teach it with
   anti-hagiography: what does Lepkyi restore, soften, or dramatize?
+- **`Видиш` / `Чуєш` incipit:** learners may see the original / textual witness
+  `Видиш, брате мій` and the popular song variant `Чуєш, брате мій`. Do not
+  "correct" one away without naming the variant tradition.
 - **Polish context:** Lepkyi lived much of his career in Kraków, wrote across
   Ukrainian-Polish cultural space, and served as a Polish senator representing
   Galician Ukrainians. Do not flatten this into either assimilation or pure
@@ -228,6 +231,8 @@ module without a rights and edition check.
 
 - Освіта.ua. "`Чуєш, брате мій` Богдан Лепкий."
   https://osvita.ua/school/literature/l/70605/. Accessed 2026-07-01.
+- Освіта.ua. "`Видиш, брате мій...` Богдан Лепкий."
+  https://osvita.ua/school/literature/l/70639/. Accessed 2026-07-01.
 - Мислене древо. "Лепкий Б. Мотря - Ніч."
   https://www.myslenedrevo.com.ua/uk/Lit/L/LepkyB/Prose/Mazepa/Motrja/Nich.html.
   Accessed 2026-07-01.

--- a/docs/research/bio/bohdan-lepkyi.md
+++ b/docs/research/bio/bohdan-lepkyi.md
@@ -1,0 +1,260 @@
+# Богдан Сильвестрович Лепкий — Research Dossier
+
+**Slug:** `bohdan-lepkyi`
+**Block:** +77 expansion — literary / civic additions
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #368
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Source acronym legend:** ESU = Encyclopedia of Modern Ukraine; IEU =
+Internet Encyclopedia of Ukraine; EHIU = Encyclopedia of History of Ukraine;
+BLM = Berezhany Bohdan Lepky Museum.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional sources cited
+- [x] Pressure mechanism framed as imperial memory struggle, wartime
+  displacement, POW-camp cultural work, interwar minority advocacy, and
+  occupation-era precarity; no invented NKVD/KGB case
+- [x] At least 2 primary-source Ukrainian text anchors supplied
+- [x] Cross-track links verified `test -e` on 2026-07-01 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Богдан Сильвестрович Лепкий.
+- **Extended baptismal / family form:** Богдан Теодор Нестор Сильвестрович
+  Лепкий appears in biographical tradition; keep shorter canonical learner
+  title unless a source requires the longer form.
+- **Project English canonical:** Bohdan Lepkyi.
+- **Aliases / pseudonyms:** ESU lists many pseudonyms and cryptonyms, including
+  Федір Кригулецький, Нестор, Ярослав Марченко, Л. Богдан, Б. Л., Петро Тихий,
+  Б. Бережанський. Use only where source metadata or authorship history needs
+  them.
+- **Born / died:** ESU and EHIU give 04 November 1872, хутір Кривенький near
+  Кригулець / Крогулець, now Ternopil region; 21 July 1941, Kraków, Poland.
+  IEU also gives 4 November 1872 and 21 July 1941. Some popular memorial
+  sources use 9 November; flag as date-style / commemoration discrepancy rather
+  than silently replacing institutional dates.
+- **Family / education:** ESU identifies him as son of Sylvestr Lepky and
+  brother of Levko and Mykola Lepky. He finished the Berezhany gymnasium,
+  studied in Vienna and Lviv, and graduated from Lviv University in 1895.
+- **Career:** ESU / IEU place him in Berezhany teaching, then Kraków
+  gymnasiums and Jagiellonian University. IEU says his Kraków home was a
+  meeting place for Ukrainian writers, artists, and scholars; from 1932 he held
+  the Ukrainian literature chair.
+- **Death / burial:** EHIU states he died in Kraków and is buried in Rakowicki
+  Cemetery, with a later grave relief installed in 1972.
+
+## 2. Oppression / pressure mechanism
+
+- **Load-bearing frame:** Lepkyi is not a Soviet security-service biography.
+  Do not invent an NKVD, MGB, or KGB file. His BIO fit is cultural survival
+  across empire, war, emigration, and memory conflict.
+- **Imperial memory struggle:** His `Мазепа` cycle matters because Russian
+  imperial historiography made Mazepa a betrayal myth. Lepkyi's historical
+  fiction returns subjectivity to a Ukrainian statesman and teaches readers to
+  see the Hetmanate as a political world, not as a footnote to Peter I.
+- **First World War displacement / service:** IEU says he worked in Vienna for
+  the Ukrainian Cultural Council and Union for the Liberation of Ukraine, then
+  taught Ukrainians interned in German POW camps at Wetzlar and Rastatt. EHIU
+  gives the same cultural-educational frame among Ukrainian POWs from the
+  Russian army.
+- **Interwar minority work:** IEU says he promoted Ukrainian culture in Polish
+  circles and served in the Polish Senate in 1938-1939. EHIU says he
+  represented Ukrainians of Galicia. Treat this as minority advocacy under the
+  Second Polish Republic, not as simple assimilation.
+- **Occupation-era precarity:** ESU / EHIU say after Germany occupied Poland in
+  1939 he lost steady work and lived in poverty while continuing literary work
+  and working with Ukrainian publishing in Kraków. Avoid both hagiography and
+  unsupported collaboration framing.
+
+## 3. Major works / contributions
+
+- **Poetry and song canon:** `Чуєш, брате мій` / `Журавлі` became the best-known
+  song from his text, with music by his brother Levko Lepky. It crosses BIO,
+  FOLK, and war-song memory because the cranes image condenses exile, death
+  abroad, and parting.
+- **Historical prose:** IEU describes the `Мазепа` epic: `Мотря`, `Не вбивай`,
+  `Батурин`, `Полтава`, and posthumous `З-під Полтави до Бендер`. ESU says
+  the cycle grew to seven narratives; use "cycle" unless a lesson source
+  explains the trilogy / pentalogy naming.
+- **Literary scholarship / editing:** ESU credits him with literary histories,
+  Polish-language Ukrainian literature surveys, and prepared editions of
+  Shevchenko, Marko Vovchok, Yevhen Hrebinka, Panteleimon Kulish, and others.
+- **Translation / mediation:** ESU notes translations from world literature
+  into Ukrainian and Ukrainian literature into Polish. IEU emphasizes his role
+  promoting Ukrainian culture in Polish circles.
+- **Visual art:** ESU and EHIU identify him as painter / artist; BLM displays
+  family and youth-period material, portraits, and works connected with his
+  art practice.
+
+## 4. Primary-source quote / visual anchors
+
+Use short excerpts; do not reproduce full poems or long novel passages in the
+module without a rights and edition check.
+
+- **`Чуєш, брате мій` / `Журавлі`:** "Чуєш, брате мій, / Товаришу мій".
+  Source: school-text witness at Освіта.ua; poem/song text. Pedagogical use:
+  grief is addressed directly to a companion, so the learner hears exile as
+  relationship, not abstract patriotism.
+- **`Мотря`, chapter `Ніч`:** "В кого совість чиста, в того й сон здоровий".
+  Source: Myslene Drevo edition of `Мотря`. Pedagogical use: the guard's
+  proverb-like sentence opens a lesson on rumor, conscience, and how Lepkyi
+  stages Mazepa through other people's speech.
+- **Mazepa-cycle visual anchor:** pair a public-domain Mazepa / Baturyn
+  historical image with the existing HIST Mazepa plans; do not make Lepkyi's
+  fiction substitute for history.
+- **Museum anchor:** BLM in Berezhany is a place-memory anchor: childhood,
+  gymnasium, Kraków period, painting, and editions.
+
+## 5. Language register
+
+- **Register:** lyrical-elegiac poetry, Galician prose, historical-romantic
+  fiction, literary-critical prose, public-cultural mediation.
+- **CEFR readiness:** B1/B2 can handle selected song stanzas and short lyric
+  passages. C1 is appropriate for `Мазепа` because of historical syntax,
+  archaic lexicon, Hetmanate institutions, and narrator irony.
+- **Learner lexicon:** `журавлі`, `чужина`, `вирій`, `гетьман`, `державність`,
+  `вигнання`, `полонені`, `читальня`, `Просвіта`, `літературознавець`,
+  `перекладач`, `епопея`, `історична повість`, `культурна реституція`.
+- **Style note:** The BIO module should tell a human story: a Galician priest's
+  son, teacher, poet, artist, Kraków professor, wartime educator of Ukrainian
+  POWs, and writer who turned song and historical fiction into portable
+  Ukrainian memory.
+
+## 6. Contested points
+
+- **Birth date:** Institutional Ukrainian sources used here give 4 November
+  1872; some popular sources give 9 November. Use 4 November in metadata and
+  mention date-style discrepancy only if learners see both.
+- **Trilogy / pentalogy / cycle:** Curriculum already has "Mazepa trilogy"
+  labels. The dossier should note that sources describe a larger cycle; module
+  builders should not imply exactly three books unless they are referring to
+  a specific teaching selection.
+- **Mazepa restoration vs. new myth:** The `Мазепа` cycle is decolonial because
+  it resists imperial demonization, but it can also idealize. Teach it with
+  anti-hagiography: what does Lepkyi restore, soften, or dramatize?
+- **Polish context:** Lepkyi lived much of his career in Kraków, wrote across
+  Ukrainian-Polish cultural space, and served as a Polish senator representing
+  Galician Ukrainians. Do not flatten this into either assimilation or pure
+  exile.
+- **Occupation-era Kraków:** He worked in difficult circumstances after 1939.
+  Source the institutional wording and avoid unsupported moral shortcuts.
+
+## 7. Cross-track links
+
+**Existing BIO / literary-network links (VERIFIED `test -e` on 2026-07-01):**
+
+- `docs/research/bio/ivan-franko.md`
+- `docs/research/bio/vasyl-stefanyk.md`
+- `docs/research/bio/olha-kobylianska.md`
+- `docs/research/bio/ivan-mazepa.md`
+- `curriculum/l2-uk-en/bio/discovery/ivan-mazepa.yaml`
+- `curriculum/l2-uk-en/bio/discovery/ivan-franko.yaml`
+- `curriculum/l2-uk-en/bio/discovery/vasyl-stefanyk.yaml`
+
+**Existing LIT / HIST / FOLK links (VERIFIED `test -e` on 2026-07-01):**
+
+- `curriculum/l2-uk-en/plans/lit-hist-fic/lepkyi-mazepa.yaml`
+- `curriculum/l2-uk-en/plans/lit/lepkyi-mazepa-trilogy.yaml`
+- `curriculum/l2-uk-en/lit/discovery/lepkyi-mazepa-trilogy.yaml`
+- `curriculum/l2-uk-en/plans/hist/ivan-mazepa-derzhavnyk.yaml`
+- `curriculum/l2-uk-en/plans/hist/ivan-mazepa-poltava.yaml`
+- `curriculum/l2-uk-en/plans/hist/ivan-mazepa-kultura.yaml`
+- `curriculum/l2-uk-en/plans/lit-war/sich-riflemen-poetry.yaml`
+- `curriculum/l2-uk-en/plans/folk/striletski-povstanski-pisni.yaml`
+- `curriculum/l2-uk-en/folk/striletski-povstanski-pisni/module.md`
+
+**Future / planned BIO links (not existing module files yet):**
+
+- BIO #368 `bohdan-lepkyi`
+- BIO #369 `ulas-samchuk`
+- Possible future cross-link Levko Lepky if a composer / Sich Riflemen song
+  dossier appears.
+
+## 8. Naming-canonical
+
+- **Slug:** `bohdan-lepkyi`.
+- **EN canonical:** Bohdan Lepkyi.
+- **UA canonical:** Богдан Сильвестрович Лепкий.
+- **Common source forms:** Bohdan Lepky; Богдан Лепкий; Lepky, Bohdan; older
+  transliteration `Lepkyj` in IEU metadata.
+- **Avoid:** Russianized forms in learner labels; keep Polish forms only where
+  source titles, Kraków institutions, or Polish-language scholarship require
+  them.
+- **Related names:** Levko Lepky is a separate figure and composer of
+  `Журавлі`; do not collapse brother roles.
+
+## 9. Image/media rights
+
+- **Best portrait candidate:** Wikimedia Commons `File:Лепкий Богдан.jpg`
+  is marked public domain in life+70 jurisdictions and should be checked for
+  a US public-domain tag before reuse.
+- **Backup candidate:** Commons `File:Lepki Bohdan NAC 1.jpg` has National
+  Digital Archive provenance and a Commons license page; verify page license
+  before use.
+- **Museum images:** BLM pages show exhibits and museum context. Treat museum
+  photographs as rights-controlled unless an explicit license is supplied.
+- **Text rights:** Lepkyi died in 1941, so his works are public-domain in
+  Ukraine/EU life+70 terms. US status can vary by publication date; Wikisource
+  flags pre-1931 publications as public domain in the United States and later
+  works as variable. Keep excerpting conservative.
+- **Caption policy:** Captions should connect image to the teaching claim:
+  Kraków mediator, Berezhany memory, Mazepa-cycle restitution, or song canon.
+
+## 10. Sources used
+
+**Tier 1 / Tier 2 encyclopedic institutional sources:**
+
+- Енциклопедія Сучасної України. "Лепкий Богдан Сильвестрович."
+  https://esu.com.ua/article-54373. Accessed 2026-07-01.
+- Internet Encyclopedia of Ukraine. "Lepky, Bohdan."
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CL%5CE%5CLepkyBohdan.htm.
+  Accessed 2026-07-01.
+- Енциклопедія історії України. "Лепкий Богдан Сильвестрович."
+  https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=DOP&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Lepkiy_B_S&Z21ID=.
+  Accessed 2026-07-01.
+- Тернопільська обласна бібліотека для молоді. "Музей Богдана Лепкого."
+  https://tobm.org.ua/muzej-bogdana-lepkogo/. Accessed 2026-07-01.
+
+**Primary / text witnesses and rights sources:**
+
+- Освіта.ua. "`Чуєш, брате мій` Богдан Лепкий."
+  https://osvita.ua/school/literature/l/70605/. Accessed 2026-07-01.
+- Мислене древо. "Лепкий Б. Мотря - Ніч."
+  https://www.myslenedrevo.com.ua/uk/Lit/L/LepkyB/Prose/Mazepa/Motrja/Nich.html.
+  Accessed 2026-07-01.
+- Вікіджерела. "Автор:Богдан Лепкий."
+  https://uk.wikisource.org/wiki/Автор:Богдан_Лепкий. Accessed 2026-07-01.
+- Wikimedia Commons. "File:Лепкий Богдан.jpg."
+  https://commons.wikimedia.org/wiki/File:Лепкий_Богдан.jpg. Accessed
+  2026-07-01.
+- Wikimedia Commons. "File:Lepki Bohdan NAC 1.jpg."
+  https://commons.wikimedia.org/wiki/File:Lepki_Bohdan_NAC_1.jpg. Accessed
+  2026-07-01.
+
+**Primary-source documents accessed:** published literary works only; no
+NKVD/KGB/court file applies to this biography.
+
+---
+
+## Decolonization self-check
+
+Per `docs/audits/bio-decolonization-checklist.md` (#2310):
+
+- [x] No Russocentric framing
+- [x] No Russian-imperial transliterations in body text except source-critical
+  alias / legacy metadata discussion
+- [x] No Russocentric periodization
+- [x] No uncritical Soviet propaganda terms
+- [x] No "lost life" euphemisms for documented executions
+- [x] All place names use modern UA canonical form where applicable
+- [x] Holodomor framing not applicable to this dossier
+- [x] Crimea/2014/2022 framing not applicable to this dossier


### PR DESCRIPTION
## Summary

- Adds the BIO #368 Bohdan Lepkyi research dossier.
- Keeps the strict +77 base-prep scope: dossier only, no plan YAML, module, site MDX, activities, vocabulary, status/audit artifacts, telemetry DB, or config changes.
- Frames Lepkyi through literary/civic memory, Mazepa-cycle cultural restitution, Ukrainian POW-camp educational work, interwar minority advocacy, and occupation-era precarity without inventing security-service/KGB framing.

## Validation

- npx markdownlint-cli2 docs/research/bio/bohdan-lepkyi.md
- .venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/bohdan-lepkyi.md
- git diff --check origin/main...HEAD
- .venv/bin/python scripts/audit/lint_agent_trailer.py

## Telemetry

Dossier-only base-prep PR; module-build telemetry is not applicable.

swarm_used: false
swarm_note: solo run; no swarm used
