### PR TITLE
docs(bio): add Mykola Riabchuk dossier

### DIFF
--- a/docs/research/bio/mykola-riabchuk.md
+++ b/docs/research/bio/mykola-riabchuk.md
@@ -1,0 +1,141 @@
+# Микола Юрійович Рябчук - Research Dossier
+
+**Slug:** `mykola-riabchuk`
+**Block:** +77 expansion - essayistics / postcolonial Ukraine / public intellectual culture
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #384
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Source acronym legend:** IPIEND = Kuras Institute of Political and Ethnic Studies, NAS of Ukraine; PEN = PEN Ukraine; PRU = President of Ukraine; IWM = Institute for Human Sciences; CUP = Columbia University Press / ibidem; Gov.pl = Government of Poland service; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional or scholarly sources cited
+- [x] Pressure mechanism framed as Soviet censorship, unauthorized literary activity, post-Soviet oligarchic/imperial discourse, and living public-intellectual controversy; no invented arrest, exile, camp term, or dissident sentence
+- [x] At least 2 primary-source text / voice anchors supplied
+- [x] Cross-track links verified `test -e` / `rg` on 2026-07-01 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing: Russian/Soviet imperial discourse is named as Riabchuk's object of critique, not the neutral interpretive baseline.
+- [x] Ukrainian agency is central: the dossier treats Ukraine as a subject producing concepts about itself, not as a case study appended to Russian/post-Soviet studies.
+- [x] The "Two Ukraines" model is flagged as influential and contested, not taught as a permanent ethnic/civilizational split.
+- [x] Living figure claims are time-stamped: current roles and public essays must be rechecked at build time.
+- [x] Anti-hagiography retained: Riabchuk's postcolonial vocabulary and sharp polemical style are useful, but future lessons must ask what his frameworks reveal, obscure, or risk reifying.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Микола Юрійович Рябчук.
+- **Project English canonical:** Mykola Riabchuk.
+- **Birth:** IPIEND gives 27 September 1953, Lutsk. PEN and Gov.pl give 1953 and Lutsk; use IPIEND for exact date.
+- **Living figure:** Riabchuk is a living writer, essayist, political scientist, critic, translator, and public intellectual. Re-verify present-tense roles before module build.
+- **Current institutional role:** IPIEND lists him as a leading researcher at the Kuras Institute of Political and Ethnic Studies, NAS of Ukraine. It also lists editorial-board roles in `Krytyka`, `New Eastern Europe`, `Political Studies`, and `Journal of Soviet and Post-Soviet Politics and Society`, honorary president of PEN Ukraine, and Angelus jury work.
+- **Education / early pressure:** PEN says he studied at Lviv Polytechnic Institute in 1970-1973 but was expelled for unauthorized literary activity and later completed an M.A. at the Gorky Literary Institute in Moscow as perestroika advanced. Treat this as cultural/political pressure, not as a formal prison-case biography.
+- **Core BIO identity:** essayist and theorist of postcolonial Ukraine; public interpreter of postcommunist transformation, national identity, civil society, language/cultural politics, Ukrainian-Polish and Ukrainian-Russian relations, and Western "imperial knowledge" about Ukraine.
+- **Recognition:** IPIEND lists POLCUL award (1998), Antonovych Prize (2003), Bene merito medal of the Polish Foreign Ministry (2009), Warsaw University commemorative medal (2017), NAS Ukraine medal `For Professional Achievements` (2018), and the 2022 Taras Shevchenko National Prize for `Лексикон націоналіста та інші есеї`.
+
+## 2. Oppression / pressure mechanism
+
+- **Not prison-case biography:** Do not invent arrest, exile, camp term, KGB case, or dissident sentence. Riabchuk's pressure mechanism is late-Soviet censorship / unauthorized cultural activity, exclusion from formal study, samvydav/underground circulation, post-Soviet oligarchic media manipulation, and imperial epistemic power.
+- **Unauthorized literary activity:** PEN's biographical note says he was expelled from Lviv Polytechnic for unauthorized literary activity and had to work odd jobs before later entering literary/editorial work. This can anchor how informal culture and samvydav shaped his critical sensibility without turning him into a fabricated imprisoned dissident.
+- **Imperial knowledge:** In the PEN essay `Mapping a "Nowhere Nation"`, Riabchuk argues that Western and Russian discourse often normalized imperial narratives about Ukraine, making Ukrainians repeatedly explain basic facts about language, culture, history, and statehood. Teach this as a discourse-power mechanism, not simply "bad foreign journalism."
+- **Post-Soviet manipulation:** His IWM `Ukraine: One State, Two Countries?` essay reads ambivalence, regional difference, media manipulation, authoritarian blackmail, and oligarchic "peacekeeping" as obstacles to democratic consolidation. This is pressure by institutions and narratives rather than direct physical repression.
+- **Postcolonial vocabulary:** `From "Little Russia" to Ukraine`, `Postcolonial Syndrome`, and `The Nationalist's Lexicon` frame Ukraine's intellectual work as breaking internalized inferiority and imperial categories. Keep the decolonial focus precise: Russian imperial knowledge and Soviet/post-Soviet structures are being analyzed, not used as the reference norm.
+- **Living polemic caution:** Riabchuk's essays after 2014/2022 are timely, argumentative, and public. Use exact dates and source labels; do not turn polemical claims into timeless course facts.
+
+## 3. Major works / contributions
+
+- **Early literary criticism / essayistics:** PEN lists `Потреба слова` / `Need for Word`, `Каміння Сізіфа` / `Sisyphus Rocks`, poetry `Зима у Львові`, prose collections, and long-running editorial work at `Vsesvit` and `Krytyka`. This matters because his public-political essays grew from literary-critical practice, not only political science.
+- **Postcolonial Ukraine:** `From "Little Russia" to Ukraine` / `Від Малоросії до України` and `Postcolonial Syndrome` are key anchors for postcolonial analysis of Ukrainian identity, language hierarchy, and internalized imperial frames.
+- **"Two Ukraines":** `Two Ukraines` and the IWM essay `Ukraine: One State, Two Countries? With Comments` made the concept widely visible. The dossier must teach the model with its own built-in caveat: Riabchuk says it can "explain and clarify as much as confuse and obscure."
+- **Authoritarianism / post-Soviet politics:** `Gleichschaltung. Authoritarian Consolidation in Ukraine, 2010-2012` captures his analysis of Yanukovych-era authoritarian consolidation and post-Soviet political control.
+- **European frame:** `At the Fence of Metternich's Garden` / CUP-ibidem and `The Fence of Metternich's Garden` frame Ukraine, Europe, "between Europe and Europe," and the politics of recognition. This is a bridge to EU/NATO/civilizational discourse without reducing Ukraine to borderland.
+- **2022 prize work:** PRU/Shevchenko Prize sources identify `Лексикон націоналіста та інші есеї` as the 2022 Shevchenko Prize work. Use as late-career anchor for the public essayist as national interpreter.
+- **Institution-building:** Riabchuk co-founded `Krytyka` with George Grabowicz, served as executive editor, participated in PEN leadership, editorial boards, fellowships, and international teaching. BIO value is also building platforms where Ukrainian thought reaches Ukrainian and global audiences.
+
+## 4. Primary-source quote / visual anchors
+
+Use short excerpts only. Riabchuk is living; essays, interviews, and books are copyright-protected unless a specific open license is confirmed.
+
+- **Concept caveat anchor:** IWM preserves Riabchuk's short self-qualification of "Two Ukraines": `explain and clarify as much as confuse and obscure`. This is the safest teaching anchor because it prevents the model from becoming a frozen map.
+- **Decolonial title anchor:** `Mapping a "Nowhere Nation"` is a compact prompt about who gets to place Ukraine on the world map and who keeps it "nowhere."
+- **Postcolonial title anchor:** `From "Little Russia" to Ukraine` and `Postcolonial Syndrome` foreground the shift from imperial name/position to Ukrainian subjecthood.
+- **Prize-work anchor:** `Лексикон націоналіста` / `The Nationalist's Lexicon` can prompt learners to ask how the word "nationalist" changes meaning under Soviet accusation, postcolonial recovery, and wartime defense.
+- **Visual anchor:** Commons `File:Рябчук Микола Mykola Rjabtschuk 2009.jpg`, Cologne, 11 December 2009, own work by Elke Wetzig / Elya, licensed under GFDL and CC BY-SA 3.0/2.5/2.0/1.0. The file has a personality-rights warning; use with attribution/share-alike compliance.
+
+## 5. Language register
+
+- **Register:** essayistic, polemical, analytical, literary-critical, postcolonial, political-science informed; often mixes cultural metaphor with institutional analysis.
+- **CEFR readiness:** B2+/C1 for short public essays with scaffolding; C1 for `Two Ukraines` excerpts; C2 for dense postcolonial or political-science passages because students must track irony, quotation, contested categories, and layered public debate.
+- **Core vocabulary:** `постколоніалізм`, `малоросійство`, `імперське знання`, `креолізація`, `суб'єктність`, `національна ідентичність`, `амбівалентність`, `громадянське суспільство`, `олігархія`, `самвидав`, `дискурс`, `наратив`, `русифікація`, `європеїзація`, `націоналізм`.
+- **Teaching caution:** Do not present "two Ukraines" as a geography of good West versus bad East. Riabchuk's own later caveat and Ukraine's post-2014/post-2022 civic consolidation must remain visible.
+- **Bridge activities:** Ask learners to rewrite claims about Ukraine from object-position to subject-position: "Ukraine is divided by..." becomes "Ukrainians debate, resist, and redefine..."
+
+## 6. Contested points
+
+- **Current roles:** IPIEND and PEN pages list multiple roles, including honorary PEN status and Angelus jury work. Because Riabchuk is living and active, use present-tense roles only from current pages and time-stamp them.
+- **"Two Ukraines" controversy:** The model is influential, but it can reify regional stereotypes, obscure internal diversity, or be used politically. Use IWM's own ambiguity sentence and cross-link the existing course plan's anti-hagiography prompt.
+- **Nationalism terminology:** `The Nationalist's Lexicon` deliberately reworks a term weaponized by Soviet discourse. Future lessons should distinguish civic national self-assertion, ethnic exclusivism, Soviet accusation, and Russian wartime propaganda.
+- **Transliteration variants:** `Riabchuk` is project canonical. `Ryabchuk`, `Riabczuk`, `Rjabtschuk`, and `Riabtchouk` appear in English/German/Polish/French contexts and Commons metadata. Keep variants in aliases/search notes.
+- **PEN biography older wording:** PEN page text still says "president Ukrainian PEN-center" in one body paragraph, while helper/source context reports honorary president. Use exact source wording or IPIEND role list, not a generalized present-tense claim.
+- **Russian-language publications:** Riabchuk has written/published in multiple languages including Russian. Do not treat that as Russocentric default; use it as multilingual public-intellectual reach.
+- **Post-2022 reception:** War sharpened decolonial readings of his earlier arguments. Avoid back-projecting 2022 conclusions into 1992/2002 essays without date labels.
+
+## 7. Cross-track links
+
+- **Existing LIT-ESSAY Riabchuk surfaces (VERIFIED `test -e` 2026-07-01):** `curriculum/l2-uk-en/plans/lit-essay/riabchuk-two-ukraines.yaml`, `curriculum/l2-uk-en/lit-essay/discovery/riabchuk-two-ukraines.yaml`, `wiki/literature/works/riabchuk-two-ukraines.md`, `wiki/literature/works/riabchuk-two-ukraines.sources.yaml`
+- **Existing LIT / ISTORIO plan surfaces (VERIFIED `test -e` 2026-07-01):** `curriculum/l2-uk-en/plans/lit/decolonization-theory-literature.yaml`, `curriculum/l2-uk-en/plans/istorio/tsykl-kulturnykh-vidrodzhen.yaml`, `curriculum/l2-uk-en/plans/istorio/hromadianske-suspilstvo.yaml`
+- **Existing related LIT / LIT-ESSAY / LIT-DOC plan surfaces (VERIFIED `test -e` 2026-07-01):** `curriculum/l2-uk-en/plans/lit-essay/malaniuk-little-russianism.yaml`, `curriculum/l2-uk-en/plans/lit-essay/zabuzhko-longest-journey.yaml`, `curriculum/l2-uk-en/plans/lit-essay/lutsky-diaspora-bridge.yaml`, `curriculum/l2-uk-en/plans/lit-doc/shcherbak-chornobyl-documentary.yaml`, `curriculum/l2-uk-en/plans/lit/matios-sweet-darusia.yaml`, `curriculum/l2-uk-en/plans/lit/new-prose-displacement.yaml`, `curriculum/l2-uk-en/plans/lit/tanja-maljartschuk-prose.yaml`
+- **Existing historiography / wiki surfaces (VERIFIED `test -e` 2026-07-01):** `wiki/historiography/metodolohiia-dekolonizatsii.md`, `wiki/index.md`
+- **Existing BIO research cross-links (VERIFIED `test -e` 2026-07-01):** `docs/research/bio/yurii-shcherbak.md`, `docs/research/bio/oksana-zabuzhko.md`, `docs/research/bio/mykola-khvylovyi.md`
+- **Existing site index surfaces (VERIFIED `rg` 2026-07-01):** `site/src/content/docs/bio/index.mdx` includes `num: 384`, `slug: mykola-riabchuk`, status locked; `site/src/content/docs/lit-essay/index.mdx` exposes `riabchuk-two-ukraines`.
+- **Candidate / future BIO surfaces not created in this PR:** `curriculum/l2-uk-en/plans/bio/mykola-riabchuk.yaml`, `curriculum/l2-uk-en/bio/discovery/mykola-riabchuk.yaml`, `wiki/figures/mykola-riabchuk.md`, `site/src/content/docs/bio/mykola-riabchuk.mdx`, `curriculum/l2-uk-en/bio/mykola-riabchuk/module.md`, `curriculum/l2-uk-en/bio/mykola-riabchuk/activities.yaml`, `curriculum/l2-uk-en/bio/mykola-riabchuk/vocabulary.yaml`, `curriculum/l2-uk-en/bio/mykola-riabchuk/resources.yaml`
+
+## 8. Naming-canonical
+
+- **Slug:** `mykola-riabchuk`
+- **EN canonical (project):** Mykola Riabchuk.
+- **UA canonical:** Микола Юрійович Рябчук.
+- **Aliases future YAML:** `Микола Рябчук`; `Рябчук Микола Юрійович`; `Mykola Riabchuk`; `Mykola Yuriiovych Riabchuk`; `Mykola Ryabchuk`; `Mikołaj Riabczuk`; `Mykola Rjabtschuk`; `Mykola Riabtchouk`; `Mykola Riabtchuk`; `Nikolay Ryabchuk` (catalogue/search only, noncanonical).
+- **Forbidden / noncanonical learner-facing defaults:** Russian `Николай Юрьевич Рябчук`; `Nikolai Ryabchuk`; `Rjabtschuk` as English display; treating `Two Ukraines` as his whole identity.
+- **Search note:** Use `Ryabchuk`, `Riabczuk`, `Rjabtschuk`, and `Riabtchouk` for Polish/German/French/Commons searches. Keep learner-facing display as `Mykola Riabchuk`.
+
+## 9. Image candidates
+
+- **Primary reusable candidate:** Wikimedia Commons `File:Рябчук Микола Mykola Rjabtschuk 2009.jpg`; event in Cologne, 11 December 2009; source own work; author Elke Wetzig / Elya; licensed under GFDL and CC BY-SA 3.0/2.5/2.0/1.0. Use CC BY-SA 3.0 attribution/share-alike path by default.
+- **Category lead:** Commons `Category:Mykola Riabchuk` contains this single file at the time of review; no alternate Commons portrait found in helper pass.
+- **Personality rights caution:** Commons file page includes a personality-rights warning. For ordinary educational biography use this is acceptable, but avoid implying endorsement or using the image in promotional/commercial contexts.
+- **Avoid by default:** PEN/IPIEND/Paris/Gov.pl profile photos, publisher headshots, event screenshots, book covers, and social-media images without file-level reusable license.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- Інститут політичних і етнонаціональних досліджень ім. І. Ф. Кураса НАН України. "Mykola Yurioivych Riabchuk." https://ipiend.gov.ua/en/employee/mykola-yurioivych-riabchuk/. Accessed 2026-07-01.
+- PEN Ukraine. "Riabchuk Mykola." https://pen.org.ua/en/headship/ryabchuk-mykola. Accessed 2026-07-01.
+- President of Ukraine. "Decree No. 118/2022." https://www.president.gov.ua/documents/1182022-41617. Accessed 2026-07-01.
+
+**Tier 2 (scholarly / publisher / institutional profile evidence):**
+
+- Institute for Human Sciences. "Ukraine: One State, Two Countries? With Comments." https://www.iwm.at/transit-online/ukraine-one-state-two-countries-with-comments. Accessed 2026-07-01.
+- PEN Ukraine. "Mapping a 'Nowhere Nation'." https://pen.org.ua/en/mapuvannya-naciyi-nizvidky. Accessed 2026-07-01.
+- PEN Ukraine. "Authors: Riabchuk Mykola." https://pen.org.ua/en/autors/ryabchuk-mykola. Accessed 2026-07-01.
+- Columbia University Press / ibidem. `The Fence of Metternich's Garden: Ukrainian Essays on Europe, Ukraine, and Europeanization.` https://cup.columbia.edu/book/the-fence-of-metternichs-garden/9783838214849/. Accessed 2026-07-01.
+- Gov.pl. "Wykład Mykoły Riabczuka." https://www.gov.pl/web/litwa/wyklad-mykoly-riabczuka. Accessed 2026-07-01.
+- Paris Institute for Advanced Study. "Mykola Riabchuk." https://www.paris-iea.fr/en/fellows/mykola-riabchuk-2. Accessed 2026-07-01.
+
+**Tier 3 (secondary / critique / reception):**
+
+- Eurozine. "The myth of two Ukraines." https://www.eurozine.com/the-myth-of-two-ukraines/. Accessed 2026-07-01.
+
+**Tier 4 (image-rights / navigation only):**
+
+- Wikimedia Commons. `Category:Mykola Riabchuk`. https://commons.wikimedia.org/wiki/Category:Mykola_Riabchuk. Accessed 2026-07-01.
+- Wikimedia Commons. `File:Рябчук Микола Mykola Rjabtschuk 2009.jpg`. https://commons.wikimedia.org/wiki/File:%D0%A0%D1%8F%D0%B1%D1%87%D1%83%D0%BA_%D0%9C%D0%B8%D0%BA%D0%BE%D0%BB%D0%B0_Mykola_Rjabtschuk_2009.jpg. Accessed 2026-07-01.
+- Ukrainian Wikipedia / Wikidata were used only as search/navigation leads; no learner-facing facts depend on Wikipedia alone.


### PR DESCRIPTION
## Summary

Adds the BIO #384 base dossier for Mykola Riabchuk.

Changed file:
- `docs/research/bio/mykola-riabchuk.md`

## Scope

Dossier-only base-prep PR. This PR does not change plan YAML, module markdown, activities, vocabulary, resources, site MDX, wiki packets, audit/review/status artifacts, telemetry DB files, linter configs, package files, or unrelated files.

## Validation

- `npx markdownlint-cli2 docs/research/bio/mykola-riabchuk.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/mykola-riabchuk.md`
- `git diff --check origin/main...HEAD`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Review Notes

Please pay particular attention to living-person current-role phrasing, the contested framing of the "Two Ukraines" thesis, decolonization/Russocentric defaults, naming variants, existing cross-track paths in section 7, and the Commons image rights note.
