### PR TITLE
docs(bio): add Mykhailo Stelmakh dossier

### DIFF
--- a/docs/research/bio/mykhailo-stelmakh.md
+++ b/docs/research/bio/mykhailo-stelmakh.md
@@ -1,0 +1,282 @@
+# Михайло Панасович Стельмах - Research Dossier
+
+**Slug:** `mykhailo-stelmakh`
+**Block:** +77 expansion - Soviet-era prose / village memory / censorship nuance
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #379
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Source acronym legend:** NAS = National Academy of Sciences of Ukraine;
+KNPU = Taras Shevchenko National Prize Committee; EU = Internet Encyclopedia
+of Ukraine; NBUV = Vernadsky National Library Ukraine / Ukrainica; CSAMM =
+Central State Archive-Museum of Literature and Art of Ukraine; Commons =
+Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional or scholarly sources cited
+- [x] Pressure mechanism framed as Soviet literary-state constraint and
+censorship; no invented arrest, camp term, exile, or dissident case
+- [x] At least 2 primary-source text / voice anchors supplied
+- [x] Cross-track links verified with `test -e` on 2026-07-01 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Михайло Панасович Стельмах.
+- **Project English canonical:** Mykhailo Stelmakh.
+- **Birth:** NAS gives 24 May 1912, Diakivtsi / Дяківці, now Vinnytsia
+region. KNPU gives dual-date form 11 (24) May 1912. Use 24 May 1912 in
+modern-style learner text; if old-style date matters, explain calendar
+conversion rather than treating it as contradiction.
+- **Death:** 27 September 1983, Kyiv, per NAS, EU, and CSAMM.
+- **Education / early work:** KNPU says he graduated literary faculty
+Vinnytsia Pedagogical Institute in 1933, taught in Vinnytsia and Kyiv-region
+villages during 1933-1939, published poetry from 1936, and served in World War
+II.
+- **Academic / institutional status:** NAS records work at the Institute of
+Fine Arts, Folklore, and Ethnography of the Academy of Sciences of the Ukrainian
+SSR in 1945-1953. EU and KNPU identify him as full member / academician of the
+Academy from 1978.
+- **Core BIO identity:** Stelmakh is a Ukrainian prose writer, poet,
+dramatist, and folklorist whose usable BIO lesson is not a dissident-prison
+arc. It is a harder Soviet-era case: a village-memory and folk-language writer
+inside official institutions, awards, and censorship, whose work both complied
+with and strained the permitted literary frame.
+
+## 2. Oppression / pressure mechanism
+
+- **Not a prison-case biography:** Do not invent arrest, Gulag sentence,
+exile, KGB investigation, or formal dissident membership. Major sources place
+him inside Soviet literary institutions: academician, prize winner, Supreme
+Soviet deputy, and state-recognized author.
+- **Soviet literary-state pressure:** EU says Stelmakh's prose shows
+conformity to changing Party policy and that his last novel was distorted under
+censorship pressure. This is the central pressure mechanism for BIO: a writer
+with official privileges still had to negotiate what could be said about
+village life, collectivization, famine, war, and postwar violence.
+- **Rewrite / permissible speech:** EU treats `Велика рідня` and later
+`Кров людська - не водиця` as part of a post-Stalin reworking. Future module
+writers should frame this as Soviet publication history, not as simple moral
+exoneration or simple condemnation.
+- **Holodomor / 1933 constraint:** KNPU's library note on `Чотири броди` says
+the novel addressed the painful topic of the 1933 famine. CSAMM also says
+Stelmakh was among writers who raised the problems of the 1932-1933 famine and
+OUN-UPA struggle against the USSR. Treat these as historically important
+source claims but verify any detailed lesson claims against text and scholarly
+work.
+- **Official recognition paradox:** CSAMM and KNPU list high Soviet-era
+awards, including Stalin / Lenin-era recognition and the Shevchenko Prize for
+`Чотири броди`. BIO should preserve the paradox: official elevation could
+enable publication, archive survival, and village-language preservation, while
+also shaping what the prose could and could not say.
+
+## 3. Major works / contributions
+
+- **Poetry / wartime books:** EU lists poetry collections `Добрий ранок`
+(1941), `За ясні зорі` (1942), `Провесінь` (1942), `Шляхи світання` (1948),
+`Жито сили набирається` (1954), `Поезії` (1958), and `Мак цвіте` (1968).
+KNPU notes wartime collections edited by Maksym Rylskyi.
+- **Village prose cycle:** EU and KNPU list `Березовий сік`, `Велика рідня`,
+`Кров людська - не водиця`, `Хліб і сіль`, `Правда і кривда`, `Дума про тебе`,
+`Чотири броди`, `Над Черемошем`, `Гуси-лебеді летять`, and `Щедрий вечір`.
+- **Autobiographical childhood prose:** `Гуси-лебеді летять` and `Щедрий
+вечір` are the most learner-ready bridge for memory, rural childhood, sensory
+language, family, school, poverty, and dignity without requiring the whole
+Soviet-political apparatus first.
+- **Drama and screen:** KNPU lists plays including `Золота метелиця`, `Кров
+людська - не водиця`, `На Івана Купала (Дума про Морозенка)`, `Зачарований
+вітряк`, `Кум королю`, and `Дума про любов`.
+- **Folklore / ethnography:** NAS and NBUV both preserve his connection to
+folklore and the Academy's folklore / ethnography institution. Use this to
+explain why his prose is lexically dense, song-like, and saturated with rural
+customs rather than treating the style as generic "Soviet realism."
+- **Shevchenko Prize work:** KNPU identifies the 1980 Shevchenko Prize for the
+novel `Чотири броди`.
+
+## 4. Primary-source quote / visual anchors
+
+Use short excerpts only. Stelmakh died in 1983, so literary texts remain under
+copyright. Future learner modules should prefer brief quoted phrases plus
+paraphrase, unless a public-domain or licensed excerpt is separately cleared.
+
+- **Childhood-memory anchor:** title phrase `Гуси-лебеді летять...` works as
+the cleanest access point for childhood perception, sound, movement, and desire
+for flight.
+- **Moral vocabulary anchor:** short phrase `Хто не мав своєї волі...` appears
+in library excerpt circulation and can anchor vocabulary around воля /
+приневолення, but verify edition context before learner-facing use.
+- **Village-sensory anchor:** a short landscape phrase from `Чотири броди` or
+`Гуси-лебеді летять...` can demonstrate how syntax, scent, weather, and rural
+work carry memory. Keep it under fair-use length.
+- **Censorship anchor:** EU's phrase `pressure of censorship` is a concise
+English source anchor for the dossier's pressure mechanism.
+- **Voice / media anchor:** Suspilne Mediateka social post points to 1972
+interview footage and 1973 author reading of the poem `Дніпро`. Rights and
+embedding terms require separate review, but the lead is valuable for voice and
+performance.
+- **Visual anchor:** 2012 Ukrposhta stamp on Commons is the safest portrait
+lead because the file is marked public domain under Ukrainian postage-stamp /
+official-symbol rules.
+
+## 5. Language register
+
+- **Register:** lyrical, rural, sensory, proverb-rich, folk-lexical,
+ethnographic, sometimes socialist-realist and declamatory in official passages.
+The strongest prose often turns landscape, work, family speech, and village
+objects into memory structure.
+- **CEFR readiness:** B2+ guided excerpts from `Гуси-лебеді летять...` and
+`Щедрий вечір`; C1 for `Правда і кривда`, `Дума про тебе`, and selected
+`Чотири броди`; C2 only if the module asks students to track ideology,
+censorship, and narrative compromise.
+- **Vocabulary fields:** `село`, `дитинство`, `пам'ять`, `колективізація`,
+`голод`, `воля`, `правда`, `кривда`, `рід`, `брід`, `фольклор`, `етнографія`,
+`цензура`, `соцреалізм`, `академік`, `лауреат`, `депутат`, `канон`.
+- **Teaching caution:** Do not flatten Stelmakh into a sentimental rural
+writer. Also do not flatten him into a regime writer. The useful language task
+is to see how rich Ukrainian village speech survives inside constrained
+Soviet-era literary forms.
+
+## 6. Contested points
+
+- **Panasovych vs Opanasovych:** Project canonical is `Михайло Панасович
+Стельмах`; some bibliographic records, including NBUV work metadata, use
+`Михайло Опанасович Стельмах`. Keep `Панасович` in learner-facing body and list
+`Опанасович` only as search / catalog alias.
+- **Birth-date form:** KNPU gives 11 (24) May 1912. NAS and EU use 24 May 1912.
+This is calendar notation, not a biographical dispute.
+- **Academy institute end-year:** NAS, EU, and KNPU support 1945-1953 for the
+Academy folklore / ethnography institution work; some secondary summaries use
+1945-1954. Keep the project date source-attributed unless a later archive-level
+source requires a timeline note.
+- **Official insider vs censored writer:** Sources support both official status
+and censorship pressure. BIO should not force a single verdict. A good lesson
+question can ask how a writer preserves language and memory while working
+inside official cultural institutions.
+- **UPA / underground claims:** CSAMM says Stelmakh was among the first to raise
+OUN-UPA struggle against the USSR in his work, but detailed stories about
+direct underground cooperation require stronger source-by-source verification
+before use. Do not present them as settled fact in base BIO.
+- **Holodomor wording:** KNPU and CSAMM identify `Чотири броди` as important
+for raising the 1933 famine problem. Future module work should compare the
+text, publication history, and scholarship before claiming exactly how open,
+coded, censored, or delayed the representation was.
+- **Soviet prizes:** Stalin Prize / Lenin Prize / Hero Socialist Labour /
+Shevchenko Prize are part of reception history. Do not omit them because they
+are uncomfortable; do not let them become the only interpretive frame.
+
+## 7. Cross-track links
+
+- **Existing LIT / wiki surfaces (VERIFIED `test -e` on 2026-07-01):**
+  - `curriculum/l2-uk-en/plans/lit/mykhailo-stelmakh-shchedryi-vechir.yaml`
+  - `curriculum/l2-uk-en/lit/discovery/mykhailo-stelmakh-shchedryi-vechir.yaml`
+  - `wiki/literature/works/mykhailo-stelmakh-shchedryi-vechir.md`
+  - `wiki/literature/works/mykhailo-stelmakh-shchedryi-vechir.sources.yaml`
+- **Candidate / do not list as existing yet:**
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-stelmakh.yaml`
+  - `curriculum/l2-uk-en/bio/discovery/mykhailo-stelmakh.yaml`
+  - `wiki/figures/mykhailo-stelmakh.md`
+  - `wiki/figures/mykhailo-stelmakh.sources.yaml`
+  - `site/src/content/docs/bio/mykhailo-stelmakh.mdx`
+  - `curriculum/l2-uk-en/bio/mykhailo-stelmakh/module.md`
+  - `curriculum/l2-uk-en/bio/mykhailo-stelmakh/activities.yaml`
+  - `curriculum/l2-uk-en/bio/mykhailo-stelmakh/vocabulary.yaml`
+  - `curriculum/l2-uk-en/bio/mykhailo-stelmakh/resources.yaml`
+  - Possible future work modules for `Правда і кривда`, `Дума про тебе`,
+    `Гуси-лебеді летять`, or `Чотири броди`; repo-local references exist, but
+    no dedicated content path was verified at dossier stage.
+
+## 8. Naming-canonical
+
+- **Slug:** `mykhailo-stelmakh`
+- **EN canonical (BGN/PCGN 2010):** Mykhailo Stelmakh.
+- **UA canonical:** Михайло Панасович Стельмах.
+- **Aliases future YAML:** `Михайло Стельмах`; `Михайло Панасович Стельмах`;
+`Mykhailo Stelmakh`; `Mykhailo Panasovych Stelmakh`; `Mykhaylo Stelmakh`;
+`Mychajlo Stelmach`; `Mychajlo Panasovyč Stel'mach`; `Михайло Опанасович
+Стельмах` (catalog variant only).
+- **Forbidden learner-facing body forms except search-note context:** `Михаил
+Стельмах`; `Михаил Афанасьевич Стельмах`; `Стельмах Михаил Афанасьевич`;
+`Michail Afanassjewitsch Stelmach`; `Mikhail Stelmakh`.
+- **Work slugs / aliases:** `mykhailo-stelmakh-shchedryi-vechir` exists in LIT;
+future candidate slugs should use transliterated Ukrainian titles, not Russian
+translations.
+
+## 9. Image candidates
+
+- **Primary safe candidate:** Commons `File:Михайло Стельмах.jpg`, 2012
+Ukrposhta stamp, marked public domain in Ukraine under official-symbol /
+postage-stamp rules. Good default because it is a portrait-like image with
+clear rights page.
+- **Alternate safe candidate:** Commons `File:Stamp 2012 Stelmakh (1).jpg`,
+same 2012 Ukrposhta issue, public-domain marking. Use only after final
+file-page license check in the implementation PR.
+- **Context image:** Commons photo of memorial plaque at Zaporizhzhia National
+University, CC BY-SA 4.0. Useful for memory / commemoration angle, not as first
+portrait.
+- **Context image:** Commons grave photo `File:Могила Михайла Стельмаха.JPG`,
+CC BY-SA 4.0. Use only if lesson discusses memorialization; not ideal primary
+visual.
+- **Avoid by default:** unsourced portrait scans from news sites, book covers,
+retail images, or social-media reposts. Many are visually useful but have no
+clear educational reuse license.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- Національна академія наук України. "Стельмах Михайло Панасович."
+https://old.nas.gov.ua/UA/PersonalSite/Pages/Biography.aspx?PersonID=0000012898.
+Accessed 2026-07-01.
+- Комітет з Національної премії України імені Тараса Шевченка. "Стельмах
+Михайло Панасович."
+https://knpu.gov.ua/winners/stelmakh-mykhajlo-panasovych/. Accessed
+2026-07-01.
+- Internet Encyclopedia of Ukraine. "Stelmakh, Mykhailo."
+https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CT%5CStelmakhMykhailo.htm.
+Accessed 2026-07-01.
+- Центральний державний архів-музей літератури і мистецтва України. "Михайло
+Стельмах (1912-1983)." https://csamm.archives.gov.ua/2022/05/24/mykhailo-stelmakh-1912-1983/.
+Accessed 2026-07-01.
+- Національна бібліотека України імені В. І. Вернадського, Електронна
+бібліотека "Україніка". "Стельмах Михайло Панасович."
+https://irbis-nbuv.gov.ua/ulib/item/ref0000016256. Accessed 2026-07-01.
+- Національна бібліотека України імені В. І. Вернадського, Електронна
+бібліотека "Україніка". `Кров людська - не водиця` record.
+https://irbis-nbuv.gov.ua/ulib/item/ukr0000027406. Accessed 2026-07-01.
+
+**Tier 2 (institutional / field-specific / collection leads):**
+
+- Комітет з Національної премії України імені Тараса Шевченка, бібліотека
+комітету. "Михайло Стельмах `Чотири броди. Вибрані твори у 2-х томах` т. 1."
+https://knpu.gov.ua/biblioteka-shevchenkivskogo-komitetu/mykhajlo-stelmakh-chotyry-brody-vybrani-tvory-u-2-kh-tomakh-t-1/.
+Accessed 2026-07-01.
+- Комітет з Національної премії України імені Тараса Шевченка, бібліотека
+комітету. "Михайло Стельмах `Гуси-лебеді летять... Щедрий вечір. Вибрані
+твори у 2-х томах` т. 2."
+https://knpu.gov.ua/biblioteka-shevchenkivskogo-komitetu/mykhajlo-stelmakh-husy-lebedi-letiat-shchedryj-vechir-vybrani-tvory-u-2-kh-tomakh-t-2/.
+Accessed 2026-07-01.
+- ЦДАМЛМ України. "Фонди від No. 1 до No. 100" (Fond No. 66, Mykhailo
+Stelmakh, 419 archival units, 1914-1987).
+https://csamm.archives.gov.ua/fondy-vid-%E2%84%961-do-%E2%84%96100/.
+Accessed 2026-07-01.
+- Wikimedia Commons. "Category:Mykhailo Stelmakh" and file pages
+`File:Михайло Стельмах.jpg`, `File:Stamp 2012 Stelmakh (1).jpg`,
+`File:Меморіальна дошка Михайлу Стельмаху на першому корпусі ЗНУ.jpg`,
+`File:Могила Михайла Стельмаха.JPG`. Used only for image-rights leads; final
+embedding requires file-page license recheck.
+
+**Tier 3 / cautionary leads:**
+
+- Suspilne Mediateka social-media posts about 1972 interview footage and 1973
+`Дніпро` reading. Treat as voice/media lead only until original Mediateka item
+and reuse terms are verified.
+- Popular articles and Wikipedia pages about alleged UPA contacts. Useful for
+question discovery only; do not use as factual basis for learner-facing claims
+without archival or scholarly confirmation.


### PR DESCRIPTION
## Scope
- Add BIO #379 research dossier for `mykhailo-stelmakh`.
- Dossier-only change: `docs/research/bio/mykhailo-stelmakh.md`.
- No plan YAML, module, activities, vocabulary, resources, MDX, wiki, audit/status, telemetry, linter, package, or unrelated files changed.

## BIO coverage
- Frames Stelmakh as a Soviet-era literary-state/censorship case, not a prison/exile/dissident-case biography.
- Captures official recognition, censorship pressure, Holodomor/UPA handling caution, works, language register, cross-track links, naming aliases, and image-rights leads.
- Cross-track existing paths were verified with repo-local `test -e` checks before inclusion.

## Helper checks
- Read-only source/fact helper supplied authoritative source pack.
- Read-only repo/image helper supplied cross-track path and Commons license leads.

## Validation
- `npx markdownlint-cli2 docs/research/bio/mykhailo-stelmakh.md`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/mykhailo-stelmakh.md`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Review gate
Independent read-only Claude review is required before merge. Unresolved findings block merge.