### PR TITLE
docs(bio): add Ivan Malkovych dossier

### DIFF
--- a/docs/research/bio/ivan-malkovych.md
+++ b/docs/research/bio/ivan-malkovych.md
@@ -1,0 +1,292 @@
+# Іван Антонович Малкович - Research Dossier
+
+**Slug:** `ivan-malkovych`
+**Block:** +77 expansion - literary / civic / children's book culture additions
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #376
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Source acronym legend:** ESU = Encyclopedia of Modern Ukraine; ESU-ABABA = ESU
+article on `А-БА-БА-ГА-ЛА-МА-ГА`; ABABA = official publisher site; KNPU = Taras
+Shevchenko National Prize Committee; NBU-Children = National Library of Ukraine
+for Children; Chytomo = Ukrainian book and publishing media; Commons =
+Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional or field-specific sources cited
+- [x] Pressure mechanism framed through Ukrainian-language children's publishing,
+  Soviet/post-Soviet market conditions, and living-figure canonicity; no invented
+  arrest, camp term, censorship file, or dissident case
+- [x] At least 2 primary-source Ukrainian text / interview anchors supplied
+- [x] Cross-track links verified `test -e` on 2026-07-01 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Іван Антонович Малкович.
+- **Project English canonical:** Ivan Malkovych.
+- **Pseudonyms / aliases:** no stable pen name used professionally; see §8 for
+  transliteration aliases and forbidden Russianized forms.
+- **Born:** 10 May 1961, Nyzhnii Bereziv / Березів Нижній, then Kosiv district,
+  Stanislav region, Ukrainian SSR; now Ivano-Frankivsk region, Ukraine.
+  ESU gives this date and place; Commons/Wikidata category repeats the same
+  birth date / Nyzhnii Bereziv data.
+- **Died:** N/A - living as of 2026-07-01.
+- **Education / early work:** ESU records Kyiv University graduation in 1985,
+  writer-union membership from 1986, work in `Веселка` children's editing in
+  1986-87, `Молодь` poetry editing in 1987-89, `Соняшник` in 1991-92, and
+  children's programming at `Укртелефільм` in 1992. Note for future build:
+  Ukrainian Wikipedia names the 1986 institution as the USSR Writers' Union and
+  gives `Молодь` as 1987-91; keep ESU as dossier authority unless exact tenure
+  becomes load-bearing. A 2026 interview with The Ukrainians adds first-person
+  detail about earlier violin study at the Ivano-Frankivsk music college before
+  philology.
+- **Publishing-house date:** ESU and Chytomo give 1992; ABABA gives the more
+  exact founding date 20 April 1992. Use the exact date only with ABABA
+  attribution.
+- **Core BIO identity:** Malkovych is a living Ukrainian poet and publisher whose
+  settled contribution is not only a set of poems, but the post-1991 institution
+  of high-quality Ukrainian children's books through `А-БА-БА-ГА-ЛА-МА-ГА`.
+
+## 2. Oppression / pressure mechanism
+
+- **Load-bearing frame:** Malkovych is not a prison, trial, exile, or secret-police
+  case biography. Future BIO work must not invent a KGB file, dissident network,
+  samizdat sentence, or formal censorship case for him.
+- **Late-Soviet language pressure:** Poetry International describes
+  `Напучування сільського вчителя` as a quiet-language manifesto at a time when
+  Ukrainian was oppressed by the Soviet regime. Treat that as a cultural-language
+  pressure frame, not as evidence of direct state prosecution.
+- **Institution-building after Soviet scarcity:** ESU-ABABA calls
+  `А-БА-БА-ГА-ЛА-МА-ГА` the first private publisher of children's literature in
+  Ukraine, founded by Malkovych in Kyiv in 1992 and debuted with `Українська
+  абетка`. This matters because the biography sits at the turn from Soviet
+  children's-book institutions to independent Ukrainian book design, copyright,
+  illustration, and market trust.
+- **Market and quality pressure:** Malkovych chose visually ambitious Ukrainian
+  books in a fragile post-Soviet market. KNPU credits projects such as
+  `Снігова королева`, `Улюблені вірші`, and the Harry Potter cycle with
+  bestseller status in Ukrainian editions; treat this as cultural infrastructure,
+  not automatic patriotism.
+- **Living-figure caution:** Malkovych remains active. BIO should build only on
+  completed, settled contributions: published poetry, the 1992 publishing house,
+  documented children's-book lists, and the 2017 Shevchenko Prize for
+  `Подорожник з новими віршами`. Avoid predictive claims about future leadership
+  or symbolic inevitability.
+
+## 3. Major works / contributions
+
+- **Early poetry and the 1980s generation:** ESU says first poems appeared in
+  `Літературна Україна` on 6 January 1981. KNPU presents `Білий камінь` (1984),
+  `Ключ` (1988), `Вірші` (1992), and `Із янголом на плечі` (1997) as early and
+  mid-career anchors.
+- **Poetry collections after independence:** ESU lists `Вірші на зиму` (2006),
+  `Все поруч` (2010/2011), and `Подорожник` (2013); KNPU records
+  `Подорожник з новими віршами` (Kyiv, `А-БА-БА-ГА-ЛА-МА-ГА`, 2016) as the
+  Shevchenko Prize work in literature / publicistics / journalism.
+- **Children's-book authorship and editing:** ESU names `Українська абетка`,
+  `Золотий павучок`, `Абетка`, `Вовченятко, яке запливло далеко в море`,
+  `Різдвяна рукавичка`, `Ліза та її сни`, `Велике місто, маленький зайчик, або
+  Мед для мами`, `Дитяча Євангелія`, `Улюблені вірші`, and `100 казок` among
+  books he edited, arranged, wrote, or translated for children.
+- **Publisher as cultural designer:** Chytomo Export identifies the company as
+  independent Ukraine's first private children's publisher, later expanding
+  beyond children's books. This supports a BIO arc in which design, illustration,
+  paper, translation rights, and reader trust become cultural work.
+
+## 4. Primary-source quote / visual anchors
+
+Use short excerpts only. Malkovych is living, and literary texts remain under
+copyright. The future learner module should quote sparingly and rely on linked or
+excerpt-only readings unless permissions / public excerpts are confirmed.
+
+- **`Напучування сільського вчителя` / `Свічечка букви "ї"` anchor:** the phrase
+  `крихітну свічечку букви "ї"` is the most useful short quotation. It condenses
+  his non-declamatory language-defense poetics: a child, a letter, a fragile
+  flame, and responsibility without official rhetoric.
+- **`Із янголом на плечі` anchor:** the title phrase `із янголом на плечі` is a
+  safe short anchor for the old-ballad, baroque, religious / folk-theatrical
+  register. It can lead to music settings by Maria Burmaka / Plach Yeremii, but
+  do not use song recordings as text source unless rights are checked.
+- **Interview / publishing credo anchor:** in The Ukrainians interview Malkovych
+  explains that at first he thought not about a publishing house but about "one
+  book" - the alphabet book beginning with `Ангел`. Use as a primary voice for
+  the bridge between poetry, childhood, and design.
+
+## 5. Language register
+
+- **Register:** lyrical, neo-baroque, prayer / ballad inflected, often child-
+  addressed; combines Carpathian mythopoetic memory, Christian and folk images,
+  compact metaphor, and careful sound patterning.
+- **CEFR readiness:** C1 for full literary and institutional module. B2+ excerpts
+  are possible for short poems or children's prose if heavily scaffolded, but the
+  publisher / postcolonial book-culture argument is C1.
+- **Lexicon notes:** `абетка`, `видавництво`, `упорядник`, `переспів`,
+  `дитяча література`, `книжка-картинка`, `книговидання`, `поліграфія`,
+  `вертепність`, `міфопоетика`, `бароковий`, `вісімдесятники`, `канон`,
+  `рецепція`, `деколонізація`.
+- **Stylistic features:** refrains, diminutives with serious stakes, candle /
+  letter imagery, angel / Herod / old-world ballad figures, music-like pacing,
+  and anti-urban Carpathian rootedness noted by ESU.
+- **Pedagogical caution:** Do not flatten the poetry into patriotic slogan.
+  Malkovych is useful because he often lowers the volume: the political work is
+  done through a letter, a child, a book page, a rhythm, or the physical quality
+  of Ukrainian print.
+
+## 6. Contested points
+
+- **Poet vs. publisher:** Popular memory often knows Malkovych through
+  `А-БА-БА-ГА-ЛА-МА-ГА`; literary treatment must keep the poet visible. The LIT-
+  YOUTH plan already asks whether the poet or the publisher is more important,
+  which should remain a live question rather than a verdict.
+- **Success-story risk:** It is tempting to tell a simple story: excellent books
+  in Ukrainian made readers patriotic. Use sources carefully. The Ukrainians
+  interview includes readers' memory and Maidan / wartime continuities, but that
+  is testimony and reception, not a deterministic claim about whole generations.
+- **Canonization while living:** Malkovych is already a prize-winning figure, but
+  he is alive and active. Avoid bronze-statue language. The strongest BIO tone is
+  institution-building under constraint, plus self-critique about taste, market,
+  and access.
+- **Commercial book culture:** Ukrainian rights, translation, high print quality,
+  and bestseller status are part of the story. Do not treat commerce as a stain,
+  but also do not equate sales with cultural value. Ask what expensive beautiful
+  books include and exclude.
+- **Source freshness:** Some recent interviews from 2025/2026 are useful for
+  voice and current perspective, but settled facts should still rest on ESU,
+  KNPU, ESU-ABABA, Chytomo, and library / book-sector sources.
+- **Public controversy:** Chytomo reported a 2019 PEN-related exit by Malkovych
+  and Maksym Strikha. If used later, summarize neutrally as public positioning,
+  not as either scandal bait or proof of character.
+- **Russianized forms:** Search results and foreign profiles may use
+  `Malkovich` or Russian-language name forms. Use them only in aliases /
+  disambiguation; body text should use Ukrainian canonical forms.
+
+## 7. Cross-track links
+
+**Existing LIT-YOUTH / wiki surfaces (VERIFIED `test -e` on 2026-07-01):**
+
+- `curriculum/l2-uk-en/plans/lit-youth/malkovych-poems.yaml`
+- `curriculum/l2-uk-en/lit-youth/discovery/malkovych-poems.yaml`
+- `wiki/literature/works/malkovych-poems.md`
+- `wiki/literature/works/malkovych-poems.sources.yaml`
+- `curriculum/l2-uk-en/plans/lit-youth/kids-poetry-anthology.yaml`
+
+**Candidate / do not list as Existing yet:**
+
+- `curriculum/l2-uk-en/plans/bio/ivan-malkovych.yaml` - absent at dossier stage.
+- `wiki/figures/ivan-malkovych.md` and `wiki/figures/ivan-malkovych.sources.yaml`
+  - absent at dossier stage.
+- `site/src/content/docs/bio/ivan-malkovych.mdx` - absent / locked; do not build
+  in this PR.
+- `wiki/lit/youth/malkovych-ivan.md` appears in the LIT-YOUTH plan as a future or
+  legacy-looking wiki path, but `test -e` failed on 2026-07-01. Do not cite as
+  existing.
+
+## 8. Naming-canonical
+
+- **Slug:** `ivan-malkovych`
+- **EN canonical (BGN/PCGN 2010):** Ivan Malkovych.
+- **UA canonical:** Іван Антонович Малкович.
+- **Aliases for future YAML:** `Іван Малкович`; `Іван Антонович Малкович`;
+  `Ivan Malkovych`; `Ivan Antonovych Malkovych`; `Iwan Malkowytsch` (German
+  library / Commons variant); `Ivan Malkovich` (legacy / non-canonical English,
+  FORBIDDEN in learner-facing body text unless discussing search variants);
+  `Иван Антонович Малкович` (Russian form, FORBIDDEN in body text).
+- **Potential confusion:** `John Malkovich` search results are unrelated and must
+  never be used as an image/source match.
+
+## 9. Image candidates
+
+- **Best CC portrait candidate:** `File:Malkovych.jpg` on Wikimedia Commons.
+  File page states September 2007, self-photographed / transferred from Russian
+  Wikipedia, author `User:Russianname` / `Водник`, with GFDL and CC-BY-SA 3.0 /
+  2.5 license metadata. Verify individual file page before use.
+- **Backup CC event images:** `File:Andrukhovych_Malkovych_Yerko_02.jpg` and
+  `File:Andrukhovych_Malkovych_Yerko_03.jpg`, Wikimedia Commons, Arsenal Book
+  Festival 2016, author `Qypchak`, CC-BY-SA 4.0. Useful for literary-network /
+  book-culture framing rather than solo portraiture.
+- **Category to inspect:** `Category:Ivan Malkovych` on Wikimedia Commons lists
+  27 files. Do not assume the whole category is uniformly reusable; check each
+  selected file page license and subject identification.
+- **Avoid unless separately licensed:** book covers from `А-БА-БА-ГА-ЛА-МА-ГА`,
+  publisher promo photos, Facebook/Instagram images, and interview portraits.
+  They may be useful for source-reading, but not embeddable by default.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- Тарнашинська Л. Б. "Малкович Іван Антонович." Енциклопедія Сучасної України.
+  Інститут енциклопедичних досліджень НАН України, 2018.
+  https://esu.com.ua/article-63143. Accessed 2026-07-01.
+- Тарнашинська Л. Б. "А-ба-ба-га-ла-ма-га." Енциклопедія Сучасної України.
+  Інститут енциклопедичних досліджень НАН України, 2001.
+  https://esu.com.ua/article-42130. Accessed 2026-07-01.
+
+**Tier 2 (institutional / field-specific):**
+
+- Комітет з Національної премії України імені Тараса Шевченка. "Малкович Іван
+  Антонович." https://knpu.gov.ua/winners/malkovych-ivan-antonovych/. Accessed
+  2026-07-01.
+- Комітет з Національної премії України імені Тараса Шевченка. "`Подорожник з
+  новими віршами`." https://knpu.gov.ua/archive/podorozhnik-z-novimi-virshami/.
+  Accessed 2026-07-01.
+- Видавництво `А-БА-БА-ГА-ЛА-МА-ГА`. "Малкович Іван."
+  https://ababahalamaha.com.ua/uk/Малкович_Іван. Accessed 2026-07-01.
+- Chytomo Export. "Видавництво А-БА-БА-ГА-ЛА-МА-ГА."
+  https://export.chytomo.com/publisher/tov-vydavnycztvo-ivana-malkovycha-a-ba-ba-ga-la-ma-ga/.
+  Accessed 2026-07-01.
+- Тернопільська обласна бібліотека для дітей. `Батько дитячого книжкового дива:
+  Івану Малковичу - 60`, methodical-bibliographic material, 2021.
+  https://chl.kiev.ua/mbm/тексти/2021/Батько%20дитячого_Малковичу%2060.pdf.
+  Accessed 2026-07-01.
+
+**Tier 3 (encyclopedic / navigation):**
+
+- Wikimedia Commons. `Category:Ivan Malkovych`, `File:Malkovych.jpg`,
+  `File:Andrukhovych_Malkovych_Yerko_02.jpg`, and
+  `File:Koronatsiya_Slova_2013_1936_03.jpg`. Used only for image-rights leads;
+  individual file pages require final license verification before embedding.
+
+**Tier 4 / field-specific literary profiles:**
+
+- Poetry International. "Ivan Malkovych." https://www.poetryinternational.com/en/poets-poems/poets/poet/102-5521_Malkovych.
+  Accessed 2026-07-01.
+- BaraBooka. "Малкович Іван." https://www.barabooka.com.ua/ivan-malkovich/.
+  Accessed 2026-07-01.
+
+**Tier 5 / interview and public voice:**
+
+- The Ukrainians. "Іван Малкович: Як А-БА-БА-ГА-ЛА-МА-ГА змінила Україну."
+  https://theukrainians.org/ivan-malkovych-abetka/. Accessed 2026-07-01. Used
+  for recent first-person voice and reception, not as sole source for settled
+  facts.
+- Chytomo. "Малкович і Стріха вийшли з ПЕН-клубу..."
+  https://chytomo.com/malkovych-i-strikha-vyjshly-z-pen-klubu-na-znak-nezhody-iz-zaiavoiu-na-pidtrymku-avtora-paradu-chleniv/.
+  Accessed 2026-07-01. Used only as a caution source for public controversy.
+
+**Primary-source documents accessed:**
+
+- N/A for state-security / court / rehabilitation files. Public poetry excerpts
+  consulted only as short anchors; use brief excerpts unless permissions are
+  secured.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing
+- [x] No Russian-imperial transliterations in body text except labelled aliases /
+  search-variant warnings
+- [x] Ukrainian language pressure named without turning the living figure into a
+  fabricated Soviet persecution case
+- [x] Living-figure canonicity-over-currency rule applied
+- [x] Cross-track paths verified before listing as Existing
+- [x] Image candidates license-checked at file-page level before recommendation


### PR DESCRIPTION
## Summary

- Adds BIO #376 `ivan-malkovych` research dossier only.
- Frames Ivan Malkovych as a living poet-publisher and Ukrainian children's book culture institution-builder.
- Records verified LIT-YOUTH/wiki cross-track paths, living-figure cautions, naming aliases, source tiers, and Commons image candidates.

## Scope

Changed file:
- `docs/research/bio/ivan-malkovych.md`

Not included:
- No plan YAML, module markdown, activities, vocabulary, resources, site MDX, wiki figure packet, status/audit/review artifacts, telemetry, package files, or linter config changes.

## Validation

- `git diff --check origin/main..HEAD`
- `npx markdownlint-cli2 docs/research/bio/ivan-malkovych.md`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/ivan-malkovych.md`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `.venv/bin/python` section/path check for all 10 dossier sections and verified local cross-track paths

Note: the handoff suggested `lint_bio_dossier_xref.py --check`, but the current script interface does not support `--check`; reran with the current accepted CLI.

## BIO Status

- BIO stage: base-prep dossier
- Current BIO number: #376
- Current slug: `ivan-malkovych`
- Next queued slug after merge: #377 `oles-berdnyk`
- Open BIO PRs before this PR: none found by `gh pr list --state open --search "bio OR BIO"`
- Forbidden artifacts included: no

## Helper Usage

swarm_used: true
swarm_label: helper
swarm_note: two read-only helper explorers used: one source-pack explorer for Malkovych evidence/primary voice, one repo/image-rights explorer for existing path and Commons license checks; Codex orchestrator integrated and validated the final dossier.
