### PR TITLE
docs(bio): add Andrian Kashchenko dossier

### DIFF
--- a/docs/research/bio/andrian-kashchenko.md
+++ b/docs/research/bio/andrian-kashchenko.md
@@ -73,7 +73,7 @@ Kashchenko died in 1921, so his own texts are public domain under life+70 regime
 
 ## 6. Contested points
 
-- **Aдpiан / Андріан naming:** ESU and IEU use `Адріан` / `Adriian`; the project queue and existing plan use `Андріан` / `andrian-kashchenko`. Preserve the existing slug; teach the variant forms as catalog / curriculum variation.
+- **Адріан / Андріан naming:** ESU and IEU use `Адріан` / `Adriian`; the project queue and existing plan use `Андріан` / `andrian-kashchenko`. Preserve the existing slug; teach the variant forms as catalog / curriculum variation.
 - **Literary value vs didactic value:** IEU bluntly says the works have limited literary value and historical inaccuracies, but also says they were popular and had an important didactic patriotic role. This is the central anti-hagiography frame: Kashchenko may be more important as public-memory infrastructure than as a stylist.
 - **Historical accuracy:** Existing local plan already frames history vs fiction. Do not build a BIO module that treats `Над Кодацьким порогом` as documentary history. Pair story episodes with the question: what is documented, what is romanticized, and why did the romance work?
 - **Soviet ban / removal wording:** Use ESU and IEU source-specific language: books removed from libraries from 1933; works banned in Soviet Ukraine. Do not invent a trial, arrest, or named censor file.

--- a/docs/research/bio/andrian-kashchenko.md
+++ b/docs/research/bio/andrian-kashchenko.md
@@ -1,0 +1,150 @@
+# Адріан (Андріан) Феофанович Кащенко - Research Dossier
+
+**Slug:** `andrian-kashchenko`
+**Block:** +77 expansion - literary / historical fiction / Cossack memory additions
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #370
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Source acronym legend:** ESU = Encyclopedia Modern Ukraine; IEU = Internet Encyclopedia Ukraine; NBU = Vernadsky National Library electronic collection; DniproLibrary = Dnipro regional library `DniproKultura`; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional sources cited
+- [x] Pressure mechanism framed imperial Ukrainian-publishing bans, Prosvita civic work, 1918 publishing-house destruction, Soviet removal from libraries, and post-1991 recovery; no invented security-service case
+- [x] At least 2 primary-source Ukrainian text / publication anchors supplied
+- [x] Cross-track links verified `test -e` on 2026-07-01 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, source-canonical):** Адріан Феофанович Кащенко.
+- **Project slug / queue form:** `andrian-kashchenko`; existing curriculum title uses `Андріан Кащенко`. Keep project slug stable, but document `Адріан` as institutional-source form.
+- **Project English canonical:** Andrian Kashchenko for the existing BIO queue / slug. IEU uses `Adriian Kashchenko`; Commons / popular English pages often use `Adrian Kashchenko`.
+- **Name variants / aliases:** ESU lists pseudonyms / cryptonyms including А. Тертишний, А. Будій, Дніпровий Микола, А. К., К-о А. and others. IEU gives `Kaščenko, Adrijan` as scholarly transliteration.
+- **Born:** ESU and IEU give 1 October 1858 new style; ESU also gives 19 September old style. Place: Veselyi khutir, Oleksandrivske county, Katerynoslav gubernia; now in Zaporizhzhia region.
+- **Died:** ESU and IEU give 29 March 1921, Katerynoslav, now Dnipro. ESU states his grave has not been preserved.
+- **Family / education / work:** ESU: brother of Mykola Kashchenko; finished a cadet / junker school in the 1870s, served in the military, then worked in railway administration in Katerynoslav, Perm, Saint Petersburg, and Tuapse.
+- **Civic role:** ESU and DniproLibrary identify him as one of the founders and deputy head of Katerynoslav `Просвіта`, organizer of a Ukrainian people's choir, library work in the People's House, Shevchenko memorial evenings, lectures, and public education.
+- **Publishing role:** ESU states he founded `Українське видавництво А. Кащенка в Катеринославі` in 1917 and republished much of his own work there.
+
+## 2. Oppression / pressure mechanism
+
+- **Load-bearing frame:** Kashchenko is not a Soviet security-service biography. Do not invent a Cheka / NKVD / KGB case. His BIO pressure story is censorship, Ukrainian-publication restriction, civic work under empire, destruction of publishing infrastructure, Soviet removal from libraries, and loss of archive / grave memory.
+- **Imperial Ukrainian-publishing pressure:** IEU says he began writing in 1883 but became known only after the 1905 Revolution, when the ban on Ukrainian publishing in Russian-ruled Ukraine was lifted. This is the key structural pressure: the market for Ukrainian popular history had been artificially constrained by imperial language policy.
+- **Prosvita as civic pressure response:** In Katerynoslav, Kashchenko used `Просвіта`, choir, library, Shevchenko evenings, lectures, and popular booklets as public-memory infrastructure. Teach this as institution-building, not merely "local activism."
+- **1918 destruction of his publishing house:** ESU states his publishing house burned down at the end of 1918 and Kashchenko suffered a stroke. Treat this as the collapse of a personal cultural project during revolutionary violence, not as a tidy literary-career setback.
+- **Central Rada pension refusal:** ESU says he came to Kyiv in autumn 1917 asking the Central Rada for a pension and was refused. This should be handled without melodrama: a popular writer / educator was materially insecure at the exact moment his national memory work was most needed.
+- **Soviet removal:** ESU says his books were removed from libraries from 1933. IEU says his works were banned in Soviet Ukraine, while many editions appeared in interwar Galicia. The pressure is not death in prison; it is cultural deletion of popular Cossack memory from the Soviet reading space.
+- **Archive / grave loss:** ESU says no personal archive or correspondence has been found and the grave has not been preserved. This is a concrete memory-loss mechanism and belongs in the future module.
+
+## 3. Major works / contributions
+
+- **Popular Cossack historical prose:** IEU says most of his stories and novellas are set in the Cossack period. His importance is not high modernist style; it is making Zaporizhian history readable for broad audiences.
+- **`Над Кодацьким порогом` (1913):** ESU identifies it as a historical portrait about hetman Ivan Sulyma. Existing LIT-HIST-FIC module already uses it as the local hook for history-vs-fiction and Cossack myth.
+- **`Оповідання про славне Військо Запорозьке низове` (1916):** ESU calls this his main work; NBU / library records describe it as popularizing the history of the Zaporozhian Host.
+- **Cossack memory cycle:** ESU lists `Запорожська слава`, `На руїнах Січі`, `Мандрівка на пороги`, `Під Корсунем`, `З Дніпра на Дунай`, `У запалі боротьби`, `Зруйноване гніздо`, `Гетьман Сагайдачний`, and `Кость Гордієнко-Головко - останній лицар Запоріжжя`.
+- **After-Sich tragedy:** DniproLibrary emphasizes that `З Дніпра на Дунай` and `Зруйноване гніздо` show the tragic fate of Zaporozhian Cossacks after the destruction of the Sich.
+- **Ethnographic / public-education writing:** ESU lists `Басурманська неволя в українській народній поезії` and `Великий Луг запорожський` as 1917 works.
+- **Translation:** ESU and DniproLibrary note his Ukrainian translation of Pushkin's `Казка про рибалку та рибку` (1907). Mention only as a side fact; it is not the BIO reason for selection.
+
+## 4. Primary-source quote / visual anchors
+
+Kashchenko died in 1921, so his own texts are public domain under life+70 regimes. Still use short excerpts in modules and verify edition text / orthography before quoting.
+
+- **`Над Кодацьким порогом`:** the existing school-text witness highlights the idea that "розбрат ... і зрада" must give way to unity. Pedagogical use: ask learners whether the story teaches history, moral unity, or both.
+- **`Зруйноване гніздо`:** NBU's bibliographic record gives the subtitle "повість з часів скасування Запорозької Січи." Pedagogical use: the title and subtitle already stage the Sich not as a museum object but as a destroyed home.
+- **`Оповідання про славне Військо Запорозьке низове`:** use the title / table-of-contents structure as a primary anchor for popular-history pedagogy: how does a civic educator turn archives and legends into chapters for mass readers?
+- **Publishing-house visual anchor:** a cover / scan from Commons or NBU can show how early-20th-century Ukrainian popular history looked materially: small book, accessible title, explicit Cossack subject.
+- **Portrait candidate:** Commons file `Кащенко А.jpg` identifies the portrait as 1880s-1890s, unknown author, with a 2024 correction warning that an earlier version had been misidentified. Use only after checking the current file page and captioning the correction risk.
+
+## 5. Language register
+
+- **Register:** popular historical prose, civic-educational narration, romanticized Cossack memory, Prosvita public lecture / booklet style, early-20th-century orthographic variants.
+- **CEFR readiness:** B2 can handle selected episodes from `Над Кодацьким порогом` with historical glossary. C1 is better for evaluating source reliability, romantic idealization, and Soviet / post-Soviet reception.
+- **Learner lexicon:** `поріг`, `Січ`, `Запоріжжя`, `козакофільство`, `історична повість`, `народне читання`, `популяризатор`, `романтизація`, `ідеалізація`, `просвіта`, `громадсько-культурний діяч`, `видавництво`, `бібліотека`, `хор`, `пам'ять`, `вилучення з бібліотек`.
+- **Style note for future module builders:** Tell the tale of a railway official who spent his civic energy giving readers a usable Cossack past. The lesson should not sound like an authoring memo. It should let learners feel why easy, sometimes naive historical prose mattered when Ukrainian readers had been denied normal access to their own past.
+
+## 6. Contested points
+
+- **Aдpiан / Андріан naming:** ESU and IEU use `Адріан` / `Adriian`; the project queue and existing plan use `Андріан` / `andrian-kashchenko`. Preserve the existing slug; teach the variant forms as catalog / curriculum variation.
+- **Literary value vs didactic value:** IEU bluntly says the works have limited literary value and historical inaccuracies, but also says they were popular and had an important didactic patriotic role. This is the central anti-hagiography frame: Kashchenko may be more important as public-memory infrastructure than as a stylist.
+- **Historical accuracy:** Existing local plan already frames history vs fiction. Do not build a BIO module that treats `Над Кодацьким порогом` as documentary history. Pair story episodes with the question: what is documented, what is romanticized, and why did the romance work?
+- **Soviet ban / removal wording:** Use ESU and IEU source-specific language: books removed from libraries from 1933; works banned in Soviet Ukraine. Do not invent a trial, arrest, or named censor file.
+- **Grave / archive loss:** ESU says archive and correspondence have not been found and grave not preserved. Treat this as source-attested memory loss, not an opportunity for sentimental invention.
+- **Post-1991 return:** NBU and later editions make the recovery visible. Avoid saying "forgotten by everyone"; his works lived in interwar Galicia, diaspora, and later reprints.
+
+## 7. Cross-track links
+
+**Existing LIT-HIST-FIC modules (VERIFIED `test -e` on 2026-07-01):**
+
+- `curriculum/l2-uk-en/plans/lit-hist-fic/andrian-kashchenko-cossack-myth.yaml`
+- `curriculum/l2-uk-en/lit-hist-fic/discovery/andrian-kashchenko-cossack-myth.yaml`
+
+**Existing BIO / research network links (VERIFIED `test -e` on 2026-07-01):**
+
+- `docs/research/bio/mykola-kostomarov.md` - nineteenth-century Ukrainian historical imagination / popular history background.
+- `docs/research/bio/panteleimon-kulish.md` - historical fiction, language, and anti-hagiographic Cossack debate.
+- `docs/research/bio/taras-shevchenko.md` - Shevchenko commemorative civic work and Cossack memory.
+- `docs/research/bio/ivan-franko.md` - Galician publication / reception frame for banned eastern Ukrainian writers.
+- `docs/research/bio/bohdan-lepkyi.md` - popular historical fiction and memory recovery, though a later Galician / emigration case.
+- `docs/research/bio/ulas-samchuk.md` - popular historical / national memory prose later removed from Soviet canon.
+
+**Future / planned BIO links (not existing module files yet):**
+
+- BIO #370 `andrian-kashchenko`
+- BIO #371 `roman-ivanychuk`
+- BIO #372 `pavlo-zahrebelnyi`
+- BIO #375 `volodymyr-rutkivskyi`
+
+## 8. Naming-canonical
+
+- **Slug:** `andrian-kashchenko`.
+- **UA source-canonical:** Адріан Феофанович Кащенко.
+- **UA project / plan variant:** Андріан Кащенко.
+- **EN project canonical:** Andrian Kashchenko.
+- **EN institutional / catalog variants:** Adriian Kashchenko, Adrian Kashchenko, Kaščenko / Adrijan in scholarly transliteration.
+- **Aliases / pseudonyms:** А. Тертишний, А. Будій, Дніпровий Микола, А. К., К-о А. and other cryptonyms listed in ESU.
+- **Works title policy:** Preserve historical orthography in source titles when citing editions: `Запорожська`, `Січи`, `низове`; modernize only in explanatory prose.
+
+## 9. Image / media candidates
+
+- **Commons portrait candidate:** `File:Кащенко А.jpg`. Commons lists unknown author, 1880s-1890s date, CC BY-SA / PD-RusEmpire metadata, and a 2024 replacement note because an older image was misattributed. Before site reuse, verify current license and use a caption that does not overstate certainty.
+- **Commons text scans:** Commons category includes early scans such as `Над Кодацьким порогом (1919).djvu`, `Оповідання про славне військо Запорожське низове (1919).djvu`, and `Зруйноване гніздо (1922).pdf`. These are good source witnesses and possible media only after page-level rights check.
+- **NBU scans:** NBU record for the 1941 Prague `Зруйноване гніздо` edition is useful as a bibliographic witness. Treat NBU page images as library-hosted scans; verify reuse rights before embedding.
+- **Safer visual approach:** a route / place map (Veselyi khutir, Katerynoslav / Dnipro, Perm, Saint Petersburg, Tuapse) or a text-cover collage from rights-cleared Commons scans can teach the life arc without relying on a possibly uncertain portrait.
+- **Caption policy:** Captions should connect media to civic pedagogy: Prosvita, Cossack popular history, lost publishing house, or Soviet removal from libraries. Avoid generic "great writer" captions.
+
+## 10. Sources used
+
+**Tier 1 / Tier 2 encyclopedic and institutional sources:**
+
+- Чабан М. П. "Кащенко Адріан Феофанович." *Енциклопедія Сучасної України*. https://esu.com.ua/article-11502. Accessed 2026-07-01.
+- "Kashchenko, Adriian." *Internet Encyclopedia of Ukraine*. Canadian Institute of Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CA%5CKashchenkoAdriian.htm. Accessed 2026-07-01.
+- "Адріан Феофанович Кащенко." *ДніпроКультура*, Dnipro regional library. https://www.dnipro.libr.dp.ua/index.php?news_id=212&route=information%2Fnews%2Finfo. Accessed 2026-07-01.
+- "Кащенко А. Ф. Зруйноване гніздо (1941)." NBU electronic library record. https://irbis-nbuv.gov.ua/ulib/item/ukr0000029900. Accessed 2026-07-01.
+
+**Primary / text / media witnesses:**
+
+- Кащенко А. `Над Кодацьким порогом`, school-text / public-domain witness at UkrLib. https://www.ukrlib.com.ua/tvory/book.php?bookid=285. Accessed 2026-07-01.
+- Commons `File:Кащенко А.jpg`. https://commons.wikimedia.org/wiki/File:%D0%9A%D0%B0%D1%89%D0%B5%D0%BD%D0%BA%D0%BE_%D0%90.jpg. Accessed 2026-07-01.
+- Commons scan records listed under the Kashchenko file usage page, including `Над Кодацьким порогом (1919)` and `Оповідання про славне військо Запорожське низове (1919)`. Accessed 2026-07-01.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing: Kashchenko is treated as a Ukrainian civic educator and popularizer of Cossack memory.
+- [x] No invented security-service case: no Cheka / NKVD / KGB frame added.
+- [x] Imperial Ukrainian-publishing restriction named through IEU.
+- [x] Soviet deletion named through ESU / IEU library-removal and ban language.
+- [x] Cossack memory treated critically: romanticization and historical inaccuracy are named, not hidden.
+- [x] Project naming variant `andrian` preserved while institutional `Адріан` is documented.
+- [x] Image uncertainty and prior misidentification warning are surfaced.
+- [x] Future module should teach a human life and civic function, not just a list of works.


### PR DESCRIPTION
## Summary
- Add BIO #370 `andrian-kashchenko` research dossier for the +77 base-prep gate.
- Document the source-canonical `Адріан` / project `Андріан` naming split, Cossack popular-history role, Prosvita civic work, imperial publishing pressure, 1918 publishing-house loss, Soviet removal from libraries, and post-1991 recovery.
- Keep the slice dossier-only: no plan YAML, module markdown, activities, vocabulary, site MDX, wiki output, status/audit/review artifacts, telemetry DB files, linter configs, package files, or unrelated files.

## Validation
- `npx markdownlint-cli2 docs/research/bio/andrian-kashchenko.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/andrian-kashchenko.md`
- `git diff --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Review
- Claude read-only review requested separately after PR creation.

## Telemetry
- Dossier-only base-prep slice; module-build telemetry not applicable.
- `swarm_used: false`
- `swarm_note: solo run; no swarm used`