### PR TITLE
docs(bio): add Lukian Kobylytsia dossier

### DIFF
--- a/docs/research/bio/lukian-kobylytsia.md
+++ b/docs/research/bio/lukian-kobylytsia.md
@@ -1,0 +1,296 @@
+# Лук'ян Кобилиця - Research Dossier
+
+**Slug:** `lukian-kobylytsia`
+**Block:** +77 backfill - Bukovynian peasant politics / Hutsul rights / Habsburg 1848
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #313
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-02
+
+**Source acronym legend:** EIU = Encyclopedia of History of Ukraine / Institute of
+History of Ukraine, NASU; IEU = Internet Encyclopedia of Ukraine / Canadian
+Institute of Ukrainian Studies; OBL = Österreichisches Biographisches Lexikon;
+DAOChO = State Archive of Chernivtsi Oblast; HIST / ISTORIO / BIO = existing
+learn-ukrainian track materials; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional, encyclopedia, archival, or
+  image-rights sources cited
+- [x] Pressure mechanism framed as Habsburg Bukovyna landlord power, corvee,
+  forest and pasture rights, community self-government, and 1848 politics; no
+  one-note nationalist or Soviet class-war flattening
+- [x] At least 2 title / source / visual anchors supplied
+- [x] Cross-track links verified `test -e` / `rg` on 2026-07-02 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check
+
+- [x] No Russocentric framing: Kobylytsia is not read through Russian imperial or
+  Soviet retrospective categories as the interpretive center.
+- [x] Ukrainian / Hutsul / Bukovynian agency central: rural communities, Hutsul
+  councils, peasant deputies, and regional political claims remain visible.
+- [x] Habsburg administrative setting explicit: Bukovyna, Vienna, Reichstag,
+  landlords, dominia, corvee, forests, pastures, police surveillance.
+- [x] Anti-hagiography: the dossier keeps together peasant rights, armed pressure,
+  folk heroization, disputed dates/places, and multiethnic Bukovyna politics.
+
+## 1. Identity facts
+
+- **Canonical learner-facing name:** `Лук'ян Кобилиця`; English `Lukian
+  Kobylytsia`. Use `lukian-kobylytsia` for the BIO slug.
+- **Index forms:** Ukrainian `Кобилиця Лук'ян`; English `Kobylytsia, Lukian`.
+- **Search variants:** IEU uses `Kobylycja, Lukjan`; OBL uses `Kobylicza,
+  Lucian`; other useful search forms include `Lucian Kobylytsia`, `Luk'ian
+  Kobylytsia`, `Luchian Cobiliță`, `Лук’ян Кобилиця`, and `Кобилиця Лук’ян`.
+- **Dates:** Death date is stable as 24 October 1851 in EIU/IEU. Birth year is
+  source-sensitive: EIU gives 1812, IEU gives `ca 1803` with 1812 in some
+  sources, and OBL gives 1803. Learner-facing chronology should use
+  `ca. 1803/1812-1851` or label a chosen date to its source.
+- **Birthplace:** EIU gives Putyla-Storonets, now Putyla; IEU gives
+  Storonets-Putyliv; DAOChO/local memory also points to Krasnyi Dil near Serhii.
+  Treat these as source-labeled Putyla-area / Bukovyna locality variants, not a
+  reason to invent one harmonized birthplace.
+- **Death place:** IEU gives Solca and notes Gura Humorului as another source
+  variant; OBL gives Solka / Solca. Keep the modern Romania location context if
+  used in module geography.
+- **Core identity:** Bukovynian Hutsul peasant leader and political actor under
+  Habsburg rule, associated with 1840s peasant movements and the Austrian
+  Reichstag / Parliament of 1848.
+
+## 2. Oppression / pressure mechanism
+
+- **Landlord domination:** EIU frames Kobylytsia as a leader of peasant movement
+  against the pressure of `дідичі` / landlords in Bukovyna.
+- **Corvee and estate labor:** EIU's uprising entry ties the 1848-1849 movement
+  to attempts to force Hutsul shepherds and woodcutters into corvee-like labor
+  under "voluntary agreements."
+- **Forest and pasture rights:** EIU and DAOChO both foreground the ban on
+  peasant use of forests and pastures that landlords treated as estate property.
+  This is a core pressure mechanism, not background scenery.
+- **Community self-government:** DAOChO records communities removing estate
+  administration, re-electing village elders, refusing obligations, and seeking
+  state-peasant status and schools.
+- **1848 political opening:** IEU's 1848 revolution entry shows peasant
+  politicization, Reichstag elections, and unresolved questions about landlord
+  compensation and community rights to forests and pastures.
+- **Multiethnic Bukovyna caution:** IEU discusses Romanian political leadership
+  and Bukovyna's status debates. Use this as regional politics, not as ethnicized
+  hostility toward Romanian communities.
+
+## 3. Major events / historical footprint
+
+- **1839 community representative:** EIU says peasants elected Kobylytsia as a
+  community representative and that he organized petitions to Bukovynian,
+  Galician, and Vienna authorities.
+- **1842-1844 conflict cycle:** DAOChO archival exhibit points to 1842 meetings
+  over refusal to deliver sheep as obligations and 1843 investigations. IEU says
+  Kobylytsia was imprisoned in 1842-1844.
+- **1843-1844 uprising:** EIU records an active action by 22 village communities
+  after forest-use restrictions; this should anchor module explanations of
+  `панщина`, `дідич`, `ліс`, `пасовище`, and `громада`.
+- **1847 imprisonment:** IEU lists another imprisonment in 1847 before the
+  revolutionary wave.
+- **1848 Reichstag / Austrian Parliament:** IEU and OBL record his election to
+  the Austrian Parliament/Reichstag; IEU says he campaigned for Bukovyna
+  autonomy, attachment to Galicia, and peasant land distribution without
+  landlord compensation.
+- **1848-1849 armed movement:** IEU describes Hutsul councils, armed Hutsul
+  groups, and the spread of uprising across Bukovyna and into Galicia; EIU says
+  spring 1849 was the largest phase.
+- **Suppression and surveillance:** EIU says Austrian troops suppressed the
+  uprising in May 1849; IEU says Kobylytsia was arrested in Zhabie in April 1850,
+  released in 1851, barred from returning to the Hutsul region, and kept under
+  police surveillance in Solca.
+- **Folk-memory afterlife:** IEU says he became a folk hero in songs, legends,
+  and a popular poem by Yurii Fedkovych. Treat these as reception anchors.
+
+## 4. Pedagogical anchors
+
+- **Bukovyna 1848 anchor:** Existing HIST `bukovyna-zakarpattia` materials ask
+  whether Habsburg rule was modernization or colonial control. Kobylytsia gives
+  a concrete peasant-rights case for that debate.
+- **Forest/pasture rights anchor:** Learners can compare "rights to use land" vs
+  "formal landlord property" through forests, pastures, sheep obligations, and
+  community petitions.
+- **Parliamentary politics anchor:** Kobylytsia lets modules connect village
+  grievances to Vienna Reichstag politics, not only local unrest.
+- **Myth-vs-record anchor:** Pair the folk-hero memory with EIU/IEU records of
+  arrests, armed groups, administrative claims, and police surveillance.
+- **Regional-autonomy anchor:** Bukovyna autonomy and proposed attachment to
+  Galicia should be taught as 1848 Habsburg politics, not as a simple modern
+  nation-state program.
+- **Visual anchor:** Commons `File:Лук'ян_Кобилиця_(Lukian_Kobylytsia).jpg`
+  provides a public-domain old image scan, but source/author are unknown; caption
+  as a historical image, not a verified life portrait.
+- **Monument anchor:** Commons images of the Vyzhnytsia monument support public
+  memory / commemoration lessons; preserve CC BY-SA attribution and avoid
+  treating monument inscriptions as neutral biography.
+
+## 5. Language register
+
+- **Register:** Habsburg Bukovyna, peasant petitions, corvee, landlord estate
+  rights, Hutsul mountain communities, 1848 revolution, parliamentary politics,
+  folk heroization, and regional memory.
+- **CEFR readiness:** B1+/B2 concise biography and vocabulary on community rights;
+  B2/C1 comparison of petition, uprising, and parliament; C1/C2 seminar on
+  empire, peasant politicization, regional autonomy, and memory.
+- **Core vocabulary:** `Буковина`, `Гуцульщина`, `гуцули`, `селянин`, `громада`,
+  `уповноважений`, `дідич`, `домінія`, `панщина`, `повинність`, `ліс`,
+  `пасовище`, `вівчар`, `лісоруб`, `скарга`, `петиція`, `повстання`,
+  `Рейхстаг`, `автономія`, `депутат`, `поліцейський нагляд`, `народний герой`.
+- **Register caution:** `народний герой`, `король гуцулів`, and `революціонер`
+  are reception or source-specific labels. Pair them with source-labeled social
+  and political mechanisms.
+
+## 6. Risks / open questions
+
+- **Birth year split:** Do not silently choose between 1803 and 1812. EIU uses
+  1812, IEU/OBL support ca. 1803; a future module should label the source.
+- **Birthplace harmonization:** Putyla-Storonets, Storonets-Putyliv, Putyla area,
+  and Krasnyi Dil near Serhii should be handled as source variants.
+- **Nationalist flattening:** Kobylytsia belongs in Ukrainian/Bukovynian history,
+  but his primary dossier frame should be rural rights, community autonomy, and
+  Habsburg politics rather than a clean modern nationalist biography.
+- **Soviet class-war flattening:** Soviet-era monographs are useful
+  historiography, but should not be allowed to erase regional, legal, and
+  parliamentary dimensions.
+- **Ethnicized conflict:** IEU mentions conflict with Romanian leaders in
+  Bukovyna politics. Use precise political claims and avoid implying collective
+  ethnic blame.
+- **Death-cause legends:** Some public retellings add torture/poisoning claims.
+  Keep them out of learner-facing factual chronology unless a strong source is
+  added and the claim is labeled.
+- **Image uncertainty:** Public-domain portrait files are reusable but have
+  unknown author/source. Use monument imagery when the lesson needs an
+  unambiguous modern visual.
+
+## 7. Cross-track links
+
+- **Existing HIST plan surface (VERIFIED `test -e` / `rg` 2026-07-02):**
+  `curriculum/l2-uk-en/plans/hist/bukovyna-zakarpattia.yaml`
+- **Existing HIST discovery surface (VERIFIED `test -e` / `rg` 2026-07-02):**
+  `curriculum/l2-uk-en/hist/discovery/bukovyna-zakarpattia.yaml`
+- **Existing ISTORIO plan surface (VERIFIED `test -e` / `rg` 2026-07-02):**
+  `curriculum/l2-uk-en/plans/istorio/bukovyna-mizh-imperiiamy.yaml`
+- **Existing ISTORIO discovery surface (VERIFIED `test -e` / `rg` 2026-07-02):**
+  `curriculum/l2-uk-en/istorio/discovery/halychyna-pid-avstriieyu.yaml`
+- **Existing BIO regional / Habsburg plan surfaces (VERIFIED `test -e` / `rg` 2026-07-02):**
+  `curriculum/l2-uk-en/plans/bio/olha-kobylianska.yaml`,
+  `curriculum/l2-uk-en/plans/bio/vasyl-vyshyvanyi.yaml`
+- **Existing BIO regional research cross-link (VERIFIED `test -e` / `rg` 2026-07-02):**
+  `docs/research/bio/olha-kobylianska.md` for later Bukovynian Habsburg/Romanian
+  regional context.
+- **Existing BIO index / audit surfaces (VERIFIED `rg` 2026-07-02):**
+  `site/src/content/docs/bio/index.mdx` reserves BIO #313 `lukian-kobylytsia`;
+  `docs/audits/bio-readiness-matrix-2026-06-29.md` and
+  `docs/audits/bio-ukrainian-expansion-research-2026-06-29.md` list the gap.
+- **Planned BIO surfaces (ABSENT `test -e` 2026-07-02):**
+  `curriculum/l2-uk-en/plans/bio/lukian-kobylytsia.yaml`,
+  `curriculum/l2-uk-en/bio/discovery/lukian-kobylytsia.yaml`,
+  `wiki/figures/lukian-kobylytsia.md`,
+  `site/src/content/docs/bio/lukian-kobylytsia.mdx`,
+  `curriculum/l2-uk-en/bio/lukian-kobylytsia/module.md`,
+  `curriculum/l2-uk-en/bio/lukian-kobylytsia/activities.yaml`,
+  `curriculum/l2-uk-en/bio/lukian-kobylytsia/vocabulary.yaml`,
+  `curriculum/l2-uk-en/bio/lukian-kobylytsia/resources.yaml`
+
+## 8. Naming / indexing
+
+- **Canonical UA:** `Лук'ян Кобилиця`; index form `Кобилиця Лук'ян`.
+- **Canonical EN:** `Lukian Kobylytsia`; index form `Kobylytsia, Lukian`.
+- **Search variants:** `Лук’ян Кобилиця`, `Кобилиця Лук’ян`, `Lukian
+  Kobylytsia`, `Kobylycja, Lukjan`, `Lukjan Kobylyzja`, `Lucian Kobylicza`,
+  `Lucian Kobylytsia`, `Luchian Cobiliță`, `Huzulenkonig`, `Huzulenkoenig`,
+  `Bukovynian peasant uprising`, `Буковинське селянське повстання`,
+  `Рейхстаг`, `Вижниця`, `Путила`, `Путила-Сторонець`, `Сторонець-Путилів`,
+  `Красний Діл`, `Солка`, `Solca`, `Gura Humorului`.
+- **Avoid:** Do not normalize learner-facing English to `Kobylycja`,
+  `Kobylicza`, or Romanian/German spellings unless discussing source provenance.
+  Do not use Russian forms as defaults.
+
+## 9. Image rights
+
+- **Preferred portrait / historical-image candidate:** Commons
+  `File:Лук'ян_Кобилиця_(Lukian_Kobylytsia).jpg`; public domain, unknown date,
+  unknown source/author, scan of old image. Use only with a source-uncertainty
+  caption.
+- **Alternate portrait/art candidate:** Commons `File:Лук`ян_Кобилиця.jpg`;
+  faithful photographic reproduction of a two-dimensional public-domain work of
+  art. Confirm file-level metadata before final use.
+- **Preferred monument candidate:** Commons
+  `File:Пам'ятник_Лук'яну_Кобилиці_у_Вижниці.jpg`; photo by Bukovynka, CC BY-SA
+  4.0, monument number `73-205-0063`.
+- **Alternate monument candidate:** Commons
+  `File:IMG_Пам'ятник_Лук'яну_Кобилиці_1812—1851.jpg`; photo by Vi Ko, CC BY-SA
+  4.0, same Vyzhnytsia monument. Useful for public-memory lessons.
+- **Additional place candidate:** Commons `File:Вижниця_15.jpg`; own work by
+  Yadigshonuff, CC BY-SA 4.0. Use as a contextual monument/place image, not as a
+  portrait.
+- **Category lead:** Commons `Category:Lukian Kobylytsia` contains a small file
+  set; use file-level license pages, not the category alone.
+- **Avoid default:** museum-house social-media photos, school-site portraits,
+  unsourced modern illustrations, YouTube/video frames, and local-news photos
+  without explicit reusable licensing.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- Стеблій Ф.І. "КОБИЛИЦЯ Лук'ян." Енциклопедія історії України, Інститут
+  історії України НАН України.
+  https://history.org.ua/?termin=Kobylycya_L. Accessed 2026-07-02.
+- "Kobylytsia, Lukian." Internet Encyclopedia of Ukraine / Canadian Institute of
+  Ukrainian Studies.
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CO%5CKobylytsiaLukian.htm.
+  Accessed 2026-07-02.
+- "Kobylicza, Lucian." Osterreichisches Biographisches Lexikon 1815-1950.
+  https://www.biographien.ac.at/oebl/oebl_K/Kobylicza_Lucian_1803_1851.xml.
+  Accessed 2026-07-02.
+- Ясь О.В. "БУКОВИНСЬКЕ СЕЛЯНСЬКЕ ПОВСТАННЯ 1848-49 РР." Енциклопедія історії
+  України, Інститут історії України НАН України.
+  https://history.org.ua/?termin=Bukovynske_selianske_1848. Accessed 2026-07-02.
+- "Revolution of 1848-9 in the Habsburg monarchy." Internet Encyclopedia of
+  Ukraine / Canadian Institute of Ukrainian Studies.
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CR%5CE%5CRevolutionof1848hD79intheHabsburgmonarchy.htm.
+  Accessed 2026-07-02.
+
+**Tier 2 (archival / scholarly / local institutional / reception):**
+
+- Державний архів Чернівецької області. "Лук'ян Кобилиця - народний герой
+  Буковини." https://cv.archives.gov.ua/lukian.html. Accessed 2026-07-02.
+- Hrushevsky History Portal. "Кобилиця Лук'ян (1812-1851)."
+  https://hrushevsky.history.org.ua/item/0014316. Accessed 2026-07-02.
+- Resource History. Catalog record: Шевченко Ф. П. `Лук'ян Кобилиця: з історії
+  антифеодальної боротьби селянства Буковини в першій половині XIX ст.`
+  https://resource.history.org.ua/item/0000210. Accessed 2026-07-02.
+- Дім Франка. Record for Ivan Franko, `Лук'ян Кобилиця. Епізод із історії
+  Гуцульщини в першій половині XIX в.`
+  https://dimfranka.lviv.ua/material/%D0%BB%D1%83%D0%BA%D1%8F%D0%BD-%D0%BA%D0%BE%D0%B1%D0%B8%D0%BB%D0%B8%D1%86%D1%8F.
+  Accessed 2026-07-02.
+- Existing learn-ukrainian HIST/BIO surfaces listed in Section 7, verified
+  2026-07-02.
+
+**Tier 4 (image-rights / media-rights checks):**
+
+- Wikimedia Commons. `Category:Lukian Kobylytsia`.
+  https://commons.wikimedia.org/wiki/Category:Lukian_Kobylytsia. Accessed
+  2026-07-02.
+- Wikimedia Commons. `File:Лук'ян_Кобилиця_(Lukian_Kobylytsia).jpg`.
+  https://commons.wikimedia.org/wiki/File:%D0%9B%D1%83%D0%BA%27%D1%8F%D0%BD_%D0%9A%D0%BE%D0%B1%D0%B8%D0%BB%D0%B8%D1%86%D1%8F_(Lukian_Kobylytsia).jpg.
+  Accessed 2026-07-02.
+- Wikimedia Commons. `File:Лук`ян_Кобилиця.jpg`.
+  https://commons.wikimedia.org/wiki/File:%D0%9B%D1%83%D0%BA%60%D1%8F%D0%BD_%D0%9A%D0%BE%D0%B1%D0%B8%D0%BB%D0%B8%D1%86%D1%8F.jpg.
+  Accessed 2026-07-02.
+- Wikimedia Commons. `File:Пам'ятник_Лук'яну_Кобилиці_у_Вижниці.jpg`.
+  https://commons.wikimedia.org/wiki/File:%D0%9F%D0%B0%D0%BC%27%D1%8F%D1%82%D0%BD%D0%B8%D0%BA_%D0%9B%D1%83%D0%BA%27%D1%8F%D0%BD%D1%83_%D0%9A%D0%BE%D0%B1%D0%B8%D0%BB%D0%B8%D1%86%D1%96_%D1%83_%D0%92%D0%B8%D0%B6%D0%BD%D0%B8%D1%86%D1%96.jpg.
+  Accessed 2026-07-02.
+- Wikimedia Commons. `File:IMG_Пам'ятник_Лук'яну_Кобилиці_1812—1851.jpg`.
+  https://commons.wikimedia.org/wiki/File:IMG_%D0%9F%D0%B0%D0%BC%27%D1%8F%D1%82%D0%BD%D0%B8%D0%BA_%D0%9B%D1%83%D0%BA%27%D1%8F%D0%BD%D1%83_%D0%9A%D0%BE%D0%B1%D0%B8%D0%BB%D0%B8%D1%86%D1%96_1812%E2%80%941851.jpg.
+  Accessed 2026-07-02.
+- Wikimedia Commons. `File:Вижниця_15.jpg`.
+  https://commons.wikimedia.org/wiki/File:%D0%92%D0%B8%D0%B6%D0%BD%D0%B8%D1%86%D1%8F_15.jpg.
+  Accessed 2026-07-02.


### PR DESCRIPTION
## Summary

Adds the BIO #313 research dossier for `lukian-kobylytsia` as the next +77 backfill dossier.

The dossier frames Lukian Kobylytsia as a Bukovynian Hutsul peasant political actor under Habsburg rule, centered on landlord pressure, corvee, forest/pasture rights, village community self-government, and 1848 Reichstag politics. It explicitly avoids flattening him into either a one-note nationalist hero or a Soviet-style class-war emblem.

## Scope

Changed only:

- `docs/research/bio/lukian-kobylytsia.md`

No plan YAML, module content, activities, vocabulary, resources, site MDX, wiki packet, status/audit/review artifact, telemetry, package, or linter config files are included.

## Validation

- `npx markdownlint-cli2 docs/research/bio/lukian-kobylytsia.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/lukian-kobylytsia.md`
- `git diff --check`
- `git diff --cached --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Independent review

Completed through Claude bridge task `review-bio-313-lukian-kobylytsia-dossier`.

Verdict: approve, ready to merge. No blockers or major findings. Claude verified the Section 7 path claims, BIO index reservation, audit-gap references, OBL birth-year handling, and source-count gate.
