### PR TITLE
docs(bio): add Valerii Shevchuk dossier

### DIFF
--- a/docs/research/bio/valerii-shevchuk.md
+++ b/docs/research/bio/valerii-shevchuk.md
@@ -1,0 +1,146 @@
+# Валерій Олександрович Шевчук - Research Dossier
+
+**Slug:** `valerii-shevchuk`
+**Block:** +77 expansion - literary / shistdesiatnyky / baroque-memory additions
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #373
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Source acronym legend:** EHIU = Encyclopedia of History Ukraine; IEU = Internet Encyclopedia Ukraine; LNU = Ivan Franko National University of Lviv; IL = Shevchenko Institute of Literature, NASU; KNPU = Taras Shevchenko National Prize Committee; NLU = National Library of Ukraine named after Yaroslav Mudryi; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional sources cited
+- [x] Pressure mechanism framed through late-Soviet publication blockage, official criticism, brother's arrest / prisoner contacts, and documented KDB scrutiny; no invented arrest or camp term for Valerii Shevchuk
+- [x] At least 2 primary-source Ukrainian text / publication anchors supplied
+- [x] Cross-track links verified `test -e` on 2026-07-01 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Валерій Олександрович Шевчук.
+- **Project English canonical:** Valerii Shevchuk.
+- **Birth / death:** 20 August 1939, Zhytomyr; 6 May 2025, Kyiv. EHIU is an older 2013 entry and lists only birth; IEU and LNU record the 2025 death. This updates the older BIO readiness note that still marked him living.
+- **Family pressure context:** Older brother Anatolii Shevchuk was arrested in 1965; IEU says Valerii Shevchuk maintained contact with imprisoned dissidents. KNPU notes he had to leave the Kyiv Historical Museum after his brother's arrest.
+- **Education / early work:** Graduated from Kyiv University's historical-philosophical faculty in 1963; worked briefly for `Молода гвардія`, served in the army near Murmansk, then worked in museum / publishing contexts before becoming a professional writer.
+- **Literary identity:** Prose writer, dramatist, literary scholar, translator, historian-medievalist, interpreter of Ukrainian Baroque, and one of the major prose voices of the shistdesiatnyky generation.
+- **Awards / honors:** Shevchenko Prize 1988 for the novel-triptych `Три листки за вікном`; Antonovych Foundation Prize; Order of Prince Yaroslav the Wise 5th class 1999; honorary professor / doctor links with Kyiv-Mohyla, Zhytomyr, and Lviv university contexts, depending on source.
+- **Core BIO identity:** Shevchuk made Ukrainian Baroque, old chronicles, moral inwardness, and gothic / psychological prose into a long twentieth-century project of cultural memory under Soviet pressure and after independence.
+
+## 2. Oppression / pressure mechanism
+
+- **Load-bearing frame:** Shevchuk is a pressure / inner-emigration biography, not an arrest biography. Do not invent a KGB arrest, prison sentence, interrogation transcript, camp term, or trial for Valerii Shevchuk.
+- **Publication blockage:** IEU says that after the late-1960s / 1972 wave of repression he was denied permission to publish and remained silent until the end of the 1970s. KNPU similarly says his works were almost not printed in the 1970s and he wrote for himself.
+- **Official criticism:** IEU records official Soviet criticism of excessive psychological `microanalysis`. This matters pedagogically: the charge was aesthetic on the surface, ideological underneath, because inward conscience did not fit socialist-realist sorting.
+- **Documented KDB scrutiny:** KNPU republishes a BBC Ukraine account of a 1971 KDB memo, reported by Eduard Andriushchenko, recommending review of a planned Shevchuk book and his role in translating chronicles; KNPU says the book did not appear and his works were not published for eight years. Use this as a source-attributed pressure detail, not a generalized invented security-service story.
+- **Dissident kinship / contact:** IEU says he did not sever contacts with imprisoned dissidents, including brother Anatolii, and corresponded with / visited prisoners in Siberian labor camps. Keep focus on Valerii's solidarity and risk, not on making him identical to imprisoned dissidents.
+- **Inner emigration:** Future BIO can teach the human shape of pressure: a writer withdraws into archives, old books, Baroque language, and morally difficult prose. Avoid saying he simply "escaped" Soviet power; the archive was both shelter and a contested public act.
+
+## 3. Major works / contributions
+
+- **Early psychological prose:** `Серед тижня` (1967), `Набережна, 12` with `Середохрестя` (1968), `Вечір святої осені` (1969). IEU frames these as realist psychological prose that found extraordinary moral states in seemingly ordinary lives.
+- **Delayed historical / magic-realist turn:** IEU says he turned to historical topics in 1968 and wrote `Панна сотниківна`, but it only appeared in the early 1980s inside `Дім на горі`. This delayed publication is a clean pressure-and-poetics anchor.
+- **`Дім на горі` (1983):** novel-ballad / prose cycle; strong BIO entry for house, memory, women / men, tales, and gothic-Baroque atmosphere. Existing LIT plan anchors this work.
+- **`На полі смиренному` (1983):** historical / parabolic rewriting from monastic and early Ukrainian material. Useful for teaching humility, power, and stylized old-text voice.
+- **`Три листки за вікном` (1986):** novel-triptych; Shevchenko Prize 1988. Existing LIT-HIST-FIC plan treats it as historiographic metafiction / Baroque intellectual game; future BIO should distinguish source, invention, and moral argument.
+- **Late-Soviet / independence-era prose:** `Птахи з невидимого острова` (1989), `Дзиґар одвічний` (1990), `Панна квітів` (1990), `Стежка в траві. Житомирська сага` (1994), `Око прірви` (1996), `Жінка-змія` (1998), `Юнаки з вогненної печі` (1999), `Срібне молоко` (2002), `Тіні зникомі` (2002), `Привид мертвого дому` (2005).
+- **Old Ukrainian literature / Baroque recovery:** Translated, edited, and popularized Skovoroda, Ivan Vyshenskyi, Samiilo Velychko's chronicle, Baroque poetry anthologies, `Марсове поле`, `Пісні Купідона`, `Муза Роксоланська`, and `Тисяча років української суспільно-політичної думки`. EHIU makes this central, not peripheral.
+- **History of statehood thought:** `Козацька держава як ідея...` and related essays joined historical scholarship, civic memory, and literary work. BIO can connect this with modern wartime interest in state continuity without forcing presentism.
+- **Autobiographical / memoir anchor:** IEU notes `Сад житейських думок, трудів та почуттів` (2003). This is useful for humanizing the scholar-writer without letting the lesson become only bibliography.
+
+## 4. Primary-source quote / visual anchors
+
+Use short excerpts only. Shevchuk died in 2025, so the literary works remain under copyright in Ukraine / EU / Canada under life+70 rules. Full online texts are research witnesses, not reusable site assets.
+
+- **`Панна сотниківна` delay anchor:** Written in 1968, published only in the early 1980s as part of `Дім на горі` according to IEU. Future lesson can put the dates side by side before asking what kind of story had to wait.
+- **`Дім на горі` anchor:** The house / tale-cycle structure lets learners see memory as architecture. Use a very short excerpt only, ideally around threshold, room, window, tale, or return imagery.
+- **`Три листки за вікном` edition anchor:** KNPU identifies the Shevchenko Prize object; library records give the 1986 `Радянський письменник` publication witness. Use as a material anchor for prize, late-Soviet publication, and historical-metafiction debate.
+- **Baroque translation anchor:** EHIU and KNPU list `Аполлонова лютня`, `Пісні Купідона`, `Марсове поле`, `Літопис` Samiilo Velychko, and Skovoroda editions. These show Shevchuk not merely writing about the past but rebuilding access to older Ukrainian textual worlds.
+- **KDB memo anchor:** KNPU / BBC account of the 1971 memo can support a source-reading workbook task: what exactly does the memo fear, publication, translation, popularity, or old Ukrainian memory?
+- **Safer visual anchor:** Commons file `Валерій Шевчук.JPG` shows him at a 2011 Kyiv-Mohyla Academy book presentation; source own work, author Andrii Makukha, CC BY-SA 3.0. Good for module media after attribution check.
+- **Avoid:** do not use family / obituary / news portraits unless exact rights are checked. Do not reproduce long passages from `Дім на горі`, `Три листки за вікном`, or `Сад житейських думок`.
+
+## 5. Language register
+
+- **Register:** intellectual, Baroque-inflected, psychological, gothic, parabolic, archive-aware; sentences often ask learners to track moral nuance rather than plot alone.
+- **CEFR readiness:** C1 is the safe floor. B2+ can handle short, strongly scaffolded excerpts from `Дім на горі`; `Три листки за вікном` and Baroque-historiographic debate should be C1/C2.
+- **Learner lexicon:** `шістдесятники`, `внутрішня еміграція`, `бароко`, `химерна проза`, `готична проза`, `притча`, `психологізм`, `мікроаналіз`, `архів`, `літопис`, `стилізація`, `інтертекстуальність`, `метафікція`, `історіографія`, `совість`, `мовчання`, `табуювання друку`, `КДБ`, `самвидав`, `давньоукраїнська література`.
+- **Tone note future module builders:** Tell the tale of a Zhytomyr boy who went through a technical school and concrete plant, found himself in old Ukrainian books, watched his brother imprisoned, lost print for years, and made an archive into living prose. Do not let the lesson sound like a thesis abstract or production memo.
+- **Activity placement note:** Future module generation should use V2 activities with separated `inline:` and `workbook:` lists. Inline: timeline, comprehension, excerpt noticing, source-vocabulary checks. Workbook: KDB memo source reading, Baroque-text comparison, reflection on inner emigration, longer literary analysis.
+
+## 6. Contested points
+
+- **Death status / outdated queue:** The 2026-06 readiness matrix labels him living. Current sources record death on 6 May 2025. Treat him as recently deceased; do not write predictive biography or present-tense career claims.
+- **KDB framing:** There is source-backed KDB pressure, but the BIO should not become a spy-police story. The human and literary mechanism is publication blockage, inward withdrawal, archive labor, and contact with imprisoned friends / family.
+- **"Anti-Soviet novel" shortcut:** Existing plans sometimes call `Дім на горі` deeply anti-Soviet. Dossier recommendation: make the argument through form, publication history, conscience, archive, and non-socialist-realist poetics, not a flat label.
+- **Hagiography risk:** Shevchuk's difficulty is part of the lesson. Some readers find the prose elitist, archaizing, and inaccessible; this belongs in discussion, not as a dismissal.
+- **"Khymerna prose" taxonomy:** IEU says his magic realism is related to but distinct from Ukrainian `химерна проза`. Future modules should not reduce him to a single genre label.
+- **Modern wartime resonance:** His Baroque / Cossack / statehood work matters during Russia's war against Ukraine because it protects long Ukrainian textual continuity. Use source-based continuity, not vague "eternal nation" rhetoric.
+
+## 7. Cross-track links
+
+**Existing LIT / LIT-HIST-FIC / C2 modules (VERIFIED `test -e` on 2026-07-01):**
+
+- `curriculum/l2-uk-en/plans/lit/valeriy-shevchuk-dim-na-hori.yaml`
+- `curriculum/l2-uk-en/lit/discovery/valeriy-shevchuk-dim-na-hori.yaml`
+- `curriculum/l2-uk-en/plans/lit/valeriy-shevchuk-prose.yaml`
+- `curriculum/l2-uk-en/lit/discovery/valeriy-shevchuk-prose.yaml`
+- `curriculum/l2-uk-en/plans/lit-hist-fic/shevchuk-three-leaves.yaml`
+- `curriculum/l2-uk-en/lit-hist-fic/discovery/shevchuk-three-leaves.yaml`
+- `curriculum/l2-uk-en/plans/c2/individual-voice-i.yaml`
+
+**Existing BIO / research network links (VERIFIED `test -e` on 2026-07-01):**
+
+- `docs/research/bio/roman-ivanychuk.md` - late-Soviet historical fiction and national memory.
+- `docs/research/bio/pavlo-zahrebelnyi.md` - Soviet-era literary institution / historical prose complexity.
+- `docs/research/bio/ivan-drach.md` - shistdesiatnyky context and public literary thaw.
+- `docs/research/bio/ivan-dziuba.md` - Soviet pressure, criticism, and civic intellectual context.
+- `docs/research/bio/lina-kostenko.md` - shistdesiatnyky, silence, historical imagination.
+- `docs/research/bio/hryhir-tiutiunnyk.md` - psychological prose, conscience, late-Soviet literary pressure.
+- `docs/research/bio/yevhen-hutsalo.md` - prose generation context named beside Shevchuk in IEU.
+- `docs/research/bio/hryhoriy-skovoroda.md` - explicit teacher / Baroque moral-philosophical anchor.
+
+**Future / planned links:**
+
+- Older-text figures and chroniclers such as Ivan Vyshenskyi and Samiilo Velychko are central to Shevchuk's work but do not currently have verified BIO dossier files under those names. Add verified paths only after they exist.
+- BIO #373 `valerii-shevchuk` should later connect forward to BIO #374 `vsevolod-nestaiko` as a contrast in readership / prose register, not as the same literary problem.
+
+## 8. Naming / canonicalization
+
+- **UA canonical:** Валерій Олександрович Шевчук.
+- **EN project canonical:** Valerii Shevchuk.
+- **Slug:** `valerii-shevchuk`.
+- **Existing path variant:** Existing LIT paths use `valeriy-shevchuk-*`. Do not rename those inside this dossier-only slice. Future route-normalization may add aliases if the project standardizes transliteration.
+- **Avoid as canonical:** `Valery Shevchuk`, `Valeriy Shevchuk`, `Валерий Шевчук` except in source titles, existing file paths, or transliteration notes.
+- **Disambiguation:** Do not confuse with George Shevelov's alias `Гр. Шевчук`, Russian musician Yuri Shevchuk, or other Shevchuks in search results.
+
+## 9. Image / rights guidance
+
+- **Commons portrait:** `File:Валерій Шевчук.JPG` is the strongest candidate. Commons lists it as own work by Andrii Makukha, 14 December 2011, at Kyiv-Mohyla Academy, CC BY-SA 3.0. Use with full attribution and license link.
+- **Obituary / institutional portraits:** LNU, KNPU, Suspilne, UBI / Facebook, and news sites may show useful portraits, but do not embed unless page-specific reuse rights are checked.
+- **Text scans / online full texts:** Treat as research and excerpt-selection aids only. Copyright remains active after his 2025 death; reproduce no long passages.
+- **Alternative visuals:** A rights-cleared portrait, a book-cover / title-page only if rights permit, or a map/timeline linking Zhytomyr, Kyiv, Murmansk, archives, and Koncha-Ozerna. For `Дім на горі`, avoid generic gothic imagery that makes the prose look like genre decoration.
+- **Caption policy:** Caption should connect the image to work: Kyiv-Mohyla book presentation / old-text recovery / Baroque archive / recently remembered writer, not a generic "famous author" label.
+
+## 10. Sources used
+
+**Tier 1 / Tier 2 encyclopedic institutional sources:**
+
+- Тарнашинська Л. Б. "Шевчук Валерій Олександрович." *Енциклопедія історії України*, Institute of History of Ukraine, NASU. https://www.history.org.ua/?termin=Shevchuk_V. Accessed 2026-07-01.
+- Stech, Marko Robert. "Shevchuk, Valerii." *Internet Encyclopedia of Ukraine*. Canadian Institute of Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CH%5CShevchukValerii.htm. Accessed 2026-07-01.
+- "Шевчук Валерій Олександрович." *Комітет з Національної премії України імені Тараса Шевченка*. https://knpu.gov.ua/winners/shevchuk-valerij-oleksandrovych/. Accessed 2026-07-01.
+- "Відійшов у Вічність Почесний доктор Львівського університету Валерій Шевчук." *Львівський національний університет імені Івана Франка*. https://lnu.edu.ua/vidiyshov-u-vichnist-pochesnyy-doktor-lvivskoho-universytetu-valeriy-shevchuk/. Accessed 2026-07-01.
+- "Пам'яті Валерія Шевчука." *Інститут літератури ім. Т. Г. Шевченка НАН України*. http://www.ilnan.gov.ua/index.php/uk/new/item/1284-pamiati-valeriia-shevchuka. Accessed 2026-07-01.
+- "Валерій Шевчук." *Національна бібліотека України імені Ярослава Мудрого*. https://nlu.org.ua/event.php?id=1269. Accessed 2026-07-01.
+
+**Publication / pressure / media witnesses:**
+
+- "Помер письменник Валерій Шевчук. Як він відкривав нові світи і як його карав КДБ." *Комітет з Національної премії України імені Тараса Шевченка* / BBC Україна republication. https://knpu.gov.ua/pomer-pysmennyk-valerij-shevchuk-iak-vin-vidkryvav-novi-svity-i-iak-joho-karav-kdb/. Accessed 2026-07-01.
+- `File:Валерій Шевчук.JPG`. *Wikimedia Commons*. https://commons.wikimedia.org/wiki/File:%D0%92%D0%B0%D0%BB%D0%B5%D1%80%D1%96%D0%B9_%D0%A8%D0%B5%D0%B2%D1%87%D1%83%D0%BA.JPG. Accessed 2026-07-01.
+- `Category:Valeriy Shevchuk`. *Wikimedia Commons*. https://commons.wikimedia.org/wiki/Category:Valeriy_Shevchuk. Accessed 2026-07-01.


### PR DESCRIPTION
## Summary

- Adds the dossier-only BIO #373 base-prep file for `valerii-shevchuk`.
- Frames Shevchuk through shistdesiatnyky pressure, publication blockage, documented KDB scrutiny, Baroque archive work, and gothic / psychological prose.
- Corrects the old readiness-matrix assumption that he was living: current sources record death on 2025-05-06.
- Links existing LIT, LIT-HIST-FIC, C2, and nearby BIO research anchors.

## Validation

- `npx markdownlint-cli2 docs/research/bio/valerii-shevchuk.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/valerii-shevchuk.md`
- `git diff --check origin/main..HEAD`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Telemetry

Dossier-only base-prep PR. Module-build telemetry is not applicable and was not posted.

- `swarm_used: false`
- `swarm_note: solo run; no swarm used`
