### PR TITLE
[codex] Distinguish matched pair activity tiles

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 581611447150cf1ee82a8f32b0ef0ba4346cc453b13d4d5faa1e5563d73d1687
+  components_sha256: c003b923ee101841f85692bcb8c7cc7793ad5c9aaab50e5393c2143433d9542b
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/Activities.module.css
+++ b/site/src/components/Activities.module.css
@@ -359,9 +359,26 @@
 }
 
 .matchItem.matched {
-  border-color: var(--lu-state-correct-fg);
-  background: var(--lu-state-correct-bg);
+  --match-pair-hue: 142;
+  --match-pair-bg: hsl(var(--match-pair-hue) 68% 43% / 0.14);
+  --match-pair-border: hsl(var(--match-pair-hue) 72% 35%);
+  --match-pair-fg: var(--lu-text);
+
+  border-color: var(--match-pair-border);
+  background: var(--match-pair-bg);
+  color: var(--match-pair-fg);
   cursor: default;
+  box-shadow: inset 4px 0 0 var(--match-pair-border);
+}
+
+.matchColumn:first-child .matchItem.matched {
+  box-shadow: inset -4px 0 0 var(--match-pair-border);
+}
+
+.matchColumn .matchItem.matched {
+  border-color: var(--match-pair-border);
+  background: var(--match-pair-bg);
+  color: var(--match-pair-fg);
 }
 
 .matchItem.matched::after {
@@ -2648,6 +2665,15 @@
   background: var(--lu-match-right);
 }
 
+[data-theme='dark'] .matchColumn .matchItem.matched {
+  --match-pair-bg: hsl(var(--match-pair-hue) 82% 65% / 0.24);
+  --match-pair-border: hsl(var(--match-pair-hue) 82% 75%);
+
+  border-color: var(--match-pair-border);
+  background: var(--match-pair-bg);
+  color: var(--lu-text);
+}
+
 /* drag pools · prompts → violet */
 [data-theme='dark'] .chipDraggable,
 [data-theme='dark'] .wordPool.dropTarget,
@@ -2656,10 +2682,9 @@
   background: var(--lu-state-drag);
 }
 
-/* correct · matched → green (+ legible text) */
+/* correct → green (+ legible text) */
 [data-theme='dark'] .option.correct,
 [data-theme='dark'] .blank.correct,
-[data-theme='dark'] .matchItem.matched,
 [data-theme='dark'] .trueButton:hover:not(:disabled),
 [data-theme='dark'] .tfButton.correct,
 [data-theme='dark'] .answerZone.correct,

--- a/site/src/components/MatchUp.tsx
+++ b/site/src/components/MatchUp.tsx
@@ -35,6 +35,22 @@ interface MatchUpProps {
   onComplete?: () => void;
 }
 
+const MATCH_PAIR_HUES = [
+  199, 32, 262, 174, 239, 92, 286, 151, 215, 49,
+  271, 188, 230, 108, 300, 164, 206, 67, 253, 181,
+  222, 132, 288, 192, 243, 78, 278, 142, 218, 58,
+] as const;
+const MATCH_PAIR_COLOR_COUNT = MATCH_PAIR_HUES.length;
+
+type MatchPairStyle = React.CSSProperties & {
+  '--match-pair-hue': string;
+};
+
+const getMatchedPairStyle = (index: number, isMatched: boolean): MatchPairStyle | undefined => {
+  if (!isMatched) return undefined;
+  return { '--match-pair-hue': String(MATCH_PAIR_HUES[index % MATCH_PAIR_COLOR_COUNT]) };
+};
+
 export default function MatchUp({ pairs, instruction, isUkrainian, onComplete }: MatchUpProps) {
   const [selectedLeft, setSelectedLeft] = useState<number | null>(null);
   const [matched, setMatched] = useState<Set<number>>(new Set());
@@ -102,7 +118,9 @@ export default function MatchUp({ pairs, instruction, isUkrainian, onComplete }:
                 }`}
               data-activity="match-left-tile"
               data-matched={matched.has(index) ? 'true' : 'false'}
+              data-pair-color={matched.has(index) ? index % MATCH_PAIR_COLOR_COUNT : undefined}
               data-selected={selectedLeft === index ? 'true' : 'false'}
+              style={getMatchedPairStyle(index, matched.has(index))}
               onClick={() => handleLeftClick(index)}
               disabled={matched.has(index)}
             >
@@ -119,6 +137,8 @@ export default function MatchUp({ pairs, instruction, isUkrainian, onComplete }:
               data-activity="match-right-tile"
               data-matched={matched.has(originalIndex) ? 'true' : 'false'}
               data-original-index={originalIndex}
+              data-pair-color={matched.has(originalIndex) ? originalIndex % MATCH_PAIR_COLOR_COUNT : undefined}
+              style={getMatchedPairStyle(originalIndex, matched.has(originalIndex))}
               onClick={() => handleRightClick(originalIndex)}
               disabled={matched.has(originalIndex)}
             >


### PR DESCRIPTION
## Summary
- Give matched `match-up` pairs stable non-red pair colors so completed activities still show which tiles belong together.
- Expand the palette to 30 hue slots, with pair colors derived from one shared hue in light and dark mode.
- Update `docs/lesson-schema.yaml` fingerprint generated by the pre-commit schema drift hook.

## Impact
Learners can visually identify completed pairs after finishing a `Знайдіть пару` activity instead of seeing every matched tile collapse into the same green success state. Red remains reserved for wrong pair feedback.

## Validation
- `git diff --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `npm run build` from `site/`
- Playwright smoke test on `/a2/genitive-adjectives-pronouns/`: 8 matched pairs produced 8 distinct colors and matching left/right computed styles.
