### PR TITLE
docs(bio): add ustym karmaliuk dossier

### DIFF
--- a/docs/research/bio/ustym-karmaliuk.md
+++ b/docs/research/bio/ustym-karmaliuk.md
@@ -1,0 +1,292 @@
+# Устим Якимович Кармалюк - Research Dossier
+
+**Slug:** `ustym-karmaliuk`
+**Block:** +77 backfill - Podilia social resistance / folk memory / historical song
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #311
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-02
+
+**Source acronym legend:** EIU = Encyclopedia of the History of Ukraine / Institute of
+History of Ukraine, NASU; IEU = Internet Encyclopedia of Ukraine / Canadian Institute of
+Ukrainian Studies; NBUV = Vernadsky National Library of Ukraine; VOUNB = Vinnytsia
+Regional Universal Scientific Library; FOLK = existing learn-ukrainian FOLK materials;
+Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional, encyclopedia, library, or image-rights sources cited
+- [x] Pressure mechanism framed as serfdom, Russian imperial military/repressive power,
+  Podilia landlord economy, exile, katorga, and folk-memory contestation; no simplified
+  Robin Hood myth
+- [x] At least 2 title / source / visual anchors supplied
+- [x] Cross-track links verified `test -e` / `rg` on 2026-07-02 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check
+
+- [x] No Russocentric framing: Karmaliuk is not reduced to a Russian imperial police category
+  such as "bandit" or to a Soviet-only class hero.
+- [x] Ukrainian agency central: Podilia folk memory, Ukrainian historical-song reception,
+  and local social resistance are kept visible.
+- [x] Social oppression is specific: serfdom, landlord coercion, forced recruitment,
+  corporal punishment, Siberian katorga, and Russian imperial policing.
+- [x] Anti-hagiography: the dossier flags contested raids and source tensions; it does not
+  teach Karmaliuk as a clean "Ukrainian Robin Hood."
+
+## 1. Identity
+
+- **Canonical learner-facing name:** `Устим Кармалюк` / `Ustym Karmaliuk`. Use
+  `ustym-karmaliuk` for slug and file surfaces.
+- **Name variants:** EIU gives `Кармалюк`, `Кармелюк`, `Карменюк`, and family surname
+  `Карманюк`. NBUV also lists `Кармелюк`; Commons records many transliterations including
+  `Karmaljuk`, `Karmelyuk`, `Karmaluk`, and `Oustym Karmaliouk`.
+- **Patronymic:** `Устим Якимович Кармалюк`.
+- **Dates:** EIU gives 10 March / 27 February 1787 and 22 / 10 October 1835. IEU uses
+  Gregorian 10 March 1787 and 22 October 1835. A Ukrainian historical-journal source on
+  naming / archival variants treats the 27 February old-style entry as baptism evidence,
+  so the exact birth day should be handled cautiously. Use `1787-1835` or source-labeled
+  Gregorian dates for learner-facing chronology.
+- **Birthplace:** EIU says Holovchyntsi, Letychiv county, Podilia voivodeship; now
+  Karmaliukove, Zhmerinka district, Vinnytsia oblast. IEU says Holovchyntsi, now
+  Karmaliukove, Lityn county in its historical-geography phrasing. Treat county labels as
+  source-specific.
+- **Death / burial:** EIU says he was killed from ambush on the night of 22 / 10 October
+  1835 by nobleman F. Rudkovskyi in Shliakhovi Korychyntsi, Letychiv county, Podilia
+  gubernia; EIU's Ukrainian text uses `Рудковським`. EIU identifies the modern village as
+  Voloske, Derazhnia district, Khmelnytskyi oblast. EIU and Commons place burial at
+  Letychiv.
+- **Core identity:** Ukrainian Podilia peasant rebel / folk-memory figure, born a serf,
+  associated with anti-landlord raids and repeated escapes from imperial punishment.
+
+## 2. Oppression / pressure mechanism
+
+- **Serfdom and landlord coercion:** EIU says Karmaliuk was born in a serf family and that
+  landowner Pihlowskyi sent him into military recruitment in 1812. IEU frames the broader
+  context as the highly repressive and commercially profitable stage of serfdom in the
+  Russian Empire.
+- **Forced military service / desertion:** IEU says his landlord sent him into the army in
+  1812; Karmaliuk fled and organized bands with other deserters. This is a coercion story,
+  not a free career choice.
+- **Imperial punishment:** IEU records capture in 1814, a sentence in Kamianets-Podilskyi
+  to 500 blows while running a gauntlet, dispatch to Crimea, and escape. EIU says he was
+  four times sentenced to Siberian katorga and escaped, returning by foot over thousands of
+  versts.
+- **Geography of resistance:** EIU locates his most intensive activity in Lityn and
+  Letychiv counties, with raids also in Balta, Vinnytsia, Mohyliv, Proskuriv counties and
+  partly in Bessarabia. IEU says the peak in 1830-1835 spread into Kyiv, Volhynia, and
+  Bessarabia.
+- **Multiethnic social world:** EIU notes bands made up of serfs, military deserters, minor
+  nobles, and town Jews, and describes Karmaliuk's connections with Jewish townspeople.
+  Teach this as source-bounded social history; avoid ethnicized criminal stereotypes.
+- **Historiographic tension:** IEU emphasizes redistribution of captured goods to village
+  poor; EIU includes attacks on landlord estates, roadside taverns, and wealthy peasants.
+  This tension is the reason modules must avoid a simple Robin Hood frame.
+
+## 3. Major events / historical footprint
+
+- **1812 recruitment and flight:** The point where landlord coercion, imperial military
+  power, and local resistance converge. Useful for explaining `рекрутчина`, `кріпацтво`,
+  and `втеча`.
+- **1814 punishment / escape cycle:** The Kamianets-Podilskyi sentence and escape from
+  transfer to Crimea become a concrete anchor for corporal punishment and imperial penal
+  geography.
+- **1814-1828 rebellion phase:** IEU describes rebellion in Lityn, Letychiv, and Proskuriv
+  counties, attracting peasants, deserters, and urban poor.
+- **Siberian-katorga cycle:** EIU's "four times sentenced to Siberian katorga" is a compact
+  way to teach exile, forced labor, and return in folk memory.
+- **1830-1835 peak:** IEU says Karmaliuk's struggle reached its height in these years,
+  involved up to 20,000 peasants, and included around 1,000 raids on landlord estates.
+- **Death in ambush:** EIU's death account should be kept factual. Do not reproduce magical
+  bullet / button legends as history; if used, label them clearly as folklore.
+- **Memory after death:** EIU says he was poetized and enveloped in folk-avenger fame
+  already during his life. Existing FOLK surfaces connect his image to `За Сибіром сонце
+  сходить`.
+
+## 4. Pedagogical anchors
+
+- **Historical-song anchor:** `За Сибіром сонце сходить` already exists in the repo as a
+  reading surface and FOLK module resource. Use it to show how first-person song voice
+  turns a contested figure into folk memory. Carry forward the existing FOLK research
+  do-not-quote caveat: verify exact incipit/text against the reading surface before using
+  direct quotation.
+- **Myth-vs-record anchor:** Pair EIU's raids on wealthy peasants / taverns with IEU's
+  redistribution-to-poor synthesis. The learner task can ask what a folk song preserves and
+  what it simplifies.
+- **Imperial-penal vocabulary anchor:** `рекрут`, `каторга`, `Сибір`, `втеча`, `заслання`,
+  `батіг`, `замок`, `корчма`, `поміщик`, `кріпак`.
+- **Geography anchor:** Podilia, Letychiv, Lityn, Kamianets-Podilskyi, Bessarabia, Volhynia,
+  Kyiv region, Siberia. Map work should distinguish historical administrative units from
+  modern oblast/raion names.
+- **Visual anchor:** Commons `File:Karmelyuk.JPG`, a faithful reproduction of Vasyl
+  Tropinin's portrait `Ustim Karmaluk`, public domain because Tropinin died in 1857. Good
+  default, but mention the painting's Russian imperial museum/source chain if image context
+  is discussed.
+- **Alternative visual anchor:** Commons grave and Letychiv monument categories can support
+  memory/place lessons better than a heroic portrait if the module emphasizes commemoration.
+  The specific monument photo `File:Пам'ятник Устиму Кармалюку в смт Летичів.jpg` is a
+  useful CC BY-SA 4.0 candidate for that route.
+
+## 5. Language register
+
+- **Register:** historical biography, folk song, social resistance, imperial legal and
+  punishment vocabulary, local memory, anti-hagiographic comparison.
+- **CEFR readiness:** B1+/B2 short biography and song-context tasks; B2/C1 comparison of
+  historical record vs folk image; C1/C2 historiography and decolonization discussions.
+- **Core vocabulary:** `кріпак`, `кріпацтво`, `поміщик`, `панщина`, `рекрут`, `втеча`,
+  `повстанський загін`, `ватажок`, `гайдамака`, `народний месник`, `корчма`, `маєток`,
+  `заслання`, `каторга`, `Сибір`, `засідка`, `переказ`, `історична пісня`, `фольклор`,
+  `опоетизувати`, `міфологізація`.
+- **Register caution:** Folk-song pathos and Soviet-era class-war phrasing can overrun the
+  historical record. Learner-facing text should keep plain factual wording beside any
+  poetic or legendary phrasing.
+
+## 6. Risks / open questions
+
+- **Birthplace county mismatch:** EIU and IEU phrase historical county affiliation
+  differently. Use birthplace village confidently; avoid overloading learner-facing prose
+  with county labels unless the module teaches historical geography.
+- **Shooter-name spelling:** EIU's page uses `Рудковським`; if a later module uses another
+  spelling such as `Рутковський`, keep the form source-labeled rather than silently
+  normalizing it.
+- **Exact birth-date caution:** The standard 10 March / 27 February 1787 date is common in
+  reference works, but archival discussion treats the old-style entry as baptism evidence
+  rather than direct proof of the exact birth day. Prefer `born in 1787` unless the module
+  needs date-conversion practice.
+- **Robber / rebel / folk hero labels:** `Outlaw`, `rebel`, `haidamaka`, `folk hero`, and
+  `peasant-movement leader` each carry different source politics. Define the label before
+  using it as a verdict.
+- **Robin Hood shortcut:** Existing public summaries often call him a Ukrainian Robin Hood.
+  This can be useful as a comparison prompt but should not be the main claim.
+- **Ethnicity of participants:** EIU's mention of minor nobles and Jews is important for
+  social history, but sensitive. Avoid implying collective ethnic guilt or romanticizing
+  criminal networks.
+- **Soviet-era bibliography:** VOUNB and NBUV point to many Soviet publications and memory
+  practices. Use those as reception/history-of-memory evidence, not automatically as
+  factual authority for every claim.
+- **Image identity uncertainty:** Some Tropinin/Karmaliuk-related files have uncertain
+  captions, e.g. `Elderly Ukrainian peasant by Tropinin.jpg` includes a question mark in
+  the Karmaliuk identification. Prefer `Karmelyuk.JPG` or place/monument imagery unless a
+  module needs to discuss uncertain portrait attribution.
+
+## 7. Cross-track links
+
+- **Existing FOLK module surfaces (VERIFIED `test -e` / `rg` 2026-07-02):**
+  `curriculum/l2-uk-en/folk/istorychni-pisni/module.md`,
+  `curriculum/l2-uk-en/folk/istorychni-pisni/activities.yaml`,
+  `curriculum/l2-uk-en/folk/istorychni-pisni/resources.yaml`
+- **Existing FOLK plan / research surfaces (VERIFIED `test -e` / `rg` 2026-07-02):**
+  `curriculum/l2-uk-en/plans/folk/istorychni-pisni.yaml`,
+  `curriculum/l2-uk-en/plans/folk/istorychni-perekazy.yaml`,
+  `docs/research/folk/istorychni-pisni.md`,
+  `docs/research/folk/istorychni-perekazy.md`,
+  `docs/research/folk/istorychni-reading-catalog.md`,
+  `wiki/folk/historical/istorychni-pisni.md`
+- **Existing site / reading surfaces (VERIFIED `test -e` / `rg` 2026-07-02):**
+  `site/src/content/docs/folk/istorychni-pisni.mdx`,
+  `site/src/content/readings/istorychna-pisnia-za-sybirom.mdx`
+- **Existing BIO index / audit surfaces (VERIFIED `rg` 2026-07-02; do not edit in dossier
+  PR):** `site/src/content/docs/bio/index.mdx` includes BIO #311 `ustym-karmaliuk`;
+  `docs/audits/bio-readiness-matrix-2026-06-29.md` flags contested social resistance, not
+  Robin Hood myth; `docs/audits/bio-ukrainian-expansion-research-2026-06-29.md` lists the
+  Podilia folk-memory figure and serf-born rebel framing.
+- **Future BIO surfaces (not present on 2026-07-02):**
+  `curriculum/l2-uk-en/plans/bio/ustym-karmaliuk.yaml`,
+  `curriculum/l2-uk-en/bio/discovery/ustym-karmaliuk.yaml`,
+  `wiki/figures/ustym-karmaliuk.md`,
+  `site/src/content/docs/bio/ustym-karmaliuk.mdx`,
+  `curriculum/l2-uk-en/bio/ustym-karmaliuk/module.md`,
+  `curriculum/l2-uk-en/bio/ustym-karmaliuk/activities.yaml`,
+  `curriculum/l2-uk-en/bio/ustym-karmaliuk/vocabulary.yaml`,
+  `curriculum/l2-uk-en/bio/ustym-karmaliuk/resources.yaml`.
+
+## 8. Naming / transliteration
+
+- **Slug:** `ustym-karmaliuk`
+- **UA display:** `Устим Кармалюк`
+- **Full UA display when needed:** `Устим Якимович Кармалюк`
+- **EN display:** `Ustym Karmaliuk`
+- **Source variants:** `Кармелюк`, `Карменюк`, `Карманюк`, `Karmeliuk`, `Karmelyuk`,
+  `Karmaljuk`, `Karmaluk`, `Karmaliuk`, `Oustym Karmaliouk`.
+- **Search variants:** `Устим Кармалюк`, `Устим Кармелюк`, `Кармалюк Устим Якимович`,
+  `Кармелюк Устим Якимович`, `Ustym Karmaliuk`, `Ustym Karmeliuk`, `Ustim Karmaluk`,
+  `За Сибіром сонце сходить`.
+- **Avoid:** Do not default to non-canonical `Устим Кармелюк` spellings when the canonical
+  Ukrainian learner-facing form is available; use those spellings only as source, folk, or
+  search variants.
+
+## 9. Image rights
+
+- **Preferred candidate:** Commons `File:Karmelyuk.JPG`; Vasyl Tropinin, `Ustim Karmaluk`,
+  1820, collection listed as Nizhniy Tagil State Museum of Fine Arts; faithful reproduction
+  of a public-domain two-dimensional artwork. Commons marks the work public domain because
+  the artist died in 1857 and the reproduction is treated as PD-Art.
+- **Attribution/context caution:** The portrait is artistically and institutionally mediated
+  through a Russian imperial / Russian museum chain. It is copyright-safe, but do not treat
+  it as unproblematic eyewitness photography.
+- **Backup candidate:** Commons `File:Elderly Ukrainian peasant by Tropinin.jpg`; public
+  domain, but the title includes `Устим Кармелюк?`, so use only with attribution uncertainty.
+- **Memory/place candidates:** Commons `Category:Grave of Ustym Karmaliuk` and
+  `Category:Monument to Ustym Karmaliuk` contain Letychiv grave/monument files. Check each
+  file-level license before use; category-level presence is not enough.
+- **Specific monument candidate:** Commons `File:Пам'ятник Устиму Кармалюку в смт
+  Летичів.jpg`, photo by `Культура лет.рб`, CC BY-SA 4.0. Useful when a learner surface
+  emphasizes public memory and Letychiv commemoration instead of portrait authority.
+- **Specific grave candidate:** Commons `File:МогилаУстима Кармалюка.jpg`, photo by
+  Aniskov, CC BY-SA 4.0. Useful for commemoration/place context, subject to normal
+  attribution and respectful-use framing.
+- **Avoid by default:** Soviet postal covers, modern book covers, screenshots, school-site
+  illustrations, museum page images, and tourist photos without a clear file-level reusable
+  license.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- Любченко В.Б. "КАРМАЛЮК Устим Якимович." Енциклопедія історії України, Т. 4:
+  Ка-Ком. Інститут історії України НАН України. https://history.org.ua/?termin=Karmalyuk.
+  Accessed 2026-07-02.
+- "Karmaliuk, Ustym." Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian
+  Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CA%5CKarmaliukUstym.htm.
+  Accessed 2026-07-02.
+- Національна бібліотека України імені В. І. Вернадського. "Кармалюк Устим Якович"
+  [sic; catalog title uses this patronymic form, while EIU and the dossier use
+  `Якимович`].
+  https://irbis-nbuv.gov.ua/ulib/item/REF0005738. Accessed 2026-07-02.
+- Вінницька обласна універсальна наукова бібліотека імені Валентина Отамановського.
+  "Устим Кармалюк." https://library.vn.ua/e-library/katalog/ustim-karmalyuk. Accessed
+  2026-07-02.
+
+**Tier 2 (bibliography / reception / existing curriculum anchors):**
+
+- Київська молодіжна бібліотека. "Устим Кармелюк. Народний месник, ватажок повстанців."
+  https://msmb.org.ua/books/thematic_bibliography/504/. Accessed 2026-07-02.
+- "Кармалюк чи Карманюк?" Український історичний журнал, 1997.
+  https://history.org.ua/JournALL/journal/1997/1/10.pdf. Accessed 2026-07-02.
+- learn-ukrainian FOLK module surfaces for `istorychni-pisni`, `istorychni-perekazy`, and
+  reading `istorychna-pisnia-za-sybirom`, verified locally on 2026-07-02.
+
+**Tier 4 (image-rights / navigation only):**
+
+- Wikimedia Commons. "Category:Ustym Karmaliuk."
+  https://commons.wikimedia.org/wiki/Category:Ustym_Karmaliuk. Accessed 2026-07-02.
+- Wikimedia Commons. `File:Karmelyuk.JPG`. https://commons.wikimedia.org/wiki/File:Karmelyuk.JPG.
+  Accessed 2026-07-02.
+- Wikimedia Commons. `File:Elderly Ukrainian peasant by Tropinin.jpg`.
+  https://commons.wikimedia.org/wiki/File:Elderly_Ukrainian_peasant_by_Tropinin.jpg.
+  Accessed 2026-07-02.
+- Wikimedia Commons. "Category:Grave of Ustym Karmaliuk."
+  https://commons.wikimedia.org/wiki/Category:Grave_of_Ustym_Karmaliuk. Accessed
+  2026-07-02.
+- Wikimedia Commons. "Category:Monument to Ustym Karmaliuk."
+  https://commons.wikimedia.org/wiki/Category:Monument_to_Ustym_Karmaliuk. Accessed
+  2026-07-02.
+- Wikimedia Commons. `File:Пам'ятник Устиму Кармалюку в смт Летичів.jpg`.
+  https://commons.wikimedia.org/wiki/File:%D0%9F%D0%B0%D0%BC%27%D1%8F%D1%82%D0%BD%D0%B8%D0%BA_%D0%A3%D1%81%D1%82%D0%B8%D0%BC%D1%83_%D0%9A%D0%B0%D1%80%D0%BC%D0%B0%D0%BB%D1%8E%D0%BA%D1%83_%D0%B2_%D1%81%D0%BC%D1%82_%D0%9B%D0%B5%D1%82%D0%B8%D1%87%D1%96%D0%B2.jpg.
+  Accessed 2026-07-02.
+- Wikimedia Commons. `File:МогилаУстима Кармалюка.jpg`.
+  https://commons.wikimedia.org/wiki/File:%D0%9C%D0%BE%D0%B3%D0%B8%D0%BB%D0%B0%D0%A3%D1%81%D1%82%D0%B8%D0%BC%D0%B0_%D0%9A%D0%B0%D1%80%D0%BC%D0%B0%D0%BB%D1%8E%D0%BA%D0%B0.jpg.
+  Accessed 2026-07-02.


### PR DESCRIPTION
## Summary
- add BIO #311 `ustym-karmaliuk` research dossier
- keep scope to `docs/research/bio/ustym-karmaliuk.md` only
- include contested social-resistance framing, cross-track FOLK links, and image-rights notes

## Scope
Changed file:
- `docs/research/bio/ustym-karmaliuk.md`

No plan YAML, module markdown, activities, vocabulary, resources, MDX, wiki packets, audit/status artifacts, telemetry, linter configs, or package files are touched.

## Validation
- `npx markdownlint-cli2 docs/research/bio/ustym-karmaliuk.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/ustym-karmaliuk.md`
- `git diff --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Review notes
- Decolonization: frames Karmaliuk through serfdom, Russian imperial coercion, Podilia social resistance, and folk-memory contestation; avoids a clean Robin Hood myth.
- Cross-track: verifies existing FOLK song/reading/research surfaces and planned BIO surfaces.
- Image rights: recommends public-domain Tropinin portrait or CC BY-SA 4.0 Letychiv commemoration images with attribution/context cautions.