### PR TITLE
docs(bio): add Oles Berdnyk dossier

### DIFF
--- a/docs/research/bio/oles-berdnyk.md
+++ b/docs/research/bio/oles-berdnyk.md
@@ -1,0 +1,285 @@
+# Олесь (Олександр) Павлович Бердник - Research Dossier
+
+**Slug:** `oles-berdnyk`
+**Block:** +77 expansion - literary / civic / speculative imagination additions
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #377
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Source acronym legend:** ESU = Encyclopedia of Modern Ukraine; EIU =
+Encyclopedia of the History of Ukraine; KHPG = Kharkiv Human Rights Protection
+Group / Dissident Movement in Ukraine archive; UINP = Ukrainian Institute of
+National Memory; UHHRU = Ukrainian Helsinki Human Rights Union; CIUS =
+Canadian Institute of Ukrainian Studies archives; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional sources cited
+- [x] Repression mechanism includes dates, articles, agencies, camp locations,
+  censorship order, UHG role, and later coerced/contested recantation
+- [x] At least 2 primary-source text / voice anchors supplied
+- [x] Cross-track links verified with `test -e` on 2026-07-01 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Олесь (Олександр) Павлович Бердник. Use
+  `Олесь Бердник` for display, with `Олександр Павлович Бердник` in aliases.
+- **Project English canonical:** Oles Berdnyk.
+- **Born:** ESU gives 27 November 1926, Vavylove, then Snihurivka district,
+  Kherson region, now Mykolaiv region. KHPG preserves the document date
+  25 December 1927 but explicitly notes that he was actually born in 1926.
+- **Died:** 18 March 2003, Kyiv. KHPG records burial in Hrebeni, Kyiv region,
+  under a viburnum he had planted.
+- **Family / education / early work:** KHPG says his family moved to Kyiv in
+  1930 and later to the village of Kyiiv (`Кийлів`), Boryspil district, where
+  he experienced the Holodomor as a child. He volunteered for the army in late
+  1943, was wounded,
+  demobilized in 1946, and studied in 1946-1949 at the theatre studio attached
+  to the Ivan Franko theatre in Kyiv. ESU records theatre-studio graduation in
+  1949 and early acting work.
+- **Core BIO identity:** Berdnyk is both a major Ukrainian speculative writer
+  and a Ukrainian Helsinki Group figure. The future lesson must hold together
+  cosmic / spiritual prose, Soviet censorship, prison-camp experience,
+  rights-movement work, and later controversial public turns.
+
+## 2. Oppression mechanism
+
+- **First Soviet case:** KHPG says Berdnyk was arrested on 24 October 1949 in
+  Halych after an open-party-meeting speech at the Ivan Franko theatre during
+  the anti-"cosmopolitan" campaign. State-security lieutenant Rozumnyi charged
+  him with counterrevolutionary propaganda and agitation. On 23 April 1950 he
+  was convicted under Article 54-10 of the Criminal Code of the Ukrainian SSR
+  and sentenced to 10 years' imprisonment, 5 years' exile, and 3 years' loss of
+  rights. ESU gives the same arrest and sentence dates, summarizing the charge
+  as `зрада Батьківщині`; treat that ESU phrase as a broad summary, not as a
+  replacement for KHPG's precise Article 54-10 anti-Soviet-agitation frame.
+- **Camp sequence and escape:** KHPG records imprisonment near Kyiv, in Pechora,
+  and in Karaganda camps. Berdnyk escaped on 10 October 1953, was recaptured,
+  and received a new 10-year sentence under Article 58-14 of the RSFSR code. He
+  was pardoned in 1955; ESU gives release in 1954, so use KHPG for the detailed
+  camp chronology and flag the release-date difference if it becomes
+  load-bearing.
+- **Censorship pressure before UHG:** In April 1972 KGB officers searched the
+  Rudenko apartment where Berdnyk was living, seized Ivan Dziuba's
+  `Інтернаціоналізм чи русифікація?` and two typewriters. Berdnyk and Valentyna
+  Sokorynska-Berdnyk undertook a 16-day hunger strike. KHPG says the typewriters
+  were returned, but advertising of his public appearances was stopped and his
+  works stopped appearing.
+- **Book-removal order:** KHPG records Main Directorate for the Protection of
+  State Secrets in the Press order No. 31 of 13 August 1976, ordering Berdnyk's
+  books removed from general and special libraries and from the Soviet book
+  trade. He was also excluded from the writers' union and worked as a decorator
+  / stained-glass artist at the `Художник` association.
+- **Ukrainian Helsinki Group work:** Berdnyk became a founding member of the UHG
+  on 9 November 1976, signing the Declaration and Memorandum No. 1. KHPG records
+  his participation in letters, memoranda, searches, confiscations, and transfer
+  of UHG materials abroad. UINP and UHHRU identify him among the founders, and
+  both note that he informally helped lead the group after arrests of other
+  members.
+- **Second Soviet case:** Berdnyk was arrested on 6 March 1979 for
+  "anti-Soviet agitation and propaganda." On 17-21 December 1979 the Kyiv
+  regional court sitting in Kaharlyk sentenced him under Article 62 part 2 of
+  the Ukrainian SSR code and Article 70 part 2 of the RSFSR code to 6 years in
+  special-regime camps and 3 years' exile. KHPG says he was declared an
+  especially dangerous recidivist. He was held in Perm camp VS-389/36-1 at
+  Kuchino, later VS-389/35, and was pardoned by decree of 14 March 1984.
+- **Contested recantation:** KHPG records a 17 May 1984 statement in
+  `Літературна Україна` denouncing the Helsinki movement and Rudenko /
+  Lukyanenko. Future BIO work must treat this as a documented, damaging
+  pressure-era rupture in public memory. Do not erase it in hagiography; do not
+  present it as a simple free-worldview shift without prison and pardon context.
+
+## 3. Major works / contributions
+
+- **Ukrainian science fiction:** ESU calls Berdnyk one of the founders of the
+  science-fiction genre in Ukrainian literature. Early works include `Поза часом
+  і простором` (1956), `Шляхи титанів` (1958), `Стріла часу` (1960), `Серце
+  Всесвіту` (1962), `Діти Безмежжя` (1964), `Подвиг Вайвасвати` (1965),
+  `Хто ти?` (1966), `Чаша Амріти` (1968), and `Покривало Ізіди` (1969).
+- **`Зоряний корсар`:** ESU identifies the banned 1971 novel as the first book
+  of the later `Камертон Дажбога` dilogy and treats it as programmatic for
+  Berdnyk's cosmic-spiritual vision. Existing LIT-FANTASTIKA plans already
+  center this novel; future BIO planning should cross-reference them instead of
+  duplicating or contradicting them.
+- **Poetry / exile-era texts:** ESU lists `Блакитний коваль` (Toronto, 1975),
+  `Кажу Вам (Священні знаки)` (Kyiv / New York, 1989), the cycle `Зорі крізь
+  грати`, and poems / dramatic poems such as `По Ра...`, `Тарасове закляття`,
+  `Остання ніч`, and `Тартар`.
+- **Post-release civic / spiritual projects:** KHPG records `Ноосферний фронт
+  "Зоряний ключ"` in 1987, election as leader of `Українська Духовна
+  Республіка` in 1989, world sobor activity in Kolomyia in 1990, and an
+  unregistered 1991 presidential candidacy. This is central to reception but
+  must be handled analytically, not as cultic endorsement or mockery.
+- **Public recognition:** Presidential Decree No. 937/2006 posthumously awarded
+  Berdnyk the Order "For Courage" I class among founders and activists of the
+  Ukrainian Helsinki Group.
+
+## 4. Primary-source quote / visual anchors
+
+Use short excerpts only. Berdnyk's literary texts remain under copyright unless
+rights are separately cleared; public institutional excerpts can anchor source
+reading but should not become long quoted passages.
+
+- **Holodomor autobiographical anchor:** UINP quotes the opening `Настав
+  страшний рік. Тридцять третій.` from `Пітьма вогнища не розпалює...`. This is
+  the most compact bridge between childhood memory and later ethical / cosmic
+  writing.
+- **Self-description anchor:** KHPG's interview with Valentyna
+  Sokorynska-Berdnyk reports Berdnyk's line `Я проповідник... через фантастичну
+  літературу`. Use cautiously because it is relayed by his wife, but it explains
+  how he understood genre.
+- **UHG document anchor:** KHPG records Berdnyk writing the 9 November 1977
+  `Маніфест Українського Правозахисного Руху` and other appeals. Future module
+  work should connect him to UHG documents, not only to later mysticism.
+- **Visual anchor:** The 1988 Commons photograph of Berdnyk speaking at a Kyiv
+  science-fiction-club conference is useful because it shows a post-release
+  public writer, not a state-security image.
+
+## 5. Language register
+
+- **Register:** elevated, prophetic, philosophical, mythopoetic, often
+  declamatory; combines science-fiction vocabulary, Christian / gnostic imagery,
+  Ukrainian national allegory, cosmic evolution, and rhetorical pathos.
+- **CEFR readiness:** C1 guided excerpts from `Зоряний корсар`; C2 full essays
+  and late spiritual-political texts. B2 excerpts are possible only as short
+  scene-based passages with heavy vocabulary support.
+- **Lexicon notes:** `фантастика`, `космізм`, `ноосфера`, `кордоцентризм`,
+  `УГГ`, `самвидав`, `антирадянська агітація`, `спецтабір`, `заслання`,
+  `візія`, `утопія`, `езотерика`, `правозахисний рух`, `Голодомор`.
+- **Stylistic features:** neologisms, allegorical empires / prisons, spiritual
+  transformation language, cosmic scale, rhetorical questions, mythic naming,
+  and futurist blends of Ukrainian cultural memory.
+
+## 6. Contested points
+
+- **Birth-date discrepancy:** Prefer 27 November 1926 per ESU, while noting the
+  KHPG document-date variant 25 December 1927. Do not flatten the discrepancy.
+- **Death-place discrepancy:** ESU and KHPG give death in Kyiv; some secondary
+  profiles connect death to Hrebeni. Treat Hrebeni as burial / late-life place
+  unless a stronger source proves death there.
+- **1984 statement:** This is the hardest anti-hagiographic point. It must be
+  included with prison/pardon pressure context and with attention to damage it
+  caused in UHG memory.
+- **Mysticism / politics:** Berdnyk's late Ukrainian Spiritual Republic,
+  noospheric projects, Christian-gnostic vocabulary, and 1991 political
+  ambitions are part of reception. Do not mock them, but do not teach them as
+  neutral truth claims.
+- **Genre inflation:** He is central to Ukrainian speculative writing, but avoid
+  claiming he founded every Ukrainian fantasy or science-fiction subgenre unless
+  a source explicitly supports the narrower claim.
+- **Russocentric risk:** Do not frame him as a "Soviet/Russian sci-fi dissident."
+  Center Ukrainian-language literary culture, the Ukrainian rights movement, and
+  Soviet suppression of Ukrainian public agency.
+
+## 7. Cross-track links
+
+- **Existing LIT-FANTASTIKA / wiki surfaces (VERIFIED `test -e` on
+  2026-07-01):**
+  - `curriculum/l2-uk-en/plans/lit-fantastika/berdnyk-star-corsair-1.yaml`
+  - `curriculum/l2-uk-en/plans/lit-fantastika/berdnyk-star-corsair-2.yaml`
+  - `curriculum/l2-uk-en/plans/lit-fantastika/berdnyk-prometheus.yaml`
+  - `wiki/literature/works/berdnyk-star-corsair-1.md`
+  - `wiki/literature/works/berdnyk-star-corsair-2.md`
+  - `wiki/literature/works/berdnyk-prometheus.md`
+- **Candidate / do not list as existing yet:**
+  - `curriculum/l2-uk-en/plans/bio/oles-berdnyk.yaml`
+  - `wiki/figures/oles-berdnyk.md`
+  - `wiki/figures/oles-berdnyk.sources.yaml`
+  - `site/src/content/docs/bio/oles-berdnyk.mdx`
+  - Legacy-looking metadata paths such as `wiki/lit/berdnyk-oles.md`,
+    `wiki/lit/berdnyk-star-corsair.md`, and `wiki/lit/berdnyk-prometheus.md`
+    are not current files in the repo layout.
+
+## 8. Naming-canonical
+
+- **Slug:** `oles-berdnyk`
+- **EN canonical (BGN/PCGN 2010):** Oles Berdnyk.
+- **UA canonical:** Олесь (Олександр) Павлович Бердник; display
+  `Олесь Бердник`.
+- **Aliases future YAML:** `Олександр Павлович Бердник`; `Олесь Павлович
+  Бердник`; `Oles Berdnyk`; `Oleksandr Pavlovych Berdnyk`; `Oles' Berdnyk`
+  (legacy apostrophe variant); `Григорій Волосожар` (pseudonym, source-check
+  before learner display).
+- **Forbidden / noncanonical body forms:** `Oles' Berdnik`; `Oleś Berdnyk`;
+  Russian patronymic or Russian title forms as learner-facing defaults; source
+  titles may be reproduced in bibliography only.
+
+## 9. Image candidates
+
+- **Best CC candidate:** Wikimedia Commons
+  `File:Олесь Бердник - Всесоюзная конференция Клубов любителей фантастики,
+  Киев, 1988.jpg`; date 17 March 1988; author Dmitrii Kraiukhin; license
+  CC-BY-SA 4.0. Verify the individual file page before final image packaging.
+- **Additional candidate:** EIU portrait image appears on a page whose hosting
+  terms indicate CC BY-SA for text/images, but image-level attribution and reuse
+  metadata should be checked before production use.
+- **Rights-review only:** KHPG page images, State Archives PDF images, and OUN
+  archive photos are useful for source reading but not safe as default UI images
+  without separate license confirmation.
+- **Avoid:** unsourced social-media portraits, book covers without publisher
+  license, propaganda / secret-police visual material unless explicitly taught
+  as document evidence.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- Герасимова Г. П. "Бердник Олесь (Олександр) Павлович." Енциклопедія
+  Сучасної України. Інститут енциклопедичних досліджень НАН України, 2003.
+  https://esu.com.ua/article-39187. Accessed 2026-07-01.
+- Енциклопедія історії України / Інститут історії України НАН України.
+  "Бердник Олесь (Олександр) Павлович."
+  https://resource.history.org.ua/cgi-bin/eiu/history.exe?S21STR=Berdnyk_O.
+  Accessed 2026-07-01.
+- Президент України. Указ No. 937/2006 "Про відзначення державними нагородами
+  України засновників та активістів Української Громадської Групи сприяння
+  виконанню Гельсінкських угод."
+  https://www.president.gov.ua/documents/9372006-5025. Accessed 2026-07-01.
+
+**Tier 2 (institutional / rights-history / memory institutions):**
+
+- Харківська правозахисна група, Віртуальний музей "Дисидентський рух в
+  Україні." "Бердник Олександр (Олесь) Павлович."
+  https://museum.khpg.org/1113843843. Accessed 2026-07-01.
+- Харківська правозахисна група. "Бердник Олесь Павлович. Інтерв'ю з
+  Валентиною Сокоринською-Бердник." https://museum.khpg.org/1197812917.
+  Accessed 2026-07-01.
+- Український інститут національної пам'яті. "1976 - утворення Української
+  гельсінської групи."
+  https://uinp.gov.ua/istorychnyy-kalendar/lystopad/9/1976-utvorennya-ukrayinskoyi-gelsinskoyi-grupy.
+  Accessed 2026-07-01.
+- Українська Гельсінська спілка з прав людини. "Українська Громадська Група
+  сприяння виконанню Гельсінських угод."
+  https://www.helsinki.org.ua/articles/ukrajinska-hromadska-hrupa-spryyannya-vykonannyu-helsinskyh-uhod/.
+  Accessed 2026-07-01.
+- Український інститут національної пам'яті. "Інформаційні матеріали до 88-х
+  роковин Голодомору 1932-1933 років."
+  https://uinp.gov.ua/informaciyni-materialy/derzhsluzhbovcyam/informaciyni-materialy-ukrayinskogo-instytutu-nacionalnoyi-pamyati-do-88-h-rokovyn-golodomoru-1932-1933-rokiv.
+  Accessed 2026-07-01.
+
+**Tier 3 (navigation / encyclopedic):**
+
+- Українська Вікіпедія. "Бердник Олесь Павлович." Used only to identify common
+  discrepancies and search paths; checked against ESU and KHPG.
+- Wikimedia Commons.
+  `File:Олесь Бердник - Всесоюзная конференция Клубов любителей фантастики,
+  Киев, 1988.jpg`. Accessed 2026-07-01.
+
+**Tier 4 (scholarly / diaspora):**
+
+- Dobczansky, Jurij. "Oles Berdnyk: Bibliographical Overview." Journal of
+  Ukrainian Graduate Studies, Vol. 4, Issue 1, CIUS Archives, 1979.
+  https://cius-archives.ca/items/show/367. Accessed 2026-07-01.
+
+**Primary-source documents accessed / identified for later learner work:**
+
+- KHPG references to UHG documents, memoranda, Berdnyk's 1977 manifesto, and
+  the 1984 `Літературна Україна` statement. Full source-edition check still
+  needed before learner-facing quotation beyond short anchors above.


### PR DESCRIPTION
## Scope

Adds the dossier-only BIO #377 source pack for `oles-berdnyk`.

Changed file:
- `docs/research/bio/oles-berdnyk.md`

No plan YAML, module markdown, activities, vocabulary, resources, MDX, generated status/audit/review artifacts, telemetry, linter config, or package files are touched.

## BIO coverage

- Separates 1949 Stalin-era case, 1953 escape/sentence, and 1979 UHG prosecution.
- Preserves source discrepancy on birth date: ESU 27 Nov 1926; KHPG document-date variant 25 Dec 1927 with actual 1926 note.
- Covers censorship order No. 31, UHG founding/leadership role, camps, pardon, 1984 recantation context, late Ukrainian Spiritual Republic reception, and image-rights candidates.
- Keeps absent BIO surfaces as candidate-only and verified existing LIT-FANTASTIKA links under `wiki/literature/works/`.

## Helper checks

- Source-pack explorer returned ESU, EIU, KHPG, UINP, UHHRU, Presidential Decree No. 937/2006, and primary/samizdat candidates.
- Repo/image explorer confirmed no built BIO #377 files exist, verified current LIT-FANTASTIKA/wiki paths, and identified the 1988 Commons CC BY-SA 4.0 image as the best candidate.

## Validation

- `npx markdownlint-cli2 docs/research/bio/oles-berdnyk.md`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/oles-berdnyk.md`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Notes

Independent read-only Claude review is still required before merge.
