### PR TITLE
docs(bio): add Maksym Zalizniak dossier

### DIFF
--- a/docs/research/bio/maksym-zalizniak.md
+++ b/docs/research/bio/maksym-zalizniak.md
@@ -1,0 +1,179 @@
+# Максим Ієвлевич Залізняк - Research Dossier
+
+**Slug:** `maksym-zalizniak`
+**Block:** +77 backfill - Koliivshchyna / haidamaka violence / contested memory
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #314
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-02
+
+**Source acronym legend:** EIU = Encyclopedia of History Ukraine / Institute History Ukraine, NASU; IEU = Internet Encyclopedia Ukraine / Canadian Institute Ukrainian Studies; NASU-IAU = Institute Ukrainian Archaeography and Source Studies / NASU document collection; JVL = Jewish Virtual Library / Encyclopaedia Judaica-derived entry; JE = Jewish Encyclopedia; LH = Local History; HIST / LIT / FOLK / BIO = existing learn-ukrainian track materials; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional, encyclopedia, scholarly, document, and image-rights sources cited
+- [x] Pressure mechanism framed Right-Bank Ukraine under Polish-Lithuanian magnate power, serfdom, confessional politics, Bar Confederation, Russian imperial manipulation/suppression, and Uman violence; no clean liberation-hero myth
+- [x] At least 2 title / source / visual anchors supplied
+- [x] Cross-track links verified `test -e` / `rg` on 2026-07-02 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check
+
+- [x] No Russocentric framing: Russian imperial troops and proclamations are treated as political actors that helped create and then suppress the crisis, not as neutral liberators.
+- [x] Ukrainian agency central but not romanticized: peasant, Cossack, Orthodox, and local Right-Bank actors remain visible without erasing violence against Polish, Jewish, Roman Catholic, and Uniate communities.
+- [x] Polish-Lithuanian context specific: magnate estate power, Bar Confederation politics, and confessional hierarchy are named rather than flattened into generic "foreign oppression."
+- [x] Jewish, Polish, and Uniate victim memory is explicit: Uman is not reduced to a triumphant capture, and death tolls are source-labeled / contested.
+- [x] Soviet and nationalist simplifications flagged: the dossier avoids both Soviet class-war-only framing and hagiographic national-avenger framing.
+- [x] Literary reception separated from history: Shevchenko's `Гайдамаки`, folk songs, and later monuments are reception anchors, not event-level biography evidence unless separately sourced.
+
+## 1. Identity / chronology
+
+- **Canonical UA:** `Максим Ієвлевич Залізняк`.
+- **Canonical EN:** `Maksym Zalizniak`.
+- **Core identity:** Zaporozhian Cossack, haidamaka leader, and central leader of the 1768-1769 Koliivshchyna rebellion in Right-Bank Ukraine.
+- **Birth:** EIU and IEU support `ca. 1740`; EIU gives Medvedivka, now Cherkasy oblast, as birthplace. Some later or popular sources shift the village to Ivkivtsi / nearby Kholodnyi Yar memory geography; treat those as local-memory variants unless backed by a cited source.
+- **Family / early status:** EIU says he was born into a peasant family, joined the Tymoshivka kurin of the New Sich after his father's death, worked as a hired laborer in Cossack winter settlements and fishing / salt trades, and by 1762 was a Sich `підпушкарій` / artillery assistant.
+- **1767-1768 turn:** EIU says he returned to his native region in 1767; EIU / IEU place the decisive rebel organization in Kholodnyi Yar / Motronynskyi Monastery milieu in late May / early June 1768.
+- **Uman / Koliivshchyna:** EIU and IEU agree that Zalizniak's detachments moved through Medvedivka, Zhabotyn, Smila, Cherkasy, Korsun, Kaniv, Bohuslav, and Lysianka, then joined Ivan Gonta around Uman. Uman was taken on 20-21 June 1768 by new-style dating in IEU / EIU-linked chronology.
+- **Arrest and punishment:** EIU says Zalizniak and Ivan Gonta were arrested by Russian troops on 26 June (OS) / 7 July (NS) 1768. IEU says Russian general Mikhail Krechetnikov arrested Zalizniak and leading starshyna on 8 July 1768; because Zalizniak was a Russian imperial subject he was sentenced to life hard labor in Nerchinsk mines, where he probably died.
+- **Death:** Unknown; learner-facing chronology should use `ca. 1740-after 1768` or `ca. 1740-death unknown, probably in exile` unless a module explicitly explains source uncertainty.
+
+## 2. Oppression / pressure mechanism
+
+- **Right-Bank social pressure:** IEU frames the haidamaka uprisings as eighteenth-century rebellions against social, national, and religious oppression under Polish regime in Right-Bank Ukraine; EIU's Koliivshchyna entry names economic, social, political, geopolitical, and religious factors together.
+- **Serfdom and estate power:** IEU emphasizes difficult serfdom conditions and magnate / noble power. This is the structural frame, not a story of spontaneous ethnic hatred detached from estate rule.
+- **Confessional pressure:** IEU and Barbara Skinner foreground Orthodox grievances and religious borderland tensions. Skinner argues that secular nationalist or socioeconomic explanations alone cannot explain the pattern of violence, including violence against Ukrainians.
+- **Bar Confederation trigger:** EIU says the Bar Confederation sharply worsened the political and social situation, while Russian military entry against confederates created illusions among some Orthodox communities that Russian support could be expected.
+- **False imperial support:** EIU points to the so-called "Golden Charter" of Catherine II as an illusion / rumor of imperial backing; modules should teach this as rumor, manipulation, and political misreading, not a legitimate liberation mandate.
+- **Russian imperial suppression:** EIU and IEU show the same empire that benefited from Orthodox-rights politics also suppressed Koliivshchyna once it threatened imperial diplomacy, Ottoman relations, and regional order.
+- **Violence and communal targeting:** IEU's Koliivshchyna and Haidamaka entries record killing of Polish nobles, Catholic clergy, Jewish stewards / money-lenders, and Uman residents. EIU's Koliivshchyna entry states that rebel actions included cruelty on interethnic and religious grounds. This is central evidence, not a footnote.
+- **Victim memory:** JVL / Encyclopaedia Judaica and JE preserve Jewish community memory of Uman as massacre / pogrom. Use these for Jewish memory and victim perspective while flagging older language, polemical framing, and disputed numbers.
+
+## 3. Major events / historical footprint
+
+- **Pre-1768 haidamaka background:** Haidamaka uprisings in 1734 and 1750 predate Zalizniak; IEU treats 1768 as the major escalation, not the invention of unrest from nothing.
+- **Motronynskyi / Kholodnyi Yar organization:** EIU says the preparation and march of Zalizniak's Cossack detachment began in the Motronynskyi Holy Trinity Monastery / Kholodnyi Yar setting. This is the best place-memory anchor.
+- **Initial advance:** EIU and IEU list the rapid capture or control of Right-Bank towns including Medvedivka, Zhabotyn, Smila, Cherkasy, Korsun, Kaniv, Bohuslav, Kamianyi Brid, and Lysianka.
+- **Uman capture:** IEU names Uman as a major fortified trading center; the city was captured on 20-21 June 1768 after Gonta's Uman militia joined the uprising.
+- **Uman violence:** EIU's Uman tragedy entry, IEU's Uman / Koliivshchyna entries, JVL, and JE all require explicit treatment of mass killing of Jewish, Polish, Catholic, and Uniate residents / refugees. Do not frame this as a victorious episode without civilian suffering.
+- **Attempted Cossack order:** EIU says Zalizniak made efforts on controlled territories to restore economic life and establish Cossack organs of authority; IEU says he was proclaimed hetman and began governing territories according to Cossack order. Pair this with the violence record, not as exoneration.
+- **Arrest by Russian troops:** EIU says the Russian expeditionary corps under Mikhail Krechetnikov acted to suppress the movement, arrested Zalizniak and Gonta, and the main centers were suppressed by mid-July 1768, though smaller detachments continued into 1769.
+- **Punitive aftermath:** Gonta, a Polish-Lithuanian subject, was handed to Polish authorities and executed; Zalizniak, treated as a Russian imperial subject, was punished by Russian imperial jurisdiction and sent to Siberian hard labor.
+- **Memory afterlife:** IEU says Zalizniak became the subject of Ukrainian historical songs and literary works, including Shevchenko's `Гайдамаки`, `Холодний Яр`, `Невольник`, and Yurii Mushketyk's novel `Гайдамаки`.
+
+## 4. Pedagogical anchors
+
+- **Koliivshchyna anchor:** Existing HIST `koliivshchyna` surfaces already carry the event frame. Zalizniak supplies the person-centered entry point for leadership, rumor, ideology, and violence.
+- **Uman tragedy anchor:** Learners should meet the phrase `Уманська трагедія / Уманська різанина` alongside `здобуття Умані`. This prevents a single triumphalist vocabulary from controlling the module.
+- **False-charter anchor:** The "Golden Charter" lets a lesson compare rumor, imperial disinformation, and political expectation: who believed Catherine would support the rebellion, why, and what happened when imperial interests changed.
+- **Confessional-borderland anchor:** Skinner's article supports a C1/C2 seminar question: how did Orthodox, Uniate, Roman Catholic, Polish-Lithuanian, and Russian imperial identities overlap in a borderland crisis?
+- **Shevchenko anchor:** `Гайдамаки` is indispensable for reception but dangerous as literal historical evidence. Teach as poetry and memory shaping, not a neutral chronicle.
+- **Historical-song anchor:** Existing reading `istorychna-pisnia-maksym-kozak-zalizniak.mdx` offers a FOLK bridge; use it to ask how songs compress violence, grievance, and hero-making.
+- **Comparison set:** Pair Zalizniak with Dovbush and Karmaliuk to compare outlaw / rebel memory, but keep the Uman massacre as a sharper anti-hagiography requirement than in many outlaw-hero biographies.
+- **Place-memory anchor:** Kholodnyi Yar, Motronynskyi Monastery, Medvedivka, Lysianka, Uman, and Nerchinsk create a geography sequence from local uprising to imperial penal exile.
+- **Visual anchor:** Commons portrait `File:Maxim Zalizniak.jpg` is a public-domain reproduction of a late-18th-century portrait from Sumy Art Museum. Caption as historical portrait / attributed image, not verified life likeness.
+- **Landscape-memory anchor:** Commons `File:Maksym Zalizniak Oak Tree-2024.jpg` documents the Zalizniak Oak in Kholodnyi Yar under CC BY 4.0. Use only with attribution and as memory/place, not biography proof.
+
+## 5. Language register
+
+- **Register:** contested historical biography, rebellion, confessional politics, massacre memory, folk/literary reception, and decolonization critique.
+- **CEFR readiness:** B1+/B2 can handle a short factual biography with place/time sequencing; B2/C1 can compare `повстання`, `різанина`, `пам'ять`; C1/C2 can debate borderland religion, violence, and historiography.
+- **Core vocabulary:** `Коліївщина`, `гайдамаки`, `Правобережна Україна`, `Річ Посполита`, `шляхта`, `магнат`, `кріпацтво`, `панщина`, `Барська конфедерація`, `православні`, `уніати`, `римо-католики`, `єврейська громада`, `повстання`, `ватажок`, `загін`, `отаман`, `гетьман`, `Холодний Яр`, `Мотронинський монастир`, `Уманська трагедія`, `різанина`, `погром`, `Золота грамота`, `арешт`, `каторга`, `Нерчинськ`, `історична пісня`, `міфологізація`.
+- **Register caution:** `народний герой`, `месник`, `визвольний похід`, `кривава свобода`, `польсько-єврейський ворог`, and `зрадник` are high-risk labels. Use only as source-labeled reception terms or discussion prompts.
+- **Victim-language caution:** Avoid repeating old antisemitic or dehumanizing phrases except in tightly contextualized source analysis. Prefer neutral descriptions: `Jewish residents/refugees`, `Polish nobles/residents/refugees`, `Uniate clergy/laity`, `Roman Catholic clergy`.
+- **Date caution:** When presenting old/new calendar dates, label them clearly: EIU often gives paired old/new dates; IEU usually gives the new-style date.
+
+## 6. Risks / open questions
+
+- **Birthplace variant:** EIU/IEU use Medvedivka; LH / popular local accounts may say neighboring Ivkivtsi. Use EIU/IEU for canonical biography; mention local-memory variants only if needed.
+- **Uman death tolls:** Older Jewish and Polish memory sources often give high figures such as 20,000; Skinner notes total numbers remain elusive and many historians avoid precise tallies. Future modules must not give an unqualified number.
+- **Responsibility framing:** Zalizniak and Gonta jointly led the force that took Uman, but specific command decisions, rumor, local defections, and massacre dynamics vary by source. Avoid monocausal blame or exoneration.
+- **Antisemitic drift:** Estate and leasehold structures included Jewish stewards, tavernkeepers, and money-lenders in some sources, but this must never become collective Jewish guilt. The violence against Jewish civilians must be stated plainly.
+- **Polonophobic drift:** Polish-Lithuanian noble / magnate rule and Bar Confederation violence are central, but modules must not collapse all Poles or Catholics into the oppressor category.
+- **Confessional simplification:** Orthodox grievance is real, but Skinner warns that the violence pattern cannot be explained by national and class categories alone. Keep Orthodox-Uniate-Catholic-Russian borderland politics visible.
+- **Russian-imperial myth:** Catherine's supposed support and Russian Orthodox protector role should be treated as political illusion / imperial leverage. The Russian army ultimately crushed the uprising.
+- **Soviet-era bibliography:** Soviet works may be useful historiography, but they tend to over-stabilize the "anti-feudal people's war" frame. Use cautiously and label historiographic period.
+- **Hagiographic school summaries:** School / patriotic biographies often erase Uman or present it only as triumph. Do not use as factual authority.
+- **Image identity:** Commons has multiple Zalizniak images; avoid `File:Maksym_Zalizniak.jpg` where file discussion says it may depict another haidamaka. Prefer `File:Maxim Zalizniak.jpg` with Sumy Art Museum source or memory-landscape images.
+
+## 7. Cross-track links
+
+- **Existing HIST plan / discovery surfaces (VERIFIED `test -e` 2026-07-02):** `curriculum/l2-uk-en/plans/hist/koliivshchyna.yaml`, `curriculum/l2-uk-en/hist/discovery/koliivshchyna.yaml`
+- **Existing HIST context plans (VERIFIED `test -e` 2026-07-02):** `curriculum/l2-uk-en/plans/hist/beresteyska-uniia.yaml`, `curriculum/l2-uk-en/plans/hist/pravoslavna-tserkva-17.yaml`, `curriculum/l2-uk-en/plans/hist/rich-pospolyta.yaml`
+- **Existing LIT plan / discovery surfaces (VERIFIED `test -e` / `rg` 2026-07-02):** `curriculum/l2-uk-en/plans/lit/haidamaky.yaml`, `curriculum/l2-uk-en/lit/discovery/haidamaky.yaml`
+- **Existing FOLK plan / module surfaces (VERIFIED `test -e` 2026-07-02):** `curriculum/l2-uk-en/plans/folk/istorychni-pisni.yaml`, `curriculum/l2-uk-en/folk/istorychni-pisni/module.md`
+- **Existing wiki surfaces (VERIFIED `test -e` 2026-07-02):** `wiki/periods/koliivshchyna.md`, `wiki/literature/works/haidamaky.md`, `wiki/periods/beresteyska-uniia.md`, `wiki/periods/rich-pospolyta.md`, `wiki/periods/kozatski-povstannia-16.md`, `wiki/periods/shevchenko-awakening.md`, `wiki/historiography/hreko-katolytska-tserkva.md`
+- **Existing reading surface (VERIFIED `test -e` 2026-07-02):** `site/src/content/readings/istorychna-pisnia-maksym-kozak-zalizniak.mdx`
+- **Existing BIO anchors (VERIFIED `test -e` / `rg` 2026-07-02):** `site/src/content/docs/bio/index.mdx` lists BIO #314 `maksym-zalizniak`; `docs/research/bio/taras-shevchenko.md` notes `Гайдамаки` / Koliivshchyna cross-track context; `docs/research/bio/oleksa-dovbush.md` and `docs/research/bio/ustym-karmaliuk.md` support rebel-memory comparisons.
+- **Planned BIO surfaces (ABSENT `test -e` 2026-07-02):** `curriculum/l2-uk-en/plans/bio/maksym-zalizniak.yaml`, `curriculum/l2-uk-en/bio/discovery/maksym-zalizniak.yaml`, `wiki/figures/maksym-zalizniak.md`, `site/src/content/docs/bio/maksym-zalizniak.mdx`, `curriculum/l2-uk-en/bio/maksym-zalizniak/module.md`, `curriculum/l2-uk-en/bio/maksym-zalizniak/activities.yaml`, `curriculum/l2-uk-en/bio/maksym-zalizniak/vocabulary.yaml`, `curriculum/l2-uk-en/bio/maksym-zalizniak/resources.yaml`
+
+## 8. Naming / indexing
+
+- **Canonical UA:** `Максим Ієвлевич Залізняк`; index form `Залізняк Максим Ієвлевич`.
+- **Canonical EN:** `Maksym Zalizniak`; index form `Zalizniak, Maksym`.
+- **Allowed English source variant:** `Maksym Zaliznjak` appears in IEU bracket form; use only in search aliases / bibliography, not as primary learner-facing spelling.
+- **Russian / Polish source variants:** `Максим Железняк`, `Maxim Zheleznyak`, `Maksim Żeleźniak`, `Zhelyeznyak`, `Zaliznyak`. Use only for source search, provenance, or old captions.
+- **Search variants:** `Максим Залізняк`, `Залізняк Максим`, `Максим Ієвлевич Залізняк`, `Maksym Zalizniak`, `Maksym Zaliznjak`, `Maxim Zalizniak`, `Maxim Zheleznyak`, `Zhelyeznyak`, `Koliivshchyna`, `Koliyivshchyna`, `Коліївщина`, `haidamaka`, `haydamak`, `гайдамаки`, `Уманська трагедія`, `Уманська різанина`, `Massacre of Uman`, `Kholodnyi Yar`, `Холодний Яр`, `Motronynskyi Monastery`, `Мотронинський монастир`.
+- **Learner-facing pairing:** `Максим Залізняк (Maksym Zalizniak), leader of the Koliivshchyna rebellion, ca. 1740-after 1768, death unknown`.
+- **Index caution:** Do not conflate with the twentieth-century linguist Andrey / Andrii Zalizniak referenced in OES plan bibliographies.
+
+## 9. Image rights / media candidates
+
+- **Default historical portrait:** Commons `File:Maxim Zalizniak.jpg`; description says portrait of Maksym Zalizniak / Maxym Zheleznyak, late 18th century, Sumy Art Museum; author unknown; Commons marks faithful reproduction of a public-domain two-dimensional artwork. Caption should say `portrait, late eighteenth century, Sumy Art Museum source, not a verified life portrait`.
+- **Alternative local/public-domain image:** English Wikipedia `File:Maksym_Zalizniak_(2).jpg`; scanned from an early 19th-century pamphlet, public domain because copyright expired. Use only after file-level transfer/licensing review because it is not on Commons and has a bot transfer note.
+- **Place-memory image:** Commons `File:Maksym_Zalizniak_Oak_Tree-2024.jpg`; photo of Zalizniak Oak in Kholodnyi Yar, own work by Maxim Gavrilyuk, CC BY 4.0. Good for memory/place lessons with required attribution.
+- **Shevchenko reception option:** Commons `File:Гайдамаки 1886 іл. Сластіон 10.jpg`; public domain on Commons and useful for `Гайдамаки` reception rather than biography.
+- **Reception / Uman option:** Commons `File:Гонта та Залізняк. Умань.PNG`; CC BY-SA 4.0. Requires attribution and share-alike; use as modern illustration/reception, not historical evidence.
+- **Memorial context option:** Commons `File:Koliyivshchyna Mass Grave in Kodnia (Apr 2019) 2.jpg`; CC BY-SA 4.0. Useful for aftermath / repression memory, not Zalizniak portraiture.
+- **Avoid / caution:** Commons `File:Maksym_Zalizniak.jpg` has a file-talk warning that it may not depict Zalizniak but another haidamaka, Khoma of Zhytomyr. Do not use as default portrait unless a later rights/identity check resolves it.
+- **Avoid default:** YouTube thumbnails, school-site illustrations, patriotic posters, Facebook images, AI colorizations, film stills, or modern monument photos without explicit reusable licensing.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- Смолій В.А. "Залізняк Максим Ієвлевич." Енциклопедія історії України, Інститут історії України НАН України. https://www.history.org.ua/?termin=Zaliznyak_M. Accessed 2026-07-02.
+- Смолій В.А. "Коліївщина." Енциклопедія історії України, Інститут історії України НАН України. https://www.history.org.ua/?termin=Koliivshchyna. Accessed 2026-07-02.
+- "Уманська трагедія 1768, Уманська різанина." Енциклопедія історії України, Інститут історії України НАН України. https://www.history.org.ua/?termin=umanska_tragedija_1768_umanska_rizanyna. Accessed 2026-07-02.
+- "Гайдамацький рух." Енциклопедія історії України, Інститут історії України НАН України. https://www.history.org.ua/?termin=Gajdamackij_ruh. Accessed 2026-07-02.
+- "Zalizniak, Maksym." Internet Encyclopedia Ukraine / Canadian Institute Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CZ%5CA%5CZalizniakMaksym.htm. Accessed 2026-07-02.
+- "Koliivshchyna rebellion." Internet Encyclopedia Ukraine / Canadian Institute Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CO%5CKoliivshchynarebellion.htm. Accessed 2026-07-02.
+- "Haidamaka uprisings." Internet Encyclopedia Ukraine / Canadian Institute Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CH%5CA%5CHaidamakauprisings.htm. Accessed 2026-07-02.
+- "Uman." Internet Encyclopedia Ukraine / Canadian Institute Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CU%5CM%5CUman.htm. Accessed 2026-07-02.
+- Синяк І.Л., упоряд.; Смолій В.А., гол. ред. `Коліївщина: 1768-1769 роки у документальній та мемуарній спадщині. Т. 1: Документи архіву Коша Нової Запорозької Січі`. Інститут історії України НАН України / Інститут української археографії та джерелознавства ім. М.С. Грушевського НАН України / ЦДІАК України, 2019. https://resource.history.org.ua/item/0014806. Accessed 2026-07-02.
+
+**Tier 2 (scholarly / expert context):**
+
+- Skinner, Barbara. "Borderlands of Faith: Reconsidering the Origins of a Ukrainian Tragedy." `Slavic Review` 64, no. 1 (Spring 2005): 88-116. https://doi.org/10.2307/3650068. Cambridge Core abstract accessed 2026-07-02.
+- "Uman." Jewish Virtual Library / Encyclopaedia Judaica. https://www.jewishvirtuallibrary.org/uman. Accessed 2026-07-02. Use for Jewish memory / community framing; note the page contains a likely 1788 typo for the 1768 event.
+- Rosenthal, Herman; Lipman, J.G. "Haidamacks." Jewish Encyclopedia. https://www.jewishencyclopedia.com/articles/7056-haidamacks. Accessed 2026-07-02. Use as older Jewish historiographic / memory source; language and numbers require contextualization.
+- "Гайдамаки з Мотриного лісу." Локальна історія. https://localhistory.org.ua/texts/statti/gaidamaki-z-motrinogo-lisu/. Accessed 2026-07-02. Use for accessible expert-media synthesis and local place-memory cues, not as sole authority.
+
+**Tier 3 (learn-ukrainian cross-track materials):**
+
+- `curriculum/l2-uk-en/plans/hist/koliivshchyna.yaml`
+- `curriculum/l2-uk-en/hist/discovery/koliivshchyna.yaml`
+- `curriculum/l2-uk-en/plans/hist/beresteyska-uniia.yaml`
+- `curriculum/l2-uk-en/plans/hist/pravoslavna-tserkva-17.yaml`
+- `curriculum/l2-uk-en/plans/hist/rich-pospolyta.yaml`
+- `curriculum/l2-uk-en/plans/lit/haidamaky.yaml`
+- `curriculum/l2-uk-en/lit/discovery/haidamaky.yaml`
+- `curriculum/l2-uk-en/plans/folk/istorychni-pisni.yaml`
+- `curriculum/l2-uk-en/folk/istorychni-pisni/module.md`
+- `wiki/periods/koliivshchyna.md`
+- `wiki/literature/works/haidamaky.md`
+- `site/src/content/readings/istorychna-pisnia-maksym-kozak-zalizniak.mdx`
+- `site/src/content/docs/bio/index.mdx`
+
+**Tier 4 (image-rights / media-rights checks):**
+
+- Commons `File:Maxim Zalizniak.jpg`. https://commons.wikimedia.org/wiki/File:Maxim_Zalizniak.jpg. Public-domain reproduction of public-domain two-dimensional artwork; verify file page at use time.
+- Commons `File:Maksym Zalizniak Oak Tree-2024.jpg`. https://commons.wikimedia.org/wiki/File:Maksym_Zalizniak_Oak_Tree-2024.jpg. CC BY 4.0, author Maxim Gavrilyuk; attribution required.
+- English Wikipedia `File:Maksym Zalizniak (2).jpg`. https://en.wikipedia.org/wiki/File:Maksym_Zalizniak_(2).jpg. Public-domain claim; not Commons-hosted as of check, so requires extra review before production use.
+- Commons `File:Гайдамаки 1886 іл. Сластіон 10.jpg`. https://commons.wikimedia.org/wiki/File:%D0%93%D0%B0%D0%B9%D0%B4%D0%B0%D0%BC%D0%B0%D0%BA%D0%B8_1886_%D1%96%D0%BB._%D0%A1%D0%BB%D0%B0%D1%81%D1%82%D1%96%D0%BE%D0%BD_10.jpg. Public-domain reception image; verify file page at use time.
+- Commons `File:Гонта та Залізняк. Умань.PNG`. https://commons.wikimedia.org/wiki/File:%D0%93%D0%BE%D0%BD%D1%82%D0%B0_%D1%82%D0%B0_%D0%97%D0%B0%D0%BB%D1%96%D0%B7%D0%BD%D1%8F%D0%BA._%D0%A3%D0%BC%D0%B0%D0%BD%D1%8C.PNG. CC BY-SA 4.0; attribution and share-alike required.
+- Commons `File:Koliyivshchyna Mass Grave in Kodnia (Apr 2019) 2.jpg`. https://commons.wikimedia.org/wiki/File:Koliyivshchyna_Mass_Grave_in_Kodnia_(Apr_2019)_2.jpg. CC BY-SA 4.0; attribution and share-alike required.
+- Commons `File:Maksym_Zalizniak.jpg` discussion page. https://commons.wikimedia.org/wiki/File_talk:Maksym_Zalizniak.jpg. Identity warning; avoid default portrait.


### PR DESCRIPTION
## Summary\n- Add BIO #314 research dossier for Maksym Zalizniak.\n- Frame Koliivshchyna, Uman violence, confessional-borderland pressure, Russian imperial manipulation/suppression, and contested folk/literary memory.\n- Keep scope to `docs/research/bio/maksym-zalizniak.md` only.\n\n## Validation\n- `npx markdownlint-cli2 docs/research/bio/maksym-zalizniak.md`\n- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/maksym-zalizniak.md`\n- `git diff --check`\n- `.venv/bin/python scripts/audit/lint_agent_trailer.py`\n\n## Independent review\n- Claude Opus 4.8 read-only review completed for task `review-bio-314-maksym-zalizniak-dossier-retry`.\n- Verdict: approve / merge-ready. One non-blocking date-label nit was fixed and force-pushed.