### PR TITLE
docs(bio): add fleet orchestration prompt rules

### DIFF
--- a/docs/guardrails/agent-fleet-tooling.md
+++ b/docs/guardrails/agent-fleet-tooling.md
@@ -15,6 +15,49 @@ Use these project entry points for agent fleet work:
 Gemini CLI and Gemini Code Assist are unsupported for this project. Do not
 document them as current fallback, review, dispatch, or restoration paths.
 
+## Stream Orchestration Model
+
+Long-running curriculum streams should have one orchestrator thread per stream
+and worker threads or dispatched worktrees per task. The orchestrator thread is
+the source of queue state and merge decisions; worker threads are disposable,
+scoped, and replaceable.
+
+Minimum stream toolset expected inside Codex UI:
+
+- View stream queue, current slug/module, active worker threads, open PRs, and
+  paused/active monitor state.
+- Spawn worker thread or delegated worktree with a narrow brief, target files,
+  forbidden writes, validation commands, and required `X-Agent` trailer.
+- Read worker result and PR/check status back into the orchestrator thread.
+- Archive completed worker threads and preserve a compact handoff summary.
+- Resume stream orchestration in a new thread from queue state when the old
+  thread becomes unusable.
+
+Until UI-level stream controls exist, encode stream state in heartbeat prompts,
+PR bodies, handoff summaries, and branch/worktree names. Keep worker briefs
+compact and source-heavy; avoid moving long logs or source dumps between
+threads without Headroom compression.
+
+## Fleet Role Routing
+
+- **Codex:** orchestration, integration, deterministic validation, PR/merge
+  control, scoped code/docs edits.
+- **Claude:** independent read-only review for BIO narrative, source framing,
+  leakage, and final merge gates.
+- **AGY (Gemini-family via bridge):** adversarial factual/source checks,
+  alternate-source search, and broad read-only sweeps through the project
+  bridge.
+- **DeepSeek/Hermes-style reviewers:** sensitive decolonization/framing review
+  when available through the bridge.
+- **Grok-build:** build/CI diagnostics and native build-tool checks when
+  available through the bridge.
+- **Cursor:** UI/front-end and larger code navigation/diff work when the route
+  is active; do not block stream progress while the route needs renewal.
+
+Use the full fleet when work is parallelizable or model specialization improves
+quality. Do not fan out for a tiny single-file change when deterministic tools
+and one independent review are cheaper and safer.
+
 ## Command Examples
 
 ```bash

--- a/docs/prompts/orchestrators/bio/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/bio/suite-orchestrator.md
@@ -26,6 +26,37 @@ Orchestrate BIO work without touching unrelated tracks. Keep the +77 expansion b
 
 **Hard rule for +77:** do not write any BIO module under `curriculum/l2-uk-en/bio/<slug>/...` until that slug's dossier and plan exist and pass. The Bilash pilot (`oleksandr-bilash`, #4004) is an exception because its source artifacts already exist and it is the production/remediation pilot.
 
+## Fleet Operating Model
+
+BIO has hundreds of figures; do not run it as one agent doing every step. Use a
+fleet pipeline, but keep the orchestrator accountable for integration.
+
+- **Codex orchestrator:** owns queue state, worktree creation, branch naming,
+  final diff review, PR creation, independent-review routing, merge decisions,
+  scheduler updates, and artifact hygiene.
+- **Parallel dossier workers:** may draft or repair one dossier file each:
+  `docs/research/bio/<slug>.md`. A dossier worker must not touch plan YAML,
+  modules, activities, vocabulary, MDX, wiki packets, status/audit/review
+  artifacts, telemetry DB files, linter configs, package files, or unrelated
+  files.
+- **Source/cross-track explorers:** use cheap read-only agents for existing
+  curriculum links, source-tier packets, naming variants, image-rights notes,
+  and factual-risk summaries. They report claims and citations, not essays.
+- **Specialist review routing:** Claude is the preferred independent reviewer
+  for BIO content. Use AGY (Gemini-family via bridge) for adversarial source/factual checks,
+  DeepSeek/Hermes-style review for decolonization and sensitive framing when
+  available, Grok-build for build/CI diagnostics, and Cursor for UI/front-end or
+  larger code diffs when the route is active.
+- **Sequential merge queue:** multiple dossiers may be prepared in parallel,
+  but merge in BIO order unless the orchestrator records an explicit reason to
+  skip or hold a slug. CI/CodeQL and unresolved independent-review findings are
+  blockers.
+- **Token economy:** deterministic tools first. Do not ask a model to verify
+  paths, whitespace, YAML parseability, or CI state. Compress large logs/source
+  dumps with Headroom before cross-agent handoff. Keep worker briefs compact and
+  include only slug, scope, target file, source leads, validation commands, and
+  forbidden writes.
+
 ## WORKTREE_ROOT Setup
 
 ```bash
@@ -148,6 +179,22 @@ Treat scores below 8/10 or any leakage fail as blockers unless the PR is explici
 Use read-only helpers for source-tier packets, image-rights checks, politically charged framing review, rendered-page reading, leakage scoring, and activity placement verification. Compress long findings with Headroom. The main orchestrator owns edits, PR creation, independent review routing, and merge decisions.
 
 Independent BIO review must be read-only and must inspect source files and generated learner-facing MDX/page for factual grounding, Ukrainian-centered framing, narrative human tone, English/internal leakage, LLM fingerprint, and Lesson vs Workbook/Activities placement. Treat unresolved findings as blockers.
+
+Use helper agents deliberately and record whether helpers were used. Helpers
+are for bounded work that can run in parallel without lowering quality:
+source-tier packets, image-rights checks, politically charged framing review,
+cross-track path discovery, rendered-page reading, leakage scoring, activity
+placement verification, and CI/build triage. Compress long findings with
+Headroom before passing them between agents.
+
+Do not use the full fleet as theater. For a single narrow dossier, one Codex
+integration pass plus Claude review may be the economical path. For batches,
+prepare several read-only/source or one-file dossier tasks in parallel, then
+merge sequentially.
+
+The main orchestrator owns edits, PR creation, independent review routing, and
+merge decisions. Worker diffs are never trusted until the orchestrator reviews
+changed files and validates scope.
 
 ## Validation Commands
 

--- a/docs/templates/bio-research-dossier-template.md
+++ b/docs/templates/bio-research-dossier-template.md
@@ -11,6 +11,23 @@
 
 > **No-module-writing gate (#2535 / #4006 prompt gate before #4005).** A dossier is the FIRST base-prep artifact. Writing a dossier is permitted only after the slug is promoted out of the readiness gate; do NOT write the plan YAML, site doc, or wiki packet from the same pass. Promotion order is fixed: dossier → `plans/bio/{slug}.yaml` → site/wiki. For the +77, honor the canonicity-over-currency and HIST-alignment constraints recorded in the expansion memo (see §6 and §7 below).
 
+**Fleet/worker rule for dossier batches.** A worker drafting this template owns
+exactly one file: `docs/research/bio/{slug}.md`. The worker may perform
+read-only source discovery and path checks, but must not stage, commit, create
+PRs, request independent review, merge, or edit any other file. The BIO
+orchestrator reviews and integrates worker output, runs deterministic checks,
+routes Claude/AGY (Gemini-family via bridge)/other independent review as
+needed, and merges in BIO order. Use Headroom for long source packets or logs
+instead of pasting them into agent-to-agent prompts.
+
+**Token-economy rule.** Use deterministic commands before model calls: `rg`,
+`test -e`, `npx markdownlint-cli2`,
+`.venv/bin/python scripts/audit/lint_bio_dossier_xref.py`, `git diff --check`,
+and `.venv/bin/python scripts/audit/lint_agent_trailer.py`. Do not ask models
+to re-check facts that local tools can prove. A model review should focus on
+source interpretation, Ukrainian-centered framing, contested points, and
+overclaiming risk.
+
 **Acceptance criteria for closing the research ticket on a figure**:
 - [ ] All 10 sections completed (skip a section only if NA — document why)
 - [ ] ≥3 Tier 1/Tier 2 sources cited (per `bio-research-source-tiers.md`)


### PR DESCRIPTION
## Summary
- Add a BIO fleet operating model to the BIO orchestrator prompt: Codex owns orchestration/integration, worker agents own bounded one-file/source tasks, and merge stays sequential.
- Add worker/token-economy constraints to the BIO research dossier template.
- Add general stream orchestration and fleet role routing guidance for Codex UI / agent fleet usage.

## Notes
- This codifies the six operating suggestions: central orchestrator, parallel dossier workers, specialist review lanes, sequential merge queue, token-economy rules, and quality gates.
- Cursor is documented as useful when active, but not a blocker while renewal is pending.

## Validation
- `npx markdownlint-cli2 docs/prompts/orchestrators/bio/suite-orchestrator.md docs/templates/bio-research-dossier-template.md docs/guardrails/agent-fleet-tooling.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/lint/lint_prompts.py`
- `git diff --check origin/main..HEAD`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Telemetry
- telemetry: not applicable; prompt/docs-only change, no module build.
- swarm_used: false
- swarm_note: solo integration; no swarm used for this prompt patch
