### PR TITLE
docs(bio): add Oksana Kis dossier

### DIFF
--- a/docs/research/bio/oksana-kis.md
+++ b/docs/research/bio/oksana-kis.md
@@ -1,0 +1,152 @@
+# Оксана Романівна Кісь - Research Dossier
+
+**Slug:** `oksana-kis`
+**Block:** +77 expansion - women's history / feminist anthropology / Gulag and Holodomor memory
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #383
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Source acronym legend:** NRFU = National Research Foundation of Ukraine; NAS = National Academy of Sciences of Ukraine; IE-NAS = Institute of Ethnology, NAS of Ukraine; VUIAS = Virtual Ukraine Institute for Advanced Study; IKK = Imre Kertesz Kolleg Jena; HURI = Harvard Ukrainian Research Institute; UCU = Ukrainian Catholic University; UHJ = Ukrainian Historical Journal; JGR = Journal of Genocide Research; UBI = Ukrainian Book Institute; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional or scholarly sources cited
+- [x] Pressure mechanism framed as Soviet/Russian imperial historiography, patriarchal archive/canon bias, gendered violence, Gulag/Holodomor memory politics; no invented arrest, exile, camp term, or dissident sentence for Kis herself
+- [x] At least 2 primary-source text / voice anchors supplied
+- [x] Cross-track links verified `test -e` / `rg` on 2026-07-01 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing: Gulag and Soviet history are taught through Ukrainian women prisoners, Ukrainian memory, and epistemic justice, not through default Russian dissident canons.
+- [x] Gender is not treated as decorative add-on: Kis's work changes what counts as archive, agency, resistance, and historical evidence.
+- [x] Russian/Soviet imperial narratives are named as objects of critique, especially in Gulag studies and Holodomor memory, not as neutral baseline.
+- [x] Living scholar claims are time-stamped: NRFU leadership and fellowships must be rechecked at build time.
+- [x] Anti-hagiography retained: her "survival as victory" framework is taught as a powerful argument with methodological stakes and limits, not as a slogan that erases suffering or ambiguity.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Оксана Романівна Кісь.
+- **Project English canonical:** Oksana Kis.
+- **Birth:** IKK gives 1970, Lviv, Ukraine. Several secondary bios give 11 January 1970, Lviv; use the exact day only with secondary-source caveat unless a primary institutional record is found.
+- **Living figure:** Kis is a living historian, anthropologist, public scholar, and research administrator. Re-verify current roles before module build.
+- **Current top institutional role:** NRFU says Cabinet of Ministers order No. 158-r appointed Oksana Kis Head of the National Research Foundation of Ukraine on 25 February 2025, for 8 March 2025 to 18 April 2027. NAS published the same appointment on 26 February 2025.
+- **Earlier / concurrent scholarly base:** NAS describes her as a leading research fellow of the Institute of Ethnology, NAS of Ukraine, and president of the Ukrainian Association for Research in Women's History. IKK says she worked at the Institute of Ethnology from 1994 to 2025 and headed the Department of Social Anthropology in 2020-2024.
+- **Education / degrees:** IKK states she graduated in history from Franko State University of Lviv in 1992, completed postgraduate study in psychology in 1994, earned kandydat nauk in History/Ethnology in 2002, and doktor nauk / habilitation equivalent in History/Ethnology in 2018.
+- **Core BIO identity:** feminist historian and anthropologist; scholar of Ukrainian women's history, feminist anthropology, oral history, Gulag studies, Holodomor women's experience, gender transformations in post-socialist countries, femactivism, and decolonizing Soviet/Russian-centered historiography.
+- **Organizations / editorial roles:** IKK records her as co-founder and president of the Ukrainian Association for Research in Women's History from 2010, board member of Association of Women in Slavic Studies from 2022, editor of `Aspasia`, editor-in-chief of `Ukraina Moderna` in 2014-2020, and co-founder / vice-president of the Ukrainian Oral History Association in 2006-2023.
+
+## 2. Oppression / pressure mechanism
+
+- **Not prison-case biography:** Do not invent arrest, exile, camp sentence, KGB file, or dissident conviction for Kis herself. Her BIO pressure mechanism is historiographical and institutional: recovering women as actors where archives, public memory, and scholarly canons often made them marginal or invisible.
+- **Imperial archive problem:** Kis's Gulag work challenges male-centered and Russian-centered models of camp history. HURI describes `Survival as Victory` as the first anthropological study of daily life in Soviet forced labor camps as experienced by Ukrainian women prisoners, based on memoirs, autobiographies, and oral histories of more than 150 survivors.
+- **Gendered violence / survival:** The pressure frame is not only "women suffered too." Kis's work asks what counts as resistance when the battlefield is hunger, labor, motherhood, body, faith, language, memory, mutual care, and maintaining Ukrainian identity under dehumanizing camp conditions.
+- **Holodomor and motherhood:** Her JGR article on women's experience of the Holodomor centers motherhood, ambiguity, and survival under genocidal conditions. Avoid sentimentalizing mothers; the point is historical agency under impossible constraints.
+- **Patriarchal national memory:** Existing ISTORIO planning rightly uses Kis to challenge stories where women appear only as victims, supporters, muses, or symbols. The lesson should ask who becomes grammatical subject of history and whose documents count as evidence.
+- **Decolonial method:** Her 2024 UHJ article title, `Як деколонізувати студії ҐУЛАҐу? Панівні російські наративи та перспективи відновлення епістемологічної справедливості`, makes decolonization explicit. Use this to name epistemic justice rather than only representation.
+- **State-research governance pressure:** Since 2025, Kis also holds a public research-administration role. BIO must separate her scholarship from her NRFU office and avoid presenting future policy outcomes as already achieved.
+
+## 3. Major works / contributions
+
+- **Traditional culture / gender anthropology:** `Жінка в традиційній українській культурі другої половини XIX - початку XX століття` (2008; 2nd ed. 2012) is a base work for premodern/modern gender roles, family, body, labor, and social norms.
+- **Gulag women:** `Українки в ГУЛАГу: вижити значить перемогти` (2017; 2nd revised ed. 2020) is the central BIO text. IE-NAS notes the book received the Lviv Book Forum `Місто` distinction in 2020 and entered UBI's list of 30 important books of Ukrainian independence in 2021.
+- **English-language reach:** `Survival as Victory: Ukrainian Women in the Gulag`, translated by Lidia Wolanskyj and published in the Harvard Series in Ukrainian Studies, made the work accessible in English. HURI frames it as a study of Ukrainian women's camp agency and survival strategies; VUIAS and IKK note the Peterson Literary Fund Translated Book Prize.
+- **Women's history field-building:** Kis edited / co-edited `Українські жінки у горнилі модернізації`, `Жіночі виміри минулого: уявлення, досвіди, репрезентації`, and `Жіночі історії лідерства в Україні`. These matter because her work builds infrastructure, not just individual interpretation.
+- **Holodomor gender studies:** `Women's Experience of the Holodomor: Challenges and Ambiguities of Motherhood` anchors Holodomor memory through gender, motherhood, and moral ambiguity under genocidal violence.
+- **Decolonizing Gulag studies:** `Як деколонізувати студії ҐУЛАҐу?` is the direct bridge to decolonization and epistemological justice; future BIO can connect it to ISTORIO methodology modules.
+- **Public humanities:** NAS, Gender in Detail, The Ukrainians, HURI, Princeton, VUIAS, IKK, and REESOURCES show her as a public scholar explaining why women's history, feminist method, and oral history matter for Ukrainian memory.
+
+## 4. Primary-source quote / visual anchors
+
+Use short excerpts only. Kis is living, and her books/articles/interviews are copyright-protected unless a specific open license is confirmed.
+
+- **Title-level thesis anchor:** `вижити значить перемогти` is the central short phrase. It should be taught as an argument about daily survival and agency in the Gulag, not as a denial of trauma.
+- **Decolonial method anchor:** `Як деколонізувати студії ҐУЛАҐу?` is a strong prompt title for asking what Russian-centered Gulag studies omit.
+- **Holodomor anchor:** `Women's Experience of the Holodomor` lets the lesson connect genocide memory, gender, motherhood, and survival strategies.
+- **Field-building anchor:** `Жіночі виміри минулого` signals that "women's history" is not a separate corner but a changed dimension of the whole past.
+- **Visual anchor:** Commons `File:Oksana Kis 468310885 10236227814094389 7144985998105021624 n.jpg` is a 2018 portrait before her doctoral defense, CC BY-SA 4.0, license reviewed on 20 January 2025. Commons `File:Оксана Кісь.jpg` is a 2016 International Women's Day action photo, own work by Admiral July, CC BY-SA 4.0. Use academic portrait first; use protest image only when lesson explicitly foregrounds feminist public activism.
+
+## 5. Language register
+
+- **Register:** scholarly, anthropological, feminist, source-critical, oral-history based, sometimes public-humanities explanatory. Dense academic passages use abstract vocabulary; interviews and public essays are more accessible.
+- **CEFR readiness:** B2+/C1 for interviews and public essays with scaffolding; C1 for book introductions / article abstracts; C2 for dense methodology around epistemological justice, gendered agency, oral history, and decolonizing Gulag studies.
+- **Core vocabulary:** `жіноча історія`, `гендерна антропологія`, `усна історія`, `его-документи`, `ГУЛАГ`, `Голодомор`, `виживання`, `суб'єктність`, `тілесність`, `материнство`, `посестра`, `віктимізація`, `епістемологічна справедливість`, `деколонізація`, `історіографія`, `пам'ять`.
+- **Teaching caution:** Avoid using "female experience" as a soft human-interest supplement. In Kis's work, gender changes the source base, the research question, and the definition of resistance.
+- **Bridge activities:** Ask learners to compare how `вижити`, `перемогти`, `свідчити`, and `пам'ятати` function as historical verbs. Who acts in each sentence, and who disappears?
+
+## 6. Contested points
+
+- **Exact birth date:** 11 January 1970, Lviv appears in Wikipedia-derived and commercial bios. IKK gives 1970, Lviv. Use year/place confidently; use exact day only with source caveat until a stronger institutional/personnel source is found.
+- **Current role drift:** Older pages say head of Department of Social Anthropology or senior/leading research fellow at IE-NAS. NRFU/NAS 2025 pages supersede that for present-tense role. Treat department-head language as historical unless a current institute page reconfirms.
+- **Institute page typo:** IE-NAS lists `Survival as History: Ukrainian Women in the Gulag`; the consistent title in HURI, HUP/JSTOR, VUIAS, IKK, and repo plan is `Survival as Victory`. Future module should not reproduce the typo except as a source note.
+- **Gulag spelling:** English sources use both `Gulag` and `GULAG`; Ukrainian sources use `ГУЛАГ` or `ҐУЛАҐ` depending on style/title. Preserve source titles; use a consistent learner-facing form in course copy.
+- **Not all women's history is feminist activism:** Kis is both scholar and feminist public voice, but not every scholarly claim should be treated as activism. Distinguish method, field-building, public intervention, and state-administration role.
+- **"Survival as victory" risk:** The phrase can sound triumphalist if isolated. Always pair it with body, hunger, labor, motherhood, faith, mutual care, national identity, and the cost of survival.
+- **Russian-centered camp canon:** Solzhenitsyn/Shalamov comparisons can help students see historiographical defaults, but should not recentralize Russian male texts as the measure of Ukrainian women's testimony.
+
+## 7. Cross-track links
+
+- **Existing LIT-ESSAY plan surfaces (VERIFIED `test -e` 2026-07-01):** `curriculum/l2-uk-en/plans/lit-essay/kis-survival-as-victory.yaml`
+- **Existing ISTORIO / HIST plan surfaces (VERIFIED `test -e` 2026-07-01):** `curriculum/l2-uk-en/plans/istorio/zhinky-v-revoiuutsiiakh.yaml`, `curriculum/l2-uk-en/plans/hist/zlochyny-stiikist.yaml`
+- **Existing discovery / wiki surfaces (VERIFIED `test -e` 2026-07-01):** `curriculum/l2-uk-en/lit-essay/discovery/kis-survival-as-victory.yaml`, `curriculum/l2-uk-en/istorio/discovery/zhinky-v-revoiuutsiiakh.yaml`, `curriculum/l2-uk-en/hist/discovery/zlochyny-stiikist.yaml`, `wiki/literature/works/kis-survival-as-victory.md`, `wiki/literature/works/kis-survival-as-victory.sources.yaml`, `wiki/historiography/zhinky-v-revoiuutsiiakh.md`, `wiki/historiography/zhinky-v-revoiuutsiiakh.sources.yaml`, `wiki/periods/zlochyny-stiikist.md`, `wiki/periods/zlochyny-stiikist.sources.yaml`
+- **Existing historiography surfaces with Kis mentions (VERIFIED `test -e` 2026-07-01):** `wiki/historiography/holodomor-istorio.md`, `wiki/historiography/holodomor-svidky.md`, `wiki/historiography/svidchennia-holodomoru-i.md`, `wiki/historiography/holodomor-mekhanizmy-i.md`, `wiki/historiography/istorychna-pamiat-i-polityka.md`
+- **Existing BIO research cross-links (VERIFIED `test -e` 2026-07-01):** `docs/research/bio/tamara-hundorova.md`, `docs/research/bio/vira-aheieva.md`, `docs/research/bio/oksana-zabuzhko.md`
+- **Existing site index surfaces (VERIFIED `rg` 2026-07-01):** `site/src/content/docs/bio/index.mdx` includes `num: 383`, `slug: oksana-kis`, status locked; `site/src/content/docs/lit-essay/index.mdx` exposes `kis-survival-as-victory`.
+- **Candidate / future BIO surfaces not created in this PR:** `curriculum/l2-uk-en/plans/bio/oksana-kis.yaml`, `curriculum/l2-uk-en/bio/discovery/oksana-kis.yaml`, `wiki/figures/oksana-kis.md`, `site/src/content/docs/bio/oksana-kis.mdx`, `curriculum/l2-uk-en/bio/oksana-kis/module.md`, `curriculum/l2-uk-en/bio/oksana-kis/activities.yaml`, `curriculum/l2-uk-en/bio/oksana-kis/vocabulary.yaml`, `curriculum/l2-uk-en/bio/oksana-kis/resources.yaml`
+
+## 8. Naming-canonical
+
+- **Slug:** `oksana-kis`
+- **EN canonical (project):** Oksana Kis.
+- **UA canonical:** Оксана Романівна Кісь.
+- **Aliases future YAML:** `Оксана Кісь`; `Кісь Оксана Романівна`; `Oksana Kis`; `Oksana Romanivna Kis`; `Oksana Kis'`; `Oksana Kiś`; `Oksana Kiss` (Wikidata / structured-data variant only, noncanonical).
+- **Forbidden / noncanonical learner-facing defaults:** Russian `Оксана Романовна Кись`; `Oxana Kis`; `Oksana Kiss` except as a search-note / metadata anomaly; English `Survival as History` unless explicitly flagging the IE-NAS typo.
+- **Search note:** Use `Kis'`, `Kis`, `Кісь`, and `Оксана Романівна Кісь` for catalogues and Commons. Avoid Russian patronymic search defaults unless investigating hostile/imperial metadata.
+
+## 9. Image candidates
+
+- **Primary academic portrait:** Commons `File:Oksana Kis 468310885 10236227814094389 7144985998105021624 n.jpg`; 17 April 2018; source Facebook; author Oksana Kis, rights-owner statement; CC BY-SA 4.0; license review by Commons reviewer Ahonc on 20 January 2025. Best fit for academic BIO portrait if attribution/share-alike requirements are met.
+- **Secondary public-scholar portrait:** Commons `File:Oksana Kis 75317351 10221300326156520 1630278338981396480 n.jpg`; 6 November 2019, Harvard; source Facebook; author Oksana Kis; CC BY-SA 4.0; license reviewed on 20 January 2025. Useful HURI/public-academic context.
+- **Activism-context image:** Commons `File:Оксана Кісь.jpg`; 8 March 2016; own work by Admiral July; CC BY-SA 4.0; depicts Kis at `Чому мені потрібен фемінізм?` action. Use only if the lesson foregrounds feminist public activism, not as default formal portrait.
+- **Avoid by default:** NRFU/NAS/VUIAS/IKK/HURI profile photos unless a file-level reusable license is verified; book covers; screenshots from talks; social-media images not already Commons-reviewed.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- National Research Foundation of Ukraine. "Head of the Foundation." https://nrfu.org.ua/en/about-us/fund-structure/chairman-of-the-foundation/. Accessed 2026-07-01.
+- National Research Foundation of Ukraine. "The Cabinet of Ministers of Ukraine appointed Oksana Kis as the Head of the National Research Foundation of Ukraine." https://nrfu.org.ua/en/news-en/the-cabinet-of-ministers-of-ukraine-appointed-oksana-kis-as-the-head-of-the-national-research-foundation-of-ukraine/. Accessed 2026-07-01.
+- Національна академія наук України. "Провідна наукова співробітниця Інституту народознавства НАН України Оксана Кісь очолила Національний фонд досліджень України." https://www.nas.gov.ua/news/providna-naukova-spivrobitnicya-institutu-narodoznavstva-nan-ukrani-oksana-kis-ocholila-nacionalniy-fond-doslidzhen-ukrani. Accessed 2026-07-01.
+- Інститут народознавства НАН України. "Відділ соціальної антропології." https://ethnology.lviv.ua/naukovi-pidrozdili/viddil-socialnoji-antropologiji. Accessed 2026-07-01.
+
+**Tier 2 (scholarly / institutional profile / publisher evidence):**
+
+- Imre Kertesz Kolleg Jena. "Professor Oksana Kis." https://www.imre-kertesz-kolleg.uni-jena.de/fellows/incoming-fellows/professor-oksana-kis. Accessed 2026-07-01.
+- Virtual Ukraine Institute for Advanced Study. "Oksana Kis." https://vuias.org/person/oksana-kis/. Accessed 2026-07-01.
+- Princeton University Department of History. "Oksana Kis." https://history.princeton.edu/speakers/oksana-kis. Accessed 2026-07-01.
+- Harvard Ukrainian Research Institute. "Book Release: Survival as Victory by Oksana Kis." https://www.huri.harvard.edu/news/book-release-kis. Accessed 2026-07-01.
+- Harvard Ukrainian Research Institute. "Oksana Kis." https://www.huri.harvard.edu/people/oksana-kis. Accessed 2026-07-01.
+- Ukrainian Catholic University repository. `Феміністські студії та фемактивізм у незалежній Україні: кроки назустріч собі`. https://er.ucu.edu.ua/items/d876b0ef-005c-42e5-be7c-a0dc8a80aced. Accessed 2026-07-01.
+- Український історичний журнал. "Як деколонізувати студії ҐУЛАҐу? Панівні російські наративи та перспективи відновлення епістемологічної справедливості." https://nasu-periodicals.org.ua/index.php/uhj/article/view/10774. Accessed 2026-07-01.
+- Journal of Genocide Research. "Women's Experience of the Holodomor: Challenges and Ambiguities of Motherhood." https://www.tandfonline.com/doi/full/10.1080/14623528.2020.1834713. Accessed 2026-07-01.
+- UCU Library catalogue. `Жінка в традиційній українській культурі другої половини ХІХ - початку ХХ ст.` https://opac.ucu.edu.ua/cgi-bin/koha/opac-detail.pl?biblionumber=236112. Accessed 2026-07-01.
+- UCU Library catalogue. `Українки в ГУЛАГу: вижити значить перемогти.` https://opac.ucu.edu.ua/cgi-bin/koha/opac-detail.pl?biblionumber=292928. Accessed 2026-07-01.
+
+**Tier 3 (public humanities / current voice):**
+
+- REESOURCES / Center for Urban History. "Оксана Кісь." https://edu.lvivcenter.org/authors/oksana-kis/. Accessed 2026-07-01.
+- Gender in Detail. "Оксана Кісь." https://genderindetail.org.ua/library/authors/oxana-kis.html. Accessed 2026-07-01.
+- The Ukrainians. "Оксана Кісь: Жінки - не слабка стать." https://theukrainians.org/oksana-kis/. Accessed 2026-07-01.
+- Nash Format. "Оксана Кісь." https://nashformat.ua/authors/oksana-kis-books. Used only as secondary lead for exact birth date; not authoritative for core facts. Accessed 2026-07-01.
+
+**Tier 4 (image-rights / navigation only):**
+
+- Wikimedia Commons. `File:Oksana Kis 468310885 10236227814094389 7144985998105021624 n.jpg`. https://commons.wikimedia.org/wiki/File:Oksana_Kis_468310885_10236227814094389_7144985998105021624_n.jpg. Accessed 2026-07-01.
+- Wikimedia Commons. `File:Oksana Kis 75317351 10221300326156520 1630278338981396480 n.jpg`. https://commons.wikimedia.org/wiki/File:Oksana_Kis_75317351_10221300326156520_1630278338981396480_n.jpg. Accessed 2026-07-01.
+- Wikimedia Commons. `File:Оксана Кісь.jpg`. https://commons.wikimedia.org/wiki/File:%D0%9E%D0%BA%D1%81%D0%B0%D0%BD%D0%B0_%D0%9A%D1%96%D1%81%D1%8C.jpg. Accessed 2026-07-01.
+- Ukrainian Wikipedia / Wikiquote were used only as navigation leads; no learner-facing facts depend on Wikipedia alone.


### PR DESCRIPTION
## Summary
- add BIO #383 research dossier for Oksana Kis
- document women’s history, feminist anthropology, Gulag/Holodomor memory, decolonial historiography, naming, cross-track, and image-rights anchors
- keep scope to dossier-only base prep

## Scope
- Changed only: docs/research/bio/oksana-kis.md
- Did not touch plan YAML, module/activity/vocabulary/resources, site MDX, wiki packets, generated artifacts, linter configs, package files, or telemetry

## Validation
- npx markdownlint-cli2 docs/research/bio/oksana-kis.md
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/oksana-kis.md
- git diff --check
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py

X-Agent: codex/bio-383-oksana-kis-dossier