### PR TITLE
docs(bio): add artem chekh dossier

### DIFF
--- a/docs/research/bio/artem-chekh.md
+++ b/docs/research/bio/artem-chekh.md
@@ -1,0 +1,299 @@
+# Артем Чех - Research Dossier
+
+**Slug:** `artem-chekh`
+**Block:** +77 expansion - contemporary prose / veteran-writer / war witness
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #387
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-01
+
+**Source acronym legend:** PEN = PEN Ukraine; SSP = Seven Stories Press; SSPUK = Seven
+Stories Press UK; EBRD = European Bank for Reconstruction and Development;
+Chytomo = Chytomo publishing media; PI Kyiv = Polish Institute in Kyiv; UP =
+Ukrainska Pravda; MC = Meridian Czernowitz; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional, publisher, prize, or media sources cited
+- [x] Pressure mechanism framed as Russia's war against Ukraine, frontline military service,
+  wartime authorship, and post-Soviet memory; no invented arrest, exile, camp term, or
+  dissident sentence
+- [x] At least 2 title / source / visual anchors supplied
+- [x] Cross-track links verified `test -e` / `rg` on 2026-07-01 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check
+
+- [x] No Russocentric framing: the central pressure is Russian aggression against Ukraine
+  and Ukrainian cultural self-narration, not neutral "post-Soviet conflict."
+- [x] Ukrainian agency central: Chekh is treated as a Ukrainian writer and serviceman
+  shaping witness and form, not as an object of outside discovery.
+- [x] Soviet-Afghan and 1990s post-Soviet memory in `Хто ти такий?` is framed through
+  Ukrainian generational and colonial afterlife, not nostalgia.
+- [x] Anti-hagiography: military service and injury reports are handled as source-bounded
+  facts; do not turn them into heroic myth or private-life spectacle.
+
+## 1. Identity
+
+- **Canonical learner-facing name:** `Артем Чех` / `Artem Chekh`. Use `artem-chekh` for
+  file and slug surfaces.
+- **Legal name / variant:** PEN Ukraine gives the real name as `Артем Олександрович
+  Чередник`; English-language sources commonly shorten this to `Artem Cherednyk` or
+  transliterate `Cherednik`.
+- **Birth:** PEN Ukraine gives 13 June 1985, Cherkasy.
+- **Living figure:** Chekh is living. Re-check current service status, injuries, events,
+  and publications before module build or learner-facing present-tense claims.
+- **Core identity:** PEN and SSP identify him as a Ukrainian writer; SSP and EBRD also
+  foreground his military service. Chytomo identifies him as writer, journalist,
+  screenwriter, and serviceman.
+- **Book-count caution:** MC says he is the author of more than fifteen prose and
+  nonfiction books; SSP says "some sixteen books." Use those only with source labels.
+- **Education / early work:** PEN says he graduated from the State / National Academy of
+  Culture and Arts Management in Kyiv as a sociologist, but did not work in that specialty;
+  it lists earlier work as actor, guard, seller, promoter, journalist/copywriter, and
+  model-maker.
+- **Military chronology:** PEN Ukrainian states he served in the Armed Forces of Ukraine
+  from May 2015 to July 2016 and returned to the Armed Forces after Russia's full-scale
+  invasion. Treat the older PEN English line saying he was demobilized as stale for current
+  status.
+- **Recognition:** PEN lists `LitAccent of the Year` 2017, `Warrior of Light` 2018,
+  Mykola Gogol Prize 2018, Joseph Conrad-Korzeniowski Prize 2019, and BBC Book of the
+  Year 2021. PEN's Shevelyov Prize 2025 report gives Chekh the Radio Kultura special
+  distinction for `Гра в перевдягання`.
+
+## 2. Oppression / pressure mechanism
+
+- **Not prison-case biography:** Do not invent arrest, exile, camp term, KGB file, or
+  dissident-sentence biography. Chekh's pressure mechanism is wartime service, the
+  Russian-Ukrainian war, public witness, post-Soviet memory, and the conversion of
+  frontline / 1990s experience into prose.
+- **2015-2016 Donbas service:** PEN links `Точка нуль` to his experience of service in
+  the Russian-Ukrainian war in Donbas; the English PEN page says the book reflects ten
+  months on the frontline.
+- **Full-scale invasion:** PEN Ukrainian and SSP describe Chekh as returned to / currently
+  serving in the Ukrainian Armed Forces. Use dated wording and re-check before publication.
+- **Injury / Bakhmut caution:** UP reported on 25 May 2023 that Chekh sustained a concussion
+  after days under fire near Bakhmut, citing Iryna Tsilyk and his own social posts. This is
+  useful for pressure context but should not be sensationalized.
+- **Civilian-military identity pressure:** MC frames `Гра в перевдягання` as prose about
+  how a Ukrainian soldier experiences himself inside the army and tries to protect his
+  civilian self. This supports a nuanced module frame without triumphalist war rhetoric.
+- **Language / translation pressure:** Chekh's books have circulated in English, Polish,
+  Czech, German, Georgian, and Russian-language contexts. Keep Ukrainian authorship and
+  source language visible; do not treat Russian translation as cultural center.
+
+## 3. Major works / contributions
+
+- **`Цього ви не знайдете в Яндексі` (2007):** debut associated by PEN with the Folio
+  `Urban Youth Novel` competition win.
+- **`Точка нуль` / `Absolute Zero` (2017):** documentary / essay prose from 2015-2016
+  military service; PEN records LitAccent, Warrior of Light, and Mykola Gogol prize
+  recognition. SSP identifies `Absolute Zero` as one of the books available in English
+  translation.
+- **`Район "Д"` / `District D` (2019):** Meridian Czernowitz prose about memory and
+  place; PEN records a Cherkasy Book Festival special distinction and existing LIT surfaces
+  treat it as autofiction / memory prose.
+- **`На великій землі` (2021):** listed in PEN's bibliography and MC author context; keep
+  as part of the post-2014 / pre-full-scale war nonfiction-prose arc.
+- **`Хто ти такий?` / `Rock, Paper, Grenade` (2021; English 2025):** BBC News Ukraine Book
+  of the Year 2021 per PEN, SSPUK, and EBRD/EBRD-partner reporting. Chytomo and SSPUK
+  identify Olena Jennings and Oksana Rosenblum as the English translators.
+- **`Я і Фелікс` / `Rock. Paper. Grenade` film adaptation (2024):** Chytomo says Iryna
+  Tsilyk directed the film adaptation of `Хто ти такий?` and that Chekh co-authored the
+  script. The film title is commonly stylized with periods; the book translation uses
+  `Rock, Paper, Grenade`. Cross-link to the Tsilyk dossier but avoid making Chekh's
+  biography depend on family detail.
+- **`Пісня відкритого шляху` (2024):** MC describes this historical adventure novel around
+  a former Ukrainian serf, the Crimean War, America, the U.S. Civil War, and identity.
+- **`Гра в перевдягання` (2025):** MC / publisher pages present this as new war prose about
+  soldierly selfhood, pain, escape fantasies, and the gap between civilian and military
+  identities.
+
+## 4. Pedagogical anchors
+
+- **War-witness prose anchor:** `Точка нуль` can support B2/C1 lessons on diary-like
+  observation, military everyday vocabulary, anti-pathetic style, and ethics of testimony.
+- **1990s memory anchor:** `Хто ти такий?` / `Rock, Paper, Grenade` lets a module connect
+  childhood, Cherkasy, family instability, Soviet-Afghan afterlives, PTSD, and post-1991
+  Ukrainian identity.
+- **Translation / world-literature anchor:** EBRD lists `Rock, Paper, Grenade` on the
+  2026 shortlist but not among the 2026 finalists on the current EBRD prize page. Use
+  `shortlisted` only, and re-check after the 2 July 2026 award ceremony.
+- **Adaptation anchor:** `Я і Фелікс` connects biography, novel, and cinema through Iryna
+  Tsilyk's film adaptation; use it to cross-link film/literature modules, not as private
+  relationship filler.
+- **Visual anchor:** Commons `File:Artem Tschech am Meridian Czernowitz, 2021.png`, own
+  work by `Germany2019`, CC BY-SA 4.0, at Meridian Czernowitz in Chernivtsi, 19 December
+  2021.
+- **Avoid direct quote carryover:** Existing LIT wiki/plan surfaces may contain generated
+  interpretation and long quotations. Verify any direct quotations against a primary text
+  or licensed excerpt before learner-facing use.
+
+## 5. Language register
+
+- **Register:** contemporary Ukrainian prose, documentary war prose, autofiction,
+  post-Soviet childhood memory, military everyday speech, literary prize / translation
+  discourse, screen adaptation vocabulary.
+- **CEFR readiness:** B2 concise biography, work summaries, and military/civilian identity
+  vocabulary; C1 excerpts from `Точка нуль` or `Хто ти такий?`; C2 seminar discussion of
+  autofiction, witness ethics, translation reception, and decolonial memory.
+- **Core vocabulary:** `письменник`, `військовослужбовець`, `ветеран`, `фронт`,
+  `повномасштабне вторгнення`, `російсько-українська війна`, `посттравматичний стрес`,
+  `автофікшн`, `документальна проза`, `свідчення`, `пам'ять`, `ідентичність`,
+  `переклад`, `екранізація`, `сценарій`, `лауреат`, `шортліст`.
+- **Register caution:** Chekh's prose may include blunt military, bodily, and colloquial
+  language. Future modules should mark learner-facing excerpts for age/sensitivity and
+  avoid sanitizing the style into generic patriotic prose.
+
+## 6. Risks / open questions
+
+- **Current service status:** SSP and PEN Ukrainian say he is serving / returned to the
+  Armed Forces after full-scale invasion. Re-check current status before publication;
+  avoid operational or location detail.
+- **PEN English stale line:** The English PEN member page still says he is demobilized and
+  lives in Kyiv. Prefer the Ukrainian PEN page and newer publisher/event sources for
+  service status.
+- **EBRD 2026 timing:** On 2026-07-01, EBRD's current prize page lists `Rock, Paper,
+  Grenade` on the 2026 shortlist, while the three finalists are different books. The
+  winner is scheduled for 2026-07-02; update any module after that date.
+- **Private-life details:** Tsilyk connection matters for `Я і Фелікс`; otherwise avoid
+  spouse/child details unless needed and source-backed.
+- **Book-count drift:** MC says "more than fifteen" and SSP says "some sixteen books";
+  PEN bibliography is selective and older. Use book counts only with the specific source
+  label.
+- **Translation titles:** `Точка нуль` appears as `Zero Point`, `Point Zero`, and
+  `Absolute Zero` in English-language contexts. Use the publisher-specific English title
+  when citing an edition.
+- **Existing repo surfaces:** LIT plan/wiki files for Chekh are useful cross-track
+  references, but generated content must not be treated as source authority.
+
+## 7. Cross-track links
+
+- **Existing LIT plan surfaces (VERIFIED `test -e` 2026-07-01):**
+  `curriculum/l2-uk-en/plans/lit/artem-chekh-absolute-zero.yaml`,
+  `curriculum/l2-uk-en/plans/lit/artem-chekh-district-d.yaml`,
+  `curriculum/l2-uk-en/plans/lit/artem-chekh-who-are-you.yaml`
+- **Existing LIT discovery surfaces (VERIFIED `test -e` 2026-07-01):**
+  `curriculum/l2-uk-en/lit/discovery/artem-chekh-absolute-zero.yaml`,
+  `curriculum/l2-uk-en/lit/discovery/artem-chekh-district-d.yaml`,
+  `curriculum/l2-uk-en/lit/discovery/artem-chekh-who-are-you.yaml`
+- **Existing LIT wiki surfaces (VERIFIED `test -e` 2026-07-01):**
+  `wiki/literature/works/artem-chekh-absolute-zero.md`,
+  `wiki/literature/works/artem-chekh-district-d.md`,
+  `wiki/literature/works/artem-chekh-who-are-you.md`
+- **Existing LIT-WAR surfaces (VERIFIED `test -e` / `rg` 2026-07-01):**
+  `curriculum/l2-uk-en/plans/lit-war/chekh-absolute-zero.yaml`,
+  `curriculum/l2-uk-en/plans/lit-war/chekh-point-zero.yaml`,
+  `curriculum/l2-uk-en/lit-war/discovery/chekh-absolute-zero.yaml`,
+  `curriculum/l2-uk-en/lit-war/discovery/chekh-point-zero.yaml`,
+  `wiki/literature/works/chekh-absolute-zero.md`,
+  `wiki/literature/works/chekh-point-zero.md`
+- **Existing BIO cross-link (VERIFIED `test -e` 2026-07-01):**
+  `docs/research/bio/iryna-tsilyk.md`
+- **Existing index / audit surfaces (VERIFIED `rg` 2026-07-01; do not edit in dossier PR):**
+  `site/src/content/docs/bio/index.mdx` includes BIO #387 `artem-chekh`;
+  `docs/audits/bio-lit-cross-reference-gaps.md` maps LIT Chekh plans to missing
+  `artem-chekh.yaml`; `docs/audits/bio-readiness-matrix-2026-06-29.md` flags living
+  veteran-writer / completed-work-only.
+- **Future BIO surfaces (not present on 2026-07-01):** `curriculum/l2-uk-en/plans/bio/artem-chekh.yaml`,
+  `curriculum/l2-uk-en/bio/discovery/artem-chekh.yaml`, `wiki/figures/artem-chekh.md`,
+  `site/src/content/docs/bio/artem-chekh.mdx`, `curriculum/l2-uk-en/bio/artem-chekh/module.md`,
+  `curriculum/l2-uk-en/bio/artem-chekh/activities.yaml`,
+  `curriculum/l2-uk-en/bio/artem-chekh/vocabulary.yaml`,
+  `curriculum/l2-uk-en/bio/artem-chekh/resources.yaml`.
+
+## 8. Naming / transliteration
+
+- **Slug:** `artem-chekh`
+- **UA display:** `Артем Чех`
+- **Legal-name note:** `Артем Олександрович Чередник` can appear in instructor notes or
+  advanced biography; learner-facing titles should use the established pen name.
+- **EN display:** `Artem Chekh`; Commons category uses German-style `Artem Tschech`; some
+  sources use `Artem Cherednyk` / `Cherednik` for the legal surname.
+- **Search variants:** `Artem Chekh`, `Artem Tschech`, `Artem Cherednyk`, `Artem
+  Cherednik`, `Артем Чех`, `Артем Чередник`, `Артем Олександрович Чередник`,
+  `Точка нуль`, `Absolute Zero`, `Point Zero`, `Zero Point`, `Район Д`, `District D`,
+  `Хто ти такий?`, `Who Are You?`, `Rock, Paper, Grenade`, `Я і Фелікс`,
+  `Гра в перевдягання`, `Пісня відкритого шляху`.
+- **Avoid hostile/imperial default:** Do not use Russian `Артём Чех` except inside source
+  metadata or image-file provenance notes.
+
+## 9. Image rights
+
+- **Preferred candidate:** Commons `File:Artem Tschech am Meridian Czernowitz, 2021.png`;
+  author/uploader `Germany2019`; own work; 19 December 2021; licensed CC BY-SA 4.0. Use
+  with attribution, license link, change indication, and share-alike compliance.
+- **Backup candidate:** Commons `File:Artem-CHeh.-Foto-Irina-TSilik.jpg`; source own work,
+  author `Іван та кобила`, date 15 May 2017, CC BY-SA 4.0. Re-check before use because the
+  filename suggests a photo-credit relationship not reflected in the Commons author field.
+- **Older backup:** Commons `File:ВП Артем Чех.jpg`; taken 12 September 2008, transferred
+  from Russian Wikipedia, author / attribution `Водник`, CC BY-SA 3.0. Usable only with
+  careful attribution and source-chain check; prefer newer Ukrainian/Commons context if
+  available.
+- **Category lead:** Commons `Category:Artem Tschech` lists three files and includes
+  variant names / authority metadata.
+- **Personality / endorsement caution:** Educational biography use is normal, but avoid
+  implying Chekh endorses the course or a political/commercial message.
+- **Avoid by default:** publisher author photos, book covers, film stills, trailer frames,
+  social-media images, screenshots, or event photographs without file-level reusable
+  license.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- PEN Ukraine. "Чех Артем." https://pen.org.ua/members/chekh-artem. Accessed 2026-07-01.
+- PEN Ukraine. "Chekh Artem." https://pen.org.ua/en/members/chekh-artem. Accessed
+  2026-07-01.
+- European Bank for Reconstruction and Development. "EBRD Literature Prize." Current 2026
+  prize page. https://www.ebrd.com/home/news-and-events/news/events/ebrd-literature-prize.html.
+  Accessed 2026-07-01.
+- European Bank for Reconstruction and Development. "EBRD Literature Prize 2026 shortlist
+  announced." 1 April 2026.
+  https://www.ebrd.com/home/news-and-events/news/2026/ebrd-literature-prize-2026-shortlist-announced.html.
+  Accessed 2026-07-01.
+
+**Tier 2 (publisher / prize / cultural institution / reliable media):**
+
+- Seven Stories Press. "Artem Chekh." https://www.sevenstories.com/authors/678-artem-chekh.
+  Accessed 2026-07-01.
+- Seven Stories Press UK. "Rock, Paper, Grenade."
+  https://www.sevenstoriespress.co.uk/books/rock-paper-grenade. Accessed 2026-07-01.
+- Chytomo. "Seven Stories Press will publish Artem Chekh's novel 'Rock, Paper, Grenade' in
+  the USA." 17 September 2024.
+  https://chytomo.com/en/seven-stories-press-will-publish-artem-chekh-s-novel-rock-paper-grenade-in-the-usa/.
+  Accessed 2026-07-01.
+- Polish Institute in Kyiv. "Conrad Award / Artem Chekh - Laureate 2019."
+  https://instytutpolski.pl/kyiv/en/2019/11/15/artem-chekh-laureate-of-the-conrad-award-2019/.
+  Accessed 2026-07-01.
+- Polish Institute in Kyiv. "The Conrad Award." https://instytutpolski.pl/kyiv/en/awards/the-conrad-award/.
+  Accessed 2026-07-01.
+- Ukrainska Pravda. "Ukrainian writer Artem Chekh concussed in Bakhmut." 25 May 2023.
+  https://www.pravda.com.ua/eng/news/2023/05/25/7403803/. Accessed 2026-07-01.
+- Meridian Czernowitz. "Артем Чех 'Пісня відкритого шляху'."
+  https://www.meridiancz.com/blog/artem-chekh-pisnia-vidkrytoho-shliakhu/. Accessed
+  2026-07-01.
+- Meridian Czernowitz. "Артем Чех 'Гра в перевдягання'."
+  https://www.meridiancz.com/blog/artem-chekh-hra-v-perevdiahannia/. Accessed 2026-07-01.
+- Meridian Czernowitz. "Артем Чех." Author bio. https://shop.meridiancz.com/bio-cheh.
+  Accessed 2026-07-01.
+- PEN Ukraine. "Лауреатом Премії імені Шевельова 2025 року став Артур Дронь."
+  https://pen.org.ua/laureatom-premiyi-imeni-shevelova-2025-roku-stav-artur-dron.
+  Accessed 2026-07-01.
+
+**Tier 4 (image-rights / navigation only):**
+
+- Wikimedia Commons. "Category:Artem Tschech."
+  https://commons.wikimedia.org/wiki/Category:Artem_Tschech. Accessed 2026-07-01.
+- Wikimedia Commons. `File:Artem Tschech am Meridian Czernowitz, 2021.png`.
+  https://commons.wikimedia.org/wiki/File:Artem_Tschech_am_Meridian_Czernowitz,_2021.png.
+  Accessed 2026-07-01.
+- Wikimedia Commons. `File:Artem-CHeh.-Foto-Irina-TSilik.jpg`.
+  https://commons.wikimedia.org/wiki/File:Artem-CHeh.-Foto-Irina-TSilik.jpg. Accessed
+  2026-07-01.
+- Wikimedia Commons. `File:ВП Артем Чех.jpg`.
+  https://commons.wikimedia.org/wiki/File:%D0%92%D0%9F_%D0%90%D1%80%D1%82%D0%B5%D0%BC_%D0%A7%D0%B5%D1%85.jpg.
+  Accessed 2026-07-01.


### PR DESCRIPTION
## Summary
- add BIO #387 `artem-chekh` research dossier
- keep scope to `docs/research/bio/artem-chekh.md` only
- include living-person, decolonization, cross-track, and image-rights notes

## Scope
Changed file:
- `docs/research/bio/artem-chekh.md`

No plan YAML, module markdown, activities, vocabulary, resources, MDX, wiki packets, audit/status artifacts, telemetry, linter configs, or package files are touched.

## Validation
- `npx markdownlint-cli2 docs/research/bio/artem-chekh.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/artem-chekh.md`
- `git diff --cached --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Review notes
- Living-person status: re-check service/current status before learner-facing module build.
- Decolonization: frames Russian aggression and Ukrainian cultural agency directly; avoids neutral post-Soviet conflict framing.
- Cross-track: verifies existing LIT/LIT-WAR paths and planned BIO surfaces.
- Image rights: recommends Commons 2021 Meridian Czernowitz image under CC BY-SA 4.0; flags personality/endorsement caution.