### PR TITLE
docs(bio): add Yurii Shcherbak dossier

### DIFF
--- a/docs/research/bio/yurii-shcherbak.md
+++ b/docs/research/bio/yurii-shcherbak.md
@@ -1,0 +1,309 @@
+# Юрій Миколайович Щербак - Research Dossier
+
+**Slug:** `yurii-shcherbak`
+**Block:** +77 expansion - Chornobyl / ecology / diplomacy / late-career political prose
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #380
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Source acronym legend:** EIU = Encyclopedia History of Ukraine; KNPU =
+Taras Shevchenko National Prize Committee; NLU = National Library of Ukraine
+named after Yaroslav Mudryi; CIUS = Canadian Institute of Ukrainian Studies;
+MFA = Ministry of Foreign Affairs of Ukraine; PRU = President of Ukraine;
+CCU = Constitutional Court of Ukraine; PRH = Penguin Random House; RFE/RL =
+Radio Free Europe / Radio Liberty; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional or scholarly sources cited
+- [x] Pressure mechanism framed as Soviet information restriction,
+Chornobyl/ecology politics, and living-figure public controversy; no invented
+arrest, exile, camp term, or dissident sentence
+- [x] At least 2 primary-source text / voice anchors supplied
+- [x] Cross-track links verified with `test -e` on 2026-07-01 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Юрій Миколайович Щербак.
+- **Project English canonical:** Yurii Shcherbak.
+- **Birth:** EIU, KNPU, NLU, and Commons authority data give 12 October 1934,
+Kyiv. Use this project date/place. See §6 for English-page date noise.
+- **Living figure:** Shcherbak is alive and publicly active. Future BIO work
+must avoid posthumous register and must time-stamp current roles.
+- **Medical / scientific path:** EIU says he graduated Kyiv Medical Institute
+in 1958 and worked in 1958-1987 at the Kyiv research institute of epidemiology
+and infectious diseases, from junior to senior researcher. EIU also says both
+his 1965 candidate dissertation and 1983 doctoral dissertation concerned
+epidemiology of especially dangerous infectious diseases.
+- **Core BIO identity:** Shcherbak is writer, physician-epidemiologist,
+screenwriter, public figure, environmental activist, politician, diplomat, and
+political analyst. The BIO arc should not choose only one lane: medical
+expertise, documentary witness, ecological politics, diplomacy, and later
+anti-imperial political prose reinforce each other.
+- **2026 recognition:** PRU decree No. 220/2026 awarded him the 2026
+Shevchenko National Prize for `Мертва пам'ять. Голоси і крики`; KNPU profile
+identifies the same late-career prose work.
+
+## 2. Oppression / pressure mechanism
+
+- **Not a prison-case biography:** Do not invent Soviet arrest, exile, Gulag
+sentence, KGB case, or dissident conviction. Shcherbak's pressure mechanism is
+public speech under late-Soviet information control, then open civic /
+diplomatic confrontation with imperial and post-Soviet systems.
+- **Chornobyl information control:** The central late-Soviet mechanism is
+controlled disclosure around the 1986 Chornobyl catastrophe. CIUS describes
+Shcherbak travelling into the danger zone, living there, and interviewing
+firefighters, first-aid workers, party and government officials, local media,
+and foreign visitors; the resulting eyewitness account was unusually detailed
+and frank.
+- **Glasnost as constrained opening:** The dossier should frame `Чорнобиль` as
+Perestroika-era documentary prose produced inside a narrowing/widening speech
+window, not as simple free press. RFE/RL's 2006 interview records Shcherbak's
+view that propaganda and absence of reliable information shattered trust in
+Soviet power.
+- **Ecology as national politics:** EIU identifies him as founder/leader of
+`Зелений світ`, founder and first leader of the Green Party of Ukraine, USSR
+People's Deputy, member of the Sakharov-led Interregional Deputy Group, and
+initiator of a commission to investigate Chornobyl causes. This was not neutral
+green lifestyle activism; it connected ecological truth, anti-imperial civic
+mobilization, and Ukrainian state-building.
+- **State office / diplomacy:** His post-1991 roles created a different
+pressure frame: environment minister, member of the National Security Council,
+ambassador to Israel, the United States, Mexico, and Canada. Future BIO work
+should handle public-state power, not only oppositional biography.
+- **Living-figure caution:** Recent commentary on Russia, Crimea, NATO,
+Ukrainian memory, and war appears in interviews and late prose. Use dated
+sources; do not freeze his evolving public positions into timeless doctrine.
+
+## 3. Major works / contributions
+
+- **Medicine / epidemiology:** EIU and KNPU both identify Kyiv Medical
+Institute training, long epidemiology institute work, cholera / rabies /
+dangerous-infection expertise, and the medical doctorate. CCU 2021 event note
+shows he still used epidemiology experience publicly during COVID-era
+discussion.
+- **Early prose / medicine milieu:** NLU lists first novella `Як на війні`
+(1966), novel `Бар'єр несумісності` (1971), story / novella collection
+`Маленька футбольна команда` (1973), poetry `Фрески і фотографії` (1984), and
+novel `Причини і наслідки` (1986).
+- **Screen and documentary work:** NLU notes screenplays for feature and
+documentary films including `Карантин`, `Шлях до серця`, `Державне ставлення`,
+and `Якось у грудні`. KNPU also identifies him as screenwriter and member of
+the National Union of Cinematographers.
+- **Chornobyl documentary prose:** EIU and NLU identify `Чорнобиль` as a
+documentary novella / account translated widely. CIUS preserves the 1989
+English `Chernobyl: A Documentary Story` and describes the interview method.
+This is the obvious LIT-DOC / HIST bridge.
+- **Ecological politics and state-building:** EIU records the `Зелений світ`
+and Green Party leadership, Congress of People's Deputies work, Chornobyl
+investigation commission, first minister of environmental protection of
+independent Ukraine in 1991-1992, and participation in the 1992 Rio Earth
+Summit.
+- **Diplomacy:** EIU gives ambassador sequence: Israel 1992-1994, United
+States 1994-1998, Mexico concurrently from 1997-1998, Canada 2000-2003, plus
+ICAO representation. MFA Israel and MFA USA histories corroborate the relevant
+embassy postings.
+- **Later geopolitical prose:** KNPU lists `Час смертохристів`, `Час Великої
+Гри`, `Час тирана`, `Україна в епоху війномиру`, `Мертва пам'ять. Голоси і
+крики`, `Вбити імперію зла`, `Третя світова війна України`, and `Рашизм. Звір
+із безодні`. Teach as political antiutopia / prophetic public prose, not
+neutral policy textbook.
+
+## 4. Primary-source quote / visual anchors
+
+Use short excerpts only. Shcherbak is living; all literary and interview
+materials remain copyrighted unless an explicit reuse license is confirmed.
+
+- **Chornobyl opening anchor:** `Все. Зона!` gives a compact documentary-space
+entry point, but verify edition context and quote only as fragment.
+- **Soviet trust anchor:** RFE/RL interview phrase `Партія нас обманула?`
+captures Shcherbak's reading of Chornobyl as collapse of Soviet credibility.
+- **Civic-humanist anchor:** PEN Ukraine preserves his phrase `вільне
+суспільство вільних людей`, useful for linking shistdesiatnyky memory, culture,
+and civic imagination.
+- **Crimea / decolonization anchor:** Krym.Realii title phrase `територію
+майбутньої державності кримськотатарського народу` is useful, but only with
+2022 interview date and Crimean Tatar sovereignty context.
+- **Late-prose anchor:** `Мертва пам'ять. Голоси і крики` title phrase works
+as the 2026-prize anchor for memory, warning, and war-era political prose.
+- **Visual anchor:** Commons 2017 Shevchenko National Prize ceremony cropped
+photo, Presidential Administration of Ukraine, CC BY 4.0, presents him as
+public cultural figure in an institutional setting.
+
+## 5. Language register
+
+- **Register:** documentary, testimonial, medical-scientific, civic,
+geopolitical, prophetic, sometimes satirical / grotesque in late antiutopian
+prose. Chornobyl prose combines interview montage, witness ethics, bureaucratic
+language, and moral judgment.
+- **CEFR readiness:** B2+ for guided biographical / interview excerpts; C1 for
+`Чорнобиль` documentary fragments and late public essays; C2 for `Час...`
+political antiutopia and `Мертва пам'ять` because students must track genre,
+prophecy, geopolitical vocabulary, and polemic.
+- **Vocabulary fields:** `епідеміолог`, `інфекційні хвороби`, `сказ`,
+`холера`, `Чорнобиль`, `радіація`, `ліквідатор`, `зона`, `свідчення`,
+`гласність`, `екологічний рух`, `дипломатія`, `посол`, `державність`,
+`пам'ять`, `рашизм`, `антиутопія`.
+- **Teaching caution:** Avoid making him only "the Chornobyl writer." The
+biographical value is the transfer of habits: doctor learns evidence,
+documentary writer records testimony, green politician investigates state
+failure, ambassador translates Ukraine outward, late novelist turns warning
+into anti-imperial fiction.
+
+## 6. Contested points
+
+- **Birth date:** Ukrainian institutional sources use 12 October 1934. Some
+English derivative pages have 23 October 1934. Treat 23 October as date noise
+unless a primary record justifies it; project default is 12 October.
+- **Yurii / Yuriy / Yuri:** Project canonical is `Yurii Shcherbak`; many
+English-language publisher and library pages use `Yuriy` or `Yuri`, and CIUS
+uses `Iurii`. Keep variants as search aliases, not canonical display.
+- **Chornobyl publication dates:** Ukrainian and English records may cite 1987
+for the Ukrainian documentary work and 1989 for CIUS English edition. Do not
+collapse them; specify edition/language when date matters.
+- **Ecology vs nationalism:** The Green movement angle can be misread as
+single-issue environmentalism. EIU's record shows ecology, Chornobyl truth,
+anti-Soviet parliamentary opposition, and state-building interlocked.
+- **State power vs opposition:** He moved from late-Soviet ecological
+opposition into ministerial and ambassadorial authority. BIO should not
+sanitize state power, and should not keep him frozen as only opposition voice.
+- **Living polemic:** Recent books and interviews are active political
+interventions about Russia, war, memory, Crimea, and Ukrainian state strategy.
+Use exact dates and avoid presenting polemical claims as settled course facts.
+- **2026 prize context:** He chaired the Shevchenko Prize Committee in
+2016-2019 and became a 2026 laureate. KNPU/PRU document the award; if future
+lesson discusses reception or controversy, it needs current source review.
+
+## 7. Cross-track links
+
+- **Existing LIT-DOC / HIST / wiki surfaces (VERIFIED `test -e` on 2026-07-01):**
+  - `curriculum/l2-uk-en/plans/lit-doc/shcherbak-chornobyl-documentary.yaml`
+  - `curriculum/l2-uk-en/plans/hist/chornobyl.yaml`
+  - `curriculum/l2-uk-en/hist/discovery/chornobyl.yaml`
+  - `wiki/periods/chornobyl.md`
+  - `wiki/periods/chornobyl.sources.yaml`
+- **Existing related Chornobyl-literature surfaces (VERIFIED `test -e` on 2026-07-01):**
+  - `curriculum/l2-uk-en/plans/lit/hundorova-post-chornobyl-library.yaml`
+  - `curriculum/l2-uk-en/lit/discovery/hundorova-post-chornobyl-library.yaml`
+  - `wiki/literature/works/hundorova-post-chornobyl-library.md`
+  - `wiki/literature/works/hundorova-post-chornobyl-library.sources.yaml`
+  - `curriculum/l2-uk-en/plans/lit-drama/arie-chornobyl.yaml`
+  - `curriculum/l2-uk-en/lit-drama/discovery/arie-chornobyl.yaml`
+  - `wiki/literature/works/arie-chornobyl.md`
+  - `wiki/literature/works/arie-chornobyl.sources.yaml`
+- **Candidate / do not list as existing yet:**
+  - `curriculum/l2-uk-en/plans/bio/yurii-shcherbak.yaml`
+  - `curriculum/l2-uk-en/bio/discovery/yurii-shcherbak.yaml`
+  - `wiki/figures/yurii-shcherbak.md`
+  - `wiki/figures/yurii-shcherbak.sources.yaml`
+  - `site/src/content/docs/bio/yurii-shcherbak.mdx`
+  - `curriculum/l2-uk-en/bio/yurii-shcherbak/module.md`
+  - `curriculum/l2-uk-en/bio/yurii-shcherbak/activities.yaml`
+  - `curriculum/l2-uk-en/bio/yurii-shcherbak/vocabulary.yaml`
+  - `curriculum/l2-uk-en/bio/yurii-shcherbak/resources.yaml`
+  - `curriculum/l2-uk-en/lit-doc/discovery/shcherbak-chornobyl-documentary.yaml`
+  - `wiki/lit/doc/shcherbak-chornobyl.md`
+  - `wiki/literature/works/shcherbak-chornobyl-documentary.md`
+  - `wiki/literature/works/shcherbak-chornobyl-documentary.sources.yaml`
+
+## 8. Naming-canonical
+
+- **Slug:** `yurii-shcherbak`
+- **EN canonical (BGN/PCGN 2010):** Yurii Shcherbak.
+- **UA canonical:** Юрій Миколайович Щербак.
+- **Aliases future YAML:** `Юрій Щербак`; `Юрій Миколайович Щербак`; `Yurii
+Shcherbak`; `Yurii Mykolaiovych Shcherbak`; `Yuriy Shcherbak`; `Yuriy
+Mykolayovych Shcherbak`; `Yuri Shcherbak`; `Iurii Shcherbak`; `Yuri
+Scherbak`; `Jurij Mykolajowytsch Schtscherbak`; `Jurij Mykolajovyč Ščerbak`.
+- **Forbidden learner-facing body forms except search-note context:** `Юрий
+Николаевич Щербак`; `Щербак Юрий Николаевич`; `Юрий Щербак`; `Yuri
+Nikolayevich Shcherbak`; `Iurii Nikolaevich Shcherbak`.
+- **Work / theme slugs:** Existing LIT-DOC plan uses
+`shcherbak-chornobyl-documentary`; BIO should not invent `chernobyl` slugs for
+Ukrainian learner-facing paths unless the surrounding LIT-DOC convention
+requires English form.
+
+## 9. Image candidates
+
+- **Primary safe candidate:** Commons
+`File:Shevchenko National Prize award ceremony 2017 Yuriy Shcherbak cropped.jpg`;
+Presidential Administration of Ukraine; 9 March 2017; CC BY 4.0. Good
+institutional portrait-like image and rights page.
+- **Alternate portrait:** Commons `File:Щербак Юрій.jpg`; 10 December 2015,
+Kyiv bookstore event; own work by Qypchak; CC BY-SA 4.0. Good speaking /
+book-culture image.
+- **Alternate portrait:** Commons `File:Щербак Юрій Миколайович (2).JPG`; 15
+December 2014; own work by Nick Grapsy; CC BY-SA 4.0.
+- **Alternate / older portrait:** Commons `File:Yuri Scherbak.jpg`; 3 January
+2014; own work by Nikolai Scherbak; CC BY-SA 3.0. Useful, but note older
+license and family-name uploader; file-page check required before embedding.
+- **Supplemental:** Commons signature file from 1990 is useful only for a
+document/source sidebar, not primary portrait.
+- **Avoid by default:** publisher jacket images, screenshots from interview
+videos, news-site portraits, and PRU/KNPU event photos not already present on
+Commons with explicit file-level license.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- Стрикун І. С. "Щербак Юрій Миколайович." Енциклопедія історії України, Т.
+10. Інститут історії України НАН України, 2013.
+https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIU&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Scherbak_Yurij&Z21ID=.
+Accessed 2026-07-01.
+- Комітет з Національної премії України імені Тараса Шевченка. "Щербак Юрій
+Миколайович." https://knpu.gov.ua/winners/shcherbak-iurij-mykolajovych/.
+Accessed 2026-07-01.
+- Президент України. Указ No. 220/2026 "Про присудження Національної премії
+України імені Тараса Шевченка."
+https://www.president.gov.ua/documents/2202026-58769. Accessed 2026-07-01.
+- Посольство України в Державі Ізраїль / MFA Ukraine. "З історії Посольства
+України в Ізраїлі."
+https://israel.mfa.gov.ua/posolstvo/424-z-istoriji-posolystva-ukrajini-v-izrajili.
+Accessed 2026-07-01.
+- Embassy of Ukraine in the United States / MFA Ukraine. "З історії Посольства
+України в США."
+https://usa.mfa.gov.ua/posolstvo/z-istoriyi-posolstva-ukrayini-v-ssha.
+Accessed 2026-07-01.
+- Національна бібліотека України імені Ярослава Мудрого. "До 90-річчя від дня
+народження Юрія Щербака (1934)." https://nlu.org.ua/event.php?id=2323.
+Accessed 2026-07-01.
+
+**Tier 2 (scholarly / institutional / field-specific):**
+
+- Canadian Institute of Ukrainian Studies Archives. `Chernobyl: A Documentary
+Story` record. https://cius-archives.ca/items/show/1550. Accessed 2026-07-01.
+- Конституційний Суд України. "Yurii Shcherbak on the challenges of the XXI
+century." https://ccu.gov.ua/en/novina/yurii-shcherbak-challenges-xxi-century.
+Accessed 2026-07-01.
+- Penguin Random House. "Yuri Shcherbak" author page.
+https://www.penguinrandomhouse.com/authors/2325770/yuri-shcherbak/. Accessed
+2026-07-01.
+- Радіо Свобода. "Інтерв'ю з письменником Юрієм Щербаком." 25 April 2006.
+https://www.radiosvoboda.org/a/943717.html. Accessed 2026-07-01.
+- PEN Ukraine / Ukrinform quotation page. "Що відкрив Мирон Петровський у
+Києві, в Україні, в самих нас."
+https://pen.org.ua/shho-vidkryv-myron-petrovskyj-u-kyyevi-v-ukrayini-v-samyh-nas.
+Accessed 2026-07-01.
+- Крим.Реалії. "Юрій Щербак: Уже в 90-х потрібно було визначити Крим як
+територію майбутньої державності кримськотатарського народу." 14 July 2022.
+https://ua.krymr.com/a/rosiya-ukraina-viyna-crym-yuriy-shcherbak/31943449.html.
+Accessed 2026-07-01.
+
+**Tier 3 (image / rights leads):**
+
+- Wikimedia Commons. `Category:Yuriy Shcherbak`.
+https://commons.wikimedia.org/wiki/Category:Yuriy_Shcherbak. Accessed
+2026-07-01.
+- Wikimedia Commons. `File:Shevchenko National Prize award ceremony 2017 Yuriy
+Shcherbak cropped.jpg`, `File:Щербак Юрій.jpg`, `File:Щербак Юрій Миколайович
+(2).JPG`, `File:Yuri Scherbak.jpg`, `File:Yuriy Shcherbak Signature 1990.png`.
+Used only for image-rights leads; final embedding requires file-page license
+recheck.


### PR DESCRIPTION
## Scope

- Adds BIO #380 research dossier for Yurii Shcherbak.
- Dossier-only change: docs/research/bio/yurii-shcherbak.md.
- No plan YAML, module, activities, vocabulary, resources, MDX, wiki packet, status/audit/review, telemetry, linter config, or package files touched.

## Validation

- npx markdownlint-cli2 docs/research/bio/yurii-shcherbak.md
- .venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/yurii-shcherbak.md
- git diff --check
- .venv/bin/python scripts/audit/lint_agent_trailer.py

## Review gate

- Independent read-only Claude review required before ready/merge.
- Unresolved findings block merge.
