### PR TITLE
docs(bio): add Tamara Hundorova dossier

### DIFF
--- a/docs/research/bio/tamara-hundorova.md
+++ b/docs/research/bio/tamara-hundorova.md
@@ -1,0 +1,147 @@
+# Тамара Іванівна Гундорова - Research Dossier
+
+**Slug:** `tamara-hundorova`
+**Block:** +77 expansion - decolonial literary criticism / post-Chornobyl culture / gender and modernism
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #382
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Source acronym legend:** ESU = Encyclopedia Modern Ukraine; NAS = National Academy of Sciences of Ukraine; IL-NAN = Shevchenko Institute of Literature, NAS of Ukraine; HURI = Harvard Ukrainian Research Institute; VUIAS = Virtual Ukraine Institute for Advanced Study; WIKO = Wissenschaftskolleg zu Berlin; PEN = PEN Ukraine; ASP = Academic Studies Press; Ukraїner = Ukraїner interview project; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional or scholarly sources cited
+- [x] Pressure mechanism framed as Soviet / post-Soviet canon constraint, imperial hierarchy, Chornobyl trauma, gendered canon politics; no invented arrest, exile, camp term, or dissident sentence
+- [x] At least 2 primary-source text / voice anchors supplied
+- [x] Cross-track links verified `test -e` / `rg` on 2026-07-01 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing: Russian/Soviet imperial cultural hierarchy is named as an object of Hundorova's analysis, not as the default interpretive center.
+- [x] Ukrainian subjectivity remains primary: Hundorova is framed as a Ukrainian literary scholar who helps build Ukrainian decolonial vocabulary and canon debates, not as a regional add-on to Russian studies.
+- [x] No Russian-imperial transliteration used in learner-facing body text. `Gundorova` appears only as a search alias in §8 because some English catalogues and older profiles use it.
+- [x] Living scholar claims time-stamped: present-tense affiliations and active projects should be rechecked at build time.
+- [x] Anti-hagiography retained: her models of postcolonial trauma, kitsch, Chornobyl, and canon revision are taught as influential arguments with limits, not as unquestionable doctrine.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Тамара Іванівна Гундорова.
+- **Project English canonical:** Tamara Hundorova.
+- **Birth:** ESU gives 17 July 1955, village Klymivka, then Karlivka raion, Poltava oblast. PEN confirms 17 July 1955 in Poltava region. WIKO gives 1955 in Poltava, Ukraine.
+- **Living figure:** Hundorova is a living scholar and public intellectual. Re-verify current titles, fellowships, and institutional appointments before converting this dossier into a lesson/module.
+- **Education / degree:** ESU says she graduated Kyiv University in 1977 and later became doctor of philological sciences in 1996; HURI / WIKO identify her doctorate in theory of literature and Ukrainian literature.
+- **Core institutional role:** NAS lists her as corresponding member of NAS Ukraine, doctor of philological sciences, professor, and chief research fellow at the Shevchenko Institute of Literature, NAS of Ukraine. HURI's 2025 fellow page describes her as principal research fellow at the Shevchenko Institute of Literature, HURI associate, and dean of the Ukrainian Free University.
+- **International academic profile:** ESU, HURI, VUIAS, WIKO, and ASP record teaching/research affiliations across Harvard, Princeton, Toronto, Monash, Hokkaido, Ukrainian Free University, Kyiv-Mohyla Academy, Kyiv National University, and other institutions. Use specific dates only from a current source.
+- **Field identity:** literary scholar, critic, culturologist, professor, theorist of Ukrainian modernism/postmodernism, gender studies, Chornobyl studies, kitsch, postcolonial and decolonial Ukrainian studies.
+- **Recognition:** ESU records corresponding member NASU (2003), Honored Worker of Science and Technology of Ukraine (2006), Order of Princess Olga 3rd class (2026), and literary / scholarly prizes including `Світовид`, `Сучасність`, and Ivan Franko Prize.
+
+## 2. Oppression / pressure mechanism
+
+- **Not a prison-case biography:** Do not invent arrest, exile, camp sentence, KGB case, dissident conviction, or direct state prosecution. Hundorova's pressure frame is intellectual labor under Soviet canon restriction, late/post-Soviet institutional inertia, Russian imperial cultural hierarchy, gendered canon gatekeeping, and the trauma of Chornobyl and war.
+- **Soviet knowledge constraint:** Ukraїner frames her education and early scholarly formation in the period of Soviet stagnation and censorship, when alternative sources and publications were difficult to access. Future lesson work can use this as a research-method pressure: how to build arguments when archives, editions, and theory circulate unevenly.
+- **Imperial hierarchy as object of critique:** Hundorova's work argues against reducing Ukrainian literature to provincial folklore, secondary Russian/Soviet context, or ethnographic "margin." The lesson should show how criticism can change what a culture is allowed to count as modern, European, postmodern, feminist, or decolonial.
+- **Chornobyl as cultural trauma:** `The Post-Chornobyl Library` connects the 1986 disaster with post-Soviet time, trauma, decolonization of national culture, crisis of language, and the emergence of Ukrainian postmodernism. This is not disaster trivia; it is a model of cultural consciousness after totalitarianism.
+- **Gender / canon pressure:** Hundorova's work on Olha Kobylianska, Lesia Ukrainka, feminism, and gender studies belongs with the same canon-revision pressure as Vira Aheieva, Solomea Pavlychko, and Oksana Zabuzhko. Avoid treating feminism as a side theme separated from decolonization.
+- **Living public intellectual caution:** Recent interviews and essays engage Russia's war, Western misunderstanding of Ukraine, decolonization, displacement, and humanitarian strategy. Use dates and source labels; do not turn current polemic into timeless neutral fact.
+
+## 3. Major works / contributions
+
+- **Ukrainian modernism:** ESU and ASP identify `ПроЯвлення слова: дискурсія раннього українського модернізму` as a central contribution to the study of early Ukrainian modernism. HURI/WIKO list it among her key books. This is the main bridge to modernism/canon modules.
+- **Gender studies / feminist criticism:** `Femina melancholica. Стать і культура в гендерній утопії Ольги Кобилянської` is core for teaching how gender, melancholy, culture, and canon intersect in Ukrainian literature.
+- **Franko re-reading:** `Франко - не Каменяр` / `Franko i/ne Kameniar` signals her method: do not freeze canonical authors into slogans. Teach as de-monumentalization rather than anti-canon iconoclasm.
+- **Kitsch and cultural hierarchy:** `Кітч і література. Травестії` is key for postcolonial and popular-culture discussion: kitsch is not only "bad taste" but a symptom of transition, hierarchy, and self-representation under pressure.
+- **Chornobyl / postmodernism:** `Післячорнобильська бібліотека. Український літературний постмодерн` and the ASP English translation `The Post-Chornobyl Library: Ukrainian Postmodernism of the 1990s` are the most direct cross-track anchors. ASP lists the English edition as 2019, translated by Sergiy Yakovenko, and describes the Chornobyl disaster as central to Ukrainian postmodern writing of trauma and decolonization.
+- **Postcolonial trauma / decolonization:** HURI/VUIAS list `Tranzytna cul'tura i postcolonial'na travma` / `Транзитна культура. Симптоми постколоніальної травми`; HURI's 2025 project connects her current research to decolonization, Ukrainian DP camps, Europe, Occidentalism, and the "problem of the West."
+- **Public humanities:** PEN, Ukraїner, Vikhola, HURI events, ASP interviews, and Ukrainian media preserve her public-facing work on imperial legacy, Chornobyl, illness and sanatorium culture, plagiarism, feminism, and cultural strategy.
+
+## 4. Primary-source quote / visual anchors
+
+Use short excerpts only. Hundorova is living, and her books/interviews are copyright-protected unless a specific open license is confirmed.
+
+- **Decolonial visibility anchor:** Ukraїner headline/interview preserves the short phrase `змінювати уявлення на Заході про нас як маргіналію`. This is useful for a spoken-voice prompt about Ukraine as subject, not margin.
+- **Chornobyl title anchor:** `Післячорнобильська бібліотека` / `The Post-Chornobyl Library` is a safe title-level anchor for Chornobyl, library, archive, postmodernism, trauma, and decolonization.
+- **Postcolonial trauma anchor:** `Транзитна культура. Симптоми постколоніальної травми` is a compact concept-title anchor. Future module can ask learners why "transit" and "trauma" are paired.
+- **Canon de-monumentalization anchor:** `Франко - не Каменяр` / `Franko i/ne Kameniar` can launch a lesson question: what happens when criticism refuses a monument-name and returns the writer to conflict, irony, body, and modernity?
+- **Occidentalism project anchor:** HURI's 2025 research-project page frames Ukrainian DP-camp debates about Europe, decolonization, and "Occidentalism." This gives a current scholarly anchor beyond the 1990s/postmodern frame.
+- **Visual anchor:** Commons `File:Tamara Hundorova.JPG` is a 2011 CC0 portrait by Silin2005. Commons `File:Tamara Hundorova-DAN09274.jpg` is a 2019 portrait by Данило Павлов / danil pavlov, CC BY-SA 4.0 with VRT confirmation. Prefer Commons file-page verification before embedding.
+
+## 5. Language register
+
+- **Register:** academic-critical, theoretical, polemical, essayistic, transnational; combines Ukrainian literary close reading with concepts from postmodernism, postcolonial studies, trauma studies, gender studies, and cultural theory.
+- **CEFR readiness:** B2+/C1 for guided interview excerpts; C1 for short scholarly prose with strong vocabulary scaffolding; C2 for dense passages from `Післячорнобильська бібліотека`, `Транзитна культура`, and `Кітч і література` because students must track theory, metaphor, and long analytic syntax.
+- **Core vocabulary:** `модернізм`, `постмодернізм`, `постколоніалізм`, `деколонізація`, `травма`, `кітч`, `канон`, `рецепція`, `дискурс`, `маргіналія`, `суб'єктність`, `гендер`, `фемінізм`, `Чорнобиль`, `архів`, `пам'ять`, `транзитність`, `євроцентризм`.
+- **Pedagogical caution:** Do not flatten her work into "Russia bad, Ukraine good" slogans. The learning value is methodological: how a critic reads language, trauma, canon, gender, and institutional power to change the map of Ukrainian literature.
+- **Bridge activities:** Ask learners to compare title-level arguments: `Франко - не Каменяр`, `Післячорнобильська бібліотека`, `Кітч і література`, `Транзитна культура`. What kind of cultural habit does each title challenge?
+
+## 6. Contested points
+
+- **Current role wording:** NAS now lists `Головний науковий співробітник`; older pages and profiles use "head/chair of department" or "principal research fellow." Use NAS for current Ukrainian institutional wording and time-stamp any role copied from HURI/VUIAS/WIKO.
+- **Transliteration variants:** `Hundorova` is the project canonical English form. `Gundorova` appears on some institutional/CV/search records; `Hundorowa` appears in Polish/German contexts. Keep variants in aliases/search notes, not default learner-facing text.
+- **Existing repo typo/anomaly:** The project has an existing LIT-ESSAY slug and title using `oxana-hundorova-postcolonialism` / "Оксана Гундорова". That surface appears to discuss Tamara Hundorova's postcolonial criticism but carries an `Oksana` name anomaly. Do not edit that in this dossier PR; flag it for future cross-track cleanup.
+- **"Postcolonial" vs "decolonial":** Hundorova uses and is cited through postcolonial theory, postcolonial trauma, and newer decolonization debates. Future modules should not collapse the terms; ask students what each framework can and cannot explain about Ukraine.
+- **Western theory dependency risk:** Her work productively dialogues with Said, Spivak, Chakrabarty, postmodernism, and trauma studies. Avoid implying Ukrainian scholarship merely imports Western theory. HURI's current project explicitly asks how Ukrainian debates provincialize Europe and complicate the West itself.
+- **Public intellectual reception:** Interviews after 2014/2022 can be sharp, timely, and political. Treat them as dated public interventions rather than neutral encyclopedia facts.
+- **Image recency vs license:** The 2011 CC0 image is easiest rights-wise but older and lower resolution; the 2019/2021 Danilo Pavlov Commons images are better portraits but require CC BY-SA 4.0 attribution and share-alike handling.
+
+## 7. Cross-track links
+
+- **Existing LIT plan surfaces (VERIFIED `test -e` 2026-07-01):** `curriculum/l2-uk-en/plans/lit/hundorova-post-chornobyl-library.yaml`
+- **Existing LIT-ESSAY plan surfaces (VERIFIED `test -e` 2026-07-01, name anomaly noted in §6):** `curriculum/l2-uk-en/plans/lit-essay/oxana-hundorova-postcolonialism.yaml`, `curriculum/l2-uk-en/plans/lit-essay/solomea-pavlychko-modernism.yaml`, `curriculum/l2-uk-en/plans/lit-essay/vira-ageyeva-canon.yaml`, `curriculum/l2-uk-en/plans/lit-essay/zabuzhko-fortinbras.yaml`
+- **Existing HIST / ISTORIO / LIT-DRAMA plan surfaces (VERIFIED `test -e` 2026-07-01):** `curriculum/l2-uk-en/plans/hist/chornobyl.yaml`, `curriculum/l2-uk-en/plans/istorio/metodolohiia-dekolonizatsii.yaml`, `curriculum/l2-uk-en/plans/lit-drama/arie-chornobyl.yaml`, `curriculum/l2-uk-en/plans/lit-drama/lesia-ukrainka-dramatic-legacy.yaml`
+- **Existing discovery / wiki surfaces (VERIFIED `test -e` 2026-07-01):** `curriculum/l2-uk-en/lit/discovery/hundorova-post-chornobyl-library.yaml`, `curriculum/l2-uk-en/lit-essay/discovery/oxana-hundorova-postcolonialism.yaml`, `curriculum/l2-uk-en/istorio/discovery/metodolohiia-dekolonizatsii.yaml`, `wiki/literature/works/hundorova-post-chornobyl-library.md`, `wiki/literature/works/hundorova-post-chornobyl-library.sources.yaml`, `wiki/literature/works/oxana-hundorova-postcolonialism.md`, `wiki/historiography/metodolohiia-dekolonizatsii.md`, `wiki/literature/works/lutsyshyna-whale.md`
+- **Existing BIO research cross-links (VERIFIED `test -e` 2026-07-01):** `docs/research/bio/vira-aheieva.md`, `docs/research/bio/oksana-zabuzhko.md`, `docs/research/bio/olha-kobylianska.md`, `docs/research/bio/lesya-ukrainka.md`, `docs/research/bio/yurii-shcherbak.md`
+- **Existing site index surface (VERIFIED `rg` 2026-07-01):** `site/src/content/docs/bio/index.mdx` includes `num: 382`, `slug: tamara-hundorova`, status locked. LIT/LIT-ESSAY indexes expose the direct Hundorova work modules.
+- **Candidate / future BIO surfaces not created in this PR:** `curriculum/l2-uk-en/plans/bio/tamara-hundorova.yaml`, `curriculum/l2-uk-en/bio/discovery/tamara-hundorova.yaml`, `wiki/figures/tamara-hundorova.md`, `site/src/content/docs/bio/tamara-hundorova.mdx`, `curriculum/l2-uk-en/bio/tamara-hundorova/module.md`, `curriculum/l2-uk-en/bio/tamara-hundorova/activities.yaml`, `curriculum/l2-uk-en/bio/tamara-hundorova/vocabulary.yaml`, `curriculum/l2-uk-en/bio/tamara-hundorova/resources.yaml`
+
+## 8. Naming-canonical
+
+- **Slug:** `tamara-hundorova`
+- **EN canonical (project):** Tamara Hundorova.
+- **UA canonical:** Тамара Іванівна Гундорова.
+- **Aliases future YAML:** `Тамара Гундорова`; `Гундорова Тамара Іванівна`; `Tamara Hundorova`; `Tamara Ivanivna Hundorova`; `Tamara Gundorova`; `Tamara Ivanivna Gundorova`; `Tamara Hundorowa`; `Tamara Goundorova`.
+- **Forbidden / noncanonical learner-facing defaults:** `Tamara Gundorova` as display default; Russian `Тамара Ивановна Гундорова`; `Oksana Hundorova` except when explicitly discussing the existing repo-local anomaly in §6.
+- **Search note:** Use `Gundorova` and `Hundorowa` when searching library catalogues, old CVs, Polish/German pages, and older English profiles. Keep lesson display as `Tamara Hundorova`.
+
+## 9. Image candidates
+
+- **Primary low-friction option:** Commons `File:Tamara Hundorova.JPG`; 11 March 2011; source own work; author Silin2005; license CC0 1.0 Universal Public Domain Dedication. It is older and lower resolution but easiest for reuse.
+- **Primary high-quality option:** Commons `File:Tamara Hundorova-DAN09274.jpg`; Ukrainian caption Tamara Hundorova (2019); source own work; author Данило Павлов / danil pavlov; CC BY-SA 4.0; VRT ticket listed on file page. Use with attribution and share-alike compliance.
+- **Additional Commons category lead:** `Category:Tamara Hundorova` lists 11 files, including Danilo Pavlov portraits, Olena Anhelova / Gender in Detail portraits, a 2013 Vienna conference image, and a 1998 New York Shevelov/Hundorova image. Verify each file page before embedding.
+- **Institutional images:** NAS, HURI, VUIAS, PEN, WIKO pages include images, but no reusable license was verified for those pages. Do not embed institutional images unless a file-level reusable license is confirmed.
+- **Avoid by default:** screenshots from interviews/videos, publisher headshots, book covers, PEN/Ukraїner/HURI images without explicit reusable license, and social-media photos.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- Енциклопедія Сучасної України. "Гундорова Тамара Іванівна." https://esu.com.ua/article-24725. Accessed 2026-07-01.
+- Національна академія наук України. "Гундорова Тамара Іванівна." https://www.nas.gov.ua/employee/nastamara-gundorova. Accessed 2026-07-01.
+- Інститут літератури ім. Т. Г. Шевченка НАН України. "Гундорова Тамара Іванівна." https://www.ilnan.gov.ua/index.php/pro-instytut/pidrozdily-instytutu/viddil-teorii-literatury/item/85-hundorova-tamara-ivanivna. Accessed 2026-07-01.
+
+**Tier 2 (scholarly / institutional profile / publisher evidence):**
+
+- Harvard Ukrainian Research Institute. "Tamara Hundorova." 2025 research fellow profile. https://www.huri.harvard.edu/people/fellow-tamara-hundorova-2025. Accessed 2026-07-01.
+- Virtual Ukraine Institute for Advanced Study. "Tamara Hundorova." https://vuias.org/person/tamara-hundorova/. Accessed 2026-07-01.
+- Wissenschaftskolleg zu Berlin. "Tamara Hundorova, Dr." https://www.wiko-berlin.de/en/fellows/academic-year/2025/hundorova-tamara. Accessed 2026-07-01.
+- PEN Ukraine. "Hundorova Tamara." https://pen.org.ua/en/members/hundorova-tamara. Accessed 2026-07-01.
+- Academic Studies Press. "Tamara Hundorova." https://www.academicstudiespress.com/author/tamara-hundorova/. Accessed 2026-07-01.
+- Academic Studies Press. `The Post-Chornobyl Library: Ukrainian Postmodernism of the 1990s`. https://www.academicstudiespress.com/9781644692394/. Accessed 2026-07-01.
+
+**Tier 3 (public humanities / interviews / current voice):**
+
+- Ukraїner. "Тамара Гундорова про імперський спадок у літературі." https://www.ukrainer.net/tamara-hundorova/. Accessed 2026-07-01.
+- Видавництво Віхола. "Тамара Гундорова." https://www.vikhola.com/en/authors/tamara-hundorova. Accessed 2026-07-01.
+- Academic Studies Press Blog. "An Interview with Tamara Hundorova, Author of The Post-Chornobyl Library." https://www.academicstudiespress.com/blog/2020-4-26-an-interview-with-tamara-hundorova-author-of-the-post-chornobyl-library/. Accessed 2026-07-01.
+
+**Tier 4 (image-rights / navigation only):**
+
+- Wikimedia Commons. `Category:Tamara Hundorova`. https://commons.wikimedia.org/wiki/Category:Tamara_Hundorova. Accessed 2026-07-01.
+- Wikimedia Commons. `File:Tamara Hundorova.JPG`. https://commons.wikimedia.org/wiki/File:Tamara_Hundorova.JPG. Accessed 2026-07-01.
+- Wikimedia Commons. `File:Tamara Hundorova-DAN09274.jpg`. https://commons.wikimedia.org/wiki/File:Tamara_Hundorova-DAN09274.jpg. Accessed 2026-07-01.
+- Ukrainian Wikipedia / English Wikipedia were used only as search/navigation leads; no learner-facing facts depend on Wikipedia alone.

--- a/docs/research/bio/tamara-hundorova.md
+++ b/docs/research/bio/tamara-hundorova.md
@@ -7,7 +7,7 @@
 **Researcher:** Codex orchestrator (GPT-5)
 **Completed:** 2026-07-01
 
-**Source acronym legend:** ESU = Encyclopedia Modern Ukraine; NAS = National Academy of Sciences of Ukraine; IL-NAN = Shevchenko Institute of Literature, NAS of Ukraine; HURI = Harvard Ukrainian Research Institute; VUIAS = Virtual Ukraine Institute for Advanced Study; WIKO = Wissenschaftskolleg zu Berlin; PEN = PEN Ukraine; ASP = Academic Studies Press; Ukraїner = Ukraїner interview project; Commons = Wikimedia Commons.
+**Source acronym legend:** ESU = Encyclopedia Modern Ukraine; NAS = National Academy of Sciences of Ukraine; IL-NAN = Shevchenko Institute of Literature, NAS of Ukraine; PRU = President of Ukraine; HURI = Harvard Ukrainian Research Institute; VUIAS = Virtual Ukraine Institute for Advanced Study; WIKO = Wissenschaftskolleg zu Berlin; PEN = PEN Ukraine; ASP = Academic Studies Press; Ukraїner = Ukraїner interview project; Commons = Wikimedia Commons.
 
 **Acceptance self-check:**
 - [x] All 10 sections completed
@@ -39,7 +39,7 @@
 - **Core institutional role:** NAS lists her as corresponding member of NAS Ukraine, doctor of philological sciences, professor, and chief research fellow at the Shevchenko Institute of Literature, NAS of Ukraine. HURI's 2025 fellow page describes her as principal research fellow at the Shevchenko Institute of Literature, HURI associate, and dean of the Ukrainian Free University.
 - **International academic profile:** ESU, HURI, VUIAS, WIKO, and ASP record teaching/research affiliations across Harvard, Princeton, Toronto, Monash, Hokkaido, Ukrainian Free University, Kyiv-Mohyla Academy, Kyiv National University, and other institutions. Use specific dates only from a current source.
 - **Field identity:** literary scholar, critic, culturologist, professor, theorist of Ukrainian modernism/postmodernism, gender studies, Chornobyl studies, kitsch, postcolonial and decolonial Ukrainian studies.
-- **Recognition:** ESU records corresponding member NASU (2003), Honored Worker of Science and Technology of Ukraine (2006), Order of Princess Olga 3rd class (2026), and literary / scholarly prizes including `Світовид`, `Сучасність`, and Ivan Franko Prize.
+- **Recognition:** ESU records corresponding member NASU (2003), Honored Worker of Science and Technology of Ukraine (2006), and literary / scholarly prizes including `Світовид`, `Сучасність`, and Ivan Franko Prize. ESU and PRU decree No. 136/2026 record the Order of Princess Olga 3rd class (2026).
 
 ## 2. Oppression / pressure mechanism
 
@@ -123,6 +123,7 @@ Use short excerpts only. Hundorova is living, and her books/interviews are copyr
 - Енциклопедія Сучасної України. "Гундорова Тамара Іванівна." https://esu.com.ua/article-24725. Accessed 2026-07-01.
 - Національна академія наук України. "Гундорова Тамара Іванівна." https://www.nas.gov.ua/employee/nastamara-gundorova. Accessed 2026-07-01.
 - Інститут літератури ім. Т. Г. Шевченка НАН України. "Гундорова Тамара Іванівна." https://www.ilnan.gov.ua/index.php/pro-instytut/pidrozdily-instytutu/viddil-teorii-literatury/item/85-hundorova-tamara-ivanivna. Accessed 2026-07-01.
+- Президент України. "Указ Президента України No. 136/2026." https://www.president.gov.ua/documents/1362026-58373. Accessed 2026-07-01.
 
 **Tier 2 (scholarly / institutional profile / publisher evidence):**
 


### PR DESCRIPTION
## Summary
- add BIO #382 research dossier for Tamara Hundorova
- document decolonial/postcolonial, Chornobyl, gender/canon, cross-track, naming, and image-rights anchors
- keep scope to dossier-only base prep

## Scope
- Changed only: docs/research/bio/tamara-hundorova.md
- Did not touch plan YAML, module/activity/vocabulary/resources, site MDX, wiki packets, generated artifacts, linter configs, package files, or telemetry

## Validation
- npx markdownlint-cli2 docs/research/bio/tamara-hundorova.md
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/tamara-hundorova.md
- git diff --check
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py

X-Agent: codex/bio-382-tamara-hundorova-dossier