### PR TITLE
docs(bio): add Pavlo Zahrebelnyi dossier

### DIFF
--- a/docs/research/bio/pavlo-zahrebelnyi.md
+++ b/docs/research/bio/pavlo-zahrebelnyi.md
@@ -1,0 +1,154 @@
+# Павло Архипович Загребельний - Research Dossier
+
+**Slug:** `pavlo-zahrebelnyi`
+**Block:** +77 expansion - historical-fiction / Soviet-institutional complexity / memory additions
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #372
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Source acronym legend:** ESU = Encyclopedia Modern Ukraine; EHIU = Encyclopedia of History Ukraine; UINP = Ukrainian Institute of National Memory; IEU = Internet Encyclopedia Ukraine; NBU = Vernadsky National Library / electronic library; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional sources cited
+- [x] Pressure mechanism framed through war captivity, post-POW Soviet stigma, Soviet literary-institutional constraint, censorship-adjacent compromise, and support for younger writers; no invented KGB case
+- [x] At least 2 primary-source Ukrainian text / publication anchors supplied
+- [x] Cross-track links verified `test -e` on 2026-07-01 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Павло Архипович Загребельний.
+- **Project English canonical:** Pavlo Zahrebelnyi. Existing curriculum sometimes uses `Zahrebelny`; preserve published path slugs unless a broader rename is explicitly scheduled.
+- **Birth / death:** 25 August 1924, Солошине, then Kobeliaky raion / Poltava region; 3 February 2009, Kyiv. ESU, IEU, UINP agree on dates; UINP says he is buried at Baikove Cemetery.
+- **Pseudonyms:** ESU lists `П. Архипенко`, `А. Довгань`, `П. Чумаченко`.
+- **War biography:** After finishing secondary school in 1941 he volunteered for the front, was wounded, returned to service, was wounded again in 1942, and spent the rest of the war in German captivity / camps before release in 1945. UINP presents this as three years of Nazi camps; ESU uses broader wording `нім. і радянських концтаборів`, which needs source-specific handling.
+- **Postwar education / journalism:** Entered the philology faculty at Dnipropetrovsk University in 1946 and graduated in 1951; worked in `Днепровская правда`, `Вітчизна`, and as chief editor of `Літературна Україна` in 1961-1963. ESU / UINP agree on the broad sequence.
+- **Institutions and offices:** Secretary / first secretary of the Writers' Union of Ukraine (ESU: secretary 1964-1979, first secretary 1979-1986), chair of the Shevchenko Prize committee 1979-1987, deputy of the Verkhovna Rada of the Ukrainian SSR and Supreme Soviet of the USSR. NBU tags him as writer, state / political figure, public figure.
+- **Honors:** Shevchenko Prize 1974 for `Первоміст` and `Смерть у Києві`; USSR State Prize 1980 for `Розгін`; Hero of Ukraine 2004; Order of Prince Yaroslav the Wise 5th class 1999. NBU bibliography records the relevant Ukrainian legal acts.
+- **Core BIO identity:** Ukrainian novelist, editor, screenwriter, and literary functionary whose historical fiction made Kyivan Rus, Roksolana, and Bohdan Khmelnytskyi available to late-Soviet mass readers, while his public life remained entangled with Soviet literary institutions and their compromises.
+
+## 2. Oppression / pressure mechanism
+
+- **Load-bearing frame:** Zahrebelnyi is not a straightforward dissident-martyr biography. Do not invent arrest, interrogation, samizdat network, Gulag sentence, or named KGB case. His pressure story is captivity, former-POW stigma, Soviet ideological limits, and negotiated space inside official literary institutions.
+- **Former-POW stigma:** UINP says he avoided Stalinist camps but remembered sixteen years as a `людина другого гатунку` because former prisoners of war were treated as suspect. This is a strong human anchor: survival did not end in 1945; stigma followed him into the years when he began writing.
+- **Source-specific camp wording:** ESU says `в'язень німецьких і радянських концтаборів`; UINP says he avoided Stalinist camps. Future builders should not flatten this contradiction. Phrase cautiously: Nazi captivity is secure; Soviet post-captivity pressure / suspicion is secure; exact Soviet-camp claim needs explicit attribution to ESU if used.
+- **Writing inside Soviet constraints:** IEU sharply notes that `Я, Богдан` was written under pressure of the official Soviet `unification of peoples` theme and therefore carries historical falsification. This does not erase the novel's power; it gives learners a concrete way to see both achievement and compromise.
+- **Institutional insider complexity:** Zahrebelnyi led `Літературна Україна`, then later held high Writers' Union positions and Soviet deputy roles. BIO should teach him as a person working within and sometimes stretching official culture, not as pure opposition or pure apparatchik.
+- **Support for the Sixtiers:** UINP cites Ivan Drach's memory that Zahrebelnyi gave him work after university expulsion and published / supported the new literary wave in `Літературна газета` / `Літературна Україна`. This belongs beside the institutional-compromise story.
+- **Modern reception / de-Russification hook:** A Kyiv street formerly named after Nikolay Raevsky was renamed for Pavlo Zahrebelnyi in 2022. Use this carefully as evidence of post-2022 memory politics, not as proof all controversies are settled.
+
+## 3. Major works / contributions
+
+- **Early prose and war memory:** `Каховські оповідання` (1953, with Yu. Ponomarenko), `Степові квіти` (1955), `Учитель` (1957), `Дума про невмирущого` (1957). ESU identifies `Дума про невмирущого` as a work with autobiographical ground, centered on a young Red Army soldier's human feat in a Nazi camp.
+- **Contemporary / industrial / Soviet-era novels:** `Європа 45`, `Європа. Захід`, `Спека`, `День для прийдешнього`, `Шепіт`, `Добрий диявол`, `З погляду вічності`, `Переходимо до любові`, `Намилена трава`, `Розгін`. ESU reads these through his recurring concern with personality, agency, irony, and resistance to faceless conformity.
+- **`Диво` (1968):** First major turn to historical material. ESU highlights its three time-lines, with Sophia of Kyiv as the through-image binding the 11th and 20th centuries, and the tension between people, power, art, and historical creation. This is the strongest BIO narrative entry point.
+- **Kyivan Rus novels:** `Первоміст` (1972), `Смерть у Києві` (1973), `Євпраксія` (1975). `Первоміст` and `Смерть у Києві` received the Shevchenko Prize in 1974. Existing LIT-HIST-FIC work already has `Смерть у Києві` as a cross-track anchor.
+- **`Роксолана` (1980):** Historical novel about Anastasia Lisovska / Hurrem Sultan. NBU's electronic library record says it was first printed in 1980 and notes Zahrebelnyi's stated source inspirations in Ahatanhel Krymskyi and V. Gordlevsky. Future BIO should avoid naive "Ukrainian woman conquers empire" triumphalism and teach myth-making / survival / power.
+- **`Я, Богдан (Сповідь у славі)` (1983):** Monologue-form historical novel on Bohdan Khmelnytskyi. ESU praises its scale and moral self-judgment; IEU flags Soviet `unification` pressure and historical falsification. This is the key anti-hagiography work.
+- **Post-independence prose:** `Гола душа`, `Ангельська плоть`, `Тисячолітній Миколай`, `Юлія`, `Попіл снів`, `Зона особливої охорони`, `Брухт`, `Стовпотворіння`, late essays / speeches. NBU bibliography usefully separates pre-1991 and post-1991 publication lists.
+- **Screenplays and film:** ESU and NBU list film work including `Ракети не повинні злетіти`, `Перевірено - мін немає`, `Лаври`, `Ярослав Мудрий`, `Прискорення`.
+- **Editorial contribution:** As editor of `Літературна Україна`, he made a newspaper into a public literary platform during the early 1960s thaw. This may be more BIO-relevant than a mere works list.
+
+## 4. Primary-source quote / visual anchors
+
+Use short excerpts only. Zahrebelnyi died in 2009, so the texts remain under copyright in Ukraine / EU / Canada under life+70 rules. Full online texts are research witnesses, not automatic assets for publication.
+
+- **`Дума про невмирущого` anchor:** NBU bibliography records the 1957 Kyiv `Молодь` edition. Use this to link the young soldier / captivity experience with later memory work. If excerpting, keep to a short classroom passage and credit edition.
+- **`Диво` anchor:** ESU gives a strong interpretive anchor: Sophia of Kyiv binds 11th-century, wartime, and contemporary lines. Future module can open with learners seeing the cathedral not as postcard architecture but as a witness carrying makers, invaders, scholars, and memory across time.
+- **`Роксолана` edition witness:** NBU electronic library item `ukr0000017979` describes the historical novel and notes first publication in 1980. Use for bibliographic anchoring and for a source-evaluation activity on what materials Zahrebelnyi said inspired him.
+- **`Я, Богдан` anchor:** Use ESU / IEU together: ESU for monologue, epic reach, historical self-judgment; IEU for the Soviet `unification of peoples` pressure. A future activity can ask learners to mark where confession becomes history, where history becomes myth, and where Soviet framing presses on the text.
+- **`Літературна Україна` editorial anchor:** UINP's Drach memory gives a vivid scene: an editor opening the page and the workplace to young writers under pressure. This is a human biography anchor, not only a bibliographic footnote.
+- **Safer visual candidates:** Commons has `Pavlo Zahrebelnyi Signature 1969.png` and a `Grave of Pavlo Zahrebelnyi (writer)` category at Baikove Cemetery. The signature is a modest but rights-clear source witness; the grave photograph may support memory / burial discussion after file-page license check.
+- **Avoid:** do not embed UINP / uain.press portraits or IEU historical photos unless their exact license and reuse terms are checked. Do not use stills from films without a separate rights rationale.
+
+## 5. Language register
+
+- **Register:** intellectually dense Ukrainian prose, historical-philosophical narration, irony, long syntactic movement, sharp publicistic energy, shifts among epic panorama, interior monologue, and debate.
+- **CEFR readiness:** C1 is the safer floor for direct literary work. B2+ can handle carefully excerpted narrative from `Диво` with glossed architecture / power / art vocabulary. `Я, Богдан` and reception debate should be C1/C2.
+- **Learner lexicon:** `історичний роман`, `епічність`, `монолог`, `сповідь`, `Софія Київська`, `зодчий`, `пам'ятка`, `пам'ять`, `міфотворення`, `історична вигадка`, `публіцистичність`, `цензура`, `пристосуванство`, `конформізм`, `військовополонений`, `полон`, `стигма`, `шістдесятники`, `Спілка письменників`, `лауреат`, `де-русифікація`.
+- **Tone note future module builders:** Tell the tale of a boy from a Dnipro-side village who survived war and captivity, learned what suspicion does to a person, then spent decades writing history as a living argument. The lesson should not sound like a production memo. It should let learners feel why his novels mattered, then make them examine where power shaped what could be said.
+- **Activity placement note:** Future module generation should use V2 activities with separated `inline:` and `workbook:` lists. Inline activities: comprehension, timeline sorting, excerpt reading, short image/source checks. Workbook activities: source comparison, Soviet-framing critique, de-Russification memory discussion, longer writing.
+
+## 6. Contested points
+
+- **Victim / insider tension:** Zahrebelnyi was both wounded former prisoner of war under suspicion and a later Soviet literary official, deputy, prize committee chair, and party-era public figure. Do not resolve this tension too cheaply. It is the biography.
+- **Camp wording contradiction:** ESU says German and Soviet camps; UINP says he avoided Stalinist camps but carried former-POW stigma. Treat Nazi captivity as secure; treat Soviet-camp wording as source-attributed until a stronger biographical source clarifies exactly what post-liberation institution / filtering is meant.
+- **Historical fiction versus national myth:** His novels opened Ukrainian history to mass readers, but they dramatize, simplify, and sometimes inherit Soviet frames. IEU's critique of `Я, Богдан` is especially important for anti-hagiography.
+- **Roksolana risk:** Avoid turning `Роксолана` into uncomplicated empowerment or anti-Tatar / anti-Muslim stereotyping. Teach captivity, gendered power, imperial court survival, and myth-making with source humility.
+- **Russian / Soviet transliterations:** Avoid canonicalizing `Pavel Zagrebelny` / `Павел Загребельный` except in source-title contexts. English project form should be `Pavlo Zahrebelnyi`.
+- **Modern wartime resonance:** Zahrebelnyi matters now because historical memory, de-Russification, and the right to tell Kyiv / Kyivan Rus from Ukrainian perspectives are live questions during Russia's war against Ukraine. Use direct contemporary analogies sparingly and with source work.
+
+## 7. Cross-track links
+
+**Existing LIT-HIST-FIC modules (VERIFIED `test -e` on 2026-07-01):**
+
+- `curriculum/l2-uk-en/plans/lit-hist-fic/zahrebelny-dyvo.yaml`
+- `curriculum/l2-uk-en/lit-hist-fic/discovery/zahrebelny-dyvo.yaml`
+- `curriculum/l2-uk-en/plans/lit-hist-fic/zahrebelny-death-in-kyiv.yaml`
+- `curriculum/l2-uk-en/lit-hist-fic/discovery/zahrebelny-death-in-kyiv.yaml`
+- `curriculum/l2-uk-en/plans/lit-hist-fic/zahrebelny-roksolana-1.yaml`
+- `curriculum/l2-uk-en/lit-hist-fic/discovery/zahrebelny-roksolana-1.yaml`
+- `curriculum/l2-uk-en/plans/lit-hist-fic/zahrebelny-roksolana-2.yaml`
+- `curriculum/l2-uk-en/lit-hist-fic/discovery/zahrebelny-roksolana-2.yaml`
+
+**Existing BIO / research network links (VERIFIED `test -e` on 2026-07-01):**
+
+- `docs/research/bio/roman-ivanychuk.md` - late-Soviet / post-Soviet historical fiction, national memory under pressure.
+- `docs/research/bio/andrian-kashchenko.md` - popular historical fiction and Cossack memory for broad readers.
+- `docs/research/bio/bohdan-lepkyi.md` - historical fiction and restoration of contested state memory.
+- `docs/research/bio/ulas-samchuk.md` - prose, national memory, Soviet silencing / public writer complexity.
+- `docs/research/bio/lina-kostenko.md` - `Маруся Чурай`, historical-poetic memory, Sixtiers context.
+- `docs/research/bio/ivan-drach.md` - Sixtiers, editorial support, UINP memory anchor.
+- `docs/research/bio/ivan-dziuba.md` - Sixtiers / Soviet pressure / critique context.
+- `docs/research/bio/bohdan-khmelnytskyy.md` - `Я, Богдан` historical protagonist / myth.
+- `docs/research/bio/kniaz-yaroslav-mudryi.md` and `docs/research/bio/volodymyr-velykii.md` if / when Kyivan Rus biography links are needed for `Диво` and `Ярослав Мудрий`.
+
+**Future / planned BIO links:**
+
+- BIO #372 `pavlo-zahrebelnyi` should later connect to BIO #371 `roman-ivanychuk`, BIO #373 `valerii-shevchuk`, and any future LIT-HIST-FIC historical-fiction cluster review.
+
+## 8. Naming / canonicalization
+
+- **UA canonical:** Павло Архипович Загребельний.
+- **EN project canonical:** Pavlo Zahrebelnyi.
+- **Slug:** `pavlo-zahrebelnyi`.
+- **Existing path variant:** LIT-HIST-FIC paths currently use `zahrebelny-*` without final `i`. Do not rename those inside this dossier-only slice. Future route-normalization may add aliases if the project standardizes transliteration.
+- **Avoid as canonical:** `Pavel Zagrebelny`, `Павел Загребельный`, `Zahrebelny` unless quoting / citing a source's title or preserving an existing file path.
+- **Patronymic:** Архипович, not `Архіпович` unless a source title uses it.
+
+## 9. Image / rights guidance
+
+- **Portrait risk:** UINP and IEU display useful portraits / group photographs, but their reuse status is not automatically clear. Treat them as reference-only until exact rights are verified.
+- **Commons safe candidates:** `Pavlo Zahrebelnyi Signature 1969.png` appears in the Commons category for the writer; `Category:Grave of Pavlo Zahrebelnyi (writer)` contains one Baikove grave image. Check file pages for license / freedom-of-panorama implications before embedding.
+- **Text scans / online full texts:** Zahrebelnyi's literary texts are still copyrighted. Online full-text repositories may be helpful for research / excerpt selection, but do not reproduce long passages. Use short excerpts with citation and classroom-purpose justification.
+- **Possible non-portrait visual approach:** Sophia of Kyiv, a timeline map Soloshyne - Kyiv - Dnipropetrovsk / Dnipro - Germany - Kyiv, or a rights-cleared book-cover / bibliographic-card style if source permissions allow. Visuals should serve biography and memory, not generic Soviet-writer decoration.
+- **Caption policy:** Caption should state why the image matters: signature as authorial trace; grave as memory marker; Sophia as the object that `Диво` turns into a time-bridge; not "great writer portrait" filler.
+
+## 10. Sources used
+
+**Tier 1 / Tier 2 encyclopedic institutional sources:**
+
+- Дончик В. Г. "Загребельний Павло Архипович." *Енциклопедія Сучасної України*. https://esu.com.ua/article-15239. Accessed 2026-07-01.
+- "ЗАГРЕБЕЛЬНИЙ ПАВЛО АРХИПОВИЧ." *Енциклопедія історії України*, Institute of History of Ukraine, NASU. https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIU&P21DBN=EIU&S21All=%3C.%3ETIT%3D%D0%97%D0%90%D0%93%D0%A0%D0%95%D0%91%D0%95%D0%9B%D0%AC%D0%9D%D0%98%D0%99%20%D0%9F%D0%90%D0%92%D0%9B%D0%9E%20%D0%90%D0%A0%D0%A5%D0%98%D0%9F%D0%9E%D0%92%D0%98%D0%A7%3C.%3E&S21CNR=20&S21FMT=brief_eiu&S21REF=2&S21SRD=UP&S21SRW=nz&S21STN=1. Accessed 2026-07-01.
+- Koshelivets, Ivan. "Zahrebelny, Pavlo." *Internet Encyclopedia of Ukraine*. Canadian Institute of Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CZ%5CA%5CZahrebelnyPavlo.htm. Accessed 2026-07-01.
+- "1924 - народився Павло Загребельний, письменник." *Український інститут національної пам'яті*. https://uinp.gov.ua/istorychnyy-kalendar/serpen/25/1924-narodyvsya-pavlo-zagrebelnyy-pysmennyk. Accessed 2026-07-01.
+- "Загребельний Павло Архипович: до 100-річчя від дня народження." *Національна бібліотека України імені В. І. Вернадського*. https://www.nbuv.gov.ua/node/6586. Accessed 2026-07-01.
+- "Загребельний Павло Архипович." *Електронна бібліотека Україніка*, NBUV. https://irbis-nbuv.gov.ua/ulib/item/REF0007245. Accessed 2026-07-01.
+
+**Primary / publication witnesses and media checks:**
+
+- Загребельний П. А. `Роксолана` (1980), NBU electronic library record. https://irbis-nbuv.gov.ua/ulib/item/ukr0000017979. Accessed 2026-07-01.
+- Загребельний П. А. `Дума про невмирущого` (1957), NBU bibliography record in 100th-anniversary bibliography. https://www.nbuv.gov.ua/node/6586. Accessed 2026-07-01.
+- "Category:Pavlo Zahrebelnyi (writer)." *Wikimedia Commons*. https://commons.wikimedia.org/wiki/Category%3APavlo_Zahrebelnyi_%28writer%29. Accessed 2026-07-01.
+- "Category:Grave of Pavlo Zahrebelnyi (writer)." *Wikimedia Commons*. https://commons.wikimedia.org/wiki/Category%3AGrave_of_Pavlo_Zahrebelnyi_%28writer%29. Accessed 2026-07-01.
+
+**Modern memory / context source:**
+
+- "Віталій Кличко: Київрада дерусифікувала ще 32 вулиці столиці..." *Київська міська рада*. https://kmr.gov.ua/news/vitaliy-klichko-kiivrada-derusifikuvala-shche-32-vulitsi-stolitsi-zokrema-pereymenuvala-bulvar-druzhbi-narodiv. Accessed 2026-07-01.


### PR DESCRIPTION
## Summary

- Adds the dossier-only BIO #372 base-prep file for `pavlo-zahrebelnyi`.
- Frames Zahrebelnyi through war captivity, post-POW Soviet stigma, Soviet literary-institutional complexity, historical fiction, and modern Ukrainian memory.
- Links existing LIT-HIST-FIC Zahrebelnyi plans/discovery files and nearby BIO research dossiers.

## Validation

- `npx markdownlint-cli2 docs/research/bio/pavlo-zahrebelnyi.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/pavlo-zahrebelnyi.md`
- `git diff --check origin/main..HEAD`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Telemetry

Dossier-only base-prep PR. Module-build telemetry is not applicable and was not posted.

- `swarm_used: false`
- `swarm_note: solo run; no swarm used`
