### PR TITLE
docs(bio): add Volodymyr Rutkivskyi dossier

### DIFF
--- a/docs/research/bio/volodymyr-rutkivskyi.md
+++ b/docs/research/bio/volodymyr-rutkivskyi.md
@@ -1,0 +1,298 @@
+# Володимир Григорович Рутківський - Research Dossier
+
+**Slug:** `volodymyr-rutkivskyi`
+**Block:** +77 expansion - children's / youth historical fiction / Cossack
+memory additions
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #375
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Source acronym legend:** ESU = Encyclopedia of Modern Ukraine; KNPU =
+Taras Shevchenko National Prize Committee; UBI = Ukrainian Book Institute;
+BaraBooka = Ukrainian children's-book portal; Chytomo = Ukrainian book /
+publishing media; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional sources cited
+- [x] Pressure mechanism framed through wartime childhood, Soviet-era
+      Ukrainian-nationalism accusations / Ukrainian publication blockage,
+      delayed recognition, and post-independence children's-book culture; no
+      invented arrest, camp term, KGB case, or dissident network
+- [x] At least 2 primary-source Ukrainian text / publication anchors supplied
+- [x] Cross-track links verified `test -e` on 2026-07-01 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Володимир Григорович Рутківський.
+- **Project English canonical:** Volodymyr Rutkivskyi.
+- **Birth / death:** 18 April 1937, Khrestyteleve, now Zolotonosha district /
+  Cherkasy region; 31 October 2021, Odesa. ESU and KNPU agree on core dates
+  and places.
+- **Education / work:** Graduated from the chemical-technological faculty of
+  Odesa Polytechnic Institute in 1959; completed Higher Literary Courses at
+  the Moscow Literary Institute in 1975. Worked at the Odesa superphosphate
+  plant, Odesa regional radio / television, Odesa Film Studio, Micron plant,
+  Odesa writers' organization, and newspaper `Одеські вісті`.
+- **Professional identity:** writer, publicist, journalist, poet, children's
+  and youth prose author. ESU records membership in the Writers' Union from
+  1969.
+- **Honors:** Taras Shevchenko National Prize 2012 for the `Джури` trilogy;
+  Mykola Trublaini Prize, Lesia Ukrainka Prize, Viktor Blyznets `Звук
+  павутинки` Prize, BBC Book of the Year 2011 for `Сині води`, and IBBY
+  honour-list recognition for `Гості на мітлі` according to BaraBooka.
+- **Core BIO identity:** Rutkivskyi gave post-independence Ukrainian children
+  and teenagers readable historical adventure in which Cossacks, medieval
+  borderlands, childhood memory, humor, fear, loyalty, and moral choice become
+  story rather than textbook slogan.
+
+## 2. Oppression / pressure mechanism
+
+- **Load-bearing frame:** Rutkivskyi is a publication-pressure / delayed-
+  recognition biography, not a dissident-prison biography. Do not invent an
+  arrest, trial, camp term, KGB interrogation, samizdat circle, or named
+  censorship file for him.
+- **Wartime childhood:** Born in 1937, he passed early childhood through war.
+  `Потерчата` turns that experience into autobiographical prose about hunger,
+  fear, death, helplessness, and the need to remain human. This should anchor
+  BIO's emotional story before the adventure canon.
+- **Soviet Ukrainian-publication pressure:** BaraBooka says his works were long
+  unavailable to Ukrainian readers; in Soviet times he was accused more than
+  once of Ukrainian nationalism, and Ukrainian-language publication was refused
+  while Russian translations could appear in Moscow. Use this as source-
+  attributed pressure, not as a generalized martyr narrative.
+- **Institutional ambiguity:** ESU records ordinary Soviet-era employment,
+  union membership, Russian-language publication, and literary courses in
+  Moscow. The lesson should keep both sides: he was not underground, but his
+  Ukrainian historical imagination was not easily welcomed in Ukrainian print.
+- **Post-independence recovery:** Recognition came mainly after independence,
+  especially through `Сторожова застава`, `Сині води`, and `Джури`. This makes
+  him a good BIO figure for how a children's writer can become canonical late,
+  when readers and publishers finally have room for the story he wanted to
+  tell.
+- **Modern wartime caution:** `Джури` are useful for teaching Ukrainian
+  defensive memory during Russia's war against Ukraine, but do not turn the
+  writer into a recruitment poster. Let the children, fear, humor, and moral
+  choices carry the meaning.
+
+## 3. Major works / contributions
+
+- **Poetry and early prose:** First publications appeared in 1959. Early books
+  include poetry collections `Краплини сонця` (1966), `Плоти` (1968),
+  `Повітря на двох` (1973), `Відчиніть Богданкове вікно` (1974),
+  `Рівновага` (1976), and `Знак глибини` (1987).
+- **Early children's / youth prose:** `Аннушка` (1977), `Бухтик из тихой
+  заводи` (1981, Russian edition), `Гості на мітлі`, `Бухтик з тихого затону`,
+  `Канікули у Воронівці`, `Намети над річкою`, and `Слуга баби-Яги` show the
+  shift from lyric poet to child-facing storyteller.
+- **`Сторожова застава`:** ESU lists the 2001 Odesa book edition; Chytomo says
+  the original story appeared in `Однокласник` in 1991 and the book first
+  appeared in 2001. The 2017 Yurii Kovaliov film adaptation made Rutkivskyi's
+  Kyivan Rus / time-travel adventure widely visible.
+- **`Потерчата`:** autobiographical war-childhood prose, published in 2008 and
+  later editions. BaraBooka reads it as a book that opens the experience of
+  children of war to later readers. Future BIO should not skip this in favor of
+  only heroic Cossack material.
+- **`Сині води`:** historical novel / dilogy about 14th-century Ukrainian
+  borderland and state-memory questions; BaraBooka and ESU connect it to the
+  BBC Book of the Year 2011 recognition.
+- **`Джури` cycle:** `Джури козака Швайки` (2007), `Джури-характерники`
+  (2009), `Джури і підводний човен` (2010), later `Джури і Кудлатик` (2015).
+  KNPU identifies the original trilogy as the Shevchenko Prize object in 2012.
+- **Prize infrastructure:** BaraBooka says Rutkivskyi used interest from the
+  monetary part of the Shevchenko Prize to found the private children's-
+  literature award `Джури`. This is useful for BIO as literary citizenship, not
+  just personal prestige.
+- **Children's-book culture:** UBI / BaraBooka kept him in the `Живі
+  письменники` catalogue after his death as a memorial exception, calling him a
+  major influence and teacher for modern Ukrainian children's authors.
+
+## 4. Primary-source quote / visual anchors
+
+Use short excerpts only. Rutkivskyi died in 2021, so literary texts remain
+under copyright in Ukraine / EU / Canada under life+70 rules.
+
+- **`Потерчата` anchor:** Use a short passage around a child seeing war hunger,
+  fear, and guilt. This can ground the future lesson's emotional arc: adventure
+  writer who first knew helpless childhood.
+- **`Джури козака Швайки` anchor:** Use a short scene of boys entering danger,
+  testing courage, or learning the difference between bravado and responsible
+  action. Avoid making the excerpt only Cossack costume.
+- **`Сторожова застава` anchor:** Chytomo records the 1991 magazine appearance,
+  2001 book, and 2017 film adaptation. Good source-reading task: how does a
+  modern schoolchild's time travel change the reader's relation to Kyivan Rus?
+- **`Сині води` anchor:** Use a bibliographic / prize anchor for historical
+  memory beyond the Cossack era; it shows Rutkivskyi's historical imagination
+  was not limited to one series.
+- **Authorial credo anchor:** UBI catalogue quotes Rutkivskyi on writing and
+  happiness; if used, keep the excerpt very short and connect it to craft, not
+  sentimentality.
+- **Visual caution:** Publisher portraits, author pages, and obituary photos
+  are not automatically reusable. Do not embed without page-specific rights.
+- **Safer visual direction:** map of Khrestyteleve - Odesa - Kyiv / `Джури`
+  geography, timeline, rights-cleared book-launch image only with license, or
+  a Commons file for Volodymyra Rutkivskoho Street in Odesa after file-page
+  license verification.
+
+## 5. Language register
+
+- **Register:** accessible, adventurous, humorous, historically textured,
+  youth-facing prose with quick action, moral testing, folklore / fantasy
+  touches, and clear emotional stakes.
+- **CEFR readiness:** B2+ can handle guided excerpts from `Джури` or
+  `Сторожова застава`; C1 safer for Soviet publication pressure,
+  historiographic claims, `Сині води`, and comparisons between history,
+  legend, and fantasy.
+- **Learner lexicon:** `історичний роман`, `пригодницька повість`,
+  `історико-фантастична повість`, `козаки`, `джура`, `характерник`,
+  `побратимство`, `кордон`, `плавні`, `орда`, `зрада`, `відвага`,
+  `відповідальність`, `дитинство війни`, `автобіографічна повість`,
+  `публікація`, `заборона`, `визнання`, `екранізація`, `дитяча література`,
+  `підліткова література`, `історична пам'ять`.
+- **Tone note future module builders:** Teach him as a human who carried a war
+  child's fear into books that trusted children with danger, humor, and
+  history. The BIO lesson should tell the life story first, then show why the
+  Cossack adventure mattered to readers after independence.
+- **Activity placement note:** Future module generation should use V2
+  activities separated into `inline:` and `workbook:` lists. Inline: timeline,
+  brief source-checks, character / map noticing, terms like `джура` and
+  `характерник`. Workbook: source comparison of ESU / KNPU / BaraBooka,
+  pressure-frame discussion, `Потерчата` reflection, `Джури` myth-vs-history
+  analysis, and a modern reception task on film / school reading.
+
+## 6. Contested points
+
+- **Publication pressure wording:** BaraBooka's statement about accusations of
+  Ukrainian nationalism is strong and useful, but do not amplify it into an
+  unsupported state-security case. Phrase as "BaraBooka reports..." unless
+  another archival source is added later.
+- **Russian-language editions:** ESU lists Russian-language titles and
+  translations. This is part of the pressure story: some works circulated in
+  Russian / Moscow contexts when Ukrainian publication was difficult, but it
+  does not make Rutkivskyi a Russian-language writer for project purposes.
+- **`Джури` count:** KNPU's 2012 award is for the trilogy:
+  `Джури козака Швайки`, `Джури-характерники`, `Джури і підводний човен`.
+  Later `Джури і Кудлатик` makes the series a tetralogy in many reader-facing
+  summaries. Be precise by time period.
+- **Cossack heroization risk:** Existing LIT-YOUTH plans correctly include
+  anti-hagiography prompts. Future BIO should ask what the books leave out:
+  violence, Tatars as characters rather than props, class and gender limits,
+  and how historical fantasy can both repair and simplify memory.
+- **Tatar / steppe framing:** Avoid flat enemy-race storytelling. Teach the
+  series as Ukrainian borderland adventure with source humility, not ethnic
+  stereotyping.
+- **Kyivan Rus / `Сторожова застава`:** Use `Kyivan Rus` / `Київська Русь`
+  and avoid Russian-imperial ownership language. Film adaptation may simplify
+  the book; distinguish novel, screenplay, and movie reception.
+- **Death cause:** Some news accounts mention COVID complications; ESU gives
+  only date / place. BIO does not need cause unless a source-specific note is
+  required.
+
+## 7. Cross-track links
+
+**Existing LIT-YOUTH modules (VERIFIED `test -e` on 2026-07-01):**
+
+- `curriculum/l2-uk-en/plans/lit-youth/rutkivsky-dzhury.yaml`
+- `curriculum/l2-uk-en/plans/lit-youth/rutkivsky-dzhury-1.yaml`
+- `curriculum/l2-uk-en/plans/lit-youth/rutkivsky-dzhury-2.yaml`
+- `curriculum/l2-uk-en/plans/lit-youth/rutkivsky-dzhury-3.yaml`
+- `curriculum/l2-uk-en/lit-youth/discovery/rutkivsky-dzhury.yaml`
+- `curriculum/l2-uk-en/lit-youth/discovery/rutkivsky-dzhury-1.yaml`
+- `curriculum/l2-uk-en/lit-youth/discovery/rutkivsky-dzhury-2.yaml`
+- `curriculum/l2-uk-en/lit-youth/discovery/rutkivsky-dzhury-3.yaml`
+
+**Existing BIO dossiers for comparison (VERIFIED `test -e` on 2026-07-01):**
+
+- `docs/research/bio/vsevolod-nestaiko.md`
+- `docs/research/bio/andrian-kashchenko.md`
+- `docs/research/bio/roman-ivanychuk.md`
+- `docs/research/bio/pavlo-zahrebelnyi.md`
+- `docs/research/bio/valerii-shevchuk.md`
+- `docs/research/bio/bohdan-lepkyi.md`
+- `docs/research/bio/ulas-samchuk.md`
+
+**Forward BIO link:** BIO #376 `ivan-malkovych` should connect through
+children's-book culture, publishing, and post-independence Ukrainian reading
+infrastructure; the file is not yet present at the time of this dossier.
+
+## 8. Naming / canonicalization
+
+- **UA canonical:** Володимир Григорович Рутківський.
+- **EN project canonical:** Volodymyr Rutkivskyi.
+- **Slug:** `volodymyr-rutkivskyi`.
+- **Existing path variant:** Existing LIT-YOUTH files use `rutkivsky-*`.
+  Preserve those paths unless a separate route-normalization task is
+  scheduled.
+- **Common alternate English spellings:** `Volodymyr Rutkivsky`, `Vladimir
+  Rutkovskij`, `Vladimir Rutkovsky`. Use only for source matching or old
+  Russian-language bibliographic titles.
+- **Avoid canonical:** `Владимир Рутковский`, `Vladimir Rutkovsky`, Russian
+  title variants, or Anglicized shortcuts except where quoting source titles /
+  translations.
+- **Disambiguation:** Do not confuse `Джури` with the general historical term
+  `джура`; do not confuse `Сині води` with unrelated modern political /
+  geographic uses.
+
+## 9. Image / rights guidance
+
+- **Portrait risk:** ESU, KNPU, publisher pages, news pages, and BaraBooka may
+  show portraits, but they are not automatically open-license assets. Treat as
+  research reference unless exact reuse rights are confirmed.
+- **Publisher / book covers:** `А-БА-БА-ГА-ЛА-МА-ГА`, VSL, and other covers are
+  copyrighted. Do not embed covers without permission or a clear fair-use
+  policy accepted by the project.
+- **Commons candidate:** `Category:Volodymyra Rutkivskoho Street` can provide a
+  posthumous memory / Odesa toponymy visual only after checking individual file
+  licenses. It does not replace an author portrait.
+- **Film stills:** `Сторожова застава` stills, posters, and trailers require
+  separate film-rights review. Do not use as default module art.
+- **Alternative visuals:** timeline, map of Khrestyteleve - Odesa - Kyiv /
+  Cossack steppe geography, public-domain historical map background if
+  verified, or original generated / designed classroom visual for "history as
+  adventure".
+- **Text rights:** All major works remain copyrighted. Use only short,
+  attributed excerpts for classroom purposes; do not reproduce full scenes from
+  `Джури`, `Потерчата`, `Сторожова застава`, or `Сині води`.
+
+## 10. Sources used
+
+**Tier 1 / Tier 2 institutional and prize sources:**
+
+- Логвиненко О. О. "Рутківський Володимир Григорович." *Енциклопедія Сучасної
+  України*. https://esu.com.ua/article-889970. Accessed 2026-07-01.
+- "Рутківський Володимир Григорович." *Комітет з Національної премії України
+  імені Тараса Шевченка*.
+  https://knpu.gov.ua/winners/rutkivskyj-volodymyr-hryhorovych/. Accessed
+  2026-07-01.
+- *Каталог сучасних дитячих письменників: #ЖивіПисьменники*. Ukrainian Book
+  Institute / BaraBooka. https://aw.ubi.org.ua/wp-content/uploads/2021/11/Ukr_Writers-1.pdf.
+  Accessed 2026-07-01.
+
+**Critical / reception / children's-book sources:**
+
+- "Рутківський Володимир." *Простір української дитячої книги: BaraBooka*.
+  https://www.barabooka.com.ua/volodimir-rutkivs-kij/. Accessed 2026-07-01.
+- Качак Т. "Знакова книга Рутківського." *BaraBooka*.
+  https://www.barabooka.com.ua/znakova-kniga-volodimira-rutkivs-kogo/.
+  Accessed 2026-07-01.
+- "У вільному доступі з'явився фільм `Сторожова застава`, знятий за повістю
+  Рутківського." *Читомо*.
+  https://chytomo.com/u-vilnomu-dostupi-z-iavyvsia-film-storozhova-zastava-zniatyj-za-povistiu-rutkivskoho/.
+  Accessed 2026-07-01.
+- "В Одесі помер відомий український письменник Володимир Рутківський."
+  *Укрінформ*.
+  https://www.ukrinform.ua/rubric-culture/3342340-v-odesi-pomer-vidomij-ukrainskij-pismennik-volodimir-rutkivskij.html.
+  Accessed 2026-07-01.
+
+**Rights / media / memory context:**
+
+- "Category:Volodymyra Rutkivskoho Street." *Wikimedia Commons*.
+  https://commons.wikimedia.org/wiki/Category:Volodymyra_Rutkivskoho_Street.
+  Accessed 2026-07-01.


### PR DESCRIPTION
## Summary
- Add the BIO #375 research dossier for `volodymyr-rutkivskyi`.
- Frame future BIO work around youth historical fiction, war-childhood memory, Soviet-era Ukrainian publication pressure, `Джури`, `Сторожова застава`, and post-independence children's-book culture.
- Keep the slice dossier-only: no plan YAML, module markdown, activities, vocabulary, site MDX, wiki output, status/audit/review artifacts, telemetry DB files, linter configs, package files, or unrelated files.

## Validation
- `npx markdownlint-cli2 docs/research/bio/volodymyr-rutkivskyi.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/volodymyr-rutkivskyi.md`
- `git diff --check origin/main..HEAD`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Telemetry
- telemetry: not applicable for dossier-only base-prep PR; no module build was run.
- swarm_used: false
- swarm_note: solo run; no swarm used
