### PR TITLE
docs(bio): add Vsevolod Nestaiko dossier

### DIFF
--- a/docs/research/bio/vsevolod-nestaiko.md
+++ b/docs/research/bio/vsevolod-nestaiko.md
@@ -1,0 +1,301 @@
+# Всеволод Зіновійович Нестайко - Research Dossier
+
+**Slug:** `vsevolod-nestaiko`
+**Block:** +77 expansion - children's literature / youth canon / memory additions
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #374
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Source acronym legend:** ESU = Encyclopedia of Modern Ukraine; UINP =
+Ukrainian Institute of National Memory; TsDAMLM = Central State Archive-Museum
+of Literature and Arts of Ukraine; KLIUCH = National Library of Ukraine for
+Children critical portal; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional sources cited
+- [x] Pressure mechanism framed through father's Soviet repression, famine /
+      wartime childhood, Soviet children's-publishing constraints, and
+      post-independence authorial revision; no invented arrest or dissident case
+      for Vsevolod Nestaiko
+- [x] At least 2 primary-source Ukrainian text / publication anchors supplied
+- [x] Cross-track links verified `test -e` on 2026-07-01 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Всеволод Зіновійович Нестайко. ESU spelling
+  uses `Зиновійович`; project Ukrainian display should use the common modern
+  `Зіновійович` unless a source title is quoted.
+- **Project English canonical:** Vsevolod Nestaiko.
+- **Birth / death:** 30 January 1930, Berdychiv; 16 August 2014, Kyiv. ESU,
+  UINP, TsDAMLM, and Commons agree on dates and places.
+- **Education / work:** Kyiv University philology graduate, 1952. Worked from
+  student years as literary editor at `Барвінок`, then `Молодь`; from 1956 to
+  1987 headed the younger-schoolchildren editorial section at `Веселка`.
+  Later work included children's journals / publishers and `Радіобайка
+  Всеволода Нестайка` on National Radio.
+- **Professional identity:** prose writer, dramatist, classic of modern
+  Ukrainian children's literature; member of the Ukrainian / Soviet writers'
+  union from the 1950s.
+- **Honors:** Oleksandr Kopylenko Prize, Lesia Ukrainka Literary Prize,
+  Mykola Trublaini Prize, first All-Union children's-book competition award,
+  and Order of Prince Yaroslav the Wise 5th class, 2010. ESU and TsDAMLM list
+  the major awards; exact wording varies by source.
+- **Core BIO identity:** Nestaiko turned the wounds of a stolen childhood into
+  a durable Ukrainian world of play, friendship, moral testing, school comedy,
+  village and city adventure, and living children's speech.
+
+## 2. Oppression / pressure mechanism
+
+- **Load-bearing frame:** Nestaiko is not a dissident-arrest biography. Do not
+  invent KGB interrogation, samizdat network, camp term, publication ban, or
+  trial for the writer himself.
+- **Family repression:** UINP and TsDAMLM record that his father, Zynovii
+  Nestaiko, had served in the Ukrainian Sich Riflemen / Ukrainian Galician Army
+  and was arrested by Soviet authorities in 1933 as an `enemy of the people`;
+  he died after deportation / camp imprisonment. Keep this as family trauma and
+  Soviet violence, not as direct repression of the child author.
+- **Hunger and displacement:** UINP says mother and son fled hunger to Kyiv
+  after the father's arrest. This creates the first human contrast: the writer
+  remembered a childhood under fear, hunger, fatherlessness, and war, then
+  chose to write toward joy.
+- **Wartime childhood:** Kyiv wartime / occupation childhood belongs in the
+  pressure story as lost school years and early deprivation. Use only
+  source-backed details; do not overstate partisan or frontline experience.
+- **Soviet children's publishing constraint:** Nestaiko spent decades inside
+  official children's periodicals and `Веселка`. The constraint is editorial
+  culture, school canon, expected "correct" child characters, and ideological
+  layers in Soviet-era editions, not underground opposition.
+- **Post-independence revision:** KLIUCH says Nestaiko republished Soviet-era
+  works in new authorial editions and removed ideological layering, including
+  in `Тореадори з Васюківки`, `Одиниця з обманом`, and `П'ятірка з хвостиком`.
+  Future BIO should teach this as evidence of a writer revisiting the terms on
+  which children could read him after 1991.
+- **Decolonization caution:** Existing LIT-YOUTH plans sometimes ask whether
+  the Vasivka world was quiet resistance. The BIO dossier recommendation is
+  more conservative: show Ukrainian language, village specificity, children's
+  subjectivity, and later de-ideologized editions; avoid declaring every comic
+  scene anti-Soviet proof.
+
+## 3. Major works / contributions
+
+- **Early publications:** First printed story `Шурка і Шурко` appeared in 1954;
+  first book of the same title came in 1956. `Це було в Києві` followed in
+  1957. TsDAMLM records early critical approval and union membership.
+- **Sunny Bunnies cycle:** `В Країні Сонячних Зайчиків` appeared in 1959 and
+  became a long-lived fantasy anchor; sequels include `Незнайомка з Країни
+  Сонячних Зайчиків` and `В Країні Місячних Зайчиків`. Useful BIO entry for
+  light as ethical imagination, not escapism alone.
+- **`Тореадори з Васюківки`:** trilogy built from `Пригоди Робінзона
+  Кукурузо` (1964), `Незнайомець з 13-ї квартири` (1966), and `Таємниця трьох
+  невідомих` (1970); TsDAMLM says the full version appeared in 1972, while ESU
+  lists `Тореадори з Васюківки` 1973. Note the source-specific bibliographic
+  difference.
+- **International recognition:** ESU, UINP, and TsDAMLM state that in 1979 the
+  International Board on Books for Young People placed `Тореадори з Васюківки`
+  on the Hans Christian Andersen special honour list / special honour list.
+- **School and youth canon:** KLIUCH says `Тореадори` became one of the first
+  works by a living classic to enter Ukrainian school programs after the 1990s.
+  This is a strong BIO link between literature, childhood memory, and national
+  educational reform after independence.
+- **Other school / adventure prose:** `Одиниця з обманом`, `П'ятірка з
+  хвостиком`, `Пригоди Грицька Половинки`, `Таємниця Віті Зайчика`, `Чудеса в
+  Гарбузянах`, `Таємничий голос за спиною`, and `Неймовірні детективи` extend
+  the school, friendship, mystery, and comic-moral line.
+- **Forest School and animal / fairy-tale prose:** `Дивовижні пригоди в
+  лісовій школі` won the Lesia Ukrainka Prize and remains one of his most
+  accessible primary-school / lower-secondary entry points.
+- **Drama / radio / adaptations:** Plays include `Марсіанський жених`,
+  `Робінзон Кукурудзо`, `Вітька Магеллан`, `Загадковий Яшка`, and stage /
+  puppet-theatre works. ESU records film adaptations and festival awards for
+  `Тореадори з Васюківки` and `Одиниця з обманом`.
+
+## 4. Primary-source quote / visual anchors
+
+Use short excerpts only. Nestaiko died in 2014, so literary texts remain under
+copyright in Ukraine / EU / Canada under life+70 rules.
+
+- **Authorial credo anchor:** TsDAMLM opens with Nestaiko's statement that
+  children's literature should protect the child's psyche while still showing
+  life with loss, grief, and suffering. Use a short, attributed excerpt if the
+  lesson needs to connect ethics and joy.
+- **`Тореадори` origin anchor:** KLIUCH cites Nestaiko's explanation that the
+  trilogy began from two 1963 stories and grew into the three-part Yava /
+  Pavlusha adventure arc. Good lesson opener: what begins as mischief becomes
+  a world with memory.
+- **Publication witness:** TsDAMLM displays archival items for `Тореадори з
+  Васюківки` title page, selected tales, and manuscript / proof materials in
+  Fund 892 and related collections. Use as source-reading / material-culture
+  anchor, not as automatically reusable images.
+- **`В Країні Сонячних Зайчиків` anchor:** 1959 fantasy text can support a
+  close-reading activity on light, naming, kindness, and the ethics of play.
+- **`Дивовижні пригоди в лісовій школі` anchor:** Forest-school world supports
+  lower-stakes vocabulary / character work and a comparison between school
+  satire and moral instruction.
+- **Interview / public line:** The newspaper `День` interview title records
+  the claim that Ukraine's independence depends on Ukrainian children's
+  literature. Use as discussion prompt, not as slogan pasted unexamined.
+- **Image caution:** ESU, UINP, TsDAMLM, and publishers display useful
+  portraits and archival images, but page-specific reuse rights must be
+  checked before embedding.
+- **Safer visual direction:** Use a rights-cleared map of Berdychiv - Kyiv,
+  a timeline, a non-copyrighted school notebook / radio motif, or a Commons
+  grave / category file only after checking the individual file license.
+
+## 5. Language register
+
+- **Register:** warm, witty, oral, fast-moving adventure prose; children's
+  dialogue, comic naming, school slang, village speech, fantasy motifs, and
+  moral clarity without sermon tone.
+- **CEFR readiness:** B2+ is possible for short guided excerpts from
+  `Тореадори` or `Лісова школа`; C1 safer for reception, Soviet-era edition
+  comparison, school canon, and post-independence revision.
+- **Learner lexicon:** `дитяча література`, `пригодницька повість`, `трилогія`,
+  `шкільна повість`, `гумор`, `іронія`, `витівка`, `дружба`, `чесність`,
+  `порядність`, `мужність`, `доброта`, `фантазія`, `казкова повість`,
+  `перевидання`, `авторська редакція`, `ідеологічні нашарування`,
+  `шкільний канон`, `радіобайка`, `дитяча суб'єктність`.
+- **Tone note future module builders:** Tell the tale of a boy who lost his
+  father to Soviet terror, grew up with hunger and war, and then gave Ukrainian
+  children a literature where children act, joke, make mistakes, invent worlds,
+  and learn responsibility. The lesson must sound like a human biography, not a
+  production memo about a canon item.
+- **Activity placement note:** Future module generation should use V2
+  activities separated into `inline:` and `workbook:` lists. Inline: timeline,
+  brief comprehension checks, character / quote noticing, publication-date
+  ordering. Workbook: authorial revision comparison, source reading from ESU /
+  TsDAMLM / KLIUCH, reflection on why children's literature matters for
+  national memory, and a longer analysis of Yava / Pavlusha friendship.
+
+## 6. Contested points
+
+- **Transliteration:** Ukrainian search and existing LIT-YOUTH paths use
+  `Nestayko`; this BIO slug uses `vsevolod-nestaiko`. Do not rename existing
+  LIT-YOUTH paths inside a dossier slice. Mention path variance only where it
+  helps future route consistency.
+- **Patronymic spelling:** ESU has `Зиновійович`; many Ukrainian sources use
+  `Зіновійович`. Do not "correct" source titles. Project-facing display should
+  follow `Зіновійович` unless a metadata policy says otherwise.
+- **`Тореадори` date:** TsDAMLM says the trilogy's parts appeared in 1964,
+  1966, 1970 and the full printing in 1972; ESU lists `Тореадори з Васюківки`
+  1973. Future modules should avoid a single unqualified date if it matters.
+- **Father's fate wording:** UINP and TsDAMLM agree on Soviet arrest and death
+  after repression, but details are compressed. Use source-specific wording:
+  arrested in 1933; sent to camp / repressed; the child did not see him again.
+  Do not add unsupported execution dates or locations.
+- **Soviet vs. Ukrainian frame:** Nestaiko worked in Soviet institutions and
+  was widely published. The point is not to make him an underground writer; it
+  is to show how Ukrainian children's imagination could survive, and later be
+  re-edited, inside and after Soviet systems.
+- **Pastoral risk:** Vasivka can become nostalgic countryside decoration.
+  Teach it as a comic social world with living Ukrainian speech, children's
+  agency, friendship, embarrassment, accountability, and local memory.
+- **Modern wartime resonance:** Nestaiko matters in wartime Ukraine because
+  children's books hold language, courage, humor, and continuity for families.
+  Keep this concrete; avoid turning a children's writer into a generic
+  "national weapon" trope.
+
+## 7. Cross-track links
+
+**Existing LIT-YOUTH modules (VERIFIED `test -e` on 2026-07-01):**
+
+- `curriculum/l2-uk-en/plans/lit-youth/nestayko-toreadors-1.yaml`
+- `curriculum/l2-uk-en/plans/lit-youth/nestayko-toreadors-2.yaml`
+- `curriculum/l2-uk-en/plans/lit-youth/nestayko-toreadors-3.yaml`
+- `curriculum/l2-uk-en/plans/lit-youth/nestayko-fantasy.yaml`
+- `curriculum/l2-uk-en/plans/lit-youth/nestayko-forest-school.yaml`
+- `curriculum/l2-uk-en/lit-youth/discovery/nestayko-toreadors-1.yaml`
+- `curriculum/l2-uk-en/lit-youth/discovery/nestayko-toreadors-2.yaml`
+- `curriculum/l2-uk-en/lit-youth/discovery/nestayko-toreadors-3.yaml`
+- `curriculum/l2-uk-en/lit-youth/discovery/nestayko-fantasy.yaml`
+- `curriculum/l2-uk-en/lit-youth/discovery/nestayko-forest-school.yaml`
+
+**Existing BIO dossiers for comparison (VERIFIED `test -e` on 2026-07-01):**
+
+- `docs/research/bio/pavlo-zahrebelnyi.md`
+- `docs/research/bio/valerii-shevchuk.md`
+- `docs/research/bio/roman-ivanychuk.md`
+- `docs/research/bio/yevhen-hutsalo.md`
+- `docs/research/bio/hryhir-tiutiunnyk.md`
+- `docs/research/bio/lina-kostenko.md`
+- `docs/research/bio/ivan-drach.md`
+- `docs/research/bio/ivan-dziuba.md`
+
+**Forward BIO link:** BIO #375 `volodymyr-rutkivskyi` should connect through
+children's / youth historical adventure prose, but the file is not yet present
+at the time of this dossier.
+
+## 8. Naming / canonicalization
+
+- **UA canonical:** Всеволод Зіновійович Нестайко.
+- **EN project canonical:** Vsevolod Nestaiko.
+- **Slug:** `vsevolod-nestaiko`.
+- **Existing path variant:** Existing LIT-YOUTH plan and discovery files use
+  `nestayko-*`. Preserve existing paths unless a route-normalization task is
+  explicitly scheduled.
+- **Common alternate English spellings:** `Vsevolod Nestayko`, `Vsevolod
+  Nestaiko`, `Vsevolod Nestajko`. Use only for source matching or search.
+- **Avoid canonical:** `Всеволод Зиновьевич Нестайко`, `Vsevolod Zinovievich
+  Nestayko`, Russian patronymic spellings, or Russian-language title variants
+  except in source titles / bibliographic notes.
+- **Disambiguation:** Do not confuse with other `Всеволод` curriculum entries
+  such as Sviatoslav Vsevolodovych / medieval rulers.
+
+## 9. Image / rights guidance
+
+- **Commons category:** `Category:Vsevolod Nestayko` exists and records basic
+  authority data. Individual files still require file-page license checks
+  before use.
+- **Institutional images:** TsDAMLM images are archival and educationally
+  valuable, but the page requires attribution / linkback and does not by itself
+  mean open reuse for site embedding. Treat them as research witnesses unless
+  explicit reuse rights are cleared.
+- **ESU / UINP / publisher portraits:** Do not embed without checking the image
+  license or getting a rights-cleared alternative.
+- **Safer module visuals:** map, timeline, illustrated notebook motif, radio
+  microphone, children's-library card, or a rights-cleared photo of Baikove
+  Cemetery / memorial context if a Commons file license allows it.
+- **Text rights:** All main works remain under copyright. Use only short,
+  attributed excerpts for pedagogy; do not reproduce long passages from
+  `Тореадори`, `Сонячні Зайчики`, `Лісова школа`, or posthumous editions.
+- **Caption policy:** Caption should say what the visual teaches: lost
+  childhood, school canon, authorial revision, radio storytelling, or how
+  Ukrainian children's books keep language alive.
+
+## 10. Sources used
+
+**Tier 1 / Tier 2 institutional sources:**
+
+- Тичініна А. Р. "Нестайко Всеволод Зиновійович." *Енциклопедія Сучасної
+  України*. https://esu.com.ua/article-73735. Accessed 2026-07-01.
+- "1930 - народився Всеволод Нестайко, дитячий письменник." *Український
+  інститут національної пам'яті*. https://www.uinp.gov.ua/istorychnyy-kalendar/sichen/30/1930-narodyvsya-vsevolod-nestayko-dytyachyy-pysmennyk.
+  Accessed 2026-07-01.
+- Онищук С. "Всеволод Зіновійович Нестайко (1930-2014)." *ЦДАМЛМ України*.
+  https://csamm.archives.gov.ua/2020/02/03/vsevolod-zinoviiovych-nestaiko-1930-2014/.
+  Accessed 2026-07-01.
+
+**Critical / reception / pedagogical sources:**
+
+- Овдійчук Л. М. "Всеволод Нестайко - майстер пригодницької прози." *КЛЮЧ*,
+  Національна бібліотека України для дітей.
+  https://chl.kiev.ua/key/Books/ShowBook/304. Accessed 2026-07-01.
+- "Всеволод Нестайко: письменник, який подарував дітям щасливе дитинство."
+  *Суспільне Культура*. https://suspilne.media/culture/202012-pamatauci-svoe-nevesele-ditinstvo-a-namagavsa-pisati-akomoga-veselise-den-narodzenna-nestajka/.
+  Accessed 2026-07-01.
+- "Всеволод НЕСТАЙКО: 'Незалежність України залежить від української дитячої
+  літератури'." *День*. https://day.kyiv.ua/article/taym-aut/vsevolod-nestayko-nezalezhnist-ukrayiny-zalezhyt-vid-ukrayinskoyi-dytyachoyi.
+  Accessed 2026-07-01.
+
+**Rights / media / authority context:**
+
+- "Category:Vsevolod Nestayko." *Wikimedia Commons*.
+  https://commons.wikimedia.org/wiki/Category:Vsevolod_Nestayko. Accessed
+  2026-07-01.


### PR DESCRIPTION
## Summary
- Add the BIO #374 research dossier for `vsevolod-nestaiko`.
- Frame the future BIO module around Ukrainian children's literature, stolen childhood, family repression, school canon, and post-independence authorial revision.
- Keep the slice dossier-only: no plan YAML, module markdown, activities, vocabulary, site MDX, wiki output, status/audit/review artifacts, telemetry DB files, linter configs, package files, or unrelated files.

## Validation
- `npx markdownlint-cli2 docs/research/bio/vsevolod-nestaiko.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/vsevolod-nestaiko.md`
- `git diff --check origin/main..HEAD`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Telemetry
- telemetry: not applicable for dossier-only base-prep PR; no module build was run.
- swarm_used: false
- swarm_note: solo run; no swarm used
