### PR TITLE
docs(bio): add Natalena Koroleva dossier

### DIFF
--- a/docs/research/bio/natalena-koroleva.md
+++ b/docs/research/bio/natalena-koroleva.md
@@ -1,0 +1,317 @@
+# Наталена Андріанівна Королева - Research Dossier
+
+**Slug:** `natalena-koroleva`
+**Block:** +77 expansion - diaspora / historical prose / European-Ukrainian bridge
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #378
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Source acronym legend:** ESU = Encyclopedia of Modern Ukraine; EIU =
+Encyclopedia of the History of Ukraine; EU = Internet Encyclopedia of Ukraine;
+Diasporiana = Ukrainian diaspora digital library; UHJ = Ukrainian Historical
+Journal; NBUV = Vernadsky National Library of Ukraine authority catalogue; LNU
+Library = Ivan Franko National University of Lviv Scientific Library; Commons =
+Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional or scholarly sources cited
+- [x] Oppression / pressure mechanism framed as exile, archive fragility, and
+  Soviet-era erasure; no invented arrest, camp, or KGB case
+- [x] At least 2 primary-source text / voice anchors supplied
+- [x] Cross-track links verified with `test -e` on 2026-07-01 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Наталена Андріанівна Королева.
+- **Project English canonical:** Natalena Koroleva.
+- **Birth:** ESU and EIU give 3 March 1888, monastery of San Pedro de Cardeña
+  near Burgos, Spain. Use this as the project date/place while noting in §6 that
+  scholarship also tracks Volhynia / Lutsk document variants and that early-life
+  evidence is unusually contested.
+- **Death:** ESU and EIU give 1 July 1966, Melnik, then Czechoslovakia, now
+  Czechia.
+- **Family / identity frame:** ESU and EIU present her as a writer, art
+  historian, and archaeologist; wife of Vasyl Koroliv-Staryi. EIU identifies her
+  father as Polish count Adrian Dunin-Borkowski and her mother as Maria-Clara de
+  Castro Lacerda Medina of an old Spanish family. Treat these inherited-status
+  claims with scholarly caution because later research flags weak documentation
+  for the first decades of her life.
+- **Education / skills:** ESU records education in the Notre-Dame de Sion
+  convent in France, residence in Kyiv from 1904, graduation from the Kyiv
+  Institute for Noble Maidens in 1906, music lessons with Mykola Lysenko, and
+  later study at archaeological and art institutions in St Petersburg. EIU also
+  notes dramatic courses and stage work.
+- **Core BIO identity:** Koroleva is a non-ethnic-Ukrainian, European-educated
+  author who deliberately entered Ukrainian literature in exile. Her biography
+  is useful for teaching Ukrainian literary identity as cultural choice,
+  language apprenticeship, and diaspora historical imagination rather than
+  bloodline or birthplace.
+
+## 2. Oppression / pressure mechanism
+
+- **Not a prison-case biography:** Do not invent an arrest, Gulag sentence,
+  secret-police case, or formal Soviet trial. Koroleva's pressure mechanism is
+  displacement, political emigration, post-war poverty, and Soviet-era literary
+  erasure.
+- **World War I and UPR displacement:** ESU says she was in Kyiv at the
+  beginning of World War I and joined the Red Cross. EIU records that in 1919
+  she worked in the diplomatic mission of the Ukrainian People's Republic in
+  Czechoslovakia. ESU says she left for Prague with that mission and remained
+  there.
+- **Language and exile:** EIU says she began publishing in French in 1909 and
+  began writing fiction in Ukrainian from 1919 on Vasyl Koroliv-Staryi's advice.
+  His role matters, but the dossier must not reduce her Ukrainian authorship to
+  being "made Ukrainian by her husband": sources also show her own multilingual
+  preparation, Ukrainian attachments, and sustained literary agency. Her first
+  Ukrainian story, `Гріх (з пам'ятної книжки)`, appeared in the Vienna Ukrainian
+  weekly `Воля` on 15 January 1921 under the signature `Н. Ковалівська-Короліва`.
+- **Soviet canon erasure:** Her core books appeared in Lviv, Prague, Chicago,
+  Toronto, Cleveland, and Presov rather than Soviet Ukraine. Future BIO should
+  explain how geography, emigration, Catholic / European themes, and UPR links
+  made her difficult to absorb into Soviet school canon.
+- **Late-life isolation:** Popular and library profiles describe the final
+  decades in Czechoslovakia as materially difficult and poorly visible to Soviet
+  Ukrainian readers. Treat this as reception / erasure evidence unless backed by
+  archival documents for a specific pension or censorship claim.
+- **Post-1991 return:** `Предок` appeared in Kyiv in 1991 according to ESU, and
+  later Ukrainian editions revived `Легенди старокиївські` and autobiographical
+  prose. The curriculum should frame this as recovery of a displaced literary
+  branch, not as sudden discovery of an uncomplicated heroine.
+
+## 3. Major works / contributions
+
+- **Historical prose across civilizations:** ESU says Koroleva depicted ancient
+  Rome, the early Christian era, medieval Europe, and ancient Ukrainian history.
+  This makes her a bridge figure between Ukrainian historical prose and wider
+  Mediterranean / Christian / European cultural memory.
+- **Ukrainian-language prose after 1919:** EIU records that she began writing
+  Ukrainian fiction after Vasyl Koroliv-Staryi's advice; this is a central BIO
+  moment because Ukrainian authorship becomes chosen practice, not inherited
+  default.
+- **Major works:** ESU lists `Во дні они` (1935), `Інакший світ` (1936),
+  `Подорожній` (Toronto, 1953), `Предок` (1937; Kyiv, 1991), `Сон тіні` (1938;
+  Presov, 1966), `Quid est veritas?` (Chicago, 1961), `Без коріння` (1936;
+  Cleveland, 1968), and `Легенди старокиївські` (Prague, 1942). EIU also names
+  `1313`, `Останній біг`, `Шляхами і стежками життя`, and `Місячні арфи`.
+- **`Легенди старокиївські`:** Diasporiana preserves the Prague 1942 edition.
+  Existing LIT-HIST-FIC planning already uses this work, so BIO should
+  cross-link rather than duplicate the literary module.
+- **Translation / religious prose:** ESU records her Ukrainian translation of
+  Thomas a Kempis's medieval Christian text `Наслідування Христа` (Zhovkva,
+  1923). This supports a register of Catholic / Christian humanist culture that
+  must be explained, not flattened into Orthodox-only national memory.
+- **Archive and research value:** ESU says part of her archive is preserved in
+  the manuscript department of the Institute of Literature of the NAS of Ukraine
+  in Kyiv. UHJ scholarship treats her life and work as an open research field,
+  especially because autobiographical material and documentary evidence do not
+  always align cleanly.
+
+## 4. Primary-source quote / visual anchors
+
+Use short excerpts only. Koroleva died in 1966, so her literary works remain
+copyright-sensitive in Ukraine until the posthumous term expires; future lessons
+should use short excerpts, public-domain contextual material, or cleared
+editions.
+
+- **Title anchor:** `Без коріння` is a compact autobiographical concept for
+  rootlessness, chosen belonging, and the problem of writing oneself into a new
+  language.
+- **First Ukrainian publication anchor:** `Гріх (з пам'ятної книжки)`, printed
+  in `Воля` on 15 January 1921, marks the turn from French-language publication
+  to Ukrainian prose.
+- **Kyiv legend anchor:** `Легенди старокиївські` lets the module connect
+  biography to existing LIT-HIST-FIC work on ancient Kyiv, legend, and historical
+  imagination.
+- **Self-positioning anchor:** Later profiles quote her phrase about becoming a
+  Ukrainian writer after seeing Volyn and Kyiv; if used, keep to a short phrase
+  such as `духовну землю` and cite the edition or letter source, not only a
+  retelling.
+- **Exile-politics anchor:** `Будувати державу з еміграції є чистий абсурд` is
+  a sharp political / diaspora reflection, but needs edition-level citation
+  before learner-facing use.
+- **Non-xenophobic decolonization anchor:** `Не слід навчати ненависти` is a
+  useful short phrase for separating Ukrainian cultural choice from ethnic
+  hostility; verify the full letter context before quoting.
+- **Authorial-method anchor:** Her image of `двома невтомними садівниками` for
+  `Легенди` helps explain imagination plus affection rather than strict
+  historiography.
+- **Visual anchor:** The Commons 1905 public-domain portrait is the first
+  portrait candidate. A source-object fallback is the 1942 Prague
+  `Легенди старокиївські` title page, but only after rights/provenance review.
+
+## 5. Language register
+
+- **Register:** ornate, historical, neoromantic, learned, Christian-humanist,
+  sometimes archaizing; draws on archaeology, medieval legend, Roman / early
+  Christian settings, and a deliberately Europeanized Ukrainian prose horizon.
+- **CEFR readiness:** C1 for guided excerpts from `Легенди старокиївські`;
+  C2 for `Quid est veritas?`, `Сон тіні`, and essays / autobiographical prose.
+  B2 use should be limited to short narrative passages with strong vocabulary
+  support.
+- **Lexicon notes:** `легенда`, `історична белетристика`, `еміграція`,
+  `безкорінність`, `археологія`, `єгиптологія`, `католицький`, `раннє
+  християнство`, `середньовіччя`, `історіософія`, `міфотворення`,
+  `княжий Київ`, `діаспора`, `переклад`.
+- **Stylistic features:** long periodic sentences, antique and biblical
+  allusions, archaic or elevated diction, foreign names and Latin phrases,
+  legend-like framing, moral-philosophical reflection.
+- **Pedagogical caution:** Do not reduce her to "Spanish countess becomes
+  Ukrainian writer." That hook is useful, but the lesson must move quickly to
+  craft, language choice, historical imagination, and the contested status of
+  her self-narrated biography.
+
+## 6. Contested points
+
+- **Birthplace and early-life documentation:** K-PNU Library, UHJ-linked
+  scholarship, and identity-construction research warn that the first decades of
+  Koroleva's life are difficult to document and often depend on autobiographical
+  works, letters, and later retellings. Present the ESU/EIU Spanish birth-place
+  version as the project default, but flag the Volhynia / Lutsk document trail
+  and the evidence problem.
+- **Autobiography vs. mythmaking:** Some scholarship treats facts in her works
+  as autobiographical evidence; other scholarship warns about self-mythologizing
+  and genealogical invention. Future BIO work should not present every
+  adventurous claim as archival fact.
+- **Name at birth:** Popular sources give long Spanish-style names with
+  variant order/spelling. Keep `Наталена Андріанівна Королева` as project
+  canonical and place long birth-name forms only in aliases with source caution.
+- **Inflated credentials:** Claims about exact language count, multiple
+  doctorates, royal-court intimacy, and some travel / expedition details need
+  separate archival confirmation. Use conservative phrasing unless the lesson
+  has a source in hand.
+- **Not "foreign curiosity":** Her Spanish / Polish / Catholic / European
+  background should not make her a decorative exotic exception. The BIO question
+  is how Ukrainian literature has been built by chosen affiliation and diaspora
+  institutions as well as by native-born writers.
+- **Catholic lens on Kyiv:** Existing LIT-HIST-FIC planning rightly identifies a
+  Catholic / European lens on early Ukrainian history. Teach this as a productive
+  interpretive angle with limits, not as a replacement for Orthodox, Byzantine,
+  Jewish, steppe, and local Ukrainian contexts.
+- **Soviet erasure vs. simple victimhood:** She was neglected and difficult to
+  access in Soviet Ukraine, but this is not the same mechanism as direct
+  imprisonment. Keep categories precise.
+
+## 7. Cross-track links
+
+- **Existing LIT-HIST-FIC / wiki surfaces (VERIFIED `test -e` on 2026-07-01):**
+  - `curriculum/l2-uk-en/plans/lit-hist-fic/natalena-koroleva-lehendy.yaml`
+  - `curriculum/l2-uk-en/lit-hist-fic/discovery/natalena-koroleva-lehendy.yaml`
+  - `wiki/literature/works/natalena-koroleva-lehendy.md`
+  - `wiki/literature/works/natalena-koroleva-lehendy.sources.yaml`
+- **Existing BIO adjacent context (VERIFIED `test -e` on 2026-07-01):**
+  - `curriculum/l2-uk-en/plans/bio/vasyl-koroliv-staryi.yaml`
+  - `curriculum/l2-uk-en/plans/bio/dokiia-humenna.yaml`
+- **Candidate / do not list as existing yet:**
+  - `curriculum/l2-uk-en/plans/bio/natalena-koroleva.yaml`
+  - `wiki/figures/natalena-koroleva.md`
+  - `wiki/figures/natalena-koroleva.sources.yaml`
+  - `site/src/content/docs/bio/natalena-koroleva.mdx`
+  - `site/src/content/docs/lit-hist-fic/natalena-koroleva-lehendy.mdx`
+  - `curriculum/l2-uk-en/bio/378-natalena-koroleva.md`
+  - `curriculum/l2-uk-en/bio/activities/natalena-koroleva.yaml`
+  - `curriculum/l2-uk-en/bio/vocabulary/natalena-koroleva.yaml`
+  - `curriculum/l2-uk-en/bio/resources/natalena-koroleva.yaml`
+  - `wiki/lit/authors/natalena-koroleva.md` appears in older plan metadata but
+    is not a current file in the repo layout.
+
+## 8. Naming-canonical
+
+- **Slug:** `natalena-koroleva`
+- **EN canonical (BGN/PCGN 2010):** Natalena Koroleva.
+- **UA canonical:** Наталена Андріанівна Королева.
+- **Aliases future YAML:** `Наталена Королева`; `Н. Ковалівська-Короліва`;
+  `Nathalie Kowalewska`; `Н. Чужа`; `Natalena Koroleva`; `Natalena Andrianivna
+  Koroleva`; `Кармен-Альфонса-Фернанда-Естерелья-Наталена
+  Дуніна-Борковська`; long birth-name variants only with source-specific note.
+- **Forbidden / noncanonical body forms:** Russianized name forms as defaults;
+  unsourced "princess/countess" branding; confident long Spanish birth-name
+  forms without source caution; treating `Королева` as title rather than surname.
+
+## 9. Image candidates
+
+- **Best rights candidate:** Wikimedia Commons
+  `File:Pic K O Koroleva Natalena (1905 photo).jpg`; Commons metadata reports a
+  1905 photograph, unknown author, credit to the Internet Encyclopedia of
+  Ukraine, public domain, and `Copyrighted: False`. Re-check the file page before
+  final packaging, but this is the strongest portrait candidate.
+- **Rights-review candidates:** Ukrainian Wikipedia local file `NatKoroleva2.jpg`
+  is not on Commons and needs local-license review. ESU and Internet Encyclopedia
+  of Ukraine portraits are useful source context but should not be treated as
+  rights-clear UI assets without separate license confirmation.
+- **Potential source-object visual:** Diasporiana's `Леґенди старокиївські` 1942
+  title-page scan can support source-reading context, but cover/title-page reuse
+  should still be checked before UI embedding.
+- **Avoid:** unsourced social-media portraits, bookstore cover thumbnails,
+  cropped school-site images, or AI-restored portraits without provenance.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- Мушинка М. І. "Королева Наталена Андріанівна." Енциклопедія Сучасної України.
+  Інститут енциклопедичних досліджень НАН України, 2014.
+  https://esu.com.ua/article-6015. Accessed 2026-07-01.
+- Бондарчук П. М. "Королева Наталена Андріанівна." Енциклопедія історії
+  України, т. 5. Інститут історії України НАН України, 2008.
+  https://www.history.org.ua/?termin=Koroleva_N. Accessed 2026-07-01.
+- "Koroleva, Natalena." Internet Encyclopedia of Ukraine.
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CO%5CKorolevaNatalena.htm.
+  Accessed 2026-07-01.
+
+**Tier 2 (institutional / scholarly / library):**
+
+- Тюрменко І. "Наталена Королева: стан і перспективи дослідження життя та
+  творчості." Український історичний журнал, 2010, No. 3.
+  https://nasu-periodicals.org.ua/index.php/uhj/article/download/28363/22701.
+  Accessed 2026-07-01.
+- Наукова бібліотека Львівського національного університету імені Івана Франка.
+  "Наталена Королева: біобібліографічний покажчик."
+  https://www.lnulibrary.lviv.ua/wp-content/uploads/2023/04/12_Koroleva.pdf.
+  Accessed 2026-07-01.
+- Бібліотека Кам'янець-Подільського національного університету імені Івана
+  Огієнка. "Таємнича письменниця (до 135-ліття з дня народження Наталени
+  Королевої)." https://library.kpnu.edu.ua/?p=886. Accessed 2026-07-01.
+- NBUV. Authority record / digital-library entry for Natalena Koroleva.
+  https://irbis-nbuv.gov.ua/ulib/item/REF0006151. Accessed 2026-07-01.
+- Щур Н. "Аспекти конструювання ідентичності в автобіографічній прозі Наталени
+  Королевої." Питання літературознавства, 2014.
+  https://pytlit.chnu.edu.ua/article/download/73305/68645. Accessed 2026-07-01.
+- Ліховий Д. "Наталена Королева - письменниця і дипломат." Зовнішні справи,
+  2021. https://uaforeignaffairs.com/en/article/read/85. Accessed 2026-07-01.
+
+**Tier 3 (navigation / editions / reception):**
+
+- Diasporiana. "Королева Н. Леґенди старокиївські ч. 1."
+  https://diasporiana.org.ua/proza/4820-koroleva-n-legendi-starokiyivski-ch-1/.
+  Accessed 2026-07-01.
+- Diasporiana. "Королева Н. Леґенди Старокиївські. Ч. ІІ."
+  https://diasporiana.org.ua/proza/koroleva-n-legendy-starokyyivski-ch-ii/.
+  Accessed 2026-07-01.
+- Diasporiana. "Королева Н. Во дни они."
+  https://diasporiana.org.ua/proza/11508-koroleva-n-vo-dni-oni-opovidannya-z-yevangelskimi-motivami/.
+  Accessed 2026-07-01.
+- Diasporiana. "Королева Н. Подорожній."
+  https://diasporiana.org.ua/proza/5123-koroleva-n-podorozhniy/. Accessed
+  2026-07-01.
+- Diasporiana. "Королева Н. Сон тіні. 1313."
+  https://diasporiana.org.ua/proza/koroleva-n-son-tini-1313/. Accessed
+  2026-07-01.
+- Українська Вікіпедія. "Королева Наталена Андріанівна." Used only to identify
+  common search paths and variants; checked against ESU/EIU.
+
+**Primary-source documents accessed / identified for later learner work:**
+
+- `Леґенди старокиївські`, Prague 1942 edition via Diasporiana.
+- `Гріх (з пам'ятної книжки)`, first Ukrainian story identified through EIU
+  publication record; source-edition check needed before learner-facing excerpt.
+- Autobiographical prose `Без коріння` and `Шляхами і стежками життя`; use only
+  after edition-level verification because biography and self-mythologizing are
+  part of the learning problem.


### PR DESCRIPTION
## Scope

Adds the dossier-only BIO #378 source pack for `natalena-koroleva`.

Changed file:
- `docs/research/bio/natalena-koroleva.md`

No plan YAML, module markdown, activities, vocabulary, resources, MDX, generated status/audit/review artifacts, telemetry, linter config, package files, or unrelated files are touched.

## BIO coverage

- Frames Koroleva as Ukrainian historical prose / diaspora / European-Ukrainian bridge figure.
- Keeps pressure mechanism precise: state-collapse exile, UPR diplomatic displacement, Soviet-era erasure, archive fragility; no invented arrest/Gulag/KGB case.
- Flags contested early-life evidence and Spanish birth-place T1 default versus Volhynia/Lutsk document trail.
- Covers language choice, Vasyl Koroliv-Staryi influence without reducing her agency, major works, Catholic/European lens, `Легенди старокиївські`, and source-edition cautions.
- Records image rights: Commons 1905 public-domain portrait is strongest candidate; ESU/IEU/popular portraits need review.

## Helper checks

- Source-pack explorer returned ESU, EIU, Internet Encyclopedia of Ukraine, NBUV authority, UHJ/Tюрменко, identity-construction scholarship, UPR diplomacy article, and Diasporiana primary editions.
- Repo/image explorer confirmed real LIT-HIST-FIC/wiki surfaces, absent BIO/wiki/MDX/module surfaces, and the Commons image metadata for `Pic K O Koroleva Natalena (1905 photo).jpg`.

## Validation

- `npx markdownlint-cli2 docs/research/bio/natalena-koroleva.md`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/natalena-koroleva.md`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Notes

Independent read-only Claude review is still required before merge.
