### PR TITLE
docs(bio): add Roman Ivanychuk dossier

### DIFF
--- a/docs/research/bio/roman-ivanychuk.md
+++ b/docs/research/bio/roman-ivanychuk.md
@@ -1,0 +1,347 @@
+# Роман Іванович Іваничук - Research Dossier
+
+**Slug:** `roman-ivanychuk`
+**Block:** +77 expansion - historical-fiction / memory / late-Soviet civic additions
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #371
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Source acronym legend:** ESU = Encyclopedia of Modern Ukraine; EHIU =
+Encyclopedia of History Ukraine; UINP = Ukrainian Institute of National
+Memory; LNU = Ivan Franko National University of Lviv; IEU = Internet
+Encyclopedia Ukraine literature overview; NBU = Vernadsky National Library
+catalog / electronic library; DSP = Diasporiana; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional sources cited
+- [x] Pressure mechanism framed university expulsion, Soviet cultural control,
+  official criticism, publication blockage, delayed publication, and
+  independence-era civic work; no invented security-service case
+- [x] At least 2 primary-source Ukrainian text / publication anchors supplied
+- [x] Cross-track links verified `test -e` on 2026-07-01 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Роман Іванович Іваничук.
+- **Project English canonical:** Roman Ivanychuk.
+- **Birth / death:** 27 May 1929, Tрач, now Kosiv raion,
+  Ivano-Frankivsk oblast; 17 September 2016, Lviv. ESU and UINP agree on these
+  dates and places; UINP notes burial in Lviv, and Commons has a Lychakiv
+  Cemetery grave photograph.
+- **Family / education:** Born in a teacher's family. Studied at Kolomyia
+  gymnasium / school; entered Lviv University, left geology for Ukrainian
+  philology, was expelled in 1949 in an ideological case, served in the Soviet
+  Army, and graduated from Lviv University in 1957.
+- **Teaching and editorial work:** Taught Ukrainian language and literature in
+  1957-1963. From 1963 to 1990 he headed the prose department of the Lviv
+  journal `Жовтень`, later `Дзвін`.
+- **Academic role:** LNU identifies him as professor from 1995 and describes
+  his research interest as `білі плями` of national history. ESU gives
+  1996-2009 for his professorship at Lviv University; keep date wording
+  source-specific if a future timeline needs precision.
+- **Writers' union / honors:** Member of the Soviet / Ukrainian writers'
+  unions from 1960; Shevchenko State Prize for `Вода з каменю` and
+  `Четвертий вимір` in the mid-1980s; Hero of Ukraine in 2009; multiple other
+  state and literary awards in ESU / EHIU / LNU.
+- **Civic and political work:** People's Deputy of Ukraine, 1990-1994. EHIU
+  says he headed the Lviv organization of the Taras Shevchenko Ukrainian
+  Language Society / `Просвіта` in 1988-1996 and helped restore the
+  `Червона калина` publishing house.
+- **Core BIO identity:** historical novelist, editor, professor, public
+  intellectual, and independence-era language / memory civic actor whose novels
+  made forbidden or damaged Ukrainian historical memory legible to late-Soviet
+  and post-Soviet readers.
+
+## 2. Oppression / pressure mechanism
+
+- **Load-bearing frame:** Ivanychuk is not a security-service martyr
+  biography. Do not invent a KGB file, arrest, interrogation, camp term, or
+  named case. The documented pressure is ideological: university expulsion,
+  late-Stalin / Brezhnev cultural control, official criticism, publication
+  blockage, and strategic use of historical fiction.
+- **University expulsion:** UINP says he was denounced after refusing Komsomol
+  conformity and wearing embroidered clothing at holidays, then expelled in
+  1949 for `anti-Soviet activity`. EHIU phrases the same institutional pressure
+  as expulsion for being an `індивідуаліст` and `прихований ворог народу`.
+  Teach this as early contact with Soviet ideological policing, not as a full
+  dissident-prison biography.
+- **`Мальви` pressure point:** ESU says `Мальви` (1968) drew categorical
+  rejection from official criticism and that Ivanychuk was long deprived of the
+  possibility to publish his works. UINP repeats the same frame. The lesson
+  should let students feel how a historical novel about janissaries could be
+  read as an allegory of assimilation, betrayal, and national memory.
+- **Delayed publication:** ESU, EHIU, and LNU all identify `Журавлиний крик`
+  as written in 1968 and published only in 1988. This is the cleanest
+  publication-blockage example; do not blur it into a generic "all works were
+  banned" claim.
+- **Historical fiction as pressure response:** Ivanychuk did not simply "write
+  about the past." Under Soviet conditions, he used the past to ask questions
+  about loyalty, statehood, language, and the damage done when a person or
+  society is taught to serve another empire's memory.
+- **Independence-era public work:** From 1988 onward, he moved visibly into
+  language activism, `Просвіта`, publishing, parliamentary work, and the
+  sovereignty / independence moment. BIO should connect the novelist's archive
+  of historical scenes to the public work of naming and defending Ukrainian
+  sovereignty.
+
+## 3. Major works / contributions
+
+- **Early prose:** `Прут несе кригу` (1958) brought early recognition; other
+  early prose includes `Не рубайте ясенів`, `Під склепінням храму`,
+  `Тополина заметіль`, and `Край битого шляху`.
+- **`Мальви` / `Яничари` (1968):** ESU frames the novel through janissary
+  themes: betrayal and fidelity, patriotism and apostasy. It is the best first
+  BIO teaching anchor because the human story of mother, children, captivity,
+  and recognition carries the political allegory.
+- **`Журавлиний крик` (written 1968, published 1988):** novel on destruction of
+  the Zaporizhian Sich and the tragedy of Petro Kalnyshevskyi. Its twenty-year
+  delay turns publication history itself into evidence of pressure.
+- **Lviv / early-modern memory:** `Манускрипт з вулиці Руської` (1979)
+  reconstructs medieval / early-modern Lviv and belongs in future cross-track
+  work with urban history and cultural multilingualism.
+- **Galician national awakening:** `Вода з каменю` (1982) and `Четвертий
+  вимір` (1984), about Markiian Shashkevych and Petro Hulak-Artemovskyi
+  respectively, received the Shevchenko Prize. Good BIO use: how a late-Soviet
+  writer made nineteenth-century linguistic awakening emotionally visible.
+- **Franko and cultural inheritance:** `Шрами на скалі` (1987) is source-
+  attested as a novel about Ivan Franko. Keep separate from any curriculum
+  shorthand using `Шрам`.
+- **Imperial satire:** ESU describes `Орда` (1992) as a satirical portrayal of
+  Peter I's Russian empire with resonances in late Soviet Ukraine. This is a
+  strong decolonial bridge, but teach it through text and context, not slogans.
+- **OUN / UPA fiction:** ESU says Ivanychuk first turned to the OUN-UPA theme
+  in Ukrainian fiction with the tetralogy `Вогненні стовпи` (2005). Use this
+  wording source-critically; do not turn it into an unsupported absolute across
+  every Ukrainian-language text.
+- **Editorial and civic institution-building:** `Жовтень` / `Дзвін`,
+  `Просвіта`, `Червона калина`, and the first Verkhovna Rada connect literary
+  work to institution-building.
+
+## 4. Primary-source quote / visual anchors
+
+Use short excerpts only. Ivanychuk died in 2016, so his works remain under
+copyright in Ukraine / EU / Canada under life+70 rules. Full-work scans and
+long passages visible online are text witnesses for research, not automatic
+site media assets.
+
+- **`Мальви` scene anchor:** the recognition between mother and son is the
+  human core. Use no more than a short phrase such as "Мамо! ... То я, твій
+  син!" and build the activity around what recognition changes in the room.
+  Source witnesses: DSP 1968 New York edition; school-text witnesses at
+  UkrLib / Osvita when checked for classroom excerpting.
+- **`Мальви` publication anchor:** DSP has `Мальви`, New York, 1968, 138 pages,
+  published by `Наша Батьківщина`; another DSP record has Winnipeg, 1969,
+  `Тризуб`. Pedagogical use: diaspora circulation made a Soviet-pressured text
+  readable outside the Soviet literary system.
+- **`Журавлиний крик` bibliographic anchor:** EHIU / ESU / LNU all preserve the
+  striking pair `1968 / опубл. 1988`. Use this as timeline evidence before
+  asking why a novel about the Sich and Kalnyshevskyi threatened official
+  narratives.
+- **`Вода з каменю` edition anchor:** NBU records the 1982 Lviv `Каменяр`
+  edition. Use as material witness for a Shevchenko-Prize novel about
+  nineteenth-century cultural awakening.
+- **Memoir / essay anchor:** `Дороги вольні і невольні`,
+  `Благослови, душе моя, Господа`, and `Чистий метал людського слова` show
+  Ivanychuk reflecting directly on literature, travel, and public history.
+- **Safer visual anchor:** Commons grave photograph at Lychakiv Cemetery is
+  CC BY-SA 4.0 and cleaner than uncertain portraits for first module media.
+- **Portrait caution:** Commons has `ВП Роман Иванычук.jpg` under CC BY-SA 3.0,
+  but the upload log includes a confusing original-description mismatch. Use
+  only after manual identity / caption verification.
+- **UINP photo caution:** UINP article uses a Marian Striltsiv / ZIK credit.
+  UINP site text is CC BY 4.0 unless noted, but the credited photo still needs
+  separate media-rights verification.
+
+## 5. Language register
+
+- **Register:** historical novel, allegory, civic essay, editorial prose,
+  late-Soviet public Ukrainian, memory-work vocabulary, Lviv / Galician
+  cultural references, and source-critical discussion of Soviet euphemisms.
+- **CEFR readiness:** B2 can follow a carefully excerpted `Мальви` scene with
+  guided vocabulary. C1 is better for allegory, censorship, historical fiction
+  versus historiography, and late-Soviet / independence-era reception.
+- **Learner lexicon:** `яничарство`, `ясир`, `відступництво`, `зрада`,
+  `вірність`, `самоідентичність`, `історичний роман`, `алегорія`,
+  `цензура`, `офіційна критика`, `публікаційна заборона`, `білі плями`,
+  `державність`, `Просвіта`, `суверенітет`, `незалежність`, `пам'ять`,
+  `рецепція`, `історична травма`.
+- **Tone note future module builders:** The BIO lesson should tell the story of
+  a boy from a teacher's house who learned early what Soviet conformity
+  demanded, then spent a life turning silenced history into scenes readers
+  could feel. Avoid meta-language about "building this lesson," "we will cover,"
+  or "this module teaches." The page should teach by narration, image, scene,
+  and question.
+- **Activity placement note:** Future module generation should use V2
+  activities when lesson-tab and workbook-tab work diverge: short comprehension
+  / reading checks inline, deeper source evaluation and writing in workbook.
+
+## 6. Contested points
+
+- **`Мальви` versus `Яничари`:** The novel is commonly taught as `Мальви`; LNU
+  and other sources also identify `Яничари` as an alternate / later title.
+  Teach title politics directly: neutral floral title, explicit janissary title,
+  and why both matter.
+- **`Шрам` curriculum shorthand:** Existing `ivanychuk-scar` plan material uses
+  `Шрам`, while institutional sources list `Шрами на скалі` (1987) about Ivan
+  Franko. Future LIT-HIST-FIC repair/build should verify the target work before
+  using the plan as a factual source.
+- **Publication blockage wording:** It is safe to say `Мальви` provoked
+  official rejection and Ivanychuk was deprived for a long time of publication
+  opportunities. It is not safe to invent a precise ban order, censor memo, or
+  KGB operation without a source.
+- **"First OUN-UPA fiction" wording:** Attribute to ESU if used. The wording is
+  valuable but needs source-specific framing because "first" claims are often
+  genre- and corpus-dependent.
+- **Award chronology:** ESU gives Shevchenko Prize 1985 for `Вода з каменю`
+  and `Четвертий вимір`; LNU page says Shevchenko State Prize 1984. Use ESU
+  for prize-year precision unless another source is intentionally quoted.
+- **"Soviet writer" label:** Chronologically true for much of his publishing
+  life, but pedagogically misleading if it becomes identity. Prefer "Ukrainian
+  writer working under Soviet institutions and pressures."
+- **Historical fiction versus history:** Ivanychuk restores suppressed memory,
+  but he also dramatizes, selects, and invents. Future lessons need
+  anti-hagiography: where does the novel open history, and where does it make a
+  new myth?
+- **Modern wartime resonance:** The themes of assimilation, collaboration,
+  empire, and memory resonate during Russia's war against Ukraine. Use this
+  carefully through reader questions, not by forcing every seventeenth- or
+  eighteenth-century scene into a direct current-events analogy.
+
+## 7. Cross-track links
+
+**Existing LIT-HIST-FIC modules (VERIFIED `test -e` on 2026-07-01):**
+
+- `curriculum/l2-uk-en/plans/lit-hist-fic/ivanychuk-malvy.yaml`
+- `curriculum/l2-uk-en/lit-hist-fic/discovery/ivanychuk-malvy.yaml`
+- `curriculum/l2-uk-en/plans/lit-hist-fic/ivanychuk-water.yaml`
+- `curriculum/l2-uk-en/lit-hist-fic/discovery/ivanychuk-water.yaml`
+- `curriculum/l2-uk-en/plans/lit-hist-fic/ivanychuk-scar.yaml`
+- `curriculum/l2-uk-en/lit-hist-fic/discovery/ivanychuk-scar.yaml`
+
+**Existing BIO / research network links (VERIFIED `test -e` on 2026-07-01):**
+
+- `docs/research/bio/andrian-kashchenko.md` - earlier popular historical
+  fiction / Cossack memory for broad readers.
+- `docs/research/bio/ulas-samchuk.md` - prose, exile / Soviet silencing, and
+  national memory under political pressure.
+- `docs/research/bio/bohdan-lepkyi.md` - historical fiction as restoration of
+  Mazepa / Ukrainian state memory.
+- `docs/research/bio/panteleimon-kulish.md` - historical fiction, Cossack
+  debate, and anti-hagiographic memory work.
+- `docs/research/bio/mykola-kostomarov.md` - historian / writer background for
+  national historical imagination.
+- `docs/research/bio/ivan-franko.md` - `Шрами на скалі` connection and
+  cross-century literary memory.
+- `docs/research/bio/taras-shevchenko.md` - memory, language, and civic canon.
+- `docs/research/bio/mykhailo-starytsky.md` - historical drama / prose and
+  nineteenth-century cultural institution-building.
+- `docs/research/bio/petro-kalnyshevskyy.md` - `Журавлиний крик` historical
+  subject and Sich destruction memory.
+
+**Future / planned BIO links:**
+
+- BIO #371 `roman-ivanychuk` - this dossier.
+- BIO #372 `pavlo-zahrebelnyi` - neighboring late-Soviet historical novelist;
+  future comparison should separate `Роксолана` / court fiction from
+  Ivanychuk's memory-allegory method.
+- BIO #373 `valerii-shevchuk` - prose, baroque memory, and late-Soviet
+  literary survival.
+- Candidate future link: Yurii Mushketyk / Lina Kostenko historical prose, if
+  added to BIO or LIT-HIST-FIC later.
+
+## 8. Naming and slug
+
+- **Canonical slug:** `roman-ivanychuk`.
+- **UA source-canonical display:** Роман Іванович Іваничук.
+- **EN display:** Roman Ivanychuk.
+- **Avoid Russian-derived forms:** Do not use `Roman Ivanychuk` with
+  Russianized patronymic / spelling variants except inside quoted catalog
+  metadata. Avoid making Russian-language Wikipedia or Soviet catalog wording
+  the naming authority.
+- **Title handling:** Use `Мальви` as learner-facing title; mention
+  `Яничари` as alternate title. Use `Журавлиний крик`, `Вода з каменю`,
+  `Четвертий вимір`, `Шрами на скалі`, and `Орда` in Ukrainian.
+- **Place handling:** Use modern Ukrainian place frames: Tрач / Kosiv raion,
+  Ivano-Frankivsk oblast; Lviv; Lychakiv Cemetery. Historical state labels
+  belong in context, not primary identity.
+
+## 9. Image / media rights
+
+- **Portrait candidate:** Commons `File:ВП Роман Иванычук.jpg`, CC BY-SA 3.0,
+  describes a September 2008 photograph of Ivanychuk, but the original upload
+  log contains a description mismatch. Use only after manual verification.
+- **Grave candidate:** Commons `File:Р. і С. Іваничуки - Личаківський
+  цвинтар.jpg`, CC BY-SA 4.0, own work by Igor Monchuk, identifies the grave of
+  Roman and Sofiia Ivanychuk at Lychakiv Cemetery. Safer for a first BIO module
+  if the page needs a rights-clean visual anchor.
+- **Book scans:** DSP `Мальви` records and NBU bibliographic records are useful
+  publication witnesses. Do not embed scans / covers until rights status is
+  checked for the specific edition and image.
+- **UINP image:** The UINP calendar article credits a photo to Marian
+  Striltsiv / ZIK. Treat as rights-controlled unless a separate reusable
+  license is confirmed for that photo.
+- **Caption policy:** Captions should teach: Tрач to Lviv, `Мальви` and
+  janissary allegory, `Журавлиний крик` delayed publication, `Просвіта` /
+  independence work, and the Lychakiv memory site. Avoid generic "great
+  writer" captions.
+
+## 10. Sources used
+
+**Tier 1 / Tier 2 encyclopedic and institutional sources:**
+
+- Бартко О. А. "Іваничук Роман Іванович." *Енциклопедія Сучасної України*.
+  https://esu.com.ua/article-14213. Accessed 2026-07-01.
+- Герасимова Г. П. "Іваничук Роман Іванович." *Енциклопедія історії
+  України*. https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=DOP&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Ivanychuk_R&Z21ID=.
+  Accessed 2026-07-01.
+- "1929 - народився Роман Іваничук, письменник, педагог, політик." Ukrainian
+  Institute of National Memory.
+  https://uinp.gov.ua/istorychnyy-kalendar/traven/27/1929-narodyvsya-roman-ivanychuk-pysmennyk-pedagog-polityk.
+  Accessed 2026-07-01.
+- "Іваничук Роман Іванович." Ivan Franko National University of Lviv.
+  https://lnu.edu.ua/about/honorary-doctors/roman-ivanychuk/. Accessed
+  2026-07-01.
+- "Ivanychuk Roman Ivanovych." Ivan Franko National University of Lviv.
+  https://lnu.edu.ua/en/about/honorary-doctors/ivanychuk-roman-ivanovych/.
+  Accessed 2026-07-01.
+- "Literature." *Internet Encyclopedia Ukraine*, Canadian Institute of
+  Ukrainian Studies.
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CL%5CI%5CLiterature.htm.
+  Accessed 2026-07-01.
+
+**Primary / bibliographic / media witnesses:**
+
+- "Іваничук Р. Мальви." *Diasporiana*, New York 1968 edition record.
+  https://diasporiana.org.ua/proza/ivanychuk-r-malvy-2/. Accessed 2026-07-01.
+- "Іваничук Р. Мальви." *Diasporiana*, Winnipeg 1969 edition record.
+  https://diasporiana.org.ua/proza/ivanychuk-r-malvy/. Accessed 2026-07-01.
+- "Іваничук Р. І. Вода з каменю (1982)." NBU electronic-library record.
+  https://search.nbuv.gov.ua/cgi-bin/ua/elib.exe?C21COM=S&I21DBN=UKRLIB&P21DBN=UKRLIB&S21All=%3C.%3EID%3Dukr0000030029%3C.%3E&S21CNR=20&S21FMT=fullwebr&S21REF=2&S21STN=1.
+  Accessed 2026-07-01.
+- Wikimedia Commons. "Category:Roman Ivanychuk."
+  https://commons.wikimedia.org/wiki/Category:Roman_Ivanychuk. Accessed
+  2026-07-01.
+- Wikimedia Commons. "File:ВП Роман Иванычук.jpg."
+  https://commons.wikimedia.org/wiki/File:%D0%92%D0%9F_%D0%A0%D0%BE%D0%BC%D0%B0%D0%BD_%D0%98%D0%B2%D0%B0%D0%BD%D1%8B%D1%87%D1%83%D0%BA.jpg.
+  Accessed 2026-07-01.
+- Wikimedia Commons. "File:Р. і С. Іваничуки - Личаківський цвинтар.jpg."
+  https://commons.wikimedia.org/wiki/File:%D0%A0._%D1%96_%D0%A1._%D0%86%D0%B2%D0%B0%D0%BD%D0%B8%D1%87%D1%83%D0%BA%D0%B8_-_%D0%9B%D0%B8%D1%87%D0%B0%D0%BA%D1%96%D0%B2%D1%81%D1%8C%D0%BA%D0%B8%D0%B9_%D1%86%D0%B2%D0%B8%D0%BD%D1%82%D0%B0%D1%80.jpg.
+  Accessed 2026-07-01.
+
+**Primary-source and decolonization self-check:**
+
+- No NKVD / KGB / court case invented.
+- Soviet pressure described through source-attested university expulsion,
+  official criticism, publication blockage, delayed publication, and late-
+  Soviet civic language work.
+- Historical-fiction restoration framed with anti-hagiography: memory recovery
+  and myth-making are both teachable.
+- Russian-imperial / Soviet labels treated as context, not naming authority.

--- a/docs/research/bio/roman-ivanychuk.md
+++ b/docs/research/bio/roman-ivanychuk.md
@@ -107,10 +107,11 @@ catalog / electronic library; DSP = Diasporiana; Commons = Wikimedia Commons.
 - **Lviv / early-modern memory:** `Манускрипт з вулиці Руської` (1979)
   reconstructs medieval / early-modern Lviv and belongs in future cross-track
   work with urban history and cultural multilingualism.
-- **Galician national awakening:** `Вода з каменю` (1982) and `Четвертий
-  вимір` (1984), about Markiian Shashkevych and Petro Hulak-Artemovskyi
-  respectively, received the Shevchenko Prize. Good BIO use: how a late-Soviet
-  writer made nineteenth-century linguistic awakening emotionally visible.
+- **Nineteenth-century awakening and brotherhood memory:** `Вода з каменю`
+  (1982), about Markiian Shashkevych, and `Четвертий вимір` (1984), about
+  Mykola Hulak of the Cyril-Methodius Brotherhood, received the Shevchenko
+  Prize. Good BIO use: how a late-Soviet writer made nineteenth-century
+  linguistic awakening and political brotherhood memory emotionally visible.
 - **Franko and cultural inheritance:** `Шрами на скалі` (1987) is source-
   attested as a novel about Ivan Franko. Keep separate from any curriculum
   shorthand using `Шрам`.
@@ -237,7 +238,8 @@ site media assets.
 - `docs/research/bio/panteleimon-kulish.md` - historical fiction, Cossack
   debate, and anti-hagiographic memory work.
 - `docs/research/bio/mykola-kostomarov.md` - historian / writer background for
-  national historical imagination.
+  national historical imagination and Cyril-Methodius Brotherhood context for
+  `Четвертий вимір`.
 - `docs/research/bio/ivan-franko.md` - `Шрами на скалі` connection and
   cross-century literary memory.
 - `docs/research/bio/taras-shevchenko.md` - memory, language, and civic canon.
@@ -325,6 +327,9 @@ site media assets.
   https://diasporiana.org.ua/proza/ivanychuk-r-malvy/. Accessed 2026-07-01.
 - "Іваничук Р. І. Вода з каменю (1982)." NBU electronic-library record.
   https://search.nbuv.gov.ua/cgi-bin/ua/elib.exe?C21COM=S&I21DBN=UKRLIB&P21DBN=UKRLIB&S21All=%3C.%3EID%3Dukr0000030029%3C.%3E&S21CNR=20&S21FMT=fullwebr&S21REF=2&S21STN=1.
+  Accessed 2026-07-01.
+- "Роман Іваничук. Повне зібрання творів. Том 10. Четвертий вимір." Vivat.
+  https://vivat.com.ua/product/roman-ivanychuk-povne-zibrannia-tvoriv-10/.
   Accessed 2026-07-01.
 - Wikimedia Commons. "Category:Roman Ivanychuk."
   https://commons.wikimedia.org/wiki/Category:Roman_Ivanychuk. Accessed

--- a/docs/research/bio/roman-ivanychuk.md
+++ b/docs/research/bio/roman-ivanychuk.md
@@ -17,7 +17,7 @@ catalog / electronic library; DSP = Diasporiana; Commons = Wikimedia Commons.
 
 - [x] All 10 sections completed
 - [x] At least 3 Tier 1/Tier 2 institutional sources cited
-- [x] Pressure mechanism framed university expulsion, Soviet cultural control,
+- [x] Pressure mechanism framed through university expulsion, Soviet cultural control,
   official criticism, publication blockage, delayed publication, and
   independence-era civic work; no invented security-service case
 - [x] At least 2 primary-source Ukrainian text / publication anchors supplied
@@ -32,7 +32,7 @@ catalog / electronic library; DSP = Diasporiana; Commons = Wikimedia Commons.
 
 - **Full name (UA, canonical):** Роман Іванович Іваничук.
 - **Project English canonical:** Roman Ivanychuk.
-- **Birth / death:** 27 May 1929, Tрач, now Kosiv raion,
+- **Birth / death:** 27 May 1929, Трач, now Kosiv raion,
   Ivano-Frankivsk oblast; 17 September 2016, Lviv. ESU and UINP agree on these
   dates and places; UINP notes burial in Lviv, and Commons has a Lychakiv
   Cemetery grave photograph.
@@ -262,14 +262,14 @@ site media assets.
 - **Canonical slug:** `roman-ivanychuk`.
 - **UA source-canonical display:** Роман Іванович Іваничук.
 - **EN display:** Roman Ivanychuk.
-- **Avoid Russian-derived forms:** Do not use `Roman Ivanychuk` with
-  Russianized patronymic / spelling variants except inside quoted catalog
-  metadata. Avoid making Russian-language Wikipedia or Soviet catalog wording
-  the naming authority.
+- **Avoid Russian-derived forms:** Do not use Russianized form
+  `Роман Иванычук` or Russianized patronymic / spelling variants except inside
+  quoted catalog metadata. Avoid making Russian-language Wikipedia or Soviet
+  catalog wording the naming authority.
 - **Title handling:** Use `Мальви` as learner-facing title; mention
   `Яничари` as alternate title. Use `Журавлиний крик`, `Вода з каменю`,
   `Четвертий вимір`, `Шрами на скалі`, and `Орда` in Ukrainian.
-- **Place handling:** Use modern Ukrainian place frames: Tрач / Kosiv raion,
+- **Place handling:** Use modern Ukrainian place frames: Трач / Kosiv raion,
   Ivano-Frankivsk oblast; Lviv; Lychakiv Cemetery. Historical state labels
   belong in context, not primary identity.
 
@@ -288,7 +288,7 @@ site media assets.
 - **UINP image:** The UINP calendar article credits a photo to Marian
   Striltsiv / ZIK. Treat as rights-controlled unless a separate reusable
   license is confirmed for that photo.
-- **Caption policy:** Captions should teach: Tрач to Lviv, `Мальви` and
+- **Caption policy:** Captions should teach: Трач to Lviv, `Мальви` and
   janissary allegory, `Журавлиний крик` delayed publication, `Просвіта` /
   independence work, and the Lychakiv memory site. Avoid generic "great
   writer" captions.


### PR DESCRIPTION
## Summary
- Adds BIO #371 dossier for `roman-ivanychuk`.
- Frames Ivanychuk through historical fiction, late-Soviet publication pressure, `Мальви`, delayed `Журавлиний крик`, and independence-era language / memory civic work.
- Keeps this strict +77 base-prep slice dossier-only.

## Scope guard
- No plan YAML, module markdown, activities, vocabulary, site MDX, wiki output, status/audit/review artifacts, telemetry DB files, linter configs, package files, or unrelated files changed.

## Validation
- `npx markdownlint-cli2 docs/research/bio/roman-ivanychuk.md`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/roman-ivanychuk.md`
- `git diff --check origin/main..HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Telemetry
- module-build telemetry: not applicable for dossier-only base-prep PR
- swarm_used: false
- swarm_note: solo run; no swarm used
