### PR TITLE
docs(bio): add Oleksa Dovbush dossier

### DIFF
--- a/docs/research/bio/oleksa-dovbush.md
+++ b/docs/research/bio/oleksa-dovbush.md
@@ -1,0 +1,270 @@
+# Олекса Васильович Довбуш - Research Dossier
+
+**Slug:** `oleksa-dovbush`
+**Block:** +77 backfill - Carpathian opryshky / Hutsul folk memory / contested outlaw hero
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #312
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-02
+
+**Source acronym legend:** EIU = Encyclopedia of History of Ukraine / Institute of
+History of Ukraine, NASU; IEU = Internet Encyclopedia of Ukraine / Canadian
+Institute of Ukrainian Studies; LH = Local History; FOLK = existing
+learn-ukrainian FOLK materials; HIST = existing learn-ukrainian HIST materials;
+Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional, encyclopedia, expert-media, or
+  image-rights sources cited
+- [x] Pressure mechanism framed as Carpathian landlord, rentier, usurer, and
+  frontier-policing power, plus folk-memory contestation; no clean Robin Hood myth
+- [x] At least 2 title / source / visual anchors supplied
+- [x] Cross-track links verified `test -e` / `rg` on 2026-07-02 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check
+
+- [x] No Russocentric framing: Dovbush is not folded into a generic "Slavic
+  bandit" archetype or narrated through later imperial policing categories.
+- [x] Ukrainian / Hutsul agency central: Pokuttia, Hutsul, Prykarpattia, and
+  Carpathian oral-memory contexts remain visible.
+- [x] Polish-Lithuanian Commonwealth landlord, leaseholder, creditor, and
+  military pursuit pressures are named without turning multiethnic victims into
+  ethnic blame.
+- [x] Anti-hagiography: the dossier holds together violence, criminalization,
+  popular sympathy, and later folklore instead of giving a sainted hero story.
+
+## 1. Identity facts
+
+- **Canonical learner-facing name:** `Олекса Довбуш`; English `Oleksa Dovbush`.
+  Use `oleksa-dovbush` for the BIO slug.
+- **Variants:** EIU/IEU and image repositories surface `Dovbuš`, `Dovbushchuk`,
+  `Dobosh`, `Dobosz`, and `Dowbusz`. Treat them as search/provenance variants,
+  not separate identities or learner-facing defaults.
+- **Dates:** EIU and IEU give birth year 1700 and death on 24 August 1745. Use
+  `1700-1745` or source-labeled exact death date; avoid calendar-conversion claims
+  unless separately rechecked.
+- **Birthplace:** Pechenizhyn is the best-supported encyclopedia birthplace.
+  Later legend and noncritical retellings sometimes shift the birthplace; label
+  those as folklore or reception if used.
+- **Death:** EIU/IEU place his death at Kosmach. Historical accounts normally
+  identify Stepan Dzvinchuk, husband of Dzvinka, as the killer, while the
+  surrounding story is heavily folklorized.
+- **Core identity:** Ukrainian Carpathian opryshok leader in the 1730s-1740s and
+  a major Hutsul / Pokuttia folk-memory figure.
+- **Early life:** EIU describes Dovbush as coming from a poor `коморник` family
+  and acting with his brother Ivan in 1738-1739 before the brothers split.
+
+## 2. Oppression / pressure mechanism
+
+- **Mountain social world:** LH places Dovbush inside Carpathian / Vlach pastoral
+  outlaw traditions, poverty, weakening local privileges, legal powerlessness,
+  and Commonwealth crisis conditions.
+- **Landlord and rentier pressure:** EIU describes raids against `пани`,
+  rentiers, and usurers; IEU summarizes targets as landlords, rentiers, usurers,
+  merchants, nobles, and rich Jews. Teach the social-power structure rather than
+  ethnic blame.
+- **Frontier policing:** EIU records crown-hetman Jozef Potocki and Colonel
+  Przeluski pursuing opryshky with military force.
+- **Violence / anti-hagiography:** EIU explicitly includes physical violence,
+  arson, and seizure of property and money. LH stresses that raids affected
+  Polish, Jewish, Armenian, Ruthenian / Ukrainian, and other communities.
+- **Folk-memory pressure:** IEU and existing FOLK/HIST surfaces preserve the
+  admired popular image; LH warns against treating that image as a simple,
+  archive-proven revolutionary program.
+
+## 3. Major events / historical footprint
+
+- **1738-1739 activity with Ivan:** EIU identifies the early phase when Oleksa and
+  his brother Ivan acted together before a quarrel and split.
+- **Chornohora / Mount Stih base:** EIU places Dovbush's band from 1740 in the
+  Chornohora region, using Mount Stih near the Galicia, Moldavia, and Hungary
+  borderlands.
+- **Regional raids:** EIU connects the band with Prykarpattia, Zakarpattia, and
+  Bukovyna, and with 1744-1745 raids around Drohobych, Turka, Solotvyn, Nadvirna,
+  and Rohatyn.
+- **Bohorodchany fortress:** EIU records the capture of Bohorodchany fortress as
+  one of the best-known episodes in the Dovbush cycle.
+- **Death at Kosmach:** Use the Kosmach death account factually and label
+  romantic or magic-bullet motifs as folklore.
+- **Memory geography:** EIU/IEU note that caves, rocks, and other Carpathian
+  places bear Dovbush's name, including Dovbush Rocks as a durable landscape
+  memory anchor.
+
+## 4. Pedagogical anchors
+
+- **Opryshky anchor:** Existing HIST `opryshky` materials ask whether Dovbush was
+  a cruel bandit or a noble avenger. This dossier supplies a source-grounded
+  vocabulary and ethics frame for that question.
+- **Historical-legend anchor:** Existing FOLK `istorychni-perekazy` uses the
+  axe-splitting-rock legend. Treat it as folklore and place memory, not literal
+  biography.
+- **Myth-vs-record anchor:** Pair IEU's Robin Hood-like reception shorthand with
+  EIU's record of raids, violence, arson, military pursuit, and LH's anti-myth
+  framing.
+- **Geography anchor:** Pechenizhyn, Kosmach, Pokuttia, Hutsul region,
+  Chornohora, Mount Stih, Prykarpattia, Zakarpattia, Bukovyna, Bohorodchany, and
+  Dovbush Rocks.
+- **Film/pop-culture caution:** Modern films and school summaries can intensify
+  superhero or romance frames. Use them for reception only after source checking,
+  not as default historical biography.
+- **Visual anchor:** Commons `File:Олекса_Довбуш,_Ярослав_Пстрак.jpg` is a public
+  domain historic postcard portrait by Yaroslav Pstrak; caption as an artwork,
+  not documentary likeness.
+- **Older-print anchor:** Commons `File:Aleksy_Dobosz_grafika_(cropped).jpg` is
+  a 1746 public-domain Polona / National Library of Poland graphic. Preserve the
+  source-title variant while foregrounding `Олекса Довбуш`.
+- **Place-memory anchor:** Commons Dovbush Rocks images such as
+  `File:Скелі_Довбуша_20160510_002.jpg` are useful for landscape memory when
+  file-level CC BY-SA attribution is preserved.
+
+## 5. Language register
+
+- **Register:** historical biography, Carpathian social resistance, outlawry,
+  folk legend, regional geography, source criticism, and decolonial memory.
+- **CEFR readiness:** B1+/B2 concise biography and map tasks; B2/C1 myth-vs-record
+  comparison; C1/C2 discussion of outlaw heroization, violence, and source ethics.
+- **Core vocabulary:** `опришок`, `ватажок`, `загін`, `Гуцульщина`, `Покуття`,
+  `Чорногора`, `полонина`, `коморник`, `можновладець`, `пан`, `орендар`,
+  `лихвар`, `фортеця`, `рейд`, `переказ`, `легенда`, `народний месник`,
+  `розбійник`, `міфологізація`, `джерело`, `свідчення`, `усна пам'ять`.
+- **Register caution:** `народний месник` and `Робін Гуд` are reception labels,
+  not neutral historical descriptions. Pair them with concrete source language
+  about raids, violence, and community harm.
+
+## 6. Risks / open questions
+
+- **Birthplace / exactness:** Pechenizhyn and 1700 are safest per EIU/IEU. Treat
+  other birthplaces or exact childhood anecdotes as later reception unless a
+  stronger source is added.
+- **Robin Hood shortcut:** IEU uses the comparison and public media repeats it,
+  but the module thesis should stay `historical opryshok leader with a large
+  folkloric afterlife`.
+- **Ethnicized victim lists:** Source victim lists include social, estate,
+  occupational, and ethnic/confessional categories. Use them only to explain a
+  multiethnic social world and avoid stereotype reproduction.
+- **Anti-feudal overclaim:** LH explicitly complicates simple anti-feudal /
+  revolutionary readings. Do not make Dovbush a programmatic modern politician.
+- **Modern film drift:** The 2023 film `Довбуш` and related reception are useful
+  culture-history objects, but should not silently supply motives or plot details.
+- **Image-title variants:** Non-Ukrainian source captions such as `Aleksy Dobosz`
+  are useful provenance data, not learner-facing name policy.
+
+## 7. Cross-track links
+
+- **Existing HIST plan surfaces (VERIFIED `test -e` / `rg` 2026-07-02):**
+  `curriculum/l2-uk-en/plans/hist/opryshky.yaml`,
+  `curriculum/l2-uk-en/plans/hist/bukovyna-zakarpattia.yaml`
+- **Existing HIST discovery surfaces (VERIFIED `test -e` / `rg` 2026-07-02):**
+  `curriculum/l2-uk-en/hist/discovery/opryshky.yaml`,
+  `curriculum/l2-uk-en/hist/discovery/bukovyna-zakarpattia.yaml`
+- **Existing FOLK plan surfaces (VERIFIED `test -e` / `rg` 2026-07-02):**
+  `curriculum/l2-uk-en/plans/folk/istorychni-perekazy.yaml`,
+  `curriculum/l2-uk-en/plans/folk/istorychni-pisni.yaml`
+- **Existing FOLK module / vocabulary surfaces (VERIFIED `test -e` / `rg` 2026-07-02):**
+  `curriculum/l2-uk-en/folk/istorychni-pisni/module.md`,
+  `curriculum/l2-uk-en/folk/istorychni-pisni/vocabulary.yaml`
+- **Existing FOLK research / wiki surfaces (VERIFIED `test -e` / `rg` 2026-07-02):**
+  `docs/research/folk/istorychni-perekazy.md`,
+  `docs/research/folk/istorychni-pisni.md`,
+  `wiki/folk/historical/istorychni-pisni.md`
+- **Existing BIO index / audit surfaces (VERIFIED `rg` 2026-07-02):**
+  `site/src/content/docs/bio/index.mdx` reserves BIO #312 `oleksa-dovbush`;
+  `docs/audits/bio-readiness-matrix-2026-06-29.md` and
+  `docs/audits/bio-ukrainian-expansion-research-2026-06-29.md` list the gap.
+- **Planned BIO surfaces (ABSENT `test -e` 2026-07-02):**
+  `curriculum/l2-uk-en/plans/bio/oleksa-dovbush.yaml`,
+  `curriculum/l2-uk-en/bio/discovery/oleksa-dovbush.yaml`,
+  `wiki/figures/oleksa-dovbush.md`,
+  `site/src/content/docs/bio/oleksa-dovbush.mdx`,
+  `curriculum/l2-uk-en/bio/oleksa-dovbush/module.md`,
+  `curriculum/l2-uk-en/bio/oleksa-dovbush/activities.yaml`,
+  `curriculum/l2-uk-en/bio/oleksa-dovbush/vocabulary.yaml`,
+  `curriculum/l2-uk-en/bio/oleksa-dovbush/resources.yaml`
+
+## 8. Naming / indexing
+
+- **Canonical UA:** `Олекса Довбуш`; fuller form `Олекса Васильович Довбуш`.
+- **Canonical EN:** `Oleksa Dovbush`.
+- **Search variants:** `Олекса Довбуш`, `Довбуш Олекса Васильович`,
+  `Oleksa Dovbush`, `Oleksa Dovbuš`, `Oleksa Dovbouch`, `Aleksy Dobosz`,
+  `Dobosh`, `Dowbusz`, `опришки`, `Opryshky`, `Скелі Довбуша`, `Dovbush Rocks`,
+  `Богородчани`, `Bohorodchany fortress`, `Степан Дзвінчук`.
+- **Avoid:** Do not default to `Aleksy Dobosz` or other non-Ukrainian
+  source-title variants in learner-facing text. Use them only in source,
+  catalog, or image-rights notes.
+
+## 9. Image rights
+
+- **Preferred portrait/art candidate:** Commons
+  `File:Олекса_Довбуш,_Ярослав_Пстрак.jpg`; historic postcard by Yaroslav
+  Pstrak, public domain on Commons. Use a caption that says artwork/postcard, not
+  documentary portrait.
+- **Older print candidate:** Commons `File:Aleksy_Dobosz_grafika_(cropped).jpg`;
+  1746 graphic via Polona.pl / National Library of Poland, author unknown,
+  public domain. Include the Polish title only as provenance.
+- **Place-memory candidate:** Commons `File:Скелі_Довбуша_20160510_002.jpg`;
+  Dovbush Rocks by TommyGUN, CC BY-SA 4.0. Preserve attribution, license link,
+  and share-alike obligations.
+- **Alternate place candidates:** Commons Dovbush Rocks / Bubnyshche images such
+  as `File:Печерний_комплекс_в_Бубнище_01.jpg` can support landscape-memory
+  lessons after file-level license confirmation.
+- **Memorial candidates:** Commons memorial signs and plaques in Kryvorivnia,
+  Bohorodchany, or Pechenizhyn may serve reception / commemoration lessons after
+  file-level license checks.
+- **Avoid default:** film stills, posters, YouTube frames, stock/tourism photos,
+  school-site illustrations, unsourced portraits, colorized private-collection
+  images, or modern artwork without explicit reusable licensing.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- Смолій В.А. "Довбуш Олекса Васильович." Енциклопедія історії України,
+  Інститут історії України НАН України. https://history.org.ua/?termin=Dovbush_O.
+  Accessed 2026-07-02.
+- "Dovbush, Oleksa." Internet Encyclopedia of Ukraine / Canadian Institute of
+  Ukrainian Studies.
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CD%5CO%5CDovbushOleksa.htm.
+  Accessed 2026-07-02.
+- "Opryshoks." Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian
+  Studies.
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CO%5CP%5COpryshoks.htm.
+  Accessed 2026-07-02.
+- Fialkova, L. "Oleksa Dovbush: An Alternative Mythical Biography of the
+  Ukrainian Hero..." Fabula / De Gruyter. https://www.degruyterbrill.com/document/doi/10.1515/fabl.2011.008/html.
+  Accessed 2026-07-02.
+- Національна бібліотека України імені В. І. Вернадського. Catalog record for
+  Hrabovetskyi's monograph `Олекса Довбуш (1700-1745)`.
+  https://irbis-nbuv.gov.ua/ulib/item/UKR0008263. Accessed 2026-07-02.
+
+**Tier 2 (expert media / local institutional / reception):**
+
+- Local History. "Ким насправді був Олекса Довбуш?"
+  https://localhistory.org.ua/texts/statti/kim-naspravdi-buv-oleksa-dovbush/.
+  Accessed 2026-07-02.
+- Ivano-Frankivsk Regional Museum page for the Dovbush museum.
+  https://www.museum.if.ua/museums/r2/69.html. Accessed 2026-07-02.
+- New Eastern Europe. "The infamous Dovbush: a robber of trust."
+  https://neweasterneurope.eu/2024/02/07/the-infamous-dovbush-a-robber-of-trust/.
+  Accessed 2026-07-02.
+- Existing learn-ukrainian HIST/FOLK surfaces listed in Section 7, verified
+  2026-07-02.
+
+**Tier 4 (image-rights / media-rights checks):**
+
+- Wikimedia Commons. `Category:Oleksa Dovbush`.
+  https://commons.wikimedia.org/wiki/Category:Oleksa_Dovbush. Accessed 2026-07-02.
+- Wikimedia Commons. `File:Олекса_Довбуш,_Ярослав_Пстрак.jpg`.
+  https://commons.wikimedia.org/wiki/File:%D0%9E%D0%BB%D0%B5%D0%BA%D1%81%D0%B0_%D0%94%D0%BE%D0%B2%D0%B1%D1%83%D1%88,_%D0%AF%D1%80%D0%BE%D1%81%D0%BB%D0%B0%D0%B2_%D0%9F%D1%81%D1%82%D1%80%D0%B0%D0%BA.jpg.
+  Accessed 2026-07-02.
+- Wikimedia Commons. `File:Aleksy_Dobosz_grafika_(cropped).jpg`.
+  https://commons.wikimedia.org/wiki/File:Aleksy_Dobosz_grafika_(cropped).jpg.
+  Accessed 2026-07-02.
+- Wikimedia Commons. `File:Скелі_Довбуша_20160510_002.jpg`.
+  https://commons.wikimedia.org/wiki/File:%D0%A1%D0%BA%D0%B5%D0%BB%D1%96_%D0%94%D0%BE%D0%B2%D0%B1%D1%83%D1%88%D0%B0_20160510_002.jpg.
+  Accessed 2026-07-02.


### PR DESCRIPTION
## Summary

Adds the BIO #312 research dossier for `oleksa-dovbush` as the next +77 backfill dossier.

The dossier frames Oleksa Dovbush as a historical Carpathian opryshok leader with a large Hutsul/Ukrainian folkloric afterlife, while keeping anti-hagiographic cautions around violence, outlawry, ethnicized victim lists, and Robin Hood shorthand.

## Scope

Changed only:

- `docs/research/bio/oleksa-dovbush.md`

No plan YAML, module content, activities, vocabulary, resources, site MDX, wiki packet, status/audit/review artifact, telemetry, package, or linter config files are included.

## Validation

- `npx markdownlint-cli2 docs/research/bio/oleksa-dovbush.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/oleksa-dovbush.md`
- `git diff --check`
- `git diff --cached --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Independent review

Completed through Claude bridge task `review-bio-312-oleksa-dovbush-dossier`.

Verdict: approve, no blockers. Two nits around `Dzvinchuk` / `Dzvinka` wording and Ukrainian name consistency were fixed before marking ready.
