### PR TITLE
docs(bio): add Nataliia Vorozhbyt dossier

### DIFF
--- a/docs/research/bio/nataliia-vorozhbyt.md
+++ b/docs/research/bio/nataliia-vorozhbyt.md
@@ -1,0 +1,150 @@
+# Наталія Анатоліївна Ворожбит - Research Dossier
+
+**Slug:** `nataliia-vorozhbyt`
+**Block:** +77 expansion - contemporary drama / documentary theatre / war cinema
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #386
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Source acronym legend:** PEN = PEN Ukraine; UDT = Ukrainian Drama Translations / Ukrainian Institute; PRU = President of Ukraine; KNPU = Taras Shevchenko National Prize Committee; UFA = Ukrainian Film Academy; USFA = State Agency of Ukraine for Cinema; NHB = Nick Hern Books; MK = Munchner Kammerspiele; UI = Ukrainian Institute; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional, prize, publisher, or theatre sources cited
+- [x] Pressure mechanism framed as Holodomor memory, Euromaidan documentary theatre, war in Donbas, full-scale Russian invasion, displacement, and Ukrainian theatre/film institution-building; no invented arrest, exile, camp term, or dissident sentence
+- [x] At least 2 title / source / visual anchors supplied
+- [x] Cross-track links verified `test -e` / `rg` on 2026-07-01 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check
+
+- [x] No Russocentric framing: Moscow training and Russian-language history are treated as biographical/literary facts, not as interpretive center or identity verdict.
+- [x] Russian aggression named precisely where sources do: war in Donbas, occupied Donbas, full-scale Russian invasion, displacement, and Ukrainian resistance.
+- [x] Ukrainian agency central: Vorozhbyt is framed as builder of contemporary Ukrainian drama, documentary theatre, and war cinema, not as regional witness translated for outside validation.
+- [x] Language-choice caution applied: do not use language of writing as proxy for loyalty or cultural ownership.
+- [x] Anti-hagiography: awards and influence noted, but dossier foregrounds ethical risks of staging trauma, testimony, sexual violence, and wartime suffering.
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Наталія Анатоліївна Ворожбит.
+- **Project English canonical:** Nataliia Vorozhbyt.
+- **Professional name note:** PEN, UDT, and USFA use `Natalka Vorozhbyt`; NHB uses `Natalka Vorozhbit`; Commons English file/category handles use `Natalya Vorozhbit`, while Ukrainian filename metadata uses `Наталка Ворожбит`. Many English-language theatre sources also use `Natalya`, `Natalia`, or `Natal'ya Vorozhbit`.
+- **Birth:** PEN says born in Kyiv in 1975. Exact date `4 April 1975` appears in encyclopedic/metadata sources, but use exact day only after re-verifying against a stronger institutional or author-controlled source.
+- **Living figure:** Vorozhbyt is living. Re-check present-tense roles, residences, fellowships, and projects before module build.
+- **Core identity:** PEN describes her as playwright, screenwriter, director, and curator of theatre and social projects. UDT calls her a playwright, screenwriter, director, and supervisor of social/theatre projects.
+- **Education / return to Kyiv:** PEN says she graduated from the Gorky Literary Institute in Moscow in 2000 and has lived/worked in Kyiv since 2004. Treat this as a career chronology, not a Russocentric credential hierarchy.
+- **Institutions / field-building:** PEN and UDT list co-founding / co-author roles in Topical Play Week, Theatre of the Displaced, Playwrights Theatre, `Maidan Diaries`, and Class Act: East-West.
+- **Recognition:** PRU/KNPU record Shevchenko Prize 2022 for the stage production `Погані дороги` with Tamara Trunova, Yurii Larionov, Andrii Isaienko, and Valeriia Khodos. USFA records Dovzhenko State Prize 2021. UFA records `Opening of the Year` and screenplay recognition for `Погані дороги` at Golden Dzyga 2021.
+
+## 2. Oppression / pressure mechanism
+
+- **Not prison-case biography:** Do not invent arrest, exile, camp term, KGB file, or dissident-sentence biography. Vorozhbyt's pressure mechanism is documentary theatre under historical violence: Holodomor memory, Euromaidan testimony, war in Donbas, displaced people, full-scale invasion, and the ethical pressure of turning lived trauma into stage/film form.
+- **Holodomor memory:** `The Grain Store` / `Зерносховище` is the major Holodomor-related anchor. It matters because Ukrainian famine history enters English-language theatre without being reduced to Soviet/Russian explanatory frames.
+- **Maidan and documentary theatre:** PEN/UDT identify Vorozhbyt as co-author of `Maidan Diaries`; this belongs in documentary-theatre and civic-witness context, not only as protest chronology.
+- **War in Donbas:** `Bad Roads` grew from the war in eastern Ukraine and testimony around `Cyborgs`; UI's Crimea 5am page says `Bad Roads` focuses on Russian aggression and its impact on women. Use `war in Donbas`, `occupied Donbas`, or `Russia's war against Ukraine` rather than vague "post-Soviet conflict."
+- **Displacement / refugee pressure:** `Green Corridors` stages forced displacement after the full-scale invasion. Avoid using "refugee story" as generic European trauma; keep Ukrainian displacement and agency visible.
+- **Language pressure:** Some sources note she has written in both Ukrainian and Russian. Treat this as a historical language-practice fact under changing war conditions, not as a suspicion marker.
+
+## 3. Major works / contributions
+
+- **`The Grain Store` / `Зерносховище` (2009):** NHB and UDT identify this as a major play, connected to Holodomor memory and international staging.
+- **`Maidan Diaries` (2014):** documentary-theatre project connected to Euromaidan testimony; listed by PEN/UDT.
+- **`Take the Rubbish Out, Sasha` / `Саша, винеси сміття` (2014):** NHB-published play; useful bridge for everyday domestic speech, death, war, and absurdist intimacy.
+- **`Bad Roads` / `Погані дороги` (play 2016/2017; film 2020):** central Vorozhbyt work in repo. Royal Court/NHB stage context; film directorial debut; Venice Critics' Week / Verona Film Club Award, Golden Dzyga and Kinokolo recognition; Ukrainian Oscar Committee selection in 2021 per UDT/PEN.
+- **`Cyborgs` / `Кіборги` (2017):** screenwriter for film about defenders of Donetsk airport; UDT lists Golden Dzyga for screenplay.
+- **`Wild Field` / `Дике поле` (2018):** screenwriter; adaptation of Serhiy Zhadan's `Voroshylovhrad`.
+- **`To Catch the Kaidash` / `Спіймати Кайдаша` (2020):** screenwriter and showrunner; PEN/UDT describe national recognition. Link carefully to Nechui-Levytskyi and modern Ukrainian TV adaptation, not only "comedy."
+- **`Green Corridors` / `Зелені коридори` (2023):** MK-commissioned play about Ukrainian displacement after full-scale invasion; UDT lists translation.
+- **`Are You OK?` (2022):** short film directed by Vorozhbyt, listed by PEN; keep as filmography note unless later module needs it.
+
+## 4. Primary-source quote / visual anchors
+
+Use short excerpts only. Vorozhbyt is living; plays, screenplays, interviews, films, and theatre recordings are copyright-protected unless a specific open license is confirmed.
+
+- **Title anchor:** `Погані дороги` is the central safe anchor: roads, blocked movement, moral danger, war-zone geography, and documentary theatre compressed into two words.
+- **Holodomor title anchor:** `Зерносховище` / `The Grain Store` can launch a question about food, memory, famine, and the theatre of historical witness.
+- **Documentary form anchor:** `Maidan Diaries` and `Theatre of the Displaced` are safe title/source anchors for testimony, verbatim practice, and social theatre.
+- **Screenwriting bridge:** `Кіборги`, `Дике поле`, and `Спіймати Кайдаша` let future lessons show Vorozhbyt moving between war cinema, literary adaptation, and television language.
+- **Visual anchor:** Commons `File:Natalya Vorozhbit Golden Dzyga 2021 (cropped).jpg`, derived from Golden Dzyga 2021 award photo, CC BY 4.0. Prefer checking parent file before final use.
+- **Avoid direct quote carryover:** Existing plan/wiki surfaces include generated language and may contain unverified quotes or paraphrases. Verify direct quotations against primary source before learner-facing use.
+
+## 5. Language register
+
+- **Register:** contemporary drama, documentary / verbatim theatre, war testimony, colloquial Ukrainian and Russian-language history, film/TV screenwriting, cultural diplomacy, displacement vocabulary.
+- **CEFR readiness:** B2 for concise biographies and film/play summaries; C1 for `Bad Roads` excerpts, documentary-theatre ethics, and war/sexual-violence content; C2 for scholarly discussions of new drama, trauma staging, and language politics.
+- **Core vocabulary:** `драматургиня`, `сценаристка`, `режисерка`, `кураторка`, `документальний театр`, `вербатім`, `свідчення`, `свідок`, `травма`, `сіра зона`, `лінія розмежування`, `окупація`, `переселенці`, `вимушене переселення`, `Голодомор`, `Майдан`, `повномасштабне вторгнення`, `адаптація`, `шоуранерка`.
+- **Teaching caution:** The plays often involve violence, sexual violence, fear, and displacement. Use content warnings and avoid "trauma extraction" activities that ask students to perform suffering.
+- **Bridge activity:** Ask learners to compare `свідчити`, `розповідати`, `грати`, `документувати`, and `вигадувати`. Which verb belongs to the witness, playwright, actor, director, or viewer?
+
+## 6. Contested points
+
+- **Name romanization:** `Nataliia Vorozhbyt` is project canonical from slug; `Natalka` is a professional/common name used by PEN/UDT/USFA/NHB; `Natalya/Natalia Vorozhbit` appears in English theatre and film records. Keep variants in search notes.
+- **Exact birth date:** Use `1975, Kyiv` unless exact day is reverified by a stronger source than encyclopedia metadata.
+- **Language history:** Do not present Russian-language writing as assimilation, betrayal, or "Russian drama." It is a historically situated part of Ukrainian new drama and changed reception after 2014/2022.
+- **Award attribution:** Shevchenko Prize 2022 was for the stage production `Погані дороги` and shared with production collaborators; do not state it as a solo prize for the film.
+- **`Bad Roads` dates:** Play text, Royal Court production, film production, festival premiere, Ukrainian Oscar selection, and Ukrainian release dates can differ by source. Use exact labels when dates matter.
+- **Existing repo surfaces:** Current lit-drama wiki/plan material is useful cross-track context but generated. Do not rely on it as a source for biographical facts without independent verification.
+- **Private-life details:** Avoid spouse/partner/family claims unless directly needed and source-backed; this dossier does not need them.
+
+## 7. Cross-track links
+
+- **Existing LIT-DRAMA plan surfaces (VERIFIED `test -e` / `rg` 2026-07-01):** `curriculum/l2-uk-en/plans/lit-drama/vorozhbyt-bad-roads.yaml`, `curriculum/l2-uk-en/plans/lit-drama.yaml`, `curriculum/l2-uk-en/plans/lit-drama/nezdana-contemporary-women-drama.yaml`
+- **Existing C1 / HIST plan surfaces (VERIFIED `test -e` / `rg` 2026-07-01):** `curriculum/l2-uk-en/plans/c1/teatralne-mystetstvo-2.yaml`, `curriculum/l2-uk-en/plans/hist/viyna-donbas.yaml`
+- **Existing LIT / LIT-HUMOR adaptation surfaces (VERIFIED `test -e` 2026-07-01):** `curriculum/l2-uk-en/plans/lit/kaidash-family-characters.yaml`, `curriculum/l2-uk-en/plans/lit/kaidash-family-conflict.yaml`, `curriculum/l2-uk-en/plans/lit-humor/nechuy-levytsky-kaidash-humor.yaml`
+- **Existing discovery / wiki surfaces (VERIFIED `test -e` 2026-07-01):** `curriculum/l2-uk-en/lit-drama/discovery/vorozhbyt-bad-roads.yaml`, `wiki/literature/works/vorozhbyt-bad-roads.md`, `wiki/literature/works/vorozhbyt-bad-roads.sources.yaml`
+- **Existing BIO research cross-links (VERIFIED `test -e` 2026-07-01):** `docs/research/bio/iryna-tsilyk.md`, `docs/research/bio/oleg-sentsov.md`, `docs/research/bio/serhiy-zhadan.md`, `docs/research/bio/oleksandr-dovzhenko.md`
+- **Existing site/index surfaces (VERIFIED `rg` 2026-07-01):** `site/src/content/docs/bio/index.mdx` lists BIO #386 `nataliia-vorozhbyt`; `site/src/content/docs/lit-drama/index.mdx` lists `vorozhbyt-bad-roads`; `wiki/index.md` indexes the Vorozhbyt/Bad Roads wiki page.
+- **Future BIO PR surfaces to create later:** `curriculum/l2-uk-en/plans/bio/nataliia-vorozhbyt.yaml`, `curriculum/l2-uk-en/bio/discovery/nataliia-vorozhbyt.yaml`, `wiki/figures/nataliia-vorozhbyt.md`, `site/src/content/docs/bio/nataliia-vorozhbyt.mdx`, `curriculum/l2-uk-en/bio/nataliia-vorozhbyt/module.md`, `curriculum/l2-uk-en/bio/nataliia-vorozhbyt/activities.yaml`, `curriculum/l2-uk-en/bio/nataliia-vorozhbyt/vocabulary.yaml`, `curriculum/l2-uk-en/bio/nataliia-vorozhbyt/resources.yaml`
+
+## 8. Naming / canonical
+
+- **Slug:** `nataliia-vorozhbyt`
+- **EN canonical:** Nataliia Vorozhbyt.
+- **UA canonical:** Наталія Ворожбит; full formal name Наталія Анатоліївна Ворожбит.
+- **Professional/common form:** Наталка Ворожбит appears in Ukrainian metadata. `Natalka Vorozhbyt` appears in PEN/UDT/USFA contexts; `Natalka Vorozhbit` appears at NHB; `Natalya Vorozhbit` appears in Commons English file/category handles. Use the form carried by the source title when citing or searching.
+- **Search variants:** `Natalka Vorozhbyt`, `Natalia Vorozhbyt`, `Natalya Vorozhbit`, `Natal'ya Vorozhbit`, `Nataliya Vorozhbyt`, `Natalia Vorojbyt`, `Ворожбит Наталія Анатоліївна`, Russian `Наталья Ворожбит` only for search/navigation and hostile/imperial metadata checks; do not normalize learner-facing text to Russian form.
+- **Title policy:** Preserve Ukrainian titles beside English titles where possible: `Погані дороги / Bad Roads`, `Зерносховище / The Grain Store`, `Саша, винеси сміття / Take the Rubbish Out, Sasha`, `Зелені коридори / Green Corridors`.
+
+## 9. Image candidates
+
+- **Primary reusable candidate:** Commons `File:Natalya Vorozhbit Golden Dzyga 2021 (cropped).jpg`; CC BY 4.0, crop from Golden Dzyga 2021 award photo. Preserve attribution chain and prefer checking parent file for final crop/metadata.
+- **Parent image:** Commons `File:Золота дзиґа 2021. Наталка Ворожбит.jpg`; re-open before use to confirm license and author/source metadata.
+- **Backup candidate:** Commons `File:Natalya Vorozhbit April 2023.jpg`; Commons marks CC BY 3.0, but it is a YouTube-derived screenshot, so verify the source video license and attribution before use.
+- **Category lead:** Commons `Category:Natalya Vorozhbit` contains three files at helper review time.
+- **Personality / endorsement caution:** Educational biography use is normal, but avoid implying Vorozhbyt endorses the course or any political/commercial message.
+- **Avoid by default:** trailer frames, performance stills, theatre/film posters, publisher headshots, festival photos, and screenshots without file-level reusable license.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- PEN Ukraine. "Natalka Vorozhbyt." https://pen.org.ua/en/members/vorozhbyt-natalya. Accessed 2026-07-01.
+- Президент України. "Указ Президента України No. 118/2022." https://www.president.gov.ua/documents/1182022-41617. Accessed 2026-07-01.
+- Комітет з Національної премії України імені Тараса Шевченка. "Указ Президента України 118/2022." https://knpu.gov.ua/ukazy-prezydenta-ukrainy/ukaz-prezydenta-ukrainy-118-2022-pro-prysudzhennia-natsionalnoi-premii-ukrainy-imeni-tarasa-shevchenka/. Accessed 2026-07-01.
+- Державне агентство України з питань кіно. "Лауреатом Державної премії України імені Олександра Довженка 2021 року стала Наталка Ворожбит." https://usfa.gov.ua/documents-page/laureatom-derzhavnoi-premii-ukrainy-imeni-oleksandra-dovzhenka-2021-roku-stala-natalka-vorozhbyt-i700. Accessed 2026-07-01.
+- Українська кіноакадемія. "Золота Дзиґа 2021: названо лауреатів П'ятої Національної кінопремії." https://uafilmacademy.org/news/zolota-dziga-2021-nazvano-laureativ-pjatoji-natsionalnoji-kinopremiji.html. Accessed 2026-07-01.
+
+**Tier 2 (publisher / theatre / institutional profile evidence):**
+
+- Ukrainian Drama Translations. "Natalka Vorozhbyt." https://ukrdrama.ui.org.ua/en/author/natalka-vorozhbyt?language_content_entity=en. Accessed 2026-07-01.
+- Nick Hern Books. "Natalka Vorozhbit." https://www.nickhernbooks.co.uk/plays-to-perform/natalka-vorozhbit. Accessed 2026-07-01.
+- Nick Hern Books. "Bad Roads." https://www.nickhernbooks.co.uk/bad-roads. Accessed 2026-07-01.
+- Nick Hern Books. "The Grain Store." https://www.nickhernbooks.co.uk/the-grain-store. Accessed 2026-07-01.
+- Nick Hern Books. "Take the Rubbish Out, Sasha." https://www.nickhernbooks.co.uk/take-the-rubbish-out-sasha. Accessed 2026-07-01.
+- Ukrainian Institute. "Documentary performance Crimea 5am." https://ui.org.ua/en/sectors-en/en-projects/documentary-performance-crimea-5am/. Accessed 2026-07-01.
+- Munchner Kammerspiele. "Green Corridors." https://www.muenchner-kammerspiele.de/en/programm/18949-green-corridors. Accessed 2026-07-01.
+
+**Tier 3 (context / navigation):**
+
+- Ukrainian Institute. "Natalka Vorozhbyt - Ukrainian Drama Translations" related translation catalog entries. Accessed 2026-07-01.
+- Dramox. "Bad Roads." https://www.dramox.tv/theatres/190-left-bank-theater/332-bad-roads. Accessed 2026-07-01.
+
+**Tier 4 (image-rights / navigation only):**
+
+- Wikimedia Commons. `Category:Natalya Vorozhbit`. https://commons.wikimedia.org/wiki/Category:Natalya_Vorozhbit. Accessed 2026-07-01.
+- Wikimedia Commons. `File:Natalya Vorozhbit Golden Dzyga 2021 (cropped).jpg`. https://commons.wikimedia.org/wiki/File:Natalya_Vorozhbit_Golden_Dzyga_2021_(cropped).jpg. Accessed 2026-07-01.
+- Wikimedia Commons. `File:Золота дзиґа 2021. Наталка Ворожбит.jpg`. https://commons.wikimedia.org/wiki/File:%D0%97%D0%BE%D0%BB%D0%BE%D1%82%D0%B0_%D0%B4%D0%B7%D0%B8%D2%91%D0%B0_2021._%D0%9D%D0%B0%D1%82%D0%B0%D0%BB%D0%BA%D0%B0_%D0%92%D0%BE%D1%80%D0%BE%D0%B6%D0%B1%D0%B8%D1%82.jpg. Accessed 2026-07-01.


### PR DESCRIPTION
## Summary

Adds the BIO #386 base dossier for Nataliia Vorozhbyt.

Changed file:
- `docs/research/bio/nataliia-vorozhbyt.md`

## Scope

Dossier-only base-prep PR. This PR does not change plan YAML, module markdown, activities, vocabulary, resources, site MDX, wiki packets, audit/review/status artifacts, telemetry DB files, linter configs, package files, or unrelated files.

## Validation

- `npx markdownlint-cli2 docs/research/bio/nataliia-vorozhbyt.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/nataliia-vorozhbyt.md`
- `git diff --check origin/main...HEAD`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Review Notes

Please pay particular attention to living-person phrasing, exact birth-date caution, Nataliia/Natalka/Natalya/Natalia naming variants, language-history handling, Shevchenko Prize attribution as shared stage-production award, documentary-war/decolonization framing, section 7 existing paths, and Commons image-rights notes.
