### PR TITLE
docs(bio): add Ivan Gonta dossier

### DIFF
--- a/docs/research/bio/ivan-gonta.md
+++ b/docs/research/bio/ivan-gonta.md
@@ -1,0 +1,186 @@
+# Іван Гонта - Research Dossier
+
+**Slug:** `ivan-gonta`
+**Block:** +77 backfill - Koliivshchyna / Uman militia defection / contested martyr memory
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #315
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-02
+
+**Source acronym legend:** EIU = Encyclopedia of History Ukraine / Institute History Ukraine, NASU; IEU = Internet Encyclopedia Ukraine / Canadian Institute Ukrainian Studies; UIJ = Ukrainian Historical Journal / Institute History Ukraine, NASU; NASU-IAU = Institute Ukrainian Archaeography and Source Studies / NASU document collection; JVL = Jewish Virtual Library / Encyclopaedia Judaica-derived entry; JE = Jewish Encyclopedia; HIST / LIT / FOLK / BIO = existing learn-ukrainian track materials; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional, encyclopedia, scholarly, document, and image-rights sources cited
+- [x] Pressure mechanism framed Right-Bank Ukraine under Polish-Lithuanian magnate power, household militia service, confessional politics, Bar Confederation, Russian imperial suppression, Polish-Lithuanian punitive justice, and Uman violence; no clean martyr-only myth
+- [x] At least 2 title / source / visual anchors supplied
+- [x] Cross-track links verified `test -e` / `rg` on 2026-07-02 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check
+
+- [x] No Russocentric framing: Russian troops are treated as suppressors and political deceivers in the post-Uman arrest sequence, not as neutral restorers of order.
+- [x] Ukrainian agency central but not romanticized: Gonta's choice, militia command, and later memory remain visible beside the mass violence in Uman.
+- [x] Polish-Lithuanian context specific: Potocki household militia, Bratslav / Kamianets voivodeship geography, magnate service, and Polish-Lithuanian punitive jurisdiction are named.
+- [x] Jewish, Polish, Catholic, and Uniate victim memory explicit: Uman is not only "capture" or "liberation"; civilian killing is a core dossier fact.
+- [x] Shevchenko / folk reception separated from event history: `Гонта в Умані`, folk songs, portraits, monuments, and legends are treated as memory constructions unless backed by event-level sources.
+- [x] Antisemitic and polonophobic drift blocked: social and estate categories are not allowed to become collective ethnic guilt.
+
+## 1. Identity / chronology
+
+- **Canonical UA:** `Іван Гонта`.
+- **Canonical EN:** `Ivan Gonta`.
+- **Core identity:** Senior sotnyk / captain of the Uman household Cossack militia of Kyiv voivode Franciszek Salezy Potocki; one of the leaders of the 1768 Koliivshchyna rebellion after joining Maksym Zalizniak's forces.
+- **Birth / origin:** EIU says birth year and birthplace are unknown, while Gonta came from a peasant family and lived with his family in Rozsishky, now in the Khrystynivka area of Cherkasy oblast. IEU gives birth in Rozsishky near Uman. Learner-facing chronology should say `birth unknown; associated with Rozsishky near Uman`.
+- **Social position:** EIU stresses that Gonta was not a simple outlaw figure: he had a substantial household in Rozsishky, authority among subordinate Cossacks, and standing in the noble environment before the uprising.
+- **Pre-uprising service:** IEU says he served in Potocki's Uman household militia from 1757. This matters pedagogically because his defection came from inside the armed apparatus defending Uman.
+- **Early June 1768 switch:** EIU says after negotiations with Maksym Zalizniak near Uman in early June 1768, Gonta led his Uman household-militia units to the insurgent side. IEU says he had been ordered to attack Zalizniak's approaching haidamaka forces but instead joined them.
+- **Uman capture:** EIU gives 9-10 June 1768 for the storming of Uman; IEU gives 21 June 1768. Treat this as old-style / new-style date presentation rather than a contradiction unless a module explains calendars.
+- **Arrest:** EIU says Russian regular-army troops arrested Gonta on 26 June (OS) 1768 and, because he was a Polish-Lithuanian subject, handed him to the Polish side. IEU describes a Russian Don Cossack regiment under Colonel Gurev tricking rebels into believing it supported them, then seizing about 900 people.
+- **Execution:** EIU gives 14 July 1768 in Serby, now Hontivka, after prolonged torture and a noble-court sentence. IEU says he was tortured for several days and parts of his body were nailed to gallows in 14 towns.
+
+## 2. Oppression / pressure mechanism
+
+- **Right-Bank social pressure:** EIU's Koliivshchyna entry names economic, social, political, geopolitical, and religious factors; IEU frames the wider haidamaka movement as rebellion against oppression under Polish-Lithuanian rule in Right-Bank Ukraine.
+- **Household militia pressure:** Gonta's role inside Potocki's household militia makes him a case study in local coercive service. He was part of the order defending Uman before he defected from it.
+- **Magnate / estate order:** Potocki's household force and Uman fortress show how magnate power was militarized locally. This frame is more precise than simply calling Gonta a free peasant rebel.
+- **Confessional and Bar Confederation context:** The same Orthodox, Uniate, Roman Catholic, Bar Confederation, and Russian imperial dynamics named in the Zalizniak dossier apply here. Gonta's story should not be detached from confessional-borderland crisis.
+- **Uman civilian violence:** IEU explicitly says the joint forces captured and ravaged Uman, massacring Polish nobles, Jews, and Uniates. EIU's Uman tragedy entry supplies the broader victim-memory frame.
+- **Russian imperial suppression:** IEU's Gonta entry is especially clear that Russian troops deceived and seized rebels after Uman. EIU shows Gonta's arrest by Russian regular troops and transfer to Polish jurisdiction.
+- **Punitive justice:** Gonta's torture and execution demonstrate Polish-Lithuanian punitive authority over a rebel subject. Teach this as state / noble retribution, not only martyr legend.
+- **Memory pressure:** Folk songs and Shevchenko transformed Gonta into a martyr and father-symbol; future modules must keep that reception separate from what EIU / IEU say about his documented actions.
+
+## 3. Major events / historical footprint
+
+- **1757 militia service:** IEU's service date gives a concrete pre-uprising anchor: Gonta was already an established captain in the Uman militia before Koliivshchyna.
+- **Early June negotiations:** EIU names negotiations with Zalizniak near Uman at the beginning of June 1768. This is the decisive political/military pivot.
+- **Militia defection:** Gonta did not merely join as an individual; he brought entrusted Uman household-militia units to the rebel side, changing the balance before the storming of Uman.
+- **Storming of Uman:** EIU gives 9-10 June; IEU gives 21 June. Use paired-calendar explanation when building chronology.
+- **Uman massacre:** IEU and EIU require the massacre to be named plainly. Gonta's dossier must not reproduce only the "Uman sotnyk hero" frame.
+- **Post-Uman insurgent authority:** IEU says Gonta was proclaimed colonel of Uman. EIU says he became one of Zalizniak's closest associates and helped expand the uprising and social actions on occupied territories.
+- **Russian seizure:** IEU says Colonel Gurev invited rebels to a banquet and seized about 900; EIU says Russian regular troops arrested Gonta on 26 June.
+- **Execution in Serby / Hontivka:** EIU gives the place and modern name; IEU adds the public display of body parts in 14 towns. This is a high-intensity detail; use sparingly in learner-facing material.
+- **Folk-song afterlife:** EIU's Maksymovych folk-song entry names songs about Gonta and Zalizniak, including `Да стояв, стояв сотник Гонта` and `Виїхав Гонта та з Умані`.
+- **Shevchenko afterlife:** IEU and UIJ / EIU Shevchenko sources place Gonta inside `Гайдамаки`, especially the poetic `Гонта в Умані` construction.
+
+## 4. Pedagogical anchors
+
+- **Militia-defection anchor:** Gonta lets learners ask how local armed service under a magnate could flip during crisis. This is more concrete than generic "rebellion broke out."
+- **Gonta-Zalizniak comparison:** Zalizniak was a Zaporozhian / haidamaka organizer; Gonta was the Uman militia captain whose defection opened the city. Pairing the dossiers prevents one figure absorbing the other's role.
+- **Uman tragedy anchor:** Teach `здобуття Умані` beside `Уманська трагедія / Уманська різанина`. For Gonta, this is not optional because Uman is his central historical footprint.
+- **Old/new calendar anchor:** EIU 9-10 June and IEU 21 June for Uman create a useful date-conversion note; do not present the dates as unresolved factual chaos.
+- **Punishment anchor:** Gonta's fate allows a B2/C1 discussion of jurisdiction: Zalizniak was punished by Russian imperial authorities; Gonta, as a Polish-Lithuanian subject, was handed to Polish authorities and executed.
+- **Shevchenko caution anchor:** `Гонта в Умані` is powerful but not documentary. UIJ's Yaremenko article is useful for showing deliberate poetic construction.
+- **Folk-song anchor:** Maksymovych collections and existing FOLK historical-song surfaces support lessons on how songs make memory durable and selective.
+- **Image anchor:** Commons `File:Ivan Gonta.png` is a public-domain reproduction of a public-domain artwork; caption as portrait tradition, not verified documentary likeness.
+- **Museum-portrait anchor:** Commons `File:Unknown - Portrait of Ivan Gonta (d. 1768), one of the insurrection leaders in Ukraine - MP 2958 MNW - National Museum in Warsaw.jpg` is a National Museum in Warsaw object image. Verify file-level license at production use; useful for discussing how Gonta is represented in Polish museum metadata.
+- **Memorial / illustration anchor:** Commons `File:Гонта та Залізняк. Умань.PNG` and Kodnia mass-grave images are reception / memory objects, not event evidence.
+
+## 5. Language register
+
+- **Register:** contested historical biography, militia service, rebellion, massacre memory, punitive justice, folk song, and literary reception.
+- **CEFR readiness:** B1+/B2 concise biography and place sequencing; B2/C1 comparison of Gonta / Zalizniak and terms `сотник`, `надвірне військо`, `різанина`; C1/C2 seminar on memory, violence, and poetic transformation.
+- **Core vocabulary:** `Іван Гонта`, `сотник`, `надвірне військо`, `уманська міліція`, `воєвода`, `Потоцький`, `Правобережна Україна`, `Річ Посполита`, `шляхта`, `магнат`, `Барська конфедерація`, `Коліївщина`, `гайдамаки`, `М. Залізняк`, `Умань`, `перейти на бік`, `повстанці`, `здобуття міста`, `Уманська трагедія`, `різанина`, `єврейська громада`, `уніати`, `арешт`, `зрада`, `тортури`, `страта`, `Гонтівка`, `історична пісня`, `легенда`, `Гайдамаки`.
+- **Register caution:** `мученик`, `народний герой`, `зрадник`, `визволитель`, `каратель`, and ethnicized blame phrases are high-risk. Use as source-labeled memory language, not neutral narration.
+- **Victim-language caution:** Say `Jewish residents/refugees`, `Polish nobles/residents`, `Uniate clergy/laity`, `Roman Catholic clergy` rather than inherited polemical formulas.
+- **Violence-detail caution:** Torture and body-display details are source-supported but graphic; include only where pedagogically necessary and with age / level sensitivity.
+- **Poetry-language caution:** Shevchenko's dramatic choices should be called poetry, memory, and moral imagination, not biography.
+
+## 6. Risks / open questions
+
+- **Birth uncertainty:** EIU says unknown birth year and unknown birthplace; IEU gives Rozsishky. Use source-labeled phrasing rather than inventing a birth year.
+- **Calendar split:** EIU dates Uman 9-10 June; IEU dates 21 June. Label old/new style if used in a timeline.
+- **Children legend:** Shevchenko's `Гайдамаки` includes the famous sons episode; modern summaries often repeat or deny it. The dossier should not treat this as documentary history without a separate source.
+- **Uman death tolls:** As with Zalizniak, older sources may give high round numbers. Avoid unqualified totals.
+- **Responsibility simplification:** Gonta's defection was decisive, but Uman violence involved joined forces, local dynamics, rumors, panic, and command structures. Avoid making him either sole culprit or pure martyr.
+- **Antisemitic drift:** Do not translate estate and leasehold grievances into collective Jewish blame. The massacre of Jewish civilians is central.
+- **Polonophobic drift:** Potocki, magnate service, and Polish-Lithuanian punitive structures are historical institutions; do not collapse all Poles or Catholics into oppressors.
+- **Russocentric drift:** Russian troops suppressed and deceived the rebels; avoid "Russia restored order" framing.
+- **Hagiographic reception:** Folk songs, monuments, portraits, and school summaries often make Gonta a pure martyr. Keep those in a reception section.
+- **Image identity / rights:** Portraits are historical representations with uncertain likeness; Commons public-domain status still requires file-level verification before production use.
+
+## 7. Cross-track links
+
+- **Existing HIST plan / discovery surfaces (VERIFIED `test -e` 2026-07-02):** `curriculum/l2-uk-en/plans/hist/koliivshchyna.yaml`, `curriculum/l2-uk-en/hist/discovery/koliivshchyna.yaml`
+- **Existing HIST context plans / discovery surfaces (VERIFIED `test -e` 2026-07-02):** `curriculum/l2-uk-en/plans/hist/beresteyska-uniia.yaml`, `curriculum/l2-uk-en/hist/discovery/beresteyska-uniia.yaml`, `curriculum/l2-uk-en/plans/hist/pravoslavna-tserkva-17.yaml`, `curriculum/l2-uk-en/plans/hist/rich-pospolyta.yaml`, `curriculum/l2-uk-en/hist/discovery/shevchenko-awakening.yaml`
+- **Existing LIT plan / discovery surfaces (VERIFIED `test -e` / `rg` 2026-07-02):** `curriculum/l2-uk-en/plans/lit/haidamaky.yaml`, `curriculum/l2-uk-en/lit/discovery/haidamaky.yaml`
+- **Existing FOLK plan / module surfaces (VERIFIED `test -e` 2026-07-02):** `curriculum/l2-uk-en/plans/folk/istorychni-pisni.yaml`, `curriculum/l2-uk-en/folk/istorychni-pisni/module.md`
+- **Existing wiki surfaces (VERIFIED `test -e` 2026-07-02):** `wiki/periods/koliivshchyna.md`, `wiki/literature/works/haidamaky.md`, `wiki/periods/beresteyska-uniia.md`, `wiki/periods/rich-pospolyta.md`, `wiki/periods/kozatski-povstannia-16.md`, `wiki/periods/shevchenko-awakening.md`, `wiki/periods/khmelnychchyna-prychyny.md`, `wiki/periods/andrusivske-peremyrya.md`, `wiki/historiography/hreko-katolytska-tserkva.md`
+- **Existing reading surface (VERIFIED `test -e` 2026-07-02):** `site/src/content/readings/istorychna-pisnia-maksym-kozak-zalizniak.mdx`
+- **Existing BIO anchors (VERIFIED `test -e` / `rg` 2026-07-02):** `site/src/content/docs/bio/index.mdx` lists BIO #315 `ivan-gonta`; `docs/research/bio/maksym-zalizniak.md` supplies paired Koliivshchyna context; `docs/research/bio/taras-shevchenko.md` notes `Гайдамаки` / Koliivshchyna cross-track context.
+- **Planned BIO surfaces (ABSENT `test -e` 2026-07-02):** `curriculum/l2-uk-en/plans/bio/ivan-gonta.yaml`, `curriculum/l2-uk-en/bio/discovery/ivan-gonta.yaml`, `wiki/figures/ivan-gonta.md`, `site/src/content/docs/bio/ivan-gonta.mdx`, `curriculum/l2-uk-en/bio/ivan-gonta/module.md`, `curriculum/l2-uk-en/bio/ivan-gonta/activities.yaml`, `curriculum/l2-uk-en/bio/ivan-gonta/vocabulary.yaml`, `curriculum/l2-uk-en/bio/ivan-gonta/resources.yaml`
+- **Stale path caution (ABSENT `test -e` 2026-07-02):** some plan metadata may still mention older wiki paths such as `wiki/hist/koliivshchyna.md`, `wiki/hist/events/beresteyska-uniia.md`, or `wiki/history/shevchenko-awakening.md`; use the verified `wiki/periods/...` paths above instead.
+
+## 8. Naming / indexing
+
+- **Canonical UA:** `Іван Гонта`; index form `Гонта Іван`.
+- **Canonical EN:** `Ivan Gonta`; index form `Gonta, Ivan`.
+- **Ukrainian spelling variant:** `Іван Ґонта` appears in some modern Ukrainian usage. Use as search alias; default learner-facing spelling should follow EIU / IEU `Гонта`.
+- **Contemporary / variant forms:** `Гонтенко`, `Iwan Gonta`, `Jan Gonta`, `Ivan Honta`, `Iwan Honta`, `Gonta Ivan`, `Honta Ivan`, `Gonta`.
+- **Search variants:** `Іван Гонта`, `Іван Ґонта`, `Гонта Іван`, `Ivan Gonta`, `Ivan Honta`, `Iwan Gonta`, `Iwan Honta`, `Gonta Ivan`, `Gonta`, `Gontenko`, `Уманський сотник`, `Uman sotnyk`, `Potocki household militia`, `Koliivshchyna`, `Коліївщина`, `Уманська трагедія`, `Уманська різанина`, `Гонта в Умані`, `Гайдамаки Шевченко`.
+- **Learner-facing pairing:** `Іван Гонта (Ivan Gonta), Uman household-militia sotnyk and Koliivshchyna leader, birth unknown-1768`.
+- **Index caution:** Do not conflate Ivan Gonta with twentieth-century artist Ivan Honchar / `Гончар Іван Макарович`, which appears in EIU related-term lists.
+
+## 9. Image rights / media candidates
+
+- **Default portrait candidate:** Commons `File:Ivan Gonta.png`; public-domain faithful reproduction of a public-domain two-dimensional artwork. Caption as portrait tradition, not verified life likeness.
+- **Small direct portrait candidate:** Commons `File:Gonta Ivan s.jpg`; public-domain / PD-art reproduction. Direct Gonta portrait but very low resolution; use cautiously.
+- **Museum-object candidate:** Commons `File:Unknown - Portrait of Ivan Gonta (d. 1768), one of the insurrection leaders in Ukraine - MP 2958 MNW - National Museum in Warsaw.jpg`; National Museum in Warsaw object image, anonymous portrait. Verify the file-level license at use time and preserve museum metadata in caption.
+- **Print-history candidate:** Commons `File:Історія України-Русі. 1912. Уманський сотник Іван Гонта.jpg`; extracted from Mykola Arkas's 1912 `Історія України-Русі`, public-domain print context. Good for reception / textbook-memory history.
+- **Graphic-art candidate:** Commons `File:Ждаха Иван Гонта.jpg`; public-domain reproduction; author died in 1927. Russian-captioned filename should be source/provenance only, not learner-facing naming.
+- **Reception / Uman candidate:** Commons `File:Гонта та Залізняк. Умань.PNG`; CC BY-SA 4.0. Requires attribution and share-alike; use as modern illustration/reception, not historical evidence.
+- **Memorial context candidate:** Commons `File:Koliyivshchyna Mass Grave in Kodnia (Apr 2019) 2.jpg`; CC BY-SA 4.0. Useful for repression / aftermath memory, not Gonta portraiture.
+- **Avoid default:** YouTube thumbnails, school slides, patriotic posters, Facebook images, AI colorizations, film stills, or modern monument photos without explicit reusable licensing.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- Смолій В.А. "Гонта Іван." Енциклопедія історії України, Інститут історії України НАН України. https://www.history.org.ua/?termin=Gonta_I. Accessed 2026-07-02.
+- Смолій В.А. "Коліївщина." Енциклопедія історії України, Інститут історії України НАН України. https://www.history.org.ua/?termin=Koliivshchyna. Accessed 2026-07-02.
+- "Уманська трагедія 1768, Уманська різанина." Енциклопедія історії України, Інститут історії України НАН України. https://www.history.org.ua/?termin=umanska_tragedija_1768_umanska_rizanyna. Accessed 2026-07-02.
+- Смолій В.А. "Залізняк Максим Ієвлевич." Енциклопедія історії України, Інститут історії України НАН України. https://www.history.org.ua/?termin=Zaliznyak_M. Accessed 2026-07-02.
+- "Українські народні пісні у збірниках Михайла Максимовича." Енциклопедія історії України, Інститут історії України НАН України. https://www.history.org.ua/?termin=ukrajinski_narodni_pisni_u_zbirnykakh_mykhajla_maksymovycha. Accessed 2026-07-02.
+- "Шевченко Тарас Григорович." Енциклопедія історії України, Інститут історії України НАН України. https://history.org.ua/?termin=Shevchenko_Taras. Accessed 2026-07-02.
+- "Gonta, Ivan." Internet Encyclopedia Ukraine / Canadian Institute Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CG%5CO%5CGontaIvan.htm. Accessed 2026-07-02.
+- "Koliivshchyna rebellion." Internet Encyclopedia Ukraine / Canadian Institute Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CO%5CKoliivshchynarebellion.htm. Accessed 2026-07-02.
+- "Uman." Internet Encyclopedia Ukraine / Canadian Institute Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CU%5CM%5CUman.htm. Accessed 2026-07-02.
+- Синяк І.Л., упоряд.; Смолій В.А., гол. ред. `Коліївщина: 1768-1769 роки у документальній та мемуарній спадщині. Т. 1: Документи архіву Коша Нової Запорозької Січі`. Інститут історії України НАН України / Інститут української археографії та джерелознавства ім. М.С. Грушевського НАН України / ЦДІАК України, 2019. https://resource.history.org.ua/item/0014806. Accessed 2026-07-02.
+
+**Tier 2 (scholarly / expert context):**
+
+- Яременко В.І. "Історіософський зміст Шевченкових `Гайдамаків` (до 170-річчя виходу поеми)." `Український історичний журнал`, 2011, no. 2. https://resource.history.org.ua/publ/journal_2011_2_159. Accessed 2026-07-02.
+- Skinner, Barbara. "Borderlands of Faith: Reconsidering the Origins of a Ukrainian Tragedy." `Slavic Review` 64, no. 1 (Spring 2005): 88-116. https://doi.org/10.2307/3650068. Cambridge Core abstract accessed 2026-07-02.
+- "Uman." Jewish Virtual Library / Encyclopaedia Judaica. https://www.jewishvirtuallibrary.org/uman. Accessed 2026-07-02. Use for Jewish memory / community framing; note the page contains a likely 1788 typo for the 1768 event.
+- Rosenthal, Herman; Lipman, J.G. "Haidamacks." Jewish Encyclopedia. https://www.jewishencyclopedia.com/articles/7056-haidamacks. Accessed 2026-07-02. Use as older Jewish historiographic / memory source; language and numbers require contextualization.
+
+**Tier 3 (learn-ukrainian cross-track materials):**
+
+- `docs/research/bio/maksym-zalizniak.md`
+- `docs/research/bio/taras-shevchenko.md`
+- `curriculum/l2-uk-en/plans/hist/koliivshchyna.yaml`
+- `curriculum/l2-uk-en/hist/discovery/koliivshchyna.yaml`
+- `curriculum/l2-uk-en/plans/hist/beresteyska-uniia.yaml`
+- `curriculum/l2-uk-en/plans/hist/pravoslavna-tserkva-17.yaml`
+- `curriculum/l2-uk-en/plans/hist/rich-pospolyta.yaml`
+- `curriculum/l2-uk-en/plans/lit/haidamaky.yaml`
+- `curriculum/l2-uk-en/lit/discovery/haidamaky.yaml`
+- `curriculum/l2-uk-en/plans/folk/istorychni-pisni.yaml`
+- `curriculum/l2-uk-en/folk/istorychni-pisni/module.md`
+- `wiki/periods/koliivshchyna.md`
+- `wiki/literature/works/haidamaky.md`
+- `site/src/content/readings/istorychna-pisnia-maksym-kozak-zalizniak.mdx`
+- `site/src/content/docs/bio/index.mdx`
+
+**Tier 4 (image-rights / media-rights checks):**
+
+- Commons `File:Ivan Gonta.png`. https://commons.wikimedia.org/wiki/File:Ivan_Gonta.png. Public-domain reproduction of public-domain two-dimensional artwork; verify file page at use time.
+- Commons `File:Gonta Ivan s.jpg`. https://commons.wikimedia.org/wiki/File:Gonta_Ivan_s.jpg. Public-domain / PD-art reproduction; low-resolution direct portrait.
+- Commons `File:Unknown - Portrait of Ivan Gonta (d. 1768), one of the insurrection leaders in Ukraine - MP 2958 MNW - National Museum in Warsaw.jpg`. https://commons.wikimedia.org/wiki/File:Unknown_-_Portrait_of_Ivan_Gonta_(d._1768),_one_of_the_insurrection_leaders_in_Ukraine_-_MP_2958_MNW_-_National_Museum_in_Warsaw.jpg. Museum object image; verify file page at use time.
+- Commons `File:Історія України-Русі. 1912. Уманський сотник Іван Гонта.jpg`. https://commons.wikimedia.org/wiki/File:%D0%86%D1%81%D1%82%D0%BE%D1%80%D1%96%D1%8F_%D0%A3%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D0%B8-%D0%A0%D1%83%D1%81%D1%96._1912._%D0%A3%D0%BC%D0%B0%D0%BD%D1%81%D1%8C%D0%BA%D0%B8%D0%B9_%D1%81%D0%BE%D1%82%D0%BD%D0%B8%D0%BA_%D0%86%D0%B2%D0%B0%D0%BD_%D0%93%D0%BE%D0%BD%D1%82%D0%B0.jpg. Public-domain print context; verify file page at use time.
+- Commons `File:Ждаха Иван Гонта.jpg`. https://commons.wikimedia.org/wiki/File:%D0%96%D0%B4%D0%B0%D1%85%D0%B0_%D0%98%D0%B2%D0%B0%D0%BD_%D0%93%D0%BE%D0%BD%D1%82%D0%B0.jpg. Public-domain reproduction; Russian-captioned filename is provenance only.
+- Commons `File:Гонта та Залізняк. Умань.PNG`. https://commons.wikimedia.org/wiki/File:%D0%93%D0%BE%D0%BD%D1%82%D0%B0_%D1%82%D0%B0_%D0%97%D0%B0%D0%BB%D1%96%D0%B7%D0%BD%D1%8F%D0%BA._%D0%A3%D0%BC%D0%B0%D0%BD%D1%8C.PNG. CC BY-SA 4.0; attribution and share-alike required.
+- Commons `File:Koliyivshchyna Mass Grave in Kodnia (Apr 2019) 2.jpg`. https://commons.wikimedia.org/wiki/File:Koliyivshchyna_Mass_Grave_in_Kodnia_(Apr_2019)_2.jpg. CC BY-SA 4.0; attribution and share-alike required.


### PR DESCRIPTION
## Summary\n- Add BIO #315 research dossier for Ivan Gonta.\n- Frame Uman household-militia defection, Koliivshchyna, Uman violence, Polish-Lithuanian punitive justice, Russian suppression/deception, folk-song and Shevchenko reception.\n- Keep scope to `docs/research/bio/ivan-gonta.md` only.\n\n## Validation\n- `npx markdownlint-cli2 docs/research/bio/ivan-gonta.md`\n- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/ivan-gonta.md`\n- `git diff --check`\n- `.venv/bin/python scripts/audit/lint_agent_trailer.py`\n\n## Independent review\n- Claude Opus 4.8 read-only review completed for task `review-bio-315-ivan-gonta-dossier`.\n- Verdict: pass / mergeable. One non-blocking date-label nit was fixed and force-pushed.