### PR TITLE
docs(bio): add Vira Aheieva dossier

### DIFF
--- a/docs/research/bio/vira-aheieva.md
+++ b/docs/research/bio/vira-aheieva.md
@@ -1,0 +1,310 @@
+# Віра Павлівна Агеєва - Research Dossier
+
+**Slug:** `vira-aheieva`
+**Block:** +77 expansion - feminist literary criticism / decolonial canon / public memory
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #381
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Source acronym legend:** ESU = Encyclopedia of Modern Ukraine; KNPU =
+Taras Shevchenko National Prize Committee; NaUKMA = National University of
+Kyiv-Mohyla Academy; KMHJ = Kyiv-Mohyla Humanities Journal; PEN = PEN Ukraine;
+UINP = Ukrainian Institute of National Memory; PRU = President of Ukraine;
+EKMAIR = eKMAIR / NaUKMA institutional repository; Commons = Wikimedia
+Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional or scholarly sources cited
+- [x] Pressure mechanism framed as Soviet / post-Soviet canon constraint,
+patriarchal gatekeeping, and imperial memory politics; no invented arrest,
+exile, camp term, or dissident sentence
+- [x] At least 2 primary-source text / voice anchors supplied
+- [x] Cross-track links verified with `test -e` on 2026-07-01 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Віра Павлівна Агеєва.
+- **Project English canonical:** Vira Aheieva.
+- **Birth:** ESU and KNPU give 30 July 1958, Bakhmach, Chernihiv oblast.
+- **Living figure:** Aheieva is a living scholar and public intellectual.
+Future BIO work must re-verify current status and affiliations at build time.
+- **Education / degree:** ESU and KNPU say she graduated Kyiv University in
+1980; ESU and KNPU identify her as doctor of philological sciences from 1995.
+- **Institutional path:** ESU says she worked at the Shevchenko Institute of
+Literature, NASU, in 1985-1996, served as deputy editor of `Слово і час` in
+1995-1997, and has been professor at NaUKMA since 1996. NaUKMA lists her in
+the literature department as doctor of philology, professor, and Shevchenko
+Prize laureate.
+- **Core BIO identity:** literary scholar, literary critic, professor,
+philologist, feminist critic, decolonial reader of Ukrainian culture, and
+public essayist. Do not reduce her to a general "book critic"; her BIO value
+is method: how a scholar changes what a culture can read in itself.
+- **Awards:** KNPU documents the 1996 Shevchenko Prize for the collective
+two-volume textbook `Історія української літератури XX століття`. ESU and PRU
+document the 2026 Order of Princess Olga, 3rd class; PRU decree No. 136/2026
+names her as literary scholar and writer.
+
+## 2. Oppression / pressure mechanism
+
+- **Not a prison-case biography:** Do not invent arrest, exile, camp term,
+KGB case, formal dissident membership, or personal persecution. Aheieva's
+pressure frame is intellectual work against Soviet censorship, post-Soviet
+inertia, patriarchal canon-making, and Russian imperial cultural hierarchy.
+- **Late-Soviet academic constraint:** Her formative university years and
+early scholarly work took place under late Soviet humanities norms. The
+Ukrainians interview frames her post-Soviet path as recovery of previously
+banned works and use of interpretive methods that had been unavailable or
+mocked in Soviet/post-Soviet classrooms.
+- **Canon as pressure site:** The pressure mechanism is not only police power.
+It is what a syllabus, anthology, review journal, and public memory permit
+readers to call "important." Aheieva's work presses on those institutions by
+re-reading Lesia Ukrainka, modernists, women writers, Rylskyi, Bazhan,
+Domontovych, and the Executed Renaissance.
+- **Feminist interpretation:** Vikhola presents her as one of the first in the
+post-Soviet period to speak about revising patriarchal values. Teach this as
+a method of reading and public argument, not as a generic biography label.
+- **Decolonial public voice:** Her recent essays and interviews argue about
+Russian imperial culture, Ukrainian memory, erased archives, and cultural
+amnesia. Use dated sources and avoid turning a living public intellectual's
+current polemical positions into timeless course doctrine.
+- **Institutional authority:** Aheieva is not only an oppositional reader. She
+is a professor, prize laureate, editor / editorial-board participant, public
+lecturer, and canon-maker. BIO must keep the anti-hagiography question open:
+who gets to revise a canon, and what new exclusions might a revision create?
+
+## 3. Major works / contributions
+
+- **Early scholarship:** ESU lists early works including `Літературний процес
+60-80-х рр.` (1989, coauthor), `Пам'ять подвигу: Українська воєнна проза
+60-80-х років` (1989, coauthor), `Олекса Слісаренко` (1990, coauthor),
+`Українська імпресіоністична проза` (1994, coauthor), and an article on
+existential motifs in Mykola Kulish.
+- **Textbook / prize work:** KNPU and NaUKMA identify her as one of the
+Shevchenko Prize co-laureates for `Історія української літератури XX
+століття` in two books. This matters for BIO because she is both critic of
+the canon and producer of a teaching canon.
+- **Lesia Ukrainka:** ESU lists `Поетеса на зламі століть. Творчість Лесі
+Українки в постмодерній інтерпретації` (1999). EKMAIR preserves a later
+Aheieva article, `Anti-Colonial Discourse in Lesia Ukrainka's Dramas`, which
+confirms the continuing anti-colonial line of her Lesia Ukrainka work.
+- **Feminist / gender criticism:** Chytomo identifies her with early feminist
+seminars, the Kyiv Center / Institute for Gender Studies, and feminist
+literary interpretation; Vikhola lists `Жіночий простір: Феміністичний
+дискурс українського модернізму`.
+- **Domontovych / intellectual prose:** Vikhola and publisher pages list
+`Поетика парадокса: інтелектуальна проза Віктора
+Петрова-Домонтовича`; repo already has cross-track surfaces for Domontovych,
+so future BIO can connect literary criticism to existing LIT work.
+- **Rylskyi and Bazhan biographies:** Vikhola lists `Мистецтво рівноваги.
+Максим Рильський і його час` and `Візерунок на камені. Микола Бажан: життєпис
+(не)радянського поета`. Existing BIO dossiers for Rylskyi and Bazhan cite
+Aheieva as a key modern interpreter.
+- **Recent public essays:** Vikhola lists `За лаштунками імперії`, `Марсіани
+на Хрещатику`, and `Проти культурної амнезії. Есеї про національну пам'ять та
+ідентичність`. Ukrainian Pages describes `Martians on Khreshchatyk` as a
+journey through early twentieth-century literary Kyiv.
+- **Public humanities:** KMHJ lists Prof. Vira Ageyeva on the journal's
+editorial board; PEN, The Ukrainians, LIGA, UINP, and BookForum preserve her
+public-facing lectures / interviews on essayistics, memory, decolonization,
+and literary history.
+
+## 4. Primary-source quote / visual anchors
+
+Use short excerpts only. Aheieva is living; her essays, interviews, lectures,
+and publisher text are copyrighted unless a separate license is confirmed.
+
+- **Feminist-method anchor:** Vikhola phrase `ревізії патріархальних
+цінностей` compactly signals why her work belongs in BIO rather than only LIT.
+- **Essay freedom anchor:** PEN preserves lecture fragments such as `Есей -
+це розмисел` and the broader formulation of essayistics as intellectual
+freedom. Quote only a very short fragment and link to the full PEN page.
+- **Memory / decolonization anchor:** `Проти культурної амнезії` is a safe
+title-level anchor for memory, identity, and anti-amnesia framing.
+- **Anti-imperial public voice anchor:** Media titles around `За лаштунками
+імперії` and "great Russian culture" are useful, but treat them as dated
+public-interview anchors, not as neutral biographical facts.
+- **Literary Kyiv visual-text anchor:** `Марсіани на Хрещатику` title phrase
+and Ukrainian Pages' product description can anchor the literary-city module
+connection without quoting the book itself.
+- **Visual anchor:** Commons `File:Vera ageeva.jpg`, taken 12 September 2013
+at the Lviv Publishers' Forum, own work by Водник, CC BY-SA 3.0 / GFDL, is the
+only obvious Commons portrait lead.
+
+## 5. Language register
+
+- **Register:** scholarly, essayistic, polemical, feminist-critical,
+decolonial, archival, public-humanities. She moves between academic prose,
+literary biography, public lecture, interview, and essay.
+- **CEFR readiness:** B2+ for guided biographical / interview excerpts; C1 for
+literary-critical passages about canon, memory, and modernism; C2 for dense
+essayistic or scholarly fragments on anti-colonial discourse, Lesia Ukrainka,
+Domontovych, Rylskyi, Bazhan, or cultural memory.
+- **Vocabulary fields:** `літературознавиця`, `критикиня`, `канон`,
+`деколонізація`, `пам'ять`, `ідентичність`, `модернізм`, `феміністична
+інтерпретація`, `патріархальні цінності`, `амнезія`, `імперія`,
+`есеїстика`, `архів`, `суб'єктність`, `переосмислення`, `полеміка`.
+- **Teaching caution:** Avoid teaching her as "the correct answer" to the
+canon. The productive lesson question is how a critic builds evidence, chooses
+what to recover, and persuades readers that familiar literature must be read
+again.
+
+## 6. Contested points
+
+- **Aheieva / Ageyeva / Aheyeva / Ageeva:** Project canonical is `Vira
+Aheieva`, following Ukrainian transliteration. English sources often use
+`Vira Ageyeva`; Commons category uses `Vera Ageeva`; Chytomo's English author
+URL uses `vira-aheeva`. Keep these as search aliases, not display default.
+- **Віра / Вера:** Use Ukrainian `Віра Павлівна Агеєва` in learner-facing
+body. Russian `Вера Павловна Агеева` may appear only in search-note context.
+- **Book-title variants:** ESU gives `Поетеса на зламі століть`; some
+secondary lists and search snippets render variants like `Поетеса зламу
+століть`. Use source-attributed title forms.
+- **Kyiv Institute / Center for Gender Studies:** English pages vary between
+"Institute" and "Center" for the Ukrainian gender-studies institution. If a
+future YAML needs an exact institutional name, verify against Ukrainian
+founding documents or a specialist source.
+- **Current roles:** She is living and publicly active. Publisher bios,
+festival profiles, and editorial-board pages can change; time-stamp all
+current affiliation claims.
+- **Public polemic:** Recent media interviews on Russian culture, Pushkin,
+memory, and war are part of her public intellectual profile but should not
+become unsourced course claims about all Russian literature or all Ukrainian
+readers.
+- **Commercial source bias:** Vikhola and Ukrainian Pages are useful for
+current book lists and publisher framing; prefer ESU/KNPU/NaUKMA/KMHJ for
+baseline biographical facts.
+
+## 7. Cross-track links
+
+- **Existing LIT-ESSAY / wiki surfaces (VERIFIED `test -e` on 2026-07-01):**
+  - `curriculum/l2-uk-en/plans/lit-essay/vira-ageyeva-canon.yaml`
+  - `curriculum/l2-uk-en/lit-essay/discovery/vira-ageyeva-canon.yaml`
+  - `wiki/literature/works/vira-ageyeva-canon.md`
+  - `wiki/literature/works/vira-ageyeva-canon.sources.yaml`
+- **Existing related BIO / LIT surfaces (VERIFIED `test -e` on 2026-07-01):**
+  - `docs/research/bio/maksym-rylskyi.md`
+  - `docs/research/bio/mykola-bazhan.md`
+  - `wiki/figures/lesya-ukrainka.md`
+  - `wiki/figures/oksana-zabuzhko.md`
+  - `wiki/literature/works/solomea-pavlychko-modernism.md`
+  - `curriculum/l2-uk-en/plans/lit/domontovych-dr-seraphicus.yaml`
+  - `curriculum/l2-uk-en/plans/lit/domontovych-intellectuals.yaml`
+  - `curriculum/l2-uk-en/plans/lit/pidmohylny-small-prose.yaml`
+  - `curriculum/l2-uk-en/plans/lit/kobrynska-pershyi-vinok.yaml`
+  - `curriculum/l2-uk-en/plans/lit/lesia-forest-song-2.yaml`
+  - `curriculum/l2-uk-en/plans/lit/zabuzhko-museum.yaml`
+- **Candidate / do not list as existing yet:**
+  - `curriculum/l2-uk-en/plans/bio/vira-aheieva.yaml`
+  - `curriculum/l2-uk-en/bio/discovery/vira-aheieva.yaml`
+  - `wiki/figures/vira-aheieva.md`
+  - `wiki/figures/vira-aheieva.sources.yaml`
+  - `site/src/content/docs/bio/vira-aheieva.mdx`
+  - `curriculum/l2-uk-en/bio/vira-aheieva/module.md`
+  - `curriculum/l2-uk-en/bio/vira-aheieva/activities.yaml`
+  - `curriculum/l2-uk-en/bio/vira-aheieva/vocabulary.yaml`
+  - `curriculum/l2-uk-en/bio/vira-aheieva/resources.yaml`
+  - `wiki/lit/critics/vira-ageyeva.md`
+  - `wiki/literature/works/martians-on-khreshchatyk.md`
+  - `wiki/literature/works/za-lashtunkamy-imperii.md`
+  - `wiki/literature/works/proty-kulturnoi-amnezii.md`
+
+## 8. Naming-canonical
+
+- **Slug:** `vira-aheieva`
+- **EN canonical (BGN/PCGN 2010):** Vira Aheieva.
+- **UA canonical:** Віра Павлівна Агеєва.
+- **Aliases future YAML:** `Віра Агеєва`; `Віра Павлівна Агеєва`; `Vira
+Aheieva`; `Vira Pavlivna Aheieva`; `Vira Ageyeva`; `Vira Pavlivna Ageyeva`;
+`Vira Aheyeva`; `Vira Ageeva`; `Vera Ageyeva`; `Vera Ageeva`; `Wira Ahejewa`;
+`Vìra Ahejeva`.
+- **Forbidden learner-facing body forms except search-note context:** `Вера
+Павловна Агеева`; `Вера Агеева`; `Агеева Вера Павловна`; `Vera Pavlovna
+Ageeva`.
+- **Cross-track naming note:** Existing LIT-ESSAY surfaces use
+`vira-ageyeva-canon`. BIO can keep `vira-aheieva` while listing
+`vira-ageyeva` as a repo-local search alias.
+
+## 9. Image candidates
+
+- **Primary safe candidate:** Commons `File:Vera ageeva.jpg`; own work by
+Водник; taken 12 September 2013; CC BY-SA 3.0 / GFDL. It is the only file in
+`Category:Vera Ageeva` and depicts Aheieva at a public book event.
+- **Category lead:** Commons `Category:Vera Ageeva` contains the portrait file
+and authority metadata. Use category for discovery, but embed only the checked
+file page.
+- **Avoid by default:** publisher portraits, festival pages, PEN / media /
+YouTube screenshots, and bookstore product images unless a file-level reuse
+license is confirmed. Many are useful source pages but not safe image sources.
+- **Caption caution:** If used in a future module, caption as `Vira Aheieva`
+even though the Commons filename and category use `Vera Ageeva`; keep the
+filename only in attribution / source metadata.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- Лущій С. І. "Агеєва Віра Павлівна." Енциклопедія Сучасної України.
+https://esu.com.ua/article-42527. Accessed 2026-07-01.
+- Комітет з Національної премії України імені Тараса Шевченка. "Агеєва Віра
+Павлівна." https://knpu.gov.ua/winners/aheieva-vira-pavlivna/. Accessed
+2026-07-01.
+- Національний університет "Києво-Могилянська академія." "Кафедра
+літературознавства ім. В. Моренця."
+https://www.ukma.edu.ua/index.php/osvita/fakulteti/fgn/kafedra-literaturi-ta-inozemnikh-mov.
+Accessed 2026-07-01.
+- Kyiv-Mohyla Humanities Journal. "Editorial Board."
+https://kmhj.ukma.edu.ua/editorial. Accessed 2026-07-01.
+- Президент України. Указ No. 136/2026 "Про відзначення державними нагородами
+України." https://www.president.gov.ua/documents/1362026-58373. Accessed
+2026-07-01.
+- eKMAIR / Національний університет "Києво-Могилянська академія."
+"Anti-Colonial Discourse in Lesia Ukrainka's Dramas."
+https://ekmair.ukma.edu.ua/items/240bc23b-d4b5-4928-b4a9-58b0906e899e.
+Accessed 2026-07-01.
+
+**Tier 2 (publisher / field / public humanities):**
+
+- Видавництво Віхола. "Віра Агеєва."
+https://www.vikhola.com/authors/vira-aheieva. Accessed 2026-07-01.
+- Chytomo. "Vira Aheieva" author profile.
+https://chytomo.com/en/authors/vira-aheeva/. Accessed 2026-07-01.
+- PEN Ukraine. "Віра Агеєва: 'Ті, хто бачив ворога крізь приціл зброї,
+інакше ставляться до російської культури'." 15 April 2022.
+https://pen.org.ua/vira-ageyeva-ti-hto-bachyv-voroga-kriz-prytsil-zbroyi-inakshe-stavlyatsya-do-rosijskoyi-kultury.
+Accessed 2026-07-01.
+- The Ukrainians. "Vira Aheieva: 'The 1990s were an incredible reading
+experience for me'." 24 May 2021.
+https://theukrainians.org/en/vira-aheieva-eng/. Accessed 2026-07-01.
+- Ukrainian Pages. `Martians on Khreshchatyk: Literary Kyiv of the 20th
+Century` product page.
+https://ukrainian-pages.com/en/products/martians-on-khreshchatyk-literary-kyiv-of-the-20-th-century.
+Accessed 2026-07-01.
+- Chytomo. "У Польщі та США видадуть `За лаштунками імперії` Віри Агеєвої."
+https://chytomo.com/u-polshchi-vydadut-za-lashtunkamy-imperii-viry-aheievoi/.
+Accessed 2026-07-01.
+- LIGA.net. "Without Pushkin there would be no Putin? Vira Ageieva on Ukraine,
+historical memory, and her new book."
+https://www.liga.net/en/politics/interview/without-pushkin-there-would-be-no-putin-vira-ageeva-on-ukraine-historical-memory-and-her-new-book.
+Accessed 2026-07-01.
+- BookForum. "Vira Aheieva" participant page.
+https://bookforum.ua/en/participants/1188. Accessed 2026-07-01.
+- Український інститут національної пам'яті. "`Деколонізація: віднайти своє`:
+перший круглий стіл у Харкові."
+https://uinp.gov.ua/pres-centr/novyny/dekolonizaciya-vidnayty-svoye-pershyy-kruglyy-stil-u-harkovi.
+Accessed 2026-07-01.
+
+**Tier 3 (image-rights / file-page checks):**
+
+- Wikimedia Commons. `Category:Vera Ageeva`.
+https://commons.wikimedia.org/wiki/Category:Vera_Ageeva. Accessed
+2026-07-01.
+- Wikimedia Commons. `File:Vera ageeva.jpg`.
+https://commons.wikimedia.org/wiki/File:Vera_ageeva.jpg. Accessed 2026-07-01.

--- a/docs/research/bio/vira-aheieva.md
+++ b/docs/research/bio/vira-aheieva.md
@@ -27,6 +27,24 @@ exile, camp term, or dissident sentence
 - [x] Image-rights policy applied
 - [x] Dossier-only scope observed
 
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Soviet / post-Soviet academic constraints and
+Russian imperial cultural hierarchy are named as pressure mechanisms, not used
+as the default viewpoint.
+- [x] No Russian-imperial transliterations in body text — Russophone forms are
+confined to §8, labelled as forbidden, and used only for search-note context.
+- [x] No Russocentric periodization — late-Soviet and post-Soviet framing is
+used; no "Great Patriotic War" or equivalent imperial period labels.
+- [x] No uncritical Soviet / Russian propaganda terms — canon, empire, and
+memory language is analytical and source-attributed.
+- [x] Ukrainian place and person names use Ukrainian forms in learner-facing
+prose, including Bakhmach, NaUKMA, Lesia Ukrainka, and Oksana Zabuzhko.
+- [x] Russian full-scale-war and imperial-culture claims are handled as dated
+public-interview positions, not as timeless unsourced doctrine.
+- [x] No advocacy close — Aheieva is presented as critic and canon-maker with
+anti-hagiography caution, not as an unquestioned authority.
+
 ---
 
 ## 1. Verified facts


### PR DESCRIPTION
## Scope

- Adds BIO #381 research dossier for Vira Aheieva.
- Dossier-only change: docs/research/bio/vira-aheieva.md.
- No plan YAML, module, activities, vocabulary, resources, MDX, wiki packet, status/audit/review, telemetry, linter config, or package files touched.

## Validation

- npx markdownlint-cli2 docs/research/bio/vira-aheieva.md
- .venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/vira-aheieva.md
- git diff --check
- .venv/bin/python scripts/audit/lint_agent_trailer.py

Note: this worktree does not contain its own .venv, so Python validation was run through the root project virtualenv against the worktree file.

## Review gate

- Independent read-only Claude review required before ready/merge.
- Unresolved findings block merge.
